### PR TITLE
feat(sync): LevelWise scope_root convergence verdict at HC parity (cutover C1b)

### DIFF
--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -805,7 +805,10 @@ async fn run_initiator_impl<T: SyncTransport>(
 /// Returns `Ok(None)` when the peer closes the stream or replies with an
 /// unexpected payload — an older peer that does not handle this mid-session
 /// request — so the caller can fall back to the handshake root.
-async fn query_peer_current_root<T: SyncTransport>(
+/// Mid-session re-query of the peer's CURRENT root + `scope_root` (the #2607
+/// end-of-session convergence read). `pub(crate)` so LevelWise reuses the exact
+/// same re-query to reach HashComparison's authoritative-verdict parity (C1b).
+pub(crate) async fn query_peer_current_root<T: SyncTransport>(
     transport: &mut T,
     context_id: ContextId,
     identity: PublicKey,

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -605,15 +605,22 @@ async fn run_initiator_impl<T: SyncTransport>(
     if !stats.root_hash_verified {
         // Entities agree but scope_root differs ⇒ pure ACL/governance divergence
         // (the case the entity root hides); distinct marker, parity with HC.
-        if local_root_hash == peer_current_root
-            && matches!((local_scope_root, peer_scope_root), (Some(l), Some(p)) if l != p)
+        // Destructure both scope_roots (vs `matches!` + `unwrap_or_default`): this
+        // case needs both resolved, and binding them avoids a dead default branch
+        // and any reliance on `[u8; 32]` being `Copy`.
+        let governance_divergence = match (local_scope_root, peer_scope_root) {
+            (Some(local), Some(peer)) => local_root_hash == peer_current_root && local != peer,
+            _ => false,
+        };
+        if let (true, Some(local_scope_root), Some(peer_scope_root)) =
+            (governance_divergence, local_scope_root, peer_scope_root)
         {
             warn!(
                 marker = "scope_root_governance_divergence",
                 %context_id,
                 entity_root = %hex::encode(&local_root_hash[..8]),
-                local_scope_root = %hex::encode(&local_scope_root.unwrap_or_default()[..8]),
-                peer_scope_root = %hex::encode(&peer_scope_root.unwrap_or_default()[..8]),
+                local_scope_root = %hex::encode(&local_scope_root[..8]),
+                peer_scope_root = %hex::encode(&peer_scope_root[..8]),
                 "entity roots agree but scope_root differs — ACL/membership divergence; \
                  awaiting governance sync to propagate the rotation"
             );

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -566,39 +566,70 @@ async fn run_initiator_impl<T: SyncTransport>(
         }
     }
 
+    // C1b: re-query the peer's CURRENT root + scope_root before closing — the
+    // #2407 comment below noted LevelWise "can't distinguish a real divergence bug
+    // from legitimate drift without a second handshake round-trip"; this IS that
+    // round-trip (parity with HashComparison's #2607 end-of-session read). Falls
+    // back to the stale handshake root only if the peer doesn't answer (older
+    // peer).
+    let (peer_current_root, peer_scope_root) =
+        match super::hash_comparison_protocol::query_peer_current_root(
+            transport, context_id, identity,
+        )
+        .await
+        {
+            Ok(Some((root, scope_root))) => (root, scope_root),
+            Ok(None) | Err(_) => (remote_root_hash, None),
+        };
+
     // Close the transport to signal completion
     transport.close().await?;
 
-    // Post-sync convergence check (#2407). Previously this was
-    // silently debug-logged on mismatch with the comment "expected
-    // if local had concurrent changes" — true for one narrow case,
-    // but it also masked actual merge-correctness bugs.
-    //
-    // We can't distinguish "real divergence bug" from "legitimate
-    // bidirectional drift / concurrent local writes" without a
-    // second handshake round-trip, so we surface mismatch at WARN
-    // (was: debug) and rely on the sync manager / metrics consumer
-    // to react to *patterns* of unverified syncs across many ticks
-    // — that's the failure shape #2407 documents.
+    // Post-sync convergence check. `scope_root` is the AUTHORITATIVE verdict (C1b),
+    // parity with HashComparison: it folds the governance projection's ACL +
+    // membership onto the entity root, so LevelWise can't declare converged while
+    // authorization disagrees. When either side can't fold the scope (cold
+    // projection / non-group context, `None`), fall back to the entity-root compare
+    // — now against the peer's RE-QUERIED current root rather than the stale
+    // handshake root, so even the fallback is sharper than the prior #2407 check.
     let local_root_hash = with_runtime_env(runtime_env.clone(), || {
         get_local_root_hash_for_context(context_id)
     })?;
 
-    stats.root_hash_verified = local_root_hash == remote_root_hash;
+    let local_scope_root = super::helpers::local_scope_root(store, &context_id, local_root_hash);
+    stats.root_hash_verified = match (local_scope_root, peer_scope_root) {
+        (Some(local), Some(peer)) => local == peer,
+        _ => local_root_hash == peer_current_root,
+    };
 
     if !stats.root_hash_verified {
-        warn!(
-            %context_id,
-            local_hash = %hex::encode(&local_root_hash[..8]),
-            remote_hash = %hex::encode(&remote_root_hash[..8]),
-            levels_synced = stats.levels_synced,
-            nodes_compared = stats.nodes_compared,
-            entities_merged = stats.entities_merged,
-            "LevelWise sync did not match remote handshake root (#2407). \
-             Legitimate in bidirectional sync or with concurrent local writes; \
-             persistent occurrences across many interval-sync ticks indicate a real \
-             merge convergence bug."
-        );
+        // Entities agree but scope_root differs ⇒ pure ACL/governance divergence
+        // (the case the entity root hides); distinct marker, parity with HC.
+        if local_root_hash == peer_current_root
+            && matches!((local_scope_root, peer_scope_root), (Some(l), Some(p)) if l != p)
+        {
+            warn!(
+                marker = "scope_root_governance_divergence",
+                %context_id,
+                entity_root = %hex::encode(&local_root_hash[..8]),
+                local_scope_root = %hex::encode(&local_scope_root.unwrap_or_default()[..8]),
+                peer_scope_root = %hex::encode(&peer_scope_root.unwrap_or_default()[..8]),
+                "entity roots agree but scope_root differs — ACL/membership divergence; \
+                 awaiting governance sync to propagate the rotation"
+            );
+        } else {
+            warn!(
+                %context_id,
+                local_hash = %hex::encode(&local_root_hash[..8]),
+                peer_hash = %hex::encode(&peer_current_root[..8]),
+                levels_synced = stats.levels_synced,
+                nodes_compared = stats.nodes_compared,
+                entities_merged = stats.entities_merged,
+                "LevelWise sync did not converge with the peer's re-queried root. \
+                 Persistent occurrences across many interval-sync ticks indicate a \
+                 real merge convergence bug."
+            );
+        }
     } else {
         debug!(
             %context_id,
@@ -845,6 +876,40 @@ async fn run_responder_loop<T: SyncTransport>(
                 requests_handled += 1;
 
                 info!(%context_id, applied, total, "Applied pushed tombstones (delete-wins)");
+            }
+
+            // C1b: end-of-session convergence re-read, parity with HashComparison
+            // (the #2607 path). Re-read our root NOW — after every leaf/tombstone
+            // applied this session — and fold the governance projection onto it so
+            // the initiator's verdict catches a hash-neutral ACL/membership
+            // divergence the bare entity root hides. `scope_root` is `None` on a
+            // non-group / cold projection ⇒ the initiator falls back to the entity
+            // compare.
+            InitPayload::DagHeadsRequest { .. } => {
+                let current_root = with_runtime_env(runtime_env.clone(), || {
+                    get_local_root_hash_for_context(context_id)
+                })
+                .unwrap_or([0u8; 32]);
+
+                let scope_root = context_client
+                    .map(|cc| cc.datastore_handle().into_inner())
+                    .and_then(|store| {
+                        super::helpers::local_scope_root(&store, &context_id, current_root)
+                    })
+                    .map(calimero_primitives::hash::Hash::from);
+
+                let response = StreamMessage::Message {
+                    sequence_id,
+                    payload: MessagePayload::DagHeadsResponse {
+                        dag_heads: Vec::new(),
+                        root_hash: calimero_primitives::hash::Hash::from(current_root),
+                        scope_root,
+                    },
+                    next_nonce: generate_nonce(),
+                };
+                transport.send(&response).await?;
+                sequence_id += 1;
+                requests_handled += 1;
             }
 
             _ => {

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -579,7 +579,19 @@ async fn run_initiator_impl<T: SyncTransport>(
         .await
         {
             Ok(Some((root, scope_root))) => (root, scope_root),
-            Ok(None) | Err(_) => (remote_root_hash, None),
+            // Older peer that doesn't answer the re-query — expected, quiet.
+            Ok(None) => (remote_root_hash, None),
+            // Transport fault on the re-query: distinct from the older-peer case, so
+            // log it (a persistent fault degrades the verdict to the stale handshake
+            // root and would otherwise masquerade as a quiet version mismatch).
+            Err(e) => {
+                debug!(
+                    %context_id, %e,
+                    "LevelWise: end-of-session peer re-query failed; \
+                     falling back to the handshake root for the convergence check"
+                );
+                (remote_root_hash, None)
+            }
         };
 
     // Close the transport to signal completion

--- a/docs/design/unified-causal-log-cutover-plan.md
+++ b/docs/design/unified-causal-log-cutover-plan.md
@@ -103,11 +103,25 @@ signal only once this canary is green.
   projection / non-group context falls back to the bare entity compare (no
   context drops below the pre-C1 check). This is the kernel security win on the
   general sync path.
-- **C1b (follow-up)** — the remaining compare sites: LevelWise (its verdict is
-  currently advisory off the handshake root — needs `scope_root` threaded through
-  the handshake), the snapshot boundary (`snapshot.rs`), and the protocol
-  selector's converged-decision. Sliced out because LevelWise/snapshot carry
-  their own staleness semantics and are independently reviewable.
+- **C1b (drafted 2026-06-24)** — **LevelWise** brought to HashComparison parity:
+  it now does the same end-of-session peer re-query (the #2407 comment said it
+  *needed* "a second handshake round-trip" to tell real divergence from drift —
+  this is that round-trip, reusing `query_peer_current_root`) and decides on
+  `scope_root` with the same entity fallback. Closes the blind spot on the
+  wide-shallow-tree path.
+- **NOT folded into `scope_root`, deliberately:**
+  - **Snapshot boundary** (`snapshot.rs`) stays entity-root-based. The snapshot
+    streams the *data plane*; its boundary check is streaming-integrity ("did the
+    responder's entity state drift mid-stream"). Folding governance in would abort
+    a perfectly valid entity snapshot whenever governance moves independently
+    (over-conservative). Post-snapshot convergence — including authorization — is
+    verified by the next HC/LevelWise session's `scope_root` verdict (C1a/C1b).
+  - **Protocol selector's `None` arm** ("roots match ⇒ no sync") stays entity-root
+    based. Governance reconciles on its *own* independent tick (the
+    `namespace_sync` beacon), so a selector that skips state-sync on equal entity
+    roots never strands a governance divergence — it's pulled by governance sync,
+    and the following state-sync's `scope_root` verdict confirms convergence.
+    Folding `scope_root` here would only add redundant state-sync work.
 
 **Goal.** Replace the bare entity `root_hash` on the wire and in comparison with
 `scope_root`, where


### PR DESCRIPTION
**Stacked on #2900 (C1a) → #2899 (C0).** Retargets up the chain as each lands. **Merge-gated on C0's e2e canary** like the rest of the stack.

## What

Brings **LevelWise** to HashComparison's authoritative-verdict parity (C1a). LevelWise deliberately avoided an end-of-session re-query — its own #2407 comment noted it *"can't distinguish a real divergence bug from legitimate drift without a second handshake round-trip,"* so its verdict was advisory off the **stale handshake root**. This adds exactly that round-trip and decides convergence on `scope_root`:

- **Responder**: new `DagHeadsRequest` arm re-reads the post-merge root and folds the governance projection onto it (parity with the HC responder); `None` on cold/non-group.
- **Initiator**: re-queries the peer's *current* root + `scope_root` before closing, then
  ```rust
  root_hash_verified = match (local_scope_root, peer_scope_root) {
      (Some(l), Some(p)) => l == p,            // authoritative
      _ => local_root_hash == peer_current_root, // entity fallback, now vs RE-QUERIED root
  };
  ```
  Same shape as C1a; even the fallback is sharper than the prior #2407 check (re-queried, not stale handshake).
- Same `scope_root_governance_divergence` marker for the entities-agree/scope-differs case.
- `query_peer_current_root` is now `pub(crate)` (shared by both Merkle protocols).

## Deliberately NOT folded into scope_root

(reasoned in the cutover plan C1 section)

- **Snapshot boundary** stays entity-root-based — it streams the *data plane*; its check is streaming-integrity ("did the responder's entities drift mid-stream"). Folding governance would abort a valid entity snapshot whenever governance moves independently. Post-snapshot convergence (incl. authorization) is caught by the next HC/LevelWise `scope_root` verdict.
- **Protocol selector's roots-match/no-sync arm** stays entity-root-based — governance reconciles on its own `namespace_sync` tick, so a skipped state-sync never strands a governance divergence; the following state-sync's verdict confirms it.

## Test
- `cargo test -p calimero-node --features calimero-storage/testing` — pass (incl. the full LevelWise sim suite — the new re-query round-trips through the simulator)
- `cargo clippy -p calimero-node --all-targets --features calimero-storage/testing -- -D warnings` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes load-bearing sync convergence on the LevelWise path and add wire round-trips; behavior is aligned with an already-landed HC pattern but mis-handled `scope_root` or re-query fallback could affect false positive/negative sync verdicts.
> 
> **Overview**
> **LevelWise** post-sync convergence now matches **HashComparison (C1a)**: the initiator calls `query_peer_current_root` before closing (replacing the stale handshake root), and **`root_hash_verified`** prefers **`scope_root`** when both sides resolve it, otherwise compares entity roots against the **re-queried** peer root.
> 
> The **LevelWise responder** handles mid-session **`DagHeadsRequest`** by returning the current entity root plus an optional **`scope_root`** from `local_scope_root`. **`query_peer_current_root`** is **`pub(crate)`** so LevelWise shares the same **`DagHeadsRequest`/`DagHeadsResponse`** path as HC.
> 
> Warnings distinguish **`scope_root_governance_divergence`** (entity roots match, ACL/membership differ) from ordinary non-convergence; transport failures on re-query are **`debug!`** logged with fallback to the handshake root.
> 
> The **unified causal log cutover plan** documents C1b as drafted and records that **snapshot** and **protocol selector** checks stay entity-root-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be3c219eff5884a4f19159762fee02a38a3f0d07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->