### PR TITLE
fix(ci): stop doc-update from looping on its own auto-doc PRs

### DIFF
--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -17,6 +17,13 @@ name: Doc Auto-Update
 on:
   push:
     branches: [main, master]
+    # Doc-only merges — including this workflow's OWN auto-doc PRs — must not
+    # trigger another run, else the bot generates docs for its own doc PRs in an
+    # infinite loop. Mirrors the paths-ignore in ai-review.yaml.
+    paths-ignore:
+      - 'docs/**'
+      - 'architecture/**'
+      - 'docs-static/**'
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
## The loop

`doc-update.yaml` runs on **every** push to `master` with no `paths-ignore`. So when an auto-doc PR (which only touches `architecture/**`) is merged, the workflow re-triggers and generates docs **for that doc PR** — recursively:

```
#2827 fix(context)  ──merge──▶ bot opens #2832 (docs for #2827)
#2832               ──merge──▶ bot opens #2833 (docs for #2832 — docs for #2827)
#2833               ──merge──▶ bot opens #2834 (docs for #2833 — docs for #2832 — …)
```

The PR titles nest cumulatively — that's the tell.

## Fix

Add the **same `paths-ignore`** `ai-review.yaml` already uses to the `push` trigger. A merge that touches only `docs/**`, `architecture/**`, or `docs-static/**` no longer triggers a doc run, so the bot's own doc-only PRs can't re-trigger it. Real code merges (`crates/**`, etc.) still trigger normally.

This is the symmetric guard the doc workflow was missing — `ai-review.yaml` skips doc-only PRs for the same reason (don't act on doc-only diffs).

## To fully stop the current loop
Merge this, then **close #2834** (don't merge it) — merging it would be one more doc-only merge, harmless once this lands but it adds junk doc content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger filtering only; no runtime or application code changes.
> 
> **Overview**
> **Doc Auto-Update** previously ran on every push to `main`/`master`, so merging an auto-generated doc PR (changes only under `docs/**`, `architecture/**`, or `docs-static/**`) fired another run and produced nested “docs for the doc PR” cycles.
> 
> This change adds the **same `paths-ignore` globs** already used on `ai-review.yaml` to the `push` trigger in `doc-update.yaml`. Pushes that touch only those doc paths are skipped; merges that include real code (e.g. `crates/**`) still run doc generation as before. `workflow_dispatch` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 820576506b0179662aacaeb69e86b07cd3fc91b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->