### PR TITLE
feat(governance): apply-auth at-cut authorizer seam (F5 #28 stage 3a)

### DIFF
--- a/crates/context/src/governance_dag.rs
+++ b/crates/context/src/governance_dag.rs
@@ -104,9 +104,17 @@ impl NamespaceGovernanceApplier {
 #[async_trait::async_trait]
 impl DeltaApplier<SignedNamespaceOp> for NamespaceGovernanceApplier {
     async fn apply(&self, delta: &CausalDelta<SignedNamespaceOp>) -> Result<(), ApplyError> {
-        let outcome =
-            calimero_governance_store::apply_signed_namespace_op(&self.store, &delta.payload)
-                .map_err(|e| ApplyError::Application(e.to_string()))?;
+        // F5 #28: thread the op's causal cut + the at-cut apply-auth source into the
+        // governance-store apply gates. `LIVE_FALLBACK_AUTHORIZER` always returns
+        // `None`, so the gates keep using the live resolver — this commit only opens
+        // the seam; a projection-backed authorizer replaces it in the flip stage.
+        let outcome = calimero_governance_store::apply_signed_namespace_op_at_cut(
+            &self.store,
+            &delta.payload,
+            &delta.parents,
+            &calimero_governance_store::LIVE_FALLBACK_AUTHORIZER,
+        )
+        .map_err(|e| ApplyError::Application(e.to_string()))?;
         if let Some(report) = outcome.divergence {
             // Last-writer-wins on the outbox. The applier instance
             // is single-flight per actor message turn, so multiple

--- a/crates/governance-store/src/authorizer.rs
+++ b/crates/governance-store/src/authorizer.rs
@@ -1,0 +1,79 @@
+//! At-cut apply authorization seam (F5 #28).
+//!
+//! The apply-time governance gates (e.g. [`NamespaceApplyCtx::require_namespace_admin`])
+//! historically read the LIVE membership resolver, which has no causal context —
+//! they decide against the receiver's current state, not the op's own parents. F5
+//! moves that decision onto the unified projection, resolved at the op's causal
+//! cut. But the projection lives in `crates/context`, which DEPENDS on this crate,
+//! so this crate cannot reach it directly.
+//!
+//! [`AtCutAuthorizer`] inverts that dependency: this crate defines the trait the
+//! apply gates call; `crates/context` implements it backed by the projection and
+//! injects it at the apply call site. The gate stays here; only the decision
+//! source is abstracted. `None` from any method means "the projection has no
+//! authoritative verdict at this cut" (an incomplete fold) — the gate falls back
+//! to the live resolver, exactly as the read-side consumers do.
+//!
+//! [`NamespaceApplyCtx::require_namespace_admin`]: crate::ops::namespace::NamespaceApplyCtx
+
+use calimero_context_config::types::ContextGroupId;
+use calimero_primitives::identity::PublicKey;
+
+/// The apply-gate decision source, resolved at an op's causal cut (its parent op
+/// hashes). Implemented in `crates/context` over the unified projection; this
+/// crate calls it from the apply gates without depending on the projection.
+///
+/// Every method returns `Option<bool>`: `Some(verdict)` when the projection's
+/// cited ancestry is fully folded and the answer is authoritative, `None` when it
+/// isn't (the caller defers to the live resolver).
+pub trait AtCutAuthorizer {
+    /// Is `signer` an admin of `group` at the cut named by `parents`?
+    fn is_admin_at_cut(
+        &self,
+        group: ContextGroupId,
+        signer: &PublicKey,
+        parents: &[[u8; 32]],
+    ) -> Option<bool>;
+
+    /// Is `signer` an admin of `group`, OR a holder of `capability`, at the cut
+    /// named by `parents`?
+    fn is_admin_or_capability_at_cut(
+        &self,
+        group: ContextGroupId,
+        signer: &PublicKey,
+        capability: u32,
+        parents: &[[u8; 32]],
+    ) -> Option<bool>;
+}
+
+/// The identity authorizer: always `None`, so every gate falls back to the live
+/// resolver. The default for [`NamespaceGovernance`](crate::NamespaceGovernance)
+/// constructions that don't carry an apply-auth context (tests, the sign path,
+/// read-only facades) and the behavior-preserving injection while the projection-
+/// backed implementation is wired up but not yet authoritative.
+pub struct LiveFallbackAuthorizer;
+
+impl AtCutAuthorizer for LiveFallbackAuthorizer {
+    fn is_admin_at_cut(
+        &self,
+        _group: ContextGroupId,
+        _signer: &PublicKey,
+        _parents: &[[u8; 32]],
+    ) -> Option<bool> {
+        None
+    }
+
+    fn is_admin_or_capability_at_cut(
+        &self,
+        _group: ContextGroupId,
+        _signer: &PublicKey,
+        _capability: u32,
+        _parents: &[[u8; 32]],
+    ) -> Option<bool> {
+        None
+    }
+}
+
+/// A shared `'static` [`LiveFallbackAuthorizer`] so a default `&dyn AtCutAuthorizer`
+/// needs no allocation or caller-held value.
+pub static LIVE_FALLBACK_AUTHORIZER: LiveFallbackAuthorizer = LiveFallbackAuthorizer;

--- a/crates/governance-store/src/authorizer.rs
+++ b/crates/governance-store/src/authorizer.rs
@@ -40,15 +40,10 @@ pub trait AtCutAuthorizer: Send + Sync {
         parents: &[[u8; 32]],
     ) -> Option<bool>;
 
-    /// Is `signer` an admin of `group`, OR a holder of `capability`, at the cut
-    /// named by `parents`?
-    fn is_admin_or_capability_at_cut(
-        &self,
-        group: ContextGroupId,
-        signer: &PublicKey,
-        capability: u32,
-        parents: &[[u8; 32]],
-    ) -> Option<bool>;
+    // The capability gate (`is_admin_or_capability_at_cut`) lands with its caller
+    // in the next stage (the `PermissionChecker` capability-check flip), per the
+    // no-premature-API convention — it isn't added here because no gate in this
+    // stage calls it.
 }
 
 /// The identity authorizer: always `None`, so every gate falls back to the live
@@ -63,16 +58,6 @@ impl AtCutAuthorizer for LiveFallbackAuthorizer {
         &self,
         _group: ContextGroupId,
         _signer: &PublicKey,
-        _parents: &[[u8; 32]],
-    ) -> Option<bool> {
-        None
-    }
-
-    fn is_admin_or_capability_at_cut(
-        &self,
-        _group: ContextGroupId,
-        _signer: &PublicKey,
-        _capability: u32,
         _parents: &[[u8; 32]],
     ) -> Option<bool> {
         None

--- a/crates/governance-store/src/authorizer.rs
+++ b/crates/governance-store/src/authorizer.rs
@@ -26,7 +26,12 @@ use calimero_primitives::identity::PublicKey;
 /// Every method returns `Option<bool>`: `Some(verdict)` when the projection's
 /// cited ancestry is fully folded and the answer is authoritative, `None` when it
 /// isn't (the caller defers to the live resolver).
-pub trait AtCutAuthorizer {
+///
+/// `Send + Sync`: the apply path runs inside the namespace DAG applier's `async
+/// fn apply`, whose future must be `Send` (it's spawned). A `&dyn AtCutAuthorizer`
+/// is only `Send` when the trait object is `Sync`, so the bound is required for the
+/// apply future — and the axum handlers that drive it — to stay `Send`.
+pub trait AtCutAuthorizer: Send + Sync {
     /// Is `signer` an admin of `group` at the cut named by `parents`?
     fn is_admin_at_cut(
         &self,

--- a/crates/governance-store/src/authorizer.rs
+++ b/crates/governance-store/src/authorizer.rs
@@ -31,11 +31,19 @@ use calimero_primitives::identity::PublicKey;
 /// fn apply`, whose future must be `Send` (it's spawned). A `&dyn AtCutAuthorizer`
 /// is only `Send` when the trait object is `Sync`, so the bound is required for the
 /// apply future — and the axum handlers that drive it — to stay `Send`.
+///
+/// Deliberately synchronous (object-safe): the gates call this through a
+/// `&dyn AtCutAuthorizer`, and the implementation resolves against an in-memory /
+/// store-backed projection fold, which is synchronous. Methods added later (the
+/// capability gate) must stay synchronous too — an `async` method would need
+/// `async_trait` boxing and would not compose with the `&dyn` use in the apply
+/// path. If a future verdict ever needs async I/O, resolve it before the apply call
+/// and pass the result in, rather than making the trait async.
 pub trait AtCutAuthorizer: Send + Sync {
     /// Is `signer` an admin of `group` at the cut named by `parents`?
     fn is_admin_at_cut(
         &self,
-        group: ContextGroupId,
+        group: &ContextGroupId,
         signer: &PublicKey,
         parents: &[[u8; 32]],
     ) -> Option<bool>;
@@ -56,7 +64,7 @@ pub struct LiveFallbackAuthorizer;
 impl AtCutAuthorizer for LiveFallbackAuthorizer {
     fn is_admin_at_cut(
         &self,
-        _group: ContextGroupId,
+        _group: &ContextGroupId,
         _signer: &PublicKey,
         _parents: &[[u8; 32]],
     ) -> Option<bool> {

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -38,6 +38,7 @@ pub mod registration_notify;
 
 pub mod absorb;
 pub mod absorb_record;
+pub mod authorizer;
 mod capabilities;
 pub mod cascade;
 mod context_registration;
@@ -66,6 +67,7 @@ use self::local_state::{op_log_contains_content_hash, persist_group_governance_p
 
 pub use self::absorb::AbsorbRepository;
 pub use self::absorb_record::{AbsorbRecord, AbsorbedEntity, AbsorbedLeaf};
+pub use self::authorizer::{AtCutAuthorizer, LiveFallbackAuthorizer, LIVE_FALLBACK_AUTHORIZER};
 pub use self::capabilities::CapabilitiesRepository;
 
 pub use self::context_registration::ContextRegistrationService;
@@ -99,12 +101,13 @@ pub use self::metadata::MetadataRepository;
 pub use self::namespace::NamespaceRepository;
 pub use self::namespace::MAX_NAMESPACE_DEPTH;
 pub use self::namespace::{
-    apply_received_group_key, apply_signed_namespace_op, build_group_key_delivery,
-    collect_skeleton_delta_ids_for_group, decrypt_group_op, namespace_groups_awaiting_key,
-    sign_and_publish_namespace_op, sign_apply_and_publish_namespace_op, ApplyNamespaceOpResult,
-    CascadePayload, KeyUnwrapFailure, NamespaceDagService, NamespaceGovernance, NamespaceHead,
-    NamespaceIdentityRecord, NamespaceMembershipService, NamespaceOpLogService,
-    NamespaceRetryService, ReparentOutcome, ResolvedNamespaceIdentity,
+    apply_received_group_key, apply_signed_namespace_op, apply_signed_namespace_op_at_cut,
+    build_group_key_delivery, collect_skeleton_delta_ids_for_group, decrypt_group_op,
+    namespace_groups_awaiting_key, sign_and_publish_namespace_op,
+    sign_apply_and_publish_namespace_op, ApplyNamespaceOpResult, CascadePayload, KeyUnwrapFailure,
+    NamespaceDagService, NamespaceGovernance, NamespaceHead, NamespaceIdentityRecord,
+    NamespaceMembershipService, NamespaceOpLogService, NamespaceRetryService, ReparentOutcome,
+    ResolvedNamespaceIdentity,
 };
 pub use self::pending_self_purge::PendingSelfPurgeRepository;
 pub use self::permission_checker::PermissionChecker;

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -80,6 +80,16 @@ pub(crate) fn classify_report_readiness(
 pub struct NamespaceGovernance<'a> {
     store: &'a Store,
     namespace_id: [u8; 32],
+    /// The op's causal cut (its parent op hashes), threaded to the apply gates so
+    /// they can authorize against the projection AS OF the op's parents. Empty for
+    /// constructions outside the live apply path (sign/read/tests), which keep the
+    /// live resolver via the default authorizer below.
+    parents: &'a [[u8; 32]],
+    /// The at-cut apply-auth decision source (F5 #28). Defaults to
+    /// [`LiveFallbackAuthorizer`] (always `None` → live), overridden on the live
+    /// apply path by [`with_apply_auth`](Self::with_apply_auth) with a projection-
+    /// backed authorizer.
+    authorizer: &'a dyn crate::authorizer::AtCutAuthorizer,
 }
 
 impl<'a> NamespaceGovernance<'a> {
@@ -87,7 +97,24 @@ impl<'a> NamespaceGovernance<'a> {
         Self {
             store,
             namespace_id,
+            parents: &[],
+            authorizer: &crate::authorizer::LIVE_FALLBACK_AUTHORIZER,
         }
+    }
+
+    /// Attach the op's causal cut + the at-cut apply-auth source for the live apply
+    /// path (F5 #28). Without this the gates use the live resolver (the default
+    /// authorizer returns `None`); with it they consult the projection at `parents`
+    /// and fall back to live only when the cited ancestry isn't fully folded.
+    #[must_use]
+    pub fn with_apply_auth(
+        mut self,
+        parents: &'a [[u8; 32]],
+        authorizer: &'a dyn crate::authorizer::AtCutAuthorizer,
+    ) -> Self {
+        self.parents = parents;
+        self.authorizer = authorizer;
+        self
     }
 
     /// Returns current DAG head as parent hashes + next nonce.
@@ -1476,9 +1503,15 @@ impl<'a> NamespaceGovernance<'a> {
             }
         }
 
-        // Per-variant logic lives in `ops/namespace/<variant>.rs` (#2481).
-        let mut ctx =
-            super::super::ops::namespace::NamespaceApplyCtx::new(self.store, self.namespace_id);
+        // Per-variant logic lives in `ops/namespace/<variant>.rs` (#2481). The
+        // op's causal cut + the at-cut authorizer ride along so the gates can
+        // authorize against the projection at the op's parents (F5 #28).
+        let mut ctx = super::super::ops::namespace::NamespaceApplyCtx::new(
+            self.store,
+            self.namespace_id,
+            self.parents,
+            self.authorizer,
+        );
         super::super::ops::namespace::dispatch_root_op(&mut ctx, op, root)?;
         Ok(ctx.take_events())
     }
@@ -1508,11 +1541,30 @@ fn root_op_commits_to_namespace_state(op: &RootOp) -> bool {
     )
 }
 
+/// Apply a signed namespace op with the LIVE apply-auth gates (no causal cut).
+/// The backward-compatible entry for call sites without an at-cut authorizer
+/// (tests, internal facades); the production apply path uses
+/// [`apply_signed_namespace_op_at_cut`].
 pub fn apply_signed_namespace_op(
     store: &Store,
     op: &SignedNamespaceOp,
 ) -> EyreResult<ApplyNamespaceOpResult> {
-    NamespaceGovernance::new(store, op.namespace_id).apply_signed_op(op)
+    apply_signed_namespace_op_at_cut(store, op, &[], &crate::authorizer::LIVE_FALLBACK_AUTHORIZER)
+}
+
+/// Apply a signed namespace op, authorizing the apply gates against `authorizer`
+/// at the op's causal cut `parents` (F5 #28). The gate consults the projection-
+/// backed authorizer first and falls back to the live resolver on `None` (an
+/// incomplete fold). This is the production apply path.
+pub fn apply_signed_namespace_op_at_cut(
+    store: &Store,
+    op: &SignedNamespaceOp,
+    parents: &[[u8; 32]],
+    authorizer: &dyn crate::authorizer::AtCutAuthorizer,
+) -> EyreResult<ApplyNamespaceOpResult> {
+    NamespaceGovernance::new(store, op.namespace_id)
+        .with_apply_auth(parents, authorizer)
+        .apply_signed_op(op)
 }
 
 /// Decrypt the cleartext [`GroupOp`] carried by a `NamespaceOp::Group` envelope

--- a/crates/governance-store/src/namespace/mod.rs
+++ b/crates/governance-store/src/namespace/mod.rs
@@ -27,10 +27,11 @@ pub use self::core::{
 pub use self::dag::{NamespaceDagService, NamespaceHead};
 pub(crate) use self::governance::classify_report_readiness;
 pub use self::governance::{
-    apply_received_group_key, apply_signed_namespace_op, build_group_key_delivery,
-    collect_skeleton_delta_ids_for_group, decrypt_group_op, namespace_groups_awaiting_key,
-    sign_and_publish_namespace_op, sign_apply_and_publish_namespace_op, ApplyNamespaceOpResult,
-    KeyUnwrapFailure, NamespaceGovernance,
+    apply_received_group_key, apply_signed_namespace_op, apply_signed_namespace_op_at_cut,
+    build_group_key_delivery, collect_skeleton_delta_ids_for_group, decrypt_group_op,
+    namespace_groups_awaiting_key, sign_and_publish_namespace_op,
+    sign_apply_and_publish_namespace_op, ApplyNamespaceOpResult, KeyUnwrapFailure,
+    NamespaceGovernance,
 };
 pub use self::membership::NamespaceMembershipService;
 pub use self::op_log::NamespaceOpLogService;

--- a/crates/governance-store/src/ops/namespace/context.rs
+++ b/crates/governance-store/src/ops/namespace/context.rs
@@ -7,6 +7,7 @@
 //! rather than pre-built — namespace handlers don't share a fixed
 //! set of helpers the way the group-op handlers do.
 
+use crate::authorizer::AtCutAuthorizer;
 use crate::{MembershipError, MembershipRepository};
 use calimero_context_config::types::ContextGroupId;
 use calimero_primitives::identity::PublicKey;
@@ -16,6 +17,13 @@ use eyre::{bail, Result as EyreResult};
 pub(crate) struct NamespaceApplyCtx<'a> {
     store: &'a Store,
     namespace_id: [u8; 32],
+    /// The applied op's causal cut (parent op hashes), for at-cut authorization
+    /// (F5 #28). Empty outside the live apply path.
+    parents: &'a [[u8; 32]],
+    /// The at-cut apply-auth decision source (F5 #28). The default
+    /// [`LiveFallbackAuthorizer`](crate::authorizer::LiveFallbackAuthorizer)
+    /// always returns `None`, so gates fall back to the live resolver.
+    authorizer: &'a dyn AtCutAuthorizer,
     /// Op-events queued during apply, flushed AFTER the namespace op-log
     /// entry is persisted (#2770). Handlers MUST queue_event rather than
     /// calling op_events::notify directly, or they reintroduce the
@@ -24,10 +32,17 @@ pub(crate) struct NamespaceApplyCtx<'a> {
 }
 
 impl<'a> NamespaceApplyCtx<'a> {
-    pub(crate) fn new(store: &'a Store, namespace_id: [u8; 32]) -> Self {
+    pub(crate) fn new(
+        store: &'a Store,
+        namespace_id: [u8; 32],
+        parents: &'a [[u8; 32]],
+        authorizer: &'a dyn AtCutAuthorizer,
+    ) -> Self {
         Self {
             store,
             namespace_id,
+            parents,
+            authorizer,
             pending_events: Vec::new(),
         }
     }
@@ -56,9 +71,23 @@ impl<'a> NamespaceApplyCtx<'a> {
     /// `NamespaceGovernance::require_namespace_admin` so handlers
     /// living in `ops/namespace/` don't need to thread the
     /// authorization helper through every call.
+    ///
+    /// Resolves through the at-cut [`AtCutAuthorizer`] FIRST (F5 #28): when the
+    /// projection has folded the op's cited ancestry it answers authoritatively AS
+    /// OF the op's parents (causal-honor); when it hasn't (`None`) the live resolver
+    /// decides, as before. The default `LiveFallbackAuthorizer` always returns
+    /// `None`, so the live path is byte-identical until a projection-backed
+    /// authorizer is injected.
     pub(crate) fn require_namespace_admin(&self, signer: &PublicKey) -> EyreResult<()> {
         let ns_gid = ContextGroupId::from(self.namespace_id);
-        if !MembershipRepository::new(self.store).is_admin(&ns_gid, signer)? {
+        let authorized = match self
+            .authorizer
+            .is_admin_at_cut(ns_gid, signer, self.parents)
+        {
+            Some(verdict) => verdict,
+            None => MembershipRepository::new(self.store).is_admin(&ns_gid, signer)?,
+        };
+        if !authorized {
             bail!(MembershipError::NotAdmin {
                 group_id: hex::encode(self.namespace_id),
                 identity: format!("{signer}"),

--- a/crates/governance-store/src/ops/namespace/context.rs
+++ b/crates/governance-store/src/ops/namespace/context.rs
@@ -82,7 +82,7 @@ impl<'a> NamespaceApplyCtx<'a> {
         let ns_gid = ContextGroupId::from(self.namespace_id);
         let authorized = match self
             .authorizer
-            .is_admin_at_cut(ns_gid, signer, self.parents)
+            .is_admin_at_cut(&ns_gid, signer, self.parents)
         {
             Some(verdict) => verdict,
             None => MembershipRepository::new(self.store).is_admin(&ns_gid, signer)?,


### PR DESCRIPTION
## What

Opens the dependency-inversion **seam** for the final F5 consumer — apply-time governance-op authorization (#28). Behavior-neutral: this commit threads the plumbing; the actual flip onto the projection is stage 3b.

## Why a seam

The apply gates (e.g. `NamespaceApplyCtx::require_namespace_admin`) read the **live** membership resolver, which has no causal context — they decide against the receiver's current state, not the op's parents. F5 moves that decision onto the projection at the op's causal cut. But the projection lives in `crates/context`, which *depends on* `governance-store`, so governance-store can't call it directly.

`AtCutAuthorizer` inverts the dependency: **governance-store defines the trait the gates call; `crates/context` implements it over the projection and injects it** at the apply call site. The gate stays put; only the decision *source* is abstracted.

## How (this PR)

- `AtCutAuthorizer` trait + `LiveFallbackAuthorizer` (always `None` → defer to live) in `governance-store::authorizer`.
- `NamespaceGovernance::with_apply_auth` threads the op's parent cut + `&dyn AtCutAuthorizer` into the apply path; `NamespaceApplyCtx` carries them; `require_namespace_admin` consults `is_admin_at_cut` first, live on `None`.
- Production path `apply_signed_namespace_op_at_cut` (called from the context DAG applier, where `delta.parents` lives) passes the op's parents + the `LiveFallbackAuthorizer` — so gates keep using live. `apply_signed_namespace_op` stays a live-default shim; all existing callers unchanged.

## Safety

Byte-identical: `LiveFallbackAuthorizer` always returns `None`, so every gate falls through to the live resolver exactly as before. **All 399 governance-store tests pass unchanged.** No gate decision moves in this PR.

## Next

- **3b**: implement `AtCutAuthorizer` in `crates/context` over `ScopeProjections`, inject it from the DAG applier → the actual flip (live as `None`-fallback), gated on the existing `governance-auth` shadow staying divergence-free.
- **4**: capability gates + circular last-admin invariants (need the parent cut, now threaded).

## Test

- `cargo clippy --all-targets -- -D warnings` / `fmt` clean; governance-store 399/399 unchanged; projection equivalence 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches namespace admin apply gates and the production DAG apply path, but `LiveFallbackAuthorizer` preserves live-only decisions; risk rises when stage 3b swaps in projection-backed auth.
> 
> **Overview**
> Introduces an **at-cut apply authorization seam** (F5 #28) so namespace governance gates can eventually authorize against the unified projection at each op’s causal cut, without `governance-store` depending on `crates/context`.
> 
> Adds **`AtCutAuthorizer`** and **`LiveFallbackAuthorizer`** (always `None` → live membership). **`NamespaceGovernance::with_apply_auth`** threads parent op hashes and a `&dyn AtCutAuthorizer` through apply; **`NamespaceApplyCtx::require_namespace_admin`** tries **`is_admin_at_cut`** first and falls back to **`MembershipRepository::is_admin`** on `None`. **`apply_signed_namespace_op_at_cut`** is the new entry point; **`apply_signed_namespace_op`** delegates to it with empty parents and the live fallback. The namespace DAG applier calls **`apply_signed_namespace_op_at_cut`** with **`delta.parents`** and **`LIVE_FALLBACK_AUTHORIZER`**.
> 
> **Behavior is unchanged in this PR**: the fallback authorizer never supplies a verdict, so gates still use the live resolver. Stage 3b will inject a projection-backed implementation from `crates/context`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cf6298e13dd36defc3eb546c1f017ab19f34b2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->