### PR TITLE
chore: cut release 0.11.0-rc.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@
 - **`SortedSet<T>` collection** — the `BTreeSet` to `UnorderedSet`'s `HashSet`: an ordered set with `range`/`prefix`/`page`/`first`/`last`, same add-wins union merge and the same on-disk ordered index as `SortedMap` ([#2559])
 - **In-process unit-test harness (`calimero_sdk::testing::TestHost`)** - Exercise app logic as ordinary Rust under `cargo test` — no WASM build, no node, no merobox. `TestHost::new(MyApp::init)` runs methods via `call`/`view` against an in-memory mock host that records `app::emit!` events and `app::log!` lines and serves a configurable executor identity (`call_as` for multi-author CRDT tests). The `#[app::state]` macro generates the storage bridge; apps opt in with `calimero-storage`'s `testing` feature as a dev-dependency. All core example apps now ship `#[cfg(test)]` tests using it ([#2551])
 
+## [0.11.0-rc.6] - 2026-06-19
+
+### Added
+
+- **SDK compile-time misuse diagnostics** — common app-authoring mistakes (including guarded-storage misuse) now surface as compile-time errors, and the macro lint suite is revived as a CI gate ([#2795])
+- **SDK capability-trait diagnostics** — clearer compile-time errors for collection key types and at the RPC boundary ([#2801])
+- **Richer host-boundary panic messages** — panics crossing the app/host boundary now carry more actionable detail ([#2805])
+
+### Fixed
+
+- **Fleet TEE nodes replicate Open subgroups, and TEE eviction is namespace-wide** — a root-admitted `ReadOnlyTee` now auto-follows (replicates) the contexts of Open subgroups it inherits, instead of only being authorized for them. And a namespace-root `MemberRemoved` of a `ReadOnlyTee` now cascades through every descendant subgroup (including Restricted subgroups created by other members), so a namespace owner can evict a fleet TEE node namespace-wide with a single root removal. The cascade is scoped to `ReadOnlyTee`; normal-member Restricted-subgroup membership autonomy is unchanged ([#2809])
+- **`#[app::view]` resolves in downstream crates** — registered as a no-op marker so it no longer fails to resolve when used through a dependency ([#2799])
+- **Blob-aware same-id update skip** — the context update path now correctly skips a redundant blob update when the blob id is unchanged ([#2796])
+- **`LwwRegister::value_mut` drop-stamping guard** — guards against an incorrect last-writer timestamp being stamped on mutable-borrow drop ([#2806])
+
 ## [0.11.0-rc.5] - 2026-06-18
 
 ### Added
@@ -263,7 +278,8 @@ Integrations:
 
 <!-- versions -->
 
-[unreleased]: https://github.com/calimero-network/core/compare/0.11.0-rc.5...HEAD
+[unreleased]: https://github.com/calimero-network/core/compare/0.11.0-rc.6...HEAD
+[0.11.0-rc.6]: https://github.com/calimero-network/core/compare/0.11.0-rc.5...0.11.0-rc.6
 [0.11.0-rc.5]: https://github.com/calimero-network/core/compare/0.11.0-rc.4...0.11.0-rc.5
 [0.8.0]: https://github.com/calimero-network/core/compare/0.7.0...0.8.0
 [0.7.0]: https://github.com/calimero-network/core/compare/0.6.0...0.7.0
@@ -285,6 +301,13 @@ Integrations:
 
 <!-- patches -->
 
+[#2809]: https://github.com/calimero-network/core/pull/2809
+[#2805]: https://github.com/calimero-network/core/pull/2805
+[#2801]: https://github.com/calimero-network/core/pull/2801
+[#2806]: https://github.com/calimero-network/core/pull/2806
+[#2795]: https://github.com/calimero-network/core/pull/2795
+[#2799]: https://github.com/calimero-network/core/pull/2799
+[#2796]: https://github.com/calimero-network/core/pull/2796
 [#2772]: https://github.com/calimero-network/core/pull/2772
 [#2776]: https://github.com/calimero-network/core/pull/2776
 [#2792]: https://github.com/calimero-network/core/pull/2792

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.5"
+version = "0.11.0-rc.6"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Cuts **0.11.0-rc.6** (bumps `[workspace.metadata.workspaces].version`). Merging to `master` fires the release workflow (tag `0.11.0-rc.6` + `merod`/`meroctl` assets).

## Included since rc.5

**Fixed**
- Fleet TEE nodes now replicate Open subgroups they inherit, and a namespace-root `MemberRemoved` of a `ReadOnlyTee` cascades namespace-wide (incl. non-owner Restricted subgroups), so an owner can evict a fleet TEE with a single root removal — scoped to `ReadOnlyTee` ([#2809])
- `#[app::view]` resolves in downstream crates ([#2799])
- Blob-aware same-id update skip ([#2796])
- `LwwRegister::value_mut` drop-stamping guard ([#2806])

**Added**
- SDK compile-time misuse diagnostics + macro lint CI gate ([#2795])
- SDK capability-trait diagnostics for collection keys + RPC boundary ([#2801])
- Richer host-boundary panic messages ([#2805])

(CI/test/docs-only PRs since rc.5 omitted from the changelog, per convention. `[Unreleased]` SortedMap/SortedSet/TestHost entries left as-is — unchanged by this cut.)

## Downstream after release
- `mero-tee/versions.json` `merodVersion` -> 0.11.0-rc.6 (+ node-image rebuild) so fleet nodes get Fix B replication.
- `tauri-app/merod-config.json` pin -> 0.11.0-rc.6 (+ desktop rebuild) so the owner/desktop gets the Fix A cascade.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The PR only bumps workspace version metadata and updates the changelog; runtime risk comes from the already-merged changes listed in the release notes, not from this diff.
> 
> **Overview**
> Cuts **0.11.0-rc.6** by bumping `[workspace.metadata.workspaces].version` in `Cargo.toml` from `0.11.0-rc.5` to `0.11.0-rc.6` (no application code in the diff). Merging is intended to trigger the release workflow (tag + `merod`/`meroctl` assets).
> 
> **CHANGELOG** adds a dated `0.11.0-rc.6` section documenting what ships in this RC—SDK compile-time diagnostics and macro lint CI ([#2795], [#2801], [#2805]), fixes for fleet **ReadOnlyTee** Open-subgroup replication and namespace-wide eviction cascade ([#2809]), `#[app::view]` in downstream crates ([#2799]), blob same-id update skip ([#2796]), and `LwwRegister::value_mut` drop-stamping ([#2806). It retargets `[unreleased]` compare links and adds patch reference URLs. **`[Unreleased]`** entries (e.g. SortedMap/SortedSet/TestHost) are left unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a5325dbc130e0a7bdd7653a0efd08b85cc43f44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->