### PR TITLE
feat(sdk): capability-trait diagnostics for collection keys + RPC boundary (#2801)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2647,6 +2647,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "custom-key-store"
+version = "0.0.0"
+dependencies = [
+ "calimero-sdk",
+ "calimero-storage",
+ "calimero-wasm-abi",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [
     "./apps/blobs",
     "./apps/collaborative-editor",
     "./apps/kv-store",
+    "./apps/custom-key-store",
     "./apps/migration-harness-example",
     "./apps/sorted-kv-store",
     "./apps/sorted-set-store",
@@ -124,6 +125,7 @@ members = [
 
     "./apps/scaffolding-e2e",
     "./apps/kv-store",
+    "./apps/custom-key-store",
     "./apps/migration-harness-example",
     "./apps/sorted-kv-store",
     "./apps/sorted-set-store",

--- a/apps/custom-key-store/Cargo.toml
+++ b/apps/custom-key-store/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "custom-key-store"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+thiserror.workspace = true
+calimero-sdk.workspace = true
+calimero-storage.workspace = true
+
+[build-dependencies]
+calimero-wasm-abi.workspace = true
+serde_json.workspace = true
+
+[package.metadata.workspaces]
+independent = true
+
+[dev-dependencies]
+# Enables `register_crdt_merge` + the native mock host so `TestHost` can drive
+# CRDT state under `cargo test`.
+calimero-storage = { workspace = true, features = ["testing"] }

--- a/apps/custom-key-store/build.rs
+++ b/apps/custom-key-store/build.rs
@@ -1,0 +1,38 @@
+use std::fs;
+use std::path::Path;
+
+use calimero_wasm_abi::emitter::emit_manifest;
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/lib.rs");
+
+    // Parse the source code
+    let src_path = Path::new("src/lib.rs");
+    let src_content = fs::read_to_string(src_path).expect("Failed to read src/lib.rs");
+
+    // Generate ABI manifest using the emitter
+    let manifest = emit_manifest(&src_content).expect("Failed to emit ABI manifest");
+
+    // Serialize the manifest to JSON
+    let json = serde_json::to_string_pretty(&manifest).expect("Failed to serialize manifest");
+
+    // Write the ABI JSON to the res directory
+    let res_dir = Path::new("res");
+    if !res_dir.exists() {
+        fs::create_dir_all(res_dir).expect("Failed to create res directory");
+    }
+
+    let abi_path = res_dir.join("abi.json");
+    fs::write(&abi_path, json).expect("Failed to write ABI JSON");
+
+    // Extract and write the state schema
+    if let Ok(mut state_schema) = manifest.extract_state_schema() {
+        state_schema.schema_version = "wasm-abi/1".to_owned();
+
+        let state_schema_json =
+            serde_json::to_string_pretty(&state_schema).expect("Failed to serialize state schema");
+        let state_schema_path = res_dir.join("state-schema.json");
+        fs::write(&state_schema_path, state_schema_json)
+            .expect("Failed to write state schema JSON");
+    }
+}

--- a/apps/custom-key-store/src/lib.rs
+++ b/apps/custom-key-store/src/lib.rs
@@ -1,0 +1,80 @@
+//! Example: using a **custom key type** in a Calimero collection.
+//!
+//! Collection keys are addressed by their bytes, so a key type must implement
+//! `AsRef<[u8]>` (the SDK's `StorageKey` requirement). A bare numeric or
+//! arbitrary struct key is rejected at compile time:
+//!
+//! ```ignore
+//! items: UnorderedMap<u64, LwwRegister<String>>   // ERROR: `u64` can't be a
+//!                                                  // collection key — not
+//!                                                  // byte-encodable
+//! ```
+//!
+//! The fix is a thin newtype that owns a byte-encodable representation and
+//! forwards `AsRef<[u8]>`. `Slug` below wraps a `String` (already byte-encodable)
+//! and adds domain meaning + validation, while staying a valid key. The same
+//! shape works for an id newtype over `[u8; 32]`, etc.
+//!
+//! Everything else mirrors a normal app: CRDT state (`UnorderedMap` of
+//! `LwwRegister` values), owned `String` method arguments, and `app::Result`
+//! returns — all of which already satisfy the SDK's `StorageKey` / `AppArg` /
+//! `AppReturn` boundaries.
+
+use calimero_sdk::app;
+use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_storage::collections::{LwwRegister, UnorderedMap};
+
+/// A normalized, lowercase slug used as a map key.
+///
+/// It is a `StorageKey` because it is borsh-(de)serializable, `PartialEq`,
+/// `'static`, and — crucially — `AsRef<[u8]>` (forwarded to the inner
+/// `String`). That last impl is what makes it usable as a collection key; a
+/// plain struct without it would be rejected by `UnorderedMap::insert`.
+#[derive(Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "calimero_sdk::borsh")]
+pub struct Slug(String);
+
+impl Slug {
+    fn new(raw: &str) -> Self {
+        Self(raw.trim().to_lowercase())
+    }
+}
+
+impl AsRef<[u8]> for Slug {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+#[app::state]
+pub struct CustomKeyStore {
+    // The custom key type in action. `Slug: StorageKey`, so this compiles and
+    // every key operation (`insert`/`get`/…) is available.
+    pages: UnorderedMap<Slug, LwwRegister<String>>,
+}
+
+#[app::logic]
+impl CustomKeyStore {
+    #[app::init]
+    pub fn init() -> CustomKeyStore {
+        CustomKeyStore {
+            pages: UnorderedMap::new(),
+        }
+    }
+
+    /// Upsert a page body under a normalized slug. `title` is an owned `String`
+    /// argument (`AppArg`-valid: `DeserializeOwned`).
+    pub fn set_page(&mut self, title: String, body: String) -> app::Result<()> {
+        self.pages.insert(Slug::new(&title), body.into())?;
+        Ok(())
+    }
+
+    /// Fetch a page body. Returns `Option<String>` — a serializable
+    /// (`AppReturn`-valid) type, encoded to JSON for the caller.
+    pub fn get_page(&self, title: String) -> app::Result<Option<String>> {
+        Ok(self
+            .pages
+            .get(&Slug::new(&title))?
+            .map(|body| body.get().clone()))
+    }
+}

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -112,6 +112,19 @@ impl ToTokens for PublicLogicMethod<'_> {
                 quote! {}
             };
 
+            // Owned arguments are decoded from the caller's JSON, so they must be
+            // `DeserializeOwned`. Assert it explicitly so a non-deserializable
+            // argument surfaces the clear `AppArg` diagnostic at the method,
+            // rather than a raw serde-derive error. Borrowed (`&_`) args are
+            // validated by the input struct's `Deserialize` derive instead —
+            // their lifetime ties to the input buffer, which an owned assertion
+            // can't express.
+            let owned_arg_tys = args
+                .iter()
+                .filter(|arg| !arg.ty.ref_)
+                .map(|arg| &arg.ty)
+                .collect::<::std::vec::Vec<_>>();
+
             quote_spanned! {name.span()=>
                 #[derive(::calimero_sdk::serde::Deserialize)]
                 #[serde(crate = "::calimero_sdk::serde", deny_unknown_fields)]
@@ -120,6 +133,10 @@ impl ToTokens for PublicLogicMethod<'_> {
                         #args
                     ),*
                 }
+
+                #(
+                    let _ = ::calimero_sdk::__private::assert_app_arg::<#owned_arg_tys>;
+                )*
 
                 let Some(input) = ::calimero_sdk::env::input() else {
                     ::calimero_sdk::env::panic_str("Expected input since method has arguments.")

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -83,7 +83,33 @@ pub mod app {
 
 #[doc(hidden)]
 pub mod __private {
-    pub use crate::returns::{IntoResult, WrappedReturn};
+    pub use crate::returns::{AppReturn, IntoResult, WrappedReturn};
+
+    /// The bound an *owned* app-method argument must satisfy: arguments are
+    /// decoded from the caller's JSON, so the type must be
+    /// `serde::de::DeserializeOwned`.
+    ///
+    /// SDK-owned alias over `DeserializeOwned` whose only job is to carry a clear
+    /// diagnostic — a non-deserializable argument otherwise fails inside the
+    /// generated input-struct's serde derive. Blanket-implemented, so exactly as
+    /// permissive as the bound it names. Borrowed (`&_`) arguments are validated
+    /// by that derive directly instead: their lifetime ties to the input buffer,
+    /// which a standalone owned assertion can't express.
+    #[diagnostic::on_unimplemented(
+        message = "(calimero)> `{Self}` can't be an app-method argument — it is not JSON-deserializable",
+        label = "not deserializable",
+        note = "method arguments are decoded from the caller's JSON. Derive `serde::Deserialize` \
+                (with `#[serde(crate = \"calimero_sdk::serde\")]`), or use a type that already \
+                implements it."
+    )]
+    pub trait AppArg: crate::serde::de::DeserializeOwned {}
+
+    impl<T: crate::serde::de::DeserializeOwned> AppArg for T {}
+
+    /// Naming `assert_app_arg::<T>` forces the `AppArg` bound on an owned argument
+    /// type, so a non-deserializable argument surfaces the `AppArg` diagnostic at
+    /// the method rather than deep in serde's derive.
+    pub fn assert_app_arg<T: AppArg>() {}
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]

--- a/crates/sdk/src/returns.rs
+++ b/crates/sdk/src/returns.rs
@@ -7,6 +7,25 @@ mod private {
     pub trait Sealed {}
 }
 
+/// The bound an app method's return value (and its error type) must satisfy: it
+/// is JSON-encoded for the caller, so it must be `serde::Serialize`.
+///
+/// This is an SDK-owned alias over `serde::Serialize` whose only job is to carry
+/// a clear diagnostic — a non-serializable return otherwise fails deep inside
+/// the return-encoding machinery (`WrappedReturn::…to_json()`), far from the
+/// method. Blanket-implemented for every `Serialize` type, so it is exactly as
+/// permissive as the bound it replaces.
+#[diagnostic::on_unimplemented(
+    message = "(calimero)> `{Self}` can't be returned from an app method — it is not JSON-serializable",
+    label = "not serializable",
+    note = "a method's return value (and error type) is encoded to JSON for the caller. Derive \
+            `serde::Serialize` (with `#[serde(crate = \"calimero_sdk::serde\")]`), or return a type \
+            that already implements it."
+)]
+pub trait AppReturn: Serialize {}
+
+impl<T: Serialize + ?Sized> AppReturn for T {}
+
 pub trait IntoResult: Sealed {
     type Ok;
     type Err;
@@ -19,8 +38,8 @@ pub struct ReturnsResult<T, E>(Result<T, E>);
 
 impl<T, E> ReturnsResult<T, E>
 where
-    T: Serialize,
-    E: Serialize,
+    T: AppReturn,
+    E: AppReturn,
 {
     #[inline]
     pub fn to_json(&self) -> JsonResult<Result<Vec<u8>, Vec<u8>>> {
@@ -55,7 +74,7 @@ pub enum Infallible {}
 impl<T> Sealed for WrappedReturn<T> {}
 impl<T> IntoResult for WrappedReturn<T>
 where
-    T: Serialize,
+    T: AppReturn,
 {
     type Ok = T;
     type Err = Infallible;

--- a/crates/sdk/tests/macros.rs
+++ b/crates/sdk/tests/macros.rs
@@ -79,4 +79,10 @@ fn all() {
     t.compile_fail("tests/macros/error_emits_non_event.rs");
     // `PermissionedStorage<T, A>` policy must implement `Authorizer`.
     t.compile_fail("tests/macros/error_bad_authorizer.rs");
+    // Collection keys must be byte-encodable (`StorageKey`).
+    t.compile_fail("tests/macros/error_non_byte_key.rs");
+    // Note: the `AppArg`/`AppReturn` diagnostics (non-(de)serializable method
+    // args/returns) live in the `#[cfg(target_arch = "wasm32")]` export body, so
+    // they only fire for a wasm build — the host-compiled trybuild suite can't
+    // exercise them. They're covered by building the example apps for wasm.
 }

--- a/crates/sdk/tests/macros/error_non_byte_key.rs
+++ b/crates/sdk/tests/macros/error_non_byte_key.rs
@@ -1,0 +1,28 @@
+//! A collection key that isn't byte-encodable (`u64` lacks `AsRef<[u8]>`) must
+//! give the `StorageKey` diagnostic at the first key operation.
+//!
+//! The map is a local (not a `#[app::state]` field) so the `StorageKey` error
+//! surfaces directly: an in-state `UnorderedMap<u64, _>` would first fail the
+//! `Mergeable` field check, shadowing this message.
+
+use calimero_sdk::app;
+use calimero_storage::collections::{LwwRegister, UnorderedMap};
+
+#[app::state]
+struct S;
+
+#[app::logic]
+impl S {
+    #[app::init]
+    pub fn init() -> S {
+        S
+    }
+
+    pub fn put(&self) -> app::Result<()> {
+        let mut map: UnorderedMap<u64, LwwRegister<String>> = UnorderedMap::new();
+        map.insert(1u64, "x".to_owned().into())?;
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/crates/sdk/tests/macros/error_non_byte_key.stderr
+++ b/crates/sdk/tests/macros/error_non_byte_key.stderr
@@ -1,0 +1,17 @@
+error[E0277]: (calimero)> `u64` can't be used as a collection key — keys must be byte-encodable
+  --> tests/macros/error_non_byte_key.rs:23:13
+   |
+23 |         map.insert(1u64, "x".to_owned().into())?;
+   |             ^^^^^^ not a storage key
+   |
+   = help: the trait `AsRef<[u8]>` is not implemented for `u64`
+   = note: collection keys are addressed by their bytes, so the key type must implement `AsRef<[u8]>` (and be borsh-(de)serializable + `PartialEq` + `'static`). Use `String`, `Vec<u8>`, a `[u8; N]`, or a newtype that implements `AsRef<[u8]>`; a numeric key needs an explicit byte encoding.
+   = note: required for `u64` to implement `StorageKey`
+note: required by a bound in `calimero_storage::collections::UnorderedMap::<K, V, S>::insert`
+  --> $WORKSPACE/crates/storage/src/collections/unordered_map.rs
+   |
+   |     pub fn insert(&mut self, key: K, value: V) -> Result<Option<V>, StoreError>
+   |            ------ required by a bound in this associated function
+   |     where
+   |         K: StorageKey,
+   |            ^^^^^^^^^^ required by this bound in `UnorderedMap::<K, V, S>::insert`

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -28,7 +28,7 @@ pub use rga::ReplicatedGrowableArray;
 pub mod lww_register;
 pub use lww_register::LwwRegister;
 pub mod crdt_meta;
-pub use crdt_meta::{CrdtMeta, CrdtType, Decomposable, Mergeable, StorageStrategy};
+pub use crdt_meta::{CrdtMeta, CrdtType, Decomposable, Mergeable, StorageKey, StorageStrategy};
 // Re-export of the `Mergeable` *derive macro*, whose single canonical
 // implementation lives in `calimero-sdk-macros` (it shares the forbidden-type
 // field lint with `#[app::state]`, which is why it can't live in this crate's

--- a/crates/storage/src/collections/crdt_meta.rs
+++ b/crates/storage/src/collections/crdt_meta.rs
@@ -85,6 +85,31 @@ pub trait Mergeable {
     fn merge(&mut self, other: &Self) -> Result<(), MergeError>;
 }
 
+/// Marker for types usable as a **key** in a Calimero collection
+/// (`UnorderedMap`/`SortedMap` keys, `UnorderedSet`/`SortedSet` elements).
+///
+/// Keys are addressed by their byte representation, so the type must be
+/// `AsRef<[u8]>` (plus borsh-(de)serializable, `PartialEq`, and `'static` — the
+/// requirements every key path already imposes). This is an SDK-owned alias over
+/// those bounds whose only job is to carry a clear diagnostic: a numeric key
+/// like `u64` satisfies everything *except* `AsRef<[u8]>` and would otherwise
+/// fail with a bare "`AsRef<[u8]>` is not implemented" error at some method call.
+/// Blanket-implemented, so it is exactly as permissive as the bounds it names.
+#[diagnostic::on_unimplemented(
+    message = "(calimero)> `{Self}` can't be used as a collection key — keys must be byte-encodable",
+    label = "not a storage key",
+    note = "collection keys are addressed by their bytes, so the key type must implement \
+            `AsRef<[u8]>` (and be borsh-(de)serializable + `PartialEq` + `'static`). Use `String`, \
+            `Vec<u8>`, a `[u8; N]`, or a newtype that implements `AsRef<[u8]>`; a numeric key needs \
+            an explicit byte encoding."
+)]
+pub trait StorageKey:
+    BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static
+{
+}
+
+impl<T: BorshSerialize + BorshDeserialize + AsRef<[u8]> + PartialEq + 'static> StorageKey for T {}
+
 /// Errors that can occur during CRDT merging
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MergeError {

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -80,7 +80,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::ser::SerializeMap;
 use serde::Serialize;
 
-use super::{compute_id, Collection, CrdtType, EntryMut, StorageAdaptor, ValueRef};
+use super::{compute_id, Collection, CrdtType, EntryMut, StorageAdaptor, StorageKey, ValueRef};
 use crate::address::Id;
 use crate::collections::error::StoreError;
 use crate::entities::{ChildInfo, Data, Element, StorageType};
@@ -300,7 +300,7 @@ where
     /// returned.
     pub fn insert(&mut self, key: K, value: V) -> Result<Option<V>, StoreError>
     where
-        K: AsRef<[u8]> + PartialEq + 'static,
+        K: StorageKey,
         V: 'static,
     {
         // Entries inherit this collection's own storage domain (Public for an

--- a/crates/storage/src/collections/sorted_set.rs
+++ b/crates/storage/src/collections/sorted_set.rs
@@ -45,7 +45,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::ser::SerializeSeq;
 use serde::Serialize;
 
-use super::{compute_id, Collection, CrdtType};
+use super::{compute_id, Collection, CrdtType, StorageKey};
 use crate::address::Id;
 use crate::collections::error::StoreError;
 use crate::entities::Data;
@@ -178,7 +178,7 @@ where
     /// will be returned.
     pub fn insert(&mut self, value: V) -> Result<bool, StoreError>
     where
-        V: AsRef<[u8]> + PartialEq + 'static,
+        V: StorageKey,
     {
         super::rekey::register_rekey::<Self>();
         let collection = self.inner.id();

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -36,7 +36,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::ser::SerializeMap;
 use serde::Serialize;
 
-use super::{compute_id, Collection, CrdtType, EntryMut, StorageAdaptor, ValueRef};
+use super::{compute_id, Collection, CrdtType, EntryMut, StorageAdaptor, StorageKey, ValueRef};
 use crate::address::Id;
 use crate::collections::error::StoreError;
 use crate::entities::{ChildInfo, Data, Element, StorageType};
@@ -314,7 +314,7 @@ where
     ///
     pub fn insert(&mut self, key: K, value: V) -> Result<Option<V>, StoreError>
     where
-        K: AsRef<[u8]> + PartialEq + 'static,
+        K: StorageKey,
         V: 'static,
     {
         // Children inherit this collection's own storage domain. For an ordinary

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -34,7 +34,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::ser::SerializeSeq;
 use serde::Serialize;
 
-use super::{compute_id, Collection, CrdtType};
+use super::{compute_id, Collection, CrdtType, StorageKey};
 use crate::collections::error::StoreError;
 use crate::entities::Data;
 use crate::store::{MainStorage, StorageAdaptor};
@@ -214,7 +214,7 @@ where
     ///
     pub fn insert(&mut self, value: V) -> Result<bool, StoreError>
     where
-        V: AsRef<[u8]> + PartialEq + 'static,
+        V: StorageKey,
     {
         // Register this set type's nested-id re-key thunk so that when the set
         // is itself stored as a map/set/vector value, `insert`'s re-key path


### PR DESCRIPTION
Implements #2801 — the full "capability-trait" design for SDK misuse diagnostics at two boundaries that previously produced cryptic foreign-trait errors. Each new trait is SDK-owned, carries `#[diagnostic::on_unimplemented]`, and is blanket-implemented over the underlying requirement, so it's **exactly as permissive as the bound it replaces** (behavior-preserving). Same pattern as the merged `Mergeable`/`AppEvent`/`Authorizer` work.

## `StorageKey` — collection keys
A key is addressed by its bytes, so it must be `AsRef<[u8]>` (+ borsh + `PartialEq` + `'static`). The `insert` of `UnorderedMap`/`SortedMap`/`UnorderedSet`/`SortedSet` now bounds the key on `StorageKey`:

```
UnorderedMap<u64, LwwRegister<String>>   // (calimero)> `u64` can't be used as a
                                         // collection key — keys must be byte-encodable
```

**Design note:** bound at the `insert` boundary, *not* the struct. A struct-level `K: StorageKey` is the "purest" form but rippled to **~117 errors** across one collection alone (every impl + wrappers) and changed construction semantics (you couldn't `new()` a non-key map) — disproportionate for an identical user-facing diagnostic.

## `AppReturn` — method return types
A return value (and error type) is JSON-encoded for the caller, so it must be `serde::Serialize`. Replaces the `Serialize` bounds in the return encoder (`returns.rs`) so a non-serializable return points at `derive(Serialize)` instead of failing deep inside `WrappedReturn::…to_json()`.

## `AppArg` — method arguments
An *owned* argument is decoded from the caller's JSON, so it must be `DeserializeOwned`; the macro asserts it per owned arg. Borrowed (`&_`) args stay validated by the generated input-struct's `Deserialize` derive (their lifetime ties to the input buffer, which a standalone owned assertion can't express).

## Testing note
`AppArg`/`AppReturn` live in the `#[cfg(target_arch = "wasm32")]` export body, so they're enforced on a **real wasm build** but not by the host-compiled trybuild suite (same class as the enum-state check). Verified by building `custom-key-store` for wasm and by ad-hoc bad-arg/bad-return wasm builds (both surface the `(calimero)>` messages). `StorageKey` fires in user method bodies (host-compiled) and is covered by a new `error_non_byte_key` compile_fail fixture.

## Example app
Adds `apps/custom-key-store` — a worked example of the **custom-key pattern** the `StorageKey` diagnostic guides toward: a `Slug` newtype forwarding `AsRef<[u8]>`, used as an `UnorderedMap` key, with owned-`String` args and serializable returns. The common cases (String keys, owned args, `app::Result`) were already covered by `kv-store` et al.; this fills the custom-key gap. (Dogfooding bonus: the SDK's own borsh-derive diagnostic caught an early version of the example.)

## Verification
- `cargo build --workspace --all-targets` + all apps for `wasm32` → clean
- trybuild suite (`cargo test -p calimero-sdk --test macros`) → `all ... ok`
- `calimero-storage` / `calimero-sdk` / `calimero-sdk-macros` tests → green
- `cargo fmt --check` + `cargo clippy` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving trait aliases and diagnostic-only macro assertions; collection bounds are equivalent to the previous requirements at insert sites.
> 
> **Overview**
> Adds **SDK-owned capability traits** with `(calimero)>` compile-time diagnostics at three misuse boundaries, without tightening who can compile valid apps (blanket impls over the same bounds as before).
> 
> **`StorageKey`** marks types usable as map/set keys (byte-addressable via `AsRef<[u8]>` plus borsh/`PartialEq`/`'static`). **`UnorderedMap` / `SortedMap` / `UnorderedSet` / `SortedSet`** now bound **`insert`** on `K: StorageKey` instead of raw `AsRef<[u8]>`, so invalid keys like `u64` fail with a guided message at the call site. A new **`error_non_byte_key`** trybuild fixture locks in that diagnostic.
> 
> **`AppReturn`** aliases `Serialize` for method return (and error) JSON encoding in **`returns.rs`**. **`AppArg`** aliases `DeserializeOwned`; **`#[app::logic]`** codegen asserts **`assert_app_arg`** for each **owned** argument so bad args surface at the method (borrowed `&_` args still go through the generated `Deserialize` struct).
> 
> Ships **`apps/custom-key-store`** as a wasm example: a **`Slug`** newtype forwarding **`AsRef<[u8]>`** as an **`UnorderedMap`** key, plus ABI **`build.rs`**. Workspace **`Cargo.toml`** / lockfile register the new app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5339e27fcb8b870917e7c77e716ff9c47a4c9b83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->