### PR TITLE
feat(context): C2.2 read shadow — op-store reconstruction vs governance-DAG fold

### DIFF
--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -362,6 +362,61 @@ impl ScopeProjections {
             .map(|state| state.scope_root_with_entities(entities_root))
     }
 
+    /// The governance-plane `scope_root` reconstructed PURELY from the unified
+    /// op-store for `scope` — load every persisted op for the scope and fold it,
+    /// then read `scope_root_for` with a fixed (zero) `entities_root` so the result
+    /// reflects only the membership / admin / ACL planes the op-store backs.
+    ///
+    /// The C2.2 read-shadow's view: compared against the governance-DAG fold, a
+    /// mismatch means the dual-write op-store is missing ops the governance DAG has.
+    /// `Ok(None)` when the scope has no persisted ops; `Err` on a store fault.
+    pub fn scope_root_from_op_store(
+        store: &Store,
+        scope: &ScopeId,
+    ) -> eyre::Result<Option<[u8; 32]>> {
+        let ops = crate::unified_op_store::load_scope_ops(store, scope)?;
+        if ops.is_empty() {
+            return Ok(None);
+        }
+        let mut proj = Self::new();
+        for op in &ops {
+            proj.ingest_op(op);
+        }
+        Ok(proj.scope_root_for(scope, [0u8; 32]))
+    }
+
+    /// C2.2 read shadow (observe-only): compare THIS maintained projection's
+    /// governance `scope_root` for `namespace_id` against the same scope
+    /// reconstructed purely from the unified op-store, logging
+    /// `unified_op_store_divergence` on a mismatch. It's how we verify the
+    /// dual-write op-store is COMPLETE (missing no ops the governance DAG has)
+    /// before the op-store becomes the projection's authoritative source (C2.2b).
+    /// Skips silently when this projection hasn't folded the scope, the op-store is
+    /// empty for it, or the store can't be read — none of those are divergences.
+    pub fn shadow_compare_op_store(&self, store: &Store, namespace_id: [u8; 32]) {
+        let scope = ScopeId::from(namespace_id);
+        let Some(dag_root) = self.scope_root_for(&scope, [0u8; 32]) else {
+            return;
+        };
+        match Self::scope_root_from_op_store(store, &scope) {
+            Ok(Some(store_root)) if store_root != dag_root => {
+                tracing::warn!(
+                    marker = "unified_op_store_divergence",
+                    namespace = ?namespace_id,
+                    dag_root = %hex::encode(&dag_root[..8]),
+                    store_root = %hex::encode(&store_root[..8]),
+                    "op-store replay diverges from the governance-DAG fold (dual-write incomplete?)"
+                );
+            }
+            Ok(_) => {}
+            Err(err) => tracing::debug!(
+                %err,
+                namespace = ?namespace_id,
+                "op-store read shadow: op-store load failed; skipping compare"
+            ),
+        }
+    }
+
     /// [`scope_root_for`](Self::scope_root_for) from an EPHEMERAL fold built fresh
     /// from the store, resolving the namespace scope from a `group`. For sync sites
     /// that hold a `Store` but not the node's maintained projection — the C0

--- a/crates/context/src/unified_op_store.rs
+++ b/crates/context/src/unified_op_store.rs
@@ -199,6 +199,19 @@ mod tests {
             .expect("load other")
             .is_empty());
 
+        // The C2.2 read-shadow's reconstruction (`scope_root_from_op_store`) matches
+        // the in-memory fold, and is `None` for a scope with no persisted ops.
+        assert_eq!(
+            ScopeProjections::scope_root_from_op_store(&store, &scope).expect("ok"),
+            Some(want),
+            "op-store reconstruction must match the in-memory fold"
+        );
+        assert_eq!(
+            ScopeProjections::scope_root_from_op_store(&store, &other).expect("ok"),
+            None,
+            "an empty scope reconstructs to None"
+        );
+
         // Reload + replay through the DAG (which re-establishes causal order).
         let loaded = load_scope_ops(&store, &scope).expect("load");
         assert_eq!(loaded.len(), ops.len(), "every persisted op reloaded");

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -787,6 +787,17 @@ fn refresh_projection_for_cut(
             node_state
                 .write_scope_projections()
                 .apply_backfill(namespace_id, ops);
+
+            // C2.2 read shadow (observe-only): the unified op-store must reconstruct
+            // the same governance scope this backfill just folded from the
+            // governance DAG. A mismatch means the dual-write op-store is missing ops
+            // the governance DAG has — the gap C2.2b's read-flip can't tolerate (the
+            // projection is the sole auth decider). Runs only on an actual backfill
+            // (controlled frequency); the compare logs `unified_op_store_divergence`
+            // and never affects the apply.
+            node_state
+                .read_scope_projections()
+                .shadow_compare_op_store(datastore, namespace_id);
         }
     }
 }


### PR DESCRIPTION
The first slice of the read-flip (C2.2). Builds on the dual-write (#2911 + #2912, now merged).

## Why a shadow first

The projection is the **sole authorization decider** (post-F5). Flipping its durable backing from the governance DAG to the unified op-store can't be blind: if the op-store is *incomplete*, auth goes wrong. So C2.2 first **verifies the op-store is complete** — the same shadow-before-flip discipline that carried C0 → C1.

## What

On every controlled-frequency projection backfill (`refresh_projection_for_cut`, which only fires when a cut needs refreshing), rebuild the same namespace scope **purely from the op-store** and compare its governance `scope_root` to the just-folded governance-DAG projection. A mismatch logs `unified_op_store_divergence` — the signal that the dual-write op-store is missing ops the governance DAG has (e.g. an apply path the C2.1b hook doesn't cover, like a backfill path).

**Observe-only**: never affects the apply; skips silently when the scope isn't folded, the op-store is empty for it, or the store can't be read.

- `ScopeProjections::scope_root_from_op_store` — reconstruct a scope's governance `scope_root` purely from `load_scope_ops` + fold.
- `ScopeProjections::shadow_compare_op_store` — the maintained-projection-vs-op-store compare + divergence log (keeps `calimero_op`/`ScopeId` out of the node crate).

## Gate

The e2e divergence gate greps `unified_op_store_divergence`. A clean run across the governance/membership scenarios proves the dual-write op-store faithfully reconstructs the projection — the green light for **C2.2b** (the authoritative read-flip).

## Test

- `scope_root_from_op_store` unit-tested (matches the in-memory fold; `None` for an empty scope), on top of #2911's round-trip-replay test.
- `cargo test -p calimero-context --features calimero-storage/testing` — pass
- `cargo clippy -p calimero-context -p calimero-node --all-targets --features calimero-storage/testing -- -D warnings` — clean
- `cargo build -p calimero-node` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observe-only logging on controlled-frequency backfill; no change to projection reads or auth decisions until C2.2b.
> 
> **Overview**
> Adds **C2.2 observe-only read shadow** so the dual-write unified op-store can be checked for completeness before a future authoritative read-flip (C2.2b).
> 
> **`ScopeProjections::scope_root_from_op_store`** reloads all ops for a namespace scope via `load_scope_ops`, folds them, and returns the governance **`scope_root`** (zero `entities_root`). **`shadow_compare_op_store`** compares that to the maintained projection’s fold and logs **`unified_op_store_divergence`** on mismatch. Unfolded scope, empty op-store, or load errors skip quietly.
> 
> The node calls the shadow **only after a real namespace backfill** in `refresh_projection_for_cut` (same path that refreshes at-cut membership). It does not change apply or authorization.
> 
> Unit tests assert `scope_root_from_op_store` matches the in-memory fold and returns `None` for empty scopes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71155594c323e23da7c36b7f18b240bc5943133e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->