### PR TITLE
fix(context): re-persist late-decrypted governance ops to the op-store on key delivery (C2.2c)

### DIFF
--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1084,6 +1084,46 @@ impl ScopeProjections {
         Some(ops)
     }
 
+    /// Refresh the unified op-store for `namespace_id` from the governance DAG with
+    /// the keys present NOW — the fix for the read-flip blocker (C2.2c).
+    ///
+    /// The apply-time dual-write decodes each governance op with whatever key was
+    /// available at apply time; an encrypted group op applied BEFORE its group key
+    /// arrived was frozen into the op-store as a `Noop`. Once the key lands (the
+    /// key-delivery / `recover_missing_group_keys` path), this re-walks the namespace
+    /// via [`collect_namespace_ops`](Self::collect_namespace_ops) — the canonical
+    /// decode path, which re-decrypts at read time — and re-persists every op. The
+    /// now-decryptable ops re-decode to their real payload (e.g. `MemberAdded`) and
+    /// OVERWRITE the stale `Noop` (same content-addressed op id), so the op-store
+    /// converges to exactly what the projection folds.
+    ///
+    /// Best-effort and idempotent: it runs only on key delivery (infrequent), is
+    /// bounded by the same `MAX_BACKFILL_OPS` walk cap, and a persist failure just
+    /// leaves the op-store stale until the next delivery — it never affects the
+    /// governance apply. Re-persisting an unchanged op rewrites identical bytes.
+    pub fn repersist_namespace_ops(store: &Store, namespace_id: [u8; 32]) {
+        let Some(ops) = Self::collect_namespace_ops(store, namespace_id) else {
+            return;
+        };
+        let mut refreshed = 0usize;
+        for op in &ops {
+            match crate::unified_op_store::persist_op(store, op) {
+                Ok(()) => refreshed += 1,
+                Err(err) => tracing::warn!(
+                    %err,
+                    namespace = ?namespace_id,
+                    op = ?op.id,
+                    "op-store: failed to re-persist governance op after key delivery"
+                ),
+            }
+        }
+        tracing::debug!(
+            namespace = ?namespace_id,
+            count = refreshed,
+            "op-store: re-persisted governance ops with current decryption after key delivery"
+        );
+    }
+
     /// Ingest the ops [`collect_namespace_ops`] gathered and mark the namespace
     /// backfilled — the cheap, lock-held half. Always ingests (no early-out on an
     /// already-backfilled namespace) so a *refresh* re-walk — triggered when the

--- a/crates/context/tests/op_store_reconstruction.rs
+++ b/crates/context/tests/op_store_reconstruction.rs
@@ -1,30 +1,27 @@
-//! Deterministic repro for the C2.2b read-flip blocker (deferred in PR #2916).
+//! Deterministic before/after for the C2.2b read-flip blocker + its C2.2c fix.
 //!
 //! The unified op-store must reconstruct the SAME namespace-governance membership
 //! that `collect_namespace_ops` (the governance-DAG walk) does — otherwise making
 //! the op-store the projection's authoritative backing silently drops members.
 //!
-//! The bug this pins: an encrypted group `MemberAdded` can be applied to the
-//! governance DAG BEFORE its group key arrives (keys travel on a separate
-//! delivery/pull path and lag — see the buffer-awaiting-key replay in
-//! `apply_group_op_inner`). At that moment the apply-time dual-write decrypts with
-//! no key, so `op_from_namespace_op` folds the op as `Noop` and that `Noop` is
-//! frozen into the op-store. Once the key lands, `collect_namespace_ops`
-//! re-decrypts the SAME op at read time and recovers the real `MemberAdded` — but
-//! the op-store still holds the frozen `Noop`. Flipping the projection onto the
-//! op-store therefore loses the membership, the new member's writes are rejected,
-//! and sync never converges (the joiner-write timeout seen across group-3node /
-//! scaffolding-e2e / shared-storage-rotation when the flip was live).
+//! The bug: an encrypted group `MemberAdded` can be applied to the governance DAG
+//! BEFORE its group key arrives (keys travel on a separate delivery/pull path and
+//! lag — see the buffer-awaiting-key replay in `apply_group_op_inner`). At that
+//! moment the apply-time dual-write decrypts with no key, so `op_from_namespace_op`
+//! folds the op as `Noop` and that `Noop` is frozen into the op-store. Once the key
+//! lands, `collect_namespace_ops` re-decrypts the SAME op at read time and recovers
+//! the real `MemberAdded` — but the op-store still held the frozen `Noop`, so a
+//! projection read off the op-store loses the membership, the new member's writes
+//! are rejected, and sync never converges (the joiner-write timeout seen across
+//! group-3node / scaffolding-e2e / shared-storage-rotation when the flip was live).
+//! `scope_root` doesn't catch it: at shadow time neither side has decrypted yet
+//! (both `Noop` → roots match); the divergence only appears post-key.
 //!
-//! `scope_root` alone does NOT catch this: at the moment the C2.2 shadow runs,
-//! neither side has decrypted yet (both `Noop`), so the roots match. The
-//! divergence only surfaces after the key arrives — which is why only e2e caught
-//! it. This test makes it deterministic.
-//!
-//! Run it with `cargo test -p calimero-context --test op_store_reconstruction --
-//! --ignored`. It is `#[ignore]`d (it FAILS today, on purpose) so it doesn't break
-//! CI; un-ignore it as the gate for the fix that makes `load_scope_ops` faithfully
-//! reconstruct late-decrypted membership.
+//! The fix (`ScopeProjections::repersist_namespace_ops`, called on the
+//! key-delivery path): once the key lands, re-walk the namespace with current
+//! decryption and re-persist every op, overwriting the frozen `Noop` with the real
+//! `MemberAdded`. This test asserts the op-store diverges BEFORE the re-persist and
+//! converges AFTER.
 
 use std::sync::Arc;
 
@@ -70,11 +67,7 @@ fn meta(admin: PublicKey) -> GroupMetaValue {
 }
 
 #[test]
-#[ignore = "reproduces the C2.2b read-flip blocker (PR #2916): the unified op-store freezes a \
-            Noop for an encrypted MemberAdded applied before its group key arrives, while \
-            collect_namespace_ops re-decrypts it once the key is present. Un-ignore as the gate \
-            for the fix that makes load_scope_ops faithfully reconstruct late-decrypted membership."]
-fn op_store_reconstruction_matches_governance_dag_for_late_decrypted_membership() {
+fn op_store_reconstruction_recovers_late_decrypted_membership_after_key_delivery() {
     let store = store();
     let admin = PrivateKey::random(&mut OsRng).public_key();
     let member = PrivateKey::random(&mut OsRng).public_key();
@@ -131,34 +124,45 @@ fn op_store_reconstruction_matches_governance_dag_for_late_decrypted_membership(
     let frozen = op_from_namespace_op(&signed, None, delta_id, hlc(1), &[]);
     persist_op(&store, &frozen).unwrap();
 
-    // Reconstruct the projection BOTH ways the flip could, then read membership at
-    // the op's cut.
     let heads = [delta_id];
 
+    // Read membership from a fresh fold of whatever the op-store currently holds.
+    let store_membership = |store: &Store| {
+        let store_ops = load_scope_ops(store, &ScopeId::from(ns_bytes)).unwrap();
+        let mut proj = ScopeProjections::new();
+        proj.apply_backfill(ns_bytes, store_ops);
+        proj.member_at_cut(store, ns, &member, &heads)
+    };
+
+    // The governance-DAG walk re-decrypts (key present) and sees the member — this
+    // is the truth the op-store must match.
     let dag_ops = ScopeProjections::collect_namespace_ops(&store, ns_bytes).unwrap();
     let mut p_dag = ScopeProjections::new();
     p_dag.apply_backfill(ns_bytes, dag_ops);
     let dag_member = p_dag.member_at_cut(&store, ns, &member, &heads);
-
-    let store_ops = load_scope_ops(&store, &ScopeId::from(ns_bytes)).unwrap();
-    let mut p_store = ScopeProjections::new();
-    p_store.apply_backfill(ns_bytes, store_ops);
-    let store_member = p_store.member_at_cut(&store, ns, &member, &heads);
-
-    // Sanity: the governance-DAG walk re-decrypts and DOES see the member.
     assert_eq!(
         dag_member,
         Some(true),
         "governance-DAG reconstruction should re-decrypt the MemberAdded and see the member"
     );
 
-    // The invariant the flip needs: the op-store reconstruction must agree. It does
-    // NOT today — it froze a Noop, so the member is missing. This is the joiner-write
-    // divergence that broke sync when the read-flip was live.
+    // BEFORE the fix: the op-store froze a Noop, so its reconstruction drops the
+    // member — the joiner-write divergence that broke sync when the flip was live.
     assert_eq!(
-        store_member, dag_member,
-        "op-store reconstruction must match the governance-DAG reconstruction; the op-store froze \
-         a Noop for the encrypted MemberAdded (key absent at apply) while collect re-decrypted it \
-         (key present at read) — flipping onto the op-store drops the member"
+        store_membership(&store),
+        Some(false),
+        "precondition: the op-store froze the encrypted MemberAdded as a Noop"
+    );
+
+    // THE FIX: a key delivery re-persists the namespace's ops with current
+    // decryption, overwriting the frozen Noop with the real MemberAdded.
+    ScopeProjections::repersist_namespace_ops(&store, ns_bytes);
+
+    // AFTER: the op-store reconstruction now matches the governance-DAG fold.
+    assert_eq!(
+        store_membership(&store),
+        dag_member,
+        "after key delivery the op-store must reconstruct the same membership as the governance \
+         DAG; repersist_namespace_ops should have overwritten the frozen Noop with the MemberAdded"
     );
 }

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -1408,6 +1408,19 @@ impl SyncManager {
                             self.reconcile_after_divergence(report).await;
                         }
                         self.drain_governance_pending_after_sync().await;
+
+                        // The arrived key may have made governance ops that were
+                        // applied (and frozen as `Noop` in the unified op-store)
+                        // before the key landed now decode to their real payload.
+                        // Refresh the op-store from the governance DAG with the key
+                        // present so its reconstruction matches the projection — the
+                        // C2.2c fix for the read-flip's late-decrypted-membership gap.
+                        let store = self.context_client.datastore_handle().into_inner();
+                        calimero_context::scope_projection::ScopeProjections::repersist_namespace_ops(
+                            &store,
+                            namespace_id,
+                        );
+                        drop(store);
                     }
                     Err(err) => {
                         warn!(


### PR DESCRIPTION
## What

Fixes the root cause behind the C2.2b read-flip's joiner-write divergence (diagnosed + reproduced in #2916).

**The bug:** the apply-time dual-write decodes each governance op with whatever group key is present *at apply time*. An encrypted group op (e.g. `MemberAdded`) applied **before its key arrives** — keys lag on a separate delivery/pull path; the buffer-awaiting-key replay in `apply_group_op_inner` exists precisely for this — is frozen into the unified op-store as a `Noop`. `collect_namespace_ops` re-decrypts the same op at *read* time once the key lands, but the op-store still holds the `Noop`. So a projection read off the op-store **drops the membership** → the joiner's writes are rejected → sync never converges. (`scope_root` doesn't catch it: at shadow time neither side has decrypted, both `Noop` → roots match.)

## The fix

`ScopeProjections::repersist_namespace_ops` re-walks the namespace via `collect_namespace_ops` (the canonical decode path, which re-decrypts at read time) and re-persists every op. The now-decryptable ops re-decode to their real payload and **overwrite the stale `Noop`** (same content-addressed op id), so the op-store converges to exactly what the projection folds.

Wired into `recover_missing_group_keys` — the single runtime key-delivery chokepoint — right after a key is applied. It is:
- **best-effort + idempotent** (re-persisting an unchanged op rewrites identical bytes),
- **bounded** by `MAX_BACKFILL_OPS`,
- **rare** (runs only on key delivery), and
- **never affects the governance apply** (failures are logged, not propagated).

## Test

`tests/op_store_reconstruction.rs` is now a deterministic **before/after** (un-ignored, runs in CI):
- BEFORE the re-persist: op-store reconstruction = `Some(false)` (froze a `Noop`), governance-DAG fold = `Some(true)` → diverges.
- AFTER `repersist_namespace_ops`: op-store reconstruction = `Some(true)` → converges.

## Scope / sequencing

No behavioral change to auth or sync — nothing reads the op-store yet. This is **unit-gated** (the regression test) and unblocks re-attempting the read-flip, which lands as a **separate, e2e-gated PR**.

Stacked on #2916 (it builds on that PR's repro test); will rebase onto master when #2916 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes membership reconstruction on the governance/sync key-delivery path, but behavior is best-effort, idempotent, and gated by a deterministic regression test; governance apply is unchanged.
> 
> **Overview**
> Fixes **C2.2c**: when an encrypted group governance op was dual-written to the unified op-store **before** its group key arrived, it was stored as a `Noop` while `collect_namespace_ops` later decrypts it at read time. That mismatch would drop membership if projection reads came from the op-store.
> 
> Adds **`ScopeProjections::repersist_namespace_ops`**, which re-walks the namespace through `collect_namespace_ops` and re-persists each op so decryptable payloads overwrite stale `Noop` entries (same op id). It is best-effort, bounded by `MAX_BACKFILL_OPS`, and does not affect governance apply.
> 
> Hooks this into **`recover_missing_group_keys`** immediately after a successful direct key delivery, so the op-store is refreshed when keys land.
> 
> The **`op_store_reconstruction`** test is enabled in CI as a before/after gate: frozen `Noop` diverges from the DAG fold pre-repersist, then converges after.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0eb22b531b28277ceacf36c90d1a52a134db454. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->