### PR TITLE
ci: authenticate doc-update and ai-review as MeroReviewer App

### DIFF
--- a/.ai-reviewer.yaml
+++ b/.ai-reviewer.yaml
@@ -6,9 +6,10 @@
 version: 1
 
 # Anthropic Messages API.
-# We deliberately use Sonnet (cheaper than Opus) for review agents and Haiku
-# (cheaper still) for doc-prose generation. Do not switch to Opus without an
-# explicit cost discussion.
+# We deliberately use Sonnet (cheaper than Opus) for both review agents and
+# doc generation. Haiku was too weak for the doc HTML-patch task — it failed
+# to emit valid find/replace patches and most files were silently skipped.
+# Do not switch to Opus without an explicit cost discussion.
 anthropic:
   default_model: claude-sonnet-4-6
   enable_prompt_caching: true
@@ -18,7 +19,7 @@ anthropic:
 # Disabled by default upstream; enabled here so doc-update.yaml has work to do.
 doc_generation:
   enabled: true
-  model: claude-haiku-4-5-20251001  # Haiku is sufficient for prose / HTML drafting
+  model: claude-sonnet-4-6  # Sonnet: Haiku failed the HTML find/replace patch task
   max_files: 15
   static_docs_dirs:
     - architecture/   # GitHub Pages source for the architecture site

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -62,6 +62,19 @@ jobs:
       - name: Install ai-code-reviewer
         run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@06d0a027b59caba85269b5a63bac4b0e53ffa0ea
 
+      # Authenticate as the MeroReviewer App so review comments genuinely
+      # come from meroreviewer[bot] (not whatever GH_PAT/GITHUB_TOKEN
+      # resolves to), matching the --reviewer-name label below.
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: "2793509"
+          private-key: ${{ secrets.MERO_REVIEWER_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            core
+
       - name: Determine PR number and agent count
         id: pr
         run: |
@@ -77,7 +90,7 @@ jobs:
       - name: Run AI Code Review
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           ai-reviewer review-pr \
             ${{ github.repository }} \

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -66,10 +66,10 @@ jobs:
       # come from meroreviewer[bot] (not whatever GH_PAT/GITHUB_TOKEN
       # resolves to), matching the --reviewer-name label below.
       - name: Create GitHub App token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
-          app-id: "2793509"
+          app-id: ${{ vars.MERO_REVIEWER_APP_ID }}
           private-key: ${{ secrets.MERO_REVIEWER_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -60,6 +60,20 @@ jobs:
       - name: Install ai-code-reviewer
         run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@06d0a027b59caba85269b5a63bac4b0e53ffa0ea
 
+      # Mint a short-lived MeroReviewer App installation token. Unlike the
+      # default GITHUB_TOKEN, an App token is not subject to the org/repo
+      # "Allow GitHub Actions to create and approve pull requests" setting,
+      # so `ai-reviewer update-docs` can actually open the doc PR.
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: "2793509"
+          private-key: ${{ secrets.MERO_REVIEWER_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            core
+
       - name: Get merged PR number
         id: pr
         # All event-derived values flow through `env` so the shell only sees
@@ -73,7 +87,7 @@ jobs:
         # merges — and unlike the time-ordered list, it doesn't race with
         # other PRs that merge in the same window.
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number }}
           REPO: ${{ github.repository }}
           SHA: ${{ github.sha }}
@@ -113,7 +127,7 @@ jobs:
         # through `env` so the shell never string-interpolates them.
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -65,10 +65,10 @@ jobs:
       # "Allow GitHub Actions to create and approve pull requests" setting,
       # so `ai-reviewer update-docs` can actually open the doc PR.
       - name: Create GitHub App token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
-          app-id: "2793509"
+          app-id: ${{ vars.MERO_REVIEWER_APP_ID }}
           private-key: ${{ secrets.MERO_REVIEWER_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |


### PR DESCRIPTION
## Problem

The `Doc Auto-Update` workflow fails on every run with:

```
Request POST /repos/calimero-network/core/pulls failed with 403: Forbidden
Error: GitHub REST API 403 Forbidden — check token scopes
```

The job generates docs and commits them fine, then 403s at `create_pull`. Root cause: the token resolves to the default `GITHUB_TOKEN` (the `GH_PAT || GITHUB_TOKEN` fallback), and the org/repo setting **"Allow GitHub Actions to create and approve pull requests"** is disabled (`can_approve_pull_request_reviews: false`). That setting blocks `GITHUB_TOKEN` from opening PRs — but not App installation tokens.

## Fix

Mint a short-lived **MeroReviewer** App installation token (`app-id 2793509`, key in `secrets.MERO_REVIEWER_PRIVATE_KEY`) and use it in both workflows:

- **`doc-update.yaml`** — App token can open the doc PR (no longer subject to the create-PR restriction).
- **`ai-review.yaml`** — review comments now genuinely come from `meroreviewer[bot]`, matching the `--reviewer-name "MeroReviewer"` label.

This removes the last `secrets.GH_PAT` references in the repo.

## Follow-up after merge

`GH_PAT` is now unused and can be deleted:
```
gh secret delete GH_PAT --repo calimero-network/core
```

## Prerequisites (already done / to verify)

- [x] `MERO_REVIEWER_PRIVATE_KEY` secret added
- [ ] MeroReviewer App installed on `core` with **Contents: R/W** + **Pull requests: R/W**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CI authenticates to GitHub (App private key and token minting) and affects automated PR creation and review comments; misconfiguration of App install or permissions would break both workflows.
> 
> **Overview**
> Fixes **403 Forbidden** when **Doc Auto-Update** tries to open PRs by replacing `GH_PAT` / default `GITHUB_TOKEN` with a short-lived **MeroReviewer** GitHub App installation token in **`doc-update.yaml`** and **`ai-review.yaml`**. App tokens can create pull requests even when the org blocks Actions from approving/creating PRs with `GITHUB_TOKEN`.
> 
> **AI Code Review** comments now post as **`meroreviewer[bot]`**, aligned with `--reviewer-name "MeroReviewer"`. Both workflows add a pinned **`actions/create-github-app-token`** step using `vars.MERO_REVIEWER_APP_ID` and `secrets.MERO_REVIEWER_PRIVATE_KEY`, scoped to the **`core`** repo.
> 
> **`.ai-reviewer.yaml`** bumps **doc generation** from Haiku to **Sonnet** because Haiku failed to produce valid HTML find/replace patches and most doc files were skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d89cd8057de828203c71268f63ecdd6adc524559. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->