### PR TITLE
feat(context): membership query auth-gates resolve via projection (gated)

### DIFF
--- a/crates/context/src/handlers/get_cascade_status.rs
+++ b/crates/context/src/handlers/get_cascade_status.rs
@@ -1,6 +1,6 @@
 use actix::{ActorResponse, Handler, Message};
 use calimero_context_client::group::{CascadeStatusEntry, GetCascadeStatusRequest};
-use calimero_governance_store::{MembershipRepository, NamespaceRepository, UpgradesRepository};
+use calimero_governance_store::{NamespaceRepository, UpgradesRepository};
 use eyre::bail;
 
 use crate::ContextManager;
@@ -47,9 +47,11 @@ impl Handler<GetCascadeStatusRequest> for ContextManager {
             let Some((node_identity, _)) = self.node_namespace_identity(&namespace_id) else {
                 bail!("node has no group identity configured");
             };
-            if !MembershipRepository::new(&self.datastore)
-                .is_member(&namespace_id, &node_identity)?
-            {
+            if !crate::scope_projection::ScopeProjections::member_now_checked(
+                &self.datastore,
+                &namespace_id,
+                &node_identity,
+            )? {
                 bail!("node is not a member of namespace '{namespace_id:?}'");
             }
             collect_cascade_status(&self.datastore, &namespace_id)

--- a/crates/context/src/handlers/get_group_upgrade_status.rs
+++ b/crates/context/src/handlers/get_group_upgrade_status.rs
@@ -1,6 +1,6 @@
 use actix::{ActorResponse, Handler, Message};
 use calimero_context_client::group::GetGroupUpgradeStatusRequest;
-use calimero_governance_store::{MembershipRepository, UpgradesRepository};
+use calimero_governance_store::UpgradesRepository;
 use eyre::bail;
 
 use crate::ContextManager;
@@ -17,7 +17,11 @@ impl Handler<GetGroupUpgradeStatusRequest> for ContextManager {
             let Some((node_identity, _)) = self.node_namespace_identity(&group_id) else {
                 bail!("node has no group identity configured");
             };
-            if !MembershipRepository::new(&self.datastore).is_member(&group_id, &node_identity)? {
+            if !crate::scope_projection::ScopeProjections::member_now_checked(
+                &self.datastore,
+                &group_id,
+                &node_identity,
+            )? {
                 bail!("node is not a member of group '{group_id:?}'");
             }
             UpgradesRepository::new(&self.datastore)

--- a/crates/context/src/handlers/list_all_groups.rs
+++ b/crates/context/src/handlers/list_all_groups.rs
@@ -1,7 +1,7 @@
 use actix::{ActorResponse, Handler, Message};
 use calimero_context_client::group::{GroupSummary, ListAllGroupsRequest};
 use calimero_context_config::types::ContextGroupId;
-use calimero_governance_store::{MembershipRepository, MetaRepository, MetadataRepository};
+use calimero_governance_store::{MetaRepository, MetadataRepository};
 
 use crate::ContextManager;
 use calimero_governance_store;
@@ -23,9 +23,22 @@ impl Handler<ListAllGroupsRequest> for ContextManager {
                 let Some((node_identity, _)) = self.node_namespace_identity(&group_id) else {
                     continue;
                 };
-                if MembershipRepository::new(&self.datastore)
-                    .is_member(&group_id, &node_identity)?
-                {
+                // Skip (don't abort the whole listing) on a per-group membership
+                // error — mirrors the `node_namespace_identity` miss above. A
+                // transient store fault on one group must not discard every group
+                // already accumulated.
+                let is_member = match crate::scope_projection::ScopeProjections::member_now_checked(
+                    &self.datastore,
+                    &group_id,
+                    &node_identity,
+                ) {
+                    Ok(m) => m,
+                    Err(err) => {
+                        tracing::warn!(group_id = ?group_id, %err, "list_all_groups: membership check failed; skipping group");
+                        continue;
+                    }
+                };
+                if is_member {
                     let name = MetadataRepository::new(&self.datastore)
                         .group_metadata(&group_id)
                         .ok()

--- a/crates/context/src/handlers/list_group_contexts.rs
+++ b/crates/context/src/handlers/list_group_contexts.rs
@@ -1,6 +1,6 @@
 use actix::{ActorResponse, Handler, Message};
 use calimero_context_client::group::{GroupContextEntry, ListGroupContextsRequest};
-use calimero_governance_store::{MembershipRepository, MetadataRepository};
+use calimero_governance_store::MetadataRepository;
 use eyre::bail;
 
 use crate::ContextManager;
@@ -21,7 +21,11 @@ impl Handler<ListGroupContextsRequest> for ContextManager {
             let Some((node_identity, _)) = self.node_namespace_identity(&group_id) else {
                 bail!("node has no group identity configured");
             };
-            if !MembershipRepository::new(&self.datastore).is_member(&group_id, &node_identity)? {
+            if !crate::scope_projection::ScopeProjections::member_now_checked(
+                &self.datastore,
+                &group_id,
+                &node_identity,
+            )? {
                 bail!("node is not a member of group '{group_id:?}'");
             }
             MetadataRepository::new(&self.datastore)

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -443,6 +443,88 @@ impl ScopeProjections {
             .map(|head| head.parent_hashes)
     }
 
+    /// Current-state membership via a projection built FRESH from the store — for
+    /// the context-layer query handlers, which (unlike the node) hold no cached
+    /// `ScopeProjections`. Resolves the namespace, folds its governance DAG, and
+    /// reads `member_at_cut` at the current heads. `None` when the namespace/heads
+    /// can't be resolved or the cut isn't decidable.
+    ///
+    /// Per-query rebuild: acceptable for low-frequency read endpoints (a real
+    /// namespace's governance history is small); hot paths use the node's cached
+    /// projection via `projection_member_at_cut` instead.
+    #[must_use]
+    pub fn member_now_ephemeral(
+        store: &Store,
+        group: &ContextGroupId,
+        member: &PublicKey,
+    ) -> Option<bool> {
+        let namespace_id = NamespaceRepository::new(store)
+            .resolve(group)
+            .ok()?
+            .to_bytes();
+        let mut proj = Self::new();
+        let Some(ops) = Self::collect_namespace_ops(store, namespace_id) else {
+            // Governance head unreadable (store fault). Don't silently read an empty
+            // projection — surface it and let the caller fall back to live.
+            tracing::warn!(
+                group_id = ?group,
+                "member_now_ephemeral: governance head unreadable; falling back to live"
+            );
+            return None;
+        };
+        proj.apply_backfill(namespace_id, ops);
+        // Read the cut heads AFTER folding so the cut never names ops the fold is
+        // missing: the fold covers the head observed by `collect_namespace_ops`, and
+        // these heads are read no earlier than that, so if a concurrent governance
+        // op advanced the head mid-rebuild, the new head's ancestry isn't fully
+        // folded and `member_at_cut`'s completeness guard returns `None` (defer to
+        // live) rather than deciding against a stale cut that predates a revocation.
+        let heads = NamespaceDagService::new(store, namespace_id)
+            .read_head_record()
+            .ok()?
+            .parent_hashes;
+        proj.member_at_cut(store, *group, member, &heads)
+    }
+
+    /// The membership verdict a query gate should ACT on: the projection's
+    /// current-state answer ([`member_now_ephemeral`](Self::member_now_ephemeral)),
+    /// falling back to live only when the projection can't decide (`None`). Logs
+    /// `unified_projection_divergence` (plane `membership-query`, caught by the e2e
+    /// gate) when the two definitely disagree — keeping live as the gated
+    /// cross-check until the resolver is deleted in F5.
+    pub fn member_now_checked(
+        store: &Store,
+        group: &ContextGroupId,
+        member: &PublicKey,
+    ) -> eyre::Result<bool> {
+        if let Some(p) = Self::member_now_ephemeral(store, group, member) {
+            // The projection decided. Cross-check live BEST-EFFORT — a transient
+            // live-read error must not deny a verdict the projection already formed;
+            // log the divergence only when live also produced an answer.
+            match MembershipRepository::new(store).is_member(group, member) {
+                Ok(live) if live != p => tracing::warn!(
+                    marker = "unified_projection_divergence",
+                    plane = "membership-query",
+                    group_id = ?group,
+                    ?member,
+                    projection = p,
+                    live,
+                    "query-gate: projection disagrees with live membership"
+                ),
+                Ok(_) => {}
+                Err(err) => tracing::warn!(
+                    group_id = ?group,
+                    %err,
+                    "query-gate: live cross-check failed; acting on projection verdict"
+                ),
+            }
+            return Ok(p);
+        }
+        // Projection couldn't decide (cold/partial fold or store fault) — live is
+        // authoritative here, so its error legitimately propagates.
+        MembershipRepository::new(store).is_member(group, member)
+    }
+
     #[must_use]
     pub fn collect_namespace_ops(store: &Store, namespace_id: [u8; 32]) -> Option<Vec<Op>> {
         let dag = NamespaceDagService::new(store, namespace_id);


### PR DESCRIPTION
## What

F5 consumer migration (unified causal log, core#2716), stacked on #2840. Migrates the four **read-endpoint membership auth-gates** off the live `MembershipRepository::is_member` onto the unified projection:
- `list_all_groups` (filter groups by node membership)
- `list_group_contexts` (gate)
- `get_cascade_status` (gate)
- `get_group_upgrade_status` (gate)

## How

Unlike the node, the context-layer query handlers hold **no cached `ScopeProjections`** — so they build one **fresh from the store per query** (`ScopeProjections::member_now_ephemeral`: resolve namespace → fold its governance DAG → `member_at_cut` at the current heads). Per-query rebuild is fine for these low-frequency read endpoints; the governance history is small, and hot paths still use the node's cached projection.

`member_now_checked` centralizes the decision so each site is a one-line swap: act on the projection's verdict, fall back to live only when the projection can't decide (`None`), and trip `unified_projection_divergence` (plane `membership-query`, caught by the same e2e gate) when the two definitely disagree.

## Scope

Boolean `is_member` gates only. The member-**enumeration** endpoints (`list_group_members`, `get_group_info`, `get_migration_status`) need a projection member-enumeration API (direct + inherited members) and follow as a separate PR.

## Test

- `cargo build`/`clippy --all-targets` (warning-free gate)/`fmt` clean; equivalence harness 3/3 green.
- e2e `membership-query` divergence gate validates equivalence on real traffic. (Production has the full governance history in the namespace DAG, which `member_now_ephemeral` folds; the deterministic harness uses direct ingest for structural ops so it doesn't exercise the ephemeral rebuild — e2e covers that.)

Stacked on #2840 (#26 sync peer selection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization for group read APIs (membership-sensitive), but projection verdicts are cross-checked against live with fallback when undecidable and e2e divergence monitoring.
> 
> **Overview**
> Moves **four read-endpoint membership gates** from live `MembershipRepository::is_member` to **`ScopeProjections::member_now_checked`**: `list_all_groups`, `list_group_contexts`, `get_cascade_status`, and `get_group_upgrade_status`.
> 
> Context handlers have no cached projection, so **`member_now_ephemeral`** builds one per query (namespace resolve → governance DAG fold → `member_at_cut` at current heads). **`member_now_checked`** uses that verdict when decidable, falls back to live when the projection returns `None`, and logs **`unified_projection_divergence`** (plane `membership-query`) when projection and live disagree.
> 
> **`list_all_groups`** now **skips** a group on membership-check errors (with a warn) instead of failing the entire listing, matching existing behavior for missing node identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05c0ce9ad9c4d7911717bf3c5b8f9403ef2df0bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->