### PR TITLE
chore(governance-store): remove dead GroupMembershipView::{admin_count,member_count}

### DIFF
--- a/crates/governance-store/src/membership/tests.rs
+++ b/crates/governance-store/src/membership/tests.rs
@@ -286,31 +286,6 @@ fn membership_policy_rules_report_rejection_reasons() {
 }
 
 #[test]
-fn membership_view_reports_admin_and_member_counts() {
-    let store = test_store();
-    let gid = test_group_id();
-    let admin1 = PublicKey::from([0xD1; 32]);
-    let admin2 = PublicKey::from([0xD2; 32]);
-    let member = PublicKey::from([0xD3; 32]);
-
-    MembershipRepository::new(&store)
-        .add_member(&gid, &admin1, GroupMemberRole::Admin)
-        .unwrap();
-    MembershipRepository::new(&store)
-        .add_member(&gid, &admin2, GroupMemberRole::Admin)
-        .unwrap();
-    MembershipRepository::new(&store)
-        .add_member(&gid, &member, GroupMemberRole::Member)
-        .unwrap();
-
-    let view = GroupMembershipView::new(&store, gid);
-    assert!(view.is_admin(&admin1).unwrap());
-    assert!(!view.is_admin(&member).unwrap());
-    assert_eq!(view.admin_count().unwrap(), 2);
-    assert_eq!(view.member_count().unwrap(), 3);
-}
-
-#[test]
 fn count_members_and_admins() {
     let store = test_store();
     let gid = test_group_id();

--- a/crates/governance-store/src/membership/view.rs
+++ b/crates/governance-store/src/membership/view.rs
@@ -28,24 +28,11 @@ impl<'a> GroupMembershipView<'a> {
         MembershipRepository::new(self.store).is_member(&self.group_id, member)
     }
 
-    pub fn admin_count(&self) -> EyreResult<usize> {
-        self.list_members()?
-            .iter()
-            .try_fold(0usize, |count, row| match row.1 {
-                GroupMemberRole::Admin => Ok(count + 1),
-                _ => Ok(count),
-            })
-    }
-
     pub fn has_another_admin(&self, excluded: &PublicKey) -> EyreResult<bool> {
         Ok(self
             .list_members()?
             .into_iter()
             .any(|(member, role)| role == GroupMemberRole::Admin && member != *excluded))
-    }
-
-    pub fn member_count(&self) -> EyreResult<usize> {
-        Ok(self.list_members()?.len())
     }
 
     pub fn list_members(&self) -> EyreResult<Vec<(PublicKey, GroupMemberRole)>> {


### PR DESCRIPTION
Small dead-code cleanup surfaced while sweeping after the F5 migration (which retired the live membership resolver).

`GroupMembershipView::admin_count` and `member_count` are **test-only** — the production admin/member counting paths use `MembershipRepository::count_admins` / `count` directly, not these view helpers. The dead-code lint doesn't catch them because `GroupMembershipView` is `pub` and re-exported, so a public method with zero real callers slips past `clippy -D warnings`.

Drops both methods and the one test that exercised them (`membership_view_reports_admin_and_member_counts`; its `is_admin` assertions are already covered by the `require_admin` / `has_another_admin` tests).

## Test
- `cargo test -p calimero-governance-store --features calimero-storage/testing` — 366 pass
- `cargo clippy -p calimero-governance-store --all-targets --features calimero-storage/testing -- -D warnings` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only API removal with no production call sites; membership counting behavior in production is unchanged.
> 
> **Overview**
> Removes **`GroupMembershipView::admin_count`** and **`member_count`**, which listed all members and folded or counted rows but had **no production callers** after the F5 migration (live paths already use **`MembershipRepository::count`** and **`count_admins`**).
> 
> Also deletes the **`membership_view_reports_admin_and_member_counts`** test that only exercised those helpers; overlapping **`is_admin`** behavior remains covered elsewhere (e.g. **`require_admin`** / **`has_another_admin`** tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a1099ec98da89b742f02f77eb5a76705811b2a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->