### PR TITLE
chore(lint): manual cleanups across non-consensus crates (2/4)

### DIFF
--- a/apps/migration-harness-example/src/lib.rs
+++ b/apps/migration-harness-example/src/lib.rs
@@ -449,7 +449,7 @@ mod tests {
     fn derived_with_transforms_and_emit_fires() {
         let mut app = TestHost::new(DocV1::init);
         app.call(|s| s.set_title("hello".to_owned())).unwrap();
-        app.take_events(); // discard pre-migration events
+        let _ = app.take_events(); // discard pre-migration events
 
         let v2 = app.migrate(upper_migrate);
 

--- a/apps/migrations/migration-suite-v3-remove-field/src/lib.rs
+++ b/apps/migrations/migration-suite-v3-remove-field/src/lib.rs
@@ -40,6 +40,11 @@ struct MigrationSuiteV2 {
     items: UnorderedMap<String, LwwRegister<String>>,
     description: LwwRegister<String>,
     counter: LwwRegister<u64>,
+    // Present only to be removed by the v3 migration under test.
+    #[allow(
+        dead_code,
+        reason = "old-schema field exercised by the remove-field migration"
+    )]
     notes: LwwRegister<String>,
 }
 

--- a/apps/migrations/scenario-identity-downgrade-v2/src/lib.rs
+++ b/apps/migrations/scenario-identity-downgrade-v2/src/lib.rs
@@ -17,6 +17,8 @@ pub struct ScenarioIdentityDowngradeV2 {
 #[derive(BorshDeserialize)]
 #[borsh(crate = "calimero_sdk::borsh")]
 struct ScenarioIdentityDowngradeV1 {
+    // Old-schema field exercised by the downgrade migration under test.
+    #[allow(dead_code, reason = "old-schema field exercised by the migration")]
     wiki: AuthoredMap<String, LwwRegister<String>>,
 }
 

--- a/apps/migrations/scenario-migration-check-fail-v2/src/lib.rs
+++ b/apps/migrations/scenario-migration-check-fail-v2/src/lib.rs
@@ -51,7 +51,7 @@ pub struct SchemaInfo {
 
 #[derive(BorshDeserialize)]
 #[borsh(crate = "calimero_sdk::borsh")]
-struct ScenarioMigrationCheckFailV1 {
+pub struct ScenarioMigrationCheckFailV1 {
     items: UnorderedMap<String, LwwRegister<String>>,
     title: LwwRegister<String>,
 }

--- a/apps/migrations/scenario-migration-check-pass-v2/src/lib.rs
+++ b/apps/migrations/scenario-migration-check-pass-v2/src/lib.rs
@@ -40,7 +40,7 @@ pub struct SchemaInfo {
 
 #[derive(BorshDeserialize)]
 #[borsh(crate = "calimero_sdk::borsh")]
-struct ScenarioMigrationCheckPassV1 {
+pub struct ScenarioMigrationCheckPassV1 {
     items: UnorderedMap<String, LwwRegister<String>>,
     title: LwwRegister<String>,
 }

--- a/apps/nested-crdt-test/src/lib.rs
+++ b/apps/nested-crdt-test/src/lib.rs
@@ -133,10 +133,9 @@ impl NestedCrdtTest {
     // ===== SortedMap Operations =====
 
     pub fn set_sorted_score(&mut self, key: String, value: u64) -> app::Result<()> {
-        drop(
-            self.sorted_scores
-                .insert(key.clone(), LwwRegister::new(value))?,
-        );
+        let _ = self
+            .sorted_scores
+            .insert(key.clone(), LwwRegister::new(value))?;
 
         app::emit!(TestEvent::SortedScoreSet { key, value });
 

--- a/crates/auth/src/auth/middleware.rs
+++ b/crates/auth/src/auth/middleware.rs
@@ -171,7 +171,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_missing_authorization_header() {
-        let (storage, token_manager, _) = create_test_setup().await;
+        let (_storage, token_manager, _) = create_test_setup().await;
         let headers = HeaderMap::new();
 
         let result = token_manager.verify_token_from_headers(&headers).await;
@@ -186,7 +186,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_bearer_token() {
-        let (storage, token_manager, _) = create_test_setup().await;
+        let (_storage, token_manager, _) = create_test_setup().await;
         let mut headers = HeaderMap::new();
         headers.insert("Authorization", HeaderValue::from_static("Bearer "));
 
@@ -202,7 +202,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_bearer_prefix_only() {
-        let (storage, token_manager, _) = create_test_setup().await;
+        let (_storage, token_manager, _) = create_test_setup().await;
         let mut headers = HeaderMap::new();
         headers.insert("Authorization", HeaderValue::from_static("Bearer"));
 
@@ -219,7 +219,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_invalid_authorization_scheme() {
-        let (storage, token_manager, _) = create_test_setup().await;
+        let (_storage, token_manager, _) = create_test_setup().await;
         let mut headers = HeaderMap::new();
         headers.insert(
             "Authorization",
@@ -238,7 +238,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_malformed_token_no_dots() {
-        let (storage, token_manager, _) = create_test_setup().await;
+        let (_storage, token_manager, _) = create_test_setup().await;
         let mut headers = HeaderMap::new();
         headers.insert(
             "Authorization",
@@ -257,7 +257,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_malformed_token_single_dot() {
-        let (storage, token_manager, _) = create_test_setup().await;
+        let (_storage, token_manager, _) = create_test_setup().await;
         let mut headers = HeaderMap::new();
         headers.insert(
             "Authorization",
@@ -276,7 +276,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_malformed_token_invalid_base64() {
-        let (storage, token_manager, _) = create_test_setup().await;
+        let (_storage, token_manager, _) = create_test_setup().await;
         let mut headers = HeaderMap::new();
         // Token with invalid base64 characters
         headers.insert(
@@ -296,7 +296,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_malformed_token_valid_base64_invalid_json() {
-        let (storage, token_manager, _) = create_test_setup().await;
+        let (_storage, token_manager, _) = create_test_setup().await;
         let mut headers = HeaderMap::new();
         // Base64 encoded non-JSON strings: "notjson", "alsonotjson", "signature"
         headers.insert(
@@ -316,7 +316,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_token_with_extra_segments() {
-        let (storage, token_manager, _) = create_test_setup().await;
+        let (_storage, token_manager, _) = create_test_setup().await;
         let mut headers = HeaderMap::new();
         headers.insert(
             "Authorization",
@@ -335,7 +335,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_token_with_unicode_characters() {
-        let (storage, token_manager, _) = create_test_setup().await;
+        let (_storage, token_manager, _) = create_test_setup().await;
         let mut headers = HeaderMap::new();
         // Cannot put unicode directly in header value, but we can test with ASCII that looks suspicious
         headers.insert(
@@ -355,7 +355,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_token_with_null_bytes() {
-        let (storage, token_manager, _) = create_test_setup().await;
+        let (_storage, token_manager, _) = create_test_setup().await;
         let mut headers = HeaderMap::new();
         // Base64 encoded string with null bytes won't parse as valid JWT
         headers.insert("Authorization", HeaderValue::from_static("Bearer AA.AA.AA"));
@@ -367,7 +367,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_extremely_long_token() {
-        let (storage, token_manager, _) = create_test_setup().await;
+        let (_storage, token_manager, _) = create_test_setup().await;
         let mut headers = HeaderMap::new();
         // Create a very long token (but still valid header format)
         let long_segment = "a".repeat(10000);

--- a/crates/auth/src/auth/service.rs
+++ b/crates/auth/src/auth/service.rs
@@ -206,8 +206,11 @@ impl AuthService {
     ///
     /// # Returns
     ///
-    /// * `Option<&Box<dyn AuthProvider>>` - The provider if found
-    pub fn get_provider(&self, provider_name: &str) -> Option<&Box<dyn AuthProvider>> {
-        self.providers.iter().find(|p| p.name() == provider_name)
+    /// * `Option<&dyn AuthProvider>` - The provider if found
+    pub fn get_provider(&self, provider_name: &str) -> Option<&dyn AuthProvider> {
+        self.providers
+            .iter()
+            .find(|p| p.name() == provider_name)
+            .map(|p| &**p)
     }
 }

--- a/crates/auth/src/providers/core/provider_data_registry.rs
+++ b/crates/auth/src/providers/core/provider_data_registry.rs
@@ -39,8 +39,8 @@ impl AuthDataRegistry {
         self.types.insert(method, auth_type);
     }
 
-    fn get(&self, method: &str) -> Option<&Box<dyn AuthDataType>> {
-        self.types.get(method)
+    fn get(&self, method: &str) -> Option<&dyn AuthDataType> {
+        self.types.get(method).map(|t| &**t)
     }
 
     fn get_all_methods(&self) -> Vec<String> {

--- a/crates/auth/src/storage/key_manager.rs
+++ b/crates/auth/src/storage/key_manager.rs
@@ -222,8 +222,6 @@ impl KeyManager {
             return Ok(false);
         }
 
-        let auth_methods = auth_methods;
-
         // Iterate through keys, deserializing one at a time until we find a match
         for key_path in keys {
             if let Some(data) = self.storage.get(&key_path).await? {

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -2243,9 +2243,11 @@ mod get_context_version_tests {
             "file://test.wasm".into(),
             vec![].into(),
             key::BlobMeta::new([2u8; 32].into()),
-            "com.test.app".into(),
-            "2.1.0".into(),
-            "signer".into(),
+            calimero_store::types::PackageInfo {
+                package: "com.test.app".into(),
+                version: "2.1.0".into(),
+                signer_id: "signer".into(),
+            },
         );
         let cid = ContextId::from([0x07; 32]);
         let ctx_meta = types::ContextMeta::new(app_key, [0u8; 32], vec![], None);

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -1030,13 +1030,16 @@ impl ContextClient {
         &self,
         protocol: String,
         application_id: &ApplicationId,
-        service_name: Option<String>,
-        identity_secret: Option<PrivateKey>,
-        init_params: Vec<u8>,
-        seed: Option<[u8; DIGEST_SIZE]>,
-        group_id: ContextGroupId,
-        name: Option<String>,
+        params: CreateContextParams,
     ) -> eyre::Result<CreateContextResponse> {
+        let CreateContextParams {
+            service_name,
+            identity_secret,
+            init_params,
+            seed,
+            group_id,
+            name,
+        } = params;
         let (sender, receiver) = oneshot::channel();
 
         self.context_manager
@@ -2341,4 +2344,14 @@ mod get_context_version_tests {
             .expect("context present");
         assert_eq!(ctx.name, None);
     }
+}
+
+/// Grouped inputs for [`ContextClient::create_context`].
+pub struct CreateContextParams {
+    pub service_name: Option<String>,
+    pub identity_secret: Option<PrivateKey>,
+    pub init_params: Vec<u8>,
+    pub seed: Option<[u8; DIGEST_SIZE]>,
+    pub group_id: ContextGroupId,
+    pub name: Option<String>,
 }

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -799,7 +799,7 @@ impl ContextRegistry {
     /// # Arguments
     ///
     /// * `start` - An optional `ContextId` from which to begin the stream. If `None`,
-    ///    the stream starts from the beginning.
+    ///   the stream starts from the beginning.
     ///
     /// # Returns
     ///
@@ -884,7 +884,7 @@ impl ContextRegistry {
     ///
     /// * `context_id` - The context to query for members.
     /// * `owned` - If `Some(true)`, the stream returns only members for which this node holds
-    ///    the private key. If `Some(false)` or `None`, it returns all members.
+    ///   the private key. If `Some(false)` or `None`, it returns all members.
     ///
     /// # Returns
     ///
@@ -1069,13 +1069,13 @@ impl ContextClient {
     /// # Arguments
     /// * `context_id` - The context to invite the new member to.
     /// * `inviter_id` - The public key of the existing member creating the invitation.
-    ///                  This node must have the corresponding private key for this identity.
+    ///   This node must have the corresponding private key for this identity.
     /// * `valid_for_seconds` - How long (in seconds) the invitation remains valid.
     /// * `_secret_salt` - Unused; a fresh random salt is generated internally.
     ///
     /// # Returns
     /// * A `Result` containing the `SignedOpenInvitation` if successful, or an error if
-    /// the inviter's private key is not found or signing fails.
+    ///   the inviter's private key is not found or signing fails.
     /// * Returns `Ok(None)` if the context configuration cannot be found locally.
     pub async fn invite_member(
         &self,

--- a/crates/context/primitives/src/client/sync.rs
+++ b/crates/context/primitives/src/client/sync.rs
@@ -330,9 +330,11 @@ impl ContextClient {
                         "calimero://pending-blob-share".to_owned().into_boxed_str(),
                         Vec::new().into_boxed_slice(),
                         zero_blob,
-                        String::new().into_boxed_str(),
-                        String::new().into_boxed_str(),
-                        String::new().into_boxed_str(),
+                        types::PackageInfo {
+                            package: String::new().into_boxed_str(),
+                            version: String::new().into_boxed_str(),
+                            signer_id: String::new().into_boxed_str(),
+                        },
                     );
                     handle.put(&app_key, &stub_meta)?;
                     debug!(

--- a/crates/context/src/handlers/execute/upgrade_gate.rs
+++ b/crates/context/src/handlers/execute/upgrade_gate.rs
@@ -258,9 +258,11 @@ mod tests {
                     String::new().into_boxed_str(),
                     Box::new([]),
                     calimero_store::key::BlobMeta::new([0u8; 32].into()),
-                    String::new().into_boxed_str(),
-                    String::new().into_boxed_str(),
-                    String::new().into_boxed_str(),
+                    calimero_store::types::PackageInfo {
+                        package: String::new().into_boxed_str(),
+                        version: String::new().into_boxed_str(),
+                        signer_id: String::new().into_boxed_str(),
+                    },
                 ),
             )
             .unwrap();

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -1558,9 +1558,11 @@ mod tests {
             "file://test.wasm".into(),
             vec![].into(),
             key::BlobMeta::new([2u8; 32].into()),
-            "com.test.app".into(),
-            "1.0.0".into(),
-            signer_id.into(),
+            types::PackageInfo {
+                package: "com.test.app".into(),
+                version: "1.0.0".into(),
+                signer_id: signer_id.into(),
+            },
         )
     }
 

--- a/crates/context/tests/hlc_fence.rs
+++ b/crates/context/tests/hlc_fence.rs
@@ -127,9 +127,11 @@ fn install_application(store: &Store, app_id: ApplicationId, app_key: [u8; 32]) 
         "test://hlc-fence".to_owned().into_boxed_str(),
         Box::new([]),
         bytecode_blob,
-        "hlc-fence-test-pkg".to_owned().into_boxed_str(),
-        "1.0.0".to_owned().into_boxed_str(),
-        "hlc-fence-test-signer".to_owned().into_boxed_str(),
+        calimero_store::types::PackageInfo {
+            package: "hlc-fence-test-pkg".to_owned().into_boxed_str(),
+            version: "1.0.0".to_owned().into_boxed_str(),
+            signer_id: "hlc-fence-test-signer".to_owned().into_boxed_str(),
+        },
     );
     store
         .handle()

--- a/crates/dag/src/lib.rs
+++ b/crates/dag/src/lib.rs
@@ -661,12 +661,12 @@ impl<T: Clone> DagStore<T> {
     /// A tuple containing:
     /// 1. The list of deltas found (`Vec<CausalDelta>`).
     /// 2. A "cursor" (`Vec<[u8; 32]>`) containing the next IDs to fetch. Client can pass this to `start_id` in
-    ///   the next call to resume the process. If the cursor is empty, the traversal is complete.
+    ///    the next call to resume the process. If the cursor is empty, the traversal is complete.
     ///
-    ///   NOTE: if the client requested more than a `limit` - the node will return only that
-    ///   amount, without raising an error. Only a warning log will be produced.
-    ///   In future, we might change it, if needed, but for now looks like a clean behaviour, the
-    ///   client should be responsible for the pagination himself.
+    ///    NOTE: if the client requested more than a `limit` - the node will return only that
+    ///    amount, without raising an error. Only a warning log will be produced.
+    ///    In future, we might change it, if needed, but for now looks like a clean behaviour, the
+    ///    client should be responsible for the pagination himself.
     pub fn get_deltas_since(
         &self,
         ancestor: [u8; 32],

--- a/crates/dag/src/tests_convergence.rs
+++ b/crates/dag/src/tests_convergence.rs
@@ -154,30 +154,17 @@ enum CrdtOperation {
 /// Applier that simulates CRDT merge behavior
 struct CrdtApplier {
     state: Arc<Mutex<CrdtState>>,
-    applied_order: Arc<Mutex<Vec<[u8; 32]>>>,
-    /// For tracking which deltas were merges vs sequential
-    merge_deltas: Arc<Mutex<Vec<[u8; 32]>>>,
 }
 
 impl CrdtApplier {
     fn new() -> Self {
         Self {
             state: Arc::new(Mutex::new(CrdtState::new())),
-            applied_order: Arc::new(Mutex::new(Vec::new())),
-            merge_deltas: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
     async fn get_state(&self) -> CrdtState {
         self.state.lock().await.clone()
-    }
-
-    async fn get_applied_order(&self) -> Vec<[u8; 32]> {
-        self.applied_order.lock().await.clone()
-    }
-
-    async fn get_merge_deltas(&self) -> Vec<[u8; 32]> {
-        self.merge_deltas.lock().await.clone()
     }
 }
 
@@ -198,7 +185,6 @@ impl DeltaApplier<CrdtOperation> for CrdtApplier {
             }
         }
 
-        self.applied_order.lock().await.push(delta.id);
         Ok(())
     }
 }

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -1265,9 +1265,11 @@ impl<'a> NamespaceGovernance<'a> {
                         effective_source.into_boxed_str(),
                         Vec::new().into_boxed_slice(),
                         blob_meta,
-                        String::new().into_boxed_str(),
-                        String::new().into_boxed_str(),
-                        String::new().into_boxed_str(),
+                        calimero_store::types::PackageInfo {
+                            package: String::new().into_boxed_str(),
+                            version: String::new().into_boxed_str(),
+                            signer_id: String::new().into_boxed_str(),
+                        },
                     );
                     let mut wh = self.store.handle();
                     wh.put(&app_key, &stub)?;

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -80,8 +80,9 @@ pub use wire::{
 /// before triggering a cascade. See
 /// docs/superpowers/specs/2026-05-22-namespace-cascade-app-upgrade-design.md.
 ///
-/// Schema v7: replaces the two ordered cascade ops (`CascadeTargetApplicationSet`
-/// + `CascadeGroupMigrationSet`) with a single atomic `CascadeUpgrade` op
+/// Schema v7: replaces the two ordered cascade ops
+/// (`CascadeTargetApplicationSet` + `CascadeGroupMigrationSet`) with a single
+/// atomic `CascadeUpgrade` op
 /// that carries `cascade_hlc` — a fence timestamp stamped once by the
 /// initiator so every node records an identical boundary. This eliminates
 /// the out-of-order apply window that existed between the two v6 ops.
@@ -393,7 +394,7 @@ impl GroupOp {
 /// Every delta in the DAG carries exactly one `NamespaceOp`:
 /// - `Root` ops are cleartext and visible to all namespace members.
 /// - `Group` ops have a cleartext `group_id` tag (for topic routing and
-///    skeleton storage) but the actual mutation is encrypted.
+///   skeleton storage) but the actual mutation is encrypted.
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub enum NamespaceOp {
     /// Cleartext namespace-wide administrative operation.
@@ -656,7 +657,6 @@ pub fn namespace_signable_bytes(
 }
 
 /// Content hash for a namespace op (SHA-256 of [`namespace_signable_bytes`]).
-#[must_use]
 pub fn namespace_op_content_hash(
     signable: &SignableNamespaceOp,
 ) -> Result<[u8; 32], GovernanceError> {
@@ -846,7 +846,6 @@ pub fn signable_bytes(signable: &SignableGroupOp) -> Result<Vec<u8>, GovernanceE
 }
 
 /// Stable content id for idempotency: SHA-256 of [`signable_bytes`].
-#[must_use]
 pub fn op_content_hash(signable: &SignableGroupOp) -> Result<[u8; 32], GovernanceError> {
     let bytes = signable_bytes(signable)?;
     Ok(Sha256::digest(&bytes).into())

--- a/crates/meroctl/src/cli.rs
+++ b/crates/meroctl/src/cli.rs
@@ -151,10 +151,7 @@ impl RootCommand {
         let output = Output::new(self.args.output_format);
 
         // Some commands don't require a connection (like node commands)
-        let needs_connection = match &self.action {
-            SubCommands::Node(_) => false,
-            _ => true,
-        };
+        let needs_connection = !matches!(&self.action, SubCommands::Node(_));
 
         let connection = if needs_connection {
             Some(self.prepare_connection(output).await?)

--- a/crates/meroctl/src/cli/context/create.rs
+++ b/crates/meroctl/src/cli/context/create.rs
@@ -110,15 +110,17 @@ impl CreateCommand {
                 let _ = create_context(
                     environment,
                     &client_clone,
-                    context_seed,
-                    app_id,
-                    service,
-                    params,
-                    identity,
-                    context,
-                    group_id,
-                    identity_secret,
-                    group_name,
+                    CreateContextArgs {
+                        context_seed,
+                        application_id: app_id,
+                        service,
+                        params,
+                        identity,
+                        context,
+                        group_id,
+                        identity_secret,
+                        group_name,
+                    },
                 )
                 .await?;
             }
@@ -155,15 +157,17 @@ impl CreateCommand {
                 let (context_id, member_public_key) = create_context(
                     environment,
                     &client_clone,
-                    context_seed,
-                    application_id,
-                    service,
-                    params,
-                    identity,
-                    context,
-                    group_id,
-                    identity_secret,
-                    group_name,
+                    CreateContextArgs {
+                        context_seed,
+                        application_id,
+                        service,
+                        params,
+                        identity,
+                        context,
+                        group_id,
+                        identity_secret,
+                        group_name,
+                    },
                 )
                 .await?;
 
@@ -187,16 +191,19 @@ impl CreateCommand {
 pub async fn create_context(
     environment: &mut Environment,
     client: &Client,
-    context_seed: Option<Hash>,
-    application_id: ApplicationId,
-    service: Option<String>,
-    params: Option<String>,
-    identity: Option<Alias<PublicKey>>,
-    context: Option<Alias<ContextId>>,
-    group_id: String,
-    identity_secret: Option<String>,
-    group_name: Option<String>,
+    args: CreateContextArgs,
 ) -> Result<(ContextId, PublicKey)> {
+    let CreateContextArgs {
+        context_seed,
+        application_id,
+        service,
+        params,
+        identity,
+        context,
+        group_id,
+        identity_secret,
+        group_name,
+    } = args;
     let response: GetApplicationResponse = client.get_application(&application_id).await?;
 
     if response.data.application.is_none() {
@@ -307,4 +314,17 @@ async fn watch_app_and_update_context(
     }
 
     Ok(())
+}
+
+/// Grouped inputs for [`create_context`].
+pub struct CreateContextArgs {
+    pub context_seed: Option<Hash>,
+    pub application_id: ApplicationId,
+    pub service: Option<String>,
+    pub params: Option<String>,
+    pub identity: Option<Alias<PublicKey>>,
+    pub context: Option<Alias<ContextId>>,
+    pub group_id: String,
+    pub identity_secret: Option<String>,
+    pub group_name: Option<String>,
 }

--- a/crates/meroctl/src/cli/dev.rs
+++ b/crates/meroctl/src/cli/dev.rs
@@ -103,9 +103,11 @@ impl StartCommand {
             watch_and_reload(
                 environment,
                 context_id,
-                watch_target,
-                artifact_path,
-                self.path.clone(),
+                ReloadPaths {
+                    watch_target,
+                    artifact_path,
+                    project_path: self.path.clone(),
+                },
                 self.no_build,
                 metadata,
                 member_public_key,
@@ -348,13 +350,16 @@ fn find_first_wasm_in(dir: &Path) -> Result<Option<Utf8PathBuf>> {
 async fn watch_and_reload(
     environment: &mut Environment,
     context_id: ContextId,
-    watch_target: Utf8PathBuf,
-    artifact_path: Utf8PathBuf,
-    project_path: Utf8PathBuf,
+    paths: ReloadPaths,
     no_build: bool,
     metadata: Vec<u8>,
     member_public_key: PublicKey,
 ) -> Result<()> {
+    let ReloadPaths {
+        watch_target,
+        artifact_path,
+        project_path,
+    } = paths;
     let is_project = project_path.as_std_path().is_dir();
     let watch_dir = if is_project {
         let src = watch_target.join("src");
@@ -464,4 +469,11 @@ async fn watch_and_reload(
     }
 
     Ok(())
+}
+
+/// The watch / build-output / project paths threaded into [`watch_and_reload`].
+struct ReloadPaths {
+    watch_target: Utf8PathBuf,
+    artifact_path: Utf8PathBuf,
+    project_path: Utf8PathBuf,
 }

--- a/crates/merod/src/cli/run.rs
+++ b/crates/merod/src/cli/run.rs
@@ -121,10 +121,12 @@ impl RunCommand {
         let server_config = ServerConfig::with_auth(
             server_source.listen,
             config.identity.keypair.clone(),
-            server_source.admin,
-            server_source.jsonrpc,
-            server_source.websocket,
-            server_source.sse,
+            calimero_server::config::ServiceConfigs {
+                admin: server_source.admin,
+                jsonrpc: server_source.jsonrpc,
+                websocket: server_source.websocket,
+                sse: server_source.sse,
+            },
             server_source.auth_mode,
             server_source.embedded_auth,
         );

--- a/crates/merod/src/cli/run.rs
+++ b/crates/merod/src/cli/run.rs
@@ -105,8 +105,7 @@ impl RunCommand {
             // Resolve relative RocksDB paths against the node's home directory
             if let AuthStorageConfig::RocksDB { path: storage_path } = &mut auth_config.storage {
                 if storage_path.is_relative() {
-                    let joined = path.as_std_path().join(&*storage_path);
-                    *storage_path = joined.try_into().expect("Invalid UTF-8 path");
+                    *storage_path = path.as_std_path().join(&*storage_path);
                 }
             }
 
@@ -115,8 +114,7 @@ impl RunCommand {
             // Also resolve paths for proxy mode if config exists
             if let AuthStorageConfig::RocksDB { path: storage_path } = &mut cfg.storage {
                 if storage_path.is_relative() {
-                    let joined = path.as_std_path().join(&*storage_path);
-                    *storage_path = joined.try_into().expect("Invalid UTF-8 path");
+                    *storage_path = path.as_std_path().join(&*storage_path);
                 }
             }
         }

--- a/crates/merod/tests/panic_hook.rs
+++ b/crates/merod/tests/panic_hook.rs
@@ -6,6 +6,7 @@
 //! - The test process actually panics; without `catch_unwind` the test fails.
 //! - With `catch_unwind`, the panic hook runs in the same process and may interact
 //!   with the test harness or stderr in non-deterministic ways.
+//!
 //! Running the real binary in a subprocess and using `Command::output()` gives
 //! deterministic, full stderr capture and no in-process panic.
 

--- a/crates/node/primitives/src/client/alias.rs
+++ b/crates/node/primitives/src/client/alias.rs
@@ -6,6 +6,9 @@ use eyre::{bail, OptionExt};
 
 use super::NodeClient;
 
+/// A resolved alias entry: the alias, its target value, and optional scope.
+type AliasEntry<T, S> = (Alias<T>, T, Option<S>);
+
 impl NodeClient {
     pub fn create_alias<T>(
         &self,
@@ -81,7 +84,7 @@ impl NodeClient {
     pub fn list_aliases<T>(
         &self,
         scope: Option<T::Scope>,
-    ) -> eyre::Result<Vec<(Alias<T>, T, Option<T::Scope>)>>
+    ) -> eyre::Result<Vec<AliasEntry<T, T::Scope>>>
     where
         T: Aliasable + From<[u8; 32]>,
         T::Scope: Copy + PartialEq + StoreScopeCompat,

--- a/crates/node/primitives/src/client/application.rs
+++ b/crates/node/primitives/src/client/application.rs
@@ -10,13 +10,9 @@ use calimero_primitives::blobs::BlobId;
 use calimero_store::key;
 use calimero_store::key::AsKeyParts;
 use eyre::bail;
-use futures_util::TryStreamExt;
-use sha2::Digest;
 use tracing::{debug, warn};
 
 use super::NodeClient;
-
-const MAX_ERROR_BODY_LEN: usize = 256;
 
 impl NodeClient {
     pub fn get_application(
@@ -184,9 +180,7 @@ impl NodeClient {
                         }
                     }
 
-                    canonical_extract_candidate.try_into().map_err(|_| {
-                        eyre::eyre!("Failed to convert extract_dir path to Utf8PathBuf")
-                    })?
+                    canonical_extract_candidate
                 };
 
                 // Ensure canonical_wasm is within canonical_extract

--- a/crates/node/primitives/src/client/application/install.rs
+++ b/crates/node/primitives/src/client/application/install.rs
@@ -229,11 +229,6 @@ impl NodeClient {
         .await
     }
 
-    /// Check if a path points to a bundle archive (.mpk - Mero Package Kit)
-    fn is_bundle_archive(path: &Utf8Path) -> bool {
-        path.extension().map(|ext| ext == "mpk").unwrap_or(false)
-    }
-
     pub async fn install_application_from_path(
         &self,
         path: Utf8PathBuf,
@@ -562,9 +557,7 @@ impl NodeClient {
                         }
                     }
 
-                    canonical_extract_candidate.try_into().map_err(|_| {
-                        eyre::eyre!("Failed to convert extract_dir path to Utf8PathBuf")
-                    })?
+                    canonical_extract_candidate
                 };
 
                 if !canonical_wasm.starts_with(&canonical_extract) {

--- a/crates/node/primitives/src/client/application/install.rs
+++ b/crates/node/primitives/src/client/application/install.rs
@@ -41,9 +41,11 @@ impl NodeClient {
             source.to_string().into_boxed_str(),
             metadata.into_boxed_slice(),
             key::BlobMeta::new(BlobId::from([0; 32])),
-            package.to_owned().into_boxed_str(),
-            version.to_owned().into_boxed_str(),
-            "".to_owned().into_boxed_str(),
+            types::PackageInfo {
+                package: package.to_owned().into_boxed_str(),
+                version: version.to_owned().into_boxed_str(),
+                signer_id: String::new().into_boxed_str(),
+            },
         );
 
         let application_id = {
@@ -68,9 +70,7 @@ impl NodeClient {
         size: u64,
         source: &ApplicationSource,
         metadata: Vec<u8>,
-        package: &str,
-        version: &str,
-        signer_id: &str,
+        info: types::PackageInfo,
         services: Vec<types::ServiceMeta>,
     ) -> eyre::Result<ApplicationId> {
         let mut application = types::ApplicationMeta::new(
@@ -79,9 +79,7 @@ impl NodeClient {
             source.to_string().into_boxed_str(),
             metadata.into_boxed_slice(),
             key::BlobMeta::new(BlobId::from([0; 32])),
-            package.to_owned().into_boxed_str(),
-            version.to_owned().into_boxed_str(),
-            signer_id.to_owned().into_boxed_str(),
+            info,
         );
         application.services = services;
 
@@ -168,9 +166,11 @@ impl NodeClient {
             stored_size,
             source,
             bundle_metadata,
-            package,
-            version,
-            &signer_id,
+            types::PackageInfo {
+                package: package.as_str().into(),
+                version: version.as_str().into(),
+                signer_id: signer_id.into(),
+            },
             services,
         )
     }

--- a/crates/node/primitives/src/client/blob.rs
+++ b/crates/node/primitives/src/client/blob.rs
@@ -405,6 +405,7 @@ impl NodeClient {
     /// Returns a list of all root blob IDs and their metadata. Root blobs are either:
     /// - Blobs that contain links to chunks (segmented large files)
     /// - Standalone blobs that aren't referenced as chunks by other blobs
+    ///
     /// This excludes individual chunk blobs to provide a cleaner user experience.
     pub fn list_blobs(&self) -> eyre::Result<Vec<BlobInfo>> {
         let handle = self.datastore.clone().handle();

--- a/crates/node/primitives/src/delta_buffer.rs
+++ b/crates/node/primitives/src/delta_buffer.rs
@@ -343,13 +343,10 @@ mod tests {
         assert_eq!(d.governance_drain_attempts, 0);
     }
 
-    #[test]
-    fn governance_drain_attempts_constant_within_u8() {
-        // Constant must fit u8 (we store the counter as u8 to keep
-        // BufferedDelta compact). Sanity-check the bound.
-        assert!(MAX_GOVERNANCE_DRAIN_ATTEMPTS < u8::MAX);
-        assert!(MAX_GOVERNANCE_DRAIN_ATTEMPTS > 0);
-    }
+    // Constant must fit u8 (we store the counter as u8 to keep BufferedDelta
+    // compact). Checked at compile time.
+    const _: () = assert!(MAX_GOVERNANCE_DRAIN_ATTEMPTS < u8::MAX);
+    const _: () = assert!(MAX_GOVERNANCE_DRAIN_ATTEMPTS > 0);
 
     #[test]
     fn test_buffer_basic() {

--- a/crates/node/primitives/src/sync/bloom_filter.rs
+++ b/crates/node/primitives/src/sync/bloom_filter.rs
@@ -652,7 +652,7 @@ mod tests {
 
         // Different IDs should produce different hashes
         let other_id = [0xCD; 32];
-        let (h1_other, h2_other) = DeltaIdBloomFilter::compute_hashes(&other_id);
+        let (h1_other, _h2_other) = DeltaIdBloomFilter::compute_hashes(&other_id);
         assert_ne!(h1_a, h1_other);
     }
 

--- a/crates/node/primitives/src/sync/state_machine.rs
+++ b/crates/node/primitives/src/sync/state_machine.rs
@@ -150,7 +150,7 @@ pub fn estimate_max_depth(entity_count: u64) -> u32 {
         // log2(n) ≈ 64 - leading_zeros(n)
         // For a balanced tree, depth is roughly log2(entity_count)
         let log2_approx = 64u32.saturating_sub(entity_count.leading_zeros());
-        log2_approx.max(1).min(32)
+        log2_approx.clamp(1, 32)
     }
 }
 

--- a/crates/node/primitives/src/sync/subtree.rs
+++ b/crates/node/primitives/src/sync/subtree.rs
@@ -793,16 +793,13 @@ mod tests {
     // Heuristic Function Tests
     // =========================================================================
 
-    #[test]
-    fn test_heuristic_constants_are_sensible() {
-        // Verify the constants have sensible values
-        assert!(DEEP_TREE_THRESHOLD > 0);
-        assert!(DEEP_TREE_THRESHOLD < MAX_SUBTREE_DEPTH);
-        assert!(MAX_DIVERGENCE_RATIO > 0.0);
-        assert!(MAX_DIVERGENCE_RATIO < 1.0);
-        assert!(MAX_CLUSTERED_SUBTREES > 0);
-        assert!(MAX_CLUSTERED_SUBTREES <= MAX_SUBTREES_PER_REQUEST);
-    }
+    // Heuristic constants must hold sensible relationships; checked at compile time.
+    const _: () = assert!(DEEP_TREE_THRESHOLD > 0);
+    const _: () = assert!(DEEP_TREE_THRESHOLD < MAX_SUBTREE_DEPTH);
+    const _: () = assert!(MAX_DIVERGENCE_RATIO > 0.0);
+    const _: () = assert!(MAX_DIVERGENCE_RATIO < 1.0);
+    const _: () = assert!(MAX_CLUSTERED_SUBTREES > 0);
+    const _: () = assert!(MAX_CLUSTERED_SUBTREES <= MAX_SUBTREES_PER_REQUEST);
 
     #[test]
     fn test_should_use_subtree_prefetch_basic() {

--- a/crates/node/primitives/tests/bundle_installation.rs
+++ b/crates/node/primitives/tests/bundle_installation.rs
@@ -4,7 +4,6 @@ use std::fs;
 
 use std::sync::Arc;
 
-use base64::Engine;
 use calimero_blobstore::config::BlobStoreConfig;
 use calimero_blobstore::{BlobManager as BlobStore, FileSystem};
 use calimero_network_primitives::client::NetworkClient;
@@ -16,7 +15,7 @@ use calimero_store::db::InMemoryDB;
 use calimero_store::Store;
 use calimero_utils_actix::LazyRecipient;
 use camino::Utf8PathBuf;
-use ed25519_dalek::{Signer, SigningKey};
+use ed25519_dalek::SigningKey;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use futures_util::io::Cursor;

--- a/crates/node/src/cascade_dispatch_e2e.rs
+++ b/crates/node/src/cascade_dispatch_e2e.rs
@@ -169,9 +169,11 @@ fn install_application(store: &Store, app_id: ApplicationId, app_key: [u8; 32], 
         "test://cascade".to_owned().into_boxed_str(),
         Box::new([]),
         bytecode_blob,
-        "cascade-test-pkg".to_owned().into_boxed_str(),
-        version.to_owned().into_boxed_str(),
-        "cascade-test-signer".to_owned().into_boxed_str(),
+        calimero_store::types::PackageInfo {
+            package: "cascade-test-pkg".to_owned().into_boxed_str(),
+            version: version.to_owned().into_boxed_str(),
+            signer_id: "cascade-test-signer".to_owned().into_boxed_str(),
+        },
     );
     let mut handle = store.handle();
     handle

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -2286,9 +2286,11 @@ mod tests {
                 "".into(),
                 Box::default(),
                 key::BlobMeta::new(BlobId::from([0; 32])),
-                "".into(),
-                "".into(),
-                "".into(),
+                calimero_store::types::PackageInfo {
+                    package: "".into(),
+                    version: "".into(),
+                    signer_id: "".into(),
+                },
             );
             let ctx_meta = ContextMeta::new(app_key, [0; 32], vec![], None);
 

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -637,9 +637,11 @@ async fn create_restricted_subgroup(
         "test://app".into(),
         Box::new([]),
         calimero_store::key::BlobMeta::new(calimero_primitives::blobs::BlobId::from([0xDDu8; 32])),
-        "test-package".into(),
-        "0.0.0".into(),
-        "test-signer".into(),
+        calimero_store::types::PackageInfo {
+            package: "test-package".into(),
+            version: "0.0.0".into(),
+            signer_id: "test-signer".into(),
+        },
     );
     node.store
         .handle()
@@ -994,9 +996,11 @@ async fn root_admitted_tee_auto_follows_open_subgroup_context() {
         "calimero://stub-app".into(),
         Box::new([]),
         stub_blob,
-        "stub-package".into(),
-        "0.0.0".into(),
-        "stub-signer".into(),
+        calimero_store::types::PackageInfo {
+            package: "stub-package".into(),
+            version: "0.0.0".into(),
+            signer_id: "stub-signer".into(),
+        },
     );
     node.store
         .handle()
@@ -1234,9 +1238,11 @@ async fn integrated_tee_lifecycle_open_replication_and_scoped_root_cascade() {
         "calimero://stub-app".into(),
         Box::new([]),
         stub_blob,
-        "stub-package".into(),
-        "0.0.0".into(),
-        "stub-signer".into(),
+        calimero_store::types::PackageInfo {
+            package: "stub-package".into(),
+            version: "0.0.0".into(),
+            signer_id: "stub-signer".into(),
+        },
     );
     node.store
         .handle()

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -1309,9 +1309,11 @@ mod tests {
             "test://loaded".to_owned().into_boxed_str(),
             Box::new([]),
             blob,
-            "loaded-test-pkg".to_owned().into_boxed_str(),
-            version.to_owned().into_boxed_str(),
-            "loaded-test-signer".to_owned().into_boxed_str(),
+            calimero_store::types::PackageInfo {
+                package: "loaded-test-pkg".to_owned().into_boxed_str(),
+                version: version.to_owned().into_boxed_str(),
+                signer_id: "loaded-test-signer".to_owned().into_boxed_str(),
+            },
         );
         let mut handle = store.handle();
         handle

--- a/crates/node/src/sync/manager/blob_fetch.rs
+++ b/crates/node/src/sync/manager/blob_fetch.rs
@@ -135,9 +135,11 @@ impl SyncManager {
                     calimero_store::key::BlobMeta::new(calimero_primitives::blobs::BlobId::from(
                         [0u8; 32],
                     )),
-                    "unknown".to_owned().into_boxed_str(),
-                    "0.0.0".to_owned().into_boxed_str(),
-                    String::new().into_boxed_str(),
+                    calimero_store::types::PackageInfo {
+                        package: "unknown".to_owned().into_boxed_str(),
+                        version: "0.0.0".to_owned().into_boxed_str(),
+                        signer_id: String::new().into_boxed_str(),
+                    },
                 ),
             )?;
             context.application_id

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -3724,9 +3724,11 @@ mod pending_upgrade_tests {
                     calimero_store::key::BlobMeta::new(calimero_primitives::blobs::BlobId::from(
                         [0u8; 32],
                     )),
-                    "stage-pkg".to_owned().into_boxed_str(),
-                    "1.0.0".to_owned().into_boxed_str(),
-                    "stage-signer".to_owned().into_boxed_str(),
+                    calimero_store::types::PackageInfo {
+                        package: "stage-pkg".to_owned().into_boxed_str(),
+                        version: "1.0.0".to_owned().into_boxed_str(),
+                        signer_id: "stage-signer".to_owned().into_boxed_str(),
+                    },
                 ),
             )
             .expect("put app row");
@@ -3751,9 +3753,11 @@ mod pending_upgrade_tests {
                     calimero_store::key::BlobMeta::new(calimero_primitives::blobs::BlobId::from(
                         [0u8; 32],
                     )),
-                    "stage-pkg".to_owned().into_boxed_str(),
-                    "1.0.0".to_owned().into_boxed_str(),
-                    "stage-signer".to_owned().into_boxed_str(),
+                    calimero_store::types::PackageInfo {
+                        package: "stage-pkg".to_owned().into_boxed_str(),
+                        version: "1.0.0".to_owned().into_boxed_str(),
+                        signer_id: "stage-signer".to_owned().into_boxed_str(),
+                    },
                 ),
             )
             .expect("put app row");

--- a/crates/primitives/src/tests/alias.rs
+++ b/crates/primitives/src/tests/alias.rs
@@ -1,73 +1,70 @@
-#[cfg(test)]
-mod tests {
-    use serde_json::json;
+use serde_json::json;
 
-    use crate::alias::Alias;
+use crate::alias::Alias;
 
-    #[test]
-    fn test_valid_alias_creation() {
-        let alias: Alias<()> = "test-alias".parse().unwrap();
-        assert_eq!(alias.as_str(), "test-alias");
-    }
+#[test]
+fn test_valid_alias_creation() {
+    let alias: Alias<()> = "test-alias".parse().unwrap();
+    assert_eq!(alias.as_str(), "test-alias");
+}
 
-    #[test]
-    fn test_alias_length_limit() {
-        // Valid: exactly 50 chars
-        let valid = "a".repeat(50).parse::<Alias<()>>();
-        let _ignored = valid.expect("valid alias");
+#[test]
+fn test_alias_length_limit() {
+    // Valid: exactly 50 chars
+    let valid = "a".repeat(50).parse::<Alias<()>>();
+    let _ignored = valid.expect("valid alias");
 
-        // Invalid: 51 chars
-        let invalid = "a".repeat(51).parse::<Alias<()>>();
-        let _ignored = invalid.expect_err("invalid alias");
-    }
+    // Invalid: 51 chars
+    let invalid = "a".repeat(51).parse::<Alias<()>>();
+    let _ignored = invalid.expect_err("invalid alias");
+}
 
-    #[test]
-    fn test_empty_alias() {
-        // Empty string should be valid
-        let alias: Alias<()> = "".parse().unwrap();
-        assert_eq!(alias.as_str(), "");
-    }
+#[test]
+fn test_empty_alias() {
+    // Empty string should be valid
+    let alias: Alias<()> = "".parse().unwrap();
+    assert_eq!(alias.as_str(), "");
+}
 
-    #[test]
-    fn test_special_characters() {
-        // Test with various special characters
-        let special = "test-123_@#$%^&*()";
-        let alias: Alias<()> = special.parse().unwrap();
-        assert_eq!(alias.as_str(), special);
-    }
+#[test]
+fn test_special_characters() {
+    // Test with various special characters
+    let special = "test-123_@#$%^&*()";
+    let alias: Alias<()> = special.parse().unwrap();
+    assert_eq!(alias.as_str(), special);
+}
 
-    #[test]
-    fn test_unicode_characters() {
-        // Test with Unicode characters
-        let unicode = "测试-алиас-🦀";
-        let alias: Alias<()> = unicode.parse().unwrap();
-        assert_eq!(alias.as_str(), unicode);
-    }
+#[test]
+fn test_unicode_characters() {
+    // Test with Unicode characters
+    let unicode = "测试-алиас-🦀";
+    let alias: Alias<()> = unicode.parse().unwrap();
+    assert_eq!(alias.as_str(), unicode);
+}
 
-    #[test]
-    fn test_deserialize_valid_alias() {
-        let json = json!("valid-alias");
-        let alias: Alias<()> = serde_json::from_value(json).unwrap();
-        assert_eq!(alias.as_str(), "valid-alias");
-    }
+#[test]
+fn test_deserialize_valid_alias() {
+    let json = json!("valid-alias");
+    let alias: Alias<()> = serde_json::from_value(json).unwrap();
+    assert_eq!(alias.as_str(), "valid-alias");
+}
 
-    #[test]
-    fn test_deserialize_invalid_length() {
-        let long_string = "a".repeat(51);
-        let json = json!(long_string);
-        let result: Result<Alias<()>, _> = serde_json::from_value(json);
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("exceeds maximum length"));
-    }
+#[test]
+fn test_deserialize_invalid_length() {
+    let long_string = "a".repeat(51);
+    let json = json!(long_string);
+    let result: Result<Alias<()>, _> = serde_json::from_value(json);
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("exceeds maximum length"));
+}
 
-    #[test]
-    fn test_serialize_deserialize_roundtrip() {
-        let original: Alias<()> = "test-alias".parse().unwrap();
-        let serialized = serde_json::to_string(&original).unwrap();
-        let deserialized: Alias<()> = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(original, deserialized);
-    }
+#[test]
+fn test_serialize_deserialize_roundtrip() {
+    let original: Alias<()> = "test-alias".parse().unwrap();
+    let serialized = serde_json::to_string(&original).unwrap();
+    let deserialized: Alias<()> = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(original, deserialized);
 }

--- a/crates/sdk/macros/src/logic.rs
+++ b/crates/sdk/macros/src/logic.rs
@@ -127,7 +127,7 @@ impl<'a> TryFrom<LogicImplInput<'a>> for LogicImpl<'a> {
                     type_: &type_,
                     item: method,
                 }) {
-                    Ok(LogicMethod::Public(method)) => methods.push(method),
+                    Ok(LogicMethod::Public(method)) => methods.push(*method),
                     Ok(LogicMethod::Private) => {}
                     Err(err) => errors.combine(&err),
                 }

--- a/crates/sdk/macros/src/logic/arg.rs
+++ b/crates/sdk/macros/src/logic/arg.rs
@@ -14,7 +14,7 @@ pub enum SelfType<'a> {
 
 pub enum LogicArg<'a> {
     Receiver(SelfType<'a>),
-    Typed(LogicArgTyped<'a>),
+    Typed(Box<LogicArgTyped<'a>>),
 }
 
 pub struct LogicArgTyped<'a> {
@@ -102,10 +102,10 @@ impl<'a, 'b> TryFrom<LogicArgInput<'a, 'b>> for LogicArg<'a> {
 
                 errors.check()?;
 
-                Ok(LogicArg::Typed(LogicArgTyped {
+                Ok(LogicArg::Typed(Box::new(LogicArgTyped {
                     ident: &ident.ident,
                     ty,
-                }))
+                })))
             }
         }
     }

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -12,7 +12,7 @@ use crate::logic::ty::{LogicTy, LogicTyInput};
 use crate::reserved::{idents, lifetimes};
 
 pub enum LogicMethod<'a> {
-    Public(PublicLogicMethod<'a>),
+    Public(Box<PublicLogicMethod<'a>>),
     Private,
 }
 
@@ -523,7 +523,7 @@ impl<'a, 'b> TryFrom<LogicMethodImplInput<'a, 'b>> for LogicMethod<'a> {
                     (LogicArg::Receiver(_), Some(_)) => { /* handled by rustc */ }
                     (LogicArg::Typed(arg), _) => {
                         has_refs |= arg.ty.ref_;
-                        args.push(arg);
+                        args.push(*arg);
                     }
                 },
                 Err(err) => errors.combine(&err),
@@ -585,7 +585,7 @@ impl<'a, 'b> TryFrom<LogicMethodImplInput<'a, 'b>> for LogicMethod<'a> {
 
         errors.check()?;
 
-        Ok(LogicMethod::Public(PublicLogicMethod {
+        Ok(LogicMethod::Public(Box::new(PublicLogicMethod {
             name,
             self_: input.type_.clone(),
             self_type,
@@ -593,7 +593,7 @@ impl<'a, 'b> TryFrom<LogicMethodImplInput<'a, 'b>> for LogicMethod<'a> {
             ret,
             has_refs,
             modifiers,
-        }))
+        })))
     }
 }
 

--- a/crates/sdk/macros/src/migration.rs
+++ b/crates/sdk/macros/src/migration.rs
@@ -449,47 +449,39 @@ mod tests {
 
         assert!(
             expanded.contains("extern \"C\""),
-            "expected WASM extern \"C\" export in expansion: {}",
-            expanded
+            "expected WASM extern \"C\" export in expansion: {expanded}",
         );
         assert!(
             expanded.contains("value_return"),
-            "expected value_return call in expansion: {}",
-            expanded
+            "expected value_return call in expansion: {expanded}",
         );
         assert!(
             expanded.contains("__migration_logic"),
-            "expected inner __migration_logic in expansion: {}",
-            expanded
+            "expected inner __migration_logic in expansion: {expanded}",
         );
         assert!(
             expanded.contains("no_mangle"),
-            "expected #[no_mangle] in expansion: {}",
-            expanded
+            "expected #[no_mangle] in expansion: {expanded}",
         );
         assert!(
             expanded.contains("event :: register"),
-            "expected event::register call in expansion: {}",
-            expanded
+            "expected event::register call in expansion: {expanded}",
         );
         assert!(
             expanded.contains("register_schema_version"),
             "expected app::register_schema_version call in expansion (PR-6c: migrate must \
              register the new state's SCHEMA_VERSION so app::schema_version() reflects the \
-             migrated target on a real node, not the unversioned 0): {}",
-            expanded
+             migrated target on a real node, not the unversioned 0): {expanded}",
         );
         assert!(
             expanded.contains("__assign_deterministic_ids"),
             "expected __assign_deterministic_ids call in expansion (CIP I9 cross-node \
-             determinism for migrate-created collections): {}",
-            expanded
+             determinism for migrate-created collections): {expanded}",
         );
         assert!(
             expanded.contains("with_merge_mode"),
             "expected with_merge_mode wrap in expansion (CIP I9 cross-node determinism: \
-             suppresses LwwRegister/Element node-local timestamps during migrate): {}",
-            expanded
+             suppresses LwwRegister/Element node-local timestamps during migrate): {expanded}",
         );
     }
 
@@ -504,33 +496,27 @@ mod tests {
 
         assert!(
             out.contains("extern \"C\""),
-            "expected WASM extern \"C\" export in expansion: {}",
-            out
+            "expected WASM extern \"C\" export in expansion: {out}",
         );
         assert!(
             out.contains("__calimero_migration_check"),
-            "expected #[no_mangle] __calimero_migration_check export name in expansion: {}",
-            out
+            "expected #[no_mangle] __calimero_migration_check export name in expansion: {out}",
         );
         assert!(
             out.contains("read_raw"),
-            "expected read_raw() to load the old v1 root in expansion: {}",
-            out
+            "expected read_raw() to load the old v1 root in expansion: {out}",
         );
         assert!(
             out.contains("input"),
-            "expected env::input() to load the produced v2 root bytes in expansion: {}",
-            out
+            "expected env::input() to load the produced v2 root bytes in expansion: {out}",
         );
         assert!(
             out.contains("value_return"),
-            "expected value_return of the borsh Ok::<bool, _> result in expansion: {}",
-            out
+            "expected value_return of the borsh Ok::<bool, _> result in expansion: {out}",
         );
         assert!(
             out.contains("no_mangle"),
-            "expected #[no_mangle] in expansion: {}",
-            out
+            "expected #[no_mangle] in expansion: {out}",
         );
     }
 
@@ -545,14 +531,12 @@ mod tests {
 
         assert!(
             out.contains("my_check"),
-            "expected function name in expansion: {}",
-            out
+            "expected function name in expansion: {out}",
         );
         assert!(
             out.contains("not (target_arch = \"wasm32\")")
                 || out.contains("not(target_arch = \"wasm32\")"),
-            "expected native cfg stub in expansion: {}",
-            out
+            "expected native cfg stub in expansion: {out}",
         );
     }
 
@@ -568,14 +552,12 @@ mod tests {
 
         assert!(
             expanded.contains("my_migrate"),
-            "expected function name in expansion: {}",
-            expanded
+            "expected function name in expansion: {expanded}",
         );
         assert!(
             expanded.contains("not (target_arch = \"wasm32\")")
                 || expanded.contains("not(target_arch = \"wasm32\")"),
-            "expected native cfg stub in expansion: {}",
-            expanded
+            "expected native cfg stub in expansion: {expanded}",
         );
     }
 
@@ -590,19 +572,16 @@ mod tests {
 
         assert!(
             expanded.contains("emit_migration_witness"),
-            "tuple return must emit the transient witness: {}",
-            expanded
+            "tuple return must emit the transient witness: {expanded}",
         );
         // Registration uses the FIRST tuple element (the new state type), not the tuple.
         assert!(
             expanded.contains("register :: < V2 >"),
-            "event/schema registration must target the state type V2: {}",
-            expanded
+            "event/schema registration must target the state type V2: {expanded}",
         );
         assert!(
             expanded.contains("__assign_deterministic_ids"),
-            "state still gets deterministic ids under merge mode: {}",
-            expanded
+            "state still gets deterministic ids under merge mode: {expanded}",
         );
     }
 
@@ -615,13 +594,11 @@ mod tests {
 
         assert!(
             !expanded.contains("emit_migration_witness"),
-            "a non-tuple return must NOT emit a witness: {}",
-            expanded
+            "a non-tuple return must NOT emit a witness: {expanded}",
         );
         assert!(
             expanded.contains("value_return"),
-            "single return still produces the committed state via value_return: {}",
-            expanded
+            "single return still produces the committed state via value_return: {expanded}",
         );
     }
 
@@ -637,14 +614,12 @@ mod tests {
         // Input is decoded as the (new_bytes, Option<witness_bytes>) tuple.
         assert!(
             expanded.contains("__witness_opt"),
-            "check input must be decoded as a (new, witness) tuple: {}",
-            expanded
+            "check input must be decoded as a (new, witness) tuple: {expanded}",
         );
         // The witness param is bound (panics if the migrate emitted none).
         assert!(
             expanded.contains("declares a witness parameter"),
-            "3-arg check must bind the witness and guard its absence: {}",
-            expanded
+            "3-arg check must bind the witness and guard its absence: {expanded}",
         );
     }
 
@@ -657,19 +632,16 @@ mod tests {
 
         assert!(
             !expanded.contains("compile_error"),
-            "the 2-arg form must remain valid: {}",
-            expanded
+            "the 2-arg form must remain valid: {expanded}",
         );
         // Still decodes the tuple input shape (the witness slot is simply ignored).
         assert!(
             expanded.contains("__witness_opt"),
-            "2-arg check still decodes the repacked tuple input: {}",
-            expanded
+            "2-arg check still decodes the repacked tuple input: {expanded}",
         );
         assert!(
             !expanded.contains("declares a witness parameter"),
-            "2-arg check must NOT bind a witness parameter: {}",
-            expanded
+            "2-arg check must NOT bind a witness parameter: {expanded}",
         );
     }
 }

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -1545,6 +1545,13 @@ mod tests {
 
     /// Run the `#[app::state]` input validation (which includes the
     /// borsh-attribute guard) over `item`, returning whether it was accepted.
+    // The `accepted` binding ends the `StateImpl` borrow of `args` at the `;`,
+    // before `args` is dropped; folding it into the tail expression (as
+    // `let_and_return` suggests) extends that borrow and fails to compile.
+    #[allow(
+        clippy::let_and_return,
+        reason = "binding ends the borrow of `args` before drop"
+    )]
     fn state_accepts(item: StructOrEnumItem) -> bool {
         let args = StateArgs {
             emits: None,

--- a/crates/sdk/src/event.rs
+++ b/crates/sdk/src/event.rs
@@ -121,7 +121,7 @@ use crate::state::AppState;
     message = "(calimero)> `{Self}` is not an app event",
     label = "not an `#[app::event]` type",
     note = "only an enum annotated with `#[app::event]` can be emitted. Define one and emit a \
-            variant: `#[app::event] pub enum Event { Something }` then `app::emit!(Event::Something)`."
+            variant: `#[app::event] pub enum Event {{ Something }}` then `app::emit!(Event::Something)`."
 )]
 pub trait AppEvent {
     /// Returns the event kind/type as a string.
@@ -297,7 +297,7 @@ use reflect::Reflect;
     message = "(calimero)> `{Self}` cannot be emitted — it is not an app event",
     label = "not an `#[app::event]` type",
     note = "`app::emit!(...)` only accepts an enum annotated with `#[app::event]`. \
-            Define `#[app::event] pub enum Event { ... }` and emit one of its variants."
+            Define `#[app::event] pub enum Event {{ ... }}` and emit one of its variants."
 )]
 pub trait AppEventExt: AppEvent + Reflect {
     // todo! experiment with &dyn AppEventExt downcast_ref to &Self

--- a/crates/sdk/src/macros.rs
+++ b/crates/sdk/src/macros.rs
@@ -3,16 +3,16 @@
 macro_rules! __err__ {
     ($msg:literal $(,)?) => {{
         use $crate::types::__private::*;
-        (&&&&$crate::types::__private::Wrap(::std::format_args!($msg))).into_error()
+        (&&&&$crate::types::__private::Wrap(::std::format_args!($msg))).to_error()
     }};
     ($err:expr $(,)?) => {{
         #[allow(unused_imports, reason = "if expanding the next line fails, it reports this as unused")]
         use $crate::types::__private::*;
-        (&&&&$crate::types::__private::Wrap($err)).into_error()
+        (&&&&$crate::types::__private::Wrap($err)).to_error()
     }};
     ($fmt:expr, $($arg:tt)*) => {{
         use $crate::types::__private::*;
-        (&&&&$crate::types::__private::Wrap(&::std::format!($fmt, $($arg)*))).into_error()
+        (&&&&$crate::types::__private::Wrap(&::std::format!($fmt, $($arg)*))).to_error()
     }};
 }
 

--- a/crates/sdk/src/state.rs
+++ b/crates/sdk/src/state.rs
@@ -85,7 +85,6 @@ impl MigrateMyEntriesSummary {
 ///
 /// * `Some(Vec<u8>)` - The raw serialized state bytes (user data only) if state exists
 /// * `None` - If no state has been stored yet
-
 #[must_use]
 pub fn read_raw() -> Option<Vec<u8>> {
     let root_key = root_storage_key();

--- a/crates/sdk/src/types.rs
+++ b/crates/sdk/src/types.rs
@@ -52,11 +52,11 @@ pub mod __private {
     pub struct Wrap<T>(pub T);
 
     pub trait ViaStr {
-        fn into_error(&self) -> Error;
+        fn to_error(&self) -> Error;
     }
 
     impl ViaStr for &&&Wrap<&str> {
-        fn into_error(&self) -> Error {
+        fn to_error(&self) -> Error {
             let Wrap(value) = self;
             Error {
                 error: (*value).into(),
@@ -67,11 +67,11 @@ pub mod __private {
     }
 
     pub trait ViaArguments {
-        fn into_error(&self) -> Error;
+        fn to_error(&self) -> Error;
     }
 
     impl ViaArguments for &&Wrap<Arguments<'_>> {
-        fn into_error(&self) -> Error {
+        fn to_error(&self) -> Error {
             let Wrap(value) = self;
 
             let Some(msg) = value.as_str() else {
@@ -82,19 +82,19 @@ pub mod __private {
                 };
             };
 
-            (&&&&Wrap(msg)).into_error()
+            (&&&&Wrap(msg)).to_error()
         }
     }
 
     pub trait ViaSerialize {
-        fn into_error(&self) -> Error;
+        fn to_error(&self) -> Error;
     }
 
     impl<T> ViaSerialize for &Wrap<T>
     where
         T: Serialize,
     {
-        fn into_error(&self) -> Error {
+        fn to_error(&self) -> Error {
             let Wrap(value) = self;
             Error {
                 error: serde_json::json!(value),
@@ -105,14 +105,14 @@ pub mod __private {
     }
 
     pub trait ViaError {
-        fn into_error(&self) -> Error;
+        fn to_error(&self) -> Error;
     }
 
     impl<T> ViaError for Wrap<T>
     where
         T: core::error::Error,
     {
-        fn into_error(&self) -> Error {
+        fn to_error(&self) -> Error {
             let Wrap(value) = self;
             Error {
                 error: value.to_string().into(),
@@ -153,9 +153,9 @@ mod tests {
     //     bail!(Displayable("something happened"));
     // }
 
-    macro_rules! into_error {
+    macro_rules! to_error {
         ($err:expr) => {
-            (&&&&Wrap($err)).into_error()
+            (&&&&Wrap($err)).to_error()
         };
     }
 
@@ -163,7 +163,7 @@ mod tests {
     fn test_specialization() {
         let err = "beltalowda";
 
-        let error = into_error!(err);
+        let error = to_error!(err);
 
         dbg!(&error);
         assert_eq!(error.flag, 0); // used `ViaStr`
@@ -174,7 +174,7 @@ mod tests {
             name: "felota".to_string(),
         };
 
-        let error = into_error!(err);
+        let error = to_error!(err);
 
         dbg!(&error);
         assert_eq!(error.flag, 2); // used `ViaSerialize`
@@ -183,7 +183,7 @@ mod tests {
 
         let err = Errorlike;
 
-        let error = into_error!(err);
+        let error = to_error!(err);
 
         dbg!(&error);
         assert_eq!(error.flag, 3); // used `ViaError`
@@ -192,7 +192,7 @@ mod tests {
 
         let err = format_args!("beratna");
 
-        let error = into_error!(err);
+        let error = to_error!(err);
 
         dbg!(&error);
         assert_eq!(error.flag, 0); // used `ViaStr` via `ViaArguments`
@@ -201,7 +201,7 @@ mod tests {
 
         let field = Displayable("bosmang");
 
-        let error = into_error!(format_args!("{field}"));
+        let error = to_error!(format_args!("{field}"));
 
         dbg!(&error);
         assert_eq!(error.flag, 1); // used `ViaArguments`
@@ -210,7 +210,7 @@ mod tests {
 
         let field = Displayable("ke");
 
-        let error = into_error!(format_args!("sasa {}", field));
+        let error = to_error!(format_args!("sasa {}", field));
 
         dbg!(&error);
         assert_eq!(error.flag, 1); // used `ViaArguments`

--- a/crates/server/src/admin/handlers/blob.rs
+++ b/crates/server/src/admin/handlers/blob.rs
@@ -163,6 +163,7 @@ pub async fn upload_handler(
 /// Returns a list of all root blob IDs and their metadata. Root blobs are either:
 /// - Blobs that contain links to chunks (segmented large files)
 /// - Standalone blobs that aren't referenced as chunks by other blobs
+///
 /// This excludes individual chunk blobs to provide a cleaner user experience.
 pub async fn list_handler(Extension(state): Extension<Arc<AdminState>>) -> impl IntoResponse {
     info!("Listing blobs");

--- a/crates/server/src/admin/handlers/context/create_context.rs
+++ b/crates/server/src/admin/handlers/context/create_context.rs
@@ -40,12 +40,14 @@ pub async fn handler(
         .create_context(
             "local".to_owned(),
             &req.application_id,
-            req.service_name,
-            identity_secret,
-            req.initialization_params,
-            req.context_seed.map(Into::into),
-            group_id,
-            req.name,
+            calimero_context_client::client::CreateContextParams {
+                service_name: req.service_name,
+                identity_secret,
+                init_params: req.initialization_params,
+                seed: req.context_seed.map(Into::into),
+                group_id,
+                name: req.name,
+            },
         )
         .await
         .map_err(parse_api_error);

--- a/crates/server/src/admin/handlers/context/get_context.rs
+++ b/crates/server/src/admin/handlers/context/get_context.rs
@@ -23,7 +23,6 @@ pub async fn handler(
         .get_context(&context_id)
         .map_err(|err| parse_api_error(err).into_response());
 
-    #[expect(clippy::option_if_let_else, reason = "Clearer here")]
     match context {
         Ok(ctx) => match ctx {
             Some(mut context) => {

--- a/crates/server/src/admin/handlers/validation.rs
+++ b/crates/server/src/admin/handlers/validation.rs
@@ -123,7 +123,7 @@ where
 ///     // proceed with valid request
 /// }
 /// ```
-pub fn validate_request<T: Validate>(req: &T) -> Result<(), Response> {
+pub fn validate_request<T: Validate>(req: &T) -> Result<(), Box<Response>> {
     let errors = req.validate();
     if errors.is_empty() {
         Ok(())
@@ -134,10 +134,12 @@ pub fn validate_request<T: Validate>(req: &T) -> Result<(), Response> {
         } else {
             format!("Validation errors: {}", messages.join("; "))
         };
-        Err(ApiError {
-            status_code: StatusCode::BAD_REQUEST,
-            message,
-        }
-        .into_response())
+        Err(Box::new(
+            ApiError {
+                status_code: StatusCode::BAD_REQUEST,
+                message,
+            }
+            .into_response(),
+        ))
     }
 }

--- a/crates/server/src/auth.rs
+++ b/crates/server/src/auth.rs
@@ -53,7 +53,6 @@ impl BundledAuth {
         self.app.state.auth_service.clone()
     }
 
-    #[must_use]
     pub fn into_router(self) -> Router {
         self.app.router
     }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -71,13 +71,16 @@ impl ServerConfig {
     pub const fn with_auth(
         listen: Vec<Multiaddr>,
         identity: Keypair,
-        admin: Option<AdminConfig>,
-        jsonrpc: Option<JsonRpcConfig>,
-        websocket: Option<WsConfig>,
-        sse: Option<SseConfig>,
+        services: ServiceConfigs,
         auth_mode: AuthMode,
         embedded_auth: Option<AuthConfig>,
     ) -> Self {
+        let ServiceConfigs {
+            admin,
+            jsonrpc,
+            websocket,
+            sse,
+        } = services;
         Self {
             listen,
             identity,
@@ -107,4 +110,12 @@ pub fn default_addrs() -> Vec<Multiaddr> {
         .into_iter()
         .map(|addr| Multiaddr::from(addr).with(Protocol::Tcp(DEFAULT_PORT)))
         .collect()
+}
+
+/// The optional per-service endpoint configs passed to [`ServerConfig::with_auth`].
+pub struct ServiceConfigs {
+    pub admin: Option<AdminConfig>,
+    pub jsonrpc: Option<JsonRpcConfig>,
+    pub websocket: Option<WsConfig>,
+    pub sse: Option<SseConfig>,
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -48,7 +48,6 @@ impl AdminState {
     }
 }
 
-#[expect(clippy::print_stderr, reason = "Acceptable for CLI")]
 pub async fn start(
     config: ServerConfig,
     ctx_client: ContextClient,

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -117,12 +117,14 @@ pub async fn start(
     let mounted = mount_runtime_services(
         app,
         &config,
-        auth_service.clone(),
-        ctx_client,
-        node_client.clone(),
-        datastore.clone(),
-        shared_state,
-        prom_registry,
+        service_mounts::RuntimeServiceDeps {
+            auth_service: auth_service.clone(),
+            ctx_client,
+            node_client: node_client.clone(),
+            datastore: datastore.clone(),
+            shared_state,
+            prom_registry,
+        },
     );
     app = mounted.router;
     let mut service_count = mounted.added_count;

--- a/crates/server/src/service_mounts.rs
+++ b/crates/server/src/service_mounts.rs
@@ -20,13 +20,16 @@ pub(crate) struct MountedService {
 pub(crate) fn mount_runtime_services(
     app: Router,
     config: &ServerConfig,
-    auth_service: Option<Arc<mero_auth::AuthService>>,
-    ctx_client: ContextClient,
-    node_client: NodeClient,
-    datastore: Store,
-    shared_state: Arc<AdminState>,
-    prom_registry: Registry,
+    deps: RuntimeServiceDeps,
 ) -> MountedService {
+    let RuntimeServiceDeps {
+        auth_service,
+        ctx_client,
+        node_client,
+        datastore,
+        shared_state,
+        prom_registry,
+    } = deps;
     let mut app = app;
     let mut service_count = 0usize;
 
@@ -92,4 +95,14 @@ impl AuthLayerExt for axum::routing::MethodRouter {
     fn with_auth_guard(self, service: Arc<mero_auth::AuthService>) -> Self {
         self.layer(auth::guard_layer(service))
     }
+}
+
+/// Runtime dependencies threaded into [`mount_runtime_services`].
+pub(crate) struct RuntimeServiceDeps {
+    pub auth_service: Option<Arc<mero_auth::AuthService>>,
+    pub ctx_client: ContextClient,
+    pub node_client: NodeClient,
+    pub datastore: Store,
+    pub shared_state: Arc<AdminState>,
+    pub prom_registry: Registry,
 }

--- a/crates/server/src/sse/handlers.rs
+++ b/crates/server/src/sse/handlers.rs
@@ -213,6 +213,7 @@ pub async fn handle_subscription(
 /// - Resume their session with the same session ID and subscriptions
 /// - Continue receiving new events from the current counter value
 /// - **NOT** receive events that occurred during disconnection (these are skipped)
+///
 /// Clients observing gaps in event IDs should re-query application state as needed.
 pub async fn sse_handler(
     Extension(state): Extension<Arc<ServiceState>>,

--- a/crates/storage-macros/src/lib.rs
+++ b/crates/storage-macros/src/lib.rs
@@ -77,14 +77,9 @@ use syn::{parse_macro_input, Data, DeriveInput, Fields, Type};
 /// # See also
 ///
 /// * [`Collection`] - For defining a collection of child elements, for use with
-///                    [`AtomicUnit`] (the parent and children are all atomic
-///                    units, with the collection being the grouping mechanism
-///                    at field level on the parent).
+///   [`AtomicUnit`] (the parent and children are all atomic units, with the
+///   collection being the grouping mechanism at field level on the parent).
 ///
-#[expect(
-    clippy::too_many_lines,
-    reason = "Okay for now - will be restructured later"
-)]
 #[proc_macro_derive(AtomicUnit, attributes(collection, storage))]
 pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(input as DeriveInput);
@@ -215,8 +210,8 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
 /// # See also
 ///
 /// * [`AtomicUnit`] - For defining a single atomic unit of data that either
-///                    stands alone, or owns one or more collections, or is a
-///                    child in a collection.
+///   stands alone, or owns one or more collections, or is a child in a
+///   collection.
 #[proc_macro_derive(Collection, attributes(children))]
 pub fn collection_derive(input: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(input as DeriveInput);

--- a/crates/storage/src/address.rs
+++ b/crates/storage/src/address.rs
@@ -65,7 +65,6 @@ impl Id {
 }
 
 impl Display for Id {
-    #[expect(clippy::use_debug, reason = "fine for now")]
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hex::encode(self.bytes))
     }

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -468,7 +468,6 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
     /// # Arguments
     /// * `field_name` - The name of the struct field containing this collection
     /// * `crdt_type` - The CRDT type for merge dispatch
-    #[expect(clippy::expect_used, reason = "fatal error if cleanup fails")]
     pub(crate) fn reassign_deterministic_id_with_crdt_type(
         &mut self,
         field_name: &str,
@@ -556,7 +555,6 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
     /// at insert, so their reassign can early-return once the collection id
     /// is correct), this always re-keys the children: the *children* are
     /// what carry the random ids, independent of the collection's own id.
-    #[expect(clippy::expect_used, reason = "fatal error if migration fails")]
     pub(crate) fn reassign_deterministic_id_with_indexed_children(
         &mut self,
         field_name: &str,

--- a/crates/storage/src/collections/authored_map.rs
+++ b/crates/storage/src/collections/authored_map.rs
@@ -232,6 +232,15 @@ where
         self.inner.len()
     }
 
+    /// Returns `true` if there are no entries.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system.
+    pub fn is_empty(&self) -> Result<bool, StoreError> {
+        Ok(self.len()? == 0)
+    }
+
     /// Returns the entry's stamped `schema_version`, or `None` if the key is
     /// absent or the entry was never stamped (legacy). Reads the Merkle-invisible
     /// `Metadata.schema_version`; used to skip already-migrated entries.

--- a/crates/storage/src/collections/authored_vector.rs
+++ b/crates/storage/src/collections/authored_vector.rs
@@ -222,6 +222,15 @@ where
         self.inner.len()
     }
 
+    /// Returns `true` if there are no entries.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system.
+    pub fn is_empty(&self) -> Result<bool, StoreError> {
+        Ok(self.len()? == 0)
+    }
+
     #[cfg(test)]
     pub(crate) fn entry_id_at(
         &self,

--- a/crates/storage/src/collections/counter.rs
+++ b/crates/storage/src/collections/counter.rs
@@ -18,7 +18,7 @@ use crate::store::MainStorage;
 ///
 /// # Type Parameters
 /// - `ALLOW_DECREMENT`: When `false` (default), acts as G-Counter (increment-only).
-///                      When `true`, acts as PN-Counter (supports decrement).
+///   When `true`, acts as PN-Counter (supports decrement).
 /// - `S`: Storage adaptor (defaults to `MainStorage`)
 ///
 /// # G-Counter Mode (ALLOW_DECREMENT = false)

--- a/crates/storage/src/collections/crdt_impls.rs
+++ b/crates/storage/src/collections/crdt_impls.rs
@@ -244,7 +244,7 @@ impl Mergeable for ReplicatedGrowableArray {
             // re-insert, corrupting the array. A genuine absence is `Ok(None)`.
             if self.chars.get(&key)?.is_none() {
                 // Character exists in other but not in self - add it
-                drop(self.chars.insert(key, char_data)?);
+                let _ = self.chars.insert(key, char_data)?;
             }
             // If character exists in both, keep ours (they should be identical anyway,
             // since characters are immutable once inserted)

--- a/crates/storage/src/collections/crdt_meta.rs
+++ b/crates/storage/src/collections/crdt_meta.rs
@@ -170,6 +170,9 @@ impl From<crate::collections::error::StoreError> for MergeError {
 /// Trait for CRDTs that can be decomposed into field entries
 ///
 /// Used for structured storage of nested CRDTs.
+/// A flat list of decomposed `(key, value)` field entries.
+pub type DecomposedEntries<K, V> = Vec<(K, V)>;
+
 pub trait Decomposable {
     /// The key type for decomposed entries
     type Key: AsRef<[u8]> + BorshSerialize + BorshDeserialize;
@@ -181,14 +184,16 @@ pub trait Decomposable {
     /// # Errors
     ///
     /// Returns error if decomposition fails
-    fn decompose(&self) -> Result<Vec<(Self::Key, Self::Value)>, DecomposeError>;
+    fn decompose(&self) -> Result<DecomposedEntries<Self::Key, Self::Value>, DecomposeError>;
 
     /// Reconstruct from field entries
     ///
     /// # Errors
     ///
     /// Returns error if reconstruction fails
-    fn recompose(entries: Vec<(Self::Key, Self::Value)>) -> Result<Self, DecomposeError>
+    fn recompose(
+        entries: DecomposedEntries<Self::Key, Self::Value>,
+    ) -> Result<Self, DecomposeError>
     where
         Self: Sized;
 }

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -478,7 +478,6 @@ where
     ///
     /// # Errors
     /// Returns `ActionNotAllowed` if the executor is not in the writer set.
-    #[expect(clippy::unwrap_in_result, reason = "value entry id is well-formed")]
     pub fn insert(&mut self, value: T) -> Result<Option<T>, StoreError> {
         let executor: PublicKey = env::executor_id().into();
         let writers = self.current_writers();

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -473,7 +473,7 @@ where
                 .get_mut(id)?
                 .ok_or(StoreError::StorageError(StorageError::NotFound(id)))?;
 
-            Ok(Entry::Occupied(OccupiedEntry { entry_mut }))
+            Ok(Entry::Occupied(Box::new(OccupiedEntry { entry_mut })))
         } else {
             Ok(Entry::Vacant(VacantEntry { map: self, key }))
         }
@@ -950,10 +950,7 @@ where
     S: StorageAdaptor,
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        let l = self.entries().ok()?;
-        let r = other.entries().ok()?;
-
-        l.partial_cmp(r)
+        Some(self.cmp(other))
     }
 }
 
@@ -1109,7 +1106,7 @@ where
     S: StorageAdaptor,
 {
     /// An occupied entry.
-    Occupied(OccupiedEntry<'a, K, V, S>),
+    Occupied(Box<OccupiedEntry<'a, K, V, S>>),
     /// A vacant entry.
     Vacant(VacantEntry<'a, K, V, S>),
 }

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -292,7 +292,6 @@ where
     ///
     /// # Arguments
     /// * `field_name` - The name of the struct field containing this map
-    #[expect(clippy::expect_used, reason = "fatal error if migration fails")]
     pub fn reassign_deterministic_id(&mut self, field_name: &str)
     where
         K: AsRef<[u8]> + PartialEq + 'static,
@@ -421,6 +420,15 @@ where
         self.inner.len()
     }
 
+    /// Returns `true` if there are no entries.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system.
+    pub fn is_empty(&self) -> Result<bool, StoreError> {
+        Ok(self.len()? == 0)
+    }
+
     /// Get the value for a key in the map.
     ///
     /// Returns a read-only [`ValueRef`] guard (an owned, deserialized copy that
@@ -498,7 +506,7 @@ where
                 .get_mut(id)?
                 .ok_or(StoreError::StorageError(StorageError::NotFound(id)))?;
 
-            Ok(Entry::Occupied(OccupiedEntry { entry_mut }))
+            Ok(Entry::Occupied(Box::new(OccupiedEntry { entry_mut })))
         } else {
             // 3. If it doesn't exist, no `EntryMut` was created.
             Ok(Entry::Vacant(VacantEntry { map: self, key }))
@@ -787,7 +795,7 @@ where
     S: StorageAdaptor,
 {
     /// An occupied entry.
-    Occupied(OccupiedEntry<'a, K, V, S>),
+    Occupied(Box<OccupiedEntry<'a, K, V, S>>),
     /// A vacant entry.
     Vacant(VacantEntry<'a, K, V, S>),
 }

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -274,6 +274,15 @@ where
         self.inner.len()
     }
 
+    /// Returns `true` if there are no entries.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system.
+    pub fn is_empty(&self) -> Result<bool, StoreError> {
+        Ok(self.len()? == 0)
+    }
+
     /// Get the value for a key in the set.
     ///
     /// # Errors

--- a/crates/storage/src/constants.rs
+++ b/crates/storage/src/constants.rs
@@ -61,8 +61,7 @@ mod tests {
         assert_eq!(GC_INTERVAL_NANOS, hours_to_nanos(12));
     }
 
-    #[test]
-    fn threshold_is_greater_than_retention() {
-        assert!(FULL_RESYNC_THRESHOLD_NANOS > TOMBSTONE_RETENTION_NANOS);
-    }
+    // Compile-time invariant: a full resync must be triggered only after a
+    // tombstone could have been collected, never before.
+    const _: () = assert!(FULL_RESYNC_THRESHOLD_NANOS > TOMBSTONE_RETENTION_NANOS);
 }

--- a/crates/storage/src/env.rs
+++ b/crates/storage/src/env.rs
@@ -63,6 +63,16 @@ pub fn with_merge_mode<R>(f: impl FnOnce() -> R) -> R {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+/// Reference-counted host callback for reading a key's stored bytes.
+type StorageReadFn = std::rc::Rc<dyn Fn(&Key) -> Option<Vec<u8>>>;
+#[cfg(not(target_arch = "wasm32"))]
+/// Reference-counted host callback for writing a key's bytes.
+type StorageWriteFn = std::rc::Rc<dyn Fn(Key, &[u8]) -> bool>;
+#[cfg(not(target_arch = "wasm32"))]
+/// Reference-counted host callback for removing a key.
+type StorageRemoveFn = std::rc::Rc<dyn Fn(&Key) -> bool>;
+
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone)]
 /// Runtime-provided storage environment used by host functions.
 ///
@@ -73,9 +83,9 @@ pub fn with_merge_mode<R>(f: impl FnOnce() -> R) -> R {
 /// executing we install this environment thread-locally so every
 /// `Interface::<MainStorage>::*` call can reach the real context storage.
 pub struct RuntimeEnv {
-    storage_read: std::rc::Rc<dyn Fn(&Key) -> Option<Vec<u8>>>,
-    storage_write: std::rc::Rc<dyn Fn(Key, &[u8]) -> bool>,
-    storage_remove: std::rc::Rc<dyn Fn(&Key) -> bool>,
+    storage_read: StorageReadFn,
+    storage_write: StorageWriteFn,
+    storage_remove: StorageRemoveFn,
     context_id: [u8; 32],
     executor_id: [u8; 32],
 }
@@ -89,9 +99,9 @@ impl RuntimeEnv {
     /// duration of the host call but can still hand mutable access to the
     /// underlying storage when invoked from the storage crate.
     pub fn new(
-        storage_read: std::rc::Rc<dyn Fn(&Key) -> Option<Vec<u8>>>,
-        storage_write: std::rc::Rc<dyn Fn(Key, &[u8]) -> bool>,
-        storage_remove: std::rc::Rc<dyn Fn(&Key) -> bool>,
+        storage_read: StorageReadFn,
+        storage_write: StorageWriteFn,
+        storage_remove: StorageRemoveFn,
         context_id: [u8; 32],
         executor_id: [u8; 32],
     ) -> Self {
@@ -106,19 +116,19 @@ impl RuntimeEnv {
 
     #[must_use]
     /// Returns the storage read callback.
-    pub fn storage_read(&self) -> std::rc::Rc<dyn Fn(&Key) -> Option<Vec<u8>>> {
+    pub fn storage_read(&self) -> StorageReadFn {
         self.storage_read.clone()
     }
 
     #[must_use]
     /// Returns the storage write callback.
-    pub fn storage_write(&self) -> std::rc::Rc<dyn Fn(Key, &[u8]) -> bool> {
+    pub fn storage_write(&self) -> StorageWriteFn {
         self.storage_write.clone()
     }
 
     #[must_use]
     /// Returns the storage remove callback.
-    pub fn storage_remove(&self) -> std::rc::Rc<dyn Fn(&Key) -> bool> {
+    pub fn storage_remove(&self) -> StorageRemoveFn {
         self.storage_remove.clone()
     }
 
@@ -173,7 +183,6 @@ pub fn read_committed_root_entry() -> Option<Vec<u8>> {
 
 /// Commits the root hash to the runtime.
 ///
-#[expect(clippy::missing_const_for_fn, reason = "Cannot be const here")]
 pub fn commit(root_hash: &[u8; 32], artifact: &[u8]) {
     imp::commit(root_hash, artifact);
 }
@@ -311,7 +320,6 @@ pub fn ed25519_verify(signature: &[u8; 64], public_key: &[u8; 32], message: &[u8
 ///
 /// In WASM, this calls the host function. In tests, returns a fixed value.
 #[must_use]
-#[expect(clippy::missing_const_for_fn, reason = "Cannot be const here")]
 pub fn context_id() -> [u8; 32] {
     imp::context_id()
 }
@@ -320,7 +328,6 @@ pub fn context_id() -> [u8; 32] {
 ///
 /// In WASM, this calls the host function. In tests, returns a fixed value.
 #[must_use]
-#[expect(clippy::missing_const_for_fn, reason = "Cannot be const here")]
 pub fn executor_id() -> [u8; 32] {
     imp::executor_id()
 }
@@ -329,7 +336,6 @@ pub fn executor_id() -> [u8; 32] {
 ///
 /// In WASM, this calls `calimero_sdk::env::log()`, which calls the host function.
 /// In tests, it uses plain `println!()`.
-#[expect(clippy::missing_const_for_fn, reason = "Cannot be const here")]
 pub fn log(message: &str) {
     imp::log(message);
 }
@@ -347,9 +353,14 @@ pub fn hlc_timestamp() -> HybridTimestamp {
 ///
 /// # Errors
 ///
-/// Returns `Err(())` if the remote timestamp is >5s in the future (drift protection).
-pub fn update_hlc(remote_ts: &HybridTimestamp) -> Result<(), ()> {
-    imp::update_hlc(remote_ts)
+/// Error returned by [`update_hlc`] when a remote timestamp is too far in the
+/// future to accept (drift protection).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HlcDriftError;
+
+/// Returns [`HlcDriftError`] if the remote timestamp is >5s in the future (drift protection).
+pub fn update_hlc(remote_ts: &HybridTimestamp) -> Result<(), HlcDriftError> {
+    imp::update_hlc(remote_ts).map_err(|()| HlcDriftError)
 }
 
 /// Reset for testing.

--- a/crates/storage/src/js.rs
+++ b/crates/storage/src/js.rs
@@ -19,6 +19,11 @@ use calimero_primitives::identity::PublicKey;
 /// Macro support for deriving storage traits on the wrapper types.
 use calimero_storage_macros::AtomicUnit;
 
+/// Decoded `(key, value)` byte-pairs returned by JS collection iterators.
+type JsByteEntries = Vec<(Vec<u8>, Vec<u8>)>;
+/// Decoded `(public_key, value)` pairs returned by JS set iterators.
+type JsKeyedEntries = Vec<([u8; 32], Vec<u8>)>;
+
 /// A byte-oriented unordered map that integrates with Calimero storage.
 ///
 /// The map stores both keys and values as raw byte arrays (`Vec<u8>`). When
@@ -125,7 +130,7 @@ impl JsUnorderedMap {
     /// # Errors
     ///
     /// Propagates [`StoreError`] if reading from storage fails.
-    pub fn entries(&self) -> Result<Vec<(Vec<u8>, Vec<u8>)>, StoreError> {
+    pub fn entries(&self) -> Result<JsByteEntries, StoreError> {
         let iter = self.map.entries()?;
         Ok(iter.collect::<Vec<_>>())
     }
@@ -217,6 +222,15 @@ impl JsVector {
     /// Returns any [`StoreError`] emitted by the underlying vector.
     pub fn len(&self) -> Result<usize, StoreError> {
         self.vector.len()
+    }
+
+    /// Returns `true` if there are no entries.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system.
+    pub fn is_empty(&self) -> Result<bool, StoreError> {
+        Ok(self.len()? == 0)
     }
 
     /// Appends a value to the end of the vector.
@@ -333,6 +347,15 @@ impl JsUnorderedSet {
     /// Returns any [`StoreError`] produced by the set implementation.
     pub fn len(&self) -> Result<usize, StoreError> {
         self.set.len()
+    }
+
+    /// Returns `true` if there are no entries.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system.
+    pub fn is_empty(&self) -> Result<bool, StoreError> {
+        Ok(self.len()? == 0)
     }
 
     /// Inserts `value` into the set, returning whether it was newly added.
@@ -706,7 +729,7 @@ impl JsUserStorage {
     /// # Errors
     ///
     /// Propagates [`StoreError`] if reading from storage fails.
-    pub fn entries_raw(&self) -> Result<Vec<([u8; 32], Vec<u8>)>, StoreError> {
+    pub fn entries_raw(&self) -> Result<JsKeyedEntries, StoreError> {
         let iter = self.entries()?;
         Ok(iter
             .into_iter()

--- a/crates/storage/src/testing.rs
+++ b/crates/storage/src/testing.rs
@@ -113,6 +113,9 @@ type Store = Rc<RefCell<HashMap<[u8; 32], Vec<u8>>>>;
 /// A registered operation: a mutation applied to a loaded replica state.
 type Op<T> = Box<dyn Fn(&mut T)>;
 
+/// Named value-level invariants checked on each converged replica.
+type InvariantList<T> = Vec<(String, Box<dyn Fn(&T) -> bool>)>;
+
 fn new_store() -> Store {
     Rc::new(RefCell::new(HashMap::new()))
 }
@@ -157,7 +160,7 @@ pub struct Converge<T> {
     // alone is NOT correctness: deterministic LWW converges every replica to the
     // SAME wrong value, so a data-loss bug passes the hash check. Invariants let
     // a test assert the merged *value* is right.
-    invariants: Vec<(String, Box<dyn Fn(&T) -> bool>)>,
+    invariants: InvariantList<T>,
 }
 
 /// Start a CRDT convergence assertion for state type `T`, using [`Default`] as

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -910,14 +910,12 @@ mod user_storage_signature_verification {
         } = action
         {
             if let StorageType::User {
-                ref mut signature_data,
+                signature_data: Some(ref mut sig_data),
                 ..
             } = metadata.storage_type
             {
-                if let Some(ref mut sig_data) = signature_data {
-                    sig_data.signature[0] ^= 0xFF; // Flip bits
-                    sig_data.signature[31] ^= 0xFF;
-                }
+                sig_data.signature[0] ^= 0xFF; // Flip bits
+                sig_data.signature[31] ^= 0xFF;
             }
         }
 

--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -316,10 +316,6 @@ impl Blob {
             return Ok(None);
         };
 
-        #[expect(
-            clippy::semicolon_if_nothing_returned,
-            reason = "False positive; not possible with macro"
-        )]
         let stream = Box::pin(try_stream!({
             let mut chunk_index: u64 = 0;
             trace!(
@@ -380,7 +376,6 @@ impl Debug for Blob {
 }
 
 #[derive(Debug, ThisError)]
-#[expect(variant_size_differences, reason = "Doesn't matter here")]
 #[non_exhaustive]
 pub enum BlobError {
     #[error("encountered a dangling Blob ID: `{id}`, the blob store may be corrupt")]

--- a/crates/store/blobs/src/utils.rs
+++ b/crates/store/blobs/src/utils.rs
@@ -52,7 +52,7 @@ pub fn validate_path_component(component: &str, component_label: Option<&str>) {
 }
 
 #[cfg(test)]
-mod utils {
+mod tests {
     use super::*;
 
     #[test]

--- a/crates/store/src/handle.rs
+++ b/crates/store/src/handle.rs
@@ -67,10 +67,6 @@ impl<L: ReadLayer> Handle<L> {
     /// The iterator sees a frozen point-in-time view of the database,
     /// unaffected by concurrent writes. Essential for operations that
     /// need to iterate over consistent state (e.g., snapshot generation).
-    #[expect(
-        clippy::iter_not_returning_iterator,
-        reason = "TODO: This should be implemented"
-    )]
     #[expect(clippy::type_complexity, reason = "Acceptable here")]
     pub fn iter_snapshot<E: Entry<Key: FromKeyParts>>(
         &self,

--- a/crates/store/src/key/alias.rs
+++ b/crates/store/src/key/alias.rs
@@ -95,14 +95,14 @@ impl ScopeIsh for DefaultScope {
 pub trait StoreScopeCompat {
     type Scope: ScopeIsh;
 
-    fn from_primitives_scope(self) -> Self::Scope;
+    fn into_store_scope(self) -> Self::Scope;
     fn into_primitives_scope(scope: Self::Scope) -> Self;
 }
 
 impl<T: Aliasable + ScopeIsh> StoreScopeCompat for T {
     type Scope = T;
 
-    fn from_primitives_scope(self) -> T {
+    fn into_store_scope(self) -> T {
         self
     }
 
@@ -114,7 +114,7 @@ impl<T: Aliasable + ScopeIsh> StoreScopeCompat for T {
 impl StoreScopeCompat for () {
     type Scope = DefaultScope;
 
-    fn from_primitives_scope(self) -> DefaultScope {
+    fn into_store_scope(self) -> DefaultScope {
         DefaultScope
     }
 
@@ -148,7 +148,7 @@ impl Alias {
         strict: bool,
     ) -> Option<[u8; SCOPE_SIZE]> {
         match scope {
-            Some(scope) => Some(scope.from_primitives_scope().as_scope()),
+            Some(scope) => Some(scope.into_store_scope().as_scope()),
             None if <T::Scope as StoreScopeCompat>::Scope::is_default() || !strict => {
                 Some(DefaultScope.as_scope())
             }

--- a/crates/store/src/layer.rs
+++ b/crates/store/src/layer.rs
@@ -31,10 +31,6 @@ pub trait ReadLayer: Layer {
     /// The iterator sees a frozen point-in-time view of the database,
     /// unaffected by concurrent writes. Essential for operations that
     /// need to iterate over consistent state (e.g., snapshot generation).
-    #[expect(
-        clippy::iter_not_returning_iterator,
-        reason = "TODO: This should be implemented"
-    )]
     fn iter_snapshot<K: FromKeyParts>(&self) -> EyreResult<Iter<'_, Structured<K>>>;
 }
 

--- a/crates/store/src/types.rs
+++ b/crates/store/src/types.rs
@@ -8,7 +8,7 @@ mod context;
 mod generic;
 mod group;
 
-pub use application::{ApplicationMeta, ApplicationPreviousBlob, ServiceMeta};
+pub use application::{ApplicationMeta, ApplicationPreviousBlob, PackageInfo, ServiceMeta};
 pub use blobs::BlobMeta;
 pub use context::{
     ContextActivatedBlob, ContextAuthoredRemaining, ContextConfig, ContextDagDelta,

--- a/crates/store/src/types/application.rs
+++ b/crates/store/src/types/application.rs
@@ -71,18 +71,29 @@ impl BorshDeserialize for ApplicationMeta {
     }
 }
 
+/// Package-manifest fields of an [`ApplicationMeta`] (name, version, signer).
+#[derive(Debug, Clone)]
+pub struct PackageInfo {
+    pub package: Box<str>,
+    pub version: Box<str>,
+    pub signer_id: Box<str>,
+}
+
 impl ApplicationMeta {
     #[must_use]
-    pub const fn new(
+    pub fn new(
         bytecode: key::BlobMeta,
         size: u64,
         source: Box<str>,
         metadata: Box<[u8]>,
         compiled: key::BlobMeta,
-        package: Box<str>,
-        version: Box<str>,
-        signer_id: Box<str>,
+        info: PackageInfo,
     ) -> Self {
+        let PackageInfo {
+            package,
+            version,
+            signer_id,
+        } = info;
         Self {
             bytecode,
             size,

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -93,6 +93,11 @@ macro_rules! wasm_imports {
                 }
             } else {
                 $(
+                    /// # Safety
+                    ///
+                    /// Host-import stub: on non-wasm32 targets calling it always
+                    /// panics; on wasm32 the caller must uphold the host ABI contract
+                    /// for this import.
                     #[allow(unused_variables, reason = "Needed due to macro expansion")]
                     pub unsafe fn $func_name($($arg: $arg_ty),*) $(-> $returns)? {
                         panic!("host function `{}` is only available when compiled for wasm32", stringify!($func_name));

--- a/crates/sys/src/types/buffer/host.rs
+++ b/crates/sys/src/types/buffer/host.rs
@@ -13,6 +13,12 @@ impl<'a, T> Slice<'a, T> {
     }
 
     #[inline]
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    #[inline]
     pub fn new<U: AsRef<[T]> + 'a>(_value: U) -> Self {
         unimplemented!("Slice construction is only permitted in wasm32")
     }

--- a/crates/utils/actix/src/lazy.rs
+++ b/crates/utils/actix/src/lazy.rs
@@ -289,7 +289,7 @@ const _: () = {
         cmp as usize
     };
 
-    [[()][size_of_dyn]][ptr_is_good];
+    [[()][size_of_dyn]][ptr_is_good]
 };
 
 // pub struct DynResolve {

--- a/crates/wasm-abi/src/downgrade.rs
+++ b/crates/wasm-abi/src/downgrade.rs
@@ -129,7 +129,7 @@ pub fn identity_downgrades(old: &Manifest, new: &Manifest) -> Vec<IdentityDowngr
             // flags. An unresolvable→plain transition also still flags.
             Some(nf)
                 if !(new_still_gated(&nf.type_, new)
-                    || is_unresolvable(&f.type_, old) && is_unresolvable(&nf.type_, new)) =>
+                    || (is_unresolvable(&f.type_, old) && is_unresolvable(&nf.type_, new))) =>
             {
                 out.push(IdentityDowngrade {
                     field: f.name.clone(),

--- a/crates/wasm-abi/src/downgrade.rs
+++ b/crates/wasm-abi/src/downgrade.rs
@@ -128,8 +128,8 @@ pub fn identity_downgrades(old: &Manifest, new: &Manifest) -> Vec<IdentityDowngr
             // old→gated / new→plain, so it is NOT both-unresolvable and still
             // flags. An unresolvable→plain transition also still flags.
             Some(nf)
-                if !new_still_gated(&nf.type_, new)
-                    && !(is_unresolvable(&f.type_, old) && is_unresolvable(&nf.type_, new)) =>
+                if !(new_still_gated(&nf.type_, new)
+                    || is_unresolvable(&f.type_, old) && is_unresolvable(&nf.type_, new)) =>
             {
                 out.push(IdentityDowngrade {
                     field: f.name.clone(),

--- a/crates/wasm-abi/src/emitter.rs
+++ b/crates/wasm-abi/src/emitter.rs
@@ -57,13 +57,13 @@ impl<'ast> AbiEmitter {
                     // Process parameters
                     for param in &method.sig.inputs {
                         if let syn::FnArg::Typed(pat_type) = param {
-                            self.collect_types_from_type(&pat_type.ty, referenced_types);
+                            Self::collect_types_from_type(&pat_type.ty, referenced_types);
                         }
                     }
 
                     // Process return type
                     if let syn::ReturnType::Type(_, ty) = &method.sig.output {
-                        self.collect_types_from_type(ty, referenced_types);
+                        Self::collect_types_from_type(ty, referenced_types);
                     }
                 }
             }
@@ -79,12 +79,12 @@ impl<'ast> AbiEmitter {
             match &variant.fields {
                 syn::Fields::Unnamed(fields) => {
                     for field in &fields.unnamed {
-                        self.collect_types_from_type(&field.ty, referenced_types);
+                        Self::collect_types_from_type(&field.ty, referenced_types);
                     }
                 }
                 syn::Fields::Named(fields) => {
                     for field in &fields.named {
-                        self.collect_types_from_type(&field.ty, referenced_types);
+                        Self::collect_types_from_type(&field.ty, referenced_types);
                     }
                 }
                 syn::Fields::Unit => {
@@ -100,12 +100,11 @@ impl<'ast> AbiEmitter {
         referenced_types: &mut std::collections::HashSet<String>,
     ) {
         for field in &item_struct.fields {
-            self.collect_types_from_type(&field.ty, referenced_types);
+            Self::collect_types_from_type(&field.ty, referenced_types);
         }
     }
 
     fn collect_types_from_type(
-        &self,
         ty: &Type,
         referenced_types: &mut std::collections::HashSet<String>,
     ) {
@@ -119,27 +118,27 @@ impl<'ast> AbiEmitter {
                     if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
                         for arg in &args.args {
                             if let syn::GenericArgument::Type(ty) = arg {
-                                self.collect_types_from_type(ty, referenced_types);
+                                Self::collect_types_from_type(ty, referenced_types);
                             }
                         }
                     }
                 }
             }
             Type::Reference(type_ref) => {
-                self.collect_types_from_type(&type_ref.elem, referenced_types);
+                Self::collect_types_from_type(&type_ref.elem, referenced_types);
             }
             Type::Ptr(type_ptr) => {
-                self.collect_types_from_type(&type_ptr.elem, referenced_types);
+                Self::collect_types_from_type(&type_ptr.elem, referenced_types);
             }
             Type::Array(type_array) => {
-                self.collect_types_from_type(&type_array.elem, referenced_types);
+                Self::collect_types_from_type(&type_array.elem, referenced_types);
             }
             Type::Slice(type_slice) => {
-                self.collect_types_from_type(&type_slice.elem, referenced_types);
+                Self::collect_types_from_type(&type_slice.elem, referenced_types);
             }
             Type::Tuple(type_tuple) => {
                 for elem in &type_tuple.elems {
-                    self.collect_types_from_type(elem, referenced_types);
+                    Self::collect_types_from_type(elem, referenced_types);
                 }
             }
             _ => {}

--- a/tools/merodb/src/export.rs
+++ b/tools/merodb/src/export.rs
@@ -1556,7 +1556,7 @@ fn try_manual_entity_index_decode(
     dead_code,
     reason = "Fields required for Borsh deserialization structure"
 )]
-struct ChildInfo {
+pub struct ChildInfo {
     id: Id,
     merkle_hash: [u8; 32],
     metadata: Metadata,
@@ -1624,7 +1624,7 @@ impl borsh::BorshDeserialize for Metadata {
     dead_code,
     reason = "Variants required for Borsh deserialization structure"
 )]
-enum StorageType {
+pub enum StorageType {
     Public,
     User {
         owner: Id,
@@ -1644,7 +1644,7 @@ enum StorageType {
     dead_code,
     reason = "Fields required for Borsh deserialization structure"
 )]
-struct SignatureData {
+pub struct SignatureData {
     signature: [u8; 64],
     nonce: u64,
     /// Optional signer-pubkey hint added by Shared storage for O(1) verifier lookup.
@@ -1653,7 +1653,7 @@ struct SignatureData {
 }
 
 #[derive(borsh::BorshDeserialize, Clone)]
-struct UpdatedAt(u64);
+pub struct UpdatedAt(u64);
 
 impl Deref for UpdatedAt {
     type Target = u64;


### PR DESCRIPTION
## What & why

Second of the 4-PR series toward gating CI on a clean clippy build (follows #2821). This PR drives **every non-consensus crate to zero clippy/build warnings** with hand-fixes that `clippy --fix` couldn't apply. **No behavior changes** — only lint cleanups and mechanical signature regroupings; callers updated in lockstep and the whole workspace builds `--all-targets`.

### Crates taken to zero
storage, storage-macros, sys, wasm-abi, sdk, sdk-macros, store, blobstore, dag, utils-actix, node-primitives (except 2 deferred fns — see below), mero-auth, primitives, server, server-primitives, context-client, context-config, governance-types (except 3 deferred — see below), meroctl, merod, merodb, and the example/migration apps.

### Representative fixes
- **type_complexity** → named `type` aliases (storage env/js/crdt_meta, node-primitives AliasEntry, etc.).
- **large_enum_variant** → boxed the large variant (storage `Entry::Occupied`, sdk-macros `LogicArg`/`LogicMethod`).
- **too_many_arguments** → grouped cohesive params into structs: `ApplicationMeta::new`→`PackageInfo`, server `with_auth`→`ServiceConfigs` / `mount_runtime_services`→`RuntimeServiceDeps`, context-client `create_context`→`CreateContextParams`, meroctl `create_context`→`CreateContextArgs` / `watch_and_reload`→`ReloadPaths`.
- **result_large_err** → boxed large `Err` types; **borrowed_box** → `&dyn Trait` instead of `&Box<dyn Trait>`.
- **assertions_on_constants** → compile-time `const _: () = assert!(…)`.
- Stale `#[expect(…)]` left over from #2821's restriction-lint removal, doc-list continuations, unused imports/vars, `.clamp()`, private-in-public, module-inception, dead test instrumentation, etc.
- One justified per-item `#[allow]`: sdk-macros `let_and_return` (clippy's rewrite extends a borrow of `args` past its drop and fails to compile) — with an explanatory comment.

### Deferred to PR 3 (consensus tier)
These ripple into the consensus crates and/or sit on hot paths, so they belong with that review:
- `governance-types` (3): `large_enum_variant` on the `NamespaceTopicMsg`/`GroupTopicMsg`/`StoredNamespaceEntry` **wire enums** — boxing adds a per-message heap alloc on the gossip path and ripples to match-sites in node/governance-store; wants a deliberate perf call.
- `node-primitives` (2): `NodeClient::broadcast` (13/7) and `NodeClient::new` (8/7) `too_many_arguments` — broadcast is on the split-brain-sensitive delta path; its call sites span node + context.

After this PR, the **only** remaining warnings are those deferrals plus the 4 consensus crates (context, governance-store, node, runtime), which are PR 3.

## Verification
- `cargo build --workspace --all-targets` ✅
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets`: zero outside the deferred/PR-3 scope above.

## Series
1. #2821 — policy + auto-fix ✅ merged
2. **This PR** — manual cleanups, non-consensus crates
3. Consensus tier: context / governance-store / node / runtime + the deferrals above
4. Flip the gate: `[workspace.lints]` + `cargo clippy --workspace --all-targets -- -D warnings` in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical lint and signature regroupings with no described behavior changes; risk is limited to missed call-site updates, which the full-workspace build is meant to catch.
> 
> **Overview**
> This PR clears **clippy/build warnings** across non-consensus crates (part 2/4 toward a `-D warnings` CI gate). The intent is **lint hygiene**, not feature work.
> 
> **API shape (call sites updated in lockstep):** `ApplicationMeta::new` now takes a grouped **`PackageInfo`** (`package`, `version`, `signer_id`) instead of three separate strings. **`ContextClient::create_context`** takes **`CreateContextParams`**; meroctl uses **`CreateContextArgs`** / **`ReloadPaths`**; **`ServerConfig::with_auth`** takes **`ServiceConfigs`**; server startup passes **`RuntimeServiceDeps`** into **`mount_runtime_services`**. Auth registries return **`&dyn Trait`** instead of **`&Box<dyn Trait>`**; admin **`validate_request`** boxes large error responses.
> 
> **SDK / macros:** `into_error` → **`to_error`** on error helpers; **`HlcDriftError`** replaces a bare `Result<(), ()>` for HLC drift; diagnostic notes use doubled braces for enum examples. SDK macros **box** large **`LogicMethod`** / **`LogicArg`** variants to satisfy **`large_enum_variant`**. Storage map **`Entry::Occupied`** is boxed the same way.
> 
> **Storage / collections:** Adds **`is_empty()`** on several collection types; **`DecomposedEntries`** and env callback type aliases; **`update_hlc`** error typing; compile-time **`const assert!`** instead of runtime constant tests in a few places; minor doc and **`#[allow]`** cleanups on migration fixtures.
> 
> **Tests / misc:** Unused bindings prefixed with **`_`**, removed dead test helpers (e.g. DAG CRDT applier tracking), flattened alias tests, **`merod`** embedded-auth path assignment without extra UTF-8 conversion, and small refactors (**`.clamp()`**, **`matches!`**, import pruning).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2bc864ba2a2ef5099ac1c42cc42ddd14065d61e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->