### PR TITLE
fix(namespaces): admit root TEE into Restricted subgroups created via REST (mint keys before GroupCreated)

### DIFF
--- a/crates/context/src/tee_subgroup_admit.rs
+++ b/crates/context/src/tee_subgroup_admit.rs
@@ -239,12 +239,21 @@ async fn handle_new_subgroup(
     // a row, so `is_open_chain_to_namespace` fails safe (treats a not-yet-written
     // subgroup as Restricted → we proceed) rather than wrongly skipping it.
 
+    info!(
+        subgroup = %hex::encode(child_group_id),
+        namespace = %hex::encode(namespace_id),
+        "tee-subgroup-admit: new-subgroup trigger received"
+    );
+
     // Only act for Restricted subgroups — Open subgroups are already readable
     // by a root-admitted TEE node (inherited membership + namespace key).
     match CapabilitiesRepository::new(store).is_open_chain_to_namespace(&child_gid, &namespace_gid)
     {
-        Ok(true) => return, // Open → skip
-        Ok(false) => {}     // Restricted → proceed
+        Ok(true) => {
+            info!(subgroup = %hex::encode(child_group_id), "tee-subgroup-admit: skip — Open subgroup (TEE reads via inheritance)");
+            return;
+        }
+        Ok(false) => {} // Restricted → proceed
         Err(e) => {
             error!(?e, "tee-subgroup-admit: open-chain check failed");
             return;
@@ -253,8 +262,11 @@ async fn handle_new_subgroup(
 
     // Only the key-holder (the creator) can deliver the per-subgroup key.
     match GroupKeyring::new(store, child_gid).load_current_key() {
-        Ok(Some(_)) => {}   // we hold the key → we can admit + deliver
-        Ok(None) => return, // not the key-holder → leave it to the creator / pull
+        Ok(Some(_)) => {} // we hold the key → we can admit + deliver
+        Ok(None) => {
+            info!(subgroup = %hex::encode(child_group_id), "tee-subgroup-admit: skip — not the subgroup key-holder (leave to creator / key pull)");
+            return;
+        }
         Err(e) => {
             error!(?e, "tee-subgroup-admit: load_current_key failed");
             return;
@@ -275,6 +287,7 @@ async fn handle_new_subgroup(
         .map(|(member, _)| member)
         .collect();
     if tee_members.is_empty() {
+        info!(subgroup = %hex::encode(child_group_id), "tee-subgroup-admit: skip — no root ReadOnlyTee members to admit");
         return; // nothing to admit — skip the op-log scan entirely
     }
 
@@ -290,8 +303,10 @@ async fn handle_new_subgroup(
     };
     for member in tee_members {
         let Some(record) = records.get(&member) else {
+            warn!(subgroup = %hex::encode(child_group_id), %member, "tee-subgroup-admit: skip member — no admission verdict in root op-log");
             continue; // no verdict to reuse (membership row without a join op)
         };
+        info!(subgroup = %hex::encode(child_group_id), %member, "tee-subgroup-admit: admitting root TEE into new Restricted subgroup");
         admit_member_into_subgroup(context_client, store, &child_gid, &member, record).await;
     }
 }

--- a/crates/context/src/tee_subgroup_admit.rs
+++ b/crates/context/src/tee_subgroup_admit.rs
@@ -239,7 +239,7 @@ async fn handle_new_subgroup(
     // a row, so `is_open_chain_to_namespace` fails safe (treats a not-yet-written
     // subgroup as Restricted → we proceed) rather than wrongly skipping it.
 
-    info!(
+    debug!(
         subgroup = %hex::encode(child_group_id),
         namespace = %hex::encode(namespace_id),
         "tee-subgroup-admit: new-subgroup trigger received"
@@ -250,7 +250,7 @@ async fn handle_new_subgroup(
     match CapabilitiesRepository::new(store).is_open_chain_to_namespace(&child_gid, &namespace_gid)
     {
         Ok(true) => {
-            info!(subgroup = %hex::encode(child_group_id), "tee-subgroup-admit: skip — Open subgroup (TEE reads via inheritance)");
+            debug!(subgroup = %hex::encode(child_group_id), "tee-subgroup-admit: skip — Open subgroup (TEE reads via inheritance)");
             return;
         }
         Ok(false) => {} // Restricted → proceed
@@ -264,7 +264,7 @@ async fn handle_new_subgroup(
     match GroupKeyring::new(store, child_gid).load_current_key() {
         Ok(Some(_)) => {} // we hold the key → we can admit + deliver
         Ok(None) => {
-            info!(subgroup = %hex::encode(child_group_id), "tee-subgroup-admit: skip — not the subgroup key-holder (leave to creator / key pull)");
+            debug!(subgroup = %hex::encode(child_group_id), "tee-subgroup-admit: skip — not the subgroup key-holder (leave to creator / key pull)");
             return;
         }
         Err(e) => {
@@ -287,7 +287,7 @@ async fn handle_new_subgroup(
         .map(|(member, _)| member)
         .collect();
     if tee_members.is_empty() {
-        info!(subgroup = %hex::encode(child_group_id), "tee-subgroup-admit: skip — no root ReadOnlyTee members to admit");
+        debug!(subgroup = %hex::encode(child_group_id), "tee-subgroup-admit: skip — no root ReadOnlyTee members to admit");
         return; // nothing to admit — skip the op-log scan entirely
     }
 

--- a/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
@@ -84,6 +84,48 @@ pub async fn handler(
 
     let signer_sk = calimero_primitives::identity::PrivateKey::from(sk_bytes);
 
+    let group_id_cgid = calimero_context_config::types::ContextGroupId::from(group_id);
+
+    // Mint the subgroup's signing key AND group key BEFORE applying the op.
+    //
+    // The apply path drains `OpEvent::SubgroupCreated` *after* it persists the
+    // root op (emit-after-persist, #2770). The `tee_subgroup_admit` subscriber
+    // reacts to that event by reading this subgroup's group key
+    // (`GroupKeyring::load_current_key`) to decide whether it is the key-holder
+    // that should admit the namespace's root TEE members. If the key were minted
+    // only after the apply returns (as it used to be), the subscriber would race
+    // ahead of the write, observe `None`, and wrongly skip — leaving the TEE out
+    // of every Restricted subgroup created via this REST path. Writing both keys
+    // first mirrors the actor handler (crates/context/src/handlers/create_group.rs)
+    // and makes the key visible the instant the event fires. It also means a
+    // failed publish no longer silently skips key creation.
+    if let Err(err) =
+        SigningKeysRepository::new(&state.store).store_key(&group_id_cgid, &signer_pk, &sk_bytes)
+    {
+        error!(
+            group_id=%hex::encode(group_id_cgid.to_bytes()),
+            ?err,
+            "Failed to store admin signing key before group create"
+        );
+        return parse_api_error(eyre::eyre!("failed to store subgroup signing key"))
+            .into_response();
+    }
+    {
+        let group_key: [u8; 32] = {
+            use rand::Rng;
+            rand::thread_rng().gen()
+        };
+        if let Err(err) = GroupKeyring::new(&state.store, group_id_cgid).store_key(&group_key) {
+            error!(
+                group_id=%hex::encode(group_id_cgid.to_bytes()),
+                ?err,
+                "Failed to generate subgroup group key before group create"
+            );
+            return parse_api_error(eyre::eyre!("failed to mint subgroup group key"))
+                .into_response();
+        }
+    }
+
     // Strict-tree refactor: GroupCreated atomically nests the new group under
     // the namespace root in one op. Previous two-op pattern (GroupCreated then
     // GroupNested) is collapsed — orphan state is no longer reachable. See
@@ -107,44 +149,7 @@ pub async fn handler(
     {
         Ok(report) => {
             report.observe("create_group_in_namespace", "GroupCreated");
-            let group_id = calimero_context_config::types::ContextGroupId::from(group_id);
-
-            // Store the creator's signing key for the new subgroup. Without
-            // this, any subsequent group-scoped op that needs to sign a
-            // local governance message (delete_context -> ContextDetached,
-            // add_group_members -> MemberAdded, etc.) fails with
-            // "signing key not found for requester in group '...'".
-            //
-            // The direct create_group handler already stores the signing
-            // key at crates/context/src/handlers/create_group.rs:85-94;
-            // this keeps subgroups created via create_group_in_namespace in
-            // sync with that invariant.
-            if let Err(err) =
-                SigningKeysRepository::new(&state.store).store_key(&group_id, &signer_pk, &sk_bytes)
-            {
-                warn!(
-                    group_id=%hex::encode(group_id.to_bytes()),
-                    ?err,
-                    "Group created but failed to store admin signing key"
-                );
-            }
-
-            // Generate a group key for the subgroup so that encrypted
-            // group-scoped governance ops (MemberAdded, ContextRegistered)
-            // can be published and later decrypted by members.
-            {
-                let group_key: [u8; 32] = {
-                    use rand::Rng;
-                    rand::thread_rng().gen()
-                };
-                if let Err(err) = GroupKeyring::new(&state.store, group_id).store_key(&group_key) {
-                    warn!(
-                        group_id=%hex::encode(group_id.to_bytes()),
-                        ?err,
-                        "Group created but failed to generate group key"
-                    );
-                }
-            }
+            let group_id = group_id_cgid;
 
             if let Some(name) = body.group_name.as_deref() {
                 // Seed the subgroup's initial metadata record stamped with the


### PR DESCRIPTION
## Problem

A namespace's root-admitted `ReadOnlyTee` member was **not** admitted into Restricted subgroups created via the REST path (`POST /admin/.../namespaces/:id/groups`) — the path the desktop/tauri client and mdma drive. New private channels silently shipped without the TEE replica.

## Root cause

`create_group_in_namespace` minted the subgroup's signing key and group key **after** `sign_apply_and_publish_namespace_op` returned. Since emit-after-persist (#2770), that call drains `OpEvent::SubgroupCreated` *once the root op is persisted* — i.e. before this handler reached the key write. The `tee_subgroup_admit` subscriber reacts to that event by reading the new subgroup's group key (`GroupKeyring::load_current_key`) to decide whether it is the key-holder that should admit the namespace's root TEE members. It raced ahead of the write, observed `None`, logged `tee-subgroup-admit: skip — not the subgroup key-holder`, and skipped.

The actor handler (`crates/context/src/handlers/create_group.rs`) mints the key *before* applying, which is why creating/joining a channel from a local node worked while the REST path did not.

## Fix

Mint the subgroup signing key and group key **before** `sign_apply_and_publish_namespace_op`, mirroring the actor handler, so the key is visible the instant `SubgroupCreated` fires. A failed key write now fails the request instead of being a warn-only skip (a second, pre-existing gap on this handler).

Also adds decision logging at each `handle_new_subgroup` early-return so any future "TEE didn't join subgroup X" is self-diagnosing (one `info!` line per skip/admit reason).

## Verification

Reproduced and fixed on a real node (desktop owner + Phala TEE replica). Before: `skip — not the subgroup key-holder`. After:

```
tee-subgroup-admit: new-subgroup trigger received   subgroup=4b360e54… namespace=8d41cc4e…
tee-subgroup-admit: admitting root TEE into new Restricted subgroup   member=F7yj5…
TEE node admitted via attestation   group_id=4b360e54…
published KeyDelivery for admitted TEE node   group_id=4b360e54…
```

Disable-HA cascade subsequently removed the TEE from this subgroup too, confirming the full lifecycle.

## Scope

- No published-surface change (`calimero-server-primitives` / `calimero-tee-attestation` untouched); no mero-tee rev bump needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches namespace subgroup creation and TEE auto-admission timing; behavior change is intentional and aligned with the actor `create_group` handler, with no public API changes.
> 
> **Overview**
> **Fixes root TEE replicas missing from Restricted subgroups** created through the admin REST `create_group_in_namespace` path. The handler now **writes the subgroup signing key and group encryption key before** `sign_apply_and_publish_namespace_op`, so when `SubgroupCreated` fires (post-persist), `tee_subgroup_admit` sees the key-holder and can admit namespace `ReadOnlyTee` members. Previously keys were minted only after publish returned, racing the subscriber and causing a silent skip.
> 
> Key persistence failures on that path are now **request failures** instead of warn-only success responses. **`tee_subgroup_admit`** gains **debug/info/warn** lines at each early-return in `handle_new_subgroup` to make “TEE didn’t join subgroup X” diagnosable from logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 730bce3a6db050065c08cd136ef59f120de3ea9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->