### PR TITLE
fix(context): blob-aware same-id update skip (#2060)

### DIFF
--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -62,8 +62,28 @@ impl Handler<UpdateApplicationRequest> for ContextManager {
         if migration.is_none() {
             if let Some(ref context) = context_meta {
                 if application_id == context.application_id {
-                    debug!(%context_id, "Application already set and no migration requested, skipping update");
-                    return ActorResponse::reply(Ok(()));
+                    // #2060: a same ApplicationId does NOT imply same bytecode for a
+                    // signed bundle (its id is version-stable). Only skip when the
+                    // context already activated the installed blob; otherwise fall
+                    // through to the code-only swap so the new bytecode is loaded and
+                    // the activation marker recorded — a bare id compare would silently
+                    // drop a code-only upgrade and report success.
+                    let installed = self
+                        .node_client
+                        .get_application(&application_id)
+                        .ok()
+                        .flatten()
+                        .map(|app| *app.blob.bytecode.as_ref());
+                    let activated = crate::activation::activated_blob(&self.datastore, &context_id);
+                    if same_id_update_is_noop(activated, installed) {
+                        debug!(%context_id, "Application already set, installed bytecode already active, and no migration requested; skipping update");
+                        return ActorResponse::reply(Ok(()));
+                    }
+                    debug!(
+                        %context_id, %application_id,
+                        "same application id but the installed bytecode is not yet active \
+                         (code-only bundle upgrade); applying update"
+                    );
                 }
             }
         }
@@ -291,6 +311,18 @@ fn application_version(
             None
         }
     }
+}
+
+/// #2060: a signed bundle's `ApplicationId` is version-stable
+/// (`hash(package, signer)`), so a same-id no-migration update can be either a
+/// true no-op or a code-only bytecode swap. The early skip is safe ONLY when the
+/// context already executes the exact bytecode now installed under that id — its
+/// activation marker (`activated`) equals the installed blob. A missing marker
+/// or any mismatch means the new bytecode is not yet active, so the update must
+/// proceed; an unreadable application row (`installed` is `None`) also proceeds
+/// rather than silently skipping.
+fn same_id_update_is_noop(activated: Option<[u8; 32]>, installed: Option<[u8; 32]>) -> bool {
+    matches!((activated, installed), (Some(a), Some(b)) if a == b)
 }
 
 /// Builds an `AppVersionChanged` node event for a context whose application id
@@ -1507,7 +1539,10 @@ mod tests {
     use calimero_primitives::events::{ContextEvent, ContextEventPayload, NodeEvent};
 
     use super::ContextStorage;
-    use super::{app_version_changed_event, application_version, verify_appkey_continuity};
+    use super::{
+        app_version_changed_event, application_version, same_id_update_is_noop,
+        verify_appkey_continuity,
+    };
 
     /// Creates a test store with in-memory database.
     fn create_test_store() -> Store {
@@ -1630,6 +1665,29 @@ mod tests {
             }
             other => panic!("expected AppVersionChanged, got {other:?}"),
         }
+    }
+
+    // #2060: the same-id no-migration skip is safe ONLY when the context already
+    // executes the exact bytecode now installed under that id. A signed bundle's
+    // ApplicationId is version-stable, so a code-only upgrade leaves the id equal
+    // while the blob changes — the skip must NOT fire there.
+    #[test]
+    fn same_id_update_skips_only_when_installed_bytecode_already_active() {
+        let blob_v1 = [1u8; 32];
+        let blob_v2 = [2u8; 32];
+
+        // Genuine no-op: the context already activated the installed bytecode.
+        assert!(same_id_update_is_noop(Some(blob_v1), Some(blob_v1)));
+
+        // #2060: a new bundle replaced the bytecode under the same id; the
+        // context still runs the old blob, so the update must proceed.
+        assert!(!same_id_update_is_noop(Some(blob_v1), Some(blob_v2)));
+
+        // No activation marker yet — cannot prove up-to-date, so proceed.
+        assert!(!same_id_update_is_noop(None, Some(blob_v2)));
+
+        // Installed application row unreadable — proceed conservatively.
+        assert!(!same_id_update_is_noop(Some(blob_v1), None));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

For signed bundles `ApplicationId = hash(package, signer_id)` is version-stable, so the `UpdateApplicationRequest` handler's early skip —

```rust
if migration.is_none() && application_id == context.application_id {
    return Ok(());   // silently skip
}
```

— could not tell a true no-op apart from a code-only bytecode swap. A same-id bundle whose only change is the WASM binary (new version, no state migration) hit this skip, returned `Ok(())`, and never loaded the new bytecode — while reporting success (#2060).

This affected the routes that send `UpdateApplicationRequest` directly:
- the **admin route** `PUT /admin-api/.../contexts/{id}/application` (always passes `migration: None`), and
- the **eager Automatic-policy** code-only propagator.

The group-upgrade path under `LazyOnAccess` was already fixed by the bundle-propagation work — it swaps bytecode lazily via `update_application_id`, bypassing this skip (`08-scenario-pure-bugfix` proves it end-to-end). This closes the remaining direct routes.

## Fix

Gate the skip on the bytecode, not just the id: only short-circuit when the context's activation marker already equals the blob installed under that id. A missing marker or any mismatch (new bytecode under the same id) falls through to the existing code-only swap (`update_application_id`), which loads the bytecode and records the activation marker. The `LazyOnAccess` path is untouched — it never reaches this handler skip (`upgrade_group.rs` returns before the canary).

The decision is a pure `same_id_update_is_noop(activated, installed)` helper with unit coverage.

## Testing

- New unit test `same_id_update_skips_only_when_installed_bytecode_already_active`.
- `cargo test -p calimero-context` — 191/191 green.
- The path filter triggers the full `app-migration-e2e` matrix on this PR; the `LazyOnAccess` scenarios are unaffected by construction.

## Follow-up

No e2e exercises the *direct* admin-PUT route yet — merobox has no `update_context_application` step (only `upgrade_group`). A direct-route regression scenario needs a small merobox step + release; tracked as a follow-up.

Closes #2060

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core context application-update gating for direct update routes; behavior change is narrowly scoped to same-id no-migration updates with conservative proceed-on-uncertainty.
> 
> **Overview**
> Fixes **#2060**: no-migration `UpdateApplicationRequest` could treat a **code-only signed bundle upgrade** (same stable `ApplicationId`, new WASM) as success while **never loading the new bytecode**.
> 
> The handler no longer skips on **application id alone**. It compares the context’s **activation marker** to the **installed application bytecode** via `same_id_update_is_noop`; only when both match does it short-circuit. Mismatch, missing marker, or unreadable install row **falls through** to the existing `update_application_id` path (admin PUT and eager automatic propagator).
> 
> Adds a focused unit test for the helper’s skip vs proceed cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8b25ca3c9f7285d63f9053bf2f3dfd8f666ab82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->