### PR TITLE
ci: gate CI on a warning-free workspace (4/4)

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -47,15 +47,12 @@ jobs:
         run: cargo fmt --check
 
       # No-warnings gate: every workspace target (libs, bins, tests, examples)
-      # must be clippy- and rustc-warning-free. Run the same command locally
-      # before pushing: `cargo clippy --workspace --all-targets -- -D warnings`.
+      # must be clippy- and rustc-warning-free. `--features calimero-storage/testing`
+      # pulls in that crate's feature-gated `testing` harness so it's linted in the
+      # same single pass. Run the same command locally before pushing.
       - name: Cargo clippy
         if: ${{ !cancelled() }}
-        run: |
-          cargo clippy --workspace --all-targets -- -D warnings
-          # calimero-storage's feature-gated `testing` harness isn't reached by
-          # the default-feature pass above, so lint it explicitly.
-          cargo clippy -p calimero-storage --all-targets --features testing -- -D warnings
+        run: cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings
 
       - name: Cargo test
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -46,9 +46,16 @@ jobs:
       - name: Cargo format
         run: cargo fmt --check
 
+      # No-warnings gate: every workspace target (libs, bins, tests, examples)
+      # must be clippy- and rustc-warning-free. Run the same command locally
+      # before pushing: `cargo clippy --workspace --all-targets -- -D warnings`.
       - name: Cargo clippy
         if: ${{ !cancelled() }}
-        run: cargo clippy -- -A warnings
+        run: |
+          cargo clippy --workspace --all-targets -- -D warnings
+          # calimero-storage's feature-gated `testing` harness isn't reached by
+          # the default-feature pass above, so lint it explicitly.
+          cargo clippy -p calimero-storage --all-targets --features testing -- -D warnings
 
       - name: Cargo test
         if: ${{ !cancelled() }}

--- a/apps/abi_conformance/Cargo.toml
+++ b/apps/abi_conformance/Cargo.toml
@@ -23,11 +23,4 @@ serde_json.workspace = true
 [package.metadata.workspaces]
 independent = true
 
-[profile.app-release]
-inherits = "release"
-codegen-units = 1
-opt-level = "z"
-lto = true
-debug = false
-panic = "abort"
 overflow-checks = true 

--- a/apps/abi_conformance/Cargo.toml
+++ b/apps/abi_conformance/Cargo.toml
@@ -22,5 +22,3 @@ serde_json.workspace = true
 
 [package.metadata.workspaces]
 independent = true
-
-overflow-checks = true 

--- a/apps/state-schema-conformance/Cargo.toml
+++ b/apps/state-schema-conformance/Cargo.toml
@@ -24,12 +24,5 @@ serde_json.workspace = true
 [package.metadata.workspaces]
 independent = true
 
-[profile.app-release]
-inherits = "release"
-codegen-units = 1
-opt-level = "z"
-lto = true
-debug = false
-panic = "abort"
 overflow-checks = true
 

--- a/apps/state-schema-conformance/Cargo.toml
+++ b/apps/state-schema-conformance/Cargo.toml
@@ -23,6 +23,3 @@ serde_json.workspace = true
 
 [package.metadata.workspaces]
 independent = true
-
-overflow-checks = true
-

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -24,7 +24,7 @@ use calimero_governance_store::{
     CapabilitiesRepository, MembershipRepository, MetaRepository, NamespaceDagService,
     NamespaceOpLogService, NamespaceRepository,
 };
-use calimero_governance_types::{GroupOp, NamespaceOp, RootOp, SignedNamespaceOp};
+use calimero_governance_types::{GroupOp, NamespaceOp, SignedNamespaceOp};
 use calimero_op::{Op, OpPayload, ScopeId};
 use calimero_op_adapter::{payload_from_group_op, payload_from_root_op, set_writers_payload};
 use calimero_primitives::context::{ContextId, GroupMemberRole};
@@ -776,6 +776,7 @@ mod tests {
     use calimero_context_config::types::{
         ContextGroupId, GroupInvitationFromAdmin, SignedGroupOpenInvitation,
     };
+    use calimero_governance_types::RootOp;
     use calimero_op::OpPayload;
     use calimero_primitives::context::GroupMemberRole;
     use calimero_storage::entities::OpMask;

--- a/crates/tee-attestation/src/generate.rs
+++ b/crates/tee-attestation/src/generate.rs
@@ -52,13 +52,13 @@ pub fn generate_attestation(report_data: [u8; 64]) -> Result<AttestationResult, 
     // Generate TDX quote using configfs-tsm
     let quote_bytes = create_tdx_quote(report_data).map_err(|err| {
         error!(error=?err, "Failed to generate TDX quote");
-        AttestationError::QuoteGenerationFailed(format!("{:?}", err))
+        AttestationError::QuoteGenerationFailed(format!("{err:?}"))
     })?;
 
     // Parse the generated quote
     let tdx_quote = TdxQuote::from_bytes(&quote_bytes).map_err(|err| {
         error!(error=?err, "Failed to parse generated TDX quote");
-        AttestationError::QuoteParsingFailed(format!("{:?}", err))
+        AttestationError::QuoteParsingFailed(format!("{err:?}"))
     })?;
 
     // Convert to serializable format

--- a/crates/tee-attestation/src/info.rs
+++ b/crates/tee-attestation/src/info.rs
@@ -54,7 +54,7 @@ async fn detect_host_info() -> eyre::Result<TeeInfo> {
             .await
         {
             if let Ok(image) = response.text().await {
-                let image_name = image.split('/').last().unwrap_or(&image).to_owned();
+                let image_name = image.split('/').next_back().unwrap_or(&image).to_owned();
 
                 return Ok(TeeInfo {
                     cloud_provider: "gcp".to_owned(),


### PR DESCRIPTION
## What & why

Final PR of the series (follows #2821, #2823, #2825). The first three drove the whole workspace to **zero clippy/rustc warnings**; this one flips CI so it can't regress.

### The gate
`ci-checks.yml`'s clippy step changes from:
```yaml
cargo clippy -- -A warnings        # allowed every warning, lib-only
```
to:
```yaml
cargo clippy --workspace --all-targets -- -D warnings
cargo clippy -p calimero-storage --all-targets --features testing -- -D warnings
```
Any clippy- or rustc-level warning in any workspace target (libs, bins, tests, examples) now fails CI. The second line covers `calimero-storage`'s feature-gated `testing` harness, which the default-feature pass doesn't reach. Devs can run the same commands locally before pushing.

**Verified locally on this branch:** both commands exit 0 (zero warnings).

### Why CI-only (not `[workspace.lints]`)
The earlier plan considered `[workspace.lints]` for declarative enforcement. With **169 workspace members**, that means `lints.workspace = true` in 169 manifests plus `warnings = "deny"` applied to every local `cargo build` — a lot of churn and real toolchain-version fragility (a newer rustc adding a warning would break local builds). The CI gate gives the same regression protection without that cost; if we later want local enforcement too, it's an additive follow-up.

### Tidy
Dropped the redundant `[profile.app-release]` blocks from `apps/abi_conformance` and `apps/state-schema-conformance`. Cargo ignores `[profile]` on non-root members (the root already defines `app-release`, which the build scripts use via `--profile app-release`), so these only emitted "profiles … will be ignored" notices. Removal is a no-op functionally.

## Series complete
1. #2821 — policy + auto-fix ✅ merged
2. #2823 — non-consensus crates ✅ merged
3. #2825 — consensus tier (workspace warning-free) — open
4. **This PR** — the gate

> Note: stacked on #2825. Best merged after it (or rebased onto master once #2825 lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI policy, Cargo.toml cleanup, and style/clippy fixes with no intended runtime behavior change.
> 
> **Overview**
> **CI now fails on any clippy/rustc warning** across the full workspace. The Rust job’s clippy step switches from allowing warnings on a default pass to `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings`, with a short comment documenting the gate and the `calimero-storage/testing` feature so feature-gated test harness code is linted in the same run.
> 
> **Manifest tidy:** `[profile.app-release]` is removed from `apps/abi_conformance` and `apps/state-schema-conformance` because Cargo ignores profile tables on non-workspace-root packages (root already defines `app-release`), which only produced “profiles will be ignored” notices.
> 
> **Remaining warning fixes** bundled for the new gate: `RootOp` is imported only under `#[cfg(test)]` in `scope_projection.rs`; tee-attestation uses inline `format!` capture and `split('/').next_back()` instead of `.last()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c298ebdbe84881ea403501a97bc566c846bdf368. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->