### PR TITLE
feat(context): C2.2b read-flip — the unified op-store backs the projection

### DIFF
--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -385,33 +385,38 @@ impl ScopeProjections {
         Ok(proj.scope_root_for(scope, [0u8; 32]))
     }
 
-    /// The governance ops to fold for `namespace_id`.
+    /// The governance ops to fold for `namespace_id` (cutover C2.2b read-flip): the
+    /// unified **op-store** is the projection's authoritative backing, so prefer
+    /// [`load_scope_ops`](crate::unified_op_store::load_scope_ops). Falls back to the
+    /// governance-DAG walk ([`collect_namespace_ops`](Self::collect_namespace_ops))
+    /// only when the op-store has no rows for this scope (a cold namespace not yet
+    /// dual-written) or can't be read — a transitional safety net that retires with
+    /// `collect_namespace_ops` at C5.
     ///
-    /// The C2.2b read-flip (make the unified op-store the projection's authoritative
-    /// backing via [`load_scope_ops`](crate::unified_op_store::load_scope_ops)) is
-    /// DEFERRED: flipping the read onto the op-store broke convergence in the
-    /// maintainer's e2e — group-3node / scaffolding-e2e / shared-storage rotation all
-    /// timed out on the joiner's post-write sync.
-    ///
-    /// ROOT CAUSE (pinned deterministically by `tests/op_store_reconstruction.rs`):
-    /// an encrypted group `MemberAdded` can apply to the governance DAG BEFORE its
-    /// group key arrives (keys lag on a separate delivery path; see the
-    /// buffer-awaiting-key replay in `apply_group_op_inner`). The apply-time
-    /// dual-write then decrypts with no key, so the op is frozen into the op-store as
-    /// a `Noop`. `collect_namespace_ops` RE-DECRYPTS the same op at read time once the
-    /// key lands and recovers the real `MemberAdded`, but the op-store still holds the
-    /// `Noop` — so reading membership from the op-store drops the member, the joiner's
-    /// writes are rejected, and sync never converges. `scope_root` doesn't surface it
-    /// because at shadow time neither side has decrypted yet (both `Noop` → roots
-    /// match); the divergence only appears after the key arrives.
-    ///
-    /// Until the op-store faithfully reconstructs late-decrypted membership (e.g.
-    /// re-persist on the key-arrival replay, or re-decrypt on load) this stays on the
-    /// governance DAG, the proven-correct source. The op-store keeps being
-    /// dual-written.
+    /// The earlier flip attempt broke convergence because an encrypted group op
+    /// applied BEFORE its group key arrived was frozen into the op-store as a `Noop`
+    /// (the apply-time dual-write decrypts with whatever key is present then), so the
+    /// op-store dropped late-decrypted membership. That is fixed: a key delivery now
+    /// re-persists the namespace's ops with current decryption
+    /// ([`repersist_namespace_ops`](Self::repersist_namespace_ops)), so the op-store
+    /// converges to what `collect_namespace_ops` folds — proven by
+    /// `tests/op_store_reconstruction.rs`. The flip can therefore read the op-store
+    /// directly.
     #[must_use]
     pub fn ops_for_namespace(store: &Store, namespace_id: [u8; 32]) -> Option<Vec<Op>> {
-        Self::collect_namespace_ops(store, namespace_id)
+        let scope = ScopeId::from(namespace_id);
+        match crate::unified_op_store::load_scope_ops(store, &scope) {
+            Ok(ops) if !ops.is_empty() => Some(ops),
+            Ok(_) => Self::collect_namespace_ops(store, namespace_id),
+            Err(err) => {
+                tracing::warn!(
+                    %err,
+                    namespace = ?namespace_id,
+                    "op-store load failed; falling back to the governance-DAG fold"
+                );
+                Self::collect_namespace_ops(store, namespace_id)
+            }
+        }
     }
 
     /// [`scope_root_for`](Self::scope_root_for) from an EPHEMERAL fold built fresh

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -306,6 +306,23 @@ impl ScopeProjections {
         // O(1) dedup: `insert` is true only for a not-yet-seen id.
         if self.seen.entry(op.scope).or_default().insert(op.id) {
             self.logs.entry(op.scope).or_default().push(op.clone());
+        } else if !matches!(op.payload, OpPayload::Noop) {
+            // Already seen, but `op.id` is the SIGNED op's content hash, not the
+            // decoded payload's — so an encrypted op first folded as `Noop` (applied
+            // before its group key arrived) shares an id with its later, decrypted
+            // form. The op-log is what the at-cut auth view (`acl_view_at` →
+            // `member_at_cut`) folds, so a stale `Noop` left here drops the
+            // late-decrypted membership even after the op-store is corrected. Upgrade
+            // the log entry in place when a non-`Noop` payload arrives for a
+            // previously-`Noop` id; never downgrade (decryption only adds info).
+            if let Some(log) = self.logs.get_mut(&op.scope) {
+                if let Some(existing) = log
+                    .iter_mut()
+                    .find(|e| e.id == op.id && matches!(e.payload, OpPayload::Noop))
+                {
+                    *existing = op.clone();
+                }
+            }
         }
     }
 

--- a/crates/context/tests/op_store_reconstruction.rs
+++ b/crates/context/tests/op_store_reconstruction.rs
@@ -166,3 +166,83 @@ fn op_store_reconstruction_recovers_late_decrypted_membership_after_key_delivery
          DAG; repersist_namespace_ops should have overwritten the frozen Noop with the MemberAdded"
     );
 }
+
+/// The case the fresh-projection test above MISSED, which broke the e2e: a
+/// **maintained** projection that already folded the op as `Noop` (live apply
+/// before the key arrived). `op.id` is the signed-op hash, so the `Noop` and the
+/// decrypted form share an id; the op-log dedups by id, so re-ingesting the
+/// corrected op via a later backfill must UPGRADE the stale `Noop` entry — not be
+/// dropped as a duplicate — or `member_at_cut` (which folds the op-log) stays
+/// stuck on the `Noop` and the joiner's writes are rejected forever.
+#[test]
+fn maintained_projection_recovers_late_decrypted_membership_on_backfill() {
+    let store = store();
+    let admin = PrivateKey::random(&mut OsRng).public_key();
+    let member = PrivateKey::random(&mut OsRng).public_key();
+
+    let ns = ContextGroupId::from([0x11; 32]);
+    let ns_bytes = ns.to_bytes();
+
+    MetaRepository::new(&store).save(&ns, &meta(admin)).unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&ns, &admin, GroupMemberRole::Admin)
+        .unwrap();
+    let group_key = [0x5A; 32];
+    let key_id = GroupKeyring::new(&store, ns).store_key(&group_key).unwrap();
+
+    let inner = GroupOp::MemberAdded {
+        member,
+        role: GroupMemberRole::Member,
+    };
+    let encrypted = GroupKeyring::encrypt_op(&group_key, &inner).unwrap();
+    let signed = SignedNamespaceOp {
+        version: 1,
+        namespace_id: ns_bytes,
+        parent_op_hashes: Vec::new(),
+        state_hash: [0u8; 32],
+        signer: admin,
+        nonce: 1,
+        op: NamespaceOp::Group {
+            group_id: ns_bytes,
+            key_id,
+            encrypted,
+            key_rotation: None,
+        },
+        signature: [0u8; 64],
+    };
+    let delta_id = signed.content_hash().unwrap();
+    NamespaceOpLogService::new(&store, ns_bytes)
+        .store_signed_operation(&signed)
+        .unwrap();
+    NamespaceDagService::new(&store, ns_bytes)
+        .advance_dag_head(delta_id, &[], 0)
+        .unwrap();
+
+    let heads = [delta_id];
+
+    // A MAINTAINED projection that first folded the op WITHOUT the key (the live
+    // apply path before key delivery): the op-log records a `Noop`. The op-store
+    // froze the same `Noop` via the dual-write.
+    let mut proj = ScopeProjections::new();
+    let frozen = op_from_namespace_op(&signed, None, delta_id, hlc(1), &[]);
+    proj.ingest_op(&frozen);
+    persist_op(&store, &frozen).unwrap();
+    assert_eq!(
+        proj.member_at_cut(&store, ns, &member, &heads),
+        Some(false),
+        "precondition: the maintained projection folded the op as a Noop"
+    );
+
+    // Key delivery: the op-store is re-persisted with current decryption, then the
+    // projection backfills from it — exactly the production sequence.
+    ScopeProjections::repersist_namespace_ops(&store, ns_bytes);
+    let ops = ScopeProjections::ops_for_namespace(&store, ns_bytes).unwrap();
+    proj.apply_backfill(ns_bytes, ops);
+
+    // The re-ingested op must UPGRADE the stale Noop in the op-log, not dedup away.
+    assert_eq!(
+        proj.member_at_cut(&store, ns, &member, &heads),
+        Some(true),
+        "the maintained projection must recover the member after the corrected op is re-ingested"
+    );
+}

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -783,9 +783,10 @@ fn refresh_projection_for_cut(
         .read_scope_projections()
         .namespace_to_refresh(datastore, group, heads);
     if let Some(namespace_id) = needs_backfill {
-        // The projection folds the governance DAG (`ops_for_namespace`). The C2.2b
-        // read-flip onto the unified op-store is DEFERRED — it drops late-decrypted
-        // membership; see `ops_for_namespace` and the deterministic repro in
+        // C2.2b read-flip: the unified op-store is the projection's authoritative
+        // backing now (`ops_for_namespace` loads it, falling back to the governance
+        // DAG only for a cold scope). Late-decrypted membership is kept faithful by
+        // the key-delivery re-persist (`repersist_namespace_ops`); see
         // `calimero-context` `tests/op_store_reconstruction.rs`.
         if let Some(ops) = ScopeProjections::ops_for_namespace(datastore, namespace_id) {
             node_state

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -1409,20 +1409,35 @@ impl SyncManager {
                         }
 
                         // The arrived key may have made governance ops that were
-                        // applied (and frozen as `Noop` in the unified op-store)
-                        // before the key landed now decode to their real payload.
-                        // Refresh the op-store from the governance DAG with the key
-                        // present so its reconstruction matches the projection — the
-                        // C2.2c fix for the read-flip's late-decrypted-membership gap.
-                        // BEFORE the drain: the projection backs onto the op-store
-                        // now (C2.2b), so the drain's membership re-checks must see the
+                        // applied before the key landed — frozen as `Noop` both in the
+                        // unified op-store (dual-write) and in the maintained
+                        // projection's op-log (the live `ingest_op`) — now decode to
+                        // their real payload. Two-step refresh so the projection, which
+                        // backs onto the op-store (C2.2b), reflects the membership:
+                        //   1. re-persist the op-store from the governance DAG with the
+                        //      key present, then
+                        //   2. re-ingest the corrected ops into the maintained
+                        //      projection. `ingest_op` upgrades the stale `Noop` op-log
+                        //      entries in place (the op id is the signed-op hash, shared
+                        //      by both forms), so `member_at_cut` sees the membership.
+                        // BEFORE the drain: its membership re-checks must see the
                         // corrected ops, not the stale Noop.
                         let store = self.context_client.datastore_handle().into_inner();
                         calimero_context::scope_projection::ScopeProjections::repersist_namespace_ops(
                             &store,
                             namespace_id,
                         );
+                        let refreshed =
+                            calimero_context::scope_projection::ScopeProjections::ops_for_namespace(
+                                &store,
+                                namespace_id,
+                            );
                         drop(store);
+                        if let Some(ops) = refreshed {
+                            self.node_state
+                                .write_scope_projections()
+                                .apply_backfill(namespace_id, ops);
+                        }
 
                         self.drain_governance_pending_after_sync().await;
                     }

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -1407,7 +1407,6 @@ impl SyncManager {
                         if let Some(report) = divergence {
                             self.reconcile_after_divergence(report).await;
                         }
-                        self.drain_governance_pending_after_sync().await;
 
                         // The arrived key may have made governance ops that were
                         // applied (and frozen as `Noop` in the unified op-store)
@@ -1415,12 +1414,17 @@ impl SyncManager {
                         // Refresh the op-store from the governance DAG with the key
                         // present so its reconstruction matches the projection — the
                         // C2.2c fix for the read-flip's late-decrypted-membership gap.
+                        // BEFORE the drain: the projection backs onto the op-store
+                        // now (C2.2b), so the drain's membership re-checks must see the
+                        // corrected ops, not the stale Noop.
                         let store = self.context_client.datastore_handle().into_inner();
                         calimero_context::scope_projection::ScopeProjections::repersist_namespace_ops(
                             &store,
                             namespace_id,
                         );
                         drop(store);
+
+                        self.drain_governance_pending_after_sync().await;
                     }
                     Err(err) => {
                         warn!(


### PR DESCRIPTION
## What

Re-attempt of the C2.2b read-flip: `ops_for_namespace` reads the unified **op-store** (`load_scope_ops`) as the projection's authoritative governance source, falling back to the governance-DAG walk (`collect_namespace_ops`) only for a cold scope (no persisted ops) or a store read error — a transitional safety net that retires with `collect_namespace_ops` at C5.

## Why it's safe now

The first attempt (reverted in #2916) broke convergence: an encrypted group op applied **before its group key arrived** was frozen into the op-store as a `Noop`, so the op-store dropped late-decrypted membership → the joiner's writes were rejected → sync stalled.

That root cause is fixed by **#2918** (the parent of this PR): a key delivery now re-persists the namespace's ops with current decryption (`repersist_namespace_ops`), so the op-store converges to exactly what `collect_namespace_ops` folds — proven deterministically by `tests/op_store_reconstruction.rs` (op-store reconstruction diverges before the re-persist, converges after).

## Also

Reorders the re-persist to run **before** `drain_governance_pending_after_sync` in `recover_missing_group_keys`. The drain re-checks membership through the projection, which now backs onto the op-store, so it must see the corrected ops rather than the stale `Noop`.

## Gate

This is the behavioral change — **e2e-gated**. The joiner-write scenarios that timed out on the first attempt (`group-3node`, `scaffolding-e2e`, `shared-storage` rotation) must now converge. Unit coverage (op-store ≡ governance-DAG reconstruction) is green via the parent PR's regression test.

Stacked on #2918; rebases onto master when it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the authoritative source for membership folds and sync gates; mitigated by repersist-on-key-delivery, in-log Noop upgrades, and targeted tests, but e2e convergence remains the real gate.
> 
> **Overview**
> Re-enables **C2.2b**: namespace governance for projections is loaded from the unified **op-store** (`load_scope_ops`), with a fallback to the governance-DAG walk only for empty cold scopes or store read errors.
> 
> **Maintained projection fix:** when the same signed op id was first ingested as `Noop` (encrypted op before the group key) and later arrives decrypted, `ingest_op` **upgrades** the op-log entry in place instead of deduping it away, so `member_at_cut` sees late-decrypted membership.
> 
> **Sync after key recovery:** on direct group-key delivery, the node **re-persists** ops, reloads from the op-store, **backfills** the maintained projection, then runs `drain_governance_pending_after_sync` so membership re-checks see corrected ops—not stale `Noop`s.
> 
> Adds a regression test for the maintained-projection backfill path (the gap the fresh-fold test missed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbc7725d561c1bae7ddcc7020a02a9fa9121519e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->