### PR TITLE
refactor(node): retire buffering-drain live acl_view_at metric read (F5 #29b)

### DIFF
--- a/crates/node/src/handlers/state_delta/buffering.rs
+++ b/crates/node/src/handlers/state_delta/buffering.rs
@@ -6,7 +6,6 @@
 //! invoked by the apply path, the sync manager, and namespace network-event
 //! handlers once governance state advances or on startup.
 
-use calimero_context::group_store::{acl_view_at, MembershipStatus};
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
 use eyre::Result;
@@ -135,13 +134,8 @@ pub(super) async fn drain_governance_pending(input: &StateDeltaContext, context_
         //   None        → cut ancestry not fully folded yet  → re-buffer (governance
         //                 not caught up — exactly the old `Unknown` case)
         //
-        // `acl_view_at` is retained only as the divergence cross-check feeding the
-        // hard gate, and is consulted ONLY on a decisive projection verdict — never
-        // on `None`. `None` means "cut ancestry not folded yet" (re-buffer): a
-        // deferral, not a disagreement, so comparing it against live would both
-        // waste a DAG walk and risk a false-positive divergence (e.g. live already
-        // sees `Member` while the projection simply hasn't caught up). The live
-        // resolver is deleted in F5 once every consumer is validated divergence-free.
+        // F5 #29b: the drain is fully projection-sourced now — the last live
+        // `acl_view_at` read (which only named the drop metric label) is gone.
         let proj = input
             .node_state
             .read_scope_projections()
@@ -178,29 +172,21 @@ pub(super) async fn drain_governance_pending(input: &StateDeltaContext, context_
             }
             Some(false) => {
                 // The projection authoritatively denies on a COMPLETE fold (drop).
-                // live is still read SOLELY to name the drop metric label (removed
-                // vs never-member); this read retires in #29b when the label moves
-                // off live.
-                let live = acl_view_at(
-                    datastore,
-                    owning_group,
-                    &buffered.author_id,
-                    &pos.governance_dag_heads,
-                );
-                let label = match &live {
-                    Ok(MembershipStatus::Removed { .. }) => "removed",
-                    Ok(MembershipStatus::NeverMember) => "never_member",
-                    _ => "not_member",
-                };
+                // F5 #29b: the live `acl_view_at` read that distinguished the drop
+                // metric label (removed vs never-member) is retired here. The
+                // projection's `Some(false)` means "not a member at the signed cut" —
+                // the drop signal — and the historical reason was observability-only;
+                // the projection's fold doesn't expose last-known-role cheaply, so the
+                // breakdown collapses to a single `not_member` drop label.
                 warn!(
                     %context_id,
                     delta_id = ?buffered.id,
                     author = %buffered.author_id,
-                    outcome = label,
+                    outcome = "not_member",
                     "governance-pending drain: projection says author is not a member at the \
                      signed cut; dropping"
                 );
-                crate::node_metrics::record_governance_drain_outcome(label);
+                crate::node_metrics::record_governance_drain_outcome("not_member");
             }
             None => {
                 let mut buffered = buffered;


### PR DESCRIPTION
## What

First small step of #29b (delete the live causal resolver). Retires the last live `acl_view_at` read in the governance-pending **drain**.

## Why it's safe

The drain has been projection-authoritative since #2829 — `member_at_cut_authoritative` decides re-apply / drop / re-buffer. The `acl_view_at` read that remained was used **only** to name the drop metric label (removed vs never-member); the code comment already flagged it "retires in #29b". The drop decision itself is unchanged (the projection's `Some(false)`).

## Change

- Drop the live read + the removed/never-member/not-member label match; the drop metric collapses to a single `not_member` label (the projection's fold doesn't expose last-known-role cheaply, and the distinction was observability-only).
- Remove the now-unused `acl_view_at` / `MembershipStatus` import; refresh the stale comment.

This removes one of the last `acl_view_at` callers, moving toward its deletion.

## Test

- `cargo clippy --all-targets -- -D warnings` / `fmt` clean.
- No behavior change; metric-label only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No change to authorization or drain outcomes—only metrics/logging granularity and removal of a redundant live ACL read.
> 
> **Overview**
> Part of **F5 #29b** (delete the live causal resolver): the governance-pending **drain** no longer calls **`acl_view_at`** when the projection returns **`Some(false)`**.
> 
> **Apply / drop / re-buffer** decisions were already made by **`member_at_cut_authoritative`**; the retired live read only fed observability (distinguishing **removed** vs **never_member** in metrics and logs). That breakdown is collapsed to one **`not_member`** outcome for **`record_governance_drain_outcome`** and the warn log, since the projection fold does not expose last-known role cheaply.
> 
> Unused **`acl_view_at`** / **`MembershipStatus`** imports are removed and comments are updated to state the drain is fully projection-sourced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d17506d310d715f05a9606010079d6647d31d15b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->