### PR TITLE
feat(context): C3 Stage 3 — persist locally-authored group ops to the op-store (B1)

### DIFF
--- a/crates/context/src/handlers/add_group_members.rs
+++ b/crates/context/src/handlers/add_group_members.rs
@@ -37,7 +37,7 @@ impl Handler<AddGroupMembersRequest> for ContextManager {
         ActorResponse::r#async(
             async move {
                 for (identity, role) in &members {
-                    let report = calimero_governance_store::sign_apply_and_publish(
+                    let report = crate::sign_apply_and_publish_group_op(
                         &datastore,
                         &node_client,
                         &ack_router,

--- a/crates/context/src/handlers/admit_tee_node.rs
+++ b/crates/context/src/handlers/admit_tee_node.rs
@@ -199,7 +199,7 @@ impl Handler<AdmitTeeNodeRequest> for ContextManager {
                     PrivateKey::from(effective_signing_key.ok_or_else(|| {
                         eyre::eyre!("no signing key available for TEE admission")
                     })?);
-                let report = calimero_governance_store::sign_apply_and_publish(
+                let report = crate::sign_apply_and_publish_group_op(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -586,7 +586,7 @@ async fn create_context(
     // worst case is a single context associated with a since-removed member.
     {
         let sk = PrivateKey::from(*identity_secret);
-        let report = calimero_governance_store::sign_apply_and_publish(
+        let report = crate::sign_apply_and_publish_group_op(
             &datastore,
             &node_client,
             &ack_router,
@@ -609,7 +609,7 @@ async fn create_context(
 
     if let Some(ref name_str) = name {
         let sk = PrivateKey::from(*identity_secret);
-        let report = calimero_governance_store::sign_apply_and_publish(
+        let report = crate::sign_apply_and_publish_group_op(
             &datastore,
             &node_client,
             &ack_router,

--- a/crates/context/src/handlers/delete_context.rs
+++ b/crates/context/src/handlers/delete_context.rs
@@ -138,7 +138,7 @@ async fn delete_context(
                      cannot publish local detach op"
                 )
             })?;
-        let report = calimero_governance_store::sign_apply_and_publish(
+        let report = crate::sign_apply_and_publish_group_op(
             &datastore,
             &node_client,
             &ack_router,

--- a/crates/context/src/handlers/detach_context_from_group.rs
+++ b/crates/context/src/handlers/detach_context_from_group.rs
@@ -44,7 +44,7 @@ impl Handler<DetachContextFromGroupRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                let report = calimero_governance_store::sign_apply_and_publish(
+                let report = crate::sign_apply_and_publish_group_op(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/leave_group.rs
+++ b/crates/context/src/handlers/leave_group.rs
@@ -126,7 +126,7 @@ impl Handler<LeaveGroupRequest> for ContextManager {
                 // (which enforces owner / last-admin / direct-row checks
                 // again) and broadcasts to peers. Errors at apply bubble
                 // up here as the user-facing failure.
-                let report = calimero_governance_store::sign_apply_and_publish(
+                let report = crate::sign_apply_and_publish_group_op(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/leave_namespace.rs
+++ b/crates/context/src/handlers/leave_namespace.rs
@@ -120,7 +120,7 @@ impl Handler<LeaveNamespaceRequest> for ContextManager {
                 // performs the multi-scope owner / last-admin checks +
                 // cascade across descendants. If any check fails, the error
                 // surfaces here as the user-facing failure.
-                let report = calimero_governance_store::sign_apply_and_publish(
+                let report = crate::sign_apply_and_publish_group_op(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/remove_group_members.rs
+++ b/crates/context/src/handlers/remove_group_members.rs
@@ -70,6 +70,18 @@ impl Handler<RemoveGroupMembersRequest> for ContextManager {
                     )
                     .await?;
                     report.observe("remove_group_members", "MemberRemoved");
+                    // C3 Stage 3: mirror the locally-authored MemberRemoved (the
+                    // key-rotation removal path) into the op-store, like the other
+                    // group-op authoring sites.
+                    if let Ok(namespace_id) =
+                        calimero_governance_store::NamespaceRepository::new(&datastore)
+                            .resolve(&group_id)
+                    {
+                        crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
+                            &datastore,
+                            namespace_id.to_bytes(),
+                        );
+                    }
                 }
                 info!(
                     ?group_id,

--- a/crates/context/src/handlers/remove_group_members.rs
+++ b/crates/context/src/handlers/remove_group_members.rs
@@ -70,17 +70,26 @@ impl Handler<RemoveGroupMembersRequest> for ContextManager {
                     )
                     .await?;
                     report.observe("remove_group_members", "MemberRemoved");
-                    // C3 Stage 3: mirror the locally-authored MemberRemoved (the
-                    // key-rotation removal path) into the op-store, like the other
-                    // group-op authoring sites.
-                    if let Ok(namespace_id) =
-                        calimero_governance_store::NamespaceRepository::new(&datastore)
-                            .resolve(&group_id)
+                    // C3 Stage 3: mirror the locally-authored MemberRemoved into the
+                    // op-store, like the other group-op authoring sites. The
+                    // `persist_namespace_head_ops` walk persists the WHOLE namespace
+                    // fold, so the MemberRemoved op (which carries its key-rotation
+                    // bundle inline — not as separate ops) is captured regardless of
+                    // head position.
+                    match calimero_governance_store::NamespaceRepository::new(&datastore)
+                        .resolve(&group_id)
                     {
-                        crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
-                            &datastore,
-                            namespace_id.to_bytes(),
-                        );
+                        Ok(namespace_id) => {
+                            crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
+                                &datastore,
+                                namespace_id.to_bytes(),
+                            );
+                        }
+                        Err(err) => tracing::warn!(
+                            %err,
+                            ?group_id,
+                            "C3: could not resolve namespace to mirror MemberRemoved into the op-store"
+                        ),
                     }
                 }
                 info!(

--- a/crates/context/src/handlers/set_member_auto_follow.rs
+++ b/crates/context/src/handlers/set_member_auto_follow.rs
@@ -50,7 +50,7 @@ impl Handler<SetMemberAutoFollowRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                let report = calimero_governance_store::sign_apply_and_publish(
+                let report = crate::sign_apply_and_publish_group_op(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/set_member_capabilities.rs
+++ b/crates/context/src/handlers/set_member_capabilities.rs
@@ -45,7 +45,7 @@ impl Handler<SetMemberCapabilitiesRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                let report = calimero_governance_store::sign_apply_and_publish(
+                let report = crate::sign_apply_and_publish_group_op(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/set_subgroup_visibility.rs
+++ b/crates/context/src/handlers/set_subgroup_visibility.rs
@@ -67,7 +67,7 @@ impl Handler<SetSubgroupVisibilityRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                let report = calimero_governance_store::sign_apply_and_publish(
+                let report = crate::sign_apply_and_publish_group_op(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/set_tee_admission_policy.rs
+++ b/crates/context/src/handlers/set_tee_admission_policy.rs
@@ -103,7 +103,7 @@ impl Handler<SetTeeAdmissionPolicyRequest> for ContextManager {
                 let sk = PrivateKey::from(effective_signing_key.ok_or_else(|| {
                     eyre::eyre!("local group governance requires a signing key for the requester")
                 })?);
-                let report = calimero_governance_store::sign_apply_and_publish(
+                let report = crate::sign_apply_and_publish_group_op(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/update_member_role.rs
+++ b/crates/context/src/handlers/update_member_role.rs
@@ -71,7 +71,7 @@ impl Handler<UpdateMemberRoleRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                let report = calimero_governance_store::sign_apply_and_publish(
+                let report = crate::sign_apply_and_publish_group_op(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -211,7 +211,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                         // short-circuit on its applied marker, so the new
                         // bytecode would never activate.
                         for rung in &rungs {
-                            let report = calimero_governance_store::sign_apply_and_publish(
+                            let report = crate::sign_apply_and_publish_group_op(
                                 &datastore,
                                 &node_client,
                                 &ack_router_for_lazy,
@@ -224,7 +224,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                             )
                             .await?;
                             report.observe("upgrade_group", "TargetApplicationSet");
-                            let report = calimero_governance_store::sign_apply_and_publish(
+                            let report = crate::sign_apply_and_publish_group_op(
                                 &datastore,
                                 &node_client,
                                 &ack_router_for_lazy,
@@ -379,7 +379,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                     .as_ref()
                     .ok_or_else(|| eyre::eyre!("target application not found"))?;
                 let app_key = *app_meta.bytecode.blob_id().as_ref();
-                let report = calimero_governance_store::sign_apply_and_publish(
+                let report = crate::sign_apply_and_publish_group_op(
                     &datastore_for_canary,
                     &node_client,
                     &ack_router_for_canary,
@@ -395,7 +395,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                 // Unconditional — see the LazyOnAccess site: clearing a stale
                 // method on code-only upgrades keeps the same-id lazy trigger
                 // out of the migration arm.
-                let report = calimero_governance_store::sign_apply_and_publish(
+                let report = crate::sign_apply_and_publish_group_op(
                     &datastore_for_canary,
                     &node_client,
                     &ack_router_for_canary,
@@ -1614,7 +1614,7 @@ fn dispatch_cascade(
 
         let sk = PrivateKey::from(effective_signing_key);
 
-        let report = calimero_governance_store::sign_apply_and_publish(
+        let report = crate::sign_apply_and_publish_group_op(
             &datastore_for_publish,
             &node_client_for_publish,
             &ack_router_for_publish,

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -730,7 +730,7 @@ impl ContextManager {
 
         ActorResponse::r#async(
             async move {
-                let _report = calimero_governance_store::sign_apply_and_publish(
+                let _report = crate::sign_apply_and_publish_group_op(
                     &datastore,
                     &node_client,
                     &ack_router,
@@ -745,6 +745,47 @@ impl ContextManager {
             .into_actor(self),
         )
     }
+}
+
+/// Author a group governance op (the B1 local-authoring path) and mirror it into
+/// the unified op-store — C3 Stage 3.
+///
+/// `calimero_governance_store::sign_apply_and_publish` applies the op to the local
+/// group plane and publishes the encrypted `NamespaceOp::Group` to the namespace
+/// gov-DAG (`publish_post_gate` → `store_operation`), but never writes the op-store:
+/// the dual-write only fires on the receive handler, so the AUTHOR's own op-store
+/// was missing every group op it authored. That's the structural gap behind the
+/// read-flip's "governance cut not locally known" timeouts.
+///
+/// After publishing, the encrypted op is the namespace gov-DAG head and the author
+/// holds the group key, so `persist_namespace_head_ops` decrypts it and lands the
+/// real decoded op. Best-effort: a resolve/persist failure never fails authoring.
+pub(crate) async fn sign_apply_and_publish_group_op(
+    store: &calimero_store::Store,
+    node_client: &calimero_node_primitives::client::NodeClient,
+    ack_router: &calimero_context_client::local_governance::AckRouter,
+    group_id: &calimero_context_config::types::ContextGroupId,
+    signer_sk: &calimero_primitives::identity::PrivateKey,
+    op: calimero_context_client::local_governance::GroupOp,
+) -> eyre::Result<Option<calimero_governance_store::governance_broadcast::DeliveryReport>> {
+    let report = calimero_governance_store::sign_apply_and_publish(
+        store,
+        node_client,
+        ack_router,
+        group_id,
+        signer_sk,
+        op,
+    )
+    .await?;
+    if let Ok(namespace_id) =
+        calimero_governance_store::NamespaceRepository::new(store).resolve(group_id)
+    {
+        crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
+            store,
+            namespace_id.to_bytes(),
+        );
+    }
+    Ok(report)
 }
 
 impl ContextManager {

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -777,13 +777,21 @@ pub(crate) async fn sign_apply_and_publish_group_op(
         op,
     )
     .await?;
-    if let Ok(namespace_id) =
-        calimero_governance_store::NamespaceRepository::new(store).resolve(group_id)
-    {
-        crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
-            store,
-            namespace_id.to_bytes(),
-        );
+    match calimero_governance_store::NamespaceRepository::new(store).resolve(group_id) {
+        Ok(namespace_id) => {
+            crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
+                store,
+                namespace_id.to_bytes(),
+            );
+        }
+        // This is the single chokepoint for all group-op authoring, so a systematic
+        // resolve failure would leave the op-store incomplete for every authored op
+        // with no signal otherwise — warn so the divergence is observable.
+        Err(err) => tracing::warn!(
+            %err,
+            ?group_id,
+            "C3: could not resolve namespace to mirror the authored group op into the op-store"
+        ),
     }
     Ok(report)
 }


### PR DESCRIPTION
## What

Closes the **group-op plane (B1)** — the last structural incompleteness behind the read-flip's "governance cut not locally known" timeouts. The B1 author applies a group op to the local group plane and publishes the encrypted `NamespaceOp::Group` to the namespace gov-DAG (`publish_post_gate` → `store_operation`), but **never wrote the op-store** (the dual-write only fires on the receive handler). So a node's own op-store was missing every group op it authored: `MemberAdded`, `MemberRemoved`, capabilities, metadata, visibility, `ContextRegistered`, …

New `crate::sign_apply_and_publish_group_op` wraps the governance-store group publish: after it publishes, the encrypted op is the namespace gov-DAG head and the author holds the group key, so `persist_namespace_head_ops` decrypts it and lands the real decoded op. **All 19 group-author call sites** route through the wrapper (identical signature — mechanical path-swap); the key-rotation removal path (`remove_group_members`) persists inline.

## Coverage

After this, the op-store should mirror the gov-DAG for **every** governance apply path — receive + local namespace authoring (Stages 1/2) + local group authoring (this). The Stage 0 `op_store_incomplete` gate should reach **zero** across the e2e matrix — the precondition for the Stage 4 read-flip.

No read flips here. Clippy clean; reuses the Stage 1 `persist_namespace_head_ops` helper.

Stacked on #2924 → #2923 → #2922; rebases down as they merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the central governance sign/apply/publish path for many handlers; persist is best-effort so authoring still succeeds if mirroring fails, but systematic resolve failures could leave op-store divergence until observed via warnings.
> 
> **Overview**
> **Locally authored group governance ops were never written to the unified op-store** (only inbound receive paths dual-wrote), which left the authoring node’s store incomplete and contributed to read-flip “governance cut not locally known” timeouts.
> 
> This PR adds **`sign_apply_and_publish_group_op`**: it still calls `calimero_governance_store::sign_apply_and_publish`, then **best-effort** resolves the namespace and runs **`persist_namespace_head_ops`** so the author decrypts the new DAG head and mirrors the decoded op into the op-store. **Governance publish/apply failures are unchanged**; resolve/persist failures only log warnings.
> 
> **Call sites** that used `sign_apply_and_publish` now go through the wrapper (membership, contexts, upgrades, TEE policy, visibility, capabilities, leave, generic governance handler, etc.). **`remove_group_members`** keeps `sign_apply_and_publish_removal` and **inlines** the same persist step after each removal.
> 
> No read-flip behavior in this change — it completes op-store parity for the B1 local group-authoring path ahead of Stage 4.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7a565608bf75098604c700eeba6fcbcf58de4f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->