### PR TITLE
feat: migrations declared in the app, resolved by the node (migrations v2, part 1)

### DIFF
--- a/apps/abi_conformance/abi.expected.json
+++ b/apps/abi_conformance/abi.expected.json
@@ -962,5 +962,6 @@
       }
     }
   ],
-  "state_root": "AbiState"
+  "state_root": "AbiState",
+  "state_version": 1
 }

--- a/apps/migrations/migration-suite-v2-add-field/src/lib.rs
+++ b/apps/migrations/migration-suite-v2-add-field/src/lib.rs
@@ -6,7 +6,10 @@ use calimero_storage::collections::{LwwRegister, UnorderedMap};
 const SCHEMA_VERSION_V1: &str = "1.0.0";
 const SCHEMA_VERSION_V2: &str = "2.0.0";
 
-#[app::state(emits = for<'a> Event<'a>)]
+// version = 2 is what the v2 upgrade path resolves against: the node compares
+// this against the running bytecode's state_version and picks the declared
+// edge — no caller-supplied migrate_method (see workflows 00/01).
+#[app::state(version = 2, emits = for<'a> Event<'a>)]
 #[derive(app::Migrate)]
 #[migrate(
     from = MigrationSuiteV1,

--- a/apps/state-schema-conformance/state-schema.expected.json
+++ b/apps/state-schema-conformance/state-schema.expected.json
@@ -452,5 +452,6 @@
   },
   "methods": [],
   "events": [],
-  "state_root": "StateSchemaConformance"
+  "state_root": "StateSchemaConformance",
+  "state_version": 1
 }

--- a/crates/context/src/activation.rs
+++ b/crates/context/src/activation.rs
@@ -67,7 +67,12 @@ pub fn activated_blob_folding_legacy(
         .is_some_and(|method| legacy == method);
     let matches_blob = legacy == legacy_blob_marker(&meta.app_key);
     if matches_method || matches_blob {
-        record_activation(store, context_id, meta.app_key);
+        // Return the equality answer either way, but never PERSIST a zero
+        // marker: a legacy randomly-seeded/zero app_key carries no real blob
+        // identity, and a stored zero would later read as "executes blob 0".
+        if meta.app_key != [0u8; 32] {
+            record_activation(store, context_id, meta.app_key);
+        }
         return Some(meta.app_key);
     }
     // A stale legacy marker (older method / older blob) carries no usable

--- a/crates/context/src/activation.rs
+++ b/crates/context/src/activation.rs
@@ -1,0 +1,166 @@
+//! The per-context activation marker: which bytecode blob this context last
+//! ACTIVATED (a migration commit, or a code-only swap). One fact replaces the
+//! two legacy markers — the method-name row written after a migrate and the
+//! `blob:<hex>` synthetic row written after a code-only activation — so the
+//! sync gate, the lazy trigger, and the migration rollup all share a single
+//! up-to-date rule: `marker == group.app_key`.
+
+use calimero_context_config::types::ContextGroupId;
+use calimero_governance_store::MigrationsRepository;
+use calimero_primitives::context::ContextId;
+use calimero_store::key::GroupMetaValue;
+use calimero_store::Store;
+use tracing::debug;
+
+/// The blob this context last activated, if the v2 marker is set.
+pub fn activated_blob(store: &Store, context_id: &ContextId) -> Option<[u8; 32]> {
+    store
+        .handle()
+        .get(&calimero_store::key::ContextActivatedBlob::new(*context_id))
+        .ok()
+        .flatten()
+        .map(|v| v.blob)
+}
+
+/// Record that `context_id` now executes `blob` (migration committed or
+/// code-only activation applied). Best-effort: a failed write means the
+/// context re-runs its (idempotent) activation on next access.
+pub fn record_activation(store: &Store, context_id: &ContextId, blob: [u8; 32]) {
+    let mut handle = store.handle();
+    if let Err(err) = handle.put(
+        &calimero_store::key::ContextActivatedBlob::new(*context_id),
+        &calimero_store::types::ContextActivatedBlob { blob },
+    ) {
+        debug!(%context_id, %err, "failed to record activation marker");
+    }
+}
+
+/// The legacy `blob:<hex>` synthetic marker value for code-only activations
+/// (pre-v2 shape, kept for one release so mixed fleets converge).
+pub fn legacy_blob_marker(app_key: &[u8; 32]) -> String {
+    format!("blob:{}", hex::encode(app_key))
+}
+
+/// Activation state for a context, folding legacy markers forward on first
+/// read: returns the activated blob, consulting (in order) the v2 marker,
+/// then the legacy per-context migration row — which counts as "activated at
+/// the group's current app_key" when it matches either the group's recorded
+/// migrate method or the legacy `blob:` marker for the current app_key.
+/// A successful fold WRITES the v2 marker so subsequent reads are one get.
+pub fn activated_blob_folding_legacy(
+    store: &Store,
+    group_id: &ContextGroupId,
+    context_id: &ContextId,
+    meta: &GroupMetaValue,
+) -> Option<[u8; 32]> {
+    if let Some(blob) = activated_blob(store, context_id) {
+        return Some(blob);
+    }
+    let legacy = MigrationsRepository::new(store)
+        .last_migration(group_id, context_id)
+        .ok()
+        .flatten()?;
+    let matches_method = meta
+        .migration
+        .as_ref()
+        .and_then(|bytes| core::str::from_utf8(bytes).ok())
+        .is_some_and(|method| legacy == method);
+    let matches_blob = legacy == legacy_blob_marker(&meta.app_key);
+    if matches_method || matches_blob {
+        record_activation(store, context_id, meta.app_key);
+        return Some(meta.app_key);
+    }
+    // A stale legacy marker (older method / older blob) carries no usable
+    // blob information — the context predates the current upgrade.
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use calimero_store::db::InMemoryDB;
+
+    use super::*;
+
+    fn store() -> Store {
+        Store::new(Arc::new(InMemoryDB::owned()))
+    }
+
+    fn meta(app_key: [u8; 32], migration: Option<&str>) -> GroupMetaValue {
+        use calimero_primitives::application::ApplicationId;
+        use calimero_primitives::context::UpgradePolicy;
+        use calimero_primitives::identity::PublicKey;
+        GroupMetaValue {
+            app_key,
+            target_application_id: ApplicationId::from([0xEE; 32]),
+            upgrade_policy: UpgradePolicy::LazyOnAccess,
+            created_at: 1_700_000_000,
+            admin_identity: PublicKey::from([0xAD; 32]),
+            owner_identity: PublicKey::from([0xAD; 32]),
+            migration: migration.map(|s| s.as_bytes().to_vec()),
+            auto_join: true,
+        }
+    }
+
+    #[test]
+    fn marker_roundtrip() {
+        let store = store();
+        let ctx = ContextId::from([1u8; 32]);
+        assert_eq!(activated_blob(&store, &ctx), None);
+        record_activation(&store, &ctx, [7u8; 32]);
+        assert_eq!(activated_blob(&store, &ctx), Some([7u8; 32]));
+        // Moves forward on re-activation.
+        record_activation(&store, &ctx, [8u8; 32]);
+        assert_eq!(activated_blob(&store, &ctx), Some([8u8; 32]));
+    }
+
+    #[test]
+    fn folds_legacy_method_marker_forward() {
+        let store = store();
+        let gid = ContextGroupId::from([2u8; 32]);
+        let ctx = ContextId::from([3u8; 32]);
+        let m = meta([9u8; 32], Some("migrate_v1_to_v2"));
+        MigrationsRepository::new(&store)
+            .set_last_migration(&gid, &ctx, "migrate_v1_to_v2")
+            .expect("set legacy marker");
+
+        assert_eq!(
+            activated_blob_folding_legacy(&store, &gid, &ctx, &m),
+            Some([9u8; 32])
+        );
+        // Fold persisted the v2 marker.
+        assert_eq!(activated_blob(&store, &ctx), Some([9u8; 32]));
+    }
+
+    #[test]
+    fn folds_legacy_blob_marker_forward() {
+        let store = store();
+        let gid = ContextGroupId::from([4u8; 32]);
+        let ctx = ContextId::from([5u8; 32]);
+        let m = meta([0xAB; 32], None);
+        MigrationsRepository::new(&store)
+            .set_last_migration(&gid, &ctx, &legacy_blob_marker(&[0xAB; 32]))
+            .expect("set legacy marker");
+
+        assert_eq!(
+            activated_blob_folding_legacy(&store, &gid, &ctx, &m),
+            Some([0xAB; 32])
+        );
+    }
+
+    #[test]
+    fn stale_legacy_marker_does_not_fold() {
+        let store = store();
+        let gid = ContextGroupId::from([6u8; 32]);
+        let ctx = ContextId::from([7u8; 32]);
+        // Group has moved on: method recorded is the OLD release's.
+        let m = meta([0xCD; 32], Some("migrate_v2_to_v3"));
+        MigrationsRepository::new(&store)
+            .set_last_migration(&gid, &ctx, "migrate_v1_to_v2")
+            .expect("set legacy marker");
+
+        assert_eq!(activated_blob_folding_legacy(&store, &gid, &ctx, &m), None);
+        assert_eq!(activated_blob(&store, &ctx), None);
+    }
+}

--- a/crates/context/src/activation.rs
+++ b/crates/context/src/activation.rs
@@ -47,6 +47,12 @@ pub fn legacy_blob_marker(app_key: &[u8; 32]) -> String {
 /// the group's current app_key" when it matches either the group's recorded
 /// migrate method or the legacy `blob:` marker for the current app_key.
 /// A successful fold WRITES the v2 marker so subsequent reads are one get.
+///
+/// Zero `app_key` (legacy randomly-seeded groups): a matching legacy marker
+/// still answers `Some([0;32])` — callers compare against the same zero
+/// `meta.app_key`, reproducing the pre-v2 "marker matches method ⇒ applied"
+/// gate semantics exactly — but the zero value is never persisted (it carries
+/// no blob identity for the blob-keyed loading that builds on this marker).
 pub fn activated_blob_folding_legacy(
     store: &Store,
     group_id: &ContextGroupId,

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -559,8 +559,16 @@ impl Handler<ExecuteRequest> for ContextManager {
                                             .await
                                             {
                                                 Ok(_) => {
-                                                    // Record that this migration was applied so
-                                                    // maybe_lazy_upgrade skips it on future accesses.
+                                                    // Unified activation marker: the single
+                                                    // up-to-date signal for the gate, the lazy
+                                                    // trigger, and the rollup. The legacy
+                                                    // method-name marker is still written for one
+                                                    // release so pre-v2 peers' gates converge.
+                                                    crate::activation::record_activation(
+                                                        &datastore,
+                                                        &cid,
+                                                        target_app_key,
+                                                    );
                                                     if let Err(err) =
                                                         MigrationsRepository::new(&datastore).set_last_migration(&group_id, &cid, &method, )
                                                     {
@@ -630,6 +638,13 @@ impl Handler<ExecuteRequest> for ContextManager {
                                 // nothing — caches stay warm.
                                 act.evict_application_caches(target_app);
                                 clear_executing_blob_pin(&act.datastore, cid);
+                                crate::activation::record_activation(
+                                    &act.datastore,
+                                    &cid,
+                                    target_app_key,
+                                );
+                                // Legacy blob: marker still written for one release so
+                                // pre-v2 peers' gates converge.
                                 if let Err(err) = MigrationsRepository::new(&act.datastore)
                                     .set_last_migration(
                                         &group_id,

--- a/crates/context/src/handlers/execute/upgrade_gate.rs
+++ b/crates/context/src/handlers/execute/upgrade_gate.rs
@@ -113,11 +113,12 @@ pub(super) fn maybe_lazy_upgrade(
         // pending migration or a pending code-only bytecode bump. One rule
         // covers both: the context is up to date iff its activation marker
         // (legacy markers folded forward) equals the group's recorded target
-        // blob. Legacy groups whose app_key was randomly seeded read as
-        // permanently divergent, so they are exempted up front (their
-        // contexts converge through the distinct-id path or not at all —
-        // exactly the pre-v2 behavior).
-        if meta.app_key == [0u8; 32] {
+        // blob. A zero app_key (legacy randomly-seeded groups) carries no
+        // bytecode signal, so a code-only bump can never be detected there —
+        // but a recorded MIGRATION still must fire (the fold reproduces the
+        // legacy marker-matches-method rule for the zero case), so only the
+        // no-migration shape is exempted.
+        if meta.app_key == [0u8; 32] && meta.migration.is_none() {
             return None;
         }
         let activated = crate::activation::activated_blob_folding_legacy(

--- a/crates/context/src/handlers/execute/upgrade_gate.rs
+++ b/crates/context/src/handlers/execute/upgrade_gate.rs
@@ -3,7 +3,7 @@
 //! rejected mid-upgrade, the lazy-on-access migration trigger, and the
 //! producing-app-key resolver. Extracted from the execute handler.
 
-use calimero_governance_store::{MetaRepository, MigrationsRepository};
+use calimero_governance_store::MetaRepository;
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::{ContextId, UpgradePolicy};
 use calimero_store::Store;
@@ -110,48 +110,23 @@ pub(super) fn maybe_lazy_upgrade(
     // 5. Compare current vs target application
     if *current_application_id == meta.target_application_id {
         // IDs match — bundle ids are version-stable, so this is either a
-        // pending migration or a pending code-only bytecode bump.
-        match migrate_method {
-            Some(ref method) => {
-                // Check per-context marker set after a successful migration run.
-                let already_applied = MigrationsRepository::new(datastore)
-                    .last_migration(&group_id, context_id)
-                    .ok()
-                    .flatten()
-                    .map(|last| last == *method)
-                    .unwrap_or(false);
-
-                if already_applied {
-                    return None; // migration was already applied to this context
-                }
-                // Fall through: migration is pending.
-            }
-            None => {
-                // Code-only: pending until this context has ACTIVATED the
-                // group's recorded target blob (app_key). The row alone can't
-                // signal this — an in-place install flips the row before the
-                // upgrade, leaving the actor's module cache on the old build —
-                // so activation is tracked per context, as a synthetic marker
-                // in the migration-marker store (real migrate methods never
-                // collide with the "blob:" prefix). Legacy groups whose
-                // app_key was randomly seeded converge after one activation
-                // pass (the marker then matches and this stops firing).
-                if meta.app_key == [0u8; 32] {
-                    return None;
-                }
-                let marker = activation_marker(&meta.app_key);
-                let activated = MigrationsRepository::new(datastore)
-                    .last_migration(&group_id, context_id)
-                    .ok()
-                    .flatten()
-                    .map(|last| last == marker)
-                    .unwrap_or(false);
-                if activated {
-                    return None; // bytecode current — context is up to date
-                }
-                // Fall through: code-only bytecode activation is pending.
-            }
+        // pending migration or a pending code-only bytecode bump. One rule
+        // covers both: the context is up to date iff its activation marker
+        // (legacy markers folded forward) equals the group's recorded target
+        // blob. Legacy groups whose app_key was randomly seeded read as
+        // permanently divergent, so they are exempted up front (their
+        // contexts converge through the distinct-id path or not at all —
+        // exactly the pre-v2 behavior).
+        if meta.app_key == [0u8; 32] {
+            return None;
         }
+        let activated = crate::activation::activated_blob_folding_legacy(
+            datastore, &group_id, context_id, &meta,
+        );
+        if activated == Some(meta.app_key) {
+            return None; // bytecode + migration current — context is up to date
+        }
+        // Fall through: activation (migration and/or bytecode swap) pending.
     }
 
     info!(

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -361,10 +361,24 @@ pub async fn update_application_id(
     crate::activation::record_activation(
         &datastore,
         &context_id,
-        *application.blob.bytecode.as_ref(),
+        activated_row_blob(&node_client, &application),
     );
 
     Ok(application)
+}
+
+/// The bytecode blob this update activated, read FRESH from the application
+/// row. The `Application` passed through these handlers can be a cache
+/// snapshot taken before a same-id in-place install moved the row — recording
+/// its blob would mark the context as having activated the OLD bytecode.
+fn activated_row_blob(node_client: &NodeClient, application: &Application) -> [u8; 32] {
+    node_client
+        .get_application(&application.id)
+        .ok()
+        .flatten()
+        .map_or(*application.blob.bytecode.as_ref(), |fresh| {
+            *fresh.blob.bytecode.as_ref()
+        })
 }
 
 /// Verifies AppKey continuity by checking that the signerId matches between
@@ -676,7 +690,7 @@ pub(crate) async fn update_application_with_migration(
     crate::activation::record_activation(
         &datastore,
         &context_id,
-        *application.blob.bytecode.as_ref(),
+        activated_row_blob(&node_client, &application),
     );
 
     // Post-commit: recompute this node's owner's pending-authored count over the

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -354,6 +354,16 @@ pub async fn update_application_id(
         let _ = node_client.send_event(event);
     }
 
+    // Unified activation marker: code-only updates (this fn — the eager
+    // propagator's no-migration route and the lazy code-only finish) count
+    // as activations too, or the same-id up-to-date rule would keep reading
+    // these contexts as pending.
+    crate::activation::record_activation(
+        &datastore,
+        &context_id,
+        *application.blob.bytecode.as_ref(),
+    );
+
     Ok(application)
 }
 

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -660,6 +660,15 @@ pub(crate) async fn update_application_with_migration(
         let _ = node_client.send_event(event);
     }
 
+    // Unified activation marker: this context now executes the new app's
+    // bytecode (whether a migration committed above or this was a code-only
+    // update). The single up-to-date signal for the gate/trigger/rollup.
+    crate::activation::record_activation(
+        &datastore,
+        &context_id,
+        *application.blob.bytecode.as_ref(),
+    );
+
     // Post-commit: recompute this node's owner's pending-authored count over the
     // committed v2 state and persist it for the heartbeat self-report (6f.8).
     // Best-effort — a missing export / failure leaves the prior value untouched.

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -646,6 +646,15 @@ async fn resolve_upgrade_from_abis(
 
     let current_blob_id = (current_app_key != [0u8; 32]).then(|| BlobId::from(current_app_key));
 
+    /// Whether a target manifest declares anything migration-relevant: a
+    /// state version past 1 or any migration edge. When it does, an
+    /// unresolvable CURRENT side must reject the upgrade rather than guess —
+    /// code-only-by-default here is exactly the silent new-code-on-old-state
+    /// failure this resolution exists to prevent.
+    fn target_declares_migration(m: &Manifest) -> bool {
+        m.state_version_or_default() > 1 || !m.migrations.is_empty() || m.migration.is_some()
+    }
+
     let mut resolved_method: Option<String> = None;
     for service in &services {
         let target_abi = match node_client
@@ -655,23 +664,67 @@ async fn resolve_upgrade_from_abis(
             Ok(Some(bytes)) => read_embedded_state_schema(&bytes),
             _ => None,
         };
+
+        // Resolve the CURRENT side, distinguishing the safe unknowns from the
+        // dangerous ones:
+        //  * service absent from the old bundle → genuinely NEW service, no
+        //    old data to migrate → code-only for it;
+        //  * old blob missing locally / no embedded ABI / legacy random
+        //    app_key → the from-version is UNKNOWABLE. Only safe when the
+        //    target declares no migration at all (pre-versioned world);
+        //    otherwise reject — the caller can pass migrateMethod explicitly
+        //    as the escape hatch.
         let current_abi = match current_blob_id {
             Some(blob) => match node_client
                 .application_bytes_from_blob(&blob, service.as_deref())
                 .await
             {
-                Ok(Some(bytes)) => read_embedded_state_schema(&bytes),
-                // The service may not exist in the old bundle (newly added
-                // service): treat as same-version → code-only for it.
-                _ => target_abi.clone(),
+                Ok(Some(bytes)) => match read_embedded_state_schema(&bytes) {
+                    Some(m) => Some(m),
+                    None => {
+                        if target_abi.as_ref().is_some_and(target_declares_migration) {
+                            eyre::bail!(
+                                "service '{}': the currently-running bytecode has no embedded                                  ABI, but the target declares a state migration — cannot                                  determine the from-version safely. Pass migrateMethod                                  explicitly, or rebuild the previous version with the current                                  SDK",
+                                service.as_deref().unwrap_or("<single>"),
+                            );
+                        }
+                        target_abi.clone()
+                    }
+                },
+                Ok(None) => {
+                    if target_abi.as_ref().is_some_and(target_declares_migration) {
+                        eyre::bail!(
+                            "service '{}': the currently-running bytecode blob is not                              available locally, but the target declares a state migration —                              cannot determine the from-version safely. Pass migrateMethod                              explicitly, or fetch the previous version first",
+                            service.as_deref().unwrap_or("<single>"),
+                        );
+                    }
+                    target_abi.clone()
+                }
+                // The service does not exist in the old bundle (newly added
+                // service): no old data → same-version → code-only for it.
+                Err(_) => target_abi.clone(),
             },
-            // Legacy group with no blob-derived app_key: no version signal —
-            // fall back to the target's own version (code-only).
-            None => target_abi.clone(),
+            // Legacy group with no blob-derived app_key: the from-version is
+            // unknowable — same rule as above.
+            None => {
+                if target_abi.as_ref().is_some_and(target_declares_migration) {
+                    eyre::bail!(
+                        "service '{}': this group predates blob-derived app keys, but the                          target declares a state migration — cannot determine the                          from-version safely. Pass migrateMethod explicitly",
+                        service.as_deref().unwrap_or("<single>"),
+                    );
+                }
+                target_abi.clone()
+            }
         };
 
         match plan_upgrade(current_abi.as_ref(), target_abi.as_ref()) {
-            Ok(UpgradeAction::CodeOnly | UpgradeAction::Downgrade { .. }) => {}
+            Ok(UpgradeAction::CodeOnly) => {}
+            Ok(UpgradeAction::Downgrade { from, to }) => {
+                eyre::bail!(
+                    "service '{}' declares state v{to}, OLDER than the running v{from} —                      schema downgrades are not supported",
+                    service.as_deref().unwrap_or("<single>"),
+                );
+            }
             Ok(UpgradeAction::Migrate { method, from, to }) => {
                 info!(
                     service = service.as_deref().unwrap_or("<single>"),

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -731,8 +731,22 @@ async fn resolve_upgrade_from_abis(
                     %method, from, to,
                     "upgrade resolves a declared migration edge from the app ABI"
                 );
-                if resolved_method.is_none() {
-                    resolved_method = Some(method);
+                match &resolved_method {
+                    None => resolved_method = Some(method),
+                    Some(existing) if *existing == method => {}
+                    Some(existing) => {
+                        // The wire carries ONE method; running it on every
+                        // context (with missing-export = vacuous) is only
+                        // sound when all migrating services agree on the
+                        // name. Distinct names need per-service actuation —
+                        // reject rather than silently dropping one.
+                        eyre::bail!(
+                            "services declare DIFFERENT migration methods for this release \
+                             ('{existing}' vs '{method}'); migrating multiple services with \
+                             distinct methods in one release is not supported yet — use the \
+                             same method name in each service, or split the release",
+                        );
+                    }
                 }
             }
             Ok(UpgradeAction::MissingEdge { from, to }) => {
@@ -750,14 +764,18 @@ async fn resolve_upgrade_from_abis(
                     to - from,
                 );
             }
-            // Pre-ABI builds: no version signal at all. Treat the upgrade as
-            // code-only (the legacy explicit-method path remains available
-            // for apps that migrate but predate embedded ABIs).
+            // Only reachable when the TARGET build has no embedded ABI (the
+            // current-side unknowns all reject above when the target declares
+            // a migration). A pre-ABI target declares nothing — code-only
+            // here preserves the exact pre-v2 no-method semantics for legacy
+            // apps; a legacy app that migrates must pass migrateMethod
+            // explicitly, as it always had to.
             Err(err) => {
-                debug!(
+                warn!(
                     service = service.as_deref().unwrap_or("<single>"),
                     %err,
-                    "no embedded ABI for service; treating as code-only"
+                    "target build has no embedded ABI; proceeding code-only (legacy \
+                     semantics — pass migrateMethod explicitly if this release migrates)"
                 );
             }
         }

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -646,6 +646,15 @@ async fn resolve_upgrade_from_abis(
 
     let current_blob_id = (current_app_key != [0u8; 32]).then(|| BlobId::from(current_app_key));
 
+    // Service inventory of the CURRENT bundle, fetched once: a service present
+    // in the target but absent here is genuinely NEW (no old data → code-only
+    // for it). Detecting that by error-kind from the per-service bytes fetch
+    // would conflate "not in bundle" with real I/O failures.
+    let current_services: Option<Vec<Option<String>>> = match current_blob_id {
+        Some(blob) => node_client.bundle_service_names(&blob).await.ok().flatten(),
+        None => None,
+    };
+
     /// Whether a target manifest declares anything migration-relevant: a
     /// state version past 1 or any migration edge. When it does, an
     /// unresolvable CURRENT side must reject the upgrade rather than guess —
@@ -674,7 +683,12 @@ async fn resolve_upgrade_from_abis(
         //    target declares no migration at all (pre-versioned world);
         //    otherwise reject — the caller can pass migrateMethod explicitly
         //    as the escape hatch.
+        // A service the old bundle never had cannot need a data migration.
+        let new_service = current_services
+            .as_ref()
+            .is_some_and(|svcs| !svcs.contains(service));
         let current_abi = match current_blob_id {
+            Some(_) if new_service => target_abi.clone(),
             Some(blob) => match node_client
                 .application_bytes_from_blob(&blob, service.as_deref())
                 .await
@@ -700,9 +714,20 @@ async fn resolve_upgrade_from_abis(
                     }
                     target_abi.clone()
                 }
-                // The service does not exist in the old bundle (newly added
-                // service): no old data → same-version → code-only for it.
-                Err(_) => target_abi.clone(),
+                // Not "service missing" (that's `new_service` above) — a
+                // real read failure. Same unknowable-from rule as the other
+                // arms: only safe when the target declares no migration.
+                Err(err) => {
+                    if target_abi.as_ref().is_some_and(target_declares_migration) {
+                        eyre::bail!(
+                            "service '{}': failed to read the currently-running bytecode \
+                             ({err}), and the target declares a state migration — cannot \
+                             determine the from-version safely. Pass migrateMethod explicitly",
+                            service.as_deref().unwrap_or("<single>"),
+                        );
+                    }
+                    target_abi.clone()
+                }
             },
             // Legacy group with no blob-derived app_key: the from-version is
             // unknowable — same rule as above.

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -149,9 +149,26 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
         if matches!(upgrade_policy, UpgradePolicy::LazyOnAccess) {
             let datastore = self.datastore.clone();
             let ack_router_for_lazy = Arc::clone(&ack_router);
-            let has_migration = migration.is_some();
+            let target_blob_bytes: Option<[u8; 32]> = app_meta_for_contract
+                .as_ref()
+                .map(|m| *m.bytecode.blob_id().as_ref());
             return ActorResponse::r#async(
                 async move {
+                    // v2 path: the caller supplied no migrate method — resolve
+                    // the upgrade from the apps' embedded ABIs (every service
+                    // of the bundle; the wire still carries one method so
+                    // pre-v2 receivers keep working).
+                    let migration = match migration {
+                        Some(m) => Some(m),
+                        None => {
+                            let target_blob = target_blob_bytes
+                                .ok_or_else(|| eyre::eyre!("target application not found"))?;
+                            resolve_upgrade_from_abis(&node_client, current_app_key, target_blob)
+                                .await?
+                        }
+                    };
+                    let migration_bytes = migration.as_ref().map(|m| m.method.as_bytes().to_vec());
+                    let has_migration = migration.is_some();
                     // L1 identity-downgrade gate: a migration upgrade may not strip
                     // identity from a top-level state field. Runs BEFORE any group op
                     // is emitted so a forbidden downgrade never reaches the network.
@@ -318,7 +335,29 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
             .map(|m| (m.bytecode.blob_id(), m.size));
         let ack_router_for_canary = Arc::clone(&ack_router);
         let has_migration = migration_bytes.is_some();
+        let target_blob_bytes: Option<[u8; 32]> = app_meta_for_contract
+            .as_ref()
+            .map(|m| *m.bytecode.blob_id().as_ref());
         let canary_task = async move {
+            // v2 guard: the caller supplied no migrate method, but the target
+            // may still DECLARE one in its ABI. Migrations only run under
+            // LazyOnAccess — proceeding here (Automatic/Coordinated) would
+            // swap bytecode under live state without running the declared
+            // migration. Also rejects missing-edge / multi-hop targets.
+            if !has_migration {
+                if let Some(target_blob) = target_blob_bytes {
+                    if let Some(declared) =
+                        resolve_upgrade_from_abis(&node_client, current_app_key, target_blob)
+                            .await?
+                    {
+                        eyre::bail!(
+                            "target app declares migration '{}' in its ABI; migrations only \
+                             run under the LazyOnAccess upgrade policy",
+                            declared.method
+                        );
+                    }
+                }
+            }
             // L1 identity-downgrade gate: a migration upgrade may not strip
             // identity from a top-level state field. Runs BEFORE any group op
             // is emitted so a forbidden downgrade never reaches the network.
@@ -575,6 +614,103 @@ async fn resolve_pre_upgrade_schema(
         }
     }
     resolve_embedded_schema(node_client, current_application_id).await
+}
+
+/// Emit-side ABI resolution for an upgrade whose caller supplied no migrate
+/// method (the v2 default): scan EVERY service in the target bundle, plan
+/// each against the same service in the group's current bytecode, and
+/// aggregate. The wire still carries one method (the first declared edge for
+/// this hop, deterministic in bundle service order) so pre-v2 receivers keep
+/// working — v2 receivers re-resolve per context at actuation, so services
+/// without an edge activate code-only by construction.
+///
+/// Errors are the contract from the design's decision table: a service that
+/// needs a migration but declares no edge, a group more than one hop behind
+/// (chaining not shipped yet), or a version-changing upgrade whose ABIs are
+/// unreadable.
+async fn resolve_upgrade_from_abis(
+    node_client: &calimero_node_primitives::client::NodeClient,
+    current_app_key: [u8; 32],
+    target_blob: [u8; 32],
+) -> eyre::Result<Option<MigrationParams>> {
+    use calimero_primitives::blobs::BlobId;
+    use calimero_wasm_abi::embed::read_embedded_state_schema;
+
+    use crate::migration_plan::{plan_upgrade, UpgradeAction};
+
+    let target_blob_id = BlobId::from(target_blob);
+    let services = node_client
+        .bundle_service_names(&target_blob_id)
+        .await?
+        .ok_or_else(|| eyre::eyre!("target bytecode blob not available locally"))?;
+
+    let current_blob_id = (current_app_key != [0u8; 32]).then(|| BlobId::from(current_app_key));
+
+    let mut resolved_method: Option<String> = None;
+    for service in &services {
+        let target_abi = match node_client
+            .application_bytes_from_blob(&target_blob_id, service.as_deref())
+            .await
+        {
+            Ok(Some(bytes)) => read_embedded_state_schema(&bytes),
+            _ => None,
+        };
+        let current_abi = match current_blob_id {
+            Some(blob) => match node_client
+                .application_bytes_from_blob(&blob, service.as_deref())
+                .await
+            {
+                Ok(Some(bytes)) => read_embedded_state_schema(&bytes),
+                // The service may not exist in the old bundle (newly added
+                // service): treat as same-version → code-only for it.
+                _ => target_abi.clone(),
+            },
+            // Legacy group with no blob-derived app_key: no version signal —
+            // fall back to the target's own version (code-only).
+            None => target_abi.clone(),
+        };
+
+        match plan_upgrade(current_abi.as_ref(), target_abi.as_ref()) {
+            Ok(UpgradeAction::CodeOnly | UpgradeAction::Downgrade { .. }) => {}
+            Ok(UpgradeAction::Migrate { method, from, to }) => {
+                info!(
+                    service = service.as_deref().unwrap_or("<single>"),
+                    %method, from, to,
+                    "upgrade resolves a declared migration edge from the app ABI"
+                );
+                if resolved_method.is_none() {
+                    resolved_method = Some(method);
+                }
+            }
+            Ok(UpgradeAction::MissingEdge { from, to }) => {
+                eyre::bail!(
+                    "service '{}' declares state v{to} but no migration edge from v{from} — \
+                     rebuild the app with a #[derive(app::Migrate)] edge for this hop",
+                    service.as_deref().unwrap_or("<single>"),
+                );
+            }
+            Ok(UpgradeAction::Behind { from, to }) => {
+                eyre::bail!(
+                    "service '{}' is {} versions behind the target (v{from} -> v{to}); \
+                     chained upgrades are not supported yet — upgrade one version at a time",
+                    service.as_deref().unwrap_or("<single>"),
+                    to - from,
+                );
+            }
+            // Pre-ABI builds: no version signal at all. Treat the upgrade as
+            // code-only (the legacy explicit-method path remains available
+            // for apps that migrate but predate embedded ABIs).
+            Err(err) => {
+                debug!(
+                    service = service.as_deref().unwrap_or("<single>"),
+                    %err,
+                    "no embedded ABI for service; treating as code-only"
+                );
+            }
+        }
+    }
+
+    Ok(resolved_method.map(|method| MigrationParams { method }))
 }
 
 async fn resolve_embedded_schema(
@@ -1142,9 +1278,10 @@ fn dispatch_cascade(
     // per-descendant — not the signed group's policy. Reject here, before
     // emitting `CascadeUpgrade`, if any matched descendant is not LazyOnAccess.
     //
-    // Gated on `has_migration` so a code-only cascade skips loading every
-    // descendant's meta (the check is meaningless without a migration).
-    if has_migration {
+    // Collected unconditionally: a caller-supplied method checks here (sync),
+    // while the v2 no-method path resolves the migration from ABIs inside the
+    // publish task and re-checks these policies there.
+    let descendant_policies = {
         let mut descendant_policies = Vec::with_capacity(matched_descendants.len());
         for gid in &matched_descendants {
             match MetaRepository::new(&actor.datastore).load(gid) {
@@ -1157,6 +1294,9 @@ fn dispatch_cascade(
                 Err(err) => return ActorResponse::reply(Err(err)),
             }
         }
+        descendant_policies
+    };
+    if has_migration {
         if let Err(err) = ensure_cascade_migration_policies_supported(&descendant_policies) {
             return ActorResponse::reply(Err(err));
         }
@@ -1168,8 +1308,6 @@ fn dispatch_cascade(
         matched = matched_descendants.len(),
         "cascade upgrade: matched descendants enumerated"
     );
-
-    let migration_bytes = migration.as_ref().map(|m| m.method.as_bytes().to_vec());
 
     // Snapshot per-descendant context totals BEFORE emission so the
     // pre-spawn `GroupUpgradeValue` write carries the right `total` for
@@ -1201,7 +1339,6 @@ fn dispatch_cascade(
     let datastore_for_publish = datastore.clone();
     let node_client_for_publish = node_client.clone();
     let ack_router_for_publish = Arc::clone(&ack_router);
-    let migration_bytes_for_publish = migration_bytes.clone();
 
     // The signed group's CURRENT target application id (before this cascade) is
     // the "old" schema source for the L1 identity-downgrade gate. The cascade
@@ -1216,6 +1353,23 @@ fn dispatch_cascade(
     let cascade_hlc = calimero_storage::env::hlc_timestamp();
 
     let publish_task = async move {
+        // v2 path: no caller-supplied method — resolve the migration from the
+        // bundle's embedded ABIs (all services) and re-run the per-descendant
+        // policy gate that the sync section could not (resolution is async).
+        let migration = match migration {
+            Some(m) => Some(m),
+            None => {
+                let resolved =
+                    resolve_upgrade_from_abis(&node_client_for_publish, from_app_key, new_app_key)
+                        .await?;
+                if resolved.is_some() {
+                    ensure_cascade_migration_policies_supported(&descendant_policies)?;
+                }
+                resolved
+            }
+        };
+        let migration_bytes_for_publish = migration.as_ref().map(|m| m.method.as_bytes().to_vec());
+        let has_migration = migration.is_some();
         // L1 identity-downgrade gate: refuse a migration cascade that strips
         // identity from a top-level state field. Runs BEFORE the CascadeUpgrade
         // op is emitted. Fail-open when either app lacks an embedded ABI section.
@@ -1250,12 +1404,13 @@ fn dispatch_cascade(
         .await?;
         report.observe("upgrade_group", "CascadeUpgrade");
 
-        Ok::<_, eyre::Report>(())
+        Ok::<_, eyre::Report>(migration)
     }
     .into_actor(actor);
 
     ActorResponse::r#async(publish_task.map(move |publish_result, act, ctx| {
-        publish_result?;
+        let migration = publish_result?;
+        let migration_bytes = migration.as_ref().map(|m| m.method.as_bytes().to_vec());
 
         // After successful publish + local apply, spawn one propagator
         // per matched descendant. Each propagator re-enumerates its

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -36,6 +36,7 @@ pub mod governance_dag;
 pub mod handlers;
 pub mod hlc_fence;
 mod lifecycle;
+pub mod migration_plan;
 pub mod self_purge;
 
 pub(crate) use cache::{BoundedCache, Evictable};

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -28,6 +28,7 @@ use tokio::sync::{Mutex, RwLock};
 use calimero_governance_store::metrics::Metrics;
 use calimero_wasm_abi::schema::MethodIntent;
 
+pub mod activation;
 pub mod auto_follow;
 mod cache;
 pub mod config;

--- a/crates/context/src/migration_plan.rs
+++ b/crates/context/src/migration_plan.rs
@@ -1,0 +1,239 @@
+//! The per-context upgrade decision table: what the upgrade engine should do
+//! to ONE context, derived purely from the embedded ABIs (current vs target)
+//! of that context's service. No I/O — callers resolve the two manifests
+//! (`application_bytes_from_blob` + `read_embedded_state_schema`) and feed
+//! them in, which keeps every rule unit-testable.
+//!
+//! This is the v2 replacement for caller-supplied migrate-method strings:
+//! the app declares its state version and migration edges in the ABI
+//! (`#[app::state(version = N)]` + `#[derive(app::Migrate)]`), and the node
+//! derives where/whether/what to run — per service, so multi-service bundles
+//! migrate only the services whose schema actually changed.
+
+use calimero_wasm_abi::schema::Manifest;
+
+/// What the upgrade engine should do to one context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpgradeAction {
+    /// Same state version — swap bytecode and record activation. Never runs
+    /// wasm: services untouched by a release are vacuous BY CONSTRUCTION
+    /// (no MethodNotFound probing).
+    CodeOnly,
+    /// One hop behind: run `method`, then record activation.
+    Migrate { method: String, from: u32, to: u32 },
+    /// More than one hop behind — chained dispatch or peer resync territory;
+    /// running the latest edge against too-old state would corrupt it.
+    Behind { from: u32, to: u32 },
+    /// Target is OLDER than current — the identity-downgrade gate owns this.
+    Downgrade { from: u32, to: u32 },
+    /// A migration is needed (`to == from + 1`) but the target ABI declares
+    /// no edge for `from` — a mis-built app. Emit-side: reject the upgrade;
+    /// actuation-side: report apply-failed rather than guessing.
+    MissingEdge { from: u32, to: u32 },
+}
+
+/// Either side's ABI could not be resolved (blob absent, service missing,
+/// or a pre-ABI build). Emit-side callers reject migration-needing upgrades
+/// with a "rebuild with the current SDK" error; actuation-side callers fall
+/// back to legacy behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("embedded ABI unavailable for the {side} bytecode")]
+pub struct AbiUnavailable {
+    pub side: AbiSide,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AbiSide {
+    Current,
+    Target,
+}
+
+impl core::fmt::Display for AbiSide {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Current => f.write_str("current"),
+            Self::Target => f.write_str("target"),
+        }
+    }
+}
+
+/// Resolve the action for one context from its service's two manifests.
+///
+/// Version source is [`Manifest::state_version_or_default`]: the explicit
+/// `state_version` (always emitted by current SDKs), falling back to the
+/// legacy `migration.to_schema_version`, then 1 — so pre-versioned and
+/// 9.4-era builds resolve correctly.
+pub fn plan_upgrade(
+    current: Option<&Manifest>,
+    target: Option<&Manifest>,
+) -> Result<UpgradeAction, AbiUnavailable> {
+    let current = current.ok_or(AbiUnavailable {
+        side: AbiSide::Current,
+    })?;
+    let target = target.ok_or(AbiUnavailable {
+        side: AbiSide::Target,
+    })?;
+
+    let from = current.state_version_or_default();
+    let to = target.state_version_or_default();
+
+    if from == to {
+        return Ok(UpgradeAction::CodeOnly);
+    }
+    if to < from {
+        return Ok(UpgradeAction::Downgrade { from, to });
+    }
+    if to == from + 1 {
+        return Ok(match target.edge_from(from) {
+            Some(edge) => UpgradeAction::Migrate {
+                method: edge.method,
+                from,
+                to,
+            },
+            None => UpgradeAction::MissingEdge { from, to },
+        });
+    }
+    Ok(UpgradeAction::Behind { from, to })
+}
+
+#[cfg(test)]
+mod tests {
+    use calimero_wasm_abi::schema::{MigrationAbi, MigrationEdgeAbi};
+
+    use super::*;
+
+    fn manifest(state_version: Option<u32>) -> Manifest {
+        let mut m = Manifest::new();
+        m.state_version = state_version;
+        m
+    }
+
+    fn with_edge(mut m: Manifest, method: &str, from_version: u32) -> Manifest {
+        m.migrations.push(MigrationEdgeAbi {
+            method: method.to_owned(),
+            from_version,
+        });
+        m
+    }
+
+    #[test]
+    fn equal_versions_are_code_only() {
+        let cur = manifest(Some(2));
+        let tgt = manifest(Some(2));
+        assert_eq!(
+            plan_upgrade(Some(&cur), Some(&tgt)),
+            Ok(UpgradeAction::CodeOnly)
+        );
+    }
+
+    #[test]
+    fn unversioned_manifests_default_to_one_and_code_only() {
+        // Pre-versioned apps on both sides: 1 == 1.
+        let cur = manifest(None);
+        let tgt = manifest(None);
+        assert_eq!(
+            plan_upgrade(Some(&cur), Some(&tgt)),
+            Ok(UpgradeAction::CodeOnly)
+        );
+    }
+
+    #[test]
+    fn one_hop_with_edge_migrates() {
+        let cur = manifest(Some(1));
+        let tgt = with_edge(manifest(Some(2)), "migrate", 1);
+        assert_eq!(
+            plan_upgrade(Some(&cur), Some(&tgt)),
+            Ok(UpgradeAction::Migrate {
+                method: "migrate".to_owned(),
+                from: 1,
+                to: 2
+            })
+        );
+    }
+
+    #[test]
+    fn one_hop_resolves_via_legacy_single_migration() {
+        // 9.4-era target: no edge list, only the single `migration` field.
+        let cur = manifest(Some(1));
+        let mut tgt = manifest(Some(2));
+        tgt.migration = Some(MigrationAbi {
+            method: "migrate_v1_to_v2".to_owned(),
+            to_schema_version: 2,
+        });
+        assert_eq!(
+            plan_upgrade(Some(&cur), Some(&tgt)),
+            Ok(UpgradeAction::Migrate {
+                method: "migrate_v1_to_v2".to_owned(),
+                from: 1,
+                to: 2
+            })
+        );
+    }
+
+    #[test]
+    fn legacy_current_resolves_from_via_migration_target() {
+        // Current built by a 9.4-era SDK: version only visible through
+        // migration.to_schema_version.
+        let mut cur = manifest(None);
+        cur.migration = Some(MigrationAbi {
+            method: "migrate_v1_to_v2".to_owned(),
+            to_schema_version: 2,
+        });
+        let tgt = with_edge(manifest(Some(3)), "migrate_v2_to_v3", 2);
+        assert_eq!(
+            plan_upgrade(Some(&cur), Some(&tgt)),
+            Ok(UpgradeAction::Migrate {
+                method: "migrate_v2_to_v3".to_owned(),
+                from: 2,
+                to: 3
+            })
+        );
+    }
+
+    #[test]
+    fn one_hop_without_edge_is_missing_edge() {
+        let cur = manifest(Some(1));
+        let tgt = manifest(Some(2)); // declares v2 but no edge from 1
+        assert_eq!(
+            plan_upgrade(Some(&cur), Some(&tgt)),
+            Ok(UpgradeAction::MissingEdge { from: 1, to: 2 })
+        );
+    }
+
+    #[test]
+    fn multiple_hops_are_behind() {
+        let cur = manifest(Some(1));
+        let tgt = with_edge(manifest(Some(3)), "migrate_v2_to_v3", 2);
+        assert_eq!(
+            plan_upgrade(Some(&cur), Some(&tgt)),
+            Ok(UpgradeAction::Behind { from: 1, to: 3 })
+        );
+    }
+
+    #[test]
+    fn older_target_is_downgrade() {
+        let cur = manifest(Some(3));
+        let tgt = manifest(Some(2));
+        assert_eq!(
+            plan_upgrade(Some(&cur), Some(&tgt)),
+            Ok(UpgradeAction::Downgrade { from: 3, to: 2 })
+        );
+    }
+
+    #[test]
+    fn missing_abi_is_reported_per_side() {
+        let m = manifest(Some(1));
+        assert_eq!(
+            plan_upgrade(None, Some(&m)),
+            Err(AbiUnavailable {
+                side: AbiSide::Current
+            })
+        );
+        assert_eq!(
+            plan_upgrade(Some(&m), None),
+            Err(AbiUnavailable {
+                side: AbiSide::Target
+            })
+        );
+    }
+}

--- a/crates/node/primitives/src/client/application.rs
+++ b/crates/node/primitives/src/client/application.rs
@@ -286,6 +286,34 @@ impl NodeClient {
     /// (version-stable bundle id overwritten in place). Fully in-memory: the
     /// pinned version's extracted dir may be gone, but the blob is still in
     /// the blobstore. `None` when the blob itself is absent locally.
+    /// Service names inside the bundle at `blob_id`: one `Some(name)` per
+    /// declared service, or a single `None` for single-service bundles. For a
+    /// raw (non-bundle) wasm blob the result is also `[None]` — exactly the
+    /// `service` values `application_bytes_from_blob` accepts. `Ok(None)`
+    /// when the blob is absent locally.
+    pub async fn bundle_service_names(
+        &self,
+        blob_id: &BlobId,
+    ) -> eyre::Result<Option<Vec<Option<String>>>> {
+        let Some(blob_bytes) = self.get_blob_bytes(blob_id, None).await? else {
+            return Ok(None);
+        };
+        if !Self::is_bundle_blob(&blob_bytes) {
+            return Ok(Some(vec![None]));
+        }
+        let names = tokio::task::spawn_blocking(move || -> eyre::Result<Vec<Option<String>>> {
+            let (_, manifest) = bundle::extract_manifest_allow_unsigned(&blob_bytes)?;
+            Ok(manifest
+                .wasm_artifacts()
+                .iter()
+                .map(|a| a.name.map(str::to_owned))
+                .collect())
+        })
+        .await
+        .map_err(|e| eyre::eyre!("bundle manifest read task failed: {e}"))??;
+        Ok(Some(names))
+    }
+
     pub async fn application_bytes_from_blob(
         &self,
         blob_id: &BlobId,

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -3501,19 +3501,16 @@ pub(crate) fn pending_upgrade_info(
     if current_app != target {
         return Some((target, stage_blob_for(store, &meta)));
     }
-    // Same id: bundle-app upgrade. Pending while the group's migration has
-    // not been applied to this context — until the lazy migrate runs on next
-    // access, this node's pre-migration state must not reconcile against
-    // already-migrated peers.
-    let method = meta
-        .migration
-        .as_ref()
-        .and_then(|bytes| String::from_utf8(bytes.clone()).ok())?;
-    let applied = calimero_governance_store::MigrationsRepository::new(store)
-        .last_migration(&group_id, context_id)
-        .ok()
-        .flatten()
-        .is_some_and(|last| last == method);
+    // Same id: bundle-app upgrade. Gate state sync only while a MIGRATION is
+    // pending for this context — until the lazy migrate runs on next access,
+    // this node's pre-migration state must not reconcile against
+    // already-migrated peers. (Code-only swaps carry no schema hazard, so
+    // they never gate.) "Applied" is the unified activation marker — legacy
+    // method/blob markers fold forward on first read.
+    let _migration_present = meta.migration.as_ref()?;
+    let applied = calimero_context::activation::activated_blob_folding_legacy(
+        store, &group_id, context_id, &meta,
+    ) == Some(meta.app_key);
     (!applied).then(|| (target, stage_blob_for(store, &meta)))
 }
 

--- a/crates/sdk/macros/src/migrate_derive.rs
+++ b/crates/sdk/macros/src/migrate_derive.rs
@@ -184,13 +184,48 @@ fn parse_struct_args(input: &DeriveInput) -> syn::Result<StructArgs> {
              borsh layout of the previous version",
         )
     })?;
-    let method = method.unwrap_or_else(|| Ident::new("migrate", input.ident.span()));
+    // Default the export name to a VERSIONED form when `#[app::state(version =
+    // N)]` is declared: `migrate_v{N-1}_to_v{N}`. A bare `migrate` default
+    // collides across releases — a context's old applied-marker for release
+    // K's `migrate` would read as applied for release K+1's `migrate`, and two
+    // derives in one module collide at compile time. Falls back to `migrate`
+    // only for unversioned states (single-edge world, nothing to confuse).
+    let method = method.unwrap_or_else(|| match app_state_version(&input.attrs) {
+        Some(to) if to > 1 => Ident::new(
+            &format!("migrate_v{}_to_v{}", to - 1, to),
+            input.ident.span(),
+        ),
+        _ => Ident::new("migrate", input.ident.span()),
+    });
 
     Ok(StructArgs {
         from_type,
         method,
         emit,
     })
+}
+
+/// `version = N` from `#[app::state(version = N, ...)]` on the same struct,
+/// if present. Mirrors the wasm-abi emitter's parsing so the generated
+/// export name and the declared ABI edge always agree.
+fn app_state_version(attrs: &[syn::Attribute]) -> Option<u32> {
+    for attr in attrs {
+        let segs: Vec<_> = attr.path().segments.iter().collect();
+        if segs.len() == 2 && segs[0].ident == "app" && segs[1].ident == "state" {
+            let mut found = None;
+            let _ = attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("version") {
+                    let lit: syn::LitInt = meta.value()?.parse()?;
+                    found = lit.base10_parse::<u32>().ok();
+                } else if meta.input.peek(syn::Token![=]) {
+                    let _: Expr = meta.value()?.parse()?;
+                }
+                Ok(())
+            });
+            return found;
+        }
+    }
+    None
 }
 
 /// Parses a field's `#[migrate(...)]` (if any) into a [`FieldStrategy`].

--- a/crates/store/src/db.rs
+++ b/crates/store/src/db.rs
@@ -60,6 +60,7 @@ pub enum Column {
     /// migrate succeeds. Own column for the same collision reason as above.
     /// NOT synchronized; auto-created from `Column::iter()` (no DB migration).
     ContextExecutingBlob,
+    ContextActivatedBlob,
     /// Node-local per-application breadcrumb of the bytecode blob an in-place
     /// (same-id) bundle install overwrote — the source for the executing-blob
     /// pin above and the L1 downgrade gate's pre-install ABI. Own column: the

--- a/crates/store/src/key.rs
+++ b/crates/store/src/key.rs
@@ -28,9 +28,9 @@ pub use blobs::BlobMeta;
 pub use calimero_primitives::context::GroupMemberRole;
 use component::KeyComponents;
 pub use context::{
-    ContextAuthoredRemaining, ContextConfig, ContextDagDelta, ContextExecutingBlob,
-    ContextIdentity, ContextLeftMarker, ContextMeta, ContextMigrationFailed, ContextPrivateState,
-    ContextState,
+    ContextActivatedBlob, ContextAuthoredRemaining, ContextConfig, ContextDagDelta,
+    ContextExecutingBlob, ContextIdentity, ContextLeftMarker, ContextMeta, ContextMigrationFailed,
+    ContextPrivateState, ContextState,
 };
 pub use generic::{Generic, FRAGMENT_SIZE, SCOPE_SIZE};
 pub use group::{

--- a/crates/store/src/key/context.rs
+++ b/crates/store/src/key/context.rs
@@ -217,6 +217,53 @@ impl Debug for ContextExecutingBlob {
     }
 }
 
+/// Per-context activation marker key: the bytecode blob this context last
+/// ACTIVATED (migration committed, or code-only swap applied). One key per
+/// context, in its own column.
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+pub struct ContextActivatedBlob(Key<ContextId>);
+
+impl ContextActivatedBlob {
+    #[must_use]
+    pub fn new(context_id: PrimitiveContextId) -> Self {
+        Self(Key((*context_id).into()))
+    }
+
+    #[must_use]
+    pub fn context_id(&self) -> PrimitiveContextId {
+        (*AsRef::<[_; 32]>::as_ref(&self.0)).into()
+    }
+}
+
+impl AsKeyParts for ContextActivatedBlob {
+    type Components = (ContextId,);
+
+    fn column() -> Column {
+        Column::ContextActivatedBlob
+    }
+
+    fn as_key(&self) -> &Key<Self::Components> {
+        (&self.0).into()
+    }
+}
+
+impl FromKeyParts for ContextActivatedBlob {
+    type Error = Infallible;
+
+    fn try_from_parts(parts: Key<Self::Components>) -> Result<Self, Self::Error> {
+        Ok(Self(*<&_>::from(&parts)))
+    }
+}
+
+impl Debug for ContextActivatedBlob {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ContextActivatedBlob")
+            .field("id", &self.context_id())
+            .finish()
+    }
+}
+
 #[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct ContextConfig(Key<ContextId>);

--- a/crates/store/src/types.rs
+++ b/crates/store/src/types.rs
@@ -11,9 +11,9 @@ mod group;
 pub use application::{ApplicationMeta, ApplicationPreviousBlob, ServiceMeta};
 pub use blobs::BlobMeta;
 pub use context::{
-    ContextAuthoredRemaining, ContextConfig, ContextDagDelta, ContextExecutingBlob,
-    ContextIdentity, ContextLeftMarker, ContextMeta, ContextMigrationFailed, ContextPrivateState,
-    ContextState,
+    ContextActivatedBlob, ContextAuthoredRemaining, ContextConfig, ContextDagDelta,
+    ContextExecutingBlob, ContextIdentity, ContextLeftMarker, ContextMeta, ContextMigrationFailed,
+    ContextPrivateState, ContextState,
 };
 pub use generic::GenericData;
 

--- a/crates/store/src/types/context.rs
+++ b/crates/store/src/types/context.rs
@@ -323,3 +323,23 @@ impl PredefinedEntry for key::ContextExecutingBlob {
     type Codec = Borsh;
     type DataType<'a> = ContextExecutingBlob;
 }
+
+/// Value for [`key::ContextActivatedBlob`]: the bytecode blob this context
+/// last ACTIVATED — set when a migration commits or a code-only swap is
+/// applied, moved forward only. The single up-to-date check everywhere is
+/// `marker == group.app_key`; it replaces the legacy method-name and
+/// `blob:`-string markers (which are folded forward on first read).
+/// Node-local; a missing row means "never activated by v2 machinery".
+#[derive(BorshDeserialize, BorshSerialize, Clone, Copy, Debug, Eq, PartialEq)]
+#[expect(
+    clippy::exhaustive_structs,
+    reason = "single marker value; additions would need a migration"
+)]
+pub struct ContextActivatedBlob {
+    pub blob: [u8; 32],
+}
+
+impl PredefinedEntry for key::ContextActivatedBlob {
+    type Codec = Borsh;
+    type DataType<'a> = ContextActivatedBlob;
+}

--- a/crates/wasm-abi/src/emitter.rs
+++ b/crates/wasm-abi/src/emitter.rs
@@ -6,8 +6,8 @@ use syn::{Item, ItemEnum, ItemImpl, ItemStruct, Type};
 
 use crate::normalize::{normalize_type, ResolvedLocal, TypeResolver};
 use crate::schema::{
-    Event, Field, Manifest, Method, MethodIntent, MigrationAbi, Parameter, ScalarType, TypeDef,
-    TypeRef, Variant,
+    Event, Field, Manifest, Method, MethodIntent, MigrationAbi, MigrationEdgeAbi, Parameter,
+    ScalarType, TypeDef, TypeRef, Variant,
 };
 
 /// ABI emitter that processes Rust source code
@@ -763,22 +763,34 @@ pub fn emit_manifest_from_crate(
     }
 
     // Create the manifest
-    // Target schema from `#[app::state(version = N)]`, method from
-    // `#[migrate(method = …)]` (derive form) or a free `#[app::migrate] fn`.
+    // State version from `#[app::state(version = N)]` (default 1 — always
+    // recorded so version comparison is total even on code-only releases).
+    // Migration method from `#[migrate(method = …)]` (derive form, which
+    // defaults to `migrate` when omitted — mirrored by the derive macro) or a
+    // free `#[app::migrate] fn`. The single `migration` field stays emitted as
+    // a deprecated alias of the edge list.
     let mut migration = None;
+    let mut state_version = None;
+    let mut migrations = Vec::new();
     for file in &files {
         for item in &file.items {
             if let Item::Struct(s) = item {
                 if has_app_state_attribute(&s.attrs) {
-                    if let Some(to) = app_state_version(&s.attrs) {
-                        if let Some(method) = migrate_method_from_attrs(&s.attrs)
-                            .or_else(|| free_migrate_fn_name(&file.items))
-                        {
-                            migration = Some(MigrationAbi {
-                                method,
-                                to_schema_version: to,
+                    let to = app_state_version(&s.attrs).unwrap_or(1);
+                    state_version = Some(to);
+                    let method = migrate_method_from_attrs(&s.attrs)
+                        .or_else(|| free_migrate_fn_name(&file.items));
+                    if let Some(method) = method {
+                        if to > 1 {
+                            migrations.push(MigrationEdgeAbi {
+                                method: method.clone(),
+                                from_version: to - 1,
                             });
                         }
+                        migration = Some(MigrationAbi {
+                            method,
+                            to_schema_version: to,
+                        });
                     }
                 }
             }
@@ -792,6 +804,8 @@ pub fn emit_manifest_from_crate(
         events: emitter.events,
         state_root: emitter.state_type,
         migration,
+        state_version,
+        migrations,
     };
 
     // Remove any internal types that shouldn't be exposed
@@ -873,6 +887,50 @@ mod migration_tests {
         let mig = m.migration.expect("migration emitted");
         assert_eq!(mig.method, "migrate_v4_to_v5");
         assert_eq!(mig.to_schema_version, 5);
+    }
+
+    // `state_version` is always emitted (default 1) so the upgrade decision
+    // table can compare versions even across code-only releases, and the edge
+    // list mirrors the legacy single `migration` for from = N-1.
+    #[test]
+    fn state_version_and_edges_always_emitted() {
+        // Versioned migration build: version + one edge.
+        let lib = r#"
+            #[app::state(version = 2)]
+            #[derive(app::Migrate)]
+            #[migrate(from = OldState, method = migrate_v1_to_v2)]
+            pub struct State { x: u32 }
+            #[app::logic]
+            impl State { #[app::init] pub fn init() -> State { State { x: 0 } } }
+        "#;
+        let m = emit_manifest_from_crate(&[("lib.rs".to_owned(), lib.to_owned())]).unwrap();
+        assert_eq!(m.state_version, Some(2));
+        assert_eq!(m.migrations.len(), 1);
+        assert_eq!(m.migrations[0].method, "migrate_v1_to_v2");
+        assert_eq!(m.migrations[0].from_version, 1);
+
+        // Code-only build (no migration declared): version still present,
+        // no edges.
+        let lib = r#"
+            #[app::state(version = 2)]
+            pub struct State { x: u32 }
+            #[app::logic]
+            impl State { #[app::init] pub fn init() -> State { State { x: 0 } } }
+        "#;
+        let m = emit_manifest_from_crate(&[("lib.rs".to_owned(), lib.to_owned())]).unwrap();
+        assert_eq!(m.state_version, Some(2));
+        assert!(m.migrations.is_empty());
+
+        // Unversioned `#[app::state]`: defaults to 1.
+        let lib = r#"
+            #[app::state]
+            pub struct State { x: u32 }
+            #[app::logic]
+            impl State { #[app::init] pub fn init() -> State { State { x: 0 } } }
+        "#;
+        let m = emit_manifest_from_crate(&[("lib.rs".to_owned(), lib.to_owned())]).unwrap();
+        assert_eq!(m.state_version, Some(1));
+        assert!(m.migrations.is_empty());
     }
 
     #[test]

--- a/crates/wasm-abi/src/emitter.rs
+++ b/crates/wasm-abi/src/emitter.rs
@@ -326,7 +326,10 @@ fn app_state_version(attrs: &[syn::Attribute]) -> Option<u32> {
 /// attribute IS the migration declaration; `method` is optional and **defaults
 /// to `migrate`** (matching the derive macro), so a `#[migrate(from = ...)]`
 /// without an explicit method still yields the entrypoint name.
-fn migrate_method_from_attrs(attrs: &[syn::Attribute]) -> Option<String> {
+fn migrate_method_from_attrs(
+    attrs: &[syn::Attribute],
+    state_version: Option<u32>,
+) -> Option<String> {
     for attr in attrs {
         if attr.path().is_ident("migrate") {
             let mut method = None;
@@ -341,9 +344,15 @@ fn migrate_method_from_attrs(attrs: &[syn::Attribute]) -> Option<String> {
                 }
                 Ok(())
             });
-            // A `#[migrate(...)]` attr present ⇒ this is a migration; default the
-            // method name to `migrate` when not given explicitly.
-            return Some(method.unwrap_or_else(|| "migrate".to_owned()));
+            // A `#[migrate(...)]` attr present ⇒ this is a migration. The
+            // default name mirrors the derive macro: versioned
+            // (`migrate_v{N-1}_to_v{N}`) when the state declares a version
+            // past 1 — a bare `migrate` collides across releases — else
+            // `migrate`.
+            return Some(method.unwrap_or_else(|| match state_version {
+                Some(to) if to > 1 => format!("migrate_v{}_to_v{}", to - 1, to),
+                _ => "migrate".to_owned(),
+            }));
         }
     }
     None
@@ -778,7 +787,7 @@ pub fn emit_manifest_from_crate(
                 if has_app_state_attribute(&s.attrs) {
                     let to = app_state_version(&s.attrs).unwrap_or(1);
                     state_version = Some(to);
-                    let method = migrate_method_from_attrs(&s.attrs)
+                    let method = migrate_method_from_attrs(&s.attrs, Some(to))
                         .or_else(|| free_migrate_fn_name(&file.items));
                     if let Some(method) = method {
                         if to > 1 {
@@ -856,8 +865,12 @@ mod migration_tests {
         assert_eq!(mig.to_schema_version, 3);
     }
 
+    // Omitted `method = …` defaults to the VERSIONED name when the state
+    // declares a version (mirrors the derive macro): a bare `migrate` would
+    // collide across releases at the applied-marker layer. Unversioned
+    // states keep the legacy `migrate` default.
     #[test]
-    fn derive_without_explicit_method_defaults_to_migrate() {
+    fn derive_without_explicit_method_defaults_to_versioned_name() {
         let lib = r#"
             #[app::state(version = 2)]
             #[derive(app::Migrate)]
@@ -868,8 +881,19 @@ mod migration_tests {
         "#;
         let m = emit_manifest_from_crate(&[("lib.rs".to_owned(), lib.to_owned())]).unwrap();
         let mig = m.migration.expect("migration emitted");
-        assert_eq!(mig.method, "migrate");
+        assert_eq!(mig.method, "migrate_v1_to_v2");
         assert_eq!(mig.to_schema_version, 2);
+
+        let lib = r#"
+            #[app::state]
+            #[derive(app::Migrate)]
+            #[migrate(from = OldState)]
+            pub struct State { x: u32 }
+            #[app::logic]
+            impl State { #[app::init] pub fn init() -> State { State { x: 0 } } }
+        "#;
+        let m = emit_manifest_from_crate(&[("lib.rs".to_owned(), lib.to_owned())]).unwrap();
+        assert_eq!(m.migration.expect("migration emitted").method, "migrate");
     }
 
     #[test]

--- a/crates/wasm-abi/src/schema.rs
+++ b/crates/wasm-abi/src/schema.rs
@@ -14,8 +14,24 @@ pub struct Manifest {
     /// Present when the app declares a migrate via `#[app::migrate]` /
     /// `#[derive(app::Migrate)]`. Absent on code-only releases and on every
     /// pre-existing ABI — hence `default` so older manifests still deserialize.
+    /// Deprecated alias of the newest entry in `migrations`; kept emitted for
+    /// readers that predate the edge list.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub migration: Option<MigrationAbi>,
+    /// `AppState::SCHEMA_VERSION` of this build (`#[app::state(version = N)]`,
+    /// default 1). Always emitted by current SDKs; `None` only on manifests
+    /// from older SDKs — readers treat missing as 1 (via
+    /// [`Manifest::state_version_or_default`]). The total from/to source for
+    /// the upgrade decision table: unlike `migration.to_schema_version` it is
+    /// present on code-only releases too.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_version: Option<u32>,
+    /// Declared migration edges, one per retained `from → from+1` hop.
+    /// Single entry on apps that only keep the latest migration; multiple
+    /// entries enable chained dispatch for members more than one version
+    /// behind. Empty on older manifests (serde default).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub migrations: Vec<MigrationEdgeAbi>,
 }
 
 /// The app declares it migrates from an older schema: the entrypoint to invoke
@@ -30,6 +46,18 @@ pub struct MigrationAbi {
     pub to_schema_version: u32,
 }
 
+/// One declared migration edge: invoking `method` carries state from
+/// `from_version` to `from_version + 1`. Retained edges enable chained
+/// dispatch for members more than one version behind.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MigrationEdgeAbi {
+    /// The migrate entrypoint export for this hop.
+    pub method: String,
+    /// The state version this edge migrates FROM (targets `from_version + 1`).
+    pub from_version: u32,
+}
+
 impl Default for Manifest {
     fn default() -> Self {
         Self {
@@ -39,6 +67,8 @@ impl Default for Manifest {
             events: Vec::new(),
             state_root: None,
             migration: None,
+            state_version: None,
+            migrations: Vec::new(),
         }
     }
 }
@@ -386,7 +416,41 @@ impl Manifest {
             events: Vec::new(),
             state_root: None,
             migration: None,
+            state_version: None,
+            migrations: Vec::new(),
         }
+    }
+
+    /// The build's state version, total across SDK generations: explicit
+    /// `state_version` when present, else the legacy
+    /// `migration.to_schema_version` (9.4-era bundles), else 1 (pre-versioned
+    /// apps).
+    #[must_use]
+    pub fn state_version_or_default(&self) -> u32 {
+        self.state_version
+            .or_else(|| self.migration.as_ref().map(|m| m.to_schema_version))
+            .unwrap_or(1)
+    }
+
+    /// The declared edge migrating FROM `from`, if any. Falls back to the
+    /// legacy single `migration` field when the edge list is empty and that
+    /// migration targets `from + 1`.
+    #[must_use]
+    pub fn edge_from(&self, from: u32) -> Option<MigrationEdgeAbi> {
+        if let Some(edge) = self.migrations.iter().find(|e| e.from_version == from) {
+            return Some(edge.clone());
+        }
+        if self.migrations.is_empty() {
+            if let Some(m) = &self.migration {
+                if m.to_schema_version == from + 1 {
+                    return Some(MigrationEdgeAbi {
+                        method: m.method.clone(),
+                        from_version: from,
+                    });
+                }
+            }
+        }
+        None
     }
 
     /// Extract the state schema (state root type and all its dependencies)
@@ -420,6 +484,8 @@ impl Manifest {
             events: Vec::new(),
             state_root: Some(state_root_name.clone()),
             migration: self.migration.clone(),
+            state_version: self.state_version,
+            migrations: self.migrations.clone(),
         })
     }
 
@@ -802,5 +868,82 @@ mod tests {
         let old_json = r#"{"name":"old","params":[]}"#;
         let old: Method = serde_json::from_str(old_json).unwrap();
         assert_eq!(old.intent, MethodIntent::Unspecified);
+    }
+
+    // Old manifests (no state_version / migrations) must keep deserializing,
+    // and the new fields must round-trip. `state_version_or_default` is the
+    // total version source: explicit field → legacy migration target → 1.
+    #[test]
+    fn state_version_roundtrip_and_backcompat() {
+        let old = r#"{"schema_version":"wasm-abi/1","types":{},"methods":[],"events":[]}"#;
+        let m: Manifest = serde_json::from_str(old).unwrap();
+        assert_eq!(m.state_version, None);
+        assert!(m.migrations.is_empty());
+        assert_eq!(m.state_version_or_default(), 1);
+
+        let mut m2 = Manifest::new();
+        m2.state_version = Some(2);
+        m2.migrations = vec![MigrationEdgeAbi {
+            method: "migrate".to_owned(),
+            from_version: 1,
+        }];
+        let json = serde_json::to_string(&m2).unwrap();
+        assert!(json.contains("stateVersion") || json.contains("state_version"));
+        let back: Manifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.state_version, Some(2));
+        assert_eq!(back.state_version_or_default(), 2);
+        assert_eq!(back.migrations.len(), 1);
+
+        // 9.4-era manifests: only `migration.to_schema_version` present.
+        let mut legacy = Manifest::new();
+        legacy.migration = Some(MigrationAbi {
+            method: "migrate_v1_to_v2".to_owned(),
+            to_schema_version: 2,
+        });
+        assert_eq!(legacy.state_version_or_default(), 2);
+    }
+
+    // `edge_from` resolves the declared hop: exact edge-list match first,
+    // legacy single-migration fallback only for the matching from→from+1 hop.
+    #[test]
+    fn edge_from_resolution() {
+        let mut m = Manifest::new();
+        m.migrations = vec![
+            MigrationEdgeAbi {
+                method: "m1".to_owned(),
+                from_version: 1,
+            },
+            MigrationEdgeAbi {
+                method: "m2".to_owned(),
+                from_version: 2,
+            },
+        ];
+        assert_eq!(m.edge_from(1).unwrap().method, "m1");
+        assert_eq!(m.edge_from(2).unwrap().method, "m2");
+        assert!(m.edge_from(3).is_none());
+
+        let mut legacy = Manifest::new();
+        legacy.migration = Some(MigrationAbi {
+            method: "migrate_v1_to_v2".to_owned(),
+            to_schema_version: 2,
+        });
+        assert_eq!(legacy.edge_from(1).unwrap().method, "migrate_v1_to_v2");
+        assert!(legacy.edge_from(2).is_none()); // wrong hop for the legacy decl
+
+        // extract_state_schema (the EMBEDDED form the node reads) carries both.
+        let mut full = Manifest::new();
+        full.state_root = Some("Root".to_owned());
+        drop(
+            full.types
+                .insert("Root".to_owned(), TypeDef::Record { fields: vec![] }),
+        );
+        full.state_version = Some(3);
+        full.migrations = vec![MigrationEdgeAbi {
+            method: "m".to_owned(),
+            from_version: 2,
+        }];
+        let embedded = full.extract_state_schema().unwrap();
+        assert_eq!(embedded.state_version, Some(3));
+        assert_eq!(embedded.migrations.len(), 1);
     }
 }

--- a/crates/wasm-abi/wasm-abi.schema.json
+++ b/crates/wasm-abi/wasm-abi.schema.json
@@ -4,7 +4,12 @@
   "description": "Schema for Calimero WASM ABI v1 format",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "types", "methods", "events"],
+  "required": [
+    "schema_version",
+    "types",
+    "methods",
+    "events"
+  ],
   "properties": {
     "schema_version": {
       "type": "string",
@@ -35,7 +40,10 @@
     "migration": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["method", "toSchemaVersion"],
+      "required": [
+        "method",
+        "toSchemaVersion"
+      ],
       "properties": {
         "method": {
           "type": "string",
@@ -48,6 +56,34 @@
         }
       },
       "description": "Present when the app declares a migration (#[app::migrate] / #[derive(app::Migrate)])"
+    },
+    "state_version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "AppState::SCHEMA_VERSION of this build (#[app::state(version = N)], default 1). Always emitted by current SDKs; absent only on manifests from older SDKs."
+    },
+    "migrations": {
+      "type": "array",
+      "description": "Declared migration edges, one per retained from->from+1 hop. Retained edges enable chained dispatch for members more than one version behind.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "method",
+          "fromVersion"
+        ],
+        "properties": {
+          "method": {
+            "type": "string",
+            "description": "The migrate entrypoint export for this hop"
+          },
+          "fromVersion": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "The state version this edge migrates FROM (targets fromVersion + 1)"
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -56,7 +92,9 @@
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["$ref"],
+          "required": [
+            "$ref"
+          ],
           "properties": {
             "$ref": {
               "type": "string"
@@ -77,18 +115,32 @@
     "ScalarType": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["kind"],
+      "required": [
+        "kind"
+      ],
       "properties": {
         "kind": {
           "type": "string",
-          "enum": ["bool", "i32", "i64", "u32", "u64", "f32", "f64", "string", "unit"]
+          "enum": [
+            "bool",
+            "i32",
+            "i64",
+            "u32",
+            "u64",
+            "f32",
+            "f64",
+            "string",
+            "unit"
+          ]
         }
       }
     },
     "BytesType": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["kind"],
+      "required": [
+        "kind"
+      ],
       "properties": {
         "kind": {
           "const": "bytes"
@@ -123,7 +175,10 @@
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["kind", "items"],
+          "required": [
+            "kind",
+            "items"
+          ],
           "properties": {
             "kind": {
               "const": "list"
@@ -139,7 +194,11 @@
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["kind", "key", "value"],
+          "required": [
+            "kind",
+            "key",
+            "value"
+          ],
           "properties": {
             "kind": {
               "const": "map"
@@ -158,7 +217,10 @@
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["kind", "fields"],
+          "required": [
+            "kind",
+            "fields"
+          ],
           "properties": {
             "kind": {
               "const": "record"
@@ -182,7 +244,10 @@
     "Field": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "type"],
+      "required": [
+        "name",
+        "type"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -198,7 +263,9 @@
     "Variant": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -216,7 +283,10 @@
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["kind", "fields"],
+          "required": [
+            "kind",
+            "fields"
+          ],
           "properties": {
             "kind": {
               "const": "record"
@@ -232,7 +302,10 @@
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["kind", "variants"],
+          "required": [
+            "kind",
+            "variants"
+          ],
           "properties": {
             "kind": {
               "const": "variant"
@@ -248,7 +321,10 @@
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["kind", "target"],
+          "required": [
+            "kind",
+            "target"
+          ],
           "properties": {
             "kind": {
               "const": "alias"
@@ -269,7 +345,10 @@
     "Parameter": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "type"],
+      "required": [
+        "name",
+        "type"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -285,7 +364,9 @@
     "Error": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["code"],
+      "required": [
+        "code"
+      ],
       "properties": {
         "code": {
           "type": "string"
@@ -298,7 +379,10 @@
     "Method": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "params"],
+      "required": [
+        "name",
+        "params"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -323,7 +407,11 @@
         },
         "intent": {
           "type": "string",
-          "enum": ["read_only", "mutating", "unspecified"],
+          "enum": [
+            "read_only",
+            "mutating",
+            "unspecified"
+          ],
           "description": "Read/write intent declared by the app author. Absent on modules compiled before this field existed; treated as write intent by the node."
         }
       }
@@ -331,7 +419,9 @@
     "Event": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -342,4 +432,4 @@
       }
     }
   }
-} 
+}

--- a/tools/merodb/src/abi.rs
+++ b/tools/merodb/src/abi.rs
@@ -43,6 +43,8 @@ pub fn load_state_schema_from_json_value(schema_value: &serde_json::Value) -> Re
         events: Vec::new(),
         state_root: Some(state_root),
         migration: None,
+        state_version: None,
+        migrations: Vec::new(),
     };
 
     Ok(schema)
@@ -280,5 +282,7 @@ pub fn infer_schema_from_database(
         events: Vec::new(),
         state_root: Some(state_root_type),
         migration: None,
+        state_version: None,
+        migrations: Vec::new(),
     })
 }

--- a/workflows/app-migration/00-single-group-migration-baseline.yml
+++ b/workflows/app-migration/00-single-group-migration-baseline.yml
@@ -6,7 +6,8 @@ description: >
   node 2 materialises subgroup membership via inheritance + joins the
   context. Node 1 writes v1 state, waits for node 2 to catch up, then
   runs upgrade_group on the subgroup (per-context, cascade=false)
-  with migrate_v1_to_v2. Asserts the Migrated event + v2 schema shape
+  with NO migrate_method — the node resolves migrate_v1_to_v2 from the
+  target bundle's embedded ABI. Asserts the Migrated event + v2 schema shape
   on node 1 AND mirrors the post-migration schema_info on node 2 to
   prove cross-node convergence via context-sync gossip.
 
@@ -188,7 +189,10 @@ steps:
     node: app-migration-baseline-1
     group_id: "{{group_id}}"
     target_application_id: "{{app_v2}}"
-    migrate_method: migrate_v1_to_v2
+    # migrate_method intentionally omitted: the node resolves the
+    # migration from the target bundle\'s embedded ABI (declared by
+    # #[derive(app::Migrate)]). This workflow is the regression guard
+    # for that resolution path.
 
   # Fixed wait, NOT wait_for_sync: per-context migration apply is
   # asynchronous and a root_hash-based wait_for_sync polled here exits

--- a/workflows/app-migration/01-namespace-cascade-migration.yml
+++ b/workflows/app-migration/01-namespace-cascade-migration.yml
@@ -236,7 +236,10 @@ steps:
     node: app-migration-cascade-1
     group_id: "{{namespace_id}}"
     target_application_id: "{{app_v2}}"
-    migrate_method: migrate_v1_to_v2
+    # migrate_method intentionally omitted: the node resolves the
+    # migration from the target bundle\'s embedded ABI (declared by
+    # #[derive(app::Migrate)]). This workflow is the regression guard
+    # for that resolution path.
     cascade: true
 
   # Fixed wait, NOT wait_for_sync: cascade is published async, and

--- a/workflows/app-migration/build-wasms.sh
+++ b/workflows/app-migration/build-wasms.sh
@@ -73,6 +73,19 @@ for suite in "${SUITES[@]}"; do
     bash "$suite/build.sh"
 done
 
+# Embed each fixture's state schema as the wasm's `calimero_abi_v1` section
+# (AFTER build.sh so wasm-opt cannot strip it). The node reads this embedded
+# form for the upgrade decision table (state_version + migration edges) and
+# the identity-downgrade gate — without it both are fail-open/unresolvable.
+echo ">>> Building mero-abi (embed tool)"
+cargo build -p mero-abi --release
+ABI_TOOL="${CARGO_TARGET_DIR:-target}/release/mero-abi"
+for suite in "${SUITES[@]}"; do
+    dir_name="$(basename "$suite")"
+    wasm_file="${dir_name//-/_}.wasm"
+    "$ABI_TOOL" embed "$suite/res/$wasm_file" "$suite/res/state-schema.json"
+done
+
 # Wrap every fixture into a signed single-service `.mpk`. v1/v2 of a pair
 # share the package name, so they install under the SAME ApplicationId
 # (hash(package, signer)) — the realistic upgrade shape, where only the


### PR DESCRIPTION
## Summary

First of the migrations-v2 train (after #2758): **migrations are declared in the app; the node derives the rest.** Callers of `upgradeGroup` no longer supply a `migrateMethod` — the node resolves the migration per service from the embedded ABI the app already ships, and a single per-context activation marker replaces the two legacy bookkeeping markers.

Live testing of a real two-service bundle migration showed the method-name string being hand-carried (app → frontend constant → API → group state → every peer) caused four of the six bugs found. This PR removes the need to carry it.

### ABI (`calimero-wasm-abi`)
- `Manifest.state_version` — always emitted from `#[app::state(version = N)]` (default 1), so version comparison is total even across code-only releases. `state_version_or_default()` falls back to the legacy `migration.to_schema_version` for 9.4-era bundles, then 1.
- `Manifest.migrations` — declared `from → from+1` edges (one entry today; the chaining substrate). `edge_from()` resolves a hop with a legacy fallback.
- `extract_state_schema` carries both, so the **embedded** form read from bundle blobs exposes them. All serde-default: every existing manifest keeps deserializing.

### Decision table (`calimero-context::migration_plan`)
`plan_upgrade(current_abi, target_abi) → CodeOnly | Migrate{method} | Behind | Downgrade | MissingEdge` — pure, no I/O, table-tested. Services untouched by a release are vacuous **by construction** (equal versions, no wasm probing).

### Emit-side resolution (`upgrade_group`)
When the request carries no method, the node scans **every service** of the target bundle (`bundle_service_names`) and plans each against the same service in the group's current bytecode:
- a declared edge → the upgrade carries that method (wire shape unchanged — pre-v2 receivers keep working);
- a version bump without an edge, or >1 hop, → rejected with an actionable error instead of silently shipping code-only;
- the non-lazy canary gains the mirror guard: an ABI-declared migration under Automatic/Coordinated is refused (migrations only run under LazyOnAccess);
- the cascade path re-runs the per-descendant policy gate after async resolution.

### Unified activation marker (`ContextActivatedBlob`)
One per-context fact — "this context last activated bytecode blob X" — replaces the method-name marker (migrations) and the `blob:<hex>` marker (code-only), which encoded the same thing in two shapes and had already drifted once. Own store column; legacy markers fold forward on first read; writers (lazy migrate, lazy code-only, propagator commit) and readers (lazy trigger, sync gate) all keyed on it. Legacy markers still written for one release so mixed fleets converge.

### Fixtures + workflows
- `migration-suite-v2-add-field` now declares `#[app::state(version = 2)]` — the v2 way.
- Workflows **00** (single-group) and **01** (cascade) drop `migrate_method` entirely — they are the permanent regression guard for ABI resolution. The remaining workflows keep the explicit method, covering the legacy path.
- Workflow **06** (code-only, never passed a method) now exercises the version-equality CodeOnly arm.

## Testing
- `calimero-wasm-abi`: 43 tests (incl. new round-trip/back-compat/edge/emitter cases)
- `calimero-context`: 160 lib tests (9 decision-table + 4 activation/fold-forward new)
- `calimero-node`: 6 `pending_upgrade` gate tests on the unified rule
- Full app-migration e2e matrix (CI), with 00/01 on the no-method path

## Not in this PR (next in the train)
Per-context bytecode binding + version inventory (multi-version coexistence), behind-state + resync recovery, chained dispatch — and the full `docs/migrations.md` rewrite once everything it describes is true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches group upgrade emit/actuation, lazy migration triggers, and state-sync gating—errors could run wrong migrations, block sync, or mark contexts incorrectly; legacy marker folding mitigates rollout risk.
> 
> **Overview**
> **Migrations v2 (part 1):** upgrades can omit `migrateMethod`; the node reads **`state_version`** and **`migrations`** edges from each service’s embedded ABI, plans the hop via `plan_upgrade`, and rejects unsafe cases (missing edge, multi-hop, ABI-declared migration under non-lazy policies).
> 
> **Unified activation:** a new per-context **`ContextActivatedBlob`** store marker records the last activated bytecode blob. Lazy upgrade, sync gating, and post-migrate/update paths treat **marker == `group.app_key`** as up-to-date, with legacy method/`blob:` markers folded forward on read and still written briefly for mixed fleets.
> 
> **SDK / ABI:** manifests always emit `state_version` (default 1) and edge lists; default migrate export names become versioned (`migrate_v{N-1}_to_v{N}`). Fixtures embed state schema into wasm; app-migration workflows **00/01** drop explicit `migrate_method` to guard ABI resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eb6e0b8f6cecaf33082ecc3fe3194de0596b375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->