### PR TITLE
feat(storage): LwwRegister::value_mut drop-stamping guard

### DIFF
--- a/crates/storage/src/collections/lww_register.rs
+++ b/crates/storage/src/collections/lww_register.rs
@@ -85,12 +85,42 @@ impl<T> LwwRegister<T> {
         &self.value
     }
 
-    /// Get a mutable reference to the value
+    /// Get a mutable reference to the value.
     ///
-    /// **WARNING:** Direct mutation bypasses timestamp updates!
-    /// Use `set()` instead for proper CRDT behavior.
+    /// **WARNING:** direct mutation through this reference bypasses the
+    /// timestamp update, so the write keeps a stale HLC stamp and last-write-wins
+    /// merge will not pick it up — replicas silently diverge. Prefer
+    /// [`value_mut`](LwwRegister::value_mut) (mutate in place, stamped on drop) or
+    /// [`set`](LwwRegister::set) (replace wholesale).
+    #[deprecated(
+        note = "bypasses the HLC stamp and silently breaks convergence; use `value_mut()` \
+                (in-place, stamped on drop) or `set()`"
+    )]
     pub fn get_mut(&mut self) -> &mut T {
         &mut self.value
+    }
+
+    /// Mutate the value in place, stamping a fresh HLC timestamp + node id when
+    /// the returned guard is dropped — the safe equivalent of mutating a plain
+    /// field, without the [`get_mut`](LwwRegister::get_mut) footgun.
+    ///
+    /// The guard derefs to `&mut T`, so you edit the value with ordinary
+    /// semantics; the stamp is applied once, on drop, and only if the value was
+    /// actually mutated (a guard used for reads only leaves the clock untouched).
+    /// In merge mode the stamp is zeroed for cross-node determinism, exactly like
+    /// [`set`](LwwRegister::set).
+    ///
+    /// ```ignore
+    /// // tweak one field of a struct value without clone+set:
+    /// self.profile.value_mut().bio = "hi".to_owned();
+    /// // multiple edits collapse to a single stamp at end of scope:
+    /// { let mut items = self.list.value_mut(); items.push(x); items.retain(|i| i.ok); }
+    /// ```
+    pub fn value_mut(&mut self) -> LwwGuard<'_, T> {
+        LwwGuard {
+            reg: self,
+            dirty: false,
+        }
     }
 
     /// Set a new value (updates timestamp and node_id)
@@ -173,6 +203,51 @@ impl<T> std::ops::Deref for LwwRegister<T> {
 
     fn deref(&self) -> &Self::Target {
         &self.value
+    }
+}
+
+/// RAII guard returned by [`LwwRegister::value_mut`]. Derefs to `&mut T` for
+/// in-place mutation and stamps a fresh HLC timestamp + node id on drop (only if
+/// the value was actually mutated). This makes "mutate like a plain field" sound
+/// for a CRDT register — the stamp can't be forgotten the way it can with
+/// [`LwwRegister::get_mut`].
+#[must_use = "the value is stamped when the guard is dropped; bind it (or mutate through it) \
+              rather than discarding it"]
+pub struct LwwGuard<'a, T> {
+    reg: &'a mut LwwRegister<T>,
+    dirty: bool,
+}
+
+impl<T> core::ops::Deref for LwwGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.reg.value
+    }
+}
+
+impl<T> core::ops::DerefMut for LwwGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // Any mutable access counts as a write; stamp on drop.
+        self.dirty = true;
+        &mut self.reg.value
+    }
+}
+
+impl<T> Drop for LwwGuard<'_, T> {
+    fn drop(&mut self) {
+        if !self.dirty {
+            return;
+        }
+        // Same stamping rule as `LwwRegister::set` (incl. merge-mode zeroing for
+        // cross-node determinism inside `#[app::migrate]`).
+        if env::in_merge_mode() {
+            self.reg.timestamp = HybridTimestamp::zero();
+            self.reg.node_id = [0; 32];
+        } else {
+            self.reg.timestamp = env::hlc_timestamp();
+            self.reg.node_id = env::executor_id();
+        }
     }
 }
 

--- a/crates/storage/src/tests/lww_register.rs
+++ b/crates/storage/src/tests/lww_register.rs
@@ -32,6 +32,43 @@ fn test_lww_set() {
 }
 
 #[test]
+fn test_lww_value_mut_stamps_on_mutation() {
+    env::reset_for_testing();
+
+    // Start from an explicit stale stamp written by a foreign node.
+    let mut reg =
+        LwwRegister::new_with_metadata("Initial".to_string(), make_timestamp(100), [9u8; 32]);
+
+    // Mutate in place through the guard (ordinary `&mut T` semantics).
+    reg.value_mut().push_str(" + edit");
+    assert_eq!(reg.get(), "Initial + edit");
+
+    // The guard re-stamped on drop: the write is now attributed to this executor
+    // with a fresh HLC, not the foreign stamp — so LWW merge will see it (this is
+    // exactly what `get_mut` fails to do).
+    assert_eq!(reg.node_id(), env::executor_id());
+    assert_ne!(reg.timestamp(), make_timestamp(100));
+}
+
+#[test]
+fn test_lww_value_mut_readonly_does_not_stamp() {
+    env::reset_for_testing();
+
+    let mut reg =
+        LwwRegister::new_with_metadata("Initial".to_string(), make_timestamp(100), [9u8; 32]);
+
+    // Take the guard but only read through it.
+    {
+        let guard = reg.value_mut();
+        assert_eq!(&*guard, "Initial");
+    }
+
+    // No mutation → the dirty flag stayed false → the clock is untouched.
+    assert_eq!(reg.timestamp(), make_timestamp(100));
+    assert_eq!(reg.node_id(), [9u8; 32]);
+}
+
+#[test]
 fn test_lww_merge_later_timestamp_wins() {
     env::reset_for_testing();
 


### PR DESCRIPTION
## Why

`LwwRegister<T>` had two write paths, neither good for editing *part* of a value:

- `set(v)` — replaces the value wholesale **and** stamps the HLC. To tweak one field of a struct (or push to an inner `Vec`) you must `get().clone()` → mutate → `set(clone)`: a full clone + reconstruct for a small edit.
- `get_mut()` — returns `&mut T` for in-place mutation but **bypasses the timestamp update** (its own doc warns this). The write keeps a stale HLC stamp, so last-write-wins merge never picks it up → replicas silently diverge.

So you had to choose between "clone everything" and a convergence footgun.

## What

Add **`value_mut() -> LwwGuard<'_, T>`**: an RAII guard that derefs to `&mut T` for ordinary in-place mutation and **stamps a fresh HLC timestamp + node id on `Drop`** — only if the value was actually mutated (a guard used for reads leaves the clock untouched, via a `dirty` flag). Merge-mode zeroing is honored exactly like `set`.

```rust
// before
let mut p = self.profile.get().clone();
p.bio = "hi".into();
self.profile.set(p);

// after
self.profile.value_mut().bio = "hi".into();          // stamped on drop
{ let mut l = self.list.value_mut(); l.push(x); l.retain(..); }  // one stamp at end of scope
```

This is the same write-back-on-drop pattern the collections already use for `entry().or_default()` (`ValueMut`), applied to the timestamp instead of to storage — so "mutate it like a plain field" becomes **sound** for a CRDT register. The stamp can't be forgotten the way it can with `get_mut`.

Also **deprecates `get_mut`** (it had zero callers): it's exactly the footgun `value_mut` replaces. `set` remains the wholesale-replace path. Reads were already ergonomic via `Deref` (no change).

Note: `=` itself can't be involved — Rust has no assignable-trait, and a transparent `*reg = x` (via `DerefMut` on the register) would reintroduce the missed-stamp footgun. The guard is the closest sound equivalent to plain-field mutation.

## Tests

`test_lww_value_mut_stamps_on_mutation` (mutation re-stamps to this executor + fresh HLC) and `test_lww_value_mut_readonly_does_not_stamp` (read-through guard leaves the clock untouched). Storage lib suite green (619), workspace build + fmt + clippy clean; no deprecation warnings (no `get_mut` callers).

## Stacking

Stacked on #2795 (`feature/sdk-misuse-lint`) — base is set to that branch so the diff shows only the `LwwRegister` change. Once #2795 merges, I'll rebase this onto `master` and retarget the base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CRDT write semantics and convergence paths for `LwwRegister`; behavior change is intentional but callers must migrate off `get_mut()` to avoid silent replica divergence.
> 
> **Overview**
> Adds **`LwwRegister::value_mut()`**, which returns an **`LwwGuard`** that derefs to `&mut T` for in-place edits and **refreshes HLC timestamp + node id on drop** when anything was mutated (read-only guard use leaves metadata unchanged). Merge-mode stamping matches **`set()`** (zero timestamp/node id inside migrate).
> 
> **`get_mut()` is deprecated** with stronger docs: it still bypasses stamping and can break LWW convergence. **`set()`** stays for wholesale replacement.
> 
> Tests cover mutation re-stamping to the current executor and that read-only guards do not touch the clock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50e83f0e522cbef9dc4ed5c6645ebc546618c070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->