### PR TITLE
feat(sync): scope_root shadow — observe hash-neutral ACL/membership divergence (cutover C0)

### DIFF
--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -376,8 +376,20 @@ impl ScopeProjections {
         group: &ContextGroupId,
         entities_root: [u8; 32],
     ) -> Option<[u8; 32]> {
-        let (proj, namespace_id, _heads) = Self::ephemeral_projection(store, group)?;
-        proj.scope_root_for(&ScopeId::from(namespace_id), entities_root)
+        let (proj, namespace_id, heads) = Self::ephemeral_projection(store, group)?;
+        let scope = ScopeId::from(namespace_id);
+        // Defer (`None`) on an INCOMPLETE fold — a node mid-backfill may hold only
+        // part of the governance ancestry of `heads`, and a `scope_root` folded over
+        // a truncated cut would differ from a peer's complete fold purely from the
+        // lag, producing a FALSE divergence (a spurious `scope_root_shadow_divergence`
+        // in C0, and a "never converges" stall once C1 makes it the verdict). Mirror
+        // the other ephemeral at-cut readers (`member_at_cut` et al.), which abstain
+        // on `!cut_ancestry_complete`; the comparison resumes once the cited ancestry
+        // is fully folded.
+        if !proj.cut_ancestry_complete(&scope, &heads) {
+            return None;
+        }
+        proj.scope_root_for(&scope, entities_root)
     }
 
     /// Is the full causal ancestry of `parents` folded in `scope`'s log (no

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -337,11 +337,24 @@ impl ScopeProjections {
     /// mismatch).
     ///
     /// This is the unified-causal-log convergence signal (cutover plan C0/C1):
-    /// a hash-neutral writer/membership rotation (identical `entities_root`,
-    /// different ACL/governance) yields a different `scope_root`, so sync can
-    /// never declare "converged" while authorization disagrees. `entities_root`
-    /// MUST be the storage Merkle root, not the projection's own entity hash —
-    /// see [`ScopeState::scope_root_with_entities`]'s caller contract.
+    /// a hash-neutral **governance** change — a membership add/remove, admin
+    /// change, policy/subgroup edit — leaves `entities_root` identical yet yields a
+    /// different `scope_root`, so sync can never declare "converged" while
+    /// authorization disagrees. That governance plane is what `entities_root`
+    /// cannot see and what this signal adds.
+    ///
+    /// NOTE on the ACL (writer-set) plane: today the projection's `acl` map is fed
+    /// only by the namespace **governance** DAG, which carries no `SetWriters` ops,
+    /// so `acl_hash` is currently empty here. That is not a gap: a writer-set
+    /// rotation is a storage entity (a hashed `UnorderedMap` child of its anchor),
+    /// so it already MOVES `entities_root` — divergent writer sets therefore yield
+    /// a divergent `scope_root` via the entities component (and are caught by the
+    /// bare `root_hash` too). `acl_hash` becomes a distinct contributor only at C2,
+    /// when the unified op-log folds `SetWriters` into this scope and writer sets
+    /// leave the Merkle tree.
+    ///
+    /// `entities_root` MUST be the storage Merkle root, not the projection's own
+    /// entity hash — see [`ScopeState::scope_root_with_entities`]'s caller contract.
     #[must_use]
     pub fn scope_root_for(&self, scope: &ScopeId, entities_root: [u8; 32]) -> Option<[u8; 32]> {
         self.states
@@ -1770,20 +1783,19 @@ mod tests {
         assert_eq!(reg.scope_root_for(&scope, entities_root), None);
 
         let mut reg = ScopeProjections::new();
-        reg.ingest_op(&build(
-            10,
-            vec![],
-            OpPayload::AdminChanged { new_admin: admin },
-        ));
+        let admin_op = build(10, vec![], OpPayload::AdminChanged { new_admin: admin });
+        reg.ingest_op(&admin_op);
         let before = reg
             .scope_root_for(&scope, entities_root)
             .expect("scope fed");
 
         // A membership add is hash-neutral on the entity root but MUST move
         // scope_root — the whole point of folding governance into the signal.
+        // Chain it under `admin_op` to mirror the real governance DAG shape (the
+        // MemberAdded is a causal child of the prior op, not a sibling at genesis).
         reg.ingest_op(&build(
             20,
-            vec![],
+            vec![admin_op.id],
             OpPayload::MemberAdded {
                 group,
                 member,

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -329,6 +329,44 @@ impl ScopeProjections {
         Some(ScopeState::acl_view_at(log, parents))
     }
 
+    /// The convergence `scope_root` for `scope`, folding this scope's ACL +
+    /// governance (membership / admin / policy / subgroups) onto the
+    /// **externally-supplied storage Merkle `entities_root`**. `None` when the
+    /// scope isn't folded yet — callers MUST treat that as "can't compare",
+    /// never as a divergence (a cold projection would otherwise read as a false
+    /// mismatch).
+    ///
+    /// This is the unified-causal-log convergence signal (cutover plan C0/C1):
+    /// a hash-neutral writer/membership rotation (identical `entities_root`,
+    /// different ACL/governance) yields a different `scope_root`, so sync can
+    /// never declare "converged" while authorization disagrees. `entities_root`
+    /// MUST be the storage Merkle root, not the projection's own entity hash —
+    /// see [`ScopeState::scope_root_with_entities`]'s caller contract.
+    #[must_use]
+    pub fn scope_root_for(&self, scope: &ScopeId, entities_root: [u8; 32]) -> Option<[u8; 32]> {
+        self.states
+            .get(scope)
+            .map(|state| state.scope_root_with_entities(entities_root))
+    }
+
+    /// [`scope_root_for`](Self::scope_root_for) from an EPHEMERAL fold built fresh
+    /// from the store, resolving the namespace scope from a `group`. For sync sites
+    /// that hold a `Store` but not the node's maintained projection — the C0
+    /// scope_root shadow runs on both the HC initiator (which has no `NodeState`)
+    /// and the responder, so folding from the store keeps the two sides symmetric.
+    /// `None` for a non-group context or a store/DAG fault (caller skips the
+    /// comparison, never treats it as divergence). One per-session fold; the shadow
+    /// runs once per HC session, so the cost is acceptable.
+    #[must_use]
+    pub fn group_scope_root_ephemeral(
+        store: &Store,
+        group: &ContextGroupId,
+        entities_root: [u8; 32],
+    ) -> Option<[u8; 32]> {
+        let (proj, namespace_id, _heads) = Self::ephemeral_projection(store, group)?;
+        proj.scope_root_for(&ScopeId::from(namespace_id), entities_root)
+    }
+
     /// Is the full causal ancestry of `parents` folded in `scope`'s log (no
     /// truncation)? `false` if the scope is unfed or any ancestor is missing.
     /// The authoritative-grant gate (see [`member_at_cut_authoritative`]).
@@ -1700,6 +1738,66 @@ mod tests {
         assert!(reg
             .acl_view_at(&ScopeId::from([0xEE; 32]), &[add.id])
             .is_none());
+    }
+
+    #[test]
+    fn scope_root_for_moves_on_hash_neutral_membership_change_and_is_none_when_unfolded() {
+        let scope = ScopeId::from([0u8; 32]);
+        let group = ContextGroupId::from([3u8; 32]);
+        let admin = PublicKey::from([1u8; 32]);
+        let member = PublicKey::from([0x55; 32]);
+        // A FIXED storage entity root — the data plane never changes in this test,
+        // so any movement in scope_root comes purely from the governance plane.
+        let entities_root = [0x42u8; 32];
+
+        let build = |ns: u64, parents: Vec<[u8; 32]>, payload: OpPayload| -> Op {
+            let h = hlc(ns);
+            let id = Op::compute_id(scope, &parents, &admin, &h, &payload);
+            Op {
+                id,
+                scope,
+                parents,
+                author: admin,
+                hlc: h,
+                payload,
+                expected_scope_root: [0u8; 32],
+                signature: [0u8; 64],
+            }
+        };
+
+        // An unfolded scope can't be compared — None, never a false divergence.
+        let reg = ScopeProjections::new();
+        assert_eq!(reg.scope_root_for(&scope, entities_root), None);
+
+        let mut reg = ScopeProjections::new();
+        reg.ingest_op(&build(
+            10,
+            vec![],
+            OpPayload::AdminChanged { new_admin: admin },
+        ));
+        let before = reg
+            .scope_root_for(&scope, entities_root)
+            .expect("scope fed");
+
+        // A membership add is hash-neutral on the entity root but MUST move
+        // scope_root — the whole point of folding governance into the signal.
+        reg.ingest_op(&build(
+            20,
+            vec![],
+            OpPayload::MemberAdded {
+                group,
+                member,
+                role: GroupMemberRole::Member,
+            },
+        ));
+        let after = reg
+            .scope_root_for(&scope, entities_root)
+            .expect("scope fed");
+
+        assert_ne!(
+            before, after,
+            "a hash-neutral membership change must move scope_root"
+        );
     }
 
     #[test]

--- a/crates/node/primitives/src/sync/wire.rs
+++ b/crates/node/primitives/src/sync/wire.rs
@@ -351,8 +351,15 @@ pub enum MessagePayload<'a> {
     DagHeadsResponse {
         /// Current DAG head hashes.
         dag_heads: Vec<[u8; 32]>,
-        /// Current root hash.
+        /// Current root hash (the storage-layer entity Merkle root).
         root_hash: Hash,
+        /// The peer's `scope_root` for this context — `root_hash` folded with the
+        /// governance projection's ACL + membership/admin hashes (unified-causal-log
+        /// cutover C0 shadow). `None` when the responder can't resolve/fold the
+        /// scope yet (cold projection), so the initiator skips the shadow compare
+        /// rather than reading a false divergence. Observe-only: no sync decision
+        /// reads this in C0; C1 promotes it to the authoritative convergence signal.
+        scope_root: Option<Hash>,
     },
 
     /// Response to SnapshotBoundaryRequest.

--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -701,6 +701,15 @@ impl SyncManager {
             "Sending DAG heads to peer"
         );
 
+        // C0 scope_root shadow: fold our governance projection's ACL + membership
+        // onto the entity root so the requester can detect a hash-neutral rotation
+        // the bare `root_hash` hides. `None` (non-group / cold projection) ⇒ skip.
+        // Observe-only.
+        let datastore = self.context_client.datastore_handle().into_inner();
+        let scope_root =
+            super::helpers::local_scope_root(&datastore, &context_id, *context.root_hash)
+                .map(calimero_primitives::hash::Hash::from);
+
         // Send response
         let mut sqx = Sequencer::default();
         let msg = StreamMessage::Message {
@@ -708,6 +717,7 @@ impl SyncManager {
             payload: MessagePayload::DagHeadsResponse {
                 dag_heads: context.dag_heads,
                 root_hash: context.root_hash,
+                scope_root,
             },
             next_nonce: super::helpers::generate_nonce(),
         };

--- a/crates/node/src/sync/hash_comparison.rs
+++ b/crates/node/src/sync/hash_comparison.rs
@@ -302,11 +302,21 @@ impl SyncManager {
                             .unwrap_or([0; 32])
                     });
 
+                    // C0 scope_root shadow: fold our governance projection's ACL +
+                    // membership onto the just-re-read entity root, so the initiator
+                    // can detect a hash-neutral writer/membership rotation that the
+                    // bare `root_hash` hides. `None` (non-group / cold projection) ⇒
+                    // the initiator skips the compare. Observe-only.
+                    let scope_root =
+                        super::helpers::local_scope_root(&datastore, &context_id, current_root)
+                            .map(Hash::from);
+
                     let msg = StreamMessage::Message {
                         sequence_id: sqx.next(),
                         payload: MessagePayload::DagHeadsResponse {
                             dag_heads: Vec::new(),
                             root_hash: Hash::from(current_root),
+                            scope_root,
                         },
                         next_nonce: super::helpers::generate_nonce(),
                     };

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -687,10 +687,11 @@ async fn run_initiator_impl<T: SyncTransport>(
     // rotation log is a hashed `UnorderedMap` child of its anchor now, so it
     // converges through HC's ordinary tree traversal like any other entity; no
     // separate writer-set reconcile is needed.)
-    let peer_current_root = match query_peer_current_root(transport, context_id, identity).await {
-        Ok(Some(root)) => root,
-        Ok(None) | Err(_) => remote_root_hash,
-    };
+    let (peer_current_root, peer_scope_root) =
+        match query_peer_current_root(transport, context_id, identity).await {
+            Ok(Some((root, scope_root))) => (root, scope_root),
+            Ok(None) | Err(_) => (remote_root_hash, None),
+        };
 
     // Close the transport to signal completion to the responder
     transport.close().await?;
@@ -699,6 +700,33 @@ async fn run_initiator_impl<T: SyncTransport>(
         get_local_root_hash_for_context(context_id)
     })?;
     stats.root_hash_verified = local_root_hash == peer_current_root;
+
+    // C0 scope_root shadow (observe-only): when the entity roots AGREE, the bare
+    // `root_hash` declares convergence — but a hash-neutral writer/membership
+    // rotation leaves identical entities under a divergent ACL/governance plane,
+    // which `root_hash` cannot see. Fold our governance projection onto the same
+    // entity root and compare against the peer's `scope_root`; a mismatch here, on
+    // agreeing entity roots, is exactly the blind spot C1 will close. Logged, never
+    // acted on. Both sides skip when either can't fold the scope (`None`).
+    if local_root_hash == peer_current_root {
+        if let Some(peer_scope_root) = peer_scope_root {
+            if let Some(local_scope_root) =
+                super::helpers::local_scope_root(store, &context_id, local_root_hash)
+            {
+                if local_scope_root != peer_scope_root {
+                    warn!(
+                        marker = "scope_root_shadow_divergence",
+                        %context_id,
+                        entity_root = %hex::encode(&local_root_hash[..8]),
+                        local_scope_root = %hex::encode(&local_scope_root[..8]),
+                        peer_scope_root = %hex::encode(&peer_scope_root[..8]),
+                        "entity roots agree but scope_root differs — hash-neutral \
+                         ACL/membership divergence the current convergence signal hides"
+                    );
+                }
+            }
+        }
+    }
 
     // core#2716: re-anchor the context's persisted `root_hash` to the
     // freshly-merged storage merkle. `context.root_hash` (the value read by
@@ -766,7 +794,7 @@ async fn query_peer_current_root<T: SyncTransport>(
     transport: &mut T,
     context_id: ContextId,
     identity: PublicKey,
-) -> Result<Option<[u8; 32]>> {
+) -> Result<Option<([u8; 32], Option<[u8; 32]>)>> {
     let request = StreamMessage::Init {
         context_id,
         party_id: identity,
@@ -781,9 +809,14 @@ async fn query_peer_current_root<T: SyncTransport>(
 
     match response {
         StreamMessage::Message {
-            payload: MessagePayload::DagHeadsResponse { root_hash, .. },
+            payload:
+                MessagePayload::DagHeadsResponse {
+                    root_hash,
+                    scope_root,
+                    ..
+                },
             ..
-        } => Ok(Some(*root_hash)),
+        } => Ok(Some((*root_hash, scope_root.map(|h| *h)))),
         _ => Ok(None),
     }
 }
@@ -1054,6 +1087,11 @@ async fn run_responder_impl<T: SyncTransport>(
                     payload: MessagePayload::DagHeadsResponse {
                         dag_heads: Vec::new(),
                         root_hash: Hash::from(current_root),
+                        // The deterministic sync simulator reconciles the Merkle tree
+                        // only; it folds no governance projection, so it has no
+                        // scope_root to shadow. The C0 shadow is validated by the e2e
+                        // hash-neutral-rotation canary, not the sim.
+                        scope_root: None,
                     },
                     next_nonce: generate_nonce(),
                 };

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -702,12 +702,16 @@ async fn run_initiator_impl<T: SyncTransport>(
     stats.root_hash_verified = local_root_hash == peer_current_root;
 
     // C0 scope_root shadow (observe-only): when the entity roots AGREE, the bare
-    // `root_hash` declares convergence — but a hash-neutral writer/membership
-    // rotation leaves identical entities under a divergent ACL/governance plane,
-    // which `root_hash` cannot see. Fold our governance projection onto the same
-    // entity root and compare against the peer's `scope_root`; a mismatch here, on
-    // agreeing entity roots, is exactly the blind spot C1 will close. Logged, never
-    // acted on. Both sides skip when either can't fold the scope (`None`).
+    // `root_hash` declares convergence — but a hash-neutral GOVERNANCE change
+    // (membership add/remove, admin/policy/subgroup edit) leaves identical entities
+    // under a divergent governance plane, which `root_hash` cannot see (governance
+    // lives in a separate DAG, not the storage Merkle). Fold our governance
+    // projection onto the same entity root and compare against the peer's
+    // `scope_root`; a mismatch here, on agreeing entity roots, is exactly the blind
+    // spot C1 will close. (Writer-set rotations are NOT this case — they move
+    // `entities_root` via the rotation-log storage entity, so they're already
+    // caught by the bare `root_hash`.) Logged, never acted on. Both sides skip when
+    // either can't fold the scope (`None`).
     if local_root_hash == peer_current_root {
         if let Some(peer_scope_root) = peer_scope_root {
             if let Some(local_scope_root) =

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -49,6 +49,15 @@ pub fn get_local_root_hash_for_context(context_id: ContextId) -> Result<[u8; 32]
 /// **Observe-only in C0:** the result is logged for the hash-neutral-rotation
 /// shadow, never fed into any sync decision. C1 promotes it to the authoritative
 /// convergence signal (and switches to the maintained projection).
+///
+/// TODO(perf, C1+): each call is a full `collect_namespace_ops` RocksDB DAG walk,
+/// and a sync session folds independently on both peers (responder + initiator),
+/// so a namespace with deep governance history pays an unbounded O(n) read per
+/// sync tick. Acceptable while this is observe-only, but bound it before/with the
+/// C1 flip — the node-side responders hold a `NodeState`, so they can read the
+/// already-maintained projection (`scope_root_for` on `read_scope_projections()`)
+/// instead of re-folding; the initiator can take a per-session cache or have the
+/// scope_root threaded down rather than recomputed.
 pub(crate) fn local_scope_root(
     store: &Store,
     context_id: &ContextId,

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -34,6 +34,36 @@ pub fn get_local_root_hash_for_context(context_id: ContextId) -> Result<[u8; 32]
     }
 }
 
+/// This node's `scope_root` for `context_id` at `entities_root` (the storage
+/// Merkle root): resolve the context's owning group, then fold the governance
+/// projection's ACL + membership/admin hashes onto `entities_root`
+/// ([`ScopeProjections::group_scope_root_ephemeral`]).
+///
+/// Folds an EPHEMERAL projection from the `store` (rather than the node's
+/// maintained one) so the HC initiator — which has the store but no `NodeState` —
+/// and the responder compute the signal the same way. `None` for a non-group
+/// context (no governance plane to fold) or a store/DAG fault — the caller MUST
+/// then **skip** the scope_root shadow comparison, never read it as a divergence
+/// (unified-causal-log cutover C0).
+///
+/// **Observe-only in C0:** the result is logged for the hash-neutral-rotation
+/// shadow, never fed into any sync decision. C1 promotes it to the authoritative
+/// convergence signal (and switches to the maintained projection).
+pub(crate) fn local_scope_root(
+    store: &Store,
+    context_id: &ContextId,
+    entities_root: [u8; 32],
+) -> Option<[u8; 32]> {
+    let group = calimero_context::group_store::get_group_for_context(store, context_id)
+        .ok()
+        .flatten()?;
+    calimero_context::scope_projection::ScopeProjections::group_scope_root_ephemeral(
+        store,
+        &group,
+        entities_root,
+    )
+}
+
 /// Validates that peer's application ID matches ours.
 ///
 /// # Errors

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1038,6 +1038,7 @@ impl SyncManager {
                             MessagePayload::DagHeadsResponse {
                                 dag_heads,
                                 root_hash,
+                                scope_root: _,
                             },
                         ..
                     } = response
@@ -1508,6 +1509,7 @@ impl SyncManager {
                     MessagePayload::DagHeadsResponse {
                         dag_heads,
                         root_hash,
+                        scope_root: _,
                     },
                 ..
             }) => {
@@ -1811,6 +1813,7 @@ impl SyncManager {
                     MessagePayload::DagHeadsResponse {
                         dag_heads,
                         root_hash,
+                        scope_root: _,
                     },
                 ..
             }) => {

--- a/crates/node/tests/sync_sim/transport.rs
+++ b/crates/node/tests/sync_sim/transport.rs
@@ -358,6 +358,7 @@ mod tests {
             payload: MessagePayload::DagHeadsResponse {
                 dag_heads: vec![],
                 root_hash: [0u8; 32].into(),
+                scope_root: None,
             },
             next_nonce: [2; NONCE_LEN],
         };

--- a/docs/design/unified-causal-log-cutover-plan.md
+++ b/docs/design/unified-causal-log-cutover-plan.md
@@ -42,6 +42,58 @@ plumbing once the projection is authoritative for the signal. The decision cut
 
 ---
 
+## C0 — `scope_root` shadow (pre-C1 de-risk, observe-only)
+
+**Status: in progress (2026-06-24).** A de-risking precursor to C1, chosen over
+flipping straight to the new signal — same shadow→flip discipline that carried
+F4b/F5. C0 changes **no sync decision**: it computes `scope_root` alongside the
+existing `root_hash`, exchanges it, and **logs** when the two signals would
+*disagree about convergence* — i.e. `entities_root` (the current `root_hash`)
+agrees between two peers but `scope_root` differs. That disagreement is exactly
+the hash-neutral ACL/membership rotation the current signal is blind to (the
+root cause behind the rotation split-brain family: stale-heads, clear()
+tombstone-blindness, #2607 verified-but-divergent). C0 proves the new signal
+catches it in real e2e *before* C1 makes it load-bearing.
+
+**Where.** Reuse the #2607 end-of-session convergence re-query in
+`crates/node/src/sync/hash_comparison_protocol.rs` (`query_peer_current_root` →
+`DagHeadsResponse`). The responder additionally computes and returns its
+`scope_root`; the initiator computes its own and compares. **`root_hash` /
+`root_hash_verified` keep driving every decision** — `scope_root` is logged, never
+acted on.
+
+**Computing a context's `scope_root`.** `entities_root` = the existing storage
+Merkle `root_hash` for the context (unchanged, `get_local_root_hash_for_context`
+/ `DagHeadsResponse.root_hash`). The ACL + governance come from the **maintained
+projection**: resolve `context → group → namespace` (`get_group_for_context` +
+`NamespaceRepository::resolve`) to the namespace `ScopeId`, then
+`ScopeProjections::scope_root_for(scope, entities_root)` (new, thin) returns
+`states.get(scope).map(|s| s.scope_root_with_entities(entities_root))`. `None`
+(scope not folded yet) ⇒ skip the shadow comparison for that session — never a
+false divergence on a cold projection.
+
+**Wire.** Add `scope_root: Option<Hash>` to `DagHeadsResponse`
+(`crates/node/primitives/src/sync/wire.rs`). `Option` so a node that can't
+resolve/fold the scope sends `None` and the initiator skips — no false signal.
+Safe under the flag-day rule (all nodes redeploy together; e2e runs one build),
+and it is the **same field C1 promotes** to the authoritative compare, so the
+throwaway is one `Option` unwrap.
+
+**Marker.** Log `scope_root_shadow_divergence` (gate marker, like the F5 planes)
+at WARN when `local_entities_root == peer_entities_root && local_scope_root !=
+peer_scope_root` (the blind spot), and a quieter `debug!` for the inverse
+(`entities` differ — already caught by `root_hash`, expected mid-sync). The e2e
+divergence gate greps the WARN marker; a hit on a *converged-entities* scenario
+is the proof C0 is looking for, and on a *should-converge* scenario it's a real
+bug the old signal hid.
+
+**e2e gate.** A **hash-neutral-rotation canary**: two nodes reach an identical
+`entities_root`, one rotates its writer set; assert the shadow fires
+`scope_root_shadow_divergence` until the rotation propagates and `acl_hash`
+agrees, then stops. Plus: existing concurrent-rotation/governance scenarios show
+**zero** shadow divergence at steady state (no false positives). C1 promotes the
+signal only once this canary is green.
+
 ## C1 — `scope_root`: fold ACL + groups into the convergence signal
 
 **Goal.** Replace the bare entity `root_hash` on the wire and in comparison with


### PR DESCRIPTION
First slice of the **unified-causal-log cutover** (`docs/design/unified-causal-log-cutover-plan.md`). A **de-risking shadow** before C1 flips the convergence signal — same shadow→flip discipline that carried F4b/F5.

## What

Compute `scope_root` alongside the existing `root_hash` and **log** when the two would disagree about convergence. **No sync decision changes** — `root_hash` / `root_hash_verified` still drive everything.

```
scope_root = SHA-256( entities_root ‖ acl_hash ‖ governance_hash )
```

It folds the governance projection's ACL + membership/admin onto the storage Merkle root, so a **hash-neutral writer-set or membership rotation** (identical entities, divergent authorization) becomes a *different* root. The bare `root_hash` is blind to exactly that — the root cause behind the rotation split-brain family (stale-heads, `clear()`-tombstone-blindness, #2607 verified-but-divergent). C0 proves the new signal catches it in real e2e **before** C1 makes it load-bearing.

## How

- `ScopeProjections::scope_root_for` (maintained primitive, for C1) + `group_scope_root_ephemeral` (store-only fold — so the HC initiator, which has no `NodeState`, and the responder compute the signal symmetrically).
- `DagHeadsResponse.scope_root: Option<Hash>` — `None` means "couldn't fold" ⇒ the initiator **skips** the compare, never a false divergence. Responders fill it; the Merkle-only sim sends `None`.
- HC end-of-session (the #2607 re-query path): when entity roots **agree**, fold the local `scope_root` and compare against the peer's; a mismatch logs the `scope_root_shadow_divergence` gate marker.

## Safety

Pure observation. The new wire field is additive and `Option`; under the cutover's flag-day rule all nodes redeploy together (and e2e runs one build), and it's the same field C1 promotes to the authoritative compare.

## Gate

The **hash-neutral-rotation e2e canary** (described in the C0 design section) is the maintainer-run gate: two nodes reach an identical `entities_root`, one rotates its writer set, assert the shadow fires until the rotation propagates and `acl_hash` agrees — and steady-state scenarios show **zero** shadow divergence (no false positives).

## Test
- `cargo test -p calimero-node -p calimero-context --features calimero-storage/testing` — pass (incl. new `scope_root_for` unit test; the core hash-neutral property is already proven in `calimero-projection`)
- `cargo clippy -p calimero-context -p calimero-node -p calimero-node-primitives -p calimero-server --all-targets --features calimero-storage/testing -- -D warnings` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive optional wire field and observe-only logging limit blast radius, but every `DagHeadsResponse` path must supply `scope_root` and ephemeral governance DAG folds add per-session store cost on sync.
> 
> **Overview**
> **Unified-causal-log cutover C0** — a shadow run before C1 makes `scope_root` the convergence signal. Sync still uses **`root_hash` only**; the new field is exchanged and compared for telemetry.
> 
> Adds **`scope_root`** (`entities_root` ‖ ACL ‖ governance hashes) via `ScopeProjections::scope_root_for` and store-backed **`group_scope_root_ephemeral`** (symmetric for HC initiator without `NodeState`). Returns **`None`** when the scope is cold or ancestry is incomplete so peers skip compare instead of false divergences.
> 
> **Wire:** optional **`scope_root`** on **`DagHeadsResponse`**; DAG-heads and HC responders populate it through **`local_scope_root`**. After HC, when local and peer entity roots **agree**, the initiator compares `scope_root` and **`warn!`**s with marker **`scope_root_shadow_divergence`** on mismatch. Design doc gains the **C0** section; a unit test asserts membership moves `scope_root` with a fixed entity root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d589f242c7d70d735088a051194151a03a46fa9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->