### PR TITLE
docs: unified causal log cutover plan

### DIFF
--- a/docs/design/unified-causal-log-cutover-plan.md
+++ b/docs/design/unified-causal-log-cutover-plan.md
@@ -1,0 +1,155 @@
+# Unified causal log — cutover plan (P5 migration, core#2716)
+
+Status: **blueprint**. The additive foundation is complete and merged/landing
+in PR #2775 (crates `op`/`authz`/`projection`/`op-adapter`, the property
+harness, op coverage, and both halves of the data-write decision proven
+fold-equivalent — see `unified-causal-log-p5-decisions.md`). This document
+sequences the **cutover**: replacing the three separate per-context op stores
+(data DAG, governance DAGs, rotation log) and the `state_hash`/`root_hash`
+convergence signal with one op-log + `ScopeState` projection + `scope_root`,
+then deleting the old folds.
+
+## Ground rules
+
+- **§9.8 flag-day, no backwards compat.** A coordinated redeploy; nodes
+  re-bootstrap and re-sync. No migration tool, no re-projection. The on-disk
+  format already broke at #2745, so re-bootstrap is already required. Lean on
+  the migrations-v2 `resync_context` client method for the operator-facing
+  "wipe + re-sync" path rather than building a bespoke one.
+- **Each behavioral slice is its own PR, gated on a divergence-zero e2e run**
+  (merobox / scaffolding-e2e / Sync-regression), run by the maintainer. The
+  cutover slice (C4) does not merge until that signal is green.
+- **Author + unit-test in this repo; the maintainer runs CI/e2e** (ratified
+  2026-06-17). Slices are ordered so each compiles, passes unit tests, and is
+  independently reviewable.
+
+## Why the order is "augment the signal → unify the store → cut the decision → delete"
+
+The security property of #2716 (a hash-neutral ACL/membership rotation can't be
+hidden) is delivered the moment the convergence signal folds ACL + membership
+in — **before** the store is unified. So C1 (the `scope_root` signal) ships the
+security win early and low-risk. The store unification (C2/C3) is mechanical
+plumbing once the projection is authoritative for the signal. The decision cut
+(C4) and deletion (C5) are last, when nothing else reads the old folds.
+
+---
+
+## C1 — `scope_root`: fold ACL + groups into the convergence signal
+
+**Goal.** Replace the bare entity `root_hash` on the wire and in comparison
+with `scope_root = H(entities_root ‖ acl_hash ‖ groups_root)` (the combiner
+already in `calimero_op::scope_root`). `entities_root` stays the **existing,
+proven storage Merkle `root_hash`** — we do not re-hash entities. `acl_hash`
+and `groups_root` come from the projection's `AclView` / `ScopeState`.
+
+This is the kernel security win: a divergent writer set or membership becomes a
+divergent root, so sync can never declare "done" while authorization disagrees.
+
+**Touch points (from the blast-radius survey):**
+- Compute: a pure node-side `compute_scope_root(root_hash, &AclView)` helper
+  (additive, unit-tested first — slice C1a, below).
+- Ship: `DagHeadsResponse.root_hash` → carry `scope_root`
+  (`crates/node/primitives/src/sync/wire.rs`). Also `SnapshotStreamRequest`
+  /`SnapshotBoundaryResponse` boundary hashes.
+- Compare: `protocol_selector.rs:~142`, `level_sync.rs:~587`,
+  `hash_comparison.rs:~309`, `reconciler.rs:~388` — every local-vs-peer
+  root comparison switches to `scope_root`.
+- The HC entity tree-walk itself is unchanged (it still reconciles entities by
+  the storage Merkle); only the *top-level convergence decision* uses
+  `scope_root`. Divergence localized to acl/groups (entities_root equal but
+  scope_root differs) routes to a governance/ACL pull, not an entity tree-walk.
+
+**e2e gate:** concurrent-rotation + governance scenarios converge;
+hash-neutral-rotation canary now *fails to hide* (a divergent writer set keeps
+sync alive until reconciled). This subsumes the #2607 "verified-but-divergent"
+guard for the ACL/membership dimension.
+
+**C1a (verifiable now, additive, no wire change):** the pure
+`compute_scope_root` helper + tests proving a hash-neutral ACL change moves the
+root. Lands in PR #2775 or this branch without an e2e gate (no behavior change).
+
+## C2 — one `DagStore<Op>` per context (the unified store)
+
+**Goal.** Collapse `DagStore<Vec<Action>>` + `DagStore<SignedGroupOp>` +
+`DagStore<SignedNamespaceOp>` + the rotation log into a single
+`DagStore<Op>` per context, applied by one `UnifiedApplier` that folds each op
+into `ScopeState` (data → storage apply as today; acl/membership/admin →
+projection state). `Op` is the `crates/op` envelope; the per-plane encoders in
+`op-adapter` become the *construction* path (local ops) and the wire decode
+path (remote ops).
+
+**Touch points:**
+- New `UnifiedApplier: DeltaApplier<Op>` replacing `ContextStorageApplier`
+  (`delta_store.rs:245`), `GroupGovernanceApplier` + `NamespaceGovernanceApplier`
+  (`governance_dag.rs:16/67`). Data ops still drive `__calimero_sync_next`;
+  acl/membership/admin ops drive `ScopeState::apply` + the storage rotation /
+  membership writes that remain authoritative until C5.
+- Persistence: one keyspace for `Op` rows keyed `[ContextId ‖ OpId]` (repurpose
+  `Column::Delta`; retire the governance-op and rotation keyspaces). `dag_heads`
+  in `Column::Config` now tracks the unified DAG.
+- `load_persisted_deltas` / `persist_cascaded_deltas_and_update_heads`
+  (`delta_store.rs:1260/2818`) operate on `Op`.
+
+**e2e gate:** full lifecycle (create context, add/remove members, rotate
+writers, concurrent writes) converges; partial-replication isolation holds
+(Invariant 0 — non-member never receives a scope's ops).
+
+## C3 — projection-authoritative reads
+
+**Goal.** Reads that today hit the three stores (writer resolution, membership
+status, admin/policy) now read `ScopeState::acl_view_at(parents)`. The old
+resolvers (`rotation_log::resolve_local`, governance `acl_view_at`,
+`membership_status_at`) become thin shims over the projection, then are removed
+in C5. (Fold-equivalence for both halves is already proven, so this is a
+mechanical swap behind the same call signatures.)
+
+**e2e gate:** same scenarios as C2; writer/membership decisions unchanged.
+
+## C4 — `authorize` is the decision (the cut)
+
+**Goal.** Replace `authorize_delta_at_edge` (`verify.rs:60`) +
+`writers_at_authenticated` (storage) with one
+`authorize(op, ScopeState::acl_view_at(op.parents))` at every apply site. This
+is the single security decision; the two-layer split (membership gate +
+per-object writer gate) collapses into one fold. The new pull-side membership
+gate added on master by #2763 is subsumed (a non-member's ops never authorize).
+
+**e2e gate (the big one):** divergence==0 across concurrent-rotation,
+governance add/remove, group-remove (closes #19 for free — no authorless
+plane), and the snapshot/HC/level paths. **C4 does not merge until this is
+green**, per the ratified gate.
+
+## C5 — delete the old folds (~3,500 LOC)
+
+Once nothing reads them:
+- `crates/storage/src/rotation_log.rs`, `crates/node/src/sync/rotation_log_reader.rs`
+- `crates/context/src/governance_dag.rs`, `apply_local_signed_group_op`,
+  `apply_signed_namespace_op`, `membership_status_at`-as-fold
+- `state_hash` field on `SignedGroupOp`/`SignedNamespaceOp` +
+  `compute_group_state_hash` + `snapshot_context_state_hashes`
+- the `op-adapter` crate itself (its job — proving equivalence — is done)
+- `Column::Group` op rows / rotation keyspaces
+
+group-remove (#19) closes here structurally.
+
+## P6 (separate epic, after C5)
+
+Collapse `HashComparison` / `Snapshot` / `LevelWise` / `protocol_selector` /
+governance catch-up / `rotation_log_reader` into one per-scope sync engine
+(head-accumulator → pull-by-ancestry → re-project; Merkle-diff + checkpoint as
+strategies), per-shard + membership-gated (Invariant 0). The survey shows this
+surface grew with migrations-v2 (chained catch-up, parent-pull short-circuit,
+the peer-auth gate) — re-survey before starting.
+
+## Risk register
+
+- **entities_root ≠ projection entities hash.** Resolved by *keeping* the
+  storage Merkle as `entities_root` and only folding acl/groups into
+  `scope_root` (C1). The projection does not re-hash entity state.
+- **Concurrent equal-HLC rotation tiebreak.** `ScopeState` uses `op_id`
+  (content-addressed → identical on all nodes → deterministic convergence,
+  proven by the harness). The old `resolve_local` signer-digest tiebreak dies
+  with it in C5; moot under flag-day (no mixed-version window).
+- **No e2e in authoring env.** Every behavioral slice (C1 wire-up, C2–C4)
+  carries an explicit e2e gate run by the maintainer; unit + property tests are
+  the authoring-time signal.

--- a/docs/design/unified-causal-log-cutover-plan.md
+++ b/docs/design/unified-causal-log-cutover-plan.md
@@ -1,7 +1,7 @@
-# Unified causal log — cutover plan (P5 migration, core#2716)
+# Unified causal log — cutover plan
 
-Status: **blueprint**. The additive foundation is complete and merged/landing
-in PR #2775 (crates `op`/`authz`/`projection`/`op-adapter`, the property
+Status: **blueprint**. The additive foundation is merged in #2775 (the
+`op`/`authz`/`projection`/`op-adapter` crates, the scope-isolation property
 harness, op coverage, and both halves of the data-write decision proven
 fold-equivalent — see `unified-causal-log-p5-decisions.md`). This document
 sequences the **cutover**: replacing the three separate per-context op stores
@@ -9,25 +9,33 @@ sequences the **cutover**: replacing the three separate per-context op stores
 convergence signal with one op-log + `ScopeState` projection + `scope_root`,
 then deleting the old folds.
 
+> **Note on references.** This plan names files by **path + stable symbol**
+> (struct/function), not line numbers — the codebase is actively refactored
+> between slices, so line numbers would be stale by the time each slice lands.
+> Verify the symbol against `HEAD` when starting a slice.
+
 ## Ground rules
 
-- **§9.8 flag-day, no backwards compat.** A coordinated redeploy; nodes
-  re-bootstrap and re-sync. No migration tool, no re-projection. The on-disk
-  format already broke at #2745, so re-bootstrap is already required. Lean on
-  the migrations-v2 `resync_context` client method for the operator-facing
-  "wipe + re-sync" path rather than building a bespoke one.
+- **Flag-day, no backwards compat.** A coordinated redeploy; nodes re-bootstrap
+  and re-sync. No migration tool, no re-projection. The on-disk format already
+  broke in #2745, so re-bootstrap is already required. The operator-facing "wipe
+  + re-sync" path reuses the existing `resync_context` admin endpoint
+  (`crates/server/src/admin/handlers/context/resync_context.rs`, exposed via the
+  client in `crates/context/primitives/src/client/mod.rs`) rather than a bespoke
+  one. (This is the §9.7/§9.8 decision in `unified-causal-log-p5-decisions.md`,
+  recorded 2026-06-12.)
 - **Each behavioral slice is its own PR, gated on a divergence-zero e2e run**
-  (merobox / scaffolding-e2e / Sync-regression), run by the maintainer. The
-  cutover slice (C4) does not merge until that signal is green.
-- **Author + unit-test in this repo; the maintainer runs CI/e2e** (ratified
-  2026-06-17). Slices are ordered so each compiles, passes unit tests, and is
-  independently reviewable.
+  (merobox / scaffolding-e2e / Sync-regression), run by the maintainer.
+- **Author + unit-test in this repo; the maintainer runs CI/e2e.** Slices are
+  ordered so each compiles, passes unit tests, and is independently reviewable.
+  (This division of labor for the cutover PR series was agreed 2026-06-17; it is
+  about *who runs what*, separate from the design decisions above.)
 
 ## Why the order is "augment the signal → unify the store → cut the decision → delete"
 
-The security property of #2716 (a hash-neutral ACL/membership rotation can't be
-hidden) is delivered the moment the convergence signal folds ACL + membership
-in — **before** the store is unified. So C1 (the `scope_root` signal) ships the
+The security property (a hash-neutral ACL/membership rotation can't be hidden)
+is delivered the moment the convergence signal folds ACL + membership in —
+**before** the store is unified. So C1 (the `scope_root` signal) ships the
 security win early and low-risk. The store unification (C2/C3) is mechanical
 plumbing once the projection is authoritative for the signal. The decision cut
 (C4) and deletion (C5) are last, when nothing else reads the old folds.
@@ -36,63 +44,76 @@ plumbing once the projection is authoritative for the signal. The decision cut
 
 ## C1 — `scope_root`: fold ACL + groups into the convergence signal
 
-**Goal.** Replace the bare entity `root_hash` on the wire and in comparison
-with `scope_root = H(entities_root ‖ acl_hash ‖ groups_root)` (the combiner
-already in `calimero_op::scope_root`). `entities_root` stays the **existing,
-proven storage Merkle `root_hash`** — we do not re-hash entities. `acl_hash`
-and `groups_root` come from the projection's `AclView` / `ScopeState`.
+**Goal.** Replace the bare entity `root_hash` on the wire and in comparison with
+`scope_root`, where
+
+```
+scope_root = SHA-256( entities_root ‖ acl_hash ‖ governance_hash )
+```
+
+— each input a fixed 32-byte hash, concatenated (no length prefix needed since
+all three are fixed-width), as implemented by `calimero_op::scope_root` and
+`ScopeState::scope_root_with_entities` (already on master from #2775).
+`entities_root` stays the **existing, proven storage Merkle `root_hash`** — we
+do not re-hash entities. `acl_hash` and `governance_hash` (membership + admin +
+policy + live subgroups) come from the projection.
 
 This is the kernel security win: a divergent writer set or membership becomes a
 divergent root, so sync can never declare "done" while authorization disagrees.
 
-**Touch points (from the blast-radius survey):**
-- Compute: a pure node-side `compute_scope_root(root_hash, &AclView)` helper
-  (additive, unit-tested first — slice C1a, below).
-- Ship: `DagHeadsResponse.root_hash` → carry `scope_root`
-  (`crates/node/primitives/src/sync/wire.rs`). Also `SnapshotStreamRequest`
-  /`SnapshotBoundaryResponse` boundary hashes.
-- Compare: `protocol_selector.rs:~142`, `level_sync.rs:~587`,
-  `hash_comparison.rs:~309`, `reconciler.rs:~388` — every local-vs-peer
-  root comparison switches to `scope_root`.
+**Touch points (verify symbols against HEAD):**
+- Compute: `ScopeState::scope_root_with_entities` is the combiner (already
+  landed). C1 makes the projection's `acl_hash`/`governance_hash` available at
+  the sync sites — either from a live `ScopeState` (if C2 lands first) or, as
+  interim glue, derived on demand from the existing governance store + rotation
+  logs.
+- Ship: the `root_hash` field on `DagHeadsResponse` carries `scope_root`
+  (`crates/node/primitives/src/sync/wire.rs`); likewise the snapshot boundary
+  hashes (`SnapshotStreamRequest` / `SnapshotBoundaryResponse`).
+- Compare: every local-vs-peer root comparison switches to `scope_root` — the
+  protocol selector, level-wise sync, hash-comparison protocol, and the
+  post-sync reconciler (all under `crates/node/src/sync/`).
 - The HC entity tree-walk itself is unchanged (it still reconciles entities by
   the storage Merkle); only the *top-level convergence decision* uses
-  `scope_root`. Divergence localized to acl/groups (entities_root equal but
-  scope_root differs) routes to a governance/ACL pull, not an entity tree-walk.
+  `scope_root`. Divergence localized to acl/groups (equal `entities_root`,
+  different `scope_root`) routes to a governance/ACL pull, not an entity walk.
 
-**e2e gate:** concurrent-rotation + governance scenarios converge;
-hash-neutral-rotation canary now *fails to hide* (a divergent writer set keeps
-sync alive until reconciled). This subsumes the #2607 "verified-but-divergent"
-guard for the ACL/membership dimension.
-
-**C1a (verifiable now, additive, no wire change):** the pure
-`compute_scope_root` helper + tests proving a hash-neutral ACL change moves the
-root. Lands in PR #2775 or this branch without an e2e gate (no behavior change).
+**e2e gate.** Concurrent-rotation + governance scenarios still converge, **and** a
+new **hash-neutral-rotation canary** proves a divergent ACL can no longer hide:
+add (or extend) a `scaffolding-e2e` scenario where two nodes reach an identical
+`entities_root` but a node performs a writer-set rotation, and assert sync stays
+active (does not declare "converged") until the rotation has propagated and the
+`acl_hash` agrees. This subsumes the #2607 "verified-but-divergent" guard for the
+ACL/membership dimension.
 
 ## C2 — one `DagStore<Op>` per context (the unified store)
 
 **Goal.** Collapse `DagStore<Vec<Action>>` + `DagStore<SignedGroupOp>` +
-`DagStore<SignedNamespaceOp>` + the rotation log into a single
-`DagStore<Op>` per context, applied by one `UnifiedApplier` that folds each op
-into `ScopeState` (data → storage apply as today; acl/membership/admin →
-projection state). `Op` is the `crates/op` envelope; the per-plane encoders in
-`op-adapter` become the *construction* path (local ops) and the wire decode
-path (remote ops).
+`DagStore<SignedNamespaceOp>` + the rotation log into a single `DagStore<Op>` per
+context, applied by one `UnifiedApplier` that folds each op into `ScopeState`
+(data → storage apply as today; acl/membership/admin → projection state). `Op` is
+the `calimero-op` envelope; the `op-adapter` encoders become the *construction*
+path (local ops) and the wire decode path (remote ops).
 
-**Touch points:**
+**Touch points (symbols, in `crates/node/src/delta_store.rs` and
+`crates/context/src/governance_dag.rs`):**
 - New `UnifiedApplier: DeltaApplier<Op>` replacing `ContextStorageApplier`
-  (`delta_store.rs:245`), `GroupGovernanceApplier` + `NamespaceGovernanceApplier`
-  (`governance_dag.rs:16/67`). Data ops still drive `__calimero_sync_next`;
-  acl/membership/admin ops drive `ScopeState::apply` + the storage rotation /
-  membership writes that remain authoritative until C5.
+  (delta_store), `GroupGovernanceApplier` + `NamespaceGovernanceApplier`
+  (governance_dag). Data ops still drive `__calimero_sync_next`; acl/membership/
+  admin ops drive `ScopeState::apply` plus the storage rotation / membership
+  writes that remain authoritative until C5.
 - Persistence: one keyspace for `Op` rows keyed `[ContextId ‖ OpId]` (repurpose
-  `Column::Delta`; retire the governance-op and rotation keyspaces). `dag_heads`
-  in `Column::Config` now tracks the unified DAG.
+  `Column::Delta`). `dag_heads` (in `Column::Config`) now tracks the unified DAG.
+  From this slice on, the old governance-op and rotation keyspaces are **no
+  longer written**; their on-disk **column removal** is deferred to C5 (with the
+  code that reads them), so a single flag-day redeploy + `resync_context` clears
+  the old data — no in-place migration.
 - `load_persisted_deltas` / `persist_cascaded_deltas_and_update_heads`
-  (`delta_store.rs:1260/2818`) operate on `Op`.
+  (delta_store) operate on `Op`.
 
-**e2e gate:** full lifecycle (create context, add/remove members, rotate
-writers, concurrent writes) converges; partial-replication isolation holds
-(Invariant 0 — non-member never receives a scope's ops).
+**e2e gate.** Full lifecycle (create context, add/remove members, rotate writers,
+concurrent writes) converges; partial-replication isolation holds (a non-member
+never receives a scope's ops).
 
 ## C3 — projection-authoritative reads
 
@@ -100,35 +121,55 @@ writers, concurrent writes) converges; partial-replication isolation holds
 status, admin/policy) now read `ScopeState::acl_view_at(parents)`. The old
 resolvers (`rotation_log::resolve_local`, governance `acl_view_at`,
 `membership_status_at`) become thin shims over the projection, then are removed
-in C5. (Fold-equivalence for both halves is already proven, so this is a
-mechanical swap behind the same call signatures.)
+in C5. Fold-equivalence for both halves is already proven, so this is a
+mechanical swap behind the same call signatures.
 
-**e2e gate:** same scenarios as C2; writer/membership decisions unchanged.
+**e2e gate.** This slice introduces no new *behavior*, so its gate is a
+**regression check** that the swap is transparent — but it must exercise a read
+path C2's scenarios don't: add a scenario where membership/writers are resolved
+on a **snapshot-replay or DAG-catchup** path (not just live gossip apply), on a
+2-node cluster after a concurrent rotation, and assert the projection-served
+result matches what the old resolver returned pre-swap. Without that, an
+identical-to-C2 gate couldn't distinguish a C3 regression from a passing C2.
 
 ## C4 — `authorize` is the decision (the cut)
 
-**Goal.** Replace `authorize_delta_at_edge` (`verify.rs:60`) +
-`writers_at_authenticated` (storage) with one
-`authorize(op, ScopeState::acl_view_at(op.parents))` at every apply site. This
-is the single security decision; the two-layer split (membership gate +
-per-object writer gate) collapses into one fold. The new pull-side membership
-gate added on master by #2763 is subsumed (a non-member's ops never authorize).
+**Goal.** Replace `authorize_delta_at_edge`
+(`crates/node/src/handlers/state_delta/verify.rs`) + `writers_at_authenticated`
+(storage) with one `authorize(op, ScopeState::acl_view_at(op.parents))` at every
+apply site. This is the single security decision; the two-layer split (membership
+gate + per-object writer gate) collapses into one fold.
 
-**e2e gate (the big one):** divergence==0 across concurrent-rotation,
-governance add/remove, group-remove (closes #19 for free — no authorless
-plane), and the snapshot/HC/level paths. **C4 does not merge until this is
-green**, per the ratified gate.
+**Coexistence with the #2763 pull-side gate.** The pull-side membership gate
+added on master in #2763 remains the **live** authorization through C1–C3
+(C1–C3 change the *signal* and the *store*, not the decision). C4 replaces both
+it and `authorize_delta_at_edge` **atomically within this one slice** — there is
+never a window where two gates run concurrently with potentially different
+outcomes. If C4 is delayed, the #2763 gate simply stays live; nothing regresses.
+
+**e2e gate (the big one):** divergence==0 across concurrent-rotation, governance
+add/remove, the snapshot/HC/level paths, **and** an explicit group-remove
+scenario that makes the #19 closure *verifiable*: after a group-remove op is
+applied, assert that a subsequent op authored in that group's plane is **rejected
+by `authorize`** (no authorless plane survives). **C4 does not merge until this
+is green.**
 
 ## C5 — delete the old folds (~3,500 LOC)
 
-Once nothing reads them:
-- `crates/storage/src/rotation_log.rs`, `crates/node/src/sync/rotation_log_reader.rs`
-- `crates/context/src/governance_dag.rs`, `apply_local_signed_group_op`,
-  `apply_signed_namespace_op`, `membership_status_at`-as-fold
-- `state_hash` field on `SignedGroupOp`/`SignedNamespaceOp` +
-  `compute_group_state_hash` + `snapshot_context_state_hashes`
-- the `op-adapter` crate itself (its job — proving equivalence — is done)
-- `Column::Group` op rows / rotation keyspaces
+Once nothing reads them, in dependency order:
+
+1. **Persistence layer first** — drop the old on-disk keyspaces no longer written
+   since C2: the `Column::Group` op-log rows and the rotation-log keyspace, plus
+   the `state_hash` field on `SignedGroupOp`/`SignedNamespaceOp` and
+   `compute_group_state_hash` / `snapshot_context_state_hashes`.
+2. **Resolver / apply code** — `crates/storage/src/rotation_log.rs`,
+   `crates/node/src/sync/rotation_log_reader.rs`,
+   `crates/context/src/governance_dag.rs`, `apply_local_signed_group_op`,
+   `apply_signed_namespace_op`, `membership_status_at`-as-fold.
+3. **The `op-adapter` crate** (its job — proving equivalence — is done): delete
+   `crates/op-adapter`, **and** remove it from the workspace `members` list in
+   the root `Cargo.toml` and from `deny.toml` (otherwise `cargo build` fails on a
+   missing member).
 
 group-remove (#19) closes here structurally.
 
@@ -137,19 +178,22 @@ group-remove (#19) closes here structurally.
 Collapse `HashComparison` / `Snapshot` / `LevelWise` / `protocol_selector` /
 governance catch-up / `rotation_log_reader` into one per-scope sync engine
 (head-accumulator → pull-by-ancestry → re-project; Merkle-diff + checkpoint as
-strategies), per-shard + membership-gated (Invariant 0). The survey shows this
-surface grew with migrations-v2 (chained catch-up, parent-pull short-circuit,
-the peer-auth gate) — re-survey before starting.
+strategies), per-shard + membership-gated. This surface grew with the migrations
+work (chained catch-up, parent-pull short-circuit, the peer-auth gate) — re-survey
+before starting.
 
 ## Risk register
 
-- **entities_root ≠ projection entities hash.** Resolved by *keeping* the
-  storage Merkle as `entities_root` and only folding acl/groups into
-  `scope_root` (C1). The projection does not re-hash entity state.
+- **`entities_root` ≠ projection entities hash.** Resolved by *keeping* the
+  storage Merkle as `entities_root` and only folding acl/governance into
+  `scope_root` (C1). The projection does not re-hash entity state. (Corollary:
+  `scope_root_with_entities` must be called with the storage Merkle root, **not**
+  `ScopeState`'s own entity hash — the type system can't distinguish two
+  `[u8; 32]`s, so this is a documented caller contract.)
 - **Concurrent equal-HLC rotation tiebreak.** `ScopeState` uses `op_id`
-  (content-addressed → identical on all nodes → deterministic convergence,
-  proven by the harness). The old `resolve_local` signer-digest tiebreak dies
-  with it in C5; moot under flag-day (no mixed-version window).
-- **No e2e in authoring env.** Every behavioral slice (C1 wire-up, C2–C4)
-  carries an explicit e2e gate run by the maintainer; unit + property tests are
-  the authoring-time signal.
+  (content-addressed → identical on all nodes → deterministic convergence, proven
+  by the harness). The old `resolve_local` signer-digest tiebreak dies with it in
+  C5; moot under flag-day (no mixed-version window).
+- **No e2e in authoring env.** Every behavioral slice (C1–C4) carries an explicit
+  e2e gate run by the maintainer; unit + property tests are the authoring-time
+  signal.

--- a/docs/design/unified-causal-log-cutover-plan.md
+++ b/docs/design/unified-causal-log-cutover-plan.md
@@ -51,9 +51,12 @@ plumbing once the projection is authoritative for the signal. The decision cut
 scope_root = SHA-256( entities_root ‖ acl_hash ‖ governance_hash )
 ```
 
-— each input a fixed 32-byte hash, concatenated (no length prefix needed since
-all three are fixed-width), as implemented by `calimero_op::scope_root` and
-`ScopeState::scope_root_with_entities` (already on master from #2775).
+— where each input is a fixed **32-byte** value (`entities_root` is the storage
+Merkle root; `acl_hash` and `governance_hash` are SHA-256 outputs). The plain
+concatenation is collision-free **only because all three are fixed-width**; this
+invariant is load-bearing (see the risk register). Implemented by
+`calimero_op::scope_root` and `ScopeState::scope_root_with_entities` (already on
+master from #2775).
 `entities_root` stays the **existing, proven storage Merkle `root_hash`** — we
 do not re-hash entities. `acl_hash` and `governance_hash` (membership + admin +
 policy + live subgroups) come from the projection.
@@ -105,9 +108,14 @@ path (local ops) and the wire decode path (remote ops).
 - Persistence: one keyspace for `Op` rows keyed `[ContextId ‖ OpId]` (repurpose
   `Column::Delta`). `dag_heads` (in `Column::Config`) now tracks the unified DAG.
   From this slice on, the old governance-op and rotation keyspaces are **no
-  longer written**; their on-disk **column removal** is deferred to C5 (with the
-  code that reads them), so a single flag-day redeploy + `resync_context` clears
-  the old data — no in-place migration.
+  longer written** *and no longer read* (C2+ code reads only the unified op-log);
+  their on-disk **column removal** is deferred to C5 (with the code that
+  references them). So stale old-format rows left by pre-C2 code are **inert** —
+  never read, just dead bytes until C5 drops the column. A node that missed the
+  flag-day redeploy (e.g. offline during it) has *no* unified op-log and must
+  run `resync_context` to rebuild it before it can participate; its stale old
+  columns are ignored, not interpreted. There is no path where C2+ code mixes
+  old-column data with the unified op-log.
 - `load_persisted_deltas` / `persist_cascaded_deltas_and_update_heads`
   (delta_store) operate on `Op`.
 
@@ -166,10 +174,22 @@ Once nothing reads them, in dependency order:
    `crates/node/src/sync/rotation_log_reader.rs`,
    `crates/context/src/governance_dag.rs`, `apply_local_signed_group_op`,
    `apply_signed_namespace_op`, `membership_status_at`-as-fold.
-3. **The `op-adapter` crate** (its job — proving equivalence — is done): delete
-   `crates/op-adapter`, **and** remove it from the workspace `members` list in
-   the root `Cargo.toml` and from `deny.toml` (otherwise `cargo build` fails on a
-   missing member).
+3. **The `op-adapter` crate**: delete `crates/op-adapter`, **and** remove it from
+   the workspace `members` list in the root `Cargo.toml` and from `deny.toml`
+   (otherwise `cargo build` fails on a missing member).
+
+**On losing the equivalence proofs.** The fold-equivalence tests are inherently
+*transitional*: they assert "the new projection resolves the same writer set /
+membership as the **old resolver**." Once C5 deletes the old resolvers
+(`resolve_local`, `membership_status_at`), there is nothing left to compare
+against, so those tests retire *with* the code they compare to — keeping them
+would not even compile. The durable post-cutover safety net is **not** these
+proofs but the **convergence + scope-isolation property harness** in
+`calimero-projection` (`testing` feature), which is independent of the old
+resolvers and is **not** deleted. Before deleting `op-adapter`, confirm that
+harness still covers the properties the equivalence tests were guarding (it
+does today: per-scope convergence + non-member isolation); if any unique case is
+only in an `op-adapter` test, port it into the projection harness first.
 
 group-remove (#19) closes here structurally.
 
@@ -190,6 +210,13 @@ before starting.
   `scope_root_with_entities` must be called with the storage Merkle root, **not**
   `ScopeState`'s own entity hash — the type system can't distinguish two
   `[u8; 32]`s, so this is a documented caller contract.)
+- **`scope_root` concatenation assumes fixed-width inputs.** `SHA-256(a ‖ b ‖ c)`
+  is only collision-free because `a`/`b`/`c` are each exactly 32 bytes — there is
+  no length prefix or separator. Any future change that makes a component
+  variable-length (a truncated/extended hash, a different digest) silently breaks
+  collision-resistance. Enforce the widths at the `calimero_op::scope_root`
+  boundary (it takes `[u8; 32]` arguments — keep it that way) and re-check this if
+  the digest ever changes.
 - **Concurrent equal-HLC rotation tiebreak.** `ScopeState` uses `op_id`
   (content-addressed → identical on all nodes → deterministic convergence, proven
   by the harness). The old `resolve_local` signer-digest tiebreak dies with it in


### PR DESCRIPTION
The blueprint for finishing the unified causal log: replacing the three separate per-context op stores (data DAG, governance op-logs, writer-set rotation logs) and the `state_hash`/`root_hash` convergence signal with **one op-log + `ScopeState` projection + `scope_root`**, then deleting the old folds.

This PR is **the plan document only** (`docs/design/unified-causal-log-cutover-plan.md`). The actual work lands as a sequence of separate, reviewable PRs, each gated on a maintainer-run divergence-zero e2e:

1. **Augment the signal** — ship `scope_root` (entities + ACL + groups) as the wire convergence signal, so a hash-neutral writer/membership rotation can't pass sync as "converged".
2. **Unify the store** — one `DagStore<Op>` per context, applied by one applier that folds into `ScopeState`.
3. **Projection-authoritative reads** — writer/membership/admin resolution reads the projection.
4. **Cut the decision** — `authorize` becomes the single security check.
5. **Delete** the old folds (rotation log, governance DAGs, `state_hash`, ~3,500 LOC).

The foundation these build on (the `op`/`authz`/`projection`/`op-adapter` crates, the isolation harness, and the fold-equivalence proofs) merged in #2775.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; it describes future sync/auth/storage cutover work but does not change behavior in this PR.
> 
> **Overview**
> This PR **only adds** `docs/design/unified-causal-log-cutover-plan.md` — no runtime or sync code changes.
> 
> The new doc sequences finishing the unified causal log after #2775: **flag-day redeploy** (reuse `resync_context`, no migration), **one PR per slice** with maintainer-run divergence-zero e2e, and order **signal → store → reads → authorize → delete**.
> 
> **C1** — Wire and compare **`scope_root`** (storage `entities_root` + ACL + governance) instead of bare entity `root_hash` on `DagHeadsResponse`, snapshot boundaries, and sync comparison; adds a hash-neutral rotation canary.
> 
> **C2** — One **`DagStore<Op>`** + **`UnifiedApplier`**; old governance/rotation columns stop being read/written (physical drop in C5).
> 
> **C3** — Writer/membership/admin reads from **`ScopeState::acl_view_at`** with a snapshot/DAG-catchup regression gate.
> 
> **C4** — Single **`authorize`** replaces `authorize_delta_at_edge` and storage writer checks, atomically with the #2763 pull gate.
> 
> **C5** — Remove ~3.5k LOC of old folds, keyspaces, transitional equivalence tests (projection harness stays).
> 
> Also records a **risk register** (fixed-width `scope_root` inputs, caller contract for `entities_root`) and **P6** (post-C5 sync engine consolidation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 458e59ca41607f74d3473d177ea87e4c2272be55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->