### PR TITLE
feat(context): C3 Stage 1 — persist locally-authored governance ops to the op-store

### DIFF
--- a/crates/context/src/handlers/create_group.rs
+++ b/crates/context/src/handlers/create_group.rs
@@ -254,6 +254,13 @@ impl Handler<CreateGroupRequest> for ContextManager {
                     {
                         Ok(report) => {
                             report.observe("create_group", "GroupCreated");
+                            // C3 Stage 1: the local author wrote GroupCreated to the
+                            // gov-DAG; land it in the unified op-store too so the
+                            // op-store stays a complete mirror (by construction).
+                            crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
+                                &datastore,
+                                namespace_id.to_bytes(),
+                            );
                         }
                         Err(e) => {
                             tracing::warn!(?e, "failed to publish GroupCreated on namespace DAG");

--- a/crates/context/src/handlers/delete_group.rs
+++ b/crates/context/src/handlers/delete_group.rs
@@ -135,6 +135,11 @@ impl Handler<DeleteGroupRequest> for ContextManager {
                 )
                 .await?;
                 report.observe("delete_group", "GroupDeleted");
+                // C3 Stage 1: mirror the locally-authored GroupDeleted into the op-store.
+                crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
+                    &datastore,
+                    namespace_id_bytes,
+                );
 
                 // Best-effort unsubscribe — the group is gone now, no point
                 // staying on its topic. Subscriptions for descendants likewise.

--- a/crates/context/src/handlers/join_context.rs
+++ b/crates/context/src/handlers/join_context.rs
@@ -277,6 +277,12 @@ impl Handler<JoinContextRequest> for ContextManager {
                              until an admin explicitly add_group_members the joiner"
                         );
                     }
+                    // C3 Stage 1: mirror the locally-authored MemberJoinedOpen into
+                    // the op-store (a no-op if the publish/apply above errored).
+                    crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
+                        &datastore,
+                        ns_id.to_bytes(),
+                    );
                 }
 
                 Ok(JoinContextResponse {

--- a/crates/context/src/handlers/join_subgroup_inheritance.rs
+++ b/crates/context/src/handlers/join_subgroup_inheritance.rs
@@ -160,6 +160,11 @@ impl Handler<JoinSubgroupInheritanceRequest> for ContextManager {
                     );
                     e
                 })?;
+                // C3 Stage 1: mirror the locally-authored MemberJoinedOpen into the op-store.
+                crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
+                    &datastore,
+                    ns_id.to_bytes(),
+                );
 
                 Ok(JoinSubgroupInheritanceResponse {
                     group_id,

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1124,6 +1124,73 @@ impl ScopeProjections {
         );
     }
 
+    /// Persist the namespace's current gov-DAG head op(s) to the unified op-store
+    /// (cutover C3 Stage 1, by-construction): a locally-authored governance op writes
+    /// the gov-DAG (`advance_dag_head`) but NOT the op-store, because the dual-write
+    /// only fires on the receive handler. Called right after authoring, this lands the
+    /// just-authored op — now a head — without re-walking the namespace.
+    ///
+    /// Heads-only is sufficient going forward because the op-store is kept complete
+    /// incrementally: every op is persisted as it is received (the apply handler) or
+    /// authored (here), so a new op's ancestors are already present. Root ops are
+    /// cleartext; an encrypted group head the author holds the key for decodes via
+    /// `decrypt_group_op`. Best-effort and idempotent; never affects authoring.
+    pub fn persist_namespace_head_ops(store: &Store, namespace_id: [u8; 32]) {
+        let heads = match NamespaceDagService::new(store, namespace_id).read_head_record() {
+            Ok(head) => head.parent_hashes,
+            Err(err) => {
+                tracing::debug!(
+                    namespace = ?namespace_id,
+                    %err,
+                    "op-store: governance head unreadable; skipping authored-op persist"
+                );
+                return;
+            }
+        };
+        let op_log = NamespaceOpLogService::new(store, namespace_id);
+        for id in heads {
+            let signed = match op_log.get_signed_op(id) {
+                Ok(Some(signed)) => signed,
+                _ => continue,
+            };
+            let Ok(delta) = signed_namespace_op_to_delta(&signed) else {
+                continue;
+            };
+            let decrypted = match &signed.op {
+                calimero_governance_types::NamespaceOp::Group {
+                    group_id,
+                    key_id,
+                    encrypted,
+                    ..
+                } => calimero_governance_store::decrypt_group_op(
+                    store,
+                    namespace_id,
+                    ContextGroupId::from(*group_id),
+                    key_id,
+                    encrypted,
+                )
+                .ok()
+                .flatten(),
+                calimero_governance_types::NamespaceOp::Root(_) => None,
+            };
+            let op = op_from_namespace_op(
+                &signed,
+                decrypted.as_ref(),
+                delta.id,
+                delta.hlc,
+                &delta.parents,
+            );
+            if let Err(err) = crate::unified_op_store::persist_op(store, &op) {
+                tracing::warn!(
+                    %err,
+                    namespace = ?namespace_id,
+                    op = ?op.id,
+                    "op-store: failed to persist locally-authored governance op"
+                );
+            }
+        }
+    }
+
     /// Observe-only completeness gate (cutover C3 Stage 0): warn when the unified
     /// op-store is MISSING governance ops the gov-DAG has for `namespace_id`.
     ///

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1124,71 +1124,22 @@ impl ScopeProjections {
         );
     }
 
-    /// Persist the namespace's current gov-DAG head op(s) to the unified op-store
-    /// (cutover C3 Stage 1, by-construction): a locally-authored governance op writes
-    /// the gov-DAG (`advance_dag_head`) but NOT the op-store, because the dual-write
-    /// only fires on the receive handler. Called right after authoring, this lands the
-    /// just-authored op — now a head — without re-walking the namespace.
+    /// Persist a locally-authored namespace's governance ops to the unified op-store
+    /// (cutover C3 Stage 1, by-construction): a locally-authored op writes the gov-DAG
+    /// (`advance_dag_head`) but NOT the op-store, because the dual-write only fires on
+    /// the receive handler. Called right after authoring.
     ///
-    /// Heads-only is sufficient going forward because the op-store is kept complete
-    /// incrementally: every op is persisted as it is received (the apply handler) or
-    /// authored (here), so a new op's ancestors are already present. Root ops are
-    /// cleartext; an encrypted group head the author holds the key for decodes via
-    /// `decrypt_group_op`. Best-effort and idempotent; never affects authoring.
+    /// This persists the WHOLE gov-DAG fold, not just the current heads. A heads-only
+    /// persist would be racy: the caller authors, then awaits the publish round-trip,
+    /// and the actor can apply a concurrent peer op during that await — advancing the
+    /// head so the just-authored op is no longer a head and a heads-only persist skips
+    /// it. The full walk via [`repersist_namespace_ops`](Self::repersist_namespace_ops)
+    /// captures the authored op wherever it landed in the DAG, reuses
+    /// `collect_namespace_ops`'s read-error logging, and is bounded by `MAX_BACKFILL_OPS`
+    /// (local authoring is infrequent, and re-persisting an unchanged op is idempotent).
+    /// Best-effort; never affects authoring.
     pub fn persist_namespace_head_ops(store: &Store, namespace_id: [u8; 32]) {
-        let heads = match NamespaceDagService::new(store, namespace_id).read_head_record() {
-            Ok(head) => head.parent_hashes,
-            Err(err) => {
-                tracing::debug!(
-                    namespace = ?namespace_id,
-                    %err,
-                    "op-store: governance head unreadable; skipping authored-op persist"
-                );
-                return;
-            }
-        };
-        let op_log = NamespaceOpLogService::new(store, namespace_id);
-        for id in heads {
-            let signed = match op_log.get_signed_op(id) {
-                Ok(Some(signed)) => signed,
-                _ => continue,
-            };
-            let Ok(delta) = signed_namespace_op_to_delta(&signed) else {
-                continue;
-            };
-            let decrypted = match &signed.op {
-                calimero_governance_types::NamespaceOp::Group {
-                    group_id,
-                    key_id,
-                    encrypted,
-                    ..
-                } => calimero_governance_store::decrypt_group_op(
-                    store,
-                    namespace_id,
-                    ContextGroupId::from(*group_id),
-                    key_id,
-                    encrypted,
-                )
-                .ok()
-                .flatten(),
-                calimero_governance_types::NamespaceOp::Root(_) => None,
-            };
-            let op = op_from_namespace_op(
-                &signed,
-                decrypted.as_ref(),
-                delta.id,
-                delta.hlc,
-                &delta.parents,
-            );
-            if let Err(err) = crate::unified_op_store::persist_op(store, &op) {
-                tracing::warn!(
-                    %err,
-                    namespace = ?namespace_id,
-                    op = ?op.id,
-                    "op-store: failed to persist locally-authored governance op"
-                );
-            }
-        }
+        Self::repersist_namespace_ops(store, namespace_id);
     }
 
     /// Observe-only completeness gate (cutover C3 Stage 0): warn when the unified

--- a/crates/context/tests/op_store_reconstruction.rs
+++ b/crates/context/tests/op_store_reconstruction.rs
@@ -228,16 +228,31 @@ fn completeness_gate_flags_governance_ops_missing_from_the_op_store() {
 
 /// C3 Stage 1: `persist_namespace_head_ops` lands a locally-authored op (written to
 /// the gov-DAG but not the op-store) into the op-store, closing the local-author gap.
+/// Uses a REAL encrypted MemberAdded + key so the persisted op carries the decoded
+/// membership — verifying the payload decodes, not just that the id appears.
 #[test]
 fn persist_namespace_head_ops_lands_locally_authored_op_in_the_op_store() {
     let store = store();
     let admin = PrivateKey::random(&mut OsRng).public_key();
+    let member = PrivateKey::random(&mut OsRng).public_key();
     let ns = ContextGroupId::from([0x33; 32]);
     let ns_bytes = ns.to_bytes();
     MetaRepository::new(&store).save(&ns, &meta(admin)).unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&ns, &admin, GroupMemberRole::Admin)
+        .unwrap();
+    // The author holds the group key (they authored the op) — so the persist path's
+    // decrypt succeeds and the real MemberAdded is folded, not a Noop.
+    let group_key = [0x7C; 32];
+    let key_id = GroupKeyring::new(&store, ns).store_key(&group_key).unwrap();
 
-    // Simulate local authoring: the op is in the gov-DAG (op-log + head) but NOT the
-    // op-store — exactly the gap the local-author path leaves.
+    // Simulate local authoring: an encrypted MemberAdded is in the gov-DAG (op-log +
+    // head) but NOT the op-store — exactly the gap the local-author path leaves.
+    let inner = GroupOp::MemberAdded {
+        member,
+        role: GroupMemberRole::Member,
+    };
+    let encrypted = GroupKeyring::encrypt_op(&group_key, &inner).unwrap();
     let signed = SignedNamespaceOp {
         version: 1,
         namespace_id: ns_bytes,
@@ -247,11 +262,8 @@ fn persist_namespace_head_ops_lands_locally_authored_op_in_the_op_store() {
         nonce: 1,
         op: NamespaceOp::Group {
             group_id: ns_bytes,
-            key_id: [0u8; 32],
-            encrypted: EncryptedGroupOp {
-                nonce: [0u8; 12],
-                ciphertext: Vec::new(),
-            },
+            key_id,
+            encrypted,
             key_rotation: None,
         },
         signature: [0u8; 64],
@@ -273,14 +285,19 @@ fn persist_namespace_head_ops_lands_locally_authored_op_in_the_op_store() {
 
     ScopeProjections::persist_namespace_head_ops(&store, ns_bytes);
 
-    let ids: Vec<[u8; 32]> = load_scope_ops(&store, &ScopeId::from(ns_bytes))
-        .unwrap()
-        .iter()
-        .map(|op| op.id)
-        .collect();
+    // The op is now in the op-store AND decodes to the real membership: a fresh fold
+    // of the op-store sees `member` (proves the payload landed, not just the id).
+    let store_ops = load_scope_ops(&store, &ScopeId::from(ns_bytes)).unwrap();
     assert_eq!(
-        ids,
+        store_ops.iter().map(|op| op.id).collect::<Vec<_>>(),
         vec![delta_id],
-        "the authored head op must now be in the op-store"
+        "the authored op must now be in the op-store"
+    );
+    let mut proj = ScopeProjections::new();
+    proj.apply_backfill(ns_bytes, store_ops);
+    assert_eq!(
+        proj.member_at_cut(&store, ns, &member, &[delta_id]),
+        Some(true),
+        "the persisted op must decode to the real MemberAdded — the op-store fold sees the member"
     );
 }

--- a/crates/context/tests/op_store_reconstruction.rs
+++ b/crates/context/tests/op_store_reconstruction.rs
@@ -225,3 +225,62 @@ fn completeness_gate_flags_governance_ops_missing_from_the_op_store() {
         "a complete op-store yields a verified-empty missing list"
     );
 }
+
+/// C3 Stage 1: `persist_namespace_head_ops` lands a locally-authored op (written to
+/// the gov-DAG but not the op-store) into the op-store, closing the local-author gap.
+#[test]
+fn persist_namespace_head_ops_lands_locally_authored_op_in_the_op_store() {
+    let store = store();
+    let admin = PrivateKey::random(&mut OsRng).public_key();
+    let ns = ContextGroupId::from([0x33; 32]);
+    let ns_bytes = ns.to_bytes();
+    MetaRepository::new(&store).save(&ns, &meta(admin)).unwrap();
+
+    // Simulate local authoring: the op is in the gov-DAG (op-log + head) but NOT the
+    // op-store — exactly the gap the local-author path leaves.
+    let signed = SignedNamespaceOp {
+        version: 1,
+        namespace_id: ns_bytes,
+        parent_op_hashes: Vec::new(),
+        state_hash: [0u8; 32],
+        signer: admin,
+        nonce: 1,
+        op: NamespaceOp::Group {
+            group_id: ns_bytes,
+            key_id: [0u8; 32],
+            encrypted: EncryptedGroupOp {
+                nonce: [0u8; 12],
+                ciphertext: Vec::new(),
+            },
+            key_rotation: None,
+        },
+        signature: [0u8; 64],
+    };
+    let delta_id = signed.content_hash().unwrap();
+    NamespaceOpLogService::new(&store, ns_bytes)
+        .store_signed_operation(&signed)
+        .unwrap();
+    NamespaceDagService::new(&store, ns_bytes)
+        .advance_dag_head(delta_id, &[], 0)
+        .unwrap();
+
+    assert!(
+        load_scope_ops(&store, &ScopeId::from(ns_bytes))
+            .unwrap()
+            .is_empty(),
+        "precondition: the locally-authored op is absent from the op-store"
+    );
+
+    ScopeProjections::persist_namespace_head_ops(&store, ns_bytes);
+
+    let ids: Vec<[u8; 32]> = load_scope_ops(&store, &ScopeId::from(ns_bytes))
+        .unwrap()
+        .iter()
+        .map(|op| op.id)
+        .collect();
+    assert_eq!(
+        ids,
+        vec![delta_id],
+        "the authored head op must now be in the op-store"
+    );
+}


### PR DESCRIPTION
## What

Closes the **A4 gap** behind the read-flip failures: locally-authored namespace governance ops (`GroupCreated`, joins, delete) write the gov-DAG but **never the op-store** — the dual-write only fired on the receive handler. That's why the op-store-backed projection couldn't recognize cuts citing a node's *own* authored ops (`DeltaAuthOutcome::Buffer` → DAG sync timeout).

`ScopeProjections::persist_namespace_head_ops` persists the namespace's current gov-DAG head op(s) right after authoring — the just-authored op (now a head), **without re-walking the namespace**. Heads-only suffices because the op-store is kept complete incrementally (every op persisted as received *or* authored). Root heads are cleartext; an encrypted group head decodes via `decrypt_group_op`. Best-effort, idempotent, never affects authoring.

Wired into the four local namespace-authoring sites: `create_group`, `delete_group`, `join_context`, `join_subgroup_inheritance`.

## Scope / what the gate will catch

The two **admin-API** authoring paths (`create_group_in_namespace`, `reparent_group`) and the quorum post-gate (A5) are **not yet covered** — deliberately. The Stage 0 `op_store_incomplete` gate will *surface* any residual rather than it being a mystery timeout. That's the whole point of landing the net first: partial coverage is now visible and measurable, not silent.

No read flips here — the projection still folds the gov-DAG. This only makes the op-store more complete (observe-only progress toward Stage 4).

## Test

Unit test asserts an op present in the gov-DAG but absent from the op-store is landed by `persist_namespace_head_ops`.

Stacked on #2922 (Stage 0); rebases onto master when it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-author governance persistence on create/delete/join paths; failures are best-effort but incorrect mirroring could still affect future op-store-backed reads and sync convergence.
> 
> **Overview**
> **C3 Stage 1** closes the gap where **locally authored** namespace governance ops (`GroupCreated`, `GroupDeleted`, `MemberJoinedOpen`) land on the gov-DAG but never in the unified op-store, because dual-write only ran on the receive path. That omission broke op-store completeness and could make cuts citing a node’s own ops fail sync (`DeltaAuthOutcome::Buffer`).
> 
> Adds **`ScopeProjections::persist_namespace_head_ops`**, which re-walks the namespace via **`repersist_namespace_ops`** / `collect_namespace_ops` and persists the full DAG fold (not heads-only, to avoid races while awaiting publish). It is **best-effort** and does not change authoring success.
> 
> **Wired after publish** in `create_group`, `delete_group`, `join_context` (inherited `MemberJoinedOpen`), and `join_subgroup_inheritance`.
> 
> Adds a unit test that a gov-DAG-only encrypted `MemberAdded` is mirrored into the op-store with a decodable membership payload. No read flip yet; other local-author paths remain for later stages / the Stage 0 completeness gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78d20b7071d2103cadd34738b49a40eb1f6e313b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->