### PR TITLE
feat(context): flip list_group_members onto the projection enumeration

### DIFF
--- a/crates/context/src/handlers/list_group_members.rs
+++ b/crates/context/src/handlers/list_group_members.rs
@@ -74,15 +74,9 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
                 })
                 .map_or_else(
                     || -> eyre::Result<Vec<_>> {
-                        let mut live = MembershipRepository::new(&self.datastore).list(
-                            &group_id,
-                            0,
-                            usize::MAX,
-                        )?;
-                        live.extend(
-                            MembershipRepository::new(&self.datastore)
-                                .enumerate_inherited(&group_id)?,
-                        );
+                        let membership = MembershipRepository::new(&self.datastore);
+                        let mut live = membership.list(&group_id, 0, usize::MAX)?;
+                        live.extend(membership.enumerate_inherited(&group_id)?);
                         Ok(live)
                     },
                     Ok,

--- a/crates/context/src/handlers/list_group_members.rs
+++ b/crates/context/src/handlers/list_group_members.rs
@@ -24,10 +24,10 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
             let Some((node_identity, _)) = self.node_namespace_identity(&group_id) else {
                 bail!("node has no group identity configured");
             };
-            // Fold the ephemeral projection ONCE for this request: the gate below
-            // and the enum shadow further down both read from it (one RocksDB DAG
-            // walk, not two). `None` (store fault) falls back to live for the gate
-            // and skips the shadow.
+            // Fold the ephemeral projection ONCE for this request: the membership
+            // gate below and the effective-member enumeration further down both read
+            // from it (one RocksDB DAG walk, not two). `None` (store fault) falls
+            // back to live for both.
             let proj_ctx = crate::scope_projection::ScopeProjections::ephemeral_projection(
                 &self.datastore,
                 &group_id,
@@ -51,62 +51,42 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
             // the union they would never surface here even though
             // `check_group_membership` reports them as members (#2371).
             //
-            // Pagination must span the union, so the full sets are
-            // collected here and sliced after the merge rather than
-            // pushed down into the store query. Known cost: a paginated
-            // call is O(total effective members) in store reads, not
-            // O(offset+limit). This is acceptable here — group
-            // membership is governance-scale (a permission hierarchy),
-            // not an unbounded user list — and the inherited set cannot
-            // be store-paginated at all since it is computed, not
-            // stored. The inherited set is disjoint from the stored
-            // rows by construction (`enumerate_inherited_members`
-            // excludes direct members of `group_id`), so no dedup is
-            // needed.
-            let mut members =
-                MembershipRepository::new(&self.datastore).list(&group_id, 0, usize::MAX)?;
-            members
-                .extend(MembershipRepository::new(&self.datastore).enumerate_inherited(&group_id)?);
-
-            // SHADOW: validate the projection's effective-member set against this
-            // live union (logs `membership-enum` divergence; still returns live).
-            // Reuses the single fold built above for the gate.
-            if let Some((proj, ns, heads)) = &proj_ctx {
-                let live_ids: std::collections::BTreeSet<_> =
-                    members.iter().map(|(pk, _)| *pk).collect();
-                proj.shadow_member_enum_with(&self.datastore, *ns, &group_id, heads, &live_ids);
-
-                // ROLE shadow (precursor to flipping `list_group_members` onto the
-                // projection, which — unlike the count/cohort consumers — returns
-                // ROLES the identity-set shadow doesn't validate). Resolve every
-                // live member's projected role in ONE fold, then compare; `None`
-                // (not-yet-folded / projection abstains) skips.
-                // A member ABSENT from the returned map = the projection has no role
-                // opinion (not a member at the cut, the cut isn't fully folded, or
-                // the group is unfolded → materialized fallback). The role shadow
-                // skips it: member PRESENCE is owned by the identity shadow above
-                // (`membership-enum`), so this plane only validates ROLES for members
-                // both sides agree exist. Keyed lookup (not a positional zip) keeps
-                // this correct regardless of the returned map's size.
-                let member_ids: Vec<_> = members.iter().map(|(pk, _)| *pk).collect();
-                let projected_roles =
-                    proj.member_roles_for(&self.datastore, &group_id, &member_ids, heads);
-                for (member, live_role) in &members {
-                    if let Some(projected_role) = projected_roles.get(member) {
-                        if projected_role != live_role {
-                            tracing::warn!(
-                                marker = "unified_projection_divergence",
-                                plane = "membership-role",
-                                group_id = ?group_id,
-                                %member,
-                                ?projected_role,
-                                ?live_role,
-                                "query-enum: projection member role differs from live"
-                            );
-                        }
-                    }
-                }
-            }
+            // From the PROJECTION's effective-member enumeration with roles
+            // (`member_entries_with`): the identity set validated divergence-free on
+            // the `membership-enum` plane, the roles on `membership-role`. `None` —
+            // an empty/unfed namespace, a cited ancestry not fully folded, or a
+            // target group whose direct membership isn't folded (materialized
+            // fallback) — falls back to the live `list ∪ enumerate_inherited` union,
+            // which already carries roles. The live fallback retires in #29b.
+            //
+            // Pagination must span the union, so the full set is collected here and
+            // sliced after the merge rather than pushed down into the store query.
+            // Known cost: a paginated call is O(total effective members), not
+            // O(offset+limit). This is acceptable — group membership is
+            // governance-scale (a permission hierarchy), not an unbounded user list.
+            // The inherited set is disjoint from the stored rows by construction
+            // (`enumerate_inherited` excludes direct members of `group_id`), so no
+            // dedup is needed.
+            let members = proj_ctx
+                .as_ref()
+                .and_then(|(proj, ns, heads)| {
+                    proj.member_entries_with(&self.datastore, *ns, &group_id, heads)
+                })
+                .map_or_else(
+                    || -> eyre::Result<Vec<_>> {
+                        let mut live = MembershipRepository::new(&self.datastore).list(
+                            &group_id,
+                            0,
+                            usize::MAX,
+                        )?;
+                        live.extend(
+                            MembershipRepository::new(&self.datastore)
+                                .enumerate_inherited(&group_id)?,
+                        );
+                        Ok(live)
+                    },
+                    Ok,
+                )?;
 
             let entries = members
                 .into_iter()

--- a/crates/context/src/handlers/list_group_members.rs
+++ b/crates/context/src/handlers/list_group_members.rs
@@ -53,11 +53,14 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
             //
             // From the PROJECTION's effective-member enumeration with roles
             // (`member_entries_with`): the identity set validated divergence-free on
-            // the `membership-enum` plane, the roles on `membership-role`. `None` —
-            // an empty/unfed namespace, a cited ancestry not fully folded, or a
-            // target group whose direct membership isn't folded (materialized
-            // fallback) — falls back to the live `list ∪ enumerate_inherited` union,
-            // which already carries roles. The live fallback retires in #29b.
+            // the `membership-enum` plane, the roles on `membership-role`. `None`
+            // falls back to the live `list ∪ enumerate_inherited` union, which already
+            // carries roles. The `None` reasons are an empty/unfed namespace, a cited
+            // ancestry not fully folded, a target group whose direct membership isn't
+            // folded (materialized fallback) — all expected steady-state deferrals —
+            // and a fold inconsistency, the one abnormal case, already logged with a
+            // `unified_projection_divergence` warn inside `member_entries_with`. The
+            // live fallback retires in #29b.
             //
             // Pagination must span the union, so the full set is collected here and
             // sliced after the merge rather than pushed down into the store query.
@@ -67,7 +70,7 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
             // The inherited set is disjoint from the stored rows by construction
             // (`enumerate_inherited` excludes direct members of `group_id`), so no
             // dedup is needed.
-            let members = proj_ctx
+            let mut members = proj_ctx
                 .as_ref()
                 .and_then(|(proj, ns, heads)| {
                     proj.member_entries_with(&self.datastore, *ns, &group_id, heads)
@@ -81,6 +84,14 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
                     },
                     Ok,
                 )?;
+            // Sort by identity for a STABLE, path-independent pagination order: the
+            // projection path yields `PublicKey`-sorted ids (a `BTreeSet`) while the
+            // live fallback yields store order, so without this a request served by
+            // the projection and a later page served by the live fallback (e.g. mid-
+            // backfill) could skip or repeat members across pages. Sorting both paths
+            // the same way makes `skip(offset).take(limit)` consistent regardless of
+            // which produced the set.
+            members.sort_by_key(|(identity, _)| *identity);
 
             let entries = members
                 .into_iter()

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -651,12 +651,27 @@ impl ScopeProjections {
                 calimero_authz::MemberPathAtCut::Inherited {
                     anchor,
                     via_admin: false,
-                } => view
-                    .groups
-                    .get(&anchor)
-                    .and_then(|m| m.get(&id))
-                    .cloned()
-                    .unwrap_or(GroupMemberRole::Member),
+                } => {
+                    // `member_path_at_cut` only emits this arm when the anchor row is
+                    // present (the walk sets it inside `groups[anchor].contains(id)`),
+                    // read from the SAME view, so the lookup can't miss. On the
+                    // authoritative path don't silently guess `Member` if it somehow
+                    // does — that's a fold inconsistency; bail to live like the
+                    // `None` arm, rather than misreport a role with no signal.
+                    let Some(role) = view.groups.get(&anchor).and_then(|m| m.get(&id)).cloned()
+                    else {
+                        tracing::warn!(
+                            marker = "unified_projection_divergence",
+                            plane = "membership-role",
+                            group_id = ?group,
+                            %id,
+                            ?anchor,
+                            "member_entries: inherited anchor row absent; deferring whole enumeration to live"
+                        );
+                        return None;
+                    };
+                    role
+                }
             };
             entries.push((id, role));
         }

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -584,8 +584,8 @@ impl ScopeProjections {
     }
 
     /// The full effective-member ENUMERATION with roles at the cut — the
-    /// projection's answer for `list_group_members`. Returns `(identity, role)` for
-    /// every effective member, with the identity SET IDENTICAL to
+    /// projection's answer for `list_group_members`. For a FOLDED group it returns
+    /// `(identity, role)` for every effective member, with the identity SET EQUAL to
     /// [`member_identities_with`](Self::member_identities_with) (validated
     /// divergence-free on the `membership-enum` plane) and each role resolved by the
     /// same `member_path_at_cut` the `membership-role` plane validated.
@@ -593,9 +593,15 @@ impl ScopeProjections {
     /// `None` (defer to live) when the cited ancestry isn't fully folded — enforced
     /// by `auth_cut_context`, which gates on `cut_ancestry_complete` and returns
     /// `None` on a partial fold — OR the target group's direct membership isn't
-    /// folded at all (the `!view.groups.contains_key` materialized-fallback case,
-    /// where the fold has no opinion and live's `list ∪ enumerate_inherited`, which
-    /// already carries roles, is authoritative).
+    /// folded at all (`!view.groups.contains_key`).
+    ///
+    /// NOTE on the unfolded-group case: unlike `member_identities_with`, which
+    /// INJECTS live `list ∪ enumerate_inherited` rows for an unfolded group (its
+    /// materialized fallback), this returns `None` there — so the identity-set
+    /// equality above holds for FOLDED groups only. The end result is the same: on
+    /// `None` the handler falls back to the live `list ∪ enumerate_inherited` union,
+    /// yielding those same rows (with roles). Deferring via `None` keeps the live
+    /// `list` read out of this projection method.
     ///
     /// PARTIAL FOLD: the materialized fallback is all-or-nothing — a group with even
     /// one folded direct member is treated as fully folded, so a materialized
@@ -661,9 +667,13 @@ impl ScopeProjections {
                     // `None` arm, rather than misreport a role with no signal.
                     let Some(role) = view.groups.get(&anchor).and_then(|m| m.get(&id)).cloned()
                     else {
+                        // A member in the validated identity set whose anchor row is
+                        // absent from the SAME view is a structural inconsistency in
+                        // the membership graph, not a role-only mismatch — so this is
+                        // an enum-plane divergence, matching the `None` arm above.
                         tracing::warn!(
                             marker = "unified_projection_divergence",
-                            plane = "membership-role",
+                            plane = "membership-enum",
                             group_id = ?group,
                             %id,
                             ?anchor,

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -590,11 +590,12 @@ impl ScopeProjections {
     /// divergence-free on the `membership-enum` plane) and each role resolved by the
     /// same `member_path_at_cut` the `membership-role` plane validated.
     ///
-    /// `None` (defer to live) when the cited ancestry isn't fully folded OR the
-    /// target group's direct membership isn't folded at all — the
-    /// `!view.groups.contains_key` materialized-fallback case, where the fold has no
-    /// opinion and live's `list ∪ enumerate_inherited` (which already carries roles)
-    /// is authoritative.
+    /// `None` (defer to live) when the cited ancestry isn't fully folded — enforced
+    /// by `auth_cut_context`, which gates on `cut_ancestry_complete` and returns
+    /// `None` on a partial fold — OR the target group's direct membership isn't
+    /// folded at all (the `!view.groups.contains_key` materialized-fallback case,
+    /// where the fold has no opinion and live's `list ∪ enumerate_inherited`, which
+    /// already carries roles, is authoritative).
     ///
     /// PARTIAL FOLD: the materialized fallback is all-or-nothing — a group with even
     /// one folded direct member is treated as fully folded, so a materialized

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -594,9 +594,21 @@ impl ScopeProjections {
     /// target group's direct membership isn't folded at all — the
     /// `!view.groups.contains_key` materialized-fallback case, where the fold has no
     /// opinion and live's `list ∪ enumerate_inherited` (which already carries roles)
-    /// is authoritative. For a FOLDED group the validated id set is pure projection,
-    /// so every id resolves to a non-`None` path (the `continue` is unreachable,
-    /// kept defensive).
+    /// is authoritative.
+    ///
+    /// PARTIAL FOLD: the materialized fallback is all-or-nothing — a group with even
+    /// one folded direct member is treated as fully folded, so a materialized
+    /// `GroupMember` row that never entered the fold would be missing. This is a
+    /// property of the shared `member_identities_in_view` candidate universe (the
+    /// merged count/cohort consumers share it), not new here. It is bounded by sync
+    /// delivering a group's membership atomically — fully folded or fully
+    /// materialized, not partial — which is why the e2e `membership-enum` plane held
+    /// 0 divergences; the durable close is folding-completeness in P6 (#17).
+    ///
+    /// If an id from the validated set resolves to `MemberPathAtCut::None` (a fold
+    /// inconsistency — the membership walk and the candidate filter disagreeing), the
+    /// whole enumeration abandons the projection and defers to live rather than
+    /// returning a silently truncated list.
     pub fn member_entries_with(
         &self,
         store: &Store,
@@ -609,28 +621,40 @@ impl ScopeProjections {
         if !view.groups.contains_key(group) {
             return None;
         }
-        let entries = ids
-            .into_iter()
-            .filter_map(|id| {
-                let role = match view.member_path_at_cut(*group, &id, root, default_cap_base) {
-                    calimero_authz::MemberPathAtCut::None => return None,
-                    calimero_authz::MemberPathAtCut::Direct { role } => role,
-                    calimero_authz::MemberPathAtCut::Inherited {
-                        via_admin: true, ..
-                    } => GroupMemberRole::Admin,
-                    calimero_authz::MemberPathAtCut::Inherited {
-                        anchor,
-                        via_admin: false,
-                    } => view
-                        .groups
-                        .get(&anchor)
-                        .and_then(|m| m.get(&id))
-                        .cloned()
-                        .unwrap_or(GroupMemberRole::Member),
-                };
-                Some((id, role))
-            })
-            .collect();
+        let mut entries = Vec::with_capacity(ids.len());
+        for id in ids {
+            let role = match view.member_path_at_cut(*group, &id, root, default_cap_base) {
+                calimero_authz::MemberPathAtCut::None => {
+                    // The validated id set placed `id` in `group`, but the role walk
+                    // rejects it — the candidate filter and `member_path_at_cut`
+                    // disagreeing. Never silently drop the member (a truncated list
+                    // has no signal); abandon the projection enumeration and let the
+                    // caller fall back to live's complete union.
+                    tracing::warn!(
+                        marker = "unified_projection_divergence",
+                        plane = "membership-enum",
+                        group_id = ?group,
+                        %id,
+                        "member_entries: validated-set id has no at-cut path; deferring whole enumeration to live"
+                    );
+                    return None;
+                }
+                calimero_authz::MemberPathAtCut::Direct { role } => role,
+                calimero_authz::MemberPathAtCut::Inherited {
+                    via_admin: true, ..
+                } => GroupMemberRole::Admin,
+                calimero_authz::MemberPathAtCut::Inherited {
+                    anchor,
+                    via_admin: false,
+                } => view
+                    .groups
+                    .get(&anchor)
+                    .and_then(|m| m.get(&id))
+                    .cloned()
+                    .unwrap_or(GroupMemberRole::Member),
+            };
+            entries.push((id, role));
+        }
         Some(entries)
     }
 

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -534,10 +534,10 @@ impl ScopeProjections {
 
     /// Build the shared ephemeral projection for `group`'s namespace ONCE — the
     /// expensive part (`collect_namespace_ops` RocksDB DAG walk + fold) plus the
-    /// current heads. A handler that needs BOTH the membership gate and the enum
-    /// shadow folds once via this and reuses the result for
+    /// current heads. A handler that needs BOTH the membership gate and the
+    /// effective-member enumeration folds once via this and reuses the result for
     /// [`member_now_checked_with`](Self::member_now_checked_with) and
-    /// [`shadow_member_enum_with`](Self::shadow_member_enum_with), instead of two
+    /// [`member_entries_with`](Self::member_entries_with), instead of two
     /// independent folds. `None` (with a warn) on a store fault — the caller falls
     /// back to live.
     #[must_use]
@@ -554,16 +554,14 @@ impl ScopeProjections {
     }
 
     /// The effective member-identity SET of `group` from an ALREADY-built
-    /// projection (the `_with` analogue of [`shadow_member_enum_with`], but
-    /// returning the set instead of comparing it). The authoritative read for the
-    /// identity-set enumeration consumers (member count, migration cohort) now that
-    /// the set is validated divergence-free across the e2e `membership-enum` plane.
-    /// `None` when the scope wasn't fed (an empty namespace) OR the cited ancestry
-    /// isn't fully folded (a governance-backfill race) — caller falls back to live,
-    /// exactly as the membership gate's `member_at_cut` defers on an incomplete cut.
-    /// Without this guard a partial fold would silently UNDER-count. (Identity-only;
-    /// the role-bearing `list_group_members` flip needs a role-enumeration variant +
-    /// its own validation.)
+    /// projection. The authoritative read for the identity-set enumeration consumers
+    /// (member count, migration cohort) now that the set is validated divergence-free
+    /// across the e2e `membership-enum` plane; the role-bearing `list_group_members`
+    /// consumer uses [`member_entries_with`](Self::member_entries_with), which builds
+    /// on this same set. `None` when the scope wasn't fed (an empty namespace) OR the
+    /// cited ancestry isn't fully folded (a governance-backfill race) — caller falls
+    /// back to live, exactly as the membership gate's `member_at_cut` defers on an
+    /// incomplete cut. Without this guard a partial fold would silently UNDER-count.
     #[must_use]
     pub fn member_identities_with(
         &self,
@@ -583,6 +581,57 @@ impl ScopeProjections {
             namespace_id,
             group,
         ))
+    }
+
+    /// The full effective-member ENUMERATION with roles at the cut — the
+    /// projection's answer for `list_group_members`. Returns `(identity, role)` for
+    /// every effective member, with the identity SET IDENTICAL to
+    /// [`member_identities_with`](Self::member_identities_with) (validated
+    /// divergence-free on the `membership-enum` plane) and each role resolved by the
+    /// same `member_path_at_cut` the `membership-role` plane validated.
+    ///
+    /// `None` (defer to live) when the cited ancestry isn't fully folded OR the
+    /// target group's direct membership isn't folded at all — the
+    /// `!view.groups.contains_key` materialized-fallback case, where the fold has no
+    /// opinion and live's `list ∪ enumerate_inherited` (which already carries roles)
+    /// is authoritative. For a FOLDED group the validated id set is pure projection,
+    /// so every id resolves to a non-`None` path (the `continue` is unreachable,
+    /// kept defensive).
+    pub fn member_entries_with(
+        &self,
+        store: &Store,
+        namespace_id: [u8; 32],
+        group: &ContextGroupId,
+        heads: &[[u8; 32]],
+    ) -> Option<Vec<(PublicKey, GroupMemberRole)>> {
+        let ids = self.member_identities_with(store, namespace_id, group, heads)?;
+        let (view, root, default_cap_base) = self.auth_cut_context(store, *group, heads)?;
+        if !view.groups.contains_key(group) {
+            return None;
+        }
+        let entries = ids
+            .into_iter()
+            .filter_map(|id| {
+                let role = match view.member_path_at_cut(*group, &id, root, default_cap_base) {
+                    calimero_authz::MemberPathAtCut::None => return None,
+                    calimero_authz::MemberPathAtCut::Direct { role } => role,
+                    calimero_authz::MemberPathAtCut::Inherited {
+                        via_admin: true, ..
+                    } => GroupMemberRole::Admin,
+                    calimero_authz::MemberPathAtCut::Inherited {
+                        anchor,
+                        via_admin: false,
+                    } => view
+                        .groups
+                        .get(&anchor)
+                        .and_then(|m| m.get(&id))
+                        .cloned()
+                        .unwrap_or(GroupMemberRole::Member),
+                };
+                Some((id, role))
+            })
+            .collect();
+        Some(entries)
     }
 
     /// The shared fold primitive for both [`ephemeral_projection`](Self::ephemeral_projection)
@@ -622,37 +671,6 @@ impl ScopeProjections {
             return Ok(p);
         }
         MembershipRepository::new(store).is_member(group, member)
-    }
-
-    /// The enum shadow over an ALREADY-built ephemeral projection — same contract
-    /// as [`shadow_check_member_enum`](Self::shadow_check_member_enum) but reusing a
-    /// shared fold.
-    pub fn shadow_member_enum_with(
-        &self,
-        store: &Store,
-        namespace_id: [u8; 32],
-        group: &ContextGroupId,
-        heads: &[[u8; 32]],
-        live_identities: &std::collections::BTreeSet<PublicKey>,
-    ) {
-        // `None` only when the scope was never fed (an empty namespace with no
-        // governance ops) — nothing to compare, so skip rather than warn.
-        let Some(view) = self.acl_view_at(&ScopeId::from(namespace_id), heads) else {
-            return;
-        };
-        let projected = Self::member_identities_in_view(&view, store, namespace_id, group);
-        if &projected != live_identities {
-            let only_projection: Vec<_> = projected.difference(live_identities).collect();
-            let only_live: Vec<_> = live_identities.difference(&projected).collect();
-            tracing::warn!(
-                marker = "unified_projection_divergence",
-                plane = "membership-enum",
-                group_id = ?group,
-                ?only_projection,
-                ?only_live,
-                "query-enum: projection effective-member set differs from live"
-            );
-        }
     }
 
     /// The effective member-identity set of `group` from an already-folded `view`
@@ -1089,75 +1107,6 @@ impl ScopeProjections {
             default_cap_base
         };
         Some(effective & capability != 0)
-    }
-
-    /// The projection's ENUMERATION role for `member` in `group` at the cut — the
-    /// role live's `list ∪ enumerate_inherited` assigns: a direct member's folded
-    /// role, `Admin` for an inherited-via-admin member, else the member's role at
-    /// the anchor it inherits from (mirrors live's `via_admin ? Admin :
-    /// role_of(anchor)`). `None` when not a member at the cut, or the ancestry isn't
-    /// fully folded (defer to live). The role-validation read ahead of flipping the
-    /// role-bearing `list_group_members` onto the projection.
-    #[must_use]
-    pub fn member_roles_for(
-        &self,
-        store: &Store,
-        group: &ContextGroupId,
-        members: &[PublicKey],
-        heads: &[[u8; 32]],
-    ) -> std::collections::BTreeMap<PublicKey, GroupMemberRole> {
-        // Fold the view ONCE for the whole batch — the shadow resolves a full
-        // member list, so a per-member fold would re-walk the DAG N times. Returns
-        // a map keyed by member (only those the projection assigns a role) so the
-        // caller looks up positionally-independently — no zip-length coupling.
-        let Some((view, root, default_cap_base)) = self.auth_cut_context(store, *group, heads)
-        else {
-            // Namespace unresolved / cited ancestry not fully folded: abstain
-            // entirely (the shadow finds no entry and skips; the flip falls back to
-            // live).
-            return std::collections::BTreeMap::new();
-        };
-        // Materialized-fallback PARITY with the identity shadow
-        // (`member_identities_in_view`): when this group's direct membership isn't
-        // folded (no entry in `view.groups` — a Restricted subgroup arriving as
-        // materialized rows, or undecryptable member ops), the fold has NO opinion
-        // on its roles. Abstain wholesale rather than emit a walk-derived role that
-        // would spuriously differ from live's stored direct row.
-        if !view.groups.contains_key(group) {
-            return std::collections::BTreeMap::new();
-        }
-        members
-            .iter()
-            .filter_map(|member| {
-                let role = match view.member_path_at_cut(*group, member, root, default_cap_base) {
-                    // Not a member at the cut: omit. PRESENCE is the identity
-                    // shadow's job; this plane only validates roles for co-present
-                    // members.
-                    calimero_authz::MemberPathAtCut::None => return None,
-                    calimero_authz::MemberPathAtCut::Direct { role } => role,
-                    // Reached over the open chain via an admin ancestor → `Admin`,
-                    // matching live's `via_admin ? Admin : role_of(anchor)`.
-                    calimero_authz::MemberPathAtCut::Inherited {
-                        via_admin: true, ..
-                    } => GroupMemberRole::Admin,
-                    // Non-admin inheritance: the member's role at the `anchor` it
-                    // joined through. `member_path_at_cut` only emits this arm when
-                    // the anchor row is present, so the `Member` fallback is a
-                    // defensive mirror of live's `role_of(anchor).unwrap_or(Member)`
-                    // and is unreachable by construction.
-                    calimero_authz::MemberPathAtCut::Inherited {
-                        anchor,
-                        via_admin: false,
-                    } => view
-                        .groups
-                        .get(&anchor)
-                        .and_then(|m| m.get(member))
-                        .cloned()
-                        .unwrap_or(GroupMemberRole::Member),
-                };
-                Some((*member, role))
-            })
-            .collect()
     }
 
     /// Shared setup for the at-cut admin/capability reads: resolve the namespace,

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -632,7 +632,17 @@ impl ScopeProjections {
         if !view.groups.contains_key(group) {
             return None;
         }
-        let ids = Self::member_identities_in_view(&view, store, namespace_id, group);
+        // Reuse the SAME `root`/`default_cap_base` for the candidate filter that the
+        // role walk below uses, so they can't disagree across two store reads (and
+        // `Meta`/`Capabilities` are read once per request, not twice).
+        let ids = Self::member_identities_in_view_with_ctx(
+            &view,
+            store,
+            namespace_id,
+            group,
+            root,
+            default_cap_base,
+        );
         let mut entries = Vec::with_capacity(ids.len());
         for id in ids {
             let role = match view.member_path_at_cut(*group, &id, root, default_cap_base) {
@@ -765,6 +775,32 @@ impl ScopeProjections {
             .ok()
             .flatten()
             .unwrap_or(0);
+        Self::member_identities_in_view_with_ctx(
+            view,
+            store,
+            namespace_id,
+            group,
+            root,
+            default_cap_base,
+        )
+    }
+
+    /// [`member_identities_in_view`](Self::member_identities_in_view) with the
+    /// genesis `root` tuple + `default_cap_base` supplied by the caller instead of
+    /// re-read here. `member_entries_with` passes the SAME values its role walk
+    /// (`member_path_at_cut`) uses, so the candidate filter and the role resolution
+    /// can't disagree on the admin/cap base across two store reads, and the
+    /// `MetaRepository`/`CapabilitiesRepository` reads happen once per request.
+    #[must_use]
+    pub fn member_identities_in_view_with_ctx(
+        view: &calimero_authz::AclView,
+        store: &Store,
+        namespace_id: [u8; 32],
+        group: &ContextGroupId,
+        root: Option<(ContextGroupId, PublicKey)>,
+        default_cap_base: u32,
+    ) -> std::collections::BTreeSet<PublicKey> {
+        let root_group = ContextGroupId::from(namespace_id);
 
         // Candidate universe — provably COMPLETE w.r.t. `is_member_at_cut`, which
         // accepts an identity only as: a direct member of `group` or an ancestor

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -616,11 +616,16 @@ impl ScopeProjections {
         group: &ContextGroupId,
         heads: &[[u8; 32]],
     ) -> Option<Vec<(PublicKey, GroupMemberRole)>> {
-        let ids = self.member_identities_with(store, namespace_id, group, heads)?;
+        // Fold the view ONCE: `auth_cut_context` gates `cut_ancestry_complete` and
+        // builds the `acl_view_at` + root + cap. Both the validated id set and the
+        // per-member role derive from THIS view — `member_identities_in_view` is the
+        // pre-folded variant, so the ancestry walk runs once per request, not twice
+        // (the gate `member_identities_with` would otherwise fold a second time).
         let (view, root, default_cap_base) = self.auth_cut_context(store, *group, heads)?;
         if !view.groups.contains_key(group) {
             return None;
         }
+        let ids = Self::member_identities_in_view(&view, store, namespace_id, group);
         let mut entries = Vec::with_capacity(ids.len());
         for id in ids {
             let role = match view.member_path_at_cut(*group, &id, root, default_cap_base) {


### PR DESCRIPTION
## What

`list_group_members` is the **last membership-enum consumer reading the live resolver**. Flip it onto the projection.

This is the payoff of #2853 (role shadow) + #2852 (identity-set flip): the projection's at-cut effective-member enumeration is validated divergence-free on both the `membership-enum` (identities) and `membership-role` (roles) planes — the role shadow ran **0 divergences across three e2e runs**.

## How

- **`member_entries_with`** — the full effective-member enumeration **with roles**. Identity set is the already-validated `member_identities_with` set; each role is resolved by the same `member_path_at_cut` the role shadow proved equal to live. `None` (defer to live) when the cited ancestry isn't fully folded, or the target group's direct membership isn't folded — the materialized-fallback case live owns.
- **`list_group_members`** builds its member list from `member_entries_with`, falling back to the live `list ∪ enumerate_inherited` union on `None`. The live fallback retires in #29b.
- **Removed dead shadow scaffolding** for this consumer — `member_roles_for` (role shadow) and `shadow_member_enum_with` (identity shadow); this was their last caller. Doc-refs repointed.

## Safety

Behavior-preserving: the shadow proved the projection enumeration (identities + roles) equals live across the e2e scenarios, and the `None` path still defers to live for un-folded cuts. No new wire, no new shadow.

## Test

- `cargo clippy --all-targets -- -D warnings` / `fmt` clean; projection equivalence 3/3.
- e2e: behavioral (no shadow markers left); the scenarios exercising `list_group_members` now read the projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authoritative membership listing for a governance API; behavior is intended to match live via prior shadow validation and explicit defer-to-live paths, but incorrect projection enumeration could misreport members or roles until #29b removes the fallback.
> 
> **Overview**
> **`list_group_members`** now builds the effective member list from the ephemeral projection via **`member_entries_with`** (identities + roles at the cut), reusing the same single DAG fold as the membership gate. On **`None`** (unfed namespace, incomplete fold, unfolded direct membership, or fold inconsistency) it still falls back to live **`list ∪ enumerate_inherited`**. Members are **sorted by `PublicKey`** before pagination so projection and live paths share a stable page order.
> 
> **`scope_projection`** adds **`member_entries_with`** and **`member_identities_in_view_with_ctx`** (shared root/cap context for identity set vs role walk). It removes **`shadow_member_enum_with`** and **`member_roles_for`**, which were only used for shadow validation on this handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e5e0ae6ae272cb3ee0a774ae77903b1b1278a6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->