### PR TITLE
refactor(f5): remove proven cross-check scaffolding (#29a)

### DIFF
--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -486,30 +486,12 @@ impl ScopeProjections {
         member: &PublicKey,
     ) -> eyre::Result<bool> {
         if let Some(p) = Self::member_now_ephemeral(store, group, member) {
-            // The projection decided. Cross-check live BEST-EFFORT — a transient
-            // live-read error must not deny a verdict the projection already formed;
-            // log the divergence only when live also produced an answer.
-            match MembershipRepository::new(store).is_member(group, member) {
-                Ok(live) if live != p => tracing::warn!(
-                    marker = "unified_projection_divergence",
-                    plane = "membership-query",
-                    group_id = ?group,
-                    ?member,
-                    projection = p,
-                    live,
-                    "query-gate: projection disagrees with live membership"
-                ),
-                Ok(_) => {}
-                Err(err) => tracing::warn!(
-                    group_id = ?group,
-                    %err,
-                    "query-gate: live cross-check failed; acting on projection verdict"
-                ),
-            }
+            // The projection is authoritative for the query gate (validated
+            // divergence-free across the e2e `membership-query` plane); act on it.
             return Ok(p);
         }
-        // Projection couldn't decide (cold/partial fold or store fault) — live is
-        // authoritative here, so its error legitimately propagates.
+        // Projection couldn't decide (cold/partial fold or store fault) — fall back
+        // to live, whose error legitimately propagates. (Live retires in #29b.)
         MembershipRepository::new(store).is_member(group, member)
     }
 
@@ -589,8 +571,7 @@ impl ScopeProjections {
 
     /// The gate verdict over an ALREADY-built ephemeral projection — same contract
     /// as [`member_now_checked`](Self::member_now_checked) (act on the projection,
-    /// best-effort live cross-check + `membership-query` marker, live on `None`),
-    /// but reusing a shared fold.
+    /// live on `None`), but reusing a shared fold.
     pub fn member_now_checked_with(
         &self,
         store: &Store,
@@ -599,23 +580,6 @@ impl ScopeProjections {
         heads: &[[u8; 32]],
     ) -> eyre::Result<bool> {
         if let Some(p) = self.member_at_cut(store, *group, member, heads) {
-            match MembershipRepository::new(store).is_member(group, member) {
-                Ok(live) if live != p => tracing::warn!(
-                    marker = "unified_projection_divergence",
-                    plane = "membership-query",
-                    group_id = ?group,
-                    ?member,
-                    projection = p,
-                    live,
-                    "query-gate: projection disagrees with live membership"
-                ),
-                Ok(_) => {}
-                Err(err) => tracing::warn!(
-                    group_id = ?group,
-                    %err,
-                    "query-gate: live cross-check failed; acting on projection verdict"
-                ),
-            }
             return Ok(p);
         }
         MembershipRepository::new(store).is_member(group, member)

--- a/crates/node/src/handlers/state_delta/buffering.rs
+++ b/crates/node/src/handlers/state_delta/buffering.rs
@@ -153,28 +153,9 @@ pub(super) async fn drain_governance_pending(input: &StateDeltaContext, context_
             );
         match proj {
             Some(true) => {
-                // Cross-check: a grant the live resolver DEFINITELY denies (Removed /
-                // NeverMember) is the dangerous divergence (grant plane). live's
-                // `Unknown` is "not caught up", not a denial — not a disagreement.
-                let live = acl_view_at(
-                    datastore,
-                    owning_group,
-                    &buffered.author_id,
-                    &pos.governance_dag_heads,
-                );
-                if matches!(
-                    live,
-                    Ok(MembershipStatus::Removed { .. }) | Ok(MembershipStatus::NeverMember)
-                ) {
-                    warn!(
-                        marker = "unified_projection_divergence",
-                        plane = "membership-cut-grant",
-                        %context_id,
-                        delta_id = ?buffered.id,
-                        author = %buffered.author_id,
-                        "governance-drain: projection applies a delta live would drop"
-                    );
-                }
+                // The projection is authoritative for the drain (validated
+                // divergence-free across the e2e `membership-cut-grant` plane); the
+                // re-apply decision is purely `member_at_cut_authoritative`.
                 debug!(
                     %context_id,
                     delta_id = ?buffered.id,
@@ -196,25 +177,16 @@ pub(super) async fn drain_governance_pending(input: &StateDeltaContext, context_
                 }
             }
             Some(false) => {
-                // The projection denies on a COMPLETE fold; if live grants, that is a
-                // real deny-plane divergence. live also names the drop metric label
-                // (removed vs never-member); fall back to a generic label otherwise.
+                // The projection authoritatively denies on a COMPLETE fold (drop).
+                // live is still read SOLELY to name the drop metric label (removed
+                // vs never-member); this read retires in #29b when the label moves
+                // off live.
                 let live = acl_view_at(
                     datastore,
                     owning_group,
                     &buffered.author_id,
                     &pos.governance_dag_heads,
                 );
-                if matches!(live, Ok(MembershipStatus::Member(_))) {
-                    warn!(
-                        marker = "unified_projection_divergence",
-                        plane = "membership-cut",
-                        %context_id,
-                        delta_id = ?buffered.id,
-                        author = %buffered.author_id,
-                        "governance-drain: projection drops a delta live would apply"
-                    );
-                }
                 let label = match &live {
                     Ok(MembershipStatus::Removed { .. }) => "removed",
                     Ok(MembershipStatus::NeverMember) => "never_member",

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -2944,20 +2944,9 @@ impl SyncManager {
             their_identity,
             &heads,
         );
-        if let Some(p) = projected {
-            if p != live {
-                warn!(
-                    marker = "unified_projection_divergence",
-                    plane = "membership-sync",
-                    group_id = ?group_id,
-                    ?their_identity,
-                    projection = p,
-                    live,
-                    "inbound-sync auth: projection disagrees with live membership"
-                );
-            }
-        }
-        // Act on the projection; `None` (can't decide) falls back to live.
+        // The projection is authoritative for inbound-sync auth (validated
+        // divergence-free across the e2e `membership-sync` plane); `None` (can't
+        // decide) falls back to live. (The live read retires in #29b.)
         Ok(projected.unwrap_or(live))
     }
 


### PR DESCRIPTION
## What

F5 **#29a** — the first cleanup of the live-resolver endgame. The membership query gates, inbound-sync auth, and the governance-drain grant arm are **projection-authoritative** and were validated divergence-free across their e2e planes. The live cross-check that read the resolver **solely to compare + emit `unified_projection_divergence`** was pure validation scaffolding; this removes it.

## Removed (behavior-neutral — the reads never fed a decision)

| Site | Plane | Change |
|---|---|---|
| `member_now_checked` / `member_now_checked_with` | `membership-query` | drop the live `is_member` cross-check + marker; keep the `None`→live fallback |
| `peer_is_group_member` (sync) | `membership-sync` | drop the `if p != live { warn }` block; keep the live read (it's the `None` fallback) |
| governance-drain `Some(true)` | `membership-cut-grant` | drop the whole `acl_view_at` read + grant marker — re-apply is purely `member_at_cut_authoritative` |
| governance-drain `Some(false)` | `membership-cut` | drop **only** the deny marker; **keep** the `acl_view_at` read — it still feeds the drop-metric label |

## Intentionally untouched (need a flip, not cleanup)
- **Data-write arms** (`state_delta/mod.rs`, `membership-cut`/`-grant`): hybrid — live `authorize_delta_at_edge` is the base verdict; the projection co-denies/grants-over. Markers fire on real decisions. → #29b.
- **Apply-auth shadows** (`apply_signed_namespace_op.rs`, `membership`/`governance-auth`): shadow-only over an already-committed live apply. → after the #28 flip.
- **Enum shadows** (`membership-enum`): shadow-only — the handlers still *return live*. Deleting would revert, not clean up; the move there is to **flip** to the projection set, a separate decision.

The remaining live reads are the `None` fallbacks + the drain metric label, which retire in #29b when the resolver is deleted.

## Test
- `cargo build`/`clippy --all-targets -- -D warnings`/`fmt` clean; equivalence harness 3/3 green.
- e2e: the removed planes simply stop emitting; the remaining planes still gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Decision logic is unchanged—only comparison logging and redundant live reads on decisive projection paths are removed after divergence-free validation; remaining live reads are fallbacks or metric labels slated for #29b.
> 
> **Overview**
> F5 **#29a** strips **live-vs-projection comparison scaffolding** from membership paths that were already validated divergence-free in e2e. **Authorization outcomes are unchanged**: when the projection returns `Some`, that verdict still drives the gate; `None` still falls back to the live resolver.
> 
> **Query gates** (`member_now_checked` / `member_now_checked_with`): drops the extra live `is_member` read and `unified_projection_divergence` warnings on `membership-query`; projection answers are acted on directly.
> 
> **Inbound sync** (`peer_is_group_member`): removes the projection≠live warn block on `membership-sync`; keeps the live read only as the `None` fallback (`projected.unwrap_or(live)`).
> 
> **Governance-pending drain**: on **grant** (`Some(true)`), removes the `acl_view_at` cross-check and `membership-cut-grant` marker—re-apply stays purely `member_at_cut_authoritative`. On **deny** (`Some(false)`), removes only the `membership-cut` divergence warn; **keeps** `acl_view_at` for drop-metric labels (`removed` / `never_member`).
> 
> Hybrid data-write paths, apply-auth shadows, and enum shadows still emit `unified_projection_divergence` where decisions or flips are pending (#29b / post-#28).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c522768fd8b68c6d7e06c6798d287698051dfc18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->