### PR TITLE
chore(docs): doc routing mapping + stop doc-update self-loop

### DIFF
--- a/.ai-reviewer.yaml
+++ b/.ai-reviewer.yaml
@@ -35,7 +35,7 @@ documentation:
   source_to_docs_mapping:
     # Per-crate internals pages (architecture/crates/*.html)
     "crates/auth/**": ["architecture/crates/auth.html"]
-    "crates/node/**": ["architecture/crates/node.html"]
+    "crates/node/**": ["architecture/crates/node.html", "architecture/crates/sync.html"]
     "crates/context/**": ["architecture/crates/context.html", "architecture/membership-and-leave.html"]
     "crates/network/**": ["architecture/crates/network.html", "architecture/wire-protocol.html"]
     "crates/server/**": ["architecture/crates/server.html"]

--- a/.ai-reviewer.yaml
+++ b/.ai-reviewer.yaml
@@ -27,3 +27,33 @@ doc_generation:
     - automated-docs
     - documentation
   pr_draft: true
+
+# Source → docs routing. A change whose files match a glob routes deterministically
+# to the listed page(s) with no model guess (the fast mapping-hit path); unmapped
+# crates fall back to model routing. Globs are fnmatch-style (`*` spans `/`).
+documentation:
+  source_to_docs_mapping:
+    # Per-crate internals pages (architecture/crates/*.html)
+    "crates/auth/**": ["architecture/crates/auth.html"]
+    "crates/node/**": ["architecture/crates/node.html"]
+    "crates/context/**": ["architecture/crates/context.html", "architecture/membership-and-leave.html"]
+    "crates/network/**": ["architecture/crates/network.html", "architecture/wire-protocol.html"]
+    "crates/server/**": ["architecture/crates/server.html"]
+    "crates/runtime/**": ["architecture/crates/runtime.html", "architecture/app-lifecycle.html"]
+    "crates/dag/**": ["architecture/crates/dag.html"]
+    "crates/sdk/**": ["architecture/crates/sdk.html"]
+    "crates/meroctl/**": ["architecture/crates/tools.html"]
+    "crates/merod/**": ["architecture/crates/tools.html"]
+    # Storage
+    "crates/store/**": ["architecture/crates/store.html", "architecture/storage-schema.html"]
+    "crates/storage/**": ["architecture/storage-schema.html", "architecture/migrations.html"]
+    "crates/storage-macros/**": ["architecture/storage-schema.html"]
+    # Governance & op-log
+    "crates/governance-store/**": ["architecture/local-governance.html", "architecture/auto-follow.html"]
+    "crates/governance-types/**": ["architecture/local-governance.html"]
+    "crates/authz/**": ["architecture/local-governance.html"]
+    "crates/op/**": ["architecture/crates/dag.html", "architecture/auto-follow.html"]
+    "crates/op-adapter/**": ["architecture/crates/dag.html"]
+    # Subsystems
+    "crates/config/**": ["architecture/config-reference.html"]
+    "crates/tee-attestation/**": ["architecture/tee-mode.html"]

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -17,6 +17,13 @@ name: Doc Auto-Update
 on:
   push:
     branches: [main, master]
+    # Doc-only merges — including this workflow's OWN auto-doc PRs — must not
+    # trigger another run, else the bot generates docs for its own doc PRs in an
+    # infinite loop. Mirrors the paths-ignore in ai-review.yaml.
+    paths-ignore:
+      - 'docs/**'
+      - 'architecture/**'
+      - 'docs-static/**'
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
Two related doc-bot reliability fixes.

## 1. Stop the doc-update self-loop (`doc-update.yaml`)

`doc-update.yaml` ran on **every** push to `master` with no `paths-ignore`, so merging an auto-doc PR (which only touches `architecture/**`) re-triggered the workflow, which generated docs **for that doc PR** — recursively:

```
#2827 fix(context)  ──merge──▶ bot opens #2832 (docs for #2827)
#2832               ──merge──▶ bot opens #2833 (docs for #2832 — docs for #2827)
#2833               ──merge──▶ bot opens #2834 (docs for #2833 — docs for #2832 — …)
```

Cumulatively-nesting titles are the tell. Fix: add the **same `paths-ignore`** `ai-review.yaml` already uses — a merge touching only `docs/**`, `architecture/**`, or `docs-static/**` no longer triggers a doc run; real code merges still do.

> After this lands, **close #2834** (don't merge it) to drop the in-flight loop PR.

## 2. Deterministic doc routing (`.ai-reviewer.yaml`)

The Route stage had no `source_to_docs_mapping`, so every change relied on the model cold-picking a target page; a wrong/empty pick skipped the update. Map each crate to its architecture page(s) so known changes route deterministically (the fast mapping-hit path, no model call). Unmapped crates (`crypto`, `sys`, `projection`, `primitives`, `prelude`, `utils`, `build-utils`, `git-hooks`, `wasm-abi`) still fall back to model routing. All 20 target pages verified to exist; globs are `fnmatch`-style.

### Mapping — judgment calls to confirm
- **`authz/**` → `local-governance.html`** (vs `crates/auth.html`?)
- **`op/**` → `crates/dag.html` + `auto-follow.html`**
- **`governance-store/**` → `local-governance.html` + `auto-follow.html`** (both, since it drives both)
- Multi-target deep-dive pairs (`network`, `context`, `runtime`) — drop the second target if too noisy.

> Pairs with ai-code-reviewer #83 (output-cap truncation) and #84 (apply retry + fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger and AI reviewer config only; no runtime application code or auth/data paths change.
> 
> **Overview**
> Stops the **Doc Auto-Update** workflow from re-running when only documentation paths change, and makes the doc bot route crate changes to architecture pages without model guessing.
> 
> **`doc-update.yaml`** now uses **`paths-ignore`** on pushes to `main`/`master` for `docs/**`, `architecture/**`, and `docs-static/**` — aligned with **`ai-review.yaml`**. Merging auto-doc PRs that only touch those trees no longer triggers another doc run (breaking the recursive “docs for the doc PR” loop).
> 
> **`.ai-reviewer.yaml`** adds a top-level **`documentation.source_to_docs_mapping`**: fnmatch globs under `crates/**` map to one or more `architecture/*.html` targets (e.g. `node` → node + sync pages, storage crates → storage schema/migrations). Mapped hits use the fast deterministic path; unlisted crates still use model routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bc568aa864df60064ba8396712f0f6327092050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->