### PR TITLE
feat: C3 Stage 2 — persist remaining locally-authored governance ops to the op-store

### DIFF
--- a/crates/node/src/join_namespace.rs
+++ b/crates/node/src/join_namespace.rs
@@ -371,6 +371,14 @@ pub async fn await_namespace_ready(
         .await
         .map_err(|e| ReadyError::PublishMemberJoined(e.to_string()))?;
 
+    // C3 Stage 2: the quorum publish wrote MemberJoinedAt to the local gov-DAG
+    // (`publish_post_gate` → `store_operation`) without the receive handler's
+    // dual-write; mirror it into the op-store so it stays a complete mirror.
+    calimero_context::scope_projection::ScopeProjections::persist_namespace_head_ops(
+        store,
+        namespace_id,
+    );
+
     // step 4: assemble ReadyReport with post-publish observable state.
     // Note the read accessors are best-effort — if the underlying
     // store read fails we substitute defaults rather than fail the

--- a/crates/server/src/admin/handlers/groups/reparent_group.rs
+++ b/crates/server/src/admin/handlers/groups/reparent_group.rs
@@ -98,6 +98,11 @@ pub async fn handler(
     {
         Ok(report) => {
             report.observe("reparent_group", "GroupReparented");
+            // C3 Stage 2: mirror the locally-authored GroupReparented into the op-store.
+            calimero_context::scope_projection::ScopeProjections::persist_namespace_head_ops(
+                &state.store,
+                namespace_id.to_bytes(),
+            );
             ApiResponse {
                 payload: ReparentGroupApiResponse {
                     reparented: !was_already_there,

--- a/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
@@ -170,6 +170,12 @@ pub async fn handler(
     {
         Ok(report) => {
             report.observe("create_group_in_namespace", "GroupCreated");
+            // C3 Stage 2: mirror the locally-authored GroupCreated into the op-store
+            // (the admin-API authoring path, like the node handlers).
+            calimero_context::scope_projection::ScopeProjections::persist_namespace_head_ops(
+                &state.store,
+                resolved_ns_id.to_bytes(),
+            );
             let group_id = group_id_cgid;
 
             if let Some(name) = body.group_name.as_deref() {


### PR DESCRIPTION
## What

Closes the Stage 1 residual write gaps — the local-authoring paths the receive-handler dual-write doesn't cover — so the op-store mirrors the gov-DAG:

- **admin-API authoring**: `create_group_in_namespace` (GroupCreated) and `reparent_group` (GroupReparented) — both author via `sign_apply_and_publish`, same as the node handlers in Stage 1.
- **A5 quorum publish**: `join_namespace`'s `sign_and_publish_without_apply` writes `MemberJoinedAt` to the local gov-DAG via `publish_post_gate` → `store_operation` (no local state apply, but the op *is* in the gov-DAG, so `collect_namespace_ops` includes it and the op-store must too).

Each reuses `ScopeProjections::persist_namespace_head_ops` (from Stage 1).

## Why not genesis (G1)

I checked the code: `member_at_cut` reads the namespace-root founding admin **live from `MetaRepository`** as an immutable base fact, *regardless of op source* — so it's resolved identically before and after the flip and is **not a flip blocker**. Genesis is a self-sufficiency cleanup for later, not a coverage gap on the critical path. (Confirmed with @-the-user before reprioritizing.)

## Where this leaves coverage

After this, the op-store should cover every governance apply path **except the group-op plane (B1)** — that's Stage 3 (the long pole: persist decoded op from inside `apply_group_op_inner` after decrypt). The Stage 0 `op_store_incomplete` gate will confirm exactly which markers remain.

No read flips — still observe-only progress toward Stage 4. Reuses the Stage 1 helper (already unit-tested).

Stacked on #2923 → #2922; rebases down as they merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort dual-write only on success paths; no auth or read-flip changes, reusing an already-tested helper.
> 
> **Overview**
> **C3 Stage 2** closes remaining gaps where namespace governance ops land on the local gov-DAG but skip the receive-handler op-store dual-write, by calling **`ScopeProjections::persist_namespace_head_ops`** after successful publishes on three paths.
> 
> After **`await_namespace_ready`** publishes **`MemberJoinedAt`** via **`sign_and_publish_without_apply`**, the op is mirrored into the unified op-store. Admin handlers **`create_group_in_namespace`** (**`GroupCreated`**) and **`reparent_group`** (**`GroupReparented`**) get the same call after **`sign_apply_and_publish_namespace_op`**, matching Stage 1 node handler coverage.
> 
> No read-path changes; persistence is best-effort and reuses the Stage 1 full-fold helper (**`repersist_namespace_ops`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f69881ec57be2f0aa188dd6ca4639329aa95182f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->