### PR TITLE
ci: track ai-code-reviewer master instead of pinning a SHA

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -56,11 +56,14 @@ jobs:
         with:
           python-version: "3.11"
 
-      # Pinned to a specific SHA on calimero-network/ai-code-reviewer to
-      # prevent an upstream change from running with this repo's secrets.
-      # Bump deliberately when adopting new reviewer features.
+      # Tracks the latest master of calimero-network/ai-code-reviewer on
+      # every run, so reviewer fixes are adopted without a manual SHA bump.
+      # Trade-off: this step runs with this repo's secrets, so whatever is on
+      # that repo's master executes here automatically. Acceptable because we
+      # own it and gate merges to its master. If that ever stops being true,
+      # pin back to a reviewed @<sha> here (and in doc-update.yaml).
       - name: Install ai-code-reviewer
-        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@485b32abf334f1518dcadc9c3762ea98705e696c
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@master
 
       # Authenticate as the MeroReviewer App so review comments genuinely
       # come from meroreviewer[bot] (not whatever GH_PAT/GITHUB_TOKEN

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -55,10 +55,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      # Pinned to the same SHA as ai-review.yaml so both workflows install
-      # the audited version of ai-code-reviewer. Bump deliberately.
+      # Tracks ai-code-reviewer master, same as ai-review.yaml, so both
+      # workflows always run the latest reviewer without a manual bump.
+      # See the secrets trade-off note in ai-review.yaml.
       - name: Install ai-code-reviewer
-        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@485b32abf334f1518dcadc9c3762ea98705e696c
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@master
 
       # Mint a short-lived MeroReviewer App installation token. Unlike the
       # default GITHUB_TOKEN, an App token is not subject to the org/repo


### PR DESCRIPTION
## What

Both reviewer workflows now install `ai-code-reviewer` from `@master` instead of a frozen SHA:

- `.github/workflows/ai-review.yaml`
- `.github/workflows/doc-update.yaml`

Each CI run clones the current master, so reviewer and doc-bot fixes are adopted automatically — no more manual "bump the pin" PR every release.

## Trade-off (documented inline)

These steps run with this repo's secrets (`ANTHROPIC_API_KEY`, MeroReviewer App token). Pinning to a SHA meant nothing new ran with those secrets until it was reviewed. Tracking `master` removes that gate: whatever is on `ai-code-reviewer`'s master runs here on the next CI run.

Acceptable because we own that repo and gate merges to its master. The comment in `ai-review.yaml` says to pin back to `@<sha>` if that ever stops being true.

## Notes

- `pip install git+...@master` always re-resolves on a fresh runner (pip only reuses its wheel cache for immutable commit-hash URLs, not branch refs), so runs genuinely pick up new commits.
- Supersedes #2813 (the one-off SHA bump), which I'm closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI now runs whatever is on ai-code-reviewer master with secrets that were previously gated behind a reviewed SHA pin.
> 
> **Overview**
> **AI review and doc auto-update** now install `calimero-network/ai-code-reviewer` from **`@master`** instead of commit **`485b32a…`**, so CI picks up reviewer fixes without a manual pin-bump PR.
> 
> Inline comments document the trade-off: these install steps run with repo secrets (`ANTHROPIC_API_KEY`, MeroReviewer App token), so unreviewed upstream `master` changes can execute on the next run. The workflow notes that this is acceptable while the team owns and gates that repo, and to pin back to `@<sha>` in both workflows if that changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15fdad4c81322aeacd50223b71feeb6019b3478e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->