### PR TITLE
refactor(sync): P6.S1 — unify the scope_root convergence verdict

### DIFF
--- a/crates/context/src/handlers/add_group_members.rs
+++ b/crates/context/src/handlers/add_group_members.rs
@@ -37,7 +37,7 @@ impl Handler<AddGroupMembersRequest> for ContextManager {
         ActorResponse::r#async(
             async move {
                 for (identity, role) in &members {
-                    let report = crate::sign_apply_and_publish_group_op(
+                    let report = calimero_governance_store::sign_apply_and_publish(
                         &datastore,
                         &node_client,
                         &ack_router,

--- a/crates/context/src/handlers/admit_tee_node.rs
+++ b/crates/context/src/handlers/admit_tee_node.rs
@@ -199,7 +199,7 @@ impl Handler<AdmitTeeNodeRequest> for ContextManager {
                     PrivateKey::from(effective_signing_key.ok_or_else(|| {
                         eyre::eyre!("no signing key available for TEE admission")
                     })?);
-                let report = crate::sign_apply_and_publish_group_op(
+                let report = calimero_governance_store::sign_apply_and_publish(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -86,18 +86,6 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                         &delta_parents,
                     );
 
-                    // C2.1b dual-write: persist this governance op to the durable
-                    // unified op-store, keyed by its (namespace) scope. Observe-only —
-                    // nothing reads it yet (the per-plane C2 flips switch reads onto
-                    // it). A failure must never affect the governance apply, so it is
-                    // logged, not propagated.
-                    if let Err(err) = crate::unified_op_store::persist_op(&feed_store, &shadow_op) {
-                        tracing::warn!(
-                            %err,
-                            "unified op-store: failed to persist governance op (dual-write)"
-                        );
-                    }
-
                     {
                         // The member this op touches (for the per-member
                         // shadow-compare), if it's a membership op.

--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -586,7 +586,7 @@ async fn create_context(
     // worst case is a single context associated with a since-removed member.
     {
         let sk = PrivateKey::from(*identity_secret);
-        let report = crate::sign_apply_and_publish_group_op(
+        let report = calimero_governance_store::sign_apply_and_publish(
             &datastore,
             &node_client,
             &ack_router,
@@ -609,7 +609,7 @@ async fn create_context(
 
     if let Some(ref name_str) = name {
         let sk = PrivateKey::from(*identity_secret);
-        let report = crate::sign_apply_and_publish_group_op(
+        let report = calimero_governance_store::sign_apply_and_publish(
             &datastore,
             &node_client,
             &ack_router,

--- a/crates/context/src/handlers/create_group.rs
+++ b/crates/context/src/handlers/create_group.rs
@@ -254,13 +254,6 @@ impl Handler<CreateGroupRequest> for ContextManager {
                     {
                         Ok(report) => {
                             report.observe("create_group", "GroupCreated");
-                            // C3 Stage 1: the local author wrote GroupCreated to the
-                            // gov-DAG; land it in the unified op-store too so the
-                            // op-store stays a complete mirror (by construction).
-                            crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
-                                &datastore,
-                                namespace_id.to_bytes(),
-                            );
                         }
                         Err(e) => {
                             tracing::warn!(?e, "failed to publish GroupCreated on namespace DAG");

--- a/crates/context/src/handlers/delete_context.rs
+++ b/crates/context/src/handlers/delete_context.rs
@@ -138,7 +138,7 @@ async fn delete_context(
                      cannot publish local detach op"
                 )
             })?;
-        let report = crate::sign_apply_and_publish_group_op(
+        let report = calimero_governance_store::sign_apply_and_publish(
             &datastore,
             &node_client,
             &ack_router,

--- a/crates/context/src/handlers/delete_group.rs
+++ b/crates/context/src/handlers/delete_group.rs
@@ -135,11 +135,6 @@ impl Handler<DeleteGroupRequest> for ContextManager {
                 )
                 .await?;
                 report.observe("delete_group", "GroupDeleted");
-                // C3 Stage 1: mirror the locally-authored GroupDeleted into the op-store.
-                crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
-                    &datastore,
-                    namespace_id_bytes,
-                );
 
                 // Best-effort unsubscribe — the group is gone now, no point
                 // staying on its topic. Subscriptions for descendants likewise.

--- a/crates/context/src/handlers/detach_context_from_group.rs
+++ b/crates/context/src/handlers/detach_context_from_group.rs
@@ -44,7 +44,7 @@ impl Handler<DetachContextFromGroupRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                let report = crate::sign_apply_and_publish_group_op(
+                let report = calimero_governance_store::sign_apply_and_publish(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/join_context.rs
+++ b/crates/context/src/handlers/join_context.rs
@@ -277,12 +277,6 @@ impl Handler<JoinContextRequest> for ContextManager {
                              until an admin explicitly add_group_members the joiner"
                         );
                     }
-                    // C3 Stage 1: mirror the locally-authored MemberJoinedOpen into
-                    // the op-store (a no-op if the publish/apply above errored).
-                    crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
-                        &datastore,
-                        ns_id.to_bytes(),
-                    );
                 }
 
                 Ok(JoinContextResponse {

--- a/crates/context/src/handlers/join_subgroup_inheritance.rs
+++ b/crates/context/src/handlers/join_subgroup_inheritance.rs
@@ -160,11 +160,6 @@ impl Handler<JoinSubgroupInheritanceRequest> for ContextManager {
                     );
                     e
                 })?;
-                // C3 Stage 1: mirror the locally-authored MemberJoinedOpen into the op-store.
-                crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
-                    &datastore,
-                    ns_id.to_bytes(),
-                );
 
                 Ok(JoinSubgroupInheritanceResponse {
                     group_id,

--- a/crates/context/src/handlers/leave_group.rs
+++ b/crates/context/src/handlers/leave_group.rs
@@ -126,7 +126,7 @@ impl Handler<LeaveGroupRequest> for ContextManager {
                 // (which enforces owner / last-admin / direct-row checks
                 // again) and broadcasts to peers. Errors at apply bubble
                 // up here as the user-facing failure.
-                let report = crate::sign_apply_and_publish_group_op(
+                let report = calimero_governance_store::sign_apply_and_publish(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/leave_namespace.rs
+++ b/crates/context/src/handlers/leave_namespace.rs
@@ -120,7 +120,7 @@ impl Handler<LeaveNamespaceRequest> for ContextManager {
                 // performs the multi-scope owner / last-admin checks +
                 // cascade across descendants. If any check fails, the error
                 // surfaces here as the user-facing failure.
-                let report = crate::sign_apply_and_publish_group_op(
+                let report = calimero_governance_store::sign_apply_and_publish(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/remove_group_members.rs
+++ b/crates/context/src/handlers/remove_group_members.rs
@@ -70,27 +70,6 @@ impl Handler<RemoveGroupMembersRequest> for ContextManager {
                     )
                     .await?;
                     report.observe("remove_group_members", "MemberRemoved");
-                    // C3 Stage 3: mirror the locally-authored MemberRemoved into the
-                    // op-store, like the other group-op authoring sites. The
-                    // `persist_namespace_head_ops` walk persists the WHOLE namespace
-                    // fold, so the MemberRemoved op (which carries its key-rotation
-                    // bundle inline — not as separate ops) is captured regardless of
-                    // head position.
-                    match calimero_governance_store::NamespaceRepository::new(&datastore)
-                        .resolve(&group_id)
-                    {
-                        Ok(namespace_id) => {
-                            crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
-                                &datastore,
-                                namespace_id.to_bytes(),
-                            );
-                        }
-                        Err(err) => tracing::warn!(
-                            %err,
-                            ?group_id,
-                            "C3: could not resolve namespace to mirror MemberRemoved into the op-store"
-                        ),
-                    }
                 }
                 info!(
                     ?group_id,

--- a/crates/context/src/handlers/set_member_auto_follow.rs
+++ b/crates/context/src/handlers/set_member_auto_follow.rs
@@ -50,7 +50,7 @@ impl Handler<SetMemberAutoFollowRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                let report = crate::sign_apply_and_publish_group_op(
+                let report = calimero_governance_store::sign_apply_and_publish(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/set_member_capabilities.rs
+++ b/crates/context/src/handlers/set_member_capabilities.rs
@@ -45,7 +45,7 @@ impl Handler<SetMemberCapabilitiesRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                let report = crate::sign_apply_and_publish_group_op(
+                let report = calimero_governance_store::sign_apply_and_publish(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/set_subgroup_visibility.rs
+++ b/crates/context/src/handlers/set_subgroup_visibility.rs
@@ -67,7 +67,7 @@ impl Handler<SetSubgroupVisibilityRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                let report = crate::sign_apply_and_publish_group_op(
+                let report = calimero_governance_store::sign_apply_and_publish(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/set_tee_admission_policy.rs
+++ b/crates/context/src/handlers/set_tee_admission_policy.rs
@@ -103,7 +103,7 @@ impl Handler<SetTeeAdmissionPolicyRequest> for ContextManager {
                 let sk = PrivateKey::from(effective_signing_key.ok_or_else(|| {
                     eyre::eyre!("local group governance requires a signing key for the requester")
                 })?);
-                let report = crate::sign_apply_and_publish_group_op(
+                let report = calimero_governance_store::sign_apply_and_publish(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/update_member_role.rs
+++ b/crates/context/src/handlers/update_member_role.rs
@@ -71,7 +71,7 @@ impl Handler<UpdateMemberRoleRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                let report = crate::sign_apply_and_publish_group_op(
+                let report = calimero_governance_store::sign_apply_and_publish(
                     &datastore,
                     &node_client,
                     &ack_router,

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -211,7 +211,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                         // short-circuit on its applied marker, so the new
                         // bytecode would never activate.
                         for rung in &rungs {
-                            let report = crate::sign_apply_and_publish_group_op(
+                            let report = calimero_governance_store::sign_apply_and_publish(
                                 &datastore,
                                 &node_client,
                                 &ack_router_for_lazy,
@@ -224,7 +224,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                             )
                             .await?;
                             report.observe("upgrade_group", "TargetApplicationSet");
-                            let report = crate::sign_apply_and_publish_group_op(
+                            let report = calimero_governance_store::sign_apply_and_publish(
                                 &datastore,
                                 &node_client,
                                 &ack_router_for_lazy,
@@ -379,7 +379,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                     .as_ref()
                     .ok_or_else(|| eyre::eyre!("target application not found"))?;
                 let app_key = *app_meta.bytecode.blob_id().as_ref();
-                let report = crate::sign_apply_and_publish_group_op(
+                let report = calimero_governance_store::sign_apply_and_publish(
                     &datastore_for_canary,
                     &node_client,
                     &ack_router_for_canary,
@@ -395,7 +395,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                 // Unconditional — see the LazyOnAccess site: clearing a stale
                 // method on code-only upgrades keeps the same-id lazy trigger
                 // out of the migration arm.
-                let report = crate::sign_apply_and_publish_group_op(
+                let report = calimero_governance_store::sign_apply_and_publish(
                     &datastore_for_canary,
                     &node_client,
                     &ack_router_for_canary,
@@ -1614,7 +1614,7 @@ fn dispatch_cascade(
 
         let sk = PrivateKey::from(effective_signing_key);
 
-        let report = crate::sign_apply_and_publish_group_op(
+        let report = calimero_governance_store::sign_apply_and_publish(
             &datastore_for_publish,
             &node_client_for_publish,
             &ack_router_for_publish,

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -731,7 +731,7 @@ impl ContextManager {
 
         ActorResponse::r#async(
             async move {
-                let _report = crate::sign_apply_and_publish_group_op(
+                let _report = calimero_governance_store::sign_apply_and_publish(
                     &datastore,
                     &node_client,
                     &ack_router,
@@ -746,55 +746,6 @@ impl ContextManager {
             .into_actor(self),
         )
     }
-}
-
-/// Author a group governance op (the B1 local-authoring path) and mirror it into
-/// the unified op-store — C3 Stage 3.
-///
-/// `calimero_governance_store::sign_apply_and_publish` applies the op to the local
-/// group plane and publishes the encrypted `NamespaceOp::Group` to the namespace
-/// gov-DAG (`publish_post_gate` → `store_operation`), but never writes the op-store:
-/// the dual-write only fires on the receive handler, so the AUTHOR's own op-store
-/// was missing every group op it authored. That's the structural gap behind the
-/// read-flip's "governance cut not locally known" timeouts.
-///
-/// After publishing, the encrypted op is the namespace gov-DAG head and the author
-/// holds the group key, so `persist_namespace_head_ops` decrypts it and lands the
-/// real decoded op. Best-effort: a resolve/persist failure never fails authoring.
-pub(crate) async fn sign_apply_and_publish_group_op(
-    store: &calimero_store::Store,
-    node_client: &calimero_node_primitives::client::NodeClient,
-    ack_router: &calimero_context_client::local_governance::AckRouter,
-    group_id: &calimero_context_config::types::ContextGroupId,
-    signer_sk: &calimero_primitives::identity::PrivateKey,
-    op: calimero_context_client::local_governance::GroupOp,
-) -> eyre::Result<Option<calimero_governance_store::governance_broadcast::DeliveryReport>> {
-    let report = calimero_governance_store::sign_apply_and_publish(
-        store,
-        node_client,
-        ack_router,
-        group_id,
-        signer_sk,
-        op,
-    )
-    .await?;
-    match calimero_governance_store::NamespaceRepository::new(store).resolve(group_id) {
-        Ok(namespace_id) => {
-            crate::scope_projection::ScopeProjections::persist_namespace_head_ops(
-                store,
-                namespace_id.to_bytes(),
-            );
-        }
-        // This is the single chokepoint for all group-op authoring, so a systematic
-        // resolve failure would leave the op-store incomplete for every authored op
-        // with no signal otherwise — warn so the divergence is observable.
-        Err(err) => tracing::warn!(
-            %err,
-            ?group_id,
-            "C3: could not resolve namespace to mirror the authored group op into the op-store"
-        ),
-    }
-    Ok(report)
 }
 
 impl ContextManager {

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1111,24 +1111,6 @@ impl ScopeProjections {
         );
     }
 
-    /// Persist a locally-authored namespace's governance ops to the unified op-store
-    /// (cutover C3 Stage 1, by-construction): a locally-authored op writes the gov-DAG
-    /// (`advance_dag_head`) but NOT the op-store, because the dual-write only fires on
-    /// the receive handler. Called right after authoring.
-    ///
-    /// This persists the WHOLE gov-DAG fold, not just the current heads. A heads-only
-    /// persist would be racy: the caller authors, then awaits the publish round-trip,
-    /// and the actor can apply a concurrent peer op during that await — advancing the
-    /// head so the just-authored op is no longer a head and a heads-only persist skips
-    /// it. The full walk via [`repersist_namespace_ops`](Self::repersist_namespace_ops)
-    /// captures the authored op wherever it landed in the DAG, reuses
-    /// `collect_namespace_ops`'s read-error logging, and is bounded by `MAX_BACKFILL_OPS`
-    /// (local authoring is infrequent, and re-persisting an unchanged op is idempotent).
-    /// Best-effort; never affects authoring.
-    pub fn persist_namespace_head_ops(store: &Store, namespace_id: [u8; 32]) {
-        Self::repersist_namespace_ops(store, namespace_id);
-    }
-
     /// Observe-only completeness gate (cutover C3 Stage 0): warn when the unified
     /// op-store is MISSING governance ops the gov-DAG has for `namespace_id`.
     ///

--- a/crates/context/tests/op_store_reconstruction.rs
+++ b/crates/context/tests/op_store_reconstruction.rs
@@ -226,12 +226,13 @@ fn completeness_gate_flags_governance_ops_missing_from_the_op_store() {
     );
 }
 
-/// C3 Stage 1: `persist_namespace_head_ops` lands a locally-authored op (written to
-/// the gov-DAG but not the op-store) into the op-store, closing the local-author gap.
+/// C3 Stage 1: a locally-authored op is now written to the op-store ATOMICALLY with
+/// the gov-DAG by `store_signed_operation`, closing the local-author gap at the source;
+/// `repersist_namespace_ops` re-walking the namespace stays idempotent over it.
 /// Uses a REAL encrypted MemberAdded + key so the persisted op carries the decoded
 /// membership — verifying the payload decodes, not just that the id appears.
 #[test]
-fn persist_namespace_head_ops_lands_locally_authored_op_in_the_op_store() {
+fn locally_authored_op_lands_in_the_op_store_atomically() {
     let store = store();
     let admin = PrivateKey::random(&mut OsRng).public_key();
     let member = PrivateKey::random(&mut OsRng).public_key();
@@ -291,9 +292,9 @@ fn persist_namespace_head_ops_lands_locally_authored_op_in_the_op_store() {
         "store_signed_operation must persist the op atomically with the gov-DAG write"
     );
 
-    // `persist_namespace_head_ops` remains idempotent over the now-already-present
-    // op (the redundant per-site re-persist is kept as belt-and-suspenders).
-    ScopeProjections::persist_namespace_head_ops(&store, ns_bytes);
+    // `repersist_namespace_ops` remains idempotent over the now-already-present
+    // op (re-walking and re-persisting rewrites identical bytes).
+    ScopeProjections::repersist_namespace_ops(&store, ns_bytes);
 
     // The op is in the op-store AND decodes to the real membership: a fresh fold
     // of the op-store sees `member` (proves the payload landed, not just the id).

--- a/crates/node/src/join_namespace.rs
+++ b/crates/node/src/join_namespace.rs
@@ -371,14 +371,6 @@ pub async fn await_namespace_ready(
         .await
         .map_err(|e| ReadyError::PublishMemberJoined(e.to_string()))?;
 
-    // C3 Stage 2: the quorum publish wrote MemberJoinedAt to the local gov-DAG
-    // (`publish_post_gate` → `store_operation`) without the receive handler's
-    // dual-write; mirror it into the op-store so it stays a complete mirror.
-    calimero_context::scope_projection::ScopeProjections::persist_namespace_head_ops(
-        store,
-        namespace_id,
-    );
-
     // step 4: assemble ReadyReport with post-publish observable state.
     // Note the read accessors are best-effort — if the underlying
     // store read fails we substitute defaults rather than fail the

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -712,24 +712,22 @@ async fn run_initiator_impl<T: SyncTransport>(
     // exactly the pre-C1 behaviour, so no context regresses to a weaker check than
     // before.
     let local_scope_root = super::helpers::local_scope_root(store, &context_id, local_root_hash);
-    stats.root_hash_verified = match (local_scope_root, peer_scope_root) {
-        (Some(local), Some(peer)) => local == peer,
-        _ => local_root_hash == peer_current_root,
-    };
+    let verdict = super::helpers::scope_verdict(
+        local_scope_root,
+        peer_scope_root,
+        local_root_hash,
+        peer_current_root,
+    );
+    stats.root_hash_verified = verdict.converged();
 
-    // Surface the case the entity root hides: entities AGREE but `scope_root`
-    // differs ⇒ the divergence is purely in the ACL/governance plane. HC's entity
-    // tree-walk has nothing to reconcile here (the entities already match); the
-    // rotation propagates via the ordinary governance sync tick, and the next HC
-    // session re-reads an agreeing `scope_root` once it lands. Distinct marker so a
+    // Surface the case the entity root hides: entities AGREE but `scope_root` differs
+    // ⇒ the divergence is purely in the ACL/governance plane. HC's entity tree-walk
+    // has nothing to reconcile here (the entities already match); the rotation
+    // propagates via the ordinary governance sync tick, and the next HC session
+    // re-reads an agreeing `scope_root` once it lands. Distinct marker so a
     // governance-plane divergence is legible apart from a data-plane one.
-    // Destructure both scope_roots up front (vs `matches!` + `unwrap_or_default`):
-    // this case is meaningful only when BOTH sides resolved one, and binding them
-    // avoids a dead default branch and any reliance on `[u8; 32]` being `Copy`.
-    if let (Some(local_scope_root), Some(peer_scope_root)) = (local_scope_root, peer_scope_root) {
-        if !stats.root_hash_verified
-            && local_root_hash == peer_current_root
-            && local_scope_root != peer_scope_root
+    if verdict == super::helpers::ScopeVerdict::GovDiverged {
+        if let (Some(local_scope_root), Some(peer_scope_root)) = (local_scope_root, peer_scope_root)
         {
             warn!(
                 marker = "scope_root_governance_divergence",

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -726,19 +726,16 @@ async fn run_initiator_impl<T: SyncTransport>(
     // propagates via the ordinary governance sync tick, and the next HC session
     // re-reads an agreeing `scope_root` once it lands. Distinct marker so a
     // governance-plane divergence is legible apart from a data-plane one.
-    if verdict == super::helpers::ScopeVerdict::GovDiverged {
-        if let (Some(local_scope_root), Some(peer_scope_root)) = (local_scope_root, peer_scope_root)
-        {
-            warn!(
-                marker = "scope_root_governance_divergence",
-                %context_id,
-                entity_root = %hex::encode(&local_root_hash[..8]),
-                local_scope_root = %hex::encode(&local_scope_root[..8]),
-                peer_scope_root = %hex::encode(&peer_scope_root[..8]),
-                "entity roots agree but scope_root differs — ACL/membership divergence; \
-                 awaiting governance sync to propagate the rotation"
-            );
-        }
+    if let super::helpers::ScopeVerdict::GovDiverged(local_scope_root, peer_scope_root) = verdict {
+        warn!(
+            marker = "scope_root_governance_divergence",
+            %context_id,
+            entity_root = %hex::encode(&local_root_hash[..8]),
+            local_scope_root = %hex::encode(&local_scope_root[..8]),
+            peer_scope_root = %hex::encode(&peer_scope_root[..8]),
+            "entity roots agree but scope_root differs — ACL/membership divergence; \
+             awaiting governance sync to propagate the rotation"
+        );
     }
 
     // core#2716: re-anchor the context's persisted `root_hash` to the

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -81,8 +81,10 @@ pub(crate) enum ScopeVerdict {
     /// can't be folded) the bare entity roots matched.
     Converged,
     /// Entity roots agree but `scope_root` differs ⇒ pure ACL/governance divergence
-    /// (the hash-neutral case the entity root hides; awaits governance sync).
-    GovDiverged,
+    /// (the hash-neutral case the entity root hides; awaits governance sync). Carries
+    /// the two resolved scope roots `(local, peer)` so callers log them without
+    /// re-destructuring the `Option`s the verdict already proved were `Some`.
+    GovDiverged([u8; 32], [u8; 32]),
     /// Entity roots differ ⇒ the data plane needs reconciliation.
     DataDiverged,
 }
@@ -110,8 +112,15 @@ pub(crate) fn scope_verdict(
 ) -> ScopeVerdict {
     match (local_scope_root, peer_scope_root) {
         (Some(local), Some(peer)) if local == peer => ScopeVerdict::Converged,
-        (Some(_), Some(_)) if local_entity_root == peer_entity_root => ScopeVerdict::GovDiverged,
+        (Some(local), Some(peer)) if local_entity_root == peer_entity_root => {
+            ScopeVerdict::GovDiverged(local, peer)
+        }
         (Some(_), Some(_)) => ScopeVerdict::DataDiverged,
+        // Asymmetric `None` (exactly one side has a cold projection / non-group
+        // context) intentionally falls back to the bare entity-root compare rather
+        // than reporting GovDiverged: we can't fold a scope_root we don't have, so
+        // treating the mismatch as governance divergence would raise a false alarm
+        // on a partially-warmed node. This is the pre-C1 check — don't "fix" it.
         _ if local_entity_root == peer_entity_root => ScopeVerdict::Converged,
         _ => ScopeVerdict::DataDiverged,
     }
@@ -1429,9 +1438,10 @@ mod empty_chain_placement_tests {
     #[test]
     fn scope_verdict_scope_differs_entities_agree_is_gov_diverged() {
         // scope_root is authoritative: entities matching doesn't mean converged.
+        // The verdict carries the resolved roots so callers log without re-unwrapping.
         assert_eq!(
             scope_verdict(Some(A), Some(B), E1, E1),
-            ScopeVerdict::GovDiverged
+            ScopeVerdict::GovDiverged(A, B)
         );
         assert!(!scope_verdict(Some(A), Some(B), E1, E1).converged());
     }

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -73,6 +73,50 @@ pub(crate) fn local_scope_root(
     )
 }
 
+/// The cross-plane convergence verdict between two peers (cutover P6.S1 — the single
+/// source of truth all sync protocols decide against).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScopeVerdict {
+    /// Both planes agree — the authoritative `scope_root` matched, or (when a scope
+    /// can't be folded) the bare entity roots matched.
+    Converged,
+    /// Entity roots agree but `scope_root` differs ⇒ pure ACL/governance divergence
+    /// (the hash-neutral case the entity root hides; awaits governance sync).
+    GovDiverged,
+    /// Entity roots differ ⇒ the data plane needs reconciliation.
+    DataDiverged,
+}
+
+impl ScopeVerdict {
+    pub(crate) fn converged(self) -> bool {
+        matches!(self, ScopeVerdict::Converged)
+    }
+}
+
+/// The authoritative convergence verdict (C1): `scope_root` folds entities + ACL +
+/// membership/admin, so when BOTH sides resolve one it alone decides — closing the
+/// hash-neutral rotation blind spot. When either side can't fold the scope (cold
+/// projection / non-group context, `None`), fall back to the bare entity-root compare
+/// — exactly the pre-C1 behaviour, so no context regresses to a weaker check.
+///
+/// Previously this verdict was open-coded identically in `hash_comparison_protocol`,
+/// `level_sync`, and the delta paths; P6.S1 makes it one function so every sync
+/// protocol reaches the same conclusion and the later stages can route off it.
+pub(crate) fn scope_verdict(
+    local_scope_root: Option<[u8; 32]>,
+    peer_scope_root: Option<[u8; 32]>,
+    local_entity_root: [u8; 32],
+    peer_entity_root: [u8; 32],
+) -> ScopeVerdict {
+    match (local_scope_root, peer_scope_root) {
+        (Some(local), Some(peer)) if local == peer => ScopeVerdict::Converged,
+        (Some(_), Some(_)) if local_entity_root == peer_entity_root => ScopeVerdict::GovDiverged,
+        (Some(_), Some(_)) => ScopeVerdict::DataDiverged,
+        _ if local_entity_root == peer_entity_root => ScopeVerdict::Converged,
+        _ => ScopeVerdict::DataDiverged,
+    }
+}
+
 /// Validates that peer's application ID matches ours.
 ///
 /// # Errors
@@ -1365,5 +1409,52 @@ mod empty_chain_placement_tests {
         // apply path must defer instead of placing it, so the predicate
         // must report "unsafe" here.
         assert!(!super::empty_chain_placement_is_safe(false, false));
+    }
+
+    use super::{scope_verdict, ScopeVerdict};
+    const A: [u8; 32] = [0xAA; 32];
+    const B: [u8; 32] = [0xBB; 32];
+    const E1: [u8; 32] = [0x11; 32];
+    const E2: [u8; 32] = [0x22; 32];
+
+    #[test]
+    fn scope_verdict_both_resolved_and_equal_is_converged() {
+        assert_eq!(
+            scope_verdict(Some(A), Some(A), E1, E2),
+            ScopeVerdict::Converged
+        );
+        assert!(scope_verdict(Some(A), Some(A), E1, E2).converged());
+    }
+
+    #[test]
+    fn scope_verdict_scope_differs_entities_agree_is_gov_diverged() {
+        // scope_root is authoritative: entities matching doesn't mean converged.
+        assert_eq!(
+            scope_verdict(Some(A), Some(B), E1, E1),
+            ScopeVerdict::GovDiverged
+        );
+        assert!(!scope_verdict(Some(A), Some(B), E1, E1).converged());
+    }
+
+    #[test]
+    fn scope_verdict_scope_and_entities_both_differ_is_data_diverged() {
+        assert_eq!(
+            scope_verdict(Some(A), Some(B), E1, E2),
+            ScopeVerdict::DataDiverged
+        );
+    }
+
+    #[test]
+    fn scope_verdict_cold_projection_falls_back_to_entity_compare() {
+        // Either side `None` ⇒ pre-C1 entity-root compare (no regression to weaker).
+        assert_eq!(
+            scope_verdict(None, Some(A), E1, E1),
+            ScopeVerdict::Converged
+        );
+        assert_eq!(
+            scope_verdict(Some(A), None, E1, E2),
+            ScopeVerdict::DataDiverged
+        );
+        assert_eq!(scope_verdict(None, None, E1, E1), ScopeVerdict::Converged);
     }
 }

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -620,20 +620,18 @@ async fn run_initiator_impl<T: SyncTransport>(
     if !stats.root_hash_verified {
         // Entities agree but scope_root differs ⇒ pure ACL/governance divergence
         // (the case the entity root hides); distinct marker, parity with HC.
-        if verdict == super::helpers::ScopeVerdict::GovDiverged {
-            if let (Some(local_scope_root), Some(peer_scope_root)) =
-                (local_scope_root, peer_scope_root)
-            {
-                warn!(
-                    marker = "scope_root_governance_divergence",
-                    %context_id,
-                    entity_root = %hex::encode(&local_root_hash[..8]),
-                    local_scope_root = %hex::encode(&local_scope_root[..8]),
-                    peer_scope_root = %hex::encode(&peer_scope_root[..8]),
-                    "entity roots agree but scope_root differs — ACL/membership divergence; \
-                     awaiting governance sync to propagate the rotation"
-                );
-            }
+        if let super::helpers::ScopeVerdict::GovDiverged(local_scope_root, peer_scope_root) =
+            verdict
+        {
+            warn!(
+                marker = "scope_root_governance_divergence",
+                %context_id,
+                entity_root = %hex::encode(&local_root_hash[..8]),
+                local_scope_root = %hex::encode(&local_scope_root[..8]),
+                peer_scope_root = %hex::encode(&peer_scope_root[..8]),
+                "entity roots agree but scope_root differs — ACL/membership divergence; \
+                 awaiting governance sync to propagate the rotation"
+            );
         } else {
             warn!(
                 %context_id,

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -609,33 +609,31 @@ async fn run_initiator_impl<T: SyncTransport>(
     })?;
 
     let local_scope_root = super::helpers::local_scope_root(store, &context_id, local_root_hash);
-    stats.root_hash_verified = match (local_scope_root, peer_scope_root) {
-        (Some(local), Some(peer)) => local == peer,
-        _ => local_root_hash == peer_current_root,
-    };
+    let verdict = super::helpers::scope_verdict(
+        local_scope_root,
+        peer_scope_root,
+        local_root_hash,
+        peer_current_root,
+    );
+    stats.root_hash_verified = verdict.converged();
 
     if !stats.root_hash_verified {
         // Entities agree but scope_root differs ⇒ pure ACL/governance divergence
         // (the case the entity root hides); distinct marker, parity with HC.
-        // Destructure both scope_roots (vs `matches!` + `unwrap_or_default`): this
-        // case needs both resolved, and binding them avoids a dead default branch
-        // and any reliance on `[u8; 32]` being `Copy`.
-        let governance_divergence = match (local_scope_root, peer_scope_root) {
-            (Some(local), Some(peer)) => local_root_hash == peer_current_root && local != peer,
-            _ => false,
-        };
-        if let (true, Some(local_scope_root), Some(peer_scope_root)) =
-            (governance_divergence, local_scope_root, peer_scope_root)
-        {
-            warn!(
-                marker = "scope_root_governance_divergence",
-                %context_id,
-                entity_root = %hex::encode(&local_root_hash[..8]),
-                local_scope_root = %hex::encode(&local_scope_root[..8]),
-                peer_scope_root = %hex::encode(&peer_scope_root[..8]),
-                "entity roots agree but scope_root differs — ACL/membership divergence; \
-                 awaiting governance sync to propagate the rotation"
-            );
+        if verdict == super::helpers::ScopeVerdict::GovDiverged {
+            if let (Some(local_scope_root), Some(peer_scope_root)) =
+                (local_scope_root, peer_scope_root)
+            {
+                warn!(
+                    marker = "scope_root_governance_divergence",
+                    %context_id,
+                    entity_root = %hex::encode(&local_root_hash[..8]),
+                    local_scope_root = %hex::encode(&local_scope_root[..8]),
+                    peer_scope_root = %hex::encode(&peer_scope_root[..8]),
+                    "entity roots agree but scope_root differs — ACL/membership divergence; \
+                     awaiting governance sync to propagate the rotation"
+                );
+            }
         } else {
             warn!(
                 %context_id,

--- a/crates/server/src/admin/handlers/groups/reparent_group.rs
+++ b/crates/server/src/admin/handlers/groups/reparent_group.rs
@@ -98,11 +98,6 @@ pub async fn handler(
     {
         Ok(report) => {
             report.observe("reparent_group", "GroupReparented");
-            // C3 Stage 2: mirror the locally-authored GroupReparented into the op-store.
-            calimero_context::scope_projection::ScopeProjections::persist_namespace_head_ops(
-                &state.store,
-                namespace_id.to_bytes(),
-            );
             ApiResponse {
                 payload: ReparentGroupApiResponse {
                     reparented: !was_already_there,

--- a/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
@@ -170,12 +170,6 @@ pub async fn handler(
     {
         Ok(report) => {
             report.observe("create_group_in_namespace", "GroupCreated");
-            // C3 Stage 2: mirror the locally-authored GroupCreated into the op-store
-            // (the admin-API authoring path, like the node handlers).
-            calimero_context::scope_projection::ScopeProjections::persist_namespace_head_ops(
-                &state.store,
-                resolved_ns_id.to_bytes(),
-            );
             let group_id = group_id_cgid;
 
             if let Some(name) = body.group_name.as_deref() {


### PR DESCRIPTION
## What

First slice of **P6** (the sync-engine collapse). The cross-plane convergence verdict — `scope_root` is authoritative, falling back to the bare entity-root compare when a scope can't be folded (cold projection / non-group context) — was **open-coded identically** in `hash_comparison_protocol.rs` and `level_sync.rs`.

This extracts it into one `helpers::scope_verdict(local_scope_root, peer_scope_root, local_entity_root, peer_entity_root) -> ScopeVerdict { Converged | GovDiverged | DataDiverged }`. Both protocols now decide against the single function, and the later P6 stages (route gov-plane and data-plane pulls off the verdict) build on it.

## Pure refactor

No behavioral change: both sites compute the same `root_hash_verified` and emit the same `scope_root_governance_divergence` marker as before — the logic is byte-for-byte the prior match, just shared. Unit-tested (4 cases): equal→`Converged`, scope-differs-but-entities-agree→`GovDiverged`, both-differ→`DataDiverged`, cold-projection→entity-root fallback.

Clippy clean. No wire/op-id/protocol change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch all group-op authoring sites and sync convergence decisions; behavior is intended to be equivalent, but any gap in atomic op-store writes would reintroduce the local-author op-store incompleteness this PR removes mirrors for.
> 
> **Overview**
> **P6.S1** centralizes cross-plane sync convergence in `helpers::scope_verdict` → `ScopeVerdict` (`Converged` / `GovDiverged` / `DataDiverged`). **Hash comparison** and **level sync** now call that helper for `root_hash_verified` and the `scope_root_governance_divergence` warning instead of duplicating the same `match` logic.
> 
> **C3 op-store cutover cleanup** removes belt-and-suspenders mirroring now that governance writes land in the unified op-store atomically with the gov-DAG: the context crate drops `sign_apply_and_publish_group_op` and every handler/admin path calls `calimero_governance_store::sign_apply_and_publish` directly. Removed are post-author `ScopeProjections::persist_namespace_head_ops` calls, the receive-path `unified_op_store::persist_op` dual-write in `apply_signed_namespace_op`, and the `persist_namespace_head_ops` API (tests now assert atomic persistence via `store_signed_operation` / idempotent `repersist_namespace_ops`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b701580a08587414760c5db987fe4a4ee323094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->