### PR TITLE
feat(context): C3 Stage 4 — read-flip onto the unified op-store (atomic dual-write)

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -480,7 +480,7 @@ jobs:
           fi
           echo "no unified_projection_divergence markers — projection agrees with the live decision"
 
-      - name: Report unified op-store completeness (C3 Stage 0, observe-only)
+      - name: Assert unified op-store completeness (C3 Stage 4, HARD gate)
         if: always()
         run: |
           # The C3 completeness gate logs `op_store_incomplete` whenever the unified
@@ -489,19 +489,19 @@ jobs:
           # mystery 60s sync timeout (how the read-flip failed three times) into a
           # cheap, specific signal naming the missing op count per namespace.
           #
-          # OBSERVE-ONLY for now: the op-store is KNOWN incomplete until C3 closes the
-          # structural write gaps (local-authoring A4/A5/B1, genesis G1/G2). This step
-          # reports the markers so each stage can watch the count fall to zero; it does
-          # NOT fail the job. It becomes a HARD gate at C3 Stage 4, when the read flips
-          # onto the op-store and zero markers is the precondition.
+          # HARD gate from C3 Stage 4: the read now flips onto the op-store
+          # (`ops_for_namespace`), so a gov-DAG op the op-store lacks is a correctness
+          # bug, not a known transitional gap. Stages 1-3 closed every apply-path write
+          # gap; any marker here means a path was missed and MUST be fixed before merge.
           if grep -rl "op_store_incomplete" docker-logs/ 2>/dev/null | grep -q .; then
               count=$(grep -rho "op_store_incomplete" docker-logs/ | wc -l | tr -d ' ')
-              echo "::notice::op-store incomplete in ${{ matrix.workflow }} — $count marker(s) (expected during C3; observe-only)"
+              echo "::error::op-store incomplete in ${{ matrix.workflow }} — $count marker(s); a governance apply path is not writing the op-store (read-flip is unsafe)"
               echo "sample (missing_count per namespace):"
               # Match `missing_count=N` anywhere on an op_store_incomplete line — robust
               # to field ordering. Tolerates the line not carrying the field at all.
               grep -rho 'op_store_incomplete.*' docker-logs/ | grep -oE 'missing_count=[0-9]+' | sort | uniq -c | head -10
               grep -rn "op_store_incomplete" docker-logs/ | head -10
+              exit 1
           elif grep -rl "op_store_gate_unavailable" docker-logs/ 2>/dev/null | grep -q .; then
               # No gap markers, but the gate couldn't load the op-store somewhere — do
               # NOT claim a clean mirror, that would be a false "verified" line.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,6 +1339,7 @@ dependencies = [
  "calimero-network-primitives",
  "calimero-node-primitives",
  "calimero-op",
+ "calimero-op-adapter",
  "calimero-primitives",
  "calimero-projection",
  "calimero-storage",

--- a/crates/context/src/governance_dag.rs
+++ b/crates/context/src/governance_dag.rs
@@ -154,21 +154,12 @@ impl DeltaApplier<SignedNamespaceOp> for NamespaceGovernanceApplier {
     }
 }
 
-/// Build a [`CausalDelta`] from a [`SignedNamespaceOp`] for insertion into the
-/// namespace governance DAG.
-pub fn signed_namespace_op_to_delta(
-    op: &SignedNamespaceOp,
-) -> Result<CausalDelta<SignedNamespaceOp>, eyre::Error> {
-    let delta_id = op
-        .content_hash()
-        .map_err(|e| eyre::eyre!("content_hash: {e}"))?;
-    Ok(make_delta(
-        op,
-        op.parent_op_hashes.clone(),
-        op.state_hash,
-        delta_id,
-    ))
-}
+// `signed_namespace_op_to_delta` now lives in `calimero-governance-store`
+// alongside `op_from_namespace_op` (the governance apply uses both to build the
+// decoded unified op it writes atomically with the gov-DAG put). Re-exported here
+// unchanged so the existing callers in this crate keep using
+// `crate::governance_dag::signed_namespace_op_to_delta`.
+pub use calimero_governance_store::unified_op_decode::signed_namespace_op_to_delta;
 
 fn make_delta<T>(
     op: &T,

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -533,17 +533,6 @@ impl ContextManager {
     ) -> Self {
         let ack_router = Arc::clone(context_client.ack_router());
 
-        // C3 Stage 4: register the op-store mirror hook so the governance-store
-        // local-author publish paths persist the just-applied op into the unified
-        // op-store synchronously, before the publish round-trip — closing the window
-        // where the op-store lags the gov-DAG. Non-capturing `fn`, idempotent.
-        calimero_governance_store::set_op_store_persist_hook(|store, namespace_id| {
-            crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
-                store,
-                namespace_id,
-            );
-        });
-
         Self {
             datastore,
             node_client,

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -532,6 +532,18 @@ impl ContextManager {
         prometheus_registry: Option<&mut Registry>,
     ) -> Self {
         let ack_router = Arc::clone(context_client.ack_router());
+
+        // C3 Stage 4: register the op-store mirror hook so the governance-store
+        // local-author publish paths persist the just-applied op into the unified
+        // op-store synchronously, before the publish round-trip — closing the window
+        // where the op-store lags the gov-DAG. Non-capturing `fn`, idempotent.
+        calimero_governance_store::set_op_store_persist_hook(|store, namespace_id| {
+            crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
+                store,
+                namespace_id,
+            );
+        });
+
         Self {
             datastore,
             node_client,

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -306,6 +306,23 @@ impl ScopeProjections {
         // O(1) dedup: `insert` is true only for a not-yet-seen id.
         if self.seen.entry(op.scope).or_default().insert(op.id) {
             self.logs.entry(op.scope).or_default().push(op.clone());
+        } else if !matches!(op.payload, OpPayload::Noop) {
+            // Already seen, but `op.id` is the SIGNED op's content hash, not the decoded
+            // payload's — so an encrypted op first folded as `Noop` (applied before its
+            // group key arrived) shares an id with its later, decrypted form. The op-log
+            // is what the at-cut auth view (`acl_view_at` → `member_at_cut`) folds, so a
+            // stale `Noop` left here drops the late-decrypted membership even after the
+            // op-store is corrected. Upgrade the log entry in place when a non-`Noop`
+            // payload arrives for a previously-`Noop` id; never downgrade (decryption
+            // only adds info).
+            if let Some(log) = self.logs.get_mut(&op.scope) {
+                if let Some(existing) = log
+                    .iter_mut()
+                    .find(|e| e.id == op.id && matches!(e.payload, OpPayload::Noop))
+                {
+                    *existing = op.clone();
+                }
+            }
         }
     }
 
@@ -385,33 +402,37 @@ impl ScopeProjections {
         Ok(proj.scope_root_for(scope, [0u8; 32]))
     }
 
-    /// The governance ops to fold for `namespace_id`.
+    /// The governance ops to fold for `namespace_id` — cutover C3 Stage 4 read-flip.
     ///
-    /// The C2.2b read-flip (make the unified op-store the projection's authoritative
-    /// backing via [`load_scope_ops`](crate::unified_op_store::load_scope_ops)) is
-    /// DEFERRED: flipping the read onto the op-store broke convergence in the
-    /// maintainer's e2e — group-3node / scaffolding-e2e / shared-storage rotation all
-    /// timed out on the joiner's post-write sync.
+    /// The unified **op-store** is the projection's authoritative backing now:
+    /// [`load_scope_ops`](crate::unified_op_store::load_scope_ops). Falls back to the
+    /// governance-DAG walk ([`collect_namespace_ops`](Self::collect_namespace_ops))
+    /// only when the op-store has no rows for this scope (a cold namespace not yet
+    /// dual-written under an upgrade) or can't be read — a transitional safety net that
+    /// retires with `collect_namespace_ops` at C5.
     ///
-    /// ROOT CAUSE (pinned deterministically by `tests/op_store_reconstruction.rs`):
-    /// an encrypted group `MemberAdded` can apply to the governance DAG BEFORE its
-    /// group key arrives (keys lag on a separate delivery path; see the
-    /// buffer-awaiting-key replay in `apply_group_op_inner`). The apply-time
-    /// dual-write then decrypts with no key, so the op is frozen into the op-store as
-    /// a `Noop`. `collect_namespace_ops` RE-DECRYPTS the same op at read time once the
-    /// key lands and recovers the real `MemberAdded`, but the op-store still holds the
-    /// `Noop` — so reading membership from the op-store drops the member, the joiner's
-    /// writes are rejected, and sync never converges. `scope_root` doesn't surface it
-    /// because at shadow time neither side has decrypted yet (both `Noop` → roots
-    /// match); the divergence only appears after the key arrives.
-    ///
-    /// Until the op-store faithfully reconstructs late-decrypted membership (e.g.
-    /// re-persist on the key-arrival replay, or re-decrypt on load) this stays on the
-    /// governance DAG, the proven-correct source. The op-store keeps being
-    /// dual-written.
+    /// This flip is safe BY CONSTRUCTION, unlike the three earlier attempts that timed
+    /// out in e2e: C3 Stages 1-3 made every governance apply path write the op-store
+    /// (receive + local namespace + local group authoring), and the Stage 0
+    /// completeness gate (`op_store_incomplete`) proves the op-store mirrors the gov-DAG
+    /// across the e2e matrix before this flips. Late-decrypted membership is kept
+    /// faithful by the key-delivery re-persist + the maintained projection's op-log
+    /// upgrade ([`ingest_op`](Self::ingest_op)).
     #[must_use]
     pub fn ops_for_namespace(store: &Store, namespace_id: [u8; 32]) -> Option<Vec<Op>> {
-        Self::collect_namespace_ops(store, namespace_id)
+        let scope = ScopeId::from(namespace_id);
+        match crate::unified_op_store::load_scope_ops(store, &scope) {
+            Ok(ops) if !ops.is_empty() => Some(ops),
+            Ok(_) => Self::collect_namespace_ops(store, namespace_id),
+            Err(err) => {
+                tracing::warn!(
+                    %err,
+                    namespace = ?namespace_id,
+                    "op-store load failed; falling back to the governance-DAG fold"
+                );
+                Self::collect_namespace_ops(store, namespace_id)
+            }
+        }
     }
 
     /// [`scope_root_for`](Self::scope_root_for) from an EPHEMERAL fold built fresh

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -24,9 +24,8 @@ use calimero_governance_store::{
     CapabilitiesRepository, DenyListRepository, MembershipRepository, MetaRepository,
     NamespaceDagService, NamespaceOpLogService, NamespaceRepository,
 };
-use calimero_governance_types::{GroupOp, NamespaceOp, RootOp, SignedNamespaceOp};
 use calimero_op::{Op, OpPayload, ScopeId};
-use calimero_op_adapter::{payload_from_group_op, payload_from_root_op, set_writers_payload};
+use calimero_op_adapter::set_writers_payload;
 use calimero_primitives::context::{ContextId, GroupMemberRole};
 use calimero_primitives::identity::PublicKey;
 use calimero_projection::ScopeState;
@@ -197,63 +196,11 @@ pub fn load_rotation_log_direct(
     })
 }
 
-/// Convert a namespace governance op into the unified [`Op`] graph node it
-/// occupies — **always** a node, never `None`: membership ops carry their
-/// payload, and every other op (non-membership Root op, encrypted/undecryptable
-/// Group op, key transport) folds to [`OpPayload::Noop`]. The node MUST still
-/// exist so an ancestry walk can traverse *through* it; dropping it would
-/// truncate the walk and orphan every membership op behind it.
-///
-/// Governance ops are keyed under the **namespace** scope, not per-group. The
-/// live system keeps ONE governance DAG per namespace and a data write cites
-/// namespace-wide `governance_dag_heads`, so membership has to resolve over the
-/// whole namespace ancestry (a per-group log truncates the walk at the first
-/// cross-scope node — that was the bug). Membership for a specific group is read
-/// out of the folded view's `groups[group]`; the per-scope-DAG split is a
-/// post-cutover concern.
-///
-/// `id`/`hlc`/`parents` are the governance **delta's own** id, hlc, and parents
-/// (its `parent_op_hashes`) so the projection mirrors the governance DAG and the
-/// cut maps onto it (see [`build_op`]). `decrypted_group_op` is the cleartext
-/// `GroupOp` for a `NamespaceOp::Group` (via
-/// `calimero_governance_store::decrypt_group_op`), or `None` when it couldn't be
-/// decrypted — in which case the node is still recorded as `Noop`.
-#[must_use]
-pub fn op_from_namespace_op(
-    signed: &SignedNamespaceOp,
-    decrypted_group_op: Option<&GroupOp>,
-    id: [u8; 32],
-    hlc: HybridTimestamp,
-    parents: &[[u8; 32]],
-) -> Op {
-    let payload = match &signed.op {
-        // `MemberJoinedOpen` is an open-subgroup inheritance-join PROOF, not a
-        // direct membership: live's apply requires `check_path == Inherited` and
-        // writes NO persistent `GroupMember` row, re-deriving the membership from
-        // the anchor each time (so it is revoked when the anchor's membership is
-        // removed, and restored on rejoin). Folding it as a direct `MemberAdded`
-        // would make it permanent and survive anchor removal (the over-grant). Fold
-        // it as a `Noop` graph node; the inheritance walk in
-        // `AclView::is_member_at_cut` derives the membership from the foldable
-        // anchor membership + visibility + cap (default cap via base fact), so it
-        // tracks the anchor both ways.
-        NamespaceOp::Root(RootOp::MemberJoinedOpen { .. }) => OpPayload::Noop,
-        NamespaceOp::Root(root) => {
-            payload_from_root_op(root, signed.signer).unwrap_or(OpPayload::Noop)
-        }
-        NamespaceOp::Group { group_id, .. } => decrypted_group_op
-            .and_then(|g| payload_from_group_op(ContextGroupId::from(*group_id), g))
-            .unwrap_or(OpPayload::Noop),
-    };
-    build_op(
-        id,
-        ScopeId::from(signed.namespace_id),
-        signed.signer,
-        hlc,
-        parents,
-        payload,
-    )
-}
+// `op_from_namespace_op` now lives in `calimero-governance-store` (so the
+// governance apply can build the decoded op and write it to the unified op-store
+// atomically with the gov-DAG put). Re-exported here unchanged so the projection
+// callers/tests in this crate keep using `crate::scope_projection::op_from_namespace_op`.
+pub use calimero_governance_store::unified_op_decode::op_from_namespace_op;
 
 /// In-memory registry of unified-op [`ScopeState`] projections, keyed by
 /// [`ScopeId`].
@@ -1729,6 +1676,7 @@ mod tests {
     use calimero_context_config::types::{
         ContextGroupId, GroupInvitationFromAdmin, SignedGroupOpenInvitation,
     };
+    use calimero_governance_types::{NamespaceOp, RootOp, SignedNamespaceOp};
     use calimero_op::OpPayload;
     use calimero_primitives::context::GroupMemberRole;
     use calimero_storage::entities::OpMask;

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -284,6 +284,12 @@ pub struct ScopeProjections {
     /// Op ids already retained per scope — gives `ingest_op` O(1) dedup of a
     /// replayed delta instead of an O(n) scan of the log.
     seen: HashMap<ScopeId, HashSet<[u8; 32]>>,
+    /// Index in `logs` of each op id currently folded as `Noop`, per scope. The
+    /// late-decrypt upgrade (a non-`Noop` payload re-ingested for a `Noop`-folded id)
+    /// uses it to replace the entry in O(1) instead of scanning the whole log, and the
+    /// common no-upgrade re-ingest skips the scan entirely (id not present here).
+    /// Entries are removed once upgraded, so it only ever holds still-undecrypted ops.
+    noop_log_pos: HashMap<ScopeId, HashMap<[u8; 32], usize>>,
     /// Namespaces already replayed from persisted state, so `backfill_namespace`
     /// walks each governance DAG at most once (the live feed maintains it after).
     backfilled: HashSet<[u8; 32]>,
@@ -305,7 +311,17 @@ impl ScopeProjections {
         self.states.entry(op.scope).or_default().apply(op);
         // O(1) dedup: `insert` is true only for a not-yet-seen id.
         if self.seen.entry(op.scope).or_default().insert(op.id) {
-            self.logs.entry(op.scope).or_default().push(op.clone());
+            let log = self.logs.entry(op.scope).or_default();
+            if matches!(op.payload, OpPayload::Noop) {
+                // Remember where this still-undecrypted op sits so a later decrypted
+                // re-ingest can upgrade it in O(1) (see below).
+                let _ = self
+                    .noop_log_pos
+                    .entry(op.scope)
+                    .or_default()
+                    .insert(op.id, log.len());
+            }
+            log.push(op.clone());
         } else if !matches!(op.payload, OpPayload::Noop) {
             // Already seen, but `op.id` is the SIGNED op's content hash, not the decoded
             // payload's — so an encrypted op first folded as `Noop` (applied before its
@@ -314,13 +330,16 @@ impl ScopeProjections {
             // stale `Noop` left here drops the late-decrypted membership even after the
             // op-store is corrected. Upgrade the log entry in place when a non-`Noop`
             // payload arrives for a previously-`Noop` id; never downgrade (decryption
-            // only adds info).
-            if let Some(log) = self.logs.get_mut(&op.scope) {
-                if let Some(existing) = log
-                    .iter_mut()
-                    .find(|e| e.id == op.id && matches!(e.payload, OpPayload::Noop))
-                {
-                    *existing = op.clone();
+            // only adds info). Only ids currently folded as `Noop` are candidates, so the
+            // common re-ingest (already a real payload) is an O(1) miss, and an actual
+            // upgrade is an O(1) indexed replace — no log scan either way.
+            if let Some(idx) = self
+                .noop_log_pos
+                .get_mut(&op.scope)
+                .and_then(|m| m.remove(&op.id))
+            {
+                if let Some(entry) = self.logs.get_mut(&op.scope).and_then(|l| l.get_mut(idx)) {
+                    *entry = op.clone();
                 }
             }
         }

--- a/crates/context/tests/op_store_reconstruction.rs
+++ b/crates/context/tests/op_store_reconstruction.rs
@@ -276,16 +276,26 @@ fn persist_namespace_head_ops_lands_locally_authored_op_in_the_op_store() {
         .advance_dag_head(delta_id, &[], 0)
         .unwrap();
 
-    assert!(
+    // `store_signed_operation` now writes the decoded op to the unified op-store
+    // ATOMICALLY with the gov-DAG put (the op-store can never lag the gov-DAG), so
+    // the op is already present here — the local-author gap this test guarded is
+    // closed at the source. The author held the group key, so the atomic write
+    // already decoded the real MemberAdded (not a Noop).
+    assert_eq!(
         load_scope_ops(&store, &ScopeId::from(ns_bytes))
             .unwrap()
-            .is_empty(),
-        "precondition: the locally-authored op is absent from the op-store"
+            .iter()
+            .map(|op| op.id)
+            .collect::<Vec<_>>(),
+        vec![delta_id],
+        "store_signed_operation must persist the op atomically with the gov-DAG write"
     );
 
+    // `persist_namespace_head_ops` remains idempotent over the now-already-present
+    // op (the redundant per-site re-persist is kept as belt-and-suspenders).
     ScopeProjections::persist_namespace_head_ops(&store, ns_bytes);
 
-    // The op is now in the op-store AND decodes to the real membership: a fresh fold
+    // The op is in the op-store AND decodes to the real membership: a fresh fold
     // of the op-store sees `member` (proves the payload landed, not just the id).
     let store_ops = load_scope_ops(&store, &ScopeId::from(ns_bytes)).unwrap();
     assert_eq!(

--- a/crates/governance-store/Cargo.toml
+++ b/crates/governance-store/Cargo.toml
@@ -32,6 +32,8 @@ calimero-crypto.workspace = true
 calimero-dag.workspace = true
 calimero-network-primitives.workspace = true
 calimero-node-primitives.workspace = true
+calimero-op.workspace = true
+calimero-op-adapter.workspace = true
 calimero-primitives = { workspace = true, features = ["borsh", "rand"] }
 calimero-storage.workspace = true
 calimero-store = { workspace = true, features = ["datatypes"] }
@@ -40,7 +42,8 @@ calimero-utils-actix.workspace = true
 [dev-dependencies]
 # Fold-equivalence: cross-check the unified projection's membership fold
 # against this crate's live membership resolver over the same op sequences.
-calimero-op.workspace = true
+# (`calimero-op` is now a regular dependency — used by `unified_op_decode` —
+# so it no longer needs a dev-dependency entry.)
 calimero-projection.workspace = true
 # Serializes the op-event tests, which observe a process-global broadcast bus
 # (`op_events`) and would otherwise cross-talk / flood under parallel execution.

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -36,6 +36,29 @@ pub mod metrics;
 pub mod op_events;
 pub mod registration_notify;
 
+/// Op-store mirror hook (cutover C3 Stage 4). `calimero-context` registers a function
+/// here at startup that persists a namespace's just-applied governance op into the
+/// unified op-store. The local-author publish paths call it RIGHT AFTER the local
+/// apply and BEFORE the publish round-trip, so the op-store never lags the gov-DAG
+/// within the publish-await window — closing the gap where the read-flip would
+/// transiently see stale membership (and the completeness gate would fire). It is a
+/// non-capturing `fn` pointer (not a closure) to keep this crate free of a context
+/// dependency; `None` until registered (e.g. in tests), in which case it is a no-op.
+type OpStorePersistHook = fn(&Store, [u8; 32]);
+static OP_STORE_PERSIST_HOOK: std::sync::OnceLock<OpStorePersistHook> = std::sync::OnceLock::new();
+
+/// Register the op-store mirror hook. Idempotent — only the first registration wins.
+pub fn set_op_store_persist_hook(hook: OpStorePersistHook) {
+    let _ = OP_STORE_PERSIST_HOOK.set(hook);
+}
+
+/// Run the registered op-store mirror hook for `namespace_id`, if any.
+pub(crate) fn run_op_store_persist_hook(store: &Store, namespace_id: [u8; 32]) {
+    if let Some(hook) = OP_STORE_PERSIST_HOOK.get() {
+        hook(store, namespace_id);
+    }
+}
+
 pub mod absorb;
 pub mod absorb_record;
 pub mod authorizer;

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -84,6 +84,7 @@ mod pending_self_purge;
 mod permission_checker;
 mod signing_keys;
 mod tee;
+pub mod unified_op_decode;
 mod upgrade_ladder;
 mod upgrades;
 use self::local_state::{op_log_contains_content_hash, persist_group_governance_progress};

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -36,29 +36,6 @@ pub mod metrics;
 pub mod op_events;
 pub mod registration_notify;
 
-/// Op-store mirror hook (cutover C3 Stage 4). `calimero-context` registers a function
-/// here at startup that persists a namespace's just-applied governance op into the
-/// unified op-store. The local-author publish paths call it RIGHT AFTER the local
-/// apply and BEFORE the publish round-trip, so the op-store never lags the gov-DAG
-/// within the publish-await window — closing the gap where the read-flip would
-/// transiently see stale membership (and the completeness gate would fire). It is a
-/// non-capturing `fn` pointer (not a closure) to keep this crate free of a context
-/// dependency; `None` until registered (e.g. in tests), in which case it is a no-op.
-type OpStorePersistHook = fn(&Store, [u8; 32]);
-static OP_STORE_PERSIST_HOOK: std::sync::OnceLock<OpStorePersistHook> = std::sync::OnceLock::new();
-
-/// Register the op-store mirror hook. Idempotent — only the first registration wins.
-pub fn set_op_store_persist_hook(hook: OpStorePersistHook) {
-    let _ = OP_STORE_PERSIST_HOOK.set(hook);
-}
-
-/// Run the registered op-store mirror hook for `namespace_id`, if any.
-pub(crate) fn run_op_store_persist_hook(store: &Store, namespace_id: [u8; 32]) {
-    if let Some(hook) = OP_STORE_PERSIST_HOOK.get() {
-        hook(store, namespace_id);
-    }
-}
-
 pub mod absorb;
 pub mod absorb_record;
 pub mod authorizer;

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -576,13 +576,6 @@ impl<'a> NamespaceGovernance<'a> {
 
         self.apply_signed_op(&signed)?;
 
-        // C3 Stage 4: mirror the just-applied op into the unified op-store NOW —
-        // synchronously, before the publish round-trip below — so the op-store never
-        // lags the gov-DAG within the publish-await window (where the read-flip would
-        // transiently see stale membership). Op is in the gov-DAG the moment apply
-        // returns; no reason to wait for publish.
-        crate::run_op_store_persist_hook(self.store, self.namespace_id);
-
         // Notify the readiness FSM that we just advanced the local DAG on
         // the publisher path. Without this, `state_per_namespace` only
         // populates from gossipsub-receive deliveries — a node that
@@ -798,11 +791,6 @@ impl<'a> NamespaceGovernance<'a> {
         // advance the head for it — orphaning it from the DAG head lineage.
         self.advance_dag_head(delta_id, &parent_ids, head.next_nonce)?;
         self.store_operation(&signed)?;
-
-        // C3 Stage 4: mirror the just-stored op into the unified op-store NOW,
-        // before the publish below — same window-closing rationale as
-        // `sign_apply_and_publish` (the quorum / group-publish post-gate path).
-        crate::run_op_store_persist_hook(self.store, self.namespace_id);
 
         // Same signal as in `sign_apply_and_publish` above — the local DAG
         // just advanced on the publisher path, so the readiness FSM needs

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -576,6 +576,13 @@ impl<'a> NamespaceGovernance<'a> {
 
         self.apply_signed_op(&signed)?;
 
+        // C3 Stage 4: mirror the just-applied op into the unified op-store NOW —
+        // synchronously, before the publish round-trip below — so the op-store never
+        // lags the gov-DAG within the publish-await window (where the read-flip would
+        // transiently see stale membership). Op is in the gov-DAG the moment apply
+        // returns; no reason to wait for publish.
+        crate::run_op_store_persist_hook(self.store, self.namespace_id);
+
         // Notify the readiness FSM that we just advanced the local DAG on
         // the publisher path. Without this, `state_per_namespace` only
         // populates from gossipsub-receive deliveries — a node that
@@ -791,6 +798,11 @@ impl<'a> NamespaceGovernance<'a> {
         // advance the head for it — orphaning it from the DAG head lineage.
         self.advance_dag_head(delta_id, &parent_ids, head.next_nonce)?;
         self.store_operation(&signed)?;
+
+        // C3 Stage 4: mirror the just-stored op into the unified op-store NOW,
+        // before the publish below — same window-closing rationale as
+        // `sign_apply_and_publish` (the quorum / group-publish post-gate path).
+        crate::run_op_store_persist_hook(self.store, self.namespace_id);
 
         // Same signal as in `sign_apply_and_publish` above — the local DAG
         // just advanced on the publisher path, so the readiness FSM needs

--- a/crates/governance-store/src/namespace/op_log.rs
+++ b/crates/governance-store/src/namespace/op_log.rs
@@ -90,6 +90,83 @@ impl<'a> NamespaceOpLogService<'a> {
 
         let mut handle = self.store.handle();
         handle.put(&key, &value)?;
+
+        // ATOMIC unified op-store write: persist the DECODED `Op` on the SAME
+        // `handle` as the gov-DAG put above, so the op-store can never lag the
+        // gov-DAG (the read-flip blocker). The op-store is keyed by the op's
+        // **namespace** scope ‖ op id, mirroring `unified_op_store::persist_op`
+        // in `calimero-context`; that apply-time dual-write (and the per-site
+        // re-persists) stay as a redundant-but-idempotent belt-and-suspenders.
+        //
+        // For an encrypted group op, decrypt best-effort (the key may not have
+        // arrived yet); on failure fold as `Noop` (pass `None`), exactly like the
+        // dual-write — the late-key case is recovered by `repersist_namespace_ops`.
+        if let Err(err) = self.put_unified_op(&mut handle, op, delta_id) {
+            // Never fail the gov-DAG write on a decode/op-store hiccup. The op-store
+            // is a redundant projection backing here; a miss is recoverable by the
+            // existing backfill/repersist paths. Logged, not propagated.
+            tracing::warn!(
+                %err,
+                namespace_id = %hex::encode(self.namespace_id),
+                delta_id = %hex::encode(delta_id),
+                "unified op-store: atomic op-store write failed; gov-DAG write kept"
+            );
+        }
+        Ok(())
+    }
+
+    /// Build the decoded unified [`Op`] for `signed` and `put` it onto the
+    /// caller's `handle` (the SAME handle that just wrote the gov-DAG op), so the
+    /// op-store entry is atomic with the gov-DAG entry. `delta_id` is the op's
+    /// already-computed content hash (the gov-DAG key), reused to avoid re-hashing.
+    fn put_unified_op(
+        &self,
+        handle: &mut calimero_store::Handle<Store>,
+        signed: &SignedNamespaceOp,
+        delta_id: [u8; 32],
+    ) -> EyreResult<()> {
+        // Re-derive the op's id/hlc/parents exactly as the projection backfill
+        // does, so the persisted op id is byte-identical to the dual-write's.
+        let delta = crate::unified_op_decode::signed_namespace_op_to_delta(signed)?;
+
+        // Decrypt an encrypted group op so its membership change folds; a failure
+        // (no key for this group yet) leaves it a `Noop` node — still persisted so
+        // an ancestry walk can pass through it (the late-key case is repersisted
+        // once the key arrives).
+        let decrypted = match &signed.op {
+            NamespaceOp::Group {
+                group_id,
+                key_id,
+                encrypted,
+                ..
+            } => crate::decrypt_group_op(
+                self.store,
+                self.namespace_id,
+                calimero_context_config::types::ContextGroupId::from(*group_id),
+                key_id,
+                encrypted,
+            )
+            .ok()
+            .flatten(),
+            NamespaceOp::Root(_) => None,
+        };
+
+        let unified_op = crate::unified_op_decode::op_from_namespace_op(
+            signed,
+            decrypted.as_ref(),
+            delta.id,
+            delta.hlc,
+            &delta.parents,
+        );
+
+        let scope = calimero_op::ScopeId::from(self.namespace_id);
+        let key = calimero_store::key::ScopeUnifiedOp::new(*scope.as_bytes(), unified_op.id);
+        let bytes = borsh::to_vec(&unified_op).map_err(|e| eyre::eyre!("borsh op: {e}"))?;
+        let value =
+            calimero_store::types::ScopeUnifiedOp::from(calimero_store::slice::Slice::from(bytes));
+        handle.put(&key, &value)?;
+        // Sanity: the op-store and the gov-DAG must key the same op identity.
+        debug_assert_eq!(unified_op.id, delta_id, "unified op id != gov-DAG delta id");
         Ok(())
     }
 

--- a/crates/governance-store/src/unified_op_decode.rs
+++ b/crates/governance-store/src/unified_op_decode.rs
@@ -1,0 +1,125 @@
+//! Decode a `SignedNamespaceOp` (+ its decrypted `GroupOp`) into a unified
+//! [`Op`] for the causal log — the shared decode the apply path, the projection
+//! backfill, and the atomic op-store write all route through.
+//!
+//! This lives in `governance-store` (not in `calimero-context`) so the governance
+//! apply itself can build the decoded op and persist it to the unified op-store on
+//! the SAME store handle as the gov-DAG write, making the two writes atomic (the
+//! op-store can never lag the gov-DAG). `calimero-context` re-exports these so the
+//! existing projection callers keep compiling unchanged.
+
+use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
+use calimero_context_config::types::ContextGroupId;
+use calimero_dag::CausalDelta;
+use calimero_op::{Op, OpPayload, ScopeId};
+use calimero_op_adapter::{payload_from_group_op, payload_from_root_op};
+use calimero_primitives::identity::PublicKey;
+use calimero_storage::logical_clock::HybridTimestamp;
+
+use calimero_context_client::local_governance::GroupOp;
+
+/// Assemble an [`Op`] that **mirrors a source-DAG op**: its `id` and `parents`
+/// are the source delta's own id/parents, *not* a fresh [`Op::compute_id`]. This
+/// is deliberate — it makes the projection's op graph share an id space with the
+/// source DAGs, so a live decision's cut (e.g. a delta's `governance_dag_heads`,
+/// which are governance-op ids) maps directly onto the projection and
+/// `ScopeProjections::acl_view_at` resolves the same ancestry the source DAG
+/// would. The source ids are themselves content-addressed + identical on every
+/// node, so the projection's `(hlc, op_id)` LWW stays deterministic.
+fn build_op(
+    id: [u8; 32],
+    scope: ScopeId,
+    author: PublicKey,
+    hlc: HybridTimestamp,
+    parents: &[[u8; 32]],
+    payload: OpPayload,
+) -> Op {
+    Op {
+        id,
+        scope,
+        parents: parents.to_vec(),
+        author,
+        hlc,
+        payload,
+        expected_scope_root: [0u8; 32],
+        signature: [0u8; 64],
+    }
+}
+
+/// Convert a namespace governance op into the unified [`Op`] graph node it
+/// occupies — **always** a node, never `None`: membership ops carry their
+/// payload, and every other op (non-membership Root op, encrypted/undecryptable
+/// Group op, key transport) folds to [`OpPayload::Noop`]. The node MUST still
+/// exist so an ancestry walk can traverse *through* it; dropping it would
+/// truncate the walk and orphan every membership op behind it.
+///
+/// Governance ops are keyed under the **namespace** scope, not per-group. The
+/// live system keeps ONE governance DAG per namespace and a data write cites
+/// namespace-wide `governance_dag_heads`, so membership has to resolve over the
+/// whole namespace ancestry (a per-group log truncates the walk at the first
+/// cross-scope node — that was the bug). Membership for a specific group is read
+/// out of the folded view's `groups[group]`; the per-scope-DAG split is a
+/// post-cutover concern.
+///
+/// `id`/`hlc`/`parents` are the governance **delta's own** id, hlc, and parents
+/// (its `parent_op_hashes`) so the projection mirrors the governance DAG and the
+/// cut maps onto it (see [`build_op`]). `decrypted_group_op` is the cleartext
+/// `GroupOp` for a `NamespaceOp::Group` (via
+/// [`crate::decrypt_group_op`]), or `None` when it couldn't be decrypted — in
+/// which case the node is still recorded as `Noop`.
+#[must_use]
+pub fn op_from_namespace_op(
+    signed: &SignedNamespaceOp,
+    decrypted_group_op: Option<&GroupOp>,
+    id: [u8; 32],
+    hlc: HybridTimestamp,
+    parents: &[[u8; 32]],
+) -> Op {
+    let payload = match &signed.op {
+        // `MemberJoinedOpen` is an open-subgroup inheritance-join PROOF, not a
+        // direct membership: live's apply requires `check_path == Inherited` and
+        // writes NO persistent `GroupMember` row, re-deriving the membership from
+        // the anchor each time (so it is revoked when the anchor's membership is
+        // removed, and restored on rejoin). Folding it as a direct `MemberAdded`
+        // would make it permanent and survive anchor removal (the over-grant). Fold
+        // it as a `Noop` graph node; the inheritance walk in
+        // `AclView::is_member_at_cut` derives the membership from the foldable
+        // anchor membership + visibility + cap (default cap via base fact), so it
+        // tracks the anchor both ways.
+        NamespaceOp::Root(RootOp::MemberJoinedOpen { .. }) => OpPayload::Noop,
+        NamespaceOp::Root(root) => {
+            payload_from_root_op(root, signed.signer).unwrap_or(OpPayload::Noop)
+        }
+        NamespaceOp::Group { group_id, .. } => decrypted_group_op
+            .and_then(|g| payload_from_group_op(ContextGroupId::from(*group_id), g))
+            .unwrap_or(OpPayload::Noop),
+    };
+    build_op(
+        id,
+        ScopeId::from(signed.namespace_id),
+        signed.signer,
+        hlc,
+        parents,
+        payload,
+    )
+}
+
+/// Build a [`CausalDelta`] from a [`SignedNamespaceOp`] for insertion into the
+/// namespace governance DAG.
+///
+/// Also the source of the `id`/`hlc`/`parents` coordinates
+/// [`op_from_namespace_op`] needs to mirror the governance DAG.
+pub fn signed_namespace_op_to_delta(
+    op: &SignedNamespaceOp,
+) -> Result<CausalDelta<SignedNamespaceOp>, eyre::Error> {
+    let delta_id = op
+        .content_hash()
+        .map_err(|e| eyre::eyre!("content_hash: {e}"))?;
+    Ok(CausalDelta::new(
+        delta_id,
+        op.parent_op_hashes.clone(),
+        op.clone(),
+        HybridTimestamp::default(),
+        op.state_hash,
+    ))
+}

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -783,15 +783,19 @@ fn refresh_projection_for_cut(
         .read_scope_projections()
         .namespace_to_refresh(datastore, group, heads);
     if let Some(namespace_id) = needs_backfill {
-        // The projection folds the governance DAG (`ops_for_namespace`). The read-flip
-        // onto the unified op-store is being re-approached via C3 (make the op-store
-        // authoritative by construction); see the C3 plan + `ops_for_namespace`.
+        // C3 Stage 4 read-flip: the projection now folds the unified op-store
+        // (`ops_for_namespace` loads it, falling back to the gov-DAG only for a cold
+        // scope). Safe by construction — Stages 1-3 made every apply path write the
+        // op-store; the gate below keeps proving it.
         if let Some(ops) = ScopeProjections::ops_for_namespace(datastore, namespace_id) {
-            // C3 Stage 0 completeness gate (observe-only): the `ops` here are the
-            // gov-DAG fold, so cross-check that the op-store has them all and log
-            // `op_store_incomplete` for any it's missing — the deterministic signal
-            // that a governance apply path isn't dual-writing the op-store.
-            ScopeProjections::check_op_store_completeness(datastore, namespace_id, &ops);
+            // Completeness gate: `ops` is now the op-store, so the gate's gov-DAG
+            // reference must be an explicit `collect_namespace_ops` walk (comparing the
+            // op-store to itself would be vacuous). Logs `op_store_incomplete` for any
+            // gov-DAG op the op-store lacks.
+            if let Some(dag_ops) = ScopeProjections::collect_namespace_ops(datastore, namespace_id)
+            {
+                ScopeProjections::check_op_store_completeness(datastore, namespace_id, &dag_ops);
+            }
             node_state
                 .write_scope_projections()
                 .apply_backfill(namespace_id, ops);

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -1417,13 +1417,21 @@ impl SyncManager {
                         // MAINTAINED projection (`ingest_op` upgrades the stale `Noop`
                         // op-log entries in place). BEFORE the drain, whose membership
                         // re-checks must see the corrected ops, not the stale `Noop`.
+                        //
+                        // The in-process re-ingest reads the gov-DAG fold
+                        // (`collect_namespace_ops`), NOT the op-store read-back: the
+                        // re-persist is best-effort, so a partial `persist_op` failure
+                        // must not leave the maintained projection with fewer ops than
+                        // the gov-DAG (the exact gap the flip closes). We have the
+                        // freshly-decrypted fold in hand here; the op-store mirror is
+                        // for the cold-start read path.
                         let store = self.context_client.datastore_handle().into_inner();
                         calimero_context::scope_projection::ScopeProjections::repersist_namespace_ops(
                             &store,
                             namespace_id,
                         );
                         let refreshed =
-                            calimero_context::scope_projection::ScopeProjections::ops_for_namespace(
+                            calimero_context::scope_projection::ScopeProjections::collect_namespace_ops(
                                 &store,
                                 namespace_id,
                             );

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -1407,20 +1407,34 @@ impl SyncManager {
                         if let Some(report) = divergence {
                             self.reconcile_after_divergence(report).await;
                         }
-                        self.drain_governance_pending_after_sync().await;
 
-                        // The arrived key may have made governance ops that were
-                        // applied (and frozen as `Noop` in the unified op-store)
-                        // before the key landed now decode to their real payload.
-                        // Refresh the op-store from the governance DAG with the key
-                        // present so its reconstruction matches the projection — the
-                        // C2.2c fix for the read-flip's late-decrypted-membership gap.
+                        // The arrived key may have made governance ops applied (and
+                        // frozen as `Noop`) before the key landed now decode to their
+                        // real payload. Two-step refresh so the projection — which backs
+                        // onto the op-store after the C3 Stage 4 flip — reflects the
+                        // membership: (1) re-persist the op-store from the gov-DAG with
+                        // the key present, then (2) re-ingest the corrected ops into the
+                        // MAINTAINED projection (`ingest_op` upgrades the stale `Noop`
+                        // op-log entries in place). BEFORE the drain, whose membership
+                        // re-checks must see the corrected ops, not the stale `Noop`.
                         let store = self.context_client.datastore_handle().into_inner();
                         calimero_context::scope_projection::ScopeProjections::repersist_namespace_ops(
                             &store,
                             namespace_id,
                         );
+                        let refreshed =
+                            calimero_context::scope_projection::ScopeProjections::ops_for_namespace(
+                                &store,
+                                namespace_id,
+                            );
                         drop(store);
+                        if let Some(ops) = refreshed {
+                            self.node_state
+                                .write_scope_projections()
+                                .apply_backfill(namespace_id, ops);
+                        }
+
+                        self.drain_governance_pending_after_sync().await;
                     }
                     Err(err) => {
                         warn!(


### PR DESCRIPTION
## What

Flips the projection's governance read onto the unified **op-store** (`ops_for_namespace` → `load_scope_ops`) and makes the op-store authoritative **by construction** — the culmination of the C3 apply-unification arc (Stages 0–3 already merged: #2922/#2923/#2924/#2925).

## The key change: atomic dual-write

The earlier flip attempts failed e2e because the op-store was dual-written in a **separate step** from the governance apply, leaving a window where it lagged the gov-DAG (the read then saw stale membership → joiner-write rejected → 60s sync timeout). This PR closes that by writing the decoded op-store entry **on the same store handle** as the gov-DAG op, inside `NamespaceOpLogService::store_signed_operation` — the single write point every apply path funnels through (receive + local authoring). The op-store can no longer lag the gov-DAG.

- Moved the decode bridge (`op_from_namespace_op`, `signed_namespace_op_to_delta`) into `governance-store::unified_op_decode` (the `payload_from_*` helpers were already in `calimero-op-adapter`); `calimero-context` re-exports them so all callers keep working.
- `store_signed_operation` now decodes the op (decrypting when the key is present) and `handle.put`s the `ScopeUnifiedOp` entry atomically with the gov-DAG put.
- `ingest_op` upgrades a stale `Noop` op-log entry in place (O(1) via a `noop_log_pos` index) when the decrypted payload arrives, so the maintained projection recovers late-decrypted membership.
- The completeness gate is now a **HARD e2e gate** (`op_store_incomplete` → job fails).

## Verification

e2e green, and the hard gate reads clean across the full matrix: *"no op_store_incomplete markers — op-store mirrors the gov-DAG for every exercised namespace"*. The hard gate fails on a single marker, so a clean read across all suites (with sync converging) is positive proof the op-store is a faithful, atomic mirror.

## Follow-ups (not in this PR)
- The Stage 1–3 per-site persists + the receive-handler dual-write + the Stage 3 group wrapper are now **redundant** (the atomic write covers every path) → a pure-deletion cleanup PR.
- Genesis G1 (root-admin self-sufficiency) remains a deferred non-blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)