### PR TITLE
feat(context): dual-write the unified op-log on apply (cutover C2.1b)

### DIFF
--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -86,6 +86,18 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                         &delta_parents,
                     );
 
+                    // C2.1b dual-write: persist this governance op to the durable
+                    // unified op-store, keyed by its (namespace) scope. Observe-only —
+                    // nothing reads it yet (the per-plane C2 flips switch reads onto
+                    // it). A failure must never affect the governance apply, so it is
+                    // logged, not propagated.
+                    if let Err(err) = crate::unified_op_store::persist_op(&feed_store, &shadow_op) {
+                        tracing::warn!(
+                            %err,
+                            "unified op-store: failed to persist governance op (dual-write)"
+                        );
+                    }
+
                     {
                         // The member this op touches (for the per-member
                         // shadow-compare), if it's a membership op.

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -983,6 +983,21 @@ impl Handler<ExecuteRequest> for ContextManager {
                                     "scope-projections lock poisoned; skipping ACL shadow feed"
                                 ),
                             }
+
+                            // C2.1b dual-write: persist each rotation op to the
+                            // durable unified op-store, keyed by its scope.
+                            // Observe-only — nothing reads it yet. Independent of
+                            // the projection lock above and never fails execution.
+                            for op in &ops {
+                                if let Err(err) =
+                                    crate::unified_op_store::persist_op(&xcall_datastore, op)
+                                {
+                                    tracing::warn!(
+                                        %err,
+                                        "unified op-store: failed to persist rotation op (dual-write)"
+                                    );
+                                }
+                            }
                         }
                     }
 

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -42,6 +42,7 @@ pub mod scope_projection;
 pub mod self_purge;
 pub mod tee_subgroup_admit;
 pub mod unified_applier;
+pub mod unified_op_store;
 
 pub(crate) use cache::{BoundedCache, Evictable};
 

--- a/crates/context/src/unified_op_store.rs
+++ b/crates/context/src/unified_op_store.rs
@@ -1,0 +1,226 @@
+//! Persistence for the unified causal-log op-store (cutover plan C2.1).
+//!
+//! Writes each unified [`Op`] to its own keyspace — one borsh row per op, keyed
+//! `[op.scope ‖ op.id]` in [`Column::UnifiedOp`](calimero_store::db::Column) — so
+//! the op-stream that backs the projection is durable. During the dual-write
+//! transition this lives **alongside** the legacy stores and is **observe-only**:
+//! nothing reads it for a sync/auth decision yet. The per-plane flips (C2.2+)
+//! switch reads onto it; this slice validates the op-log can be written, reloaded,
+//! and replayed to reconstruct the projection.
+//!
+//! Heads are intentionally NOT persisted here: the op-log is self-describing
+//! (every op carries its `parents`), so [`load_scope_ops`] returns the rows in any
+//! order and the caller replays them through a `DagStore<Op>`, which re-establishes
+//! causal order and derives the frontier (proven by the convergence test in
+//! [`crate::unified_applier`]).
+
+use borsh::BorshDeserialize;
+use calimero_op::{Op, ScopeId};
+use calimero_store::key::ScopeUnifiedOp as ScopeUnifiedOpKey;
+use calimero_store::types::ScopeUnifiedOp as ScopeUnifiedOpValue;
+use calimero_store::Store;
+use eyre::Result as EyreResult;
+
+/// Persist one unified [`Op`] under `[op.scope ‖ op.id]` — keyed by the op's
+/// **scope**, so a scope's whole op-log is one contiguous key range (governance
+/// ops are namespace-scoped and shared across that namespace's contexts, so a
+/// single context id is the wrong partition). Idempotent — re-persisting the same
+/// op id overwrites with identical bytes (the id is a content address).
+pub fn persist_op(store: &Store, op: &Op) -> EyreResult<()> {
+    let bytes = borsh::to_vec(op)?;
+    let mut handle = store.handle();
+    handle.put(
+        &ScopeUnifiedOpKey::new(scope_bytes(&op.scope), op.id),
+        &ScopeUnifiedOpValue::from(calimero_store::slice::Slice::from(bytes)),
+    )?;
+    Ok(())
+}
+
+/// Load every persisted unified [`Op`] for `scope`, in key (not causal) order. The
+/// caller replays them through a `DagStore<Op>` to recover causal order; see the
+/// module docs.
+pub fn load_scope_ops(store: &Store, scope: &ScopeId) -> EyreResult<Vec<Op>> {
+    let scope = scope_bytes(scope);
+    let handle = store.handle();
+    let mut iter = handle.iter::<ScopeUnifiedOpKey>()?;
+    // Seek to the first row of this scope's `[scope ‖ *]` range.
+    let start = ScopeUnifiedOpKey::new(scope, [0u8; 32]);
+    let mut ops = Vec::new();
+
+    // `Iter::entries()` yields rows STRICTLY AFTER the cursor (the contract the
+    // whole codebase's seek-scan code relies on, e.g. the data-plane
+    // `load_persisted_deltas`), so the seek's own row is read once via `handle.get`
+    // and the loop below covers the rest — each row read exactly once, never
+    // duplicated. The `get`-after-`seek` is not a torn read: unified-op rows are
+    // content-addressed by op id and never rewritten or deleted in this store, so a
+    // row's bytes can't change between the seek and the get.
+    let first_key = iter.seek(start)?;
+    if let Some(key) = first_key {
+        if key.scope() != scope {
+            return Ok(ops);
+        }
+        // `seek` just reported this key exists, so `get` returning `None` is a store
+        // inconsistency — surface it as a clear error rather than a silent skip that
+        // would later look like a confusing "parent not found" during DAG replay.
+        let value = handle.get(&key)?.ok_or_else(|| {
+            eyre::eyre!("unified op-store: seek found key {key:?} but its value is missing")
+        })?;
+        ops.push(Op::try_from_slice(value.as_ref())?);
+    } else {
+        return Ok(ops);
+    }
+
+    for (key, value) in iter.entries() {
+        let key = key?;
+        if key.scope() != scope {
+            break;
+        }
+        let value = value?;
+        ops.push(Op::try_from_slice(value.as_ref())?);
+    }
+
+    Ok(ops)
+}
+
+/// `ScopeId`'s 32-byte representation (the store key is byte-addressed and can't
+/// depend on `calimero_op`).
+fn scope_bytes(scope: &ScopeId) -> [u8; 32] {
+    *scope.as_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU128;
+
+    use std::sync::Arc;
+
+    use calimero_context_config::types::ContextGroupId;
+    use calimero_dag::DagStore;
+    use calimero_op::{Op, OpPayload, ScopeId};
+    use calimero_primitives::context::GroupMemberRole;
+    use calimero_primitives::identity::PublicKey;
+    use calimero_storage::address::Id;
+    use calimero_storage::entities::OpMask;
+    use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
+    use calimero_store::db::InMemoryDB;
+
+    use super::*;
+    use crate::scope_projection::ScopeProjections;
+    use crate::unified_applier::UnifiedApplier;
+
+    const GENESIS: [u8; 32] = [0u8; 32];
+
+    fn hlc(ns: u64) -> HybridTimestamp {
+        HybridTimestamp::new(Timestamp::new(NTP64(ns), ID::from(NonZeroU128::MIN)))
+    }
+
+    fn op(scope: ScopeId, ns: u64, parents: Vec<[u8; 32]>, payload: OpPayload) -> Op {
+        let author = PublicKey::from([7u8; 32]);
+        let h = hlc(ns);
+        let id = Op::compute_id(scope, &parents, &author, &h, &payload);
+        // `expected_scope_root` and `signature` are zeroed: this is a
+        // persistence/replay round-trip test, and neither the op-store nor the
+        // projection fold verifies them (the projection folds already-verified ops
+        // on content alone). If a signature or root check is ever added to that
+        // path, this helper must produce valid values rather than zeros.
+        Op {
+            id,
+            scope,
+            parents,
+            author,
+            hlc: h,
+            payload,
+            expected_scope_root: [0u8; 32],
+            signature: [0u8; 64],
+        }
+    }
+
+    fn delta(op: &Op) -> calimero_dag::CausalDelta<Op> {
+        calimero_dag::CausalDelta::new(op.id, op.parents.clone(), op.clone(), op.hlc, [0u8; 32])
+    }
+
+    /// Persist a causal chain of mixed-plane ops, reload it from a fresh handle,
+    /// replay the loaded rows through `DagStore<Op>` + `UnifiedApplier`, and assert
+    /// the reconstructed projection's `scope_root` matches an in-memory fold of the
+    /// same ops — i.e. the durable op-log faithfully backs the projection.
+    #[tokio::test]
+    async fn persisted_op_log_reloads_and_replays_to_the_same_projection() {
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+
+        let scope = ScopeId::from([0xA1; 32]);
+        let group = ContextGroupId::from([3u8; 32]);
+        let member = PublicKey::from([0x55; 32]);
+        let admin = PublicKey::from([1u8; 32]);
+
+        let op_admin = op(
+            scope,
+            10,
+            vec![],
+            OpPayload::AdminChanged { new_admin: admin },
+        );
+        let op_member = op(
+            scope,
+            20,
+            vec![op_admin.id],
+            OpPayload::MemberAdded {
+                group,
+                member,
+                role: GroupMemberRole::Member,
+            },
+        );
+        let op_writers = op(
+            scope,
+            30,
+            vec![op_member.id],
+            OpPayload::SetWriters {
+                object: Id::new([9u8; 32]),
+                writers: [(member, OpMask::FULL)].into_iter().collect(),
+            },
+        );
+        let ops = [&op_admin, &op_member, &op_writers];
+
+        // Persist (in causal order; key order on read is by op id, unrelated).
+        for op in ops {
+            persist_op(&store, op).expect("persist");
+        }
+
+        // Reference fold, in memory.
+        let mut reference = ScopeProjections::new();
+        for op in ops {
+            reference.ingest_op(op);
+        }
+        let want = reference
+            .scope_root_for(&scope, [0u8; 32])
+            .expect("scope fed");
+
+        // A scope with no rows loads empty.
+        let other = ScopeId::from([0x22; 32]);
+        assert!(load_scope_ops(&store, &other)
+            .expect("load other")
+            .is_empty());
+
+        // Reload + replay through the DAG (which re-establishes causal order).
+        let loaded = load_scope_ops(&store, &scope).expect("load");
+        assert_eq!(loaded.len(), ops.len(), "every persisted op reloaded");
+
+        let mut dag = DagStore::<Op>::new(GENESIS);
+        let applier = UnifiedApplier::new();
+        for op in &loaded {
+            dag.add_delta(delta(op), &applier).await.expect("add_delta");
+        }
+        for op in ops {
+            assert!(dag.is_applied(&op.id), "reloaded op left unapplied");
+        }
+
+        let got = applier
+            .projection()
+            .read()
+            .expect("projection lock not poisoned in this single-threaded test")
+            .scope_root_for(&scope, [0u8; 32])
+            .expect("scope fed");
+        assert_eq!(
+            got, want,
+            "reloaded+replayed op-log diverged from the in-memory fold"
+        );
+    }
+}

--- a/crates/store/src/db.rs
+++ b/crates/store/src/db.rs
@@ -75,6 +75,14 @@ pub enum Column {
     /// `context_id`-only collision reason as the markers above. NOT
     /// synchronized; auto-created from `Column::iter()` (no DB migration).
     ContextResyncRequested,
+    /// The unified causal-log op-store (cutover C2): one borsh'd `calimero_op::Op`
+    /// per row, keyed `scope(32) ‖ op_id(32)` (see `ScopeUnifiedOp`) — the prefix is
+    /// the op's scope, so a scope's op-log is a contiguous range. Its own column
+    /// during the dual-write transition so its `(scope, op_id)` key cannot collide
+    /// with the same-shaped legacy delta key in `Delta`; the two merge once the
+    /// legacy delta rows retire (C2.5). Synchronized like the planes it will
+    /// subsume. Auto-created from `Column::iter()` at `open_cf` (no DB migration).
+    UnifiedOp,
 }
 
 pub trait Database<'a>: Debug + Send + Sync + 'static {

--- a/crates/store/src/key.rs
+++ b/crates/store/src/key.rs
@@ -30,7 +30,7 @@ use component::KeyComponents;
 pub use context::{
     ContextActivatedBlob, ContextAuthoredRemaining, ContextConfig, ContextDagDelta,
     ContextExecutingBlob, ContextIdentity, ContextLeftMarker, ContextMeta, ContextMigrationFailed,
-    ContextPrivateState, ContextResyncRequested, ContextState,
+    ContextPrivateState, ContextResyncRequested, ContextState, ScopeUnifiedOp,
 };
 pub use generic::{Generic, FRAGMENT_SIZE, SCOPE_SIZE};
 pub use group::{

--- a/crates/store/src/key/context.rs
+++ b/crates/store/src/key/context.rs
@@ -665,6 +665,70 @@ impl FromKeyParts for ContextDagDelta {
     }
 }
 
+/// Key for a unified causal-log op (cutover C2): `scope(32) ‖ op_id(32)`, in the
+/// [`Column::UnifiedOp`] column. The prefix is the op's **scope** (a
+/// `calimero_op::ScopeId`'s 32 bytes — a namespace root for governance ops, a
+/// context/object scope for data/rotation ops), so a scope's whole op-log is a
+/// contiguous key range that reconstructs that scope's projection. Same 64-byte
+/// shape as [`ContextDagDelta`] but a distinct column so the two cannot collide
+/// during the dual-write transition. Reuses the 32-byte [`DeltaId`] component for
+/// both halves (the store is agnostic to the id's meaning).
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+pub struct ScopeUnifiedOp(Key<(DeltaId, DeltaId)>);
+
+impl ScopeUnifiedOp {
+    #[must_use]
+    pub fn new(scope: [u8; 32], op_id: [u8; 32]) -> Self {
+        Self(Key(
+            GenericArray::from(scope).concat(GenericArray::from(op_id))
+        ))
+    }
+
+    #[must_use]
+    pub fn scope(&self) -> [u8; 32] {
+        let mut scope = [0; 32];
+        scope.copy_from_slice(&AsRef::<[_; 64]>::as_ref(&self.0)[..32]);
+        scope
+    }
+
+    #[must_use]
+    pub fn op_id(&self) -> [u8; 32] {
+        let mut op_id = [0; 32];
+        op_id.copy_from_slice(&AsRef::<[_; 64]>::as_ref(&self.0)[32..]);
+        op_id
+    }
+}
+
+impl AsKeyParts for ScopeUnifiedOp {
+    type Components = (DeltaId, DeltaId);
+
+    fn column() -> Column {
+        Column::UnifiedOp
+    }
+
+    fn as_key(&self) -> &Key<Self::Components> {
+        &self.0
+    }
+}
+
+impl FromKeyParts for ScopeUnifiedOp {
+    type Error = Infallible;
+
+    fn try_from_parts(parts: Key<Self::Components>) -> Result<Self, Self::Error> {
+        Ok(Self(parts))
+    }
+}
+
+impl Debug for ScopeUnifiedOp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ScopeUnifiedOp")
+            .field("scope", &self.scope())
+            .field("op_id", &self.op_id())
+            .finish()
+    }
+}
+
 impl Debug for ContextDagDelta {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("ContextDagDelta")

--- a/crates/store/src/types.rs
+++ b/crates/store/src/types.rs
@@ -13,7 +13,7 @@ pub use blobs::BlobMeta;
 pub use context::{
     ContextActivatedBlob, ContextAuthoredRemaining, ContextConfig, ContextDagDelta,
     ContextExecutingBlob, ContextIdentity, ContextLeftMarker, ContextMeta, ContextMigrationFailed,
-    ContextPrivateState, ContextState,
+    ContextPrivateState, ContextState, ScopeUnifiedOp,
 };
 pub use generic::GenericData;
 

--- a/crates/store/src/types/context.rs
+++ b/crates/store/src/types/context.rs
@@ -255,6 +255,34 @@ impl PredefinedEntry for key::ContextDagDelta {
     type DataType<'a> = ContextDagDelta;
 }
 
+/// Raw-bytes value for a unified causal-log op row (cutover C2): the
+/// borsh-serialized `calimero_op::Op`. Kept opaque (`Identity` codec) because
+/// `calimero_store` cannot depend on `calimero_op` (the dependency points the
+/// other way) — the `calimero-context` layer borsh-codes the `Op` and stores the
+/// bytes here, the same shape as [`ContextState`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct ScopeUnifiedOp<'a> {
+    pub value: Slice<'a>,
+}
+
+impl PredefinedEntry for key::ScopeUnifiedOp {
+    type Codec = Identity;
+    type DataType<'a> = ScopeUnifiedOp<'a>;
+}
+
+impl<'a> From<Slice<'a>> for ScopeUnifiedOp<'a> {
+    fn from(value: Slice<'a>) -> Self {
+        Self { value }
+    }
+}
+
+impl AsRef<[u8]> for ScopeUnifiedOp<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.value.as_ref()
+    }
+}
+
 #[cfg(test)]
 mod context_authored_remaining_tests {
     use borsh::BorshDeserialize;


### PR DESCRIPTION
**Stacked on #2911** (the op-store persistence layer). Retargets to `master` once #2911 lands.

## What

Activates the dual-write: hook `unified_op_store::persist_op` into the two apply paths that feed the projection, so every applied op is also written to the durable unified op-store (keyed by its scope).

- **governance** (`apply_signed_namespace_op`) — persist the `shadow_op` built from each applied namespace op (membership / admin / subgroup / capability), keyed by its namespace scope.
- **rotation** (`execute`) — persist each `SetWriters` op built from a writer-set rotation, keyed by its object/context scope.

Data `Put`/`Delete` ops are **not** hooked: they live in the storage Merkle tree (the `entities_root` component of `scope_root`), not the projection — so the op-store mirrors exactly the planes the projection folds.

## Why it's safe

**Observe-only** — nothing reads the op-store for a decision yet (the per-plane read flips do that). The persist is:
- independent of the projection lock,
- logged-not-propagated on failure (can never affect the governance apply or execution),
- idempotent by op id (re-applies / backfills are safe no-ops).

## Test

The persistence + replay is unit-tested in #2911 (persist → reload → replay → same `scope_root`). The hook itself is an additive call inside actix handlers, validated by: context suite stays green (199 pass), node builds, and the maintainer's e2e (the dual-write divergence — op-store-replayed projection vs the live one — surfaces there).

- `cargo test -p calimero-context --features calimero-storage/testing` — 199 pass
- `cargo clippy -p calimero-context --all-targets --features calimero-storage/testing -- -D warnings` — clean
- `cargo build -p calimero-node` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, non-authoritative writes with errors logged only; core apply and execute semantics are unchanged until a future read cutover.
> 
> **Overview**
> **C2.1b** turns on **observe-only dual-write** into the durable unified op-store wherever the scope projection is already fed, so applied ops are persisted by scope without changing read paths yet.
> 
> On **governance apply** (`apply_signed_namespace_op`), after a namespace DAG op is actually applied and the `shadow_op` is built, the handler calls `unified_op_store::persist_op` with that op (namespace scope). On **execution** (`execute`), after a successful apply that produced rotation `SetWriters` ops for the ACL shadow feed, each of those ops is persisted the same way (object/context scope). Data `Put`/`Delete` ops are intentionally **not** written here—they stay in the Merkle tree, matching what the projection folds.
> 
> Failures are **`warn!` only** and never fail governance apply or execution; rotation persistence runs **outside** the projection write lock, independent of lock poisoning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dcd2631a0b822e9c907645a4b6b6fde5777bebd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->