### PR TITLE
chore(ci): bump ai-code-reviewer pin to 485b32a (HTML-patch fix)

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -60,7 +60,7 @@ jobs:
       # prevent an upstream change from running with this repo's secrets.
       # Bump deliberately when adopting new reviewer features.
       - name: Install ai-code-reviewer
-        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@06d0a027b59caba85269b5a63bac4b0e53ffa0ea
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@485b32abf334f1518dcadc9c3762ea98705e696c
 
       # Authenticate as the MeroReviewer App so review comments genuinely
       # come from meroreviewer[bot] (not whatever GH_PAT/GITHUB_TOKEN

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -1,7 +1,7 @@
 name: Doc Auto-Update
 
 # Inlined from calimero-network/ai-code-reviewer reusable workflow at
-# SHA 06d0a027b59caba85269b5a63bac4b0e53ffa0ea, with one fix:
+# SHA 485b32abf334f1518dcadc9c3762ea98705e696c, with one fix:
 # `cache: pip` removed from `actions/setup-python@v5`. The upstream sets
 # it unconditionally, but setup-python's pip cache requires a
 # requirements.txt or pyproject.toml in the calling repo — neither
@@ -58,7 +58,7 @@ jobs:
       # Pinned to the same SHA as ai-review.yaml so both workflows install
       # the audited version of ai-code-reviewer. Bump deliberately.
       - name: Install ai-code-reviewer
-        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@06d0a027b59caba85269b5a63bac4b0e53ffa0ea
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@485b32abf334f1518dcadc9c3762ea98705e696c
 
       # Mint a short-lived MeroReviewer App installation token. Unlike the
       # default GITHUB_TOKEN, an App token is not subject to the org/repo


### PR DESCRIPTION
Bumps the pinned `ai-code-reviewer` SHA in the AI-review + doc-update workflows from `06d0a027` → current master `485b32a`.

## Why
**Headline:** [ai-code-reviewer#80](https://github.com/calimero-network/ai-code-reviewer/pull/80) — whitespace-tolerant HTML patch matching. AutoDocs was silently **skipping** HTML doc updates it wanted to make (`FIND text not found`, e.g. `architecture/crates/store.html` & `tools.html` on a recent core PR). The patcher now:
- matches the model's `FIND` block ignoring whitespace-run differences (indentation / line-wrap / internal spaces),
- splices `REPLACE` into just that span (rest of the doc untouched),
- refuses ambiguous matches (no false positives), and tolerates CRLF/trailing-space markers.

## Scope note
`06d0a027` was several commits behind master, so this also pulls in intervening ai-code-reviewer changes (config / context-builder / review / anthropic-client refactors), not just #80.

The **inlined `doc-update.yaml` body is unchanged** — between the two SHAs only `integration.yaml` changed in ai-code-reviewer, not the doc-update reusable workflow — so only the pinned SHA (the `pip install` lines + the source-SHA comment) bumps.

## Changes
- `.github/workflows/ai-review.yaml` — pin → `485b32a`
- `.github/workflows/doc-update.yaml` — pin + source-SHA comment → `485b32a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin change with no application code or secret-handling logic modified in this repo.
> 
> **Overview**
> Updates the **pinned `calimero-network/ai-code-reviewer` git SHA** used by **AI Code Review** and **Doc Auto-Update** from `06d0a027` to `485b32abf334f1518dcadc9c3762ea98705e696c`, keeping both workflows on the same audited install.
> 
> The newer reviewer build is intended to fix **AutoDocs HTML patching** that was skipping updates when model `FIND` blocks did not match exactly (whitespace/indentation), and it also picks up other upstream changes between those commits. The inlined `doc-update.yaml` job steps are otherwise unchanged; only the `pip install` pin and the source-SHA comment are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb111b6228830db2af4b6663d74ea17871a81dd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->