### PR TITLE
feat: shadow MemberJoinedOpen check_path against the projection (F5 #29b)

### DIFF
--- a/crates/context/src/apply_authorizer.rs
+++ b/crates/context/src/apply_authorizer.rs
@@ -17,7 +17,7 @@
 use std::sync::{Arc, Mutex, PoisonError};
 
 use calimero_context_config::types::ContextGroupId;
-use calimero_governance_store::AtCutAuthorizer;
+use calimero_governance_store::{AtCutAuthorizer, AtCutMembershipPath};
 use calimero_primitives::identity::PublicKey;
 use calimero_store::Store;
 
@@ -125,5 +125,27 @@ impl AtCutAuthorizer for EphemeralProjectionAuthorizer<'_> {
         self.folded(group)?
             .0
             .is_last_admin_at_cut(self.store, *group, member, parents)
+    }
+
+    fn membership_path_at_cut(
+        &self,
+        group: &ContextGroupId,
+        member: &PublicKey,
+        parents: &[[u8; 32]],
+    ) -> Option<AtCutMembershipPath> {
+        // Empty cut ⇒ defer to live (see `is_admin_at_cut`).
+        if parents.is_empty() {
+            return None;
+        }
+        let path = self
+            .folded(group)?
+            .0
+            .membership_path_at_cut(self.store, *group, member, parents)?;
+        // Project the role/anchor detail away to the kind the gate needs.
+        Some(match path {
+            calimero_authz::MemberPathAtCut::None => AtCutMembershipPath::None,
+            calimero_authz::MemberPathAtCut::Direct { .. } => AtCutMembershipPath::Direct,
+            calimero_authz::MemberPathAtCut::Inherited { .. } => AtCutMembershipPath::Inherited,
+        })
     }
 }

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1172,6 +1172,21 @@ impl ScopeProjections {
         Some(view.is_authorized_admin(group, author, root))
     }
 
+    /// How `member` reaches membership of `group` at the cut — the at-cut analogue of
+    /// live's `check_path`, for the `MemberJoinedOpen` gate. `None` on incomplete
+    /// ancestry (defer to live); otherwise the `member_path_at_cut` walk's verdict.
+    #[must_use]
+    pub fn membership_path_at_cut(
+        &self,
+        store: &Store,
+        group: ContextGroupId,
+        member: &PublicKey,
+        heads: &[[u8; 32]],
+    ) -> Option<calimero_authz::MemberPathAtCut> {
+        let (view, root, default_cap_base) = self.auth_cut_context(store, group, heads)?;
+        Some(view.member_path_at_cut(group, member, root, default_cap_base))
+    }
+
     /// Is `author` an admin of `group` OR a holder of any bit in `capability` at
     /// the cut — the apply-auth analogue of live's `is_authorized_with_capability`.
     /// Same authoritative `None`-on-incomplete-ancestry contract as

--- a/crates/governance-store/src/authorizer.rs
+++ b/crates/governance-store/src/authorizer.rs
@@ -81,6 +81,31 @@ pub trait AtCutAuthorizer: Send + Sync {
         member: &PublicKey,
         parents: &[[u8; 32]],
     ) -> Option<bool>;
+
+    /// How `member` reaches membership of `group` at the cut — the at-cut analogue of
+    /// the live `check_path`. Backs `MemberJoinedOpen` apply (an open-subgroup
+    /// inheritance join is valid only from an `Inherited` path; a `Direct` member
+    /// should use `MemberJoined`, and `None` has no path to inherit through). `None`
+    /// (the `Option`, not [`AtCutMembershipPath::None`]) = defer to live.
+    fn membership_path_at_cut(
+        &self,
+        group: &ContextGroupId,
+        member: &PublicKey,
+        parents: &[[u8; 32]],
+    ) -> Option<AtCutMembershipPath>;
+}
+
+/// How an identity reaches membership of a group at a cut — the at-cut analogue of
+/// the live `MembershipPath` (kind only; the role/anchor detail the projection's
+/// `member_path_at_cut` carries isn't needed by the `MemberJoinedOpen` gate).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AtCutMembershipPath {
+    /// Not a member of the group at the cut.
+    None,
+    /// A direct member (a stored membership row).
+    Direct,
+    /// Inherited over the open-subgroup chain.
+    Inherited,
 }
 
 /// The identity authorizer: always `None`, so every gate falls back to the live
@@ -116,6 +141,15 @@ impl AtCutAuthorizer for LiveFallbackAuthorizer {
         _member: &PublicKey,
         _parents: &[[u8; 32]],
     ) -> Option<bool> {
+        None
+    }
+
+    fn membership_path_at_cut(
+        &self,
+        _group: &ContextGroupId,
+        _member: &PublicKey,
+        _parents: &[[u8; 32]],
+    ) -> Option<AtCutMembershipPath> {
         None
     }
 }

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -67,7 +67,9 @@ use self::local_state::{op_log_contains_content_hash, persist_group_governance_p
 
 pub use self::absorb::AbsorbRepository;
 pub use self::absorb_record::{AbsorbRecord, AbsorbedEntity, AbsorbedLeaf};
-pub use self::authorizer::{AtCutAuthorizer, LiveFallbackAuthorizer, LIVE_FALLBACK_AUTHORIZER};
+pub use self::authorizer::{
+    AtCutAuthorizer, AtCutMembershipPath, LiveFallbackAuthorizer, LIVE_FALLBACK_AUTHORIZER,
+};
 pub use self::capabilities::CapabilitiesRepository;
 
 pub use self::context_registration::ContextRegistrationService;

--- a/crates/governance-store/src/ops/namespace/context.rs
+++ b/crates/governance-store/src/ops/namespace/context.rs
@@ -95,4 +95,33 @@ impl<'a> NamespaceApplyCtx<'a> {
         }
         Ok(())
     }
+
+    /// SHADOW (F5 #29b): compare the projection's at-cut membership PATH for `member`
+    /// in `group` against the `live_path` the `MemberJoinedOpen` gate computed from
+    /// `check_path`, logging a `membership-path` divergence on a mismatch. Still acts
+    /// on live (the gate decides from `live_path`); the flip follows once validated.
+    /// `None` from the authorizer (no apply-auth context / incomplete fold) skips.
+    pub(crate) fn shadow_membership_path(
+        &self,
+        group: &ContextGroupId,
+        member: &PublicKey,
+        live_path: crate::authorizer::AtCutMembershipPath,
+    ) {
+        if let Some(projected) = self
+            .authorizer
+            .membership_path_at_cut(group, member, self.parents)
+        {
+            if projected != live_path {
+                tracing::warn!(
+                    marker = "unified_projection_divergence",
+                    plane = "membership-path",
+                    group_id = ?group,
+                    %member,
+                    ?projected,
+                    ?live_path,
+                    "member-joined-open: projection membership path differs from live check_path"
+                );
+            }
+        }
+    }
 }

--- a/crates/governance-store/src/ops/namespace/member_joined_open.rs
+++ b/crates/governance-store/src/ops/namespace/member_joined_open.rs
@@ -58,7 +58,11 @@ pub(crate) fn apply(
             }
         ));
     }
-    match MembershipRepository::new(store).check_path(&gid, &member)? {
+    let live = MembershipRepository::new(store).check_path(&gid, &member)?;
+    // SHADOW (F5 #29b): cross-check the projection's at-cut path against live
+    // `check_path` (plane `membership-path`); still act on live. Flip follows.
+    ctx.shadow_membership_path(&gid, &member, membership_path_kind(&live));
+    match live {
         MembershipPath::Inherited { .. } => Ok(()),
         MembershipPath::Direct => {
             // Direct members go through `MemberJoined` or `add_group_members`
@@ -75,5 +79,14 @@ pub(crate) fn apply(
                 }
             ));
         }
+    }
+}
+
+/// The live `MembershipPath` collapsed to the at-cut path KIND the shadow compares.
+fn membership_path_kind(path: &MembershipPath) -> crate::authorizer::AtCutMembershipPath {
+    match path {
+        MembershipPath::Inherited { .. } => crate::authorizer::AtCutMembershipPath::Inherited,
+        MembershipPath::Direct => crate::authorizer::AtCutMembershipPath::Direct,
+        MembershipPath::None => crate::authorizer::AtCutMembershipPath::None,
     }
 }


### PR DESCRIPTION
## What

Second #29b step. `member_joined_open` apply validates the joiner reaches the group via an **inherited** open-subgroup path (`check_path`) — one of the last live causal-resolver (`check_path`/`MembershipPath`) consumers. This adds the at-cut path resolver and **shadows** it before flipping.

## How

- New `AtCutAuthorizer::membership_path_at_cut` returning `AtCutMembershipPath` (`None`/`Direct`/`Inherited` — the kind the gate needs). `EphemeralProjectionAuthorizer` implements it via `ScopeProjections::membership_path_at_cut` (the at-cut `member_path_at_cut` walk, role/anchor projected away). `LiveFallbackAuthorizer` → `None`.
- `member_joined_open::apply` cross-checks the projection path vs live `check_path` (`NamespaceApplyCtx::shadow_membership_path`, plane `membership-path`), **still acting on live**. The op already carries the seam's parent cut + authorizer (apply-auth #28), so no new plumbing.

## Safety

Byte-identical: live `check_path` decides; the projection path is log-only. **399/399 governance-store tests pass unchanged.**

## Next

Flip (act on the projection path, live as `None`-fallback) once `membership-path` is divergence-free. Then `verify.rs` (the data-write baseline), then delete the causal resolver.

## Test

- `cargo clippy --all-targets -- -D warnings` / `fmt` clean (governance-store + context + server + node); 399/399.
- e2e: validates the new `membership-path` plane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches governance apply validation for open-subgroup joins, but decisions remain on live `check_path`; projection output is warn-only until flip.
> 
> **Overview**
> Adds **at-cut membership path** resolution for the `MemberJoinedOpen` apply gate (F5 #29b), alongside existing admin/capability/last-admin at-cut hooks.
> 
> **`AtCutAuthorizer::membership_path_at_cut`** returns `AtCutMembershipPath` (`None` / `Direct` / `Inherited`) — the kind the open-subgroup join gate needs. **`ScopeProjections::membership_path_at_cut`** delegates to the projection’s `member_path_at_cut` walk; **`EphemeralProjectionAuthorizer`** maps that to the governance-store enum. **`LiveFallbackAuthorizer`** still returns `None` (defer to live).
> 
> **`member_joined_open` apply** still **decides from live `check_path`**; before the match it calls **`NamespaceApplyCtx::shadow_membership_path`**, which compares the projection path to the live path and logs **`unified_projection_divergence`** on plane **`membership-path`** when they differ. No behavior change until a later flip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82c8d7afa1b909026260344ee904d26a90869ab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->