### PR TITLE
feat(sdk): DX sweep — #[must_use] on Entry + #[doc(hidden)] on internal plumbing (#2804)

### DIFF
--- a/crates/storage/src/collections/rekey.rs
+++ b/crates/storage/src/collections/rekey.rs
@@ -60,6 +60,10 @@ use crate::address::Id;
 /// error at the impl site, E0478). So every `RekeyTarget` type satisfies the
 /// `+ 'static` bound the dispatch macros below want — there is no way to write a
 /// non-`'static` impl that would silently take the no-op arm.
+///
+/// `#[doc(hidden)]`: `pub` only so macro-generated `impl`s in app crates can
+/// name it; app authors never implement or reference it directly.
+#[doc(hidden)]
 pub trait RekeyTarget: Any {
     /// Re-key this value's nested collection ids relative to `parent_id` (the
     /// deterministic entity id under which this value is stored). Idempotent.

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -1099,6 +1099,8 @@ where
 
 /// A view into a single entry in a [`SortedMap`], which may either be occupied
 /// or vacant. Returned by [`SortedMap::entry`].
+#[must_use = "an Entry does nothing on its own; call `.or_insert(…)` / `.or_default()` \
+              (or match it) to read or modify the slot — dropping it is a no-op"]
 #[derive(Debug)]
 pub enum Entry<'a, K, V, S>
 where

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -777,6 +777,8 @@ where
 /// occupied or vacant.
 ///
 /// This `enum` is returned by the `UnorderedMap::entry` method.
+#[must_use = "an Entry does nothing on its own; call `.or_insert(…)` / `.or_default()` \
+              (or match it) to read or modify the slot — dropping it is a no-op"]
 #[derive(Debug)]
 pub enum Entry<'a, K, V, S>
 where

--- a/crates/storage/src/merge/registry.rs
+++ b/crates/storage/src/merge/registry.rs
@@ -275,6 +275,7 @@ where
 /// stays absent from production host builds, and this wrapper does nothing there
 /// either.
 #[cfg(not(target_arch = "wasm32"))]
+#[doc(hidden)] // test/internal plumbing — not part of the app-facing API
 pub fn register_crdt_merge_for_test<T>()
 where
     T: borsh::BorshSerialize + borsh::BorshDeserialize + crate::collections::Mergeable + 'static,
@@ -285,6 +286,7 @@ where
 
 /// Clear the merge registry (for testing only)
 #[cfg(any(test, feature = "testing"))]
+#[doc(hidden)] // test-only internal plumbing
 pub fn clear_merge_registry() {
     with_registry_mut(|registry| registry.clear());
 }
@@ -296,6 +298,7 @@ pub fn clear_merge_registry() {
 /// - `NoFunctionsRegistered` if no merge functions are registered (I5 violation)
 /// - `AllFunctionsFailed` if merge functions exist but none could merge the data
 #[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
+#[doc(hidden)] // internal merge-dispatch plumbing — not part of the app-facing API
 pub fn try_merge_registered(
     existing: &[u8],
     incoming: &[u8],


### PR DESCRIPTION
Implements #2804 — two cheap, behavior-preserving DX cleanups in the spirit of the `ValueRef` `#[must_use]` already shipped.

## `#[must_use]` on the map `Entry` type (`UnorderedMap` + `SortedMap`)
`entry()` returns `Result<Entry, _>`, so the *Result* discard is already caught. But:
```rust
map.entry(key)?;            // compiles, does NOTHING — no `or_insert`/`or_default`
map.entry(key)?.or_default()?;  // the actual write
```
`map.entry(k)?;` consumes the `Result` and drops the `Entry` — a silent no-op. `#[must_use]` on the `Entry` type turns that into a warning pointing at `or_insert`/`or_default`.

**Scoping note:** `Counter` ops (`increment`/`decrement`/`value`/…) and the `get`/iterator returns already return `Result`/`Iterator`, both `#[must_use]` in std — so no additions were needed there (adding more would be redundant). `Entry` is the one genuine gap.

## `#[doc(hidden)]` on internal plumbing
These are `pub` only so macros/the runtime can reach them, but they leaked into rust-analyzer autocomplete and docs.rs alongside the real API (`UnorderedMap`, `LwwRegister`, …):
- `try_merge_registered` (internal merge dispatch)
- `clear_merge_registry`, `register_crdt_merge_for_test` (test-only helpers)
- the `RekeyTarget` trait (`pub` only so macro-generated impls in app crates can name it; #2577)

`#[doc(hidden)]` removes them from docs/autocomplete **without changing visibility**, so the macros keep calling them — a zero-risk discoverability win.

**Left visible on purpose:** `register_crdt_merge` — it's a documented manual alternative to `#[app::state]` (real, if niche, public API), so hiding it would remove that escape hatch from the docs.

## Verification
- storage + full workspace + all wasm apps build with **no new `must_use` warnings** (checked specifically, given the workspace `-D warnings` direction)
- trybuild suite → `all ... ok`; storage lib tests → 619 passed; fmt + clippy → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Attribute-only changes; no logic, visibility, or merge/re-key behavior is modified. The only user-facing effect is new `must_use` warnings if code drops a map `Entry` without using it.
> 
> **Overview**
> This PR adds **compile-time and docs discoverability** tweaks with **no runtime behavior change**.
> 
> **`#[must_use]` on `Entry`** for both `UnorderedMap` and `SortedMap`: after `map.entry(key)?`, discarding the `Entry` is a silent no-op (unlike `std::HashMap`, where the `Result` is already `must_use`). The attribute warns callers to use `.or_insert` / `.or_default` or match the enum.
> 
> **`#[doc(hidden)]`** hides macro/runtime-only symbols from docs.rs and rust-analyzer autocomplete while keeping `pub` visibility: `RekeyTarget`, `try_merge_registered`, `clear_merge_registry`, and `register_crdt_merge_for_test`. **`register_crdt_merge`** stays documented as the intentional public escape hatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d9affd7674b38b1603f9b4de1e1cdb048a217ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->