### PR TITLE
feat(context): shadow member-enumeration roles (precursor to list_group_members flip)

### DIFF
--- a/crates/authz/src/lib.rs
+++ b/crates/authz/src/lib.rs
@@ -31,6 +31,25 @@ const CAN_JOIN_OPEN_SUBGROUPS: u32 = MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS
 /// `MAX_NAMESPACE_DEPTH`).
 const MAX_NAMESPACE_DEPTH: usize = 16;
 
+/// How `author` reaches membership of a group at a cut — the at-cut analogue of
+/// the live `MembershipPath`. Carries enough to derive the enumeration ROLE
+/// (mirrors live's `list ∪ enumerate_inherited`): a direct member keeps its
+/// folded role; an inherited member is `Admin` when reached via an admin, else
+/// its role at the `anchor` it inherits from.
+#[derive(Clone, Debug, PartialEq)]
+pub enum MemberPathAtCut {
+    /// Not a member of the group at this cut.
+    None,
+    /// A direct member, with its folded role.
+    Direct { role: GroupMemberRole },
+    /// Inherited over the open-subgroup chain from `anchor`; `via_admin` when the
+    /// path was through an admin ancestor (role resolves to `Admin`).
+    Inherited {
+        anchor: ContextGroupId,
+        via_admin: bool,
+    },
+}
+
 /// Why an op was refused. One rejection type for every plane — the caller
 /// doesn't have to know which plane said no.
 #[derive(Clone, Debug, PartialEq, Eq, ThisError)]
@@ -263,6 +282,79 @@ impl AclView {
             current = parent;
         }
         false
+    }
+
+    /// `author`'s membership PATH to `group` at the cut — the at-cut analogue of
+    /// live `check_path`, returning the role-bearing [`MemberPathAtCut`] for the
+    /// enumeration consumers. Mirrors the `is_member_at_cut` walk: direct row first
+    /// (with its folded role), then an admin of the group with no row (genesis root
+    /// admin), then up the open chain — an admin ancestor yields
+    /// `Inherited{via_admin:true}`, the first direct-member ancestor yields
+    /// `Inherited{via_admin:false}` iff it holds `CAN_JOIN_OPEN_SUBGROUPS` (else the
+    /// recorded decision is `None`, but the walk continues for an admin higher up).
+    #[must_use]
+    pub fn member_path_at_cut(
+        &self,
+        group: ContextGroupId,
+        author: &PublicKey,
+        root: Option<(ContextGroupId, PublicKey)>,
+        default_cap_base: u32,
+    ) -> MemberPathAtCut {
+        let is_admin = |g: ContextGroupId| -> bool {
+            self.is_group_admin(author, g)
+                || self.is_root_admin(author)
+                || root.is_some_and(|(root_g, root_admin)| g == root_g && *author == root_admin)
+        };
+        if let Some(role) = self.groups.get(&group).and_then(|m| m.get(author)) {
+            return MemberPathAtCut::Direct { role: role.clone() };
+        }
+        if is_admin(group) {
+            return MemberPathAtCut::Direct {
+                role: GroupMemberRole::Admin,
+            };
+        }
+        let effective_cap = |g: &ContextGroupId| -> u32 {
+            let folded = self.capability(g, author);
+            if folded != 0 {
+                folded
+            } else {
+                default_cap_base
+            }
+        };
+        let mut anchor_decision: Option<MemberPathAtCut> = None;
+        let mut current = group;
+        for _ in 0..=MAX_NAMESPACE_DEPTH {
+            let Some(edge) = self.subgroups.get(&ScopeId::from(current.to_bytes())) else {
+                return anchor_decision.unwrap_or(MemberPathAtCut::None);
+            };
+            if edge.restricted {
+                return anchor_decision.unwrap_or(MemberPathAtCut::None);
+            }
+            let parent = ContextGroupId::from(*edge.parent.as_bytes());
+            if is_admin(parent) {
+                return MemberPathAtCut::Inherited {
+                    anchor: parent,
+                    via_admin: true,
+                };
+            }
+            if anchor_decision.is_none()
+                && self
+                    .groups
+                    .get(&parent)
+                    .is_some_and(|m| m.contains_key(author))
+            {
+                anchor_decision = Some(if effective_cap(&parent) & CAN_JOIN_OPEN_SUBGROUPS != 0 {
+                    MemberPathAtCut::Inherited {
+                        anchor: parent,
+                        via_admin: false,
+                    }
+                } else {
+                    MemberPathAtCut::None
+                });
+            }
+            current = parent;
+        }
+        anchor_decision.unwrap_or(MemberPathAtCut::None)
     }
 
     /// `member`'s effective capability bitmask in `group` at the cut: the

--- a/crates/authz/src/lib.rs
+++ b/crates/authz/src/lib.rs
@@ -300,9 +300,14 @@ impl AclView {
         root: Option<(ContextGroupId, PublicKey)>,
         default_cap_base: u32,
     ) -> MemberPathAtCut {
+        // Narrow admin, IDENTICAL to `is_member_at_cut`'s: a folded group admin or
+        // the genesis root admin OF THIS GROUP ONLY. Deliberately NOT the global
+        // `is_root_admin` — the root admin is a member of a *subgroup* only over
+        // the open-subgroup chain (the walk below), never of a Restricted subgroup.
+        // Using the global predicate here would mark the root admin a direct member
+        // of every group, diverging from the membership set this path must mirror.
         let is_admin = |g: ContextGroupId| -> bool {
             self.is_group_admin(author, g)
-                || self.is_root_admin(author)
                 || root.is_some_and(|(root_g, root_admin)| g == root_g && *author == root_admin)
         };
         if let Some(role) = self.groups.get(&group).and_then(|m| m.get(author)) {

--- a/crates/authz/src/lib.rs
+++ b/crates/authz/src/lib.rs
@@ -310,6 +310,11 @@ impl AclView {
             self.is_group_admin(author, g)
                 || root.is_some_and(|(root_g, root_admin)| g == root_g && *author == root_admin)
         };
+        // Direct row FIRST (the reverse of `is_member_at_cut`, which only needs a
+        // bool so its order is immaterial): when an identity is BOTH a stored
+        // member and the genesis admin, live's `list` returns the stored row's
+        // role, so the row is authoritative. The `is_admin` carve-out below only
+        // supplies a role (`Admin`) when there is NO row to read.
         if let Some(role) = self.groups.get(&group).and_then(|m| m.get(author)) {
             return MemberPathAtCut::Direct { role: role.clone() };
         }

--- a/crates/context/src/handlers/list_group_members.rs
+++ b/crates/context/src/handlers/list_group_members.rs
@@ -81,9 +81,16 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
                 // ROLES the identity-set shadow doesn't validate). Resolve every
                 // live member's projected role in ONE fold, then compare; `None`
                 // (not-yet-folded / projection abstains) skips.
+                // `None` per entry = the projection does NOT see this member (not a
+                // member at the cut, OR the cut isn't fully folded). Either way the
+                // role shadow skips it: member PRESENCE is owned by the identity
+                // shadow above (`membership-enum`), so this plane only validates
+                // ROLES for members both sides agree exist — a missing member is
+                // already that plane's divergence, not a silent gap here.
                 let member_ids: Vec<_> = members.iter().map(|(pk, _)| *pk).collect();
                 let projected_roles =
                     proj.member_roles_for(&self.datastore, &group_id, &member_ids, heads);
+                debug_assert_eq!(members.len(), projected_roles.len());
                 for ((member, live_role), projected_role) in members.iter().zip(&projected_roles) {
                     if let Some(projected_role) = projected_role {
                         if projected_role != live_role {

--- a/crates/context/src/handlers/list_group_members.rs
+++ b/crates/context/src/handlers/list_group_members.rs
@@ -75,6 +75,29 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
                 let live_ids: std::collections::BTreeSet<_> =
                     members.iter().map(|(pk, _)| *pk).collect();
                 proj.shadow_member_enum_with(&self.datastore, *ns, &group_id, heads, &live_ids);
+
+                // ROLE shadow (precursor to flipping `list_group_members` onto the
+                // projection, which — unlike the count/cohort consumers — returns
+                // ROLES the identity-set shadow doesn't validate). Per live member,
+                // compare its role to the projection's enumeration role at the
+                // current cut; `None` (not-yet-folded / projection abstains) skips.
+                for (member, live_role) in &members {
+                    if let Some(projected_role) =
+                        proj.member_role_at_cut_with(&self.datastore, &group_id, member, heads)
+                    {
+                        if projected_role != *live_role {
+                            tracing::warn!(
+                                marker = "unified_projection_divergence",
+                                plane = "membership-role",
+                                group_id = ?group_id,
+                                %member,
+                                ?projected_role,
+                                ?live_role,
+                                "query-enum: projection member role differs from live"
+                            );
+                        }
+                    }
+                }
             }
 
             let entries = members

--- a/crates/context/src/handlers/list_group_members.rs
+++ b/crates/context/src/handlers/list_group_members.rs
@@ -81,18 +81,18 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
                 // ROLES the identity-set shadow doesn't validate). Resolve every
                 // live member's projected role in ONE fold, then compare; `None`
                 // (not-yet-folded / projection abstains) skips.
-                // `None` per entry = the projection does NOT see this member (not a
-                // member at the cut, OR the cut isn't fully folded). Either way the
-                // role shadow skips it: member PRESENCE is owned by the identity
-                // shadow above (`membership-enum`), so this plane only validates
-                // ROLES for members both sides agree exist — a missing member is
-                // already that plane's divergence, not a silent gap here.
+                // A member ABSENT from the returned map = the projection has no role
+                // opinion (not a member at the cut, the cut isn't fully folded, or
+                // the group is unfolded → materialized fallback). The role shadow
+                // skips it: member PRESENCE is owned by the identity shadow above
+                // (`membership-enum`), so this plane only validates ROLES for members
+                // both sides agree exist. Keyed lookup (not a positional zip) keeps
+                // this correct regardless of the returned map's size.
                 let member_ids: Vec<_> = members.iter().map(|(pk, _)| *pk).collect();
                 let projected_roles =
                     proj.member_roles_for(&self.datastore, &group_id, &member_ids, heads);
-                debug_assert_eq!(members.len(), projected_roles.len());
-                for ((member, live_role), projected_role) in members.iter().zip(&projected_roles) {
-                    if let Some(projected_role) = projected_role {
+                for (member, live_role) in &members {
+                    if let Some(projected_role) = projected_roles.get(member) {
                         if projected_role != live_role {
                             tracing::warn!(
                                 marker = "unified_projection_divergence",

--- a/crates/context/src/handlers/list_group_members.rs
+++ b/crates/context/src/handlers/list_group_members.rs
@@ -78,14 +78,15 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
 
                 // ROLE shadow (precursor to flipping `list_group_members` onto the
                 // projection, which — unlike the count/cohort consumers — returns
-                // ROLES the identity-set shadow doesn't validate). Per live member,
-                // compare its role to the projection's enumeration role at the
-                // current cut; `None` (not-yet-folded / projection abstains) skips.
-                for (member, live_role) in &members {
-                    if let Some(projected_role) =
-                        proj.member_role_at_cut_with(&self.datastore, &group_id, member, heads)
-                    {
-                        if projected_role != *live_role {
+                // ROLES the identity-set shadow doesn't validate). Resolve every
+                // live member's projected role in ONE fold, then compare; `None`
+                // (not-yet-folded / projection abstains) skips.
+                let member_ids: Vec<_> = members.iter().map(|(pk, _)| *pk).collect();
+                let projected_roles =
+                    proj.member_roles_for(&self.datastore, &group_id, &member_ids, heads);
+                for ((member, live_role), projected_role) in members.iter().zip(&projected_roles) {
+                    if let Some(projected_role) = projected_role {
+                        if projected_role != live_role {
                             tracing::warn!(
                                 marker = "unified_projection_divergence",
                                 plane = "membership-role",

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1099,31 +1099,50 @@ impl ScopeProjections {
     /// fully folded (defer to live). The role-validation read ahead of flipping the
     /// role-bearing `list_group_members` onto the projection.
     #[must_use]
-    pub fn member_role_at_cut_with(
+    pub fn member_roles_for(
         &self,
         store: &Store,
         group: &ContextGroupId,
-        member: &PublicKey,
+        members: &[PublicKey],
         heads: &[[u8; 32]],
-    ) -> Option<GroupMemberRole> {
-        let (view, root, default_cap_base) = self.auth_cut_context(store, *group, heads)?;
-        match view.member_path_at_cut(*group, member, root, default_cap_base) {
-            calimero_authz::MemberPathAtCut::None => None,
-            calimero_authz::MemberPathAtCut::Direct { role } => Some(role),
-            calimero_authz::MemberPathAtCut::Inherited {
-                via_admin: true, ..
-            } => Some(GroupMemberRole::Admin),
-            calimero_authz::MemberPathAtCut::Inherited {
-                anchor,
-                via_admin: false,
-            } => Some(
-                view.groups
-                    .get(&anchor)
-                    .and_then(|m| m.get(member))
-                    .cloned()
-                    .unwrap_or(GroupMemberRole::Member),
-            ),
-        }
+    ) -> Vec<Option<GroupMemberRole>> {
+        // Fold the view ONCE for the whole batch — the shadow resolves a full
+        // member list, so a per-member fold would re-walk the DAG N times.
+        let Some((view, root, default_cap_base)) = self.auth_cut_context(store, *group, heads)
+        else {
+            // Namespace unresolved / cited ancestry not fully folded: abstain for
+            // the whole batch (the shadow skips `None`, the flip falls back to live).
+            return vec![None; members.len()];
+        };
+        members
+            .iter()
+            .map(|member| {
+                match view.member_path_at_cut(*group, member, root, default_cap_base) {
+                    calimero_authz::MemberPathAtCut::None => None,
+                    calimero_authz::MemberPathAtCut::Direct { role } => Some(role),
+                    // Reached over the open chain via an admin ancestor → `Admin`,
+                    // matching live's `via_admin ? Admin : role_of(anchor)`.
+                    calimero_authz::MemberPathAtCut::Inherited {
+                        via_admin: true, ..
+                    } => Some(GroupMemberRole::Admin),
+                    // Non-admin inheritance: the member's role at the `anchor` it
+                    // joined through. `member_path_at_cut` only emits this arm when
+                    // the anchor row is present, so the `Member` fallback is a
+                    // defensive mirror of live's `role_of(anchor).unwrap_or(Member)`
+                    // and is unreachable by construction.
+                    calimero_authz::MemberPathAtCut::Inherited {
+                        anchor,
+                        via_admin: false,
+                    } => Some(
+                        view.groups
+                            .get(&anchor)
+                            .and_then(|m| m.get(member))
+                            .cloned()
+                            .unwrap_or(GroupMemberRole::Member),
+                    ),
+                }
+            })
+            .collect()
     }
 
     /// Shared setup for the at-cut admin/capability reads: resolve the namespace,

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1105,26 +1105,41 @@ impl ScopeProjections {
         group: &ContextGroupId,
         members: &[PublicKey],
         heads: &[[u8; 32]],
-    ) -> Vec<Option<GroupMemberRole>> {
+    ) -> std::collections::BTreeMap<PublicKey, GroupMemberRole> {
         // Fold the view ONCE for the whole batch — the shadow resolves a full
-        // member list, so a per-member fold would re-walk the DAG N times.
+        // member list, so a per-member fold would re-walk the DAG N times. Returns
+        // a map keyed by member (only those the projection assigns a role) so the
+        // caller looks up positionally-independently — no zip-length coupling.
         let Some((view, root, default_cap_base)) = self.auth_cut_context(store, *group, heads)
         else {
-            // Namespace unresolved / cited ancestry not fully folded: abstain for
-            // the whole batch (the shadow skips `None`, the flip falls back to live).
-            return vec![None; members.len()];
+            // Namespace unresolved / cited ancestry not fully folded: abstain
+            // entirely (the shadow finds no entry and skips; the flip falls back to
+            // live).
+            return std::collections::BTreeMap::new();
         };
+        // Materialized-fallback PARITY with the identity shadow
+        // (`member_identities_in_view`): when this group's direct membership isn't
+        // folded (no entry in `view.groups` — a Restricted subgroup arriving as
+        // materialized rows, or undecryptable member ops), the fold has NO opinion
+        // on its roles. Abstain wholesale rather than emit a walk-derived role that
+        // would spuriously differ from live's stored direct row.
+        if !view.groups.contains_key(group) {
+            return std::collections::BTreeMap::new();
+        }
         members
             .iter()
-            .map(|member| {
-                match view.member_path_at_cut(*group, member, root, default_cap_base) {
-                    calimero_authz::MemberPathAtCut::None => None,
-                    calimero_authz::MemberPathAtCut::Direct { role } => Some(role),
+            .filter_map(|member| {
+                let role = match view.member_path_at_cut(*group, member, root, default_cap_base) {
+                    // Not a member at the cut: omit. PRESENCE is the identity
+                    // shadow's job; this plane only validates roles for co-present
+                    // members.
+                    calimero_authz::MemberPathAtCut::None => return None,
+                    calimero_authz::MemberPathAtCut::Direct { role } => role,
                     // Reached over the open chain via an admin ancestor → `Admin`,
                     // matching live's `via_admin ? Admin : role_of(anchor)`.
                     calimero_authz::MemberPathAtCut::Inherited {
                         via_admin: true, ..
-                    } => Some(GroupMemberRole::Admin),
+                    } => GroupMemberRole::Admin,
                     // Non-admin inheritance: the member's role at the `anchor` it
                     // joined through. `member_path_at_cut` only emits this arm when
                     // the anchor row is present, so the `Member` fallback is a
@@ -1133,14 +1148,14 @@ impl ScopeProjections {
                     calimero_authz::MemberPathAtCut::Inherited {
                         anchor,
                         via_admin: false,
-                    } => Some(
-                        view.groups
-                            .get(&anchor)
-                            .and_then(|m| m.get(member))
-                            .cloned()
-                            .unwrap_or(GroupMemberRole::Member),
-                    ),
-                }
+                    } => view
+                        .groups
+                        .get(&anchor)
+                        .and_then(|m| m.get(member))
+                        .cloned()
+                        .unwrap_or(GroupMemberRole::Member),
+                };
+                Some((*member, role))
             })
             .collect()
     }

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1091,6 +1091,41 @@ impl ScopeProjections {
         Some(effective & capability != 0)
     }
 
+    /// The projection's ENUMERATION role for `member` in `group` at the cut — the
+    /// role live's `list ∪ enumerate_inherited` assigns: a direct member's folded
+    /// role, `Admin` for an inherited-via-admin member, else the member's role at
+    /// the anchor it inherits from (mirrors live's `via_admin ? Admin :
+    /// role_of(anchor)`). `None` when not a member at the cut, or the ancestry isn't
+    /// fully folded (defer to live). The role-validation read ahead of flipping the
+    /// role-bearing `list_group_members` onto the projection.
+    #[must_use]
+    pub fn member_role_at_cut_with(
+        &self,
+        store: &Store,
+        group: &ContextGroupId,
+        member: &PublicKey,
+        heads: &[[u8; 32]],
+    ) -> Option<GroupMemberRole> {
+        let (view, root, default_cap_base) = self.auth_cut_context(store, *group, heads)?;
+        match view.member_path_at_cut(*group, member, root, default_cap_base) {
+            calimero_authz::MemberPathAtCut::None => None,
+            calimero_authz::MemberPathAtCut::Direct { role } => Some(role),
+            calimero_authz::MemberPathAtCut::Inherited {
+                via_admin: true, ..
+            } => Some(GroupMemberRole::Admin),
+            calimero_authz::MemberPathAtCut::Inherited {
+                anchor,
+                via_admin: false,
+            } => Some(
+                view.groups
+                    .get(&anchor)
+                    .and_then(|m| m.get(member))
+                    .cloned()
+                    .unwrap_or(GroupMemberRole::Member),
+            ),
+        }
+    }
+
     /// Shared setup for the at-cut admin/capability reads: resolve the namespace,
     /// gate on COMPLETE cited ancestry (so the verdict is authoritative — `None`
     /// otherwise, defer to live), build the folded view + the genesis root tuple


### PR DESCRIPTION
## What

`list_group_members` is the last enum consumer on live. Unlike the count/cohort consumers (flipped in #2852), it returns **roles** — which the identity-set shadow never validated. This **validates the projection's enumeration roles** against live, log-only, as the precursor to flipping it.

## How

- `AclView::member_path_at_cut` — the at-cut analogue of live `check_path`, returning a role-bearing `MemberPathAtCut` (`Direct{role}` / `Inherited{anchor, via_admin}` / `None`) by mirroring the `is_member_at_cut` walk.
- `ScopeProjections::member_role_at_cut_with` — derives the enumeration role exactly as live's `list ∪ enumerate_inherited`: a direct member's folded role, `Admin` for inherited-via-admin, else the member's role at the anchor (matching live's #2846 `via_admin ? Admin : role_of(anchor)`). Gated on `cut_ancestry_complete` (abstain → skip).
- `list_group_members` shadows each live member's role vs the projection's at-cut role, logging `unified_projection_divergence` plane=`membership-role` on a mismatch. **Still returns the live list.**

## Why a shadow first

A wrong role would be a client-facing bug, so I'm validating roles on real e2e traffic before flipping (same shadow→prove→flip discipline as the rest of F5). The flip lands once the `membership-role` plane is divergence-free.

## Test

- `cargo build`/`clippy --all-targets -- -D warnings`/`fmt` clean; authz 10/10, equivalence 3/3.
- e2e: the new `membership-role` plane gates role equivalence across the scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches group membership role resolution and enumeration parity with live; behavior is shadow-only today but wrong logic would surface on the eventual list_group_members flip.
> 
> **Overview**
> Adds **log-only validation** that projected **member roles** match live for `list_group_members`, ahead of serving that API from the causal projection (the existing identity shadow did not cover roles).
> 
> **`calimero-authz`:** Introduces `MemberPathAtCut` and `AclView::member_path_at_cut`, mirroring the `is_member_at_cut` walk but returning direct role, inherited-via-admin, or inherited-from-anchor (with stored-row precedence over genesis admin).
> 
> **`scope_projection`:** Adds `member_roles_for` to resolve enumeration roles in one fold (direct / `Admin` when inherited via admin / anchor role otherwise), abstaining when ancestry is incomplete or the group has no folded direct membership (same materialized-fallback parity as the identity enum).
> 
> **`list_group_members`:** After the membership-enum shadow, compares each live member’s role to the projection map and logs `unified_projection_divergence` with plane `membership-role` on mismatch; the handler **still returns the live list**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb4720fc63830000d2f2ce20835c23d6ed1e0bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->