### PR TITLE
ci(sdk-e2e): live paired SDK e2e gate (contract-gate phase 1, stacked on #2891)

### DIFF
--- a/.github/workflows/sdk-e2e.yml
+++ b/.github/workflows/sdk-e2e.yml
@@ -1,0 +1,109 @@
+name: SDK E2E (paired)
+
+# Live behavioural gate ("core breaks first"). Builds merod from this PR, boots a
+# single node with embedded auth, then runs the mero-js e2e suite against it. A
+# renamed/removed param makes the SDK send the old shape → the node 4xx → red here,
+# on the core dev's PR. The SDK ref is paired: declare `sdk-ref: <branch>` in the
+# PR body (or push a same-named branch on mero-js) so a breaking change and its SDK
+# fix go green together; otherwise it runs against mero-js master.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - "crates/server/**"
+      - "crates/auth/**"
+      - "crates/primitives/**"
+      - "crates/merod/**"
+      - ".github/workflows/sdk-e2e.yml"
+      - "scripts/resolve-paired-ref.sh"
+  push:
+    branches:
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+  SERVER_PORT: "2428"
+
+jobs:
+  sdk-e2e:
+    name: SDK E2E (paired)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout core (PR head)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build merod
+        run: cargo build -p merod --bin merod
+
+      - name: Resolve mero-js ref (paired)
+        id: sdkref
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          chmod +x scripts/resolve-paired-ref.sh
+          REF="$(scripts/resolve-paired-ref.sh master)"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "Testing against mero-js@$REF"
+
+      - name: Checkout mero-js (paired ref)
+        uses: actions/checkout@v4
+        with:
+          repository: calimero-network/mero-js
+          ref: ${{ steps.sdkref.outputs.ref }}
+          path: _mero-js
+
+      - name: Setup Node + pnpm
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm install -g pnpm
+
+      - name: Boot merod (embedded auth, single node)
+        run: |
+          BIN="$PWD/target/debug/merod"
+          "$BIN" --node ci-node init --server-port "$SERVER_PORT" --swarm-port 2528 --auth-mode embedded
+          "$BIN" --node ci-node run &
+          echo "MEROD_PID=$!" >> "$GITHUB_ENV"
+          # Wait for the admin API to answer.
+          for i in $(seq 1 60); do
+            if curl -fsS "http://localhost:$SERVER_PORT/admin-api/health" >/dev/null 2>&1; then
+              echo "merod healthy"; break
+            fi
+            sleep 2
+            if [ "$i" = "60" ]; then echo "merod did not become healthy"; exit 1; fi
+          done
+
+      - name: Run mero-js e2e against booted node
+        working-directory: _mero-js
+        env:
+          NODE_BASE_URL: "http://localhost:2428"
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm test:e2e
+
+      - name: Stop merod
+        if: always()
+        run: kill "${MEROD_PID:-0}" 2>/dev/null || true

--- a/scripts/resolve-paired-ref.sh
+++ b/scripts/resolve-paired-ref.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Resolve which mero-js ref this core change should be tested against, so a
+# breaking wire change can be paired with its SDK fix and go green together
+# ("core breaks first"). Resolution order:
+#   1. `sdk-ref: <ref>` line in the PR body (env PR_BODY)
+#   2. a same-named branch on mero-js (env HEAD_BRANCH)
+#   3. the default (arg $1, or "master")
+#
+# Prints the resolved ref to stdout.
+set -euo pipefail
+
+DEFAULT_REF="${1:-master}"
+SDK_REPO="${SDK_REPO:-https://github.com/calimero-network/mero-js.git}"
+
+# 1. explicit `sdk-ref:` in the PR body
+if [ -n "${PR_BODY:-}" ]; then
+  ref="$(printf '%s\n' "$PR_BODY" | sed -n 's/^[[:space:]]*sdk-ref:[[:space:]]*\([^[:space:]]*\).*/\1/p' | head -n1)"
+  if [ -n "$ref" ]; then
+    echo "$ref"
+    exit 0
+  fi
+fi
+
+# 2. same-named branch on mero-js
+if [ -n "${HEAD_BRANCH:-}" ] && \
+   git ls-remote --exit-code --heads "$SDK_REPO" "$HEAD_BRANCH" >/dev/null 2>&1; then
+  echo "$HEAD_BRANCH"
+  exit 0
+fi
+
+# 3. default
+echo "$DEFAULT_REF"


### PR DESCRIPTION
## Summary

The **live behavioural gate** of the contract gate — "core breaks first". Builds merod from the PR, boots a single node with embedded auth, and runs the mero-js e2e suite against it. A renamed/removed param makes the SDK send the old shape → the node 4xx → **red on the core dev's PR**.

### Paired SDK ref (resolves the deadlock)
`scripts/resolve-paired-ref.sh` resolves which mero-js to test against:
1. `sdk-ref: <branch>` in the PR body, else
2. a same-named branch on mero-js, else
3. `master`.

So a breaking wire change and its SDK fix go green together, then merge as a pair — instead of each blocking the other.

### Boot
`merod ... init --auth-mode embedded --server-port 2428` → `merod run` → wait on `/admin-api/health` → `NODE_BASE_URL=http://localhost:2428 pnpm test:e2e` in the checked-out mero-js (uses the injectable harness from mero-js #55).

## Verification
- Script resolution logic unit-tested locally (sdk-ref extraction, same-branch fallback, default).
- Workflow YAML validated.
- The node-boot + cross-repo e2e executes in CI (can't run in the sandbox) — this is the layer that needs a live runner.

## Stacked
Base is `feat/wire-fixtures` (#2891). Review the core stack together: **#2891 fixtures → this sdk-e2e → route-manifest coverage**.

> Depends on mero-js #55 (the injectable e2e harness) for the `NODE_BASE_URL` entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only additions (workflow + helper script); no runtime or production code paths change.
> 
> **Overview**
> Adds a **live behavioural CI gate** that builds `merod` from the PR, boots a single node with embedded auth, and runs the **mero-js** e2e suite against it so wire/API mismatches fail on core PRs before merge.
> 
> The new workflow **SDK E2E (paired)** triggers on changes under server/auth/primitives/merod (and on `master` pushes). It resolves which **mero-js** ref to use via `scripts/resolve-paired-ref.sh`: `sdk-ref:` in the PR body, then a same-named branch on mero-js if it exists, else `master`. After health-checking `/admin-api/health`, it runs `pnpm test:e2e` with `NODE_BASE_URL` pointing at the local node and always tears down the background `merod` process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3363a92a75bfe614ec2974489eb6f054785f61c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->