### PR TITLE
feat(context): flip apply-auth onto the projection (F5 #28 stage 3b)

### DIFF
--- a/crates/context/src/apply_authorizer.rs
+++ b/crates/context/src/apply_authorizer.rs
@@ -44,15 +44,4 @@ impl AtCutAuthorizer for EphemeralProjectionAuthorizer<'_> {
         let (proj, _ns, _heads) = ScopeProjections::ephemeral_projection(self.store, &group)?;
         proj.is_admin_at_cut(self.store, group, signer, parents)
     }
-
-    fn is_admin_or_capability_at_cut(
-        &self,
-        group: ContextGroupId,
-        signer: &PublicKey,
-        capability: u32,
-        parents: &[[u8; 32]],
-    ) -> Option<bool> {
-        let (proj, _ns, _heads) = ScopeProjections::ephemeral_projection(self.store, &group)?;
-        proj.is_admin_or_capability_at_cut(self.store, group, signer, capability, parents)
-    }
 }

--- a/crates/context/src/apply_authorizer.rs
+++ b/crates/context/src/apply_authorizer.rs
@@ -1,0 +1,58 @@
+//! Projection-backed [`AtCutAuthorizer`] for the apply gates (F5 #28 stage 3b).
+//!
+//! Realizes the dependency inversion opened by the governance-store seam: the
+//! apply gates call the `AtCutAuthorizer` trait (defined in `governance-store`),
+//! and this implementation resolves the decision against the unified projection at
+//! the op's causal cut, falling back to the live resolver (`None`) when the cited
+//! ancestry isn't fully folded.
+//!
+//! It folds an EPHEMERAL projection from the store per call — the same mechanism
+//! the read-side query gates use ([`ScopeProjections::ephemeral_projection`]) — so
+//! it needs no shared projection state threaded into the apply path. The fold is
+//! bounded by `MAX_BACKFILL_OPS`; governance ops are infrequent, and P6 sync
+//! unification removes the per-apply fold.
+
+use calimero_context_config::types::ContextGroupId;
+use calimero_governance_store::AtCutAuthorizer;
+use calimero_primitives::identity::PublicKey;
+use calimero_store::Store;
+
+use crate::scope_projection::ScopeProjections;
+
+/// An [`AtCutAuthorizer`] that resolves each gate against a freshly folded
+/// ephemeral projection of the op's namespace, at the op's causal cut.
+pub struct EphemeralProjectionAuthorizer<'a> {
+    store: &'a Store,
+}
+
+impl<'a> EphemeralProjectionAuthorizer<'a> {
+    pub fn new(store: &'a Store) -> Self {
+        Self { store }
+    }
+}
+
+impl AtCutAuthorizer for EphemeralProjectionAuthorizer<'_> {
+    fn is_admin_at_cut(
+        &self,
+        group: ContextGroupId,
+        signer: &PublicKey,
+        parents: &[[u8; 32]],
+    ) -> Option<bool> {
+        // Fold the namespace's persisted governance DAG once, then resolve the
+        // admin verdict AT the op's parent cut. `None` (store fault, or the cited
+        // ancestry not fully folded) makes the gate defer to the live resolver.
+        let (proj, _ns, _heads) = ScopeProjections::ephemeral_projection(self.store, &group)?;
+        proj.is_admin_at_cut(self.store, group, signer, parents)
+    }
+
+    fn is_admin_or_capability_at_cut(
+        &self,
+        group: ContextGroupId,
+        signer: &PublicKey,
+        capability: u32,
+        parents: &[[u8; 32]],
+    ) -> Option<bool> {
+        let (proj, _ns, _heads) = ScopeProjections::ephemeral_projection(self.store, &group)?;
+        proj.is_admin_or_capability_at_cut(self.store, group, signer, capability, parents)
+    }
+}

--- a/crates/context/src/apply_authorizer.rs
+++ b/crates/context/src/apply_authorizer.rs
@@ -34,14 +34,14 @@ impl<'a> EphemeralProjectionAuthorizer<'a> {
 impl AtCutAuthorizer for EphemeralProjectionAuthorizer<'_> {
     fn is_admin_at_cut(
         &self,
-        group: ContextGroupId,
+        group: &ContextGroupId,
         signer: &PublicKey,
         parents: &[[u8; 32]],
     ) -> Option<bool> {
         // Fold the namespace's persisted governance DAG once, then resolve the
         // admin verdict AT the op's parent cut. `None` (store fault, or the cited
         // ancestry not fully folded) makes the gate defer to the live resolver.
-        let (proj, _ns, _heads) = ScopeProjections::ephemeral_projection(self.store, &group)?;
-        proj.is_admin_at_cut(self.store, group, signer, parents)
+        let (proj, _ns, _heads) = ScopeProjections::ephemeral_projection(self.store, group)?;
+        proj.is_admin_at_cut(self.store, *group, signer, parents)
     }
 }

--- a/crates/context/src/apply_authorizer.rs
+++ b/crates/context/src/apply_authorizer.rs
@@ -20,13 +20,15 @@ use calimero_store::Store;
 use crate::scope_projection::ScopeProjections;
 
 /// An [`AtCutAuthorizer`] that resolves each gate against a freshly folded
-/// ephemeral projection of the op's namespace, at the op's causal cut.
-pub struct EphemeralProjectionAuthorizer<'a> {
+/// ephemeral projection of the op's namespace, at the op's causal cut. Constructed
+/// at the namespace DAG applier (the one call site); `pub(crate)` because it's an
+/// implementation detail, not API other crates should depend on.
+pub(crate) struct EphemeralProjectionAuthorizer<'a> {
     store: &'a Store,
 }
 
 impl<'a> EphemeralProjectionAuthorizer<'a> {
-    pub fn new(store: &'a Store) -> Self {
+    pub(crate) fn new(store: &'a Store) -> Self {
         Self { store }
     }
 }
@@ -38,10 +40,23 @@ impl AtCutAuthorizer for EphemeralProjectionAuthorizer<'_> {
         signer: &PublicKey,
         parents: &[[u8; 32]],
     ) -> Option<bool> {
-        // Fold the namespace's persisted governance DAG once, then resolve the
-        // admin verdict AT the op's parent cut. `None` (store fault, or the cited
-        // ancestry not fully folded) makes the gate defer to the live resolver.
-        let (proj, _ns, _heads) = ScopeProjections::ephemeral_projection(self.store, group)?;
+        // Fold the namespace's persisted governance DAG, then resolve the admin
+        // verdict AT the op's parent cut.
+        let Some((proj, _ns, _heads)) = ScopeProjections::ephemeral_projection(self.store, group)
+        else {
+            // The fold itself could not be built — a store/DAG-head fault, NOT the
+            // expected "ancestry not yet folded" case (that surfaces as `None` from
+            // `is_admin_at_cut` below and is a quiet, frequent backfill state). Defer
+            // to live as the `None` contract requires, but WARN: a transient storage
+            // fault shouldn't silently downgrade the apply-auth source unobserved.
+            tracing::warn!(
+                group = ?group,
+                "apply-auth: ephemeral projection unavailable (store/DAG-head fault); gate defers to live"
+            );
+            return None;
+        };
+        // `None` here = the cited ancestry isn't fully folded; the gate defers to
+        // live (quiet — a normal mid-backfill state, not an error).
         proj.is_admin_at_cut(self.store, *group, signer, parents)
     }
 }

--- a/crates/context/src/governance_dag.rs
+++ b/crates/context/src/governance_dag.rs
@@ -104,15 +104,17 @@ impl NamespaceGovernanceApplier {
 #[async_trait::async_trait]
 impl DeltaApplier<SignedNamespaceOp> for NamespaceGovernanceApplier {
     async fn apply(&self, delta: &CausalDelta<SignedNamespaceOp>) -> Result<(), ApplyError> {
-        // F5 #28: thread the op's causal cut + the at-cut apply-auth source into the
-        // governance-store apply gates. `LIVE_FALLBACK_AUTHORIZER` always returns
-        // `None`, so the gates keep using the live resolver — this commit only opens
-        // the seam; a projection-backed authorizer replaces it in the flip stage.
+        // F5 #28 (stage 3b): authorize the apply gates against the PROJECTION at the
+        // op's causal cut. The ephemeral authorizer folds the namespace's persisted
+        // governance DAG and resolves admin authority as of `delta.parents`; on an
+        // incomplete fold it returns `None` and the gate falls back to the live
+        // resolver, so a cold/racing fold never wrongly rejects a valid op.
+        let authorizer = crate::apply_authorizer::EphemeralProjectionAuthorizer::new(&self.store);
         let outcome = calimero_governance_store::apply_signed_namespace_op_at_cut(
             &self.store,
             &delta.payload,
             &delta.parents,
-            &calimero_governance_store::LIVE_FALLBACK_AUTHORIZER,
+            &authorizer,
         )
         .map_err(|e| ApplyError::Application(e.to_string()))?;
         if let Some(report) = outcome.divergence {

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -28,6 +28,7 @@ use tokio::sync::{Mutex, RwLock};
 use calimero_governance_store::metrics::Metrics;
 
 pub mod activation;
+pub mod apply_authorizer;
 pub mod auto_follow;
 mod cache;
 pub mod config;

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -28,7 +28,7 @@ use tokio::sync::{Mutex, RwLock};
 use calimero_governance_store::metrics::Metrics;
 
 pub mod activation;
-pub mod apply_authorizer;
+pub(crate) mod apply_authorizer;
 pub mod auto_follow;
 mod cache;
 pub mod config;


### PR DESCRIPTION
## What

Stage 3b of F5 #28 — the apply-auth flip. `require_namespace_admin` now decides admin authority from the projection at the op's causal cut, not the live resolver.

## How

The seam (#2856, merged) routed the gate through `AtCutAuthorizer` (live-fallback no-op). This injects the real one:

- `EphemeralProjectionAuthorizer` (`pub(crate)` in `crates/context`) implements `AtCutAuthorizer::is_admin_at_cut` over the projection — folding an ephemeral projection of the op's namespace per apply, resolving at `delta.parents`.
- `None` defers to live: a store/DAG-head fault (warned) or ancestry not yet folded (quiet, normal mid-backfill).

The capability gate `is_admin_or_capability_at_cut` is NOT in scope — it lands with its `PermissionChecker` caller in stage 4 (no-premature-API).

## Safety

The `governance-auth` shadow (on master) resolved the same `is_admin_at_cut` verdict against live on every passing e2e; 0 divergences proves projection == live for this gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who may apply namespace governance ops by sourcing admin checks from the projection at the op's causal cut, though incomplete folds and store faults still fall back to live per the `AtCutAuthorizer` contract.
> 
> **Overview**
> **F5 #28 stage 3b** wires real at-cut admin checks into namespace governance apply: `NamespaceGovernanceApplier` no longer passes `LIVE_FALLBACK_AUTHORIZER` and instead uses a new **`EphemeralProjectionAuthorizer`**.
> 
> That authorizer implements `AtCutAuthorizer::is_admin_at_cut` by folding an **ephemeral** namespace projection (same `ScopeProjections::ephemeral_projection` path as read-side gates) and resolving admin authority at **`delta.parents`**. **`None`** still means defer to the live resolver—either ancestry not fully folded (quiet) or a store/DAG-head fault when the fold cannot be built (**warn** logged).
> 
> The module is **`pub(crate)`** in `crates/context`; capability-at-cut gates are explicitly out of scope for this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56306ef2434e196bb59394d40707c8c1b51c3186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->