### PR TITLE
ci: track ai-code-reviewer @master so the doc bot runs the latest pipeline

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -56,9 +56,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      # Tracks calimero-network/ai-code-reviewer @master so reviews always run the
-      # latest doc-update pipeline. Both repos are first-party. If you need a review
-      # gate before upstream changes run with this repo's secrets, pin to a SHA here.
+      # Tracks ai-code-reviewer @master (pin a SHA here for a deliberate review gate).
       - name: Install ai-code-reviewer
         run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@master
 

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -56,11 +56,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      # Pinned to a specific SHA on calimero-network/ai-code-reviewer to
-      # prevent an upstream change from running with this repo's secrets.
-      # Bump deliberately when adopting new reviewer features.
+      # Tracks calimero-network/ai-code-reviewer @master so reviews always run the
+      # latest doc-update pipeline. Both repos are first-party. If you need a review
+      # gate before upstream changes run with this repo's secrets, pin to a SHA here.
       - name: Install ai-code-reviewer
-        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@485b32abf334f1518dcadc9c3762ea98705e696c
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@master
 
       # Authenticate as the MeroReviewer App so review comments genuinely
       # come from meroreviewer[bot] (not whatever GH_PAT/GITHUB_TOKEN

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -55,8 +55,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      # Tracks @master (same as ai-review.yaml) so both workflows install the
-      # latest ai-code-reviewer. Pin to a SHA here if you need a review gate.
+      # Tracks ai-code-reviewer @master (pin a SHA here for a review gate).
       - name: Install ai-code-reviewer
         run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@master
 

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -55,10 +55,10 @@ jobs:
         with:
           python-version: "3.11"
 
-      # Pinned to the same SHA as ai-review.yaml so both workflows install
-      # the audited version of ai-code-reviewer. Bump deliberately.
+      # Tracks @master (same as ai-review.yaml) so both workflows install the
+      # latest ai-code-reviewer. Pin to a SHA here if you need a review gate.
       - name: Install ai-code-reviewer
-        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@485b32abf334f1518dcadc9c3762ea98705e696c
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@master
 
       # Mint a short-lived MeroReviewer App installation token. Unlike the
       # default GITHUB_TOKEN, an App token is not subject to the org/repo


### PR DESCRIPTION
## What

Switch both reviewer workflows to install `ai-code-reviewer` from **`@master`** instead of the fixed SHA `485b32a`.

```diff
- pip install git+https://github.com/calimero-network/ai-code-reviewer.git@485b32abf334f1518dcadc9c3762ea98705e696c
+ pip install git+https://github.com/calimero-network/ai-code-reviewer.git@master
```
(in `.github/workflows/ai-review.yaml` and `.github/workflows/doc-update.yaml`)

## Why

`485b32a` predates [ai-code-reviewer#81](https://github.com/calimero-network/ai-code-reviewer/pull/81), so core's doc bot was still running the **old shallow reviewer** — the one that turned a real behavioral change into a one-word rename in #2794. Tracking `@master` means core now runs the redesigned **Understand → Route → Apply → Verify** doc-update pipeline (full-PR read, flag-don't-ship verification, new-page wiring) and picks up future improvements automatically.

No `.ai-reviewer.yaml` change needed — the existing `doc_generation.model: claude-sonnet-4-6` flows through the new loader's fallback (apply/verify inherit it; understanding defaults to Sonnet).

## Trade-off

This drops the deliberate-SHA-bump gate: a merge to `ai-code-reviewer` master now runs against core's secrets + the MeroReviewer App automatically. Both repos are first-party. Re-pin to a SHA to restore the review gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Any merge to `ai-code-reviewer` master immediately runs in CI with `ANTHROPIC_API_KEY` and the MeroReviewer App, without a core-side pin to audit first.
> 
> **Overview**
> Both **AI Code Review** and **Doc Auto-Update** now install `ai-code-reviewer` from **`@master`** instead of the pinned commit `485b32a`. Inline comments were updated to describe tracking master and optionally re-pinning a SHA for a deliberate gate.
> 
> This trades the old SHA-bump review gate for always running the latest reviewer (including the newer doc-update pipeline). Workflows still use the MeroReviewer App token and the same secrets as before; only the installed package revision changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 096ffb90f2d8d6c320b0642710f72bfdea1c9783. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->