### PR TITLE
chore(lint): consensus-tier cleanups — workspace now warning-free (3/4)

### DIFF
--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -190,6 +190,10 @@ struct Prepared<'a> {
 }
 
 impl Prepared<'_> {
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "orthogonal args (runtime deps, context identity, crypto keys, module) on a split-brain-critical handler; no cohesive grouping"
+    )]
     fn new(
         node_client: &NodeClient,
         context_client: &ContextClient,
@@ -293,9 +297,10 @@ impl Prepared<'_> {
                 //         and the entry within the BTreeMap is constrained to
                 //         the lifetime of the BTreeMap before it is returned
                 let entry = unsafe {
-                    mem::transmute::<_, btree_map::VacantEntry<'static, ContextId, ContextMeta>>(
-                        entry,
-                    )
+                    mem::transmute::<
+                        btree_map::VacantEntry<'_, ContextId, ContextMeta>,
+                        btree_map::VacantEntry<'static, ContextId, ContextMeta>,
+                    >(entry)
                 };
 
                 context = Some(Some((entry, context_id, context_secret)));
@@ -330,6 +335,10 @@ impl Prepared<'_> {
     }
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "orthogonal args (runtime deps, context identity, crypto keys, module) on a split-brain-critical handler; no cohesive grouping"
+)]
 async fn create_context(
     datastore: Store,
     node_client: NodeClient,

--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -293,7 +293,7 @@ impl Prepared<'_> {
                     continue;
                 }
 
-                // safety: the VacantEntry only lives as long as this function
+                // SAFETY: the VacantEntry only lives as long as this function
                 //         and the entry within the BTreeMap is constrained to
                 //         the lifetime of the BTreeMap before it is returned
                 let entry = unsafe {

--- a/crates/context/src/handlers/delete_context.rs
+++ b/crates/context/src/handlers/delete_context.rs
@@ -153,7 +153,6 @@ async fn delete_context(
     Ok(())
 }
 
-#[expect(clippy::unwrap_in_result, reason = "pre-validated")]
 fn delete_context_scoped<K, const N: usize>(
     datastore: &mut Store,
     context_id: &ContextId,

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1697,6 +1697,10 @@ impl ContextManager {
     }
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "orthogonal args (runtime deps, context identity, crypto keys, module) on a split-brain-critical handler; no cohesive grouping"
+)]
 async fn internal_execute(
     datastore: Store,
     node_client: &NodeClient,

--- a/crates/context/src/handlers/execute/signing.rs
+++ b/crates/context/src/handlers/execute/signing.rs
@@ -218,7 +218,8 @@ pub(crate) fn persist_signed_signatures(
             //    real signature already stored for that entity.
             // 3. Anything else falls through to
             //    `update_signature_in_place`.
-            let signed_with_real_sig = match &storage_type {
+            let signed_with_real_sig = matches!(
+                &storage_type,
                 StorageType::Shared {
                     signature_data: Some(sig),
                     ..
@@ -230,9 +231,8 @@ pub(crate) fn persist_signed_signatures(
                 | StorageType::SharedMember {
                     signature_data: Some(sig),
                     ..
-                } if sig.signature != [0u8; 64] => true,
-                _ => false,
-            };
+                } if sig.signature != [0u8; 64]
+            );
             if !signed_with_real_sig {
                 continue;
             }

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -1246,15 +1246,15 @@ pub(crate) fn clear_migration_failed(datastore: &calimero_store::Store, context_
     }
 }
 
-/// Storage callback closures used by the `calimero-storage` runtime environment.
-///
-/// These closures bridge the `calimero-storage` [`Key`]-based interface to the
-/// underlying `calimero-store` [`key::ContextState`]-based KV store.
 /// Reference-counted host storage callbacks (read / write / remove).
 pub(crate) type ReadFn = Rc<dyn Fn(&Key) -> Option<Vec<u8>>>;
 pub(crate) type WriteFn = Rc<dyn Fn(Key, &[u8]) -> bool>;
 pub(crate) type RemoveFn = Rc<dyn Fn(&Key) -> bool>;
 
+/// Storage callback closures used by the `calimero-storage` runtime environment.
+///
+/// These closures bridge the `calimero-storage` [`Key`]-based interface to the
+/// underlying `calimero-store` [`key::ContextState`]-based KV store.
 pub(crate) struct StorageCallbacks {
     pub(crate) read: ReadFn,
     pub(crate) write: WriteFn,

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -346,6 +346,10 @@ fn app_version_changed_event(
     })
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "orthogonal args (runtime deps, context identity, crypto keys, module) on a split-brain-critical handler; no cohesive grouping"
+)]
 pub async fn update_application_id(
     datastore: calimero_store::Store,
     node_client: NodeClient,
@@ -526,6 +530,10 @@ fn verify_appkey_continuity(
 /// 3. Executes the migration function
 /// 4. Writes returned state bytes to root storage key
 /// 5. Updates context metadata and triggers sync
+#[allow(
+    clippy::too_many_arguments,
+    reason = "orthogonal args (runtime deps, context identity, crypto keys, module) on a split-brain-critical handler; no cohesive grouping"
+)]
 pub(crate) async fn update_application_with_migration(
     datastore: calimero_store::Store,
     node_client: NodeClient,
@@ -1242,10 +1250,15 @@ pub(crate) fn clear_migration_failed(datastore: &calimero_store::Store, context_
 ///
 /// These closures bridge the `calimero-storage` [`Key`]-based interface to the
 /// underlying `calimero-store` [`key::ContextState`]-based KV store.
+/// Reference-counted host storage callbacks (read / write / remove).
+pub(crate) type ReadFn = Rc<dyn Fn(&Key) -> Option<Vec<u8>>>;
+pub(crate) type WriteFn = Rc<dyn Fn(Key, &[u8]) -> bool>;
+pub(crate) type RemoveFn = Rc<dyn Fn(&Key) -> bool>;
+
 pub(crate) struct StorageCallbacks {
-    pub(crate) read: Rc<dyn Fn(&Key) -> Option<Vec<u8>>>,
-    pub(crate) write: Rc<dyn Fn(Key, &[u8]) -> bool>,
-    pub(crate) remove: Rc<dyn Fn(&Key) -> bool>,
+    pub(crate) read: ReadFn,
+    pub(crate) write: WriteFn,
+    pub(crate) remove: RemoveFn,
 }
 
 /// Create storage callback closures that route `calimero-storage` operations to the datastore.
@@ -1256,7 +1269,7 @@ pub(crate) fn create_storage_callbacks(
     datastore: &calimero_store::Store,
     context_id: ContextId,
 ) -> StorageCallbacks {
-    let read: Rc<dyn Fn(&Key) -> Option<Vec<u8>>> = {
+    let read: ReadFn = {
         let handle = datastore.handle();
         let ctx_id = context_id;
         Rc::new(move |key: &Key| {
@@ -1278,7 +1291,7 @@ pub(crate) fn create_storage_callbacks(
         })
     };
 
-    let write: Rc<dyn Fn(Key, &[u8]) -> bool> = {
+    let write: WriteFn = {
         let handle_cell: Rc<RefCell<_>> = Rc::new(RefCell::new(datastore.handle()));
         let ctx_id = context_id;
         Rc::new(move |key: Key, value: &[u8]| {
@@ -1293,7 +1306,7 @@ pub(crate) fn create_storage_callbacks(
         })
     };
 
-    let remove: Rc<dyn Fn(&Key) -> bool> = {
+    let remove: RemoveFn = {
         let handle_cell: Rc<RefCell<_>> = Rc::new(RefCell::new(datastore.handle()));
         let ctx_id = context_id;
         Rc::new(move |key: &Key| {

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -1,4 +1,3 @@
-#![expect(clippy::unwrap_in_result, reason = "Repr transmute")]
 #![allow(clippy::multiple_inherent_impl, reason = "better readability")]
 
 use calimero_governance_store::{

--- a/crates/context/src/tee_subgroup_admit.rs
+++ b/crates/context/src/tee_subgroup_admit.rs
@@ -152,7 +152,7 @@ async fn run(
         // harmless. `Store` and `ContextClient` are cheap, shared-backing clones.
         let store = store.clone();
         let context_client = context_client.clone();
-        let _ = tokio::spawn(async move {
+        tokio::spawn(async move {
             match trigger {
                 AdmitTrigger::NewSubgroup {
                     namespace_id,

--- a/crates/context/tests/cascade_apply_walk.rs
+++ b/crates/context/tests/cascade_apply_walk.rs
@@ -8,7 +8,7 @@
 //! here: it sits one layer above and requires a full actor context.
 //! The cascade engine's *behaviour* lives in `cascade::walk_for_predicate`
 //! + the apply arm in `group_store::apply_group_op_mutations`, and that
-//! is exactly what `apply_local_signed_group_op` drives.
+//!   is exactly what `apply_local_signed_group_op` drives.
 
 use calimero_context::group_store::{MembershipRepository, MetaRepository, NamespaceRepository};
 use std::sync::Arc;

--- a/crates/governance-store/src/absorb.rs
+++ b/crates/governance-store/src/absorb.rs
@@ -17,6 +17,9 @@ use eyre::Result as EyreResult;
 use super::collect_keys_with_prefix;
 use crate::AbsorbRecord;
 
+/// Absorb records keyed by their (entity, field) id pair.
+type AbsorbEntries = Vec<(([u8; 32], [u8; 32]), AbsorbRecord)>;
+
 /// Typed Repository for the per-context absorb buffer.
 ///
 /// Holds one [`AbsorbRecord`] per `(context, producing_app_key, delta_id)`
@@ -88,10 +91,7 @@ impl<'a> AbsorbRepository<'a> {
     /// contiguous per-context block; otherwise any smaller context present in
     /// the CF fails `belongs` on the very first key and terminates the scan
     /// early. Mirrors `CapabilitiesRepository::enumerate_members`.
-    pub fn enumerate_pending(
-        &self,
-        context_id: &ContextId,
-    ) -> EyreResult<Vec<(([u8; 32], [u8; 32]), AbsorbRecord)>> {
+    pub fn enumerate_pending(&self, context_id: &ContextId) -> EyreResult<AbsorbEntries> {
         let target = *context_id.as_ref();
         let keys = collect_keys_with_prefix(
             self.store,

--- a/crates/governance-store/src/governance_broadcast.rs
+++ b/crates/governance-store/src/governance_broadcast.rs
@@ -514,6 +514,9 @@ impl BroadcastTransport for calimero_network_primitives::client::NetworkClient {
 /// `report.acked_by` at the call site — at that point the helper to
 /// turn a partial report into `Err` will be added alongside the first
 /// caller that needs it.
+// Gossip-publish entry on the namespace governance path: transport handles,
+// the op, and ack/gate sizing are orthogonal with no cohesive grouping.
+#[allow(clippy::too_many_arguments, reason = "orthogonal broadcast-path args")]
 pub async fn publish_and_await_ack_namespace(
     store: &Store,
     transport: &dyn BroadcastTransport,

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -122,6 +122,9 @@ use self::local_state::{append_op_log_entry, set_op_head};
 #[cfg(test)]
 use self::upgrades::extract_application_id;
 
+/// A resolved member identity: public key plus its two associated 32-byte keys.
+pub type ResolvedIdentity = (PublicKey, [u8; 32], [u8; 32]);
+
 // ---------------------------------------------------------------------------
 // Typed errors for group store operations
 // ---------------------------------------------------------------------------
@@ -570,9 +573,7 @@ impl<'a> GroupHandle<'a> {
     pub fn resolve_namespace(&self) -> EyreResult<ContextGroupId> {
         NamespaceRepository::new(self.store).resolve(&self.group_id)
     }
-    pub fn resolve_namespace_identity(
-        &self,
-    ) -> EyreResult<Option<(PublicKey, [u8; 32], [u8; 32])>> {
+    pub fn resolve_namespace_identity(&self) -> EyreResult<Option<ResolvedIdentity>> {
         NamespaceRepository::new(self.store).resolve_identity(&self.group_id)
     }
     pub fn get_or_create_namespace_identity(
@@ -630,7 +631,7 @@ impl<'a> NamespaceHandle<'a> {
         self.namespace_id
     }
 
-    pub fn get_identity(&self) -> EyreResult<Option<(PublicKey, [u8; 32], [u8; 32])>> {
+    pub fn get_identity(&self) -> EyreResult<Option<ResolvedIdentity>> {
         NamespaceRepository::new(self.store).identity(&ContextGroupId::from(self.namespace_id))
     }
 
@@ -825,6 +826,7 @@ pub fn now_secs() -> u64 {
 ///    Once the network has fully rolled forward to signed-claim ops
 ///    the zero sentinel becomes dead and can be removed; the
 ///    empty-list "no contexts" case stays valid forever.
+///
 /// Re-export of the cross-crate `DivergenceReport` carried inside
 /// `NamespaceApplyOutcome::Applied`. Defined in `calimero-context-client`
 /// because the message type that carries it lives there, and

--- a/crates/governance-store/src/membership/mod.rs
+++ b/crates/governance-store/src/membership/mod.rs
@@ -19,6 +19,7 @@ mod tests;
 
 pub use self::core::{MembershipPath, MembershipRepository};
 pub use self::policy::MembershipPolicy;
+pub use self::policy_rules::TeeAttestationClaims;
 pub(crate) use self::status::role_from_invited_role;
 pub use self::status::{acl_view_at, MembershipStatus};
 pub use self::view::GroupMembershipView;

--- a/crates/governance-store/src/membership/policy.rs
+++ b/crates/governance-store/src/membership/policy.rs
@@ -79,24 +79,9 @@ impl<'a> MembershipPolicy<'a> {
     pub fn validate_tee_attestation_allowlists(
         &self,
         policy: &TeeAdmissionPolicy,
-        mrtd: &str,
-        rtmr0: &str,
-        rtmr1: &str,
-        rtmr2: &str,
-        rtmr3: &str,
-        tcb_status: &str,
+        claims: &TeeAttestationClaims<'_>,
     ) -> EyreResult<()> {
-        self.validate_tee_attestation_allowlists_record(
-            policy,
-            &TeeAttestationClaims {
-                mrtd,
-                rtmr0,
-                rtmr1,
-                rtmr2,
-                rtmr3,
-                tcb_status,
-            },
-        )
+        self.validate_tee_attestation_allowlists_record(policy, claims)
     }
 
     pub fn validate_tee_attestation_allowlists_record(

--- a/crates/governance-store/src/membership/policy_rules.rs
+++ b/crates/governance-store/src/membership/policy_rules.rs
@@ -6,6 +6,12 @@ pub const TEE_REJECT_RTMR2: &str = "rtmr2_not_allowed";
 pub const TEE_REJECT_RTMR3: &str = "rtmr3_not_allowed";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// Each variant names the specific attestation field a policy rejected; the
+// shared `NotAllowed` suffix is meaningful domain vocabulary, not redundancy.
+#[allow(
+    clippy::enum_variant_names,
+    reason = "each variant is a distinct policy-rejection reason"
+)]
 pub enum MembershipPolicyRejection {
     MrtdNotAllowed,
     TcbStatusNotAllowed,

--- a/crates/governance-store/src/membership/tests.rs
+++ b/crates/governance-store/src/membership/tests.rs
@@ -23,6 +23,7 @@ use super::super::test_fixtures::{
     test_store,
 };
 use super::super::*;
+use super::TeeAttestationClaims;
 
 #[test]
 fn add_and_check_membership() {
@@ -179,13 +180,43 @@ fn membership_policy_guards_last_admin_and_tee_paths() {
 
     let policy = membership.read_required_tee_admission_policy().unwrap();
     assert!(membership
-        .validate_tee_attestation_allowlists(&policy, "m1", "r0", "x", "y", "z", "ok")
+        .validate_tee_attestation_allowlists(
+            &policy,
+            &TeeAttestationClaims {
+                mrtd: "m1",
+                rtmr0: "r0",
+                rtmr1: "x",
+                rtmr2: "y",
+                rtmr3: "z",
+                tcb_status: "ok"
+            },
+        )
         .is_ok());
     assert!(membership
-        .validate_tee_attestation_allowlists(&policy, "wrong", "r0", "x", "y", "z", "ok")
+        .validate_tee_attestation_allowlists(
+            &policy,
+            &TeeAttestationClaims {
+                mrtd: "wrong",
+                rtmr0: "r0",
+                rtmr1: "x",
+                rtmr2: "y",
+                rtmr3: "z",
+                tcb_status: "ok"
+            },
+        )
         .is_err());
     assert!(membership
-        .validate_tee_attestation_allowlists(&policy, "m1", "wrong", "x", "y", "z", "ok")
+        .validate_tee_attestation_allowlists(
+            &policy,
+            &TeeAttestationClaims {
+                mrtd: "m1",
+                rtmr0: "wrong",
+                rtmr1: "x",
+                rtmr2: "y",
+                rtmr3: "z",
+                tcb_status: "ok"
+            },
+        )
         .is_err());
 
     let tee_joined = PrivateKey::random(&mut rng).public_key();

--- a/crates/governance-store/src/metrics.rs
+++ b/crates/governance-store/src/metrics.rs
@@ -655,11 +655,11 @@ mod tests {
     ///
     /// As with `self_purge_failures_register_and_encode`, we build the family
     /// + registry locally rather than going through the process-global
-    /// `GROUP_STORE_METRICS` sink (a `OnceLock` another test may have set), so
-    /// the assertion targets *this* registry. The label-building logic
-    /// (`ReconcileOutcome::as_label`) is what we assert on; the
-    /// no-op-without-sink behaviour of the public recorder is covered by the
-    /// early-return and exercised below.
+    ///   `GROUP_STORE_METRICS` sink (a `OnceLock` another test may have set), so
+    ///   the assertion targets *this* registry. The label-building logic
+    ///   (`ReconcileOutcome::as_label`) is what we assert on; the
+    ///   no-op-without-sink behaviour of the public recorder is covered by the
+    ///   early-return and exercised below.
     #[test]
     fn self_purge_reconcile_register_and_encode() {
         let mut registry = Registry::default();

--- a/crates/governance-store/src/namespace/core.rs
+++ b/crates/governance-store/src/namespace/core.rs
@@ -481,7 +481,7 @@ impl<'a> NamespaceRepository<'a> {
     pub fn identity(
         &self,
         namespace_id: &ContextGroupId,
-    ) -> EyreResult<Option<(PublicKey, [u8; 32], [u8; 32])>> {
+    ) -> EyreResult<Option<crate::ResolvedIdentity>> {
         Ok(self
             .identity_record(namespace_id)?
             .map(|record| (record.public_key, record.private_key, record.sender_key)))
@@ -527,7 +527,7 @@ impl<'a> NamespaceRepository<'a> {
     pub fn resolve_identity(
         &self,
         group_id: &ContextGroupId,
-    ) -> EyreResult<Option<(PublicKey, [u8; 32], [u8; 32])>> {
+    ) -> EyreResult<Option<crate::ResolvedIdentity>> {
         Ok(self
             .resolve_identity_record(group_id)?
             .map(|record| (record.public_key, record.private_key, record.sender_key)))

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -602,6 +602,9 @@ impl<'a> NamespaceGovernance<'a> {
     /// visible) and passes it in here. Recomputing inside this function
     /// would shift the hash forward and every member-mutating op would
     /// permanently bail on the receiver's staleness check.
+    // Gossip-publish entry on the namespace governance path: transport handles,
+    // the op, and ack/gate sizing are orthogonal with no cohesive grouping.
+    #[allow(clippy::too_many_arguments, reason = "orthogonal broadcast-path args")]
     pub(crate) async fn sign_and_publish_post_gate(
         &self,
         node_client: &calimero_node_primitives::client::NodeClient,
@@ -644,6 +647,9 @@ impl<'a> NamespaceGovernance<'a> {
     /// * `true` (group-op apply-and-publish path) — the local mutation is
     ///   already committed, so a publish failure is swallowed into a
     ///   `Degraded` [`DeliveryReport`] and propagation falls to sync.
+    // Gossip-publish entry on the namespace governance path: transport handles,
+    // the op, and ack/gate sizing are orthogonal with no cohesive grouping.
+    #[allow(clippy::too_many_arguments, reason = "orthogonal broadcast-path args")]
     async fn publish_post_gate(
         &self,
         node_client: &calimero_node_primitives::client::NodeClient,

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -665,7 +665,7 @@ fn namespace_retry_service_orders_candidates_by_signer_nonce() {
     // rather than silently succeeding with in-order ops.
     let max_attempts = 64;
     let mut found = false;
-    let mut raw_nonces: Vec<u64> = Vec::new();
+    let raw_nonces: Vec<u64>;
     for _ in 0..max_attempts {
         let signer_sk = PrivateKey::random(&mut rng);
         let signed_ops: Vec<SignedNamespaceOp> = (1u64..=4)

--- a/crates/governance-store/src/ops/group.rs
+++ b/crates/governance-store/src/ops/group.rs
@@ -131,7 +131,17 @@ pub(crate) fn dispatch(ctx: &mut GroupApplyCtx<'_>, op: &GroupOp) -> EyreResult<
             tcb_status,
             role,
         } => member_joined_via_tee_attestation::apply(
-            ctx, member, mrtd, rtmr0, rtmr1, rtmr2, rtmr3, tcb_status, role,
+            ctx,
+            member,
+            &crate::membership::TeeAttestationClaims {
+                mrtd: mrtd.as_str(),
+                rtmr0: rtmr0.as_str(),
+                rtmr1: rtmr1.as_str(),
+                rtmr2: rtmr2.as_str(),
+                rtmr3: rtmr3.as_str(),
+                tcb_status: tcb_status.as_str(),
+            },
+            role,
         )?,
         GroupOp::MemberSetAutoFollow {
             target,

--- a/crates/governance-store/src/ops/group/member_joined_via_tee_attestation.rs
+++ b/crates/governance-store/src/ops/group/member_joined_via_tee_attestation.rs
@@ -3,6 +3,7 @@
 
 use super::super::super::build_auto_follow_set_if_enabled;
 use super::context::GroupApplyCtx;
+use crate::membership::TeeAttestationClaims;
 use crate::{DenyListRepository, MembershipError};
 use calimero_primitives::context::GroupMemberRole;
 use calimero_primitives::identity::PublicKey;
@@ -11,12 +12,7 @@ use eyre::{bail, Result as EyreResult};
 pub(crate) fn apply(
     ctx: &mut GroupApplyCtx<'_>,
     member: &PublicKey,
-    mrtd: &str,
-    rtmr0: &str,
-    rtmr1: &str,
-    rtmr2: &str,
-    rtmr3: &str,
-    tcb_status: &str,
+    claims: &TeeAttestationClaims<'_>,
     role: &GroupMemberRole,
 ) -> EyreResult<()> {
     let signer = ctx.signer();
@@ -32,9 +28,7 @@ pub(crate) fn apply(
         .membership_policy()
         .read_required_tee_admission_policy()?;
     ctx.membership_policy()
-        .validate_tee_attestation_allowlists(
-            &policy, mrtd, rtmr0, rtmr1, rtmr2, rtmr3, tcb_status,
-        )?;
+        .validate_tee_attestation_allowlists(&policy, claims)?;
     ctx.membership_policy()
         .admit_member_if_absent(member, role)?;
     // Same rationale as `MemberAdded`: a TEE rejoining after a

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -2402,8 +2402,8 @@ fn tee_policy_and_quote_hash_scan_latest_and_match() {
 ///   3. applies a DIFFERENT op B (nonce 2) and asserts the op-log now holds
 ///      TWO entries (A preserved at seq 1, B appended at seq 2) — i.e. B did
 ///      not overwrite the orphan.
-/// A partial bootstrap seed (meta written, admin member row missing) must be
-/// repaired by a later seed call, not skipped forever (PR #2473, finding C).
+///      A partial bootstrap seed (meta written, admin member row missing) must be
+///      repaired by a later seed call, not skipped forever (PR #2473, finding C).
 ///
 /// `seed_bootstrap_admin_if_absent` writes two non-atomic rows: group meta and
 /// the admin member row. A crash between them leaves meta present but the member

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -767,6 +767,10 @@ pub struct OpaqueSkeleton {
 /// This removes ambiguity from polymorphic storage payloads by explicitly
 /// tagging whether a row contains a full signed op or an opaque skeleton.
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+#[allow(
+    clippy::large_enum_variant,
+    reason = "gossip/stored message: constructed, borsh-serialized, then dropped; boxing the common large variant adds a per-message heap allocation without real benefit"
+)]
 pub enum StoredNamespaceEntry {
     Signed(SignedNamespaceOp),
     Opaque(OpaqueSkeleton),

--- a/crates/governance-types/src/wire.rs
+++ b/crates/governance-types/src/wire.rs
@@ -346,6 +346,10 @@ pub struct ReadinessProbe {
 /// Adding a variant requires a coordinated cluster upgrade (pre-1.0,
 /// no rolling-upgrade compatibility path).
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[allow(
+    clippy::large_enum_variant,
+    reason = "gossip/stored message: constructed, borsh-serialized, then dropped; boxing the common large variant adds a per-message heap allocation without real benefit"
+)]
 pub enum NamespaceTopicMsg {
     Op(SignedNamespaceOp),
     Ack(SignedAck),
@@ -360,6 +364,10 @@ pub enum NamespaceTopicMsg {
 /// topic; this enum reserves the wire format so a future migration to
 /// per-group topics does not require another schema bump.
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+#[allow(
+    clippy::large_enum_variant,
+    reason = "gossip/stored message: constructed, borsh-serialized, then dropped; boxing the common large variant adds a per-message heap allocation without real benefit"
+)]
 pub enum GroupTopicMsg {
     Op(SignedGroupOp),
     Ack(SignedAck),

--- a/crates/node/primitives/src/client.rs
+++ b/crates/node/primitives/src/client.rs
@@ -224,6 +224,10 @@ pub struct NodeClient {
 
 impl NodeClient {
     #[must_use]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "orthogonal service dependencies wired into the NodeClient constructor"
+    )]
     pub fn new(
         datastore: Store,
         blob_manager: BlobManager,
@@ -513,6 +517,10 @@ impl NodeClient {
         self.network_client.network_status().await
     }
 
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "orthogonal args (delta payload, crypto identity, governance position) on the split-brain-critical broadcast path; no cohesive grouping"
+    )]
     pub async fn broadcast(
         &self,
         context: &Context,

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -35,6 +35,9 @@ use tracing::{debug, info, warn};
 
 use crate::sync::rotation_log_reader;
 
+/// Shared, swappable parent-topology map keyed by delta id.
+type TopologyHandle = Arc<RwLock<Arc<IndexMap<[u8; 32], Vec<[u8; 32]>>>>>;
+
 /// Maximum entries in the applier-local topology mirror. Exceeding this
 /// triggers oldest-first eviction (insertion-ordered via `IndexMap`)
 /// down to 90% of the cap. Applied both inside `apply()` (steady state)
@@ -148,6 +151,12 @@ impl AnchorPendingBuffer {
     /// Buffer `input` under `anchor`. Returns `Ok(())` if buffered; returns
     /// `Err(input)` (handing ownership back) if it was already buffered or the
     /// global cap is reached, so the caller can fall back to the normal path.
+    // The Err variant deliberately hands `input` ownership back so the caller
+    // can fall back to the normal path; boxing would defeat that.
+    #[allow(
+        clippy::result_large_err,
+        reason = "Err returns the input back for caller fallback"
+    )]
     fn buffer(&mut self, anchor: Id, input: BatchDeltaInput) -> Result<(), BatchDeltaInput> {
         if self.seen.contains(&input.delta.id) {
             return Err(input);
@@ -181,6 +190,7 @@ impl AnchorPendingBuffer {
     }
 
     /// Total buffered deltas across all anchors.
+    #[cfg(test)]
     fn len(&self) -> usize {
         self.seen.len()
     }
@@ -282,7 +292,7 @@ struct ContextStorageApplier {
     /// hot sync path. With the inner `Arc`, reads bump a refcount and
     /// writers `Arc::make_mut` to clone-on-first-write only when a reader
     /// snapshot is still live.
-    topology: Arc<RwLock<Arc<IndexMap<[u8; 32], Vec<[u8; 32]>>>>>,
+    topology: TopologyHandle,
     /// Armed by [`DeltaStore::add_delta_internal`] around its `dag.add_delta`
     /// call so the inbound `apply()` *retains* the per-context execution lock
     /// (stashing the guard in [`Self::apply_lock_slot`]) instead of releasing
@@ -982,10 +992,10 @@ fn cap_topology(topology: &mut IndexMap<[u8; 32], Vec<[u8; 32]>>) {
     drop(topology.drain(0..excess));
 }
 
-/// Read a `RotationLog` directly from the datastore for a given context
-/// + entity, bypassing `calimero_storage::rotation_log::load` (which
-/// goes through the `RUNTIME_ENV` thread-local that's only installed
-/// inside `context_client.execute()`).
+/// Read a `RotationLog` directly from the datastore for a given
+/// context + entity, bypassing `calimero_storage::rotation_log::load`
+/// (which goes through the `RUNTIME_ENV` thread-local that's only
+/// installed inside `context_client.execute()`).
 ///
 /// The on-disk shape mirrors what
 /// `calimero_node_primitives::sync::storage_bridge::create_runtime_env`

--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -448,6 +448,10 @@ pub(super) fn handle_namespace_state_heartbeat(
 /// callers don't know which specific ancestor ids are still missing — the
 /// pending chain can be arbitrarily deep, and the responder caps at
 /// `MAX_BACKFILL_OPS` per response anyway.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "orthogonal args on a consensus sync/handler path; no cohesive grouping"
+)]
 async fn resolve_namespace_pending(
     context_client: &calimero_context_client::client::ContextClient,
     node_client: &calimero_node_primitives::client::NodeClient,
@@ -533,6 +537,10 @@ async fn resolve_namespace_pending(
     }
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "orthogonal args on a consensus sync/handler path; no cohesive grouping"
+)]
 async fn fetch_and_apply_namespace_backfill(
     context_client: &calimero_context_client::client::ContextClient,
     node_client: &calimero_node_primitives::client::NodeClient,

--- a/crates/node/src/handlers/state_delta/events.rs
+++ b/crates/node/src/handlers/state_delta/events.rs
@@ -41,6 +41,10 @@ pub(super) struct CascadeOutcome {
 /// has somewhere to go, but callers must NOT use `?` to propagate it: doing so
 /// would abort delta handling *after* the DAG has already been mutated. Match
 /// and log instead.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "orthogonal args on a consensus sync/handler path; no cohesive grouping"
+)]
 pub(super) async fn execute_cascaded_events(
     cascaded_events: &[([u8; 32], Vec<u8>)],
     node_client: &NodeClient,

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -122,6 +122,7 @@ pub(crate) struct ReplayBufferedDeltaInput {
 /// 4. Requests missing parents if needed
 /// 5. Executes event handlers
 /// 6. Re-emits events to WebSocket clients
+///
 /// Apply path for an authorized state delta — runs the snapshot-sync buffer
 /// check, decryption, DAG insert, handler execution, and heartbeat broadcast.
 ///
@@ -1018,6 +1019,10 @@ pub async fn handle_state_delta(
 /// child's stored events along in its `AddDeltaResult`; callers *must* run
 /// `execute_cascaded_events` on the returned list, otherwise handler execution
 /// for cascaded children silently never happens.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "orthogonal args on a consensus sync/handler path; no cohesive grouping"
+)]
 async fn request_missing_deltas(
     network_client: calimero_network_primitives::client::NetworkClient,
     sync_timeout: std::time::Duration,

--- a/crates/node/src/join_namespace.rs
+++ b/crates/node/src/join_namespace.rs
@@ -405,6 +405,10 @@ pub async fn await_namespace_ready(
 ///
 /// Callers who want fine-grained control should call `join_namespace`
 /// and `await_namespace_ready` directly.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "orthogonal args on a consensus sync/handler path; no cohesive grouping"
+)]
 pub async fn join_and_wait_ready(
     store: &Store,
     node_client: &NodeClient,

--- a/crates/node/src/node_metrics.rs
+++ b/crates/node/src/node_metrics.rs
@@ -115,9 +115,13 @@ pub(crate) struct NodeMetrics {
 
     // Process resource gauges — polled periodically on linux via
     // /proc/self/status + /proc/self/fd; no-op on other platforms.
+    #[allow(dead_code, reason = "recorded by the linux-only /proc resource poller")]
     pub(crate) process_resident_memory_bytes: Gauge,
+    #[allow(dead_code, reason = "recorded by the linux-only /proc resource poller")]
     pub(crate) process_virtual_memory_bytes: Gauge,
+    #[allow(dead_code, reason = "recorded by the linux-only /proc resource poller")]
     pub(crate) process_threads: Gauge,
+    #[allow(dead_code, reason = "recorded by the linux-only /proc resource poller")]
     pub(crate) process_open_fds: Gauge,
 }
 

--- a/crates/node/src/readiness/tests.rs
+++ b/crates/node/src/readiness/tests.rs
@@ -362,7 +362,7 @@ async fn await_first_fresh_beacon_resolves_on_late_arrival() {
     let cache_w = cache.clone();
     let notify_w = notify.clone();
     let pk = PrivateKey::random(&mut rand::thread_rng()).public_key();
-    let _ = tokio::spawn(async move {
+    tokio::spawn(async move {
         tokio::time::sleep(Duration::from_millis(50)).await;
         cache_w.insert(&make_beacon(pk, 7, true));
         notify_w.notify([42u8; 32]);

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -1119,14 +1119,16 @@ mod tests {
 
     #[test]
     fn test_stats_tracking() {
-        let mut stats = LevelWiseStats::default();
-        stats.levels_synced = 2;
-        stats.nodes_compared = 100;
-        stats.entities_merged = 25;
-        stats.nodes_skipped = 75;
-        stats.max_nodes_per_level = 50;
-        stats.requests_sent = 3;
-        stats.root_hash_verified = true;
+        let stats = LevelWiseStats {
+            levels_synced: 2,
+            nodes_compared: 100,
+            entities_merged: 25,
+            nodes_skipped: 75,
+            max_nodes_per_level: 50,
+            requests_sent: 3,
+            root_hash_verified: true,
+            ..Default::default()
+        };
 
         assert_eq!(stats.levels_synced, 2);
         assert_eq!(stats.nodes_compared, 100);

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -175,12 +175,7 @@ pub struct SyncManager {
             oneshot::Sender<eyre::Result<JoinBundle>>,
         )>,
     >,
-    pub(super) open_subgroup_join_rx: Option<
-        mpsc::Receiver<(
-            OpenSubgroupJoinParams,
-            oneshot::Sender<eyre::Result<Vec<u8>>>,
-        )>,
-    >,
+    pub(super) open_subgroup_join_rx: Option<OpenSubgroupJoinRx>,
 
     /// Dispatch handle for the dedicated `SyncSessionActor` (#2316).
     /// Set via [`SyncManager::set_session_handles`] after the actor is
@@ -210,9 +205,7 @@ pub struct SyncManager {
     /// resolves to a real blob would otherwise issue one doomed BlobShare per
     /// sync tick forever; with the memo a failed stage retries at most every
     /// few minutes. Shared across clones (initiator/responder handles).
-    pub(super) stale_blob_attempts: Arc<
-        std::sync::Mutex<std::collections::HashMap<(ContextId, [u8; 32]), (Option<Instant>, u32)>>,
-    >,
+    pub(super) stale_blob_attempts: StaleBlobAttempts,
 
     /// Reconcile-after-divergence orchestrator. Owns the orchestration
     /// for [`Self::reconcile_after_divergence`]; that method is a thin
@@ -357,6 +350,10 @@ where
 }
 
 impl SyncManager {
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "orthogonal args on a consensus sync/handler path; no cohesive grouping"
+    )]
     pub(crate) fn new(
         sync_config: SyncConfig,
         node_client: NodeClient,
@@ -421,6 +418,7 @@ impl SyncManager {
     /// keep the construction-time `Arc` and their network calls on the
     /// reconcile / protocol-dispatch paths bypass the mock.
     #[cfg(test)]
+    #[allow(dead_code, reason = "test utility for swapping in a mock SyncNetwork")]
     pub(crate) fn set_sync_network(&mut self, sync_network: Arc<dyn super::network::SyncNetwork>) {
         self.sync_network = Arc::clone(&sync_network);
         self.reconciler = super::reconciler::Reconciler::new(
@@ -2777,6 +2775,7 @@ impl SyncManager {
     ///   `NotMaterialized` (verified member, context not yet materialised); or
     /// - silently, with NO close message, when the dialer disconnected during
     ///   the wait (the peer is already gone).
+    ///
     /// See the race-window rationale inline below.
     async fn resolve_inbound_context(
         &self,
@@ -3775,6 +3774,15 @@ mod namespace_sync;
 // via `super::super::` (they now live in `namespace_sync`).
 #[cfg(test)]
 use namespace_sync::{resolve_namespace_id, should_backfill_governance};
+
+/// Channel for inbound open-subgroup join requests with their reply senders.
+type OpenSubgroupJoinRx = mpsc::Receiver<(
+    OpenSubgroupJoinParams,
+    oneshot::Sender<eyre::Result<Vec<u8>>>,
+)>;
+/// Per-(context, blob) stale-blob retry bookkeeping: (last attempt, count).
+type StaleBlobAttempts =
+    Arc<std::sync::Mutex<std::collections::HashMap<(ContextId, [u8; 32]), (Option<Instant>, u32)>>>;
 
 #[cfg(test)]
 mod tests;

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -1,5 +1,3 @@
-use super::*;
-
 use calimero_node_primitives::sync::{
     build_handshake_from_raw, estimate_entity_count, estimate_max_depth, SyncHandshake,
 };
@@ -208,7 +206,7 @@ fn test_max_depth_calculation() {
             0
         } else {
             let log2_approx = 64u32.saturating_sub(entity_count.leading_zeros());
-            (log2_approx / 4).max(1).min(32)
+            (log2_approx / 4).clamp(1, 32)
         };
 
         assert!(

--- a/crates/node/src/sync/network/mock.rs
+++ b/crates/node/src/sync/network/mock.rs
@@ -61,6 +61,10 @@ use tokio::time;
 use super::SyncNetwork;
 
 /// Per-call directive for a mocked `open_stream` response.
+#[allow(
+    clippy::large_enum_variant,
+    reason = "test mock directive enum, low instance count"
+)]
 pub(crate) enum OpenStreamResponse {
     /// Hand back a successfully-opened stream — an in-memory
     /// `Stream::test_pair()` end. Lets tests exercise the

--- a/crates/node/src/sync/rotation_log_reader.rs
+++ b/crates/node/src/sync/rotation_log_reader.rs
@@ -558,9 +558,8 @@ mod tests {
         let log_node2 = log_of(vec![r2, r1, r3]);
 
         // R1 and R2 both happen-before R3; R1 and R2 are concurrent.
-        let happens_before = |a: &[u8; 32], b: &[u8; 32]| {
-            (a == &[1; 32] && b == &[3; 32]) || (a == &[2; 32] && b == &[3; 32])
-        };
+        let happens_before =
+            |a: &[u8; 32], b: &[u8; 32]| (a == &[1; 32] || a == &[2; 32]) && b == &[3; 32];
         let parents = [[3; 32]];
 
         let from_node1 = writers_at(&log_node1, &parents, happens_before);

--- a/crates/node/src/sync/session.rs
+++ b/crates/node/src/sync/session.rs
@@ -206,8 +206,6 @@ impl SessionTracker {
         };
         let failure_count = state.failure_count();
         let last_error = state.last_error().map(ToOwned::to_owned);
-        // Drop the borrow of `self.state` before touching the sink/emitter.
-        drop(state);
         self.publish_state(ctx, phase, failure_count, last_error);
     }
 

--- a/crates/node/src/sync/snapshot.rs
+++ b/crates/node/src/sync/snapshot.rs
@@ -31,6 +31,9 @@ use tracing::{debug, info, warn};
 use super::manager::SyncManager;
 use super::tracking::Sequencer;
 
+/// Members deferred during snapshot apply: (entity id, key, value, parent).
+type DeferredMembers = Vec<(Id, Vec<u8>, Vec<u8>, Option<[u8; 32]>)>;
+
 /// Maximum uncompressed bytes per snapshot page (64 KB).
 pub const DEFAULT_PAGE_BYTE_LIMIT: u32 = 64 * 1024;
 
@@ -586,7 +589,7 @@ impl SyncManager {
         // still reports an `observed_schema` (pass 1 only sets it from regular
         // Entity records, so without this the settle would bind to the group
         // target instead of the schema the synced entities actually carry).
-        let mut deferred_members: Vec<(Id, Vec<u8>, Vec<u8>, Option<[u8; 32]>)> = Vec::new();
+        let mut deferred_members: DeferredMembers = Vec::new();
 
         loop {
             let msg = StreamMessage::Init {
@@ -2050,12 +2053,8 @@ fn settle_snapshot_activation(
     }
     drop(handle);
 
-    let Some(gid) = get_group_for_context(store, &context_id).ok().flatten() else {
-        return None;
-    };
-    let Some(meta) = MetaRepository::new(store).load(&gid).ok().flatten() else {
-        return None;
-    };
+    let gid = get_group_for_context(store, &context_id).ok().flatten()?;
+    let meta = MetaRepository::new(store).load(&gid).ok().flatten()?;
     // Bind to the schema the synced data actually carries; fall back to the
     // group target only when the snapshot carried no schema stamp.
     let bind = data_schema

--- a/crates/node/src/sync/state_access_mock.rs
+++ b/crates/node/src/sync/state_access_mock.rs
@@ -62,6 +62,7 @@ impl MockSyncStateAccess {
     /// Register a `DeltaStore` so subsequent `delta_store(ctx)` calls
     /// return it (rather than `None`) and `get_or_register_delta_store`
     /// reports `created=false`.
+    #[allow(dead_code, reason = "mock test helper for test authoring")]
     pub(crate) fn insert_delta_store(&self, context_id: ContextId, store: DeltaStore) {
         let _replaced = self.delta_stores.lock().insert(context_id, store);
     }
@@ -106,6 +107,7 @@ impl MockSyncStateAccess {
     /// directly — that path now installs a cooldown the same way the
     /// production impl does (see [`SyncStateAccess::record_reconcile_failure`]'s
     /// mock body).
+    #[allow(dead_code, reason = "mock test helper for test authoring")]
     pub(crate) fn set_reconcile_cooldown(
         &self,
         context_id: ContextId,

--- a/crates/node/tests/concurrent_branches_root_hash.rs
+++ b/crates/node/tests/concurrent_branches_root_hash.rs
@@ -26,6 +26,7 @@ async fn test_concurrent_branches_track_expected_root_hash() {
 
     // Simple test applier that doesn't actually apply to storage
     struct TestApplier {
+        #[allow(clippy::type_complexity, reason = "test fixture")]
         applied: Arc<Mutex<Vec<([u8; 32], [u8; 32])>>>, // (delta_id, expected_root_hash)
     }
 
@@ -87,6 +88,7 @@ async fn test_merge_delta_expected_root_hash() {
     use tokio::sync::Mutex;
 
     struct TestApplier {
+        #[allow(clippy::type_complexity, reason = "test fixture")]
         applied: Arc<Mutex<Vec<([u8; 32], [u8; 32])>>>,
     }
 

--- a/crates/node/tests/dag_causal_shared_e2e.rs
+++ b/crates/node/tests/dag_causal_shared_e2e.rs
@@ -72,6 +72,8 @@ use core::num::NonZeroU128;
 use ed25519_dalek::SigningKey;
 use tokio::sync::RwLock;
 
+type TopologyMap = Arc<RwLock<IndexMap<[u8; 32], Vec<[u8; 32]>>>>;
+
 // =============================================================================
 // Helpers
 // =============================================================================
@@ -126,7 +128,7 @@ struct SharedRotationApplier {
     /// successful apply. Used as the snapshot the `happens_before`
     /// closure runs against during resolution. `IndexMap` to mirror
     /// production's deterministic insertion-order iteration.
-    topology: Arc<RwLock<IndexMap<[u8; 32], Vec<[u8; 32]>>>>,
+    topology: TopologyMap,
     /// Successful-apply log (id + action count + serialized artifact
     /// size) for assertions.
     applied: Arc<RwLock<Vec<AppliedDelta>>>,

--- a/crates/node/tests/network_simulation.rs
+++ b/crates/node/tests/network_simulation.rs
@@ -25,6 +25,8 @@ use calimero_storage::address::Id;
 use calimero_storage::delta::StorageDelta;
 use tokio::sync::{Mutex, RwLock};
 
+type ReceivedDeltas = Arc<Mutex<Vec<([u8; 32], Vec<Action>)>>>;
+
 // ============================================================
 // Mock Network Infrastructure
 // ============================================================
@@ -37,7 +39,7 @@ struct MockPeer {
     dag: Arc<RwLock<DagStore<Vec<Action>>>>,
 
     /// Received deltas (for verification)
-    received_deltas: Arc<Mutex<Vec<([u8; 32], Vec<Action>)>>>,
+    received_deltas: ReceivedDeltas,
 
     /// Network delay simulation (milliseconds)
     latency_ms: u64,
@@ -89,6 +91,7 @@ struct MockNetwork {
 }
 
 #[derive(Clone)]
+#[allow(dead_code, reason = "test fixture fields kept for clarity")]
 struct BroadcastMessage {
     context_id: ContextId,
     author_id: PublicKey,
@@ -122,6 +125,10 @@ impl MockNetwork {
     }
 
     /// Broadcast a delta to all subscribers
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "test harness mirror of NodeClient::broadcast"
+    )]
     async fn broadcast(
         &self,
         context_id: ContextId,

--- a/crates/node/tests/sync_protocols.rs
+++ b/crates/node/tests/sync_protocols.rs
@@ -60,6 +60,7 @@ impl DeltaApplier<Vec<Action>> for TestApplier {
 // Simulated Node with DAG
 // ============================================================
 
+#[allow(dead_code, reason = "test fixture field kept for clarity")]
 struct SimulatedNode {
     node_id: String,
     dag: Arc<RwLock<DagStore<Vec<Action>>>>,

--- a/crates/node/tests/sync_sim/storage.rs
+++ b/crates/node/tests/sync_sim/storage.rs
@@ -54,6 +54,9 @@ use calimero_storage::store::{Key, MainStorage};
 use calimero_store::db::InMemoryDB;
 use calimero_store::{key, types, Store};
 
+type ReadCb = Rc<dyn Fn(&Key) -> Option<Vec<u8>>>;
+type WriteCb = Rc<dyn Fn(Key, &[u8]) -> bool>;
+
 /// In-memory storage for simulation.
 ///
 /// Wraps a `calimero_store::Store` backed by `InMemoryDB` and provides
@@ -133,7 +136,7 @@ impl SimStorage {
         let context_id = self.context_id;
 
         // Read callback - converts storage Key to ContextState key and reads
-        let read: Rc<dyn Fn(&Key) -> Option<Vec<u8>>> = {
+        let read: ReadCb = {
             let handle = store.handle();
             let ctx_id = context_id;
             Rc::new(move |key: &Key| {
@@ -148,7 +151,7 @@ impl SimStorage {
         };
 
         // Write callback - converts storage Key to ContextState and writes
-        let write: Rc<dyn Fn(Key, &[u8]) -> bool> = {
+        let write: WriteCb = {
             let handle_cell: Rc<RefCell<_>> = Rc::new(RefCell::new(store.handle()));
             let ctx_id = context_id;
             Rc::new(move |key: Key, value: &[u8]| {
@@ -226,6 +229,7 @@ impl SimStorage {
     }
 
     /// Recursively count entities in the tree.
+    #[allow(clippy::only_used_in_recursion, reason = "test tree-walk helper")]
     fn count_entities_recursive(&self, id: Id) -> usize {
         let index = match Index::<MainStorage>::get_index(id).ok().flatten() {
             Some(idx) => idx,
@@ -251,6 +255,7 @@ impl SimStorage {
     }
 
     /// Recursively count leaf nodes.
+    #[allow(clippy::only_used_in_recursion, reason = "test tree-walk helper")]
     fn count_leaves_recursive(&self, id: Id, is_root: bool) -> usize {
         let index = match Index::<MainStorage>::get_index(id).ok().flatten() {
             Some(idx) => idx,
@@ -297,6 +302,7 @@ impl SimStorage {
     }
 
     /// Recursively compute depth of the tree.
+    #[allow(clippy::only_used_in_recursion, reason = "test tree-walk helper")]
     fn compute_depth_recursive(&self, id: Id) -> u32 {
         let index = match Index::<MainStorage>::get_index(id).ok().flatten() {
             Some(idx) => idx,

--- a/crates/runtime/examples/demo.rs
+++ b/crates/runtime/examples/demo.rs
@@ -2,8 +2,6 @@
 
 use core::str;
 use std::env;
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 
 use calimero_runtime::store::InMemoryStorage;
@@ -48,7 +46,7 @@ fn main() -> EyreResult<()> {
         eyre::bail!("KV wasm file not found");
     }
 
-    let file = File::open(path)?.bytes().collect::<Result<Vec<u8>, _>>()?;
+    let file = std::fs::read(path)?;
 
     let mut storage = InMemoryStorage::default();
 

--- a/crates/runtime/examples/fetch.rs
+++ b/crates/runtime/examples/fetch.rs
@@ -1,8 +1,6 @@
 #![allow(unused_crate_dependencies)]
 
 use std::env;
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 
 use calimero_runtime::store::InMemoryStorage;
@@ -23,7 +21,7 @@ fn main() -> EyreResult<()> {
         eyre::bail!("Gen-ext wasm file not found");
     }
 
-    let file = File::open(path)?.bytes().collect::<Result<Vec<u8>, _>>()?;
+    let file = std::fs::read(path)?;
 
     let mut storage = InMemoryStorage::default();
 

--- a/crates/runtime/examples/rps.rs
+++ b/crates/runtime/examples/rps.rs
@@ -2,8 +2,6 @@
 #![allow(dead_code)]
 
 use std::env;
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 
 use calimero_runtime::store::InMemoryStorage;
@@ -62,7 +60,7 @@ fn main() -> EyreResult<()> {
         eyre::bail!("RPS wasm file not found");
     }
 
-    let file = File::open(path)?.bytes().collect::<Result<Vec<u8>, _>>()?;
+    let file = std::fs::read(path)?;
 
     let mut storage = InMemoryStorage::default();
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -44,6 +44,13 @@ pub type RuntimeResult<T, E = VMRuntimeError> = Result<T, E>;
 ///
 /// * `Ok(())` if the method name is valid
 /// * `Err(FunctionCallError)` if the method name is invalid
+// FunctionCallError carries wasmer's large CompileError/LinkError via #[from];
+// boxing the variant would break the derive and ripple through the crate, and
+// this is not a hot path.
+#[allow(
+    clippy::result_large_err,
+    reason = "pervasive #[from] error enum; boxing breaks the derive"
+)]
 fn validate_method_name(method: &str, max_length: u64) -> Result<(), FunctionCallError> {
     // Check for empty method name
     if method.is_empty() {
@@ -164,6 +171,10 @@ impl Engine {
         Self::new(engine, limits)
     }
 
+    #[allow(
+        clippy::result_large_err,
+        reason = "pervasive #[from] error enum; boxing breaks the derive"
+    )]
     pub fn compile(&self, bytes: &[u8]) -> Result<Module, FunctionCallError> {
         // Check module size before compilation to prevent memory exhaustion attacks
         // Note: `as u64` is safe because usize <= u64 on all supported platforms (32-bit and 64-bit)
@@ -250,6 +261,13 @@ impl Module {
 
     /// Run a method with no cross-context origin (direct/RPC call). Thin
     /// wrapper over [`run_with_origin`](Self::run_with_origin).
+    // The args are orthogonal (identity, method, I/O, storage, node client) with
+    // no cohesive grouping, and this is the runtime's primary hot execution entry
+    // called from many sites; a param struct would add ceremony without clarity.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "orthogonal args on the primary execution entry point"
+    )]
     pub fn run<'a>(
         &'a self,
         context: ContextId,
@@ -1122,8 +1140,10 @@ mod wasm_integration_tests {
         let wasm = wat::parse_str(wat).expect("Failed to parse WAT");
 
         // Create an engine with a very small module size limit (smaller than our module)
-        let mut limits = VMLimits::default();
-        limits.max_module_size = 10; // 10 bytes - way too small for any valid module
+        let limits = VMLimits {
+            max_module_size: 10, // 10 bytes - way too small for any valid module
+            ..Default::default()
+        };
 
         let engine = Engine::new(wasmer::Engine::default(), limits);
 
@@ -1155,8 +1175,10 @@ mod wasm_integration_tests {
         let wasm = wat::parse_str(wat).expect("Failed to parse WAT");
 
         // Create an engine with a large enough module size limit
-        let mut limits = VMLimits::default();
-        limits.max_module_size = 1024 * 1024; // 1 MiB - plenty of room
+        let limits = VMLimits {
+            max_module_size: 1024 * 1024, // 1 MiB - plenty of room
+            ..Default::default()
+        };
 
         let engine = Engine::new(wasmer::Engine::default(), limits);
 
@@ -1183,8 +1205,10 @@ mod wasm_integration_tests {
         let wasm = wat::parse_str(wat).expect("Failed to parse WAT");
 
         // Create an engine with module size limit exactly equal to the WASM size
-        let mut limits = VMLimits::default();
-        limits.max_module_size = wasm.len() as u64; // Exact size limit
+        let limits = VMLimits {
+            max_module_size: wasm.len() as u64, // Exact size limit
+            ..Default::default()
+        };
 
         let engine = Engine::new(wasmer::Engine::default(), limits);
 
@@ -1235,8 +1259,10 @@ mod wasm_integration_tests {
         let wasm = wat::parse_str(wat).expect("Failed to parse WAT");
 
         // Create an engine with max_module_size = 0
-        let mut limits = VMLimits::default();
-        limits.max_module_size = 0;
+        let limits = VMLimits {
+            max_module_size: 0,
+            ..Default::default()
+        };
 
         let engine = Engine::new(wasmer::Engine::default(), limits);
 

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -427,7 +427,7 @@ impl VMLogic<'_> {
     /// # Arguments
     ///
     /// * `err` - An optional `FunctionCallError` that occurred during execution (e.g., a trap).
-    ///           If `None`, the outcome is determined by the `returns` field.
+    ///   If `None`, the outcome is determined by the `returns` field.
     #[must_use]
     pub fn finish(mut self, err: Option<FunctionCallError>) -> Outcome {
         let log_count = self.logs.len();
@@ -470,7 +470,7 @@ impl VMLogic<'_> {
         // The runtime's catch_unwind wrapper ensures finish() is always called,
         // even when execution fails mid-way or panics occur.
         if let Some(memory) = self.memory {
-            drop(memory);
+            let _ = memory;
             trace!(target: "runtime::logic", "VMLogic::finish: cleaned up WASM memory");
         }
 

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -470,7 +470,13 @@ impl VMLogic<'_> {
         // The runtime's catch_unwind wrapper ensures finish() is always called,
         // even when execution fails mid-way or panics occur.
         if let Some(memory) = self.memory {
-            let _ = memory;
+            // Explicit drop documents the intended wasmer-memory cleanup (see above);
+            // clippy::drop_non_drop fires because the handle has no Drop glue itself.
+            #[allow(
+                clippy::drop_non_drop,
+                reason = "explicit drop documents wasmer memory cleanup intent"
+            )]
+            drop(memory);
             trace!(target: "runtime::logic", "VMLogic::finish: cleaned up WASM memory");
         }
 

--- a/crates/runtime/src/logic/host_functions/blobs.rs
+++ b/crates/runtime/src/logic/host_functions/blobs.rs
@@ -134,7 +134,7 @@ impl VMHostFunctions<'_> {
     ///
     /// * `fd` - The file descriptor obtained from `blob_create()` operation.
     /// * `src_data_ptr` - A pointer to a source-buffer `sys::Buffer` in guest memory
-    /// containing the data chunk to write.
+    ///   containing the data chunk to write.
     ///
     /// # Returns
     ///
@@ -205,7 +205,7 @@ impl VMHostFunctions<'_> {
     ///
     /// * `fd` - The file descriptor to close.
     /// * `dest_blob_id_ptr` - A pointer to a 32-byte destination buffer `sys::BufferMut`
-    /// in guest memory where the final `BlobId` will be written (for write handles).
+    ///   in guest memory where the final `BlobId` will be written (for write handles).
     ///
     /// # Returns
     ///
@@ -214,7 +214,7 @@ impl VMHostFunctions<'_> {
     /// # Errors
     ///
     /// * `HostError::InvalidMemoryAccess` if the `blob_id_ptr` buffer is not 32 bytes
-    /// or if memory access fails for a descriptor buffer.
+    ///   or if memory access fails for a descriptor buffer.
     /// * `HostError::InvalidBlobHandle` if the `fd` is invalid.
     /// * `HostError::BlobsNotSupported` if the node client is not supported or upload operation fails.
     pub fn blob_close(&mut self, fd: u64, dest_blob_id_ptr: u64) -> VMLogicResult<u32> {
@@ -272,9 +272,9 @@ impl VMHostFunctions<'_> {
     /// # Arguments
     ///
     /// * `src_blob_id_ptr` - pointer to a 32-byte source-buffer `sys::Buffer` in guest memory,
-    /// containing the 32-byte `BlobId`.
+    ///   containing the 32-byte `BlobId`.
     /// * `src_context_id_ptr` - pointer to a 32-byte source-buffer `sys::Buffer` in guest memory,
-    /// containing the 32-byte `ContextId`.
+    ///   containing the 32-byte `ContextId`.
     ///
     /// # Returns
     ///
@@ -328,7 +328,7 @@ impl VMHostFunctions<'_> {
     /// # Arguments
     ///
     /// * `src_blob_id_ptr` - pointer to a 32-byte source-buffer `sys::Buffer` in guest memory,
-    /// containing the 32-byte `BlobId`.
+    ///   containing the 32-byte `BlobId`.
     ///
     /// # Returns
     ///
@@ -394,7 +394,7 @@ impl VMHostFunctions<'_> {
     ///
     /// * `fd` - The file descriptor obtained from `blob_open`.
     /// * `dest_data_ptr` - A pointer to a destination buffer `sys::BufferMut` in guest memory where
-    /// the read data will be stored
+    ///   the read data will be stored
     ///
     /// # Returns
     ///

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -13,7 +13,7 @@ impl VMHostFunctions<'_> {
     ///
     /// * `src_key_ptr` - A pointer to the key source-buffer in guest memory.
     /// * `dest_register_id` - The ID of the destination register in host memory where
-    /// to place the value (if found).
+    ///   to place the value (if found).
     ///
     /// # Returns
     ///
@@ -79,7 +79,7 @@ impl VMHostFunctions<'_> {
     ///
     /// * `src_key_ptr` - A pointer to the key source-buffer in guest memory.
     /// * `dest_register_id` - The ID of the destination register in host memory where to place
-    /// the value (if found).
+    ///   the value (if found).
     ///
     /// # Returns
     ///
@@ -153,7 +153,7 @@ impl VMHostFunctions<'_> {
     /// * `src_key_ptr` - A pointer to the key source-buffer in guest memory.
     /// * `src_value_ptr` - A pointer to the value source-buffer in guest memory.
     /// * `dest_register_id` - The ID of the destination register in host memory where to place
-    /// the old value (if found).
+    ///   the old value (if found).
     ///
     /// # Returns
     ///
@@ -343,9 +343,7 @@ impl VMHostFunctions<'_> {
 
         // Access private storage
         let value = self.with_logic_mut(|logic| {
-            let Some(ref mut private_storage) = logic.private_storage else {
-                return None;
-            };
+            let private_storage = logic.private_storage.as_mut()?;
             private_storage.remove(&key)
         });
 
@@ -779,9 +777,11 @@ mod tests {
     #[test]
     fn test_storage_read_key_too_long() {
         let mut storage = SimpleMockStorage::new();
-        let mut limits = VMLimits::default();
         // Set a small key size limit for testing.
-        limits.max_storage_key_size = std::num::NonZeroU64::new(10).unwrap();
+        let limits = VMLimits {
+            max_storage_key_size: std::num::NonZeroU64::new(10).unwrap(),
+            ..Default::default()
+        };
         let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
         let mut host = logic.host_functions(store.as_store_mut());
 
@@ -805,9 +805,11 @@ mod tests {
     #[test]
     fn test_storage_write_key_too_long() {
         let mut storage = SimpleMockStorage::new();
-        let mut limits = VMLimits::default();
         // Set a small key size limit for testing.
-        limits.max_storage_key_size = std::num::NonZeroU64::new(10).unwrap();
+        let limits = VMLimits {
+            max_storage_key_size: std::num::NonZeroU64::new(10).unwrap(),
+            ..Default::default()
+        };
         let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
         let mut host = logic.host_functions(store.as_store_mut());
 
@@ -839,9 +841,11 @@ mod tests {
     #[test]
     fn test_storage_write_value_too_long() {
         let mut storage = SimpleMockStorage::new();
-        let mut limits = VMLimits::default();
         // Set a small value size limit for testing.
-        limits.max_storage_value_size = std::num::NonZeroU64::new(10).unwrap();
+        let limits = VMLimits {
+            max_storage_value_size: std::num::NonZeroU64::new(10).unwrap(),
+            ..Default::default()
+        };
         let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
         let mut host = logic.host_functions(store.as_store_mut());
 
@@ -873,9 +877,11 @@ mod tests {
     #[test]
     fn test_storage_remove_key_too_long() {
         let mut storage = SimpleMockStorage::new();
-        let mut limits = VMLimits::default();
         // Set a small key size limit for testing.
-        limits.max_storage_key_size = std::num::NonZeroU64::new(10).unwrap();
+        let limits = VMLimits {
+            max_storage_key_size: std::num::NonZeroU64::new(10).unwrap(),
+            ..Default::default()
+        };
         let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
         let mut host = logic.host_functions(store.as_store_mut());
 
@@ -1101,10 +1107,10 @@ mod tests {
 
         // Read all keys and verify values.
         for i in 0..5 {
-            let key = format!("key_{i}");
+            let _key = format!("key_{i}");
             let expected_value = format!("value_{i}");
 
-            let key_ptr = (100 + i * 100) as u64;
+            let _key_ptr = (100 + i * 100) as u64;
             let key_buf_ptr = (16 + i * 32) as u64;
             // Reuse the already prepared descriptors.
 

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -1107,12 +1107,10 @@ mod tests {
 
         // Read all keys and verify values.
         for i in 0..5 {
-            let _key = format!("key_{i}");
             let expected_value = format!("value_{i}");
 
-            let _key_ptr = (100 + i * 100) as u64;
+            // Reuse the key descriptor prepared in the write loop above.
             let key_buf_ptr = (16 + i * 32) as u64;
-            // Reuse the already prepared descriptors.
 
             let register_id = (i + 10) as u64;
             let res = host.storage_read(key_buf_ptr, register_id).unwrap();

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -169,7 +169,7 @@ impl VMHostFunctions<'_> {
     /// # Arguments
     ///
     /// * `src_panic_msg_ptr` - A pointer in guest memory to a source-buffer `sys::Buffer` containing
-    /// the UTF-8 panic message.
+    ///   the UTF-8 panic message.
     /// * `src_location_ptr` - A pointer in guest memory to a `sys::Location` struct for the panic's origin.
     ///
     /// # Returns/Errors
@@ -248,7 +248,7 @@ impl VMHostFunctions<'_> {
     ///
     /// * `register_id` - The ID of the register to read from.
     /// * `dest_data_ptr` - A pointer in guest memory to a destination buffer `sys::BufferMut`
-    /// where the data should be copied.
+    ///   where the data should be copied.
     ///
     /// # Returns
     ///
@@ -457,7 +457,7 @@ impl VMHostFunctions<'_> {
     /// # Arguments
     ///
     /// * `src_value_ptr` - A pointer in guest memory to a source-`sys::ValueReturn`,
-    /// which is an enum indicating success or error, along with the data buffer.
+    ///   which is an enum indicating success or error, along with the data buffer.
     ///
     /// # Errors
     ///
@@ -606,7 +606,7 @@ impl VMHostFunctions<'_> {
     /// # Arguments
     ///
     /// * `src_event_ptr` - A pointer in guest memory to a `sys::Event` struct, which
-    /// contains source-buffers for the event `kind` and `data`.
+    ///   contains source-buffers for the event `kind` and `data`.
     ///
     /// # Errors
     ///
@@ -811,7 +811,7 @@ impl VMHostFunctions<'_> {
     /// # Errors
     ///
     /// * `HostError::InvalidMemoryAccess` if this function is called more than once or if memory
-    /// access fails for descriptor buffers.
+    ///   access fails for descriptor buffers.
     pub fn commit(&mut self, src_root_hash_ptr: u64, src_artifact_ptr: u64) -> VMLogicResult<()> {
         let root_hash =
             unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_root_hash_ptr)? };
@@ -1400,8 +1400,10 @@ mod tests {
     #[test]
     fn test_log_utf8_overflow() {
         let mut storage = SimpleMockStorage::new();
-        let mut limits = VMLimits::default();
-        limits.max_logs = 5;
+        let limits = VMLimits {
+            max_logs: 5,
+            ..Default::default()
+        };
         let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
         let mut host = logic.host_functions(store.as_store_mut());
 
@@ -1433,8 +1435,10 @@ mod tests {
     #[test]
     fn test_log_utf8_length_overflow() {
         let mut storage = SimpleMockStorage::new();
-        let mut limits = VMLimits::default();
-        limits.max_log_size = 4;
+        let limits = VMLimits {
+            max_log_size: 4,
+            ..Default::default()
+        };
         let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
         let mut host = logic.host_functions(store.as_store_mut());
 
@@ -1477,8 +1481,10 @@ mod tests {
     #[test]
     fn test_js_std_d_print_length_overflow() {
         let mut storage = SimpleMockStorage::new();
-        let mut limits = VMLimits::default();
-        limits.max_log_size = 5;
+        let limits = VMLimits {
+            max_log_size: 5,
+            ..Default::default()
+        };
         let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
         let mut host = logic.host_functions(store.as_store_mut());
 

--- a/crates/runtime/src/logic/host_functions/utility.rs
+++ b/crates/runtime/src/logic/host_functions/utility.rs
@@ -20,18 +20,18 @@ impl VMHostFunctions<'_> {
     ///
     /// * `src_url_ptr` - Pointer to the URL string source-buffer in guest memory.
     /// * `src_method_ptr` - Pointer to the HTTP method string source-buffer (e.g., "GET", "POST")
-    /// in guest memory.
+    ///   in guest memory.
     /// * `src_headers_ptr` - Pointer to a borsh-serialized `Vec<(String, String)>` source-buffer of
-    /// headers in guest memory.
+    ///   headers in guest memory.
     /// * `src_body_ptr` - Pointer to the request body source-buffer in guest memory.
     /// * `dest_register_id` - The ID of the destination register in host memory where to store
-    /// the response body.
+    ///   the response body.
     ///
     /// # Returns
     ///
     /// * Returns `0` on success (HTTP 2xx)
     /// * Returns `1` on failure.
-    /// The response body or error message is placed in the host register.
+    ///   The response body or error message is placed in the host register.
     ///
     /// # Errors
     ///
@@ -141,12 +141,12 @@ impl VMHostFunctions<'_> {
     /// # Arguments
     ///
     /// * `dest_ptr` - A pointer to an 8-byte destination buffer `sys::BufferMut`
-    /// in guest memory where the `u64` timestamp will be written.
+    ///   in guest memory where the `u64` timestamp will be written.
     ///
     /// # Errors
     ///
     /// * `HostError::InvalidMemoryAccess` if the provided buffer is not exactly 8 bytes long
-    /// or if memory access fails for a descriptor buffer.
+    ///   or if memory access fails for a descriptor buffer.
     #[expect(
         clippy::cast_possible_truncation,
         reason = "Impossible to overflow in normal circumstances"
@@ -193,7 +193,7 @@ impl VMHostFunctions<'_> {
     ///
     /// * `HostError::InvalidMemoryAccess` if memory access fails for descriptor buffers.
     /// * `HostError::Ed25519IncorrectPublicKey` if the provided public key is not a ED25519 Public
-    /// Key.
+    ///   Key.
     pub fn ed25519_verify(
         &mut self,
         src_signature_ptr: u64,

--- a/crates/runtime/tests/crdt_conformance.rs
+++ b/crates/runtime/tests/crdt_conformance.rs
@@ -274,7 +274,7 @@ fn round(cluster: &mut Cluster, writes: &[(usize, &str, Value)]) -> Vec<[u8; 32]
 
     let n = cluster.len();
     let mut roots = vec![None::<[u8; 32]>; n];
-    for node in 0..n {
+    for (node, root) in roots.iter_mut().enumerate() {
         for (origin, artifact) in &deltas {
             if *origin == node {
                 continue;
@@ -282,7 +282,7 @@ fn round(cluster: &mut Cluster, writes: &[(usize, &str, Value)]) -> Vec<[u8; 32]
             let m = cluster.module;
             let h = apply_delta(m, &mut cluster.nodes[node], artifact)
                 .unwrap_or_else(|e| panic!("apply on node {node} failed: {e}"));
-            roots[node] = Some(h);
+            *root = Some(h);
         }
     }
     // Every node must have applied at least one foreign delta, otherwise its


### PR DESCRIPTION
## What & why

Third of the 4-PR series toward gating CI on a clean clippy build (follows #2821, #2823). This PR clears the **consensus-critical crates** — `calimero-runtime`, `calimero-governance-store`, `calimero-context`, `calimero-node` — plus the two items deliberately deferred from PR 2 (`governance-types` wire enums, `node-primitives` `broadcast`/`new`).

**After this PR, `cargo clippy --workspace --all-targets` reports zero clippy/rustc warnings.** (The only remaining cargo output is the pre-existing "profiles for non-root package" manifest notices, which aren't lints — addressed in PR 4.)

No behavior changes — lint cleanups, mechanical regroupings, and documented judgment calls.

### Representative fixes
- **runtime**: ~22 doc-list continuations, ~11 `field_reassign` → struct-init, examples `fs::read`, let-else→`?`, loop-index, `result_large_err`/`run` justified allows.
- **governance-store**: docs, `ResolvedIdentity`/`AbsorbEntries` aliases, the TEE handlers refactored to take the existing `TeeAttestationClaims` struct, gossip-publish allows.
- **context**: `matches!`, `let_underscore_future`, transmute annotation, type aliases; the 5 core create/execute/update handlers get justified `too_many_arguments` allows.
- **node**: docs, mechanical (clamp/let-else/De-Morgan/struct-init/drop-ref), type aliases (`TopologyHandle`, `StaleBlobAttempts`, …), dead-code allows on documented test helpers + linux-only metric gauges, sync/handler `too_many_arguments` allows.
- **deferred**: `large_enum_variant` allow on the gossip/stored wire enums; `too_many_arguments` allow on `NodeClient::broadcast`/`new`.

### On the judgment calls (`#[allow]`)
Every allow is per-item with an inline `reason`. The rule applied throughout the series:
- **Refactor** when args/types have a cohesive grouping with few callers (e.g. `TeeAttestationClaims`, `PackageInfo`, server `ServiceConfigs`, the `StorageCallbacks`/topology type aliases).
- **Justified `#[allow]`** only when args are genuinely orthogonal on a hot consensus path with many call sites, where a param struct adds arg-mapping risk without readability gain (the create/execute/update handlers, gossip-publish, `broadcast`, `NodeClient::new`), or when the lint fights an intentional design (wire-enum boxing on the gossip hot path; `result_large_err` where the Err hands ownership back for fallback).

Happy to convert any specific `#[allow]` into a refactor if a reviewer prefers.

## Verification
- `cargo build --workspace --all-targets` ✅
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets` (incl. `-p calimero-storage --features testing`) → **zero warnings** ✅

## Series
1. #2821 — policy + auto-fix ✅ merged
2. #2823 — non-consensus crates ✅ merged
3. **This PR** — consensus tier; workspace now warning-free
4. Flip the gate: `[workspace.lints]` + `cargo clippy --workspace --all-targets -- -D warnings` in CI (+ tidy the non-root `[profile]` manifest notices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only and naming/refactor cleanups with explicit no-behavior-change intent; the TEE claims struct is a pass-through API reshape on existing validation logic.
> 
> **Overview**
> Brings **consensus-tier crates** (`calimero-runtime`, `calimero-governance-store`, `calimero-context`, `calimero-node`, plus deferred `governance-types` / `node-primitives` items) to a **warning-free** `cargo clippy --workspace --all-targets` build. Intended as **no functional change**—mechanical fixes, docs, and documented lint exceptions.
> 
> **Clippy hygiene:** Per-item `#[allow(..., reason = "...")]` on long-parameter handlers (`create_context`, `internal_execute`, gossip publish, `NodeClient::broadcast`/`new`, sync paths), wire enums (`large_enum_variant`), and runtime error types (`result_large_err`). Removes crate-level `unwrap_in_result` expect from `calimero-context`.
> 
> **Small refactors for readability:** TEE admission now threads a single `TeeAttestationClaims` through policy validation and `MemberJoinedViaTeeAttestation` apply (replacing seven string args). Adds type aliases (`ResolvedIdentity`, `AbsorbEntries`, storage callback types, `TopologyHandle`, sync manager channel maps, test fixture aliases). Context signing uses `matches!`; runtime/examples use `std::fs::read` and struct-init for `VMLimits` in tests.
> 
> **Otherwise mechanical:** doc-list indentation, `SAFETY:` comment style, explicit `transmute` type params, `let-else`/`?` in a few spots, dropping ignored `tokio::spawn` bindings, `#[cfg(test)]` on test-only helpers, and comment-only doc fixes in node sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a93c529c62f87279fda72f913ec7633c3254e24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->