### PR TITLE
feat(governance): flip MemberJoinedOpen check_path onto the projection (F5 #29b)

### DIFF
--- a/crates/governance-store/src/ops/namespace/context.rs
+++ b/crates/governance-store/src/ops/namespace/context.rs
@@ -96,20 +96,20 @@ impl<'a> NamespaceApplyCtx<'a> {
         Ok(())
     }
 
-    /// The at-cut membership PATH for `member` in `group`, for the `MemberJoinedOpen`
-    /// gate (F5 #29b flip): the projection's `membership_path_at_cut` at the op's
+    /// The PROJECTION's at-cut membership PATH for `member` in `group`, for the
+    /// `MemberJoinedOpen` gate (F5 #29b flip): `membership_path_at_cut` at the op's
     /// causal cut, validated divergence-free on the `membership-path` plane. `None`
-    /// (no apply-auth context — sign/test — or an incomplete fold) falls back to the
-    /// `live_path` the caller computed from `check_path`. The live fallback retires
-    /// once `check_path` is deleted.
-    pub(crate) fn membership_path(
+    /// (no apply-auth context — sign/test — or an incomplete fold) means the caller
+    /// must fall back to live `check_path`. Returning the `Option` (rather than taking
+    /// an eager `live_path`) lets the caller compute live LAZILY — only when the
+    /// projection abstains — so a `check_path` store error can't abort an apply the
+    /// projection would have decided.
+    pub(crate) fn projection_membership_path(
         &self,
         group: &ContextGroupId,
         member: &PublicKey,
-        live_path: crate::authorizer::AtCutMembershipPath,
-    ) -> crate::authorizer::AtCutMembershipPath {
+    ) -> Option<crate::authorizer::AtCutMembershipPath> {
         self.authorizer
             .membership_path_at_cut(group, member, self.parents)
-            .unwrap_or(live_path)
     }
 }

--- a/crates/governance-store/src/ops/namespace/context.rs
+++ b/crates/governance-store/src/ops/namespace/context.rs
@@ -96,32 +96,20 @@ impl<'a> NamespaceApplyCtx<'a> {
         Ok(())
     }
 
-    /// SHADOW (F5 #29b): compare the projection's at-cut membership PATH for `member`
-    /// in `group` against the `live_path` the `MemberJoinedOpen` gate computed from
-    /// `check_path`, logging a `membership-path` divergence on a mismatch. Still acts
-    /// on live (the gate decides from `live_path`); the flip follows once validated.
-    /// `None` from the authorizer (no apply-auth context / incomplete fold) skips.
-    pub(crate) fn shadow_membership_path(
+    /// The at-cut membership PATH for `member` in `group`, for the `MemberJoinedOpen`
+    /// gate (F5 #29b flip): the projection's `membership_path_at_cut` at the op's
+    /// causal cut, validated divergence-free on the `membership-path` plane. `None`
+    /// (no apply-auth context — sign/test — or an incomplete fold) falls back to the
+    /// `live_path` the caller computed from `check_path`. The live fallback retires
+    /// once `check_path` is deleted.
+    pub(crate) fn membership_path(
         &self,
         group: &ContextGroupId,
         member: &PublicKey,
         live_path: crate::authorizer::AtCutMembershipPath,
-    ) {
-        if let Some(projected) = self
-            .authorizer
+    ) -> crate::authorizer::AtCutMembershipPath {
+        self.authorizer
             .membership_path_at_cut(group, member, self.parents)
-        {
-            if projected != live_path {
-                tracing::warn!(
-                    marker = "unified_projection_divergence",
-                    plane = "membership-path",
-                    group_id = ?group,
-                    %member,
-                    ?projected,
-                    ?live_path,
-                    "member-joined-open: projection membership path differs from live check_path"
-                );
-            }
-        }
+            .unwrap_or(live_path)
     }
 }

--- a/crates/governance-store/src/ops/namespace/member_joined_open.rs
+++ b/crates/governance-store/src/ops/namespace/member_joined_open.rs
@@ -60,11 +60,15 @@ pub(crate) fn apply(
         ));
     }
     // F5 #29b flip: decide the membership PATH from the projection at the op's causal
-    // cut (validated divergence-free on the `membership-path` plane), with live
-    // `check_path` as the `None`-fallback. The live read retires when `check_path` is
-    // deleted.
-    let live = MembershipRepository::new(store).check_path(&gid, &member)?;
-    match ctx.membership_path(&gid, &member, membership_path_kind(&live)) {
+    // cut (validated divergence-free on the `membership-path` plane). Live `check_path`
+    // is the `None`-fallback, computed LAZILY — only when the projection abstains — so
+    // a `check_path` store error can't abort an apply the projection would have
+    // decided. The live read retires when `check_path` is deleted.
+    let path = match ctx.projection_membership_path(&gid, &member) {
+        Some(projected) => projected,
+        None => membership_path_kind(&MembershipRepository::new(store).check_path(&gid, &member)?),
+    };
+    match path {
         AtCutMembershipPath::Inherited => Ok(()),
         AtCutMembershipPath::Direct => {
             // Direct members go through `MemberJoined` or `add_group_members`

--- a/crates/governance-store/src/ops/namespace/member_joined_open.rs
+++ b/crates/governance-store/src/ops/namespace/member_joined_open.rs
@@ -13,6 +13,7 @@
 //! direct pull-based key-delivery path, not from this op.
 
 use super::context::NamespaceApplyCtx;
+use crate::authorizer::AtCutMembershipPath;
 use crate::{
     ApplyError, MemberJoinedOpenRejection, MembershipPath, MembershipRepository,
     NamespaceRepository,
@@ -58,20 +59,21 @@ pub(crate) fn apply(
             }
         ));
     }
+    // F5 #29b flip: decide the membership PATH from the projection at the op's causal
+    // cut (validated divergence-free on the `membership-path` plane), with live
+    // `check_path` as the `None`-fallback. The live read retires when `check_path` is
+    // deleted.
     let live = MembershipRepository::new(store).check_path(&gid, &member)?;
-    // SHADOW (F5 #29b): cross-check the projection's at-cut path against live
-    // `check_path` (plane `membership-path`); still act on live. Flip follows.
-    ctx.shadow_membership_path(&gid, &member, membership_path_kind(&live));
-    match live {
-        MembershipPath::Inherited { .. } => Ok(()),
-        MembershipPath::Direct => {
+    match ctx.membership_path(&gid, &member, membership_path_kind(&live)) {
+        AtCutMembershipPath::Inherited => Ok(()),
+        AtCutMembershipPath::Direct => {
             // Direct members go through `MemberJoined` or `add_group_members`
             // — they shouldn't be using this op.
             eyre::bail!(ApplyError::MemberJoinedOpenRejected(
                 MemberJoinedOpenRejection::AlreadyDirectMember(format!("{member}"))
             ));
         }
-        MembershipPath::None => {
+        AtCutMembershipPath::None => {
             eyre::bail!(ApplyError::MemberJoinedOpenRejected(
                 MemberJoinedOpenRejection::NoMembershipPath {
                     member: format!("{member}"),
@@ -82,11 +84,11 @@ pub(crate) fn apply(
     }
 }
 
-/// The live `MembershipPath` collapsed to the at-cut path KIND the shadow compares.
-fn membership_path_kind(path: &MembershipPath) -> crate::authorizer::AtCutMembershipPath {
+/// The live `MembershipPath` collapsed to the at-cut path KIND (the `None`-fallback).
+fn membership_path_kind(path: &MembershipPath) -> AtCutMembershipPath {
     match path {
-        MembershipPath::Inherited { .. } => crate::authorizer::AtCutMembershipPath::Inherited,
-        MembershipPath::Direct => crate::authorizer::AtCutMembershipPath::Direct,
-        MembershipPath::None => crate::authorizer::AtCutMembershipPath::None,
+        MembershipPath::Inherited { .. } => AtCutMembershipPath::Inherited,
+        MembershipPath::Direct => AtCutMembershipPath::Direct,
+        MembershipPath::None => AtCutMembershipPath::None,
     }
 }


### PR DESCRIPTION
## What

Flips `member_joined_open`'s membership-path gate onto the projection. Follows #2878 (the `membership-path` shadow, which validated **0 divergences**).

## How

`member_joined_open::apply` now resolves the path via `NamespaceApplyCtx::membership_path` → the projection's `membership_path_at_cut` at the op's causal cut, with live `check_path` as the `None`-fallback. `shadow_membership_path` becomes `membership_path` (returns the resolved kind rather than just logging).

## Safety

The membership-path equivalence was validated divergence-free on real e2e traffic (#2878); the `None`-fallback keeps live for cold/incomplete folds. Causal-honor: the join is judged against its own ancestry.

## Test

- `cargo clippy --all-targets -- -D warnings` / `fmt` clean; 399/399.
- e2e: behavioral (the gate now runs on the projection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who may pass open-subgroup join apply checks when projection and live `check_path` disagree; fallback preserves prior behavior when the projection abstains.
> 
> **Overview**
> **MemberJoinedOpen** membership-path authorization now uses the **at-cut projection** (`membership_path_at_cut` at the op’s causal parents) instead of always reading live `check_path` while only shadow-logging mismatches.
> 
> `NamespaceApplyCtx::shadow_membership_path` is replaced by **`projection_membership_path`**, which returns `Option<AtCutMembershipPath>` and no longer compares or warns against an eager live path. In **`member_joined_open::apply`**, the gate takes the projected path when present; on `None` (no apply-auth context, incomplete fold, or default live-only authorizer) it **lazily** falls back to live `check_path` via `membership_path_kind`, so store errors on live reads cannot reject applies the projection would allow. Accept/reject branches now match on **`AtCutMembershipPath`** directly rather than live `MembershipPath`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 197850c8ef79b2f15ff55728396df677fa3f2a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->