### PR TITLE
ci: bump ai-code-reviewer pin to 841cacd

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -60,7 +60,7 @@ jobs:
       # prevent an upstream change from running with this repo's secrets.
       # Bump deliberately when adopting new reviewer features.
       - name: Install ai-code-reviewer
-        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@485b32abf334f1518dcadc9c3762ea98705e696c
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@841cacd80464ea2897426197eb1edb9dda94908d
 
       # Authenticate as the MeroReviewer App so review comments genuinely
       # come from meroreviewer[bot] (not whatever GH_PAT/GITHUB_TOKEN

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -58,7 +58,7 @@ jobs:
       # Pinned to the same SHA as ai-review.yaml so both workflows install
       # the audited version of ai-code-reviewer. Bump deliberately.
       - name: Install ai-code-reviewer
-        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@485b32abf334f1518dcadc9c3762ea98705e696c
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@841cacd80464ea2897426197eb1edb9dda94908d
 
       # Mint a short-lived MeroReviewer App installation token. Unlike the
       # default GITHUB_TOKEN, an App token is not subject to the org/repo


### PR DESCRIPTION
## What

Bumps the `ai-code-reviewer` SHA pin in both consuming workflows from `485b32a` → `841cacd80464ea2897426197eb1edb9dda94908d` (latest [`master`](https://github.com/calimero-network/ai-code-reviewer/commits/master), via [PR #81](https://github.com/calimero-network/ai-code-reviewer/pull/81)).

- `.github/workflows/ai-review.yaml`
- `.github/workflows/doc-update.yaml`

Both stay pinned to the **same** audited SHA, as the inline comments require.

## Why

The pin was 37 commits behind upstream `master`. The intervening work is the doc-update pipeline rewrite (Understand → Route → Apply → Verify), plus multi-target mapping support, a stage-4 verify gate, duplicate-page coalescing, and several routing/parse robustness fixes. Adopting it keeps core's AutoDocs and PR-review on the current reviewer.

## Notes

- Pin is by full git SHA (no version tag; upstream `pyproject` version is still `0.1.0`), so bumping the SHA is the adoption mechanism.
- No behavior change to core itself — CI tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency pin bump; no runtime or product code paths change, though CI behavior for reviews and auto-docs will follow the new reviewer release.
> 
> **Overview**
> **CI only:** both workflows that `pip install` `calimero-network/ai-code-reviewer` now pin commit `841cacd80464ea2897426197eb1edb9dda94908d` instead of `485b32a`, keeping **AI Code Review** and **Doc Auto-Update** on one audited SHA as the inline comments require.
> 
> No application or Rust code changes—only which reviewer version runs in Actions (including newer doc-update pipeline behavior from upstream).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 839b7aefbf8be173bd98e664d511e614e7d84cf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->