### PR TITLE
feat(sync): scope_root is the authoritative HC convergence verdict (cutover C1a)

### DIFF
--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -699,37 +699,43 @@ async fn run_initiator_impl<T: SyncTransport>(
     let local_root_hash = with_runtime_env(runtime_env.clone(), || {
         get_local_root_hash_for_context(context_id)
     })?;
-    stats.root_hash_verified = local_root_hash == peer_current_root;
 
-    // C0 scope_root shadow (observe-only): when the entity roots AGREE, the bare
-    // `root_hash` declares convergence — but a hash-neutral GOVERNANCE change
-    // (membership add/remove, admin/policy/subgroup edit) leaves identical entities
-    // under a divergent governance plane, which `root_hash` cannot see (governance
-    // lives in a separate DAG, not the storage Merkle). Fold our governance
-    // projection onto the same entity root and compare against the peer's
-    // `scope_root`; a mismatch here, on agreeing entity roots, is exactly the blind
-    // spot C1 will close. (Writer-set rotations are NOT this case — they move
-    // `entities_root` via the rotation-log storage entity, so they're already
-    // caught by the bare `root_hash`.) Logged, never acted on. Both sides skip when
-    // either can't fold the scope (`None`).
-    if local_root_hash == peer_current_root {
-        if let Some(peer_scope_root) = peer_scope_root {
-            if let Some(local_scope_root) =
-                super::helpers::local_scope_root(store, &context_id, local_root_hash)
-            {
-                if local_scope_root != peer_scope_root {
-                    warn!(
-                        marker = "scope_root_shadow_divergence",
-                        %context_id,
-                        entity_root = %hex::encode(&local_root_hash[..8]),
-                        local_scope_root = %hex::encode(&local_scope_root[..8]),
-                        peer_scope_root = %hex::encode(&peer_scope_root[..8]),
-                        "entity roots agree but scope_root differs — hash-neutral \
-                         ACL/membership divergence the current convergence signal hides"
-                    );
-                }
-            }
-        }
+    // C1: `scope_root` is the AUTHORITATIVE convergence verdict. It folds the
+    // governance projection's ACL + membership/admin onto the entity root, so two
+    // nodes converge only when BOTH the data plane AND authorization agree — closing
+    // the hash-neutral rotation blind spot the bare entity root left open (the
+    // rotation split-brain family: stale-heads, clear()-tombstone-blindness, the
+    // #2607 verified-but-divergent case). `scope_root` already subsumes the entity
+    // root (it is hashed in), so when both sides resolve a `scope_root` it alone
+    // decides; only when either side can't fold the scope (cold projection /
+    // non-group context, `None`) do we fall back to the bare entity-root compare —
+    // exactly the pre-C1 behaviour, so no context regresses to a weaker check than
+    // before.
+    let local_scope_root = super::helpers::local_scope_root(store, &context_id, local_root_hash);
+    stats.root_hash_verified = match (local_scope_root, peer_scope_root) {
+        (Some(local), Some(peer)) => local == peer,
+        _ => local_root_hash == peer_current_root,
+    };
+
+    // Surface the case the entity root hides: entities AGREE but `scope_root`
+    // differs ⇒ the divergence is purely in the ACL/governance plane. HC's entity
+    // tree-walk has nothing to reconcile here (the entities already match); the
+    // rotation propagates via the ordinary governance sync tick, and the next HC
+    // session re-reads an agreeing `scope_root` once it lands. Distinct marker so a
+    // governance-plane divergence is legible apart from a data-plane one.
+    if !stats.root_hash_verified
+        && local_root_hash == peer_current_root
+        && matches!((local_scope_root, peer_scope_root), (Some(l), Some(p)) if l != p)
+    {
+        warn!(
+            marker = "scope_root_governance_divergence",
+            %context_id,
+            entity_root = %hex::encode(&local_root_hash[..8]),
+            local_scope_root = %hex::encode(&local_scope_root.unwrap_or_default()[..8]),
+            peer_scope_root = %hex::encode(&peer_scope_root.unwrap_or_default()[..8]),
+            "entity roots agree but scope_root differs — ACL/membership divergence; \
+             awaiting governance sync to propagate the rotation"
+        );
     }
 
     // core#2716: re-anchor the context's persisted `root_hash` to the

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -723,19 +723,24 @@ async fn run_initiator_impl<T: SyncTransport>(
     // rotation propagates via the ordinary governance sync tick, and the next HC
     // session re-reads an agreeing `scope_root` once it lands. Distinct marker so a
     // governance-plane divergence is legible apart from a data-plane one.
-    if !stats.root_hash_verified
-        && local_root_hash == peer_current_root
-        && matches!((local_scope_root, peer_scope_root), (Some(l), Some(p)) if l != p)
-    {
-        warn!(
-            marker = "scope_root_governance_divergence",
-            %context_id,
-            entity_root = %hex::encode(&local_root_hash[..8]),
-            local_scope_root = %hex::encode(&local_scope_root.unwrap_or_default()[..8]),
-            peer_scope_root = %hex::encode(&peer_scope_root.unwrap_or_default()[..8]),
-            "entity roots agree but scope_root differs — ACL/membership divergence; \
-             awaiting governance sync to propagate the rotation"
-        );
+    // Destructure both scope_roots up front (vs `matches!` + `unwrap_or_default`):
+    // this case is meaningful only when BOTH sides resolved one, and binding them
+    // avoids a dead default branch and any reliance on `[u8; 32]` being `Copy`.
+    if let (Some(local_scope_root), Some(peer_scope_root)) = (local_scope_root, peer_scope_root) {
+        if !stats.root_hash_verified
+            && local_root_hash == peer_current_root
+            && local_scope_root != peer_scope_root
+        {
+            warn!(
+                marker = "scope_root_governance_divergence",
+                %context_id,
+                entity_root = %hex::encode(&local_root_hash[..8]),
+                local_scope_root = %hex::encode(&local_scope_root[..8]),
+                peer_scope_root = %hex::encode(&peer_scope_root[..8]),
+                "entity roots agree but scope_root differs — ACL/membership divergence; \
+                 awaiting governance sync to propagate the rotation"
+            );
+        }
     }
 
     // core#2716: re-anchor the context's persisted `root_hash` to the

--- a/docs/design/unified-causal-log-cutover-plan.md
+++ b/docs/design/unified-causal-log-cutover-plan.md
@@ -96,6 +96,19 @@ signal only once this canary is green.
 
 ## C1 — `scope_root`: fold ACL + groups into the convergence signal
 
+**Landing incrementally (merge-gated on C0's canary):**
+- **C1a (drafted 2026-06-24)** — the **HashComparison end-of-session verdict**
+  (`hash_comparison_protocol.rs`, the #2607 re-query path C0 instrumented). When
+  both peers resolve a `scope_root` it alone decides `root_hash_verified`; cold
+  projection / non-group context falls back to the bare entity compare (no
+  context drops below the pre-C1 check). This is the kernel security win on the
+  general sync path.
+- **C1b (follow-up)** — the remaining compare sites: LevelWise (its verdict is
+  currently advisory off the handshake root — needs `scope_root` threaded through
+  the handshake), the snapshot boundary (`snapshot.rs`), and the protocol
+  selector's converged-decision. Sliced out because LevelWise/snapshot carry
+  their own staleness semantics and are independently reviewable.
+
 **Goal.** Replace the bare entity `root_hash` on the wire and in comparison with
 `scope_root`, where
 


### PR DESCRIPTION
**Stacked on #2899 (C0).** Retargets to `master` once C0 lands.

⚠️ **Merge-gated on C0's e2e canary.** C1 turns the C0 shadow into the *actual* convergence verdict, so a C0 false-positive divergence would become a "never converges" stall here. Do **not** merge until C0 shows the hash-neutral-rotation canary fires correctly **and** steady-state scenarios stay divergence-free.

## What

Promotes the C0 shadow from observe-only to the **authoritative verdict**. HashComparison's end-of-session convergence check (`root_hash_verified`, the #2607 re-query path) now decides on `scope_root` when both peers resolve one:

```rust
stats.root_hash_verified = match (local_scope_root, peer_scope_root) {
    (Some(local), Some(peer)) => local == peer,         // scope_root subsumes entities — it alone decides
    _ => local_root_hash == peer_current_root,          // cold projection / non-group → pre-C1 fallback
};
```

`scope_root` folds the governance projection's ACL + membership/admin onto the entity root, so two nodes converge only when **both** the data plane **and** authorization agree — closing the hash-neutral rotation blind spot behind the rotation split-brain family (stale-heads, `clear()`-tombstone-blindness, #2607 verified-but-divergent).

No context drops below its pre-C1 check: when either side can't fold the scope (`None`), it falls back to the exact bare-entity compare from before.

A new `scope_root_governance_divergence` marker distinguishes the case the entity root hides (entities agree, `scope_root` differs ⇒ pure ACL/governance divergence; the entity tree-walk has nothing to reconcile, and the rotation propagates via the ordinary governance sync tick).

## Scope (C1a)

The HashComparison verdict only — the general sync path C0 instrumented. **C1b** follows for LevelWise (advisory handshake-root verdict — needs `scope_root` threaded through the handshake), the snapshot boundary (`snapshot.rs`), and the protocol selector. Sliced out because those carry their own staleness semantics and are independently reviewable. See the C1 section of `docs/design/unified-causal-log-cutover-plan.md`.

## e2e gate

The C1 hash-neutral-rotation canary (maintainer-run): two nodes reach an identical `entities_root`, one rotates its writer set; assert HC **does not** declare converged until the rotation propagates and `acl_hash` agrees. Plus zero false positives on steady-state concurrent-rotation/governance scenarios.

## Test
- `cargo test -p calimero-node --features calimero-storage/testing` — pass
- `cargo clippy -p calimero-node --all-targets --features calimero-storage/testing -- -D warnings` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This changes load-bearing sync convergence semantics; a false `scope_root` divergence from C0 would cause HC to never report converged until governance catches up—explicitly merge-gated on C0’s e2e canary.
> 
> **Overview**
> **C1a** promotes C0’s observe-only `scope_root` shadow into the real HashComparison end-of-session convergence check (`root_hash_verified` on the #2607 peer re-query path).
> 
> When **both** peers resolve a `scope_root`, that value alone decides convergence (ACL + governance folded onto the entity root). If either side returns `None` (cold projection / non-group), behavior stays the pre-C1 bare entity-root compare—no weaker check than before.
> 
> The old C0-only path that only **logged** `scope_root_shadow_divergence` when entity roots agreed is removed. A new **`scope_root_governance_divergence`** WARN marks the case entities match but governance/`scope_root` does not (HC has nothing to merge on the entity tree; rotation is expected to land via governance sync).
> 
> `docs/design/unified-causal-log-cutover-plan.md` documents **C1a** (this HC verdict) vs **C1b** (LevelWise, snapshot, protocol selector) as incremental slices, merge-gated on C0’s e2e canary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0178acc34c1928d7a16e1912980f2e75a0e1f7f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->