### PR TITLE
chore: cut release 0.11.0-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@
 - **`SortedSet<T>` collection** — the `BTreeSet` to `UnorderedSet`'s `HashSet`: an ordered set with `range`/`prefix`/`page`/`first`/`last`, same add-wins union merge and the same on-disk ordered index as `SortedMap` ([#2559])
 - **In-process unit-test harness (`calimero_sdk::testing::TestHost`)** - Exercise app logic as ordinary Rust under `cargo test` — no WASM build, no node, no merobox. `TestHost::new(MyApp::init)` runs methods via `call`/`view` against an in-memory mock host that records `app::emit!` events and `app::log!` lines and serves a configurable executor identity (`call_as` for multi-author CRDT tests). The `#[app::state]` macro generates the storage bridge; apps opt in with `calimero-storage`'s `testing` feature as a dev-dependency. All core example apps now ship `#[cfg(test)]` tests using it ([#2551])
 
+## [0.11.0-rc.5] - 2026-06-18
+
+### Added
+
+- **Transparent TEE admission into Restricted subgroups** — an entitled fleet TEE node admitted at the namespace root is now automatically admitted (as `ReadOnlyTee`) into the namespace's Restricted subgroups and delivered their per-group keys, so it serves reads across the whole namespace without per-subgroup configuration. Open subgroups need no admission (covered by inherited membership + the namespace key) ([#2772])
+
+### Fixed
+
+- **Governance op-events now emit after the op-log entry is persisted** — events are collected during apply and flushed only after the op-log append (both the group-op and namespace RootOp paths), closing a race where a subscriber reacting to an event could read the op-log back before it was written. Replays of an already-logged op no longer re-emit ([#2792])
+
+### Security
+
+- **Leave/eviction now deletes group encryption keys (forward secrecy)** — self-purge on a `ReadOnlyTee` removal, and namespace/subgroup deletion, now delete the AES group encryption keys (`GroupKeyEntry`) in addition to the per-member signing keys, so an evicted fleet replica retains no decryption material for the groups it left ([#2776])
+
 ## [0.10.1-rc.10] - 2026-03-30
 
 ### Added
@@ -249,7 +263,8 @@ Integrations:
 
 <!-- versions -->
 
-[unreleased]: https://github.com/calimero-network/core/compare/0.8.0...HEAD
+[unreleased]: https://github.com/calimero-network/core/compare/0.11.0-rc.5...HEAD
+[0.11.0-rc.5]: https://github.com/calimero-network/core/compare/0.11.0-rc.4...0.11.0-rc.5
 [0.8.0]: https://github.com/calimero-network/core/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/calimero-network/core/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/calimero-network/core/compare/0.5.0...0.6.0
@@ -270,6 +285,11 @@ Integrations:
 
 <!-- patches -->
 
+[#2772]: https://github.com/calimero-network/core/pull/2772
+[#2776]: https://github.com/calimero-network/core/pull/2776
+[#2792]: https://github.com/calimero-network/core/pull/2792
+[#2559]: https://github.com/calimero-network/core/pull/2559
+[#2551]: https://github.com/calimero-network/core/pull/2551
 [#1171]: https://github.com/calimero-network/core/pull/1171
 [#1223]: https://github.com/calimero-network/core/pull/1223
 [#1181]: https://github.com/calimero-network/core/pull/1181

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
## Release cut: 0.11.0-rc.5

Bumps `[workspace.metadata.workspaces].version` 0.11.0-rc.4 → **0.11.0-rc.5** and records the cut in the CHANGELOG. Rebased on latest `master`.

> ⚠️ **Merging this PR to `master` fires the release automatically.** `release.yml` triggers on a `Cargo.toml` change to `master` when no release for the version exists yet — it creates the `0.11.0-rc.5` tag, builds + uploads the `merod`/`meroctl`/`mero-abi`/`mero-auth` assets, publishes the workspace crates to crates.io, pushes the `ghcr.io/.../merod` images, and opens the homebrew-tap bump PR. **Merge = release.** Merge when you intend to release.

### What's in this release (everything in `0.11.0-rc.4..master`)
- **#2772** — transparent TEE admission into Restricted subgroups (merged).
- **#2776** — leave/eviction deletes the AES group encryption keys, not just signing keys (merged, forward-secrecy).
- **#2792** — governance op-events now emit after the op-log entry persists; replays no longer re-emit (merged, race fix).

This rc gives us a `merod` carrying all three, so the fleet node image (mero-tee #191) can bake it for the disable→leave→purge e2e.

### Contents (2 files)
- `Cargo.toml`: version → `0.11.0-rc.5` (single source of truth; per-crate versions are `version.workspace = true`, no cascade; `Cargo.lock` unaffected).
- `CHANGELOG.md`: new dated `[0.11.0-rc.5]` section with #2772 / #2792 / #2776 + footer links.

### Review note (addressed)
The AI reviewer flagged a CHANGELOG attribution issue. Verified against `git log 0.11.0-rc.4..master`: **#2559 (SortedMap/SortedSet) and #2551 (TestHost) are NOT in this range** — they shipped in an earlier rc (and sat unrecorded in `[Unreleased]` because rc.1–4 didn't maintain the changelog). They've been **moved back to `[Unreleased]`** so they aren't misattributed to rc.5; only the three PRs genuinely new since rc.4 are recorded under `[0.11.0-rc.5]`. (The broader CHANGELOG footer drift from earlier unrecorded rc cuts is pre-existing and out of scope for this cut.) The doc-bot's AGENTS.md/CONTRIBUTING.md notes don't apply to a version bump.

### Tag / asset format (consumer contract — unchanged)
Bare tag `0.11.0-rc.5` (no `v`); assets `merod_<target>.tar.gz` etc. — matches mdma's `startup_script.py` and tauri's `merod-config.json`.

### Post-merge
Release fires from the merge commit. Watch `gh run list --workflow release.yml`; merge the separate homebrew-tap formula-bump PR; verify `gh release view 0.11.0-rc.5 --json assets`.
