### PR TITLE
docs(pr): wire-contract (SDK gate) section in PR template (contract-gate phase 1, stacked on #2893)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,24 @@ instructions so we can reproduce. Is it possible to add a test case to our
 end-to-end tests with changes from this PR? Add screenshots or videos for
 changes in the user-interface.
 
+## Wire contract (SDK gate)
+
+If this PR changes an HTTP wire DTO or route, the SDKs mirror it by hand — keep
+them in sync or the contract gate goes red:
+
+- [ ] Regenerated wire fixtures (if a DTO changed):
+      `UPDATE_FIXTURES=1 cargo test -p calimero-server-primitives --test wire_fixtures`
+- [ ] Updated `crates/server/endpoints.json` (if routes changed):
+      `UPDATE_MANIFEST=1 cargo test -p calimero-server --test route_manifest`
+- [ ] Linked the matching mero-js PR — a breaking wire change needs a paired SDK update
+
+To run the live SDK e2e against your paired SDK branch, add a line to this body
+(defaults to `master`):
+
+```
+sdk-ref: <your-mero-js-branch>
+```
+
 ## Documentation update
 
 Mention here what part (if any) of public or internal documentation should be


### PR DESCRIPTION
## Summary

Operationalizes the contract gate in the core PR template: a **Wire contract (SDK gate)** checklist that prompts the dev to regenerate fixtures / update `endpoints.json` / link the paired mero-js PR when an HTTP DTO or route changes, and documents the `sdk-ref: <branch>` line that points the live SDK e2e at a paired SDK branch.

(macOS case-insensitive FS: `pull_request_template.md` and `PULL_REQUEST_TEMPLATE.md` are the same file — one edit covers both.)

## Stacked
Tip of the core stack: **#2891 → #2892 → #2893 → this**. The mero-js-side template (`core-ref:`) is a sibling PR on the mero-js stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the PR template; no runtime, API, or CI logic is modified.
> 
> **Overview**
> Extends `.github/pull_request_template.md` with a **Wire contract (SDK gate)** section between **Test plan** and **Documentation update**, so core PR authors see what to do when HTTP DTOs or routes change.
> 
> The new block explains that hand-mirrored SDKs must stay in sync with the contract gate, and adds three optional checkboxes: regenerate wire fixtures via `UPDATE_FIXTURES=1 cargo test -p calimero-server-primitives --test wire_fixtures`, refresh `crates/server/endpoints.json` via `UPDATE_MANIFEST=1 cargo test -p calimero-server --test route_manifest`, and link a paired **mero-js** PR for breaking wire changes.
> 
> It also documents putting `sdk-ref: <your-mero-js-branch>` in the PR body so live SDK e2e can target a paired SDK branch instead of defaulting to `master`—matching behavior already described in `.github/workflows/sdk-e2e.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db0bfddfca4582f39758eb562b6ae92a5ce4b87c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->