### PR TITLE
fix(sdk): register #[app::view] as a no-op marker so it resolves downstream

### DIFF
--- a/apps/abi_conformance/abi.expected.json
+++ b/apps/abi_conformance/abi.expected.json
@@ -919,6 +919,22 @@
       "returns": {
         "$ref": "Status"
       }
+    },
+    {
+      "name": "view_constant",
+      "params": [],
+      "returns": {
+        "kind": "u32"
+      },
+      "intent": "read_only"
+    },
+    {
+      "name": "xcall_noop",
+      "params": [],
+      "returns": {
+        "kind": "unit"
+      },
+      "xcall_callable": true
     }
   ],
   "events": [

--- a/apps/abi_conformance/src/lib.rs
+++ b/apps/abi_conformance/src/lib.rs
@@ -360,6 +360,22 @@ impl AbiState {
         Ok(Status::Active { timestamp })
     }
 
+    // Read-only and cross-context entry points. They keep the `#[app::view]`
+    // and `#[app::xcall]` markers covered by the conformance golden, which
+    // records each method's `intent` / `xcall_callable` flag.
+
+    /// Read-only method — must surface `intent: read_only` in the ABI.
+    #[app::view]
+    pub fn view_constant(&self) -> app::Result<u32> {
+        Ok(42)
+    }
+
+    /// Cross-context entry point — must surface `xcall_callable: true` in the ABI.
+    #[app::xcall]
+    pub fn xcall_noop(&mut self) -> app::Result<()> {
+        Ok(())
+    }
+
     // Private method - should NOT appear in ABI
     const fn private_helper(value: u32) -> u32 {
         let internal_data = InternalData {

--- a/crates/sdk/macros/src/lib.rs
+++ b/crates/sdk/macros/src/lib.rs
@@ -212,8 +212,11 @@ pub fn xcall(_args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// # Usage
 ///
-/// Apply `#[app::view]` to a public, read-only (`&self`) logic method. Mutually
-/// exclusive with `#[app::init]` and `#[app::xcall]`.
+/// Apply `#[app::view]` to a public, read-only (`&self`) logic method. The
+/// mutual exclusivity with `#[app::init]` and `#[app::xcall]` is enforced at
+/// compile time; the read-only contract is not. This attribute does not require
+/// a `&self` receiver — a `#[app::view]` method that mutates state is rejected
+/// by the node at runtime, not by the compiler.
 #[proc_macro_attribute]
 pub fn view(_args: TokenStream, input: TokenStream) -> TokenStream {
     // this is a no-op, the attribute is just a marker

--- a/crates/sdk/macros/src/lib.rs
+++ b/crates/sdk/macros/src/lib.rs
@@ -185,9 +185,8 @@ pub fn init(_args: TokenStream, input: TokenStream) -> TokenStream {
 /// `Method.xcall_callable`; on its own it does not modify the method. The node
 /// uses the flag to restrict `xcall` dispatch to declared entry points.
 ///
-/// Must be a registered attribute (not just read syntactically like
-/// `#[app::view]`) so it resolves at the method site when `#[app::logic]`
-/// re-emits the impl verbatim.
+/// Must be a registered attribute so it resolves at the method site when
+/// `#[app::logic]` re-emits the impl verbatim (as `#[app::view]` also is).
 ///
 /// # Usage
 ///
@@ -197,6 +196,26 @@ pub fn init(_args: TokenStream, input: TokenStream) -> TokenStream {
 /// target's return value would go nowhere).
 #[proc_macro_attribute]
 pub fn xcall(_args: TokenStream, input: TokenStream) -> TokenStream {
+    // this is a no-op, the attribute is just a marker
+    input
+}
+
+/// Marks a logic method as read-only (a "view").
+///
+/// A marker consumed by `#[app::logic]` and recorded in the ABI as
+/// `Method.intent = read_only`; on its own it does not modify the method. The
+/// node can take a shared read lock (instead of an exclusive write lock) for
+/// such methods, and rejects any that produce a state mutation at runtime.
+///
+/// Like `#[app::xcall]`, it must be a registered attribute so it resolves at
+/// the method site when `#[app::logic]` re-emits the impl verbatim.
+///
+/// # Usage
+///
+/// Apply `#[app::view]` to a public, read-only (`&self`) logic method. Mutually
+/// exclusive with `#[app::init]` and `#[app::xcall]`.
+#[proc_macro_attribute]
+pub fn view(_args: TokenStream, input: TokenStream) -> TokenStream {
     // this is a no-op, the attribute is just a marker
     input
 }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -42,7 +42,7 @@ pub mod app {
 
     pub use calimero_sdk_macros::{
         bail, destroy, emit, err, event, init, log, logic, migrate, migration_check, private,
-        state, xcall, Mergeable, Migrate,
+        state, view, xcall, Mergeable, Migrate,
     };
 
     use core::sync::atomic::{AtomicU32, Ordering};

--- a/crates/sdk/tests/macros/attribute_interactions.rs
+++ b/crates/sdk/tests/macros/attribute_interactions.rs
@@ -169,4 +169,29 @@ impl DeprecatedMethodState {
     }
 }
 
+// Test that #[app::view] (the read-only intent marker) compiles, on its own
+// and combined with other attributes like #[must_use].
+#[app::state]
+struct ViewState {
+    value: String,
+}
+
+#[app::logic]
+impl ViewState {
+    #[app::view]
+    pub fn get_value(&self) -> &str {
+        &self.value
+    }
+
+    #[app::view]
+    #[must_use]
+    pub fn value_len(&self) -> usize {
+        self.value.len()
+    }
+
+    pub fn set_value(&mut self, value: String) {
+        self.value = value;
+    }
+}
+
 fn main() {}

--- a/scripts/verify-abi.sh
+++ b/scripts/verify-abi.sh
@@ -35,6 +35,17 @@ fi
 # Spot checks with jq
 echo "Running jq spot checks..."
 
+# A #[app::view] method must surface intent=read_only, and a #[app::xcall]
+# method must surface xcall_callable=true, in the emitted ABI.
+if ! jq -e '.methods[] | select(.name=="view_constant").intent == "read_only"' "$OUT" >/dev/null; then
+    echo "ERROR: view_constant (#[app::view]) missing intent=read_only"
+    exit 1
+fi
+if ! jq -e '.methods[] | select(.name=="xcall_noop").xcall_callable == true' "$OUT" >/dev/null; then
+    echo "ERROR: xcall_noop (#[app::xcall]) missing xcall_callable=true"
+    exit 1
+fi
+
 # Check nullable on opt methods
 if ! jq -e '.methods[] | select(.name=="opt_u32").params[0].nullable == true' "$OUT" >/dev/null; then
     echo "ERROR: opt_u32 method parameter missing nullable=true"


### PR DESCRIPTION
Fixes #2798.

## Problem

`#[app::view]` (added in #2707) is parsed by `#[app::logic]` and recorded in the ABI as `read_only` intent, but was never registered as a no-op `proc_macro_attribute` nor re-exported from the `app` module. Because `#[app::logic]` re-emits the impl **verbatim**, the surviving attribute fails to resolve in any downstream app:

```
error[E0433]: failed to resolve: could not find `view` in `app`
  |
  |     #[app::view]
  |            ^^^^ could not find `view` in `app`
```

### Why no test caught it

Every test of the feature asserted **hand-constructed** `Method { intent: … }` ABI structs (`crates/wasm-abi/tests/`) — the ABI *data layer*, which was never broken. The actual macro→`rustc`→ABI path was never exercised because there were **zero** compiled `#[app::view]` usages anywhere (only doc-comments and error strings). A feature with no consumer shipped green while being non-functional.

## Fix

- Register `view` as a no-op `proc_macro_attribute` in `crates/sdk/macros/src/lib.rs`, symmetric to `init`/`xcall`/`destroy` (the marker design relies on `#[app::logic]` re-emitting verbatim and markers resolving in place as registered no-ops).
- Re-export `view` from the `app` module in `crates/sdk/src/lib.rs`.
- Align the `xcall` doc comment, and document that the read-only contract is runtime-enforced (the attribute is a no-op; only init/xcall mutual-exclusivity is compile-checked).

## Testing — close the gap for the whole marker family

Rather than only fixing `view`, make the always-on **ABI Validation** job a real guard:

- `apps/abi_conformance` now exercises a `#[app::view]` and a `#[app::xcall]` method. These only compile because of the registration above, so a forgotten/unwired marker fails the **build** step.
- The golden `apps/abi_conformance/abi.expected.json` records `view_constant → intent: read_only` and `xcall_noop → xcall_callable: true`. A macro→ABI wiring regression fails the **golden diff**.
- `scripts/verify-abi.sh` gains explicit jq spot-checks for both intents.
- A compile-pass `trybuild` fixture in `crates/sdk/tests/macros/attribute_interactions.rs` covers `#[app::view]` on its own and combined with `#[must_use]`.

Verified the guard **fails** (golden diff) when the `#[app::view]` marker is dropped — so this regresses loudly in CI instead of shipping green.

## Verification

- `cargo check -p calimero-sdk` — the `view` re-export resolves to a real macro.
- `cargo check -p kv-store` with `#[app::view]` on a `&self` method — **compiles** (was `E0433` before).
- `./scripts/verify-abi.sh` — golden diff clean, all spot-checks pass.

## Follow-up (not in this PR)

`#[app::destroy]` is registered + re-exported but the `#[app::logic]` parser doesn't recognize it and no consumer was found in the macro/ABI/execute layers — it appears to resolve yet do nothing. Worth a separate triage (wire it or remove it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
