### PR TITLE
fix(authz,projection): harden required_mask_for + scope_root_with_entities; doc clarifications

### DIFF
--- a/crates/authz/src/lib.rs
+++ b/crates/authz/src/lib.rs
@@ -60,6 +60,12 @@ pub struct AclView {
 /// `ADMIN` — rotating an object's writer set still requires an explicit ACL
 /// grant (ownership), so a plain member can't lock others out of a default
 /// entity.
+///
+/// Implication, by design: any member can write **and delete** any
+/// non-restricted entity in the scope (a single compromised member can wipe
+/// default data) — this matches a shared key-value store, where membership is
+/// the write boundary. Data that needs a narrower writer/deleter set must be a
+/// restricted object with an explicit ACL.
 const DEFAULT_MEMBER_MASK: OpMask = OpMask::WRITE.union(OpMask::DELETE);
 
 impl AclView {
@@ -122,13 +128,19 @@ impl AclView {
     }
 }
 
-/// The capability a data op requires of its author.
+/// The capability a **data** op requires of its author, or `None` for a
+/// non-data op (whose authority is decided by ownership/admin, not a mask).
+///
+/// Returning `None` rather than `OpMask::NONE` is deliberate: the empty mask is
+/// contained by *every* mask, so a `NONE` requirement fed to [`AclView::may`]
+/// would authorize anyone — a footgun if a non-data payload ever reached a
+/// `may` check. `None` makes that misuse impossible to express.
 #[must_use]
-pub fn required_mask_for(payload: &OpPayload) -> OpMask {
+pub fn required_mask_for(payload: &OpPayload) -> Option<OpMask> {
     match payload {
-        OpPayload::Put { .. } => OpMask::WRITE,
-        OpPayload::Delete { .. } => OpMask::DELETE,
-        _ => OpMask::NONE,
+        OpPayload::Put { .. } => Some(OpMask::WRITE),
+        OpPayload::Delete { .. } => Some(OpMask::DELETE),
+        _ => None,
     }
 }
 
@@ -141,7 +153,9 @@ pub fn required_mask_for(payload: &OpPayload) -> OpMask {
 pub fn authorize(op: &Op, acl_at_cut: &AclView) -> Result<(), Rejected> {
     match &op.payload {
         OpPayload::Put { entity, .. } | OpPayload::Delete { entity } => {
-            let required = required_mask_for(&op.payload);
+            // `required_mask_for` is total over data payloads, and this arm
+            // matches only data payloads, so the mask is always present.
+            let required = required_mask_for(&op.payload).unwrap_or(OpMask::FULL);
             if acl_at_cut.may(&op.author, *entity, required) {
                 Ok(())
             } else {

--- a/crates/authz/src/lib.rs
+++ b/crates/authz/src/lib.rs
@@ -144,6 +144,20 @@ pub fn required_mask_for(payload: &OpPayload) -> Option<OpMask> {
     }
 }
 
+/// `Ok` iff `author` holds `required` on `entity` (the data-plane check).
+fn check_data(
+    acl_at_cut: &AclView,
+    author: &PublicKey,
+    entity: Id,
+    required: OpMask,
+) -> Result<(), Rejected> {
+    if acl_at_cut.may(author, entity, required) {
+        Ok(())
+    } else {
+        Err(Rejected::NotPermitted { required })
+    }
+}
+
 /// Authorize `op` against `acl_at_cut` — the [`AclView`] resolved at
 /// `op.parents`. The **only** causal-auth decision in the unified model.
 ///
@@ -152,16 +166,12 @@ pub fn required_mask_for(payload: &OpPayload) -> Option<OpMask> {
 /// authority the op's payload requires.
 pub fn authorize(op: &Op, acl_at_cut: &AclView) -> Result<(), Rejected> {
     match &op.payload {
-        OpPayload::Put { entity, .. } | OpPayload::Delete { entity } => {
-            // `required_mask_for` is total over data payloads, and this arm
-            // matches only data payloads, so the mask is always present.
-            let required = required_mask_for(&op.payload).unwrap_or(OpMask::FULL);
-            if acl_at_cut.may(&op.author, *entity, required) {
-                Ok(())
-            } else {
-                Err(Rejected::NotPermitted { required })
-            }
-        }
+        // Split per data op so each carries its literal required mask — no
+        // `Option` to unwrap, so there is no unreachable fallback that could
+        // silently deny (or panic) if the arms ever drift. `required_mask_for`
+        // remains the public helper for external callers.
+        OpPayload::Put { entity, .. } => check_data(acl_at_cut, &op.author, *entity, OpMask::WRITE),
+        OpPayload::Delete { entity } => check_data(acl_at_cut, &op.author, *entity, OpMask::DELETE),
         OpPayload::SetWriters { object, .. } => {
             if acl_at_cut.is_owner(&op.author, *object) {
                 Ok(())

--- a/crates/op-adapter/src/lib.rs
+++ b/crates/op-adapter/src/lib.rs
@@ -97,10 +97,14 @@ fn role_from_invited_role(value: u8) -> GroupMemberRole {
 ///   *at auth time* (the context→group lookup), so it lives in that index, not
 ///   inside a scope's `ScopeState`.
 ///
-/// A `_` catch-all (rather than an exhaustive match) keeps this transitional
-/// adapter compiling as `GroupOp` grows; any genuinely auth-relevant new
-/// variant must be armed explicitly above, and the fold-equivalence coverage
-/// tests would catch a divergence if one slipped through.
+/// The auth-relevant (in-model) variants are armed explicitly; everything else
+/// maps to `None`. `GroupOp` is `#[non_exhaustive]`, so a `_` arm is mandatory
+/// here (a downstream crate cannot match it exhaustively) — which means a new
+/// upstream variant lands in `_ => None` by default. The safety net against a
+/// new *auth-relevant* op being silently dropped is the fold-equivalence test
+/// (`prefix_walk_resolution_matches_reference_under_random_inputs` in
+/// `calimero-governance-store`): if a new variant changes membership in a way
+/// the projection doesn't see, that test diverges.
 #[must_use]
 pub fn payload_from_group_op(group: ContextGroupId, op: &GroupOp) -> Option<OpPayload> {
     match op {
@@ -189,6 +193,8 @@ pub fn payload_from_root_op(op: &RootOp) -> Option<OpPayload> {
         RootOp::GroupDeleted { root_group_id, .. } => Some(OpPayload::SubgroupDeleted {
             scope: ScopeId::from(*root_group_id),
         }),
+        // Out-of-model: `KeyDelivery` is key transport, not authorization
+        // state. (`RootOp` is `#[non_exhaustive]`, so a `_` arm is mandatory.)
         _ => None,
     }
 }

--- a/crates/projection/src/lib.rs
+++ b/crates/projection/src/lib.rs
@@ -247,6 +247,16 @@ impl ScopeState {
     /// *different* root, so sync can never declare "converged" while
     /// authorization disagrees. The projection never re-hashes entity state;
     /// `entities_root` is authoritative for the data plane.
+    ///
+    /// **Caller contract:** `entities_root` MUST be the **storage layer's
+    /// Merkle root**, not this projection's own [`entities_hash`](Self) — they
+    /// are different functions (the storage Merkle vs a SHA-256 over the
+    /// projection's `BTreeMap`) and the type system can't tell two `[u8; 32]`s
+    /// apart. Passing the projection's own entity hash would produce a
+    /// valid-looking root that doesn't carry the intended cross-layer semantics.
+    /// This is intentionally NOT [`root`](Self::root) (which uses the
+    /// projection's entity hash) — the whole point is to fold authorization onto
+    /// the *storage* root.
     #[must_use]
     pub fn scope_root_with_entities(&self, entities_root: [u8; 32]) -> [u8; 32] {
         scope_root(entities_root, self.acl_hash(), self.governance_hash())
@@ -467,6 +477,29 @@ mod tests {
         assert_ne!(
             base, member_added,
             "a membership change must move scope_root even with identical entities"
+        );
+
+        // An admin change moves the root too (governance_hash folds in
+        // root_admin), so a silent admin takeover can't pass as converged.
+        let admin_changed =
+            ScopeState::from_ops([&op(10, OpPayload::AdminChanged { new_admin: pk })])
+                .scope_root_with_entities(entities_root);
+        assert_ne!(
+            base, admin_changed,
+            "an admin change must move scope_root even with identical entities"
+        );
+
+        // A policy change moves the root (governance_hash folds in policy).
+        let policy_changed = ScopeState::from_ops([&op(
+            10,
+            OpPayload::PolicyUpdated {
+                policy_bytes: vec![1, 2, 3],
+            },
+        )])
+        .scope_root_with_entities(entities_root);
+        assert_ne!(
+            base, policy_changed,
+            "a policy change must move scope_root even with identical entities"
         );
 
         // The entities component still matters: same projection, different

--- a/crates/projection/src/lib.rs
+++ b/crates/projection/src/lib.rs
@@ -614,7 +614,6 @@ mod tests {
 
     #[test]
     fn scope_tree_create_reparent_delete_is_order_independent() {
-        let scope = ScopeId::from([0u8; 32]);
         let child = ScopeId::from([0xC1; 32]);
         let p1 = ScopeId::from([0x11; 32]);
         let p2 = ScopeId::from([0x22; 32]);


### PR DESCRIPTION
Follow-up to #2775 (merged), addressing the last round of review comments.

## Changes
- **`authz::required_mask_for` → `Option<OpMask>`.** It previously returned `OpMask::NONE` for non-data payloads; since the empty mask is contained by *every* mask, feeding it to `may` would authorize anyone — a footgun if a non-data payload ever reached a `may` check. `None` makes that impossible to express, and `authorize` falls back to `OpMask::FULL` (deny-by-default) on the unreachable case, never the empty mask.
- **`DEFAULT_MEMBER_MASK` doc** now spells out the implication: any member can WRITE **and DELETE** any non-restricted entity (a single member can wipe default data). This matches a shared key-value store; narrower control needs a restricted object with an explicit ACL.
- **op-adapter encoders** document *why* they keep a `_ => None` arm — `GroupOp`/`RootOp` are `#[non_exhaustive]`, so a downstream crate **cannot** match them exhaustively (a compile-time guard isn't possible). The membership fold-equivalence property test is the safety net against a new auth-relevant variant being silently dropped.
- **projection** — removed a dead `let scope` binding in a test.

## Answered on the PR (by design, no change)
Signature verification is a wire-boundary concern (done at decode, before projection/authz see an op — same as the existing delta path); `expected_scope_root` is an unsigned assertion peers **recompute**, not trust (mirrors `CausalDelta::expected_root_hash`); `acl_view_at`'s completeness precondition is guaranteed by the DAG buffering an op until its parents are present; `.expect()` on infallible in-memory borsh matches the repo convention (276 occurrences) and carries a `# Panics` note.

All four scaffold crates green; fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and type-safety around existing auth behavior; Put/Delete authorization logic is unchanged aside from explicit mask literals.
> 
> **Overview**
> Follow-up on the unified-op foundation: **tightens the auth API** and **documents security contracts** without changing the authorization model.
> 
> **`authz`:** `required_mask_for` now returns `Option<OpMask>` (`None` for non-data ops) so callers cannot accidentally pass `OpMask::NONE` into `AclView::may` (empty mask is contained by every mask). `authorize` routes Put/Delete through a shared `check_data` helper with **literal** `WRITE`/`DELETE` masks per arm instead of unwrapping the option. Docs spell out that **default-write = membership** implies any member can write **and delete** any non-restricted entity.
> 
> **`op-adapter`:** Comments explain why `GroupOp`/`RootOp` encoders must use `_ => None` (`#[non_exhaustive]`) and point to fold-equivalence tests as the guard against silently dropped auth-relevant variants; `KeyDelivery` is called out as out-of-model.
> 
> **`projection`:** Documents the caller contract for `scope_root_with_entities` (must pass the **storage** Merkle root, not the projection’s own entity hash). Tests assert **admin** and **policy** ops change `scope_root` when entity data is unchanged; removes an unused `scope` binding in a scope-tree test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db17e404cfa2dc77a2a44906019ccd280e9a50b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->