### PR TITLE
chore: bump node version to 0.11.0-rc.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Bumps the workspace release version from `0.11.0-rc.3` to `0.11.0-rc.4`.

Updates `[workspace.metadata.workspaces].version` in `Cargo.toml` — the canonical shared version stamped onto all public crates by cargo-workspaces at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata version bump with no runtime, API, or logic changes.
> 
> **Overview**
> Bumps the **cargo-workspaces** shared release version in `Cargo.toml` from `0.11.0-rc.3` to **`0.11.0-rc.4`**.
> 
> This updates `[workspace.metadata.workspaces].version`, the canonical version applied to public crates at release time (per `docs/RELEASE.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dcd223646981db22e90d0c786b8f5dda5eddba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->