### PR TITLE
feat(context): unified op-store persistence + round-trip replay (cutover C2.1)

### DIFF
--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -42,6 +42,7 @@ pub mod scope_projection;
 pub mod self_purge;
 pub mod tee_subgroup_admit;
 pub mod unified_applier;
+pub mod unified_op_store;
 
 pub(crate) use cache::{BoundedCache, Evictable};
 

--- a/crates/context/src/unified_op_store.rs
+++ b/crates/context/src/unified_op_store.rs
@@ -1,0 +1,226 @@
+//! Persistence for the unified causal-log op-store (cutover plan C2.1).
+//!
+//! Writes each unified [`Op`] to its own keyspace — one borsh row per op, keyed
+//! `[op.scope ‖ op.id]` in [`Column::UnifiedOp`](calimero_store::db::Column) — so
+//! the op-stream that backs the projection is durable. During the dual-write
+//! transition this lives **alongside** the legacy stores and is **observe-only**:
+//! nothing reads it for a sync/auth decision yet. The per-plane flips (C2.2+)
+//! switch reads onto it; this slice validates the op-log can be written, reloaded,
+//! and replayed to reconstruct the projection.
+//!
+//! Heads are intentionally NOT persisted here: the op-log is self-describing
+//! (every op carries its `parents`), so [`load_scope_ops`] returns the rows in any
+//! order and the caller replays them through a `DagStore<Op>`, which re-establishes
+//! causal order and derives the frontier (proven by the convergence test in
+//! [`crate::unified_applier`]).
+
+use borsh::BorshDeserialize;
+use calimero_op::{Op, ScopeId};
+use calimero_store::key::ScopeUnifiedOp as ScopeUnifiedOpKey;
+use calimero_store::types::ScopeUnifiedOp as ScopeUnifiedOpValue;
+use calimero_store::Store;
+use eyre::Result as EyreResult;
+
+/// Persist one unified [`Op`] under `[op.scope ‖ op.id]` — keyed by the op's
+/// **scope**, so a scope's whole op-log is one contiguous key range (governance
+/// ops are namespace-scoped and shared across that namespace's contexts, so a
+/// single context id is the wrong partition). Idempotent — re-persisting the same
+/// op id overwrites with identical bytes (the id is a content address).
+pub fn persist_op(store: &Store, op: &Op) -> EyreResult<()> {
+    let bytes = borsh::to_vec(op)?;
+    let mut handle = store.handle();
+    handle.put(
+        &ScopeUnifiedOpKey::new(scope_bytes(&op.scope), op.id),
+        &ScopeUnifiedOpValue::from(calimero_store::slice::Slice::from(bytes)),
+    )?;
+    Ok(())
+}
+
+/// Load every persisted unified [`Op`] for `scope`, in key (not causal) order. The
+/// caller replays them through a `DagStore<Op>` to recover causal order; see the
+/// module docs.
+pub fn load_scope_ops(store: &Store, scope: &ScopeId) -> EyreResult<Vec<Op>> {
+    let scope = scope_bytes(scope);
+    let handle = store.handle();
+    let mut iter = handle.iter::<ScopeUnifiedOpKey>()?;
+    // Seek to the first row of this scope's `[scope ‖ *]` range.
+    let start = ScopeUnifiedOpKey::new(scope, [0u8; 32]);
+    let mut ops = Vec::new();
+
+    // `Iter::entries()` yields rows STRICTLY AFTER the cursor (the contract the
+    // whole codebase's seek-scan code relies on, e.g. the data-plane
+    // `load_persisted_deltas`), so the seek's own row is read once via `handle.get`
+    // and the loop below covers the rest — each row read exactly once, never
+    // duplicated. The `get`-after-`seek` is not a torn read: unified-op rows are
+    // content-addressed by op id and never rewritten or deleted in this store, so a
+    // row's bytes can't change between the seek and the get.
+    let first_key = iter.seek(start)?;
+    if let Some(key) = first_key {
+        if key.scope() != scope {
+            return Ok(ops);
+        }
+        // `seek` just reported this key exists, so `get` returning `None` is a store
+        // inconsistency — surface it as a clear error rather than a silent skip that
+        // would later look like a confusing "parent not found" during DAG replay.
+        let value = handle.get(&key)?.ok_or_else(|| {
+            eyre::eyre!("unified op-store: seek found key {key:?} but its value is missing")
+        })?;
+        ops.push(Op::try_from_slice(value.as_ref())?);
+    } else {
+        return Ok(ops);
+    }
+
+    for (key, value) in iter.entries() {
+        let key = key?;
+        if key.scope() != scope {
+            break;
+        }
+        let value = value?;
+        ops.push(Op::try_from_slice(value.as_ref())?);
+    }
+
+    Ok(ops)
+}
+
+/// `ScopeId`'s 32-byte representation (the store key is byte-addressed and can't
+/// depend on `calimero_op`).
+fn scope_bytes(scope: &ScopeId) -> [u8; 32] {
+    *scope.as_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU128;
+
+    use std::sync::Arc;
+
+    use calimero_context_config::types::ContextGroupId;
+    use calimero_dag::DagStore;
+    use calimero_op::{Op, OpPayload, ScopeId};
+    use calimero_primitives::context::GroupMemberRole;
+    use calimero_primitives::identity::PublicKey;
+    use calimero_storage::address::Id;
+    use calimero_storage::entities::OpMask;
+    use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
+    use calimero_store::db::InMemoryDB;
+
+    use super::*;
+    use crate::scope_projection::ScopeProjections;
+    use crate::unified_applier::UnifiedApplier;
+
+    const GENESIS: [u8; 32] = [0u8; 32];
+
+    fn hlc(ns: u64) -> HybridTimestamp {
+        HybridTimestamp::new(Timestamp::new(NTP64(ns), ID::from(NonZeroU128::MIN)))
+    }
+
+    fn op(scope: ScopeId, ns: u64, parents: Vec<[u8; 32]>, payload: OpPayload) -> Op {
+        let author = PublicKey::from([7u8; 32]);
+        let h = hlc(ns);
+        let id = Op::compute_id(scope, &parents, &author, &h, &payload);
+        // `expected_scope_root` and `signature` are zeroed: this is a
+        // persistence/replay round-trip test, and neither the op-store nor the
+        // projection fold verifies them (the projection folds already-verified ops
+        // on content alone). If a signature or root check is ever added to that
+        // path, this helper must produce valid values rather than zeros.
+        Op {
+            id,
+            scope,
+            parents,
+            author,
+            hlc: h,
+            payload,
+            expected_scope_root: [0u8; 32],
+            signature: [0u8; 64],
+        }
+    }
+
+    fn delta(op: &Op) -> calimero_dag::CausalDelta<Op> {
+        calimero_dag::CausalDelta::new(op.id, op.parents.clone(), op.clone(), op.hlc, [0u8; 32])
+    }
+
+    /// Persist a causal chain of mixed-plane ops, reload it from a fresh handle,
+    /// replay the loaded rows through `DagStore<Op>` + `UnifiedApplier`, and assert
+    /// the reconstructed projection's `scope_root` matches an in-memory fold of the
+    /// same ops — i.e. the durable op-log faithfully backs the projection.
+    #[tokio::test]
+    async fn persisted_op_log_reloads_and_replays_to_the_same_projection() {
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+
+        let scope = ScopeId::from([0xA1; 32]);
+        let group = ContextGroupId::from([3u8; 32]);
+        let member = PublicKey::from([0x55; 32]);
+        let admin = PublicKey::from([1u8; 32]);
+
+        let op_admin = op(
+            scope,
+            10,
+            vec![],
+            OpPayload::AdminChanged { new_admin: admin },
+        );
+        let op_member = op(
+            scope,
+            20,
+            vec![op_admin.id],
+            OpPayload::MemberAdded {
+                group,
+                member,
+                role: GroupMemberRole::Member,
+            },
+        );
+        let op_writers = op(
+            scope,
+            30,
+            vec![op_member.id],
+            OpPayload::SetWriters {
+                object: Id::new([9u8; 32]),
+                writers: [(member, OpMask::FULL)].into_iter().collect(),
+            },
+        );
+        let ops = [&op_admin, &op_member, &op_writers];
+
+        // Persist (in causal order; key order on read is by op id, unrelated).
+        for op in ops {
+            persist_op(&store, op).expect("persist");
+        }
+
+        // Reference fold, in memory.
+        let mut reference = ScopeProjections::new();
+        for op in ops {
+            reference.ingest_op(op);
+        }
+        let want = reference
+            .scope_root_for(&scope, [0u8; 32])
+            .expect("scope fed");
+
+        // A scope with no rows loads empty.
+        let other = ScopeId::from([0x22; 32]);
+        assert!(load_scope_ops(&store, &other)
+            .expect("load other")
+            .is_empty());
+
+        // Reload + replay through the DAG (which re-establishes causal order).
+        let loaded = load_scope_ops(&store, &scope).expect("load");
+        assert_eq!(loaded.len(), ops.len(), "every persisted op reloaded");
+
+        let mut dag = DagStore::<Op>::new(GENESIS);
+        let applier = UnifiedApplier::new();
+        for op in &loaded {
+            dag.add_delta(delta(op), &applier).await.expect("add_delta");
+        }
+        for op in ops {
+            assert!(dag.is_applied(&op.id), "reloaded op left unapplied");
+        }
+
+        let got = applier
+            .projection()
+            .read()
+            .expect("projection lock not poisoned in this single-threaded test")
+            .scope_root_for(&scope, [0u8; 32])
+            .expect("scope fed");
+        assert_eq!(
+            got, want,
+            "reloaded+replayed op-log diverged from the in-memory fold"
+        );
+    }
+}

--- a/crates/store/src/db.rs
+++ b/crates/store/src/db.rs
@@ -75,6 +75,14 @@ pub enum Column {
     /// `context_id`-only collision reason as the markers above. NOT
     /// synchronized; auto-created from `Column::iter()` (no DB migration).
     ContextResyncRequested,
+    /// The unified causal-log op-store (cutover C2): one borsh'd `calimero_op::Op`
+    /// per row, keyed `scope(32) ‖ op_id(32)` (see `ScopeUnifiedOp`) — the prefix is
+    /// the op's scope, so a scope's op-log is a contiguous range. Its own column
+    /// during the dual-write transition so its `(scope, op_id)` key cannot collide
+    /// with the same-shaped legacy delta key in `Delta`; the two merge once the
+    /// legacy delta rows retire (C2.5). Synchronized like the planes it will
+    /// subsume. Auto-created from `Column::iter()` at `open_cf` (no DB migration).
+    UnifiedOp,
 }
 
 pub trait Database<'a>: Debug + Send + Sync + 'static {

--- a/crates/store/src/key.rs
+++ b/crates/store/src/key.rs
@@ -30,7 +30,7 @@ use component::KeyComponents;
 pub use context::{
     ContextActivatedBlob, ContextAuthoredRemaining, ContextConfig, ContextDagDelta,
     ContextExecutingBlob, ContextIdentity, ContextLeftMarker, ContextMeta, ContextMigrationFailed,
-    ContextPrivateState, ContextResyncRequested, ContextState,
+    ContextPrivateState, ContextResyncRequested, ContextState, ScopeUnifiedOp,
 };
 pub use generic::{Generic, FRAGMENT_SIZE, SCOPE_SIZE};
 pub use group::{

--- a/crates/store/src/key/context.rs
+++ b/crates/store/src/key/context.rs
@@ -665,6 +665,70 @@ impl FromKeyParts for ContextDagDelta {
     }
 }
 
+/// Key for a unified causal-log op (cutover C2): `scope(32) ‖ op_id(32)`, in the
+/// [`Column::UnifiedOp`] column. The prefix is the op's **scope** (a
+/// `calimero_op::ScopeId`'s 32 bytes — a namespace root for governance ops, a
+/// context/object scope for data/rotation ops), so a scope's whole op-log is a
+/// contiguous key range that reconstructs that scope's projection. Same 64-byte
+/// shape as [`ContextDagDelta`] but a distinct column so the two cannot collide
+/// during the dual-write transition. Reuses the 32-byte [`DeltaId`] component for
+/// both halves (the store is agnostic to the id's meaning).
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+pub struct ScopeUnifiedOp(Key<(DeltaId, DeltaId)>);
+
+impl ScopeUnifiedOp {
+    #[must_use]
+    pub fn new(scope: [u8; 32], op_id: [u8; 32]) -> Self {
+        Self(Key(
+            GenericArray::from(scope).concat(GenericArray::from(op_id))
+        ))
+    }
+
+    #[must_use]
+    pub fn scope(&self) -> [u8; 32] {
+        let mut scope = [0; 32];
+        scope.copy_from_slice(&AsRef::<[_; 64]>::as_ref(&self.0)[..32]);
+        scope
+    }
+
+    #[must_use]
+    pub fn op_id(&self) -> [u8; 32] {
+        let mut op_id = [0; 32];
+        op_id.copy_from_slice(&AsRef::<[_; 64]>::as_ref(&self.0)[32..]);
+        op_id
+    }
+}
+
+impl AsKeyParts for ScopeUnifiedOp {
+    type Components = (DeltaId, DeltaId);
+
+    fn column() -> Column {
+        Column::UnifiedOp
+    }
+
+    fn as_key(&self) -> &Key<Self::Components> {
+        &self.0
+    }
+}
+
+impl FromKeyParts for ScopeUnifiedOp {
+    type Error = Infallible;
+
+    fn try_from_parts(parts: Key<Self::Components>) -> Result<Self, Self::Error> {
+        Ok(Self(parts))
+    }
+}
+
+impl Debug for ScopeUnifiedOp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ScopeUnifiedOp")
+            .field("scope", &self.scope())
+            .field("op_id", &self.op_id())
+            .finish()
+    }
+}
+
 impl Debug for ContextDagDelta {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("ContextDagDelta")

--- a/crates/store/src/types.rs
+++ b/crates/store/src/types.rs
@@ -13,7 +13,7 @@ pub use blobs::BlobMeta;
 pub use context::{
     ContextActivatedBlob, ContextAuthoredRemaining, ContextConfig, ContextDagDelta,
     ContextExecutingBlob, ContextIdentity, ContextLeftMarker, ContextMeta, ContextMigrationFailed,
-    ContextPrivateState, ContextState,
+    ContextPrivateState, ContextState, ScopeUnifiedOp,
 };
 pub use generic::GenericData;
 

--- a/crates/store/src/types/context.rs
+++ b/crates/store/src/types/context.rs
@@ -255,6 +255,34 @@ impl PredefinedEntry for key::ContextDagDelta {
     type DataType<'a> = ContextDagDelta;
 }
 
+/// Raw-bytes value for a unified causal-log op row (cutover C2): the
+/// borsh-serialized `calimero_op::Op`. Kept opaque (`Identity` codec) because
+/// `calimero_store` cannot depend on `calimero_op` (the dependency points the
+/// other way) — the `calimero-context` layer borsh-codes the `Op` and stores the
+/// bytes here, the same shape as [`ContextState`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct ScopeUnifiedOp<'a> {
+    pub value: Slice<'a>,
+}
+
+impl PredefinedEntry for key::ScopeUnifiedOp {
+    type Codec = Identity;
+    type DataType<'a> = ScopeUnifiedOp<'a>;
+}
+
+impl<'a> From<Slice<'a>> for ScopeUnifiedOp<'a> {
+    fn from(value: Slice<'a>) -> Self {
+        Self { value }
+    }
+}
+
+impl AsRef<[u8]> for ScopeUnifiedOp<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.value.as_ref()
+    }
+}
+
 #[cfg(test)]
 mod context_authored_remaining_tests {
     use borsh::BorshDeserialize;


### PR DESCRIPTION
The durable backing for the unified op-log — the next slice after the `UnifiedApplier` foundation (#2906).

## What

Each unified `Op` persists as one borsh row keyed **`[op.scope ‖ op.id]`** in a new **`Column::UnifiedOp`** — keyed by the op's **scope** (a namespace root for governance ops, a context/object scope for data/rotation), so a scope's whole op-log is one contiguous range that reconstructs that scope's projection. (Governance ops are namespace-scoped and shared across that namespace's contexts, so a single context id is the wrong partition.) Own column so the `(scope, op_id)` key can't collide with the same-shaped legacy delta key in `Column::Delta` during dual-write; they merge when the legacy delta rows retire.

- **store**: `Column::UnifiedOp` + `ScopeUnifiedOp` key (mirrors `ContextDagDelta`, 64-byte `scope ‖ op_id`) + a raw-bytes value wrapper (`Identity` codec — `calimero_store` can't depend on `calimero_op`, so the context layer borsh-codes the `Op`).
- **context**: `unified_op_store::{persist_op, load_scope_ops}`. Heads are deliberately **not** persisted: the op-log is self-describing (each op carries its `parents`), so `load_scope_ops` returns rows in any order and the caller replays them through a `DagStore<Op>`, which re-establishes causal order (the C2.0 `UnifiedApplier`).

## Scope

**Additive + observe-only** — nothing in production writes or reads this yet. Hooking `persist_op` into the apply paths (the actual dual-write) and switching reads onto it are the next slices.

## Test

A round-trip-replay test: persist a causal chain of mixed-plane ops (admin → member → writers), reload from a fresh handle, replay through `DagStore<Op>` + `UnifiedApplier`, and assert the reconstructed `scope_root` matches an in-memory fold — i.e. the durable op-log faithfully backs the projection. (Plus: an empty scope loads no rows.)

- `cargo test -p calimero-store -p calimero-context --features calimero-storage/testing` — 199 ctx pass
- `cargo clippy -p calimero-store -p calimero-context --all-targets --features calimero-storage/testing -- -D warnings` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New column and persistence API only; no production read/write wiring, so sync and auth behavior are unchanged until later cutover slices.
> 
> **Overview**
> Adds **durable storage for the unified causal op-log** (cutover C2.1): each `calimero_op::Op` is written as one borsh row under **`scope ‖ op_id`** in a new synchronized **`Column::UnifiedOp`**, with **`ScopeUnifiedOp`** key/value types in `calimero-store` (opaque bytes via `Identity` codec, mirroring `ContextState`).
> 
> **`calimero-context`** exposes **`unified_op_store::{persist_op, load_scope_ops}`**: scope-prefixed range scan (same seek-then-`entries` pattern as legacy delta loads), no persisted heads—callers replay loaded ops through **`DagStore<Op>`** + **`UnifiedApplier`** to recover causal order and projections.
> 
> This slice is **additive and observe-only**: no production apply/sync path calls `persist_op` or reads this column yet; dual-write and read cutover are follow-ups. A test persists a mixed-plane op chain, reloads, replays, and checks **`scope_root`** matches an in-memory fold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b3417466408d0a7ba784a227b58b6306fd1a93f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->