### PR TITLE
feat(context): flip identity-set enum consumers onto the projection

### DIFF
--- a/crates/context/src/handlers/get_group_info.rs
+++ b/crates/context/src/handlers/get_group_info.rs
@@ -58,9 +58,10 @@ impl Handler<GetGroupInfoRequest> for ContextManager {
             // scans the full group state on every call.
             // Effective member count from the PROJECTION's effective-member set
             // (direct ∪ inherited), validated divergence-free across the e2e
-            // `membership-enum` plane. `None` (empty/unfed namespace or store fault)
-            // falls back to the live `count + enumerate_inherited` union. The live
-            // fallback retires in #29b.
+            // `membership-enum` plane. `None` — an empty/unfed namespace, or a cited
+            // ancestry not fully folded (governance-backfill race) — falls back to
+            // the live `count + enumerate_inherited` union. The live fallback retires
+            // in #29b.
             let member_count = proj_ctx
                 .as_ref()
                 .and_then(|(proj, ns, heads)| {

--- a/crates/context/src/handlers/get_group_info.rs
+++ b/crates/context/src/handlers/get_group_info.rs
@@ -56,28 +56,26 @@ impl Handler<GetGroupInfoRequest> for ContextManager {
             // chain walk bounded by `MAX_NAMESPACE_DEPTH`. This is minor
             // next to `compute_group_state_hash` below, which already
             // scans the full group state on every call.
-            // Resolve the open-subgroup inherited members ONCE — reused for the
-            // count and (below) the shadow's live id set, instead of two parent
-            // walks.
-            let inherited =
-                MembershipRepository::new(&self.datastore).enumerate_inherited(&group_id)?;
-            let member_count = (MembershipRepository::new(&self.datastore).count(&group_id)?
-                + inherited.len()) as u64;
-
-            // SHADOW: compare the projection's effective-member SET against the live
-            // union (not just the count — equal counts with different members would
-            // otherwise slip through). Logs `membership-enum` divergence; still
-            // returns the live `member_count`. Reuses the single fold from the gate.
-            if let Some((proj, ns, heads)) = &proj_ctx {
-                let live_ids: std::collections::BTreeSet<_> =
-                    MembershipRepository::new(&self.datastore)
-                        .list(&group_id, 0, usize::MAX)?
-                        .into_iter()
-                        .map(|(pk, _)| pk)
-                        .chain(inherited.into_iter().map(|(pk, _)| pk))
-                        .collect();
-                proj.shadow_member_enum_with(&self.datastore, *ns, &group_id, heads, &live_ids);
-            }
+            // Effective member count from the PROJECTION's effective-member set
+            // (direct ∪ inherited), validated divergence-free across the e2e
+            // `membership-enum` plane. `None` (empty/unfed namespace or store fault)
+            // falls back to the live `count + enumerate_inherited` union. The live
+            // fallback retires in #29b.
+            let member_count = proj_ctx
+                .as_ref()
+                .and_then(|(proj, ns, heads)| {
+                    proj.member_identities_with(&self.datastore, *ns, &group_id, heads)
+                })
+                .map(|ids| ids.len() as u64)
+                .map_or_else(
+                    || -> eyre::Result<u64> {
+                        let membership = MembershipRepository::new(&self.datastore);
+                        Ok((membership.count(&group_id)?
+                            + membership.enumerate_inherited(&group_id)?.len())
+                            as u64)
+                    },
+                    Ok,
+                )?;
 
             let context_count =
                 MetadataRepository::new(&self.datastore).count_contexts(&group_id)? as u64;

--- a/crates/context/src/handlers/get_migration_status.rs
+++ b/crates/context/src/handlers/get_migration_status.rs
@@ -30,6 +30,21 @@ pub fn collect_migration_cohort(
     let mut groups = vec![*namespace_id];
     groups.extend(NamespaceRepository::new(store).collect_descendants(namespace_id)?);
 
+    // The cohort is the PROJECTION's effective-member union across the subtree —
+    // folded ONCE at a SINGLE cut — validated divergence-free across the e2e
+    // `membership-enum` plane. `None` (empty/unfed namespace or store fault) falls
+    // back to the live `list ∪ enumerate_inherited` union below; that live fallback
+    // retires in #29b.
+    if let Some(projected) =
+        crate::scope_projection::ScopeProjections::member_identities_subtree_ephemeral(
+            store,
+            namespace_id,
+            &groups,
+        )
+    {
+        return Ok(projected.into_iter().collect());
+    }
+
     let membership = MembershipRepository::new(store);
     // BTreeSet both dedups across the subtree (a member can appear directly in
     // one group and inherited in another) and yields a deterministic order.
@@ -42,33 +57,6 @@ pub fn collect_migration_cohort(
             let _ = cohort.insert(pk);
         }
     }
-
-    // SHADOW: union the projection's effective-member set across the same subtree
-    // — folding the namespace ONCE at a SINGLE cut (not per-group, which would
-    // re-fold and evaluate groups at different cuts under concurrent governance) —
-    // and compare to the live cohort. Logs `membership-enum` divergence; still
-    // returns the live cohort.
-    if let Some(projected) =
-        crate::scope_projection::ScopeProjections::member_identities_subtree_ephemeral(
-            store,
-            namespace_id,
-            &groups,
-        )
-    {
-        if projected != cohort {
-            let only_projection: Vec<_> = projected.difference(&cohort).collect();
-            let only_live: Vec<_> = cohort.difference(&projected).collect();
-            tracing::warn!(
-                marker = "unified_projection_divergence",
-                plane = "membership-enum",
-                namespace_id = ?namespace_id,
-                ?only_projection,
-                ?only_live,
-                "query-enum: projection migration cohort differs from live"
-            );
-        }
-    }
-
     Ok(cohort.into_iter().collect())
 }
 

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -546,6 +546,31 @@ impl ScopeProjections {
         Some((proj, namespace_id, heads))
     }
 
+    /// The effective member-identity SET of `group` from an ALREADY-built
+    /// projection (the `_with` analogue of [`shadow_member_enum_with`], but
+    /// returning the set instead of comparing it). The authoritative read for the
+    /// identity-set enumeration consumers (member count, migration cohort) now that
+    /// the set is validated divergence-free across the e2e `membership-enum` plane.
+    /// `None` when the scope wasn't fed (an empty namespace) — caller falls back to
+    /// live. (Identity-only; the role-bearing `list_group_members` flip needs a
+    /// role-enumeration variant + its own validation.)
+    #[must_use]
+    pub fn member_identities_with(
+        &self,
+        store: &Store,
+        namespace_id: [u8; 32],
+        group: &ContextGroupId,
+        heads: &[[u8; 32]],
+    ) -> Option<std::collections::BTreeSet<PublicKey>> {
+        let view = self.acl_view_at(&ScopeId::from(namespace_id), heads)?;
+        Some(Self::member_identities_in_view(
+            &view,
+            store,
+            namespace_id,
+            group,
+        ))
+    }
+
     /// The shared fold primitive for both [`ephemeral_projection`](Self::ephemeral_projection)
     /// and [`ephemeral_view`](Self::ephemeral_view): collect `namespace_id`'s
     /// persisted governance DAG into a fresh projection and read its current heads

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -512,7 +512,14 @@ impl ScopeProjections {
             .resolve(namespace_root)
             .ok()?
             .to_bytes();
-        let view = Self::ephemeral_view(store, namespace_id)?;
+        let (proj, heads) = Self::ephemeral_fold(store, namespace_id)?;
+        let scope = ScopeId::from(namespace_id);
+        // Defer to live on a partial fold (governance-backfill race) rather than
+        // returning an under-counted cohort — same guard as the membership gate.
+        if !proj.cut_ancestry_complete(&scope, &heads) {
+            return None;
+        }
+        let view = proj.acl_view_at(&scope, &heads)?;
         let mut out = std::collections::BTreeSet::new();
         for group in groups {
             out.extend(Self::member_identities_in_view(
@@ -551,9 +558,12 @@ impl ScopeProjections {
     /// returning the set instead of comparing it). The authoritative read for the
     /// identity-set enumeration consumers (member count, migration cohort) now that
     /// the set is validated divergence-free across the e2e `membership-enum` plane.
-    /// `None` when the scope wasn't fed (an empty namespace) — caller falls back to
-    /// live. (Identity-only; the role-bearing `list_group_members` flip needs a
-    /// role-enumeration variant + its own validation.)
+    /// `None` when the scope wasn't fed (an empty namespace) OR the cited ancestry
+    /// isn't fully folded (a governance-backfill race) — caller falls back to live,
+    /// exactly as the membership gate's `member_at_cut` defers on an incomplete cut.
+    /// Without this guard a partial fold would silently UNDER-count. (Identity-only;
+    /// the role-bearing `list_group_members` flip needs a role-enumeration variant +
+    /// its own validation.)
     #[must_use]
     pub fn member_identities_with(
         &self,
@@ -562,7 +572,11 @@ impl ScopeProjections {
         group: &ContextGroupId,
         heads: &[[u8; 32]],
     ) -> Option<std::collections::BTreeSet<PublicKey>> {
-        let view = self.acl_view_at(&ScopeId::from(namespace_id), heads)?;
+        let scope = ScopeId::from(namespace_id);
+        if !self.cut_ancestry_complete(&scope, heads) {
+            return None;
+        }
+        let view = self.acl_view_at(&scope, heads)?;
         Some(Self::member_identities_in_view(
             &view,
             store,
@@ -639,15 +653,6 @@ impl ScopeProjections {
                 "query-enum: projection effective-member set differs from live"
             );
         }
-    }
-
-    /// Build a fresh ephemeral projection of `namespace_id`'s governance DAG and
-    /// return its at-cut [`AclView`] at the namespace's current heads. `None` (with
-    /// a warn) when the governance head is unreadable — a store fault that the
-    /// caller surfaces by falling back to live, never silently.
-    fn ephemeral_view(store: &Store, namespace_id: [u8; 32]) -> Option<calimero_authz::AclView> {
-        let (proj, heads) = Self::ephemeral_fold(store, namespace_id)?;
-        proj.acl_view_at(&ScopeId::from(namespace_id), &heads)
     }
 
     /// The effective member-identity set of `group` from an already-folded `view`


### PR DESCRIPTION
## What

F5 enum flip (identity-set subset), continuing after #2851 (#29a). The enum shadow validated that the projection's effective-member **set** matches live's `list ∪ enumerate_inherited` across the e2e `membership-enum` plane. This flips the two consumers that need only the identity set off live onto the projection:

- **`get_group_info` member_count** → the projection set's `len()` (one shared fold; `None` on an empty/unfed namespace falls back to live `count + enumerate_inherited`).
- **`get_migration_status` cohort** → `member_identities_subtree_ephemeral` (folded once at one cut for the whole subtree; `None` falls back to the live union).

Both drop their `membership-enum` shadow comparison — the projection is now the answer, not a cross-check. The live fallbacks retire in #29b.

## Not flipped (on purpose)

**`list_group_members`** returns per-member **roles**, and the shadow validated only the identity **set**, not roles. Flipping it needs a role-bearing enumeration (`member_entries_in_view`) plus its own role-divergence validation pass — a follow-up. It keeps its live + shadow for now.

Adds `member_identities_with` (the set read off an already-built fold).

## Test

- `cargo build`/`clippy --all-targets -- -D warnings`/`fmt` clean; equivalence harness 3/3 green.
- e2e: the two `membership-enum` consumers now act on the projection; `list_group_members`'s `membership-enum` shadow still gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes observable counts and migration cohort membership for admin APIs; incomplete-fold guards and live fallback limit wrong answers, but behavior shifts from always-live to projection-first.
> 
> **Overview**
> After the `membership-enum` shadow validated projection vs live, **identity-set enumeration** now uses the governance projection as the primary answer instead of live store unions plus shadow comparison.
> 
> **`get_group_info`** derives `member_count` from `member_identities_with` on the shared ephemeral fold (set length), reusing the same fold as the membership gate. **`collect_migration_cohort`** returns early from `member_identities_subtree_ephemeral` when the projection succeeds, instead of building the live cohort first and only comparing afterward.
> 
> **`scope_projection`** adds `member_identities_with` (authoritative set off an existing fold) and tightens `member_identities_subtree_ephemeral` with `cut_ancestry_complete` before reading the ACL view so partial folds cannot under-count. **`ephemeral_view`** is removed in favor of `ephemeral_fold` + completeness checks.
> 
> When projection returns `None` (unfed namespace, store fault, or incomplete ancestry during governance backfill), both handlers still fall back to live `count`/`list` ∪ `enumerate_inherited`; those paths are slated to retire in #29b. **`list_group_members`** is unchanged—still live + shadow—because it needs roles, not identity sets only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ac16b527d7cf0a83b18e9efbbe747f077459986. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->