### PR TITLE
feat(node): shadow the data-write role against the projection (F5 #29b)

### DIFF
--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1396,16 +1396,19 @@ impl ScopeProjections {
             calimero_authz::MemberPathAtCut::Inherited {
                 via_admin: true, ..
             } => Some(GroupMemberRole::Admin),
+            // `member_path_at_cut` only emits this arm when the anchor row is present,
+            // so the lookup resolves; if it somehow doesn't, return `None` (defer to
+            // live / skip the shadow) rather than GUESS `Member` — guessing could emit
+            // a spurious `data-write-role` divergence. Matches `member_entries_with`,
+            // which bails rather than fabricating a role on the same inconsistency.
             calimero_authz::MemberPathAtCut::Inherited {
                 anchor,
                 via_admin: false,
-            } => Some(
-                view.groups
-                    .get(&anchor)
-                    .and_then(|m| m.get(member))
-                    .cloned()
-                    .unwrap_or(GroupMemberRole::Member),
-            ),
+            } => view
+                .groups
+                .get(&anchor)
+                .and_then(|m| m.get(member))
+                .cloned(),
         }
     }
 

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1372,11 +1372,15 @@ impl ScopeProjections {
             .cloned()
     }
 
-    /// [`role_at_cut`](Self::role_at_cut) resolving the namespace from `group` and
-    /// gating on COMPLETE cited ancestry — the node-side accessor for the data-write
-    /// role (the role written through to peer-identity observation). `None` when the
-    /// namespace is unresolved, the cut isn't fully folded (defer to live), or
-    /// `member` has no folded direct row at the cut.
+    /// The EFFECTIVE role of `member` in `group` at the cut, resolving the namespace
+    /// from `group` and gating on COMPLETE cited ancestry — the node-side accessor for
+    /// the data-write role (written through to peer-identity observation). Mirrors
+    /// live `acl_view_at`'s `Member(role)`, which is the *effective* role: a direct
+    /// member's folded role, `Admin` for an inherited-via-admin member, else the
+    /// member's role at the anchor it inherits from (the same derivation the
+    /// `membership-role` plane validated — NOT just `groups[group]`, which would miss
+    /// inherited/admin paths). `None` when the namespace is unresolved, the cut isn't
+    /// fully folded (defer to live), or `member` isn't a member at the cut.
     #[must_use]
     pub fn role_at_cut_for_group(
         &self,
@@ -1385,15 +1389,24 @@ impl ScopeProjections {
         member: &PublicKey,
         heads: &[[u8; 32]],
     ) -> Option<GroupMemberRole> {
-        let namespace_id = NamespaceRepository::new(store)
-            .resolve(&group)
-            .ok()?
-            .to_bytes();
-        let scope = ScopeId::from(namespace_id);
-        if !self.cut_ancestry_complete(&scope, heads) {
-            return None;
+        let (view, root, default_cap_base) = self.auth_cut_context(store, group, heads)?;
+        match view.member_path_at_cut(group, member, root, default_cap_base) {
+            calimero_authz::MemberPathAtCut::None => None,
+            calimero_authz::MemberPathAtCut::Direct { role } => Some(role),
+            calimero_authz::MemberPathAtCut::Inherited {
+                via_admin: true, ..
+            } => Some(GroupMemberRole::Admin),
+            calimero_authz::MemberPathAtCut::Inherited {
+                anchor,
+                via_admin: false,
+            } => Some(
+                view.groups
+                    .get(&anchor)
+                    .and_then(|m| m.get(member))
+                    .cloned()
+                    .unwrap_or(GroupMemberRole::Member),
+            ),
         }
-        self.role_at_cut(&scope, &group, member, heads)
     }
 
     /// The role the projection records for `member` in `group` within `scope`,

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1372,6 +1372,30 @@ impl ScopeProjections {
             .cloned()
     }
 
+    /// [`role_at_cut`](Self::role_at_cut) resolving the namespace from `group` and
+    /// gating on COMPLETE cited ancestry — the node-side accessor for the data-write
+    /// role (the role written through to peer-identity observation). `None` when the
+    /// namespace is unresolved, the cut isn't fully folded (defer to live), or
+    /// `member` has no folded direct row at the cut.
+    #[must_use]
+    pub fn role_at_cut_for_group(
+        &self,
+        store: &Store,
+        group: ContextGroupId,
+        member: &PublicKey,
+        heads: &[[u8; 32]],
+    ) -> Option<GroupMemberRole> {
+        let namespace_id = NamespaceRepository::new(store)
+            .resolve(&group)
+            .ok()?
+            .to_bytes();
+        let scope = ScopeId::from(namespace_id);
+        if !self.cut_ancestry_complete(&scope, heads) {
+            return None;
+        }
+        self.role_at_cut(&scope, &group, member, heads)
+    }
+
     /// The role the projection records for `member` in `group` within `scope`,
     /// or `None` if absent (member not present, or the scope hasn't been fed).
     /// The `states` fast-path snapshot — order-converged but NOT causal for

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -1036,6 +1036,29 @@ pub async fn handle_state_delta(
                     );
                     return Ok(());
                 }
+
+                // ROLE SHADOW (F5 #29b): `projection_member_at_cut` just refreshed the
+                // projection for this cut; read its at-cut ROLE and compare to live's
+                // `role` (which `verify.rs` derived from `acl_view_at` and which writes
+                // through to peer-identity observation below). Log-only — the verify.rs
+                // flip will SOURCE the role here, retiring `acl_view_at`. `None`
+                // (incomplete fold / no folded row) skips.
+                if let Some(projected_role) = node_state
+                    .read_scope_projections()
+                    .role_at_cut_for_group(datastore, group, &author_id, heads)
+                {
+                    if projected_role != role {
+                        warn!(
+                            marker = "unified_projection_divergence",
+                            plane = "data-write-role",
+                            group_id = ?group,
+                            %author_id,
+                            ?projected_role,
+                            live_role = ?role,
+                            "projection role differs from live role at the data-write cut"
+                        );
+                    }
+                }
             }
 
             // Both authorities concur (or the projection abstained). Record the


### PR DESCRIPTION
## What

The validate-first step for the `verify.rs` data-write migration (the substantial #29b piece). `verify.rs` derives the authorized author's **role** from live `acl_view_at`, and that role writes through to peer-identity observation (sync peer selection + durable cache). The membership verdict is already projection-validated (`membership-cut`/`membership-cut-grant`); the **role** is the last un-validated piece — so shadow it before flipping verify.rs off `acl_view_at`.

## How

- `ScopeProjections::role_at_cut_for_group` — `role_at_cut` with namespace resolution + `cut_ancestry_complete` gating (node-side accessor).
- In the gossip-receive `Authorized` arm, after the existing co-authorizer refresh (`projection_member_at_cut`), read the projection's at-cut role and log `unified_projection_divergence` plane=`data-write-role` on a mismatch. **Reuses the refresh already done** — no extra fold. Log-only.

## Safety

Behavior-neutral: live's `role` still flows to peer observation; the projection role is log-only. The membership decision is unchanged (already projection-authoritative).

## Next

Once `data-write-role` is divergence-free: flip `verify.rs` to source role + membership from the projection, compute `Buffer{needed}` via a direct op-log presence check, retiring `acl_view_at`. Then the deletion PR.

## Test

- `cargo clippy --all-targets -- -D warnings` / `fmt` clean.
- e2e: validates the new `data-write-role` plane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Log-only shadow on an already-gated Authorized path; live membership and role observation are unchanged until a follow-up flip.
> 
> **Overview**
> Adds **`ScopeProjections::role_at_cut_for_group`**, which resolves the **effective** author role at the governance cut (direct, inherited-via-admin, or anchor role) using the same `member_path_at_cut` path as membership-role validation, with namespace resolution and **`cut_ancestry_complete`** gating.
> 
> On the gossip **Authorized** path, after the existing membership co-authorizer refresh, the handler compares that projected role to live’s role from **`verify.rs`** / **`acl_view_at`**. Mismatches emit **`unified_projection_divergence`** with plane **`data-write-role`** only — **no change** to authorization or peer-identity observation (live role still wins).
> 
> This is the validate-first step before flipping verify to source role from the projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d24eefc7e4a351babfb12906b6cc562d07eeb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->