### PR TITLE
chore(lint): drop storage restriction-lint header + workspace clippy --fix (1/4)

### DIFF
--- a/apps/collaborative-editor/src/lib.rs
+++ b/apps/collaborative-editor/src/lib.rs
@@ -271,11 +271,10 @@ impl EditorState {
 
         Ok(format!(
             "Document Statistics:\n\
-             - Title: {}\n\
-             - Length: {} characters\n\
-             - Total edits: {}\n\
-             - Owner: {}",
-            title, length, total_edits, owner
+             - Title: {title}\n\
+             - Length: {length} characters\n\
+             - Total edits: {total_edits}\n\
+             - Owner: {owner}"
         ))
     }
 

--- a/apps/kv-store-with-handlers/src/lib.rs
+++ b/apps/kv-store-with-handlers/src/lib.rs
@@ -82,7 +82,7 @@ impl KvStore {
         Ok(self.items.len()?)
     }
 
-    pub fn get<'a>(&self, key: &'a str) -> app::Result<Option<String>> {
+    pub fn get(&self, key: &str) -> app::Result<Option<String>> {
         app::log!("Getting key: {:?}", key);
 
         Ok(self.items.get(key)?.map(|v| v.get().clone()))
@@ -95,7 +95,7 @@ impl KvStore {
         Ok(self.items.get(key)?.expect("key not found").get().clone())
     }
 
-    pub fn get_result<'a>(&self, key: &'a str) -> app::Result<String> {
+    pub fn get_result(&self, key: &str) -> app::Result<String> {
         app::log!("Getting key, possibly failing: {:?}", key);
 
         let Some(value) = self.get(key)? else {
@@ -133,7 +133,7 @@ impl KvStore {
 
     /// Handle insert events
     pub fn insert_handler(&mut self, key: &str, value: &str) -> app::Result<()> {
-        self.log_handler_call("insert_handler", &format!("key={}, value={}", key, value))?;
+        self.log_handler_call("insert_handler", &format!("key={key}, value={value}"))?;
         // Add your insert-specific logic here
         // For example: send notifications, update external systems, etc.
         Ok(())
@@ -141,7 +141,7 @@ impl KvStore {
 
     /// Handle update events
     pub fn update_handler(&mut self, key: &str, value: &str) -> app::Result<()> {
-        self.log_handler_call("update_handler", &format!("key={}, value={}", key, value))?;
+        self.log_handler_call("update_handler", &format!("key={key}, value={value}"))?;
         // Add your update-specific logic here
         // For example: log changes, update caches, etc.
         Ok(())
@@ -149,7 +149,7 @@ impl KvStore {
 
     /// Handle remove events
     pub fn remove_handler(&mut self, key: &str) -> app::Result<()> {
-        self.log_handler_call("remove_handler", &format!("key={}", key))?;
+        self.log_handler_call("remove_handler", &format!("key={key}"))?;
         // Add your remove-specific logic here
         // For example: cleanup external resources, etc.
         Ok(())

--- a/apps/kv-store-with-user-and-frozen-storage/src/lib.rs
+++ b/apps/kv-store-with-user-and-frozen-storage/src/lib.rs
@@ -213,7 +213,7 @@ impl KvStore {
     pub fn add_frozen(&mut self, value: String) -> app::Result<String> {
         app::log!("Adding frozen value: {:?}", value);
 
-        let hash = self.frozen_items.insert(value.clone().into())?;
+        let hash = self.frozen_items.insert(value.clone())?;
 
         app::emit!(Event::FrozenAdded {
             hash,
@@ -234,8 +234,7 @@ impl KvStore {
         Ok(self
             .frozen_items
             .get(&hash)?
-            .map(|v| v.clone())
-            .ok_or_else(|| Error::FrozenNotFound("Frozen value is not found"))?)
+            .ok_or(Error::FrozenNotFound("Frozen value is not found"))?)
     }
 
     // --- Original KvStore Methods (Public) ---

--- a/apps/migrations/scenario-crdt-native-v2/src/lib.rs
+++ b/apps/migrations/scenario-crdt-native-v2/src/lib.rs
@@ -45,7 +45,7 @@ pub fn migrate_v1_to_v2() -> ScenarioCrdtNativeV2 {
 
     let old_state: ScenarioCrdtNativeV1 = BorshDeserialize::deserialize(&mut &old_bytes[..])
         .unwrap_or_else(|e| {
-            panic!("Migration failed: V1 deserialization error {:?}", e);
+            panic!("Migration failed: V1 deserialization error {e:?}");
         });
 
     app::emit!(Event::Migrated {
@@ -68,7 +68,7 @@ pub fn migrate_v1_to_v2() -> ScenarioCrdtNativeV2 {
     let mut keys: Vec<String> = old_state
         .items
         .entries()
-        .unwrap_or_else(|e| panic!("Migration failed: V1 items iteration error {:?}", e))
+        .unwrap_or_else(|e| panic!("Migration failed: V1 items iteration error {e:?}"))
         .map(|(k, _v)| k)
         .collect();
     keys.sort();
@@ -76,7 +76,7 @@ pub fn migrate_v1_to_v2() -> ScenarioCrdtNativeV2 {
     let mut tags: Vector<LwwRegister<String>> = Vector::new();
     for k in keys {
         tags.push(k.into())
-            .unwrap_or_else(|e| panic!("Migration failed: V2 tags seed error {:?}", e));
+            .unwrap_or_else(|e| panic!("Migration failed: V2 tags seed error {e:?}"));
     }
 
     ScenarioCrdtNativeV2 {

--- a/apps/migrations/scenario-field-remove-archive-v2/src/lib.rs
+++ b/apps/migrations/scenario-field-remove-archive-v2/src/lib.rs
@@ -47,7 +47,7 @@ pub fn migrate_v1_to_v2() -> ScenarioFieldRemoveArchiveV2 {
 
     let old_state: ScenarioFieldRemoveArchiveV1 =
         BorshDeserialize::deserialize(&mut &old_bytes[..]).unwrap_or_else(|e| {
-            panic!("Migration failed: V1 deserialization error {:?}", e);
+            panic!("Migration failed: V1 deserialization error {e:?}");
         });
 
     app::emit!(Event::Migrated {
@@ -60,7 +60,7 @@ pub fn migrate_v1_to_v2() -> ScenarioFieldRemoveArchiveV2 {
     archived_legacy
         .insert("latest".to_owned(), LwwRegister::new(legacy_value))
         .unwrap_or_else(|e| {
-            panic!("Migration failed: archive insert error {:?}", e);
+            panic!("Migration failed: archive insert error {e:?}");
         });
 
     ScenarioFieldRemoveArchiveV2 {

--- a/apps/migrations/scenario-field-split-v2/src/lib.rs
+++ b/apps/migrations/scenario-field-split-v2/src/lib.rs
@@ -48,7 +48,7 @@ pub fn migrate_v1_to_v2() -> ScenarioFieldSplitV2 {
 
     let old_state: ScenarioFieldSplitV1 = BorshDeserialize::deserialize(&mut &old_bytes[..])
         .unwrap_or_else(|e| {
-            panic!("Migration failed: V1 deserialization error {:?}", e);
+            panic!("Migration failed: V1 deserialization error {e:?}");
         });
 
     app::emit!(Event::Migrated {

--- a/apps/migrations/scenario-frozen-storage-v2/src/lib.rs
+++ b/apps/migrations/scenario-frozen-storage-v2/src/lib.rs
@@ -71,7 +71,7 @@ pub fn migrate_v1_to_v2() -> ScenarioFrozenStorageV2 {
 
     let old_state: ScenarioFrozenStorageV1 = BorshDeserialize::deserialize(&mut &old_bytes[..])
         .unwrap_or_else(|e| {
-            panic!("Migration failed: V1 deserialization error {:?}", e);
+            panic!("Migration failed: V1 deserialization error {e:?}");
         });
 
     app::emit!(Event::Migrated {
@@ -88,7 +88,7 @@ pub fn migrate_v1_to_v2() -> ScenarioFrozenStorageV2 {
     let derived = derived_doc_content(old_state.title.get());
     let new_hash = documents
         .insert(derived)
-        .unwrap_or_else(|e| panic!("Migration failed: derived-doc freeze error {:?}", e));
+        .unwrap_or_else(|e| panic!("Migration failed: derived-doc freeze error {e:?}"));
 
     ScenarioFrozenStorageV2 {
         documents,

--- a/apps/migrations/scenario-identity-downgrade-v2/src/lib.rs
+++ b/apps/migrations/scenario-identity-downgrade-v2/src/lib.rs
@@ -33,7 +33,7 @@ pub fn migrate_v1_to_v2() -> ScenarioIdentityDowngradeV2 {
         panic!("Migration failed: no existing state. Create a V1 context first.");
     });
     let _old: ScenarioIdentityDowngradeV1 = BorshDeserialize::deserialize(&mut &old_bytes[..])
-        .unwrap_or_else(|e| panic!("Migration failed: V1 deserialization error {:?}", e));
+        .unwrap_or_else(|e| panic!("Migration failed: V1 deserialization error {e:?}"));
 
     // A real downgrade would copy entries into the plain map, discarding the
     // per-entry authorship — which is exactly why this is unsafe and why the

--- a/apps/migrations/scenario-invariant-reshuffle-v2/src/lib.rs
+++ b/apps/migrations/scenario-invariant-reshuffle-v2/src/lib.rs
@@ -63,7 +63,7 @@ pub fn migrate_v1_to_v2() -> ScenarioInvariantReshuffleV2 {
 
     let old_state: ScenarioInvariantReshuffleV1 =
         BorshDeserialize::deserialize(&mut &old_bytes[..]).unwrap_or_else(|e| {
-            panic!("Migration failed: V1 deserialization error {:?}", e);
+            panic!("Migration failed: V1 deserialization error {e:?}");
         });
 
     app::emit!(Event::Migrated {
@@ -88,15 +88,12 @@ pub fn migrate_v1_to_v2() -> ScenarioInvariantReshuffleV2 {
     let mut total: u64 = 0;
     let mut per_item: UnorderedMap<String, LwwRegister<u64>> = UnorderedMap::new();
     for (k, v) in old_state.per_item_counts.entries().unwrap_or_else(|e| {
-        panic!(
-            "Migration failed: V1 per_item_counts iteration error {:?}",
-            e
-        );
+        panic!("Migration failed: V1 per_item_counts iteration error {e:?}");
     }) {
         let n = *v.get();
         total += n;
         per_item.insert(k, n.into()).unwrap_or_else(|e| {
-            panic!("Migration failed: V2 per_item insert error {:?}", e);
+            panic!("Migration failed: V2 per_item insert error {e:?}");
         });
     }
 

--- a/apps/migrations/scenario-migration-check-fail-v2/src/lib.rs
+++ b/apps/migrations/scenario-migration-check-fail-v2/src/lib.rs
@@ -64,7 +64,7 @@ pub fn migrate_v1_to_v2() -> (ScenarioMigrationCheckFailV2, MigrationWitness) {
 
     let old_state: ScenarioMigrationCheckFailV1 =
         BorshDeserialize::deserialize(&mut &old_bytes[..]).unwrap_or_else(|e| {
-            panic!("Migration failed: V1 deserialization error {:?}", e);
+            panic!("Migration failed: V1 deserialization error {e:?}");
         });
 
     app::emit!(Event::Migrated {
@@ -86,7 +86,7 @@ pub fn migrate_v1_to_v2() -> (ScenarioMigrationCheckFailV2, MigrationWitness) {
     let mut items = old_state.items;
     let mut keys: Vec<String> = items
         .entries()
-        .unwrap_or_else(|e| panic!("Migration failed: V1 items iteration error {:?}", e))
+        .unwrap_or_else(|e| panic!("Migration failed: V1 items iteration error {e:?}"))
         .map(|(k, _)| k)
         .collect();
     keys.sort();
@@ -94,7 +94,7 @@ pub fn migrate_v1_to_v2() -> (ScenarioMigrationCheckFailV2, MigrationWitness) {
     if let Some(smallest) = keys.first() {
         items
             .remove(smallest)
-            .unwrap_or_else(|e| panic!("Migration failed: V2 items drop error {:?}", e));
+            .unwrap_or_else(|e| panic!("Migration failed: V2 items drop error {e:?}"));
     }
 
     (

--- a/apps/migrations/scenario-migration-check-pass-v2/src/lib.rs
+++ b/apps/migrations/scenario-migration-check-pass-v2/src/lib.rs
@@ -53,7 +53,7 @@ pub fn migrate_v1_to_v2() -> ScenarioMigrationCheckPassV2 {
 
     let old_state: ScenarioMigrationCheckPassV1 =
         BorshDeserialize::deserialize(&mut &old_bytes[..]).unwrap_or_else(|e| {
-            panic!("Migration failed: V1 deserialization error {:?}", e);
+            panic!("Migration failed: V1 deserialization error {e:?}");
         });
 
     app::emit!(Event::Migrated {

--- a/apps/migrations/scenario-unordered-set-v2/src/lib.rs
+++ b/apps/migrations/scenario-unordered-set-v2/src/lib.rs
@@ -52,7 +52,7 @@ pub fn migrate_v1_to_v2() -> ScenarioUnorderedSetV2 {
 
     let old_state: ScenarioUnorderedSetV1 = BorshDeserialize::deserialize(&mut &old_bytes[..])
         .unwrap_or_else(|e| {
-            panic!("Migration failed: V1 deserialization error {:?}", e);
+            panic!("Migration failed: V1 deserialization error {e:?}");
         });
 
     app::emit!(Event::Migrated {
@@ -71,15 +71,15 @@ pub fn migrate_v1_to_v2() -> ScenarioUnorderedSetV2 {
     let mut tags = old_state.tags;
     let mut old_tags: Vec<String> = tags
         .iter()
-        .unwrap_or_else(|e| panic!("Migration failed: V1 tags iteration error {:?}", e))
+        .unwrap_or_else(|e| panic!("Migration failed: V1 tags iteration error {e:?}"))
         .collect();
     old_tags.sort();
 
     tags.clear()
-        .unwrap_or_else(|e| panic!("Migration failed: V2 tags clear error {:?}", e));
+        .unwrap_or_else(|e| panic!("Migration failed: V2 tags clear error {e:?}"));
     for tag in old_tags {
         tags.insert(tag.to_uppercase())
-            .unwrap_or_else(|e| panic!("Migration failed: V2 tag insert error {:?}", e));
+            .unwrap_or_else(|e| panic!("Migration failed: V2 tag insert error {e:?}"));
     }
 
     ScenarioUnorderedSetV2 {

--- a/apps/private_data/src/lib.rs
+++ b/apps/private_data/src/lib.rs
@@ -52,7 +52,6 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use bs58;
 use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;

--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -817,7 +817,7 @@ impl E2eKvStore {
         let blob_id = parse_blob_id_base58(&blob_id_str)?;
 
         let current_counter = *self.file_counter.get();
-        let file_id = format!("file_{}", current_counter);
+        let file_id = format!("file_{current_counter}");
         self.file_counter.set(current_counter + 1);
 
         let uploader_id = env::executor_id();

--- a/crates/auth/build.rs
+++ b/crates/auth/build.rs
@@ -171,7 +171,7 @@ fn target_dir() -> eyre::Result<PathBuf> {
 
     while out_dir.pop() {
         if let Some(name) = out_dir.file_name().and_then(|n| n.to_str()) {
-            if profile_names.iter().any(|&pn| pn == name) {
+            if profile_names.contains(&name) {
                 return Ok(out_dir);
             }
         }

--- a/crates/auth/src/auth/middleware.rs
+++ b/crates/auth/src/auth/middleware.rs
@@ -675,11 +675,8 @@ mod tests {
 
         // Simulate middleware error handling
         let mut headers = HeaderMap::new();
-        match &err {
-            crate::AuthError::TokenExpired => {
-                headers.insert("X-Auth-Error", "token_expired".parse().unwrap());
-            }
-            _ => {}
+        if let crate::AuthError::TokenExpired = &err {
+            headers.insert("X-Auth-Error", "token_expired".parse().unwrap());
         }
 
         assert_eq!(
@@ -713,11 +710,8 @@ mod tests {
         let err = crate::AuthError::InvalidRequest("Missing Authorization header".to_string());
 
         let mut headers = HeaderMap::new();
-        match &err {
-            crate::AuthError::InvalidRequest(_) => {
-                headers.insert("X-Auth-Error", "invalid_request".parse().unwrap());
-            }
-            _ => {}
+        if let crate::AuthError::InvalidRequest(_) = &err {
+            headers.insert("X-Auth-Error", "invalid_request".parse().unwrap());
         }
 
         assert_eq!(
@@ -1095,7 +1089,7 @@ mod tests {
     #[test]
     fn test_permissions_header_format() {
         // Test X-Auth-Permissions header with multiple permissions
-        let permissions = vec!["admin", "read", "write"];
+        let permissions = ["admin", "read", "write"];
         let permissions_str = permissions.join(",");
 
         let mut headers = HeaderMap::new();

--- a/crates/auth/src/auth/permissions/types.rs
+++ b/crates/auth/src/auth/permissions/types.rs
@@ -335,7 +335,7 @@ impl FromStr for Permission {
                         PackagePermission::GetLatestVersion(scope),
                     )),
                     "" => Ok(Permission::Package(PackagePermission::All)),
-                    _ => Err(format!("Unknown package action: {}", action)),
+                    _ => Err(format!("Unknown package action: {action}")),
                 }
             }
 
@@ -503,15 +503,15 @@ impl fmt::Display for Permission {
                 PackagePermission::All => write!(f, "package"),
                 PackagePermission::ListPackages(scope) => {
                     let params = format_params(scope, &UserScope::Any, &None);
-                    write!(f, "package:list-packages{}", params)
+                    write!(f, "package:list-packages{params}")
                 }
                 PackagePermission::ListVersions(scope) => {
                     let params = format_params(scope, &UserScope::Any, &None);
-                    write!(f, "package:list-versions{}", params)
+                    write!(f, "package:list-versions{params}")
                 }
                 PackagePermission::GetLatestVersion(scope) => {
                     let params = format_params(scope, &UserScope::Any, &None);
-                    write!(f, "package:get-latest-version{}", params)
+                    write!(f, "package:get-latest-version{params}")
                 }
             },
             Permission::Blob(blob_perm) => match blob_perm {
@@ -846,21 +846,18 @@ mod tests {
     fn test_permission_display() {
         // Test Display trait implementation
         let perm = Permission::Admin(AdminPermission);
-        assert_eq!(format!("{}", perm), "admin");
+        assert_eq!(format!("{perm}"), "admin");
         assert_eq!(perm.to_string(), "admin");
 
         let perm = Permission::Keys(KeyPermission::Create);
-        assert_eq!(format!("{}", perm), "keys:create");
+        assert_eq!(format!("{perm}"), "keys:create");
         assert_eq!(perm.to_string(), "keys:create");
 
         let perm = Permission::Context(ContextPermission::Alias(AliasPermission::Lookup(
             AliasType::Identity,
             ResourceScope::Specific(vec!["ctx-123".to_string()]),
         )));
-        assert_eq!(
-            format!("{}", perm),
-            "context:alias:lookup:identity[ctx-123]"
-        );
+        assert_eq!(format!("{perm}"), "context:alias:lookup:identity[ctx-123]");
         assert_eq!(perm.to_string(), "context:alias:lookup:identity[ctx-123]");
     }
 

--- a/crates/auth/src/auth/permissions/validator.rs
+++ b/crates/auth/src/auth/permissions/validator.rs
@@ -733,7 +733,7 @@ mod tests {
 
             let perms = validator.determine_required_permissions(&req);
             // Each parameterized route should return exactly one permission
-            assert!(!perms.is_empty(), "No permissions found for {}", path);
+            assert!(!perms.is_empty(), "No permissions found for {path}");
         }
 
         // Note: The performance benefit comes from:

--- a/crates/client/src/auth.rs
+++ b/crates/client/src/auth.rs
@@ -64,15 +64,15 @@ pub struct ConsoleOutputHandler;
 
 impl OutputHandler for ConsoleOutputHandler {
     fn display_message(&self, message: &str) {
-        println!("{}", message);
+        println!("{message}");
     }
 
     fn display_error(&self, error: &str) {
-        eprintln!("Error: {}", error);
+        eprintln!("Error: {error}");
     }
 
     fn display_success(&self, message: &str) {
-        println!("✓ {}", message);
+        println!("✓ {message}");
     }
 
     fn open_browser(&self, url: &Url) -> Result<()> {
@@ -81,13 +81,19 @@ impl OutputHandler for ConsoleOutputHandler {
     }
 
     fn wait_for_input(&self, prompt: &str) -> Result<String> {
-        print!("{}", prompt);
+        print!("{prompt}");
         io::stdout().flush()?;
 
         let mut input = String::new();
         let _ = io::stdin().read_line(&mut input)?;
 
         Ok(input.trim().to_owned())
+    }
+}
+
+impl Default for CliAuthenticator {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -123,7 +129,7 @@ impl ClientAuthenticator for CliAuthenticator {
         // 4. Return the tokens
 
         self.output
-            .display_message(&format!("Please authenticate at: {}", api_url));
+            .display_message(&format!("Please authenticate at: {api_url}"));
 
         // Simulate authentication process
         let access_token = self.output.wait_for_input("Enter access token: ")?;
@@ -176,9 +182,9 @@ impl ClientAuthenticator for CliAuthenticator {
         // Try to open the authentication URL in the browser
         if let Err(e) = self.output.open_browser(api_url) {
             self.output
-                .display_error(&format!("Failed to open browser: {}", e));
+                .display_error(&format!("Failed to open browser: {e}"));
             self.output
-                .display_message(&format!("Please manually visit: {}", api_url));
+                .display_message(&format!("Please manually visit: {api_url}"));
         }
 
         // Wait for user to complete authentication
@@ -210,6 +216,12 @@ impl ClientAuthenticator for CliAuthenticator {
 pub struct HeadlessAuthenticator {
     /// Pre-configured tokens
     tokens: Option<JwtToken>,
+}
+
+impl Default for HeadlessAuthenticator {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl HeadlessAuthenticator {

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -180,7 +180,7 @@ where
         let response = self
             .connection
             .post(
-                &format!("admin-api/alias/create/identity/{}", context_id),
+                &format!("admin-api/alias/create/identity/{context_id}"),
                 request,
             )
             .await?;
@@ -214,7 +214,7 @@ where
         let prefix = "admin-api/alias/create";
         let kind = T::KIND;
         let scope_path = T::scoped(scope.as_ref())
-            .map(|scope| format!("/{}", scope))
+            .map(|scope| format!("/{scope}"))
             .unwrap_or_default();
 
         let body = CreateAliasRequest {
@@ -240,7 +240,7 @@ where
         let prefix = "admin-api/alias/delete";
         let kind = T::KIND;
         let scope_path = T::scoped(scope.as_ref())
-            .map(|scope| format!("/{}", scope))
+            .map(|scope| format!("/{scope}"))
             .unwrap_or_default();
 
         let response = self
@@ -257,7 +257,7 @@ where
         let prefix = "admin-api/alias/list";
         let kind = T::KIND;
         let scope_path = T::scoped(scope.as_ref())
-            .map(|scope| format!("/{}", scope))
+            .map(|scope| format!("/{scope}"))
             .unwrap_or_default();
 
         let response = self
@@ -278,7 +278,7 @@ where
         let prefix = "admin-api/alias/lookup";
         let kind = T::KIND;
         let scope_path = T::scoped(scope.as_ref())
-            .map(|scope| format!("/{}", scope))
+            .map(|scope| format!("/{scope}"))
             .unwrap_or_default();
 
         let response = self

--- a/crates/client/src/connection.rs
+++ b/crates/client/src/connection.rs
@@ -569,7 +569,7 @@ mod tests {
     fn test_long_json_message_truncated() {
         let s = reqwest::StatusCode::BAD_REQUEST;
         let long_msg = "x".repeat(400);
-        let body = format!(r#"{{"message":"{}"}}"#, long_msg);
+        let body = format!(r#"{{"message":"{long_msg}"}}"#);
         let result = extract_error_message(&body, s);
         // "HTTP 400: " (10 chars) + 300 x's + "…" (1 char) = 312 chars
         assert!(result.starts_with("HTTP 400: "));

--- a/crates/client/src/errors.rs
+++ b/crates/client/src/errors.rs
@@ -35,7 +35,7 @@ impl From<reqwest::Error> for ClientError {
             }
         } else if err.is_connect() {
             ClientError::Network {
-                message: format!("Connection failed: {}", err),
+                message: format!("Connection failed: {err}"),
             }
         } else if err.is_status() {
             if let Some(status) = err.status() {
@@ -44,12 +44,12 @@ impl From<reqwest::Error> for ClientError {
                 }
             } else {
                 ClientError::Network {
-                    message: format!("HTTP error: {}", err),
+                    message: format!("HTTP error: {err}"),
                 }
             }
         } else {
             ClientError::Network {
-                message: format!("Network error: {}", err),
+                message: format!("Network error: {err}"),
             }
         }
     }
@@ -58,7 +58,7 @@ impl From<reqwest::Error> for ClientError {
 impl From<serde_json::Error> for ClientError {
     fn from(err: serde_json::Error) -> Self {
         ClientError::Internal {
-            message: format!("Serialization error: {}", err),
+            message: format!("Serialization error: {err}"),
         }
     }
 }
@@ -73,7 +73,7 @@ impl From<std::io::Error> for ClientError {
                 message: "Permission denied".to_owned(),
             },
             _ => ClientError::Storage {
-                message: format!("IO error: {}", err),
+                message: format!("IO error: {err}"),
             },
         }
     }
@@ -82,7 +82,7 @@ impl From<std::io::Error> for ClientError {
 impl From<url::ParseError> for ClientError {
     fn from(err: url::ParseError) -> Self {
         ClientError::Network {
-            message: format!("Invalid URL: {}", err),
+            message: format!("Invalid URL: {err}"),
         }
     }
 }

--- a/crates/context/config/src/types.rs
+++ b/crates/context/config/src/types.rs
@@ -448,9 +448,8 @@ impl BorshDeserialize for GovernanceParentEdge {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!(
-                    "GovernanceParentEdge.governance_dag_heads length {} exceeds \
-                     MAX_GOVERNANCE_DAG_HEADS={}",
-                    len, MAX_GOVERNANCE_DAG_HEADS,
+                    "GovernanceParentEdge.governance_dag_heads length {len} exceeds \
+                     MAX_GOVERNANCE_DAG_HEADS={MAX_GOVERNANCE_DAG_HEADS}",
                 ),
             ));
         }
@@ -1081,7 +1080,7 @@ mod tests {
     fn governance_edge_serde_rejects_duplicate_heads() {
         // JSON path mirrors borsh — duplicates rejected at decode time.
         let h = (0..32).map(|_| "171").collect::<Vec<_>>().join(",");
-        let json = format!(r#"{{"governance_dag_heads":[[{}],[{}]]}}"#, h, h,);
+        let json = format!(r#"{{"governance_dag_heads":[[{h}],[{h}]]}}"#,);
         let err = serde_json::from_str::<GovernanceParentEdge>(&json)
             .expect_err("duplicate heads must reject");
         assert!(

--- a/crates/context/primitives/src/client/crypto.rs
+++ b/crates/context/primitives/src/client/crypto.rs
@@ -261,7 +261,7 @@ mod tests {
         let mut handle = client.registry.datastore.handle();
         let key = key::ContextIdentity::new(context_id, public_key);
         let id_data = types::ContextIdentity {
-            private_key: Some(private_key_bytes.into()),
+            private_key: Some(private_key_bytes),
             sender_key: None,
         };
         handle.put(&key, &id_data).unwrap();

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -255,10 +255,10 @@ impl ContextRegistry {
         // Human-readable name from the owning group's per-context metadata
         // record, when set.
         let name = handle
-            .get(&key::ContextGroupRef::new((*context_id).into()))?
+            .get(&key::ContextGroupRef::new(*context_id))?
             .and_then(|gid: [u8; 32]| {
                 handle
-                    .get(&key::GroupContextMetadata::new(gid, (*context_id).into()))
+                    .get(&key::GroupContextMetadata::new(gid, *context_id))
                     .ok()
                     .flatten()
             })
@@ -2302,11 +2302,11 @@ mod get_context_version_tests {
                 .put(&key::ContextMeta::new(cid), &ctx_meta)
                 .expect("seed ctx meta");
             handle
-                .put(&key::ContextGroupRef::new(cid.into()), &gid)
+                .put(&key::ContextGroupRef::new(cid), &gid)
                 .expect("seed group ref");
             handle
                 .put(
-                    &key::GroupContextMetadata::new(gid, cid.into()),
+                    &key::GroupContextMetadata::new(gid, cid),
                     &calimero_primitives::metadata::MetadataRecord {
                         name: Some("docs-workspace".to_owned()),
                         ..Default::default()

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -1018,7 +1018,7 @@ impl From<calimero_store::key::GroupUpgradeValue> for GroupUpgradeInfo {
             migration: v.migration,
             initiated_at: v.initiated_at,
             initiated_by: v.initiated_by,
-            status: v.status.into(),
+            status: v.status,
         }
     }
 }

--- a/crates/context/src/auto_follow.rs
+++ b/crates/context/src/auto_follow.rs
@@ -48,9 +48,7 @@ use tracing::{debug, info, warn};
 
 use calimero_governance_store;
 use calimero_governance_store::op_events::{self, OpEvent};
-use calimero_governance_store::{
-    MembershipPath, MembershipRepository, MetaRepository, NamespaceRepository,
-};
+use calimero_governance_store::{MembershipPath, MembershipRepository, NamespaceRepository};
 
 /// Token-bucket rate limit for auto-follow emissions.
 ///

--- a/crates/context/src/handlers/create_group.rs
+++ b/crates/context/src/handlers/create_group.rs
@@ -154,10 +154,10 @@ impl Handler<CreateGroupRequest> for ContextManager {
                     target_application_id: effective_application_id,
                     upgrade_policy,
                     created_at: now,
-                    admin_identity: admin_identity.into(),
+                    admin_identity,
                     // Creator is the initial Owner. Transferable via
                     // `GroupOp::TransferOwnership`.
-                    owner_identity: admin_identity.into(),
+                    owner_identity: admin_identity,
                     migration: None,
                     auto_join: true,
                 };

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -813,11 +813,11 @@ impl Handler<ExecuteRequest> for ContextManager {
                     .await?;
 
                 let duration = start.elapsed().as_secs_f64();
-                let status = outcome
-                    .returns
-                    .is_ok()
-                    .then_some("success")
-                    .unwrap_or("failure");
+                let status = if outcome.returns.is_ok() {
+                    "success"
+                } else {
+                    "failure"
+                };
 
                 // Update execution count metrics
                 if let Some(execution_count) = execution_count {
@@ -833,7 +833,7 @@ impl Handler<ExecuteRequest> for ContextManager {
 
                 // Update execution duration metrics
                 if let Some(execution_duration) = execution_duration {
-                    let _ignored = execution_duration
+                    execution_duration
                         .clone()
                         .get_or_create(&ExecutionLabels {
                             context_id: context_id.to_string(),
@@ -1950,7 +1950,7 @@ async fn internal_execute(
             };
 
             // The artifact was `StorageDelta::Actions`.
-            if actions.len() != 0 {
+            if !actions.is_empty() {
                 info!(
                     context_id = %context.id,
                     actions_count = actions.len(),
@@ -1980,7 +1980,7 @@ async fn internal_execute(
                 // change (variant flip, writer-set or owner change),
                 // so the merkle hash and the entity's
                 // access-control triple stay invariant.
-                persist_signed_signatures(&store, &context, identity_private_key, &actions)
+                persist_signed_signatures(&store, context, identity_private_key, &actions)
                     .wrap_err("Failed to persist signed signature_data after execute")?;
 
                 // Re-serialize the *signed* actions into a new artifact
@@ -2388,7 +2388,7 @@ fn substitute_aliases_in_payload(
             let public_key = node_client
                 .resolve_alias(*alias, Some(context_id))
                 .map_err(|_| ExecuteError::InternalError)?
-                .ok_or_else(|| ExecuteError::AliasResolutionFailed { alias: *alias })?;
+                .ok_or(ExecuteError::AliasResolutionFailed { alias: *alias })?;
 
             // Substitution hot path: bs58-encode the 32-byte key into a
             // stack buffer rather than allocating a fresh String per alias.

--- a/crates/context/src/handlers/execute/upgrade_gate.rs
+++ b/crates/context/src/handlers/execute/upgrade_gate.rs
@@ -269,7 +269,7 @@ mod tests {
                 &calimero_store::key::ContextMeta::new(*ctx),
                 &ContextMeta::new(
                     calimero_store::key::ApplicationMeta::new(app_id),
-                    [0u8; 32].into(),
+                    [0u8; 32],
                     vec![],
                     None,
                 ),

--- a/crates/context/src/handlers/list_namespaces.rs
+++ b/crates/context/src/handlers/list_namespaces.rs
@@ -226,7 +226,7 @@ mod tests {
             .store_identity(
                 &group_id_with_membership,
                 &node_identity_pk,
-                &*node_identity_sk,
+                &node_identity_sk,
                 &sender_key,
             )
             .expect("store namespace identity for first namespace");
@@ -234,7 +234,7 @@ mod tests {
             .store_identity(
                 &group_id_without_membership,
                 &node_identity_pk,
-                &*node_identity_sk,
+                &node_identity_sk,
                 &sender_key,
             )
             .expect("store namespace identity for second namespace");

--- a/crates/context/src/handlers/remove_group_members.rs
+++ b/crates/context/src/handlers/remove_group_members.rs
@@ -80,7 +80,7 @@ impl Handler<RemoveGroupMembersRequest> for ContextManager {
 
                 // Unsubscribe if this node's identity was removed
                 if let Some(self_pk) = self_identity {
-                    if members.iter().any(|pk| *pk == self_pk) {
+                    if members.contains(&self_pk) {
                         let _ = node_client.unsubscribe_namespace(group_id.to_bytes()).await;
                     }
                 }

--- a/crates/context/src/handlers/resync_context.rs
+++ b/crates/context/src/handlers/resync_context.rs
@@ -38,13 +38,13 @@ impl Handler<ResyncContextRequest> for ContextManager {
                 let in_group = get_group_for_context(&datastore, &context_id)?.is_some();
                 let heads = datastore
                     .handle()
-                    .get(&key::ContextMeta::new(context_id.into()))?
+                    .get(&key::ContextMeta::new(context_id))?
                     .map_or(0, |m| m.dag_heads.len());
                 if let Err(refusal) = resync_admission(in_group, heads, force) {
                     bail!("context {context_id}: {refusal}");
                 }
 
-                let marker = key::ContextResyncRequested::new(context_id.into());
+                let marker = key::ContextResyncRequested::new(context_id);
                 datastore.handle().put(&marker, &())?;
                 // Roll the marker back if the sync can't even be enqueued, so a
                 // failed request can't leave the context stuck forcing snapshots.

--- a/crates/context/src/handlers/retry_group_upgrade.rs
+++ b/crates/context/src/handlers/retry_group_upgrade.rs
@@ -124,9 +124,6 @@ impl Handler<RetryGroupUpgradeRequest> for ContextManager {
             act.active_propagators.remove(&group_id);
         }));
 
-        ActorResponse::reply(Ok(UpgradeGroupResponse {
-            group_id,
-            status: status.into(),
-        }))
+        ActorResponse::reply(Ok(UpgradeGroupResponse { group_id, status }))
     }
 }

--- a/crates/context/src/handlers/store_group_meta.rs
+++ b/crates/context/src/handlers/store_group_meta.rs
@@ -24,7 +24,7 @@ impl Handler<StoreGroupMetaRequest> for ContextManager {
         // Only skip if BOTH metadata and admin member exist (full success previously).
         // If metadata exists but admin is missing, fall through to repair.
         if let Ok(Some(ref meta)) = existing_meta {
-            let admin_identity = meta.admin_identity.into();
+            let admin_identity = meta.admin_identity;
             // Direct-row check: this guard's intent is "did the previous
             // bootstrap finish writing the admin's direct membership row?"
             // The inheritance-aware `check_group_membership` walks the
@@ -52,7 +52,7 @@ impl Handler<StoreGroupMetaRequest> for ContextManager {
             },
         };
 
-        let admin_identity = meta.admin_identity.into();
+        let admin_identity = meta.admin_identity;
 
         // save_group_meta is idempotent — safe to call on retry
         if !matches!(

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -335,7 +335,7 @@ fn app_version_changed_event(
     from_version: Option<String>,
     to_version: Option<String>,
 ) -> Option<NodeEvent> {
-    (old_application_id != new_application_id).then(|| {
+    (old_application_id != new_application_id).then_some({
         NodeEvent::Context(ContextEvent {
             context_id,
             payload: ContextEventPayload::AppVersionChanged(AppVersionChangedPayload {
@@ -1823,21 +1823,18 @@ mod tests {
         let result = verify_appkey_continuity(&store, &context, &new_app_id);
         assert!(
             result.is_err(),
-            "AppKey continuity check should reject downgrade from signed to unsigned: {:?}",
-            result
+            "AppKey continuity check should reject downgrade from signed to unsigned: {result:?}"
         );
 
         // Verify the error message contains the expected content
         let error_message = result.unwrap_err().to_string();
         assert!(
             error_message.contains("Security downgrade rejected"),
-            "Error should mention security downgrade rejection: {}",
-            error_message
+            "Error should mention security downgrade rejection: {error_message}"
         );
         assert!(
             error_message.contains("signed application"),
-            "Error should mention signed application: {}",
-            error_message
+            "Error should mention signed application: {error_message}"
         );
     }
 
@@ -1917,13 +1914,11 @@ mod tests {
         let error_message = result.unwrap_err().to_string();
         assert!(
             error_message.contains("AppKey continuity violation"),
-            "Error should mention AppKey continuity violation: {}",
-            error_message
+            "Error should mention AppKey continuity violation: {error_message}"
         );
         assert!(
             error_message.contains("signerId mismatch"),
-            "Error should mention signerId mismatch: {}",
-            error_message
+            "Error should mention signerId mismatch: {error_message}"
         );
     }
 
@@ -1959,8 +1954,7 @@ mod tests {
         let error_message = result.unwrap_err().to_string();
         assert!(
             error_message.contains("not found"),
-            "Error should mention app not found: {}",
-            error_message
+            "Error should mention app not found: {error_message}"
         );
     }
 
@@ -2005,8 +1999,7 @@ mod tests {
         let error_message = result.unwrap_err().to_string();
         assert!(
             error_message.contains("signerId mismatch"),
-            "Error should indicate signerId mismatch: {}",
-            error_message
+            "Error should indicate signerId mismatch: {error_message}"
         );
     }
 

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -296,7 +296,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
 
                     Ok(UpgradeGroupResponse {
                         group_id,
-                        status: completed_status.into(),
+                        status: completed_status,
                     })
                 }
                 .into_actor(self),
@@ -326,7 +326,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
         };
 
         if let Err(err) = UpgradesRepository::new(&self.datastore).save(&group_id, &upgrade_value) {
-            return ActorResponse::reply(Err(err.into()));
+            return ActorResponse::reply(Err(err));
         }
 
         // --- Async: run canary upgrade ---
@@ -534,13 +534,13 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
 
                         return Ok(UpgradeGroupResponse {
                             group_id: group_id_clone,
-                            status: completed_status.into(),
+                            status: completed_status,
                         });
                     }
 
                     Ok(UpgradeGroupResponse {
                         group_id: group_id_clone,
-                        status: status.into(),
+                        status,
                     })
                 }
             },
@@ -1141,7 +1141,7 @@ pub(crate) async fn propagate_upgrade(
     // Build the list of contexts to upgrade (excluding the canary)
     let mut pending: Vec<ContextId> = contexts
         .into_iter()
-        .filter(|cid| skip_context.map_or(true, |skip| *cid != skip))
+        .filter(|cid| skip_context != Some(*cid))
         .collect();
 
     // If the canary was removed from the group between the initial upgrade
@@ -1761,7 +1761,7 @@ fn dispatch_cascade(
 
         Ok(UpgradeGroupResponse {
             group_id,
-            status: signed_status.into(),
+            status: signed_status,
         })
     }))
 }

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -27,7 +27,6 @@ use prometheus_client::registry::Registry;
 use tokio::sync::{Mutex, RwLock};
 
 use calimero_governance_store::metrics::Metrics;
-use calimero_wasm_abi::schema::MethodIntent;
 
 pub mod activation;
 pub mod auto_follow;

--- a/crates/context/src/self_purge.rs
+++ b/crates/context/src/self_purge.rs
@@ -1279,8 +1279,8 @@ mod tests {
             target_application_id: ApplicationId::from([0xCC; 32]),
             upgrade_policy: UpgradePolicy::Automatic,
             created_at: 1_700_000_000,
-            admin_identity: admin.into(),
-            owner_identity: admin.into(),
+            admin_identity: admin,
+            owner_identity: admin,
             migration: None,
             auto_join: false,
         }

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -14,8 +14,7 @@ use calimero_context::group_store::{
 };
 use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
 use calimero_context_config::types::{
-    ContextGroupId, GovernanceParentEdge, GroupInvitationFromAdmin, SignedGroupOpenInvitation,
-    SignerId,
+    ContextGroupId, GroupInvitationFromAdmin, SignedGroupOpenInvitation, SignerId,
 };
 use calimero_context_config::MemberCapabilities;
 use calimero_dag::DagStore;
@@ -1548,7 +1547,7 @@ fn cascade_removal_on_member_kick() {
     {
         use calimero_store::key::ContextIdentity;
         let mut handle = store.handle();
-        let key = ContextIdentity::new(context_id, member_pk.into());
+        let key = ContextIdentity::new(context_id, member_pk);
         handle
             .put(
                 &key,
@@ -1563,7 +1562,7 @@ fn cascade_removal_on_member_kick() {
     {
         use calimero_store::key::ContextIdentity;
         let handle = store.handle();
-        let key = ContextIdentity::new(context_id, member_pk.into());
+        let key = ContextIdentity::new(context_id, member_pk);
         assert!(
             handle.has(&key).unwrap(),
             "member should be in context before kick"
@@ -1590,7 +1589,7 @@ fn cascade_removal_on_member_kick() {
     {
         use calimero_store::key::ContextIdentity;
         let handle = store.handle();
-        let key = ContextIdentity::new(context_id, member_pk.into());
+        let key = ContextIdentity::new(context_id, member_pk);
         assert!(
             !handle.has(&key).unwrap(),
             "member should be cascade-removed from context"
@@ -1630,7 +1629,7 @@ fn cascade_removal_deterministic_across_nodes() {
         use calimero_store::key::ContextIdentity;
         let mut handle = store.handle();
         for ctx in [ctx1, ctx2] {
-            let key = ContextIdentity::new(ctx, member_pk.into());
+            let key = ContextIdentity::new(ctx, member_pk);
             handle
                 .put(
                     &key,
@@ -1659,7 +1658,7 @@ fn cascade_removal_deterministic_across_nodes() {
         use calimero_store::key::ContextIdentity;
         let handle = store.handle();
         for ctx in [ctx1, ctx2] {
-            let key = ContextIdentity::new(ctx, member_pk.into());
+            let key = ContextIdentity::new(ctx, member_pk);
             assert!(
                 !handle.has(&key).unwrap(),
                 "{label}: member should be cascade-removed from context {}",

--- a/crates/dag/src/lib.rs
+++ b/crates/dag/src/lib.rs
@@ -557,7 +557,7 @@ impl<T: Clone> DagStore<T> {
 
         let mut missing_ids = HashSet::new();
 
-        'outer: for (_pending_id, pending) in &self.pending {
+        'outer: for pending in self.pending.values() {
             for parent in &pending.delta.parents {
                 if missing_ids.len() >= delta_query_limit {
                     warn!(

--- a/crates/dag/src/tests_convergence.rs
+++ b/crates/dag/src/tests_convergence.rs
@@ -446,8 +446,8 @@ async fn test_e2e_divergence_scenario() {
     let state1 = applier1.get_state().await;
     let state2 = applier2.get_state().await;
 
-    println!("Node-1 state: {:?}", state1);
-    println!("Node-2 state: {:?}", state2);
+    println!("Node-1 state: {state1:?}");
+    println!("Node-2 state: {state2:?}");
     println!("Node-1 hash: {:?}", state1.compute_hash());
     println!("Node-2 hash: {:?}", state2.compute_hash());
 

--- a/crates/governance-store/src/context_tree.rs
+++ b/crates/governance-store/src/context_tree.rs
@@ -87,7 +87,7 @@ impl<'a> ContextTreeService<'a> {
         let contexts = self.enumerate_contexts(0, usize::MAX)?;
         let mut handle = self.store.handle();
         for context_id in &contexts {
-            let identity_key = ContextIdentity::new(*context_id, (*member).into());
+            let identity_key = ContextIdentity::new(*context_id, *member);
             if handle.has(&identity_key)? {
                 handle.delete(&identity_key)?;
                 tracing::info!(

--- a/crates/governance-store/src/contexts.rs
+++ b/crates/governance-store/src/contexts.rs
@@ -225,7 +225,7 @@ pub fn restore_member_context_identities(
     let contexts = enumerate_group_contexts(store, group_id, 0, usize::MAX)?;
     let mut handle = store.handle();
     for context_id in &contexts {
-        let identity_key = calimero_store::key::ContextIdentity::new(*context_id, (*member).into());
+        let identity_key = calimero_store::key::ContextIdentity::new(*context_id, *member);
         // Three cases:
         //   * No row              → write a fresh `Some(private_key)` row.
         //   * Row, private_key None → repair it: the rejoiner can't sign

--- a/crates/governance-store/src/governance_broadcast.rs
+++ b/crates/governance-store/src/governance_broadcast.rs
@@ -694,7 +694,7 @@ pub async fn publish_and_await_ack_namespace(
                         continue;
                     }
                 }
-                if !acked_by.iter().any(|p| *p == ack.signer_pubkey) {
+                if !acked_by.contains(&ack.signer_pubkey) {
                     acked_by.push(ack.signer_pubkey);
                 }
                 if acked_by.len() >= min_acks {

--- a/crates/governance-store/src/governance_broadcast/tests.rs
+++ b/crates/governance-store/src/governance_broadcast/tests.rs
@@ -497,8 +497,7 @@ async fn no_peers_with_min_acks_positive_returns_no_ack_received() {
 
     assert!(
         matches!(res, Err(GovernanceBroadcastError::NoAckReceived { .. })),
-        "min_acks=1 + NoPeersSubscribedToTopic must surface as NoAckReceived; got {:?}",
-        res
+        "min_acks=1 + NoPeersSubscribedToTopic must surface as NoAckReceived; got {res:?}"
     );
 }
 

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -15,7 +15,7 @@ use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
 use calimero_context_config::types::ContextGroupId;
 use calimero_primitives::context::{ContextId, GroupMemberRole};
 use calimero_primitives::identity::{PrivateKey, PublicKey};
-use calimero_primitives::metadata::{validate_metadata_payload, MetadataRecord};
+use calimero_primitives::metadata::MetadataRecord;
 use calimero_store::key::FromKeyParts;
 use calimero_store::key::{
     AsKeyParts, GroupMemberValue, GroupMetaValue, GroupOpHeadValue, GroupUpgradeValue,

--- a/crates/governance-store/src/membership/status.rs
+++ b/crates/governance-store/src/membership/status.rs
@@ -19,13 +19,11 @@
 //! Collapsing these into `Option<GroupMemberRole>` (as the legacy
 //! `get_member_role` API does) makes "forgot to check" a silent runtime bug;
 //! [`MembershipStatus`] makes it a non-exhaustive-match warning.
-use crate::{ApplyError, GroupKeyring, MembershipRepository, MetaRepository, NamespaceRepository};
+use crate::{ApplyError, GroupKeyring, MembershipRepository, NamespaceRepository};
 use std::collections::{HashSet, VecDeque};
 
 use calimero_context_client::local_governance::{GroupOp, NamespaceOp, RootOp, SignedNamespaceOp};
-use calimero_context_config::types::{
-    ContextGroupId, GovernanceParentEdge, MAX_GOVERNANCE_DAG_HEADS,
-};
+use calimero_context_config::types::{ContextGroupId, MAX_GOVERNANCE_DAG_HEADS};
 use calimero_primitives::context::GroupMemberRole;
 use calimero_primitives::identity::PublicKey;
 use calimero_store::Store;
@@ -1024,12 +1022,12 @@ mod tests {
             target_application_id: ApplicationId::from([0u8; 32]),
             upgrade_policy: UpgradePolicy::LazyOnAccess,
             created_at: 0,
-            admin_identity: admin.into(),
-            owner_identity: admin.into(),
+            admin_identity: admin,
+            owner_identity: admin,
             migration: None,
             auto_join: false,
         };
-        MetaRepository::new(&store)
+        crate::MetaRepository::new(&store)
             .save(&group_id, &meta)
             .expect("save_group_meta");
 

--- a/crates/governance-store/src/membership/tests.rs
+++ b/crates/governance-store/src/membership/tests.rs
@@ -1053,8 +1053,7 @@ fn membership_path_inherited_admin_overrides_anchor_cap_denial() {
             );
         }
         other => panic!(
-            "expected Inherited{{ via_admin: true, anchor: ns }} for parent admin, got {:?}",
-            other
+            "expected Inherited{{ via_admin: true, anchor: ns }} for parent admin, got {other:?}"
         ),
     }
 

--- a/crates/governance-store/src/meta.rs
+++ b/crates/governance-store/src/meta.rs
@@ -90,7 +90,7 @@ impl<'a> MetaRepository<'a> {
     pub fn compute_state_hash(&self, group_id: &ContextGroupId) -> EyreResult<[u8; 32]> {
         let meta = self
             .load(group_id)?
-            .ok_or_else(|| MetaError::GroupNotFoundForHash)?;
+            .ok_or(MetaError::GroupNotFoundForHash)?;
 
         let mut members = MembershipRepository::new(self.store).list(group_id, 0, usize::MAX)?;
         members.sort_by(|a, b| a.0.cmp(&b.0));
@@ -116,7 +116,7 @@ impl<'a> MetaRepository<'a> {
     ) -> EyreResult<[u8; 32]> {
         let meta = self
             .load(group_id)?
-            .ok_or_else(|| MetaError::GroupNotFoundForHash)?;
+            .ok_or(MetaError::GroupNotFoundForHash)?;
 
         let mut members = MembershipRepository::new(self.store).list(group_id, 0, usize::MAX)?;
         members.retain(|(pk, _role)| pk != removed_member);

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -1,7 +1,5 @@
 use crate::{
-    ApplyError, CapabilitiesError, DenyListRepository, GroupCreatedRejection,
-    GroupDeletedRejection, GroupKeyring, MemberJoinedOpenRejection, MembershipError,
-    MembershipRepository, MetaRepository, NamespaceError, NamespaceRepository,
+    DenyListRepository, GroupKeyring, MembershipRepository, MetaRepository, NamespaceRepository,
 };
 use calimero_context_client::local_governance::{
     hash_scoped_namespace, AckRouter, EncryptedGroupOp, GroupOp, KeyEnvelope, NamespaceOp, RootOp,
@@ -12,7 +10,7 @@ use calimero_primitives::application::ZERO_APPLICATION_ID;
 use calimero_primitives::context::GroupMemberRole;
 use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_store::Store;
-use eyre::{bail, Result as EyreResult};
+use eyre::Result as EyreResult;
 use libp2p::gossipsub::TopicHash;
 
 use crate::governance_broadcast::{
@@ -24,10 +22,9 @@ use crate::op_events::{notify as notify_op_event, OpEvent};
 
 use super::super::{
     apply_group_op_mutations, load_nonce_window, restore_member_context_identities,
-    store_nonce_window, PermissionChecker,
+    store_nonce_window,
 };
 use super::dag::{NamespaceDagService, NamespaceHead};
-use super::membership::NamespaceMembershipService;
 use super::op_log::NamespaceOpLogService;
 use super::retry::NamespaceRetryService;
 
@@ -869,8 +866,8 @@ impl<'a> NamespaceGovernance<'a> {
                 ),
                 upgrade_policy: calimero_primitives::context::UpgradePolicy::default(),
                 created_at: 0,
-                admin_identity: (*founder).into(),
-                owner_identity: (*founder).into(),
+                admin_identity: (*founder),
+                owner_identity: (*founder),
                 migration: None,
                 auto_join: true,
             };

--- a/crates/governance-store/src/namespace/membership.rs
+++ b/crates/governance-store/src/namespace/membership.rs
@@ -82,9 +82,7 @@ impl<'a> NamespaceMembershipService<'a> {
         // Open-subgroup self-joiner with `contexts: true` (the post-#2422
         // default) would only auto-follow FUTURE contexts, not the ones
         // already registered when they joined.
-        Ok(build_auto_follow_set_if_enabled(
-            self.store, &group_id, member,
-        )?)
+        build_auto_follow_set_if_enabled(self.store, &group_id, member)
     }
 
     /// Validate an open invitation for the responder key-delivery path:

--- a/crates/governance-store/src/namespace/mod.rs
+++ b/crates/governance-store/src/namespace/mod.rs
@@ -25,13 +25,13 @@ pub use self::core::{
     ResolvedNamespaceIdentity,
 };
 pub use self::dag::{NamespaceDagService, NamespaceHead};
+pub(crate) use self::governance::classify_report_readiness;
 pub use self::governance::{
     apply_received_group_key, apply_signed_namespace_op, build_group_key_delivery,
     collect_skeleton_delta_ids_for_group, namespace_groups_awaiting_key,
     sign_and_publish_namespace_op, sign_apply_and_publish_namespace_op, ApplyNamespaceOpResult,
     KeyUnwrapFailure, NamespaceGovernance,
 };
-pub(crate) use self::governance::{classify_report_readiness, min_acks_after_local_mutation};
 pub use self::membership::NamespaceMembershipService;
 pub use self::op_log::NamespaceOpLogService;
 pub use self::retry::NamespaceRetryService;

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -2526,7 +2526,7 @@ fn execute_group_deleted_subset_check_allows_partial_retry() {
 
 #[test]
 fn min_acks_after_local_mutation_uses_publish_time_subscribers() {
-    let min_acks = super::min_acks_after_local_mutation(1, 0);
+    let min_acks = super::governance::min_acks_after_local_mutation(1, 0);
 
     assert_eq!(
         min_acks, 0,

--- a/crates/governance-store/src/ops/group/member_added.rs
+++ b/crates/governance-store/src/ops/group/member_added.rs
@@ -4,10 +4,7 @@
 use super::super::super::build_auto_follow_set_if_enabled;
 use super::super::super::contexts::restore_member_context_identities;
 use super::context::GroupApplyCtx;
-use crate::{
-    cascade_remove_member_from_group_tree, DenyListRepository, MembershipError,
-    MembershipRepository,
-};
+use crate::{DenyListRepository, MembershipError, MembershipRepository};
 use calimero_primitives::context::GroupMemberRole;
 use calimero_primitives::identity::PublicKey;
 use eyre::{bail, Result as EyreResult};

--- a/crates/governance-store/src/permission_checker.rs
+++ b/crates/governance-store/src/permission_checker.rs
@@ -48,7 +48,7 @@ impl<'a> PermissionChecker<'a> {
         // callers that match on `MembershipError::NotAdmin` keep working.
         bail!(MembershipError::NotAdmin {
             group_id: format!("{:?}", self.group_id),
-            identity: format!("{:?}", identity),
+            identity: format!("{identity:?}"),
         });
     }
 

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -326,7 +326,7 @@ fn context_tree_service_register_move_detach_and_cascade_cleanup() {
     let mut handle = store.handle();
     handle
         .put(
-            &calimero_store::key::ContextIdentity::new(context, member.into()),
+            &calimero_store::key::ContextIdentity::new(context, member),
             &calimero_store::types::ContextIdentity {
                 private_key: None,
                 sender_key: Some([0u8; 32]),
@@ -337,7 +337,7 @@ fn context_tree_service_register_move_detach_and_cascade_cleanup() {
 
     tree_b.cascade_remove_member(&member).unwrap();
     let handle = store.handle();
-    let identity_key = calimero_store::key::ContextIdentity::new(context, member.into());
+    let identity_key = calimero_store::key::ContextIdentity::new(context, member);
     assert!(!handle.has(&identity_key).unwrap());
 
     tree_b.unregister_context(&context).unwrap();
@@ -1787,8 +1787,7 @@ fn is_open_chain_to_namespace_bails_on_depth_overflow() {
     assert!(
         res.is_err(),
         "is_open_chain_to_namespace must bail on MAX_NAMESPACE_DEPTH overflow, \
-         got {:?}",
-        res
+         got {res:?}"
     );
 }
 
@@ -3034,7 +3033,7 @@ fn restore_member_context_identities_writes_missing_rows() {
 
     let handle = store.handle();
     for ctx in [&ctx_a, &ctx_b] {
-        let key = calimero_store::key::ContextIdentity::new(*ctx, member.into());
+        let key = calimero_store::key::ContextIdentity::new(*ctx, member);
         let row = handle.get(&key).unwrap().expect("row should be created");
         assert_eq!(
             row.private_key,
@@ -3064,7 +3063,7 @@ fn restore_member_context_identities_no_op_when_not_local_rejoiner() {
 
     // No namespace identity at all → no-op.
     restore_member_context_identities(&store, &gid, &member).unwrap();
-    let key = calimero_store::key::ContextIdentity::new(ctx, member.into());
+    let key = calimero_store::key::ContextIdentity::new(ctx, member);
     assert!(
         !store.handle().has(&key).unwrap(),
         "no namespace identity stored → must not write a row"
@@ -3105,7 +3104,7 @@ fn restore_member_context_identities_is_idempotent() {
         let mut handle = store.handle();
         handle
             .put(
-                &calimero_store::key::ContextIdentity::new(ctx, member.into()),
+                &calimero_store::key::ContextIdentity::new(ctx, member),
                 &calimero_store::types::ContextIdentity {
                     private_key: Some(original_sk),
                     sender_key: Some(original_sender),
@@ -3118,10 +3117,7 @@ fn restore_member_context_identities_is_idempotent() {
 
     let handle = store.handle();
     let row = handle
-        .get(&calimero_store::key::ContextIdentity::new(
-            ctx,
-            member.into(),
-        ))
+        .get(&calimero_store::key::ContextIdentity::new(ctx, member))
         .unwrap()
         .unwrap();
     assert_eq!(
@@ -3159,7 +3155,7 @@ fn restore_member_context_identities_repairs_keyless_row() {
         let mut handle = store.handle();
         handle
             .put(
-                &calimero_store::key::ContextIdentity::new(ctx, member.into()),
+                &calimero_store::key::ContextIdentity::new(ctx, member),
                 &calimero_store::types::ContextIdentity {
                     private_key: None,
                     sender_key: Some(delivered_sender),
@@ -3172,10 +3168,7 @@ fn restore_member_context_identities_repairs_keyless_row() {
 
     let row = store
         .handle()
-        .get(&calimero_store::key::ContextIdentity::new(
-            ctx,
-            member.into(),
-        ))
+        .get(&calimero_store::key::ContextIdentity::new(ctx, member))
         .unwrap()
         .unwrap();
     assert_eq!(
@@ -3241,7 +3234,7 @@ fn member_added_after_remove_restores_context_identity_for_local_rejoiner() {
         let mut handle = store.handle();
         handle
             .put(
-                &calimero_store::key::ContextIdentity::new(ctx, member_pk.into()),
+                &calimero_store::key::ContextIdentity::new(ctx, member_pk),
                 &calimero_store::types::ContextIdentity {
                     private_key: Some(member_sk_bytes),
                     sender_key: Some([0x77; 32]),
@@ -3264,7 +3257,7 @@ fn member_added_after_remove_restores_context_identity_for_local_rejoiner() {
     // Confirm cascade ran — row gone.
     {
         let handle = store.handle();
-        let key = calimero_store::key::ContextIdentity::new(ctx, member_pk.into());
+        let key = calimero_store::key::ContextIdentity::new(ctx, member_pk);
         assert!(
             !handle.has(&key).unwrap(),
             "cascade must have deleted the ContextIdentity row"
@@ -3288,7 +3281,7 @@ fn member_added_after_remove_restores_context_identity_for_local_rejoiner() {
     apply_local_signed_group_op(&store, &readded).unwrap();
 
     let handle = store.handle();
-    let key = calimero_store::key::ContextIdentity::new(ctx, member_pk.into());
+    let key = calimero_store::key::ContextIdentity::new(ctx, member_pk);
     let row = handle
         .get(&key)
         .unwrap()
@@ -3367,7 +3360,7 @@ fn member_added_after_remove_restores_context_identity_for_subgroup_with_real_na
         let mut handle = store.handle();
         handle
             .put(
-                &calimero_store::key::ContextIdentity::new(ctx, member_pk.into()),
+                &calimero_store::key::ContextIdentity::new(ctx, member_pk),
                 &calimero_store::types::ContextIdentity {
                     private_key: Some(member_sk_bytes),
                     sender_key: Some([0x33; 32]),
@@ -3385,7 +3378,7 @@ fn member_added_after_remove_restores_context_identity_for_subgroup_with_real_na
     )
     .unwrap();
     apply_local_signed_group_op(&store, &removed).unwrap();
-    let id_key = calimero_store::key::ContextIdentity::new(ctx, member_pk.into());
+    let id_key = calimero_store::key::ContextIdentity::new(ctx, member_pk);
     assert!(
         !store.handle().has(&id_key).unwrap(),
         "cascade must have deleted the ContextIdentity row before the rejoin test"
@@ -3493,7 +3486,7 @@ fn member_joined_open_clears_deny_list_and_restores_context_identity() {
     assert!(DenyListRepository::new(&store)
         .is_denied(&subgroup, &member_pk)
         .unwrap());
-    let id_key = calimero_store::key::ContextIdentity::new(ctx, member_pk.into());
+    let id_key = calimero_store::key::ContextIdentity::new(ctx, member_pk);
     assert!(!store.handle().has(&id_key).unwrap());
 
     // The local node IS the rejoiner — its namespace identity matches
@@ -3594,7 +3587,7 @@ fn member_added_does_nothing_for_non_rejoiner_peers() {
     apply_local_signed_group_op(&store, &added).unwrap();
 
     let handle = store.handle();
-    let key = calimero_store::key::ContextIdentity::new(ctx, rejoiner_pk.into());
+    let key = calimero_store::key::ContextIdentity::new(ctx, rejoiner_pk);
     assert!(
         !handle.has(&key).unwrap(),
         "non-rejoiner peers must NOT create a ContextIdentity row for someone else"
@@ -6479,7 +6472,7 @@ mod tee_member_removed_event_tests {
         // context registered in the Open subgroup, despite no direct row.
         let context = ContextId::from([0xC5; 32]);
         register_context_in_group(&store, &subgroup, &context).unwrap();
-        let identity_key = calimero_store::key::ContextIdentity::new(context, tee_pk.into());
+        let identity_key = calimero_store::key::ContextIdentity::new(context, tee_pk);
         {
             let mut handle = store.handle();
             handle

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 
-use super::*;
 use calimero_primitives::identity::PrivateKey;
 use rand::rngs::OsRng;
 
@@ -470,7 +469,7 @@ fn cascade_target_application_set_borsh_round_trip() {
             assert_eq!(app_key, [10u8; 32]);
             assert_eq!(target_application_id, sample_application_id(0x42));
         }
-        other => panic!("expected CascadeTargetApplicationSet, got {:?}", other),
+        other => panic!("expected CascadeTargetApplicationSet, got {other:?}"),
     }
 }
 
@@ -493,7 +492,7 @@ fn cascade_group_migration_set_borsh_round_trip() {
             assert_eq!(from_app_key, [9u8; 32]);
             assert_eq!(migration.as_deref(), Some(b"migrate_v1_to_v2".as_ref()));
         }
-        other => panic!("expected CascadeGroupMigrationSet, got {:?}", other),
+        other => panic!("expected CascadeGroupMigrationSet, got {other:?}"),
     }
 
     // Also cover migration = None.
@@ -511,7 +510,7 @@ fn cascade_group_migration_set_borsh_round_trip() {
             assert_eq!(from_app_key, [0u8; 32]);
             assert!(migration.is_none());
         }
-        other => panic!("expected CascadeGroupMigrationSet, got {:?}", other),
+        other => panic!("expected CascadeGroupMigrationSet, got {other:?}"),
     }
 }
 
@@ -577,9 +576,8 @@ fn cascade_upgrade_back_compat_discriminant_fixed() {
             assert_eq!(cascade_hlc, HybridTimestamp::zero());
         }
         other => panic!(
-            "frozen CascadeUpgrade bytes (discriminant 25) decoded as {:?}; a \
-             variant was inserted mid-enum, shifting prior variant tags",
-            other
+            "frozen CascadeUpgrade bytes (discriminant 25) decoded as {other:?}; a \
+             variant was inserted mid-enum, shifting prior variant tags"
         ),
     }
 }

--- a/crates/meroctl/src/auth.rs
+++ b/crates/meroctl/src/auth.rs
@@ -50,11 +50,9 @@ pub async fn authenticate(api_url: &Url, output: Output) -> Result<JwtToken> {
         "Opening browser for authentication — you have 2 minutes to complete sign-in.",
     ));
 
-    if let Err(e) = webbrowser::open(&auth_url.to_string()) {
-        let warning_msg = format!(
-            "Failed to open browser: {}. Please manually open this URL: {}",
-            e, auth_url
-        );
+    if let Err(e) = webbrowser::open(auth_url.as_ref()) {
+        let warning_msg =
+            format!("Failed to open browser: {e}. Please manually open this URL: {auth_url}");
         output.write(&WarnLine(&warning_msg));
     }
 
@@ -284,7 +282,7 @@ async fn start_callback_server() -> Result<(u16, oneshot::Receiver<Result<AuthCa
         if let Err(e) = result {
             if let Ok(mut guard) = tx.lock() {
                 if let Some(sender) = guard.take() {
-                    drop(sender.send(Err(format!("Server error: {}", e))));
+                    drop(sender.send(Err(format!("Server error: {e}"))));
                 }
             }
         }
@@ -300,7 +298,7 @@ fn build_auth_url(api_url: &Url, callback_port: u16) -> Result<Url> {
         .query_pairs_mut()
         .append_pair(
             "callback-url",
-            &format!("http://127.0.0.1:{}/callback", callback_port),
+            &format!("http://127.0.0.1:{callback_port}/callback"),
         )
         .append_pair("app-url", api_url.as_str().trim_end_matches('/'))
         .append_pair("permissions", "admin");
@@ -504,9 +502,9 @@ impl calimero_client::ClientAuthenticator for MeroctlAuthenticator {
         // Open the OAuth URL in the browser
         if let Err(e) = self.output.open_browser(&auth_url) {
             self.output
-                .display_error(&format!("Failed to open browser: {}", e));
+                .display_error(&format!("Failed to open browser: {e}"));
             self.output
-                .display_message(&format!("Please manually visit: {}", auth_url));
+                .display_message(&format!("Please manually visit: {auth_url}"));
         }
 
         // Wait for the OAuth callback
@@ -534,7 +532,7 @@ impl calimero_client::ClientAuthenticator for MeroctlAuthenticator {
             }
             Err(e) => {
                 self.output
-                    .display_error(&format!("OAuth authentication failed: {}", e));
+                    .display_error(&format!("OAuth authentication failed: {e}"));
                 Err(eyre!("OAuth authentication failed: {}", e))
             }
         }
@@ -565,9 +563,9 @@ impl calimero_client::ClientAuthenticator for MeroctlAuthenticator {
         // Try to open the authentication URL in the browser
         if let Err(e) = self.output.open_browser(api_url) {
             self.output
-                .display_error(&format!("Failed to open browser: {}", e));
+                .display_error(&format!("Failed to open browser: {e}"));
             self.output
-                .display_message(&format!("Please manually visit: {}", api_url));
+                .display_message(&format!("Please manually visit: {api_url}"));
         }
 
         // Wait for user to complete authentication
@@ -627,7 +625,7 @@ impl auth::MeroctlOutputHandler for MeroctlOutputWrapper {
     fn wait_for_input(&self, prompt: &str) -> Result<String> {
         use std::io::{self, Write};
 
-        print!("{}", prompt);
+        print!("{prompt}");
         io::stdout().flush()?;
 
         let mut input = String::new();

--- a/crates/meroctl/src/cli.rs
+++ b/crates/meroctl/src/cli.rs
@@ -206,7 +206,7 @@ impl RootCommand {
             // Check if it's a local node at <home>/<node>
             let config = load_config(&self.args.home, node).await?;
             let multiaddr = fetch_multiaddr(&config)?;
-            let url = multiaddr_to_url(&multiaddr, "")?;
+            let url = multiaddr_to_url(multiaddr, "")?;
 
             // Pass the home directory (not home/node) so persist_node_in_config stores it as
             // NodeConnection::Local { path: home }.  get_connection later calls
@@ -218,8 +218,7 @@ impl RootCommand {
         } else if let Some(api_url) = &self.args.api {
             // Use specific API URL - check session cache first, then authenticate if needed
             let connection =
-                authenticate_with_session_cache(api_url, &api_url.to_string(), None, output)
-                    .await?;
+                authenticate_with_session_cache(api_url, api_url.as_ref(), None, output).await?;
             Ok(connection)
         } else {
             // Try to use active node
@@ -272,8 +271,8 @@ impl Report for CliError {
         let mut table = Table::new();
         let _ = table.set_header(vec![Cell::new("ERROR").fg(Color::Red)]);
         let _ = table.add_row(vec![match self {
-            CliError::ClientError(e) => format!("Client Error: {}", e),
-            CliError::Other(e) => format!("Error: {:?}", e),
+            CliError::ClientError(e) => format!("Client Error: {e}"),
+            CliError::Other(e) => format!("Error: {e:?}"),
         }]);
         println!("{table}");
     }

--- a/crates/meroctl/src/cli/app/install.rs
+++ b/crates/meroctl/src/cli/app/install.rs
@@ -74,7 +74,7 @@ impl InstallCommand {
             client.install_dev_application(request).await?
         } else if let Some(app_url) = self.url.as_ref() {
             let request = InstallApplicationRequest::new(
-                Url::parse(&app_url)?,
+                Url::parse(app_url)?,
                 self.hash,
                 metadata,
                 Some(self.package.clone()),

--- a/crates/meroctl/src/cli/app/watch.rs
+++ b/crates/meroctl/src/cli/app/watch.rs
@@ -87,7 +87,7 @@ impl WatchCommand {
         let target_app_id = self.current_app_id.unwrap_or(initial_app_id);
 
         // Get all contexts that use this application
-        let target_contexts = get_contexts_using_application(&client, &target_app_id).await?;
+        let target_contexts = get_contexts_using_application(client, &target_app_id).await?;
 
         if target_contexts.is_empty() {
             return handle_no_contexts_found(environment, &target_app_id);
@@ -174,17 +174,15 @@ async fn watch_app_and_update_contexts(
             .application_id;
 
         environment.output.write(&InfoLine(&format!(
-            "📦 Installed new application version: {}",
-            new_application_id
+            "📦 Installed new application version: {new_application_id}"
         )));
 
         // Refresh context list to catch any new contexts using the baseline app
-        let target_contexts = get_contexts_using_application(&client, &baseline_app_id).await?;
+        let target_contexts = get_contexts_using_application(client, &baseline_app_id).await?;
 
         if target_contexts.is_empty() {
             environment.output.write(&InfoLine(&format!(
-                "No contexts currently use application {}.",
-                baseline_app_id
+                "No contexts currently use application {baseline_app_id}."
             )));
             return handle_no_contexts_found(environment, &baseline_app_id);
         }
@@ -212,8 +210,7 @@ async fn watch_app_and_update_contexts(
                         *first_identity
                     } else {
                         environment.output.write(&ErrorLine(&format!(
-                            "✗ No identities found for context {}. Skipping.",
-                            context_id
+                            "✗ No identities found for context {context_id}. Skipping."
                         )));
                         error_count += 1;
                         continue;
@@ -221,8 +218,7 @@ async fn watch_app_and_update_contexts(
                 }
                 Err(err) => {
                     environment.output.write(&ErrorLine(&format!(
-                        "✗ Failed to get identities for context {}: {}. Skipping.",
-                        context_id, err
+                        "✗ Failed to get identities for context {context_id}: {err}. Skipping."
                     )));
                     error_count += 1;
                     continue;
@@ -234,16 +230,14 @@ async fn watch_app_and_update_contexts(
             match client.update_context_application(context_id, request).await {
                 Ok(response) => {
                     environment.output.write(&InfoLine(&format!(
-                        "✓ Updated context {} with application {}",
-                        context_id, new_application_id
+                        "✓ Updated context {context_id} with application {new_application_id}"
                     )));
                     environment.output.write(&response);
                     success_count += 1;
                 }
                 Err(err) => {
                     environment.output.write(&ErrorLine(&format!(
-                        "✗ Failed to update context {}: {}",
-                        context_id, err
+                        "✗ Failed to update context {context_id}: {err}"
                     )));
                     error_count += 1;
                 }
@@ -251,23 +245,20 @@ async fn watch_app_and_update_contexts(
         }
 
         environment.output.write(&InfoLine(&format!(
-            "📊 Update complete: {} successful, {} failed",
-            success_count, error_count
+            "📊 Update complete: {success_count} successful, {error_count} failed"
         )));
 
         // If we had successful updates, update the baseline to track the new app ID
         if success_count > 0 {
             baseline_app_id = new_application_id;
             environment.output.write(&InfoLine(&format!(
-                "🔄 Updated baseline tracking to application {}",
-                baseline_app_id
+                "🔄 Updated baseline tracking to application {baseline_app_id}"
             )));
         } else {
             // If all updates failed, the contexts are still using the old app ID
             // Continue tracking the old baseline for next iteration
             environment.output.write(&InfoLine(&format!(
-                "All context updates failed. Continuing to track application {}",
-                baseline_app_id
+                "All context updates failed. Continuing to track application {baseline_app_id}"
             )));
         }
     }
@@ -294,15 +285,13 @@ async fn get_contexts_using_application(
 /// Helper function to provide consistent messaging when no contexts are found
 fn handle_no_contexts_found(environment: &mut Environment, app_id: &ApplicationId) -> Result<()> {
     environment.output.write(&ErrorLine(&format!(
-        "No contexts found using application {}.",
-        app_id
+        "No contexts found using application {app_id}."
     )));
     environment.output.write(&InfoLine(
         "To use this watch command, first create contexts with this application:",
     ));
     environment.output.write(&InfoLine(&format!(
-        "  meroctl context create --application-id {} --protocol <protocol_name>",
-        app_id
+        "  meroctl context create --application-id {app_id} --protocol <protocol_name>"
     )));
     environment
         .output
@@ -330,7 +319,7 @@ mod tests {
     fn test_watch_command_parsing_minimal() {
         use clap::Parser;
 
-        let cmd = WatchCommand::try_parse_from(&["watch", "--path", "./test.wasm"]).unwrap();
+        let cmd = WatchCommand::try_parse_from(["watch", "--path", "./test.wasm"]).unwrap();
 
         assert_eq!(cmd.path.as_str(), "./test.wasm");
         assert_eq!(cmd.metadata, None);
@@ -341,7 +330,7 @@ mod tests {
     fn test_watch_command_parsing_with_metadata() {
         use clap::Parser;
 
-        let cmd = WatchCommand::try_parse_from(&[
+        let cmd = WatchCommand::try_parse_from([
             "watch",
             "--path",
             "./test.wasm",
@@ -360,7 +349,7 @@ mod tests {
         use clap::Parser;
 
         let app_id = ApplicationId::from([42u8; 32]);
-        let cmd = WatchCommand::try_parse_from(&[
+        let cmd = WatchCommand::try_parse_from([
             "watch",
             "--path",
             "./test.wasm",
@@ -379,7 +368,7 @@ mod tests {
         use clap::Parser;
 
         let app_id = ApplicationId::from([1u8; 32]);
-        let cmd = WatchCommand::try_parse_from(&[
+        let cmd = WatchCommand::try_parse_from([
             "watch",
             "--path",
             "./test.wasm",
@@ -399,7 +388,7 @@ mod tests {
     fn test_watch_command_parsing_short_flags() {
         use clap::Parser;
 
-        let cmd = WatchCommand::try_parse_from(&["watch", "-p", "./test.wasm"]).unwrap();
+        let cmd = WatchCommand::try_parse_from(["watch", "-p", "./test.wasm"]).unwrap();
 
         assert_eq!(cmd.path.as_str(), "./test.wasm");
     }
@@ -408,7 +397,7 @@ mod tests {
     fn test_watch_command_missing_path_fails() {
         use clap::Parser;
 
-        let result = WatchCommand::try_parse_from(&["watch"]);
+        let result = WatchCommand::try_parse_from(["watch"]);
         assert!(result.is_err(), "Command should fail when path is missing");
     }
 
@@ -416,7 +405,7 @@ mod tests {
     fn test_watch_command_invalid_app_id_fails() {
         use clap::Parser;
 
-        let result = WatchCommand::try_parse_from(&[
+        let result = WatchCommand::try_parse_from([
             "watch",
             "--path",
             "./test.wasm",

--- a/crates/meroctl/src/cli/context/alias.rs
+++ b/crates/meroctl/src/cli/context/alias.rs
@@ -54,8 +54,7 @@ impl ContextAliasCommand {
                 let client = environment.client()?.clone();
                 if !context_exists(&client, &context_id).await? {
                     environment.output.write(&ErrorLine(&format!(
-                        "Context with ID '{}' does not exist",
-                        context_id
+                        "Context with ID '{context_id}' does not exist"
                     )));
                     return Ok(());
                 }
@@ -159,8 +158,7 @@ impl UseCommand {
 
             if !self.force {
                 environment.output.write(&ErrorLine(&format!(
-                    "Default alias already points to '{}'. Use --force to overwrite.",
-                    existing_context
+                    "Default alias already points to '{existing_context}'. Use --force to overwrite."
                 )));
                 return Ok(());
             }

--- a/crates/meroctl/src/cli/context/create.rs
+++ b/crates/meroctl/src/cli/context/create.rs
@@ -199,7 +199,7 @@ pub async fn create_context(
 ) -> Result<(ContextId, PublicKey)> {
     let response: GetApplicationResponse = client.get_application(&application_id).await?;
 
-    if !response.data.application.is_some() {
+    if response.data.application.is_none() {
         bail!("Application is not installed on node.")
     }
 

--- a/crates/meroctl/src/cli/context/identity.rs
+++ b/crates/meroctl/src/cli/context/identity.rs
@@ -95,22 +95,19 @@ impl ContextIdentityCommand {
                 if let Some(existing_identity) = lookup_result.data.value {
                     if existing_identity == identity {
                         environment.output.write(&ErrorLine(&format!(
-                            "Default alias already points to '{}'. Use --force to overwrite.",
-                            existing_identity
+                            "Default alias already points to '{existing_identity}'. Use --force to overwrite."
                         )));
                         return Ok(());
                     }
 
                     if !force {
                         environment.output.write(&ErrorLine(&format!(
-                            "Default alias already points to '{}'. Use --force to overwrite.",
-                            existing_identity
+                            "Default alias already points to '{existing_identity}'. Use --force to overwrite."
                         )));
                         return Ok(());
                     }
                     environment.output.write(&ErrorLine(&format!(
-                        "Overwriting existing default alias from '{}' to '{}'",
-                        existing_identity, identity
+                        "Overwriting existing default alias from '{existing_identity}' to '{identity}'"
                     )));
                     let _ = client
                         .delete_alias(default_alias, Some(context_id))

--- a/crates/meroctl/src/cli/context/identity/alias.rs
+++ b/crates/meroctl/src/cli/context/identity/alias.rs
@@ -92,8 +92,7 @@ impl ContextIdentityAliasCommand {
 
                 if !identity_exists {
                     environment.output.write(&ErrorLine(&format!(
-                        "Identity '{}' does not exist in context '{}'",
-                        identity, context
+                        "Identity '{identity}' does not exist in context '{context}'"
                     )));
                     return Ok(());
                 }
@@ -103,23 +102,18 @@ impl ContextIdentityAliasCommand {
                 if let Some(existing_identity) = lookup_result.data.value {
                     if existing_identity == identity {
                         environment.output.write(&ErrorLine(&format!(
-                            "Alias '{}' already exists and points to '{}'. Use --force to overwrite.",
-                            name,
-                            existing_identity
+                            "Alias '{name}' already exists and points to '{existing_identity}'. Use --force to overwrite."
                         )));
                         return Ok(());
                     }
                     if !force {
                         environment.output.write(&ErrorLine(&format!(
-                            "Alias '{}' already exists and points to '{}'. Use --force to overwrite.",
-                            name,
-                            existing_identity
+                            "Alias '{name}' already exists and points to '{existing_identity}'. Use --force to overwrite."
                         )));
                         return Ok(());
                     }
                     environment.output.write(&ErrorLine(&format!(
-                        "Overwriting existing alias '{}' from '{}' to '{}'",
-                        name, existing_identity, identity
+                        "Overwriting existing alias '{name}' from '{existing_identity}' to '{identity}'"
                     )));
                     let _ignored = client
                         .delete_alias(name, Some(context_id))

--- a/crates/meroctl/src/cli/context/watch.rs
+++ b/crates/meroctl/src/cli/context/watch.rs
@@ -66,7 +66,7 @@ impl Report for ExecutionOutput<'_> {
     fn report(&self) {
         println!("Command executed: {}", self.cmd.join(" "));
         if let Some(status) = self.status {
-            println!("Exit status: {}", status);
+            println!("Exit status: {status}");
         }
         if !self.stdout.is_empty() {
             println!("Stdout: {}", self.stdout);
@@ -79,7 +79,7 @@ impl Report for ExecutionOutput<'_> {
 
 impl Report for Response {
     fn report(&self) {
-        println!("Received response: {:?}", self);
+        println!("Received response: {self:?}");
     }
 }
 
@@ -114,7 +114,7 @@ impl WatchCommand {
 
         environment
             .output
-            .write(&InfoLine(&format!("Subscribed to context {}", context_id)));
+            .write(&InfoLine(&format!("Subscribed to context {context_id}")));
 
         if let Some(cmd) = &self.exec {
             environment.output.write(&InfoLine(&format!(

--- a/crates/meroctl/src/cli/node.rs
+++ b/crates/meroctl/src/cli/node.rs
@@ -113,13 +113,13 @@ impl NodeCommand {
             NodeCommand::Add(cmd) => {
                 let location_type = detect_location_type(&cmd.location)?;
 
-                let output = environment.output.clone();
+                let output = environment.output;
 
                 let connection = match location_type {
                     LocationType::Local(path) => {
                         let config = load_config(&path, &cmd.name).await?;
                         let multiaddr = fetch_multiaddr(&config)?;
-                        let url = multiaddr_to_url(&multiaddr, "")?;
+                        let url = multiaddr_to_url(multiaddr, "")?;
 
                         let jwt_tokens = determine_auth_tokens(
                             &cmd,

--- a/crates/meroctl/src/cli/validation.rs
+++ b/crates/meroctl/src/cli/validation.rs
@@ -85,8 +85,7 @@ pub fn valid_node_name(s: &str) -> Result<String, String> {
         .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
     {
         return Err(format!(
-            "Node name '{}' contains invalid characters. Only alphanumeric characters, hyphens (-), and underscores (_) are allowed",
-            s
+            "Node name '{s}' contains invalid characters. Only alphanumeric characters, hyphens (-), and underscores (_) are allowed"
         ));
     }
 
@@ -100,8 +99,7 @@ pub fn valid_url(s: &str) -> Result<String, String> {
     match url::Url::parse(s) {
         Ok(_) => Ok(s.to_string()),
         Err(e) => Err(format!(
-            "Invalid URL '{}': {}. Expected format: http(s)://hostname[:port][/path]",
-            s, e
+            "Invalid URL '{s}': {e}. Expected format: http(s)://hostname[:port][/path]"
         )),
     }
 }

--- a/crates/meroctl/src/config.rs
+++ b/crates/meroctl/src/config.rs
@@ -115,15 +115,12 @@ impl Config {
             } => {
                 let config = load_config(path, node)
                     .await
-                    .wrap_err_with(|| format!("Failed to load config for local node '{}'", node))?;
+                    .wrap_err_with(|| format!("Failed to load config for local node '{node}'"))?;
                 let multiaddr = fetch_multiaddr(&config).wrap_err_with(|| {
-                    format!("Failed to fetch multiaddr for local node '{}'", node)
+                    format!("Failed to fetch multiaddr for local node '{node}'")
                 })?;
-                let url = multiaddr_to_url(&multiaddr, "").wrap_err_with(|| {
-                    format!(
-                        "Failed to convert multiaddr to URL for local node '{}'",
-                        node
-                    )
+                let url = multiaddr_to_url(multiaddr, "").wrap_err_with(|| {
+                    format!("Failed to convert multiaddr to URL for local node '{node}'")
                 })?;
 
                 ConnectionInfo::new(

--- a/crates/meroctl/src/storage.rs
+++ b/crates/meroctl/src/storage.rs
@@ -18,6 +18,12 @@ pub struct JwtToken {
 #[derive(Debug, Clone, Copy)]
 pub struct FileTokenStorage;
 
+impl Default for FileTokenStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FileTokenStorage {
     /// Create a new file token storage instance
     pub fn new() -> Self {

--- a/crates/meroctl/src/version.rs
+++ b/crates/meroctl/src/version.rs
@@ -42,7 +42,7 @@ pub async fn check_for_update() {
     }
 
     if let Err(err) = _check_for_update().await {
-        eprintln!("Version check failed: {}", err);
+        eprintln!("Version check failed: {err}");
     }
 }
 

--- a/crates/merod/src/cli/validation.rs
+++ b/crates/merod/src/cli/validation.rs
@@ -13,7 +13,6 @@ use calimero_server::config::AuthMode;
 use camino::Utf8Path;
 use eyre::{bail, Result as EyreResult, WrapErr};
 use multiaddr::{Multiaddr, Protocol};
-use tracing;
 
 /// Minimum sync timeout in milliseconds
 const MIN_SYNC_TIMEOUT_MS: u64 = 1000; // 1 second
@@ -131,8 +130,7 @@ fn validate_port_conflicts(config: &ConfigFile) -> EyreResult<()> {
                     TransportProtocol::Udp => "UDP",
                 };
                 conflicts.push(format!(
-                    "Duplicate swarm address: {} {}:{}",
-                    proto_str, host, port
+                    "Duplicate swarm address: {proto_str} {host}:{port}"
                 ));
             } else {
                 used_ports.push((proto, host.clone(), port, PortOwner::Swarm));
@@ -151,16 +149,13 @@ fn validate_port_conflicts(config: &ConfigFile) -> EyreResult<()> {
                 };
                 match owner {
                     PortOwner::Swarm => conflicts.push(format!(
-                        "Server {} port {} conflicts with swarm on {}",
-                        proto_str, port, host
+                        "Server {proto_str} port {port} conflicts with swarm on {host}"
                     )),
                     PortOwner::Server => conflicts.push(format!(
-                        "Duplicate server address: {} {}:{}",
-                        proto_str, host, port
+                        "Duplicate server address: {proto_str} {host}:{port}"
                     )),
                     PortOwner::EmbeddedAuth => conflicts.push(format!(
-                        "Server {} port {} conflicts with embedded auth on {}",
-                        proto_str, port, host
+                        "Server {proto_str} port {port} conflicts with embedded auth on {host}"
                     )),
                 }
             } else {
@@ -178,16 +173,13 @@ fn validate_port_conflicts(config: &ConfigFile) -> EyreResult<()> {
         if let Some(owner) = check_conflict(&used_ports, &TransportProtocol::Tcp, &host, port) {
             match owner {
                 PortOwner::Swarm => conflicts.push(format!(
-                    "Embedded auth TCP port {} conflicts with swarm on {}",
-                    port, host
+                    "Embedded auth TCP port {port} conflicts with swarm on {host}"
                 )),
                 PortOwner::Server => conflicts.push(format!(
-                    "Embedded auth TCP port {} conflicts with server on {}",
-                    port, host
+                    "Embedded auth TCP port {port} conflicts with server on {host}"
                 )),
                 PortOwner::EmbeddedAuth => conflicts.push(format!(
-                    "Duplicate embedded auth address: TCP {}:{}",
-                    host, port
+                    "Duplicate embedded auth address: TCP {host}:{port}"
                 )),
             }
         } else {
@@ -201,7 +193,7 @@ fn validate_port_conflicts(config: &ConfigFile) -> EyreResult<()> {
             "Port conflicts detected:\n{}",
             conflicts
                 .iter()
-                .map(|c| format!("  - {}", c))
+                .map(|c| format!("  - {c}"))
                 .collect::<Vec<_>>()
                 .join("\n")
         );

--- a/crates/merod/src/kms/mod.rs
+++ b/crates/merod/src/kms/mod.rs
@@ -856,7 +856,7 @@ async fn fetch_from_phala(
     // 2) Create report_data with challenge nonce in [0..32] and SHA256(peer_id) in [32..64].
     let peer_id_hash = hash_peer_id(peer_id);
     debug!(
-        peer_id_hash = %hex::encode(&peer_id_hash),
+        peer_id_hash = %hex::encode(peer_id_hash),
         "Generated peer ID hash for attestation"
     );
 
@@ -930,10 +930,7 @@ fn build_kms_http_client(phala_config: &PhalaKmsConfig) -> Result<reqwest::Clien
         // Intentional sync I/O: this path is executed during startup preflight
         // key-fetch/probe setup and keeps client construction fail-closed.
         let ca_pem = std::fs::read(ca_cert_path).with_context(|| {
-            format!(
-                "Failed to read tee.kms.phala.tls.ca_cert_path at {}",
-                ca_cert_path
-            )
+            format!("Failed to read tee.kms.phala.tls.ca_cert_path at {ca_cert_path}")
         })?;
         let cert = reqwest::Certificate::from_pem(&ca_pem)
             .context("Failed to parse tee.kms.phala.tls.ca_cert_path as PEM certificate")?;
@@ -954,16 +951,10 @@ fn build_kms_http_client(phala_config: &PhalaKmsConfig) -> Result<reqwest::Clien
 
             // Intentional sync I/O for startup-only TLS material loading.
             let client_cert_pem = std::fs::read(client_cert_path).with_context(|| {
-                format!(
-                    "Failed to read tee.kms.phala.tls.client_cert_path at {}",
-                    client_cert_path
-                )
+                format!("Failed to read tee.kms.phala.tls.client_cert_path at {client_cert_path}")
             })?;
             let client_key_pem = std::fs::read(client_key_path).with_context(|| {
-                format!(
-                    "Failed to read tee.kms.phala.tls.client_key_path at {}",
-                    client_key_path
-                )
+                format!("Failed to read tee.kms.phala.tls.client_key_path at {client_key_path}")
             })?;
 
             let mut identity_pem =
@@ -1175,26 +1166,17 @@ fn load_external_attestation_policy(
 ) -> Result<ExternalKmsAttestationPolicy> {
     // Intentional sync I/O: this path is used during startup preflight only.
     let policy_raw = std::fs::read_to_string(policy_path).with_context(|| {
-        format!(
-            "Failed to read external KMS attestation policy file at {}",
-            policy_path
-        )
+        format!("Failed to read external KMS attestation policy file at {policy_path}")
     })?;
 
     serde_json::from_str::<ExternalKmsAttestationPolicy>(&policy_raw).with_context(|| {
-        format!(
-            "Failed to parse external KMS attestation policy JSON at {}",
-            policy_path
-        )
+        format!("Failed to parse external KMS attestation policy JSON at {policy_path}")
     })
 }
 
 fn canonicalize_external_policy_path(policy_path: &Utf8Path) -> Result<Utf8PathBuf> {
     let canonical_path = std::fs::canonicalize(policy_path).with_context(|| {
-        format!(
-            "Failed to canonicalize external KMS attestation policy path at {}",
-            policy_path
-        )
+        format!("Failed to canonicalize external KMS attestation policy path at {policy_path}")
     })?;
     Utf8PathBuf::from_path_buf(canonical_path).map_err(|path| {
         eyre::eyre!(

--- a/crates/merod/src/kms_policy.rs
+++ b/crates/merod/src/kms_policy.rs
@@ -132,10 +132,10 @@ pub fn use_env_policy() -> bool {
 /// - verifies Fulcio certificate chain and GitHub workflow identity constraints
 pub async fn fetch_policy_from_release(version: &str) -> EyreResult<KmsAttestationPolicy> {
     let version = normalize_release_version(version)?;
-    let tag = format!("mero-kms-v{}", version);
-    let policy_url = format!("{}/{}/{}", POLICY_RELEASE_BASE, tag, POLICY_JSON_ASSET);
-    let signature_url = format!("{}/{}/{}", POLICY_RELEASE_BASE, tag, POLICY_SIG_ASSET);
-    let bundle_url = format!("{}/{}/{}", POLICY_RELEASE_BASE, tag, POLICY_BUNDLE_ASSET);
+    let tag = format!("mero-kms-v{version}");
+    let policy_url = format!("{POLICY_RELEASE_BASE}/{tag}/{POLICY_JSON_ASSET}");
+    let signature_url = format!("{POLICY_RELEASE_BASE}/{tag}/{POLICY_SIG_ASSET}");
+    let bundle_url = format!("{POLICY_RELEASE_BASE}/{tag}/{POLICY_BUNDLE_ASSET}");
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .user_agent("merod/1.0")
@@ -234,8 +234,7 @@ async fn fetch_release_asset(
         Ok(resp) if resp.status().is_success() => match resp.text().await {
             Ok(body) => AssetFetchResult::Success(body),
             Err(err) => AssetFetchResult::Transient(format!(
-                "Failed to read {asset_name} response body: {}",
-                err
+                "Failed to read {asset_name} response body: {err}"
             )),
         },
         Ok(resp) => {
@@ -248,7 +247,7 @@ async fn fetch_release_asset(
                 AssetFetchResult::Permanent(error)
             }
         }
-        Err(err) => AssetFetchResult::Transient(format!("Failed to fetch {asset_name}: {}", err)),
+        Err(err) => AssetFetchResult::Transient(format!("Failed to fetch {asset_name}: {err}")),
     }
 }
 

--- a/crates/merod/src/version.rs
+++ b/crates/merod/src/version.rs
@@ -43,7 +43,7 @@ pub fn check_for_update() {
 
     let _ignored = tokio::spawn(async move {
         if let Err(err) = _check_for_update().await {
-            eprintln!("Version check failed: {}", err);
+            eprintln!("Version check failed: {err}");
         }
     });
 }

--- a/crates/network/src/discovery.rs
+++ b/crates/network/src/discovery.rs
@@ -621,7 +621,7 @@ impl NetworkManager {
         let listener_id = self
             .swarm
             .listen_on(relayed_addr.clone())
-            .wrap_err_with(|| format!("Failed to listen on relayed addr {}", relayed_addr))?;
+            .wrap_err_with(|| format!("Failed to listen on relayed addr {relayed_addr}"))?;
 
         // Record the listener id so the ListenerClosed handler can route
         // recovery back to this relay peer even if the close event comes

--- a/crates/node/primitives/src/bundle/signature.rs
+++ b/crates/node/primitives/src/bundle/signature.rs
@@ -46,7 +46,7 @@ pub fn derive_signer_id_did_key(pubkey: &[u8; 32]) -> String {
     // Encode with base58btc (multibase 'z' prefix)
     let encoded = bs58::encode(&multicodec_key).into_string();
 
-    format!("did:key:z{}", encoded)
+    format!("did:key:z{encoded}")
 }
 
 /// Canonicalizes a manifest JSON value using RFC 8785 (JCS).
@@ -510,7 +510,7 @@ mod tests {
 
     #[test]
     fn test_decode_public_key_invalid_length() {
-        let short_key = URL_SAFE_NO_PAD.encode(&[0u8; 16]);
+        let short_key = URL_SAFE_NO_PAD.encode([0u8; 16]);
         let result = decode_public_key(&short_key);
         assert!(result.is_err());
         assert!(result
@@ -522,14 +522,14 @@ mod tests {
     #[test]
     fn test_decode_signature_valid() {
         let sig_bytes = [0u8; 64];
-        let encoded = URL_SAFE_NO_PAD.encode(&sig_bytes);
+        let encoded = URL_SAFE_NO_PAD.encode(sig_bytes);
         let decoded = decode_signature(&encoded).unwrap();
         assert_eq!(decoded, sig_bytes);
     }
 
     #[test]
     fn test_decode_signature_invalid_length() {
-        let short_sig = URL_SAFE_NO_PAD.encode(&[0u8; 32]);
+        let short_sig = URL_SAFE_NO_PAD.encode([0u8; 32]);
         let result = decode_signature(&short_sig);
         assert!(result.is_err());
         assert!(result

--- a/crates/node/primitives/src/client/application.rs
+++ b/crates/node/primitives/src/client/application.rs
@@ -2,28 +2,17 @@ pub mod bundle;
 mod install;
 mod query;
 
-use std::io::{self, ErrorKind};
 use std::sync::Arc;
 
-use crate::bundle::{BundleManifest, ManifestVerification};
-use calimero_primitives::application::{
-    Application, ApplicationBlob, ApplicationId, ApplicationSource,
-};
+use crate::bundle::BundleManifest;
+use calimero_primitives::application::{Application, ApplicationBlob, ApplicationId};
 use calimero_primitives::blobs::BlobId;
-use calimero_primitives::hash::Hash;
+use calimero_store::key;
 use calimero_store::key::AsKeyParts;
-use calimero_store::{key, types};
-use camino::{Utf8Path, Utf8PathBuf};
 use eyre::bail;
-use flate2::read::GzDecoder;
-use futures_util::{io::Cursor, TryStreamExt};
-use reqwest::Url;
-use sha2::{Digest, Sha256};
-use std::fs;
-use tar::Archive;
-use tokio::fs::File;
-use tokio_util::compat::TokioAsyncReadCompatExt;
-use tracing::{debug, trace, warn};
+use futures_util::TryStreamExt;
+use sha2::Digest;
+use tracing::{debug, warn};
 
 use super::NodeClient;
 

--- a/crates/node/primitives/src/client/application/bundle.rs
+++ b/crates/node/primitives/src/client/application/bundle.rs
@@ -142,7 +142,7 @@ pub fn extract_bundle_manifest(
                 validate_artifact_path(&abi.path, "abi.path")?;
             }
             for (i, migration) in manifest.migrations.iter().enumerate() {
-                validate_artifact_path(&migration.path, &format!("migrations[{}].path", i))?;
+                validate_artifact_path(&migration.path, &format!("migrations[{i}].path"))?;
             }
 
             let current_runtime_version = Version::parse(env!("CALIMERO_RELEASE_VERSION"))

--- a/crates/node/primitives/src/client/application/install.rs
+++ b/crates/node/primitives/src/client/application/install.rs
@@ -5,9 +5,7 @@ use std::sync::Arc;
 
 use super::bundle;
 use crate::bundle::{BundleManifest, ManifestVerification};
-use calimero_primitives::application::{
-    Application, ApplicationBlob, ApplicationId, ApplicationSource,
-};
+use calimero_primitives::application::{ApplicationId, ApplicationSource};
 use calimero_primitives::blobs::BlobId;
 use calimero_primitives::hash::Hash;
 use calimero_store::{key, types};

--- a/crates/node/primitives/src/client/application/tests.rs
+++ b/crates/node/primitives/src/client/application/tests.rs
@@ -8,8 +8,7 @@ fn test_validate_path_component_valid() {
     for path in valid_paths {
         assert!(
             bundle::validate_path_component(path, "test").is_ok(),
-            "Valid path '{}' should pass validation",
-            path
+            "Valid path '{path}' should pass validation"
         );
     }
 }
@@ -20,8 +19,7 @@ fn test_validate_path_component_path_traversal() {
     for path in invalid_paths {
         assert!(
             bundle::validate_path_component(path, "test").is_err(),
-            "Path traversal '{}' should be rejected",
-            path
+            "Path traversal '{path}' should be rejected"
         );
     }
 }
@@ -32,8 +30,7 @@ fn test_validate_path_component_directory_separators() {
     for path in invalid_paths {
         assert!(
             bundle::validate_path_component(path, "test").is_err(),
-            "Path with separator '{}' should be rejected",
-            path
+            "Path with separator '{path}' should be rejected"
         );
     }
 }
@@ -53,8 +50,7 @@ fn test_validate_path_component_windows_drive() {
     for path in invalid_paths {
         assert!(
             bundle::validate_path_component(path, "test").is_err(),
-            "Windows drive path '{}' should be rejected",
-            path
+            "Windows drive path '{path}' should be rejected"
         );
     }
 }
@@ -73,8 +69,7 @@ fn test_validate_artifact_path_valid() {
     for path in valid_paths {
         assert!(
             bundle::validate_artifact_path(path, "test").is_ok(),
-            "Valid artifact path '{}' should pass validation",
-            path
+            "Valid artifact path '{path}' should pass validation"
         );
     }
 }
@@ -120,8 +115,7 @@ fn test_validate_artifact_path_absolute_windows() {
     for path in invalid_paths {
         assert!(
             bundle::validate_artifact_path(path, "test").is_err(),
-            "Windows absolute path '{}' should be rejected",
-            path
+            "Windows absolute path '{path}' should be rejected"
         );
     }
 }
@@ -132,8 +126,7 @@ fn test_validate_artifact_path_traversal() {
     for path in invalid_paths {
         assert!(
             bundle::validate_artifact_path(path, "test").is_err(),
-            "Path traversal '{}' should be rejected",
-            path
+            "Path traversal '{path}' should be rejected"
         );
     }
 }

--- a/crates/node/primitives/src/sync/bloom_filter.rs
+++ b/crates/node/primitives/src/sync/bloom_filter.rs
@@ -100,7 +100,7 @@ impl DeltaIdBloomFilter {
             (k.ceil() as u8).clamp(MIN_NUM_HASHES, MAX_NUM_HASHES)
         };
 
-        let num_bytes = (num_bits + 7) / 8;
+        let num_bytes = num_bits.div_ceil(8);
 
         Self {
             bits: vec![0; num_bytes],
@@ -121,7 +121,7 @@ impl DeltaIdBloomFilter {
         let num_bits = num_bits.max(MIN_NUM_BITS);
         let num_hashes = num_hashes.clamp(MIN_NUM_HASHES, MAX_NUM_HASHES);
 
-        let num_bytes = (num_bits + 7) / 8;
+        let num_bytes = num_bits.div_ceil(8);
         Self {
             bits: vec![0; num_bytes],
             num_bits,
@@ -478,10 +478,8 @@ mod tests {
 
         let actual_fp_rate = false_positives as f64 / test_count as f64;
         assert!(
-            actual_fp_rate < target_fp_rate as f64 * 3.0,
-            "FP rate {} too high (target {})",
-            actual_fp_rate,
-            target_fp_rate
+            actual_fp_rate < target_fp_rate * 3.0,
+            "FP rate {actual_fp_rate} too high (target {target_fp_rate})"
         );
     }
 
@@ -625,9 +623,7 @@ mod tests {
             let filter = DeltaIdBloomFilter::new(100, fp_rate);
             assert!(
                 filter.bit_count() > 0,
-                "Filter with fp_rate {} ({}) should have positive bit count",
-                fp_rate,
-                description
+                "Filter with fp_rate {fp_rate} ({description}) should have positive bit count"
             );
         }
     }
@@ -806,7 +802,7 @@ mod tests {
         assert!(filter.is_valid());
 
         // bits.len() should be >= (num_bits + 7) / 8
-        let required_bytes = (filter.bit_count() + 7) / 8;
+        let required_bytes = filter.bit_count().div_ceil(8);
         assert!(filter.bits().len() >= required_bytes);
     }
 

--- a/crates/node/primitives/src/sync/storage_bridge.rs
+++ b/crates/node/primitives/src/sync/storage_bridge.rs
@@ -257,14 +257,14 @@ mod tests {
                     copied += 1;
                 }
             }
-            eprintln!("Copied {} ContextState records", copied);
+            eprintln!("Copied {copied} ContextState records");
             assert!(copied > 0, "should have copied records");
         }
 
         // Read from store2 via bridge (like the HashComparison responder)
         let env2 = create_runtime_env(&store2, context_id, identity);
         let read_result2 = with_runtime_env(env2, || Index::<MainStorage>::get_index(root_id));
-        eprintln!("Read from store2: {:?}", read_result2);
+        eprintln!("Read from store2: {read_result2:?}");
         assert!(
             read_result2.is_ok(),
             "get_index from snapshot-restored store should not error: {:?}",

--- a/crates/node/primitives/src/sync/transport.rs
+++ b/crates/node/primitives/src/sync/transport.rs
@@ -116,7 +116,7 @@ impl EncryptionState {
     /// Get current encryption parameters.
     #[must_use]
     pub fn get(&self) -> Option<(SharedKey, Nonce)> {
-        self.key_nonce.clone()
+        self.key_nonce
     }
 
     /// Encrypt data if encryption is configured.

--- a/crates/node/primitives/tests/bundle_installation.rs
+++ b/crates/node/primitives/tests/bundle_installation.rs
@@ -4,7 +4,6 @@ use std::fs;
 
 use std::sync::Arc;
 
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use calimero_blobstore::config::BlobStoreConfig;
 use calimero_blobstore::{BlobManager as BlobStore, FileSystem};
@@ -41,7 +40,7 @@ fn create_test_bundle(
     abi_content: Option<&[u8]>,
     migrations: Vec<(&str, &[u8])>,
 ) -> Utf8PathBuf {
-    let bundle_path = temp_dir.path().join(format!("{}-{}.mpk", package, version));
+    let bundle_path = temp_dir.path().join(format!("{package}-{version}.mpk"));
     let bundle_file = fs::File::create(&bundle_path).unwrap();
     let encoder = GzEncoder::new(bundle_file, Compression::default());
     let mut tar = Builder::new(encoder);
@@ -51,7 +50,7 @@ fn create_test_bundle(
     let signer_id = derive_signer_id_did_key(signing_key.verifying_key().as_bytes());
 
     // Create manifest.json (without signature initially)
-    let mut manifest = BundleManifest {
+    let manifest = BundleManifest {
         version: "1.0".to_string(),
         package: package.to_string(),
         app_version: version.to_string(),
@@ -475,8 +474,7 @@ async fn test_bundle_validation_missing_fields() {
             || error_msg.contains("empty")
             || error_msg.contains("manifest")
             || error_msg.contains("parse"),
-        "Error should mention missing package field, manifest issue, or parse error, got: {}",
-        error_msg
+        "Error should mention missing package field, manifest issue, or parse error, got: {error_msg}"
     );
 }
 
@@ -522,7 +520,7 @@ fn create_test_bundle_custom_wasm_path(
     wasm_path: &str,
     wasm_content: &[u8],
 ) -> Utf8PathBuf {
-    let bundle_path = temp_dir.path().join(format!("{}-{}.mpk", package, version));
+    let bundle_path = temp_dir.path().join(format!("{package}-{version}.mpk"));
     let bundle_file = fs::File::create(&bundle_path).unwrap();
     let encoder = GzEncoder::new(bundle_file, Compression::default());
     let mut tar = Builder::new(encoder);
@@ -719,8 +717,7 @@ async fn test_bundle_validation_empty_package() {
     let error_msg = result.unwrap_err().to_string();
     assert!(
         error_msg.contains("package") && error_msg.contains("empty"),
-        "Error should mention empty package field, got: {}",
-        error_msg
+        "Error should mention empty package field, got: {error_msg}"
     );
 }
 
@@ -774,8 +771,7 @@ async fn test_bundle_validation_empty_app_version() {
     let error_msg = result.unwrap_err().to_string();
     assert!(
         error_msg.contains("appVersion") || error_msg.contains("version"),
-        "Error should mention empty appVersion field, got: {}",
-        error_msg
+        "Error should mention empty appVersion field, got: {error_msg}"
     );
 }
 
@@ -831,8 +827,7 @@ async fn test_bundle_validation_missing_app_version() {
             || error_msg.contains("missing field")
             || error_msg.contains("version")
             || error_msg.contains("parse"),
-        "Error should mention missing appVersion field, got: {}",
-        error_msg
+        "Error should mention missing appVersion field, got: {error_msg}"
     );
 }
 
@@ -1184,8 +1179,7 @@ async fn test_install_application_from_bundle_blob_missing_blob() {
     let error_msg = result.unwrap_err().to_string();
     assert!(
         error_msg.contains("not found") || error_msg.contains("fatal"),
-        "Error should mention blob not found, got: {}",
-        error_msg
+        "Error should mention blob not found, got: {error_msg}"
     );
 }
 
@@ -1453,7 +1447,7 @@ fn create_unsigned_bundle(
 ) -> Utf8PathBuf {
     let bundle_path = temp_dir
         .path()
-        .join(format!("{}-{}-unsigned.mpk", package, version));
+        .join(format!("{package}-{version}-unsigned.mpk"));
     let bundle_file = fs::File::create(&bundle_path).unwrap();
     let encoder = GzEncoder::new(bundle_file, Compression::default());
     let mut tar = Builder::new(encoder);
@@ -1502,7 +1496,7 @@ fn create_tampered_bundle(
 ) -> Utf8PathBuf {
     let bundle_path = temp_dir
         .path()
-        .join(format!("{}-{}-tampered.mpk", package, version));
+        .join(format!("{package}-{version}-tampered.mpk"));
     let bundle_file = fs::File::create(&bundle_path).unwrap();
     let encoder = GzEncoder::new(bundle_file, Compression::default());
     let mut tar = Builder::new(encoder);
@@ -1584,7 +1578,7 @@ fn create_signer_id_mismatch_bundle(
 
     let bundle_path = temp_dir
         .path()
-        .join(format!("{}-{}-signer-mismatch.mpk", package, version));
+        .join(format!("{package}-{version}-signer-mismatch.mpk"));
     let bundle_file = fs::File::create(&bundle_path).unwrap();
     let encoder = GzEncoder::new(bundle_file, Compression::default());
     let mut tar = Builder::new(encoder);
@@ -1656,7 +1650,7 @@ fn create_test_bundle_with_key(
 ) -> Utf8PathBuf {
     let bundle_path = temp_dir
         .path()
-        .join(format!("{}-{}-keyed.mpk", package, version));
+        .join(format!("{package}-{version}-keyed.mpk"));
     let bundle_file = fs::File::create(&bundle_path).unwrap();
     let encoder = GzEncoder::new(bundle_file, Compression::default());
     let mut tar = Builder::new(encoder);
@@ -1759,8 +1753,7 @@ async fn test_bundle_installation_fails_with_invalid_signature() {
     let error_msg = result.unwrap_err().to_string();
     assert!(
         error_msg.contains("signature") || error_msg.contains("verification"),
-        "Error should mention signature verification failure, got: {}",
-        error_msg
+        "Error should mention signature verification failure, got: {error_msg}"
     );
 }
 
@@ -1795,8 +1788,7 @@ async fn test_bundle_installation_fails_signer_id_mismatch() {
     let error_msg = result.unwrap_err().to_string();
     assert!(
         error_msg.contains("signerId") || error_msg.contains("mismatch"),
-        "Error should mention signerId mismatch, got: {}",
-        error_msg
+        "Error should mention signerId mismatch, got: {error_msg}"
     );
 }
 
@@ -1878,9 +1870,8 @@ async fn test_bundle_application_id_derived_from_package_and_signer_id() {
     assert_ne!(
         app_id_a, app_id_b,
         "Same package with different signers should produce different ApplicationIds.\n\
-         app_id_a (signer S1): {}\n\
-         app_id_b (signer S2): {}",
-        app_id_a, app_id_b
+         app_id_a (signer S1): {app_id_a}\n\
+         app_id_b (signer S2): {app_id_b}"
     );
 
     // ASSERTION 2: app_id_a == app_id_c (same package + signer = same ApplicationId)
@@ -1888,9 +1879,8 @@ async fn test_bundle_application_id_derived_from_package_and_signer_id() {
     assert_eq!(
         app_id_a, app_id_c,
         "Same package with same signer should produce same ApplicationId (version upgrade).\n\
-         app_id_a (v1.0.0): {}\n\
-         app_id_c (v2.0.0): {}",
-        app_id_a, app_id_c
+         app_id_a (v1.0.0): {app_id_a}\n\
+         app_id_c (v2.0.0): {app_id_c}"
     );
 
     // Verify all applications can be retrieved
@@ -2141,8 +2131,7 @@ async fn test_bundle_validation_path_traversal_in_package() {
     let error_msg = result.unwrap_err().to_string();
     assert!(
         error_msg.contains("path traversal") || error_msg.contains("'..'"),
-        "Error should mention path traversal, got: {}",
-        error_msg
+        "Error should mention path traversal, got: {error_msg}"
     );
 }
 
@@ -2188,8 +2177,7 @@ async fn test_bundle_validation_path_traversal_in_version() {
     let error_msg = result.unwrap_err().to_string();
     assert!(
         error_msg.contains("path traversal") || error_msg.contains("'..'"),
-        "Error should mention path traversal, got: {}",
-        error_msg
+        "Error should mention path traversal, got: {error_msg}"
     );
 }
 
@@ -2235,8 +2223,7 @@ async fn test_bundle_validation_forward_slash_in_package() {
     let error_msg = result.unwrap_err().to_string();
     assert!(
         error_msg.contains("directory separator") || error_msg.contains("package"),
-        "Error should mention directory separator, got: {}",
-        error_msg
+        "Error should mention directory separator, got: {error_msg}"
     );
 }
 
@@ -2282,8 +2269,7 @@ async fn test_bundle_validation_backslash_in_package() {
     let error_msg = result.unwrap_err().to_string();
     assert!(
         error_msg.contains("directory separator") || error_msg.contains("package"),
-        "Error should mention directory separator, got: {}",
-        error_msg
+        "Error should mention directory separator, got: {error_msg}"
     );
 }
 
@@ -2329,8 +2315,7 @@ async fn test_bundle_validation_windows_absolute_path_in_package() {
     let error_msg = result.unwrap_err().to_string();
     assert!(
         error_msg.contains("absolute path") || error_msg.contains("package"),
-        "Error should mention absolute path, got: {}",
-        error_msg
+        "Error should mention absolute path, got: {error_msg}"
     );
 }
 
@@ -2341,7 +2326,7 @@ async fn test_bundle_validation_valid_package_names() {
     let (node_client, _data_dir, _blob_dir) = create_test_node_client(None).await;
 
     // Test various valid package name formats
-    let valid_packages = vec![
+    let valid_packages = [
         "com.example.myapp",
         "my-app",
         "my_app_v2",
@@ -2354,7 +2339,7 @@ async fn test_bundle_validation_valid_package_names() {
         let bundle_path = create_test_bundle(
             &temp_dir,
             package,
-            &format!("1.0.{}", i), // Unique version to avoid conflicts
+            &format!("1.0.{i}"), // Unique version to avoid conflicts
             b"wasm content",
             None,
             vec![],

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1298,7 +1298,7 @@ impl DeltaStore {
 
         // Combined stream: first (manual) entry + subsequent
         // value-buffered entries from the iterator.
-        let mut stream: Box<dyn Iterator<Item = Result<_>>> = match first_entry {
+        let stream: Box<dyn Iterator<Item = Result<_>>> = match first_entry {
             Some(entry) => Box::new(
                 std::iter::once(Ok(entry))
                     .chain(iter.entries().map(|(k, v)| -> Result<_> { Ok((k?, v?)) })),
@@ -1306,7 +1306,7 @@ impl DeltaStore {
             None => Box::new(iter.entries().map(|(k, v)| -> Result<_> { Ok((k?, v?)) })),
         };
 
-        while let Some(entry) = stream.next() {
+        for entry in stream {
             let (key, stored_delta) = entry?;
 
             // Sorted by context_id first — once the prefix changes we're
@@ -3093,7 +3093,7 @@ impl DeltaStore {
         cascaded_count: usize,
     ) {
         let hold_ms = hold.as_secs_f64() * 1000.0;
-        let hold_ms_s = format!("{:.2}", hold_ms);
+        let hold_ms_s = format!("{hold_ms:.2}");
         let plans = plans_count.unwrap_or(0);
         if hold.as_millis() >= 500 {
             warn!(

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -17,7 +17,6 @@ use tracing::{debug, info, warn};
 
 use crate::delta_store::DeltaStore;
 use crate::peer_identity_cache::ObservedMembership;
-use crate::utils::choose_stream;
 
 mod buffering;
 mod crypto;
@@ -1007,684 +1006,6 @@ pub async fn handle_state_delta(
     .await
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use calimero_crypto::{SharedKey, NONCE_LEN};
-    use calimero_storage::delta::StorageDelta;
-    use rand::thread_rng;
-
-    #[test]
-    fn parse_events_payload_success() {
-        let events = vec![ExecutionEvent {
-            kind: "test".to_string(),
-            data: vec![1, 2, 3],
-            handler: Some("handler_fn".to_string()),
-        }];
-        let serialized = serde_json::to_vec(&events).expect("serialization should succeed");
-
-        // Should deserialize valid event JSON
-        let parsed = parse_events_payload(&Some(serialized), &ContextId::zero())
-            .expect("events should parse");
-
-        assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed[0].kind, "test");
-        assert_eq!(parsed[0].handler.as_deref(), Some("handler_fn"));
-    }
-
-    #[test]
-    fn parse_events_payload_invalid() {
-        // Invalid JSON should be rejected gracefully
-        let parsed = parse_events_payload(&Some(b"not-json".to_vec()), &ContextId::zero());
-        assert!(parsed.is_none());
-    }
-
-    // ---- HLC fence (PR-3): the guard the receive path calls ----
-    //
-    // Exercises `calimero_context::hlc_fence::delta_is_fenced` against a
-    // store shaped exactly as the receive path sees it after a cascade
-    // migration (group meta `app_key` = current target + a completed
-    // upgrade row carrying `cascade_hlc`). Mirrors `group_id_check_tests`'
-    // store setup so a regression in the fence resolution (wrong app_key
-    // source, missing cascade boundary read) is caught here rather than at
-    // apply time.
-    mod fence_drop_tests {
-        use std::sync::Arc;
-
-        use calimero_context::group_store::{
-            register_context_in_group, MetaRepository, UpgradesRepository,
-        };
-        use calimero_context::hlc_fence::delta_is_fenced;
-        use calimero_context_config::types::ContextGroupId;
-        use calimero_primitives::application::ApplicationId;
-        use calimero_primitives::context::{ContextId, UpgradePolicy};
-        use calimero_primitives::identity::PublicKey;
-        use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
-        use calimero_store::db::InMemoryDB;
-        use calimero_store::key::{GroupMetaValue, GroupUpgradeStatus, GroupUpgradeValue};
-        use calimero_store::Store;
-        use core::num::NonZeroU128;
-
-        // App-schema keys: v1 is the *pre*-cascade schema, v2 is the schema
-        // the context now targets after the migration.
-        const APP_V1: [u8; 32] = [0x11; 32];
-        const APP_V2: [u8; 32] = [0x22; 32];
-
-        fn fresh_store() -> Store {
-            Store::new(Arc::new(InMemoryDB::owned()))
-        }
-
-        /// Build a store whose context [0xF1;32] lives under group [0xF2;32],
-        /// targets app schema v2, and — when `boundary` is `Some` — has a
-        /// completed cascade upgrade recording that HLC as the fence boundary.
-        fn cascaded_store(boundary: Option<HybridTimestamp>) -> (Store, ContextId) {
-            let store = fresh_store();
-            let context_id = ContextId::from([0xF1; 32]);
-            let group_id = ContextGroupId::from([0xF2; 32]);
-
-            register_context_in_group(&store, &group_id, &context_id)
-                .expect("register_context_in_group");
-
-            let dummy_pk = PublicKey::from([0xAB; 32]);
-            MetaRepository::new(&store)
-                .save(
-                    &group_id,
-                    &GroupMetaValue {
-                        app_key: APP_V2,
-                        target_application_id: ApplicationId::from([0xCC; 32]),
-                        upgrade_policy: UpgradePolicy::Automatic,
-                        created_at: 1_700_000_000,
-                        admin_identity: dummy_pk,
-                        owner_identity: dummy_pk,
-                        migration: None,
-                        auto_join: false,
-                    },
-                )
-                .expect("save group meta");
-
-            if let Some(cascade_hlc) = boundary {
-                UpgradesRepository::new(&store)
-                    .save(
-                        &group_id,
-                        &GroupUpgradeValue {
-                            from_version: "1.0.0".to_owned(),
-                            to_version: "2.0.0".to_owned(),
-                            migration: None,
-                            initiated_at: 1_700_000_000,
-                            initiated_by: dummy_pk,
-                            status: GroupUpgradeStatus::Completed { completed_at: None },
-                            cascade_hlc: Some(cascade_hlc),
-                            cascade_seq: None,
-                        },
-                    )
-                    .expect("save group upgrade");
-            }
-
-            (store, context_id)
-        }
-
-        /// A `HybridTimestamp` strictly greater than `zero()` — a delta
-        /// produced after the cascade boundary at `zero()`.
-        fn hlc_after_zero() -> HybridTimestamp {
-            let id = ID::from(NonZeroU128::new(1).expect("1 is non-zero"));
-            HybridTimestamp::new(Timestamp::new(NTP64(1), id))
-        }
-
-        #[test]
-        fn drops_stale_v1_delta_after_cascade() {
-            // v1 schema (≠ current v2) + delta after boundary ⇒ fenced.
-            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
-            assert!(delta_is_fenced(&store, &ctx, APP_V1, hlc_after_zero()).unwrap());
-        }
-
-        #[test]
-        fn keeps_current_v2_delta() {
-            // Delta produced under the current target schema ⇒ never fenced.
-            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
-            assert!(!delta_is_fenced(&store, &ctx, APP_V2, hlc_after_zero()).unwrap());
-        }
-
-        #[test]
-        fn keeps_delta_when_no_cascade_recorded() {
-            // No cascade boundary ⇒ never fence, even a stale-schema delta.
-            let (store, ctx) = cascaded_store(None);
-            assert!(!delta_is_fenced(&store, &ctx, APP_V1, hlc_after_zero()).unwrap());
-        }
-
-        // ---- PR-6b Task 6b.4: absorb-don't-drop at the gossip fence ----
-
-        use calimero_context::group_store::{AbsorbRecord, AbsorbRepository};
-        use calimero_node_primitives::delta_buffer::BufferedDelta;
-        use calimero_primitives::hash::Hash;
-
-        use super::super::{fence_and_maybe_absorb, FenceOutcome};
-
-        /// A minimal `BufferedDelta` carrying the replay fields the absorb path
-        /// persists. `producing_app_key` is the schema discriminator the fence
-        /// keys on.
-        fn sample_buffered(delta_id: [u8; 32], producing_app_key: [u8; 32]) -> BufferedDelta {
-            BufferedDelta {
-                id: delta_id,
-                parents: vec![],
-                hlc: hlc_after_zero(),
-                payload: vec![1, 2, 3],
-                nonce: [0; 12],
-                author_id: PublicKey::from([0xAB; 32]),
-                root_hash: Hash::default(),
-                events: None,
-                source_peer: libp2p::PeerId::random(),
-                key_id: [0; 32],
-                governance_position: None,
-                delta_signature: Some([7; 64]),
-                governance_drain_attempts: 0,
-                producing_app_key: Some(producing_app_key),
-            }
-        }
-
-        /// A `Buffer`-decision delta (schema ≠ the loaded reader, after the
-        /// cascade boundary) must be persisted into the AbsorbBuffer, not
-        /// dropped — and the call reports `Handled` so the caller returns early.
-        #[test]
-        fn buffer_decision_persists_absorb_record_not_drop() {
-            // Loaded reader falls back to GroupMeta.app_key = APP_V2 here, so an
-            // APP_V1 delta after the boundary is unreadable now ⇒ Buffer.
-            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
-            let bd = sample_buffered([3; 32], APP_V1);
-
-            let outcome = fence_and_maybe_absorb(
-                &store,
-                &ctx,
-                APP_V1,
-                bd.id,
-                bd.author_id,
-                bd.hlc,
-                false,
-                || bd.clone(),
-            )
-            .unwrap();
-
-            assert!(matches!(outcome, FenceOutcome::Handled));
-            let pending = AbsorbRepository::new(&store)
-                .enumerate_pending(&ctx)
-                .unwrap();
-            assert_eq!(
-                pending.len(),
-                1,
-                "a stale-schema delta to a behind-reader node must be absorbed, not dropped"
-            );
-            assert_eq!((pending[0].1).id, [3; 32]);
-        }
-
-        /// REGRESSION (the SECOND PR-6b drain bug — fence re-absorb): the absorb
-        /// drain re-feeds a buffered straggler through the real apply path
-        /// ([`apply_authorized_state_delta`]), whose fence step is exactly
-        /// [`fence_and_maybe_absorb`]. For a STALE v1 straggler that the drain
-        /// already selected for replay (`producing == v1`, node advanced to
-        /// `loaded == target == v2`, delta after the boundary), the *un-bypassed*
-        /// fence returns [`FenceOutcome::Handled`] and RE-ABSORBS the delta —
-        /// it bounces off the fence and never converges (infinite no-op /
-        /// silent drop). The drain-replay call must therefore BYPASS the fence:
-        /// with `bypass == true` the already-authorized, already-decided delta
-        /// falls through ([`FenceOutcome::Fall`]) and is applied, NOT re-buffered.
-        ///
-        /// Negative-verify in the same shape: with `bypass == false` (the normal
-        /// gossip-receive path) the identical stale straggler IS re-absorbed —
-        /// proving the bypass, not a weakened fence, is what makes it apply.
-        #[test]
-        fn drain_replay_bypasses_fence_for_stale_straggler() {
-            // loaded reader falls back to GroupMeta.app_key = APP_V2; the stale
-            // straggler was produced under APP_V1, after the cascade boundary.
-            // This is precisely the record the drain selected for verbatim replay.
-            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
-            let bd = sample_buffered([0xB2; 32], APP_V1);
-
-            // Un-bypassed (normal receive): the fence re-absorbs — the bug.
-            let outcome = fence_and_maybe_absorb(
-                &store,
-                &ctx,
-                APP_V1,
-                bd.id,
-                bd.author_id,
-                bd.hlc,
-                false,
-                || bd.clone(),
-            )
-            .unwrap();
-            assert!(
-                matches!(outcome, FenceOutcome::Handled),
-                "the un-bypassed fence re-absorbs the stale straggler (the bug)"
-            );
-            assert_eq!(
-                AbsorbRepository::new(&store)
-                    .enumerate_pending(&ctx)
-                    .unwrap()
-                    .len(),
-                1,
-                "un-bypassed: the straggler bounces off the fence and is re-buffered"
-            );
-
-            // Bypassed (drain replay): the fence is skipped — the delta falls
-            // through to be applied, and NOTHING new is written to the buffer.
-            // Use a fresh store so the un-bypassed half's re-absorb can't mask
-            // a bypassed write.
-            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
-            let outcome = fence_and_maybe_absorb(
-                &store,
-                &ctx,
-                APP_V1,
-                bd.id,
-                bd.author_id,
-                bd.hlc,
-                true,
-                || bd.clone(),
-            )
-            .unwrap();
-            assert!(
-                matches!(outcome, FenceOutcome::Fall),
-                "drain replay must bypass the fence and fall through to apply"
-            );
-            assert!(
-                AbsorbRepository::new(&store)
-                    .enumerate_pending(&ctx)
-                    .unwrap()
-                    .is_empty(),
-                "bypassed: the drain-replayed straggler is applied, not re-absorbed"
-            );
-        }
-
-        /// An `Apply`-decision delta (schema matches the loaded reader) must
-        /// fall through and must NOT land in the AbsorbBuffer.
-        #[test]
-        fn apply_decision_does_not_persist_absorb_record() {
-            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
-            let bd = sample_buffered([4; 32], APP_V2);
-
-            let outcome = fence_and_maybe_absorb(
-                &store,
-                &ctx,
-                APP_V2,
-                bd.id,
-                bd.author_id,
-                bd.hlc,
-                false,
-                || bd.clone(),
-            )
-            .unwrap();
-
-            assert!(matches!(outcome, FenceOutcome::Fall));
-            let pending = AbsorbRepository::new(&store)
-                .enumerate_pending(&ctx)
-                .unwrap();
-            assert!(
-                pending.is_empty(),
-                "a readable delta must apply normally, not be absorbed"
-            );
-        }
-
-        // ---- PR-6b Task 6b.5: drain-on-advance (verbatim replay) ----
-
-        use super::super::drain_absorbed_records;
-
-        /// Build a durable `AbsorbRecord` mirroring a buffered straggler delta.
-        fn sample_record(delta_id: [u8; 32], producing_app_key: [u8; 32]) -> AbsorbRecord {
-            AbsorbRecord::from_buffered(&sample_buffered(delta_id, producing_app_key))
-        }
-
-        /// Install a loaded reader for `context_id` resolving to `blob`, so
-        /// [`loaded_reader_app_key`] returns `blob` (instead of falling back to
-        /// `GroupMeta.app_key`). Lets a test model `loaded != target`.
-        fn install_loaded_reader(store: &Store, context_id: &ContextId, blob: [u8; 32]) {
-            use calimero_primitives::application::ApplicationId;
-            use calimero_primitives::blobs::BlobId;
-            use calimero_store::key;
-            use calimero_store::types::{ApplicationMeta, ContextMeta};
-
-            let app_key = key::ApplicationMeta::new(ApplicationId::from([0xCC; 32]));
-            let app_meta = ApplicationMeta::new(
-                key::BlobMeta::new(BlobId::from(blob)),
-                0,
-                "".into(),
-                Box::default(),
-                key::BlobMeta::new(BlobId::from([0; 32])),
-                "".into(),
-                "".into(),
-                "".into(),
-            );
-            let ctx_meta = ContextMeta::new(app_key, [0; 32], vec![], None);
-
-            let mut handle = store.handle();
-            handle
-                .put(&key::ContextMeta::new(*context_id), &ctx_meta)
-                .expect("put ContextMeta");
-            handle
-                .put(&app_key, &app_meta)
-                .expect("put ApplicationMeta");
-        }
-
-        /// REGRESSION (the PR-6b drain bug): a STALE v1 straggler delta —
-        /// `producing_app_key == v1`, the node already advanced to
-        /// `loaded == target == v2` — must be REPLAYED (verbatim) and deleted,
-        /// NOT skipped forever. The drain-ready signal is "the node reached the
-        /// migration target", not "producing == loaded". This test FAILS against
-        /// the old `producing_app_key != Some(loaded)` skip (the stale record was
-        /// dropped, losing the offline write).
-        #[tokio::test]
-        async fn drain_replays_stale_straggler_when_node_reached_target() {
-            // Loaded reader falls back to GroupMeta.app_key = APP_V2, and the
-            // migration target is also APP_V2 ⇒ loaded == target.
-            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
-            let repo = AbsorbRepository::new(&store);
-
-            // The stale v1 straggler buffered while this node was on v1; the node
-            // has since advanced to v2 (loaded == target == v2). It is now behind
-            // the loaded reader yet replayable through the current wasm.
-            repo.save(&ctx, APP_V1, &sample_record([0xB2; 32], APP_V1))
-                .unwrap();
-
-            let replayed = std::sync::Arc::new(std::sync::Mutex::new(Vec::<[u8; 32]>::new()));
-            let replayed_capture = replayed.clone();
-
-            let drained = drain_absorbed_records(&store, &ctx, move |buffered| {
-                let replayed = replayed_capture.clone();
-                async move {
-                    // Verbatim: the replay sees the original payload bytes,
-                    // never a translated re-encoding.
-                    assert_eq!(buffered.payload, vec![1, 2, 3]);
-                    replayed.lock().unwrap().push(buffered.id);
-                    Ok::<bool, eyre::Report>(true)
-                }
-            })
-            .await
-            .unwrap();
-
-            assert_eq!(
-                drained, 1,
-                "a stale straggler must drain once the node reached the target"
-            );
-            assert_eq!(
-                *replayed.lock().unwrap(),
-                vec![[0xB2; 32]],
-                "the stale v1 straggler is replayed verbatim, not dropped"
-            );
-            assert!(
-                repo.enumerate_pending(&ctx).unwrap().is_empty(),
-                "the replayed straggler must be deleted, not left to leak"
-            );
-        }
-
-        /// A FUTURE-schema delta — `producing == v2` (the target), node still
-        /// behind on `loaded == v1 < target` — must be SKIPPED (the binary can't
-        /// read it yet, never translate). Once the node advances so
-        /// `loaded == target == v2`, the same record drains.
-        #[tokio::test]
-        async fn drain_skips_future_delta_until_node_advances() {
-            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
-            // Node behind: loaded reader = v1, target (GroupMeta.app_key) = v2.
-            install_loaded_reader(&store, &ctx, APP_V1);
-            let repo = AbsorbRepository::new(&store);
-
-            // Future delta: produced under the target schema v2.
-            repo.save(&ctx, APP_V2, &sample_record([0xC3; 32], APP_V2))
-                .unwrap();
-
-            let noop = |_buffered: BufferedDelta| async move { Ok::<bool, eyre::Report>(true) };
-
-            // While behind (loaded == v1 != target == v2, producing == v2 !=
-            // loaded), the future delta must NOT be replayed.
-            let drained = drain_absorbed_records(&store, &ctx, noop).await.unwrap();
-            assert_eq!(drained, 0, "a future-schema delta is skipped while behind");
-            let pending = repo.enumerate_pending(&ctx).unwrap();
-            assert_eq!(pending.len(), 1, "the future delta stays pending");
-            assert_eq!((pending[0].1).id, [0xC3; 32]);
-
-            // The node advances to the target → loaded == target == v2 → drains.
-            install_loaded_reader(&store, &ctx, APP_V2);
-            let drained = drain_absorbed_records(&store, &ctx, noop).await.unwrap();
-            assert_eq!(drained, 1, "the future delta drains once the node advances");
-            assert!(repo.enumerate_pending(&ctx).unwrap().is_empty());
-        }
-
-        /// Leaf- and entity-shaped sync-repair records are NOT replayable deltas
-        /// and must be SKIPPED by the delta drain (they are drained by the
-        /// leaf/entity-replay path), even when the node has reached the target.
-        #[tokio::test]
-        async fn delta_drain_skips_leaf_and_entity_records() {
-            // loaded == target == v2.
-            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
-            let repo = AbsorbRepository::new(&store);
-
-            // A sync-repair leaf and a snapshot entity, both stamped v2 (the
-            // target) — the delta drain must still leave them untouched.
-            repo.save(
-                &ctx,
-                APP_V2,
-                &AbsorbRecord::from_leaf([0xD4; 32], vec![1, 2, 3], APP_V2),
-            )
-            .unwrap();
-            repo.save(
-                &ctx,
-                APP_V2,
-                &AbsorbRecord::from_snapshot_entity([0xE5; 32], vec![1], vec![2], APP_V2),
-            )
-            .unwrap();
-
-            let replayed = std::sync::Arc::new(std::sync::Mutex::new(0usize));
-            let replayed_capture = replayed.clone();
-            let drained = drain_absorbed_records(&store, &ctx, move |_buffered| {
-                let replayed = replayed_capture.clone();
-                async move {
-                    *replayed.lock().unwrap() += 1;
-                    Ok::<bool, eyre::Report>(true)
-                }
-            })
-            .await
-            .unwrap();
-
-            assert_eq!(drained, 0, "the delta drain replays no leaf/entity records");
-            assert_eq!(
-                *replayed.lock().unwrap(),
-                0,
-                "leaf/entity records are never fed to the delta replay path"
-            );
-            assert_eq!(
-                repo.enumerate_pending(&ctx).unwrap().len(),
-                2,
-                "leaf/entity records are left for the leaf/entity drain path"
-            );
-        }
-
-        /// Re-running the drain after a successful pass is a no-op (idempotent
-        /// via delta_id key): the deleted record does not re-replay.
-        #[tokio::test]
-        async fn drain_is_idempotent_after_success() {
-            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
-            let repo = AbsorbRepository::new(&store);
-            repo.save(&ctx, APP_V2, &sample_record([0xA1; 32], APP_V2))
-                .unwrap();
-
-            let noop = |_buffered: BufferedDelta| async move { Ok::<bool, eyre::Report>(true) };
-
-            let first = drain_absorbed_records(&store, &ctx, noop).await.unwrap();
-            assert_eq!(first, 1);
-            let second = drain_absorbed_records(&store, &ctx, noop).await.unwrap();
-            assert_eq!(second, 0, "no records survive a successful drain");
-            assert!(repo.enumerate_pending(&ctx).unwrap().is_empty());
-        }
-
-        /// A record whose replay fails is NOT deleted — it survives for the
-        /// next drain pass (delete-after-success only).
-        #[tokio::test]
-        async fn failed_replay_leaves_record_pending() {
-            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
-            let repo = AbsorbRepository::new(&store);
-            repo.save(&ctx, APP_V2, &sample_record([0xA1; 32], APP_V2))
-                .unwrap();
-
-            let drained = drain_absorbed_records(&store, &ctx, |_buffered| async move {
-                Err::<bool, eyre::Report>(eyre::eyre!("replay failed"))
-            })
-            .await
-            .unwrap();
-
-            assert_eq!(drained, 0, "a failed replay drains nothing");
-            let pending = repo.enumerate_pending(&ctx).unwrap();
-            assert_eq!(pending.len(), 1, "a failed-replay record must survive");
-            assert_eq!((pending[0].1).id, [0xA1; 32]);
-        }
-
-        // ---- PR-6b Task 6b.6: startup recovery scan ----
-
-        use super::super::recover_absorbed_records;
-
-        /// On node startup the AbsorbBuffer is durable (RocksDB CF), so any
-        /// straggler delta persisted before a restart must be re-considered for
-        /// drain. With the loaded reader at the migration target, both a
-        /// target-schema record and a STALE v1 straggler (behind the loaded
-        /// reader) are now replayable and must drain — a restart mid-window must
-        /// not lose buffered deltas. A genuinely future record (target not yet
-        /// reached) is left behind; that path is exercised below.
-        #[tokio::test]
-        async fn startup_recovery_drains_records_once_target_reached() {
-            // The store's loaded reader falls back to GroupMeta.app_key = APP_V2,
-            // and the target is APP_V2 ⇒ loaded == target.
-            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
-            let repo = AbsorbRepository::new(&store);
-
-            // Persisted-before-restart, target-schema: must drain on startup.
-            repo.save(&ctx, APP_V2, &sample_record([0xA1; 32], APP_V2))
-                .unwrap();
-            // Persisted-before-restart, stale v1 straggler (behind the loaded
-            // reader but the node reached the target): must ALSO drain — the
-            // current wasm verbatim-replays it.
-            repo.save(&ctx, APP_V1, &sample_record([0xB2; 32], APP_V1))
-                .unwrap();
-
-            let replayed = std::sync::Arc::new(std::sync::Mutex::new(Vec::<[u8; 32]>::new()));
-            let replayed_capture = replayed.clone();
-
-            let drained = recover_absorbed_records(&store, move |context_id, buffered| {
-                let replayed = replayed_capture.clone();
-                async move {
-                    // The recovery threads the right context to the replay.
-                    assert_eq!(context_id, ctx);
-                    // Verbatim: the recovery replay sees the original bytes.
-                    assert_eq!(buffered.payload, vec![1, 2, 3]);
-                    replayed.lock().unwrap().push(buffered.id);
-                    Ok::<bool, eyre::Report>(true)
-                }
-            })
-            .await
-            .unwrap();
-
-            assert_eq!(
-                drained, 2,
-                "both the target-schema and the stale straggler drain on startup"
-            );
-            let mut seen = replayed.lock().unwrap().clone();
-            seen.sort_unstable();
-            assert_eq!(
-                seen,
-                vec![[0xA1; 32], [0xB2; 32]],
-                "both records are replayed verbatim once the node reached the target"
-            );
-
-            assert!(
-                repo.enumerate_pending(&ctx).unwrap().is_empty(),
-                "no record is left stranded once the node reached the target"
-            );
-        }
-
-        /// A node restarting *still behind* the target (loaded reader < target)
-        /// leaves the unreadable future record pending across the startup scan.
-        #[tokio::test]
-        async fn startup_recovery_keeps_future_record_while_behind() {
-            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
-            // Node behind: loaded reader = v1, target (GroupMeta.app_key) = v2.
-            install_loaded_reader(&store, &ctx, APP_V1);
-            let repo = AbsorbRepository::new(&store);
-
-            // Future delta (target schema) the behind-reader node can't read yet.
-            repo.save(&ctx, APP_V2, &sample_record([0xC3; 32], APP_V2))
-                .unwrap();
-
-            let noop = |_ctx: ContextId, _buffered: BufferedDelta| async move {
-                Ok::<bool, eyre::Report>(true)
-            };
-            let drained = recover_absorbed_records(&store, noop).await.unwrap();
-
-            assert_eq!(
-                drained, 0,
-                "a behind node drains no future record on startup"
-            );
-            let pending = repo.enumerate_pending(&ctx).unwrap();
-            assert_eq!(
-                pending.len(),
-                1,
-                "the future record survives the startup scan"
-            );
-            assert_eq!((pending[0].1).id, [0xC3; 32]);
-        }
-
-        /// The startup scan is idempotent across two recovery calls (e.g. a
-        /// double-init or a quick restart): an already-drained record does not
-        /// re-replay, and a record the node is still too far behind to read
-        /// stays put.
-        #[tokio::test]
-        async fn startup_recovery_is_idempotent_across_two_calls() {
-            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
-            // Node behind: loaded == v1 < target == v2, so the future record is
-            // a stable survivor across both scans.
-            install_loaded_reader(&store, &ctx, APP_V1);
-            let repo = AbsorbRepository::new(&store);
-            // Readable now (matches the loaded reader v1): drains on the 1st scan.
-            repo.save(&ctx, APP_V1, &sample_record([0xA1; 32], APP_V1))
-                .unwrap();
-            // Future (target schema v2): the behind node leaves it pending.
-            repo.save(&ctx, APP_V2, &sample_record([0xB2; 32], APP_V2))
-                .unwrap();
-
-            let noop = |_ctx: ContextId, _buffered: BufferedDelta| async move {
-                Ok::<bool, eyre::Report>(true)
-            };
-
-            let first = recover_absorbed_records(&store, noop).await.unwrap();
-            assert_eq!(first, 1);
-            let second = recover_absorbed_records(&store, noop).await.unwrap();
-            assert_eq!(second, 0, "a second startup scan re-drains nothing");
-
-            let pending = repo.enumerate_pending(&ctx).unwrap();
-            assert_eq!(pending.len(), 1, "the future record persists");
-            assert_eq!((pending[0].1).id, [0xB2; 32]);
-        }
-
-        // NOTE: startup drain of buffered snapshot-**entity** records is not
-        // unit-tested via a standalone recovery function any more. The entity
-        // arm of `drain_absorbed_leaves` (the live startup hook runs it over
-        // every context with a pending absorb) already drains both leaf- and
-        // entity-shaped records with the identical `schema_app_key == loaded`
-        // gate and the same `persist_buffered_snapshot_entity` path; the entity
-        // persist/redrive/pending logic is covered directly by
-        // `sync::snapshot::tests::test_persist_buffered_snapshot_entity_*`, and
-        // `delta_drain_skips_leaf_and_entity_records` pins that the delta drain
-        // leaves entity records for that path.
-
-        /// With nothing buffered (the common case) the startup scan is a cheap
-        /// no-op and never panics.
-        #[tokio::test]
-        async fn startup_recovery_is_noop_when_nothing_buffered() {
-            let (store, _ctx) = cascaded_store(Some(HybridTimestamp::zero()));
-            let noop = |_ctx: ContextId, _buffered: BufferedDelta| async move {
-                Ok::<bool, eyre::Report>(true)
-            };
-            let drained = recover_absorbed_records(&store, noop).await.unwrap();
-            assert_eq!(
-                drained, 0,
-                "no contexts with pending absorbs ⇒ nothing drains"
-            );
-        }
-    }
-}
-
 /// Requests missing parent deltas from a peer
 ///
 /// Opens a stream to the peer and requests each missing delta sequentially.
@@ -2627,4 +1948,679 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
     }
 
     Ok(add_result.applied)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_events_payload_success() {
+        let events = vec![ExecutionEvent {
+            kind: "test".to_string(),
+            data: vec![1, 2, 3],
+            handler: Some("handler_fn".to_string()),
+        }];
+        let serialized = serde_json::to_vec(&events).expect("serialization should succeed");
+
+        // Should deserialize valid event JSON
+        let parsed = parse_events_payload(&Some(serialized), &ContextId::zero())
+            .expect("events should parse");
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].kind, "test");
+        assert_eq!(parsed[0].handler.as_deref(), Some("handler_fn"));
+    }
+
+    #[test]
+    fn parse_events_payload_invalid() {
+        // Invalid JSON should be rejected gracefully
+        let parsed = parse_events_payload(&Some(b"not-json".to_vec()), &ContextId::zero());
+        assert!(parsed.is_none());
+    }
+
+    // ---- HLC fence (PR-3): the guard the receive path calls ----
+    //
+    // Exercises `calimero_context::hlc_fence::delta_is_fenced` against a
+    // store shaped exactly as the receive path sees it after a cascade
+    // migration (group meta `app_key` = current target + a completed
+    // upgrade row carrying `cascade_hlc`). Mirrors `group_id_check_tests`'
+    // store setup so a regression in the fence resolution (wrong app_key
+    // source, missing cascade boundary read) is caught here rather than at
+    // apply time.
+    mod fence_drop_tests {
+        use std::sync::Arc;
+
+        use calimero_context::group_store::{
+            register_context_in_group, MetaRepository, UpgradesRepository,
+        };
+        use calimero_context::hlc_fence::delta_is_fenced;
+        use calimero_context_config::types::ContextGroupId;
+        use calimero_primitives::application::ApplicationId;
+        use calimero_primitives::context::{ContextId, UpgradePolicy};
+        use calimero_primitives::identity::PublicKey;
+        use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
+        use calimero_store::db::InMemoryDB;
+        use calimero_store::key::{GroupMetaValue, GroupUpgradeStatus, GroupUpgradeValue};
+        use calimero_store::Store;
+        use core::num::NonZeroU128;
+
+        // App-schema keys: v1 is the *pre*-cascade schema, v2 is the schema
+        // the context now targets after the migration.
+        const APP_V1: [u8; 32] = [0x11; 32];
+        const APP_V2: [u8; 32] = [0x22; 32];
+
+        fn fresh_store() -> Store {
+            Store::new(Arc::new(InMemoryDB::owned()))
+        }
+
+        /// Build a store whose context [0xF1;32] lives under group [0xF2;32],
+        /// targets app schema v2, and — when `boundary` is `Some` — has a
+        /// completed cascade upgrade recording that HLC as the fence boundary.
+        fn cascaded_store(boundary: Option<HybridTimestamp>) -> (Store, ContextId) {
+            let store = fresh_store();
+            let context_id = ContextId::from([0xF1; 32]);
+            let group_id = ContextGroupId::from([0xF2; 32]);
+
+            register_context_in_group(&store, &group_id, &context_id)
+                .expect("register_context_in_group");
+
+            let dummy_pk = PublicKey::from([0xAB; 32]);
+            MetaRepository::new(&store)
+                .save(
+                    &group_id,
+                    &GroupMetaValue {
+                        app_key: APP_V2,
+                        target_application_id: ApplicationId::from([0xCC; 32]),
+                        upgrade_policy: UpgradePolicy::Automatic,
+                        created_at: 1_700_000_000,
+                        admin_identity: dummy_pk,
+                        owner_identity: dummy_pk,
+                        migration: None,
+                        auto_join: false,
+                    },
+                )
+                .expect("save group meta");
+
+            if let Some(cascade_hlc) = boundary {
+                UpgradesRepository::new(&store)
+                    .save(
+                        &group_id,
+                        &GroupUpgradeValue {
+                            from_version: "1.0.0".to_owned(),
+                            to_version: "2.0.0".to_owned(),
+                            migration: None,
+                            initiated_at: 1_700_000_000,
+                            initiated_by: dummy_pk,
+                            status: GroupUpgradeStatus::Completed { completed_at: None },
+                            cascade_hlc: Some(cascade_hlc),
+                            cascade_seq: None,
+                        },
+                    )
+                    .expect("save group upgrade");
+            }
+
+            (store, context_id)
+        }
+
+        /// A `HybridTimestamp` strictly greater than `zero()` — a delta
+        /// produced after the cascade boundary at `zero()`.
+        fn hlc_after_zero() -> HybridTimestamp {
+            let id = ID::from(NonZeroU128::new(1).expect("1 is non-zero"));
+            HybridTimestamp::new(Timestamp::new(NTP64(1), id))
+        }
+
+        #[test]
+        fn drops_stale_v1_delta_after_cascade() {
+            // v1 schema (≠ current v2) + delta after boundary ⇒ fenced.
+            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
+            assert!(delta_is_fenced(&store, &ctx, APP_V1, hlc_after_zero()).unwrap());
+        }
+
+        #[test]
+        fn keeps_current_v2_delta() {
+            // Delta produced under the current target schema ⇒ never fenced.
+            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
+            assert!(!delta_is_fenced(&store, &ctx, APP_V2, hlc_after_zero()).unwrap());
+        }
+
+        #[test]
+        fn keeps_delta_when_no_cascade_recorded() {
+            // No cascade boundary ⇒ never fence, even a stale-schema delta.
+            let (store, ctx) = cascaded_store(None);
+            assert!(!delta_is_fenced(&store, &ctx, APP_V1, hlc_after_zero()).unwrap());
+        }
+
+        // ---- PR-6b Task 6b.4: absorb-don't-drop at the gossip fence ----
+
+        use calimero_context::group_store::{AbsorbRecord, AbsorbRepository};
+        use calimero_node_primitives::delta_buffer::BufferedDelta;
+        use calimero_primitives::hash::Hash;
+
+        use super::super::{fence_and_maybe_absorb, FenceOutcome};
+
+        /// A minimal `BufferedDelta` carrying the replay fields the absorb path
+        /// persists. `producing_app_key` is the schema discriminator the fence
+        /// keys on.
+        fn sample_buffered(delta_id: [u8; 32], producing_app_key: [u8; 32]) -> BufferedDelta {
+            BufferedDelta {
+                id: delta_id,
+                parents: vec![],
+                hlc: hlc_after_zero(),
+                payload: vec![1, 2, 3],
+                nonce: [0; 12],
+                author_id: PublicKey::from([0xAB; 32]),
+                root_hash: Hash::default(),
+                events: None,
+                source_peer: libp2p::PeerId::random(),
+                key_id: [0; 32],
+                governance_position: None,
+                delta_signature: Some([7; 64]),
+                governance_drain_attempts: 0,
+                producing_app_key: Some(producing_app_key),
+            }
+        }
+
+        /// A `Buffer`-decision delta (schema ≠ the loaded reader, after the
+        /// cascade boundary) must be persisted into the AbsorbBuffer, not
+        /// dropped — and the call reports `Handled` so the caller returns early.
+        #[test]
+        fn buffer_decision_persists_absorb_record_not_drop() {
+            // Loaded reader falls back to GroupMeta.app_key = APP_V2 here, so an
+            // APP_V1 delta after the boundary is unreadable now ⇒ Buffer.
+            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
+            let bd = sample_buffered([3; 32], APP_V1);
+
+            let outcome = fence_and_maybe_absorb(
+                &store,
+                &ctx,
+                APP_V1,
+                bd.id,
+                bd.author_id,
+                bd.hlc,
+                false,
+                || bd.clone(),
+            )
+            .unwrap();
+
+            assert!(matches!(outcome, FenceOutcome::Handled));
+            let pending = AbsorbRepository::new(&store)
+                .enumerate_pending(&ctx)
+                .unwrap();
+            assert_eq!(
+                pending.len(),
+                1,
+                "a stale-schema delta to a behind-reader node must be absorbed, not dropped"
+            );
+            assert_eq!((pending[0].1).id, [3; 32]);
+        }
+
+        /// REGRESSION (the SECOND PR-6b drain bug — fence re-absorb): the absorb
+        /// drain re-feeds a buffered straggler through the real apply path
+        /// ([`apply_authorized_state_delta`]), whose fence step is exactly
+        /// [`fence_and_maybe_absorb`]. For a STALE v1 straggler that the drain
+        /// already selected for replay (`producing == v1`, node advanced to
+        /// `loaded == target == v2`, delta after the boundary), the *un-bypassed*
+        /// fence returns [`FenceOutcome::Handled`] and RE-ABSORBS the delta —
+        /// it bounces off the fence and never converges (infinite no-op /
+        /// silent drop). The drain-replay call must therefore BYPASS the fence:
+        /// with `bypass == true` the already-authorized, already-decided delta
+        /// falls through ([`FenceOutcome::Fall`]) and is applied, NOT re-buffered.
+        ///
+        /// Negative-verify in the same shape: with `bypass == false` (the normal
+        /// gossip-receive path) the identical stale straggler IS re-absorbed —
+        /// proving the bypass, not a weakened fence, is what makes it apply.
+        #[test]
+        fn drain_replay_bypasses_fence_for_stale_straggler() {
+            // loaded reader falls back to GroupMeta.app_key = APP_V2; the stale
+            // straggler was produced under APP_V1, after the cascade boundary.
+            // This is precisely the record the drain selected for verbatim replay.
+            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
+            let bd = sample_buffered([0xB2; 32], APP_V1);
+
+            // Un-bypassed (normal receive): the fence re-absorbs — the bug.
+            let outcome = fence_and_maybe_absorb(
+                &store,
+                &ctx,
+                APP_V1,
+                bd.id,
+                bd.author_id,
+                bd.hlc,
+                false,
+                || bd.clone(),
+            )
+            .unwrap();
+            assert!(
+                matches!(outcome, FenceOutcome::Handled),
+                "the un-bypassed fence re-absorbs the stale straggler (the bug)"
+            );
+            assert_eq!(
+                AbsorbRepository::new(&store)
+                    .enumerate_pending(&ctx)
+                    .unwrap()
+                    .len(),
+                1,
+                "un-bypassed: the straggler bounces off the fence and is re-buffered"
+            );
+
+            // Bypassed (drain replay): the fence is skipped — the delta falls
+            // through to be applied, and NOTHING new is written to the buffer.
+            // Use a fresh store so the un-bypassed half's re-absorb can't mask
+            // a bypassed write.
+            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
+            let outcome = fence_and_maybe_absorb(
+                &store,
+                &ctx,
+                APP_V1,
+                bd.id,
+                bd.author_id,
+                bd.hlc,
+                true,
+                || bd.clone(),
+            )
+            .unwrap();
+            assert!(
+                matches!(outcome, FenceOutcome::Fall),
+                "drain replay must bypass the fence and fall through to apply"
+            );
+            assert!(
+                AbsorbRepository::new(&store)
+                    .enumerate_pending(&ctx)
+                    .unwrap()
+                    .is_empty(),
+                "bypassed: the drain-replayed straggler is applied, not re-absorbed"
+            );
+        }
+
+        /// An `Apply`-decision delta (schema matches the loaded reader) must
+        /// fall through and must NOT land in the AbsorbBuffer.
+        #[test]
+        fn apply_decision_does_not_persist_absorb_record() {
+            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
+            let bd = sample_buffered([4; 32], APP_V2);
+
+            let outcome = fence_and_maybe_absorb(
+                &store,
+                &ctx,
+                APP_V2,
+                bd.id,
+                bd.author_id,
+                bd.hlc,
+                false,
+                || bd.clone(),
+            )
+            .unwrap();
+
+            assert!(matches!(outcome, FenceOutcome::Fall));
+            let pending = AbsorbRepository::new(&store)
+                .enumerate_pending(&ctx)
+                .unwrap();
+            assert!(
+                pending.is_empty(),
+                "a readable delta must apply normally, not be absorbed"
+            );
+        }
+
+        // ---- PR-6b Task 6b.5: drain-on-advance (verbatim replay) ----
+
+        use super::super::drain_absorbed_records;
+
+        /// Build a durable `AbsorbRecord` mirroring a buffered straggler delta.
+        fn sample_record(delta_id: [u8; 32], producing_app_key: [u8; 32]) -> AbsorbRecord {
+            AbsorbRecord::from_buffered(&sample_buffered(delta_id, producing_app_key))
+        }
+
+        /// Install a loaded reader for `context_id` resolving to `blob`, so
+        /// [`loaded_reader_app_key`] returns `blob` (instead of falling back to
+        /// `GroupMeta.app_key`). Lets a test model `loaded != target`.
+        fn install_loaded_reader(store: &Store, context_id: &ContextId, blob: [u8; 32]) {
+            use calimero_primitives::application::ApplicationId;
+            use calimero_primitives::blobs::BlobId;
+            use calimero_store::key;
+            use calimero_store::types::{ApplicationMeta, ContextMeta};
+
+            let app_key = key::ApplicationMeta::new(ApplicationId::from([0xCC; 32]));
+            let app_meta = ApplicationMeta::new(
+                key::BlobMeta::new(BlobId::from(blob)),
+                0,
+                "".into(),
+                Box::default(),
+                key::BlobMeta::new(BlobId::from([0; 32])),
+                "".into(),
+                "".into(),
+                "".into(),
+            );
+            let ctx_meta = ContextMeta::new(app_key, [0; 32], vec![], None);
+
+            let mut handle = store.handle();
+            handle
+                .put(&key::ContextMeta::new(*context_id), &ctx_meta)
+                .expect("put ContextMeta");
+            handle
+                .put(&app_key, &app_meta)
+                .expect("put ApplicationMeta");
+        }
+
+        /// REGRESSION (the PR-6b drain bug): a STALE v1 straggler delta —
+        /// `producing_app_key == v1`, the node already advanced to
+        /// `loaded == target == v2` — must be REPLAYED (verbatim) and deleted,
+        /// NOT skipped forever. The drain-ready signal is "the node reached the
+        /// migration target", not "producing == loaded". This test FAILS against
+        /// the old `producing_app_key != Some(loaded)` skip (the stale record was
+        /// dropped, losing the offline write).
+        #[tokio::test]
+        async fn drain_replays_stale_straggler_when_node_reached_target() {
+            // Loaded reader falls back to GroupMeta.app_key = APP_V2, and the
+            // migration target is also APP_V2 ⇒ loaded == target.
+            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
+            let repo = AbsorbRepository::new(&store);
+
+            // The stale v1 straggler buffered while this node was on v1; the node
+            // has since advanced to v2 (loaded == target == v2). It is now behind
+            // the loaded reader yet replayable through the current wasm.
+            repo.save(&ctx, APP_V1, &sample_record([0xB2; 32], APP_V1))
+                .unwrap();
+
+            let replayed = std::sync::Arc::new(std::sync::Mutex::new(Vec::<[u8; 32]>::new()));
+            let replayed_capture = replayed.clone();
+
+            let drained = drain_absorbed_records(&store, &ctx, move |buffered| {
+                let replayed = replayed_capture.clone();
+                async move {
+                    // Verbatim: the replay sees the original payload bytes,
+                    // never a translated re-encoding.
+                    assert_eq!(buffered.payload, vec![1, 2, 3]);
+                    replayed.lock().unwrap().push(buffered.id);
+                    Ok::<bool, eyre::Report>(true)
+                }
+            })
+            .await
+            .unwrap();
+
+            assert_eq!(
+                drained, 1,
+                "a stale straggler must drain once the node reached the target"
+            );
+            assert_eq!(
+                *replayed.lock().unwrap(),
+                vec![[0xB2; 32]],
+                "the stale v1 straggler is replayed verbatim, not dropped"
+            );
+            assert!(
+                repo.enumerate_pending(&ctx).unwrap().is_empty(),
+                "the replayed straggler must be deleted, not left to leak"
+            );
+        }
+
+        /// A FUTURE-schema delta — `producing == v2` (the target), node still
+        /// behind on `loaded == v1 < target` — must be SKIPPED (the binary can't
+        /// read it yet, never translate). Once the node advances so
+        /// `loaded == target == v2`, the same record drains.
+        #[tokio::test]
+        async fn drain_skips_future_delta_until_node_advances() {
+            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
+            // Node behind: loaded reader = v1, target (GroupMeta.app_key) = v2.
+            install_loaded_reader(&store, &ctx, APP_V1);
+            let repo = AbsorbRepository::new(&store);
+
+            // Future delta: produced under the target schema v2.
+            repo.save(&ctx, APP_V2, &sample_record([0xC3; 32], APP_V2))
+                .unwrap();
+
+            let noop = |_buffered: BufferedDelta| async move { Ok::<bool, eyre::Report>(true) };
+
+            // While behind (loaded == v1 != target == v2, producing == v2 !=
+            // loaded), the future delta must NOT be replayed.
+            let drained = drain_absorbed_records(&store, &ctx, noop).await.unwrap();
+            assert_eq!(drained, 0, "a future-schema delta is skipped while behind");
+            let pending = repo.enumerate_pending(&ctx).unwrap();
+            assert_eq!(pending.len(), 1, "the future delta stays pending");
+            assert_eq!((pending[0].1).id, [0xC3; 32]);
+
+            // The node advances to the target → loaded == target == v2 → drains.
+            install_loaded_reader(&store, &ctx, APP_V2);
+            let drained = drain_absorbed_records(&store, &ctx, noop).await.unwrap();
+            assert_eq!(drained, 1, "the future delta drains once the node advances");
+            assert!(repo.enumerate_pending(&ctx).unwrap().is_empty());
+        }
+
+        /// Leaf- and entity-shaped sync-repair records are NOT replayable deltas
+        /// and must be SKIPPED by the delta drain (they are drained by the
+        /// leaf/entity-replay path), even when the node has reached the target.
+        #[tokio::test]
+        async fn delta_drain_skips_leaf_and_entity_records() {
+            // loaded == target == v2.
+            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
+            let repo = AbsorbRepository::new(&store);
+
+            // A sync-repair leaf and a snapshot entity, both stamped v2 (the
+            // target) — the delta drain must still leave them untouched.
+            repo.save(
+                &ctx,
+                APP_V2,
+                &AbsorbRecord::from_leaf([0xD4; 32], vec![1, 2, 3], APP_V2),
+            )
+            .unwrap();
+            repo.save(
+                &ctx,
+                APP_V2,
+                &AbsorbRecord::from_snapshot_entity([0xE5; 32], vec![1], vec![2], APP_V2),
+            )
+            .unwrap();
+
+            let replayed = std::sync::Arc::new(std::sync::Mutex::new(0usize));
+            let replayed_capture = replayed.clone();
+            let drained = drain_absorbed_records(&store, &ctx, move |_buffered| {
+                let replayed = replayed_capture.clone();
+                async move {
+                    *replayed.lock().unwrap() += 1;
+                    Ok::<bool, eyre::Report>(true)
+                }
+            })
+            .await
+            .unwrap();
+
+            assert_eq!(drained, 0, "the delta drain replays no leaf/entity records");
+            assert_eq!(
+                *replayed.lock().unwrap(),
+                0,
+                "leaf/entity records are never fed to the delta replay path"
+            );
+            assert_eq!(
+                repo.enumerate_pending(&ctx).unwrap().len(),
+                2,
+                "leaf/entity records are left for the leaf/entity drain path"
+            );
+        }
+
+        /// Re-running the drain after a successful pass is a no-op (idempotent
+        /// via delta_id key): the deleted record does not re-replay.
+        #[tokio::test]
+        async fn drain_is_idempotent_after_success() {
+            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
+            let repo = AbsorbRepository::new(&store);
+            repo.save(&ctx, APP_V2, &sample_record([0xA1; 32], APP_V2))
+                .unwrap();
+
+            let noop = |_buffered: BufferedDelta| async move { Ok::<bool, eyre::Report>(true) };
+
+            let first = drain_absorbed_records(&store, &ctx, noop).await.unwrap();
+            assert_eq!(first, 1);
+            let second = drain_absorbed_records(&store, &ctx, noop).await.unwrap();
+            assert_eq!(second, 0, "no records survive a successful drain");
+            assert!(repo.enumerate_pending(&ctx).unwrap().is_empty());
+        }
+
+        /// A record whose replay fails is NOT deleted — it survives for the
+        /// next drain pass (delete-after-success only).
+        #[tokio::test]
+        async fn failed_replay_leaves_record_pending() {
+            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
+            let repo = AbsorbRepository::new(&store);
+            repo.save(&ctx, APP_V2, &sample_record([0xA1; 32], APP_V2))
+                .unwrap();
+
+            let drained = drain_absorbed_records(&store, &ctx, |_buffered| async move {
+                Err::<bool, eyre::Report>(eyre::eyre!("replay failed"))
+            })
+            .await
+            .unwrap();
+
+            assert_eq!(drained, 0, "a failed replay drains nothing");
+            let pending = repo.enumerate_pending(&ctx).unwrap();
+            assert_eq!(pending.len(), 1, "a failed-replay record must survive");
+            assert_eq!((pending[0].1).id, [0xA1; 32]);
+        }
+
+        // ---- PR-6b Task 6b.6: startup recovery scan ----
+
+        use super::super::recover_absorbed_records;
+
+        /// On node startup the AbsorbBuffer is durable (RocksDB CF), so any
+        /// straggler delta persisted before a restart must be re-considered for
+        /// drain. With the loaded reader at the migration target, both a
+        /// target-schema record and a STALE v1 straggler (behind the loaded
+        /// reader) are now replayable and must drain — a restart mid-window must
+        /// not lose buffered deltas. A genuinely future record (target not yet
+        /// reached) is left behind; that path is exercised below.
+        #[tokio::test]
+        async fn startup_recovery_drains_records_once_target_reached() {
+            // The store's loaded reader falls back to GroupMeta.app_key = APP_V2,
+            // and the target is APP_V2 ⇒ loaded == target.
+            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
+            let repo = AbsorbRepository::new(&store);
+
+            // Persisted-before-restart, target-schema: must drain on startup.
+            repo.save(&ctx, APP_V2, &sample_record([0xA1; 32], APP_V2))
+                .unwrap();
+            // Persisted-before-restart, stale v1 straggler (behind the loaded
+            // reader but the node reached the target): must ALSO drain — the
+            // current wasm verbatim-replays it.
+            repo.save(&ctx, APP_V1, &sample_record([0xB2; 32], APP_V1))
+                .unwrap();
+
+            let replayed = std::sync::Arc::new(std::sync::Mutex::new(Vec::<[u8; 32]>::new()));
+            let replayed_capture = replayed.clone();
+
+            let drained = recover_absorbed_records(&store, move |context_id, buffered| {
+                let replayed = replayed_capture.clone();
+                async move {
+                    // The recovery threads the right context to the replay.
+                    assert_eq!(context_id, ctx);
+                    // Verbatim: the recovery replay sees the original bytes.
+                    assert_eq!(buffered.payload, vec![1, 2, 3]);
+                    replayed.lock().unwrap().push(buffered.id);
+                    Ok::<bool, eyre::Report>(true)
+                }
+            })
+            .await
+            .unwrap();
+
+            assert_eq!(
+                drained, 2,
+                "both the target-schema and the stale straggler drain on startup"
+            );
+            let mut seen = replayed.lock().unwrap().clone();
+            seen.sort_unstable();
+            assert_eq!(
+                seen,
+                vec![[0xA1; 32], [0xB2; 32]],
+                "both records are replayed verbatim once the node reached the target"
+            );
+
+            assert!(
+                repo.enumerate_pending(&ctx).unwrap().is_empty(),
+                "no record is left stranded once the node reached the target"
+            );
+        }
+
+        /// A node restarting *still behind* the target (loaded reader < target)
+        /// leaves the unreadable future record pending across the startup scan.
+        #[tokio::test]
+        async fn startup_recovery_keeps_future_record_while_behind() {
+            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
+            // Node behind: loaded reader = v1, target (GroupMeta.app_key) = v2.
+            install_loaded_reader(&store, &ctx, APP_V1);
+            let repo = AbsorbRepository::new(&store);
+
+            // Future delta (target schema) the behind-reader node can't read yet.
+            repo.save(&ctx, APP_V2, &sample_record([0xC3; 32], APP_V2))
+                .unwrap();
+
+            let noop = |_ctx: ContextId, _buffered: BufferedDelta| async move {
+                Ok::<bool, eyre::Report>(true)
+            };
+            let drained = recover_absorbed_records(&store, noop).await.unwrap();
+
+            assert_eq!(
+                drained, 0,
+                "a behind node drains no future record on startup"
+            );
+            let pending = repo.enumerate_pending(&ctx).unwrap();
+            assert_eq!(
+                pending.len(),
+                1,
+                "the future record survives the startup scan"
+            );
+            assert_eq!((pending[0].1).id, [0xC3; 32]);
+        }
+
+        /// The startup scan is idempotent across two recovery calls (e.g. a
+        /// double-init or a quick restart): an already-drained record does not
+        /// re-replay, and a record the node is still too far behind to read
+        /// stays put.
+        #[tokio::test]
+        async fn startup_recovery_is_idempotent_across_two_calls() {
+            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
+            // Node behind: loaded == v1 < target == v2, so the future record is
+            // a stable survivor across both scans.
+            install_loaded_reader(&store, &ctx, APP_V1);
+            let repo = AbsorbRepository::new(&store);
+            // Readable now (matches the loaded reader v1): drains on the 1st scan.
+            repo.save(&ctx, APP_V1, &sample_record([0xA1; 32], APP_V1))
+                .unwrap();
+            // Future (target schema v2): the behind node leaves it pending.
+            repo.save(&ctx, APP_V2, &sample_record([0xB2; 32], APP_V2))
+                .unwrap();
+
+            let noop = |_ctx: ContextId, _buffered: BufferedDelta| async move {
+                Ok::<bool, eyre::Report>(true)
+            };
+
+            let first = recover_absorbed_records(&store, noop).await.unwrap();
+            assert_eq!(first, 1);
+            let second = recover_absorbed_records(&store, noop).await.unwrap();
+            assert_eq!(second, 0, "a second startup scan re-drains nothing");
+
+            let pending = repo.enumerate_pending(&ctx).unwrap();
+            assert_eq!(pending.len(), 1, "the future record persists");
+            assert_eq!((pending[0].1).id, [0xB2; 32]);
+        }
+
+        // NOTE: startup drain of buffered snapshot-**entity** records is not
+        // unit-tested via a standalone recovery function any more. The entity
+        // arm of `drain_absorbed_leaves` (the live startup hook runs it over
+        // every context with a pending absorb) already drains both leaf- and
+        // entity-shaped records with the identical `schema_app_key == loaded`
+        // gate and the same `persist_buffered_snapshot_entity` path; the entity
+        // persist/redrive/pending logic is covered directly by
+        // `sync::snapshot::tests::test_persist_buffered_snapshot_entity_*`, and
+        // `delta_drain_skips_leaf_and_entity_records` pins that the delta drain
+        // leaves entity records for that path.
+
+        /// With nothing buffered (the common case) the startup scan is a cheap
+        /// no-op and never panics.
+        #[tokio::test]
+        async fn startup_recovery_is_noop_when_nothing_buffered() {
+            let (store, _ctx) = cascaded_store(Some(HybridTimestamp::zero()));
+            let noop = |_ctx: ContextId, _buffered: BufferedDelta| async move {
+                Ok::<bool, eyre::Report>(true)
+            };
+            let drained = recover_absorbed_records(&store, noop).await.unwrap();
+            assert_eq!(
+                drained, 0,
+                "no contexts with pending absorbs ⇒ nothing drains"
+            );
+        }
+    }
 }

--- a/crates/node/src/join_namespace.rs
+++ b/crates/node/src/join_namespace.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use calimero_context::governance_broadcast::ns_topic;
-use calimero_context::group_store::{self, NamespaceGovernance};
+use calimero_context::group_store::NamespaceGovernance;
 use calimero_context::group_store::{MembershipRepository, MetaRepository, NamespaceRepository};
 use calimero_context_client::local_governance::{
     AckRouter, NamespaceOp, NamespaceTopicMsg, ReadinessProbe, RootOp,

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -377,7 +377,7 @@ impl NodeState {
         context_id: &ContextId,
     ) -> Option<calimero_node_primitives::delta_buffer::BufferedDelta> {
         let mut entry = self.governance_pending.get_mut(context_id)?;
-        let popped = entry.pop_front();
+
         // Don't remove the now-empty VecDeque here. A previous version of
         // this code did `drop(entry); remove(context_id)`, which had a
         // race: a concurrent `buffer_governance_pending` could insert a
@@ -388,7 +388,7 @@ impl NodeState {
         // accumulation ever matters, a periodic GC pass that holds the
         // entry-write-lock and `remove_if(|q| q.is_empty())` is the
         // race-free way to clean up.
-        popped
+        entry.pop_front()
     }
 
     /// Returns the current length of the governance-pending buffer for a

--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -159,7 +159,7 @@ fn verify_fetched_parent(
     // check on the catchup path even though gossip rejects it.
     // Mirror the gate `apply_authorized_state_delta` uses.
     if NamespaceRepository::new(datastore)
-        .is_read_only_for_context(&context_id, &fetched.author_id)
+        .is_read_only_for_context(context_id, &fetched.author_id)
         .unwrap_or(false)
     {
         warn!(

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1568,7 +1568,7 @@ impl SyncManager {
             .context_client
             .datastore_handle()
             .get(&calimero_store::key::ContextResyncRequested::new(
-                context_id.into(),
+                context_id,
             ))?
             .is_some();
 

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -1062,7 +1062,7 @@ impl SyncManager {
                 Ok(other) => {
                     let detail = format!(
                         "unexpected response variant: {:?}",
-                        other.as_ref().map(|m| std::mem::discriminant(m))
+                        other.as_ref().map(std::mem::discriminant)
                     );
                     debug!(
                         namespace_id = %hex::encode(params.namespace_id),

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -213,10 +213,7 @@ fn test_max_depth_calculation() {
 
         assert!(
             max_depth >= expected_min_depth,
-            "entity_count={} should have max_depth >= {}, got {}",
-            entity_count,
-            expected_min_depth,
-            max_depth
+            "entity_count={entity_count} should have max_depth >= {expected_min_depth}, got {max_depth}"
         );
     }
 }

--- a/crates/node/src/sync/network/mock.rs
+++ b/crates/node/src/sync/network/mock.rs
@@ -267,8 +267,7 @@ impl MockSyncNetwork {
         }
         if open_stream_remaining > 0 {
             panic!(
-                "MockSyncNetwork: {} unconsumed `open_stream` responses queued",
-                open_stream_remaining
+                "MockSyncNetwork: {open_stream_remaining} unconsumed `open_stream` responses queued"
             );
         }
     }

--- a/crates/node/src/sync/parent_pull.rs
+++ b/crates/node/src/sync/parent_pull.rs
@@ -164,7 +164,7 @@ mod tests {
                     assert_eq!(&p, expected, "scheduler returned wrong peer");
                     budget.record_attempt(p);
                 }
-                other => panic!("expected Peer, got {:?}", other),
+                other => panic!("expected Peer, got {other:?}"),
             }
         }
 

--- a/crates/node/src/sync/peers.rs
+++ b/crates/node/src/sync/peers.rs
@@ -275,7 +275,6 @@ mod tests {
 
     use super::*;
     use crate::sync::network::mock::MockSyncNetwork;
-    use crate::sync::state_access_mock::MockSyncStateAccess;
 
     fn ctx(byte: u8) -> ContextId {
         ContextId::from([byte; 32])

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -530,7 +530,7 @@ pub(crate) async fn dispatch_deferred_root_merges(
         // so the merged write is strictly newer than either input
         // — necessary for the next sync round's LWW comparisons to
         // resolve consistently.
-        let existing_ts: u64 = (*existing_metadata.updated_at).into();
+        let existing_ts: u64 = *existing_metadata.updated_at;
         let incoming_ts: u64 = *incoming_hlc_ts;
 
         let request = MergeRootStateRequest {

--- a/crates/node/src/sync/snapshot.rs
+++ b/crates/node/src/sync/snapshot.rs
@@ -2030,7 +2030,7 @@ fn settle_snapshot_activation(
     };
 
     let mut handle = store.handle();
-    let resync_key = calimero_store::key::ContextResyncRequested::new(context_id.into());
+    let resync_key = calimero_store::key::ContextResyncRequested::new(context_id);
     // Non-resync snapshots (bootstrap, crash recovery) leave the binding to the
     // lazy gate — see the doc above.
     if !matches!(handle.get(&resync_key), Ok(Some(()))) {
@@ -2044,7 +2044,7 @@ fn settle_snapshot_activation(
         warn!(%context_id, %err, "failed to clear resync marker after snapshot");
     }
     if let Err(err) = handle.delete(&calimero_store::key::ContextMigrationFailed::new(
-        context_id.into(),
+        context_id,
     )) {
         warn!(%context_id, %err, "failed to clear migration-failed marker after resync");
     }
@@ -2724,12 +2724,12 @@ mod tests {
         let mut handle = store.handle();
         handle
             .put(
-                &key::ContextMigrationFailed::new(ctx.into()),
+                &key::ContextMigrationFailed::new(ctx),
                 &ContextMigrationFailed { kind: 3 },
             )
             .unwrap();
         handle
-            .put(&key::ContextResyncRequested::new(ctx.into()), &())
+            .put(&key::ContextResyncRequested::new(ctx), &())
             .unwrap();
         drop(handle);
 
@@ -2743,14 +2743,14 @@ mod tests {
         let handle = store.handle();
         assert!(
             handle
-                .get(&key::ContextMigrationFailed::new(ctx.into()))
+                .get(&key::ContextMigrationFailed::new(ctx))
                 .unwrap()
                 .is_none(),
             "stranded marker must be cleared"
         );
         assert!(
             handle
-                .get(&key::ContextResyncRequested::new(ctx.into()))
+                .get(&key::ContextResyncRequested::new(ctx))
                 .unwrap()
                 .is_none(),
             "resync marker must be cleared"
@@ -2802,7 +2802,7 @@ mod tests {
         // Resync marker set ⇒ heal returns the namespace root to refresh.
         store
             .handle()
-            .put(&key::ContextResyncRequested::new(ctx.into()), &())
+            .put(&key::ContextResyncRequested::new(ctx), &())
             .unwrap();
         assert_eq!(
             settle_snapshot_activation(&store, ctx, None),
@@ -2911,7 +2911,7 @@ mod tests {
         register_context_in_group(&store, &gid, &ctx).unwrap();
         store
             .handle()
-            .put(&key::ContextResyncRequested::new(ctx.into()), &())
+            .put(&key::ContextResyncRequested::new(ctx), &())
             .unwrap();
 
         settle_snapshot_activation(&store, ctx, Some(BEHIND_KEY));
@@ -2963,12 +2963,12 @@ mod tests {
         let mut handle = store.handle();
         handle
             .put(
-                &key::ContextMeta::new(ctx.into()),
+                &key::ContextMeta::new(ctx),
                 &ContextMeta::new(key::ApplicationMeta::new(old_app), [0u8; 32], vec![], None),
             )
             .unwrap();
         handle
-            .put(&key::ContextResyncRequested::new(ctx.into()), &())
+            .put(&key::ContextResyncRequested::new(ctx), &())
             .unwrap();
         drop(handle);
 
@@ -2976,7 +2976,7 @@ mod tests {
 
         let meta = store
             .handle()
-            .get(&key::ContextMeta::new(ctx.into()))
+            .get(&key::ContextMeta::new(ctx))
             .unwrap()
             .unwrap();
         assert_eq!(

--- a/crates/node/tests/dag_persistence.rs
+++ b/crates/node/tests/dag_persistence.rs
@@ -76,7 +76,7 @@ fn test_dag_state_serialization() {
 
     // Serialize
     let serialized = state.serialize().unwrap();
-    assert!(serialized.len() > 0);
+    assert!(!serialized.is_empty());
 
     // Deserialize
     let deserialized = PersistedDagState::deserialize(&serialized).unwrap();

--- a/crates/node/tests/dag_storage_integration.rs
+++ b/crates/node/tests/dag_storage_integration.rs
@@ -462,7 +462,7 @@ async fn test_dag_storage_deep_chain_out_of_order() {
         .map(|i| {
             let action = Action::Update {
                 id: ids[i - 1],
-                data: format!("value {}", i).into_bytes(),
+                data: format!("value {i}").into_bytes(),
                 ancestors: vec![],
                 metadata: Metadata::default(),
             };
@@ -486,7 +486,7 @@ async fn test_dag_storage_deep_chain_out_of_order() {
     // Verify storage has correct final state
     for i in 1..=10 {
         let stored = Interface::<MainStorage>::get(ids[i - 1]).unwrap();
-        assert_eq!(stored, format!("value {}", i).as_bytes());
+        assert_eq!(stored, format!("value {i}").as_bytes());
     }
 
     assert_eq!(dag.pending_stats().count, 0);
@@ -583,7 +583,7 @@ async fn test_dag_storage_stress_many_deltas() {
     for i in 1..=100 {
         let action = Action::Update {
             id,
-            data: format!("version {}", i).into_bytes(),
+            data: format!("version {i}").into_bytes(),
             ancestors: vec![],
             metadata: Metadata::new(i as u64, i as u64),
         };

--- a/crates/node/tests/network_simulation.rs
+++ b/crates/node/tests/network_simulation.rs
@@ -181,7 +181,7 @@ impl MockNetwork {
                                 parents: msg.parent_ids.clone(),
                                 payload: actions,
                                 hlc: calimero_storage::env::hlc_timestamp(),
-                                expected_root_hash: msg.root_hash.into(),
+                                expected_root_hash: msg.root_hash,
                                 kind: calimero_dag::DeltaKind::Regular,
                             };
 
@@ -489,7 +489,7 @@ async fn test_concurrent_broadcasts_from_multiple_peers() {
     // Create 5 peers
     let peers: Vec<_> = (0..5)
         .map(|i| {
-            let peer = MockPeer::new(&format!("peer_{}", i), i * 5);
+            let peer = MockPeer::new(&format!("peer_{i}"), i * 5);
             network.add_peer(peer.clone());
             peer
         })
@@ -497,14 +497,14 @@ async fn test_concurrent_broadcasts_from_multiple_peers() {
 
     // All subscribe
     for i in 0..5 {
-        network.subscribe(&format!("peer_{}", i), context_id).await;
+        network.subscribe(&format!("peer_{i}"), context_id).await;
     }
 
     // All peers broadcast concurrently
     for (i, peer) in peers.iter().enumerate() {
         let storage_delta = StorageDelta::Actions(vec![]);
         let artifact = borsh::to_vec(&storage_delta).unwrap();
-        let peer_id = format!("peer_{}", i);
+        let peer_id = format!("peer_{i}");
 
         network
             .broadcast(
@@ -525,7 +525,7 @@ async fn test_concurrent_broadcasts_from_multiple_peers() {
     // Each peer should receive 4 deltas (all except own)
     for (i, peer) in peers.iter().enumerate() {
         let received = peer.received_deltas.lock().await;
-        assert_eq!(received.len(), 4, "Peer {} should receive 4 deltas", i);
+        assert_eq!(received.len(), 4, "Peer {i} should receive 4 deltas");
     }
 }
 

--- a/crates/node/tests/sync_compliance/builtin_merge.rs
+++ b/crates/node/tests/sync_compliance/builtin_merge.rs
@@ -268,8 +268,7 @@ fn test_invalid_gcounter_returns_serialization_error() {
 
     assert!(
         matches!(result, Err(MergeError::SerializationError(_))),
-        "Invalid GCounter bytes should return SerializationError, got {:?}",
-        result
+        "Invalid GCounter bytes should return SerializationError, got {result:?}"
     );
 }
 
@@ -283,8 +282,7 @@ fn test_invalid_rga_returns_serialization_error() {
 
     assert!(
         matches!(result, Err(MergeError::SerializationError(_))),
-        "Invalid RGA bytes should return SerializationError, got {:?}",
-        result
+        "Invalid RGA bytes should return SerializationError, got {result:?}"
     );
 }
 
@@ -310,8 +308,7 @@ fn test_all_builtin_types_classification() {
     for crdt_type in &builtin_types {
         assert!(
             is_builtin_crdt(crdt_type),
-            "{:?} should be builtin",
-            crdt_type
+            "{crdt_type:?} should be builtin"
         );
     }
 
@@ -356,7 +353,7 @@ fn test_builtin_merge_behavior_summary() {
 
     for crdt_type in &return_incoming {
         let result = merge_by_crdt_type(crdt_type, &existing, &incoming).unwrap();
-        assert_eq!(result, incoming, "{:?} should return incoming", crdt_type);
+        assert_eq!(result, incoming, "{crdt_type:?} should return incoming");
     }
 
     // FrozenStorage returns existing

--- a/crates/node/tests/sync_compliance/crdt_dispatch.rs
+++ b/crates/node/tests/sync_compliance/crdt_dispatch.rs
@@ -70,8 +70,7 @@ fn test_various_crdt_types_preserved() {
 
         assert!(
             node.storage().has_entity(Id::new(entity_id.0)),
-            "Entity with {:?} should be stored",
-            crdt_type
+            "Entity with {crdt_type:?} should be stored"
         );
     }
 }
@@ -160,7 +159,7 @@ fn test_custom_type_returns_wasm_required() {
         Err(MergeError::WasmRequired { type_name }) => {
             assert_eq!(type_name, "MyApp::Counter", "Type name should be preserved");
         }
-        other => panic!("Expected WasmRequired, got {:?}", other),
+        other => panic!("Expected WasmRequired, got {other:?}"),
     }
 }
 
@@ -176,12 +175,11 @@ fn test_collection_types_return_incoming() {
         CrdtType::vector("u64"),
     ] {
         let result = merge_by_crdt_type(&crdt_type, &existing, &incoming);
-        assert!(result.is_ok(), "{:?} should succeed", crdt_type);
+        assert!(result.is_ok(), "{crdt_type:?} should succeed");
         assert_eq!(
             result.unwrap(),
             incoming,
-            "{:?} should return incoming",
-            crdt_type
+            "{crdt_type:?} should return incoming"
         );
     }
 }
@@ -196,7 +194,6 @@ fn test_corrupted_data_returns_serialization_error() {
 
     assert!(
         matches!(result, Err(MergeError::SerializationError(_))),
-        "Corrupted data should return SerializationError, got {:?}",
-        result
+        "Corrupted data should return SerializationError, got {result:?}"
     );
 }

--- a/crates/node/tests/sync_scenarios/protocol_dispatch.rs
+++ b/crates/node/tests/sync_scenarios/protocol_dispatch.rs
@@ -188,13 +188,11 @@ fn test_protocol_selection_critical_invariants_with_manager_handshakes() {
         // CRITICAL: has_state must match
         assert_eq!(
             sim_hs_a.has_state, mgr_hs_a.has_state,
-            "has_state mismatch for {} (local)",
-            name
+            "has_state mismatch for {name} (local)"
         );
         assert_eq!(
             sim_hs_b.has_state, mgr_hs_b.has_state,
-            "has_state mismatch for {} (remote)",
-            name
+            "has_state mismatch for {name} (remote)"
         );
 
         let sim_selection = select_protocol(&sim_hs_a, &sim_hs_b);
@@ -214,8 +212,7 @@ fn test_protocol_selection_critical_invariants_with_manager_handshakes() {
         if mgr_hs_a.has_state {
             assert!(
                 !matches!(mgr_selection.protocol, SyncProtocol::Snapshot { .. }),
-                "I5 VIOLATION: Snapshot selected for initialized node in '{}'",
-                name
+                "I5 VIOLATION: Snapshot selected for initialized node in '{name}'"
             );
         }
     }
@@ -375,8 +372,7 @@ fn test_all_selections_have_reasons() {
 
         assert!(
             !selection.reason.is_empty(),
-            "Selection for '{}' has empty reason",
-            name
+            "Selection for '{name}' has empty reason"
         );
         assert!(
             selection.reason.len() > 5,

--- a/crates/node/tests/sync_sim/assertions.rs
+++ b/crates/node/tests/sync_sim/assertions.rs
@@ -267,8 +267,7 @@ mod tests {
         let div = divergence_percentage(&a, &b);
         assert!(
             (div - 1.0).abs() < 0.001,
-            "Expected 100% divergence for conflicting content, got {}",
-            div
+            "Expected 100% divergence for conflicting content, got {div}"
         );
     }
 

--- a/crates/node/tests/sync_sim/network/partition.rs
+++ b/crates/node/tests/sync_sim/network/partition.rs
@@ -73,7 +73,7 @@ impl ActivePartition {
     /// Check if this partition is active at the given time.
     fn is_active_at(&self, now: SimTime) -> bool {
         let started = self.start_time <= now;
-        let not_ended = self.end_time.map_or(true, |end| end > now);
+        let not_ended = self.end_time.is_none_or(|end| end > now);
         started && not_ended
     }
 }
@@ -125,7 +125,7 @@ impl PartitionManager {
     pub fn is_partitioned(&mut self, from: &NodeId, to: &NodeId, now: SimTime) -> bool {
         // Remove fully expired partitions (end_time has passed)
         self.partitions
-            .retain(|p| p.end_time.map_or(true, |end| end > now));
+            .retain(|p| p.end_time.is_none_or(|end| end > now));
 
         // Check each partition that is active at this time
         for partition in &self.partitions {

--- a/crates/node/tests/sync_sim/network/router.rs
+++ b/crates/node/tests/sync_sim/network/router.rs
@@ -194,7 +194,7 @@ impl NetworkRouter {
             } else {
                 0
             };
-            delivery_delay = delivery_delay + SimDuration::from_micros(reorder_delay_micros as u64);
+            delivery_delay += SimDuration::from_micros(reorder_delay_micros as u64);
         }
 
         let delivery_time = now + delivery_delay;
@@ -444,8 +444,8 @@ mod tests {
         // So delays should be between 10ms and 60ms
         for time in &delivery_times {
             let delay_ms = time.as_millis();
-            assert!(delay_ms >= 10, "delay {} should be >= 10", delay_ms);
-            assert!(delay_ms <= 60, "delay {} should be <= 60", delay_ms);
+            assert!(delay_ms >= 10, "delay {delay_ms} should be >= 10");
+            assert!(delay_ms <= 60, "delay {delay_ms} should be <= 60");
         }
     }
 }

--- a/crates/node/tests/sync_sim/node/state.rs
+++ b/crates/node/tests/sync_sim/node/state.rs
@@ -548,9 +548,8 @@ impl SimNode {
         let orphan_count = self.buffered_operations.len();
         debug_assert!(
             orphan_count == 0,
-            "Found {} orphaned buffered operations (delta_id not in delta_buffer). \
-             This indicates a bug in the buffering logic.",
-            orphan_count
+            "Found {orphan_count} orphaned buffered operations (delta_id not in delta_buffer). \
+             This indicates a bug in the buffering logic."
         );
 
         // Clear any remaining orphaned operations (graceful degradation in release)
@@ -1177,10 +1176,9 @@ mod tests {
         assert_eq!(real, 3, "Should have 3 real entities");
         assert!(
             total > 3,
-            "Tree should have intermediate nodes: got {}",
-            total
+            "Tree should have intermediate nodes: got {total}"
         );
-        assert!(depth > 1, "Tree should have depth > 1: got {}", depth);
+        assert!(depth > 1, "Tree should have depth > 1: got {depth}");
 
         // iter_entities should only return the 3 real entities
         let entities: Vec<_> = node.iter_entities().collect();
@@ -1239,9 +1237,7 @@ mod tests {
         assert_eq!(real, 2);
         assert!(
             total_after_second < total_after_first + 4,
-            "Should reuse intermediate nodes: first={}, second={}",
-            total_after_first,
-            total_after_second
+            "Should reuse intermediate nodes: first={total_after_first}, second={total_after_second}"
         );
     }
 }

--- a/crates/node/tests/sync_sim/runtime/clock.rs
+++ b/crates/node/tests/sync_sim/runtime/clock.rs
@@ -101,7 +101,7 @@ impl fmt::Display for SimTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let millis = self.as_millis();
         if millis < 1000 {
-            write!(f, "{}ms", millis)
+            write!(f, "{millis}ms")
         } else {
             write!(f, "{:.2}s", millis as f64 / 1000.0)
         }
@@ -183,7 +183,7 @@ impl fmt::Display for SimDuration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let millis = self.as_millis();
         if millis < 1000 {
-            write!(f, "{}ms", millis)
+            write!(f, "{millis}ms")
         } else {
             write!(f, "{:.2}s", millis as f64 / 1000.0)
         }

--- a/crates/node/tests/sync_sim/scenarios/buffering.rs
+++ b/crates/node/tests/sync_sim/scenarios/buffering.rs
@@ -235,7 +235,7 @@ mod tests {
         // But for this test, we'll use different entities to verify order
         for i in 1..=5 {
             let delta_id = delta_id_from_u64(i);
-            let operations = vec![make_insert_op(100 + i, &format!("delta_{}", i))];
+            let operations = vec![make_insert_op(100 + i, &format!("delta_{i}"))];
             rt.schedule_gossip_delta(
                 node_id.clone(),
                 delta_id,
@@ -280,7 +280,7 @@ mod tests {
             let entity = node.get_entity(&EntityId::from_u64(100 + i)).unwrap();
             assert_eq!(
                 entity.data,
-                format!("delta_{}", i).as_bytes(),
+                format!("delta_{i}").as_bytes(),
                 "Entity {} should have value from delta {} (FIFO order)",
                 100 + i,
                 i
@@ -310,7 +310,7 @@ mod tests {
             // All write to entity 999
             let operations = vec![StorageOp::Update {
                 id: EntityId::from_u64(999),
-                data: format!("value_{}", i).into_bytes(),
+                data: format!("value_{i}").into_bytes(),
                 metadata: EntityMetadata::new(CrdtType::lww_register("test"), i * 100),
             }];
             rt.schedule_gossip_delta(
@@ -417,7 +417,7 @@ mod tests {
         for i in 0..10 {
             source.insert_entity(
                 EntityId::from_u64(i),
-                format!("initial_{}", i).into_bytes(),
+                format!("initial_{i}").into_bytes(),
                 CrdtType::lww_register("test"),
             );
         }
@@ -448,7 +448,7 @@ mod tests {
         // (These arrive during sync and must be buffered)
         for i in 10..15 {
             let delta_id = delta_id_from_u64(i);
-            let data = format!("concurrent_{}", i).into_bytes();
+            let data = format!("concurrent_{i}").into_bytes();
             // Use consistent metadata for both source and fresh
             let metadata = EntityMetadata::new(CrdtType::lww_register("test"), i * 100);
             let operations = vec![StorageOp::Insert {
@@ -521,7 +521,7 @@ mod tests {
         // Send 5 deltas - should overflow buffer, evicting oldest 2
         for i in 1..=5 {
             let delta_id = delta_id_from_u64(i);
-            let operations = vec![make_insert_op(i, &format!("delta_{}", i))];
+            let operations = vec![make_insert_op(i, &format!("delta_{i}"))];
             rt.schedule_gossip_delta(
                 node_id.clone(),
                 delta_id,
@@ -602,7 +602,7 @@ mod tests {
         // Send 10 deltas - should cause 8 evictions
         for i in 1..=10 {
             let delta_id = delta_id_from_u64(i);
-            let operations = vec![make_insert_op(i, &format!("delta_{}", i))];
+            let operations = vec![make_insert_op(i, &format!("delta_{i}"))];
             rt.schedule_gossip_delta(
                 node_id.clone(),
                 delta_id,
@@ -647,7 +647,7 @@ mod tests {
         // Send 5 deltas - all should be dropped
         for i in 1..=5 {
             let delta_id = delta_id_from_u64(i);
-            let operations = vec![make_insert_op(i, &format!("delta_{}", i))];
+            let operations = vec![make_insert_op(i, &format!("delta_{i}"))];
             rt.schedule_gossip_delta(
                 node_id.clone(),
                 delta_id,

--- a/crates/node/tests/sync_sim/scenarios/deterministic.rs
+++ b/crates/node/tests/sync_sim/scenarios/deterministic.rs
@@ -30,7 +30,7 @@ pub fn generate_entities(count: usize, seed: u64) -> Vec<(EntityId, Vec<u8>, Ent
     (0..count)
         .map(|i| {
             let id = EntityId::from_u64(seed * 10000 + i as u64);
-            let data = format!("entity-{}-{}", seed, i).into_bytes();
+            let data = format!("entity-{seed}-{i}").into_bytes();
             let metadata = EntityMetadata::new(CrdtType::lww_register("test"), i as u64 * 100);
             (id, data, metadata)
         })
@@ -65,7 +65,7 @@ pub fn generate_deep_tree_entities(
             key[24..32].copy_from_slice(&(seed + i as u64).to_le_bytes());
 
             let id = EntityId::from_bytes(key);
-            let data = format!("deep-entity-{}-{}", seed, i).into_bytes();
+            let data = format!("deep-entity-{seed}-{i}").into_bytes();
             let metadata = EntityMetadata::new(CrdtType::lww_register("test"), i as u64 * 100);
             (id, data, metadata)
         })
@@ -82,7 +82,7 @@ pub fn generate_shallow_wide_tree(
     seed: u64,
 ) -> Vec<(EntityId, Vec<u8>, EntityMetadata)> {
     assert!(
-        depth >= 1 && depth <= 2,
+        (1..=2).contains(&depth),
         "shallow tree depth must be 1 or 2"
     );
 
@@ -97,7 +97,7 @@ pub fn generate_shallow_wide_tree(
             key[24..32].copy_from_slice(&(seed + i as u64).to_le_bytes());
 
             let id = EntityId::from_bytes(key);
-            let data = format!("shallow-entity-{}-{}", seed, i).into_bytes();
+            let data = format!("shallow-entity-{seed}-{i}").into_bytes();
             let metadata = EntityMetadata::new(CrdtType::lww_register("test"), i as u64 * 100);
             (id, data, metadata)
         })
@@ -350,7 +350,7 @@ impl Scenario {
 
         (0..n)
             .map(|i| {
-                let mut node = SimNode::new(format!("node-{}", i));
+                let mut node = SimNode::new(format!("node-{i}"));
                 for (id, data, metadata) in &entities {
                     node.insert_entity_with_metadata(*id, data.clone(), metadata.clone());
                 }
@@ -363,7 +363,7 @@ impl Scenario {
     pub fn n_nodes_diverged(n: usize) -> Vec<SimNode> {
         (0..n)
             .map(|i| {
-                let mut node = SimNode::new(format!("node-{}", i));
+                let mut node = SimNode::new(format!("node-{i}"));
                 for (id, data, metadata) in generate_entities(50, i as u64 + 1) {
                     node.insert_entity_with_metadata(id, data, metadata);
                 }
@@ -464,8 +464,7 @@ mod tests {
 
         assert!(
             depth_b > 3,
-            "SubtreePrefetch scenario should have max_depth > 3, got {}",
-            depth_b
+            "SubtreePrefetch scenario should have max_depth > 3, got {depth_b}"
         );
 
         // Both nodes should have similar depth (deep tree structure)
@@ -487,9 +486,7 @@ mod tests {
 
         assert!(
             depth_a <= 2 && depth_b <= 2,
-            "LevelWise scenario should have max_depth <= 2, got a={}, b={}",
-            depth_a,
-            depth_b
+            "LevelWise scenario should have max_depth <= 2, got a={depth_a}, b={depth_b}"
         );
     }
 
@@ -511,8 +508,7 @@ mod tests {
         // With depth parameter 5, we should get meaningful depth > 3
         assert!(
             depth > 3,
-            "Deep tree entities should produce depth > 3, got {}",
-            depth
+            "Deep tree entities should produce depth > 3, got {depth}"
         );
     }
 
@@ -534,8 +530,7 @@ mod tests {
         // Shallow tree should have depth <= 2
         assert!(
             depth <= 2,
-            "Shallow tree entities should produce depth <= 2, got {}",
-            depth
+            "Shallow tree entities should produce depth <= 2, got {depth}"
         );
     }
 
@@ -554,9 +549,7 @@ mod tests {
         // Deep tree should have higher depth than shallow tree
         assert!(
             deep_depth > shallow_depth,
-            "Deep tree depth ({}) should be > shallow tree depth ({})",
-            deep_depth,
-            shallow_depth
+            "Deep tree depth ({deep_depth}) should be > shallow tree depth ({shallow_depth})"
         );
     }
 }

--- a/crates/node/tests/sync_sim/scenarios/hash_comparison.rs
+++ b/crates/node/tests/sync_sim/scenarios/hash_comparison.rs
@@ -46,7 +46,7 @@ fn test_tree_traversal_basic() {
     // Alice has entities 1-10
     for i in 1..=10 {
         let id = EntityId::from_u64(i);
-        let data = format!("alice-entity-{}", i).into_bytes();
+        let data = format!("alice-entity-{i}").into_bytes();
         let metadata = EntityMetadata::new(CrdtType::lww_register("test"), i * 100);
         alice.insert_entity_with_metadata(id, data, metadata);
     }
@@ -54,7 +54,7 @@ fn test_tree_traversal_basic() {
     // Bob has entities 5-15 (overlapping 5-10)
     for i in 5..=15 {
         let id = EntityId::from_u64(i);
-        let data = format!("bob-entity-{}", i).into_bytes();
+        let data = format!("bob-entity-{i}").into_bytes();
         let metadata = EntityMetadata::new(CrdtType::lww_register("test"), i * 100 + 50);
         bob.insert_entity_with_metadata(id, data, metadata);
     }
@@ -170,13 +170,13 @@ fn test_partial_overlap_merge() {
 
         alice.insert_entity_with_metadata(
             id,
-            format!("shared-alice-{}", i).into_bytes(),
+            format!("shared-alice-{i}").into_bytes(),
             EntityMetadata::new(CrdtType::lww_register("test"), i * 100),
         );
 
         bob.insert_entity_with_metadata(
             id,
-            format!("shared-bob-{}", i).into_bytes(),
+            format!("shared-bob-{i}").into_bytes(),
             EntityMetadata::new(CrdtType::lww_register("test"), i * 100 + 50), // Newer
         );
     }
@@ -186,7 +186,7 @@ fn test_partial_overlap_merge() {
         let id = EntityId::from_u64(i);
         alice.insert_entity_with_metadata(
             id,
-            format!("alice-only-{}", i).into_bytes(),
+            format!("alice-only-{i}").into_bytes(),
             EntityMetadata::new(CrdtType::lww_register("test"), i * 100),
         );
     }
@@ -196,7 +196,7 @@ fn test_partial_overlap_merge() {
         let id = EntityId::from_u64(i);
         bob.insert_entity_with_metadata(
             id,
-            format!("bob-only-{}", i).into_bytes(),
+            format!("bob-only-{i}").into_bytes(),
             EntityMetadata::new(CrdtType::lww_register("test"), i * 100),
         );
     }
@@ -228,7 +228,7 @@ fn test_divergent_subtrees_only() {
     // Identical prefix: entities 1-10 (same on both)
     for i in 1..=10 {
         let id = EntityId::from_u64(i);
-        let data = format!("shared-{}", i).into_bytes();
+        let data = format!("shared-{i}").into_bytes();
         let metadata = EntityMetadata::new(CrdtType::lww_register("test"), i * 100);
 
         alice.insert_entity_with_metadata(id, data.clone(), metadata.clone());
@@ -240,7 +240,7 @@ fn test_divergent_subtrees_only() {
         let id = EntityId::from_u64(i);
         alice.insert_entity_with_metadata(
             id,
-            format!("alice-{}", i).into_bytes(),
+            format!("alice-{i}").into_bytes(),
             EntityMetadata::new(CrdtType::lww_register("test"), i * 100),
         );
     }
@@ -249,7 +249,7 @@ fn test_divergent_subtrees_only() {
         let id = EntityId::from_u64(i);
         bob.insert_entity_with_metadata(
             id,
-            format!("bob-{}", i).into_bytes(),
+            format!("bob-{i}").into_bytes(),
             EntityMetadata::new(CrdtType::lww_register("test"), i * 100),
         );
     }
@@ -321,8 +321,7 @@ fn test_empty_tree_handling() {
 
     assert!(
         matches!(protocol, SelectedProtocol::Snapshot { .. }),
-        "Fresh node should use Snapshot, got {:?}",
-        protocol
+        "Fresh node should use Snapshot, got {protocol:?}"
     );
 
     // But we can force HashComparison for testing edge case

--- a/crates/node/tests/sync_sim/scenarios/levelwise.rs
+++ b/crates/node/tests/sync_sim/scenarios/levelwise.rs
@@ -79,13 +79,11 @@ fn test_wide_shallow_tree_sync() {
 
     assert!(
         alice_depth <= 2,
-        "Alice should have shallow tree, got depth {}",
-        alice_depth
+        "Alice should have shallow tree, got depth {alice_depth}"
     );
     assert!(
         bob_depth <= 2,
-        "Bob should have shallow tree, got depth {}",
-        bob_depth
+        "Bob should have shallow tree, got depth {bob_depth}"
     );
 }
 
@@ -234,7 +232,7 @@ fn test_only_differing_subtrees() {
     // Shared entities (identical on both)
     for i in 1..=10 {
         let id = EntityId::from_u64(i);
-        let data = format!("shared-{}", i).into_bytes();
+        let data = format!("shared-{i}").into_bytes();
         let metadata = EntityMetadata::new(CrdtType::lww_register("test"), i * 100);
 
         alice.insert_entity_with_metadata(id, data.clone(), metadata.clone());
@@ -246,7 +244,7 @@ fn test_only_differing_subtrees() {
         let id = EntityId::from_u64(i);
         alice.insert_entity_with_metadata(
             id,
-            format!("alice-{}", i).into_bytes(),
+            format!("alice-{i}").into_bytes(),
             EntityMetadata::new(CrdtType::lww_register("test"), i * 100),
         );
     }
@@ -255,7 +253,7 @@ fn test_only_differing_subtrees() {
         let id = EntityId::from_u64(i);
         bob.insert_entity_with_metadata(
             id,
-            format!("bob-{}", i).into_bytes(),
+            format!("bob-{i}").into_bytes(),
             EntityMetadata::new(CrdtType::lww_register("test"), i * 100),
         );
     }
@@ -313,7 +311,7 @@ fn test_thousand_children_level() {
     // Create trees with 1000+ entities
     for i in 0..1000 {
         let id = EntityId::from_u64(i);
-        let data = format!("entity-{}", i).into_bytes();
+        let data = format!("entity-{i}").into_bytes();
         let metadata = EntityMetadata::new(CrdtType::lww_register("test"), i * 10);
 
         alice.insert_entity_with_metadata(id, data.clone(), metadata.clone());
@@ -326,7 +324,7 @@ fn test_thousand_children_level() {
     // Bob has some unique entities
     for i in 1000..1100 {
         let id = EntityId::from_u64(i);
-        let data = format!("bob-unique-{}", i).into_bytes();
+        let data = format!("bob-unique-{i}").into_bytes();
         let metadata = EntityMetadata::new(CrdtType::lww_register("test"), i * 10);
         bob.insert_entity_with_metadata(id, data, metadata);
     }
@@ -365,8 +363,7 @@ fn test_empty_tree_handling() {
 
     assert!(
         matches!(protocol, SelectedProtocol::Snapshot { .. }),
-        "Fresh node should use Snapshot, got {:?}",
-        protocol
+        "Fresh node should use Snapshot, got {protocol:?}"
     );
 
     // But we can force LevelWise for testing edge case
@@ -485,13 +482,11 @@ mod protocol_selection_tests {
 
         assert!(
             depth_a <= 2,
-            "force_levelwise should produce depth <= 2, got {}",
-            depth_a
+            "force_levelwise should produce depth <= 2, got {depth_a}"
         );
         assert!(
             depth_b <= 2,
-            "force_levelwise should produce depth <= 2, got {}",
-            depth_b
+            "force_levelwise should produce depth <= 2, got {depth_b}"
         );
     }
 

--- a/crates/node/tests/sync_sim/scenarios/random.rs
+++ b/crates/node/tests/sync_sim/scenarios/random.rs
@@ -111,7 +111,7 @@ impl RandomScenario {
 
         // Generate nodes
         for i in 0..self.config.node_count {
-            let mut node = SimNode::new(format!("node-{}", i));
+            let mut node = SimNode::new(format!("node-{i}"));
 
             // Check if this node should be fresh
             if self
@@ -233,7 +233,7 @@ impl RandomScenario {
         let mut nodes = Self::new(seed, config).generate();
 
         // Add exactly one fresh node
-        let fresh = SimNode::new(format!("node-{}", existing_count));
+        let fresh = SimNode::new(format!("node-{existing_count}"));
         nodes.push(fresh);
 
         nodes
@@ -362,10 +362,7 @@ mod tests {
             let overlap_ratio = shared as f64 / total as f64;
             assert!(
                 overlap_ratio > 0.3,
-                "overlap ratio {} should be > 0.3 (shared={}, total={})",
-                overlap_ratio,
-                shared,
-                total
+                "overlap ratio {overlap_ratio} should be > 0.3 (shared={shared}, total={total})"
             );
         }
     }
@@ -401,8 +398,7 @@ mod tests {
         let max_diff = counts.iter().max().unwrap() - counts.iter().min().unwrap();
         assert!(
             max_diff <= counts.iter().max().unwrap() / 2,
-            "entity counts {:?} should be similar",
-            counts
+            "entity counts {counts:?} should be similar"
         );
     }
 }

--- a/crates/node/tests/sync_sim/storage.rs
+++ b/crates/node/tests/sync_sim/storage.rs
@@ -258,7 +258,7 @@ impl SimStorage {
         };
 
         let children = index.children();
-        let has_children = children.as_ref().map_or(false, |c| !c.is_empty());
+        let has_children = children.as_ref().is_some_and(|c| !c.is_empty());
 
         if has_children {
             // Internal node: count children recursively
@@ -304,7 +304,7 @@ impl SimStorage {
         };
 
         let children = index.children();
-        if children.is_none() || children.as_ref().map_or(true, |c| c.is_empty()) {
+        if children.is_none() || children.as_ref().is_none_or(|c| c.is_empty()) {
             // Leaf node
             return 1;
         }
@@ -715,10 +715,10 @@ mod tests {
 
         // Verify entity was created
         let count = storage.entity_count();
-        eprintln!("entity_count after update_entity_data: {}", count);
+        eprintln!("entity_count after update_entity_data: {count}");
 
         // Should have at least 2: root + the new entity
-        assert!(count >= 2, "should have root + entity, got {}", count);
+        assert!(count >= 2, "should have root + entity, got {count}");
 
         // Verify data is readable
         let data = storage.get_entity_data(entity_id);
@@ -783,7 +783,7 @@ mod tests {
 
         // Original should be able to read the data written via clone
         let original_data = storage.get_entity_data(entity_id);
-        eprintln!("original sees data: {:?}", original_data);
+        eprintln!("original sees data: {original_data:?}");
         assert_eq!(
             original_data,
             Some(b"hello".to_vec()),

--- a/crates/primitives/src/tests/application.rs
+++ b/crates/primitives/src/tests/application.rs
@@ -45,7 +45,7 @@ fn test_signer_id_display() {
     let signer_id =
         SignerId::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK").unwrap();
     assert_eq!(
-        format!("{}", signer_id),
+        format!("{signer_id}"),
         "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
     );
 }
@@ -176,7 +176,7 @@ fn test_app_key_display() {
     let app_key = AppKey::new("com.example.myapp", signer_id).unwrap();
 
     assert_eq!(
-        format!("{}", app_key),
+        format!("{app_key}"),
         "com.example.myapp:did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
     );
 }

--- a/crates/runtime/examples/demo.rs
+++ b/crates/runtime/examples/demo.rs
@@ -32,7 +32,7 @@ fn parse_payload<const PRETTY: bool>(
         Err(err) => err.into_bytes(),
     };
 
-    Ok(format!("{:?}", payload))
+    Ok(format!("{payload:?}"))
 }
 
 fn main() -> EyreResult<()> {
@@ -76,7 +76,7 @@ fn main() -> EyreResult<()> {
         let outcome = module.run(
             [0; 32].into(),
             [0; 32].into(),
-            &name,
+            name,
             &input,
             &mut storage,
             None, // No private storage for example
@@ -117,7 +117,7 @@ fn main() -> EyreResult<()> {
                 println!("{}:", "Returns".green());
 
                 let payload = returns
-                    .map(|p| parse_payload::<true>(p))
+                    .map(parse_payload::<true>)
                     .transpose()?
                     .unwrap_or_default();
 
@@ -138,7 +138,7 @@ fn main() -> EyreResult<()> {
                     calimero_runtime::errors::FunctionCallError::ExecutionError(payload) => {
                         parse_payload::<true>(payload)?
                     }
-                    _ => format!("{:#?}", err),
+                    _ => format!("{err:#?}"),
                 };
 
                 for line in error.lines() {

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -1070,7 +1070,7 @@ mod tests {
         let host = logic.host_functions(store.as_store_mut());
 
         // Get the memory size - one page is 64KB (65536 bytes)
-        let memory_size = host.borrow_memory().data_size() as u64;
+        let memory_size = host.borrow_memory().data_size();
 
         // Test case 1: ptr + len exceeds memory size
         let data_ptr = memory_size - 10; // 10 bytes before end of memory
@@ -1132,7 +1132,7 @@ mod tests {
         let host = logic.host_functions(store.as_store_mut());
 
         // Get the memory size - one page is 64KB (65536 bytes)
-        let memory_size = host.borrow_memory().data_size() as u64;
+        let memory_size = host.borrow_memory().data_size();
 
         // Test case 1: ptr + len exceeds memory size
         let data_ptr = memory_size - 10; // 10 bytes before end of memory
@@ -1206,7 +1206,7 @@ mod tests {
         assert_eq!(result, test_data);
 
         // Test at the edge of memory (valid access)
-        let memory_size = host.borrow_memory().data_size() as u64;
+        let memory_size = host.borrow_memory().data_size();
         let edge_data = b"edge";
         let edge_ptr = memory_size - edge_data.len() as u64;
         host.borrow_memory().write(edge_ptr, edge_data).unwrap();

--- a/crates/runtime/src/logic/host_functions/blobs.rs
+++ b/crates/runtime/src/logic/host_functions/blobs.rs
@@ -771,7 +771,7 @@ mod tests {
             position: 0,
         };
 
-        let debug_str = format!("{:?}", handle);
+        let debug_str = format!("{handle:?}");
         assert!(debug_str.contains("BlobReadHandle"));
         assert!(debug_str.contains("blob_id"));
         assert!(debug_str.contains("<stream>"));
@@ -789,7 +789,7 @@ mod tests {
             position: 0,
         });
 
-        let debug_str = format!("{:?}", read_handle);
+        let debug_str = format!("{read_handle:?}");
         assert!(debug_str.contains("Read"));
         assert!(debug_str.contains("BlobReadHandle"));
     }

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -706,10 +706,7 @@ mod tests {
         // Verify the storage removal was successful.
         assert_eq!(res, 1);
         // Verify the storage doesn't have a specified key anymore.
-        assert_eq!(
-            host.borrow_logic().storage.has(&key.as_bytes().to_vec()),
-            false
-        );
+        assert!(!host.borrow_logic().storage.has(&key.as_bytes().to_vec()));
         // Verify the removed value was put into the host register.
         assert_eq!(
             host.borrow_logic().registers.get(register_id).unwrap(),
@@ -1084,8 +1081,8 @@ mod tests {
 
         // Write multiple keys.
         for i in 0..5 {
-            let key = format!("key_{}", i);
-            let value = format!("value_{}", i);
+            let key = format!("key_{i}");
+            let value = format!("value_{i}");
 
             let key_ptr = (100 + i * 100) as u64;
             write_str(&host, key_ptr, &key);
@@ -1104,8 +1101,8 @@ mod tests {
 
         // Read all keys and verify values.
         for i in 0..5 {
-            let key = format!("key_{}", i);
-            let expected_value = format!("value_{}", i);
+            let key = format!("key_{i}");
+            let expected_value = format!("value_{i}");
 
             let key_ptr = (100 + i * 100) as u64;
             let key_buf_ptr = (16 + i * 32) as u64;

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -302,8 +302,7 @@ impl VMHostFunctions<'_> {
         self.with_logic_mut(|logic| -> VMLogicResult<()> {
             logic
                 .registers
-                .set(logic.limits, dest_register_id, logic.context.context_id)
-                .map_err(VMLogicError::from)?;
+                .set(logic.limits, dest_register_id, logic.context.context_id)?;
             Ok(())
         })?;
 
@@ -936,10 +935,7 @@ impl VMHostFunctions<'_> {
 
             if let Some(bytes) = maybe_bytes {
                 let value_len = bytes.len();
-                logic
-                    .registers
-                    .set(logic.limits, dest_register_id, bytes)
-                    .map_err(VMLogicError::from)?;
+                logic.registers.set(logic.limits, dest_register_id, bytes)?;
 
                 info!(
                     target: "runtime::host::system",

--- a/crates/runtime/src/logic/host_functions/utility.rs
+++ b/crates/runtime/src/logic/host_functions/utility.rs
@@ -703,8 +703,7 @@ mod tests {
                 // Also valid - some versions of ed25519_dalek reject the identity point.
             }
             other => panic!(
-                "Expected invalid signature (0) or Ed25519IncorrectPublicKey error, got {:?}",
-                other
+                "Expected invalid signature (0) or Ed25519IncorrectPublicKey error, got {other:?}"
             ),
         }
     }

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -395,7 +395,7 @@ impl<'a> TryFrom<StateImplInput<'a>> for StateImpl<'a> {
                 // up front; an enum that models one-of-N belongs inside
                 // `LwwRegister<_>` as a struct field.
                 return Err(errors.finish(SynError::new_spanned(
-                    &item.enum_token,
+                    item.enum_token,
                     ParseError::StateMustBeStruct,
                 )));
             }

--- a/crates/sdk/src/private_storage.rs
+++ b/crates/sdk/src/private_storage.rs
@@ -130,7 +130,7 @@ impl<T> EntryHandle<T> {
         };
 
         let state = T::try_from_slice(&data)
-            .map_err(|e| crate::types::Error::msg(&format!("Failed to deserialize state: {e}")))?;
+            .map_err(|e| crate::types::Error::msg(format!("Failed to deserialize state: {e}")))?;
 
         Ok(Some(EntryRef {
             data: state,
@@ -235,7 +235,7 @@ impl<T> EntryHandle<T> {
             f(&mut entry_mut);
         }
         // Drop of EntryMut writes; explicit save keeps semantics clear.
-        let _ = entry.save()?;
+        entry.save()?;
         Ok(())
     }
 }
@@ -297,7 +297,7 @@ impl<T> EntryRef<T> {
         T: BorshSerialize,
     {
         let data = borsh::to_vec(&self.data)
-            .map_err(|e| crate::types::Error::msg(&format!("Failed to serialize state: {e}")))?;
+            .map_err(|e| crate::types::Error::msg(format!("Failed to serialize state: {e}")))?;
 
         // Use private storage functions (node-local, NOT synchronized)
         let _ = env::private_storage_write(self.key, &data);

--- a/crates/server/build.rs
+++ b/crates/server/build.rs
@@ -179,8 +179,7 @@ fn cached_path_with_retry(cache: &Cache, src: &str, options: &Options) -> eyre::
             Ok(path) => return Ok(path),
             Err(err) => {
                 let report = eyre::Report::new(err).wrap_err(format!(
-                    "failed to fetch CALIMERO_WEBUI_SRC from {src} (attempt {attempt}/{})",
-                    CALIMERO_WEBUI_FETCH_RETRY_ATTEMPTS
+                    "failed to fetch CALIMERO_WEBUI_SRC from {src} (attempt {attempt}/{CALIMERO_WEBUI_FETCH_RETRY_ATTEMPTS})"
                 ));
 
                 if attempt == CALIMERO_WEBUI_FETCH_RETRY_ATTEMPTS {
@@ -206,7 +205,7 @@ fn target_dir() -> eyre::Result<PathBuf> {
 
     while out_dir.pop() {
         if let Some(name) = out_dir.file_name().and_then(|n| n.to_str()) {
-            if profile_names.iter().any(|&pn| pn == name) {
+            if profile_names.contains(&name) {
                 return Ok(out_dir);
             }
         }

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -513,6 +513,12 @@ pub struct UpdateContextApplicationResponse {
     pub data: Empty,
 }
 
+impl Default for UpdateContextApplicationResponse {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl UpdateContextApplicationResponse {
     pub const fn new() -> Self {
         Self { data: Empty {} }
@@ -600,6 +606,12 @@ pub struct CreateAliasResponse {
     pub data: Empty,
 }
 
+impl Default for CreateAliasResponse {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CreateAliasResponse {
     pub const fn new() -> Self {
         Self { data: Empty {} }
@@ -610,6 +622,12 @@ impl CreateAliasResponse {
 #[serde(rename_all = "camelCase")]
 pub struct DeleteAliasResponse {
     pub data: Empty,
+}
+
+impl Default for DeleteAliasResponse {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl DeleteAliasResponse {
@@ -853,6 +871,12 @@ pub struct GrantPermissionResponse {
     pub data: Empty,
 }
 
+impl Default for GrantPermissionResponse {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl GrantPermissionResponse {
     pub const fn new() -> Self {
         Self { data: Empty {} }
@@ -890,6 +914,12 @@ pub struct RevokePermissionResponse {
     pub data: Empty,
 }
 
+impl Default for RevokePermissionResponse {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RevokePermissionResponse {
     pub const fn new() -> Self {
         Self { data: Empty {} }
@@ -900,6 +930,12 @@ impl RevokePermissionResponse {
 #[serde(rename_all = "camelCase")]
 pub struct SyncContextResponse {
     pub data: Empty,
+}
+
+impl Default for SyncContextResponse {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl SyncContextResponse {
@@ -1030,31 +1066,31 @@ impl TryFrom<tdx_quote::Quote> for Quote {
                 version: quote.header.version,
                 attestation_key_type: quote.header.attestation_key_type as u16,
                 tee_type: quote.header.tee_type as u32,
-                qe_vendor_id: hex::encode(&quote.header.qe_vendor_id),
-                user_data: hex::encode(&quote.header.user_data),
+                qe_vendor_id: hex::encode(quote.header.qe_vendor_id),
+                user_data: hex::encode(quote.header.user_data),
             },
             body: QuoteBody {
                 tdx_version: match quote.body.tdx_version {
                     tdx_quote::TDXVersion::One => "1.0".to_string(),
                     tdx_quote::TDXVersion::OnePointFive => "1.5".to_string(),
                 },
-                tee_tcb_svn: hex::encode(&quote.body.tee_tcb_svn),
-                mrseam: hex::encode(&quote.body.mrseam),
-                mrsignerseam: hex::encode(&quote.body.mrsignerseam),
-                seamattributes: hex::encode(&quote.body.seamattributes),
-                tdattributes: hex::encode(&quote.body.tdattributes),
-                xfam: hex::encode(&quote.body.xfam),
+                tee_tcb_svn: hex::encode(quote.body.tee_tcb_svn),
+                mrseam: hex::encode(quote.body.mrseam),
+                mrsignerseam: hex::encode(quote.body.mrsignerseam),
+                seamattributes: hex::encode(quote.body.seamattributes),
+                tdattributes: hex::encode(quote.body.tdattributes),
+                xfam: hex::encode(quote.body.xfam),
                 mrtd,
-                mrconfigid: hex::encode(&quote.body.mrconfigid),
-                mrowner: hex::encode(&quote.body.mrowner),
-                mrownerconfig: hex::encode(&quote.body.mrownerconfig),
+                mrconfigid: hex::encode(quote.body.mrconfigid),
+                mrowner: hex::encode(quote.body.mrowner),
+                mrownerconfig: hex::encode(quote.body.mrownerconfig),
                 rtmr0,
                 rtmr1,
                 rtmr2,
                 rtmr3,
                 reportdata,
-                tee_tcb_svn_2: quote.body.tee_tcb_svn_2.map(|v| hex::encode(&v)),
-                mrservicetd: quote.body.mrservicetd.map(|v| hex::encode(&v)),
+                tee_tcb_svn_2: quote.body.tee_tcb_svn_2.map(hex::encode),
+                mrservicetd: quote.body.mrservicetd.map(hex::encode),
             },
             signature: hex::encode(quote.signature.to_bytes()),
             attestation_key: hex::encode(quote.attestation_key.to_sec1_bytes()),
@@ -1385,9 +1421,8 @@ use crate::validation::{
         validate_bytes_size, validate_hex_string, validate_optional_hex_string,
         validate_optional_string_length, validate_string_length, validate_url,
     },
-    Validate, ValidationError, MAX_INIT_PARAMS_SIZE, MAX_METADATA_SIZE, MAX_METHOD_NAME_LENGTH,
-    MAX_NONCE_LENGTH, MAX_PACKAGE_NAME_LENGTH, MAX_PATH_LENGTH, MAX_QUOTE_B64_LENGTH,
-    MAX_VERSION_LENGTH,
+    Validate, ValidationError, MAX_INIT_PARAMS_SIZE, MAX_METADATA_SIZE, MAX_NONCE_LENGTH,
+    MAX_PACKAGE_NAME_LENGTH, MAX_PATH_LENGTH, MAX_QUOTE_B64_LENGTH, MAX_VERSION_LENGTH,
 };
 
 impl Validate for InstallApplicationRequest {
@@ -2909,8 +2944,8 @@ mod tests {
         let context_id = ContextId::from([0xAA; 32]);
         let member_pk = PublicKey::from([0xBB; 32]);
         let json = serde_json::json!({
-            "contextId": serde_json::to_value(&context_id).unwrap(),
-            "memberPublicKey": serde_json::to_value(&member_pk).unwrap()
+            "contextId": serde_json::to_value(context_id).unwrap(),
+            "memberPublicKey": serde_json::to_value(member_pk).unwrap()
         });
 
         let resp: CreateContextResponseData = serde_json::from_value(json).unwrap();

--- a/crates/server/src/admin/handlers/blob.rs
+++ b/crates/server/src/admin/handlers/blob.rs
@@ -52,7 +52,7 @@ pub struct BlobDeleteResponse {
 fn body_to_async_read(body: Body) -> impl AsyncRead {
     let byte_stream = body
         .into_data_stream()
-        .map(|result| result.map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err)));
+        .map(|result| result.map_err(std::io::Error::other));
 
     StreamReader::new(byte_stream).compat()
 }
@@ -151,7 +151,7 @@ pub async fn upload_handler(
             error!(error=?err, "Failed to upload blob");
             ApiError {
                 status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                message: format!("Failed to store blob: {}", err),
+                message: format!("Failed to store blob: {err}"),
             }
             .into_response()
         }
@@ -286,9 +286,7 @@ pub async fn download_handler(
                 blob_id
             );
 
-            let stream = blob.map(|result| {
-                result.map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))
-            });
+            let stream = blob.map(|result| result.map_err(std::io::Error::other));
 
             build_blob_response_headers(&blob_metadata, blob_id)
                 .body(Body::from_stream(stream))
@@ -309,7 +307,7 @@ pub async fn download_handler(
             tracing::error!("Failed to retrieve blob {}: {:?}", blob_id, err);
             ApiError {
                 status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                message: format!("Failed to retrieve blob: {}", err),
+                message: format!("Failed to retrieve blob: {err}"),
             }
             .into_response()
         }
@@ -360,7 +358,7 @@ pub async fn delete_handler(
             tracing::error!("Failed to delete blob {}: {:?}", blob_id, err);
             ApiError {
                 status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                message: format!("Failed to delete blob: {}", err),
+                message: format!("Failed to delete blob: {err}"),
             }
             .into_response()
         }

--- a/crates/server/src/admin/handlers/tee/attest.rs
+++ b/crates/server/src/admin/handlers/tee/attest.rs
@@ -56,7 +56,7 @@ pub async fn handler(
                 error!(application_id=%application_id, "Application not found");
                 return ApiError {
                     status_code: StatusCode::NOT_FOUND,
-                    message: format!("Application '{}' not found", application_id),
+                    message: format!("Application '{application_id}' not found"),
                 }
                 .into_response();
             }
@@ -64,7 +64,7 @@ pub async fn handler(
                 error!(application_id=%application_id, error=?err, "Failed to get application");
                 return ApiError {
                     status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                    message: format!("Failed to get application: {}", err),
+                    message: format!("Failed to get application: {err}"),
                 }
                 .into_response();
             }

--- a/crates/server/src/admin/handlers/tee/fleet_join.rs
+++ b/crates/server/src/admin/handlers/tee/fleet_join.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use axum::response::IntoResponse;
 use axum::Extension;
 use calimero_context::governance_broadcast::ObserveDelivery;
-use calimero_context::group_store;
 use calimero_context::group_store::NamespaceRepository;
 use calimero_context_client::group::{JoinContextRequest, ListGroupContextsRequest};
 use calimero_context_config::types::ContextGroupId;
@@ -65,7 +64,7 @@ pub async fn handler(
         "Using namespace identity for fleet join"
     );
 
-    let pk_hash: [u8; 32] = Sha256::digest(&*our_public_key).into();
+    let pk_hash: [u8; 32] = Sha256::digest(*our_public_key).into();
     let nonce: [u8; 32] = rand::random();
     let report_data = build_report_data(&nonce, Some(&pk_hash));
 

--- a/crates/server/src/admin/handlers/tee/info.rs
+++ b/crates/server/src/admin/handlers/tee/info.rs
@@ -35,7 +35,7 @@ pub async fn handler(Extension(_state): Extension<Arc<AdminState>>) -> impl Into
 
             ApiError {
                 status_code: StatusCode::INTERNAL_SERVER_ERROR,
-                message: format!("Failed to get TEE info: {}", err),
+                message: format!("Failed to get TEE info: {err}"),
             }
             .into_response()
         }

--- a/crates/server/src/admin/handlers/tee/verify_quote.rs
+++ b/crates/server/src/admin/handlers/tee/verify_quote.rs
@@ -78,7 +78,7 @@ async fn verify_quote(req: TeeVerifyQuoteRequest) -> Result<TeeVerifyQuoteRespon
         error!(error=?err, "Failed to decode base64 quote");
         ApiError {
             status_code: StatusCode::BAD_REQUEST,
-            message: format!("Invalid base64 quote: {}", err),
+            message: format!("Invalid base64 quote: {err}"),
         }
     })?;
 

--- a/crates/server/src/admin/handlers/usage.rs
+++ b/crates/server/src/admin/handlers/usage.rs
@@ -244,7 +244,7 @@ mod tests {
             .store_identity(
                 &namespace_id,
                 &node_identity_pk,
-                &**node_identity_sk,
+                node_identity_sk,
                 &[0x44; 32],
             )
             .expect("store identity");

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -75,7 +75,7 @@ pub(crate) fn setup(
 
     // Get the node prefix from env var
     let admin_path = if let Ok(prefix) = std::env::var("NODE_PATH_PREFIX") {
-        format!("{}{}", prefix, base_path)
+        format!("{prefix}{base_path}")
     } else {
         base_path.to_owned()
     };
@@ -386,7 +386,7 @@ pub(crate) fn site(config: &ServerConfig) -> Option<(String, Router)> {
     // First check the environment variable, fall back to config if not present
     let path = if let Ok(prefix) = std::env::var("NODE_PATH_PREFIX") {
         info!("Using path prefix from environment: {}", prefix);
-        format!("{}{}", prefix, base_path)
+        format!("{prefix}{base_path}")
     } else {
         info!("No path prefix configured");
         base_path.to_owned()
@@ -423,7 +423,7 @@ pub(crate) fn site(config: &ServerConfig) -> Option<(String, Router)> {
 async fn serve_embedded_file(uri: Uri) -> Result<impl IntoResponse, StatusCode> {
     // Get the full path prefix (node prefix + admin dashboard)
     let full_prefix = if let Ok(node_prefix) = std::env::var("NODE_PATH_PREFIX") {
-        format!("{}/admin-dashboard/", node_prefix)
+        format!("{node_prefix}/admin-dashboard/")
     } else {
         "/admin-dashboard/".to_owned()
     };
@@ -477,24 +477,24 @@ fn serve_file(file: EmbeddedFile) -> Result<impl IntoResponse, StatusCode> {
         {
             // Get the node prefix from env var
             let base_path = if let Ok(prefix) = std::env::var("NODE_PATH_PREFIX") {
-                format!("{}/admin-dashboard", prefix)
+                format!("{prefix}/admin-dashboard")
             } else {
                 "/admin-dashboard".to_owned()
             };
 
             // Replace all instances of /admin-dashboard with the correct base path
             let modified_content = content
-                .replace("\"/admin-dashboard", &format!("\"{}", base_path))
-                .replace("'/admin-dashboard", &format!("'{}", base_path))
-                .replace("(/admin-dashboard", &format!("({}", base_path))
-                .replace(" /admin-dashboard", &format!(" {}", base_path))
+                .replace("\"/admin-dashboard", &format!("\"{base_path}"))
+                .replace("'/admin-dashboard", &format!("'{base_path}"))
+                .replace("(/admin-dashboard", &format!("({base_path}"))
+                .replace(" /admin-dashboard", &format!(" {base_path}"))
                 .replace(
                     "href=\"/admin-dashboard",
-                    &format!("href=\"{}/admin-dashboard", base_path),
+                    &format!("href=\"{base_path}/admin-dashboard"),
                 )
                 .replace(
                     "src=\"/admin-dashboard",
-                    &format!("src=\"{}/admin-dashboard", base_path),
+                    &format!("src=\"{base_path}/admin-dashboard"),
                 );
             modified_content.into_bytes()
         } else {
@@ -552,7 +552,7 @@ impl IntoResponse for ApiError {
     fn into_response(self) -> Response<Body> {
         let body = json!({ "error": self.message }).to_string();
         Response::builder()
-            .status(&self.status_code)
+            .status(self.status_code)
             .header("Content-Type", "application/json")
             .body(Body::from(body))
             .unwrap()

--- a/crates/server/src/jsonrpc.rs
+++ b/crates/server/src/jsonrpc.rs
@@ -55,7 +55,7 @@ pub(crate) fn service(
 
     // Get the node prefix from env var
     let path = if let Ok(prefix) = std::env::var("NODE_PATH_PREFIX") {
-        format!("{}{}", prefix, base_path)
+        format!("{prefix}{base_path}")
     } else {
         base_path.to_owned()
     };

--- a/crates/server/src/sse/handlers.rs
+++ b/crates/server/src/sse/handlers.rs
@@ -318,7 +318,7 @@ pub async fn sse_handler(
                 .await
                 .event_counter
                 .fetch_add(1, Ordering::SeqCst);
-            let id_str = format!("{}-{}", session_id, event_id);
+            let id_str = format!("{session_id}-{event_id}");
 
             match command {
                 Command::Close(reason) => {
@@ -369,7 +369,7 @@ pub async fn sse_handler(
     });
     let initial_event = Event::default()
         .event(SseEvent::Message.as_str()) // Standard browser-compatible event type
-        .id(format!("{}-0", session_id))
+        .id(format!("{session_id}-0"))
         .retry(retry_timeout())
         .data(connect_data.to_string());
     let initial_stream = stream::once(async { Ok::<Event, Infallible>(initial_event) });

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -140,7 +140,7 @@ pub(crate) fn service(
 
     // Get the node prefix from env var
     let path = if let Ok(prefix) = std::env::var("NODE_PATH_PREFIX") {
-        format!("{}{}", prefix, base_path)
+        format!("{prefix}{base_path}")
     } else {
         base_path.to_owned()
     };
@@ -171,7 +171,7 @@ async fn ws_handler(
             debug!("Invalid WebSocket upgrade request: {}", rejection);
             return (
                 StatusCode::BAD_REQUEST,
-                format!("Invalid WebSocket upgrade request: {}", rejection),
+                format!("Invalid WebSocket upgrade request: {rejection}"),
             )
                 .into_response();
         }

--- a/crates/storage/src/address.rs
+++ b/crates/storage/src/address.rs
@@ -128,7 +128,7 @@ impl Path {
             if str.len().saturating_add(segment.len()) > 255 {
                 return Err(PathError::Overflow);
             }
-            if str.len() > 0 {
+            if !str.is_empty() {
                 #[expect(clippy::cast_possible_truncation, reason = "Can't occur here")]
                 offsets.push(str.len() as u8);
             }

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -272,7 +272,7 @@ pub fn decode_rotation_log_entry_child(
 #[expect(unused_qualifications, reason = "AtomicUnit macro is unsanitized")]
 type StoreResult<T> = std::result::Result<T, StoreError>;
 
-static ROOT_ID: LazyLock<Id> = LazyLock::new(|| Id::root());
+static ROOT_ID: LazyLock<Id> = LazyLock::new(Id::root);
 
 /// The fixed id under which an app's `Root<T>` value lives — a single
 /// child of [`ROOT_ID`]. Mirrors [`root::Root::entry_id`] but available
@@ -319,7 +319,7 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
     /// Creates a new collection.
     #[expect(clippy::expect_used, reason = "fatal error if it happens")]
     fn new(id: Option<Id>) -> Self {
-        let id = id.unwrap_or_else(|| Id::random());
+        let id = id.unwrap_or_else(Id::random);
 
         let mut this = Self {
             children_ids: RefCell::new(None),
@@ -353,7 +353,7 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         crdt_type: CrdtType,
         writers: std::collections::BTreeSet<calimero_primitives::identity::PublicKey>,
     ) -> Self {
-        let id = id.unwrap_or_else(|| Id::random());
+        let id = id.unwrap_or_else(Id::random);
 
         let mut storage = match field_name {
             Some(name) => Element::new_with_field_name_and_crdt_type(

--- a/crates/storage/src/collections/authored_map.rs
+++ b/crates/storage/src/collections/authored_map.rs
@@ -364,7 +364,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut map = Root::new(|| AuthoredMap::<String, u64>::new());
+        let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("apple".to_owned(), 1).expect("insert");
 
         assert_eq!(map.get(&"apple".to_owned()).unwrap(), Some(1));
@@ -378,7 +378,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut map = Root::new(|| AuthoredMap::<String, u64>::new());
+        let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("apple".to_owned(), 1).unwrap();
 
         let err = map
@@ -397,7 +397,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut map = Root::new(|| AuthoredMap::<String, u64>::new());
+        let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("apple".to_owned(), 1).unwrap();
         map.update(&"apple".to_owned(), 42).expect("owner update");
 
@@ -411,7 +411,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut map = Root::new(|| AuthoredMap::<String, u64>::new());
+        let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("apple".to_owned(), 1).unwrap();
 
         env::set_executor_id(BOB);
@@ -432,7 +432,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut map = Root::new(|| AuthoredMap::<String, u64>::new());
+        let mut map = Root::new(AuthoredMap::<String, u64>::new);
         let err = map
             .update(&"ghost".to_owned(), 1)
             .expect_err("missing key update must fail");
@@ -449,7 +449,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut map = Root::new(|| AuthoredMap::<String, u64>::new());
+        let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("apple".to_owned(), 1).unwrap();
 
         let removed = map.remove(&"apple".to_owned()).unwrap();
@@ -464,7 +464,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut map = Root::new(|| AuthoredMap::<String, u64>::new());
+        let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("apple".to_owned(), 1).unwrap();
 
         env::set_executor_id(BOB);
@@ -481,7 +481,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut map = Root::new(|| AuthoredMap::<String, u64>::new());
+        let mut map = Root::new(AuthoredMap::<String, u64>::new);
         assert_eq!(map.remove(&"ghost".to_owned()).unwrap(), None);
     }
 
@@ -490,7 +490,7 @@ mod tests {
     fn different_users_own_disjoint_keys_in_shared_keyspace() {
         env::reset_for_testing();
 
-        let mut map = Root::new(|| AuthoredMap::<String, u64>::new());
+        let mut map = Root::new(AuthoredMap::<String, u64>::new);
 
         env::set_executor_id(ALICE);
         map.insert("alice_key".to_owned(), 1).unwrap();
@@ -524,7 +524,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let map = Root::new(|| AuthoredMap::<String, u64>::new());
+        let map = Root::new(AuthoredMap::<String, u64>::new);
         assert_eq!(map.owner_of(&"ghost".to_owned()).unwrap(), None);
     }
 
@@ -563,7 +563,7 @@ mod tests {
         env::set_executor_id(ALICE);
 
         // Insert at the default (unversioned 0) target — the "v1" stamp.
-        let mut map = Root::new(|| AuthoredMap::<String, u64>::new());
+        let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("k".to_owned(), 1).unwrap();
         assert_eq!(map.entry_schema_version(&"k".to_owned()).unwrap(), Some(0));
 
@@ -619,7 +619,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut map = Root::new(|| AuthoredMap::<String, LwwRegister<String>>::new());
+        let mut map = Root::new(AuthoredMap::<String, LwwRegister<String>>::new);
         map.insert("k".to_owned(), LwwRegister::new("v1".to_owned()))
             .unwrap();
         assert_eq!(map.entry_schema_version(&"k".to_owned()).unwrap(), Some(0));
@@ -645,7 +645,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut map = Root::new(|| AuthoredMap::<String, u64>::new());
+        let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("apple".to_owned(), 1).unwrap();
 
         // An owner write stamps the binary's current target schema version
@@ -672,7 +672,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut map = Root::new(|| AuthoredMap::<String, u64>::new());
+        let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("a".to_owned(), 1).unwrap();
         map.insert("b".to_owned(), 2).unwrap();
         env::set_executor_id(BOB);

--- a/crates/storage/src/collections/authored_vector.rs
+++ b/crates/storage/src/collections/authored_vector.rs
@@ -355,7 +355,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut v = Root::new(|| AuthoredVector::<u64>::new());
+        let mut v = Root::new(AuthoredVector::<u64>::new);
         v.push(7).expect("push");
 
         // The pusher's write stamps the binary's current target schema version.
@@ -381,7 +381,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut v = Root::new(|| AuthoredVector::<u64>::new());
+        let mut v = Root::new(AuthoredVector::<u64>::new);
         let idx = v.push(7).expect("push");
         assert_eq!(idx, 0);
         assert_eq!(v.get(0).unwrap(), Some(7));
@@ -394,7 +394,7 @@ mod tests {
     fn concurrent_pushes_from_two_users_preserve_per_entry_owner() {
         env::reset_for_testing();
 
-        let mut v = Root::new(|| AuthoredVector::<u64>::new());
+        let mut v = Root::new(AuthoredVector::<u64>::new);
 
         env::set_executor_id(ALICE);
         let a = v.push(1).unwrap();
@@ -415,7 +415,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut v = Root::new(|| AuthoredVector::<u64>::new());
+        let mut v = Root::new(AuthoredVector::<u64>::new);
         v.push(7).unwrap();
         v.update(0, 42).expect("owner update");
         assert_eq!(v.get(0).unwrap(), Some(42));
@@ -428,7 +428,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut v = Root::new(|| AuthoredVector::<u64>::new());
+        let mut v = Root::new(AuthoredVector::<u64>::new);
         v.push(7).unwrap();
 
         env::set_executor_id(BOB);
@@ -444,7 +444,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut v = Root::new(|| AuthoredVector::<u64>::new());
+        let mut v = Root::new(AuthoredVector::<u64>::new);
         let err = v.update(5, 1).expect_err("out-of-bounds update must fail");
         assert!(err.to_string().to_lowercase().contains("out of bounds"));
     }
@@ -455,7 +455,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut v = Root::new(|| AuthoredVector::<u64>::new());
+        let mut v = Root::new(AuthoredVector::<u64>::new);
         v.push(7).unwrap();
         v.tombstone(0).expect("owner tombstone");
         // u64::default() == 0
@@ -471,7 +471,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut v = Root::new(|| AuthoredVector::<u64>::new());
+        let mut v = Root::new(AuthoredVector::<u64>::new);
         v.push(7).unwrap();
 
         env::set_executor_id(BOB);
@@ -486,7 +486,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let mut v = Root::new(|| AuthoredVector::<u64>::new());
+        let mut v = Root::new(AuthoredVector::<u64>::new);
         v.push(10).unwrap();
         v.push(20).unwrap();
         env::set_executor_id(BOB);
@@ -502,7 +502,7 @@ mod tests {
         env::reset_for_testing();
         env::set_executor_id(ALICE);
 
-        let v = Root::new(|| AuthoredVector::<u64>::new());
+        let v = Root::new(AuthoredVector::<u64>::new);
         assert_eq!(v.owner_of(0).unwrap(), None);
     }
 }

--- a/crates/storage/src/collections/composite_key.rs
+++ b/crates/storage/src/collections/composite_key.rs
@@ -214,7 +214,7 @@ impl std::fmt::Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ParseError::MissingSeparator => write!(f, "Composite key missing separator '::'"),
-            ParseError::InvalidFormat(msg) => write!(f, "Invalid composite key format: {}", msg),
+            ParseError::InvalidFormat(msg) => write!(f, "Invalid composite key format: {msg}"),
         }
     }
 }

--- a/crates/storage/src/collections/counter.rs
+++ b/crates/storage/src/collections/counter.rs
@@ -488,8 +488,7 @@ impl<S: StorageAdaptor> Counter<true, S> {
             // Safe conversion: check if u64 fits in i64
             let count_i64 = i64::try_from(count).map_err(|_| {
                 StorageError::InvalidData(format!(
-                    "Counter value {} exceeds i64::MAX, cannot represent in signed counter",
-                    count
+                    "Counter value {count} exceeds i64::MAX, cannot represent in signed counter"
                 ))
             })?;
 
@@ -506,8 +505,7 @@ impl<S: StorageAdaptor> Counter<true, S> {
             // Safe conversion: check if u64 fits in i64
             let count_i64 = i64::try_from(count).map_err(|_| {
                 StorageError::InvalidData(format!(
-                    "Counter value {} exceeds i64::MAX, cannot represent in signed counter",
-                    count
+                    "Counter value {count} exceeds i64::MAX, cannot represent in signed counter"
                 ))
             })?;
 
@@ -553,7 +551,7 @@ mod tests {
     #[should_panic(expected = "migration")]
     fn increment_panics_during_migration() {
         crate::env::reset_for_testing();
-        let mut counter = Root::new(|| GCounter::new());
+        let mut counter = Root::new(GCounter::new);
         // `increment()` stamps the current node's identity; running it inside a
         // migrate body (merge mode is active) would key the delta differently on
         // every node and diverge the network. It must refuse, loudly.
@@ -565,7 +563,7 @@ mod tests {
     #[test]
     fn increment_for_is_allowed_during_migration() {
         crate::env::reset_for_testing();
-        let mut counter = Root::new(|| GCounter::new());
+        let mut counter = Root::new(GCounter::new);
         // The deterministic replay API (explicit executor id) stays usable in a
         // migrate body — that is the sanctioned way to rebuild a counter.
         crate::env::with_merge_mode(|| {
@@ -578,7 +576,7 @@ mod tests {
     #[should_panic(expected = "migration")]
     fn decrement_panics_during_migration() {
         crate::env::reset_for_testing();
-        let mut counter = Root::new(|| PNCounter::new());
+        let mut counter = Root::new(PNCounter::new);
         // `decrement` mirrors `increment` — it stamps the running node's id, so it
         // must refuse inside a migrate (merge mode) for the same reason.
         crate::env::with_merge_mode(|| {
@@ -589,7 +587,7 @@ mod tests {
     #[test]
     fn decrement_for_is_allowed_during_migration() {
         crate::env::reset_for_testing();
-        let mut counter = Root::new(|| PNCounter::new());
+        let mut counter = Root::new(PNCounter::new);
         crate::env::with_merge_mode(|| {
             counter.decrement_for(&[1u8; 32]).unwrap();
         });
@@ -601,7 +599,7 @@ mod tests {
     #[test]
     fn test_gcounter_increment() {
         crate::env::reset_for_testing();
-        let mut counter = Root::new(|| GCounter::new());
+        let mut counter = Root::new(GCounter::new);
         let executor_id = [91u8; 32];
 
         counter.increment_for(&executor_id).unwrap();
@@ -619,14 +617,14 @@ mod tests {
     #[test]
     fn test_gcounter_starts_at_zero() {
         crate::env::reset_for_testing();
-        let counter = Root::new(|| GCounter::new());
+        let counter = Root::new(GCounter::new);
         assert_eq!(counter.value().unwrap(), 0);
     }
 
     #[test]
     fn test_gcounter_multiple_executors() {
         crate::env::reset_for_testing();
-        let mut counter = Root::new(|| GCounter::new());
+        let mut counter = Root::new(GCounter::new);
         let executor_a = [92u8; 32];
         let executor_b = [93u8; 32];
 
@@ -642,7 +640,7 @@ mod tests {
     #[test]
     fn test_gcounter_value_unsigned() {
         crate::env::reset_for_testing();
-        let mut counter = Root::new(|| Counter::<false>::new());
+        let mut counter = Root::new(Counter::<false>::new);
         let executor_id = [94u8; 32];
 
         counter.increment_for(&executor_id).unwrap();
@@ -657,7 +655,7 @@ mod tests {
     #[test]
     fn test_pncounter_increment_and_decrement() {
         crate::env::reset_for_testing();
-        let mut counter = Root::new(|| PNCounter::new());
+        let mut counter = Root::new(PNCounter::new);
         let executor_id = [95u8; 32];
 
         // Start at 0
@@ -690,7 +688,7 @@ mod tests {
     #[test]
     fn test_pncounter_multiple_executors() {
         crate::env::reset_for_testing();
-        let mut counter = Root::new(|| PNCounter::new());
+        let mut counter = Root::new(PNCounter::new);
         let executor_a = [96u8; 32];
         let executor_b = [97u8; 32];
 
@@ -724,7 +722,7 @@ mod tests {
     #[test]
     fn test_pncounter_value_signed() {
         crate::env::reset_for_testing();
-        let mut counter = Root::new(|| Counter::<true>::new());
+        let mut counter = Root::new(Counter::<true>::new);
         let executor_id = [98u8; 32];
 
         counter.increment_for(&executor_id).unwrap();
@@ -739,7 +737,7 @@ mod tests {
     #[test]
     fn test_pncounter_starts_at_zero() {
         crate::env::reset_for_testing();
-        let counter = Root::new(|| PNCounter::new());
+        let counter = Root::new(PNCounter::new);
         assert_eq!(counter.value().unwrap(), 0);
     }
 
@@ -748,7 +746,7 @@ mod tests {
     #[test]
     fn test_gcounter_overflow_detection() {
         crate::env::reset_for_testing();
-        let mut counter = Root::new(|| GCounter::new());
+        let mut counter = Root::new(GCounter::new);
         let executor_id = [99u8; 32];
 
         // Manually insert a value near u64::MAX to trigger overflow
@@ -773,7 +771,7 @@ mod tests {
     #[test]
     fn test_pncounter_cast_overflow_detection() {
         crate::env::reset_for_testing();
-        let mut counter = Root::new(|| PNCounter::new());
+        let mut counter = Root::new(PNCounter::new);
         let executor_id = [101u8; 32];
 
         // Manually insert a value that exceeds i64::MAX
@@ -791,7 +789,7 @@ mod tests {
     #[test]
     fn test_pncounter_addition_overflow_detection() {
         crate::env::reset_for_testing();
-        let mut counter = Root::new(|| PNCounter::new());
+        let mut counter = Root::new(PNCounter::new);
 
         // Insert two values that individually fit in i64 but sum > i64::MAX
         let executor_a = [102u8; 32];
@@ -814,7 +812,7 @@ mod tests {
     #[test]
     fn test_pncounter_subtraction_overflow_detection() {
         crate::env::reset_for_testing();
-        let mut counter = Root::new(|| PNCounter::new());
+        let mut counter = Root::new(PNCounter::new);
 
         // Create a scenario where pos - neg would underflow i64::MIN
         let executor_id = [104u8; 32];
@@ -839,7 +837,7 @@ mod tests {
     #[test]
     fn test_gcounter_no_false_positives() {
         crate::env::reset_for_testing();
-        let mut counter = Root::new(|| GCounter::new());
+        let mut counter = Root::new(GCounter::new);
 
         // Add some large but valid values
         for i in 0..10 {
@@ -856,7 +854,7 @@ mod tests {
     #[test]
     fn test_pncounter_no_false_positives() {
         crate::env::reset_for_testing();
-        let mut counter = Root::new(|| PNCounter::new());
+        let mut counter = Root::new(PNCounter::new);
 
         // Add some large but valid values
         let executor_a = [116u8; 32];
@@ -911,8 +909,7 @@ mod tests {
         let err_str = err.to_string();
         assert!(
             err_str.contains("Not all bytes read") || err_str.contains("Unexpected length"),
-            "Error should indicate leftover data, got: {}",
-            err_str
+            "Error should indicate leftover data, got: {err_str}"
         );
     }
 
@@ -980,8 +977,7 @@ mod tests {
         let err_str = err.to_string();
         assert!(
             err_str.contains("Not all bytes read") || err_str.contains("Unexpected length"),
-            "Error should indicate leftover data, got: {}",
-            err_str
+            "Error should indicate leftover data, got: {err_str}"
         );
     }
 

--- a/crates/storage/src/collections/crdt_impls.rs
+++ b/crates/storage/src/collections/crdt_impls.rs
@@ -571,11 +571,10 @@ mod tests {
             CrdtType::LwwRegister { inner_type } => {
                 assert!(
                     inner_type.contains("String"),
-                    "inner_type should contain 'String', got: {}",
-                    inner_type
+                    "inner_type should contain 'String', got: {inner_type}"
                 );
             }
-            other => panic!("Expected LwwRegister, got: {:?}", other),
+            other => panic!("Expected LwwRegister, got: {other:?}"),
         }
         assert!(!LwwRegister::<String>::can_contain_crdts());
     }
@@ -612,17 +611,15 @@ mod tests {
             } => {
                 assert!(
                     key_type.contains("String"),
-                    "key_type should contain 'String', got: {}",
-                    key_type
+                    "key_type should contain 'String', got: {key_type}"
                 );
                 // Value type is Counter (a CRDT), not u64 - type_name returns full path
                 assert!(
                     value_type.contains("Counter"),
-                    "value_type should contain 'Counter', got: {}",
-                    value_type
+                    "value_type should contain 'Counter', got: {value_type}"
                 );
             }
-            other => panic!("Expected UnorderedMap, got: {:?}", other),
+            other => panic!("Expected UnorderedMap, got: {other:?}"),
         }
         assert!(TestMap::can_contain_crdts()); // Maps CAN contain CRDTs!
     }
@@ -984,7 +981,7 @@ mod tests {
 
         // Test Deref
         let reg = LwwRegister::new("Hello".to_owned());
-        let s: &str = &*reg; // Deref to &String, then &str
+        let s: &str = &reg; // Deref to &String, then &str
         assert_eq!(s, "Hello");
 
         // Test AsRef
@@ -1018,10 +1015,10 @@ mod tests {
 
         // Test Display
         let display_reg = LwwRegister::new("Display Test".to_owned());
-        assert_eq!(format!("{}", display_reg), "Display Test");
+        assert_eq!(format!("{display_reg}"), "Display Test");
 
         let num_display = LwwRegister::new(123);
-        assert_eq!(format!("{}", num_display), "123");
+        assert_eq!(format!("{num_display}"), "123");
     }
 
     #[test]

--- a/crates/storage/src/collections/crdt_meta.rs
+++ b/crates/storage/src/collections/crdt_meta.rs
@@ -142,12 +142,12 @@ impl std::fmt::Display for MergeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             MergeError::IncompatibleStates => write!(f, "Incompatible CRDT states"),
-            MergeError::StorageError(msg) => write!(f, "Storage error: {}", msg),
+            MergeError::StorageError(msg) => write!(f, "Storage error: {msg}"),
             MergeError::TypeMismatch => write!(f, "Cannot merge different CRDT types"),
             MergeError::WasmRequired { type_name } => {
-                write!(f, "WASM callback required for type: {}", type_name)
+                write!(f, "WASM callback required for type: {type_name}")
             }
-            MergeError::SerializationError(msg) => write!(f, "Serialization error: {}", msg),
+            MergeError::SerializationError(msg) => write!(f, "Serialization error: {msg}"),
             MergeError::NoMergeFunctionRegistered => {
                 write!(
                     f,
@@ -207,9 +207,9 @@ pub enum DecomposeError {
 impl std::fmt::Display for DecomposeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            DecomposeError::MissingField(field) => write!(f, "Missing field: {}", field),
-            DecomposeError::InvalidValue(msg) => write!(f, "Invalid value: {}", msg),
-            DecomposeError::StorageError(msg) => write!(f, "Storage error: {}", msg),
+            DecomposeError::MissingField(field) => write!(f, "Missing field: {field}"),
+            DecomposeError::InvalidValue(msg) => write!(f, "Invalid value: {msg}"),
+            DecomposeError::StorageError(msg) => write!(f, "Storage error: {msg}"),
         }
     }
 }

--- a/crates/storage/src/collections/decompose_impls.rs
+++ b/crates/storage/src/collections/decompose_impls.rs
@@ -24,7 +24,7 @@ where
     fn decompose(&self) -> Result<Vec<(Self::Key, Self::Value)>, DecomposeError> {
         let entries = self
             .entries()
-            .map_err(|e| DecomposeError::StorageError(format!("Failed to get entries: {:?}", e)))?;
+            .map_err(|e| DecomposeError::StorageError(format!("Failed to get entries: {e:?}")))?;
 
         // Convert (K, V) to (CompositeKey, V)
         // For a nested map, we'll wrap the key in a CompositeKey
@@ -33,7 +33,7 @@ where
             .map(|(k, v)| {
                 // Serialize the key to bytes
                 let key_bytes = borsh::to_vec(&k).map_err(|e| {
-                    DecomposeError::StorageError(format!("Failed to serialize key: {:?}", e))
+                    DecomposeError::StorageError(format!("Failed to serialize key: {e:?}"))
                 })?;
 
                 // Create a CompositeKey from the serialized key
@@ -52,12 +52,12 @@ where
         for (composite_key, value) in entries {
             // Deserialize the key from composite key bytes
             let key = borsh::from_slice::<K>(composite_key.as_bytes()).map_err(|e| {
-                DecomposeError::StorageError(format!("Failed to deserialize key: {:?}", e))
+                DecomposeError::StorageError(format!("Failed to deserialize key: {e:?}"))
             })?;
 
             drop(
                 map.insert(key, value).map_err(|e| {
-                    DecomposeError::StorageError(format!("Failed to insert: {:?}", e))
+                    DecomposeError::StorageError(format!("Failed to insert: {e:?}"))
                 })?,
             );
         }
@@ -84,13 +84,13 @@ where
         // deterministic without an extra sort.
         let entries = self
             .entries()
-            .map_err(|e| DecomposeError::StorageError(format!("Failed to get entries: {:?}", e)))?;
+            .map_err(|e| DecomposeError::StorageError(format!("Failed to get entries: {e:?}")))?;
 
         let result = entries
             .into_iter()
             .map(|(k, v)| {
                 let key_bytes = borsh::to_vec(&k).map_err(|e| {
-                    DecomposeError::StorageError(format!("Failed to serialize key: {:?}", e))
+                    DecomposeError::StorageError(format!("Failed to serialize key: {e:?}"))
                 })?;
 
                 Ok((CompositeKey::from(key_bytes), v))
@@ -105,12 +105,12 @@ where
 
         for (composite_key, value) in entries {
             let key = borsh::from_slice::<K>(composite_key.as_bytes()).map_err(|e| {
-                DecomposeError::StorageError(format!("Failed to deserialize key: {:?}", e))
+                DecomposeError::StorageError(format!("Failed to deserialize key: {e:?}"))
             })?;
 
             drop(
                 map.insert(key, value).map_err(|e| {
-                    DecomposeError::StorageError(format!("Failed to insert: {:?}", e))
+                    DecomposeError::StorageError(format!("Failed to insert: {e:?}"))
                 })?,
             );
         }
@@ -138,17 +138,17 @@ where
         // Get length
         let len = self
             .len()
-            .map_err(|e| DecomposeError::StorageError(format!("Failed to get length: {:?}", e)))?;
+            .map_err(|e| DecomposeError::StorageError(format!("Failed to get length: {e:?}")))?;
 
         // Extract each element by index
         let mut result = Vec::with_capacity(len);
         for index in 0..len {
             if let Some(value) = self.get(index).map_err(|e| {
-                DecomposeError::StorageError(format!("Failed to get index {}: {:?}", index, e))
+                DecomposeError::StorageError(format!("Failed to get index {index}: {e:?}"))
             })? {
                 // Create composite key with index
                 let index_bytes = borsh::to_vec(&index).map_err(|e| {
-                    DecomposeError::StorageError(format!("Failed to serialize index: {:?}", e))
+                    DecomposeError::StorageError(format!("Failed to serialize index: {e:?}"))
                 })?;
 
                 result.push((CompositeKey::from(index_bytes), value.into_inner()));
@@ -168,7 +168,7 @@ where
             .into_iter()
             .map(|(composite_key, value)| {
                 let index = borsh::from_slice::<usize>(composite_key.as_bytes()).map_err(|e| {
-                    DecomposeError::StorageError(format!("Failed to deserialize index: {:?}", e))
+                    DecomposeError::StorageError(format!("Failed to deserialize index: {e:?}"))
                 })?;
                 Ok((index, value))
             })
@@ -184,13 +184,12 @@ where
             let (actual_index, val) = value;
             if actual_index != expected_index {
                 return Err(DecomposeError::InvalidValue(format!(
-                    "Vector has gap: expected index {}, got {}",
-                    expected_index, actual_index
+                    "Vector has gap: expected index {expected_index}, got {actual_index}"
                 )));
             }
             vector
                 .push(val)
-                .map_err(|e| DecomposeError::StorageError(format!("Failed to push: {:?}", e)))?;
+                .map_err(|e| DecomposeError::StorageError(format!("Failed to push: {e:?}")))?;
         }
 
         Ok(vector)
@@ -208,7 +207,7 @@ mod tests {
     fn test_unordered_map_decompose() {
         env::reset_for_testing();
 
-        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
         map.insert("key1".to_owned(), "value1".to_owned()).unwrap();
         map.insert("key2".to_owned(), "value2".to_owned()).unwrap();
 
@@ -220,7 +219,7 @@ mod tests {
     fn test_unordered_map_roundtrip() {
         env::reset_for_testing();
 
-        let mut original = Root::new(|| UnorderedMap::<String, u64>::new());
+        let mut original = Root::new(UnorderedMap::<String, u64>::new);
         original.insert("a".to_owned(), 1u64).unwrap();
         original.insert("b".to_owned(), 2u64).unwrap();
         original.insert("c".to_owned(), 3u64).unwrap();
@@ -262,7 +261,7 @@ mod tests {
     fn test_vector_decompose() {
         env::reset_for_testing();
 
-        let mut vec = Root::new(|| Vector::<_, MainStorage>::new());
+        let mut vec = Root::new(Vector::<_, MainStorage>::new);
         vec.push(10u64).unwrap();
         vec.push(20u64).unwrap();
         vec.push(30u64).unwrap();
@@ -275,7 +274,7 @@ mod tests {
     fn test_vector_roundtrip() {
         env::reset_for_testing();
 
-        let mut original = Root::new(|| Vector::<String>::new());
+        let mut original = Root::new(Vector::<String>::new);
         original.push("first".to_owned()).unwrap();
         original.push("second".to_owned()).unwrap();
         original.push("third".to_owned()).unwrap();

--- a/crates/storage/src/collections/lww_register.rs
+++ b/crates/storage/src/collections/lww_register.rs
@@ -285,7 +285,6 @@ mod merge_mode_tests {
     use crate::collections::{Root, UnorderedMap};
     use crate::env;
     use crate::logical_clock::HybridTimestamp;
-    use crate::store::MainStorage;
 
     #[test]
     fn lww_new_zeroes_timestamp_and_node_id_in_merge_mode() {
@@ -376,7 +375,7 @@ mod merge_mode_tests {
         env::set_executor_id([9; 32]);
 
         let total: LwwRegister<u64> = env::with_merge_mode(|| {
-            let mut map = Root::new(|| UnorderedMap::<String, LwwRegister<u64>>::new());
+            let mut map = Root::new(UnorderedMap::<String, LwwRegister<u64>>::new);
             map.insert("a".to_string(), 1_u64.into()).unwrap();
             map.insert("b".to_string(), 2_u64.into()).unwrap();
             assert!(

--- a/crates/storage/src/collections/nested.rs
+++ b/crates/storage/src/collections/nested.rs
@@ -133,7 +133,7 @@ mod tests {
     fn test_insert_nested_simple_crdt() {
         env::reset_for_testing();
 
-        let mut map = Root::new(|| UnorderedMap::<String, Counter>::new());
+        let mut map = Root::new(UnorderedMap::<String, Counter>::new);
         let counter = Counter::new();
 
         // Counter doesn't contain CRDTs, so uses standard insert
@@ -145,7 +145,7 @@ mod tests {
     fn test_insert_nested_lww_register() {
         env::reset_for_testing();
 
-        let mut map = Root::new(|| UnorderedMap::<String, LwwRegister<String>>::new());
+        let mut map = Root::new(UnorderedMap::<String, LwwRegister<String>>::new);
         let register = LwwRegister::new("Test Value".to_string());
 
         // LwwRegister doesn't contain CRDTs, so uses standard insert

--- a/crates/storage/src/collections/nested_map.rs
+++ b/crates/storage/src/collections/nested_map.rs
@@ -153,7 +153,7 @@ mod tests {
     fn test_nested_map_insert() {
         env::reset_for_testing();
 
-        let mut outer = Root::new(|| UnorderedMap::<String, UnorderedMap<String, String>>::new());
+        let mut outer = Root::new(UnorderedMap::<String, UnorderedMap<String, String>>::new);
 
         // Insert into nested map
         let result = outer.insert_nested(
@@ -170,7 +170,7 @@ mod tests {
     fn test_nested_map_get() {
         env::reset_for_testing();
 
-        let mut outer = Root::new(|| UnorderedMap::<String, UnorderedMap<String, String>>::new());
+        let mut outer = Root::new(UnorderedMap::<String, UnorderedMap<String, String>>::new);
 
         // Insert
         outer
@@ -190,7 +190,7 @@ mod tests {
     fn test_nested_map_concurrent_modification() {
         env::reset_for_testing();
 
-        let mut map1 = Root::new(|| UnorderedMap::<String, UnorderedMap<String, String>>::new());
+        let mut map1 = Root::new(UnorderedMap::<String, UnorderedMap<String, String>>::new);
 
         // Node 1: Insert title
         map1.insert_nested(
@@ -214,7 +214,7 @@ mod tests {
     fn test_nested_map_remove() {
         env::reset_for_testing();
 
-        let mut outer = Root::new(|| UnorderedMap::<String, UnorderedMap<String, String>>::new());
+        let mut outer = Root::new(UnorderedMap::<String, UnorderedMap<String, String>>::new);
 
         // Insert
         outer
@@ -240,7 +240,7 @@ mod tests {
     fn test_nested_map_contains() {
         env::reset_for_testing();
 
-        let mut outer = Root::new(|| UnorderedMap::<String, UnorderedMap<String, String>>::new());
+        let mut outer = Root::new(UnorderedMap::<String, UnorderedMap<String, String>>::new);
 
         // Insert
         outer
@@ -265,7 +265,7 @@ mod tests {
     fn test_nested_map_multiple_fields() {
         env::reset_for_testing();
 
-        let mut outer = Root::new(|| UnorderedMap::<String, UnorderedMap<String, String>>::new());
+        let mut outer = Root::new(UnorderedMap::<String, UnorderedMap<String, String>>::new);
 
         // Insert multiple fields
         outer

--- a/crates/storage/src/collections/rga.rs
+++ b/crates/storage/src/collections/rga.rs
@@ -77,8 +77,7 @@ impl BorshDeserialize for CharKey {
     fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
         let id = CharId::deserialize_reader(reader)?;
         // Reconstruct bytes from id
-        let bytes = borsh::to_vec(&id)
-            .map_err(|e| borsh::io::Error::new(borsh::io::ErrorKind::Other, e))?;
+        let bytes = borsh::to_vec(&id).map_err(borsh::io::Error::other)?;
         Ok(Self { id, bytes })
     }
 }

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -1310,7 +1310,7 @@ mod tests {
 
     #[test]
     fn test_sorted_map_basic_operations() {
-        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(SortedMap::<_, _, MainStorage>::new);
 
         assert!(map
             .insert("key".to_owned(), "value".to_owned())
@@ -1343,7 +1343,7 @@ mod tests {
 
     #[test]
     fn test_sorted_map_iterates_in_key_order_regardless_of_insertion_order() {
-        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(SortedMap::<_, _, MainStorage>::new);
 
         // Insert deliberately out of order.
         for k in ["delta", "alpha", "charlie", "bravo", "echo"] {
@@ -1363,7 +1363,7 @@ mod tests {
 
     #[test]
     fn test_sorted_map_range() {
-        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(SortedMap::<_, _, MainStorage>::new);
         for k in ["a", "b", "c", "d", "e", "f"] {
             map.insert(k.to_owned(), k.to_owned()).unwrap();
         }
@@ -1395,7 +1395,7 @@ mod tests {
 
     #[test]
     fn test_sorted_map_prefix() {
-        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(SortedMap::<_, _, MainStorage>::new);
         for k in ["user:alice", "user:bob", "post:1", "user:carol", "post:2"] {
             map.insert(k.to_owned(), String::new()).unwrap();
         }
@@ -1417,7 +1417,7 @@ mod tests {
 
     #[test]
     fn test_sorted_map_pagination() {
-        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(SortedMap::<_, _, MainStorage>::new);
         for i in 0..10u32 {
             // Zero-pad so lexicographic order matches numeric order.
             map.insert(format!("k{i:02}"), i).unwrap();
@@ -1443,7 +1443,7 @@ mod tests {
 
     #[test]
     fn test_sorted_map_first_last() {
-        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(SortedMap::<_, _, MainStorage>::new);
         assert!(map.first().unwrap().is_none());
         assert!(map.last().unwrap().is_none());
 
@@ -1457,7 +1457,7 @@ mod tests {
 
     #[test]
     fn test_sorted_map_entry_api() {
-        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(SortedMap::<_, _, MainStorage>::new);
 
         {
             let mut guard = map
@@ -1484,7 +1484,7 @@ mod tests {
 
     #[test]
     fn test_sorted_map_entry_or_default() {
-        let mut map = Root::new(|| SortedMap::<String, u64, MainStorage>::new());
+        let mut map = Root::new(SortedMap::<String, u64, MainStorage>::new);
 
         // Vacant: inserts `u64::default()` (0), guard write-back persists the bump.
         {
@@ -1523,7 +1523,7 @@ mod tests {
 
     #[test]
     fn test_sorted_map_remove_updates_order() {
-        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(SortedMap::<_, _, MainStorage>::new);
         for k in ["a", "b", "c", "d"] {
             map.insert(k.to_owned(), k.to_owned()).unwrap();
         }
@@ -1537,7 +1537,7 @@ mod tests {
 
     #[test]
     fn test_sorted_map_get_mut_preserves_order() {
-        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(SortedMap::<_, _, MainStorage>::new);
         for k in ["b", "a", "c"] {
             map.insert(k.to_owned(), 0u32).unwrap();
         }
@@ -1600,7 +1600,7 @@ mod tests {
 
     #[test]
     fn test_entry_occupied_is_used_in_match() {
-        let mut map = Root::new(|| SortedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(SortedMap::<_, _, MainStorage>::new);
         map.insert("k".to_owned(), "v".to_owned()).unwrap();
 
         let value = match map.entry("k".to_owned()).unwrap() {

--- a/crates/storage/src/collections/sorted_set.rs
+++ b/crates/storage/src/collections/sorted_set.rs
@@ -678,7 +678,7 @@ mod tests {
 
     #[test]
     fn test_sorted_set_basic_and_order() {
-        let mut set = Root::new(|| SortedSet::<_, MainStorage>::new());
+        let mut set = Root::new(SortedSet::<_, MainStorage>::new);
 
         for v in ["delta", "alpha", "charlie", "bravo"] {
             assert!(set.insert(v.to_owned()).expect("insert failed"));
@@ -696,7 +696,7 @@ mod tests {
 
     #[test]
     fn test_sorted_set_range_prefix_page_first_last() {
-        let mut set = Root::new(|| SortedSet::<_, MainStorage>::new());
+        let mut set = Root::new(SortedSet::<_, MainStorage>::new);
         for v in ["user:alice", "user:bob", "post:1", "user:carol", "post:2"] {
             set.insert(v.to_owned()).unwrap();
         }
@@ -719,7 +719,7 @@ mod tests {
 
     #[test]
     fn test_sorted_set_remove_updates_order() {
-        let mut set = Root::new(|| SortedSet::<_, MainStorage>::new());
+        let mut set = Root::new(SortedSet::<_, MainStorage>::new);
         for v in ["a", "b", "c", "d"] {
             set.insert(v.to_owned()).unwrap();
         }
@@ -732,7 +732,7 @@ mod tests {
 
     #[test]
     fn test_sorted_set_clear() {
-        let mut set = Root::new(|| SortedSet::<_, MainStorage>::new());
+        let mut set = Root::new(SortedSet::<_, MainStorage>::new);
         set.insert("x".to_owned()).unwrap();
         set.insert("y".to_owned()).unwrap();
         set.clear().unwrap();

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -977,7 +977,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_basic_operations() {
-        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
         assert!(map
             .insert("key".to_owned(), "value".to_owned())
@@ -1038,7 +1038,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_insert_and_get() {
-        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
         assert!(map
             .insert("key1".to_owned(), "value1".to_owned())
@@ -1067,16 +1067,16 @@ mod tests {
 
     #[test]
     fn test_unordered_map_update_value() {
-        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
         assert!(map
             .insert("key".to_owned(), "value".to_owned())
             .expect("insert failed")
             .is_none());
-        assert!(!map
+        assert!(map
             .insert("key".to_owned(), "new_value".to_owned())
             .expect("insert failed")
-            .is_none());
+            .is_some());
 
         assert_eq!(
             map.get("key")
@@ -1089,7 +1089,7 @@ mod tests {
 
     #[test]
     fn test_remove() {
-        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
         assert!(map
             .insert("key".to_owned(), "value".to_owned())
@@ -1105,7 +1105,7 @@ mod tests {
 
     #[test]
     fn test_clear() {
-        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
         assert!(map
             .insert("key1".to_owned(), "value1".to_owned())
@@ -1124,7 +1124,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_len() {
-        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
         assert_eq!(map.len().expect("len failed"), 0);
 
@@ -1136,10 +1136,10 @@ mod tests {
             .insert("key2".to_owned(), "value2".to_owned())
             .expect("insert failed")
             .is_none());
-        assert!(!map
+        assert!(map
             .insert("key2".to_owned(), "value3".to_owned())
             .expect("insert failed")
-            .is_none());
+            .is_some());
 
         assert_eq!(map.len().expect("len failed"), 2);
 
@@ -1153,20 +1153,20 @@ mod tests {
 
     #[test]
     fn test_unordered_map_contains() {
-        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
         assert!(map
             .insert("key".to_owned(), "value".to_owned())
             .expect("insert failed")
             .is_none());
 
-        assert_eq!(map.contains("key").expect("contains failed"), true);
-        assert_eq!(map.contains("nonexistent").expect("contains failed"), false);
+        assert!(map.contains("key").expect("contains failed"));
+        assert!(!map.contains("nonexistent").expect("contains failed"));
     }
 
     #[test]
     fn test_unordered_map_entries() {
-        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
         assert!(map
             .insert("key1".to_owned(), "value1".to_owned())
@@ -1176,10 +1176,10 @@ mod tests {
             .insert("key2".to_owned(), "value2".to_owned())
             .expect("insert failed")
             .is_none());
-        assert!(!map
+        assert!(map
             .insert("key2".to_owned(), "value3".to_owned())
             .expect("insert failed")
-            .is_none());
+            .is_some());
 
         let entries: Vec<(String, String)> = map.entries().expect("entries failed").collect();
 
@@ -1190,7 +1190,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_get_mut() {
-        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
         drop(
             map.insert("key1".to_owned(), "value1".to_owned())
                 .expect("insert failed"),
@@ -1224,7 +1224,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_entry_vacant() {
-        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
         // Test `or_insert()`
         {
@@ -1265,7 +1265,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_entry_occupied_or_insert() {
-        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
         drop(
             map.insert("key1".to_owned(), "value1".to_owned())
                 .expect("insert failed"),
@@ -1306,7 +1306,7 @@ mod tests {
             assert_eq!(*guard, "value1");
         } // Guard is dropped
 
-        assert_eq!(called, false); // Verify closure was not executed
+        assert!(!called); // Verify closure was not executed
         assert_eq!(map.len().unwrap(), 1);
         assert_eq!(
             map.get("key1").unwrap().as_deref().map(String::as_str),
@@ -1316,7 +1316,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_entry_or_default() {
-        let mut map = Root::new(|| UnorderedMap::<String, u64, MainStorage>::new());
+        let mut map = Root::new(UnorderedMap::<String, u64, MainStorage>::new);
 
         // Vacant: `or_default()` inserts `u64::default()` (0) and the write-back
         // guard persists the mutation made through it on drop.
@@ -1350,7 +1350,7 @@ mod tests {
 
     #[test]
     fn test_unordered_map_entry_occupied_mutations() {
-        let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+        let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
         drop(map.insert("key1".to_owned(), "value1".to_owned()).unwrap());
         drop(map.insert("key2".to_owned(), "value2".to_owned()).unwrap());
         drop(map.insert("key3".to_owned(), "value3".to_owned()).unwrap());
@@ -1609,7 +1609,7 @@ mod tests {
 
         // For nested maps (values in other maps), we use new() which generates random IDs.
         // This is fine because merge happens by the parent map's key, not the nested map's ID.
-        let mut parent_map = Root::new(|| UnorderedMap::<String, String>::new());
+        let mut parent_map = Root::new(UnorderedMap::<String, String>::new);
 
         // Insert an entry
         parent_map

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -497,34 +497,25 @@ mod tests {
 
     #[test]
     fn test_unordered_set_operations() {
-        let mut set = Root::new(|| UnorderedSet::<_, MainStorage>::new());
+        let mut set = Root::new(UnorderedSet::<_, MainStorage>::new);
 
         assert!(set.insert("value1".to_owned()).expect("insert failed"));
 
-        assert_eq!(
-            set.contains(&"value1".to_owned()).expect("contains failed"),
-            true
-        );
+        assert!(set.contains(&"value1".to_owned()).expect("contains failed"));
 
         assert!(!set.insert("value1".to_owned()).expect("insert failed"));
         assert!(set.insert("value2".to_owned()).expect("insert failed"));
 
-        assert_eq!(set.contains("value3").expect("get failed"), false);
-        assert_eq!(set.contains("value2").expect("get failed"), true);
+        assert!(!set.contains("value3").expect("get failed"));
+        assert!(set.contains("value2").expect("get failed"));
 
-        assert_eq!(
-            set.remove("value1").expect("error while removing key"),
-            true
-        );
-        assert_eq!(
-            set.remove("value3").expect("error while removing key"),
-            false
-        );
+        assert!(set.remove("value1").expect("error while removing key"));
+        assert!(!set.remove("value3").expect("error while removing key"));
     }
 
     #[test]
     fn test_unordered_set_len() {
-        let mut set = Root::new(|| UnorderedSet::<_, MainStorage>::new());
+        let mut set = Root::new(UnorderedSet::<_, MainStorage>::new);
 
         assert!(set.insert("value1".to_owned()).expect("insert failed"));
         assert!(set.insert("value2".to_owned()).expect("insert failed"));
@@ -539,7 +530,7 @@ mod tests {
 
     #[test]
     fn test_unordered_set_clear() {
-        let mut set = Root::new(|| UnorderedSet::<_, MainStorage>::new());
+        let mut set = Root::new(UnorderedSet::<_, MainStorage>::new);
 
         assert!(set.insert("value1".to_owned()).expect("insert failed"));
         assert!(set.insert("value2".to_owned()).expect("insert failed"));
@@ -549,13 +540,13 @@ mod tests {
         set.clear().expect("clear failed");
 
         assert_eq!(set.len().expect("len failed"), 0);
-        assert_eq!(set.contains("value1").expect("contains failed"), false);
-        assert_eq!(set.contains("value2").expect("contains failed"), false);
+        assert!(!set.contains("value1").expect("contains failed"));
+        assert!(!set.contains("value2").expect("contains failed"));
     }
 
     #[test]
     fn test_unordered_set_items() {
-        let mut set = Root::new(|| UnorderedSet::<_, MainStorage>::new());
+        let mut set = Root::new(UnorderedSet::<_, MainStorage>::new);
 
         assert!(set.insert("value1".to_owned()).expect("insert failed"));
         assert!(set.insert("value2".to_owned()).expect("insert failed"));

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -546,7 +546,7 @@ mod tests {
 
     #[test]
     fn test_vector_push() {
-        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+        let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
         let value = "test_data".to_owned();
         let result = vector.push(value.clone());
@@ -556,21 +556,21 @@ mod tests {
 
     #[test]
     fn test_vector_get() {
-        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+        let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
         let value = "test_data".to_owned();
-        let _ = vector.push(value.clone()).unwrap();
+        vector.push(value.clone()).unwrap();
         let retrieved_value = vector.get(0).unwrap().map(|v| v.into_inner());
         assert_eq!(retrieved_value, Some(value));
     }
 
     #[test]
     fn test_vector_update() {
-        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+        let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
         let value1 = "test_data1".to_owned();
         let value2 = "test_data2".to_owned();
-        let _ = vector.push(value1.clone()).unwrap();
+        vector.push(value1.clone()).unwrap();
         let old = vector.update(0, value2.clone()).unwrap();
         let retrieved_value = vector.get(0).unwrap().map(|v| v.into_inner());
         assert_eq!(retrieved_value, Some(value2));
@@ -579,20 +579,20 @@ mod tests {
 
     #[test]
     fn test_vector_get_non_existent() {
-        let vector = Root::new(|| Vector::<String>::new());
+        let vector = Root::new(Vector::<String>::new);
 
         match vector.get(0) {
             Ok(retrieved_value) => assert_eq!(retrieved_value, None),
-            Err(e) => panic!("Error occurred: {:?}", e),
+            Err(e) => panic!("Error occurred: {e:?}"),
         }
     }
 
     #[test]
     fn test_vector_pop() {
-        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+        let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
         let value = "test_data".to_owned();
-        let _ = vector.push(value.clone()).unwrap();
+        vector.push(value.clone()).unwrap();
         let popped_value = vector.pop().unwrap();
         assert_eq!(popped_value, Some(value));
         assert_eq!(vector.len().unwrap(), 0);
@@ -600,22 +600,22 @@ mod tests {
 
     #[test]
     fn test_vector_items() {
-        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+        let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
         let value1 = "test_data1".to_owned();
         let value2 = "test_data2".to_owned();
-        let _ = vector.push(value1.clone()).unwrap();
-        let _ = vector.push(value2.clone()).unwrap();
+        vector.push(value1.clone()).unwrap();
+        vector.push(value2.clone()).unwrap();
         let items: Vec<String> = vector.iter().unwrap().collect();
         assert_eq!(items, vec![value1, value2]);
     }
 
     #[test]
     fn test_vector_contains() {
-        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+        let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
         let value = "test_data".to_owned();
-        let _ = vector.push(value.clone()).unwrap();
+        vector.push(value.clone()).unwrap();
         assert!(vector.contains(&value).unwrap());
         let non_existent_value = "non_existent".to_owned();
         assert!(!vector.contains(&non_existent_value).unwrap());
@@ -623,22 +623,22 @@ mod tests {
 
     #[test]
     fn test_vector_clear() {
-        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+        let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
         let value = "test_data".to_owned();
-        let _ = vector.push(value.clone()).unwrap();
+        vector.push(value.clone()).unwrap();
         vector.clear().unwrap();
         assert_eq!(vector.len().unwrap(), 0);
     }
 
     #[test]
     fn test_vector_find() {
-        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+        let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
-        let _ = vector.push("apple".to_owned()).unwrap();
-        let _ = vector.push("banana".to_owned()).unwrap();
-        let _ = vector.push("cherry".to_owned()).unwrap();
-        let _ = vector.push("banana".to_owned()).unwrap();
+        vector.push("apple".to_owned()).unwrap();
+        vector.push("banana".to_owned()).unwrap();
+        vector.push("cherry".to_owned()).unwrap();
+        vector.push("banana".to_owned()).unwrap();
 
         // Find first element that starts with 'b'
         let result: Vec<String> = vector.find(|s| s.starts_with('b')).unwrap().collect();
@@ -657,13 +657,13 @@ mod tests {
 
     #[test]
     fn test_vector_filter() {
-        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+        let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
-        let _ = vector.push("apple".to_owned()).unwrap();
-        let _ = vector.push("banana".to_owned()).unwrap();
-        let _ = vector.push("cherry".to_owned()).unwrap();
-        let _ = vector.push("banana".to_owned()).unwrap();
-        let _ = vector.push("apricot".to_owned()).unwrap();
+        vector.push("apple".to_owned()).unwrap();
+        vector.push("banana".to_owned()).unwrap();
+        vector.push("cherry".to_owned()).unwrap();
+        vector.push("banana".to_owned()).unwrap();
+        vector.push("apricot".to_owned()).unwrap();
 
         // Filter all elements that start with 'a'
         let result: Vec<String> = vector.filter(|s| s.starts_with('a')).unwrap().collect();
@@ -687,12 +687,12 @@ mod tests {
 
     #[test]
     fn test_vector_find_with_numbers() {
-        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+        let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
-        let _ = vector.push(1u32).unwrap();
-        let _ = vector.push(5u32).unwrap();
-        let _ = vector.push(10u32).unwrap();
-        let _ = vector.push(15u32).unwrap();
+        vector.push(1u32).unwrap();
+        vector.push(5u32).unwrap();
+        vector.push(10u32).unwrap();
+        vector.push(15u32).unwrap();
 
         // Find first number > 7
         let result: Vec<u32> = vector.find(|&n| n > 7).unwrap().collect();
@@ -702,13 +702,13 @@ mod tests {
 
     #[test]
     fn test_vector_filter_with_numbers() {
-        let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+        let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
-        let _ = vector.push(1u32).unwrap();
-        let _ = vector.push(5u32).unwrap();
-        let _ = vector.push(10u32).unwrap();
-        let _ = vector.push(15u32).unwrap();
-        let _ = vector.push(20u32).unwrap();
+        vector.push(1u32).unwrap();
+        vector.push(5u32).unwrap();
+        vector.push(10u32).unwrap();
+        vector.push(15u32).unwrap();
+        vector.push(20u32).unwrap();
 
         // Filter all numbers > 7
         let result: Vec<u32> = vector.filter(|&n| n > 7).unwrap().collect();
@@ -723,7 +723,7 @@ mod tests {
 
     #[test]
     fn test_vector_get_with_max_index() {
-        let vector = Root::new(|| Vector::<String>::new());
+        let vector = Root::new(Vector::<String>::new);
 
         // Accessing with usize::MAX should return error due to overflow protection
         let result = vector.get(usize::MAX);
@@ -737,7 +737,7 @@ mod tests {
 
     #[test]
     fn test_vector_update_with_max_index() {
-        let mut vector = Root::new(|| Vector::<String>::new());
+        let mut vector = Root::new(Vector::<String>::new);
 
         // Updating with usize::MAX should return error due to overflow protection
         let result = vector.update(usize::MAX, "test".to_owned());

--- a/crates/storage/src/delta.rs
+++ b/crates/storage/src/delta.rs
@@ -90,20 +90,20 @@ impl CausalDelta {
                     id, data, metadata, ..
                 } => {
                     let id_bytes: [u8; 32] = (*id).into();
-                    hasher.update(&id_bytes);
+                    hasher.update(id_bytes);
                     hasher.update(data);
                     // Metadata and ancestors excluded - they contain timestamps
                     hash_metadata_storage_type_for_id(&mut hasher, metadata);
                 }
                 Action::DeleteRef { id, metadata, .. } => {
                     let id_bytes: [u8; 32] = (*id).into();
-                    hasher.update(&id_bytes);
+                    hasher.update(id_bytes);
                     // deleted_at excluded - it's a timestamp
                     hash_metadata_storage_type_for_id(&mut hasher, metadata);
                 }
                 Action::Compare { id } => {
                     let id_bytes: [u8; 32] = (*id).into();
-                    hasher.update(&id_bytes);
+                    hasher.update(id_bytes);
                 }
             }
         }
@@ -230,7 +230,7 @@ impl DeltaContext {
 
     /// Get HLC timestamp, creating default if empty
     fn get_hlc(&mut self) -> HybridTimestamp {
-        self.max_hlc.unwrap_or_else(|| env::hlc_timestamp())
+        self.max_hlc.unwrap_or_else(env::hlc_timestamp)
     }
 }
 
@@ -384,6 +384,62 @@ pub fn reset_delta_context() {
     });
 }
 
+// Helper function to hash Metadata storage type
+fn hash_metadata_storage_type_for_id(hasher: &mut Sha256, metadata: &Metadata) {
+    match &metadata.storage_type {
+        StorageType::Public | StorageType::Frozen => {
+            hasher.update(borsh::to_vec(&metadata.storage_type).unwrap_or_default());
+        }
+        StorageType::User {
+            owner,
+            signature_data,
+        } => {
+            // Hash the User variant *without* the signature
+            let partial_type = StorageType::User {
+                owner: *owner,
+                signature_data: signature_data.as_ref().map(|sig_data| SignatureData {
+                    nonce: sig_data.nonce,
+                    signature: [0; 64], // Use placeholder for hash
+                    signer: sig_data.signer,
+                }),
+            };
+            hasher.update(borsh::to_vec(&partial_type).unwrap_or_default());
+        }
+        StorageType::Shared {
+            writers,
+            signature_data,
+        } => {
+            // Hash the Shared variant *without* the signature
+            let partial_type = StorageType::Shared {
+                writers: writers.clone(),
+                signature_data: signature_data.as_ref().map(|sig_data| SignatureData {
+                    nonce: sig_data.nonce,
+                    signature: [0; 64], // Use placeholder for hash
+                    signer: sig_data.signer,
+                }),
+            };
+            hasher.update(borsh::to_vec(&partial_type).unwrap_or_default());
+        }
+        StorageType::SharedMember {
+            anchor,
+            signature_data,
+        } => {
+            // Hash the SharedMember variant *without* the signature. Only the
+            // anchor id is committed — the writer set lives at the anchor, so a
+            // rotation leaves every member's hash unchanged.
+            let partial_type = StorageType::SharedMember {
+                anchor: *anchor,
+                signature_data: signature_data.as_ref().map(|sig_data| SignatureData {
+                    nonce: sig_data.nonce,
+                    signature: [0; 64], // Use placeholder for hash
+                    signer: sig_data.signer,
+                }),
+            };
+            hasher.update(borsh::to_vec(&partial_type).unwrap_or_default());
+        }
+    }
+}
+
 #[cfg(test)]
 mod borsh_roundtrip_tests {
     //! `StorageDelta` has a custom `BorshDeserialize` impl that branches
@@ -531,61 +587,5 @@ mod borsh_roundtrip_tests {
             result.is_err(),
             "expected error for unknown tag, got {result:?}"
         );
-    }
-}
-
-// Helper function to hash Metadata storage type
-fn hash_metadata_storage_type_for_id(hasher: &mut Sha256, metadata: &Metadata) {
-    match &metadata.storage_type {
-        StorageType::Public | StorageType::Frozen => {
-            hasher.update(borsh::to_vec(&metadata.storage_type).unwrap_or_default());
-        }
-        StorageType::User {
-            owner,
-            signature_data,
-        } => {
-            // Hash the User variant *without* the signature
-            let partial_type = StorageType::User {
-                owner: *owner,
-                signature_data: signature_data.as_ref().map(|sig_data| SignatureData {
-                    nonce: sig_data.nonce,
-                    signature: [0; 64], // Use placeholder for hash
-                    signer: sig_data.signer,
-                }),
-            };
-            hasher.update(borsh::to_vec(&partial_type).unwrap_or_default());
-        }
-        StorageType::Shared {
-            writers,
-            signature_data,
-        } => {
-            // Hash the Shared variant *without* the signature
-            let partial_type = StorageType::Shared {
-                writers: writers.clone(),
-                signature_data: signature_data.as_ref().map(|sig_data| SignatureData {
-                    nonce: sig_data.nonce,
-                    signature: [0; 64], // Use placeholder for hash
-                    signer: sig_data.signer,
-                }),
-            };
-            hasher.update(borsh::to_vec(&partial_type).unwrap_or_default());
-        }
-        StorageType::SharedMember {
-            anchor,
-            signature_data,
-        } => {
-            // Hash the SharedMember variant *without* the signature. Only the
-            // anchor id is committed — the writer set lives at the anchor, so a
-            // rotation leaves every member's hash unchanged.
-            let partial_type = StorageType::SharedMember {
-                anchor: *anchor,
-                signature_data: signature_data.as_ref().map(|sig_data| SignatureData {
-                    nonce: sig_data.nonce,
-                    signature: [0; 64], // Use placeholder for hash
-                    signer: sig_data.signer,
-                }),
-            };
-            hasher.update(borsh::to_vec(&partial_type).unwrap_or_default());
-        }
     }
 }

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -348,7 +348,7 @@ impl Element {
     /// Use sparingly - prefer `set_updated_at()` for Law of Demeter compliance.
     #[must_use]
     pub fn updated_at_mut(&mut self) -> &mut u64 {
-        &mut *self.metadata.updated_at
+        &mut self.metadata.updated_at
     }
 
     /// Helper to set the storage domain to `User`.

--- a/crates/storage/src/env.rs
+++ b/crates/storage/src/env.rs
@@ -799,7 +799,7 @@ mod mocked {
 
     /// Prints the log
     pub(super) fn log(message: &str) {
-        println!("{}", message);
+        println!("{message}");
     }
 
     /// Sets the thread-local executor ID. Only callable from this crate

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -134,8 +134,7 @@ impl Serialize for StorageError {
             | Self::UnexpectedId(id)
             | Self::NotFound(id) => serializer.serialize_str(&id.to_string()),
             Self::InvalidTimestamp(timestamp, local_time) => serializer.serialize_str(&format!(
-                "Invalid timestamp {} for an action, too far in the future (local time: {}).",
-                timestamp, local_time
+                "Invalid timestamp {timestamp} for an action, too far in the future (local time: {local_time})."
             )),
             Self::InvalidData(ref msg) => serializer.serialize_str(msg),
             Self::InvalidSignature => serializer.serialize_str("Invalid signature"),
@@ -144,7 +143,7 @@ impl Serialize for StorageError {
             )),
             Self::NonceReplay(ref data) => {
                 let (pk, nonce) = &**data;
-                serializer.serialize_str(&format!("Nonce replay for {}: {}", pk, nonce))
+                serializer.serialize_str(&format!("Nonce replay for {pk}: {nonce}"))
             }
             Self::StoreError(ref err) => serializer.serialize_str(&err.to_string()),
             Self::DuplicateRotationInDelta(delta_id) => serializer.serialize_str(&format!(

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -802,7 +802,7 @@ impl<S: StorageAdaptor> Index<S> {
         Ok(parent_index
             .children
             .as_ref()
-            .map_or(false, |c| !c.is_empty()))
+            .is_some_and(|c| !c.is_empty()))
     }
 
     /// Recalculates ancestor hashes recursively up to root.
@@ -861,7 +861,7 @@ impl<S: StorageAdaptor> Index<S> {
                                 target: "storage::merkle",
                                 child_id = %current_id,
                                 old_child_hash = %hex::encode(child.merkle_hash()),
-                                new_child_hash = %hex::encode(&new_child_hash),
+                                new_child_hash = %hex::encode(new_child_hash),
                                 "ROOT MERKLE: Child hash updated"
                             );
                         }
@@ -882,8 +882,8 @@ impl<S: StorageAdaptor> Index<S> {
                 info!(
                     target: "storage::merkle",
                     parent_id = %parent_id,
-                    old_full_hash = %hex::encode(&old_full_hash),
-                    new_full_hash = %hex::encode(&parent_index.full_hash),
+                    old_full_hash = %hex::encode(old_full_hash),
+                    new_full_hash = %hex::encode(parent_index.full_hash),
                     children_count,
                     "ROOT MERKLE: Root hash recalculated from ancestor"
                 );
@@ -1022,10 +1022,10 @@ impl<S: StorageAdaptor> Index<S> {
             info!(
                 target: "storage::merkle",
                 %id,
-                old_own_hash = %hex::encode(&old_own_hash),
-                new_own_hash = %hex::encode(&merkle_hash),
-                old_full_hash = %hex::encode(&old_full_hash),
-                new_full_hash = %hex::encode(&index.full_hash),
+                old_own_hash = %hex::encode(old_own_hash),
+                new_own_hash = %hex::encode(merkle_hash),
+                old_full_hash = %hex::encode(old_full_hash),
+                new_full_hash = %hex::encode(index.full_hash),
                 children_count,
                 children_hashes = ?children_hashes,
                 "ROOT MERKLE: Hash update for root entity"

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -420,9 +420,7 @@ impl<S: StorageAdaptor> Interface<S> {
     /// if no rotation has been recorded yet (the parent map does not exist).
     pub fn load_rotation_log_child(anchor: Id) -> Option<crate::rotation_log::RotationLog> {
         let map_id = Self::rotation_log_child_id(anchor);
-        if S::storage_read(Key::Entry(map_id)).is_none() {
-            return None;
-        }
+        S::storage_read(Key::Entry(map_id))?;
         let map = Self::rotation_log_map(anchor);
         let mut entries: Vec<crate::rotation_log::RotationLogEntry> = map
             .entries()
@@ -481,7 +479,7 @@ impl<S: StorageAdaptor> Interface<S> {
             // only its id), so every node that materialises the parent stores
             // the same bytes and the same `own_hash`.
             let empty = to_vec(&Self::rotation_log_map(anchor))
-                .map_err(|e| StorageError::SerializationError(e.into()))?;
+                .map_err(StorageError::SerializationError)?;
             let _ = Self::save_raw(map_id, empty, meta)?;
         }
         Ok(map_id)
@@ -940,7 +938,7 @@ impl<S: StorageAdaptor> Interface<S> {
             return Ok(false);
         }
 
-        let data = to_vec(child).map_err(|e| StorageError::SerializationError(e.into()))?;
+        let data = to_vec(child).map_err(StorageError::SerializationError)?;
 
         let own_hash = Sha256::digest(&data).into();
 
@@ -1779,7 +1777,7 @@ impl<S: StorageAdaptor> Interface<S> {
                                     None => return Err(StorageError::InvalidSignature),
                                 };
                                 // Operation-granularity gate: deletes need DELETE.
-                                Self::enforce_op_mask(&signer, OpMask::DELETE, &existing_writers)?;
+                                Self::enforce_op_mask(&signer, OpMask::DELETE, existing_writers)?;
 
                                 // Replay protection (per-entity monotonic nonce).
                                 //
@@ -2225,7 +2223,7 @@ impl<S: StorageAdaptor> Interface<S> {
         else {
             return None;
         };
-        let is_rotation = pre_apply_writers.map_or(true, |stored| stored != writers);
+        let is_rotation = pre_apply_writers != Some(writers);
         if !is_rotation {
             return None;
         }
@@ -2819,7 +2817,7 @@ impl<S: StorageAdaptor> Interface<S> {
                 return Ok(());
             }
 
-            let data = to_vec(&root).map_err(|e| StorageError::SerializationError(e.into()))?;
+            let data = to_vec(&root).map_err(StorageError::SerializationError)?;
 
             Self::save_raw(id, data, root.element().metadata.clone())?
         } else {
@@ -2858,7 +2856,7 @@ impl<S: StorageAdaptor> Interface<S> {
             return Ok(false);
         }
 
-        let data = to_vec(entity).map_err(|e| StorageError::SerializationError(e.into()))?;
+        let data = to_vec(entity).map_err(StorageError::SerializationError)?;
 
         let Some(hash) = Self::save_raw(entity.id(), data, entity.element().metadata.clone())?
         else {
@@ -2966,9 +2964,9 @@ impl<S: StorageAdaptor> Interface<S> {
                         target: "storage::root_merge",
                         %id,
                         existing_len = existing_data.len(),
-                        existing_hash = %hex::encode(&existing_hash),
+                        existing_hash = %hex::encode(existing_hash),
                         incoming_len = data.len(),
-                        incoming_hash = %hex::encode(&incoming_hash),
+                        incoming_hash = %hex::encode(incoming_hash),
                         existing_created_at = last_metadata.created_at,
                         existing_updated_at = *last_metadata.updated_at,
                         incoming_updated_at,
@@ -2987,7 +2985,7 @@ impl<S: StorageAdaptor> Interface<S> {
                         target: "storage::root_merge",
                         %id,
                         merged_len = merged.len(),
-                        merged_hash = %hex::encode(&merged_hash),
+                        merged_hash = %hex::encode(merged_hash),
                         same_as_existing = (merged_hash == existing_hash),
                         same_as_incoming = (merged_hash == incoming_hash),
                         "ROOT MERGE: Completed CRDT merge"
@@ -2998,7 +2996,7 @@ impl<S: StorageAdaptor> Interface<S> {
                         target: "storage::root_merge",
                         %id,
                         incoming_len = data.len(),
-                        incoming_hash = %hex::encode(&incoming_hash),
+                        incoming_hash = %hex::encode(incoming_hash),
                         "ROOT MERGE: No existing data, using incoming directly"
                     );
                     data.to_vec()
@@ -3039,7 +3037,7 @@ impl<S: StorageAdaptor> Interface<S> {
                     target: "storage::root_merge",
                     %id,
                     incoming_len = data.len(),
-                    incoming_hash = %hex::encode(&incoming_hash),
+                    incoming_hash = %hex::encode(incoming_hash),
                     "ROOT MERGE: First time creating root entity"
                 );
                 <Index<S>>::add_root(ChildInfo::new(id, [0_u8; 32], metadata.clone()))?;
@@ -3119,8 +3117,8 @@ impl<S: StorageAdaptor> Interface<S> {
             info!(
                 target: "storage::root_merge",
                 %id,
-                own_hash = %hex::encode(&own_hash),
-                full_hash = %hex::encode(&full_hash),
+                own_hash = %hex::encode(own_hash),
+                full_hash = %hex::encode(full_hash),
                 "ROOT MERGE: Final hashes after Merkle tree update"
             );
         }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -5,56 +5,9 @@
 //!
 
 #![forbid(unreachable_pub, unsafe_op_in_unsafe_fn)]
-#![deny(
-    unsafe_code,
-    clippy::expect_used,
-    clippy::missing_errors_doc,
-    clippy::panic,
-    clippy::unwrap_in_result,
-    clippy::unwrap_used
-)]
-#![warn(
-    missing_docs,
-    clippy::future_not_send,
-    clippy::let_underscore_untyped,
-    clippy::map_err_ignore,
-    clippy::pattern_type_mismatch,
-    clippy::same_name_method,
-    clippy::shadow_reuse,
-    clippy::shadow_same,
-    clippy::shadow_unrelated,
-    clippy::unreachable,
-    clippy::use_debug
-)]
-//	Lints specifically disabled for unit tests
-#![cfg_attr(
-    test,
-    allow(
-        non_snake_case,
-        clippy::arithmetic_side_effects,
-        clippy::assigning_clones,
-        clippy::cast_lossless,
-        clippy::cast_possible_truncation,
-        clippy::cast_precision_loss,
-        clippy::cognitive_complexity,
-        clippy::default_numeric_fallback,
-        clippy::exhaustive_enums,
-        clippy::exhaustive_structs,
-        clippy::expect_used,
-        clippy::indexing_slicing,
-        clippy::let_underscore_must_use,
-        clippy::let_underscore_untyped,
-        clippy::missing_assert_message,
-        clippy::missing_panics_doc,
-        clippy::must_use_candidate,
-        clippy::panic,
-        clippy::print_stdout,
-        clippy::too_many_lines,
-        clippy::unwrap_in_result,
-        clippy::unwrap_used,
-        reason = "Not useful in unit tests"
-    )
-)]
+#![deny(unsafe_code)]
+// Unit tests use a deliberate `subject__scenario` naming convention.
+#![cfg_attr(test, allow(non_snake_case))]
 
 pub mod action;
 pub mod address;

--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -745,8 +745,7 @@ mod typed_dispatch_tests {
         );
         assert!(
             matches!(result, Err(MergeError::SerializationError(_))),
-            "expected SerializationError, got {:?}",
-            result
+            "expected SerializationError, got {result:?}"
         );
     }
 
@@ -770,8 +769,7 @@ mod typed_dispatch_tests {
         );
         assert!(
             matches!(result, Err(MergeError::SerializationError(_))),
-            "expected SerializationError, got {:?}",
-            result
+            "expected SerializationError, got {result:?}"
         );
     }
 

--- a/crates/storage/src/merge/registry.rs
+++ b/crates/storage/src/merge/registry.rs
@@ -230,10 +230,10 @@ where
     let merge_fn: MergeFn = |existing, incoming, _existing_ts, _incoming_ts| {
         // Deserialize both states
         let mut existing_state = borsh::from_slice::<T>(existing)
-            .map_err(|e| format!("Failed to deserialize existing state: {}", e))?;
+            .map_err(|e| format!("Failed to deserialize existing state: {e}"))?;
 
         let incoming_state = borsh::from_slice::<T>(incoming)
-            .map_err(|e| format!("Failed to deserialize incoming state: {}", e))?;
+            .map_err(|e| format!("Failed to deserialize incoming state: {e}"))?;
 
         // Merge using Mergeable trait
         // CRITICAL: Use merge mode to prevent timestamp generation during merge.
@@ -242,11 +242,11 @@ where
         crate::env::with_merge_mode(|| {
             existing_state
                 .merge(&incoming_state)
-                .map_err(|e| format!("Merge failed: {}", e))
+                .map_err(|e| format!("Merge failed: {e}"))
         })?;
 
         // Serialize result
-        borsh::to_vec(&existing_state).map_err(|e| format!("Serialization failed: {}", e).into())
+        borsh::to_vec(&existing_state).map_err(|e| format!("Serialization failed: {e}").into())
     };
 
     with_registry_mut(|registry| {
@@ -423,8 +423,7 @@ mod tests {
                 err,
                 crate::collections::crdt_meta::MergeError::NoMergeFunctionRegistered
             ),
-            "Expected NoMergeFunctionRegistered error, got: {:?}",
-            err
+            "Expected NoMergeFunctionRegistered error, got: {err:?}"
         );
     }
 
@@ -461,8 +460,7 @@ mod tests {
 
         assert!(
             result.is_ok(),
-            "Bootstrap (created == updated, no merger) must accept incoming, got: {:?}",
-            result
+            "Bootstrap (created == updated, no merger) must accept incoming, got: {result:?}"
         );
         assert_eq!(
             result.unwrap(),
@@ -494,8 +492,7 @@ mod tests {
 
         assert!(
             result.is_err(),
-            "Post-bootstrap with no merger must error (I5), got Ok: {:?}",
-            result
+            "Post-bootstrap with no merger must error (I5), got Ok: {result:?}"
         );
         assert!(
             matches!(

--- a/crates/storage/src/tests/authored_primitives.rs
+++ b/crates/storage/src/tests/authored_primitives.rs
@@ -150,7 +150,7 @@ fn authored_map_update_with_forged_owner_claim_is_rejected() {
 
     // Alice inserts the entry (stamped owner = Alice).
     env::set_executor_id(*alice_pk.digest());
-    let mut map = Root::new(|| AuthoredMap::<String, u64>::new());
+    let mut map = Root::new(AuthoredMap::<String, u64>::new);
     map.insert("apple".to_owned(), 1).expect("alice insert");
 
     let entry_id = map.entry_id(&"apple".to_owned());
@@ -168,7 +168,7 @@ fn authored_map_update_with_forged_owner_claim_is_rejected() {
 
     match MainInterface::apply_action(forged, &ApplyContext::empty()) {
         Err(StorageError::InvalidSignature) => {}
-        other => panic!("expected InvalidSignature, got {:?}", other),
+        other => panic!("expected InvalidSignature, got {other:?}"),
     }
 
     // Silence unused_variables warning on alice_sk (not used in this path).
@@ -187,7 +187,7 @@ fn authored_map_delete_by_non_owner_is_rejected() {
     let (bob_sk, bob_pk) = create_test_keypair();
 
     env::set_executor_id(*alice_pk.digest());
-    let mut map = Root::new(|| AuthoredMap::<String, u64>::new());
+    let mut map = Root::new(AuthoredMap::<String, u64>::new);
     map.insert("apple".to_owned(), 1).expect("alice insert");
 
     let entry_id = map.entry_id(&"apple".to_owned());
@@ -204,7 +204,7 @@ fn authored_map_delete_by_non_owner_is_rejected() {
 
     match MainInterface::apply_action(forged, &ApplyContext::empty()) {
         Err(StorageError::InvalidSignature) => {}
-        other => panic!("expected InvalidSignature, got {:?}", other),
+        other => panic!("expected InvalidSignature, got {other:?}"),
     }
 }
 
@@ -218,7 +218,7 @@ fn authored_vector_update_with_forged_owner_claim_is_rejected() {
     let (bob_sk, _bob_pk) = create_test_keypair();
 
     env::set_executor_id(*alice_pk.digest());
-    let mut v = Root::new(|| AuthoredVector::<u64>::new());
+    let mut v = Root::new(AuthoredVector::<u64>::new);
     v.push(7).expect("alice push");
 
     let entry_id = v
@@ -236,7 +236,7 @@ fn authored_vector_update_with_forged_owner_claim_is_rejected() {
 
     match MainInterface::apply_action(forged, &ApplyContext::empty()) {
         Err(StorageError::InvalidSignature) => {}
-        other => panic!("expected InvalidSignature, got {:?}", other),
+        other => panic!("expected InvalidSignature, got {other:?}"),
     }
 }
 
@@ -250,7 +250,7 @@ fn authored_vector_delete_by_non_owner_is_rejected() {
     let (bob_sk, bob_pk) = create_test_keypair();
 
     env::set_executor_id(*alice_pk.digest());
-    let mut v = Root::new(|| AuthoredVector::<u64>::new());
+    let mut v = Root::new(AuthoredVector::<u64>::new);
     v.push(7).expect("alice push");
 
     let entry_id = v
@@ -267,6 +267,6 @@ fn authored_vector_delete_by_non_owner_is_rejected() {
 
     match MainInterface::apply_action(forged, &ApplyContext::empty()) {
         Err(StorageError::InvalidSignature) => {}
-        other => panic!("expected InvalidSignature, got {:?}", other),
+        other => panic!("expected InvalidSignature, got {other:?}"),
     }
 }

--- a/crates/storage/src/tests/collections.rs
+++ b/crates/storage/src/tests/collections.rs
@@ -33,7 +33,7 @@ fn test_root_entry_has_no_crdt_type_so_merge_routes_via_registered_mergeable() {
     // fresh `Root::new` rather than stale state from a prior test.
     env::reset_for_testing();
 
-    let _root = Root::new(|| UnorderedMap::<String, String>::new());
+    let _root = Root::new(UnorderedMap::<String, String>::new);
 
     // Cross-reference the entry's id by calling `Root::entry_id()` directly
     // instead of hardcoding `[118; 32]`, so this test moves in lock-step with
@@ -70,7 +70,7 @@ fn test_root_entry_has_no_crdt_type_so_merge_routes_via_registered_mergeable() {
 
 #[test]
 fn test_unordered_map_basic_operations() {
-    let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+    let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
     assert!(map
         .insert("key".to_string(), "value".to_string())
@@ -131,7 +131,7 @@ fn test_unordered_map_basic_operations() {
 
 #[test]
 fn test_unordered_map_insert_and_get() {
-    let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+    let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
     assert!(map
         .insert("key1".to_string(), "value1".to_string())
@@ -160,16 +160,16 @@ fn test_unordered_map_insert_and_get() {
 
 #[test]
 fn test_unordered_map_update_value() {
-    let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+    let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
     assert!(map
         .insert("key".to_string(), "value".to_string())
         .expect("insert failed")
         .is_none());
-    assert!(!map
+    assert!(map
         .insert("key".to_string(), "new_value".to_string())
         .expect("insert failed")
-        .is_none());
+        .is_some());
 
     assert_eq!(
         map.get("key")
@@ -182,7 +182,7 @@ fn test_unordered_map_update_value() {
 
 #[test]
 fn test_unordered_map_remove() {
-    let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+    let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
     assert!(map
         .insert("key".to_string(), "value".to_string())
@@ -198,7 +198,7 @@ fn test_unordered_map_remove() {
 
 #[test]
 fn test_unordered_map_clear() {
-    let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+    let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
     assert!(map
         .insert("key1".to_string(), "value1".to_string())
@@ -217,7 +217,7 @@ fn test_unordered_map_clear() {
 
 #[test]
 fn test_unordered_map_len() {
-    let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+    let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
     assert_eq!(map.len().expect("len failed"), 0);
 
@@ -229,10 +229,10 @@ fn test_unordered_map_len() {
         .insert("key2".to_string(), "value2".to_string())
         .expect("insert failed")
         .is_none());
-    assert!(!map
+    assert!(map
         .insert("key2".to_string(), "value3".to_string())
         .expect("insert failed")
-        .is_none());
+        .is_some());
 
     assert_eq!(map.len().expect("len failed"), 2);
 
@@ -246,20 +246,20 @@ fn test_unordered_map_len() {
 
 #[test]
 fn test_unordered_map_contains() {
-    let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+    let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
     assert!(map
         .insert("key".to_string(), "value".to_string())
         .expect("insert failed")
         .is_none());
 
-    assert_eq!(map.contains("key").expect("contains failed"), true);
-    assert_eq!(map.contains("nonexistent").expect("contains failed"), false);
+    assert!(map.contains("key").expect("contains failed"));
+    assert!(!map.contains("nonexistent").expect("contains failed"));
 }
 
 #[test]
 fn test_unordered_map_entries() {
-    let mut map = Root::new(|| UnorderedMap::<_, _, MainStorage>::new());
+    let mut map = Root::new(UnorderedMap::<_, _, MainStorage>::new);
 
     assert!(map
         .insert("key1".to_string(), "value1".to_string())
@@ -269,10 +269,10 @@ fn test_unordered_map_entries() {
         .insert("key2".to_string(), "value2".to_string())
         .expect("insert failed")
         .is_none());
-    assert!(!map
+    assert!(map
         .insert("key2".to_string(), "value3".to_string())
         .expect("insert failed")
-        .is_none());
+        .is_some());
 
     let entries: Vec<(String, String)> = map.entries().expect("entries failed").collect();
 
@@ -287,7 +287,7 @@ fn test_unordered_map_entries() {
 
 #[test]
 fn test_vector_push() {
-    let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+    let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
     let value = "test_data".to_string();
     let result = vector.push(value.clone());
@@ -297,21 +297,21 @@ fn test_vector_push() {
 
 #[test]
 fn test_vector_get() {
-    let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+    let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
     let value = "test_data".to_string();
-    let _ = vector.push(value.clone()).unwrap();
+    vector.push(value.clone()).unwrap();
     let retrieved_value = vector.get(0).unwrap().map(|v| v.into_inner());
     assert_eq!(retrieved_value, Some(value));
 }
 
 #[test]
 fn test_vector_update() {
-    let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+    let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
     let value1 = "test_data1".to_string();
     let value2 = "test_data2".to_string();
-    let _ = vector.push(value1.clone()).unwrap();
+    vector.push(value1.clone()).unwrap();
     let old = vector.update(0, value2.clone()).unwrap();
     let retrieved_value = vector.get(0).unwrap().map(|v| v.into_inner());
     assert_eq!(retrieved_value, Some(value2));
@@ -320,20 +320,20 @@ fn test_vector_update() {
 
 #[test]
 fn test_vector_get_non_existent() {
-    let vector = Root::new(|| Vector::<String>::new());
+    let vector = Root::new(Vector::<String>::new);
 
     match vector.get(0) {
         Ok(retrieved_value) => assert_eq!(retrieved_value, None),
-        Err(e) => panic!("Error occurred: {:?}", e),
+        Err(e) => panic!("Error occurred: {e:?}"),
     }
 }
 
 #[test]
 fn test_vector_pop() {
-    let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+    let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
     let value = "test_data".to_string();
-    let _ = vector.push(value.clone()).unwrap();
+    vector.push(value.clone()).unwrap();
     let popped_value = vector.pop().unwrap();
     assert_eq!(popped_value, Some(value));
     assert_eq!(vector.len().unwrap(), 0);
@@ -341,22 +341,22 @@ fn test_vector_pop() {
 
 #[test]
 fn test_vector_items() {
-    let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+    let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
     let value1 = "test_data1".to_string();
     let value2 = "test_data2".to_string();
-    let _ = vector.push(value1.clone()).unwrap();
-    let _ = vector.push(value2.clone()).unwrap();
+    vector.push(value1.clone()).unwrap();
+    vector.push(value2.clone()).unwrap();
     let items: Vec<String> = vector.iter().unwrap().collect();
     assert_eq!(items, vec![value1, value2]);
 }
 
 #[test]
 fn test_vector_contains() {
-    let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+    let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
     let value = "test_data".to_string();
-    let _ = vector.push(value.clone()).unwrap();
+    vector.push(value.clone()).unwrap();
     assert!(vector.contains(&value).unwrap());
     let non_existent_value = "non_existent".to_string();
     assert!(!vector.contains(&non_existent_value).unwrap());
@@ -364,10 +364,10 @@ fn test_vector_contains() {
 
 #[test]
 fn test_vector_clear() {
-    let mut vector = Root::new(|| Vector::<_, MainStorage>::new());
+    let mut vector = Root::new(Vector::<_, MainStorage>::new);
 
     let value = "test_data".to_string();
-    let _ = vector.push(value.clone()).unwrap();
+    vector.push(value.clone()).unwrap();
     vector.clear().unwrap();
     assert_eq!(vector.len().unwrap(), 0);
 }
@@ -378,35 +378,27 @@ fn test_vector_clear() {
 
 #[test]
 fn test_unordered_set_operations() {
-    let mut set = Root::new(|| UnorderedSet::<_, MainStorage>::new());
+    let mut set = Root::new(UnorderedSet::<_, MainStorage>::new);
 
     assert!(set.insert("value1".to_string()).expect("insert failed"));
 
-    assert_eq!(
-        set.contains(&"value1".to_string())
-            .expect("contains failed"),
-        true
-    );
+    assert!(set
+        .contains(&"value1".to_string())
+        .expect("contains failed"));
 
     assert!(!set.insert("value1".to_string()).expect("insert failed"));
     assert!(set.insert("value2".to_string()).expect("insert failed"));
 
-    assert_eq!(set.contains("value3").expect("get failed"), false);
-    assert_eq!(set.contains("value2").expect("get failed"), true);
+    assert!(!set.contains("value3").expect("get failed"));
+    assert!(set.contains("value2").expect("get failed"));
 
-    assert_eq!(
-        set.remove("value1").expect("error while removing key"),
-        true
-    );
-    assert_eq!(
-        set.remove("value3").expect("error while removing key"),
-        false
-    );
+    assert!(set.remove("value1").expect("error while removing key"));
+    assert!(!set.remove("value3").expect("error while removing key"));
 }
 
 #[test]
 fn test_unordered_set_len() {
-    let mut set = Root::new(|| UnorderedSet::<_, MainStorage>::new());
+    let mut set = Root::new(UnorderedSet::<_, MainStorage>::new);
 
     assert!(set.insert("value1".to_string()).expect("insert failed"));
     assert!(set.insert("value2".to_string()).expect("insert failed"));
@@ -421,7 +413,7 @@ fn test_unordered_set_len() {
 
 #[test]
 fn test_unordered_set_clear() {
-    let mut set = Root::new(|| UnorderedSet::<_, MainStorage>::new());
+    let mut set = Root::new(UnorderedSet::<_, MainStorage>::new);
 
     assert!(set.insert("value1".to_string()).expect("insert failed"));
     assert!(set.insert("value2".to_string()).expect("insert failed"));
@@ -431,13 +423,13 @@ fn test_unordered_set_clear() {
     set.clear().expect("clear failed");
 
     assert_eq!(set.len().expect("len failed"), 0);
-    assert_eq!(set.contains("value1").expect("contains failed"), false);
-    assert_eq!(set.contains("value2").expect("contains failed"), false);
+    assert!(!set.contains("value1").expect("contains failed"));
+    assert!(!set.contains("value2").expect("contains failed"));
 }
 
 #[test]
 fn test_unordered_set_items() {
-    let mut set = Root::new(|| UnorderedSet::<_, MainStorage>::new());
+    let mut set = Root::new(UnorderedSet::<_, MainStorage>::new);
 
     assert!(set.insert("value1".to_string()).expect("insert failed"));
     assert!(set.insert("value2".to_string()).expect("insert failed"));

--- a/crates/storage/src/tests/common.rs
+++ b/crates/storage/src/tests/common.rs
@@ -144,6 +144,12 @@ impl Data for Paragraph {
 #[derive(BorshDeserialize, BorshSerialize, Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
 pub struct Paragraphs;
 
+impl Default for Paragraphs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Paragraphs {
     /// Creates a new paragraph collection.
     pub fn new() -> Self {

--- a/crates/storage/src/tests/concurrency.rs
+++ b/crates/storage/src/tests/concurrency.rs
@@ -515,8 +515,7 @@ fn concurrent_merge_splits_value_from_own_hash() {
         assert_eq!(
             stored, expected,
             "core#2571 (round {round}): converged on the wrong writer's value — \
-             expected the global LWW winner (t_sync's last write) but stored {:?}",
-            stored,
+             expected the global LWW winner (t_sync's last write) but stored {stored:?}",
         );
     }
 }

--- a/crates/storage/src/tests/crdt.rs
+++ b/crates/storage/src/tests/crdt.rs
@@ -541,7 +541,7 @@ fn many_sequential_updates() {
     // Apply 20 sequential updates (reduced from 100 for speed)
     for i in 1..=20 {
         std::thread::sleep(std::time::Duration::from_micros(100));
-        page.title = format!("Version {}", i);
+        page.title = format!("Version {i}");
         page.element_mut().update();
 
         let action = Action::Update {
@@ -584,7 +584,7 @@ fn rapid_add_delete_cycles() {
             TestInterface::apply_action(action, &ApplyContext::empty()).unwrap();
         } else {
             // Update (resurrect if was deleted)
-            page.title = format!("Version {}", i);
+            page.title = format!("Version {i}");
             page.element_mut().update();
 
             let action = Action::Update {

--- a/crates/storage/src/tests/delta.rs
+++ b/crates/storage/src/tests/delta.rs
@@ -107,8 +107,8 @@ fn delta_id_changes_with_parents() {
     let actions = vec![];
     let hlc = crate::env::hlc_timestamp();
 
-    let id1 = CausalDelta::compute_id(&vec![[0; 32]], &actions, &hlc);
-    let id2 = CausalDelta::compute_id(&vec![[1; 32]], &actions, &hlc);
+    let id1 = CausalDelta::compute_id(&[[0; 32]], &actions, &hlc);
+    let id2 = CausalDelta::compute_id(&[[1; 32]], &actions, &hlc);
 
     // Should be different
     assert_ne!(id1, id2);
@@ -254,7 +254,7 @@ fn delta_clears_actions_after_commit() {
 
     // Commit
     let delta1 = commit_causal_delta(&[1; 32]).unwrap().unwrap();
-    assert!(delta1.actions.len() > 0);
+    assert!(!delta1.actions.is_empty());
 
     // Reset for second commit
     reset_for_testing();
@@ -269,7 +269,7 @@ fn delta_clears_actions_after_commit() {
     let delta2 = commit_causal_delta(&[2; 32]).unwrap().unwrap();
 
     // Should only have new action (context was cleared)
-    assert!(delta2.actions.len() > 0);
+    assert!(!delta2.actions.is_empty());
     assert_ne!(delta1.actions, delta2.actions);
 }
 

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -840,7 +840,7 @@ mod user_storage_signature_verification {
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidSignature) => {}
-            other => panic!("Expected InvalidSignature error, got {:?}", other),
+            other => panic!("Expected InvalidSignature error, got {other:?}"),
         }
     }
 
@@ -882,11 +882,10 @@ mod user_storage_signature_verification {
             Err(StorageError::InvalidData(msg)) => {
                 assert!(
                     msg.contains("signed"),
-                    "Error should mention signing: {}",
-                    msg
+                    "Error should mention signing: {msg}"
                 );
             }
-            other => panic!("Expected InvalidData error, got {:?}", other),
+            other => panic!("Expected InvalidData error, got {other:?}"),
         }
     }
 
@@ -927,7 +926,7 @@ mod user_storage_signature_verification {
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidSignature) => {}
-            other => panic!("Expected InvalidSignature error, got {:?}", other),
+            other => panic!("Expected InvalidSignature error, got {other:?}"),
         }
     }
 
@@ -1214,7 +1213,7 @@ mod user_storage_replay_protection {
         // Multiple updates with increasing nonces
         for i in 2..=5 {
             sleep(Duration::from_millis(2));
-            page.title = format!("Version {}", i);
+            page.title = format!("Version {i}");
             let serialized = to_vec(&page).unwrap();
             let nonce = env::time_now();
 
@@ -1228,8 +1227,7 @@ mod user_storage_replay_protection {
             );
             assert!(
                 MainInterface::apply_action(action, &ApplyContext::empty()).is_ok(),
-                "Update {} should succeed",
-                i
+                "Update {i} should succeed"
             );
         }
 
@@ -2019,11 +2017,10 @@ mod frozen_storage_verification {
             Err(StorageError::InvalidData(msg)) => {
                 assert!(
                     msg.contains("corruption") || msg.contains("hash"),
-                    "Error should mention corruption or hash: {}",
-                    msg
+                    "Error should mention corruption or hash: {msg}"
                 );
             }
-            other => panic!("Expected InvalidData error, got {:?}", other),
+            other => panic!("Expected InvalidData error, got {other:?}"),
         }
     }
 
@@ -2080,11 +2077,10 @@ mod frozen_storage_verification {
             Err(StorageError::ActionNotAllowed(msg)) => {
                 assert!(
                     msg.contains("Frozen") && msg.contains("updated"),
-                    "Error should mention Frozen and updated: {}",
-                    msg
+                    "Error should mention Frozen and updated: {msg}"
                 );
             }
-            other => panic!("Expected ActionNotAllowed error, got {:?}", other),
+            other => panic!("Expected ActionNotAllowed error, got {other:?}"),
         }
     }
 
@@ -2129,11 +2125,10 @@ mod frozen_storage_verification {
             Err(StorageError::ActionNotAllowed(msg)) => {
                 assert!(
                     msg.contains("Frozen") && msg.contains("deleted"),
-                    "Error should mention Frozen and deleted: {}",
-                    msg
+                    "Error should mention Frozen and deleted: {msg}"
                 );
             }
-            other => panic!("Expected ActionNotAllowed error, got {:?}", other),
+            other => panic!("Expected ActionNotAllowed error, got {other:?}"),
         }
     }
 
@@ -2168,11 +2163,10 @@ mod frozen_storage_verification {
             Err(StorageError::InvalidData(msg)) => {
                 assert!(
                     msg.contains("small") || msg.contains("size"),
-                    "Error should mention size: {}",
-                    msg
+                    "Error should mention size: {msg}"
                 );
             }
-            other => panic!("Expected InvalidData error, got {:?}", other),
+            other => panic!("Expected InvalidData error, got {other:?}"),
         }
     }
 
@@ -2250,7 +2244,7 @@ mod timestamp_drift_protection {
             Err(StorageError::InvalidTimestamp(ts, local)) => {
                 assert!(ts > local + DRIFT_TOLERANCE_NANOS);
             }
-            other => panic!("Expected InvalidTimestamp error, got {:?}", other),
+            other => panic!("Expected InvalidTimestamp error, got {other:?}"),
         }
     }
 
@@ -2333,7 +2327,7 @@ mod timestamp_drift_protection {
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidTimestamp(_, _)) => {}
-            other => panic!("Expected InvalidTimestamp error, got {:?}", other),
+            other => panic!("Expected InvalidTimestamp error, got {other:?}"),
         }
     }
 }
@@ -2449,9 +2443,9 @@ mod storage_type_edge_cases {
         assert!(result.is_err());
         match result {
             Err(StorageError::ActionNotAllowed(msg)) => {
-                assert!(msg.contains("owner"), "Error should mention owner: {}", msg);
+                assert!(msg.contains("owner"), "Error should mention owner: {msg}");
             }
-            other => panic!("Expected ActionNotAllowed error, got {:?}", other),
+            other => panic!("Expected ActionNotAllowed error, got {other:?}"),
         }
     }
 
@@ -2513,7 +2507,7 @@ mod storage_type_edge_cases {
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidSignature) => {}
-            other => panic!("Expected InvalidSignature error, got {:?}", other),
+            other => panic!("Expected InvalidSignature error, got {other:?}"),
         }
     }
 
@@ -2559,11 +2553,10 @@ mod storage_type_edge_cases {
             Err(StorageError::InvalidData(msg)) => {
                 assert!(
                     msg.contains("signed"),
-                    "Error should mention signing: {}",
-                    msg
+                    "Error should mention signing: {msg}"
                 );
             }
-            other => panic!("Expected InvalidData error, got {:?}", other),
+            other => panic!("Expected InvalidData error, got {other:?}"),
         }
     }
 
@@ -2596,11 +2589,10 @@ mod storage_type_edge_cases {
             Err(StorageError::ActionNotAllowed(msg)) => {
                 assert!(
                     msg.contains("StorageType"),
-                    "Error should mention StorageType: {}",
-                    msg
+                    "Error should mention StorageType: {msg}"
                 );
             }
-            other => panic!("Expected ActionNotAllowed error, got {:?}", other),
+            other => panic!("Expected ActionNotAllowed error, got {other:?}"),
         }
     }
 
@@ -2650,11 +2642,10 @@ mod storage_type_edge_cases {
             Err(StorageError::ActionNotAllowed(msg)) => {
                 assert!(
                     msg.contains("StorageType"),
-                    "Error should mention StorageType: {}",
-                    msg
+                    "Error should mention StorageType: {msg}"
                 );
             }
-            other => panic!("Expected ActionNotAllowed error, got {:?}", other),
+            other => panic!("Expected ActionNotAllowed error, got {other:?}"),
         }
     }
 
@@ -2704,7 +2695,7 @@ mod storage_type_edge_cases {
         assert!(result.is_err());
         match result {
             Err(StorageError::NonceReplay(_)) => {}
-            other => panic!("Expected NonceReplay error, got {:?}", other),
+            other => panic!("Expected NonceReplay error, got {other:?}"),
         }
 
         // Entity should still exist

--- a/crates/storage/src/tests/lww_register.rs
+++ b/crates/storage/src/tests/lww_register.rs
@@ -212,7 +212,7 @@ fn test_lww_with_different_types() {
     // Test with bool
     let mut flag = LwwRegister::new(false);
     flag.set(true);
-    assert_eq!(*flag, true);
+    assert!(*flag);
 
     // Test with Vec
     let mut vec = LwwRegister::new(vec![1, 2, 3]);
@@ -245,7 +245,7 @@ fn test_lww_display() {
     env::reset_for_testing();
 
     let reg = LwwRegister::new("Display Test".to_string());
-    assert_eq!(format!("{}", reg), "Display Test");
+    assert_eq!(format!("{reg}"), "Display Test");
 }
 
 #[test]

--- a/crates/storage/src/tests/merge_dispatch.rs
+++ b/crates/storage/src/tests/merge_dispatch.rs
@@ -87,8 +87,7 @@ fn test_gcounter_merge_sums_contributions() {
     // Expected: alice(5) + bob(3) = 8
     assert_eq!(
         merged_value, 8,
-        "GCounter merge should sum contributions from different executors: 5 + 3 = 8, got {}",
-        merged_value
+        "GCounter merge should sum contributions from different executors: 5 + 3 = 8, got {merged_value}"
     );
 }
 
@@ -117,8 +116,7 @@ fn test_gcounter_merge_max_per_executor() {
     // Expected: max(5, 7) = 7
     assert_eq!(
         merged_value, 7,
-        "GCounter merge should take max for same executor: max(5, 7) = 7, got {}",
-        merged_value
+        "GCounter merge should take max for same executor: max(5, 7) = 7, got {merged_value}"
     );
 }
 
@@ -148,8 +146,7 @@ fn test_pncounter_merge_combines_maps() {
     // Expected: positive(alice:10, bob:5) - negative(alice:2) = 15 - 2 = 13
     assert_eq!(
         merged_value, 13,
-        "PnCounter merge should combine maps: (10+5) - 2 = 13, got {}",
-        merged_value
+        "PnCounter merge should combine maps: (10+5) - 2 = 13, got {merged_value}"
     );
 }
 
@@ -269,8 +266,7 @@ fn test_merge_corrupted_data_returns_serialization_error() {
 
     assert!(
         matches!(result, Err(MergeError::SerializationError(_))),
-        "Corrupted data should return SerializationError, got {:?}",
-        result
+        "Corrupted data should return SerializationError, got {result:?}"
     );
 }
 
@@ -344,8 +340,7 @@ fn test_merge_by_crdt_type_differs_from_lww() {
     // Verify they're different
     assert_ne!(
         lww_value, merged_value,
-        "LWW ({}) should differ from CRDT merge ({})",
-        lww_value, merged_value
+        "LWW ({lww_value}) should differ from CRDT merge ({merged_value})"
     );
     assert_eq!(lww_value, 3, "LWW should be bob's value only");
     assert_eq!(merged_value, 8, "CRDT merge should be alice + bob = 8");

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -94,9 +94,8 @@ fn test_merge_via_registry() {
     // The merge should preserve all increments
     // We'll verify it's reasonable (between 2 and 6)
     assert!(
-        final_value >= 2 && final_value <= 6,
-        "Counter value should be between 2 and 6, got {}",
-        final_value
+        (2..=6).contains(&final_value),
+        "Counter value should be between 2 and 6, got {final_value}"
     );
 
     // Verify: Both metadata keys present
@@ -840,20 +839,18 @@ fn test_merge_vector_of_counters() {
 
     let counter0 = merged.metrics.get(0).unwrap().unwrap();
     let val0 = counter0.value().unwrap();
-    println!("Counter at index 0: got {}", val0);
+    println!("Counter at index 0: got {val0}");
     assert!(
         val0 >= 3, // At minimum should have one of the values
-        "Counter at index 0: expected at least 3, got {}",
-        val0
+        "Counter at index 0: expected at least 3, got {val0}"
     );
 
     let counter1 = merged.metrics.get(1).unwrap().unwrap();
     let val1 = counter1.value().unwrap();
-    println!("Counter at index 1: got {}", val1);
+    println!("Counter at index 1: got {val1}");
     assert!(
         val1 >= 1, // At minimum should have one of the values
-        "Counter at index 1: expected at least 1, got {}",
-        val1
+        "Counter at index 1: expected at least 1, got {val1}"
     );
 
     println!("✅ Vector of Counters merge test PASSED - element-wise sum works!");
@@ -1046,17 +1043,16 @@ fn test_merge_nested_document_with_rga() {
 
     // Edit counts should sum (Counter CRDT)
     let merged_count = merged_doc.edit_count.value().unwrap();
-    println!("Forward merge edit_count: {}", merged_count);
+    println!("Forward merge edit_count: {merged_count}");
     assert_eq!(merged_count, 3); // 1 + 2
 
     // Content should contain all characters from both RGAs
     // Note: Both RGAs inserted "Hello" separately (5+5) + " World" (6) = 16 total
     let len = merged_doc.content.len().unwrap();
-    println!("Forward merge content len: {}", len);
+    println!("Forward merge content len: {len}");
     assert_eq!(
         len, 16,
-        "Expected 16 chars (Hello + Hello +  World), got {}",
-        len
+        "Expected 16 chars (Hello + Hello +  World), got {len}"
     );
 
     // Metadata should be present
@@ -1083,8 +1079,8 @@ fn test_merge_nested_document_with_rga() {
     // CRITICAL: Both merge directions should produce identical state
     let reverse_count = reverse_doc.edit_count.value().unwrap();
     let reverse_len = reverse_doc.content.len().unwrap();
-    println!("Reverse merge edit_count: {}", reverse_count);
-    println!("Reverse merge content len: {}", reverse_len);
+    println!("Reverse merge edit_count: {reverse_count}");
+    println!("Reverse merge content len: {reverse_len}");
 
     assert_eq!(
         len, reverse_len,
@@ -1192,10 +1188,9 @@ fn test_merge_determinism_reproduces_e2e_issue() {
     for (i, result) in all_merge_results.iter().enumerate().skip(1) {
         assert_eq!(
             first_result, result,
-            "Merge attempt {} produced different bytes! This is the E2E root hash divergence bug.\n\
-             First: {:?}\n\
-             Attempt {}: {:?}",
-            i, first_result, i, result
+            "Merge attempt {i} produced different bytes! This is the E2E root hash divergence bug.\n\
+             First: {first_result:?}\n\
+             Attempt {i}: {result:?}"
         );
     }
 
@@ -1324,7 +1319,7 @@ fn test_counter_serialization_architecture() {
 
     // Get the entries directly
     let entries: Vec<_> = state.handler_counter.positive.entries().unwrap().collect();
-    println!("Counter entries in storage: {:?}", entries);
+    println!("Counter entries in storage: {entries:?}");
 
     // Serialize the state
     let bytes = borsh::to_vec(&*state).unwrap();
@@ -1332,7 +1327,7 @@ fn test_counter_serialization_architecture() {
     println!(
         "Serialized state: {} bytes, hash={}",
         bytes.len(),
-        hex::encode(&hash)
+        hex::encode(hash)
     );
 
     // === KEY OBSERVATION: What gets serialized? ===
@@ -1342,10 +1337,7 @@ fn test_counter_serialization_architecture() {
     println!("\n=== Serialization Analysis ===");
     println!("State serialized to {} bytes", bytes.len());
     println!("This is just the Collection IDs, NOT the actual counter entries!");
-    println!(
-        "The entries ({:?}) are stored separately in storage.",
-        entries
-    );
+    println!("The entries ({entries:?}) are stored separately in storage.");
 
     // === Verify: deserialize and check value ===
     println!("\n=== Deserialization Test ===");
@@ -1358,8 +1350,8 @@ fn test_counter_serialization_architecture() {
         .unwrap()
         .collect();
 
-    println!("Deserialized counter value: {}", deser_value);
-    println!("Deserialized counter entries: {:?}", deser_entries);
+    println!("Deserialized counter value: {deser_value}");
+    println!("Deserialized counter entries: {deser_entries:?}");
 
     // The value should be 1 because both share MainStorage
     assert_eq!(deser_value, 1, "Counter value should be 1");
@@ -1377,7 +1369,7 @@ fn test_counter_serialization_architecture() {
     println!("  2. The actual counter entries are NOT in the serialized data");
     println!("  3. When Counter::value() is called, it reads from local storage");
     println!("  4. Local storage doesn't have Node-1's entries -> value = 0");
-    println!("");
+    println!();
     println!("The fix: Delta must include Action::Add for counter entries,");
     println!("which gets applied BEFORE the root state merge.");
 
@@ -1453,7 +1445,7 @@ fn test_e2e_sync_flow_with_isolated_storage() {
         .unwrap()
         .map(|(full, _)| full)
         .unwrap_or([0; 32]);
-    println!("Node-1 root hash after save: {}", hex::encode(&node1_hash));
+    println!("Node-1 root hash after save: {}", hex::encode(node1_hash));
 
     // Capture the delta (actions generated during save)
     let delta = commit_causal_delta(&node1_hash).unwrap();
@@ -1478,7 +1470,7 @@ fn test_e2e_sync_flow_with_isolated_storage() {
         .unwrap_or([0; 32]);
     println!(
         "Node-2 root hash BEFORE sync (empty): {}",
-        hex::encode(&node2_hash_before)
+        hex::encode(node2_hash_before)
     );
 
     // Now apply the delta from Node-1
@@ -1493,10 +1485,10 @@ fn test_e2e_sync_flow_with_isolated_storage() {
                     println!("  Action {}: Update id={}, data_len={}", i, id, data.len());
                 }
                 Action::DeleteRef { id, .. } => {
-                    println!("  Action {}: DeleteRef id={}", i, id);
+                    println!("  Action {i}: DeleteRef id={id}");
                 }
                 Action::Compare { id } => {
-                    println!("  Action {}: Compare id={}", i, id);
+                    println!("  Action {i}: Compare id={id}");
                 }
             }
         }
@@ -1515,21 +1507,21 @@ fn test_e2e_sync_flow_with_isolated_storage() {
         .unwrap_or([0; 32]);
     println!(
         "Node-2 root hash AFTER sync: {}",
-        hex::encode(&node2_hash_after)
+        hex::encode(node2_hash_after)
     );
 
     // === PHASE 3: Compare hashes ===
     println!("\n=== PHASE 3: Compare root hashes ===");
-    println!("Node-1 hash: {}", hex::encode(&node1_hash));
-    println!("Node-2 hash: {}", hex::encode(&node2_hash_after));
+    println!("Node-1 hash: {}", hex::encode(node1_hash));
+    println!("Node-2 hash: {}", hex::encode(node2_hash_after));
 
     // Assertions - root hashes should match
     assert_eq!(
         node1_hash,
         node2_hash_after,
         "Root hashes should match after sync! \nNode-1: {}\nNode-2: {}",
-        hex::encode(&node1_hash),
-        hex::encode(&node2_hash_after)
+        hex::encode(node1_hash),
+        hex::encode(node2_hash_after)
     );
 
     println!("\n✅ E2E sync flow test PASSED - hashes converged!");
@@ -1604,11 +1596,11 @@ fn test_e2e_counter_sync_with_isolated_storage() {
                             println!("        - grandchild id: {}", gc.id());
                         }
                     }
-                    Err(e) => println!("      grandchildren error: {:?}", e),
+                    Err(e) => println!("      grandchildren error: {e:?}"),
                 }
             }
         }
-        Err(e) => println!("  ROOT_ID error: {:?}", e),
+        Err(e) => println!("  ROOT_ID error: {e:?}"),
     }
 
     // Print children BEFORE reassign
@@ -1664,8 +1656,8 @@ fn test_e2e_counter_sync_with_isolated_storage() {
         .unwrap()
         .unwrap_or(([0; 32], [0; 32]));
     println!("Node-1 root:");
-    println!("  own_hash:  {}", hex::encode(&node1_own));
-    println!("  full_hash: {}", hex::encode(&node1_full));
+    println!("  own_hash:  {}", hex::encode(node1_own));
+    println!("  full_hash: {}", hex::encode(node1_full));
 
     // Print children info
     let children1 = Index::<NodeStorage>::get_children_of(crate::address::Id::root()).unwrap();
@@ -1701,8 +1693,8 @@ fn test_e2e_counter_sync_with_isolated_storage() {
         .unwrap()
         .unwrap_or(([0; 32], [0; 32]));
     println!("Node-2 root:");
-    println!("  own_hash:  {}", hex::encode(&node2_own));
-    println!("  full_hash: {}", hex::encode(&node2_full));
+    println!("  own_hash:  {}", hex::encode(node2_own));
+    println!("  full_hash: {}", hex::encode(node2_full));
 
     // Print children info
     let children2 = Index::<NodeStorage>::get_children_of(crate::address::Id::root()).unwrap();
@@ -1726,8 +1718,8 @@ fn test_e2e_counter_sync_with_isolated_storage() {
         node1_init_hash,
         node2_init_hash,
         "Nodes should have identical state after init!\nNode-1: {}\nNode-2: {}",
-        hex::encode(&node1_init_hash),
-        hex::encode(&node2_init_hash)
+        hex::encode(node1_init_hash),
+        hex::encode(node2_init_hash)
     );
     println!("✓ Both nodes have identical state after init");
 
@@ -1742,7 +1734,7 @@ fn test_e2e_counter_sync_with_isolated_storage() {
         .expect("Should be able to fetch Counter from NodeStorage");
     node1_counter.increment().unwrap();
     let node1_value = node1_counter.value().unwrap();
-    println!("Node-1 counter value after increment: {}", node1_value);
+    println!("Node-1 counter value after increment: {node1_value}");
 
     // Get the serialized data of the incremented counter
     let counter_data = borsh::to_vec(&*node1_counter).unwrap();
@@ -1768,7 +1760,7 @@ fn test_e2e_counter_sync_with_isolated_storage() {
         .unwrap_or([0; 32]);
     println!(
         "Node-1 hash after increment: {}",
-        hex::encode(&node1_final_hash)
+        hex::encode(node1_final_hash)
     );
 
     // Capture delta BEFORE any commit_root() call
@@ -1811,19 +1803,19 @@ fn test_e2e_counter_sync_with_isolated_storage() {
         .unwrap()
         .map(|(full, _)| full)
         .unwrap_or([0; 32]);
-    println!("Node-2 hash after sync: {}", hex::encode(&node2_final_hash));
+    println!("Node-2 hash after sync: {}", hex::encode(node2_final_hash));
 
     // === PHASE 4: Verify convergence ===
     println!("\n=== PHASE 4: Verification ===");
-    println!("Node-1 final hash: {}", hex::encode(&node1_final_hash));
-    println!("Node-2 final hash: {}", hex::encode(&node2_final_hash));
+    println!("Node-1 final hash: {}", hex::encode(node1_final_hash));
+    println!("Node-2 final hash: {}", hex::encode(node2_final_hash));
 
     assert_eq!(
         node1_final_hash,
         node2_final_hash,
         "Root hashes should match after sync!\nNode-1: {}\nNode-2: {}",
-        hex::encode(&node1_final_hash),
-        hex::encode(&node2_final_hash)
+        hex::encode(node1_final_hash),
+        hex::encode(node2_final_hash)
     );
 
     println!("\n✅ Counter sync test PASSED!");
@@ -2182,7 +2174,7 @@ fn test_nested_counter_in_map_concurrent_increments_converge() {
             .get(&"k".to_string())
             .unwrap()
             .map(ValueRef::into_inner)
-            .unwrap_or_else(Counter::new);
+            .unwrap_or_default();
         ctr.increment().unwrap();
         doc.counters.insert("k".to_string(), ctr).unwrap();
         let data = borsh::to_vec(&*doc).unwrap();
@@ -2328,7 +2320,7 @@ fn test_nested_counter_first_touch_concurrent_converges() {
             .get(&"k".to_string())
             .unwrap()
             .map(ValueRef::into_inner)
-            .unwrap_or_else(Counter::new);
+            .unwrap_or_default();
         ctr.increment().unwrap();
         doc.counters.insert("k".to_string(), ctr).unwrap();
         let data = borsh::to_vec(&*doc).unwrap();
@@ -2469,7 +2461,7 @@ fn test_nested_counter_first_touch_via_entry_api_converges() {
                 .counters
                 .entry("k".to_string())
                 .unwrap()
-                .or_insert_with(Counter::new)
+                .or_default()
                 .unwrap();
             guard.increment().unwrap();
         }
@@ -2999,7 +2991,7 @@ fn test_nested_set_first_touch_concurrent_converges() {
             .get(&"k".to_string())
             .unwrap()
             .map(ValueRef::into_inner)
-            .unwrap_or_else(UnorderedSet::new);
+            .unwrap_or_default();
         let _ = set.insert(tag.to_string()).unwrap();
         doc.tags.insert("k".to_string(), set).unwrap();
         let data = borsh::to_vec(&*doc).unwrap();
@@ -3159,7 +3151,7 @@ fn test_nested_pncounter_single_writer_converges() {
         .get(&"bal".to_string())
         .unwrap()
         .map(ValueRef::into_inner)
-        .unwrap_or_else(Counter::<true>::new);
+        .unwrap_or_default();
     ctr.increment().unwrap();
     ctr.increment().unwrap();
     ctr.increment().unwrap();
@@ -3285,7 +3277,7 @@ fn test_nested_pncounter_concurrent_writers_converge() {
             .get(&"bal".to_string())
             .unwrap()
             .map(ValueRef::into_inner)
-            .unwrap_or_else(Counter::<true>::new);
+            .unwrap_or_default();
         ctr.increment().unwrap();
         ctr.increment().unwrap();
         ctr.decrement().unwrap();
@@ -3307,7 +3299,7 @@ fn test_nested_pncounter_concurrent_writers_converge() {
             .get(&"bal".to_string())
             .unwrap()
             .map(ValueRef::into_inner)
-            .unwrap_or_else(Counter::<true>::new);
+            .unwrap_or_default();
         ctr.increment().unwrap();
         doc.counters.insert("bal".to_string(), ctr).unwrap();
         let data = borsh::to_vec(&*doc).unwrap();

--- a/crates/storage/src/tests/merkle.rs
+++ b/crates/storage/src/tests/merkle.rs
@@ -773,8 +773,7 @@ fn stored_full_hash_stays_authoritative_through_ancestor_walks() {
         assert_eq!(
             index.full_hash(),
             recomputed,
-            "stored full_hash must equal independent recompute for id {:?}",
-            id
+            "stored full_hash must equal independent recompute for id {id:?}"
         );
         assert_ne!(
             index.full_hash(),

--- a/crates/storage/src/tests/rga.rs
+++ b/crates/storage/src/tests/rga.rs
@@ -85,14 +85,13 @@ fn test_rga_insert_str_position_bug() {
     rga.insert_str(6, "Beautiful ").unwrap();
     let result = rga.get_text().unwrap();
 
-    eprintln!("Result: '{}'", result);
+    eprintln!("Result: '{result}'");
     eprintln!("Expected: 'Hello Beautiful World'");
 
     // Expected: "Hello Beautiful World"
     assert_eq!(
         result, "Hello Beautiful World",
-        "insert_str at position 6 should insert before 'World', got: '{}'",
-        result
+        "insert_str at position 6 should insert before 'World', got: '{result}'"
     );
 }
 
@@ -561,7 +560,7 @@ fn test_rga_serialize_deserialize() {
 
     // Check if text is preserved
     let text = rga2.get_text().unwrap();
-    println!("After deserialize: '{}'", text);
+    println!("After deserialize: '{text}'");
     println!("Length: {}", text.len());
 
     assert_eq!(
@@ -586,7 +585,7 @@ fn test_rga_serialize_deserialize_single_insert() {
     let rga2: ReplicatedGrowableArray = borsh::from_slice(&serialized).unwrap();
 
     let text = rga2.get_text().unwrap();
-    println!("After deserialize (single insert): '{}'", text);
+    println!("After deserialize (single insert): '{text}'");
 
     assert_eq!(text, "Hello", "Single insert should be preserved");
 }

--- a/crates/storage/tests/merge_registry_integration.rs
+++ b/crates/storage/tests/merge_registry_integration.rs
@@ -72,7 +72,7 @@ fn register_and_dispatch_against_production_registry() {
 
     let merged_bytes = match try_merge_registered(&bytes_a, &bytes_b, 100, 200) {
         MergeRegistryResult::Success(bytes) => bytes,
-        other => panic!("expected Success from production registry, got {:?}", other),
+        other => panic!("expected Success from production registry, got {other:?}"),
     };
 
     let merged: IntegrationState = borsh::from_slice(&merged_bytes).unwrap();

--- a/crates/tee-attestation/src/error.rs
+++ b/crates/tee-attestation/src/error.rs
@@ -53,31 +53,30 @@ impl fmt::Display for AttestationError {
                     "TEE attestation is not supported on this platform (requires Linux with TDX)"
                 )
             }
-            Self::QuoteGenerationFailed(msg) => write!(f, "Failed to generate TDX quote: {}", msg),
-            Self::QuoteParsingFailed(msg) => write!(f, "Failed to parse TDX quote: {}", msg),
+            Self::QuoteGenerationFailed(msg) => write!(f, "Failed to generate TDX quote: {msg}"),
+            Self::QuoteParsingFailed(msg) => write!(f, "Failed to parse TDX quote: {msg}"),
             Self::QuoteConversionFailed(msg) => {
-                write!(f, "Failed to convert quote to serializable format: {}", msg)
+                write!(f, "Failed to convert quote to serializable format: {msg}")
             }
             Self::QuoteVerificationFailed(msg) => {
-                write!(f, "Failed to verify quote signature: {}", msg)
+                write!(f, "Failed to verify quote signature: {msg}")
             }
             Self::CollateralFetchFailed(msg) => {
-                write!(f, "Failed to fetch collateral from Intel PCS: {}", msg)
+                write!(f, "Failed to fetch collateral from Intel PCS: {msg}")
             }
-            Self::InvalidNonce(msg) => write!(f, "Invalid nonce: {}", msg),
-            Self::InvalidApplicationHash(msg) => write!(f, "Invalid application hash: {}", msg),
+            Self::InvalidNonce(msg) => write!(f, "Invalid nonce: {msg}"),
+            Self::InvalidApplicationHash(msg) => write!(f, "Invalid application hash: {msg}"),
             Self::NonceMismatch { expected, actual } => {
-                write!(f, "Nonce mismatch: expected {}, got {}", expected, actual)
+                write!(f, "Nonce mismatch: expected {expected}, got {actual}")
             }
             Self::ApplicationHashMismatch { expected, actual } => {
                 write!(
                     f,
-                    "Application hash mismatch: expected {}, got {}",
-                    expected, actual
+                    "Application hash mismatch: expected {expected}, got {actual}"
                 )
             }
-            Self::InfoRetrievalFailed(msg) => write!(f, "Failed to get TEE info: {}", msg),
-            Self::SystemTimeError(msg) => write!(f, "System time error: {}", msg),
+            Self::InfoRetrievalFailed(msg) => write!(f, "Failed to get TEE info: {msg}"),
+            Self::SystemTimeError(msg) => write!(f, "System time error: {msg}"),
         }
     }
 }

--- a/crates/tee-attestation/src/verify.rs
+++ b/crates/tee-attestation/src/verify.rs
@@ -53,7 +53,7 @@ pub async fn verify_attestation(
     // Parse TDX quote
     let tdx_quote = TdxQuote::from_bytes(quote_bytes).map_err(|err| {
         error!(error=?err, "Failed to parse TDX quote");
-        AttestationError::QuoteParsingFailed(format!("{:?}", err))
+        AttestationError::QuoteParsingFailed(format!("{err:?}"))
     })?;
 
     info!("Quote parsed successfully");
@@ -66,7 +66,7 @@ pub async fn verify_attestation(
     // Fetch collateral from Intel PCS
     let collateral = get_collateral_from_pcs(quote_bytes).await.map_err(|err| {
         error!(error=?err, "Failed to fetch collateral from Intel PCS");
-        AttestationError::CollateralFetchFailed(format!("{:?}", err))
+        AttestationError::CollateralFetchFailed(format!("{err:?}"))
     })?;
 
     info!("Collateral fetched from Intel PCS");

--- a/crates/utils/actix/src/lazy_tests.rs
+++ b/crates/utils/actix/src/lazy_tests.rs
@@ -21,7 +21,7 @@ impl Actor for Counter {
         assert_eq!(0, self.value);
 
         // `wait` here will execute before any queued messages
-        let _ignored = ctx.wait(async {}.into_actor(self).then(|_, act, _ctx| {
+        ctx.wait(async {}.into_actor(self).then(|_, act, _ctx| {
             assert_eq!(0, act.value);
             async {}.into_actor(act)
         }));

--- a/crates/wasm-abi/src/emitter.rs
+++ b/crates/wasm-abi/src/emitter.rs
@@ -639,8 +639,7 @@ pub fn emit_manifest_from_crate(
     // Parse all files
     let mut files = Vec::new();
     for (name, content) in sources {
-        let file =
-            syn::parse_file(content).map_err(|e| format!("Failed to parse {}: {}", name, e))?;
+        let file = syn::parse_file(content).map_err(|e| format!("Failed to parse {name}: {e}"))?;
         files.push(file);
     }
 

--- a/crates/wasm-abi/src/schema.rs
+++ b/crates/wasm-abi/src/schema.rs
@@ -438,7 +438,7 @@ impl Manifest {
         let state_root_name = self
             .state_root
             .as_ref()
-            .ok_or_else(|| "No state_root defined in manifest")?;
+            .ok_or("No state_root defined in manifest")?;
 
         // Recursively collect all types referenced by the state root
         let mut collected_types = BTreeMap::new();
@@ -477,7 +477,7 @@ impl Manifest {
         // Get the type definition
         let type_def = all_types
             .get(type_name)
-            .ok_or_else(|| format!("Type '{}' not found in ABI types", type_name))?;
+            .ok_or_else(|| format!("Type '{type_name}' not found in ABI types"))?;
 
         // Add this type to collected types
         collected.insert(type_name.to_string(), type_def.clone());

--- a/crates/wasm-abi/tests/schema_validation.rs
+++ b/crates/wasm-abi/tests/schema_validation.rs
@@ -1,4 +1,4 @@
-use calimero_wasm_abi::schema::{Method, MethodIntent};
+use calimero_wasm_abi::schema::MethodIntent;
 use jsonschema::JSONSchema;
 use serde_json::Value;
 

--- a/tools/merodb/src/export.rs
+++ b/tools/merodb/src/export.rs
@@ -108,24 +108,21 @@ fn try_decode_with_field(
             };
             decode_map_entry(entry_bytes, &map_field, manifest)
                 .ok()
-                .map(|decoded| add_index_metadata(decoded, index))
-                .flatten()
+                .and_then(|decoded| add_index_metadata(decoded, index))
         }
         TypeRef::Collection {
             collection: CollectionType::List { items },
             ..
         } => decode_list_entry(entry_bytes, field, items, manifest)
             .ok()
-            .map(|decoded| add_index_metadata(decoded, index))
-            .flatten(),
+            .and_then(|decoded| add_index_metadata(decoded, index)),
         TypeRef::Collection {
             collection: CollectionType::Record { .. },
             crdt_type,
             inner_type,
         } => decode_record_entry(entry_bytes, field, crdt_type, inner_type, manifest)
             .ok()
-            .map(|decoded| add_index_metadata(decoded, index))
-            .flatten(),
+            .and_then(|decoded| add_index_metadata(decoded, index)),
         _ => None,
     }
 }
@@ -215,20 +212,17 @@ fn try_decode_collection_entry_from_index(
     // First, try to match by field_name if available (most direct and efficient)
     if let Some(ref field_name) = index.metadata.field_name {
         eprintln!(
-            "[try_decode_collection_entry_from_index] Using field_name from metadata: {}",
-            field_name
+            "[try_decode_collection_entry_from_index] Using field_name from metadata: {field_name}"
         );
         if let Some(field) = record_fields.iter().find(|f| f.name == *field_name) {
             eprintln!(
-                "[try_decode_collection_entry_from_index] Found matching field by name: {}",
-                field_name
+                "[try_decode_collection_entry_from_index] Found matching field by name: {field_name}"
             );
             // Try to decode with this specific field
             return try_decode_with_field(&entry_bytes, field, index, manifest);
         } else {
             eprintln!(
-                "[try_decode_collection_entry_from_index] Field name '{}' not found in schema, falling back to all fields",
-                field_name
+                "[try_decode_collection_entry_from_index] Field name '{field_name}' not found in schema, falling back to all fields"
             );
         }
     }
@@ -691,7 +685,7 @@ fn decode_state_entry(
             "created_at": index.metadata.created_at,
             "updated_at": *index.metadata.updated_at,
             "field_name": index.metadata.field_name,
-            "crdt_type": index.metadata.crdt_type.as_ref().map(|c| format!("{:?}", c)),
+            "crdt_type": index.metadata.crdt_type.as_ref().map(|c| format!("{c:?}")),
             "deleted_at": index.deleted_at
         }));
     } else {


### PR DESCRIPTION
## What & why

First of a 4-PR series to drive the whole workspace to **zero build + clippy warnings**, then gate CI on `-D warnings` so regressions can't creep back in. Today CI doesn't gate warnings at all (`cargo clippy -- -A warnings`), so they've accumulated across crates.

This PR is **purely mechanical** — machine-applied fixes plus one policy change. **No behavior changes.**

### Policy change
- Removes `calimero-storage`'s bespoke restriction-lint header — it was the **only** crate in the workspace with one. It opted the crate into clippy's `restriction` group (`pattern_type_mismatch`, `shadow_*`, `let_underscore_untyped`, `same_name_method`, `use_debug`, `missing_docs`), which clippy explicitly documents as *not* meant to be enabled wholesale; those accounted for ~200 of the crate's warnings.
- **Kept** the meaningful guards: rustc `forbid(unreachable_pub, unsafe_op_in_unsafe_fn)` + `deny(unsafe_code)`, and a test-only `non_snake_case` allow (the crate's tests use a deliberate `subject__scenario` naming convention).
- Net policy going forward: enforce clippy's **default** lints uniformly across the workspace (gate lands in PR 4).

### Mechanical
- `cargo clippy --fix` across the workspace: `uninlined_format_args`, `needless_borrow`, `redundant_closure`, `useless_conversion`, `field_reassign_with_default`, etc.
- Two `clippy --fix` false-positive repairs where a `cfg(test)`-only consumer made a re-export/import look unused (`MetaRepository`, `min_acks_after_local_mutation`) — referenced by canonical path from the tests instead.

## Verification
- `cargo build --workspace --all-targets` ✅
- `cargo fmt --check` ✅

## The series
1. **This PR** — policy + auto-fix.
2. Manual cleanups in non-consensus crates (docs, stale `#[expect]`, dead code, type aliases, param structs).
3. Consensus hot-path refactors (`NodeClient::broadcast`/`new` param structs; `too_many_arguments`/`large_enum_variant` in context/governance-store/node/runtime).
4. Flip the gate: `[workspace.lints]` + `cargo clippy --workspace --all-targets -- -D warnings` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical lint and style cleanup with no intended runtime or consensus behavior changes; follow-up PRs in the series handle manual refactors and the CI warning gate.
> 
> **Overview**
> Prepares the workspace for a future **`-D warnings`** CI gate by removing `calimero-storage`'s wholesale **restriction-lint** header (keeping `forbid`/`deny` safety lints and test naming allows) and applying **mechanical `cargo clippy --fix`** across apps, context, governance-store, node, auth, meroctl, and merod.
> 
> The fixes are mostly **`uninlined_format_args`**, dropping **needless borrows/conversions** (e.g. `ContextId` / `PublicKey` `.into()` at store keys), **`if let` instead of single-arm `match`**, **`Default` impls**, **`div_ceil`**, and trimming **unused imports**; a couple of **test-only re-exports** were wired through canonical paths after fix false positives (`MetaRepository`, `min_acks_after_local_mutation`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bdd9943cbb34193165596ac2bb6d39ff4b5d373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->