### PR TITLE
feat(sync): P6.S2 — pull governance on a scope_root GovDiverged verdict

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -512,6 +512,26 @@ jobs:
               echo "no op_store_incomplete or op_store_gate_unavailable markers — op-store mirrors the gov-DAG for every exercised namespace"
           fi
 
+      - name: Report scope_root governance-divergence pulls (P6.S2, observe-only)
+        if: always()
+        run: |
+          # P6.S2 routes the GovDiverged verdict (entities agree, scope_root differs)
+          # into an actual governance pull from the diverging peer — previously this
+          # case only warned. `gov_divergence_pull_triggered` fires each time the
+          # selector issues that pull. This step is INFORMATIONAL (never fails): it
+          # confirms the corrective pull fires on rotation scenarios and lets us watch
+          # for a pathological storm (the same context pulling every single tick would
+          # show as a very high count for one context_id).
+          if grep -rl "gov_divergence_pull_triggered" docker-logs/ 2>/dev/null | grep -q .; then
+              count=$(grep -rho "gov_divergence_pull_triggered" docker-logs/ | wc -l | tr -d ' ')
+              echo "::notice::scope_root governance pulls in ${{ matrix.workflow }} — $count trigger(s)"
+              echo "per-context trigger counts (watch for a single context dominating = storm):"
+              grep -rho 'gov_divergence_pull_triggered.*' docker-logs/ \
+                | grep -oE 'context_id=[0-9a-f]+' | sort | uniq -c | sort -rn | head -10
+          else
+              echo "no gov_divergence_pull_triggered markers — no scope_root governance divergence pulled this run"
+          fi
+
       - name: List docker-logs/ before upload (debug)
         if: always()
         run: ls -la docker-logs/ 2>&1 || echo "docker-logs/ missing"

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -142,6 +142,16 @@ pub struct HashComparisonStats {
     /// merge did not converge the two peers — see #2407 for the
     /// failure mode this guards against.
     pub root_hash_verified: bool,
+    /// Whether the convergence verdict was `GovDiverged` — the entity
+    /// roots agreed but the authoritative `scope_root` differed, i.e. a
+    /// pure ACL/governance-plane divergence that the entity Merkle walk
+    /// can't reconcile (governance lives outside the storage Merkle).
+    /// The caller (`ProtocolSelector`) reacts by pulling the namespace
+    /// governance DAG from the same peer (P6.S2) — without it, a node
+    /// with no stuck deltas would otherwise just warn and never converge
+    /// the governance plane. Distinct from `root_hash_verified == false`,
+    /// which also covers data-plane divergence.
+    pub gov_divergence_detected: bool,
     /// Root-state byte blobs the DFS encountered on remote leaves
     /// that the host can't merge by itself (separate-address-space
     /// merge registry — see [`crate::sync::helpers::apply_leaf_with_crdt_merge`]).
@@ -719,13 +729,16 @@ async fn run_initiator_impl<T: SyncTransport>(
         peer_current_root,
     );
     stats.root_hash_verified = verdict.converged();
+    stats.gov_divergence_detected =
+        matches!(verdict, super::helpers::ScopeVerdict::GovDiverged(..));
 
     // Surface the case the entity root hides: entities AGREE but `scope_root` differs
     // ⇒ the divergence is purely in the ACL/governance plane. HC's entity tree-walk
-    // has nothing to reconcile here (the entities already match); the rotation
-    // propagates via the ordinary governance sync tick, and the next HC session
-    // re-reads an agreeing `scope_root` once it lands. Distinct marker so a
-    // governance-plane divergence is legible apart from a data-plane one.
+    // has nothing to reconcile here (the entities already match) — governance ops
+    // live outside the storage Merkle. The selector reacts to
+    // `gov_divergence_detected` by pulling the namespace governance DAG from this
+    // same peer (P6.S2); distinct marker so a governance-plane divergence is legible
+    // apart from a data-plane one.
     if let super::helpers::ScopeVerdict::GovDiverged(local_scope_root, peer_scope_root) = verdict {
         warn!(
             marker = "scope_root_governance_divergence",
@@ -734,7 +747,7 @@ async fn run_initiator_impl<T: SyncTransport>(
             local_scope_root = %hex::encode(&local_scope_root[..8]),
             peer_scope_root = %hex::encode(&peer_scope_root[..8]),
             "entity roots agree but scope_root differs — ACL/membership divergence; \
-             awaiting governance sync to propagate the rotation"
+             pulling governance from the peer to propagate the rotation"
         );
     }
 

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -145,6 +145,11 @@ pub struct LevelWiseStats {
     pub requests_sent: u64,
     /// Whether final root hash was verified against expected.
     pub root_hash_verified: bool,
+    /// Whether the convergence verdict was `GovDiverged` (entity roots
+    /// agreed, authoritative `scope_root` differed). Same meaning and
+    /// caller reaction as [`crate::sync::hash_comparison_protocol::HashComparisonStats::gov_divergence_detected`]:
+    /// the selector pulls the namespace governance DAG from this peer (P6.S2).
+    pub gov_divergence_detected: bool,
     /// Whether parent_ids were truncated due to `MAX_PARENTS_PER_REQUEST`.
     ///
     /// If true, the sync may be incomplete and a follow-up sync might be needed.
@@ -616,10 +621,14 @@ async fn run_initiator_impl<T: SyncTransport>(
         peer_current_root,
     );
     stats.root_hash_verified = verdict.converged();
+    stats.gov_divergence_detected =
+        matches!(verdict, super::helpers::ScopeVerdict::GovDiverged(..));
 
     if !stats.root_hash_verified {
         // Entities agree but scope_root differs ⇒ pure ACL/governance divergence
-        // (the case the entity root hides); distinct marker, parity with HC.
+        // (the case the entity root hides); distinct marker, parity with HC. The
+        // selector reacts to `gov_divergence_detected` by pulling governance from
+        // the peer (P6.S2).
         if let super::helpers::ScopeVerdict::GovDiverged(local_scope_root, peer_scope_root) =
             verdict
         {
@@ -630,7 +639,7 @@ async fn run_initiator_impl<T: SyncTransport>(
                 local_scope_root = %hex::encode(&local_scope_root[..8]),
                 peer_scope_root = %hex::encode(&peer_scope_root[..8]),
                 "entity roots agree but scope_root differs — ACL/membership divergence; \
-                 awaiting governance sync to propagate the rotation"
+                 pulling governance from the peer to propagate the rotation"
             );
         } else {
             warn!(

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -3414,6 +3414,26 @@ impl super::protocol_selector::ProtocolDispatch for SyncManager {
     ) -> eyre::Result<SyncProtocol> {
         SyncManager::fallback_to_snapshot_sync(self, context_id, our_identity, chosen_peer).await
     }
+
+    async fn pull_namespace_governance(&self, context_id: ContextId, peer: PeerId) {
+        let namespace_id = {
+            let store = self.context_client.datastore_handle().into_inner();
+            namespace_sync::resolve_namespace_id(&store, &context_id)
+        };
+        let Some(namespace_id) = namespace_id else {
+            debug!(
+                %context_id,
+                "scope_root governance pull: could not resolve namespace id; skipping"
+            );
+            return;
+        };
+        // Pull the namespace governance DAG from the peer we just diverged
+        // from — it holds the rotation/ACL op our entity walk couldn't see.
+        // Same `NamespaceBackfillRequest` machinery as the pending-delta and
+        // join backfills, just edge-triggered on the scope_root verdict.
+        self.sync_namespace_from_peer(namespace_id, Some(peer))
+            .await;
+    }
 }
 
 // Driver-dispatch back into `SyncManager` for the cross-actor message

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -71,6 +71,17 @@ pub(crate) trait ProtocolDispatch {
         our_identity: PublicKey,
         chosen_peer: PeerId,
     ) -> Result<SyncProtocol>;
+
+    /// Pull the namespace governance DAG for `context_id` from `peer`
+    /// (P6.S2). Called when a data-plane sync (HashComparison /
+    /// LevelWise) reports `gov_divergence_detected` — the entity Merkle
+    /// converged but the authoritative `scope_root` did not, so the
+    /// divergence is purely in the ACL/governance plane, which lives
+    /// outside the storage Merkle and is never pulled by the entity
+    /// tree-walk. The manager resolves the namespace for the context
+    /// and issues a `NamespaceBackfillRequest` to the peer. Best-effort:
+    /// a no-op when the context has no resolvable namespace.
+    async fn pull_namespace_governance(&self, context_id: ContextId, peer: PeerId);
 }
 
 /// Protocol-dispatch component.
@@ -266,6 +277,24 @@ impl ProtocolSelector {
                             .await;
                         }
 
+                        // P6.S2: entities converged but the authoritative
+                        // `scope_root` did not ⇒ pure governance-plane
+                        // divergence the entity walk can't reach. Pull the
+                        // namespace governance DAG from this same peer so the
+                        // rotation/ACL change propagates; the next session
+                        // re-reads an agreeing `scope_root`.
+                        if stats.gov_divergence_detected {
+                            info!(
+                                marker = "gov_divergence_pull_triggered",
+                                %context_id,
+                                %chosen_peer,
+                                "scope_root governance divergence — pulling namespace governance from peer"
+                            );
+                            dispatch
+                                .pull_namespace_governance(context_id, chosen_peer)
+                                .await;
+                        }
+
                         Ok(Some(SyncProtocol::HashComparison { root_hash }))
                     }
                     Err(e) => {
@@ -400,6 +429,21 @@ impl ProtocolSelector {
                                 &stats.deferred_root_merges,
                             )
                             .await;
+                        }
+
+                        // P6.S2: governance-plane divergence the entity BFS
+                        // can't reach — pull the namespace governance from this
+                        // peer. Parity with the HashComparison arm above.
+                        if stats.gov_divergence_detected {
+                            info!(
+                                marker = "gov_divergence_pull_triggered",
+                                %context_id,
+                                %chosen_peer,
+                                "scope_root governance divergence — pulling namespace governance from peer"
+                            );
+                            dispatch
+                                .pull_namespace_governance(context_id, chosen_peer)
+                                .await;
                         }
 
                         Ok(Some(SyncProtocol::LevelWise { max_depth }))


### PR DESCRIPTION
## What

Second slice of **P6** (sync-engine collapse), built on the unified verdict from #2935 (merged).

When a data-plane sync (HashComparison / LevelWise) converges the entity Merkle but the authoritative `scope_root` still differs, the divergence is purely in the **ACL/governance plane** — which lives *outside* the storage Merkle and is never pulled by the entity tree-walk. Until now that `GovDiverged` case **only warned** ("awaiting governance sync") and took no corrective action.

### The gap this closes
The existing governance backfill fires only when (a) the governance-**pending buffer is non-empty**, or (b) an **inbound** peer isn't yet a recognized member. A node where *entities already agree, scope_root differs, and no deltas are stuck* matches neither — so it would warn every tick and **never** pull the missing rotation/ACL op. Governance isn't in the storage Merkle, so HashComparison/LevelWise never pull it incidentally either.

## How

- Both initiators set `gov_divergence_detected` on their stats when the verdict is `GovDiverged` (single source of truth: #2935's `scope_verdict`).
- `ProtocolSelector`, after a successful HC/LevelWise session, reacts by calling the new `ProtocolDispatch::pull_namespace_governance(context_id, peer)`.
- The `SyncManager` impl resolves the namespace for the context and issues a `NamespaceBackfillRequest` to **the same peer it just diverged from** (it holds the op we're missing) — reusing the existing `sync_namespace_from_peer` machinery, just edge-triggered on the scope_root verdict.

**Self-limiting:** once governance converges, the verdict stops being `GovDiverged` and the pull stops. Logs `gov_divergence_pull_triggered`; an informational (never-failing) e2e step reports per-context trigger counts so a pathological per-tick storm would be visible as one context dominating the count.

## Scope / testing
- No wire/op-id change — reuses `NamespaceBackfillRequest`. Keeps the #2327 dup-head idempotency guard and the `NamespaceGovHead` append-order sequence untouched.
- Selector orchestration tests stay stubbed (Stream fixture gap, #2458); the pull path is exercised by the partition e2e suites, and the verdict itself is unit-tested.
- fmt + clippy (`-D warnings`) clean; node lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)