### PR TITLE
feat(node): flip all sync-path delta auth onto the projection + retire live resolver (F5 #29b)

### DIFF
--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -807,10 +807,17 @@ pub(crate) fn resolve_cut_membership(
     author_id: &calimero_primitives::identity::PublicKey,
     heads: &[[u8; 32]],
 ) -> verify::CutMembership {
-    match projection_member_at_cut(node_state, datastore, group, author_id, heads) {
+    // Refresh the fold ONCE (scoped write lock), then resolve membership AND role
+    // under a SINGLE read-lock acquisition. Both are at-cut reads keyed to `heads`,
+    // so they already resolve against the same cut; holding one guard additionally
+    // pins them to the same fold epoch, so a concurrent governance `apply_backfill`
+    // can't advance the projection between the membership verdict and the role read
+    // and yield a mismatched `Member(role)` pair.
+    refresh_projection_for_cut(node_state, datastore, group, heads);
+    let projections = node_state.read_scope_projections();
+    match projections.member_at_cut(datastore, group, author_id, heads) {
         Some(true) => verify::CutMembership::Member(
-            node_state
-                .read_scope_projections()
+            projections
                 .role_at_cut_for_group(datastore, group, author_id, heads)
                 .unwrap_or(calimero_primitives::context::GroupMemberRole::Member),
         ),

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -799,7 +799,8 @@ fn refresh_projection_for_cut(
 /// (cited ancestry not yet folded) → `Incomplete`.
 ///
 /// `pub(crate)` so the sync-layer delta-auth sites (DAG-catchup, parent-pull) render
-/// the same verdict as the gossip path.
+/// the same verdict as the gossip path. This is the single refresh+read implementation;
+/// [`projection_member_at_cut`] is a thin membership-only projection of it.
 pub(crate) fn resolve_cut_membership(
     node_state: &crate::NodeState,
     datastore: &calimero_store::Store,
@@ -807,27 +808,49 @@ pub(crate) fn resolve_cut_membership(
     author_id: &calimero_primitives::identity::PublicKey,
     heads: &[[u8; 32]],
 ) -> verify::CutMembership {
-    // Refresh the fold ONCE (scoped write lock), then resolve membership AND role
-    // under a SINGLE read-lock acquisition. Both are at-cut reads keyed to `heads`,
-    // so they already resolve against the same cut; holding one guard additionally
-    // pins them to the same fold epoch, so a concurrent governance `apply_backfill`
-    // can't advance the projection between the membership verdict and the role read
-    // and yield a mismatched `Member(role)` pair.
+    // Refresh the fold (scoped write lock), then read membership AND role under a
+    // SINGLE read guard. The guard guarantees the two READS see one fold epoch, so a
+    // concurrent `apply_backfill` can't split the `Member(role)` pair across epochs.
+    // The refresh and the subsequent read are NOT one atomic critical section
+    // (std `RwLock` has no write→read downgrade, and holding the write lock across
+    // the reads would serialize this hot per-delta path against every other reader —
+    // the contention the `RwLock` exists to avoid). That gap is safe: both reads are
+    // at-cut reads keyed to `heads`, and a fold can only become MORE complete between
+    // the refresh and the read — for a fixed cut the at-cut answer is stable once the
+    // cited ancestry is folded, so seeing a more-advanced epoch never changes it.
     refresh_projection_for_cut(node_state, datastore, group, heads);
     let projections = node_state.read_scope_projections();
     match projections.member_at_cut(datastore, group, author_id, heads) {
-        Some(true) => verify::CutMembership::Member(
-            projections
+        Some(true) => {
+            // The role is an OBSERVATION hint only — it feeds `observe_peer_identity`
+            // (a routing hint, never authority) and is ignored by the apply gate,
+            // which authorizes on the membership verdict alone. ReadOnly writes are
+            // rejected by the separate upstream `is_read_only_for_context` gate, not
+            // this role. So a `None` role (member materialized but effective role not
+            // yet resolvable at the cut) defaulting to `Member` cannot over-authorize
+            // a write; it only records a less-precise hint. Log it so the condition is
+            // observable rather than silent.
+            let role = projections
                 .role_at_cut_for_group(datastore, group, author_id, heads)
-                .unwrap_or(calimero_primitives::context::GroupMemberRole::Member),
-        ),
+                .unwrap_or_else(|| {
+                    debug!(
+                        group_id = ?group,
+                        %author_id,
+                        "projection: member at cut but role unresolved; defaulting hint to Member"
+                    );
+                    calimero_primitives::context::GroupMemberRole::Member
+                });
+            verify::CutMembership::Member(role)
+        }
         Some(false) => verify::CutMembership::NotMember,
         None => verify::CutMembership::Incomplete,
     }
 }
 
 // `pub(crate)` so the sync manager's inbound-peer authorization reuses the exact
-// same refreshing deny-direction read the data-write path uses.
+// same refreshing deny-direction read the data-write path uses. Delegates to
+// [`resolve_cut_membership`] (the single refresh+read implementation) and discards
+// the role, so the two never drift.
 pub(crate) fn projection_member_at_cut(
     node_state: &crate::NodeState,
     datastore: &calimero_store::Store,
@@ -835,10 +858,11 @@ pub(crate) fn projection_member_at_cut(
     author_id: &calimero_primitives::identity::PublicKey,
     heads: &[[u8; 32]],
 ) -> Option<bool> {
-    refresh_projection_for_cut(node_state, datastore, group, heads);
-    node_state
-        .read_scope_projections()
-        .member_at_cut(datastore, group, author_id, heads)
+    match resolve_cut_membership(node_state, datastore, group, author_id, heads) {
+        verify::CutMembership::Member(_) => Some(true),
+        verify::CutMembership::NotMember => Some(false),
+        verify::CutMembership::Incomplete => None,
+    }
 }
 
 pub async fn handle_state_delta(

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -41,9 +41,7 @@ use events::{
 // `choose_owned_identity` is also reached by the sibling `buffering` module via
 // `super::` (re-exported through this import).
 use store_setup::{choose_owned_identity, init_delta_store, DeltaStoreSetup};
-pub(crate) use verify::{
-    authorize_delta_at_edge, authorize_delta_at_edge_projected, DeltaAuthOutcome,
-};
+pub(crate) use verify::{authorize_delta_at_edge_projected, DeltaAuthOutcome};
 
 pub(crate) struct StateDeltaMessage {
     pub(crate) source: PeerId,
@@ -566,6 +564,7 @@ pub(crate) async fn apply_authorized_state_delta(
                 our_identity,
                 delta_store_ref.clone(),
                 datastore_for_fetch,
+                &node_state,
             )
             .await
             {
@@ -792,6 +791,34 @@ fn refresh_projection_for_cut(
     }
 }
 
+/// Resolve the projection's at-cut membership verdict for `author` in `group` at the
+/// cited governance `heads`, in the shape [`authorize_delta_at_edge_projected`]
+/// consumes. Shared by the gossip, parent-fetch, and snapshot-replay paths so all
+/// three render the identical verdict from the maintained projection: `Some(true)`
+/// → `Member` with the effective at-cut role, `Some(false)` → `NotMember`, `None`
+/// (cited ancestry not yet folded) → `Incomplete`.
+///
+/// `pub(crate)` so the sync-layer delta-auth sites (DAG-catchup, parent-pull) render
+/// the same verdict as the gossip path.
+pub(crate) fn resolve_cut_membership(
+    node_state: &crate::NodeState,
+    datastore: &calimero_store::Store,
+    group: calimero_context_config::types::ContextGroupId,
+    author_id: &calimero_primitives::identity::PublicKey,
+    heads: &[[u8; 32]],
+) -> verify::CutMembership {
+    match projection_member_at_cut(node_state, datastore, group, author_id, heads) {
+        Some(true) => verify::CutMembership::Member(
+            node_state
+                .read_scope_projections()
+                .role_at_cut_for_group(datastore, group, author_id, heads)
+                .unwrap_or(calimero_primitives::context::GroupMemberRole::Member),
+        ),
+        Some(false) => verify::CutMembership::NotMember,
+        None => verify::CutMembership::Incomplete,
+    }
+}
+
 // `pub(crate)` so the sync manager's inbound-peer authorization reuses the exact
 // same refreshing deny-direction read the data-write path uses.
 pub(crate) fn projection_member_at_cut(
@@ -949,39 +976,23 @@ pub async fn handle_state_delta(
     //
     // INVARIANT: `ContextManager` serializes governance ops, so no concurrent
     // group reassignment can interleave between the group lookup inside
-    // `authorize_delta_at_edge` and its membership walk.
+    // `authorize_delta_at_edge_projected` and its membership walk.
     let datastore = node_clients.context.datastore();
-    // F5 #29b gossip flip: resolve membership from the PROJECTION at the op's
-    // governance cut (no live `acl_view_at`). The maintained projection is the sole
-    // authority here — validated divergence-free against live across the
-    // `membership-cut` / `membership-cut-grant` / `data-write-role` /
-    // `data-write-decision` planes. `member_at_cut` is the conservative verdict
-    // (`Some(true)` member incl. materialized, `Some(false)` not-a-member,
-    // `None` cited ancestry not folded → buffer); the role is the effective at-cut
-    // role written through to peer-identity observation. Live-only sync paths
-    // (parent-fetch, snapshot-replay) keep `authorize_delta_at_edge` until they gain
-    // projection access.
+    // F5 #29b: resolve membership from the PROJECTION at the op's governance cut (no
+    // live `acl_view_at`). The maintained projection is the sole authority here —
+    // validated divergence-free against live across the `membership-cut` /
+    // `membership-cut-grant` / `data-write-role` / `data-write-decision` planes.
+    // `member_at_cut` is the conservative verdict (`Some(true)` member incl.
+    // materialized, `Some(false)` not-a-member, `None` cited ancestry not folded →
+    // buffer); the role is the effective at-cut role written through to peer-identity
+    // observation. Every delta-auth path (gossip, parent-fetch, snapshot-replay,
+    // DAG-catchup) now shares this projection verdict via `resolve_cut_membership`.
     let delta_auth = authorize_delta_at_edge_projected(
         datastore,
         &context_id,
         &author_id,
         governance_position.as_ref(),
-        |group, heads| match projection_member_at_cut(
-            &node_state,
-            datastore,
-            group,
-            &author_id,
-            heads,
-        ) {
-            Some(true) => verify::CutMembership::Member(
-                node_state
-                    .read_scope_projections()
-                    .role_at_cut_for_group(datastore, group, &author_id, heads)
-                    .unwrap_or(calimero_primitives::context::GroupMemberRole::Member),
-            ),
-            Some(false) => verify::CutMembership::NotMember,
-            None => verify::CutMembership::Incomplete,
-        },
+        |group, heads| resolve_cut_membership(&node_state, datastore, group, &author_id, heads),
     );
 
     match delta_auth {
@@ -1131,6 +1142,10 @@ async fn request_missing_deltas(
     our_identity: PublicKey,
     delta_store: DeltaStore,
     datastore: calimero_store::Store,
+    // The maintained projection, for at-cut membership authorization of fetched
+    // deltas (F5 #29b). Borrowed for the duration of the fetch; the caller awaits
+    // inline so the borrow outlives every projection read.
+    node_state: &crate::NodeState,
 ) -> Result<Vec<([u8; 32], Vec<u8>)>> {
     use calimero_node_primitives::sync::{InitPayload, MessagePayload, StreamMessage};
 
@@ -1330,7 +1345,7 @@ async fn request_missing_deltas(
 
                     // Group/membership authorization — including the group-id
                     // anti-bypass that the old `GroupIdCheck` performed — is
-                    // done by `authorize_delta_at_edge` below (after the
+                    // done by `authorize_delta_at_edge_projected` below (after the
                     // ReadOnly gate), deriving the group from the context.
 
                     // ReadOnly check — parity with the gossip apply
@@ -1357,13 +1372,25 @@ async fn request_missing_deltas(
                     // Cross-DAG authorization against the governance parent
                     // edge: derives the group from the context (folding in the
                     // old group-id anti-bypass) and resolves membership at the
-                    // cited cut. Reject deltas whose author was removed / never
-                    // a member; skip when the cut isn't locally known.
-                    match authorize_delta_at_edge(
+                    // cited cut FROM THE PROJECTION (F5 #29b), parity with the
+                    // gossip path. Reject deltas whose author is not a member at
+                    // the cut; skip (Buffer) when the cited ancestry isn't folded
+                    // yet — the same delta re-arrives via gossip once governance
+                    // catches up, so a skip here can't cause permanent divergence.
+                    match authorize_delta_at_edge_projected(
                         &datastore,
                         &context_id,
                         &response_author,
                         governance_position.as_ref(),
+                        |group, heads| {
+                            resolve_cut_membership(
+                                node_state,
+                                &datastore,
+                                group,
+                                &response_author,
+                                heads,
+                            )
+                        },
                     ) {
                         DeltaAuthOutcome::Authorized { .. } | DeltaAuthOutcome::Ungated => {}
                         DeltaAuthOutcome::Reject(reason)
@@ -1696,21 +1723,23 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
     // this, every delta arriving inside the sync window bypasses cross-DAG
     // authorization.
     //
-    // Authorize against the governance parent edge — same
-    // `authorize_delta_at_edge` path as `handle_state_delta`, but the
-    // `Buffer` outcome is interpreted as a DROP here: after snapshot sync the
-    // receiver is at-or-ahead of any legitimate authoring cut, so persistent
-    // Unknown means the edge cites heads we provably do not have, and
-    // re-buffering would be a permanent leak.
+    // Authorize against the governance parent edge from the PROJECTION (F5 #29b),
+    // parity with the gossip path, but the `Buffer` outcome is interpreted as a
+    // DROP here: after snapshot sync the receiver is at-or-ahead of any legitimate
+    // authoring cut, so a persistently-unfolded cut means the edge cites heads we
+    // provably do not have, and re-buffering would be a permanent leak.
     //
     // INVARIANT: `ContextManager` serializes governance ops, so no concurrent
     // group reassignment can interleave between the group lookup and the walk.
     let datastore = context_client.datastore();
-    match authorize_delta_at_edge(
+    match authorize_delta_at_edge_projected(
         datastore,
         &context_id,
         &buffered.author_id,
         buffered.governance_position.as_ref(),
+        |group, heads| {
+            resolve_cut_membership(&node_state, datastore, group, &buffered.author_id, heads)
+        },
     ) {
         DeltaAuthOutcome::Ungated => {}
         DeltaAuthOutcome::Authorized { group, role } => {

--- a/crates/node/src/handlers/state_delta/verify.rs
+++ b/crates/node/src/handlers/state_delta/verify.rs
@@ -43,8 +43,10 @@ pub(crate) enum DeltaAuthOutcome {
 /// The projection's membership verdict at a governance cut — the resolver result for
 /// [`authorize_delta_at_edge_projected`] (F5 #29b). Mirrors what the live
 /// `acl_view_at` produced, minus the Removed/NeverMember split (both are "not a
-/// member", which the gossip path treats identically) and minus the `needed` set
-/// (the projection reports incompleteness as a bool; `Buffer.needed` is best-effort).
+/// member", which the gossip path treats identically) and minus any `needed` set:
+/// the projection reports incompleteness as the `Incomplete` variant alone, and
+/// `authorize_delta_at_edge_projected` populates `DeltaAuthOutcome::Buffer.needed`
+/// from the governance position's heads, not from this resolver.
 pub(crate) enum CutMembership {
     /// Author is a member at the cut, with this effective role.
     Member(calimero_primitives::context::GroupMemberRole),

--- a/crates/node/src/handlers/state_delta/verify.rs
+++ b/crates/node/src/handlers/state_delta/verify.rs
@@ -1,12 +1,13 @@
 //! Apply-time governance authorization for state deltas (core#2716 Phase 4).
 //!
-//! [`authorize_delta_at_edge`] is the single source of truth for "is this
-//! author authorized to write into this context, at the cut its governance
-//! parent edge names?", shared by the gossip-receive, governance-pending
-//! drain, snapshot-replay, and DAG-catchup paths. The group is derived from
-//! the context (canonical context→group mapping), never a signer-supplied
-//! `group_id` — which is what makes a separate `group_id`-equality anti-bypass
-//! check unnecessary.
+//! [`authorize_delta_at_edge_projected`] is the single source of truth for "is this
+//! author authorized to write into this context, at the cut its governance parent
+//! edge names?", shared by the gossip-receive, governance-pending drain,
+//! snapshot-replay, and DAG-catchup paths. It resolves membership FROM THE UNIFIED
+//! PROJECTION at the op's causal cut (F5 #29b); the live `acl_view_at` resolver it
+//! replaced is retired. The group is derived from the context (canonical
+//! context→group mapping), never a signer-supplied `group_id` — which is what makes a
+//! separate `group_id`-equality anti-bypass check unnecessary.
 
 use calimero_primitives::context::ContextId;
 
@@ -29,10 +30,9 @@ pub(crate) enum DeltaAuthOutcome {
     /// avoid silent bypass on transient I/O or corruption). The projection does
     /// not override these.
     Reject(&'static str),
-    /// Membership resolution says the author is NOT a member at the cut. On the
-    /// gossip path this is the projection's definitive not-a-member verdict
-    /// (`member_at_cut == Some(false)`); on the live sync paths it is
-    /// `acl_view_at`'s Removed / NeverMember. Either way the delta is rejected.
+    /// Membership resolution says the author is NOT a member at the cut — the
+    /// projection's definitive not-a-member verdict (`member_at_cut == Some(false)`).
+    /// The delta is rejected.
     MembershipReject { reason: &'static str },
     /// Local governance state is behind the cited cut. Buffer until catchup;
     /// `needed` lists every missing governance head so the receiver can
@@ -55,11 +55,24 @@ pub(crate) enum CutMembership {
     Incomplete,
 }
 
-/// [`authorize_delta_at_edge`] resolving membership via a caller-supplied projection
-/// `resolve` instead of the live `acl_view_at` (F5 #29b gossip flip). The structural
-/// checks (group derivation from the context, bypass / non-group rejects) are
-/// identical; only the membership verdict swaps to the projection at the op's
-/// governance cut. `resolve` wraps the node's maintained projection
+/// Authorize a state delta against its **governance parent edge** (core#2716 P4),
+/// resolving membership via a caller-supplied projection `resolve` (F5 #29b). The
+/// successor to the live `acl_view_at`-backed resolver: the structural checks (group
+/// derivation from the context, bypass / non-group rejects) are unchanged; the
+/// membership verdict comes from the projection at the op's governance cut.
+///
+/// `governance_position` is the signed envelope's edge (`None` for a non-group
+/// context); only its `governance_dag_heads` are consulted. The group is derived from
+/// `context_id` via the canonical context→group mapping — the position's own
+/// `group_id` is intentionally ignored, which is what makes the old
+/// `group_id`-equality anti-bypass structurally unnecessary.
+///
+/// **Forward-only / TOCTOU**: the projection observes only the ancestry of the cited
+/// heads, so a pre-removal write authorizes regardless of receive order; and
+/// `ContextManager` serializes governance ops, so no group reassignment interleaves
+/// between the group lookup and the resolve.
+///
+/// `resolve` wraps the node's maintained projection
 /// (`member_at_cut` + `role_at_cut_for_group`) — already validated divergence-free
 /// against live on the `membership-cut` / `membership-cut-grant` / `data-write-role`
 /// / `data-write-decision` planes. `Incomplete` maps to `Buffer` (exactly as live's
@@ -102,86 +115,5 @@ pub(crate) fn authorize_delta_at_edge_projected(
                 needed: pos.governance_dag_heads.clone(),
             },
         },
-    }
-}
-
-/// Authorize a state delta against its **governance parent edge** (core#2716
-/// P4) — the successor to the `GroupIdCheck` + `membership_status_at` pair.
-///
-/// `governance_position` is the signed envelope's edge (`None` for a
-/// non-group context); only its `governance_dag_heads` are consulted. The
-/// group is derived from `context_id` via the canonical context→group
-/// mapping — the position's own `group_id` is intentionally ignored, which is
-/// what makes the old `group_id`-equality anti-bypass structurally
-/// unnecessary: the only group ever authorized against is the context's own,
-/// so a signer cannot cite a different group it belongs to elsewhere.
-///
-/// Authorization itself is delegated to
-/// [`acl_view_at`](calimero_context::group_store::acl_view_at), which resolves
-/// membership at the cut named by the heads.
-///
-/// **Forward-only** — `acl_view_at` observes only the ancestry of the cited
-/// heads, so a pre-removal write resolves to [`DeltaAuthOutcome::Authorized`]
-/// regardless of the order the receiver observed the later removal.
-///
-/// **TOCTOU** — runs immediately before apply with no lock held;
-/// `ContextManager` serializes governance ops, so no concurrent group
-/// reassignment can interleave between the group lookup and the walk.
-pub(crate) fn authorize_delta_at_edge(
-    store: &calimero_store::Store,
-    context_id: &ContextId,
-    author: &calimero_primitives::identity::PublicKey,
-    governance_position: Option<&calimero_context_config::types::GovernanceParentEdge>,
-) -> DeltaAuthOutcome {
-    use calimero_context::group_store::{acl_view_at, MembershipStatus};
-
-    let owning = match calimero_context::group_store::get_group_for_context(store, context_id) {
-        Ok(owning) => owning,
-        Err(err) => {
-            // Log the underlying error before collapsing to a static reject
-            // reason — a transient store I/O / corruption fault here looks
-            // identical to a deliberate bypass in the caller's warn line
-            // otherwise, which hides real operational problems.
-            tracing::warn!(
-                %context_id, %author, %err,
-                "authorize_delta_at_edge: get_group_for_context failed; rejecting to avoid silent bypass"
-            );
-            return DeltaAuthOutcome::Reject(
-                "get_group_for_context failed; rejecting to avoid silent bypass",
-            );
-        }
-    };
-
-    match (owning, governance_position) {
-        (None, None) => DeltaAuthOutcome::Ungated,
-        (Some(_), None) => DeltaAuthOutcome::Reject(
-            "group context but no governance edge (likely a bypass attempt)",
-        ),
-        (None, Some(_)) => {
-            DeltaAuthOutcome::Reject("governance edge present but context is not part of any group")
-        }
-        (Some(group), Some(pos)) => {
-            match acl_view_at(store, group, author, &pos.governance_dag_heads) {
-                Ok(MembershipStatus::Member(role)) => DeltaAuthOutcome::Authorized { group, role },
-                Ok(MembershipStatus::Removed { .. }) => DeltaAuthOutcome::MembershipReject {
-                    reason: "author was removed from group at governance cut",
-                },
-                Ok(MembershipStatus::NeverMember) => DeltaAuthOutcome::MembershipReject {
-                    reason: "author is not a member of the group at governance cut",
-                },
-                Ok(MembershipStatus::Unknown { needed }) => DeltaAuthOutcome::Buffer { needed },
-                Err(err) => {
-                    // Surface the real cause (hash mismatch / store corruption /
-                    // I/O) rather than swallowing it behind the static reason.
-                    tracing::warn!(
-                        %context_id, %author, group_id = ?group, %err,
-                        "authorize_delta_at_edge: membership lookup failed; rejecting"
-                    );
-                    DeltaAuthOutcome::Reject(
-                        "membership lookup failed (hash mismatch / corruption)",
-                    )
-                }
-            }
-        }
     }
 }

--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -93,6 +93,8 @@ fn verify_fetched_parent(
     delta_id: [u8; 32],
     fetched: &FetchedDelta,
     datastore: &calimero_store::Store,
+    // The maintained projection, for at-cut membership authorization (F5 #29b).
+    node_state: &crate::NodeState,
 ) -> VerifiedParent {
     use calimero_context_config::types::GovernanceParentEdge;
 
@@ -150,7 +152,7 @@ fn verify_fetched_parent(
     }
 
     // Group/membership authorization — including the group-id anti-bypass the
-    // old `GroupIdCheck` performed — is done by `authorize_delta_at_edge`
+    // old `GroupIdCheck` performed — is done by `authorize_delta_at_edge_projected`
     // below (after the ReadOnly gate), deriving the group from the context.
 
     // ReadOnly check — parity with the gossip apply path.
@@ -171,11 +173,22 @@ fn verify_fetched_parent(
         return VerifiedParent::Skip;
     }
 
-    match crate::handlers::state_delta::authorize_delta_at_edge(
+    // Resolve membership at the cited cut FROM THE PROJECTION (F5 #29b), parity
+    // with the gossip path.
+    match crate::handlers::state_delta::authorize_delta_at_edge_projected(
         datastore,
         context_id,
         &fetched.author_id,
         pos.as_ref(),
+        |group, heads| {
+            crate::handlers::state_delta::resolve_cut_membership(
+                node_state,
+                datastore,
+                group,
+                &fetched.author_id,
+                heads,
+            )
+        },
     ) {
         crate::handlers::state_delta::DeltaAuthOutcome::Authorized { .. }
         | crate::handlers::state_delta::DeltaAuthOutcome::Ungated => {
@@ -323,6 +336,7 @@ impl SyncManager {
                             missing_id,
                             &fetched,
                             &datastore,
+                            &self.node_state,
                         ) {
                             VerifiedParent::Apply { position } => position,
                             VerifiedParent::Skip => continue,

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -2098,7 +2098,7 @@ impl SyncManager {
 
                             // Group/membership authorization — including the
                             // group-id anti-bypass the old `GroupIdCheck`
-                            // performed — is done by `authorize_delta_at_edge`
+                            // performed — is done by `authorize_delta_at_edge_projected`
                             // below (after the ReadOnly gate), deriving the
                             // group from the context in lockstep with the
                             // gossip path.
@@ -2125,13 +2125,25 @@ impl SyncManager {
 
                             {
                                 use crate::handlers::state_delta::{
-                                    authorize_delta_at_edge, DeltaAuthOutcome,
+                                    authorize_delta_at_edge_projected, resolve_cut_membership,
+                                    DeltaAuthOutcome,
                                 };
-                                match authorize_delta_at_edge(
+                                // Resolve membership at the cited cut FROM THE
+                                // PROJECTION (F5 #29b), parity with the gossip path.
+                                match authorize_delta_at_edge_projected(
                                     &datastore_for_heads,
                                     &context_id,
                                     &author,
                                     pos.as_ref(),
+                                    |group, heads| {
+                                        resolve_cut_membership(
+                                            &self.node_state,
+                                            &datastore_for_heads,
+                                            group,
+                                            &author,
+                                            heads,
+                                        )
+                                    },
                                 ) {
                                     DeltaAuthOutcome::Authorized { .. }
                                     | DeltaAuthOutcome::Ungated => {


### PR DESCRIPTION
**#2887 (the gossip flip) is now merged; this PR is rebased onto `master`.**

## What

Completes the F5 #29b data-write authorization flip. After #2887 flipped the gossip path, three live `acl_view_at`-backed call sites remained. This flips all of them onto the maintained projection at the op's governance cut:

- **parent-fetch** — `apply_authorized_state_delta` → `request_missing_deltas`
- **snapshot-replay** — `replay_buffered_delta`
- **DAG-catchup** — `SyncManager::request_missing_deltas` parent-pull (`verify_fetched_parent`) + the head-pull dispatch in `manager/mod.rs`

Each path keeps its own `Buffer` idiom — **skip-and-retry** on the recovery paths, **drop** on snapshot-replay — only the membership *verdict* swaps to the projection. All three reach it via `SyncManager.node_state` or a threaded `node_state` reference.

## Shared verdict renderer

New `resolve_cut_membership` (pub(crate)) is the single place the projection verdict is rendered — one scoped refresh, then a **single** read guard held across `member_at_cut` (conservative) + `role_at_cut_for_group` (effective role) → `CutMembership`, so the `Member(role)` pair is epoch-consistent. Gossip and every sync path call it, so they cannot drift.

## Retire the live resolver

With no callers left, the live `authorize_delta_at_edge` (and its `acl_view_at` / `MembershipStatus` use *on this path*) is deleted. The `acl_view_at` resolver itself stays for the governance-op apply path — the closing **deletion PR** retires that.

## Why safe

Same reasoning as #2887: the projection verdict was validated divergence-free against live across the `membership-cut` / `membership-cut-grant` / `data-write-role` / `data-write-decision` planes, and the only behavioral change vs live is `None` (incomplete fold) → buffer/skip/drop instead of a live grant — strictly conservative on recovery paths (the delta re-arrives via gossip). The **e2e divergence gate** validates all paths.

## Review fixes (from #2887)

Folded in the AI-reviewer findings: atomic membership+role read (single guard), structural-duplication suggestion resolved by deleting the live resolver, and the `CutMembership` doc reworded.

## Test
- `cargo test -p calimero-node --features calimero-storage/testing` — 387 + 314 pass
- `cargo clippy -p calimero-server -p calimero-node --all-targets --features calimero-storage/testing -- -D warnings` — clean
- `cargo fmt --check` — clean

Part of F5 (core#2716). After this: only `namespace_sync`'s governance-op `acl_view_at`/`check_path` use + dead folds remain → the deletion PR closes F5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization on security-critical delta apply paths (parent-fetch, DAG-catchup, snapshot replay); behavior is intended to be conservative vs live when the projection fold is incomplete.
> 
> **Overview**
> Completes **F5 #29b** by moving the last **live `acl_view_at`** delta-authorization call sites onto the **maintained scope projection** at each delta’s governance cut, matching the gossip path from #2887.
> 
> Adds **`resolve_cut_membership`** as the shared refresh-then-read path (`member_at_cut` + `role_at_cut_for_group` under one read guard) and wires **parent-fetch**, **snapshot-replay**, and **DAG-catchup** (parent-pull + head-pull) through **`authorize_delta_at_edge_projected`** with that resolver. **`projection_member_at_cut`** now delegates to it so membership-only callers stay aligned.
> 
> **Removes `authorize_delta_at_edge`** once nothing calls it. Each site keeps its existing **`Buffer`** handling (gossip buffer, recovery skip, replay drop); only the membership verdict source changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81e2eec1bd4e57df9486f80a8ef1a4fa94708dcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->