### PR TITLE
feat(governance): flip group apply-auth gates onto the projection (F5 #28 stage 4b)

### DIFF
--- a/crates/context/src/apply_authorizer.rs
+++ b/crates/context/src/apply_authorizer.rs
@@ -81,6 +81,14 @@ impl AtCutAuthorizer for EphemeralProjectionAuthorizer<'_> {
         signer: &PublicKey,
         parents: &[[u8; 32]],
     ) -> Option<bool> {
+        // No cut (empty `parents`) ⇒ no causal context to resolve against; defer to
+        // live rather than judge against an empty/genesis view (which could falsely
+        // reject a capability-holder whose grant isn't in the empty fold). Belt-and-
+        // braces: group ops carry their enclosing namespace op's parents, which are
+        // empty only for the namespace genesis itself.
+        if parents.is_empty() {
+            return None;
+        }
         // `None` here = the cited ancestry isn't fully folded; the gate defers to
         // live (quiet — a normal mid-backfill state, not an error).
         self.folded(group)?
@@ -95,6 +103,10 @@ impl AtCutAuthorizer for EphemeralProjectionAuthorizer<'_> {
         capability: u32,
         parents: &[[u8; 32]],
     ) -> Option<bool> {
+        // Empty cut ⇒ defer to live (see `is_admin_at_cut`).
+        if parents.is_empty() {
+            return None;
+        }
         self.folded(group)?
             .0
             .is_admin_or_capability_at_cut(self.store, *group, signer, capability, parents)

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -1232,9 +1232,9 @@ fn apply_group_op_mutations(
     Vec<crate::op_events::OpEvent>,
 )> {
     // The op's causal cut + at-cut authorizer ride into the apply gates so the
-    // `PermissionChecker` admin/capability gates can SHADOW the projection against
-    // live (F5 #28 stage 4). The default authorizer (live-fallback) makes the shadow
-    // inert for callers without an apply-auth context.
+    // `PermissionChecker` admin/capability gates resolve against the projection at
+    // the op's cut, with live as the `None`-fallback (F5 #28 stage 4). The default
+    // (live-fallback) authorizer keeps callers without an apply-auth context on live.
     let mut ctx = ops::group::GroupApplyCtx::new_with_apply_auth(
         store, group_id, signer, parents, authorizer,
     );
@@ -1262,9 +1262,9 @@ pub fn apply_local_signed_group_op(store: &Store, op: &SignedGroupOp) -> EyreRes
 }
 
 /// [`apply_local_signed_group_op`] with the at-cut apply-auth source attached: the
-/// `PermissionChecker` admin/capability gates SHADOW the projection against live at
-/// the op's own `parent_op_hashes` (F5 #28 stage 4, plane `group-auth`). The
-/// production apply path (the group DAG applier) injects a projection-backed
+/// `PermissionChecker` admin/capability gates resolve against the projection at the
+/// op's own `parent_op_hashes`, with live as the `None`-fallback (F5 #28 stage 4).
+/// The production apply path (the group DAG applier) injects a projection-backed
 /// authorizer; the plain `apply_local_signed_group_op` passes the inert live
 /// fallback so existing callers (tests, replay) are unchanged.
 pub fn apply_local_signed_group_op_at_cut(

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -1315,15 +1315,21 @@ impl<'a> NamespaceGovernance<'a> {
             }
         }
 
-        // Group ops carried in namespace envelopes authorize at the SAME cut as the
-        // enclosing namespace op (F5 #28 stage 4): forward the seam's parent cut +
-        // authorizer so the group `PermissionChecker` gates shadow the projection.
+        // Group ops carried in namespace envelopes authorize at the cut of THEIR OWN
+        // enclosing namespace op (F5 #28 stage 4) — `signed_group_op.parent_op_hashes`
+        // is that op's parents (copied in `decrypt_and_apply_group_op`). Use it, NOT
+        // `self.parents`: `retry_encrypted_ops_for_group` re-applies buffered group
+        // candidates within ONE KeyDelivery apply, so `self.parents` would be the
+        // KeyDelivery cut for every replayed candidate — the projection-backed gates
+        // would then judge each at the wrong cut. The authorizer carries no per-op
+        // state (its fold is the whole namespace; the cut is applied at resolve
+        // time), so reusing `self.authorizer` with the candidate's parents is correct.
         let (handled, divergence, pending_events) = apply_group_op_mutations(
             self.store,
             group_id,
             signer,
             op,
-            self.parents,
+            &signed_group_op.parent_op_hashes,
             self.authorizer,
         )?;
         if !handled {

--- a/crates/governance-store/src/ops/group/context.rs
+++ b/crates/governance-store/src/ops/group/context.rs
@@ -47,10 +47,10 @@ pub(crate) struct GroupApplyCtx<'a> {
 
 impl<'a> GroupApplyCtx<'a> {
     /// Construct the per-apply context with the op's causal cut + at-cut authorizer,
-    /// so the `PermissionChecker` admin/capability gates SHADOW the projection
-    /// against live (F5 #28 stage 4, plane `group-auth`). Pass `&[]` +
-    /// `LIVE_FALLBACK_AUTHORIZER` for constructions without an apply-auth context
-    /// (the shadow is then inert).
+    /// so the `PermissionChecker` admin/capability gates resolve against the
+    /// projection at the cut, with live as the `None`-fallback (F5 #28 stage 4). Pass
+    /// `&[]` + `LIVE_FALLBACK_AUTHORIZER` for constructions without an apply-auth
+    /// context (they then use the live resolver).
     pub(crate) fn new_with_apply_auth(
         store: &'a Store,
         group_id: &'a ContextGroupId,

--- a/crates/governance-store/src/permission_checker.rs
+++ b/crates/governance-store/src/permission_checker.rs
@@ -17,13 +17,13 @@ use super::{CapabilitiesError, MembershipError};
 pub struct PermissionChecker<'a> {
     store: &'a Store,
     group_id: ContextGroupId,
-    /// The applied op's causal cut (parent op hashes), for the at-cut apply-auth
-    /// shadow (F5 #28 stage 4). Empty outside the group-op apply path.
+    /// The applied op's causal cut (parent op hashes), at which the apply-auth gates
+    /// resolve (F5 #28 stage 4). Empty outside the group-op apply path.
     parents: &'a [[u8; 32]],
     /// The at-cut apply-auth decision source (F5 #28 stage 4). The default
     /// [`LiveFallbackAuthorizer`](crate::authorizer::LiveFallbackAuthorizer) returns
-    /// `None`, so the shadow no-ops for non-apply constructions (handler pre-checks,
-    /// cascade pre-scans, tests).
+    /// `None`, so non-apply constructions (handler pre-checks, cascade pre-scans,
+    /// tests) keep using the live resolver.
     authorizer: &'a dyn AtCutAuthorizer,
 }
 
@@ -38,9 +38,9 @@ impl<'a> PermissionChecker<'a> {
     }
 
     /// Attach the op's causal cut + the at-cut apply-auth source for the group-op
-    /// apply path (F5 #28 stage 4). With it, the admin/capability gates SHADOW the
-    /// projection verdict against live (plane `group-auth`); without it (the
-    /// default) the shadow is inert.
+    /// apply path (F5 #28 stage 4). With it, the admin/capability gates decide from
+    /// the projection at the cut (live as `None`-fallback); without it (the default)
+    /// they use the live resolver.
     #[must_use]
     pub fn with_apply_auth(
         mut self,
@@ -53,6 +53,17 @@ impl<'a> PermissionChecker<'a> {
     }
 
     pub fn is_admin(&self, identity: &PublicKey) -> EyreResult<bool> {
+        // F5 #28 stage 4b: decide from the PROJECTION at the op's causal cut — admin
+        // authority as of the op's own parents (causal-honor), validated divergence-
+        // free on the `group-auth` plane (stage 4a). `None` (no apply-auth context —
+        // a local pre-check / cascade / test — OR an incomplete fold) falls back to
+        // the live resolver. The live fallback retires in #29b.
+        if let Some(verdict) =
+            self.authorizer
+                .is_admin_at_cut(&self.group_id, identity, self.parents)
+        {
+            return Ok(verdict);
+        }
         // Issue #2256: admin authority cascades into Open subgroups
         // from any ancestor where the signer is a direct admin.
         // Uses `is_inherited_admin` (a dedicated walk) rather than
@@ -62,36 +73,7 @@ impl<'a> PermissionChecker<'a> {
         // non-admin `Member` row — which would suppress inherited
         // admin authority for parent admins who happen to also be
         // explicit subgroup members.
-        let live =
-            MembershipRepository::new(self.store).is_inherited_admin(&self.group_id, identity)?;
-        // SHADOW (F5 #28 stage 4): compare the projection's at-cut admin verdict to
-        // live and log a `group-auth` divergence; still ACT on live. Inert unless an
-        // apply-path authorizer is attached. The flip (act on projection) is stage 4b.
-        self.shadow_admin(identity, live);
-        Ok(live)
-    }
-
-    /// Emit a `group-auth` divergence if the at-cut projection admin verdict differs
-    /// from the live `live_verdict`. `None` from the authorizer (no apply-auth
-    /// context, or an incomplete fold) skips — there's nothing to compare.
-    fn shadow_admin(&self, identity: &PublicKey, live_verdict: bool) {
-        if let Some(projected) =
-            self.authorizer
-                .is_admin_at_cut(&self.group_id, identity, self.parents)
-        {
-            if projected != live_verdict {
-                tracing::warn!(
-                    marker = "unified_projection_divergence",
-                    plane = "group-auth",
-                    gate = "admin",
-                    group_id = ?self.group_id,
-                    %identity,
-                    projected,
-                    live = live_verdict,
-                    "group apply-auth: projection admin verdict differs from live"
-                );
-            }
-        }
+        MembershipRepository::new(self.store).is_inherited_admin(&self.group_id, identity)
     }
 
     pub fn require_admin(&self, identity: &PublicKey) -> EyreResult<()> {
@@ -242,6 +224,17 @@ impl<'a> PermissionChecker<'a> {
         identity: &PublicKey,
         capability_bit: u32,
     ) -> EyreResult<bool> {
+        // F5 #28 stage 4b: decide from the PROJECTION at the op's causal cut (the
+        // capability analogue of `is_admin`); `None` falls back to live. Validated on
+        // the `group-auth` plane in stage 4a.
+        if let Some(verdict) = self.authorizer.is_admin_or_capability_at_cut(
+            &self.group_id,
+            identity,
+            capability_bit,
+            self.parents,
+        ) {
+            return Ok(verdict);
+        }
         let direct = MembershipRepository::new(self.store).is_admin_or_has_capability(
             &self.group_id,
             identity,
@@ -255,33 +248,9 @@ impl<'a> PermissionChecker<'a> {
         // as any direct membership row exists in the target subgroup,
         // which would mask inherited admin authority for a parent
         // admin who is also an explicit non-admin subgroup member.
-        let live = direct
+        Ok(direct
             || MembershipRepository::new(self.store)
-                .is_inherited_admin(&self.group_id, identity)?;
-        // SHADOW (F5 #28 stage 4): compare the projection's at-cut admin-or-capability
-        // verdict to live (plane `group-auth`); still ACT on live. Inert without an
-        // apply-path authorizer. Flip is stage 4b.
-        if let Some(projected) = self.authorizer.is_admin_or_capability_at_cut(
-            &self.group_id,
-            identity,
-            capability_bit,
-            self.parents,
-        ) {
-            if projected != live {
-                tracing::warn!(
-                    marker = "unified_projection_divergence",
-                    plane = "group-auth",
-                    gate = "capability",
-                    group_id = ?self.group_id,
-                    %identity,
-                    capability_bit,
-                    projected,
-                    live,
-                    "group apply-auth: projection capability verdict differs from live"
-                );
-            }
-        }
-        Ok(live)
+                .is_inherited_admin(&self.group_id, identity)?)
     }
 
     pub fn require_admin_to_add_admin(


### PR DESCRIPTION
## What

Stage 4b of F5 #28 — flip the **group-op apply-auth gates** onto the projection. Stacked on #2866 (4a seam+shadow).

## How

4a threaded the at-cut authorizer through the group apply path and shadowed the `PermissionChecker` admin/capability gates (`group-auth` plane). This flips them:

- `PermissionChecker::is_admin` / `is_authorized_with_capability` decide from the projection at the op's causal cut (`is_admin_at_cut` / `is_admin_or_capability_at_cut`) — admin/capability authority **as of the op's own parents** (causal-honor). `None` (no apply-auth context, or incomplete fold) → live fallback (retires in #29b).
- `shadow_admin` helper removed.

## Scope (deliberately narrow)

Only the group-op **apply path** carries a projection-backed authorizer (via `GroupApplyCtx`), so only it flips. Handler-side pre-checks, cascade pre-scans, and tests keep the default live-fallback authorizer (`None` → live) — the F5 plan's "local-origination pre-checks stay on live" carve-out.

## Gating

> ⚠️ Merge-gates on #2866's `group-auth` plane being **divergence-free** across e2e — that's the proof the projection's group verdicts equal live before this flip acts on them. This PR's own e2e is the behavioral confirmation (group gates now run on the projection; any disagreement would fail a scenario).

## Test

- `cargo clippy --all-targets -- -D warnings` / `fmt` clean; governance-store 399/399.
- e2e: behavioral (no shadow markers left on these gates).

> Base is `feat/f5-group-apply-auth-seam` (#2866); rebase to master after it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Authorization on the group DAG apply path now follows projection-at-cut decisions; incorrect cut wiring or fold gaps would allow or deny ops differently than live store state until #29b removes the fallback.
> 
> **Overview**
> **F5 #28 stage 4b** moves group-op **apply** authorization from “shadow live, act on live” to **acting on the unified projection at the op’s causal cut** (`parent_op_hashes`), with **live** only when the authorizer returns `None` (no apply-auth context, incomplete fold, or empty cut).
> 
> `PermissionChecker::is_admin` and capability checks consult `is_admin_at_cut` / `is_admin_or_capability_at_cut` first; the `shadow_admin` divergence logging path is removed. Handler pre-checks and tests still use the default live-fallback authorizer.
> 
> `EphemeralProjectionAuthorizer` returns `None` when `parents` is empty so genesis/empty-cut cases are not judged against an empty fold.
> 
> Namespace-wrapped group ops now pass **`signed_group_op.parent_op_hashes`** into apply mutations instead of the enclosing `KeyDelivery` cut, so buffered encrypted-op replays are authorized at each candidate’s own parents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ac85530be1e67b3d5851039388786bd694a2bc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->