### PR TITLE
feat(sdk): richer host-boundary panic messages (#2805)

### DIFF
--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -70,6 +70,21 @@ impl ToTokens for PublicLogicMethod<'_> {
 
         let arg_idents = args.iter().map(|arg| arg.ident).collect::<Vec<_>>();
 
+        // Baked into the host-boundary (de)serialization panics below so a
+        // malformed call reports *which* method failed and *what shape* was
+        // expected — the raw serde error alone names neither, which is where app
+        // authors lose the most time when wiring a client. Both are compile-time
+        // string literals (the signature is small, so no `max_log_size` concern).
+        let method_name = name.to_string();
+        let arg_schema = {
+            let fields = args
+                .iter()
+                .map(|arg| format!("{}: {}", arg.ident, arg.ty.to_token_stream()))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{{ {fields} }}")
+        };
+
         let init_method = modifiers
             .iter()
             .any(|modifier| matches!(modifier, Modifer::Init));
@@ -91,8 +106,8 @@ impl ToTokens for PublicLogicMethod<'_> {
                         {
                             if !fields.is_empty() {
                                 ::calimero_sdk::env::panic_str(&format!(
-                                    "Failed to deserialize input from JSON: method takes no \
-                                     arguments but received unknown field(s): {:?}",
+                                    "{}: takes no arguments, but the call sent JSON field(s): {:?}",
+                                    #method_name,
                                     fields.keys().collect::<::std::vec::Vec<_>>()
                                 ));
                             }
@@ -139,16 +154,20 @@ impl ToTokens for PublicLogicMethod<'_> {
                 )*
 
                 let Some(input) = ::calimero_sdk::env::input() else {
-                    ::calimero_sdk::env::panic_str("Expected input since method has arguments.")
+                    ::calimero_sdk::env::panic_str(&format!(
+                        "{}: missing arguments — expected a JSON object {}",
+                        #method_name, #arg_schema
+                    ))
                 };
 
                 let #input_ident {
                     #(#arg_idents),*
                 } = match ::calimero_sdk::serde_json::from_slice(&input) {
                     Ok(value) => value,
-                    Err(err) => ::calimero_sdk::env::panic_str(
-                        &format!("Failed to deserialize input from JSON: {:?}", err)
-                    ),
+                    Err(err) => ::calimero_sdk::env::panic_str(&format!(
+                        "{}: failed to deserialize arguments (expected {}): {:?}",
+                        #method_name, #arg_schema, err
+                    )),
                 };
             }
         };
@@ -201,9 +220,10 @@ impl ToTokens for PublicLogicMethod<'_> {
                         .to_json()
                     {
                         Ok(output) => output,
-                        Err(err) => ::calimero_sdk::env::panic_str(
-                            &format!("Failed to serialize output to JSON: {:?}", err)
-                        ),
+                        Err(err) => ::calimero_sdk::env::panic_str(&format!(
+                            "{}: failed to serialize the return value to JSON: {:?}",
+                            #method_name, err
+                        )),
                     }
                 };
                 ::calimero_sdk::env::value_return(&output)

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -71,19 +71,12 @@ impl ToTokens for PublicLogicMethod<'_> {
         let arg_idents = args.iter().map(|arg| arg.ident).collect::<Vec<_>>();
 
         // Baked into the host-boundary (de)serialization panics below so a
-        // malformed call reports *which* method failed and *what shape* was
-        // expected — the raw serde error alone names neither, which is where app
-        // authors lose the most time when wiring a client. Both are compile-time
-        // string literals (the signature is small, so no `max_log_size` concern).
+        // malformed call reports *which* method failed (and, for arg-bearing
+        // methods, *what shape* was expected) — the raw serde error alone names
+        // neither, which is where app authors lose the most time wiring a client.
+        // A compile-time string literal; the method name is always available, the
+        // argument schema is built per-branch (only the args path needs it).
         let method_name = name.to_string();
-        let arg_schema = {
-            let fields = args
-                .iter()
-                .map(|arg| format!("{}: {}", arg.ident, arg.ty.to_token_stream()))
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("{{ {fields} }}")
-        };
 
         let init_method = modifiers
             .iter()
@@ -106,7 +99,7 @@ impl ToTokens for PublicLogicMethod<'_> {
                         {
                             if !fields.is_empty() {
                                 ::calimero_sdk::env::panic_str(&format!(
-                                    "{}: takes no arguments, but the call sent JSON field(s): {:?}",
+                                    "{}: takes no arguments, but the call sent unknown field(s): {:?}",
                                     #method_name,
                                     fields.keys().collect::<::std::vec::Vec<_>>()
                                 ));
@@ -139,6 +132,30 @@ impl ToTokens for PublicLogicMethod<'_> {
                 .filter(|arg| !arg.ty.ref_)
                 .map(|arg| &arg.ty)
                 .collect::<::std::vec::Vec<_>>();
+
+            // Expected-argument hint for the deserialize panics, e.g.
+            // `{ key: String, value: String }`. Only built here (the args path).
+            // `to_token_stream()` renders the *sanitized* type, which spaces out
+            // punctuation and carries the internal reserved input lifetime for
+            // borrowed args; strip that lifetime and collapse the spacing so the
+            // hint reads like source (`&str` → not `& 'CALIMERO_INPUT str`).
+            let reserved_lt = lifetimes::input().to_token_stream().to_string();
+            let arg_schema = {
+                let fields = args
+                    .iter()
+                    .map(|arg| {
+                        let ty = arg
+                            .ty
+                            .to_token_stream()
+                            .to_string()
+                            .replace(&reserved_lt, "");
+                        let ty = ty.split_whitespace().collect::<Vec<_>>().join(" ");
+                        format!("{}: {}", arg.ident, ty)
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{{ {fields} }}")
+            };
 
             quote_spanned! {name.span()=>
                 #[derive(::calimero_sdk::serde::Deserialize)]


### PR DESCRIPTION
Implements #2805 — richer host-boundary panic messages.

## Problem
The generated method wrapper (`crates/sdk/macros/src/logic/method.rs`) panicked on JSON (de)serialization failures with terse, context-free messages:
```
Failed to deserialize input from JSON: missing field `value`
Failed to serialize output to JSON: ...
```
They name neither **which method** failed nor **what shape** was expected — exactly the info an author needs when wiring a client to a deployed method.

## What
Bake the method name and the expected argument schema (field names + types, which the macro already knows from the generated input struct) into every host-boundary panic:

| case | message |
|---|---|
| missing args | `set: missing arguments — expected a JSON object { key: String, value: String }` |
| malformed args | `set: failed to deserialize arguments (expected { key: String, value: String }): <err>` |
| no-arg method sent fields | `ping: takes no arguments, but the call sent JSON field(s): ["x"]` |
| bad return | `get: failed to serialize the return value to JSON: <err>` |

`method_name` and `arg_schema` are compile-time string literals built at macro-expansion (the signature is small → no `max_log_size` concern).

## Verification
These panics live in the `#[cfg(target_arch = "wasm32")]` export body, so the host-compiled trybuild suite can't assert them. Verified the generated text via `cargo expand -p kv-store --target wasm32-unknown-unknown` — e.g. kv-store's `set` produces exactly:
```rust
panic_str(&format!("{0}: failed to deserialize arguments (expected {1}): {2:?}",
                   "set", "{ key: String, value: String }", err))
```
All apps build for `wasm32`; the trybuild suite, fmt, and clippy are green (the host-compiled fixtures are unaffected — the change is in the wasm export path only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics-only change in generated WASM wrappers; no change to successful call handling or host APIs.
> 
> **Overview**
> **Host-boundary errors from generated app method exports** now name the failing method and, when applicable, the expected JSON argument shape, instead of generic serde messages.
> 
> For methods with arguments, macro expansion builds a compile-time `arg_schema` string (field names + sanitized types) and uses it in **missing input**, **deserialize failure**, and **return serialize failure** panics (e.g. `set: failed to deserialize arguments (expected { key: String, value: String }): …`). For no-arg methods, unknown JSON object fields are reported as `method: takes no arguments, but the call sent unknown field(s): …`.
> 
> Changes are limited to codegen in `method.rs` and affect the `wasm32` export path only; behavior on success is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9036ff4067dd5274818b7d01d27601222e0ea21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->