### PR TITLE
test(governance-store): serialize op-event tests to fix parallel flake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,6 +1370,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/governance-store/Cargo.toml
+++ b/crates/governance-store/Cargo.toml
@@ -42,3 +42,6 @@ calimero-utils-actix.workspace = true
 # against this crate's live membership resolver over the same op sequences.
 calimero-op.workspace = true
 calimero-projection.workspace = true
+# Serializes the op-event tests, which observe a process-global broadcast bus
+# (`op_events`) and would otherwise cross-talk / flood under parallel execution.
+serial_test.workspace = true

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -11,17 +11,14 @@ use crate::{
     CapabilitiesRepository, GroupDeletedRejection, GroupKeyring, MembershipRepository,
     MetaRepository, NamespaceRepository,
 };
-use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
+use calimero_context_client::local_governance::GroupOp;
 use calimero_context_config::types::ContextGroupId;
-use calimero_primitives::application::ApplicationId;
-use calimero_primitives::context::{ContextId, GroupMemberRole, UpgradePolicy};
+use calimero_primitives::context::{ContextId, GroupMemberRole};
 use calimero_primitives::identity::{PrivateKey, PublicKey};
-use calimero_store::key::{GroupMetaValue, GroupUpgradeStatus, GroupUpgradeValue};
 use calimero_store::Store;
 
 use super::super::test_fixtures::{
-    dummy_member_removed_op, nest_for_test, sample_meta_with_admin, test_group_id, test_meta,
-    test_store,
+    nest_for_test, sample_meta_with_admin, test_group_id, test_meta, test_store,
 };
 use super::super::*;
 

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -5487,6 +5487,7 @@ mod auto_follow_tests {
     /// actor-driven `join_context` call, which needs a full merod
     /// instance (covered by the deferred merobox e2e workflow).
     #[tokio::test(flavor = "current_thread")]
+    #[serial_test::serial]
     async fn end_to_end_event_fires_after_op_apply() {
         use calimero_primitives::application::ApplicationId;
         use calimero_primitives::blobs::BlobId;
@@ -5594,6 +5595,7 @@ mod auto_follow_tests {
     /// FUTURE `OpEvent::ContextRegistered` events — pre-existing
     /// contexts in the group at join-time would be missed.
     #[tokio::test(flavor = "current_thread")]
+    #[serial_test::serial]
     async fn member_added_emits_synthesized_auto_follow_set() {
         use crate::op_events::{self, OpEvent};
 
@@ -5772,6 +5774,7 @@ mod auto_follow_tests {
     /// `Barrier` comment in the body for why a fully deterministic RED would need
     /// a test-only sync hook in the apply hot path, which we deliberately omit.
     #[test]
+    #[serial_test::serial]
     fn member_added_event_fires_after_op_log_append() {
         use std::sync::{Arc, Barrier};
 
@@ -5888,6 +5891,7 @@ mod auto_follow_tests {
     /// #2770: re-applying an already-logged op must NOT re-fire its event.
     /// The queued events are dropped on the content-hash dedup early-return.
     #[test]
+    #[serial_test::serial]
     fn replayed_group_op_does_not_re_emit() {
         use crate::op_events::{self, OpEvent};
 
@@ -5965,6 +5969,7 @@ mod auto_follow_tests {
     /// NOTE: deterministic GREEN, best-effort RED — same characterization as
     /// `member_added_event_fires_after_op_log_append` (see its body comment).
     #[test]
+    #[serial_test::serial]
     fn subgroup_created_event_fires_after_namespace_op_persist() {
         use std::sync::{Arc, Barrier};
 
@@ -6168,6 +6173,7 @@ mod tee_member_removed_event_tests {
     /// must emit BOTH `MemberRemoved` and `TeeMemberRemoved` for the
     /// same `(group_id, member)`.
     #[test]
+    #[serial_test::serial]
     fn member_removed_op_emits_tee_event_for_readonly_tee_role() {
         let store = test_store();
         let gid = test_group_id();
@@ -6220,6 +6226,7 @@ mod tee_member_removed_event_tests {
     /// leave-namespace, leave-then-rejoin-via-inheritance}` that
     /// closing #2653 was about.
     #[test]
+    #[serial_test::serial]
     fn member_removed_op_does_not_emit_tee_event_for_regular_member() {
         let store = test_store();
         let gid = test_group_id();
@@ -6268,6 +6275,7 @@ mod tee_member_removed_event_tests {
     /// a `ReadOnlyTee` self-leave emits both events; an `Admin`/
     /// `Member` self-leave emits only `MemberRemoved`.
     #[test]
+    #[serial_test::serial]
     fn member_left_op_emits_tee_event_only_for_readonly_tee_role() {
         // Case 1: TEE self-leave fires both.
         {


### PR DESCRIPTION
## Why

`subgroup_created_event_fires_after_namespace_op_persist` red'd a PR's required **Rust** check once (`392 passed; 1 failed`) and passed on rerun — a parallel-execution flake.

Root cause: it (and 7 sibling tests) observe `op_events::subscribe()`, a **process-global broadcast bus**. An observer thread spins (`yield_now`) waiting for a specific `(ns_id, parent, child)` event, then snapshots whether the op-log already contains the op. Run concurrently, the siblings fire their own events into the same bounded channel and saturate the scheduler with their own spin loops + RocksDB writes; under that contention the persist-then-notify timing the test snapshots gets perturbed, so `contains_op` reads `false` at emit and the assert at `tests.rs:6083` fails intermittently.

(The `crates/dag` `test_bug_missing_handler_broadcast` "DIVERGENCE DETECTED" panic seen alongside it in CI logs is unrelated — that's a `#[should_panic]` test behaving as designed; it was a red herring.)

## What

- Mark all **8** `op_events` subscriber tests `#[serial]` so only one bus observer runs at a time — the same approach `crates/storage` already uses for global-state test flakes. Adds `serial_test` as a dev-dependency.
- Drop the unused imports those test modules accumulated (`namespace/tests.rs`).

## Verification

`cargo test -p calimero-governance-store` → 393 passed; fmt clean. (Remaining production-source unused-import warnings in this crate are pre-existing and left untouched — some may be feature-gated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes (dev-dependency and `#[serial]` attributes); no runtime or production logic is modified.
> 
> **Overview**
> Fixes intermittent CI failures where **`op_events::subscribe()`** tests could fail when run in parallel because they all share a **process-global broadcast bus**.
> 
> Adds **`serial_test`** as a dev-dependency and marks **eight** governance-store tests that subscribe to **`op_events`** with **`#[serial_test::serial]`**, so only one such observer runs at a time (same pattern as **`calimero-storage`**). Also trims **unused imports** in **`namespace/tests.rs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cd04f721ccf4747f7b573a8f53931e1c1767d1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->