### PR TITLE
feat(context): shadow apply-time governance-op authorization (F5 #28)

### DIFF
--- a/crates/authz/src/lib.rs
+++ b/crates/authz/src/lib.rs
@@ -222,6 +222,49 @@ impl AclView {
         anchor_is_member.unwrap_or(false)
     }
 
+    /// Is `author` authorized as an ADMIN of `group` at the cut — the apply-gate
+    /// admin authority. Mirrors live's `is_authorized_with_capability` admin path:
+    /// a direct group admin (subgroup creator / `Admin`-role holder), the
+    /// namespace ROOT admin (who administers every group — folded, so it tracks
+    /// `AdminChanged`, with the genesis `root` carve-out as the un-folded base), OR
+    /// an admin of an ANCESTOR reached over the open-subgroup chain (an admin of an
+    /// Open parent administers its children). Restricted edges stop the walk.
+    ///
+    /// Admin-only — unlike [`is_member_at_cut`](Self::is_member_at_cut), a plain
+    /// inherited MEMBER is not authorized. Capability holders are checked
+    /// separately by the caller.
+    #[must_use]
+    pub fn is_authorized_admin(
+        &self,
+        group: ContextGroupId,
+        author: &PublicKey,
+        root: Option<(ContextGroupId, PublicKey)>,
+    ) -> bool {
+        let is_admin = |g: ContextGroupId| -> bool {
+            self.is_group_admin(author, g)
+                || self.is_root_admin(author)
+                || root.is_some_and(|(root_g, root_admin)| g == root_g && *author == root_admin)
+        };
+        if is_admin(group) {
+            return true;
+        }
+        let mut current = group;
+        for _ in 0..=MAX_NAMESPACE_DEPTH {
+            let Some(edge) = self.subgroups.get(&ScopeId::from(current.to_bytes())) else {
+                return false;
+            };
+            if edge.restricted {
+                return false;
+            }
+            let parent = ContextGroupId::from(*edge.parent.as_bytes());
+            if is_admin(parent) {
+                return true;
+            }
+            current = parent;
+        }
+        false
+    }
+
     /// `member`'s effective capability bitmask in `group` at the cut: the
     /// explicit per-member override if present, else the group default, else
     /// `0`. Mirrors the live `member_capability` read used by inherited-

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -117,49 +117,6 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                                         &[shadow_op.id],
                                     )
                                 });
-
-                                // APPLY-AUTH shadow (F5 #28, log-only): the op just
-                                // APPLIED, so the LIVE resolver authorized its
-                                // signer. Would the projection authorize the signer
-                                // too — at the op's PARENT cut (state EXCLUDING this
-                                // op, the correct cut to authorize against)?
-                                // `Some(false)` = the projection would REJECT what
-                                // live accepted (under-auth — safe, but a real
-                                // divergence to investigate). `None` = the cited
-                                // ancestry isn't fully folded yet → can't decide,
-                                // skip. The reverse direction (projection accepts
-                                // what live rejected) is unobservable here: a
-                                // live-rejected op never reaches this apply/fold.
-                                if let Some((auth_group, req)) =
-                                    apply_auth_requirement(&signed_op, decrypted.as_ref())
-                                {
-                                    let verdict = match req {
-                                        ApplyAuthReq::Admin => projections.is_admin_at_cut(
-                                            &feed_store,
-                                            auth_group,
-                                            &signed_op.signer,
-                                            &delta_parents,
-                                        ),
-                                        ApplyAuthReq::AdminOrCap(bits) => projections
-                                            .is_admin_or_capability_at_cut(
-                                                &feed_store,
-                                                auth_group,
-                                                &signed_op.signer,
-                                                bits,
-                                                &delta_parents,
-                                            ),
-                                    };
-                                    if verdict == Some(false) {
-                                        tracing::warn!(
-                                            marker = "unified_projection_divergence",
-                                            plane = "governance-auth",
-                                            group_id = ?auth_group,
-                                            signer = %signed_op.signer,
-                                            "projection would reject a governance op the live resolver authorized"
-                                        );
-                                    }
-                                }
-
                                 (true, role)
                             }
                             Err(err) => {
@@ -194,6 +151,54 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                                         ?projected,
                                         ?live,
                                         "unified-op projection disagrees with live membership resolver"
+                                    );
+                                }
+                            }
+                        }
+
+                        // APPLY-AUTH shadow (F5 #28, log-only): the op just APPLIED,
+                        // so the LIVE resolver authorized its signer. Would the
+                        // projection authorize the signer too — at the op's PARENT
+                        // cut (state EXCLUDING this op, the correct cut to authorize
+                        // against)? `Some(false)` = the projection would REJECT what
+                        // live accepted (under-auth — safe, but a real divergence to
+                        // investigate); `None` = ancestry not fully folded → skip.
+                        // The reverse (projection accepts what live rejected) is
+                        // unobservable here — a live-rejected op never reaches this
+                        // fold. Resolved at the parent cut (independent of the
+                        // just-ingested op), so it runs OUTSIDE the write lock under
+                        // a brief read lock — no store I/O while the apply path's
+                        // ingest is blocked.
+                        if fed {
+                            if let Some((auth_group, req)) =
+                                apply_auth_requirement(&signed_op, decrypted.as_ref())
+                            {
+                                let verdict = match scope_projections.read() {
+                                    Ok(projections) => match req {
+                                        ApplyAuthReq::Admin => projections.is_admin_at_cut(
+                                            &feed_store,
+                                            auth_group,
+                                            &signed_op.signer,
+                                            &delta_parents,
+                                        ),
+                                        ApplyAuthReq::AdminOrCap(bits) => projections
+                                            .is_admin_or_capability_at_cut(
+                                                &feed_store,
+                                                auth_group,
+                                                &signed_op.signer,
+                                                bits,
+                                                &delta_parents,
+                                            ),
+                                    },
+                                    Err(_) => None,
+                                };
+                                if verdict == Some(false) {
+                                    tracing::warn!(
+                                        marker = "unified_projection_divergence",
+                                        plane = "governance-auth",
+                                        group_id = ?auth_group,
+                                        signer = %signed_op.signer,
+                                        "projection would reject a governance op the live resolver authorized"
                                     );
                                 }
                             }
@@ -288,12 +293,14 @@ fn apply_auth_requirement(
             match root {
                 RootOp::AdminChanged { .. }
                 | RootOp::PolicyUpdated { .. }
-                | RootOp::GroupDeleted { .. }
                 | RootOp::GroupReparented { .. } => Some((ns_root, ApplyAuthReq::Admin)),
                 RootOp::GroupCreated { parent_id, .. } => Some((
                     ContextGroupId::from(*parent_id),
                     ApplyAuthReq::AdminOrCap(Cap::CAN_CREATE_SUBGROUP),
                 )),
+                // GroupDeleted authorizes the subgroup OWNER or a
+                // `CAN_DELETE_SUBGROUP` holder at the root, NOT only the root
+                // admin — owner authority isn't in this admin/cap model, so skip.
                 _ => None,
             }
         }
@@ -308,8 +315,9 @@ fn apply_auth_requirement(
                 }
                 GroupOp::MemberRoleSet { .. }
                 | GroupOp::MemberCapabilitySet { .. }
-                | GroupOp::DefaultCapabilitiesSet { .. }
-                | GroupOp::TransferOwnership { .. } => Some((group, ApplyAuthReq::Admin)),
+                | GroupOp::DefaultCapabilitiesSet { .. } => Some((group, ApplyAuthReq::Admin)),
+                // TransferOwnership gates on the current OWNER identity
+                // (`meta.owner_identity`), not group admin — outside this model.
                 _ => None,
             }
         }

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -117,6 +117,49 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                                         &[shadow_op.id],
                                     )
                                 });
+
+                                // APPLY-AUTH shadow (F5 #28, log-only): the op just
+                                // APPLIED, so the LIVE resolver authorized its
+                                // signer. Would the projection authorize the signer
+                                // too — at the op's PARENT cut (state EXCLUDING this
+                                // op, the correct cut to authorize against)?
+                                // `Some(false)` = the projection would REJECT what
+                                // live accepted (under-auth — safe, but a real
+                                // divergence to investigate). `None` = the cited
+                                // ancestry isn't fully folded yet → can't decide,
+                                // skip. The reverse direction (projection accepts
+                                // what live rejected) is unobservable here: a
+                                // live-rejected op never reaches this apply/fold.
+                                if let Some((auth_group, req)) =
+                                    apply_auth_requirement(&signed_op, decrypted.as_ref())
+                                {
+                                    let verdict = match req {
+                                        ApplyAuthReq::Admin => projections.is_admin_at_cut(
+                                            &feed_store,
+                                            auth_group,
+                                            &signed_op.signer,
+                                            &delta_parents,
+                                        ),
+                                        ApplyAuthReq::AdminOrCap(bits) => projections
+                                            .is_admin_or_capability_at_cut(
+                                                &feed_store,
+                                                auth_group,
+                                                &signed_op.signer,
+                                                bits,
+                                                &delta_parents,
+                                            ),
+                                    };
+                                    if verdict == Some(false) {
+                                        tracing::warn!(
+                                            marker = "unified_projection_divergence",
+                                            plane = "governance-auth",
+                                            group_id = ?auth_group,
+                                            signer = %signed_op.signer,
+                                            "projection would reject a governance op the live resolver authorized"
+                                        );
+                                    }
+                                }
+
                                 (true, role)
                             }
                             Err(err) => {
@@ -209,5 +252,66 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
             }
             .into_actor(self),
         )
+    }
+}
+
+/// The SIGNER-authority an apply gate requires, for the apply-auth projection
+/// shadow (F5 #28). `Admin` = the live `require_admin`/`require_namespace_admin`
+/// gate; `AdminOrCap(bits)` = `is_authorized_with_capability` (admin OR the bit).
+enum ApplyAuthReq {
+    Admin,
+    AdminOrCap(u32),
+}
+
+/// Map a just-applied governance op to the (group, signer-authority) the live
+/// apply gate enforced — so the shadow can ask whether the projection agrees the
+/// SIGNER was authorized at the op's parent cut.
+///
+/// Returns `None` (shadow skips) for variants whose authority is NOT the signer's
+/// group-admin/capability: `MemberJoined` (an admin-signed invitation — authority
+/// is the inviter's signature, not the joiner-signer), `MemberJoinedOpen` (an
+/// inheritance proof on the joiner, not an admin gate), `MemberLeft` (self-
+/// authored), `KeyDelivery`/`Noop`/metadata/context-registration ops. These are
+/// covered by later, more specific shadows; the conservative subset here is the
+/// unambiguous admin/capability gates.
+fn apply_auth_requirement(
+    signed: &calimero_context_client::local_governance::SignedNamespaceOp,
+    decrypted: Option<&calimero_context_client::local_governance::GroupOp>,
+) -> Option<(calimero_context_config::types::ContextGroupId, ApplyAuthReq)> {
+    use calimero_context_client::local_governance::{GroupOp, NamespaceOp, RootOp};
+    use calimero_context_config::types::ContextGroupId;
+    use calimero_context_config::MemberCapabilities as Cap;
+
+    match &signed.op {
+        NamespaceOp::Root(root) => {
+            let ns_root = ContextGroupId::from(signed.namespace_id);
+            match root {
+                RootOp::AdminChanged { .. }
+                | RootOp::PolicyUpdated { .. }
+                | RootOp::GroupDeleted { .. }
+                | RootOp::GroupReparented { .. } => Some((ns_root, ApplyAuthReq::Admin)),
+                RootOp::GroupCreated { parent_id, .. } => Some((
+                    ContextGroupId::from(*parent_id),
+                    ApplyAuthReq::AdminOrCap(Cap::CAN_CREATE_SUBGROUP),
+                )),
+                _ => None,
+            }
+        }
+        NamespaceOp::Group { group_id, .. } => {
+            let group = ContextGroupId::from(*group_id);
+            match decrypted? {
+                GroupOp::MemberAdded { .. } | GroupOp::MemberRemoved { .. } => {
+                    Some((group, ApplyAuthReq::AdminOrCap(Cap::MANAGE_MEMBERS)))
+                }
+                GroupOp::SubgroupVisibilitySet { .. } => {
+                    Some((group, ApplyAuthReq::AdminOrCap(Cap::CAN_MANAGE_VISIBILITY)))
+                }
+                GroupOp::MemberRoleSet { .. }
+                | GroupOp::MemberCapabilitySet { .. }
+                | GroupOp::DefaultCapabilitiesSet { .. }
+                | GroupOp::TransferOwnership { .. } => Some((group, ApplyAuthReq::Admin)),
+                _ => None,
+            }
+        }
     }
 }

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -50,6 +50,15 @@ use crate::governance_dag::signed_namespace_op_to_delta;
 /// governance history — comfortably over the in-memory prune threshold (8192).
 const MAX_BACKFILL_OPS: usize = 100_000;
 
+/// The resolved at-cut context for an apply-auth read: the folded `AclView`, the
+/// genesis root tuple `(root_group, genesis_admin)`, and the namespace default-cap
+/// base. Produced by `ScopeProjections::auth_cut_context`.
+type AuthCutContext = (
+    calimero_authz::AclView,
+    Option<(ContextGroupId, PublicKey)>,
+    u32,
+);
+
 /// Assemble an [`Op`] that **mirrors a source-DAG op**: its `id` and `parents`
 /// are the source delta's own id/parents, *not* a fresh [`Op::compute_id`]. This
 /// is deliberate — it makes the projection's op graph share an id space with the
@@ -1056,28 +1065,12 @@ impl ScopeProjections {
         author: &PublicKey,
         heads: &[[u8; 32]],
     ) -> Option<bool> {
-        let namespace_id = NamespaceRepository::new(store)
-            .resolve(&group)
-            .ok()?
-            .to_bytes();
-        let scope = ScopeId::from(namespace_id);
-        if !self.cut_ancestry_complete(&scope, heads) {
-            return None;
-        }
-        let root_group = ContextGroupId::from(namespace_id);
-        let root_admin = MetaRepository::new(store)
-            .load(&root_group)
-            .ok()
-            .flatten()
-            .map(|meta| meta.admin_identity);
-        Some(self.acl_view_at(&scope, heads).is_some_and(|v| {
-            v.is_group_admin(author, group)
-                || (group == root_group && root_admin.as_ref() == Some(author))
-        }))
+        let (view, root, _) = self.auth_cut_context(store, group, heads)?;
+        Some(view.is_authorized_admin(group, author, root))
     }
 
     /// Is `author` an admin of `group` OR a holder of any bit in `capability` at
-    /// the cut — the apply-auth analogue of live's `is_admin_or_has_capability`.
+    /// the cut — the apply-auth analogue of live's `is_authorized_with_capability`.
     /// Same authoritative `None`-on-incomplete-ancestry contract as
     /// [`is_admin_at_cut`](Self::is_admin_at_cut). The capability is the member's
     /// folded cap, falling back to the namespace default-cap base (a store-written
@@ -1091,6 +1084,30 @@ impl ScopeProjections {
         capability: u32,
         heads: &[[u8; 32]],
     ) -> Option<bool> {
+        let (view, root, default_cap_base) = self.auth_cut_context(store, group, heads)?;
+        if view.is_authorized_admin(group, author, root) {
+            return Some(true);
+        }
+        let folded = view.capability(&group, author);
+        let effective = if folded != 0 {
+            folded
+        } else {
+            default_cap_base
+        };
+        Some(effective & capability != 0)
+    }
+
+    /// Shared setup for the at-cut admin/capability reads: resolve the namespace,
+    /// gate on COMPLETE cited ancestry (so the verdict is authoritative — `None`
+    /// otherwise, defer to live), build the folded view + the genesis root tuple
+    /// (`AclView::is_authorized_admin` prefers the folded root admin, tracking
+    /// `AdminChanged`; this is the un-folded base) + the namespace default cap.
+    fn auth_cut_context(
+        &self,
+        store: &Store,
+        group: ContextGroupId,
+        heads: &[[u8; 32]],
+    ) -> Option<AuthCutContext> {
         let namespace_id = NamespaceRepository::new(store)
             .resolve(&group)
             .ok()?
@@ -1099,31 +1116,19 @@ impl ScopeProjections {
         if !self.cut_ancestry_complete(&scope, heads) {
             return None;
         }
+        let view = self.acl_view_at(&scope, heads)?;
         let root_group = ContextGroupId::from(namespace_id);
-        let root_admin = MetaRepository::new(store)
+        let root = MetaRepository::new(store)
             .load(&root_group)
             .ok()
             .flatten()
-            .map(|meta| meta.admin_identity);
+            .map(|meta| (root_group, meta.admin_identity));
         let default_cap_base = CapabilitiesRepository::new(store)
             .default_capabilities(&root_group)
             .ok()
             .flatten()
             .unwrap_or(0);
-        Some(self.acl_view_at(&scope, heads).is_some_and(|v| {
-            if v.is_group_admin(author, group)
-                || (group == root_group && root_admin.as_ref() == Some(author))
-            {
-                return true;
-            }
-            let folded = v.capability(&group, author);
-            let effective = if folded != 0 {
-                folded
-            } else {
-                default_cap_base
-            };
-            effective & capability != 0
-        }))
+        Some((view, root, default_cap_base))
     }
 
     /// Diagnostics for a divergence at `heads` — why does the projection NOT see

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1042,6 +1042,90 @@ impl ScopeProjections {
         )
     }
 
+    /// Is `author` an ADMIN of `group` at the cut named by `heads`, authoritatively
+    /// — `Some(true)`/`Some(false)` only when the COMPLETE cited ancestry is folded,
+    /// `None` otherwise (defer to live). The apply-auth analogue of
+    /// [`member_at_cut_authoritative`](Self::member_at_cut_authoritative): admin =
+    /// a folded group admin (subgroup creator / `Admin`-role holder, via
+    /// `is_group_admin`) OR the immutable genesis root admin for the root group.
+    #[must_use]
+    pub fn is_admin_at_cut(
+        &self,
+        store: &Store,
+        group: ContextGroupId,
+        author: &PublicKey,
+        heads: &[[u8; 32]],
+    ) -> Option<bool> {
+        let namespace_id = NamespaceRepository::new(store)
+            .resolve(&group)
+            .ok()?
+            .to_bytes();
+        let scope = ScopeId::from(namespace_id);
+        if !self.cut_ancestry_complete(&scope, heads) {
+            return None;
+        }
+        let root_group = ContextGroupId::from(namespace_id);
+        let root_admin = MetaRepository::new(store)
+            .load(&root_group)
+            .ok()
+            .flatten()
+            .map(|meta| meta.admin_identity);
+        Some(self.acl_view_at(&scope, heads).is_some_and(|v| {
+            v.is_group_admin(author, group)
+                || (group == root_group && root_admin.as_ref() == Some(author))
+        }))
+    }
+
+    /// Is `author` an admin of `group` OR a holder of any bit in `capability` at
+    /// the cut — the apply-auth analogue of live's `is_admin_or_has_capability`.
+    /// Same authoritative `None`-on-incomplete-ancestry contract as
+    /// [`is_admin_at_cut`](Self::is_admin_at_cut). The capability is the member's
+    /// folded cap, falling back to the namespace default-cap base (a store-written
+    /// genesis fact, as in [`member_at_cut`](Self::member_at_cut)).
+    #[must_use]
+    pub fn is_admin_or_capability_at_cut(
+        &self,
+        store: &Store,
+        group: ContextGroupId,
+        author: &PublicKey,
+        capability: u32,
+        heads: &[[u8; 32]],
+    ) -> Option<bool> {
+        let namespace_id = NamespaceRepository::new(store)
+            .resolve(&group)
+            .ok()?
+            .to_bytes();
+        let scope = ScopeId::from(namespace_id);
+        if !self.cut_ancestry_complete(&scope, heads) {
+            return None;
+        }
+        let root_group = ContextGroupId::from(namespace_id);
+        let root_admin = MetaRepository::new(store)
+            .load(&root_group)
+            .ok()
+            .flatten()
+            .map(|meta| meta.admin_identity);
+        let default_cap_base = CapabilitiesRepository::new(store)
+            .default_capabilities(&root_group)
+            .ok()
+            .flatten()
+            .unwrap_or(0);
+        Some(self.acl_view_at(&scope, heads).is_some_and(|v| {
+            if v.is_group_admin(author, group)
+                || (group == root_group && root_admin.as_ref() == Some(author))
+            {
+                return true;
+            }
+            let folded = v.capability(&group, author);
+            let effective = if folded != 0 {
+                folded
+            } else {
+                default_cap_base
+            };
+            effective & capability != 0
+        }))
+    }
+
     /// Diagnostics for a divergence at `heads` — why does the projection NOT see
     /// `author` in `group`? Distinguishes the failure modes:
     /// - `namespace_log_len == 0` → the projection is empty for this namespace


### PR DESCRIPTION
## What

Begins migrating the **last** F5 consumer — apply-time governance-op authorization — onto the unified projection, as a **log-only shadow** (the live apply gates stay authoritative). Continues the F5 series (#2829/#2840/#2841/#2843 merged).

## The crate-boundary constraint

The apply gates (`PermissionChecker`, `require_namespace_admin`) live in `calimero-governance-store`, which the projection (`calimero-context`) **depends on** — so governance-store can't reach the projection. The shadow therefore lives at the **context layer** (`apply_signed_namespace_op.rs`), alongside the existing membership shadow, which already holds the op's parents and the projection. No governance-store change.

## How

For a just-applied op (live authorized its signer), `apply_auth_requirement` maps the op variant to the signer-authority the live gate enforced, and the shadow asks whether the projection authorizes the **signer** at the op's **parent cut** — the state *excluding* this op, the correct causal cut to authorize against (the membership shadow uses the op's own id, right for a post-apply read, wrong for auth).

- `Some(false)` (projection would reject what live accepted) → `unified_projection_divergence` plane=`governance-auth`.
- `None` (cited ancestry not fully folded) → skip.
- Reverse direction is unobservable here (a live-rejected op never reaches this fold).

Adds at-cut accessors `is_admin_at_cut` + `is_admin_or_capability_at_cut`, mirroring `member_at_cut_authoritative` (resolve namespace, gate on `cut_ancestry_complete`, read genesis root admin / default cap as immutable base facts, decide from the folded `AclView`).

**Conservative coverage:** the unambiguous admin/cap gates (namespace-root admin ops, `GroupCreated`, `MemberAdded`/`Removed`, role/cap/visibility sets). Skips variants whose authority isn't the signer's group-admin/cap — an admin-signed invitation (`MemberJoined`), an inheritance proof (`MemberJoinedOpen`), a self-authored `MemberLeft`.

## The flip is a separate decision

This shadow validates equivalence; making the projection **authoritative** at the gates requires it inside governance-store (the crate boundary) — either moving the auth gates up to the context layer or dependency-inversion via a trait. That's a follow-up design, informed by this shadow's divergence data; shadow-only may even be the pragmatic endpoint for #28 (the apply gates are the deepest, most convergence-critical code and the live state is itself derived from the same ops).

## Test

- `cargo build`/`clippy --all-targets`/`fmt` clean; equivalence harness 3/3 green.
- e2e `governance-auth` gate validates the apply-auth equivalence on real traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shadow-only logging on the apply path; live authorization is unchanged. Divergence warnings are observability, not enforcement.
> 
> **Overview**
> Adds a **log-only apply-auth shadow** (F5 #28) next to the existing membership shadow in `apply_signed_namespace_op`: after a governance op is applied, it checks whether the unified projection would have authorized the **signer** at the op’s **parent cut** (`delta_parents`), not the post-apply cut.
> 
> **`calimero-authz`:** New `AclView::is_authorized_admin` mirrors live apply-gate admin authority—group admin, folded root admin (plus genesis root carve-out), or admin of an open-chain ancestor; restricted edges stop the walk. Plain inherited members are not treated as admins.
> 
> **`scope_projection`:** New `is_admin_at_cut`, `is_admin_or_capability_at_cut`, and shared `auth_cut_context` (complete ancestry gate, folded view, genesis root, default cap base).
> 
> **Apply handler:** `apply_auth_requirement` maps applied ops to `Admin` vs `AdminOrCap` requirements for a conservative subset (root admin ops, subgroup create, member add/remove, visibility, role/cap defaults). `Some(false)` logs `unified_projection_divergence` with `plane=governance-auth`. Live gates stay authoritative; no governance-store changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 367d257ecbf7a5b5afd4f07165d63fba4990eff6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->