### PR TITLE
feat(context): shadow member-enumeration endpoints against the projection

### DIFF
--- a/crates/context/src/handlers/get_group_info.rs
+++ b/crates/context/src/handlers/get_group_info.rs
@@ -51,25 +51,27 @@ impl Handler<GetGroupInfoRequest> for ContextManager {
                     .enumerate_inherited(&group_id)?
                     .len()) as u64;
 
-            // SHADOW: validate the projection's effective-member count against the
-            // live union (logs `membership-enum` divergence; still returns live).
-            if let Some(projected) =
-                crate::scope_projection::ScopeProjections::member_identities_now_ephemeral(
-                    &self.datastore,
-                    &group_id,
-                )
-            {
-                if projected.len() as u64 != member_count {
-                    tracing::warn!(
-                        marker = "unified_projection_divergence",
-                        plane = "membership-enum",
-                        group_id = ?group_id,
-                        projection_count = projected.len(),
-                        live_count = member_count,
-                        "query-enum: projection effective-member count differs from live"
-                    );
-                }
-            }
+            // SHADOW: compare the projection's effective-member SET against the live
+            // union (not just the count — equal counts with different members would
+            // otherwise slip through). Logs `membership-enum` divergence; still
+            // returns the live `member_count`.
+            let live_ids: std::collections::BTreeSet<_> =
+                MembershipRepository::new(&self.datastore)
+                    .list(&group_id, 0, usize::MAX)?
+                    .into_iter()
+                    .map(|(pk, _)| pk)
+                    .chain(
+                        MembershipRepository::new(&self.datastore)
+                            .enumerate_inherited(&group_id)?
+                            .into_iter()
+                            .map(|(pk, _)| pk),
+                    )
+                    .collect();
+            crate::scope_projection::ScopeProjections::shadow_check_member_enum(
+                &self.datastore,
+                &group_id,
+                &live_ids,
+            );
 
             let context_count =
                 MetadataRepository::new(&self.datastore).count_contexts(&group_id)? as u64;

--- a/crates/context/src/handlers/get_group_info.rs
+++ b/crates/context/src/handlers/get_group_info.rs
@@ -25,7 +25,11 @@ impl Handler<GetGroupInfoRequest> for ContextManager {
             let Some((node_identity, _)) = self.node_namespace_identity(&group_id) else {
                 bail!("node has no group identity configured");
             };
-            if !MembershipRepository::new(&self.datastore).is_member(&group_id, &node_identity)? {
+            if !crate::scope_projection::ScopeProjections::member_now_checked(
+                &self.datastore,
+                &group_id,
+                &node_identity,
+            )? {
                 bail!("node is not a member of group '{group_id:?}'");
             }
 
@@ -46,6 +50,26 @@ impl Handler<GetGroupInfoRequest> for ContextManager {
                 + MembershipRepository::new(&self.datastore)
                     .enumerate_inherited(&group_id)?
                     .len()) as u64;
+
+            // SHADOW: validate the projection's effective-member count against the
+            // live union (logs `membership-enum` divergence; still returns live).
+            if let Some(projected) =
+                crate::scope_projection::ScopeProjections::member_identities_now_ephemeral(
+                    &self.datastore,
+                    &group_id,
+                )
+            {
+                if projected.len() as u64 != member_count {
+                    tracing::warn!(
+                        marker = "unified_projection_divergence",
+                        plane = "membership-enum",
+                        group_id = ?group_id,
+                        projection_count = projected.len(),
+                        live_count = member_count,
+                        "query-enum: projection effective-member count differs from live"
+                    );
+                }
+            }
 
             let context_count =
                 MetadataRepository::new(&self.datastore).count_contexts(&group_id)? as u64;

--- a/crates/context/src/handlers/get_group_info.rs
+++ b/crates/context/src/handlers/get_group_info.rs
@@ -56,10 +56,13 @@ impl Handler<GetGroupInfoRequest> for ContextManager {
             // chain walk bounded by `MAX_NAMESPACE_DEPTH`. This is minor
             // next to `compute_group_state_hash` below, which already
             // scans the full group state on every call.
+            // Resolve the open-subgroup inherited members ONCE — reused for the
+            // count and (below) the shadow's live id set, instead of two parent
+            // walks.
+            let inherited =
+                MembershipRepository::new(&self.datastore).enumerate_inherited(&group_id)?;
             let member_count = (MembershipRepository::new(&self.datastore).count(&group_id)?
-                + MembershipRepository::new(&self.datastore)
-                    .enumerate_inherited(&group_id)?
-                    .len()) as u64;
+                + inherited.len()) as u64;
 
             // SHADOW: compare the projection's effective-member SET against the live
             // union (not just the count — equal counts with different members would
@@ -71,12 +74,7 @@ impl Handler<GetGroupInfoRequest> for ContextManager {
                         .list(&group_id, 0, usize::MAX)?
                         .into_iter()
                         .map(|(pk, _)| pk)
-                        .chain(
-                            MembershipRepository::new(&self.datastore)
-                                .enumerate_inherited(&group_id)?
-                                .into_iter()
-                                .map(|(pk, _)| pk),
-                        )
+                        .chain(inherited.into_iter().map(|(pk, _)| pk))
                         .collect();
                 proj.shadow_member_enum_with(&self.datastore, *ns, &group_id, heads, &live_ids);
             }

--- a/crates/context/src/handlers/get_group_info.rs
+++ b/crates/context/src/handlers/get_group_info.rs
@@ -25,11 +25,21 @@ impl Handler<GetGroupInfoRequest> for ContextManager {
             let Some((node_identity, _)) = self.node_namespace_identity(&group_id) else {
                 bail!("node has no group identity configured");
             };
-            if !crate::scope_projection::ScopeProjections::member_now_checked(
+            // Fold the ephemeral projection ONCE: the gate and the enum shadow
+            // below both read from it (one RocksDB DAG walk, not two). `None`
+            // (store fault) falls back to live for the gate and skips the shadow.
+            let proj_ctx = crate::scope_projection::ScopeProjections::ephemeral_projection(
                 &self.datastore,
                 &group_id,
-                &node_identity,
-            )? {
+            );
+            let is_member = match &proj_ctx {
+                Some((proj, _ns, heads)) => {
+                    proj.member_now_checked_with(&self.datastore, &group_id, &node_identity, heads)?
+                }
+                None => MembershipRepository::new(&self.datastore)
+                    .is_member(&group_id, &node_identity)?,
+            };
+            if !is_member {
                 bail!("node is not a member of group '{group_id:?}'");
             }
 
@@ -54,24 +64,22 @@ impl Handler<GetGroupInfoRequest> for ContextManager {
             // SHADOW: compare the projection's effective-member SET against the live
             // union (not just the count — equal counts with different members would
             // otherwise slip through). Logs `membership-enum` divergence; still
-            // returns the live `member_count`.
-            let live_ids: std::collections::BTreeSet<_> =
-                MembershipRepository::new(&self.datastore)
-                    .list(&group_id, 0, usize::MAX)?
-                    .into_iter()
-                    .map(|(pk, _)| pk)
-                    .chain(
-                        MembershipRepository::new(&self.datastore)
-                            .enumerate_inherited(&group_id)?
-                            .into_iter()
-                            .map(|(pk, _)| pk),
-                    )
-                    .collect();
-            crate::scope_projection::ScopeProjections::shadow_check_member_enum(
-                &self.datastore,
-                &group_id,
-                &live_ids,
-            );
+            // returns the live `member_count`. Reuses the single fold from the gate.
+            if let Some((proj, ns, heads)) = &proj_ctx {
+                let live_ids: std::collections::BTreeSet<_> =
+                    MembershipRepository::new(&self.datastore)
+                        .list(&group_id, 0, usize::MAX)?
+                        .into_iter()
+                        .map(|(pk, _)| pk)
+                        .chain(
+                            MembershipRepository::new(&self.datastore)
+                                .enumerate_inherited(&group_id)?
+                                .into_iter()
+                                .map(|(pk, _)| pk),
+                        )
+                        .collect();
+                proj.shadow_member_enum_with(&self.datastore, *ns, &group_id, heads, &live_ids);
+            }
 
             let context_count =
                 MetadataRepository::new(&self.datastore).count_contexts(&group_id)? as u64;

--- a/crates/context/src/handlers/get_migration_status.rs
+++ b/crates/context/src/handlers/get_migration_status.rs
@@ -43,6 +43,30 @@ pub fn collect_migration_cohort(
         }
     }
 
+    // SHADOW: union the projection's effective-member set across the same subtree
+    // and compare to the live cohort (logs `membership-enum` divergence; still
+    // returns the live cohort).
+    let mut projected: BTreeSet<PublicKey> = BTreeSet::new();
+    for gid in &groups {
+        if let Some(ids) =
+            crate::scope_projection::ScopeProjections::member_identities_now_ephemeral(store, gid)
+        {
+            projected.extend(ids);
+        }
+    }
+    if projected != cohort {
+        let only_projection: Vec<_> = projected.difference(&cohort).collect();
+        let only_live: Vec<_> = cohort.difference(&projected).collect();
+        tracing::warn!(
+            marker = "unified_projection_divergence",
+            plane = "membership-enum",
+            namespace_id = ?namespace_id,
+            ?only_projection,
+            ?only_live,
+            "query-enum: projection migration cohort differs from live"
+        );
+    }
+
     Ok(cohort.into_iter().collect())
 }
 

--- a/crates/context/src/handlers/get_migration_status.rs
+++ b/crates/context/src/handlers/get_migration_status.rs
@@ -44,27 +44,29 @@ pub fn collect_migration_cohort(
     }
 
     // SHADOW: union the projection's effective-member set across the same subtree
-    // and compare to the live cohort (logs `membership-enum` divergence; still
-    // returns the live cohort).
-    let mut projected: BTreeSet<PublicKey> = BTreeSet::new();
-    for gid in &groups {
-        if let Some(ids) =
-            crate::scope_projection::ScopeProjections::member_identities_now_ephemeral(store, gid)
-        {
-            projected.extend(ids);
+    // — folding the namespace ONCE at a SINGLE cut (not per-group, which would
+    // re-fold and evaluate groups at different cuts under concurrent governance) —
+    // and compare to the live cohort. Logs `membership-enum` divergence; still
+    // returns the live cohort.
+    if let Some(projected) =
+        crate::scope_projection::ScopeProjections::member_identities_subtree_ephemeral(
+            store,
+            namespace_id,
+            &groups,
+        )
+    {
+        if projected != cohort {
+            let only_projection: Vec<_> = projected.difference(&cohort).collect();
+            let only_live: Vec<_> = cohort.difference(&projected).collect();
+            tracing::warn!(
+                marker = "unified_projection_divergence",
+                plane = "membership-enum",
+                namespace_id = ?namespace_id,
+                ?only_projection,
+                ?only_live,
+                "query-enum: projection migration cohort differs from live"
+            );
         }
-    }
-    if projected != cohort {
-        let only_projection: Vec<_> = projected.difference(&cohort).collect();
-        let only_live: Vec<_> = cohort.difference(&projected).collect();
-        tracing::warn!(
-            marker = "unified_projection_divergence",
-            plane = "membership-enum",
-            namespace_id = ?namespace_id,
-            ?only_projection,
-            ?only_live,
-            "query-enum: projection migration cohort differs from live"
-        );
     }
 
     Ok(cohort.into_iter().collect())

--- a/crates/context/src/handlers/list_group_members.rs
+++ b/crates/context/src/handlers/list_group_members.rs
@@ -24,7 +24,11 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
             let Some((node_identity, _)) = self.node_namespace_identity(&group_id) else {
                 bail!("node has no group identity configured");
             };
-            if !MembershipRepository::new(&self.datastore).is_member(&group_id, &node_identity)? {
+            if !crate::scope_projection::ScopeProjections::member_now_checked(
+                &self.datastore,
+                &group_id,
+                &node_identity,
+            )? {
                 bail!("node is not a member of group '{group_id:?}'");
             }
 
@@ -52,6 +56,16 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
                 MembershipRepository::new(&self.datastore).list(&group_id, 0, usize::MAX)?;
             members
                 .extend(MembershipRepository::new(&self.datastore).enumerate_inherited(&group_id)?);
+
+            // SHADOW: validate the projection's effective-member set against this
+            // live union (logs `membership-enum` divergence; still returns live).
+            let live_ids: std::collections::BTreeSet<_> =
+                members.iter().map(|(pk, _)| *pk).collect();
+            crate::scope_projection::ScopeProjections::shadow_check_member_enum(
+                &self.datastore,
+                &group_id,
+                &live_ids,
+            );
 
             let entries = members
                 .into_iter()

--- a/crates/context/src/handlers/list_group_members.rs
+++ b/crates/context/src/handlers/list_group_members.rs
@@ -24,11 +24,22 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
             let Some((node_identity, _)) = self.node_namespace_identity(&group_id) else {
                 bail!("node has no group identity configured");
             };
-            if !crate::scope_projection::ScopeProjections::member_now_checked(
+            // Fold the ephemeral projection ONCE for this request: the gate below
+            // and the enum shadow further down both read from it (one RocksDB DAG
+            // walk, not two). `None` (store fault) falls back to live for the gate
+            // and skips the shadow.
+            let proj_ctx = crate::scope_projection::ScopeProjections::ephemeral_projection(
                 &self.datastore,
                 &group_id,
-                &node_identity,
-            )? {
+            );
+            let is_member = match &proj_ctx {
+                Some((proj, _ns, heads)) => {
+                    proj.member_now_checked_with(&self.datastore, &group_id, &node_identity, heads)?
+                }
+                None => MembershipRepository::new(&self.datastore)
+                    .is_member(&group_id, &node_identity)?,
+            };
+            if !is_member {
                 bail!("node is not a member of group '{group_id:?}'");
             }
 
@@ -59,13 +70,12 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
 
             // SHADOW: validate the projection's effective-member set against this
             // live union (logs `membership-enum` divergence; still returns live).
-            let live_ids: std::collections::BTreeSet<_> =
-                members.iter().map(|(pk, _)| *pk).collect();
-            crate::scope_projection::ScopeProjections::shadow_check_member_enum(
-                &self.datastore,
-                &group_id,
-                &live_ids,
-            );
+            // Reuses the single fold built above for the gate.
+            if let Some((proj, ns, heads)) = &proj_ctx {
+                let live_ids: std::collections::BTreeSet<_> =
+                    members.iter().map(|(pk, _)| *pk).collect();
+                proj.shadow_member_enum_with(&self.datastore, *ns, &group_id, heads, &live_ids);
+            }
 
             let entries = members
                 .into_iter()

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -583,6 +583,103 @@ impl ScopeProjections {
         Some(out)
     }
 
+    /// Build the shared ephemeral projection for `group`'s namespace ONCE — the
+    /// expensive part (`collect_namespace_ops` RocksDB DAG walk + fold) plus the
+    /// current heads. A handler that needs BOTH the membership gate and the enum
+    /// shadow folds once via this and reuses the result for
+    /// [`member_now_checked_with`](Self::member_now_checked_with) and
+    /// [`shadow_member_enum_with`](Self::shadow_member_enum_with), instead of two
+    /// independent folds. `None` (with a warn) on a store fault — the caller falls
+    /// back to live.
+    #[must_use]
+    pub fn ephemeral_projection(
+        store: &Store,
+        group: &ContextGroupId,
+    ) -> Option<(Self, [u8; 32], Vec<[u8; 32]>)> {
+        let namespace_id = NamespaceRepository::new(store)
+            .resolve(group)
+            .ok()?
+            .to_bytes();
+        let mut proj = Self::new();
+        let Some(ops) = Self::collect_namespace_ops(store, namespace_id) else {
+            tracing::warn!(
+                namespace = ?namespace_id,
+                "ephemeral_projection: governance head unreadable; caller falls back to live"
+            );
+            return None;
+        };
+        proj.apply_backfill(namespace_id, ops);
+        // Heads read AFTER the fold (see `member_now_ephemeral`).
+        let heads = NamespaceDagService::new(store, namespace_id)
+            .read_head_record()
+            .ok()?
+            .parent_hashes;
+        Some((proj, namespace_id, heads))
+    }
+
+    /// The gate verdict over an ALREADY-built ephemeral projection — same contract
+    /// as [`member_now_checked`](Self::member_now_checked) (act on the projection,
+    /// best-effort live cross-check + `membership-query` marker, live on `None`),
+    /// but reusing a shared fold.
+    pub fn member_now_checked_with(
+        &self,
+        store: &Store,
+        group: &ContextGroupId,
+        member: &PublicKey,
+        heads: &[[u8; 32]],
+    ) -> eyre::Result<bool> {
+        if let Some(p) = self.member_at_cut(store, *group, member, heads) {
+            match MembershipRepository::new(store).is_member(group, member) {
+                Ok(live) if live != p => tracing::warn!(
+                    marker = "unified_projection_divergence",
+                    plane = "membership-query",
+                    group_id = ?group,
+                    ?member,
+                    projection = p,
+                    live,
+                    "query-gate: projection disagrees with live membership"
+                ),
+                Ok(_) => {}
+                Err(err) => tracing::warn!(
+                    group_id = ?group,
+                    %err,
+                    "query-gate: live cross-check failed; acting on projection verdict"
+                ),
+            }
+            return Ok(p);
+        }
+        MembershipRepository::new(store).is_member(group, member)
+    }
+
+    /// The enum shadow over an ALREADY-built ephemeral projection — same contract
+    /// as [`shadow_check_member_enum`](Self::shadow_check_member_enum) but reusing a
+    /// shared fold.
+    pub fn shadow_member_enum_with(
+        &self,
+        store: &Store,
+        namespace_id: [u8; 32],
+        group: &ContextGroupId,
+        heads: &[[u8; 32]],
+        live_identities: &std::collections::BTreeSet<PublicKey>,
+    ) {
+        let Some(view) = self.acl_view_at(&ScopeId::from(namespace_id), heads) else {
+            return;
+        };
+        let projected = Self::member_identities_in_view(&view, store, namespace_id, group);
+        if &projected != live_identities {
+            let only_projection: Vec<_> = projected.difference(live_identities).collect();
+            let only_live: Vec<_> = live_identities.difference(&projected).collect();
+            tracing::warn!(
+                marker = "unified_projection_divergence",
+                plane = "membership-enum",
+                group_id = ?group,
+                ?only_projection,
+                ?only_live,
+                "query-enum: projection effective-member set differs from live"
+            );
+        }
+    }
+
     /// Build a fresh ephemeral projection of `namespace_id`'s governance DAG and
     /// return its at-cut [`AclView`] at the namespace's current heads. `None` (with
     /// a warn) when the governance head is unreadable — a store fault that the

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -403,27 +403,6 @@ impl ScopeProjections {
         cut_incomplete.then_some(namespace_id)
     }
 
-    /// Walk a namespace's **persisted** governance DAG from its heads and return
-    /// the [`Op`]s to ingest — the backfill's expensive half, deliberately an
-    /// associated fn taking no `&self` so it can run **outside** the projection
-    /// lock (the apply path shares that lock; holding it across a RocksDB DAG
-    /// walk would stall the actor's ingest). Pair with [`apply_backfill`].
-    ///
-    /// Replays the authoritative persisted op-log rather than persisting a
-    /// parallel copy (which could diverge), re-deriving each op's delta
-    /// coordinates (`signed_namespace_op_to_delta`) so the ingested ops carry the
-    /// same ids/parents as the live feed (see [`op_from_namespace_op`]). EVERY
-    /// op becomes a node (membership ops with their payload, the rest as `Noop`)
-    /// so the ancestry stays unbroken; encrypted `NamespaceOp::Group` ops are
-    /// decrypted best-effort (this node holds the key for groups it belongs to),
-    /// folding membership when decryptable and a `Noop` node otherwise.
-    ///
-    /// `None` when the governance head itself is unreadable — the signal to leave
-    /// the namespace un-backfilled so a transient store fault retries on the next
-    /// call rather than permanently marking it done. A missing *parent* op is a
-    /// normal partial frontier (collect what's present), not a `None`.
-    ///
-    /// [`apply_backfill`]: Self::apply_backfill
     /// The owning namespace's CURRENT governance heads for `group` — the cut that
     /// represents "now" for a current-state membership read (resolve the group to
     /// its namespace, then read that DAG's head record). `None` if the group can't
@@ -572,21 +551,31 @@ impl ScopeProjections {
             .resolve(group)
             .ok()?
             .to_bytes();
+        let (proj, heads) = Self::ephemeral_fold(store, namespace_id)?;
+        Some((proj, namespace_id, heads))
+    }
+
+    /// The shared fold primitive for both [`ephemeral_projection`](Self::ephemeral_projection)
+    /// and [`ephemeral_view`](Self::ephemeral_view): collect `namespace_id`'s
+    /// persisted governance DAG into a fresh projection and read its current heads
+    /// (AFTER the fold — see `member_now_ephemeral`). `None` (with a warn) on a
+    /// store fault so the caller falls back to live rather than reading an empty
+    /// projection.
+    fn ephemeral_fold(store: &Store, namespace_id: [u8; 32]) -> Option<(Self, Vec<[u8; 32]>)> {
         let mut proj = Self::new();
         let Some(ops) = Self::collect_namespace_ops(store, namespace_id) else {
             tracing::warn!(
                 namespace = ?namespace_id,
-                "ephemeral_projection: governance head unreadable; caller falls back to live"
+                "ephemeral_fold: governance head unreadable; caller falls back to live"
             );
             return None;
         };
         proj.apply_backfill(namespace_id, ops);
-        // Heads read AFTER the fold (see `member_now_ephemeral`).
         let heads = NamespaceDagService::new(store, namespace_id)
             .read_head_record()
             .ok()?
             .parent_hashes;
-        Some((proj, namespace_id, heads))
+        Some((proj, heads))
     }
 
     /// The gate verdict over an ALREADY-built ephemeral projection — same contract
@@ -634,6 +623,8 @@ impl ScopeProjections {
         heads: &[[u8; 32]],
         live_identities: &std::collections::BTreeSet<PublicKey>,
     ) {
+        // `None` only when the scope was never fed (an empty namespace with no
+        // governance ops) — nothing to compare, so skip rather than warn.
         let Some(view) = self.acl_view_at(&ScopeId::from(namespace_id), heads) else {
             return;
         };
@@ -657,21 +648,7 @@ impl ScopeProjections {
     /// a warn) when the governance head is unreadable — a store fault that the
     /// caller surfaces by falling back to live, never silently.
     fn ephemeral_view(store: &Store, namespace_id: [u8; 32]) -> Option<calimero_authz::AclView> {
-        let mut proj = Self::new();
-        let Some(ops) = Self::collect_namespace_ops(store, namespace_id) else {
-            tracing::warn!(
-                namespace = ?namespace_id,
-                "member enumeration: governance head unreadable; shadow falls back to live"
-            );
-            return None;
-        };
-        proj.apply_backfill(namespace_id, ops);
-        // Cut heads read AFTER the fold (same rationale as `member_now_ephemeral`):
-        // the cut never names ops the fold is missing.
-        let heads = NamespaceDagService::new(store, namespace_id)
-            .read_head_record()
-            .ok()?
-            .parent_hashes;
+        let (proj, heads) = Self::ephemeral_fold(store, namespace_id)?;
         proj.acl_view_at(&ScopeId::from(namespace_id), &heads)
     }
 
@@ -691,8 +668,9 @@ impl ScopeProjections {
     /// MATERIALIZED FALLBACK: for a group with NO direct member folded (a Restricted
     /// subgroup whose membership reached this node as materialized `GroupMember`
     /// rows, or whose member ops this node can't decrypt), the fold carries nothing
-    /// — add live's direct rows, exactly as `member_at_cut`'s `role_of` fallback
-    /// does, so the set isn't a spurious subset of live's `list`.
+    /// — defer to live's full `list ∪ enumerate_inherited` for that group, so the
+    /// set is neither a spurious subset (missing materialized direct rows) nor an
+    /// under-count (missing inherited members the unfolded structure can't derive).
     #[must_use]
     pub fn member_identities_in_view(
         view: &calimero_authz::AclView,
@@ -712,6 +690,13 @@ impl ScopeProjections {
             .flatten()
             .unwrap_or(0);
 
+        // Candidate universe — provably COMPLETE w.r.t. `is_member_at_cut`, which
+        // accepts an identity only as: a direct member of `group` or an ancestor
+        // (every group's direct members are in `view.groups.values()`), a folded
+        // group/subgroup admin of `group` or an ancestor (all in
+        // `view.group_admin.values()` — one genesis admin per group, plus Admin-role
+        // holders already counted as direct members), or the genesis root admin
+        // (`root`). So no accepted identity lies outside this set.
         let mut candidates: std::collections::BTreeSet<PublicKey> =
             std::collections::BTreeSet::new();
         for members in view.groups.values() {
@@ -748,23 +733,51 @@ impl ScopeProjections {
             })
             .collect();
 
-        // Materialized fallback for a wholly-unfolded group (mirrors `member_at_cut`).
-        // These rows are live's CURRENT direct members (`list`), which the live apply
-        // path already keeps cascade- and removal-consistent (a namespace leave
-        // removed them here, a deny doesn't touch `list`). So they deliberately
-        // bypass the fold-based cascade/deny filters above — re-filtering them
-        // through this node's INCOMPLETE fold (the reason we're falling back) would
-        // wrongly drop valid members. The set still matches live's `list` for the
-        // direct members; the inherited side is covered by the walk above when the
-        // subgroup edge is folded.
+        // Materialized fallback for a wholly-unfolded group (no direct member folded
+        // — a Restricted subgroup whose membership reached this node as materialized
+        // rows, or whose member ops it can't decrypt). The fold has NO opinion for
+        // such a group, so defer entirely to live's `list ∪ enumerate_inherited`
+        // rather than the (empty/partial) folded candidate set. These live rows are
+        // already cascade- and removal-consistent; re-filtering them through this
+        // node's INCOMPLETE fold (the reason we're falling back) would wrongly drop
+        // valid members, so they bypass the fold-based filters above by design.
         if !view.groups.contains_key(group) {
-            if let Ok(rows) = MembershipRepository::new(store).list(group, 0, usize::MAX) {
+            let live = MembershipRepository::new(store);
+            // Defer fully to live for an unfolded group: add BOTH its materialized
+            // direct rows (`list`) AND its inherited members (`enumerate_inherited`).
+            // The fold has no opinion here, so anything less would under-include the
+            // inherited side the unfolded structure can't derive.
+            if let Ok(rows) = live.list(group, 0, usize::MAX) {
                 result.extend(rows.into_iter().map(|(pk, _)| pk));
+            }
+            if let Ok(inherited) = live.enumerate_inherited(group) {
+                result.extend(inherited.into_iter().map(|(pk, _)| pk));
             }
         }
         result
     }
 
+    /// Walk a namespace's **persisted** governance DAG from its heads and return
+    /// the [`Op`]s to ingest — the backfill's expensive half, deliberately an
+    /// associated fn taking no `&self` so it can run **outside** the projection
+    /// lock (the apply path shares that lock; holding it across a RocksDB DAG
+    /// walk would stall the actor's ingest). Pair with [`apply_backfill`].
+    ///
+    /// Replays the authoritative persisted op-log rather than persisting a
+    /// parallel copy (which could diverge), re-deriving each op's delta
+    /// coordinates (`signed_namespace_op_to_delta`) so the ingested ops carry the
+    /// same ids/parents as the live feed (see [`op_from_namespace_op`]). EVERY
+    /// op becomes a node (membership ops with their payload, the rest as `Noop`)
+    /// so the ancestry stays unbroken; encrypted `NamespaceOp::Group` ops are
+    /// decrypted best-effort (this node holds the key for groups it belongs to),
+    /// folding membership when decryptable and a `Noop` node otherwise.
+    ///
+    /// `None` when the governance head itself is unreadable — the signal to leave
+    /// the namespace un-backfilled so a transient store fault retries on the next
+    /// call rather than permanently marking it done. A missing *parent* op is a
+    /// normal partial frontier (collect what's present), not a `None`.
+    ///
+    /// [`apply_backfill`]: Self::apply_backfill
     #[must_use]
     pub fn collect_namespace_ops(store: &Store, namespace_id: [u8; 32]) -> Option<Vec<Op>> {
         let dag = NamespaceDagService::new(store, namespace_id);

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -525,38 +525,10 @@ impl ScopeProjections {
         MembershipRepository::new(store).is_member(group, member)
     }
 
-    /// The set of identities the projection considers EFFECTIVE members of `group`
-    /// right now — direct plus inherited (open-subgroup parent walk) — built from a
-    /// fresh ephemeral projection. The mirror of live's `list ∪ enumerate_inherited`
-    /// for the membership-enumeration query endpoints. `None` when the
-    /// namespace/heads/view can't be resolved.
-    ///
-    /// Folds once, then defers to [`member_identities_in_view`](Self::member_identities_in_view)
-    /// for the candidate filtering. For enumerating MULTIPLE groups of one namespace
-    /// (a migration cohort), prefer [`member_identities_subtree_ephemeral`](Self::member_identities_subtree_ephemeral),
-    /// which folds once and reads ONE cut for the whole subtree.
-    #[must_use]
-    pub fn member_identities_now_ephemeral(
-        store: &Store,
-        group: &ContextGroupId,
-    ) -> Option<std::collections::BTreeSet<PublicKey>> {
-        let namespace_id = NamespaceRepository::new(store)
-            .resolve(group)
-            .ok()?
-            .to_bytes();
-        let view = Self::ephemeral_view(store, namespace_id)?;
-        Some(Self::member_identities_in_view(
-            &view,
-            store,
-            namespace_id,
-            group,
-        ))
-    }
-
-    /// Union of [`member_identities_now_ephemeral`](Self::member_identities_now_ephemeral)
-    /// across `groups`, but folding the namespace projection ONCE and reading ONE
-    /// cut — so every group is evaluated at the SAME governance position. The
-    /// per-group ephemeral path would re-fold and re-read heads for each group,
+    /// The effective member-identity union across `groups`, folding the namespace
+    /// projection ONCE and reading ONE cut — so every group is evaluated at the
+    /// SAME governance position. A per-group rebuild would re-fold and re-read heads
+    /// for each group,
     /// which both multiplies the cost by the subtree size and (under concurrent
     /// governance) evaluates groups at DIFFERENT cuts, producing a synthetic
     /// cohort mismatch. `groups` must all resolve to `namespace_root`'s namespace.
@@ -757,6 +729,10 @@ impl ScopeProjections {
             // Namespace-leave cascade: every (sub)group member must also be a
             // namespace-ROOT member (live has no subgroup member who isn't one; the
             // folded single `MemberLeft` doesn't carry the descendant-row cascade).
+            // For `group == root_group` this filter is a no-op on purpose — the
+            // FIRST filter above (`is_member_at_cut(*group, …)` with `*group ==
+            // root_group`) already decides root membership directly, and the root's
+            // `MemberLeft` IS folded, so there's no un-cascaded stale row to drop.
             .filter(|c| {
                 *group == root_group
                     || view.is_member_at_cut(root_group, c, root, default_cap_base)
@@ -773,43 +749,20 @@ impl ScopeProjections {
             .collect();
 
         // Materialized fallback for a wholly-unfolded group (mirrors `member_at_cut`).
+        // These rows are live's CURRENT direct members (`list`), which the live apply
+        // path already keeps cascade- and removal-consistent (a namespace leave
+        // removed them here, a deny doesn't touch `list`). So they deliberately
+        // bypass the fold-based cascade/deny filters above — re-filtering them
+        // through this node's INCOMPLETE fold (the reason we're falling back) would
+        // wrongly drop valid members. The set still matches live's `list` for the
+        // direct members; the inherited side is covered by the walk above when the
+        // subgroup edge is folded.
         if !view.groups.contains_key(group) {
             if let Ok(rows) = MembershipRepository::new(store).list(group, 0, usize::MAX) {
                 result.extend(rows.into_iter().map(|(pk, _)| pk));
             }
         }
         result
-    }
-
-    /// SHADOW cross-check for the membership-enumeration endpoints: compare the
-    /// projection's effective member-identity set against the `live_identities` the
-    /// caller already built, logging the hard-gated `unified_projection_divergence`
-    /// (plane `membership-enum`) on any set difference. Read-only — the caller still
-    /// returns the live list; this validates equivalence (now including the deny
-    /// asymmetry) ahead of the F5 flip to acting on the projection set.
-    pub fn shadow_check_member_enum(
-        store: &Store,
-        group: &ContextGroupId,
-        live_identities: &std::collections::BTreeSet<PublicKey>,
-    ) {
-        let Some(projected) = Self::member_identities_now_ephemeral(store, group) else {
-            return;
-        };
-        if &projected != live_identities {
-            let only_projection: Vec<_> = projected.difference(live_identities).collect();
-            let only_live: Vec<_> = live_identities.difference(&projected).collect();
-            // Hard-gated: the projection enumeration now mirrors live's deny
-            // asymmetry, so any residual set difference is a real divergence the
-            // cutover gate must catch (same marker the boolean gates use).
-            tracing::warn!(
-                marker = "unified_projection_divergence",
-                plane = "membership-enum",
-                group_id = ?group,
-                ?only_projection,
-                ?only_live,
-                "query-enum: projection effective-member set differs from live"
-            );
-        }
     }
 
     #[must_use]

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -21,8 +21,8 @@ use std::collections::{HashMap, HashSet};
 use calimero_context_client::client::ContextClient;
 use calimero_context_config::types::ContextGroupId;
 use calimero_governance_store::{
-    CapabilitiesRepository, MembershipRepository, MetaRepository, NamespaceDagService,
-    NamespaceOpLogService, NamespaceRepository,
+    CapabilitiesRepository, DenyListRepository, MembershipRepository, MetaRepository,
+    NamespaceDagService, NamespaceOpLogService, NamespaceRepository,
 };
 use calimero_governance_types::{GroupOp, NamespaceOp, RootOp, SignedNamespaceOp};
 use calimero_op::{Op, OpPayload, ScopeId};
@@ -523,6 +523,131 @@ impl ScopeProjections {
         // Projection couldn't decide (cold/partial fold or store fault) — live is
         // authoritative here, so its error legitimately propagates.
         MembershipRepository::new(store).is_member(group, member)
+    }
+
+    /// The set of identities the projection considers EFFECTIVE members of `group`
+    /// right now — direct plus inherited (open-subgroup parent walk) — built from a
+    /// fresh ephemeral projection. The mirror of live's `list ∪ enumerate_inherited`
+    /// for the membership-enumeration query endpoints. `None` when the
+    /// namespace/heads/view can't be resolved.
+    ///
+    /// One fold, then every candidate identity is filtered through the same at-cut
+    /// inheritance walk the boolean reads use, so the set is consistent with
+    /// [`member_now_ephemeral`](Self::member_now_ephemeral). The candidate universe
+    /// is every direct member of any group in the view plus the group/root admins —
+    /// a superset the walk narrows to `group`'s actual members.
+    ///
+    /// Mirrors live's enumeration DENY ASYMMETRY: a member who left/was-kicked from
+    /// an open subgroup but is still a namespace member stays `is_member`-true (an
+    /// `Inherited` path) yet is EXCLUDED from enumeration until they re-join. The
+    /// final filter drops such denied INHERITED candidates (direct members are never
+    /// deny-filtered), so the set matches live's `list ∪ enumerate_inherited`.
+    #[must_use]
+    pub fn member_identities_now_ephemeral(
+        store: &Store,
+        group: &ContextGroupId,
+    ) -> Option<std::collections::BTreeSet<PublicKey>> {
+        let namespace_id = NamespaceRepository::new(store)
+            .resolve(group)
+            .ok()?
+            .to_bytes();
+        let mut proj = Self::new();
+        let ops = Self::collect_namespace_ops(store, namespace_id)?;
+        proj.apply_backfill(namespace_id, ops);
+        // Cut heads read AFTER the fold (same rationale as `member_now_ephemeral`):
+        // the cut never names ops the fold is missing.
+        let heads = NamespaceDagService::new(store, namespace_id)
+            .read_head_record()
+            .ok()?
+            .parent_hashes;
+        let scope = ScopeId::from(namespace_id);
+        let view = proj.acl_view_at(&scope, &heads)?;
+
+        let root_group = ContextGroupId::from(namespace_id);
+        let root = MetaRepository::new(store)
+            .load(&root_group)
+            .ok()
+            .flatten()
+            .map(|meta| (root_group, meta.admin_identity));
+        let default_cap_base = CapabilitiesRepository::new(store)
+            .default_capabilities(&root_group)
+            .ok()
+            .flatten()
+            .unwrap_or(0);
+
+        let mut candidates: std::collections::BTreeSet<PublicKey> =
+            std::collections::BTreeSet::new();
+        for members in view.groups.values() {
+            candidates.extend(members.keys().copied());
+        }
+        candidates.extend(view.group_admin.values().copied());
+        if let Some((_, admin)) = root {
+            let _ = candidates.insert(admin);
+        }
+        // Mirror live's enumeration deny ASYMMETRY: `is_member`/`check_path` keeps a
+        // denied member (a still-`Inherited` path), but `enumerate_inherited`
+        // EXCLUDES a denied INHERITED member — a node that left/was-kicked from an
+        // open subgroup yet remains a namespace member. Direct members are never
+        // deny-filtered (live's `list` doesn't consult the deny-list). The deny-list
+        // is independent persisted state (not the membership resolver F5 deletes),
+        // read here as a current-state base fact exactly like the root admin/caps.
+        let deny = DenyListRepository::new(store);
+        Some(
+            candidates
+                .into_iter()
+                .filter(|c| view.is_member_at_cut(*group, c, root, default_cap_base))
+                .filter(|c| {
+                    // Every (sub)group member must also be a member of the owning
+                    // namespace ROOT. `leave_namespace` publishes ONE `MemberLeft` on
+                    // the root whose LOCAL apply cascade-removes the leaver's direct
+                    // rows across every descendant subgroup; the projection folds only
+                    // that single op's namespace-level removal, not the cascade, so a
+                    // stale direct subgroup row survives the fold. Requiring root
+                    // membership drops it (live has no subgroup member who isn't a
+                    // namespace member — a join always goes through the namespace).
+                    *group == root_group
+                        || view.is_member_at_cut(root_group, c, root, default_cap_base)
+                })
+                .filter(|c| {
+                    let is_direct = view
+                        .groups
+                        .get(group)
+                        .is_some_and(|members| members.contains_key(c));
+                    is_direct || !deny.is_denied(group, c).unwrap_or(false)
+                })
+                .collect(),
+        )
+    }
+
+    /// SHADOW cross-check for the membership-enumeration endpoints: compare the
+    /// projection's effective member-identity set against the `live_identities` the
+    /// caller already built, logging the hard-gated `unified_projection_divergence`
+    /// (plane `membership-enum`) on any set difference. Read-only — the caller still
+    /// returns the live list; this validates equivalence (now including the deny
+    /// asymmetry) ahead of the F5 flip to acting on the projection set.
+    pub fn shadow_check_member_enum(
+        store: &Store,
+        group: &ContextGroupId,
+        live_identities: &std::collections::BTreeSet<PublicKey>,
+    ) {
+        let Some(projected) = Self::member_identities_now_ephemeral(store, group) else {
+            return;
+        };
+        if &projected != live_identities {
+            let only_projection: Vec<_> = projected.difference(live_identities).collect();
+            let only_live: Vec<_> = live_identities.difference(&projected).collect();
+            // Hard-gated: the projection enumeration now mirrors live's deny
+            // asymmetry, so any residual set difference is a real divergence the
+            // cutover gate must catch (same marker the boolean gates use).
+            tracing::warn!(
+                marker = "unified_projection_divergence",
+                plane = "membership-enum",
+                group_id = ?group,
+                ?only_projection,
+                ?only_live,
+                "query-enum: projection effective-member set differs from live"
+            );
+        }
     }
 
     #[must_use]

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -531,17 +531,10 @@ impl ScopeProjections {
     /// for the membership-enumeration query endpoints. `None` when the
     /// namespace/heads/view can't be resolved.
     ///
-    /// One fold, then every candidate identity is filtered through the same at-cut
-    /// inheritance walk the boolean reads use, so the set is consistent with
-    /// [`member_now_ephemeral`](Self::member_now_ephemeral). The candidate universe
-    /// is every direct member of any group in the view plus the group/root admins —
-    /// a superset the walk narrows to `group`'s actual members.
-    ///
-    /// Mirrors live's enumeration DENY ASYMMETRY: a member who left/was-kicked from
-    /// an open subgroup but is still a namespace member stays `is_member`-true (an
-    /// `Inherited` path) yet is EXCLUDED from enumeration until they re-join. The
-    /// final filter drops such denied INHERITED candidates (direct members are never
-    /// deny-filtered), so the set matches live's `list ∪ enumerate_inherited`.
+    /// Folds once, then defers to [`member_identities_in_view`](Self::member_identities_in_view)
+    /// for the candidate filtering. For enumerating MULTIPLE groups of one namespace
+    /// (a migration cohort), prefer [`member_identities_subtree_ephemeral`](Self::member_identities_subtree_ephemeral),
+    /// which folds once and reads ONE cut for the whole subtree.
     #[must_use]
     pub fn member_identities_now_ephemeral(
         store: &Store,
@@ -551,8 +544,58 @@ impl ScopeProjections {
             .resolve(group)
             .ok()?
             .to_bytes();
+        let view = Self::ephemeral_view(store, namespace_id)?;
+        Some(Self::member_identities_in_view(
+            &view,
+            store,
+            namespace_id,
+            group,
+        ))
+    }
+
+    /// Union of [`member_identities_now_ephemeral`](Self::member_identities_now_ephemeral)
+    /// across `groups`, but folding the namespace projection ONCE and reading ONE
+    /// cut — so every group is evaluated at the SAME governance position. The
+    /// per-group ephemeral path would re-fold and re-read heads for each group,
+    /// which both multiplies the cost by the subtree size and (under concurrent
+    /// governance) evaluates groups at DIFFERENT cuts, producing a synthetic
+    /// cohort mismatch. `groups` must all resolve to `namespace_root`'s namespace.
+    #[must_use]
+    pub fn member_identities_subtree_ephemeral(
+        store: &Store,
+        namespace_root: &ContextGroupId,
+        groups: &[ContextGroupId],
+    ) -> Option<std::collections::BTreeSet<PublicKey>> {
+        let namespace_id = NamespaceRepository::new(store)
+            .resolve(namespace_root)
+            .ok()?
+            .to_bytes();
+        let view = Self::ephemeral_view(store, namespace_id)?;
+        let mut out = std::collections::BTreeSet::new();
+        for group in groups {
+            out.extend(Self::member_identities_in_view(
+                &view,
+                store,
+                namespace_id,
+                group,
+            ));
+        }
+        Some(out)
+    }
+
+    /// Build a fresh ephemeral projection of `namespace_id`'s governance DAG and
+    /// return its at-cut [`AclView`] at the namespace's current heads. `None` (with
+    /// a warn) when the governance head is unreadable — a store fault that the
+    /// caller surfaces by falling back to live, never silently.
+    fn ephemeral_view(store: &Store, namespace_id: [u8; 32]) -> Option<calimero_authz::AclView> {
         let mut proj = Self::new();
-        let ops = Self::collect_namespace_ops(store, namespace_id)?;
+        let Some(ops) = Self::collect_namespace_ops(store, namespace_id) else {
+            tracing::warn!(
+                namespace = ?namespace_id,
+                "member enumeration: governance head unreadable; shadow falls back to live"
+            );
+            return None;
+        };
         proj.apply_backfill(namespace_id, ops);
         // Cut heads read AFTER the fold (same rationale as `member_now_ephemeral`):
         // the cut never names ops the fold is missing.
@@ -560,9 +603,34 @@ impl ScopeProjections {
             .read_head_record()
             .ok()?
             .parent_hashes;
-        let scope = ScopeId::from(namespace_id);
-        let view = proj.acl_view_at(&scope, &heads)?;
+        proj.acl_view_at(&ScopeId::from(namespace_id), &heads)
+    }
 
+    /// The effective member-identity set of `group` from an already-folded `view`
+    /// of its namespace. Candidate universe = every direct member of any group in
+    /// the view plus the group/root admins (a superset the walk narrows). Mirrors
+    /// three live behaviours:
+    /// * the at-cut inheritance walk (`is_member_at_cut`), so the set is consistent
+    ///   with the boolean reads;
+    /// * the enumeration DENY ASYMMETRY — `is_member`/`check_path` keeps a denied
+    ///   member (still an `Inherited` path) but `enumerate_inherited` EXCLUDES a
+    ///   denied INHERITED member (direct members are never deny-filtered);
+    /// * the namespace-leave CASCADE — a subgroup member must also be a namespace
+    ///   ROOT member (the single `MemberLeft` op the projection folds doesn't carry
+    ///   the local cascade that removes descendant rows).
+    ///
+    /// MATERIALIZED FALLBACK: for a group with NO direct member folded (a Restricted
+    /// subgroup whose membership reached this node as materialized `GroupMember`
+    /// rows, or whose member ops this node can't decrypt), the fold carries nothing
+    /// — add live's direct rows, exactly as `member_at_cut`'s `role_of` fallback
+    /// does, so the set isn't a spurious subset of live's `list`.
+    #[must_use]
+    pub fn member_identities_in_view(
+        view: &calimero_authz::AclView,
+        store: &Store,
+        namespace_id: [u8; 32],
+        group: &ContextGroupId,
+    ) -> std::collections::BTreeSet<PublicKey> {
         let root_group = ContextGroupId::from(namespace_id);
         let root = MetaRepository::new(store)
             .load(&root_group)
@@ -584,39 +652,36 @@ impl ScopeProjections {
         if let Some((_, admin)) = root {
             let _ = candidates.insert(admin);
         }
-        // Mirror live's enumeration deny ASYMMETRY: `is_member`/`check_path` keeps a
-        // denied member (a still-`Inherited` path), but `enumerate_inherited`
-        // EXCLUDES a denied INHERITED member — a node that left/was-kicked from an
-        // open subgroup yet remains a namespace member. Direct members are never
-        // deny-filtered (live's `list` doesn't consult the deny-list). The deny-list
-        // is independent persisted state (not the membership resolver F5 deletes),
-        // read here as a current-state base fact exactly like the root admin/caps.
+
         let deny = DenyListRepository::new(store);
-        Some(
-            candidates
-                .into_iter()
-                .filter(|c| view.is_member_at_cut(*group, c, root, default_cap_base))
-                .filter(|c| {
-                    // Every (sub)group member must also be a member of the owning
-                    // namespace ROOT. `leave_namespace` publishes ONE `MemberLeft` on
-                    // the root whose LOCAL apply cascade-removes the leaver's direct
-                    // rows across every descendant subgroup; the projection folds only
-                    // that single op's namespace-level removal, not the cascade, so a
-                    // stale direct subgroup row survives the fold. Requiring root
-                    // membership drops it (live has no subgroup member who isn't a
-                    // namespace member — a join always goes through the namespace).
-                    *group == root_group
-                        || view.is_member_at_cut(root_group, c, root, default_cap_base)
-                })
-                .filter(|c| {
-                    let is_direct = view
-                        .groups
-                        .get(group)
-                        .is_some_and(|members| members.contains_key(c));
-                    is_direct || !deny.is_denied(group, c).unwrap_or(false)
-                })
-                .collect(),
-        )
+        let mut result: std::collections::BTreeSet<PublicKey> = candidates
+            .into_iter()
+            .filter(|c| view.is_member_at_cut(*group, c, root, default_cap_base))
+            // Namespace-leave cascade: every (sub)group member must also be a
+            // namespace-ROOT member (live has no subgroup member who isn't one; the
+            // folded single `MemberLeft` doesn't carry the descendant-row cascade).
+            .filter(|c| {
+                *group == root_group
+                    || view.is_member_at_cut(root_group, c, root, default_cap_base)
+            })
+            // Deny asymmetry: drop a denied INHERITED member; never deny-filter a
+            // direct member (live's `list` doesn't consult the deny-list).
+            .filter(|c| {
+                let is_direct = view
+                    .groups
+                    .get(group)
+                    .is_some_and(|members| members.contains_key(c));
+                is_direct || !deny.is_denied(group, c).unwrap_or(false)
+            })
+            .collect();
+
+        // Materialized fallback for a wholly-unfolded group (mirrors `member_at_cut`).
+        if !view.groups.contains_key(group) {
+            if let Ok(rows) = MembershipRepository::new(store).list(group, 0, usize::MAX) {
+                result.extend(rows.into_iter().map(|(pk, _)| pk));
+            }
+        }
+        result
     }
 
     /// SHADOW cross-check for the membership-enumeration endpoints: compare the


### PR DESCRIPTION
## What

Second half of the query-API migration (F5, core#2716), stacked on #2841. Cross-checks the three membership-**enumeration** endpoints against the projection's effective-member set:
- `list_group_members` (full member list)
- `get_group_info` (member count)
- `get_migration_status` (subtree cohort)

## How — shadow, not flip

Enumeration is intricate (open-subgroup parent walk, deny-list, via-admin roles), so this lands as a **SHADOW**: each handler still **returns the live result**, but logs `unified_projection_divergence` (plane `membership-enum`, caught by the e2e gate) on any set/count difference vs the live `list ∪ enumerate_inherited` it already computes. That validates the projection enumeration on real traffic before any flip — risk-free for clients.

Adds:
- `ScopeProjections::member_identities_now_ephemeral` — one fold of a fresh ephemeral projection, then the candidate universe (every direct member of any group in the view + group/root admins) filtered through the same at-cut inheritance walk the boolean reads use.
- `ScopeProjections::shadow_check_member_enum` — the set-comparison + divergence log.

Also migrates `list_group_members`' and `get_group_info`'s boolean `is_member` gates to `member_now_checked`, matching the #2841 gate handlers.

## Test

- `cargo build`/`clippy --all-targets`/`fmt` clean; equivalence harness 3/3 green.
- e2e `membership-enum` gate validates the enumeration on real traffic. If divergence surfaces (deny-list / via-admin role edge cases), it's caught here as a shadow — clients are unaffected — and is the signal to refine before the flip.

Stacked on #2841 (#25 query gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Read-path changes add extra governance DAG folds and alter membership gates when projection succeeds; API responses stay live-only, but wrong projection logic could affect access until fallback or could spam divergence noise in production.
> 
> **Overview**
> Adds **shadow** cross-checks for membership **enumeration** on `list_group_members`, `get_group_info`, and migration cohort building in `get_migration_status`. Handlers still return live `list ∪ enumerate_inherited` results; mismatches against the folded governance projection only emit `unified_projection_divergence` with plane `membership-enum`.
> 
> **`scope_projection`:** New helpers fold each namespace’s governance DAG once per request (`ephemeral_projection` / `ephemeral_fold`) and derive effective member identity sets via `member_identities_in_view` (at-cut inheritance, deny-list asymmetry, namespace-leave cascade, materialized fallback for unfolded groups). `member_now_checked_with` and `shadow_member_enum_with` reuse that fold for gates and set comparison. `member_identities_subtree_ephemeral` evaluates an entire subtree at a **single** cut for migration cohort shadowing.
> 
> **Handlers:** `list_group_members` and `get_group_info` switch the `is_member` gate to the projection path when the fold succeeds; `get_group_info` also dedupes inherited enumeration for count vs shadow. `collect_migration_cohort` compares the live subtree union to the projection cohort without changing the returned cohort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5196a6130a7741935db0316e4050aeb1e89b1d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->