### PR TITLE
feat(client): add resync_context + get_migration_status crate methods

### DIFF
--- a/crates/client/src/client/contexts.rs
+++ b/crates/client/src/client/contexts.rs
@@ -5,8 +5,9 @@ use calimero_primitives::identity::PublicKey;
 use calimero_server_primitives::admin::{
     CreateContextRequest, CreateContextResponse, DeleteContextApiRequest, DeleteContextResponse,
     GetContextClientKeysResponse, GetContextIdentitiesResponse, GetContextResponse,
-    GetContextStorageResponse, GetContextsResponse, SyncContextResponse,
-    UpdateContextApplicationRequest, UpdateContextApplicationResponse,
+    GetContextStorageResponse, GetContextsResponse, ResyncContextApiRequest,
+    ResyncContextApiResponse, SyncContextResponse, UpdateContextApplicationRequest,
+    UpdateContextApplicationResponse,
 };
 use eyre::Result;
 
@@ -110,6 +111,21 @@ where
         let response = self
             .connection
             .post_no_body(&format!("admin-api/contexts/sync/{context_id}"))
+            .await?;
+        Ok(response)
+    }
+
+    /// Resync a stranded context by adopting a peer's full state. Destructive:
+    /// `force` must be set when the context still holds local DAG heads, which
+    /// the resync discards.
+    pub async fn resync_context(
+        &self,
+        context_id: &str,
+        request: ResyncContextApiRequest,
+    ) -> Result<ResyncContextApiResponse> {
+        let response = self
+            .connection
+            .post(&format!("admin-api/contexts/{context_id}/resync"), request)
             .await?;
         Ok(response)
     }

--- a/crates/client/src/client/group.rs
+++ b/crates/client/src/client/group.rs
@@ -15,6 +15,7 @@ use calimero_server_primitives::admin::GetCascadeStatusApiResponse;
 use calimero_server_primitives::admin::GetGroupUpgradeStatusApiResponse;
 use calimero_server_primitives::admin::GetMemberCapabilitiesApiResponse;
 use calimero_server_primitives::admin::GetMetadataApiResponse;
+use calimero_server_primitives::admin::GetMigrationStatusApiResponse;
 use calimero_server_primitives::admin::GetTeeAdmissionPolicyApiResponse;
 use calimero_server_primitives::admin::GroupInfoApiResponse;
 use calimero_server_primitives::admin::JoinContextApiResponse;
@@ -247,6 +248,20 @@ where
         let response = self
             .connection
             .get(&format!("admin-api/groups/{namespace_id}/cascade-status"))
+            .await?;
+        Ok(response)
+    }
+
+    /// Pinned-cohort migration rollup for a namespace: per-member migration
+    /// state (`migrated`/`in_progress`/`unknown`/`failed`) and the `all_migrated`
+    /// flag. Observability only — never gates a write or apply.
+    pub async fn get_migration_status(
+        &self,
+        namespace_id: &str,
+    ) -> Result<GetMigrationStatusApiResponse> {
+        let response = self
+            .connection
+            .get(&format!("admin-api/groups/{namespace_id}/migration-status"))
             .await?;
         Ok(response)
     }

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -35,6 +35,7 @@ use calimero_server_primitives::admin::JoinGroupApiRequest;
 use calimero_server_primitives::admin::RegisterGroupSigningKeyApiRequest;
 use calimero_server_primitives::admin::RemoveGroupMembersApiRequest;
 use calimero_server_primitives::admin::ReparentGroupApiRequest;
+use calimero_server_primitives::admin::ResyncContextApiRequest;
 use calimero_server_primitives::admin::RetryGroupUpgradeApiRequest;
 use calimero_server_primitives::admin::SetDefaultCapabilitiesApiRequest;
 use calimero_server_primitives::admin::SetMemberCapabilitiesApiRequest;
@@ -684,6 +685,59 @@ async fn retry_group_upgrade() {
         .unwrap();
 
     assert_eq!(resp.data.group_id, GID);
+}
+
+#[tokio::test]
+async fn get_migration_status() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/admin-api/groups/{GID}/migration-status")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "targetVersion": 2,
+            "expectedMembers": 1,
+            "rollup": {
+                "migrated": 1,
+                "inProgress": 0,
+                "unknown": 0,
+                "failed": 0,
+                "total": 1,
+                "allMigrated": true,
+                "membersPendingSignature": 0
+            },
+            "members": []
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = make_client(&Url::parse(&server.uri()).unwrap());
+    let resp = client.get_migration_status(GID).await.unwrap();
+
+    assert_eq!(resp.target_version, 2);
+    assert!(resp.rollup.all_migrated);
+}
+
+#[tokio::test]
+async fn resync_context() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(format!("/admin-api/contexts/{CID}/resync")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "contextId": CID,
+            "resyncStarted": true
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = make_client(&Url::parse(&server.uri()).unwrap());
+    let resp = client
+        .resync_context(CID, ResyncContextApiRequest { force: true })
+        .await
+        .unwrap();
+
+    assert_eq!(resp.context_id, CID);
+    assert!(resp.resync_started);
 }
 
 // ---- Sync & Signing Key ----


### PR DESCRIPTION
## What

Adds two thin `calimero_client` crate wrappers for migrations-v2 admin endpoints that the engine (PRs #2758/#2759/#2760/#2761/#2766) already exposes over HTTP but the client crate did not surface:

- **`resync_context(context_id, ResyncContextApiRequest { force })`** → `POST admin-api/contexts/{id}/resync`. Recover a stranded context by adopting a peer's full state (force-gated when local DAG heads exist).
- **`get_migration_status(namespace_id)`** → `GET admin-api/groups/{namespace_id}/migration-status`. Pinned-cohort rollup: per-member `migrated`/`in_progress`/`unknown`/`failed` state + `all_migrated`.

`list_application_versions` and `create_namespace` (which already takes the whole `CreateNamespaceApiRequest`, so `app_key` flows through) were already present — no change needed there.

## Why

This is the **prerequisite that unblocks the Python client train**: `calimero-client-py` wraps this crate (pinned to `git = master`), not raw HTTP, so it can only expose what the crate exposes. With these two methods in, client-py can add `resync_context` / `get_migration_status` bindings, and merobox can build the `stranded → resync → recovers` e2e (the verification gap PR-4b deferred, tracked by merobox#281).

## Tests

Mock-server round-trip tests for both methods (mirroring the existing `get_cascade_status` / `retry_group_upgrade` tests). `cargo test -p calimero-client`: 41 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only additions delegating to existing admin endpoints; no server or apply-path logic changes, though `resync_context` triggers destructive recovery when used.
> 
> **Overview**
> Adds two **thin HTTP wrappers** on `calimero-client` for admin APIs that already exist on the engine but were not surfaced in the crate.
> 
> **`resync_context`** posts to `admin-api/contexts/{id}/resync` with `ResyncContextApiRequest` (including **`force`** when local DAG heads must be discarded) to recover a stranded context by adopting a peer’s full state. **`get_migration_status`** GETs `admin-api/groups/{namespace_id}/migration-status` for pinned-cohort migration rollup (`all_migrated`, per-member states); documented as observability-only.
> 
> Wiremock round-trip tests mirror existing patterns such as `get_cascade_status` and `retry_group_upgrade`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db953e029c3801a889e6d533eae083ebda748b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->