### PR TITLE
ci(setup-merobox): fix recurring exit-124 apt timeout in the shared merobox setup step

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -19,14 +19,8 @@ runs:
           | sudo tee /usr/share/keyrings/merobox.gpg > /dev/null
         echo "deb [signed-by=/usr/share/keyrings/merobox.gpg] https://calimero-network.github.io/merobox stable main" \
           | sudo tee /etc/apt/sources.list.d/merobox.list
-        # Refresh ONLY merobox's own list (-o Dir::Etc::*). A full `apt-get
-        # update` also probes the runner's Ubuntu mirrors; on Azure runners
-        # azure.archive.ubuntu.com is frequently dead (20s connect-timeout +
-        # retries) and the public archive.ubuntu.com fallback then crawls
-        # fetching the Packages indices — together that blew past the 120s
-        # bound and killed the step (exit 124). We don't need those repos:
-        # merobox's deps are already in the image's apt cache, and
-        # List-Cleanup=0 keeps that cache intact for the install below.
+        # Refresh only merobox's list, not the flaky Ubuntu mirrors that timed
+        # the step out; List-Cleanup=0 keeps cached deps for the install below.
         timeout 60 sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 \
           -o Acquire::https::Timeout=20 \
           -o Dir::Etc::sourcelist="sources.list.d/merobox.list" \

--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -19,8 +19,20 @@ runs:
           | sudo tee /usr/share/keyrings/merobox.gpg > /dev/null
         echo "deb [signed-by=/usr/share/keyrings/merobox.gpg] https://calimero-network.github.io/merobox stable main" \
           | sudo tee /etc/apt/sources.list.d/merobox.list
-        timeout 120 sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 \
-          -o Acquire::https::Timeout=20 update
+        # Refresh ONLY merobox's own list (-o Dir::Etc::*). A full `apt-get
+        # update` also probes the runner's Ubuntu mirrors; on Azure runners
+        # azure.archive.ubuntu.com is frequently dead (20s connect-timeout +
+        # retries) and the public archive.ubuntu.com fallback then crawls
+        # fetching the Packages indices — together that blew past the 120s
+        # bound and killed the step (exit 124). We don't need those repos:
+        # merobox's deps are already in the image's apt cache, and
+        # List-Cleanup=0 keeps that cache intact for the install below.
+        timeout 60 sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 \
+          -o Acquire::https::Timeout=20 \
+          -o Dir::Etc::sourcelist="sources.list.d/merobox.list" \
+          -o Dir::Etc::sourceparts="-" \
+          -o APT::Get::List-Cleanup="0" \
+          update
         timeout 180 sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=20 \
           -o Acquire::https::Timeout=20 install -y merobox
         merobox --version


### PR DESCRIPTION
## Problem

The shared `setup-merobox` composite action intermittently fails at the **Setup merobox** step with `Process completed with exit code 124`. It's not any code change — it's a runner network flake, and because the action is shared it can redden **any** workflow that uses it:

- `app-migration-e2e.yml`
- `e2e-rust-apps.yml`
- `e2e-rust-apps-release.yml`
- `fuzzy-load-test.yml`
- `sync-regression.yml`

The action runs a full `apt-get update`, which refreshes **every** source list, including the runner's Ubuntu mirrors. On Azure-hosted runners `azure.archive.ubuntu.com` is frequently dead, so apt waits out the full 20s connect-timeout (+3 retries), then falls back to the public `archive.ubuntu.com`, which crawls fetching the multi-MB Packages indices. Together that exceeds the `timeout 120` guard → the GNU `timeout` wrapper kills the process → exit 124.

Measured on a real failing run (`27783399102`):

| Δ | What |
|---|---|
| **0.4s** | microsoft, google, **and the merobox repo** all resolve — instant |
| **~20s** | dead silence blocked on `azure.archive.ubuntu.com` (full `Acquire::http::Timeout=20`) |
| **~7s** | 3 retries against Azure, every one `Ign`'d |
| **~91s** | slow `archive.ubuntu.com` Packages fetch, never completes → killed at the 120s mark |

So ~119s of the budget is spent **entirely on Ubuntu mirrors the step doesn't even need** — merobox + its deps come from `calimero-network.github.io/merobox` (0.4s) and the image's apt cache. In fan-out suites each matrix job runs `setup-merobox` independently, so this per-job flake compounds into the whole suite going red on most runs.

## Fix

Scope the update to only `sources.list.d/merobox.list`:

```bash
timeout 60 sudo apt-get ... \
  -o Dir::Etc::sourcelist="sources.list.d/merobox.list" \
  -o Dir::Etc::sourceparts="-" \
  -o APT::Get::List-Cleanup="0" \
  update
```

- `Dir::Etc::sourcelist` + `sourceparts=-` → apt reads *only* the merobox list, never the Ubuntu mirrors.
- `APT::Get::List-Cleanup=0` → keeps the image's already-cached Ubuntu Packages indices intact, so the unchanged `install -y merobox` step still resolves merobox's deps.

The merobox repo resolves in ~0.4s, so the step no longer touches the flaky Ubuntu mirrors at all. Single-file change to the shared action; every consumer benefits.

## How to verify

This PR touches `.github/actions/setup-merobox/**`, which is in the `app-migration-e2e` trigger filters, so its full ~35-job matrix runs here and exercises the action on every job. The **Setup merobox** step should complete in a couple seconds instead of timing out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)