### PR TITLE
feat(context): C3 Stage 0 — op-store completeness gate (observe-only)

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -480,6 +480,30 @@ jobs:
           fi
           echo "no unified_projection_divergence markers — projection agrees with the live decision"
 
+      - name: Report unified op-store completeness (C3 Stage 0, observe-only)
+        if: always()
+        run: |
+          # The C3 completeness gate logs `op_store_incomplete` whenever the unified
+          # op-store is missing a governance op the gov-DAG has — i.e. some apply path
+          # isn't dual-writing the op-store. This turns "incomplete op-store" from a
+          # mystery 60s sync timeout (how the read-flip failed three times) into a
+          # cheap, specific signal naming the missing op count per namespace.
+          #
+          # OBSERVE-ONLY for now: the op-store is KNOWN incomplete until C3 closes the
+          # structural write gaps (local-authoring A4/A5/B1, genesis G1/G2). This step
+          # reports the markers so each stage can watch the count fall to zero; it does
+          # NOT fail the job. It becomes a HARD gate at C3 Stage 4, when the read flips
+          # onto the op-store and zero markers is the precondition.
+          if grep -rl "op_store_incomplete" docker-logs/ 2>/dev/null | grep -q .; then
+              count=$(grep -rho "op_store_incomplete" docker-logs/ | wc -l | tr -d ' ')
+              echo "::notice::op-store incomplete in ${{ matrix.workflow }} — $count marker(s) (expected during C3; observe-only)"
+              echo "sample (missing_count per namespace):"
+              grep -rho 'op_store_incomplete[^}]*missing_count=[0-9]*' docker-logs/ | sed -E 's/.*(missing_count=[0-9]*).*/\1/' | sort | uniq -c | head
+              grep -rn "op_store_incomplete" docker-logs/ | head -10
+          else
+              echo "no op_store_incomplete markers — op-store mirrors the gov-DAG for every exercised namespace"
+          fi
+
       - name: List docker-logs/ before upload (debug)
         if: always()
         run: ls -la docker-logs/ 2>&1 || echo "docker-logs/ missing"

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -498,10 +498,19 @@ jobs:
               count=$(grep -rho "op_store_incomplete" docker-logs/ | wc -l | tr -d ' ')
               echo "::notice::op-store incomplete in ${{ matrix.workflow }} — $count marker(s) (expected during C3; observe-only)"
               echo "sample (missing_count per namespace):"
-              grep -rho 'op_store_incomplete[^}]*missing_count=[0-9]*' docker-logs/ | sed -E 's/.*(missing_count=[0-9]*).*/\1/' | sort | uniq -c | head
+              # Match `missing_count=N` anywhere on an op_store_incomplete line — robust
+              # to field ordering. Tolerates the line not carrying the field at all.
+              grep -rho 'op_store_incomplete.*' docker-logs/ | grep -oE 'missing_count=[0-9]+' | sort | uniq -c | head
               grep -rn "op_store_incomplete" docker-logs/ | head -10
           else
               echo "no op_store_incomplete markers — op-store mirrors the gov-DAG for every exercised namespace"
+          fi
+          # A load fault makes completeness UNVERIFIED (distinct from clean) — surface
+          # it so a store error can't read as a passing gate.
+          if grep -rl "op_store_gate_unavailable" docker-logs/ 2>/dev/null | grep -q .; then
+              gc=$(grep -rho "op_store_gate_unavailable" docker-logs/ | wc -l | tr -d ' ')
+              echo "::notice::op-store completeness UNVERIFIED in ${{ matrix.workflow }} — $gc gate-load failure(s)"
+              grep -rn "op_store_gate_unavailable" docker-logs/ | head -5
           fi
 
       - name: List docker-logs/ before upload (debug)

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -500,17 +500,16 @@ jobs:
               echo "sample (missing_count per namespace):"
               # Match `missing_count=N` anywhere on an op_store_incomplete line — robust
               # to field ordering. Tolerates the line not carrying the field at all.
-              grep -rho 'op_store_incomplete.*' docker-logs/ | grep -oE 'missing_count=[0-9]+' | sort | uniq -c | head
+              grep -rho 'op_store_incomplete.*' docker-logs/ | grep -oE 'missing_count=[0-9]+' | sort | uniq -c | head -10
               grep -rn "op_store_incomplete" docker-logs/ | head -10
-          else
-              echo "no op_store_incomplete markers — op-store mirrors the gov-DAG for every exercised namespace"
-          fi
-          # A load fault makes completeness UNVERIFIED (distinct from clean) — surface
-          # it so a store error can't read as a passing gate.
-          if grep -rl "op_store_gate_unavailable" docker-logs/ 2>/dev/null | grep -q .; then
+          elif grep -rl "op_store_gate_unavailable" docker-logs/ 2>/dev/null | grep -q .; then
+              # No gap markers, but the gate couldn't load the op-store somewhere — do
+              # NOT claim a clean mirror, that would be a false "verified" line.
               gc=$(grep -rho "op_store_gate_unavailable" docker-logs/ | wc -l | tr -d ' ')
-              echo "::notice::op-store completeness UNVERIFIED in ${{ matrix.workflow }} — $gc gate-load failure(s)"
+              echo "::notice::op-store completeness UNVERIFIED in ${{ matrix.workflow }} — no gaps seen but $gc gate-load failure(s); mirror NOT confirmed"
               grep -rn "op_store_gate_unavailable" docker-logs/ | head -5
+          else
+              echo "no op_store_incomplete or op_store_gate_unavailable markers — op-store mirrors the gov-DAG for every exercised namespace"
           fi
 
       - name: List docker-logs/ before upload (debug)

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1137,23 +1137,42 @@ impl ScopeProjections {
     /// (zero markers ⇒ the op-store provably mirrors the gov-DAG for that namespace).
     ///
     /// `dag_ops` is the gov-DAG fold the caller already computed (the backfill walk),
-    /// so this adds one op-store load, not a second DAG walk. Never affects apply.
-    /// Returns the missing op ids (empty ⇒ complete) so it is directly testable; the
-    /// node caller ignores the return and relies on the `op_store_incomplete` marker.
+    /// so this adds one op-store load, not a second DAG walk. It runs only on an
+    /// actual backfill — `namespace_to_refresh` returns `None` for an already-folded
+    /// (warm) cut, so the steady-state per-delta path does NOT pay this; the load
+    /// happens on cold/refresh cuts only, and the whole gate retires at Stage 4 when
+    /// the read flips onto the op-store. Never affects apply.
+    ///
+    /// Returns the missing op ids (empty ⇒ complete OR couldn't-check) so it is
+    /// directly testable; the node caller ignores the return and relies on the
+    /// markers: `op_store_incomplete` (a real gap) and `op_store_gate_unavailable`
+    /// (the op-store load failed, so completeness is UNVERIFIED — distinct from clean,
+    /// so a store fault can't masquerade as a passing gate).
     pub fn check_op_store_completeness(
         store: &Store,
         namespace_id: [u8; 32],
         dag_ops: &[Op],
     ) -> Vec<[u8; 32]> {
+        // Nothing to verify against an empty gov-DAG fold.
+        if dag_ops.is_empty() {
+            return Vec::new();
+        }
         let scope = ScopeId::from(namespace_id);
         let store_ids: HashSet<[u8; 32]> =
             match crate::unified_op_store::load_scope_ops(store, &scope) {
                 Ok(ops) => ops.iter().map(|op| op.id).collect(),
                 Err(err) => {
-                    tracing::debug!(
-                        %err,
+                    // A load fault must NOT read as "complete" (empty missing list):
+                    // CI treats no `op_store_incomplete` as a clean op-store, so a
+                    // store error would silently hide real gaps the gate exists to
+                    // surface. Emit a DISTINCT marker so a couldn't-check is visibly
+                    // different from a verified-clean.
+                    tracing::warn!(
+                        marker = "op_store_gate_unavailable",
                         namespace = ?namespace_id,
-                        "op-store completeness gate: load failed; skipping"
+                        %err,
+                        "op-store completeness gate could not load the op-store — \
+                         completeness UNVERIFIED for this namespace this round"
                     );
                     return Vec::new();
                 }

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1124,6 +1124,60 @@ impl ScopeProjections {
         );
     }
 
+    /// Observe-only completeness gate (cutover C3 Stage 0): warn when the unified
+    /// op-store is MISSING governance ops the gov-DAG has for `namespace_id`.
+    ///
+    /// The op-store is only authoritative once every governance apply path writes it.
+    /// Until then it is a dual-write shadow with structural gaps (locally-authored
+    /// ops and genesis never `persist_op`), and an incomplete op-store surfaces only
+    /// as a 60-second sync timeout in e2e — after a read flips onto it. This compares
+    /// the two op-id sets and emits `op_store_incomplete` with the count + a sample
+    /// missing id, so a gap is a cheap, deterministic, greppable signal INSTEAD of a
+    /// mystery timeout. It is the gate every later C3 stage is checked against
+    /// (zero markers ⇒ the op-store provably mirrors the gov-DAG for that namespace).
+    ///
+    /// `dag_ops` is the gov-DAG fold the caller already computed (the backfill walk),
+    /// so this adds one op-store load, not a second DAG walk. Never affects apply.
+    /// Returns the missing op ids (empty ⇒ complete) so it is directly testable; the
+    /// node caller ignores the return and relies on the `op_store_incomplete` marker.
+    pub fn check_op_store_completeness(
+        store: &Store,
+        namespace_id: [u8; 32],
+        dag_ops: &[Op],
+    ) -> Vec<[u8; 32]> {
+        let scope = ScopeId::from(namespace_id);
+        let store_ids: HashSet<[u8; 32]> =
+            match crate::unified_op_store::load_scope_ops(store, &scope) {
+                Ok(ops) => ops.iter().map(|op| op.id).collect(),
+                Err(err) => {
+                    tracing::debug!(
+                        %err,
+                        namespace = ?namespace_id,
+                        "op-store completeness gate: load failed; skipping"
+                    );
+                    return Vec::new();
+                }
+            };
+        let missing: Vec<[u8; 32]> = dag_ops
+            .iter()
+            .map(|op| op.id)
+            .filter(|id| !store_ids.contains(id))
+            .collect();
+        if !missing.is_empty() {
+            tracing::warn!(
+                marker = "op_store_incomplete",
+                namespace = ?namespace_id,
+                missing_count = missing.len(),
+                dag_count = dag_ops.len(),
+                op_store_count = store_ids.len(),
+                sample_missing = %hex::encode(&missing[0][..8]),
+                "unified op-store is missing governance ops the gov-DAG has — \
+                 a governance apply path is not dual-writing the op-store"
+            );
+        }
+        missing
+    }
+
     /// Ingest the ops [`collect_namespace_ops`] gathered and mark the namespace
     /// backfilled — the cheap, lock-held half. Always ingests (no early-out on an
     /// already-backfilled namespace) so a *refresh* re-walk — triggered when the

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1143,30 +1143,32 @@ impl ScopeProjections {
     /// happens on cold/refresh cuts only, and the whole gate retires at Stage 4 when
     /// the read flips onto the op-store. Never affects apply.
     ///
-    /// Returns the missing op ids (empty ⇒ complete OR couldn't-check) so it is
-    /// directly testable; the node caller ignores the return and relies on the
-    /// markers: `op_store_incomplete` (a real gap) and `op_store_gate_unavailable`
-    /// (the op-store load failed, so completeness is UNVERIFIED — distinct from clean,
-    /// so a store fault can't masquerade as a passing gate).
+    /// Returns `Some(missing_ids)` when the check ran (`Some(vec![])` ⇒ verified
+    /// complete), or `None` when the op-store couldn't be loaded (couldn't-check —
+    /// distinct from clean, so a store fault can't masquerade as a passing gate). The
+    /// node caller ignores the return and relies on the markers: `op_store_incomplete`
+    /// (a real gap) and `op_store_gate_unavailable` (load failed). The `Option`
+    /// distinction is for tests and any future programmatic caller (e.g. the Stage 4
+    /// hard gate).
     pub fn check_op_store_completeness(
         store: &Store,
         namespace_id: [u8; 32],
         dag_ops: &[Op],
-    ) -> Vec<[u8; 32]> {
-        // Nothing to verify against an empty gov-DAG fold.
+    ) -> Option<Vec<[u8; 32]>> {
+        // Nothing to verify against an empty gov-DAG fold — verified-complete.
         if dag_ops.is_empty() {
-            return Vec::new();
+            return Some(Vec::new());
         }
         let scope = ScopeId::from(namespace_id);
         let store_ids: HashSet<[u8; 32]> =
             match crate::unified_op_store::load_scope_ops(store, &scope) {
                 Ok(ops) => ops.iter().map(|op| op.id).collect(),
                 Err(err) => {
-                    // A load fault must NOT read as "complete" (empty missing list):
-                    // CI treats no `op_store_incomplete` as a clean op-store, so a
-                    // store error would silently hide real gaps the gate exists to
-                    // surface. Emit a DISTINCT marker so a couldn't-check is visibly
-                    // different from a verified-clean.
+                    // A load fault must NOT read as "complete": CI treats no
+                    // `op_store_incomplete` as a clean op-store, so a store error would
+                    // silently hide real gaps the gate exists to surface. Return `None`
+                    // (couldn't-check, distinct from `Some(vec![])` = verified clean)
+                    // and emit a distinct marker.
                     tracing::warn!(
                         marker = "op_store_gate_unavailable",
                         namespace = ?namespace_id,
@@ -1174,7 +1176,7 @@ impl ScopeProjections {
                         "op-store completeness gate could not load the op-store — \
                          completeness UNVERIFIED for this namespace this round"
                     );
-                    return Vec::new();
+                    return None;
                 }
             };
         let missing: Vec<[u8; 32]> = dag_ops
@@ -1194,7 +1196,7 @@ impl ScopeProjections {
                  a governance apply path is not dual-writing the op-store"
             );
         }
-        missing
+        Some(missing)
     }
 
     /// Ingest the ops [`collect_namespace_ops`] gathered and mark the namespace

--- a/crates/context/tests/op_store_reconstruction.rs
+++ b/crates/context/tests/op_store_reconstruction.rs
@@ -212,14 +212,16 @@ fn completeness_gate_flags_governance_ops_missing_from_the_op_store() {
 
     assert_eq!(
         ScopeProjections::check_op_store_completeness(&store, ns_bytes, &dag_ops),
-        vec![op3.id],
+        Some(vec![op3.id]),
         "the gate must flag exactly the op missing from the op-store"
     );
 
-    // Once the gap is closed, the gate is clean.
+    // Once the gap is closed, the gate is verified-clean (Some(empty)) — distinct from
+    // None (couldn't-check).
     persist_op(&store, &op3).unwrap();
-    assert!(
-        ScopeProjections::check_op_store_completeness(&store, ns_bytes, &dag_ops).is_empty(),
-        "a complete op-store yields no missing ops"
+    assert_eq!(
+        ScopeProjections::check_op_store_completeness(&store, ns_bytes, &dag_ops),
+        Some(Vec::new()),
+        "a complete op-store yields a verified-empty missing list"
     );
 }

--- a/crates/context/tests/op_store_reconstruction.rs
+++ b/crates/context/tests/op_store_reconstruction.rs
@@ -30,7 +30,9 @@ use calimero_context::group_store::{
 };
 use calimero_context::scope_projection::{op_from_namespace_op, ScopeProjections};
 use calimero_context::unified_op_store::{load_scope_ops, persist_op};
-use calimero_context_client::local_governance::{GroupOp, NamespaceOp, SignedNamespaceOp};
+use calimero_context_client::local_governance::{
+    EncryptedGroupOp, GroupOp, NamespaceOp, SignedNamespaceOp,
+};
 use calimero_context_config::types::ContextGroupId;
 use calimero_op::ScopeId;
 use calimero_primitives::context::GroupMemberRole;
@@ -164,5 +166,60 @@ fn op_store_reconstruction_recovers_late_decrypted_membership_after_key_delivery
         dag_member,
         "after key delivery the op-store must reconstruct the same membership as the governance \
          DAG; repersist_namespace_ops should have overwritten the frozen Noop with the MemberAdded"
+    );
+}
+
+/// C3 Stage 0: the completeness gate flags exactly the governance ops the gov-DAG
+/// has but the op-store is missing — the deterministic net for the structural
+/// dual-write gaps (local-authoring / genesis) that sank the read-flip in e2e.
+#[test]
+fn completeness_gate_flags_governance_ops_missing_from_the_op_store() {
+    let store = store();
+    let admin = PrivateKey::random(&mut OsRng).public_key();
+    let ns = ContextGroupId::from([0x22; 32]);
+    let ns_bytes = ns.to_bytes();
+
+    // Build distinct governance ops as the gov-DAG fold yields them (payload is
+    // irrelevant — the gate compares op ids — so fold each as a Noop envelope).
+    let op = |id: u8| {
+        let signed = SignedNamespaceOp {
+            version: 1,
+            namespace_id: ns_bytes,
+            parent_op_hashes: Vec::new(),
+            state_hash: [0u8; 32],
+            signer: admin,
+            nonce: u64::from(id),
+            op: NamespaceOp::Group {
+                group_id: ns_bytes,
+                key_id: [0u8; 32],
+                encrypted: EncryptedGroupOp {
+                    nonce: [0u8; 12],
+                    ciphertext: Vec::new(),
+                },
+                key_rotation: None,
+            },
+            signature: [0u8; 64],
+        };
+        op_from_namespace_op(&signed, None, [id; 32], hlc(u64::from(id)), &[])
+    };
+    let (op1, op2, op3) = (op(1), op(2), op(3));
+
+    // The gov-DAG fold has all three; the op-store is missing op3 (e.g. it was
+    // authored locally on a path that doesn't dual-write).
+    persist_op(&store, &op1).unwrap();
+    persist_op(&store, &op2).unwrap();
+    let dag_ops = vec![op1, op2, op3.clone()];
+
+    assert_eq!(
+        ScopeProjections::check_op_store_completeness(&store, ns_bytes, &dag_ops),
+        vec![op3.id],
+        "the gate must flag exactly the op missing from the op-store"
+    );
+
+    // Once the gap is closed, the gate is clean.
+    persist_op(&store, &op3).unwrap();
+    assert!(
+        ScopeProjections::check_op_store_completeness(&store, ns_bytes, &dag_ops).is_empty(),
+        "a complete op-store yields no missing ops"
     );
 }

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -783,11 +783,15 @@ fn refresh_projection_for_cut(
         .read_scope_projections()
         .namespace_to_refresh(datastore, group, heads);
     if let Some(namespace_id) = needs_backfill {
-        // The projection folds the governance DAG (`ops_for_namespace`). The C2.2b
-        // read-flip onto the unified op-store is DEFERRED — it drops late-decrypted
-        // membership; see `ops_for_namespace` and the deterministic repro in
-        // `calimero-context` `tests/op_store_reconstruction.rs`.
+        // The projection folds the governance DAG (`ops_for_namespace`). The read-flip
+        // onto the unified op-store is being re-approached via C3 (make the op-store
+        // authoritative by construction); see the C3 plan + `ops_for_namespace`.
         if let Some(ops) = ScopeProjections::ops_for_namespace(datastore, namespace_id) {
+            // C3 Stage 0 completeness gate (observe-only): the `ops` here are the
+            // gov-DAG fold, so cross-check that the op-store has them all and log
+            // `op_store_incomplete` for any it's missing — the deterministic signal
+            // that a governance apply path isn't dual-writing the op-store.
+            ScopeProjections::check_op_store_completeness(datastore, namespace_id, &ops);
             node_state
                 .write_scope_projections()
                 .apply_backfill(namespace_id, ops);


### PR DESCRIPTION
## Why

The C2.2b read-flip onto the unified op-store failed e2e **three times** — each a different structural gap (op froze `Noop` pre-key, maintained-projection op-log stuck, and finally **locally-authored governance ops never reaching the op-store**). Root cause: the op-store is a *partial shadow* of the gov-DAG, and an incomplete op-store only surfaced as a **60-second sync timeout**, after I'd verified a local repro green.

Per the agreed re-sequencing (**decision B**), the op-store becomes authoritative *by construction* — every governance apply path writes it — across staged PRs. **This is Stage 0: the net** that makes the remaining gaps cheap and specific instead of mystery timeouts.

## What

- `ScopeProjections::check_op_store_completeness` compares the op-store's op-id set against the gov-DAG fold the backfill already computed, and logs `op_store_incomplete` (missing count + sample id) for any op the op-store lacks. Returns the missing ids, so it's directly unit-tested.
- Wired **observe-only** into the projection backfill (`refresh_projection_for_cut`) — one extra op-store load, no second DAG walk, never affects apply.
- The e2e workflow **reports** the marker per scenario (observe-only): the op-store is *known* incomplete until later C3 stages close the write gaps (local-authoring A4/A5/B1, genesis G1/G2), so this does not fail the job. It becomes a **hard gate at Stage 4**, when the read flips onto the op-store and zero markers is the precondition.

## Scope

No behavioral change — the projection still folds the gov-DAG (`ops_for_namespace = collect_namespace_ops`). This only adds a diagnostic. Unit test asserts the gate flags exactly the missing op and is clean once closed.

## The C3 staging this opens
0. **completeness gate (this PR)**
1. close local namespace authoring (A4/A5) → `persist_op` at the local apply sites
2. close genesis (G1 root is the hard one — the namespace root has no foldable op)
3. **long pole:** persist the decoded op from inside `apply_group_op_inner` after a successful decrypt (kills the `Noop`-freeze at the source) + a local group-author hook (B1)
4. retire the `collect_namespace_ops` fallback — read the op-store only (the flip, now safe by construction); flip this gate to hard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostic-only: no change to authorization, apply paths, or which source the projection reads; failures are limited to new warn logs and CI notices until Stage 4.
> 
> **Overview**
> **C3 Stage 0** introduces a **diagnostic net** so an incomplete unified op-store shows up as greppable log markers instead of opaque e2e sync timeouts.
> 
> `ScopeProjections::check_op_store_completeness` compares op IDs from an already-computed gov-DAG fold against `load_scope_ops` for the namespace. It emits `op_store_incomplete` (with `missing_count` and a sample id) when the store is short, and `op_store_gate_unavailable` when the store cannot be loaded—so a load failure is not mistaken for “complete.”
> 
> The node calls this **observe-only** during projection backfill in `refresh_projection_for_cut` (one extra op-store read on cold/refresh cuts; steady state unchanged). Projection still folds via `ops_for_namespace` / `collect_namespace_ops`.
> 
> E2E adds an **always-on, non-failing** step that reports those markers in `docker-logs/` (intended to become a hard gate at C3 Stage 4). A unit test asserts the gate flags exactly missing ops and returns verified-clean once dual-written.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ef980a5ab28ff5387fc6ea5f01d6c7bf291d6fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->