### PR TITLE
feat(governance-store): delete group encryption keys on namespace/subgroup leave

### DIFF
--- a/crates/context/src/self_purge.rs
+++ b/crates/context/src/self_purge.rs
@@ -1382,6 +1382,14 @@ mod tests {
             .nest(&ns_id, &sub_id)
             .unwrap();
 
+        // Seed a signing key on the subgroup too, so `delete_group_local_rows`
+        // exercises the signing-key delete (not just the AES-key delete) for the
+        // subgroup — making `purged_groups == 2` a meaningful guard and matching
+        // the multi-group cascade test's seeding.
+        SigningKeysRepository::new(&store)
+            .store_key(&sub_id, &self_pk, &[0xFFu8; 32])
+            .unwrap();
+
         // Seed an AES group encryption key on BOTH groups.
         GroupKeyring::new(&store, ns_id)
             .store_key(&[0x11u8; 32])
@@ -1418,6 +1426,13 @@ mod tests {
                 .unwrap()
                 .is_none(),
             "subgroup AES group encryption key MUST be purged"
+        );
+        assert!(
+            SigningKeysRepository::new(&store)
+                .get_key(&sub_id, &self_pk)
+                .unwrap()
+                .is_none(),
+            "subgroup signing key MUST be purged"
         );
     }
 

--- a/crates/context/src/self_purge.rs
+++ b/crates/context/src/self_purge.rs
@@ -1253,7 +1253,8 @@ mod tests {
     use rand::RngCore;
 
     use calimero_governance_store::{
-        MembershipRepository, MetaRepository, PendingSelfPurgeRepository, SigningKeysRepository,
+        GroupKeyring, MembershipRepository, MetaRepository, PendingSelfPurgeRepository,
+        SigningKeysRepository,
     };
 
     use super::*;
@@ -1331,6 +1332,93 @@ mod tests {
         );
 
         (store, ns_id, self_pk)
+    }
+
+    #[test]
+    fn cascade_namespace_state_purges_group_encryption_keys_root_and_subgroups() {
+        // A namespace root + one nested subgroup, each holding an AES group
+        // encryption key. A namespace-root cascade must delete BOTH — an
+        // evicted TEE replica must not retain decryption keys (forward secrecy).
+        let mut rng = OsRng;
+        let store = empty_store();
+
+        let ns_id = ContextGroupId::from([0x70u8; 32]);
+        let sub_id = ContextGroupId::from([0x71u8; 32]);
+
+        let self_sk = PrivateKey::random(&mut rng);
+        let self_pk = self_sk.public_key();
+
+        // Root group.
+        MetaRepository::new(&store)
+            .save(&ns_id, &make_meta(self_pk))
+            .unwrap();
+        MembershipRepository::new(&store)
+            .add_member_with_keys(
+                &ns_id,
+                &self_pk,
+                GroupMemberRole::Admin,
+                Some([0xAA; 32]),
+                Some([0xBB; 32]),
+            )
+            .unwrap();
+        NamespaceRepository::new(&store)
+            .store_identity(&ns_id, &self_pk, &[0xAA; 32], &[0xBB; 32])
+            .unwrap();
+
+        // Nested subgroup under the namespace root.
+        MetaRepository::new(&store)
+            .save(&sub_id, &make_meta(self_pk))
+            .unwrap();
+        MembershipRepository::new(&store)
+            .add_member_with_keys(
+                &sub_id,
+                &self_pk,
+                GroupMemberRole::ReadOnlyTee,
+                Some([0xCC; 32]),
+                Some([0xDD; 32]),
+            )
+            .unwrap();
+        NamespaceRepository::new(&store)
+            .nest(&ns_id, &sub_id)
+            .unwrap();
+
+        // Seed an AES group encryption key on BOTH groups.
+        GroupKeyring::new(&store, ns_id)
+            .store_key(&[0x11u8; 32])
+            .unwrap();
+        GroupKeyring::new(&store, sub_id)
+            .store_key(&[0x22u8; 32])
+            .unwrap();
+        assert!(GroupKeyring::new(&store, ns_id)
+            .load_current_key()
+            .unwrap()
+            .is_some());
+        assert!(GroupKeyring::new(&store, sub_id)
+            .load_current_key()
+            .unwrap()
+            .is_some());
+
+        let result = cascade_namespace_state(&store, ns_id);
+        assert!(
+            result.purged_groups >= 2,
+            "root + subgroup must be purged, got {}",
+            result.purged_groups
+        );
+
+        assert!(
+            GroupKeyring::new(&store, ns_id)
+                .load_current_key()
+                .unwrap()
+                .is_none(),
+            "root AES group encryption key MUST be purged"
+        );
+        assert!(
+            GroupKeyring::new(&store, sub_id)
+                .load_current_key()
+                .unwrap()
+                .is_none(),
+            "subgroup AES group encryption key MUST be purged"
+        );
     }
 
     // --- Reconcile sweep (#2721) ---------------------------------------

--- a/crates/context/src/self_purge.rs
+++ b/crates/context/src/self_purge.rs
@@ -1382,10 +1382,14 @@ mod tests {
             .nest(&ns_id, &sub_id)
             .unwrap();
 
-        // Seed a signing key on the subgroup too, so `delete_group_local_rows`
-        // exercises the signing-key delete (not just the AES-key delete) for the
-        // subgroup — making `purged_groups == 2` a meaningful guard and matching
-        // the multi-group cascade test's seeding.
+        // Seed a signing key on BOTH groups so `delete_group_local_rows`
+        // exercises the signing-key delete (not just the AES-key delete) for
+        // each, symmetric with the multi-group cascade test's seeding. (The
+        // `purged_groups == 2` count itself comes from both groups having rows
+        // to drop; these seeds make the per-group signing-key delete path real.)
+        SigningKeysRepository::new(&store)
+            .store_key(&ns_id, &self_pk, &[0xEEu8; 32])
+            .unwrap();
         SigningKeysRepository::new(&store)
             .store_key(&sub_id, &self_pk, &[0xFFu8; 32])
             .unwrap();
@@ -1426,6 +1430,13 @@ mod tests {
                 .unwrap()
                 .is_none(),
             "subgroup AES group encryption key MUST be purged"
+        );
+        assert!(
+            SigningKeysRepository::new(&store)
+                .get_key(&ns_id, &self_pk)
+                .unwrap()
+                .is_none(),
+            "root signing key MUST be purged"
         );
         assert!(
             SigningKeysRepository::new(&store)

--- a/crates/context/src/self_purge.rs
+++ b/crates/context/src/self_purge.rs
@@ -1952,6 +1952,18 @@ mod tests {
                 .is_some(),
             "subgroup signing key should exist before purge"
         );
+        // Seed an AES group encryption key on the subgroup so we can assert
+        // the subgroup-ONLY leave path deletes it (forward-secrecy).
+        GroupKeyring::new(&store, sub_id)
+            .store_key(&[0x33u8; 32])
+            .unwrap();
+        assert!(
+            GroupKeyring::new(&store, sub_id)
+                .load_current_key()
+                .unwrap()
+                .is_some(),
+            "subgroup AES group key should exist before purge"
+        );
 
         purge_subgroup_for_self(&store, sub_id);
 
@@ -1984,6 +1996,13 @@ mod tests {
         assert!(
             MetaRepository::new(&store).load(&sub_id).unwrap().is_none(),
             "subgroup meta MUST be purged"
+        );
+        assert!(
+            GroupKeyring::new(&store, sub_id)
+                .load_current_key()
+                .unwrap()
+                .is_none(),
+            "subgroup-only leave MUST delete the subgroup's AES group key"
         );
         assert!(
             NamespaceRepository::new(&store)

--- a/crates/context/src/self_purge.rs
+++ b/crates/context/src/self_purge.rs
@@ -1399,9 +1399,9 @@ mod tests {
             .is_some());
 
         let result = cascade_namespace_state(&store, ns_id);
-        assert!(
-            result.purged_groups >= 2,
-            "root + subgroup must be purged, got {}",
+        assert_eq!(
+            result.purged_groups, 2,
+            "exactly root + subgroup must be purged, got {}",
             result.purged_groups
         );
 

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -92,7 +92,20 @@ impl<'a> GroupKeyring<'a> {
 
     /// Delete every stored group encryption key (`GroupKeyEntry`) for this
     /// group. Used by the purge/leave cascade for forward-secrecy hygiene —
-    /// mirrors `SigningKeysRepository::delete_all_for_group`. Idempotent.
+    /// mirrors `SigningKeysRepository::delete_all_for_group` (the group id is
+    /// taken from `self` rather than a parameter, since the keyring is already
+    /// scoped to one group). Idempotent.
+    ///
+    /// Correctness relies on `GroupKeyEntry` keys being ordered by
+    /// `(group_id, key_id)`, so all of this group's keys are contiguous and the
+    /// prefix scan collects them in a single pass — the same ordering
+    /// assumption as [`load_current_key_record`](Self::load_current_key_record).
+    ///
+    /// The scan and the deletes use separate store handles, so this is not
+    /// atomic against a concurrent writer. That is safe here because the purge
+    /// cascade removes group membership *before* calling this (see
+    /// `delete_group_local_rows`), so no new key can be delivered or rotated
+    /// into the group during the scan→delete window.
     pub fn delete_all_for_group(&self) -> EyreResult<()> {
         let gid = self.group_id.to_bytes();
         let keys = collect_keys_with_prefix(

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -90,6 +90,24 @@ impl<'a> GroupKeyring<'a> {
         Ok(best.map(|(record, _)| record))
     }
 
+    /// Delete every stored group encryption key (`GroupKeyEntry`) for this
+    /// group. Used by the purge/leave cascade for forward-secrecy hygiene —
+    /// mirrors `SigningKeysRepository::delete_all_for_group`. Idempotent.
+    pub fn delete_all_for_group(&self) -> EyreResult<()> {
+        let gid = self.group_id.to_bytes();
+        let keys = collect_keys_with_prefix(
+            self.store,
+            GroupKeyEntry::new(gid, [0u8; 32]),
+            GROUP_KEY_PREFIX,
+            |k| k.group_id() == gid,
+        )?;
+        let mut handle = self.store.handle();
+        for key in keys {
+            handle.delete(&key)?;
+        }
+        Ok(())
+    }
+
     /// Backward-compatible tuple view of [`StoredGroupKey`].
     pub fn load_current_key(&self) -> EyreResult<Option<([u8; 32], [u8; 32])>> {
         Ok(self
@@ -217,5 +235,50 @@ impl<'a> GroupKeyring<'a> {
             new_key_id,
             envelopes,
         })
+    }
+}
+
+#[cfg(test)]
+mod delete_tests {
+    use std::sync::Arc;
+
+    use calimero_store::db::InMemoryDB;
+
+    use super::*;
+
+    fn test_store() -> Store {
+        Store::new(Arc::new(InMemoryDB::owned()))
+    }
+
+    #[test]
+    fn delete_all_for_group_removes_all_keys_and_is_scoped() {
+        let store = test_store();
+        let gid = ContextGroupId::from([0x42u8; 32]);
+        let ring = GroupKeyring::new(&store, gid);
+
+        let id1 = ring.store_key(&[0x01u8; 32]).unwrap();
+        let _id2 = ring.store_key(&[0x02u8; 32]).unwrap();
+        assert!(ring.load_current_key().unwrap().is_some());
+        assert!(ring.load_key_by_id(&id1).unwrap().is_some());
+
+        // Seed a different group; it must survive the targeted delete.
+        let other = ContextGroupId::from([0x99u8; 32]);
+        let other_ring = GroupKeyring::new(&store, other);
+        let _ = other_ring.store_key(&[0x03u8; 32]).unwrap();
+
+        ring.delete_all_for_group().unwrap();
+
+        assert!(
+            ring.load_current_key().unwrap().is_none(),
+            "all group encryption keys for the target group must be gone"
+        );
+        assert!(ring.load_key_by_id(&id1).unwrap().is_none());
+        assert!(
+            other_ring.load_current_key().unwrap().is_some(),
+            "another group's keys must NOT be deleted"
+        );
+
+        // Idempotent: deleting again is a no-op.
+        ring.delete_all_for_group().unwrap();
     }
 }

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -101,11 +101,22 @@ impl<'a> GroupKeyring<'a> {
     /// prefix scan collects them in a single pass — the same ordering
     /// assumption as [`load_current_key_record`](Self::load_current_key_record).
     ///
-    /// The scan and the deletes use separate store handles, so this is not
-    /// atomic against a concurrent writer. That is safe here because the purge
-    /// cascade removes group membership *before* calling this (see
-    /// `delete_group_local_rows`), so no new key can be delivered or rotated
-    /// into the group during the scan→delete window.
+    /// The scan and the deletes use separate store handles, so this is **not**
+    /// atomic. Two windows follow from that, both benign here:
+    ///
+    /// 1. *Concurrent writer.* A `store_key` racing between the scan and the
+    ///    delete loop would be missed. This cannot happen on the purge path:
+    ///    the only writer of `GroupKeyEntry` is the governance key-delivery /
+    ///    rotation pipeline, which only writes for groups the node is a member
+    ///    of, and `delete_group_local_rows` removes the membership rows *before*
+    ///    calling this — and the cascade itself runs single-threaded. So no
+    ///    `store_key` for this group can be issued once we reach here.
+    /// 2. *Partial delete on error.* If a `handle.delete` fails mid-loop, the
+    ///    already-deleted keys stay deleted and the rest remain; the error
+    ///    propagates via `?`. The caller (`delete_group_local_rows`) propagates
+    ///    it too, keeping the purge retry anchor alive, and the next reconcile
+    ///    invocation re-scans and deletes only the survivors — idempotent across
+    ///    retries even after a partial delete.
     pub fn delete_all_for_group(&self) -> EyreResult<()> {
         let gid = self.group_id.to_bytes();
         let keys = collect_keys_with_prefix(

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -110,14 +110,18 @@ impl<'a> GroupKeyring<'a> {
     ///    rotation pipeline, which only writes for groups the node is a member
     ///    of, and `delete_group_local_rows` removes the membership rows *before*
     ///    calling this — and the cascade itself runs single-threaded. So no
-    ///    `store_key` for this group can be issued once we reach here.
+    ///    `store_key` for this group can be issued once we reach here. The
+    ///    method is `pub(crate)` precisely so this precondition is enforced
+    ///    structurally: the only caller is `delete_group_local_rows` (and the
+    ///    in-crate tests), never an external code path that might skip the
+    ///    membership removal.
     /// 2. *Partial delete on error.* If a `handle.delete` fails mid-loop, the
     ///    already-deleted keys stay deleted and the rest remain; the error
     ///    propagates via `?`. The caller (`delete_group_local_rows`) propagates
     ///    it too, keeping the purge retry anchor alive, and the next reconcile
     ///    invocation re-scans and deletes only the survivors — idempotent across
     ///    retries even after a partial delete.
-    pub fn delete_all_for_group(&self) -> EyreResult<()> {
+    pub(crate) fn delete_all_for_group(&self) -> EyreResult<()> {
         let gid = self.group_id.to_bytes();
         let keys = collect_keys_with_prefix(
             self.store,

--- a/crates/governance-store/src/local_state.rs
+++ b/crates/governance-store/src/local_state.rs
@@ -486,14 +486,14 @@ pub fn delete_group_local_rows(store: &Store, group_id: &ContextGroupId) -> Eyre
     // are gone. (The cascade's `signing_key_purge_failed` flag also covers this
     // AES-key failure path despite its signing-key-centric name.)
     //
-    // SAFETY: `delete_all_for_group` scans then deletes on separate store
+    // CORRECTNESS: `delete_all_for_group` scans then deletes on separate store
     // handles (non-atomic). That is race-free here only because this function
     // removes the group's membership rows *above* (see `remove_member` loop)
     // before this point — the sole writer of `GroupKeyEntry` is the
     // membership-gated key-delivery/rotation pipeline, so once membership is
     // gone no new key can be written for this group during the scan→delete
-    // window. Do not call `delete_all_for_group` from a path that has not
-    // already removed membership.
+    // window. The method is `pub(crate)` so no external path can skip this
+    // membership-removal precondition.
     GroupKeyring::new(store, *group_id).delete_all_for_group()?;
     DenyListRepository::new(store).clear_all_for_group(group_id)?;
     delete_op_log_and_head(store, group_id)?;

--- a/crates/governance-store/src/local_state.rs
+++ b/crates/governance-store/src/local_state.rs
@@ -485,6 +485,15 @@ pub fn delete_group_local_rows(store: &Store, group_id: &ContextGroupId) -> Eyre
     // startup reconcile sweep (#2721) re-runs this idempotently until the keys
     // are gone. (The cascade's `signing_key_purge_failed` flag also covers this
     // AES-key failure path despite its signing-key-centric name.)
+    //
+    // SAFETY: `delete_all_for_group` scans then deletes on separate store
+    // handles (non-atomic). That is race-free here only because this function
+    // removes the group's membership rows *above* (see `remove_member` loop)
+    // before this point — the sole writer of `GroupKeyEntry` is the
+    // membership-gated key-delivery/rotation pipeline, so once membership is
+    // gone no new key can be written for this group during the scan→delete
+    // window. Do not call `delete_all_for_group` from a path that has not
+    // already removed membership.
     GroupKeyring::new(store, *group_id).delete_all_for_group()?;
     DenyListRepository::new(store).clear_all_for_group(group_id)?;
     delete_op_log_and_head(store, group_id)?;

--- a/crates/governance-store/src/local_state.rs
+++ b/crates/governance-store/src/local_state.rs
@@ -478,6 +478,13 @@ pub fn delete_group_local_rows(store: &Store, group_id: &ContextGroupId) -> Eyre
     UpgradesRepository::new(store).delete(group_id)?;
     UpgradeLadderRepository::new(store).delete(group_id)?;
     SigningKeysRepository::new(store).delete_all_for_group(group_id)?;
+    // Forward secrecy: also drop the AES group *encryption* keys. Like the
+    // signing-key delete above, a failure here propagates via `?`, so the
+    // cascade classifies it as a per-group purge failure and keeps the
+    // namespace identity + pending-self-purge marker as a retry anchor — the
+    // startup reconcile sweep (#2721) re-runs this idempotently until the keys
+    // are gone. (The cascade's `signing_key_purge_failed` flag also covers this
+    // AES-key failure path despite its signing-key-centric name.)
     GroupKeyring::new(store, *group_id).delete_all_for_group()?;
     DenyListRepository::new(store).clear_all_for_group(group_id)?;
     delete_op_log_and_head(store, group_id)?;

--- a/crates/governance-store/src/local_state.rs
+++ b/crates/governance-store/src/local_state.rs
@@ -1,5 +1,5 @@
 use crate::{
-    CapabilitiesRepository, DenyListRepository, MembershipRepository, MetaRepository,
+    CapabilitiesRepository, DenyListRepository, GroupKeyring, MembershipRepository, MetaRepository,
     MetadataRepository, SigningKeysRepository, UpgradeLadderRepository, UpgradesRepository,
 };
 use calimero_context_client::local_governance::SignedGroupOp;
@@ -478,6 +478,7 @@ pub fn delete_group_local_rows(store: &Store, group_id: &ContextGroupId) -> Eyre
     UpgradesRepository::new(store).delete(group_id)?;
     UpgradeLadderRepository::new(store).delete(group_id)?;
     SigningKeysRepository::new(store).delete_all_for_group(group_id)?;
+    GroupKeyring::new(store, *group_id).delete_all_for_group()?;
     DenyListRepository::new(store).clear_all_for_group(group_id)?;
     delete_op_log_and_head(store, group_id)?;
     MetaRepository::new(store).delete(group_id)?;

--- a/docs/superpowers/plans/2026-06-17-self-purge-delete-group-keys.md
+++ b/docs/superpowers/plans/2026-06-17-self-purge-delete-group-keys.md
@@ -1,0 +1,325 @@
+# Self-Purge Deletes Group Encryption Keys — Implementation Plan (Part 1 of disable-HA leave+purge)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the self-purge / namespace-leave cascade actually delete the AES group **encryption** keys (`GroupKeyEntry`) for the namespace root and every subgroup — closing a forward-secrecy gap where an evicted TEE replica keeps decryption keys.
+
+**Architecture:** Today `delete_group_local_rows` (run per group by the purge cascade) deletes `GroupSigningKey` via `SigningKeysRepository::delete_all_for_group` but never deletes `GroupKeyEntry` (the raw 32-byte AES key managed by `GroupKeyring`). No code deletes group encryption keys anywhere. We add `GroupKeyring::delete_all_for_group` (mirroring the signing-keys pattern) and call it from `delete_group_local_rows`, so every purge path (`cascade_namespace_state` for namespace-root leave, `purge_subgroup_for_self` for subgroup leave) sweeps the AES keys automatically.
+
+**Tech Stack:** Rust (toolchain 1.88.0 — fmt via `rustup run 1.88.0 cargo fmt`), Cargo workspace, `calimero-governance-store` + `calimero-context` crates, `calimero-store` key types, `cargo test`.
+
+**Scope guardrails:**
+- ONLY Part 1 (the core key-deletion). The sidecar trigger (Part 2, mero-tee) and mdma allowlist (Part 3) are out of scope.
+- No AI attribution in commits.
+- Spec: `docs/superpowers/specs/2026-06-16-disable-ha-leave-and-purge-design.md`.
+
+**Design note (verified, no code needed):** the namespace purge deletes governance rows + signing keys + context-tree *index/edge* pointers, but does **not** separately delete the context state-CRDT / application data rows. Deleting the AES group keys **crypto-shreds** that data (ciphertext becomes unreadable), which is the intended forward-secrecy outcome. This plan does not add separate state-row deletion; the spec records this.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `crates/governance-store/src/group_keys.rs` | Modify | Add `GroupKeyring::delete_all_for_group(&self)` + unit test. |
+| `crates/governance-store/src/local_state.rs` | Modify | Call `GroupKeyring::new(store, *group_id).delete_all_for_group()` inside `delete_group_local_rows` (add import). |
+| `crates/context/src/self_purge.rs` | Modify (tests only) | Add a cascade test asserting AES keys are purged for root + subgroup. |
+
+---
+
+## Task 1: Add `GroupKeyring::delete_all_for_group`
+
+Mirror `SigningKeysRepository::delete_all_for_group`. `GroupKeyEntry`, `GROUP_KEY_PREFIX`, and `collect_keys_with_prefix` are already imported in `group_keys.rs`; the enumeration pattern already exists in `load_current_key_record`.
+
+**Files:**
+- Modify: `crates/governance-store/src/group_keys.rs`
+- Test: same file, new `#[cfg(test)]` module.
+
+- [ ] **Step 1: Write the failing test**
+
+Add at the end of `crates/governance-store/src/group_keys.rs`:
+
+```rust
+#[cfg(test)]
+mod delete_tests {
+    use super::*;
+    use calimero_store::db::InMemoryDB;
+    use std::sync::Arc;
+
+    fn test_store() -> Store {
+        Store::new(Arc::new(InMemoryDB::owned()))
+    }
+
+    #[test]
+    fn delete_all_for_group_removes_all_keys_and_is_scoped() {
+        let store = test_store();
+        let gid = ContextGroupId::from([0x42u8; 32]);
+        let ring = GroupKeyring::new(&store, gid);
+
+        let id1 = ring.store_key(&[0x01u8; 32]).unwrap();
+        let _id2 = ring.store_key(&[0x02u8; 32]).unwrap();
+        assert!(ring.load_current_key().unwrap().is_some());
+        assert!(ring.load_key_by_id(&id1).unwrap().is_some());
+
+        // Seed a different group; it must survive the targeted delete.
+        let other = ContextGroupId::from([0x99u8; 32]);
+        let other_ring = GroupKeyring::new(&store, other);
+        let _ = other_ring.store_key(&[0x03u8; 32]).unwrap();
+
+        ring.delete_all_for_group().unwrap();
+
+        assert!(
+            ring.load_current_key().unwrap().is_none(),
+            "all group encryption keys for the target group must be gone"
+        );
+        assert!(ring.load_key_by_id(&id1).unwrap().is_none());
+        assert!(
+            other_ring.load_current_key().unwrap().is_some(),
+            "another group's keys must NOT be deleted"
+        );
+
+        // Idempotent: deleting again is a no-op.
+        ring.delete_all_for_group().unwrap();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `rustup run 1.88.0 cargo test -p calimero-governance-store delete_all_for_group_removes_all_keys -- --nocapture`
+Expected: FAIL — `no method named delete_all_for_group found for struct GroupKeyring`.
+
+- [ ] **Step 3: Implement the method**
+
+In `crates/governance-store/src/group_keys.rs`, inside `impl<'a> GroupKeyring<'a>` (next to `load_current_key`), add:
+
+```rust
+/// Delete every stored group encryption key (`GroupKeyEntry`) for this
+/// group. Used by the purge/leave cascade for forward-secrecy hygiene —
+/// mirrors `SigningKeysRepository::delete_all_for_group`. Idempotent.
+pub fn delete_all_for_group(&self) -> EyreResult<()> {
+    let gid = self.group_id.to_bytes();
+    let keys = collect_keys_with_prefix(
+        self.store,
+        GroupKeyEntry::new(gid, [0u8; 32]),
+        GROUP_KEY_PREFIX,
+        |k| k.group_id() == gid,
+    )?;
+    let mut handle = self.store.handle();
+    for key in keys {
+        handle.delete(&key)?;
+    }
+    Ok(())
+}
+```
+
+(No new imports: `GroupKeyEntry`, `GROUP_KEY_PREFIX` come from the existing `use calimero_store::key::{GroupKeyEntry, GroupKeyValue, GROUP_KEY_PREFIX};`, and `collect_keys_with_prefix` from `use super::collect_keys_with_prefix;`. The seek-start is `GroupKeyEntry::new(gid, [0u8; 32])` — note the key_id tail is a raw `[u8; 32]`, so **no** `.into()`.)
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `rustup run 1.88.0 cargo test -p calimero-governance-store delete_all_for_group_removes_all_keys`
+Expected: PASS.
+
+- [ ] **Step 5: Format + commit**
+
+```bash
+rustup run 1.88.0 cargo fmt -p calimero-governance-store
+git add crates/governance-store/src/group_keys.rs
+git commit -m "feat(governance-store): add GroupKeyring::delete_all_for_group"
+```
+
+---
+
+## Task 2: Delete group encryption keys in `delete_group_local_rows`
+
+Wire the new method into the per-group purge so it fires on every cascade path (namespace-root leave and subgroup leave).
+
+**Files:**
+- Modify: `crates/governance-store/src/local_state.rs`
+
+- [ ] **Step 1: Add the import**
+
+In `crates/governance-store/src/local_state.rs`, the `delete_group_local_rows` body uses repositories imported via `use crate::{...}` near the top of the file. Add `GroupKeyring` to that import group. Find the existing `use crate::{` block (it pulls in `MembershipRepository`, `CapabilitiesRepository`, `MetadataRepository`, `UpgradesRepository`, `UpgradeLadderRepository`, `SigningKeysRepository`, `DenyListRepository`, `MetaRepository`) and add `GroupKeyring` to it. If the imports are individual `use crate::X;` lines instead, add `use crate::GroupKeyring;` alongside them.
+
+- [ ] **Step 2: Insert the deletion call**
+
+In `delete_group_local_rows`, immediately after this existing line (currently `local_state.rs:480`):
+
+```rust
+    SigningKeysRepository::new(store).delete_all_for_group(group_id)?;
+```
+
+add:
+
+```rust
+    GroupKeyring::new(store, *group_id).delete_all_for_group()?;
+```
+
+(`GroupKeyring::new` takes `group_id` by value — `ContextGroupId` is `Copy` — hence `*group_id`. Same `?`/`EyreResult` propagation as the surrounding deletes, so an AES-delete failure is load-bearing exactly like the signing-key delete, keeping the cascade's existing retry-anchor semantics.)
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `rustup run 1.88.0 cargo build -p calimero-governance-store`
+Expected: compiles clean. (Behavioral verification is Task 3's cascade test, which runs `delete_group_local_rows` via the real purge path.)
+
+- [ ] **Step 4: Run existing crate tests for no regressions**
+
+Run: `rustup run 1.88.0 cargo test -p calimero-governance-store`
+Expected: PASS.
+
+- [ ] **Step 5: Format + commit**
+
+```bash
+rustup run 1.88.0 cargo fmt -p calimero-governance-store
+git add crates/governance-store/src/local_state.rs
+git commit -m "feat(governance-store): purge group encryption keys in delete_group_local_rows"
+```
+
+---
+
+## Task 3: Cascade test — AES keys purged for root + subgroup
+
+Prove the end-to-end namespace purge deletes the AES group keys for the root **and** a nested subgroup. Self-contained test (controls all ids), placed alongside the existing `cascade_namespace_state_*` tests in `self_purge.rs`.
+
+**Files:**
+- Modify: `crates/context/src/self_purge.rs` (test module only)
+
+- [ ] **Step 1: Add `GroupKeyring` to the test module imports**
+
+In the `#[cfg(test)]` module of `crates/context/src/self_purge.rs`, the import line (around `self_purge.rs:1255`):
+
+```rust
+use calimero_governance_store::{
+    MembershipRepository, MetaRepository, PendingSelfPurgeRepository, SigningKeysRepository,
+};
+```
+
+change to add `GroupKeyring` and `NamespaceRepository` (NamespaceRepository is already in scope via `use super::*`, but import it explicitly here if the build complains):
+
+```rust
+use calimero_governance_store::{
+    GroupKeyring, MembershipRepository, MetaRepository, PendingSelfPurgeRepository,
+    SigningKeysRepository,
+};
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add this test to the same `#[cfg(test)]` module (it reuses the module's existing `empty_store()` and `make_meta()` helpers):
+
+```rust
+#[test]
+fn cascade_namespace_state_purges_group_encryption_keys_root_and_subgroups() {
+    // A namespace root + one nested subgroup, each holding an AES group
+    // encryption key. A namespace-root cascade must delete BOTH — an
+    // evicted TEE replica must not retain decryption keys (forward secrecy).
+    let mut rng = OsRng;
+    let store = empty_store();
+
+    let ns_id = ContextGroupId::from([0x70u8; 32]);
+    let sub_id = ContextGroupId::from([0x71u8; 32]);
+
+    let self_sk = PrivateKey::random(&mut rng);
+    let self_pk = self_sk.public_key();
+
+    // Root group.
+    MetaRepository::new(&store)
+        .save(&ns_id, &make_meta(self_pk))
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member_with_keys(
+            &ns_id,
+            &self_pk,
+            GroupMemberRole::Admin,
+            Some([0xAA; 32]),
+            Some([0xBB; 32]),
+        )
+        .unwrap();
+    NamespaceRepository::new(&store)
+        .store_identity(&ns_id, &self_pk, &[0xAA; 32], &[0xBB; 32])
+        .unwrap();
+
+    // Nested subgroup under the namespace root.
+    MetaRepository::new(&store)
+        .save(&sub_id, &make_meta(self_pk))
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member_with_keys(
+            &sub_id,
+            &self_pk,
+            GroupMemberRole::ReadOnlyTee,
+            Some([0xCC; 32]),
+            Some([0xDD; 32]),
+        )
+        .unwrap();
+    NamespaceRepository::new(&store).nest(&ns_id, &sub_id).unwrap();
+
+    // Seed an AES group encryption key on BOTH groups.
+    GroupKeyring::new(&store, ns_id).store_key(&[0x11u8; 32]).unwrap();
+    GroupKeyring::new(&store, sub_id).store_key(&[0x22u8; 32]).unwrap();
+    assert!(GroupKeyring::new(&store, ns_id)
+        .load_current_key()
+        .unwrap()
+        .is_some());
+    assert!(GroupKeyring::new(&store, sub_id)
+        .load_current_key()
+        .unwrap()
+        .is_some());
+
+    let result = cascade_namespace_state(&store, ns_id);
+    assert!(
+        result.purged_groups >= 2,
+        "root + subgroup must be purged, got {}",
+        result.purged_groups
+    );
+
+    assert!(
+        GroupKeyring::new(&store, ns_id)
+            .load_current_key()
+            .unwrap()
+            .is_none(),
+        "root AES group encryption key MUST be purged"
+    );
+    assert!(
+        GroupKeyring::new(&store, sub_id)
+            .load_current_key()
+            .unwrap()
+            .is_none(),
+        "subgroup AES group encryption key MUST be purged"
+    );
+}
+```
+
+- [ ] **Step 3: Run the test, verify it fails — then passes after Tasks 1+2**
+
+Run: `rustup run 1.88.0 cargo test -p calimero-context cascade_namespace_state_purges_group_encryption_keys -- --nocapture`
+Expected: With Tasks 1+2 already committed, this should **PASS**. If you are running Task 3 before Tasks 1+2 are in, it FAILS on the post-cascade `is_none()` assertions (keys survive). Confirm the assertions are real by temporarily reverting the Task 2 line if in doubt — then ensure it passes with Task 2 present.
+
+> NOTE: confirm `NamespaceRepository::nest(&parent, &child)` and `MembershipRepository::add_member_with_keys(&gid, &pk, role, Some([u8;32]), Some([u8;32]))` signatures against the file (they match `seed_namespace_self_member` + the Phase 1 tests). If `nest` differs, use whatever the existing multi-group cascade test (`cascade_namespace_state_drops_multi_group_subtree`) uses to build a nested subgroup.
+
+- [ ] **Step 4: Run the broader suites for no regressions**
+
+Run: `rustup run 1.88.0 cargo test -p calimero-context -p calimero-governance-store`
+Expected: PASS.
+
+- [ ] **Step 5: Format + commit**
+
+```bash
+rustup run 1.88.0 cargo fmt -p calimero-context
+git add crates/context/src/self_purge.rs
+git commit -m "test(context): assert namespace purge deletes group encryption keys (root + subgroup)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Workspace fmt + the affected crates**
+
+```bash
+rustup run 1.88.0 cargo fmt --all -- --check
+rustup run 1.88.0 cargo test -p calimero-governance-store -p calimero-context
+```
+Expected: fmt clean (CI fmt uses the 1.88 rustfmt), both crates green including the three new/extended tests.
+
+- [ ] **Scope self-check:** confirm only `group_keys.rs`, `local_state.rs`, and `self_purge.rs` (tests) changed; no public-API change to `calimero-server-primitives` / `calimero-tee-attestation`; no mero-tee/mdma files.

--- a/docs/superpowers/specs/2026-06-16-disable-ha-leave-and-purge-design.md
+++ b/docs/superpowers/specs/2026-06-16-disable-ha-leave-and-purge-design.md
@@ -1,0 +1,73 @@
+# Disable HA → leave namespace + all subgroups + delete data & keys — Design
+
+| | |
+|---|---|
+| **Goal** | When HA is disabled for a namespace, the TEE fleet node leaves the namespace **and every subgroup**, and deletes its local data **and all keys** (signing keys + AES group encryption keys) for that namespace subtree. |
+| **Source of truth** | **mdma.** The node leaves + purges whenever mdma definitively drops the namespace from its fleet assignments — for *any* reason (HA disabled, slot reclaimed, MRTD distrust). |
+| **Date** | 2026-06-16 |
+| **Branch (part 1)** | `feat/self-purge-delete-group-keys` (core) |
+| **Relation** | Teardown side of the namespace-TEE program; resolves proposal §11 Q6 (disable cascade) and the §6 disable-amplifier. Pairs with the merged self-purge lineage (#2686/#2721/#2724/#2725/#2764) and Phase 1 admission (PR #2772). |
+
+---
+
+## Problem
+
+Disabling HA in mdma (`HaRequest.status=disabled`) is a **soft** signal: the namespace drops out of `should-join`, the sidecar stops being assigned it, and mdma's cap accounting ages out after the freshness TTL (900s). **Nothing evicts the TEE node at the governance layer, and nothing deletes its keys.** Verified against source:
+
+1. **No trigger.** Core has no mdma client and no disable hook; mdma never writes the governance DAG. So `TeeMemberRemoved` is never emitted on disable, `self_purge` never runs. The node's `ReadOnlyTee` rows at the root and in every Restricted subgroup — and the delivered subgroup keys — **persist on-node indefinitely**.
+2. **Even an explicit leave doesn't delete the encryption keys.** `meroctl namespace leave <ns>` → `GroupOp::MemberLeft` cascade → `self_purge` *does* evict from the namespace + all subgroups and deletes membership rows, **signing** keys (`GroupSigningKey`), namespace identity, contexts, gov-op log, and unsubscribes. **But it does not delete the AES group *encryption* keys** (`GroupKeyEntry` / `GroupKeyring`). No code path in core deletes group encryption keys at all — `GroupKeyring` has no delete method. So the replica keeps the decryption keys for everything it ever held, at root and every subgroup.
+
+Net: turning HA "off" neither evicts the replica nor takes the keys away. This is the forward-secrecy / cleanup hole this design closes.
+
+---
+
+## Design
+
+Three parts, in dependency order. Part 1 (core) must land **and be released** before Part 2 (sidecar) is meaningful — otherwise a triggered leave evicts but still leaves the AES keys on disk.
+
+### Part 1 — Core: make purge actually delete the group encryption keys
+
+The eviction + cascade machinery already exists and is correct (`MemberLeft` → per-subgroup removal + `self_purge` `PurgeAction::Namespace`, which already iterates root + all descendants via `cascade_namespace_state`). The single gap is that `delete_group_local_rows` does not delete `GroupKeyEntry` rows.
+
+- Add `GroupKeyring::delete_all_for_group(&self) -> EyreResult<()>` (mirrors `SigningKeysRepository::delete_all_for_group`) that deletes all `GroupKeyEntry` rows for its `group_id`.
+- Call it inside `delete_group_local_rows` (`crates/governance-store/src/local_state.rs`), alongside the existing `SigningKeysRepository::delete_all_for_group`, so every group the purge sweeps (root + each subgroup) has its AES keys deleted too.
+- Verify the namespace purge also removes the **context state / application data** for the subtree; if `cascade_namespace_state` leaves encrypted state rows, deleting the keys crypto-shreds them (acceptable), but prefer deleting the state rows where a clean delete exists. Document whichever is the case.
+- This is a **purge-contract change** in `calimero-governance-store` (sensitive; same area as the merged self-purge work). It is independently valuable: `self_purge` should delete group keys regardless of this feature. Ship as its own core PR.
+- **Tests:** unit test that `delete_group_local_rows` removes `GroupKeyEntry` for a group; extend the self-purge namespace-cascade test to assert no `GroupKeyEntry` survives for the root or any subgroup after `PurgeAction::Namespace`. Reuse the existing self-purge test fixtures.
+
+**Non-goal for Part 1:** the trigger. Part 1 only makes "leave/purge" complete (keys deleted). It does not decide *when* to leave.
+
+### Part 2 — mero-tee: sidecar leave-on-disable, safety-gated
+
+The trigger lives in the fleet sidecar (`mero-tee/mero-tee/ansible/roles/merotee/templates/fleet-sidecar.sh.j2`), the only local agent that sees mdma and can drive `meroctl`.
+
+- **Poll-success gate (safety-critical).** Today `poll_mdma` swallows any curl failure into `{"assignments":[]}` — so a transient mdma outage looks identical to "everything disabled." Add an explicit success signal (mirror `confirm_assignment`'s `0/1` return): the leave step runs **only** on a should-join that returned **HTTP 200 with a parseable assignments body**. On any failure, do nothing (the existing benign re-join behavior is unchanged).
+- **Leave on definitive drop.** On a good response, compute `to_leave = confirmed − desired`. For each, run `meroctl --home … --node … namespace leave <group_id>` (the `group_id` is the namespace id, hex, passed verbatim from the should-join response — same value used for `fleet-join`). Make it **idempotent / non-fatal**: a leave of a namespace the node already left returns an error string ("nothing to leave" / "not a direct member") — log and continue, never abort the loop. Then let the existing intersection-prune persist the dropped set.
+- **Insertion point:** in the `while` loop, after the join-reconcile and before the existing prune, gated on poll-success.
+- **Release:** bump `mero-tee/versions.json` `imageVersion`; rebuild → new MRTD → publish `published-mrtds.json` + update `compatibility-catalog.json`.
+
+### Part 3 — mdma: release coordination
+
+- mdma must add the new node-image MRTD to its allowlist (consumed from `mero-tee-vX.Y.Z/published-mrtds.json`) before the new image rolls out, else new-image nodes get zero assignments.
+- No mdma logic change is required for the feature itself — disable already works (soft status flip). mdma stays the source of truth; the node reacts to mdma's `should-join` response.
+
+---
+
+## Safety & correctness
+
+- **Only a definitive mdma signal triggers leave.** A 200-OK should-join that omits a previously-confirmed namespace is mdma authoritatively saying "you are not assigned here" — whether due to disable, slot-reclaim, or MRTD-distrust. In all cases the node is no longer entitled, so leave + purge is correct. Transient failures (curl error/timeout/non-200/unparseable) never trigger leave.
+- **No false-purge churn.** A healthy node polls every ~1s, so its FleetAssignment never ages out (900s TTL) and is never spuriously reclaimed; it only drops on a real disable/reclaim.
+- **Idempotent + crash-safe.** `meroctl namespace leave` is a safe error on a non-member; core's self-purge has a startup reconcile sweep that completes an interrupted purge on restart.
+- **Cascade is symmetric.** `MemberLeft` removes the node's direct row in every subgroup it held one in and emits per-subgroup `TeeMemberRemoved`; `self_purge` `PurgeAction::Namespace` purges root + all descendants. After Part 1, that purge includes the AES group keys.
+
+## Out of scope
+
+- Node-resident liveness heartbeat / verifier-side revocation reaper (dropped — see memory; no driver).
+- Changing mdma's pull/soft-disable model (it stays source of truth).
+- Open-subgroup handling — covered transitively (Open subgroups inherit the namespace; purging the namespace subtree removes them too).
+
+## Sequencing
+
+1. **Part 1 (core)** — key-deletion in purge. Land + release (merod build).
+2. **Part 2 (mero-tee)** — sidecar leave-on-disable, gated. New node image (picks up the released merod + the new sidecar). New MRTD.
+3. **Part 3 (mdma)** — trust the new MRTD before rollout.


### PR DESCRIPTION
## Summary

Closes a forward-secrecy gap in the self-purge / namespace-leave cascade: an evicted node retained the **AES group encryption keys** for the namespace and every subgroup, because *no code path deleted group encryption keys anywhere* (`GroupKeyring`/`GroupKeyEntry` had no delete method; the purge deleted only `GroupSigningKey`).

- Add `GroupKeyring::delete_all_for_group` — group-scoped, idempotent, mirrors `SigningKeysRepository::delete_all_for_group`.
- Call it from `delete_group_local_rows` (right after the signing-key delete), so it fires on **every** purge/leave/delete path: namespace-root leave (`cascade_namespace_state`, root + all descendants), subgroup-only leave (`purge_subgroup_for_self`), and the group-deleted apply path.
- Deleting the keys **crypto-shreds** the encrypted context state (the purge does not separately delete state-CRDT rows — documented in the design).

This is **Part 1** of the "disable HA → leave + purge" design (`docs/superpowers/specs/2026-06-16-disable-ha-leave-and-purge-design.md`). Part 2 (mero-tee sidecar: trigger leave when mdma drops the namespace, gated on poll-success) and Part 3 (mdma MRTD allowlist) are separate, sequenced follow-ons — this PR is the foundational core piece they depend on.

## Test Plan
- [x] Unit: `delete_all_for_group` removes the target group's keys, leaves other groups' keys, idempotent (governance-store).
- [x] Cascade e2e: namespace-root purge deletes AES keys for **root + nested subgroup** via the real `cascade_namespace_state` → `delete_group_local_rows`.
- [x] Subgroup-only leave: `purge_subgroup_for_self` deletes the subgroup's own AES key.
- [x] `cargo test -p calimero-governance-store -p calimero-context` green; `cargo fmt --all --check` clean (1.88.0).

## Scope
Core only — `group_keys.rs`, `local_state.rs`, `self_purge.rs` (tests). No public-API change to `calimero-server-primitives`/`calimero-tee-attestation` (no mero-tee rev bump); no mdma/mero-tee files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the sensitive governance-store purge contract and local key deletion on leave/eviction; behavior is narrow, mirrors signing-key deletion, and failures still use existing retry-anchor semantics, but any bug could leave keys behind or affect purge completion.
> 
> **Overview**
> Closes a **forward-secrecy gap**: self-purge and leave cascades removed signing keys but left **AES group encryption keys** (`GroupKeyEntry`) on disk, so an evicted TEE replica could still decrypt stored ciphertext.
> 
> Adds **`GroupKeyring::delete_all_for_group`** (group-scoped prefix scan + delete, idempotent, `pub(crate)`) and calls it from **`delete_group_local_rows`** immediately after the existing signing-key wipe. That hooks **every** per-group teardown path—namespace-root cascade (root + descendants), subgroup-only purge, and group-delete apply—without new public APIs.
> 
> Encrypted context state rows are **not** deleted separately; removing the keys **crypto-shreds** that data, which matches the documented design.
> 
> Tests: unit coverage for scoped delete + idempotency in `group_keys.rs`; `self_purge` tests assert AES keys are gone after full namespace cascade and after subgroup-only leave. Design/plan docs added under `docs/superpowers/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f98290497ecfd6f5bd31e74f33fcc0385e34a6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->