### PR TITLE
docs: TEE/HA fleet documentation overhaul + new Fleet HA page

### DIFF
--- a/architecture/auto-follow.html
+++ b/architecture/auto-follow.html
@@ -14,7 +14,19 @@
      1. TITLE + STATS
      ═══════════════════════════════════════════════════════════════════ -->
 <h1>Auto-Follow <em>Group Membership</em></h1>
-<p class="page-subtitle">Event-driven context auto-join for group members, with per-member opt-in</p>
+<p class="page-subtitle">Event-driven <strong>context</strong> auto-join for group members, with per-member opt-in</p>
+
+<div class="card ga" style="margin-bottom:24px;">
+<h2>Scope</h2>
+<p>
+This page covers <strong>context auto-join</strong> — the <code>contexts: true</code> path. The handler
+reacts to <code>ContextRegistered</code> / <code>AutoFollowSet</code> ops and emits
+<code>JoinContextRequest</code>. It does <strong>not</strong> perform member admission and does
+<strong>not</strong> act on the <code>subgroups: true</code> flag (see
+<a href="#tee-fleet-integration">TEE Fleet Integration</a> below). For how a fleet node actually
+gains <em>subgroup</em> membership, see <a href="tee-fleet-ha.html">TEE Fleet HA</a>.
+</p>
+</div>
 
 <div class="g4" style="margin-bottom:36px;">
   <div class="stat"><div class="v">Opt-in</div><div class="l">per-member flag</div></div>
@@ -60,11 +72,24 @@ Each <code>GroupMember</code> gains a pair of opt-in flags:
 <p>
 Defaults <strong>(as of #2422)</strong>: <code>contexts: true</code>, <code>subgroups: false</code>.
 A new member added via <code>add_group_member</code> auto-follows new contexts in the group by
-default; subgroup auto-admit stays opt-in. <code>ReadOnlyTee</code> members get both set to
-<code>true</code> automatically — that's the TEE-fleet use case. The default lives in a single
+default; subgroup auto-admit stays opt-in. <code>ReadOnlyTee</code> members get both flags set to
+<code>true</code> automatically. The default lives in a single
 explicit <code>impl Default for AutoFollowFlags</code> in
 <code>crates/store/src/key/group/mod.rs</code>, so both the borsh-legacy decode fallback and
 <code>.unwrap_or_default()</code> sites pick it up.
+</p>
+<div class="card ga" style="margin:16px 0;">
+<p style="margin:0;">
+<b>The <code>subgroups: true</code> flag is currently a no-op in the auto-follow path.</b> The handler
+implements <code>contexts: true</code> only. It reads the <code>subgroups</code> field off
+<code>AutoFollowSet</code> and discards it (subgroup auto-follow is "implemented per-role in a
+follow-up" per the module docs). So although a <code>ReadOnlyTee</code> member carries
+<code>subgroups: true</code>, that flag drives no admission today. How a fleet node actually obtains
+<em>subgroup</em> access is covered in <a href="tee-fleet-ha.html">TEE Fleet HA</a> and summarised in
+<a href="#tee-fleet-integration">TEE Fleet Integration</a> below.
+</p>
+</div>
+<p>
 </p>
 <p>
 Flags are toggled by the governance op <code>GroupOp::MemberSetAutoFollow</code> with
@@ -125,7 +150,9 @@ reconcile loop.
    └─ RootOp::GroupCreated { group_id, parent_id } applied on namespace DAG
        (atomic create+nest — strict-tree invariant).
    └─ op_events::notify(OpEvent::SubgroupCreated { parent, child }).
-   └─ Handler reacts (subgroup variant — separate follow-up PR).
+   └─ The auto-follow handler IGNORES this event today (the SubgroupCreated /
+      AutoFollowSet { subgroups: true } variants fall through the catch-all
+      match arm). Subgroup membership is handled elsewhere — see TEE Fleet HA.
 
 4b. Admin moves an existing subgroup to a new parent.
     └─ RootOp::GroupReparented { child, new_parent } applied.
@@ -136,7 +163,7 @@ reconcile loop.
 <!-- ═══════════════════════════════════════════════════════════════════
      5. TEE FLEET INTEGRATION
      ═══════════════════════════════════════════════════════════════════ -->
-<div class="card gd">
+<div class="card gd" id="tee-fleet-integration">
 <h2>TEE Fleet Integration</h2>
 <p>
 A TEE fleet node calls <code>POST /admin-api/tee/fleet-join</code>. The handler in
@@ -154,21 +181,44 @@ A TEE fleet node calls <code>POST /admin-api/tee/fleet-join</code>. The handler 
   usually lacks both admin authority and the member's signing key.</li>
 </ol>
 <p>
-From this point, every new context in the group is auto-joined by the core handler. The
-<code>mero-tee</code> sidecar's per-group polling loop becomes redundant.
+From this point, every new <em>context</em> in the group is auto-joined by the core handler (the
+<code>contexts: true</code> path described on this page). The <code>mero-tee</code> sidecar's
+per-group context-polling loop becomes redundant.
 </p>
+<div class="card ga" style="margin:16px 0;">
+<p style="margin:0 0 8px;">
+<b>The <code>subgroups: true</code> flag published here is, today, a no-op.</b> The auto-follow
+handler implements <code>contexts: true</code> only — it does not act on <code>subgroups: true</code>
+and does not perform member admission. Publishing <code>subgroups: true</code> at fleet-join
+therefore does <em>not</em> cause the node to auto-join subgroups. The flag is set in anticipation of
+the per-role subgroup follow-up, but it drives no admission in the current tree.
+</p>
+<p style="margin:0;">
+Subgroup <em>access</em> for a <code>ReadOnlyTee</code> fleet node comes from two other mechanisms,
+not from auto-follow:
+</p>
+<ul style="margin:8px 0 0;">
+  <li><b>Open subgroups.</b> Inherited membership plus the namespace key the node already holds —
+  no separate admission step is required.</li>
+  <li><b>Restricted subgroups.</b> A separate <code>tee_subgroup_admit</code> subscriber (PR #2772)
+  in which an existing key-holder admits the node in response to
+  <code>SubgroupCreated</code> / <code>TeeMemberAdmitted</code> events. This is outside the
+  auto-follow path entirely.</li>
+</ul>
+<p style="margin:8px 0 0;">
+The full fleet/subgroup admission story is documented in
+<a href="tee-fleet-ha.html">TEE Fleet HA</a>.
+</p>
+</div>
 <p>
-<b>Policy scope — namespace, not per-group.</b> Because auto-follow propagates fleet-node
-membership down into subgroups without a second admission check, any TEE admission policy set on
-a subgroup would be inert. As of 2026-04-21 this is made explicit: the canonical
-<code>TeeAdmissionPolicy</code> lives on the namespace root only.
-<code>read_tee_admission_policy</code> in <code>group_store::tee</code> resolves its argument to
-the namespace root before reading, and both the write handler
+<b>Policy scope — namespace, not per-group.</b> The canonical <code>TeeAdmissionPolicy</code> lives
+on the namespace root only. <code>read_tee_admission_policy</code> in <code>group_store::tee</code>
+resolves its argument to the namespace root before reading, and both the write handler
 (<code>handlers::set_tee_admission_policy</code>) and the apply path in
 <code>group_store::apply_group_op_mutations</code> refuse a <code>TeeAdmissionPolicySet</code>
-targeting a subgroup. Subgroup policy bytes in any legacy op logs are ignored. A deferred
-follow-up adds a drift guard that validates the root policy against Calimero's canonical fleet
-measurements.
+targeting a subgroup. Subgroup policy bytes in any legacy op logs are ignored. Admission — including
+how this namespace-scoped policy is enforced — is covered in depth in
+<a href="tee-fleet-ha.html">TEE Fleet HA</a>.
 </p>
 </div>
 

--- a/architecture/config-reference.html
+++ b/architecture/config-reference.html
@@ -102,7 +102,7 @@ merod <span class="cf">--home</span> <span class="cv">~/.calimero</span> <span c
 <span class="ts">[datastore]</span>        <span class="tc"># RocksDB data path</span>
 <span class="ts">[blobstore]</span>        <span class="tc"># blob storage path</span>
 <span class="ts">[context]</span>          <span class="tc"># context client config</span>
-<span class="ts">[tee]</span>              <span class="tc"># optional TEE/KMS config</span>
+<span class="ts">[tee.kms.phala]</span>    <span class="tc"># optional TEE/KMS config (nested under [tee.kms])</span>
 <span class="ts">[specialized_node]</span> <span class="tc"># specialized node settings</span></div>
 </div>
 
@@ -460,28 +460,120 @@ merod <span class="cf">--home</span> <span class="cv">~/.calimero</span> <span c
 
 <!-- ── [tee] ── -->
 <details class="config-section">
-<summary><span class="code" style="color:var(--green)">[tee]</span> &mdash; TEE / KMS</summary>
+<summary><span class="code" style="color:var(--green)">[tee.kms.phala]</span> &mdash; TEE / KMS</summary>
 <div class="detail-body">
-<p style="margin-bottom:12px;">Optional Trusted Execution Environment and Key Management Service configuration. Only relevant for nodes running in secure enclaves.</p>
-<div class="section-source">Rust type: <a href="https://github.com/calimero-network/core/blob/master/crates/node/src/config.rs" target="_blank" rel="noopener">TeeConfig</a></div>
+<p style="margin-bottom:12px;">Optional Trusted Execution Environment and Key Management Service configuration. Only nodes with a <span class="code">[tee]</span> section perform the KMS key-fetch and attestation flow at startup; other nodes use libp2p as usual without KMS. The section is <em>nested</em>: <span class="code">[tee]</span> contains <span class="code">[tee.kms]</span>, which contains the provider block <span class="code">[tee.kms.phala]</span> (Phala Cloud KMS / mero-kms-phala is currently the only provider). There is <strong>no</strong> flat <span class="code">enabled</span> / <span class="code">kms_url</span> key &mdash; presence of the <span class="code">[tee]</span> block enables TEE mode, and the endpoint is <span class="code">tee.kms.phala.url</span>. See <a href="tee-mode.html">TEE Mode</a> for the full startup flow.</p>
+<div class="section-source">Rust type: <a href="https://github.com/calimero-network/core/blob/master/crates/config/src/lib.rs" target="_blank" rel="noopener">TeeConfig</a> / <span class="code">KmsConfig</span> / <span class="code">PhalaKmsConfig</span> (defined in <span class="code">crates/config/src/lib.rs</span>; consumed by <a href="https://github.com/calimero-network/core/blob/master/crates/merod/src/kms/mod.rs" target="_blank" rel="noopener">crates/merod/src/kms/mod.rs</a>)</div>
 
+<h3 style="margin-top:18px;">[tee.kms.phala]</h3>
+<div class="config-header"><span>Field</span><span>Type</span><span>Default</span><span>Description</span></div>
+<div class="config-field">
+  <div class="cf-key">url</div>
+  <div class="cf-type">Url</div>
+  <div class="cf-default">(required)</div>
+  <div class="cf-desc">URL of the mero-kms-phala service (the KMS endpoint). Required when the <span class="code">[tee]</span> block is present.</div>
+</div>
+
+<h3 style="margin-top:18px;">[tee.kms.phala.attestation]</h3>
+<p style="margin-bottom:12px;">KMS self-attestation verification policy (verified via <span class="code">POST /attest</span> before key requests).</p>
 <div class="config-header"><span>Field</span><span>Type</span><span>Default</span><span>Description</span></div>
 <div class="config-field">
   <div class="cf-key">enabled</div>
   <div class="cf-type">bool</div>
   <div class="cf-default">false</div>
-  <div class="cf-desc">Enable TEE attestation and sealed storage.</div>
+  <div class="cf-desc">Enable KMS attestation verification before requesting keys.</div>
 </div>
 <div class="config-field">
-  <div class="cf-key">kms_url</div>
+  <div class="cf-key">accept_mock</div>
+  <div class="cf-type">bool</div>
+  <div class="cf-default">false</div>
+  <div class="cf-desc">Accept mock attestation quotes. Development/testing only &mdash; bypasses real attestation guarantees. (Runtime also requires the <span class="code">MEROD_ALLOW_MOCK_KMS_ATTESTATION</span> env opt-in.)</div>
+</div>
+<div class="config-field">
+  <div class="cf-key">allowed_tcb_statuses</div>
+  <div class="cf-type">Vec&lt;String&gt;</div>
+  <div class="cf-default">["UpToDate"]</div>
+  <div class="cf-desc">Allowed TCB statuses for KMS quote verification.</div>
+</div>
+<div class="config-field">
+  <div class="cf-key">allowed_mrtd</div>
+  <div class="cf-type">Vec&lt;String&gt;</div>
+  <div class="cf-default">[]</div>
+  <div class="cf-desc">Allowed KMS MRTD values (hex, with or without <span class="code">0x</span> prefix). Required when <span class="code">enabled=true</span> and <span class="code">accept_mock=false</span>.</div>
+</div>
+<div class="config-field">
+  <div class="cf-key">allowed_rtmr0</div>
+  <div class="cf-type">Vec&lt;String&gt;</div>
+  <div class="cf-default">[]</div>
+  <div class="cf-desc">Allowed KMS RTMR0 values (hex). Required when <span class="code">enabled=true</span> and <span class="code">accept_mock=false</span>.</div>
+</div>
+<div class="config-field">
+  <div class="cf-key">allowed_rtmr1</div>
+  <div class="cf-type">Vec&lt;String&gt;</div>
+  <div class="cf-default">[]</div>
+  <div class="cf-desc">Allowed KMS RTMR1 values (hex). Required when <span class="code">enabled=true</span> and <span class="code">accept_mock=false</span>.</div>
+</div>
+<div class="config-field">
+  <div class="cf-key">allowed_rtmr2</div>
+  <div class="cf-type">Vec&lt;String&gt;</div>
+  <div class="cf-default">[]</div>
+  <div class="cf-desc">Allowed KMS RTMR2 values (hex). Required when <span class="code">enabled=true</span> and <span class="code">accept_mock=false</span>.</div>
+</div>
+<div class="config-field">
+  <div class="cf-key">allowed_rtmr3</div>
+  <div class="cf-type">Vec&lt;String&gt;</div>
+  <div class="cf-default">[]</div>
+  <div class="cf-desc">Allowed KMS RTMR3 values (hex). Required when <span class="code">enabled=true</span> and <span class="code">accept_mock=false</span>.</div>
+</div>
+<div class="config-field">
+  <div class="cf-key">binding_b64</div>
   <div class="cf-type">Option&lt;String&gt;</div>
   <div class="cf-default">None</div>
-  <div class="cf-desc">URL of the Key Management Service for key provisioning.</div>
+  <div class="cf-desc">Optional base64-encoded 32-byte binding value for <span class="code">/attest</span>. If unset, merod uses the default domain-separator binding.</div>
+</div>
+<div class="config-field">
+  <div class="cf-key">policy_json_path</div>
+  <div class="cf-type">Option&lt;Utf8PathBuf&gt;</div>
+  <div class="cf-default">None</div>
+  <div class="cf-desc">Optional absolute path to an externally-generated attestation policy JSON (e.g. a signed mero-tee release policy). Must reside under <span class="code">/etc/calimero</span> or <span class="code">/run/calimero</span>. Its allowlists merge over the inline values above.</div>
 </div>
 
-<div class="toml-example"><span class="ts">[tee]</span>
-<span class="tk">enabled</span> = <span class="tv">false</span>
-<span class="tc"># kms_url = "https://kms.example.com"</span></div>
+<h3 style="margin-top:18px;">[tee.kms.phala.tls]</h3>
+<p style="margin-bottom:12px;">Optional TLS hardening for KMS transport. All paths must be absolute and point to existing PEM files; setting any TLS path requires <span class="code">tee.kms.phala.url</span> to use <span class="code">https://</span>.</p>
+<div class="config-header"><span>Field</span><span>Type</span><span>Default</span><span>Description</span></div>
+<div class="config-field">
+  <div class="cf-key">ca_cert_path</div>
+  <div class="cf-type">Option&lt;Utf8PathBuf&gt;</div>
+  <div class="cf-default">None</div>
+  <div class="cf-desc">PEM-encoded CA certificate path for private trust roots. Added to merod's trust store for KMS TLS.</div>
+</div>
+<div class="config-field">
+  <div class="cf-key">client_cert_path</div>
+  <div class="cf-type">Option&lt;Utf8PathBuf&gt;</div>
+  <div class="cf-default">None</div>
+  <div class="cf-desc">PEM-encoded client certificate path for mTLS. Must be set together with <span class="code">client_key_path</span>.</div>
+</div>
+<div class="config-field">
+  <div class="cf-key">client_key_path</div>
+  <div class="cf-type">Option&lt;Utf8PathBuf&gt;</div>
+  <div class="cf-default">None</div>
+  <div class="cf-desc">PEM-encoded client private key path for mTLS. Must be set together with <span class="code">client_cert_path</span>.</div>
+</div>
+
+<div class="toml-example"><span class="ts">[tee.kms.phala]</span>
+<span class="tk">url</span> = <span class="tv">"https://kms-host:8443/"</span>
+
+<span class="ts">[tee.kms.phala.attestation]</span>
+<span class="tk">enabled</span> = <span class="tv">true</span>
+<span class="tk">accept_mock</span> = <span class="tv">false</span>
+<span class="tk">allowed_tcb_statuses</span> = [<span class="tv">"UpToDate"</span>]
+<span class="tk">allowed_mrtd</span> = [<span class="tv">"&lt;trusted_kms_mrtd_hex&gt;"</span>]
+<span class="tk">allowed_rtmr0</span> = [<span class="tv">"…"</span>]  <span class="tc"># allowed_rtmr1..3 similarly in production</span>
+
+<span class="ts">[tee.kms.phala.tls]</span>
+<span class="tc"># ca_cert_path     = "/etc/calimero/kms-ca.pem"</span>
+<span class="tc"># client_cert_path = "/etc/calimero/kms-client.pem"</span>
+<span class="tc"># client_key_path  = "/etc/calimero/kms-client.key"</span></div>
 </div>
 </details>
 
@@ -490,7 +582,7 @@ merod <span class="cf">--home</span> <span class="cv">~/.calimero</span> <span c
 <summary><span class="code" style="color:var(--green)">[specialized_node]</span> &mdash; Specialized Node</summary>
 <div class="detail-body">
 <p style="margin-bottom:12px;">Settings for specialized node roles (e.g., TEE nodes that handle key shares).</p>
-<div class="section-source">Rust type: <a href="https://github.com/calimero-network/core/blob/master/crates/node/src/config.rs" target="_blank" rel="noopener">SpecializedNodeConfig</a></div>
+<div class="section-source">Rust type: <a href="https://github.com/calimero-network/core/blob/master/crates/config/src/lib.rs" target="_blank" rel="noopener">SpecializedNodeConfig</a></div>
 
 <div class="config-header"><span>Field</span><span>Type</span><span>Default</span><span>Description</span></div>
 <div class="config-field">

--- a/architecture/glossary.html
+++ b/architecture/glossary.html
@@ -335,7 +335,7 @@
 <div class="term-row" data-term="groupkeyring group encryption keys">
   <div class="term-name">GroupKeyring (group encryption keys)</div>
   <div class="term-body">
-    The per-group symmetric encryption keys used to encrypt/decrypt a group's GroupOps and shared state. Each new member receives them via ECDH-wrapped KeyDelivery, they are rotated when a member is removed, and they are deleted from a fleet node's disk on self-purge. Distinct from the node's KMS storage key (see the <strong>two key families</strong> entry).
+    The per-group symmetric encryption keys used to encrypt/decrypt a group's GroupOps and shared state. Each new member receives them via ECDH-wrapped KeyDelivery, they are rotated when a member is removed, and (as of #2776) they are deleted from a fleet node's disk on self-purge. Distinct from the node's KMS storage key (see the <strong>two key families</strong> entry).
   </div>
 </div>
 
@@ -346,7 +346,7 @@
     <br><br>
     <strong>(1) KMS storage / disk key</strong> — per-node, fetched from the <a href="tee-mode.html">KMS</a> only after the node's TEE measurement (MRTD) is verified. Encrypts the node's on-disk datastore. One per node; never delivered over governance.
     <br><br>
-    <strong>(2) Per-group GroupKeyring encryption keys</strong> — per-group, ECDH-delivered to members via KeyDelivery, rotated on member removal, and deleted on self-purge. Encrypt group operations and shared state. See <a href="tee-fleet-ha.html">TEE Fleet HA</a>.
+    <strong>(2) Per-group GroupKeyring encryption keys</strong> — per-group, ECDH-delivered to members via KeyDelivery, rotated on member removal, and (as of #2776) deleted on self-purge. Encrypt group operations and shared state. See <a href="tee-fleet-ha.html">TEE Fleet HA</a>.
     <br><br>
     Mnemonic: the KMS key protects <em>this node's disk</em>; the GroupKeyring keys protect <em>a group's shared data across all members</em>.
   </div>
@@ -719,7 +719,7 @@
 <div class="term-row" data-term="self-purge">
   <div class="term-name">self-purge</div>
   <div class="term-body">
-    The role-scoped local cleanup a fleet node runs on eviction from <strong>ReadOnlyTee</strong>. It hard-deletes the node's own local rows and keys for the namespace — <strong>both</strong> its namespace signing-key material and its per-group GroupKeyring encryption keys — so no residual state or decryption capability lingers on disk. Driven by a pending-self-purge marker plus a startup reconcile sweep, so an eviction missed while offline is still completed on the next boot. Failures and sweep outcomes are observable via the <code>self_purge_*</code> metrics.
+    The role-scoped local cleanup a fleet node runs on eviction from <strong>ReadOnlyTee</strong>. It hard-deletes the node's own local rows and keys for the namespace — its namespace signing-key material and, as of #2776, its per-group GroupKeyring encryption keys — so no residual state or decryption capability lingers on disk. Driven by a pending-self-purge marker plus a startup reconcile sweep, so an eviction missed while offline is still completed on the next boot. Failures and sweep outcomes are observable via the <code>self_purge_*</code> metrics.
     <div class="term-source"><a href="membership-and-leave.html">Membership &amp; Leave</a> &bull; <a href="tee-fleet-ha.html">TEE Fleet HA</a></div>
   </div>
 </div>
@@ -811,7 +811,7 @@
 <div class="term-row" data-term="teeadmissionpolicy">
   <div class="term-name">TeeAdmissionPolicy</div>
   <div class="term-body">
-    The namespace-scoped measurement allowlist a fleet node's attestation is checked against. It pins the acceptable TDX measurements — <code>allowed_mrtd</code>, RTMR values, TCB/SVN bounds — plus an <code>accept_mock</code> escape hatch for non-TEE test runs. Resolved to the namespace root, so the whole namespace shares one policy. Admission of a TeeAttestationAnnounce succeeds only if the verified quote satisfies this policy.
+    The namespace-scoped measurement allowlist a fleet node's attestation is checked against. It pins the acceptable TDX measurements — <code>allowed_mrtd</code>, RTMR values, TCB-status bounds — plus an <code>accept_mock</code> escape hatch for non-TEE test runs. Resolved to the namespace root, so the whole namespace shares one policy. Admission of a TeeAttestationAnnounce succeeds only if the verified quote satisfies this policy.
     <div class="term-source"><a href="tee-fleet-ha.html">TEE Fleet HA</a></div>
   </div>
 </div>

--- a/architecture/glossary.html
+++ b/architecture/glossary.html
@@ -229,6 +229,17 @@
   </div>
 </div>
 
+<!-- ─── F ─── -->
+<div class="term-letter" data-letter="F">F</div>
+
+<div class="term-row" data-term="fleet node fleet-join">
+  <div class="term-name">Fleet node / fleet-join</div>
+  <div class="term-body">
+    A TEE replica node entitled to serve a namespace as a hardware-attested, read-only replica. It joins via the attestation announce flow — broadcasting a TeeAttestationAnnounce on the namespace topic, getting verified against the namespace TeeAdmissionPolicy, and being admitted as a ReadOnlyTee member via MemberJoinedViaTeeAttestation. Fleet-join is the end-to-end admission of such a node; eviction triggers a self-purge.
+    <div class="term-source"><a href="tee-fleet-ha.html">TEE Fleet HA</a></div>
+  </div>
+</div>
+
 <!-- ─── G ─── -->
 <div class="term-letter" data-letter="G">G</div>
 
@@ -317,7 +328,27 @@
 <div class="term-row" data-term="keydelivery">
   <div class="term-name">KeyDelivery</div>
   <div class="term-body">
-    A cleartext RootOp in the namespace governance DAG. Delivers an ECDH-wrapped group encryption key to a newly joined member. The sender wraps the key using <code>ECDH(sender_sk, joiner_pk)</code>; the joiner unwraps using <code>ECDH(joiner_sk, sender_pk)</code>.
+    A cleartext RootOp in the namespace governance DAG. Delivers an ECDH-wrapped group encryption key to a newly joined member. The sender wraps the key using <code>ECDH(sender_sk, joiner_pk)</code>; the joiner unwraps using <code>ECDH(joiner_sk, sender_pk)</code>. Delivers the per-group <strong>GroupKeyring</strong> key — not the node's KMS storage key (see the <strong>two key families</strong> entry).
+  </div>
+</div>
+
+<div class="term-row" data-term="groupkeyring group encryption keys">
+  <div class="term-name">GroupKeyring (group encryption keys)</div>
+  <div class="term-body">
+    The per-group symmetric encryption keys used to encrypt/decrypt a group's GroupOps and shared state. Each new member receives them via ECDH-wrapped KeyDelivery, they are rotated when a member is removed, and they are deleted from a fleet node's disk on self-purge. Distinct from the node's KMS storage key (see the <strong>two key families</strong> entry).
+  </div>
+</div>
+
+<div class="term-row" data-term="two key families storage key group key kms key encryption keys">
+  <div class="term-name">two key families (storage key vs. group keys)</div>
+  <div class="term-body">
+    Calimero TEE deployments involve two unrelated key families that are commonly conflated:
+    <br><br>
+    <strong>(1) KMS storage / disk key</strong> — per-node, fetched from the <a href="tee-mode.html">KMS</a> only after the node's TEE measurement (MRTD) is verified. Encrypts the node's on-disk datastore. One per node; never delivered over governance.
+    <br><br>
+    <strong>(2) Per-group GroupKeyring encryption keys</strong> — per-group, ECDH-delivered to members via KeyDelivery, rotated on member removal, and deleted on self-purge. Encrypt group operations and shared state. See <a href="tee-fleet-ha.html">TEE Fleet HA</a>.
+    <br><br>
+    Mnemonic: the KMS key protects <em>this node's disk</em>; the GroupKeyring keys protect <em>a group's shared data across all members</em>.
   </div>
 </div>
 
@@ -340,8 +371,8 @@
 <div class="term-row" data-term="groupmemberrole">
   <div class="term-name">GroupMemberRole</div>
   <div class="term-body">
-    Enum distinguishing Admin, Member, and ReadOnly members within a group.
-    <div class="term-source">Defined in: <a href="https://github.com/calimero-network/core/blob/master/crates/store/src/key/group.rs" target="_blank" rel="noopener">crates/store/src/key/group.rs</a></div>
+    Enum distinguishing the four member roles within a group: Admin, Member, ReadOnly, and ReadOnlyTee. ReadOnly and ReadOnlyTee both bar state mutation, but ReadOnlyTee is reserved for hardware-attested fleet replica nodes (directly-rowed, never inherited).
+    <div class="term-source">Defined in: <a href="https://github.com/calimero-network/core/blob/master/crates/primitives/src/context.rs" target="_blank" rel="noopener">crates/primitives/src/context.rs</a></div>
   </div>
 </div>
 
@@ -434,7 +465,7 @@
 <div class="term-row" data-term="kms">
   <div class="term-name">KMS</div>
   <div class="term-body">
-    Key Management Service. Releases encryption keys to TEE nodes via attestation. Supported: mero-kms-phala for Phala Cloud.
+    Key Management Service. Releases the per-node <strong>storage / disk key</strong> to a TEE node only after verifying its MRTD measurement (see <a href="tee-mode.html">TEE Mode</a>). This is distinct from per-group GroupKeyring encryption keys (see the <strong>two key families</strong> entry). Supported: mero-kms-phala for Phala Cloud.
   </div>
 </div>
 
@@ -477,6 +508,14 @@
   <div class="term-name">MemberCapabilities</div>
   <div class="term-body">
     Struct holding the five capability bit constants for group-level authorization.
+  </div>
+</div>
+
+<div class="term-row" data-term="memberjoinedviateeattestation">
+  <div class="term-name">MemberJoinedViaTeeAttestation</div>
+  <div class="term-body">
+    The governance operation a verifier publishes to admit a fleet node as a <strong>ReadOnlyTee</strong> member, after its TeeAttestationAnnounce has been validated against the namespace TeeAdmissionPolicy. It is the attestation-gated analogue of an ordinary member-add: it directly rows the node into the target namespace (never inherited) rather than delivering an invitation.
+    <div class="term-source"><a href="tee-fleet-ha.html">TEE Fleet HA</a></div>
   </div>
 </div>
 
@@ -627,13 +666,36 @@
   </div>
 </div>
 
+<div class="term-row" data-term="quote hash replay protection">
+  <div class="term-name">quote hash (replay protection)</div>
+  <div class="term-body">
+    A per-group dedup record of a TDX quote already used to admit a fleet node. The verifier keys on the quote's hash so the same quote cannot admit a node twice within the same group, even if re-broadcast. Combined with the per-quote nonce in <code>report_data</code>, it closes the replay window on the TeeAttestationAnnounce → MemberJoinedViaTeeAttestation path.
+    <div class="term-source"><a href="tee-fleet-ha.html">TEE Fleet HA</a></div>
+  </div>
+</div>
+
 <!-- ─── R ─── -->
 <div class="term-letter" data-letter="R">R</div>
 
 <div class="term-row" data-term="readonly">
   <div class="term-name">ReadOnly</div>
   <div class="term-body">
-    Group member role that allows joining contexts and reading state but prevents all state mutations. Enforced at both local and remote nodes.
+    Group member role that allows joining contexts and reading state but prevents all state mutations. Enforced at both local and remote nodes. A regular (non-attested) role; contrast with <strong>ReadOnlyTee</strong>, the hardware-attested fleet-node variant.
+  </div>
+</div>
+
+<div class="term-row" data-term="readonlytee">
+  <div class="term-name">ReadOnlyTee</div>
+  <div class="term-body">
+    Read-only TEE fleet-node role. Like ReadOnly it bars all state mutation, but it is <strong>directly-rowed and NEVER inherited</strong> through subgroups: a fleet replica is only ReadOnlyTee in the exact namespace it was admitted to. Admission is gated on hardware TDX attestation (see TeeAttestationAnnounce / MemberJoinedViaTeeAttestation), and on eviction the node hard-purges its local rows and keys (see self-purge). A variant of GroupMemberRole.
+    <div class="term-source">Defined in: <a href="https://github.com/calimero-network/core/blob/master/crates/primitives/src/context.rs" target="_blank" rel="noopener">crates/primitives/src/context.rs</a> &bull; <a href="tee-fleet-ha.html">TEE Fleet HA</a></div>
+  </div>
+</div>
+
+<div class="term-row" data-term="report_data">
+  <div class="term-name">report_data</div>
+  <div class="term-body">
+    The 64-byte free-form field bound into a TDX quote at generation time. For a fleet node's attestation it is <code>nonce(32) || Sha256(pubkey)</code>: a fresh 32-byte nonce concatenated with the SHA-256 of the announcing node's public key. Binding the pubkey hash into the hardware-signed quote proves the quote belongs to that key; the nonce gives freshness for replay protection.
   </div>
 </div>
 
@@ -653,6 +715,14 @@
 
 <!-- ─── S ─── -->
 <div class="term-letter" data-letter="S">S</div>
+
+<div class="term-row" data-term="self-purge">
+  <div class="term-name">self-purge</div>
+  <div class="term-body">
+    The role-scoped local cleanup a fleet node runs on eviction from <strong>ReadOnlyTee</strong>. It hard-deletes the node's own local rows and keys for the namespace — <strong>both</strong> its namespace signing-key material and its per-group GroupKeyring encryption keys — so no residual state or decryption capability lingers on disk. Driven by a pending-self-purge marker plus a startup reconcile sweep, so an eviction missed while offline is still completed on the next boot. Failures and sweep outcomes are observable via the <code>self_purge_*</code> metrics.
+    <div class="term-source"><a href="membership-and-leave.html">Membership &amp; Leave</a> &bull; <a href="tee-fleet-ha.html">TEE Fleet HA</a></div>
+  </div>
+</div>
 
 <div class="term-row" data-term="sha-256">
   <div class="term-name">SHA-256</div>
@@ -735,6 +805,22 @@
   <div class="term-name">TEE</div>
   <div class="term-body">
     Trusted Execution Environment. Hardware-isolated runtime protecting code and data. merod supports TEE mode with KMS key fetch.
+  </div>
+</div>
+
+<div class="term-row" data-term="teeadmissionpolicy">
+  <div class="term-name">TeeAdmissionPolicy</div>
+  <div class="term-body">
+    The namespace-scoped measurement allowlist a fleet node's attestation is checked against. It pins the acceptable TDX measurements — <code>allowed_mrtd</code>, RTMR values, TCB/SVN bounds — plus an <code>accept_mock</code> escape hatch for non-TEE test runs. Resolved to the namespace root, so the whole namespace shares one policy. Admission of a TeeAttestationAnnounce succeeds only if the verified quote satisfies this policy.
+    <div class="term-source"><a href="tee-fleet-ha.html">TEE Fleet HA</a></div>
+  </div>
+</div>
+
+<div class="term-row" data-term="teeattestationannounce">
+  <div class="term-name">TeeAttestationAnnounce</div>
+  <div class="term-body">
+    The broadcast a fleet node publishes on its namespace topic (<code>ns/&lt;hex&gt;</code>) to announce itself for admission. It carries a fresh TDX quote whose <code>report_data</code> is <code>nonce(32) || Sha256(pubkey)</code> — binding the node's public key into the hardware-signed quote and supplying a nonce for freshness. A verifier validates it against the TeeAdmissionPolicy and, on success, publishes MemberJoinedViaTeeAttestation to admit the node as ReadOnlyTee.
+    <div class="term-source"><a href="tee-fleet-ha.html">TEE Fleet HA</a></div>
   </div>
 </div>
 

--- a/architecture/index.html
+++ b/architecture/index.html
@@ -173,7 +173,7 @@
   </div>
   <div>
     <h3>Namespace &amp; Group</h3>
-    <p>A <strong>namespace</strong> is a root group that serves as the application boundary and identity scope. Each namespace gets its own Ed25519 keypair. Groups within a namespace share a <strong>single governance DAG</strong> with cleartext RootOps and encrypted GroupOps. Membership, capabilities, and access control propagate via gossipsub. See <a href="membership-and-leave.html">Membership &amp; Leave</a> for the leave operations and Owner role design, and <a href="auto-follow.html">Auto-Follow</a> for opt-in context auto-join.</p>
+    <p>A <strong>namespace</strong> is a root group that serves as the application boundary and identity scope. Each namespace gets its own Ed25519 keypair. Groups within a namespace share a <strong>single governance DAG</strong> with cleartext RootOps and encrypted GroupOps. Membership, capabilities, and access control propagate via gossipsub. See <a href="membership-and-leave.html">Membership &amp; Leave</a> for the leave operations and ownership-transfer design, and <a href="auto-follow.html">Auto-Follow</a> for opt-in context auto-join.</p>
   </div>
   <div>
     <h3>State Sync</h3>

--- a/architecture/local-governance.html
+++ b/architecture/local-governance.html
@@ -77,7 +77,7 @@
   <line x1="520" y1="170" x2="420" y2="170" stroke="#f59e0b" stroke-width="2"/>
   <polygon points="422,166 412,170 422,174" fill="#f59e0b"/>
   <text x="470" y="130" text-anchor="middle" fill="#f59e0b" font-family="JetBrains Mono, monospace" font-size="9" font-weight="600">gossipsub</text>
-  <text x="470" y="188" text-anchor="middle" fill="#6b6b80" font-family="JetBrains Mono, monospace" font-size="8">namespace/&lt;hex&gt; topic</text>
+  <text x="470" y="188" text-anchor="middle" fill="#6b6b80" font-family="JetBrains Mono, monospace" font-size="8">ns/&lt;hex&gt; topic</text>
 </svg>
 
 <div class="legend">

--- a/architecture/membership-and-leave.html
+++ b/architecture/membership-and-leave.html
@@ -598,7 +598,7 @@ a startup sweep, made role-safe by a durable marker (ADR&nbsp;0002 / #2721):
 </div>
 
 <!-- ═══════════════════════════════════════════════════════════════════
-     7. OWNER ROLE
+     7. OWNER (STORED IDENTITY, NOT A ROLE)
      ═══════════════════════════════════════════════════════════════════ -->
 <div class="card gd" id="owner">
 <h2>Owner (stored identity, not a role)</h2>

--- a/architecture/membership-and-leave.html
+++ b/architecture/membership-and-leave.html
@@ -14,40 +14,57 @@
      1. TITLE + STATS
      ═══════════════════════════════════════════════════════════════════ -->
 <h1>Membership &amp; <em>Leave Operations</em></h1>
-<p class="page-subtitle">Voluntary leave and Owner role across namespaces, groups, and contexts</p>
+<p class="page-subtitle">Voluntary leave, owner-initiated removal, and role-scoped TEE self-purge across namespaces, groups, and contexts</p>
 
 <div class="g4" style="margin-bottom:36px;">
   <div class="stat"><div class="v">3 leaves</div><div class="l">context · group · namespace</div></div>
-  <div class="stat"><div class="v">1 op</div><div class="l">TransferOwnership</div></div>
+  <div class="stat"><div class="v">Key rotation</div><div class="l">on removal (publisher pipeline)</div></div>
   <div class="stat"><div class="v">Direct</div><div class="l">leave deletes a row</div></div>
-  <div class="stat"><div class="v">Owner≠Admin</div><div class="l">exclusive role</div></div>
+  <div class="stat"><div class="v">TEE purge</div><div class="l">role-scoped hard delete</div></div>
+</div>
+
+<div class="card ga">
+<p style="margin:0;">
+<b>As-built page.</b> This was originally a proposal; it now documents shipped behavior. For the
+fleet-specific eviction story (owner kicks a <code>ReadOnlyTee</code> node on HA-disable, the
+self-purge listener, and the marker-gated startup reconcile) see
+<a href="tee-fleet-ha.html">Fleet HA</a>. Term definitions live in the
+<a href="glossary.html">Glossary</a>. The governing design record is
+<code>docs/adr/0002-fleet-tee-leave-protocol.md</code>.
+</p>
 </div>
 
 <!-- ═══════════════════════════════════════════════════════════════════
      2. PROBLEM &amp; MOTIVATION
      ═══════════════════════════════════════════════════════════════════ -->
 <div class="card ga">
-<h2>Problem</h2>
+<h2>Problem this solved</h2>
 <p>
-Today, the only way out of a Calimero group or namespace is to be removed by an admin —
-<code>MemberRemoved</code> is admin-initiated and there is no self-leave op. Users cannot
-voluntarily exit a workspace they joined; muting a context they're auto-followed into requires
+Originally, the only way out of a Calimero group or namespace was to be removed by an admin —
+<code>MemberRemoved</code> was admin-initiated and there was no self-leave op. Users could not
+voluntarily exit a workspace they joined; muting a context they were auto-followed into required
 client-side filtering rather than a real opt-out, because auto-follow re-adds them on the next
 <code>ContextRegistered</code> event.
 </p>
 <p>
-Separately, every group already records a single "creator / fallback admin" identity
-(<code>GroupMetaValue.admin_identity</code>) but no role distinguishes that creator from any other
-admin. There is no way to express "this person owns the group, others administrate it" — admins
-can demote each other, kick each other, and leave a group ownerless. There is no
-<code>TransferOwnership</code> op to designate a successor.
+Separately, every group records a single "creator / fallback admin" identity
+(<code>GroupMetaValue.owner_identity</code>) but the role enum did not distinguish that creator
+from any other admin. There was no clean way to express "this person owns the group, others
+administrate it."
 </p>
 <p>
-This page proposes three new leave operations and formalizes Owner as a real, exclusive,
-transferable role distinct from Admin. The four pieces share infrastructure: Owner blocks
-<code>leave_group</code>/<code>leave_namespace</code>; leave operations reuse the existing
-<code>MemberRemoved</code> key-rotation pipeline; <code>leave_namespace</code> is
-<code>leave_group</code> plus the cascade handler.
+The shipped design adds three leave operations and an owner identity stored on group metadata that
+gates self-leave and involuntary removal. The pieces share infrastructure: the stored owner blocks
+<code>leave_group</code>/<code>leave_namespace</code> and involuntary <code>MemberRemoved</code>;
+owner-initiated <code>MemberRemoved</code> reuses the group key-rotation pipeline;
+<code>leave_namespace</code> is the namespace-root <code>MemberLeft</code> plus a cascade through
+descendant groups.
+</p>
+<p>
+A separate, role-scoped mechanism layers on top for fleet TEE nodes: when a
+<code>ReadOnlyTee</code> member is removed, the evicted node <b>hard-deletes</b> its local key
+material (see <a href="#self-purge">TEE self-purge</a>), because a TEE node has no rejoin path
+under the same identity. Non-TEE removals keep the soft-leave invariant.
 </p>
 </div>
 
@@ -108,11 +125,17 @@ subgroups have one (direct invite).
 
 <h3>Roles &amp; capabilities</h3>
 <p>
-Roles defined in <code>crates/primitives/src/context.rs:253-265</code>:
+The <code>GroupMemberRole</code> enum (<code>crates/primitives/src/context.rs</code>) has exactly
+four variants:
 </p>
 <ul>
   <li><code>Admin</code>, <code>Member</code>, <code>ReadOnly</code>, <code>ReadOnlyTee</code>.</li>
-  <li>This proposal adds <code>Owner</code> as a fifth role — exactly one per group, transferable.</li>
+  <li><b>There is no <code>Owner</code> role variant.</b> "Owner" is not a member role — it is a
+  single identity stored on group metadata (<code>GroupMetaValue.owner_identity</code>). The owner
+  is whichever member's public key equals that field; they are otherwise an ordinary
+  <code>Admin</code>. Owner status is enforced by identity comparison in the apply handlers
+  (<code>OwnerImmuneFromRemoval</code>, <code>OwnerCannotSelfLeave</code>), not by a role check. See
+  the <a href="#owner">Owner</a> section.</li>
 </ul>
 <p>
 Per-member capability bits (<code>crates/context/config/src/lib.rs</code>, <code>MemberCapabilities</code>):
@@ -129,10 +152,13 @@ Per-member capability bits (<code>crates/context/config/src/lib.rs</code>, <code
   <li><b>Last-admin protection</b> (<code>membership_policy.rs:39-46</code>):
   <code>MemberRemoved</code> rejects with <code>LastAdmin</code> if it would leave a group with
   zero admins. Also enforced on demotion.</li>
-  <li><b>Key rotation on removal</b> (<code>group_governance_publisher.rs:216-220</code>):
-  publishing <code>MemberRemoved</code> automatically generates a fresh group key, wraps it for
-  remaining members, and emits <code>RootOp::KeyDelivery</code>. The leave operations in this
-  proposal hook into the same pipeline.</li>
+  <li><b>Key rotation on removal</b> (<code>group_governance_publisher.rs</code>,
+  <code>sign_apply_and_publish_inner</code>): publishing <code>MemberRemoved</code> automatically
+  generates a fresh group key via <code>GroupKeyring</code>, wraps it (<code>wrap_for_member</code>)
+  for every <em>remaining</em> member — excluding the removed one — and delivers it. The removed
+  member never receives the new key, so it cannot decrypt anything written after eviction. This is
+  the forward-secrecy mechanism for the namespace's future writes. Owner-initiated removal is the
+  cryptographically-complete leave path.</li>
 </ul>
 </div>
 
@@ -296,12 +322,22 @@ layer and keeps the synced shape clean.
      5. leave_group
      ═══════════════════════════════════════════════════════════════════ -->
 <div class="card gc">
-<h2>leave_group — distributed, two-phase, no cascade</h2>
+<h2>leave_group — self-removal, no cascade</h2>
 <p>
-Self-removal from a single group. Reuses the existing <code>MemberRemoved</code> key-rotation
-pipeline but the publisher/rotation responsibility splits across two parties: the leaver
-publishes the leave op, then a remaining admin publishes the <code>KeyDelivery</code> with the
-fresh group key. The leaver never holds the new key.
+Self-removal from a single group via <code>GroupOp::MemberLeft</code>. The leaver publishes the
+leave op; every receiver deletes the leaver's <code>(member, group)</code> row.
+</p>
+<p>
+<b>As-built caveat — no key rotation on self-leave.</b> Unlike owner-initiated
+<code>MemberRemoved</code>, <code>MemberLeft</code> deliberately does <em>not</em> trigger the
+key-rotation pipeline. The publisher of a self-leave is the leaver, and the leaver cannot generate
+the fresh group key without also retaining it — which would defeat forward secrecy. So
+<code>MemberLeft</code> is the governance-level departure (the membership row is removed, peers
+observe the leave, the leaver is deny-listed) <em>without</em> a re-key. The path to a
+cryptographically-complete leave is an admin/owner-initiated <code>MemberRemoved</code>, which
+rotates. A two-phase self-leave rotation (a remaining admin's apply hook publishes the new key) is
+a tracked follow-up, not yet shipped. See the inline note in
+<code>crates/governance-store/src/ops/group/member_left.rs</code>.
 </p>
 
 <h3>New op</h3>
@@ -318,35 +354,33 @@ Distinct from <code>MemberRemoved</code> for audit clarity — "this member chos
 
 <h3>Preconditions</h3>
 <ul>
-  <li>Signer has a <b>direct row</b> in the group (computed via
-  <code>check_group_membership_path</code>; reject with <code>NotADirectMember</code> if the
-  signer is only an inherited member — they must leave the anchor instead).</li>
-  <li>Signer is not the Owner (<code>OwnerCannotLeave</code>; must
+  <li>Signer equals the member being removed (<code>SelfLeaveOnly</code>) and has a <b>direct row</b>
+  in the group; reject with <code>MemberNotDirect</code> if the signer is only an inherited member —
+  they must leave the anchor instead.</li>
+  <li>Signer is not the group's <code>owner_identity</code> (<code>OwnerCannotSelfLeave</code>; must
   <code>TransferOwnership</code> first).</li>
-  <li>If signer is admin, removing them does not leave the group with zero admins
-  (<code>LastAdmin</code> via existing <code>ensure_not_last_admin_removal</code>).</li>
+  <li>Removing the signer does not leave the group with zero admins
+  (<code>LastAdmin</code> via <code>ensure_not_last_admin_removal</code>).</li>
 </ul>
 
 <h3>Flow</h3>
 <ol>
   <li>Leaver's client calls <code>leave_group(group_id)</code>.</li>
-  <li>Server-side validation runs the preconditions above.</li>
+  <li>Apply enforces the preconditions above (self-equality, direct-row, owner, last-admin).</li>
   <li>Leaver publishes <code>MemberLeft { member: signer }</code> via the governance DAG. Signed
   by the leaver. Targets this group.</li>
-  <li>Op broadcasts to all members of the group. Each receiver applies it: deletes the
-  <code>(leaver, group_id)</code> row from local membership state. Leaver's own node also drops
-  sync state for this group's contexts and (optionally) purges encrypted blobs.</li>
-  <li>The first remaining admin to ack the op enters <b>phase two</b>:
-  <ol>
-    <li>Generates a fresh group key via <code>build_key_rotation</code>
-    (<code>group_keys.rs:266</code>).</li>
-    <li>Wraps it for each remaining member (leaver excluded).</li>
-    <li>Publishes <code>RootOp::KeyDelivery</code> carrying the wrapped bundles.</li>
-  </ol>
-  </li>
-  <li>Each remaining member receives <code>KeyDelivery</code>, unwraps their bundle, replaces the
-  active group key. New writes use the new key from now on. The leaver's old key still decrypts
-  historical content but not new writes.</li>
+  <li>Op broadcasts to all members of the group. Each receiver applies it:
+  <code>cascade_remove_member_from_group_tree</code> drops the leaver's <code>ContextIdentity</code>
+  rows, <code>remove_member</code> deletes the <code>(leaver, group_id)</code> membership row, and
+  the leaver is added to the group deny-list so their state-delta traffic is dropped until they
+  re-join.</li>
+  <li>The apply emits <code>OpEvent::MemberRemoved</code>; if the leaver's role was
+  <code>ReadOnlyTee</code> it additionally emits <code>OpEvent::TeeMemberRemoved</code>, which drives
+  the leaver's own node to <a href="#self-purge">self-purge</a> the group's local key material.</li>
+  <li><b>No automatic re-key.</b> As noted above, <code>MemberLeft</code> does not rotate the group
+  key — the leaver still holds the last key it received and can decrypt writes made under it. Forward
+  secrecy on future writes requires the owner-initiated <code>MemberRemoved</code> path (or the
+  deferred two-phase self-leave rotation).</li>
 </ol>
 
 <h3>Cascade behavior</h3>
@@ -357,13 +391,12 @@ Distinct from <code>MemberRemoved</code> for audit clarity — "this member chos
 
 <h3>Failure modes</h3>
 <ul>
-  <li><b>Network partition between phase one and phase two.</b> <code>MemberLeft</code> lands but
-  <code>KeyDelivery</code> is delayed. Forward secrecy briefly weak — the leaver is no longer in
-  the membership list but new writes are still under the old key (which they hold). Heals on
-  partition resolve.</li>
-  <li><b>All admins offline.</b> <code>MemberLeft</code> lands; rotation never fires until an
-  admin returns. Operational mitigation: alert when no rotation follows a leave within a
-  configurable window.</li>
+  <li><b>No forward secrecy on self-leave (by design, not a failure).</b> Because
+  <code>MemberLeft</code> never rotates, the leaver retains the ability to decrypt writes made under
+  the key they last held. To revoke that, an admin/owner must issue <code>MemberRemoved</code>
+  (which rotates) or the deferred two-phase self-leave rotation must land.</li>
+  <li><b>Inherited-only membership.</b> A signer whose membership is purely inherited (no direct row)
+  is rejected with <code>MemberNotDirect</code>; they must leave the anchoring ancestor instead.</li>
 </ul>
 
 <h3>Rejoin</h3>
@@ -382,45 +415,52 @@ Distinct from <code>MemberRemoved</code> for audit clarity — "this member chos
 <div class="card gc">
 <h2>leave_namespace — cascading, heaviest</h2>
 <p>
-A namespace is the root group. Leaving it cascades through every descendant where the leaver has
-a direct row, rotating each scope's group key independently. Plus the namespace's own root key.
-This is the only operation in the proposal that fans out across multiple scopes.
+A namespace is the root group. Leaving it is a single <code>MemberLeft</code> at the namespace root
+whose apply cascades through every descendant group where the leaver has a direct row. This is the
+only leave operation that fans out across multiple scopes. As with <code>leave_group</code>, the
+self-leave op does <b>not</b> rotate keys (same publisher-holds-the-key constraint); row removal +
+deny-listing only.
 </p>
 
 <h3>Preconditions</h3>
 <ul>
-  <li>Signer has a direct row at the namespace root.</li>
-  <li>Signer does not own the namespace OR any subgroup beneath it. If they do →
-  <code>MustTransferOwnership { groups: [...] }</code> listing every owned scope.</li>
+  <li>Signer has a direct row at the namespace root (<code>MemberNotDirect</code> otherwise).</li>
+  <li>Signer is not the <code>owner_identity</code> of the namespace root
+  (<code>OwnerCannotSelfLeave</code>) nor of any subgroup beneath it where they have a direct row
+  (<code>OwnerOwnsSubgroup</code>, reporting the offending scope).</li>
   <li>Removing the signer doesn't leave any scope (namespace or descendant) admin-less. If it
-  would → <code>LastAdmin { group: G }</code> reports the offending scope, forcing a successor
-  promotion before retry.</li>
+  would → <code>LastAdmin</code> reports the offending scope, forcing a successor promotion before
+  retry. All these checks run upfront, before any mutation.</li>
 </ul>
 
 <h3>Flow</h3>
 <ol>
   <li>Client calls <code>leave_namespace(namespace_id)</code>.</li>
-  <li>Server-side validation walks the subgroup tree:
+  <li>Apply detects the no-parent (namespace-root) case and walks the subtree:
     <ul>
-      <li>Compute <code>direct_groups = [namespace, G1, G2, ...]</code> — every group in the
-      namespace where the signer has a direct row.</li>
-      <li>Run owner check + last-admin check across all of them. If any fails, surface the
-      offending scope and bail before publishing anything.</li>
+      <li>Compute the descendant groups where the signer has a direct row.</li>
+      <li>Run owner check + last-admin check across all of them upfront. If any fails
+      (<code>OwnerOwnsSubgroup</code>, <code>OwnerCannotSelfLeave</code>, <code>LastAdmin</code>) it
+      bails before mutating anything — no half-applied cleanup.</li>
     </ul>
   </li>
   <li>Signer publishes a single <code>MemberLeft { member: signer }</code> at the namespace root.</li>
-  <li>The cascade handler (<code>cascade_remove_member_from_group_tree</code>,
-  <code>mod.rs:811</code>) fans out: locally and on each receiver, fire the
-  <code>MemberLeft</code>-equivalent for each scope in <code>direct_groups</code>.</li>
-  <li>Per-scope key rotation runs the same phase-two pattern as <code>leave_group</code>, in
-  parallel. Total network ops: one root-level <code>MemberLeft</code> +
-  <span class="ty">N</span> <code>KeyDelivery</code> ops where <span class="ty">N</span> = number
-  of direct memberships in the subtree.</li>
-  <li>Local cleanup on the leaver's node:
+  <li>The apply cascades: for each direct-row descendant it calls
+  <code>cascade_remove_member_from_group_tree</code>, removes the membership row, deny-lists the
+  leaver, and emits <code>OpEvent::MemberRemoved</code>. For each descendant where the leaver's role
+  was <code>ReadOnlyTee</code> it also emits a per-subgroup <code>OpEvent::TeeMemberRemoved</code>.
+  The same removal then runs for the namespace root, emitting a root <code>MemberRemoved</code> (and
+  a root <code>TeeMemberRemoved</code> if the root role was <code>ReadOnlyTee</code>).</li>
+  <li><b>No per-scope key rotation.</b> The cascade is row-removal only — there is no
+  <code>KeyDelivery</code> fan-out. Forward secrecy on each scope's future writes is provided by the
+  owner-initiated <code>MemberRemoved</code> rotation pipeline, not by self-leave.</li>
+  <li>Local cleanup on the leaver's node is <b>role-scoped</b>, not a soft/hard toggle:
     <ul>
-      <li><b>Soft mode (default):</b> archive namespace data as read-only. Leaver can browse their
-      historical view.</li>
-      <li><b>Hard mode (opt-in):</b> purge keys, DAG entries, encrypted blobs.</li>
+      <li><b>Non-TEE roles:</b> soft leave. Local rows (identity, signing keys, contexts) are kept so
+      rejoin / keyshare / inheritance-rejoin flows can reuse them.</li>
+      <li><b><code>ReadOnlyTee</code>:</b> the emitted <code>TeeMemberRemoved</code> events drive the
+      <a href="#self-purge">self-purge</a> listener to hard-delete local key material across the
+      whole subtree and unsubscribe from the namespace gossipsub topic.</li>
     </ul>
   </li>
 </ol>
@@ -438,33 +478,145 @@ ownership but there's no one to transfer to. Use a dedicated <code>DeleteNamespa
 
 <h3>Failure modes</h3>
 <ul>
-  <li>Same as <code>leave_group</code>, multiplied across scopes. Each rotation can fail
-  independently.</li>
-  <li>Partial cascade: if some sub-rotations succeed and others don't, the leaver's root row is
-  gone everywhere but some peers may have lingering ghost rows in subgroups. Eventually
-  consistent — peers detect the leaver-not-in-root state and reconcile on next sync.</li>
+  <li><b>No forward secrecy on self-leave</b> across any scope (same constraint as
+  <code>leave_group</code>): the cascade removes rows but does not re-key. Use owner-initiated
+  <code>MemberRemoved</code> for a cryptographically-complete eviction.</li>
+  <li><b>Interrupted TEE self-purge.</b> If the leaver was a <code>ReadOnlyTee</code> node and its
+  local cascade-purge is interrupted (crash, or a signing-key delete error), a durable
+  pending-self-purge marker survives and the startup <code>reconcile_sweep</code> completes the purge
+  on next restart. See <a href="#self-purge">TEE self-purge</a>.</li>
+</ul>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     6a. TEE SELF-PURGE
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card gd" id="self-purge">
+<h2>Role-scoped TEE self-purge</h2>
+<p>
+Removal alone (the <code>MemberRemoved</code> rotation) already provides forward secrecy on a
+namespace's future writes — the evicted node never receives the rotated key. But a
+<code>ReadOnlyTee</code> fleet node still holds, on its own disk, the old key material from before
+the rotation: signing keys, the group encryption keys it last received, its
+<code>NamespaceIdentity</code>, and the governance op-log. A regular member's local rows are
+deliberately kept (the soft-leave invariant lets <code>kick-and-readd</code> /
+<code>rejoin-via-keyshare</code> / inheritance-rejoin reuse them). A <code>ReadOnlyTee</code> node has
+<em>no</em> rejoin path — re-admission via <code>MemberJoinedViaTeeAttestation</code> derives a fresh
+attestation pubkey — so that material buys nothing and is pure hygiene debt. The self-purge handler
+hard-deletes it.
+</p>
+<p>
+Design record: <code>docs/adr/0002-fleet-tee-leave-protocol.md</code>. Implementation:
+<code>crates/context/src/self_purge.rs</code>. Fleet-side framing:
+<a href="tee-fleet-ha.html">Fleet HA</a>.
+</p>
+
+<h3>Role-scoped trigger</h3>
+<p>
+The apply path emits a generic <code>OpEvent::MemberRemoved</code> for every removal, and — only when
+the removed member's stored role was <code>ReadOnlyTee</code> — an additional
+<code>OpEvent::TeeMemberRemoved</code> (see <code>ops/group/member_removed.rs</code> and
+<code>member_left.rs</code>). The self-purge listener subscribes to the op-apply event channel and
+reacts <b>only</b> to <code>TeeMemberRemoved</code>:
+</p>
+<ul>
+  <li><b>Non-TEE removals</b> (<code>Admin</code>/<code>Member</code>/<code>ReadOnly</code>) keep
+  soft-leave semantics — no purge. Hardening to hard-purge every removal would regress the
+  <code>apps/scaffolding-e2e/workflows/group-{kick,leave}-*</code> workflows that depend on the
+  retained rows.</li>
+  <li><b><code>ReadOnlyTee</code> removals</b> trigger a hard purge. The self-detection ("did this op
+  evict <em>me</em>?") is a handler concern, not part of the node-agnostic apply contract — it reads
+  this node's stored namespace identity (per-node state). This mirrors the
+  <a href="auto-follow.html">auto-follow</a> architectural split.</li>
+</ul>
+
+<h3>Subgroup vs namespace-root</h3>
+<p>
+<code>decide_purge_action</code> (pure store reads) resolves the namespace owning the evicted group,
+confirms the evicted member is this node's own identity, and then picks one of two actions:
+</p>
+<table class="properties">
+  <tr><td><b><code>PurgeAction::Subgroup</code></b></td><td>Removed from one subgroup while still a
+  member of others under the same namespace. Purge only that group's local rows
+  (<code>delete_group_local_rows</code>) plus its context-index and tree-edge rows. <b>Do not</b>
+  unsubscribe from the namespace gossipsub topic — other memberships still need it.</td></tr>
+  <tr><td><b><code>PurgeAction::Namespace</code></b></td><td>Removed from the namespace root. Cascade
+  the whole subtree, drop namespace-level state, then unsubscribe from the namespace topic.</td></tr>
+  <tr><td><b><code>PurgeAction::None</code></b></td><td>Event is for another member, or for a
+  namespace this node has no identity in. No action.</td></tr>
+</table>
+
+<h3>What gets hard-deleted</h3>
+<p>
+The cascade (<code>cascade_namespace_state</code>) iterates the root plus every descendant group and
+calls <code>delete_group_local_rows</code> per group. That helper
+(<code>crates/governance-store/src/local_state.rs</code>) deletes the membership rows, capabilities,
+metadata, upgrade records, the group op-log + head, the deny-list, and — load-bearing —
+the private key material:
+</p>
+<ul>
+  <li><b>Signing keys.</b> <code>SigningKeysRepository::delete_all_for_group</code> — the 32-byte
+  private signing-key material. Leaking these is the actual forward-secrecy hazard, so this is the
+  step the failure-class gating treats as security-critical.</li>
+  <li><b>Group encryption keys.</b> <code>GroupKeyring::delete_all_for_group</code> — the AES group
+  keys the node received while admitted (added in PR&nbsp;#2776). Without this the evicted node would
+  retain its copy of past group keys on disk even though the rotation already orphaned them for
+  future writes.</li>
+</ul>
+<p>
+Forward secrecy is therefore split cleanly: <em>future</em> writes are protected by key rotation
+(re-key excluding the removed member, done by the publisher pipeline at removal); the evicted TEE
+node's <em>own copies of past keys</em> are deleted here by self-purge. The purge does not — and need
+not — trigger any rotation itself.
+</p>
+<p>
+Namespace-level teardown (<code>delete_namespace_local_state</code>) then drops the
+<code>NamespaceIdentity</code>, the namespace governance head, and the namespace op-log. Dropping the
+identity and unsubscribing is gated on the <em>signing-key</em> purge succeeding (a best-effort
+dead-pointer cleanup failure does not block the security-critical finalize).
+</p>
+
+<h3>Durable marker + startup reconcile</h3>
+<p>
+<code>TeeMemberRemoved</code> fires once per eviction and an already-evicted identity receives no
+further removal events, so a missed or partially-failed purge has no event-driven retry. Recovery is
+a startup sweep, made role-safe by a durable marker (ADR&nbsp;0002 / #2721):
+</p>
+<ul>
+  <li>Before the namespace cascade, <code>handle_member_removed</code> writes a durable
+  <b>pending-self-purge marker</b> for the namespace. This is the one site that knows — node-aware and
+  role-aware — that this is a confirmed TEE self-eviction of our identity.</li>
+  <li>On startup, <code>reconcile_sweep</code> enumerates <em>markers only</em> and completes a purge
+  iff <b>(marker present)</b> AND <b>(still no surviving namespace-root membership)</b>. If the
+  identity is already gone, or we have been re-admitted, it clears the stale marker without purging; a
+  read error skips (never purge on uncertainty).</li>
+  <li>The marker is essential because, post-eviction, the role row is erased: a role-blind scan of
+  <code>NamespaceIdentity</code> rows could not distinguish evicted-TEE residue from a pending join or
+  non-TEE soft-leave residue, and would false-purge both. The marker is the role/intent gate; the
+  still-evicted check is the safety gate; both must hold.</li>
 </ul>
 </div>
 
 <!-- ═══════════════════════════════════════════════════════════════════
      7. OWNER ROLE
      ═══════════════════════════════════════════════════════════════════ -->
-<div class="card gd">
-<h2>Owner Role</h2>
+<div class="card gd" id="owner">
+<h2>Owner (stored identity, not a role)</h2>
 <p>
-Promotes the existing <code>GroupMetaValue.admin_identity</code> field
-(<code>crates/store/src/key/group/mod.rs:1160-1169</code>) from "fallback creator-admin" to a
-real, exclusive, transferable role. Every group has exactly one Owner. Owner is also an admin —
-all admin permissions cascade. The distinction is exclusive privileges no admin can perform, plus
-the property that Owner cannot be involuntarily removed.
+<b>Owner is not a <code>GroupMemberRole</code> variant.</b> It is a single identity stored on group
+metadata: <code>GroupMetaValue.owner_identity</code> (<code>crates/store/src/key/group/mod.rs</code>).
+Every group has exactly one Owner, and that member is otherwise an ordinary <code>Admin</code> — the
+"Owner" status is whatever the apply handlers grant by comparing the signer's public key against
+<code>owner_identity</code>. The distinction is a small set of exclusive privileges plus immunity
+from involuntary removal; it is enforced by identity comparison, not by a role bit.
 </p>
 
-<h3>Storage change</h3>
+<h3>Storage</h3>
 <p>
-Semantic rename of <code>admin_identity</code> to <code>owner_identity</code>. Field shape and
-serialization unchanged — every existing group's current <code>admin_identity</code> becomes
-its Owner. No migration needed at the data layer; the change is at the type and access-path
-layer (rename callsites, expose as a real role).
+The struct carries <em>both</em> fields: the legacy <code>admin_identity</code> (now a
+fallback creator-admin marker for pre-existing groups) and the shipped <code>owner_identity</code>.
+Newly-created groups initialize <code>owner_identity == admin_identity</code>. Field shape and
+serialization are stable.
 </p>
 
 <h3>New op</h3>
@@ -492,8 +644,8 @@ layer (rename callsites, expose as a real role).
   <tr><td>Demote admin → member</td><td>—</td><td>✓<sup>1</sup></td><td>✓</td></tr>
   <tr><td><code>TransferOwnership</code></td><td>—</td><td>—</td><td>✓</td></tr>
   <tr><td><code>DeleteGroup</code> / <code>DeleteContext</code> / <code>DeleteNamespace</code></td><td>—</td><td>—</td><td>✓</td></tr>
-  <tr><td>Be involuntarily removed (<code>MemberRemoved</code>)</td><td>✓</td><td>✓</td><td>✗ — <code>CannotRemoveOwner</code></td></tr>
-  <tr><td>Self-leave via <code>leave_group</code> / <code>leave_namespace</code></td><td>✓</td><td>✓ (last-admin permitting)</td><td>✗ — must <code>TransferOwnership</code> first</td></tr>
+  <tr><td>Be involuntarily removed (<code>MemberRemoved</code>)</td><td>✓</td><td>✓</td><td>✗ — <code>OwnerImmuneFromRemoval</code></td></tr>
+  <tr><td>Self-leave via <code>leave_group</code> / <code>leave_namespace</code></td><td>✓</td><td>✓ (last-admin permitting)</td><td>✗ — <code>OwnerCannotSelfLeave</code> / <code>OwnerOwnsSubgroup</code></td></tr>
 </table>
 <p style="font-size:0.9em; color:#6b6b80; margin-top:8px;">
 <sup>1</sup> Open question. The existing code allows admins to demote each other
@@ -548,7 +700,7 @@ parent group as before.
     <td><code>leave_group</code></td>
     <td>Single group</td>
     <td><code>MemberLeft</code></td>
-    <td>Yes (1 group)</td>
+    <td>No (self-leave; deferred)</td>
     <td>None</td>
     <td>Re-invite (Restricted) / re-inherit (Open)</td>
   </tr>
@@ -556,9 +708,25 @@ parent group as before.
     <td><code>leave_namespace</code></td>
     <td>Whole subtree</td>
     <td><code>MemberLeft</code> at root</td>
-    <td>Yes (1 + N)</td>
+    <td>No (self-leave; deferred)</td>
     <td>All direct-row scopes</td>
     <td>Re-invite at root + re-inherit</td>
+  </tr>
+  <tr>
+    <td><code>MemberRemoved</code> (owner/admin)</td>
+    <td>Single group (cascades contexts)</td>
+    <td><code>MemberRemoved</code></td>
+    <td><b>Yes</b> — re-key excludes removed</td>
+    <td>Context identities</td>
+    <td>Re-invite (re-key delivered on add)</td>
+  </tr>
+  <tr>
+    <td><code>ReadOnlyTee</code> removal + self-purge</td>
+    <td>Subgroup or whole namespace</td>
+    <td><code>MemberRemoved</code> + <code>TeeMemberRemoved</code> event</td>
+    <td>Yes (via removal) + local key delete</td>
+    <td>Subtree on namespace-root</td>
+    <td>None under same identity (fresh attestation)</td>
   </tr>
   <tr>
     <td><code>TransferOwnership</code></td>
@@ -593,17 +761,17 @@ parent group as before.
 <div class="card gb">
 <h2>Implementation Status</h2>
 <p>
-This page commits the design before any code lands. Status flips from <b>proposed</b> to
-<b>implemented</b> as each feature ships, in PRs that update the corresponding section.
+This page documents shipped behavior. Each row points at the code that implements it.
 </p>
 <table class="properties">
-  <tr><th>Section</th><th>Status</th><th>Tracking</th></tr>
+  <tr><th>Section</th><th>Status</th><th>Code</th></tr>
   <tr><td>Membership Model Recap</td><td>Documents existing code</td><td>—</td></tr>
-  <tr><td><code>leave_context</code></td><td><b>Implemented</b> (PR #2280)</td><td><code>crates/context/src/handlers/leave_context.rs</code>, <code>auto_follow.rs</code> gate, <code>POST /admin-api/contexts/:id/leave</code></td></tr>
-  <tr><td><code>leave_group</code></td><td><b>Implemented</b> (PR #2280)</td><td><code>GroupOp::MemberLeft</code>, <code>crates/context/src/handlers/leave_group.rs</code>, <code>POST /admin-api/groups/:id/leave</code> — apply enforces self-leave + direct-row + owner + last-admin. <em>No key rotation</em>; admin follow-up required for forward secrecy (deferred).</td></tr>
-  <tr><td><code>leave_namespace</code></td><td><b>Implemented</b> (PR #2280)</td><td><code>crates/context/src/handlers/leave_namespace.rs</code>, <code>POST /admin-api/namespaces/:id/leave</code>. Apply detects no-parent and cascades through descendant groups where leaver has direct rows; multi-scope owner + last-admin checked upfront. <em>No per-scope key rotation</em>.</td></tr>
-  <tr><td>Owner Role + <code>TransferOwnership</code></td><td><b>Implemented</b> (PR #2280)</td><td><code>GroupMetaValue.owner_identity</code>, <code>GroupOp::TransferOwnership</code>, <code>CannotRemoveOwner</code> gate in <code>MemberRemoved</code></td></tr>
-  <tr><td><code>DeleteGroup</code> Owner-gating</td><td><b>Implemented</b> (PR #2280)</td><td>Group-scope only — root <code>GroupDeleted</code> + <code>DeleteNamespace</code> Owner-gating planned with <code>leave_namespace</code> in PR #3</td></tr>
+  <tr><td><code>leave_context</code></td><td><b>Implemented</b></td><td><code>crates/context/src/handlers/leave_context.rs</code>, <code>auto_follow.rs</code> gate, <code>POST /admin-api/contexts/:id/leave</code></td></tr>
+  <tr><td><code>leave_group</code></td><td><b>Implemented</b></td><td><code>GroupOp::MemberLeft</code>, <code>crates/governance-store/src/ops/group/member_left.rs</code>, <code>POST /admin-api/groups/:id/leave</code> — apply enforces self-leave + direct-row + owner + last-admin. <em>No key rotation on self-leave</em> (deferred two-phase rotation).</td></tr>
+  <tr><td><code>leave_namespace</code></td><td><b>Implemented</b></td><td>Same <code>member_left.rs</code> apply detects the no-parent case and cascades through descendant groups where the leaver has direct rows; multi-scope owner + last-admin checked upfront. <em>No per-scope key rotation</em>.</td></tr>
+  <tr><td>Key rotation on <code>MemberRemoved</code></td><td><b>Implemented</b></td><td><code>crates/governance-store/src/group_governance_publisher.rs</code> (<code>sign_apply_and_publish_inner</code>) + <code>GroupKeyring</code> in <code>group_keys.rs</code> — fresh key wrapped for remaining members, excluding the removed one.</td></tr>
+  <tr><td>Role-scoped TEE self-purge</td><td><b>Implemented</b> (ADR 0002; #2680/#2724/#2725)</td><td><code>crates/context/src/self_purge.rs</code> listener + cascade + marker-gated <code>reconcile_sweep</code>; <code>delete_group_local_rows</code> in <code>governance-store/src/local_state.rs</code> deletes signing keys (and, as of #2776, <code>GroupKeyring</code> encryption keys); <code>OpEvent::TeeMemberRemoved</code> emitted from <code>member_removed.rs</code> / <code>member_left.rs</code>.</td></tr>
+  <tr><td>Owner identity + <code>TransferOwnership</code></td><td><b>Implemented</b></td><td><code>GroupMetaValue.owner_identity</code>, <code>GroupOp::TransferOwnership</code> (<code>ops/group/transfer_ownership.rs</code>), <code>OwnerImmuneFromRemoval</code> / <code>OwnerCannotSelfLeave</code> gates in <code>MemberRemoved</code> / <code>MemberLeft</code>.</td></tr>
 </table>
 </div>
 
@@ -611,22 +779,23 @@ This page commits the design before any code lands. Status flips from <b>propose
      10. OPEN QUESTIONS
      ═══════════════════════════════════════════════════════════════════ -->
 <div class="card gc">
-<h2>Open Questions</h2>
+<h2>Open Questions &amp; Follow-ups</h2>
 <ol>
-  <li><b>Soft vs hard local cleanup default for <code>leave_namespace</code>.</b> This proposal
-  defaults to soft (archive). Privacy-conscious products may want hard (purge) as the default.</li>
-  <li><b>Admin-mutual demote.</b> Today admins can demote each other. Should this be restricted
-  to Owner-only? This proposal preserves current behavior; revisit if a security concern surfaces.</li>
-  <li><b>Old owner after <code>TransferOwnership</code>.</b> Becomes a regular admin (this
-  proposal) or just a member (alternative)? Admin retains operational continuity; member is a
-  cleaner "step-down" semantic.</li>
-  <li><b>Multi-scope transfer ergonomics.</b> If an owner of a namespace + 5 subgroups wants to
-  leave, does the UI surface 6 separate prompts or one bulk-transfer flow?</li>
-  <li><b>Cascade visibility in <code>leave_namespace</code>.</b> Remaining peers see one
-  user-facing event (<code>MemberLeft</code>) or N events (one per cascading scope's
-  <code>KeyDelivery</code>)? Recommend collapsing to one user-facing event with internal fan-out.</li>
-  <li><b>Owner-leaves-with-no-successor edge case.</b> Dedicated <code>DeleteNamespace</code> op
-  (this proposal) or refuse outright?</li>
+  <li><b>Two-phase self-leave rotation.</b> <code>MemberLeft</code> currently does not re-key (the
+  leaver can't generate a key without retaining it). A deferred design has a remaining admin's apply
+  hook publish the new key after the leave. Until it lands, owner-initiated <code>MemberRemoved</code>
+  is the only rotating leave.</li>
+  <li><b>Local cleanup is role-scoped, not a toggle.</b> The earlier soft-vs-hard default question is
+  resolved by role (ADR 0002): non-TEE removals stay soft; <code>ReadOnlyTee</code> removals
+  hard-purge. No global default knob.</li>
+  <li><b>Admin-mutual demote.</b> Admins can demote each other. Whether to restrict this to
+  Owner-only is unresolved; current behavior is preserved.</li>
+  <li><b>Old owner after <code>TransferOwnership</code>.</b> Becomes a regular admin (current
+  behavior) or just a member (alternative)?</li>
+  <li><b>Subgroup-level self-purge reconcile.</b> The startup reconcile is namespace-level only; a
+  subgroup-only purge has no reconcile retry surface yet (tracked in #2726).</li>
+  <li><b>Periodic reconcile.</b> A purely-lagged-drop of <code>TeeMemberRemoved</code> writes no
+  marker and is not recovered until a future eviction; a periodic sweep is an open follow-up.</li>
 </ol>
 </div>
 

--- a/architecture/metrics-reference.html
+++ b/architecture/metrics-reference.html
@@ -357,8 +357,8 @@
      ════════════════════════════════════════════════════════ -->
 <div class="card gb">
 <h2>TEE Self-Purge Metrics</h2>
-<p style="margin-bottom:8px;">Observability for the self-purge cleanup that runs when a hardware-attested fleet node is evicted from its <span class="code">ReadOnlyTee</span> role. Self-purge hard-deletes a node's own local rows and keys (both signing-key material and per-group encryption keys) and is recovered across restarts by a marker plus a startup reconcile sweep. See <a href="membership-and-leave.html">Membership &amp; Leave</a> and <a href="tee-fleet-ha.html">TEE Fleet HA</a>.</p>
-<a class="gh-link" href="https://github.com/calimero-network/core/blob/master/crates/context/src/metrics.rs" target="_blank" rel="noopener">crates/context/src/metrics.rs</a>
+<p style="margin-bottom:8px;">Observability for the self-purge cleanup that runs when a hardware-attested fleet node is evicted from its <span class="code">ReadOnlyTee</span> role. Self-purge hard-deletes a node's own local rows and keys (signing-key material and, as of #2776, the per-group encryption keys) and is recovered across restarts by a marker plus a startup reconcile sweep. See <a href="membership-and-leave.html">Membership &amp; Leave</a> and <a href="tee-fleet-ha.html">TEE Fleet HA</a>.</p>
+<a class="gh-link" href="https://github.com/calimero-network/core/blob/master/crates/governance-store/src/metrics.rs" target="_blank" rel="noopener">crates/governance-store/src/metrics.rs</a>
 
 <div class="metric-note" style="margin-top:14px;"><strong>Naming</strong> — These families register under the <span class="code">context</span> → <span class="code">group_store</span> sub-registries, so the exported Prometheus names carry the <span class="code">context_group_store_</span> prefix (e.g. <span class="code">context_group_store_self_purge_failures_total</span>). The registered names are shown below.</div>
 

--- a/architecture/metrics-reference.html
+++ b/architecture/metrics-reference.html
@@ -40,7 +40,7 @@
   <div class="stat"><div class="v">16</div><div class="l">sync metrics</div></div>
   <div class="stat"><div class="v">5</div><div class="l">channel metrics</div></div>
   <div class="stat"><div class="v">2</div><div class="l">context metrics</div></div>
-  <div class="stat"><div class="v">4</div><div class="l">sections</div></div>
+  <div class="stat"><div class="v">3</div><div class="l">self-purge metrics</div></div>
 </div>
 
 <!-- ════════════════════════════════════════════════════════
@@ -353,7 +353,51 @@
 </div>
 
 <!-- ════════════════════════════════════════════════════════
-     5. DASHBOARD QUERIES
+     5. TEE GOVERNANCE / SELF-PURGE METRICS
+     ════════════════════════════════════════════════════════ -->
+<div class="card gb">
+<h2>TEE Self-Purge Metrics</h2>
+<p style="margin-bottom:8px;">Observability for the self-purge cleanup that runs when a hardware-attested fleet node is evicted from its <span class="code">ReadOnlyTee</span> role. Self-purge hard-deletes a node's own local rows and keys (both signing-key material and per-group encryption keys) and is recovered across restarts by a marker plus a startup reconcile sweep. See <a href="membership-and-leave.html">Membership &amp; Leave</a> and <a href="tee-fleet-ha.html">TEE Fleet HA</a>.</p>
+<a class="gh-link" href="https://github.com/calimero-network/core/blob/master/crates/context/src/metrics.rs" target="_blank" rel="noopener">crates/context/src/metrics.rs</a>
+
+<div class="metric-note" style="margin-top:14px;"><strong>Naming</strong> — These families register under the <span class="code">context</span> → <span class="code">group_store</span> sub-registries, so the exported Prometheus names carry the <span class="code">context_group_store_</span> prefix (e.g. <span class="code">context_group_store_self_purge_failures_total</span>). The registered names are shown below.</div>
+
+<table class="metric-table" style="margin-top:18px;">
+<thead><tr><th>Metric</th><th>Type</th><th>Labels</th><th>Description</th></tr></thead>
+<tbody>
+<tr>
+  <td class="mn">self_purge_failures_total</td>
+  <td class="mt">Family&lt;Counter&gt;</td>
+  <td class="ml">branch, class</td>
+  <td class="md">Self-purge local-state cleanup failures. <span class="code">branch</span> ∈ {<span class="code">namespace</span>, <span class="code">subgroup</span>}; <span class="code">class</span> ∈ {<span class="code">signing_key</span>, <span class="code">context_cleanup</span>}. The <span class="code">class="signing_key"</span> series is the security-relevant one (forward-secrecy residue on disk); <span class="code">class="context_cleanup"</span> is a best-effort dead-pointer leak and is informational.</td>
+</tr>
+<tr>
+  <td class="mn">self_purge_reconcile_total</td>
+  <td class="mt">Family&lt;Counter&gt;</td>
+  <td class="ml">outcome</td>
+  <td class="md">Startup reconcile-sweep outcomes, one increment per marked namespace processed. <span class="code">outcome</span> ∈ {<span class="code">reconciled</span>, <span class="code">retained</span>, <span class="code">cleared_stale</span>, <span class="code">stale_clear_failed</span>, <span class="code">skipped</span>}. <span class="code">retained</span> stuck across restarts means a signing-key purge keeps failing; read-uncertainty lands in <span class="code">skipped</span> (not in <span class="code">self_purge_failures_total</span>).</td>
+</tr>
+<tr>
+  <td class="mn">self_purge_events_dropped_total</td>
+  <td class="mt">Counter</td>
+  <td class="ml">—</td>
+  <td class="md">Self-purge op-events dropped by the broadcast <span class="code">Lagged</span> arm (subscriber fell behind). An upper bound on dropped eviction events, each of which writes no reconcile marker — un-recoverable on-disk residue (bounded; not a forward-secrecy hole, which is held by key rotation).</td>
+</tr>
+</tbody>
+</table>
+
+<details>
+  <summary>Self-purge metric usage notes</summary>
+  <div class="detail-body">
+    <div class="metric-note"><strong>self_purge_failures_total</strong> — Alert on any non-zero rate of <span class="code">class="signing_key"</span>: it means a node's own private signing-key material may linger on disk after eviction, pending the reconcile sweep. <span class="code">class="context_cleanup"</span> is informational (orphaned dead-pointer rows); namespace deletion and unsubscribe still proceed.</div>
+    <div class="metric-note"><strong>self_purge_reconcile_total</strong> — In steady state the startup sweep should be quiet. A namespace persistently in <span class="code">outcome="retained"</span> across restarts indicates a signing-key purge that keeps failing — investigate. <span class="code">stale_clear_failed</span> is benign (re-evaluated next restart); <span class="code">skipped</span> means the sweep declined to purge under read uncertainty (never purge on uncertainty).</div>
+    <div class="metric-note"><strong>self_purge_events_dropped_total</strong> — Any non-zero rate means the self-purge subscriber fell more than the broadcast capacity behind and some evictions may have left un-reconcilable on-disk residue. Bounded and not a forward-secrecy hole, but worth alerting as a correctness signal.</div>
+  </div>
+</details>
+</div>
+
+<!-- ════════════════════════════════════════════════════════
+     6. DASHBOARD QUERIES
      ════════════════════════════════════════════════════════ -->
 <div class="card gd">
 <h2>Dashboard Queries</h2>
@@ -440,6 +484,22 @@ network_event_channel_depth / 1000
 <span class="comment"># Protocol selection distribution</span><br>
 <span class="fn">sum</span>(<span class="fn">rate</span>(sync_protocol_selections_total[5m])) <span class="fn">by</span> (<span class="label">protocol</span>)<br>
 / <span class="fn">ignoring</span>(<span class="label">protocol</span>) <span class="fn">group_left</span> <span class="fn">sum</span>(<span class="fn">rate</span>(sync_protocol_selections_total[5m]))
+</div>
+
+<h3>TEE Self-Purge Health</h3>
+<div class="promql">
+<span class="comment"># CRITICAL: signing-key residue left on disk after eviction</span><br>
+<span class="fn">increase</span>(context_group_store_self_purge_failures_total{<span class="label">class</span>="signing_key"}[15m]) > 0
+</div>
+
+<div class="promql">
+<span class="comment"># WARNING: a namespace stuck "retained" — repeated purge failure</span><br>
+<span class="fn">increase</span>(context_group_store_self_purge_reconcile_total{<span class="label">outcome</span>="retained"}[1h]) > 0
+</div>
+
+<div class="promql">
+<span class="comment"># WARNING: dropped self-purge events — un-recoverable residue risk</span><br>
+<span class="fn">rate</span>(context_group_store_self_purge_events_dropped_total[5m]) > 0
 </div>
 </div>
 

--- a/architecture/nav.js
+++ b/architecture/nav.js
@@ -24,6 +24,7 @@
     { label: 'merod & meroctl', href: 'crates/tools.html', dot: '#f59e0b' },
     { label: 'Config Reference', href: 'config-reference.html', dot: '#f97316' },
     { label: 'TEE Mode', href: 'tee-mode.html', dot: '#ec4899' },
+    { label: 'Fleet HA', href: 'tee-fleet-ha.html', dot: '#a855f7' },
     { label: 'Release Process', href: 'release.html', dot: '#10b981' },
     { label: 'Auth Service', href: 'crates/auth.html', dot: '#84cc16' },
     { section: 'Architecture Deep-Dive' },

--- a/architecture/sequence-diagrams.html
+++ b/architecture/sequence-diagrams.html
@@ -321,7 +321,7 @@
               <line x1="300" y1="150" x2="500" y2="150" stroke="#10b981" stroke-width="1.5"/>
               <text x="400" y="143" text-anchor="middle" fill="#6b6b80" font-family="JetBrains Mono" font-size="8">create group metadata + encryption key</text>
               <line x1="300" y1="190" x2="700" y2="190" stroke="#8b5cf6" stroke-width="1.5"/>
-              <text x="500" y="183" text-anchor="middle" fill="#6b6b80" font-family="JetBrains Mono" font-size="8">subscribe namespace/&lt;hex&gt; topic</text>
+              <text x="500" y="183" text-anchor="middle" fill="#6b6b80" font-family="JetBrains Mono" font-size="8">subscribe ns/&lt;hex&gt; topic</text>
               <line x1="300" y1="230" x2="500" y2="230" stroke="#10b981" stroke-width="1.5"/>
               <text x="400" y="223" text-anchor="middle" fill="#6b6b80" font-family="JetBrains Mono" font-size="8">sign &amp; apply RootOp::GroupCreated</text>
               <line x1="300" y1="270" x2="700" y2="270" stroke="#8b5cf6" stroke-width="1.5"/>

--- a/architecture/sequence-diagrams.html
+++ b/architecture/sequence-diagrams.html
@@ -76,7 +76,7 @@
         <h4>Infrastructure</h4>
         <div class="seq-tab-row">
           <button class="tab" data-target="p-auth-flow">HTTP Auth</button>
-          <button class="tab" data-target="p-tee-invite">TEE Node Invite</button>
+          <button class="tab" data-target="p-tee-fleet-join">TEE Fleet Join</button>
         </div>
         <h4>Group Management</h4>
         <div class="seq-tab-row">
@@ -210,12 +210,12 @@
         </div>
       </div>
 
-      <!-- TEE Node Invite -->
-      <div class="panel" id="p-tee-invite">
+      <!-- TEE Fleet Join -->
+      <div class="panel" id="p-tee-fleet-join">
         <div class="card ga">
-          <p class="diagram-desc">Specialized (TEE/read-only) node invitation: discovery broadcast, attestation verification, invitation exchange, and join confirmation.</p>
-          <div class="diagram-tools"><button class="replay-btn" onclick="replay('d-tee-invite')">&#9654; Replay</button></div>
-          <div class="diagram-container animating" id="d-tee-invite"></div>
+          <p class="diagram-desc">Current fleet-admission flow (supersedes the legacy specialized-node invite handshake). A TEE node broadcasts <span class="code">TeeAttestationAnnounce</span> on <span class="code">ns/&lt;hex&gt;</span> and re-announces for up to ~30s (<span class="code">MAX_ADMISSION_WAIT</span>). A verifier runs <span class="code">verify_attestation</span>, then namespace-scoped <span class="code">admit_tee_node</span> (policy check + quote-hash replay guard), publishes <span class="code">MemberJoinedViaTeeAttestation</span> (a <span class="code">ReadOnlyTee</span> row) and a <span class="code">RootOp::KeyDelivery</span>; the node applies the key and is admitted. On disable, a <span class="code">TeeMemberRemoved</span> op triggers <span class="code">self_purge</span> on the evicted node. See <a href="tee-fleet-ha.html">TEE Fleet HA</a>.</p>
+          <div class="diagram-tools"><button class="replay-btn" onclick="replay('d-tee-fleet-join')">&#9654; Replay</button></div>
+          <div class="diagram-container animating" id="d-tee-fleet-join"></div>
         </div>
       </div>
 
@@ -827,24 +827,26 @@
         ]
       },
       {
-        id: 'd-tee-invite',
-        title: 'TEE Node Invite',
+        id: 'd-tee-fleet-join',
+        title: 'TEE Fleet Join',
         lanes: [
-          { label: 'Initiator', color: '#3b82f6' },
-          { label: 'Network',   color: '#8b5cf6' },
-          { label: 'TEE Node',  color: '#ec4899' }
+          { label: 'TEE Node', color: '#ec4899' },
+          { label: 'ns/<hex> gossip', color: '#8b5cf6' },
+          { label: 'Verifier', color: '#3b82f6' }
         ],
         steps: [
-          { from: 0, to: 1, label: 'SpecializedNodeDiscovery { nonce }' },
-          { from: 0, to: 0, label: 'store pending nonce' },
-          { from: 1, to: 2, label: 'discovery broadcast received' },
-          { from: 2, to: 2, label: 'generate attestation' },
-          { from: 2, to: 0, label: 'VerificationRequest { attestation }' },
-          { from: 0, to: 0, label: 'verify TEE attestation' },
-          { from: 0, to: 2, label: 'InvitationResponse { payload }', color: '#A5FF11' },
-          { from: 2, to: 2, label: 'join_context(invitation)' },
-          { from: 2, to: 1, label: 'JoinConfirmation { nonce }' },
-          { from: 1, to: 0, label: 'clear pending invite' }
+          { from: 0, to: 0, label: 'generate TDX attestation' },
+          { from: 0, to: 1, label: 'TeeAttestationAnnounce { quote_bytes, public_key, nonce, node_type }' },
+          { from: 0, to: 0, label: 're-announce up to ~30s (MAX_ADMISSION_WAIT)' },
+          { from: 1, to: 2, label: 'announce received' },
+          { from: 2, to: 2, label: 'verify_attestation' },
+          { from: 2, to: 2, label: 'admit_tee_node: policy check + quote-hash replay guard' },
+          { from: 2, to: 1, label: 'publish MemberJoinedViaTeeAttestation (ReadOnlyTee)', color: '#A5FF11' },
+          { from: 2, to: 1, label: 'publish RootOp::KeyDelivery (wrapped group key)', color: '#A5FF11' },
+          { from: 1, to: 0, label: 'apply MemberJoinedViaTeeAttestation + KeyDelivery' },
+          { from: 0, to: 0, label: 'admitted as ReadOnlyTee; group key held' },
+          { from: 2, to: 1, label: 'on disable: TeeMemberRemoved' },
+          { from: 1, to: 0, label: 'self_purge (drop key material + local rows)' }
         ]
       },
       {

--- a/architecture/tee-fleet-ha.html
+++ b/architecture/tee-fleet-ha.html
@@ -1,0 +1,407 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TEE Fleet High Availability — Calimero Core Architecture</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div class="main">
+<div class="content">
+<div class="breadcrumb"><a href="index.html">Home</a><span class="sep">/</span><span>Fleet HA</span></div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     1. TITLE + STATS
+     ═══════════════════════════════════════════════════════════════════ -->
+<h1>TEE Fleet <em>High Availability</em></h1>
+<p class="page-subtitle">Hardware-attested read replicas that hold group keys and serve a namespace's data</p>
+
+<div class="g4" style="margin-bottom:36px;">
+  <div class="stat"><div class="v">ReadOnlyTee</div><div class="l">replica role</div></div>
+  <div class="stat"><div class="v">Namespace</div><div class="l">HA &amp; entitlement boundary</div></div>
+  <div class="stat"><div class="v">TDX</div><div class="l">attestation trust root</div></div>
+  <div class="stat"><div class="v">Per-group</div><div class="l">encryption key model</div></div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     2. WHAT IT IS
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card ga">
+<h2>What fleet HA is</h2>
+<p>
+A <strong>TEE fleet</strong> is a pool of hardware-attested replica nodes that hold a namespace's
+group keys and serve <em>reads</em> for its data. Each replica joins as a
+<span class="code">ReadOnlyTee</span> member — it can decrypt and answer sync requests, but it can
+never write. The fleet exists so that a namespace's data stays available and queryable even when
+the human-operated owner node is offline, NAT'd, or asleep.
+</p>
+<p>
+Two planes cooperate. The <strong>control plane</strong> (the
+<a href="https://github.com/calimero-network/mdma" target="_blank" rel="noopener">mdma</a> service)
+is the source of truth for <em>entitlement</em>: a namespace is configured or paid for once, and
+mdma decides which fleet nodes <em>should</em> serve it. A <strong>fleet sidecar</strong> (shipped
+by the <a href="https://github.com/calimero-network/mero-tee" target="_blank" rel="noopener">mero-tee</a>
+repo) runs alongside each <span class="code">merod</span> replica and drives the per-node lifecycle
+by calling <span class="code">meroctl</span>. Core itself owns the on-chain governance: attestation
+verification, admission, key delivery, and purge.
+</p>
+<p>
+The key split to keep straight: <strong>entitlement is per-namespace</strong> (paid/configured
+once), but <strong>admission is per-subgroup</strong> (each Restricted subgroup the replica should
+read needs its own membership row and key). The sections below walk the full lifecycle —
+fleet-join, admission, key delivery, transparent subgroup follow-on, and disable/leave/purge.
+</p>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     3. ROLES & BOUNDARIES
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card gb">
+<h2>Roles &amp; boundaries</h2>
+
+<h3>The ReadOnlyTee role</h3>
+<ul>
+  <li><b>Directly-rowed, never inherited.</b> A <span class="code">ReadOnlyTee</span> membership is
+  always a stored <span class="code">(member, group)</span> row written by admission. It is
+  <em>never</em> conferred by the inherited-membership parent-walk — a replica is only ever a member
+  of the scopes it was explicitly admitted to.</li>
+  <li><b>Read-only.</b> The role cannot author governance ops or state deltas. It exists to
+  decrypt and serve, not to mutate.</li>
+  <li><b>Auto-follow on.</b> Admission sets both auto-follow flags
+  (<span class="code">contexts</span> and <span class="code">subgroups</span>) to
+  <span class="code">true</span>, so a replica tracks new contexts in the scopes it holds. See
+  <a href="auto-follow.html">Auto-Follow</a> for the propagation machinery.</li>
+</ul>
+
+<h3>The namespace as the HA boundary</h3>
+<p>
+A <strong>namespace is its own root group</strong> — there is no separate
+<span class="code">Namespace</span> type; the namespace <em>is</em> the no-parent
+<span class="code">ContextGroup</span> at the top of a strict tree (see
+<a href="membership-and-leave.html">Membership &amp; Leave</a> for the hierarchy recap). Fleet HA
+is scoped to a namespace: entitlement, the admission policy, and the disable/purge boundary all
+sit at the namespace root. A replica admitted at the root serves the namespace; per-subgroup rows
+extend its reach into Restricted children.
+</p>
+
+<h3>Two distinct key families</h3>
+<p>
+Do not conflate them:
+</p>
+<ul>
+  <li><b>Per-group encryption keys</b> (<span class="code">GroupKeyring</span>) — the AES keys that
+  protect a group's replicated data. These are <em>delivered</em> to a replica after admission and
+  are the subject of most of this page.</li>
+  <li><b>The node's own storage / disk key</b> — the AES-256 key <span class="code">merod</span>
+  fetches from the KMS at startup to encrypt its datastore and blobstore on disk. That is the
+  subject of <a href="tee-mode.html">TEE Mode</a>, a separate concern from group keys.</li>
+</ul>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     4. FLEET-JOIN & ANNOUNCE
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card gc">
+<h2>Fleet-join &amp; attestation announce</h2>
+<p>
+The fleet sidecar starts a replica's join by calling
+<span class="code">meroctl tee fleet-join</span>, which hits
+<span class="code">POST /admin-api/tee/fleet-join</span>. The handler
+(<span class="code">crates/server/src/admin/handlers/tee/fleet_join.rs</span>):
+</p>
+<ol>
+  <li>Resolves the node's <strong>namespace identity</strong> (the keypair the replica joins under).</li>
+  <li>Builds <span class="code">report_data = nonce(32) || Sha256(pubkey)</span>, binding a fresh
+  random nonce to the node's public key.</li>
+  <li>Calls <span class="code">generate_attestation</span> to produce a real TDX quote
+  (<span class="code">crates/tee-attestation/src/generate.rs</span>). <b>Mock quotes are rejected on
+  this path</b> — fleet-join is production hardware only.</li>
+  <li>Broadcasts
+  <span class="code">BroadcastMessage::TeeAttestationAnnounce { quote_bytes, public_key, nonce, node_type: ReadOnly }</span>
+  on the gossip topic <span class="code">ns/&lt;hex(namespace_id)&gt;</span>.</li>
+</ol>
+<p>
+A single publish into an empty mesh is silently dropped — gossipsub has no replay, and at boot the
+replica may have no peers yet. The handler defends against this by <strong>re-announcing</strong>:
+it republishes the announce roughly every 2&nbsp;s for up to ~30&nbsp;s per call, issues a namespace
+bootstrap pull each cycle to seed the mesh, and polls for its own admission between announces. If
+30&nbsp;s elapse without admission the call returns; the sidecar retries.
+</p>
+<details>
+<summary>Announce loop, step by step</summary>
+<div class="detail-body">
+<ol style="line-height:1.65;color:var(--text-dim);margin:0;padding-left:1.25rem;">
+<li>Generate nonce, build <span class="code">report_data</span>, generate the TDX quote bound to the namespace-identity pubkey.</li>
+<li>Publish <span class="code">TeeAttestationAnnounce</span> on <span class="code">ns/&lt;hex(namespace_id)&gt;</span>.</li>
+<li>Sleep ~2&nbsp;s; run a namespace bootstrap pull to populate the mesh.</li>
+<li>Poll: has a verifier written a <span class="code">ReadOnlyTee</span> row for this node yet?</li>
+<li>If not and the ~30&nbsp;s budget remains, re-announce and loop. (No replay — every publish is fresh into whatever mesh now exists.)</li>
+<li>On admission, fall through to joining contexts and publishing the self-signed auto-follow op (see <a href="auto-follow.html">Auto-Follow</a>).</li>
+</ol>
+</div>
+</details>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     5. VERIFIER ADMISSION & POLICY
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card gc">
+<h2>Verifier admission &amp; policy</h2>
+<p>
+A <strong>verifier</strong> is any existing member of the namespace that receives the announce. The
+inbound handler is <span class="code">crates/node/src/handlers/tee_attestation_admission.rs</span>.
+It verifies the quote before trusting anything: <span class="code">verify_attestation</span>
+(<span class="code">crates/tee-attestation/src/verify.rs</span>) checks the DCAP signature, that the
+nonce in <span class="code">report_data</span> is fresh, and the measurements. Only then does it
+call <span class="code">admit_tee_node</span>
+(<span class="code">crates/context/src/handlers/admit_tee_node.rs</span>).
+</p>
+
+<h3>Policy is namespace-scoped</h3>
+<p>
+The admission policy lives on the namespace root, never on a subgroup.
+<span class="code">read_tee_admission_policy</span>
+(<span class="code">crates/governance-store/src/tee.rs</span>) resolves whatever scope it is given
+up to the namespace root before reading. Any policy bytes attached to a subgroup are inert — see
+the <a href="auto-follow.html">Auto-Follow</a> page's policy-scope note for why subgroup policies
+were deliberately disabled.
+</p>
+
+<h3>Admission checks</h3>
+<ul>
+  <li><b>Measurement allowlist.</b> <span class="code">allowed_mrtd</span> must be non-empty (an
+  empty allowlist fails closed). The quote's <span class="code">mrtd</span>,
+  <span class="code">rtmr0..3</span>, and <span class="code">tcb_status</span> are checked against
+  their allowlists.</li>
+  <li><b>Mock gate.</b> Mock quotes are admitted only when <span class="code">accept_mock</span> is
+  set — a development-only escape hatch.</li>
+  <li><b>Per-group quote-hash replay.</b> <span class="code">is_quote_hash_used</span> rejects a
+  quote whose hash was already consumed in this scope, blocking replay of a captured announce.</li>
+  <li><b>Idempotent.</b> If a direct row for this member already exists, admission is a no-op rather
+  than an error — safe under the re-announce loop.</li>
+</ul>
+
+<h3>What admission writes</h3>
+<p>
+On success the verifier writes a <span class="code">ReadOnlyTee</span> direct row plus a signing
+key for the member, and publishes
+<span class="code">GroupOp::MemberJoinedViaTeeAttestation</span>. That op propagating is exactly
+what the joiner's poll in <span class="code">fleet_join.rs</span> is waiting on.
+</p>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     6. KEY DELIVERY & RECOVERY
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card gc">
+<h2>Key delivery &amp; recovery</h2>
+<p>
+A row alone is not enough — the replica needs the group's encryption key to decrypt anything. After
+admission, a <strong>key-holder</strong> (the admitting verifier, or any member that holds the key)
+delivers it.
+</p>
+
+<h3>The one-shot delivery</h3>
+<p>
+The key-holder calls <span class="code">deliver_group_key_to_member</span>, which publishes
+<span class="code">NamespaceOp::Root(RootOp::KeyDelivery { group_id, envelope })</span> on the
+namespace DAG. The envelope is ECDH-wrapped for the recipient's public key. The recipient applies
+it via <span class="code">apply_received_group_key</span> and stores the key.
+</p>
+
+<h3>The durable recovery pull</h3>
+<p>
+A one-shot delivery can be missed (offline at delivery time, dropped broadcast). The joiner side
+therefore has a durable fallback: <span class="code">recover_missing_group_keys</span>
+(<span class="code">crates/node/src/sync/manager/namespace_sync.rs</span>) sends a
+<span class="code">GroupKeyRequest</span>; a member-peer that holds the key answers with
+<span class="code">GroupKeyResponse</span>. The responder's authorization is
+<strong>role-agnostic</strong>, so it will serve a <span class="code">ReadOnlyTee</span> replica
+just as it would any member. The recovery pull runs:
+</p>
+<ul>
+  <li>at the end of every namespace sync,</li>
+  <li>on an interval, and</li>
+  <li>on receipt of the relevant gossip event.</li>
+</ul>
+<p>
+This turns key acquisition from a fragile single broadcast into a self-healing loop.
+</p>
+
+<h3>Open subgroups need no per-subgroup key</h3>
+<p>
+Data in an <strong>Open</strong>-chain subgroup is encrypted under the <em>namespace</em> key, not
+a distinct per-subgroup key. A replica admitted at the namespace root already holds that key, so it
+can read Open subgroups with no additional delivery. Per-subgroup keys only matter for
+<strong>Restricted</strong> subgroups, which is what the next section is about.
+</p>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     7. TRANSPARENT PER-SUBGROUP ADMISSION
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card gd">
+<h2>Transparent per-subgroup admission <em>(PR #2772)</em></h2>
+<p>
+Entitlement is per-namespace, but a Restricted subgroup is a private island: a root-admitted
+replica has no row in it and no key for it. Manually re-attesting into every Restricted subgroup
+would be brittle. PR #2772 makes this <strong>transparent</strong> — the replica is folded into the
+Restricted subgroups it should read without a fresh quote.
+</p>
+<p>
+<b>Scope: Restricted subgroups only.</b> Open subgroups are already readable via inherited
+membership and the namespace key, so they need nothing here.
+</p>
+
+<h3>How it works</h3>
+<p>
+A key-holder-side subscriber (<span class="code">tee_subgroup_admit</span>) reacts to two op events:
+</p>
+<ul>
+  <li><b><span class="code">OpEvent::SubgroupCreated</span></b> — a new Restricted subgroup appears.
+  The subscriber admits the namespace's existing root <span class="code">ReadOnlyTee</span> members
+  into it.</li>
+  <li><b><span class="code">OpEvent::TeeMemberAdmitted</span> at the root</b> — a new TEE replica
+  joins the namespace. The subscriber admits it into the Restricted subgroups this node holds keys
+  for.</li>
+</ul>
+<p>
+Crucially, no new attestation is requested. The member's already-verified verdict is read back from
+the root op log and reused. Both branches call the same
+<span class="code">admit_tee_node</span> used at the root — and because the actor holds the key, that
+call writes the row <em>and</em> delivers the per-subgroup key in one step.
+</p>
+
+<h3>Two safety details</h3>
+<ul>
+  <li><b>Root-only loop guard.</b> The subscriber acts only at the root, preventing fan-out echo
+  (an admission triggering an event that triggers another admission).</li>
+  <li><b>Bounded wake-then-reread.</b> The apply path can emit the op event before the op log has
+  durably persisted it. A bounded retry absorbs that timing window so the verdict read-back does not
+  race the persist.</li>
+</ul>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     8. DISABLE → LEAVE → PURGE
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card gd">
+<h2>Disable &rarr; leave &rarr; purge</h2>
+<p>
+Decommissioning a replica from a namespace is a coordinated, cross-repo flow. The control plane
+(mdma) is the source of truth and never reaches into the node directly — it uses
+<strong>soft disable</strong>.
+</p>
+
+<h3>Soft disable (control plane)</h3>
+<p>
+mdma drops the namespace from the fleet node's <span class="code">should-join</span> assignments.
+That is the entire control-plane action: there is no kill switch sent to core. The mero-tee fleet
+sidecar notices the namespace has disappeared from its assignments — but only on a
+<em>confirmed-good</em> poll, so a transient assignment-fetch failure does not trigger an accidental
+teardown.
+</p>
+
+<h3>Leave (node, via sidecar)</h3>
+<p>
+On a confirmed drop, the sidecar runs <span class="code">meroctl namespace leave &lt;namespace_id&gt;</span>.
+That publishes <span class="code">GroupOp::MemberLeft</span>
+(<span class="code">crates/governance-store/src/ops/group/member_left.rs</span>), which
+<strong>cascades</strong>: it removes the node's direct row at the root and in
+<em>every subgroup</em> it held a row in, emitting <span class="code">TeeMemberRemoved</span> per
+subgroup. (General leave/eviction semantics are covered in
+<a href="membership-and-leave.html">Membership &amp; Leave</a>.)
+</p>
+
+<h3>Purge (node, role-scoped)</h3>
+<p>
+<span class="code">self_purge</span> (<span class="code">crates/context/src/self_purge.rs</span>)
+reacts to those removals. It is <strong>role-scoped</strong>: only
+<span class="code">ReadOnlyTee</span> removals hard-purge; a non-TEE removal stays a soft-leave. For
+a TEE removal it runs <span class="code">PurgeAction::Namespace</span>, which cascades the whole
+subtree and:
+</p>
+<ul>
+  <li>deletes local replicated data,</li>
+  <li>deletes the signing keys,</li>
+  <li>deletes the AES group encryption keys <em>(PR #2776)</em>, and</li>
+  <li>unsubscribes from the namespace gossip topic.</li>
+</ul>
+<p>
+A purge that is interrupted (crash mid-cascade) is not lost: a durable
+<strong>pending-self-purge marker</strong> plus a startup reconcile sweep complete it on the next
+restart (<span class="code">crates/governance-store/src/local_state.rs</span>).
+</p>
+<details>
+<summary>Disable → purge sequence</summary>
+<div class="detail-body">
+<ol style="line-height:1.65;color:var(--text-dim);margin:0;padding-left:1.25rem;">
+<li>mdma drops the namespace from the node's <span class="code">should-join</span> assignments (soft disable).</li>
+<li>Sidecar observes the drop on a confirmed-good poll and runs <span class="code">meroctl namespace leave</span>.</li>
+<li>Core publishes <span class="code">GroupOp::MemberLeft</span>; it cascades, emitting <span class="code">TeeMemberRemoved</span> for the root and each subgroup row.</li>
+<li><span class="code">self_purge</span> sees the <span class="code">ReadOnlyTee</span> removals and runs <span class="code">PurgeAction::Namespace</span>.</li>
+<li>Local data + signing keys + AES group keys are deleted; the node unsubscribes from the gossip topic.</li>
+<li>If interrupted, the pending-self-purge marker + startup reconcile sweep finish the purge after restart.</li>
+</ol>
+</div>
+</details>
+<p>
+<b>Cross-repo contract.</b> The disable decision and the assignment feed are owned by mdma; the
+leave trigger lives in the mero-tee sidecar; core owns the leave op, the cascade, and the purge.
+Changing the shape of any of these requires coordinating across the three repos.
+</p>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     9. OPERATOR NOTES
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card ga">
+<h2>Operator notes</h2>
+<ul>
+  <li><b>Purge observability.</b> Watch <span class="code">self_purge_failures_total</span>,
+  <span class="code">self_purge_reconcile_total</span>, and
+  <span class="code">self_purge_events_dropped_total</span>. A rising failures or dropped-events
+  counter means purges are not completing cleanly; reconcile counts confirm the startup sweep is
+  doing its job. (See <a href="metrics-reference.html">Metrics Reference</a> once these are listed
+  there.)</li>
+  <li><b>MRTD alignment.</b> The node image's measurements and the control plane's
+  <span class="code">allowed_mrtd</span> allowlist must agree, or every fleet-join fails admission.
+  After a node-image bump, update the namespace's admission policy before expecting replicas to
+  join. Compare against the published measurements as in <a href="tee-mode.html">TEE Mode</a>.</li>
+  <li><b>Two key families.</b> A replica that can fetch its KMS disk key but cannot decrypt group
+  data has a <em>group-key</em> problem (delivery/recovery), not a KMS problem — and vice versa.
+  Diagnose the right family.</li>
+  <li><b>Restricted vs Open reads.</b> If a replica reads some subgroups but not others, the gap is
+  almost always missing per-subgroup admission/keys for Restricted children — the transparent
+  subgroup admission (PR #2772) is what closes it.</li>
+</ul>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     10. RELATED
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="card gb">
+<h2>Related</h2>
+<ul>
+  <li><a href="tee-mode.html">TEE Mode</a> — the node's own storage/disk KMS key and the
+  startup attestation flow (distinct from group keys).</li>
+  <li><a href="membership-and-leave.html">Membership &amp; Leave</a> — general leave and eviction
+  semantics that the fleet leave path builds on.</li>
+  <li><a href="auto-follow.html">Auto-Follow</a> — how an admitted replica tracks new contexts and
+  subgroups, and the namespace-scoped policy rationale.</li>
+  <li><a href="glossary.html">Glossary</a> — definitions for namespace, group, role, and quote
+  terms used above.</li>
+  <li>Producing repos:
+  <a href="https://github.com/calimero-network/mero-tee" target="_blank" rel="noopener">mero-tee</a>
+  (the fleet sidecar and node image) and
+  <a href="https://github.com/calimero-network/mdma" target="_blank" rel="noopener">mdma</a> (the
+  control plane that owns entitlement and disable). Their internals are out of scope for core; only
+  the contract surfaces named on this page are relied upon.</li>
+</ul>
+</div>
+
+</div>
+</div>
+<script src="nav.js"></script>
+</body>
+</html>

--- a/architecture/tee-fleet-ha.html
+++ b/architecture/tee-fleet-ha.html
@@ -340,7 +340,7 @@ restart (<span class="code">crates/governance-store/src/local_state.rs</span>).
 <li>Sidecar observes the drop on a confirmed-good poll and runs <span class="code">meroctl namespace leave</span>.</li>
 <li>Core publishes <span class="code">GroupOp::MemberLeft</span>; it cascades, emitting <span class="code">TeeMemberRemoved</span> for the root and each subgroup row.</li>
 <li><span class="code">self_purge</span> sees the <span class="code">ReadOnlyTee</span> removals and runs <span class="code">PurgeAction::Namespace</span>.</li>
-<li>Local data + signing keys + AES group keys are deleted; the node unsubscribes from the gossip topic.</li>
+<li>Local data + signing keys are deleted (plus the AES group keys <em>(PR #2776)</em>); the node unsubscribes from the gossip topic.</li>
 <li>If interrupted, the pending-self-purge marker + startup reconcile sweep finish the purge after restart.</li>
 </ol>
 </div>
@@ -362,8 +362,7 @@ Changing the shape of any of these requires coordinating across the three repos.
   <span class="code">self_purge_reconcile_total</span>, and
   <span class="code">self_purge_events_dropped_total</span>. A rising failures or dropped-events
   counter means purges are not completing cleanly; reconcile counts confirm the startup sweep is
-  doing its job. (See <a href="metrics-reference.html">Metrics Reference</a> once these are listed
-  there.)</li>
+  doing its job. (See <a href="metrics-reference.html">Metrics Reference</a>.)</li>
   <li><b>MRTD alignment.</b> The node image's measurements and the control plane's
   <span class="code">allowed_mrtd</span> allowlist must agree, or every fleet-join fails admission.
   After a node-image bump, update the namespace's admission policy before expecting replicas to

--- a/architecture/tee-mode.html
+++ b/architecture/tee-mode.html
@@ -9,8 +9,20 @@
 <div class="main">
 <div class="content">
 <div class="breadcrumb"><a href="index.html">Home</a><span class="sep">/</span><span>TEE Mode</span></div>
-<h1>TEE <em>Mode</em></h1>
-<p class="page-subtitle">Trusted Execution Environment operation</p>
+<h1>TEE <em>Mode</em> <span class="page-subtitle" style="display:inline;">(storage key / KMS)</span></h1>
+<p class="page-subtitle">Trusted Execution Environment operation — the node's storage/disk encryption key</p>
+
+<div class="card gd">
+<h2>Which key this page is about</h2>
+<p>
+This page covers the <strong>node's storage / disk encryption key obtained from the KMS</strong> —
+a <em>per-node</em>, MRTD-gated key fetched at startup and used to encrypt the local datastore and
+blobstore. It is <strong>distinct</strong> from the <strong>per-group <code>GroupKeyring</code>
+encryption keys</strong> delivered via <code>KeyDelivery</code>, which protect fleet-HA application
+data shared across a group. The two are unrelated mechanisms — do not conflate them. For the
+fleet / per-group key story, see <a href="tee-fleet-ha.html">TEE Fleet HA</a>.
+</p>
+</div>
 
 <div class="card ga">
 <h2>Overview</h2>

--- a/architecture/wire-protocol.html
+++ b/architecture/wire-protocol.html
@@ -107,7 +107,7 @@
     <div class="typedef"><span class="kw">struct</span> <span class="ty">TeeAttestationAnnounce</span> {
     <span class="field">quote_bytes</span>: <span class="ty">Vec&lt;u8&gt;</span>,            <span class="comment">// TDX attestation quote bytes</span>
     <span class="field">public_key</span>:  <span class="ty">PublicKey</span>,           <span class="comment">// announcing node's identity public key</span>
-    <span class="field">nonce</span>:       <span class="ty">[u8; 32]</span>,            <span class="comment">// group DAG head hash for freshness binding</span>
+    <span class="field">nonce</span>:       <span class="ty">[u8; 32]</span>,            <span class="comment">// fresh random 32 bytes; report_data = nonce(32) || Sha256(pubkey)</span>
     <span class="field">node_type</span>:   <span class="ty">SpecializedNodeType</span>, <span class="comment">// specialized node type (e.g. ReadOnlyTee)</span>
 }</div>
     <div class="borsh-note">Published on ns/&lt;hex(namespace_id)&gt; · drives fleet admission in crates/server/src/admin/handlers/tee/fleet_join.rs</div>

--- a/architecture/wire-protocol.html
+++ b/architecture/wire-protocol.html
@@ -46,8 +46,8 @@
      1. BROADCAST MESSAGE (GOSSIPSUB)
      ═══════════════════════════════════════════════════════════ -->
 <div class="card ga">
-<h2>BroadcastMessage <span class="transport-badge badge-gossip">gossipsub</span> <span class="variant-count">10 variants</span></h2>
-<p class="section-intro">Top-level enum for all messages published via gossipsub topics. Each variant is Borsh-serialized before being sent as a gossipsub message payload. Context topics use <span class="code">context/&lt;hex&gt;</span>, group topics use <span class="code">group/&lt;hex&gt;</span>, namespace topics use <span class="code">namespace/&lt;hex&gt;</span>.</p>
+<h2>BroadcastMessage <span class="transport-badge badge-gossip">gossipsub</span> <span class="variant-count">11 variants</span></h2>
+<p class="section-intro">Top-level enum for all messages published via gossipsub topics. Each variant is Borsh-serialized before being sent as a gossipsub message payload. Context topics use <span class="code">context/&lt;hex&gt;</span>, group topics use <span class="code">group/&lt;hex&gt;</span>, namespace topics use <span class="code">ns/&lt;hex&gt;</span> (hex of the 32-byte namespace id, which is the root group id).</p>
 
 <details open>
   <summary>StateDelta <span class="variant-count">— application state replication</span></summary>
@@ -97,6 +97,20 @@
     <div class="typedef"><span class="kw">struct</span> <span class="ty">SpecializedNodeJoinConfirmation</span> {
     <span class="field">nonce</span>: <span class="ty">Nonce</span>,  <span class="comment">// matches the discovery nonce</span>
 }</div>
+  </div>
+</details>
+
+<details>
+  <summary>TeeAttestationAnnounce <span class="variant-count">— fleet-join attestation</span></summary>
+  <div class="detail-body">
+    <p style="margin-bottom:10px;">A TEE fleet node announces its TDX attestation to join a namespace as a <span class="code">ReadOnlyTee</span> member. Published on the namespace topic <span class="code">ns/&lt;hex(namespace_id)&gt;</span> and re-announced for up to ~30s until a verifier admits it. The verifier runs <span class="code">verify_attestation</span>, then namespace-scoped <span class="code">admit_tee_node</span> (policy check + quote-hash replay guard). See <a href="tee-fleet-ha.html">TEE Fleet HA</a> and <a href="sequence-diagrams.html">Sequence Diagrams</a>.</p>
+    <div class="typedef"><span class="kw">struct</span> <span class="ty">TeeAttestationAnnounce</span> {
+    <span class="field">quote_bytes</span>: <span class="ty">Vec&lt;u8&gt;</span>,            <span class="comment">// TDX attestation quote bytes</span>
+    <span class="field">public_key</span>:  <span class="ty">PublicKey</span>,           <span class="comment">// announcing node's identity public key</span>
+    <span class="field">nonce</span>:       <span class="ty">[u8; 32]</span>,            <span class="comment">// group DAG head hash for freshness binding</span>
+    <span class="field">node_type</span>:   <span class="ty">SpecializedNodeType</span>, <span class="comment">// specialized node type (e.g. ReadOnlyTee)</span>
+}</div>
+    <div class="borsh-note">Published on ns/&lt;hex(namespace_id)&gt; · drives fleet admission in crates/server/src/admin/handlers/tee/fleet_join.rs</div>
   </div>
 </details>
 
@@ -155,7 +169,7 @@
     <span class="field">namespace_id</span>: <span class="ty">[u8; 32]</span>,  <span class="comment">// target namespace (root group)</span>
     <span class="field">payload</span>:      <span class="ty">Vec&lt;u8&gt;</span>,   <span class="comment">// borsh(SignedNamespaceOp)</span>
 }</div>
-    <div class="borsh-note">Payload size capped by MAX_SIGNED_GROUP_OP_PAYLOAD_BYTES &middot; Published on namespace/&lt;hex&gt; topic</div>
+    <div class="borsh-note">Payload size capped by MAX_SIGNED_GROUP_OP_PAYLOAD_BYTES &middot; Published on ns/&lt;hex&gt; topic</div>
   </div>
 </details>
 
@@ -224,7 +238,7 @@
      4. INIT PAYLOAD
      ═══════════════════════════════════════════════════════════ -->
 <div class="card gd">
-<h2>InitPayload <span class="transport-badge badge-stream">stream init</span> <span class="variant-count">13 variants</span></h2>
+<h2>InitPayload <span class="transport-badge badge-stream">stream init</span> <span class="variant-count">14 variants</span></h2>
 <p class="section-intro">Sent as the first message on a new stream. Determines the protocol/purpose of the stream and carries initial handshake data.</p>
 
 <details open>
@@ -350,13 +364,26 @@
 }</div>
   </div>
 </details>
+
+<details>
+  <summary>GroupKeyRequest <span class="variant-count">— pull-based group-key recovery</span></summary>
+  <div class="detail-body">
+    <p style="margin-bottom:10px;">Pull-based recovery for a group key the requester is already an admitted member of but does not yet hold locally — the durable replacement for the old on-DAG <span class="code">KeyDelivery</span> push. The joiner sends this each sync round (via <span class="code">recover_missing_group_keys</span>) until it has the key. The responder validates that <span class="code">requester_public_key</span> is a current member of <span class="code">group_id</span>, then ECDH-wraps the group key and replies with <span class="code">GroupKeyResponse</span>.</p>
+    <div class="typedef"><span class="kw">struct</span> <span class="ty">GroupKeyRequest</span> {
+    <span class="field">namespace_id</span>:          <span class="ty">[u8; 32]</span>,  <span class="comment">// which namespace</span>
+    <span class="field">group_id</span>:              <span class="ty">[u8; 32]</span>,  <span class="comment">// the group whose key is being recovered</span>
+    <span class="field">requester_public_key</span>:  <span class="ty">PublicKey</span>, <span class="comment">// namespace identity (membership check + ECDH recipient)</span>
+}</div>
+    <div class="borsh-note">Appended at the tail of InitPayload (existing discriminants unchanged) · responder in crates/node/src/sync/manager/namespace_sync.rs</div>
+  </div>
+</details>
 </div>
 
 <!-- ═══════════════════════════════════════════════════════════
      5. MESSAGE PAYLOAD
      ═══════════════════════════════════════════════════════════ -->
 <div class="card ga">
-<h2>MessagePayload <span class="transport-badge badge-stream">stream data</span> <span class="variant-count">14 variants</span></h2>
+<h2>MessagePayload <span class="transport-badge badge-stream">stream data</span> <span class="variant-count">15 variants</span></h2>
 <p class="section-intro">Subsequent data frames sent after the initial <span class="code">Init</span> on a stream. The variant matches the stream type established by <span class="code">InitPayload</span>.</p>
 
 <details open>
@@ -503,6 +530,18 @@
     <span class="field">dag_heads</span>: <span class="ty">Vec&lt;[u8; 32]&gt;</span>,  <span class="comment">// DAG heads after sync</span>
     <span class="field">total_entities</span>: <span class="ty">u64</span>,       <span class="comment">// total entities transferred</span>
 }</div>
+  </div>
+</details>
+
+<details>
+  <summary>GroupKeyResponse <span class="variant-count">— pull-based group-key delivery</span></summary>
+  <div class="detail-body">
+    <p style="margin-bottom:10px;">Response to <span class="code">GroupKeyRequest</span>. Carries the ECDH-wrapped group-key envelope; <span class="code">key_envelope_bytes</span> is empty when the responder doesn't hold the key or the requester isn't a member (the joiner retries another peer next sync round). <span class="code">responder_identity</span> is the trust anchor a keyless bootstrap joiner uses to seed the namespace admin when it receives the root-group key without an invitation (replaces the old <span class="code">KeyDelivery</span>-signer anchor).</p>
+    <div class="typedef"><span class="kw">struct</span> <span class="ty">GroupKeyResponse</span> {
+    <span class="field">key_envelope_bytes</span>: <span class="ty">Vec&lt;u8&gt;</span>,   <span class="comment">// borsh(KeyEnvelope), ECDH-wrapped; empty ⇒ no key</span>
+    <span class="field">responder_identity</span>: <span class="ty">PublicKey</span>,  <span class="comment">// responder's namespace identity (the wrap sender)</span>
+}</div>
+    <div class="borsh-note">Appended at the tail of MessagePayload (existing discriminants unchanged) · pairs with InitPayload::GroupKeyRequest</div>
   </div>
 </details>
 </div>


### PR DESCRIPTION
## Summary

Overhauls the public TEE / HA / fleet documentation (`architecture/*.html`, deployed to GitHub Pages). A code-vs-docs audit found the TEE docs were substantially stale and incomplete — well beyond the leave/eviction story — so this is a comprehensive correction + a new cohesive page.

### New
- **`tee-fleet-ha.html`** (+ nav entry under *Operators*) — the full fleet HA lifecycle that previously had no home: fleet-join attestation announce → verifier admission + namespace-scoped policy → group key delivery + joiner-side recovery pull → transparent per-subgroup admission → disable → leave → purge. Cross-linked from the existing pages.

### Corrected (these described behavior already in `master` inaccurately)
- **`config-reference.html`** — replaced the fictional flat `[tee]` (`enabled`/`kms_url`) with the real nested `[tee.kms.phala]` / `.attestation` / `.tls` schema (`crates/config/src/lib.rs`).
- **`auto-follow.html`** — the most misleading claim: it implied `subgroups:true` drives subgroup membership via auto-follow. It doesn't — the handler is `contexts:true` only and discards `subgroups`. Subgroup access is inheritance (Open) or the `tee_subgroup_admit` subsystem (Restricted).
- **`membership-and-leave.html`** — rewritten from proposal-era to as-built: leave **does** rotate keys and (as of #2776) delete group encryption keys; role-scoped self-purge (`TeeMemberRemoved`-only, `PurgeAction` Namespace/Subgroup split, marker + reconcile sweep); Owner is a stored identity + `TransferOwnership` op, **not** a role variant.
- **`wire-protocol.html`** — namespace topic is `ns/<hex>` (not `namespace/<hex>`); added `TeeAttestationAnnounce` and `GroupKeyRequest`/`GroupKeyResponse`.
- **`sequence-diagrams.html`** — replaced the legacy "TEE Node Invite" diagram with the current fleet-join → admit → key-delivery → purge sequence.
- **`glossary.html`** — added `ReadOnlyTee` (+ fixed the role enum), fleet-join, `TeeAttestationAnnounce`, `MemberJoinedViaTeeAttestation`, `TeeAdmissionPolicy`, `self-purge`, `report_data`, quote-hash; plus the **two-key-family** clarification (KMS disk key vs per-group `GroupKeyring` keys).
- **`metrics-reference.html`** — added `self_purge_failures_total` / `self_purge_reconcile_total` / `self_purge_events_dropped_total` (with labels + the `context_group_store_` export prefix).
- **`tee-mode.html`** — disambiguated as the node's storage/disk KMS key; cross-linked the fleet page.
- Swept residual `namespace/<hex>` / "Owner role" stragglers on `local-governance.html` and `index.html`.

## Dependency / timing
Documents behavior from **#2772** (transparent per-subgroup admission) and **#2776** (purge deletes AES group encryption keys). Those bits are explicitly tagged in-page ("PR #2772", "as of #2776") and are **not** in `master` yet — ideally merge this **with/after** #2772 and #2776 for full accuracy. The bulk (config schema, topic name, auto-follow correction, role-scoped purge, wire messages, metrics, glossary) describes behavior already in `master` and is accurate today.

## Verification
- Every load-bearing claim cross-checked against current code (topic prefix, namespace-scoped policy, self-purge trigger/actions, auto-follow match arms, config struct fields/defaults, exact metric names/labels, wire struct fields).
- HTML well-formedness checked; new page + edits reuse only existing CSS classes; `nav.js` valid; cross-links/anchors resolve.
- Docs-only — no Rust/public-API change.

Out of scope (noted for follow-up): pre-existing `wire-protocol.html` variant-count drift unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> HTML documentation only; no runtime or API changes. Accuracy for #2772/#2776 sections depends on merging those PRs.
> 
> **Overview**
> **Docs-only** overhaul of `architecture/*.html` so TEE, fleet HA, and membership behavior match the current codebase (and upcoming #2772 / #2776 where tagged).
> 
> Adds **`tee-fleet-ha.html`** (nav: *Fleet HA*) as the end-to-end fleet story: attestation announce → verifier admission → group key delivery/recovery → transparent Restricted-subgroup admission → disable/leave/self-purge, with cross-links from the rest of the site.
> 
> **Corrects misleading or stale claims** across existing pages: **`config-reference.html`** documents the real nested `[tee.kms.phala]` schema (not flat `enabled`/`kms_url`); **`auto-follow.html`** states that only `contexts: true` is implemented and `subgroups: true` is a no-op, pointing subgroup access to inheritance and `tee_subgroup_admit`; **`membership-and-leave.html`** is rewritten as as-built (owner as `owner_identity`, not a role; `MemberLeft` without self-leave re-key; role-scoped TEE self-purge via `TeeMemberRemoved`); **`wire-protocol.html`** uses `ns/<hex>`, adds `TeeAttestationAnnounce` and `GroupKeyRequest`/`GroupKeyResponse`; **`sequence-diagrams.html`** replaces legacy TEE invite with fleet-join; **`glossary.html`** and **`metrics-reference.html`** add fleet/TEE terms and self-purge Prometheus families; **`tee-mode.html`** scopes to KMS disk key vs group keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef3755b070679503c2545107d013d70e309edc11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->