### PR TITLE
fix(node/sync): short-circuit peer retry when parent pull exhausts the mesh

### DIFF
--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -93,6 +93,36 @@ impl std::fmt::Display for NoPeersAvailable {
 
 impl std::error::Error for NoPeersAvailable {}
 
+/// Parent-pull budget exhausted with DAG parents still missing from the whole
+/// mesh. Typed so the per-peer retry can distinguish it from peer-specific
+/// failures and stop rather than re-run the pipeline for the same miss.
+#[derive(Debug, Clone, Copy)]
+pub struct PendingParentsUnresolved {
+    pub context_id: ContextId,
+    pub remaining: usize,
+    pub attempts: usize,
+}
+
+impl std::fmt::Display for PendingParentsUnresolved {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "pending parents unresolved for context {}: {} remaining after {} peer attempt(s)",
+            self.context_id, self.remaining, self.attempts
+        )
+    }
+}
+
+impl std::error::Error for PendingParentsUnresolved {}
+
+/// Whether the `perform_interval_sync` loop should stop trying peers. Only
+/// `PendingParentsUnresolved` stops it (the parent-pull loop already swept the
+/// mesh); other errors are peer-specific and the loop advances. Downcasts
+/// through eyre context so it matches after `handle_dag_sync`'s `wrap_err`.
+fn should_stop_peer_retry(err: &eyre::Error) -> bool {
+    err.downcast_ref::<PendingParentsUnresolved>().is_some()
+}
+
 /// Network synchronization manager.
 ///
 /// Orchestrates sync protocols: full resync, delta sync, state sync.
@@ -671,8 +701,15 @@ impl SyncManager {
             );
         }
         for peer_id in &shuffled {
-            if let Ok(result) = self.initiate_sync(context_id, *peer_id).await {
-                return Ok(result);
+            match self.initiate_sync(context_id, *peer_id).await {
+                Ok(result) => return Ok(result),
+                Err(err) => {
+                    // Stop if the mesh genuinely lacks the parents; otherwise
+                    // the failure is peer-specific, so try the next peer.
+                    if should_stop_peer_retry(&err) {
+                        return Err(err);
+                    }
+                }
             }
         }
 
@@ -2245,12 +2282,11 @@ impl SyncManager {
                         peer_attempts = budget.total_attempts(),
                         "DAG sync ended with unresolved missing parents"
                     );
-                    bail!(
-                        "pending parents unresolved for context {}: {} remaining after {} peer attempt(s)",
+                    return Err(eyre::Error::new(PendingParentsUnresolved {
                         context_id,
-                        final_missing.missing_ids.len(),
-                        budget.total_attempts(),
-                    );
+                        remaining: final_missing.missing_ids.len(),
+                        attempts: budget.total_attempts(),
+                    }));
                 }
 
                 // Success: DAG is fully resolved.

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -2226,7 +2226,8 @@ impl SyncManager {
                             match budget.next(&mesh_peers) {
                                 super::parent_pull::NextPeer::Peer(p) => p,
                                 other => {
-                                    mesh_exhausted =
+                                    // Sticky: once swept, stay swept.
+                                    mesh_exhausted |=
                                         matches!(other, super::parent_pull::NextPeer::NoMorePeers);
                                     debug!(
                                         %context_id,
@@ -2293,22 +2294,17 @@ impl SyncManager {
                         mesh_exhausted,
                         "DAG sync ended with unresolved missing parents"
                     );
-                    // Typed (caller short-circuits) only when the whole mesh
-                    // was swept; a cap/time-budget stop leaves untried peers, so
-                    // a plain error lets the caller's loop try the next peer.
-                    if mesh_exhausted {
-                        return Err(eyre::Error::new(PendingParentsUnresolved {
-                            context_id,
-                            remaining: final_missing.missing_ids.len(),
-                            attempts: budget.total_attempts(),
-                        }));
-                    }
-                    bail!(
-                        "pending parents unresolved for context {}: {} remaining after {} peer attempt(s)",
+                    let unresolved = PendingParentsUnresolved {
                         context_id,
-                        final_missing.missing_ids.len(),
-                        budget.total_attempts(),
-                    );
+                        remaining: final_missing.missing_ids.len(),
+                        attempts: budget.total_attempts(),
+                    };
+                    // Typed only on a fully-swept mesh (caller short-circuits);
+                    // else a plain error lets the caller try remaining peers.
+                    if mesh_exhausted {
+                        return Err(eyre::Error::new(unresolved));
+                    }
+                    bail!("{unresolved}");
                 }
 
                 // Success: DAG is fully resolved.

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -121,6 +121,7 @@ impl std::error::Error for PendingParentsUnresolved {}
 /// through eyre's context chain, so it matches under the `wrap_err` layers
 /// added between the error origin and `perform_interval_sync`.
 fn should_stop_peer_retry(err: &eyre::Error) -> bool {
+    // Whitelist by type: NoPeersAvailable and transport errors fall through on purpose.
     err.downcast_ref::<PendingParentsUnresolved>().is_some()
 }
 

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -93,14 +93,14 @@ impl std::fmt::Display for NoPeersAvailable {
 
 impl std::error::Error for NoPeersAvailable {}
 
-/// Parent-pull budget exhausted with DAG parents still missing from the whole
-/// mesh. Typed so the per-peer retry can distinguish it from peer-specific
-/// failures and stop rather than re-run the pipeline for the same miss.
+/// Parent-pull tried every mesh peer and DAG parents are still missing. Typed
+/// so the per-peer retry stops instead of re-running the pipeline for the same
+/// miss; emitted only on a fully-swept mesh, not a capped/timed-out pull.
 #[derive(Debug, Clone, Copy)]
-pub struct PendingParentsUnresolved {
-    pub context_id: ContextId,
-    pub remaining: usize,
-    pub attempts: usize,
+pub(crate) struct PendingParentsUnresolved {
+    pub(crate) context_id: ContextId,
+    pub(crate) remaining: usize,
+    pub(crate) attempts: usize,
 }
 
 impl std::fmt::Display for PendingParentsUnresolved {
@@ -116,9 +116,10 @@ impl std::fmt::Display for PendingParentsUnresolved {
 impl std::error::Error for PendingParentsUnresolved {}
 
 /// Whether the `perform_interval_sync` loop should stop trying peers. Only
-/// `PendingParentsUnresolved` stops it (the parent-pull loop already swept the
+/// `PendingParentsUnresolved` stops it (the parent-pull loop swept the whole
 /// mesh); other errors are peer-specific and the loop advances. Downcasts
-/// through eyre context so it matches after `handle_dag_sync`'s `wrap_err`.
+/// through eyre's context chain, so it matches under the `wrap_err` layers
+/// added between the error origin and `perform_interval_sync`.
 fn should_stop_peer_retry(err: &eyre::Error) -> bool {
     err.downcast_ref::<PendingParentsUnresolved>().is_some()
 }
@@ -2206,6 +2207,10 @@ impl SyncManager {
                     self.sync_config.parent_pull_budget,
                 );
                 let mut mesh_peers = self.sync_network.subscribed_peers(topic.clone()).await;
+                // True only if every mesh peer was tried (NoMorePeers); a
+                // cap/time-budget stop leaves untried peers. Only a fully-swept
+                // mesh makes retrying another peer pointless.
+                let mut mesh_exhausted = false;
 
                 loop {
                     let after = delta_store_ref.get_missing_parents().await;
@@ -2221,6 +2226,8 @@ impl SyncManager {
                             match budget.next(&mesh_peers) {
                                 super::parent_pull::NextPeer::Peer(p) => p,
                                 other => {
+                                    mesh_exhausted =
+                                        matches!(other, super::parent_pull::NextPeer::NoMorePeers);
                                     debug!(
                                         %context_id,
                                         ?other,
@@ -2237,8 +2244,11 @@ impl SyncManager {
                             );
                             break;
                         }
-                        super::parent_pull::NextPeer::MaxPeersReached
-                        | super::parent_pull::NextPeer::NoMorePeers => break,
+                        super::parent_pull::NextPeer::MaxPeersReached => break,
+                        super::parent_pull::NextPeer::NoMorePeers => {
+                            mesh_exhausted = true;
+                            break;
+                        }
                     };
 
                     budget.record_attempt(next_peer);
@@ -2280,13 +2290,25 @@ impl SyncManager {
                         %context_id,
                         remaining = final_missing.missing_ids.len(),
                         peer_attempts = budget.total_attempts(),
+                        mesh_exhausted,
                         "DAG sync ended with unresolved missing parents"
                     );
-                    return Err(eyre::Error::new(PendingParentsUnresolved {
+                    // Typed (caller short-circuits) only when the whole mesh
+                    // was swept; a cap/time-budget stop leaves untried peers, so
+                    // a plain error lets the caller's loop try the next peer.
+                    if mesh_exhausted {
+                        return Err(eyre::Error::new(PendingParentsUnresolved {
+                            context_id,
+                            remaining: final_missing.missing_ids.len(),
+                            attempts: budget.total_attempts(),
+                        }));
+                    }
+                    bail!(
+                        "pending parents unresolved for context {}: {} remaining after {} peer attempt(s)",
                         context_id,
-                        remaining: final_missing.missing_ids.len(),
-                        attempts: budget.total_attempts(),
-                    }));
+                        final_missing.missing_ids.len(),
+                        budget.total_attempts(),
+                    );
                 }
 
                 // Success: DAG is fully resolved.

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -464,6 +464,17 @@ mod pending_parents_short_circuit {
     }
 
     #[test]
+    fn non_swept_path_message_alone_does_not_short_circuit() {
+        // The cap/time-budget path bail!s the same wording untyped; only the
+        // type stops the loop, so a message-identical plain error must not.
+        let plain = eyre::eyre!(
+            "pending parents unresolved for context {}: 3 remaining after 4 peer attempt(s)",
+            ctx()
+        );
+        assert!(!should_stop_peer_retry(&plain));
+    }
+
+    #[test]
     fn display_pins_operator_log_format() {
         // The non-swept path bail!s via this Display, so keep the operator-facing
         // line stable regardless of which path produced it.

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -425,22 +425,21 @@ mod pending_parents_short_circuit {
     }
 
     #[test]
-    fn budget_exhausted_parent_pull_stops_the_peer_loop() {
+    fn mesh_swept_parent_pull_stops_the_peer_loop() {
+        // Emitted only when the whole mesh was swept — another peer is pointless.
         let err = eyre::Error::new(PendingParentsUnresolved {
             context_id: ctx(),
             remaining: 3,
             attempts: 4,
         });
-        assert!(
-            should_stop_peer_retry(&err),
-            "budget-exhausted parent pull is unsatisfiable by another peer"
-        );
+        assert!(should_stop_peer_retry(&err));
     }
 
     #[test]
-    fn detection_survives_wrap_err() {
-        // handle_dag_sync wraps the error before it reaches the retry loop;
-        // if downcast didn't traverse the chain the fix would be a no-op.
+    fn detection_survives_nested_wrap_err() {
+        // Production wraps twice (handle_dag_sync + initiate_sync_inner) before
+        // the retry loop; if downcast didn't traverse the whole eyre chain the
+        // fix would be a silent no-op.
         use eyre::WrapErr as _;
         let wrapped = Err::<(), _>(eyre::Error::new(PendingParentsUnresolved {
             context_id: ctx(),
@@ -448,6 +447,7 @@ mod pending_parents_short_circuit {
             attempts: 2,
         }))
         .wrap_err("request DAG heads and sync")
+        .wrap_err("DAG sync")
         .unwrap_err();
         assert!(should_stop_peer_retry(&wrapped));
     }

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -462,4 +462,25 @@ mod pending_parents_short_circuit {
             NoPeersAvailable { context_id: ctx() }
         )));
     }
+
+    #[test]
+    fn display_pins_operator_log_format() {
+        // The non-swept path bail!s via this Display, so keep the operator-facing
+        // line stable regardless of which path produced it.
+        let shown = format!(
+            "{}",
+            PendingParentsUnresolved {
+                context_id: ctx(),
+                remaining: 3,
+                attempts: 4,
+            }
+        );
+        assert_eq!(
+            shown,
+            format!(
+                "pending parents unresolved for context {}: 3 remaining after 4 peer attempt(s)",
+                ctx()
+            )
+        );
+    }
 }

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -412,3 +412,54 @@ mod key_recovery_trigger {
             .is_empty());
     }
 }
+
+// `should_stop_peer_retry` stops `perform_interval_sync` only for the
+// unsatisfiable PendingParentsUnresolved, not peer-specific failures.
+mod pending_parents_short_circuit {
+    use calimero_primitives::context::ContextId;
+
+    use super::super::{should_stop_peer_retry, NoPeersAvailable, PendingParentsUnresolved};
+
+    fn ctx() -> ContextId {
+        ContextId::from([7u8; 32])
+    }
+
+    #[test]
+    fn budget_exhausted_parent_pull_stops_the_peer_loop() {
+        let err = eyre::Error::new(PendingParentsUnresolved {
+            context_id: ctx(),
+            remaining: 3,
+            attempts: 4,
+        });
+        assert!(
+            should_stop_peer_retry(&err),
+            "budget-exhausted parent pull is unsatisfiable by another peer"
+        );
+    }
+
+    #[test]
+    fn detection_survives_wrap_err() {
+        // handle_dag_sync wraps the error before it reaches the retry loop;
+        // if downcast didn't traverse the chain the fix would be a no-op.
+        use eyre::WrapErr as _;
+        let wrapped = Err::<(), _>(eyre::Error::new(PendingParentsUnresolved {
+            context_id: ctx(),
+            remaining: 1,
+            attempts: 2,
+        }))
+        .wrap_err("request DAG heads and sync")
+        .unwrap_err();
+        assert!(should_stop_peer_retry(&wrapped));
+    }
+
+    #[test]
+    fn peer_specific_errors_keep_iterating() {
+        // A different peer can still succeed, so these must not short-circuit.
+        assert!(!should_stop_peer_retry(&eyre::eyre!(
+            "connection reset by peer"
+        )));
+        assert!(!should_stop_peer_retry(&eyre::Error::new(
+            NoPeersAvailable { context_id: ctx() }
+        )));
+    }
+}


### PR DESCRIPTION
Closes #2210.

## Problem

The cross-peer parent-pull loop in `request_dag_heads_and_sync` already enumerates **every** mesh peer (`subscribed_peers(topic)`) up to its budget. When it exhausts that budget with DAG parents still missing, it bailed with an opaque `eyre` string:

```
pending parents unresolved for context {}: {} remaining after {} peer attempt(s)
```

That error propagates up through `handle_dag_sync` → `initiate_sync_inner` → `initiate_sync` → `perform_interval_sync`, whose per-peer loop swallowed it with `if let Ok(result) = …` and moved to the next peer — **re-running the entire sync pipeline** (handshake, key share, DAG heads, blob share, parent-pull loop) against every remaining peer. Since the inner loop already swept the whole mesh, a different peer returns the same "no": O(N) full pipelines for one unsatisfiable miss.

## Change

- Add a typed `PendingParentsUnresolved` error, a sibling of the existing `NoPeersAvailable` struct error.
- `request_dag_heads_and_sync` returns it instead of `bail!`. Its `Display` is byte-identical to the old string, so operator logs are unchanged.
- Add `should_stop_peer_retry`, which `downcast_ref`s through eyre's context chain (so it still matches after `handle_dag_sync`'s `.wrap_err(...)`).
- `perform_interval_sync`'s loop now stops and surfaces the error on `PendingParentsUnresolved`, while still advancing to the next peer for peer-specific failures (transport, protocol mismatch, peer behind).

Behavior is unchanged for every other failure mode; only the genuinely-unsatisfiable case stops churning.

## Tests

Three unit tests pin the classifier (`crates/node/src/sync/manager/tests.rs`):
- short-circuits on `PendingParentsUnresolved`,
- detection survives the `wrap_err` layer (guards against a silent no-op),
- peer-specific errors and `NoPeersAvailable` do **not** short-circuit.

Full sync suite green (`223 passed; 0 failed`); clippy (`-A warnings`) and rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes DAG catch-up failure propagation and interval-sync peer selection; misclassification could either churn sync or stop retries too early, though tests cover mesh-swept vs budget-capped paths.
> 
> **Overview**
> When cross-peer **parent-pull** finishes with missing DAG parents after sweeping the whole mesh, the sync manager now returns a typed **`PendingParentsUnresolved`** error (same log text as before) instead of a plain `eyre` string.
> 
> **`perform_interval_sync`** stops trying additional peers when that error is detected via **`should_stop_peer_retry`** (eyre downcast through `wrap_err` layers), instead of re-running the full sync pipeline on every remaining peer for an unsatisfiable miss. Parent-pull tracks **`mesh_exhausted`** so the typed error is only used when every mesh peer was tried; cap/budget stops still bail with an untyped message so outer loops can keep other peers.
> 
> Unit tests lock down the classifier, wrapped-error detection, and the distinction from peer-specific failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 379ecb2bc88cdc32fda0d0849360ae3fcf8dff37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->