### PR TITLE
feat(node): inbound-sync peer authorization resolves via projection (gated)

### DIFF
--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -424,6 +424,25 @@ impl ScopeProjections {
     /// normal partial frontier (collect what's present), not a `None`.
     ///
     /// [`apply_backfill`]: Self::apply_backfill
+    /// The owning namespace's CURRENT governance heads for `group` — the cut that
+    /// represents "now" for a current-state membership read (resolve the group to
+    /// its namespace, then read that DAG's head record). `None` if the group can't
+    /// be resolved or the head record is unreadable. Pair with
+    /// [`member_at_cut`](Self::member_at_cut) (via the node's refreshing wrapper) to
+    /// answer "is X a member right now" off the projection instead of the live
+    /// materialized rows.
+    #[must_use]
+    pub fn namespace_current_heads(store: &Store, group: ContextGroupId) -> Option<Vec<[u8; 32]>> {
+        let namespace_id = NamespaceRepository::new(store)
+            .resolve(&group)
+            .ok()?
+            .to_bytes();
+        NamespaceDagService::new(store, namespace_id)
+            .read_head_record()
+            .ok()
+            .map(|head| head.parent_hashes)
+    }
+
     #[must_use]
     pub fn collect_namespace_ops(store: &Store, namespace_id: [u8; 32]) -> Option<Vec<Op>> {
         let dag = NamespaceDagService::new(store, namespace_id);

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -790,7 +790,9 @@ fn refresh_projection_for_cut(
     }
 }
 
-fn projection_member_at_cut(
+// `pub(crate)` so the sync manager's inbound-peer authorization reuses the exact
+// same refreshing deny-direction read the data-write path uses.
+pub(crate) fn projection_member_at_cut(
     node_state: &crate::NodeState,
     datastore: &calimero_store::Store,
     group: calimero_context_config::types::ContextGroupId,

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -2839,7 +2839,7 @@ impl SyncManager {
                     if let Some(group_id) =
                         calimero_context::group_store::get_group_for_context(store, &context_id)?
                     {
-                        if MembershipRepository::new(store).is_member(&group_id, &their_identity)? {
+                        if self.peer_is_group_member(store, group_id, &their_identity)? {
                             dialer_verified = true;
                         }
                     }
@@ -2913,6 +2913,54 @@ impl SyncManager {
         }
     }
 
+    /// Inbound-sync membership authorization via the unified projection — current
+    /// state, direct OR inherited (open-subgroup parent walk) — with the live
+    /// resolver kept as the gated cross-check. The projection's verdict decides;
+    /// a disagreement trips `unified_projection_divergence` (plane
+    /// `membership-sync`, caught by the same e2e gate). `None` (cold or partially
+    /// folded projection) falls back to live so a sync peer is never spuriously
+    /// rejected on a stale fold — the inbound path's own catch-up retry then
+    /// re-resolves once governance advances. Reuses the data-write path's
+    /// refreshing `projection_member_at_cut`, so sync and writes decide against an
+    /// identically up-to-date fold.
+    fn peer_is_group_member(
+        &self,
+        store: &calimero_store::Store,
+        group_id: calimero_context_config::types::ContextGroupId,
+        their_identity: &PublicKey,
+    ) -> eyre::Result<bool> {
+        let live = MembershipRepository::new(store).is_member(&group_id, their_identity)?;
+        let Some(heads) =
+            calimero_context::scope_projection::ScopeProjections::namespace_current_heads(
+                store, group_id,
+            )
+        else {
+            return Ok(live);
+        };
+        let projected = crate::handlers::state_delta::projection_member_at_cut(
+            &self.node_state,
+            store,
+            group_id,
+            their_identity,
+            &heads,
+        );
+        if let Some(p) = projected {
+            if p != live {
+                warn!(
+                    marker = "unified_projection_divergence",
+                    plane = "membership-sync",
+                    group_id = ?group_id,
+                    ?their_identity,
+                    projection = p,
+                    live,
+                    "inbound-sync auth: projection disagrees with live membership"
+                );
+            }
+        }
+        // Act on the projection; `None` (can't decide) falls back to live.
+        Ok(projected.unwrap_or(live))
+    }
+
     /// Authorize the dialing peer as a sync-eligible member of `context_id` —
     /// direct context/group membership, or inheritance-eligible parent
     /// membership (`Open` subgroups). On an unknown member, refresh context
@@ -2944,7 +2992,7 @@ impl SyncManager {
             else {
                 return Ok(false);
             };
-            MembershipRepository::new(store).is_member(&group_id, &their_identity)
+            self.peer_is_group_member(store, group_id, &their_identity)
         };
 
         if !self


### PR DESCRIPTION
## What

Next F5 consumer migration (unified causal log, core#2716 Phase 5), continuing after #2827/#2828/#2829. Migrates the **sync manager's inbound-peer membership authorization** off the live `MembershipRepository::is_member` onto the unified projection.

## How

Both call sites — the materialization-wait verification and `verify_inbound_member`'s inherited-member check — now route through one helper, `peer_is_group_member`, which resolves **current-state** membership (direct OR inherited open-subgroup) at the owning namespace's **current governance heads** via the data-write path's refreshing `projection_member_at_cut` (made `pub(crate)`).

New `ScopeProjections::namespace_current_heads` (resolve group → namespace → DAG head record) supplies the "now" cut for current-state reads.

## Safety

The live resolver is retained as the **gated cross-check**: a disagreement trips `unified_projection_divergence` (plane `membership-sync`, caught by the same e2e gate). The projection's verdict decides; `None` (cold or partially folded projection) **falls back to live** so a sync peer is never spuriously rejected on a stale fold — and the inbound path's existing catch-up retry (`sync_context_config` + direct governance request) re-resolves once governance advances. This reuses the same refreshing read the write path uses, so sync and writes decide against an identically up-to-date fold.

## Test

- `cargo build`/`clippy`/`fmt` clean; projection equivalence harness (3/3) still green.
- e2e divergence gate validates `membership-sync` divergence-free on real sync traffic.

Stacks conceptually after #2829 (all merged); branches off `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who is allowed to sync based on membership, but None/unreadable heads fall back to live and disagreements are gated for e2e detection rather than silently trusting projection alone.
> 
> **Overview**
> **Inbound sync** no longer authorizes dialing peers with live `MembershipRepository::is_member` alone. Materialization-wait verification and `verify_inbound_member` inherited checks both go through **`peer_is_group_member`**, which treats the projection as the decision and keeps live membership as a gated cross-check.
> 
> **`ScopeProjections::namespace_current_heads`** resolves a group to its namespace and returns the governance DAG’s current head hashes—the “now” cut for current-state membership reads.
> 
> **`projection_member_at_cut`** is **`pub(crate)`** so sync reuses the same refreshing backfill + `member_at_cut` path as state-delta writes. When heads are unreadable or the projection returns **`None`** (cold/partial fold), behavior **falls back to live** so peers aren’t wrongly rejected; projection vs live mismatch logs **`unified_projection_divergence`** on plane **`membership-sync`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d260b2d7c901eacfdebb8fbd0a92ff0436c5bcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->