### PR TITLE
fix(governance): C5.S3a — state_hash mismatch warns, never bails (local group apply)

### DIFF
--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -1467,6 +1467,8 @@ fn state_hash_mismatch_does_not_reject_concurrent_ops() {
         },
     )
     .unwrap();
+    // nonce is per-signer: admin_c's nonce=1 does not collide with admin_a's
+    // nonce=1 — each signer has its own independent nonce window.
     let op_c = SignedGroupOp::sign(
         &admin_c_sk,
         gid_bytes,
@@ -1532,6 +1534,22 @@ fn state_hash_mismatch_does_not_reject_concurrent_ops() {
     assert_eq!(
         final_b, final_c,
         "nodes converge to identical state regardless of apply order"
+    );
+
+    // Replay safety is unaffected by dropping the state_hash gate: the per-signer
+    // NONCE WINDOW (not state_hash) is the anti-replay guard, and it is unchanged.
+    // Re-applying op_a (admin_a, nonce 1) is a no-op — the nonce is already in the
+    // window — so a DAG replay of a seen op cannot double-apply its mutation.
+    assert!(
+        apply_local_signed_group_op(&node_b, &op_a).is_ok(),
+        "replaying op_a is accepted (deduped, not errored)"
+    );
+    let after_replay_b = MetaRepository::new(&node_b)
+        .compute_state_hash(&gid)
+        .unwrap();
+    assert_eq!(
+        final_b, after_replay_b,
+        "replaying a seen op is a no-op — nonce window dedups it, state is unchanged"
     );
 }
 

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -1540,6 +1540,10 @@ fn state_hash_mismatch_does_not_reject_concurrent_ops() {
     // NONCE WINDOW (not state_hash) is the anti-replay guard, and it is unchanged.
     // Re-applying op_a (admin_a, nonce 1) is a no-op — the nonce is already in the
     // window — so a DAG replay of a seen op cannot double-apply its mutation.
+    let members_before_replay = MembershipRepository::new(&node_b)
+        .list(&gid, 0, usize::MAX)
+        .unwrap()
+        .len();
     assert!(
         apply_local_signed_group_op(&node_b, &op_a).is_ok(),
         "replaying op_a is accepted (deduped, not errored)"
@@ -1550,6 +1554,18 @@ fn state_hash_mismatch_does_not_reject_concurrent_ops() {
     assert_eq!(
         final_b, after_replay_b,
         "replaying a seen op is a no-op — nonce window dedups it, state is unchanged"
+    );
+    // Pin the actual member set, not just its hash: the dedup must return before
+    // `apply_group_op_mutations`, so no duplicate member row escapes (a future
+    // regression where the dedup fires but a side-effect still mutates would slip
+    // past a hash-only check if the side-effect were hash-neutral).
+    let members_after_replay = MembershipRepository::new(&node_b)
+        .list(&gid, 0, usize::MAX)
+        .unwrap()
+        .len();
+    assert_eq!(
+        members_before_replay, members_after_replay,
+        "replay must not add a duplicate member row"
     );
 }
 

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -1401,7 +1401,21 @@ fn dag_heads_are_capped_at_max() {
 }
 
 #[test]
-fn state_hash_prevents_concurrent_op_divergence() {
+fn state_hash_mismatch_does_not_reject_concurrent_ops() {
+    // Cutover C5.S3a: a group op's signed `state_hash` is staleness TELEMETRY,
+    // not an apply gate. Two admins concurrently sign INDEPENDENT ops against the
+    // same genesis state; whichever lands second carries a now-stale `state_hash`.
+    // The old behaviour hard-`bail!`ed on that mismatch, which stranded a
+    // legitimate concurrent sibling and broke multi-node convergence (the whole
+    // reason `apply_group_op_inner` already warns-not-bails). Now the local path
+    // matches: the mismatch only warns and the op applies, so both nodes converge
+    // regardless of apply order. `scope_root` + CRDT merge are the convergence
+    // mechanism; signature + nonce-window remain the real safety gates.
+    //
+    // Independent ADDS (not the old admin-removes-admin scenario) deliberately
+    // avoid an authorization-order confound: under the live-fallback authorizer a
+    // removed admin's later op would fail on *authorization*, not state_hash, which
+    // would mask the gate-removal this test pins down.
     let mut rng = OsRng;
     let gid = sample_group_id();
     let gid_bytes = gid.to_bytes();
@@ -1414,19 +1428,11 @@ fn state_hash_prevents_concurrent_op_divergence() {
     let admin_c_sk = PrivateKey::random(&mut rng);
     let admin_c_pk = admin_c_sk.public_key();
     let new_member_d = PrivateKey::random(&mut rng).public_key();
-
-    // Test exercises admin-removing-admin semantics under concurrent state.
-    // The owner-immunity gate (`CannotRemoveOwner`) would block op_c if
-    // admin_a were the owner — assign owner to a separate "founder" identity
-    // so neither admin_a nor admin_c is owner-protected.
-    let founder_pk = PrivateKey::random(&mut rng).public_key();
-    let mut meta = sample_meta(admin_a_pk);
-    meta.owner_identity = founder_pk;
+    let new_member_e = PrivateKey::random(&mut rng).public_key();
 
     for store in [&node_b, &node_c] {
-        MetaRepository::new(store).save(&gid, &meta).unwrap();
-        MembershipRepository::new(store)
-            .add_member(&gid, &founder_pk, GroupMemberRole::Admin)
+        MetaRepository::new(store)
+            .save(&gid, &sample_meta(admin_a_pk))
             .unwrap();
         MembershipRepository::new(store)
             .add_member(&gid, &admin_a_pk, GroupMemberRole::Admin)
@@ -1447,7 +1453,8 @@ fn state_hash_prevents_concurrent_op_divergence() {
         "nodes start with identical state hash"
     );
 
-    // A signs: add member D (against current state)
+    // A adds D; C adds E — independent, non-conflicting, both signed against the
+    // SAME genesis state (concurrent).
     let op_a = SignedGroupOp::sign(
         &admin_a_sk,
         gid_bytes,
@@ -1460,60 +1467,71 @@ fn state_hash_prevents_concurrent_op_divergence() {
         },
     )
     .unwrap();
-
-    // C signs: remove A (against the SAME state — concurrent)
     let op_c = SignedGroupOp::sign(
         &admin_c_sk,
         gid_bytes,
         vec![[0u8; 32]],
         state_hash_c,
         1,
-        dummy_member_removed(admin_a_pk),
+        GroupOp::MemberAdded {
+            member: new_member_e,
+            role: GroupMemberRole::Member,
+        },
     )
     .unwrap();
 
-    // Node B receives op_a first, then op_c
-    let result_a_on_b = apply_local_signed_group_op(&node_b, &op_a);
-    assert!(result_a_on_b.is_ok(), "op_a should succeed on node_b");
-
-    let result_c_on_b = apply_local_signed_group_op(&node_b, &op_c);
+    // Node B: op_a first, then op_c (op_c's state_hash is now stale).
     assert!(
-        result_c_on_b.is_err(),
-        "op_c should FAIL on node_b (state changed after op_a)"
-    );
-
-    // Node C receives op_c first, then op_a
-    let result_c_on_c = apply_local_signed_group_op(&node_c, &op_c);
-    assert!(result_c_on_c.is_ok(), "op_c should succeed on node_c");
-
-    let result_a_on_c = apply_local_signed_group_op(&node_c, &op_a);
-    assert!(
-        result_a_on_c.is_err(),
-        "op_a should FAIL on node_c (state changed after op_c)"
-    );
-
-    // Node B: A is still admin, D was added, C's removal of A was rejected
-    assert!(
-        calimero_context::group_store::MembershipRepository::new(&node_b)
-            .is_member(&gid, &admin_a_pk)
-            .unwrap()
+        apply_local_signed_group_op(&node_b, &op_a).is_ok(),
+        "op_a applies on node_b"
     );
     assert!(
-        calimero_context::group_store::MembershipRepository::new(&node_b)
-            .is_member(&gid, &new_member_d)
-            .unwrap()
+        apply_local_signed_group_op(&node_b, &op_c).is_ok(),
+        "op_c applies on node_b despite a stale state_hash (telemetry, not a gate)"
     );
 
-    // Node C: A was removed by C, D was NOT added
+    // Node C: op_c first, then op_a (op_a's state_hash is now stale).
     assert!(
-        !calimero_context::group_store::MembershipRepository::new(&node_c)
-            .is_member(&gid, &admin_a_pk)
-            .unwrap()
+        apply_local_signed_group_op(&node_c, &op_c).is_ok(),
+        "op_c applies on node_c"
     );
     assert!(
-        !calimero_context::group_store::MembershipRepository::new(&node_c)
-            .is_member(&gid, &new_member_d)
-            .unwrap()
+        apply_local_signed_group_op(&node_c, &op_a).is_ok(),
+        "op_a applies on node_c despite a stale state_hash"
+    );
+
+    // Both nodes converge to {A, C admins + D, E members}, regardless of order.
+    for (label, store) in [("node_b", &node_b), ("node_c", &node_c)] {
+        let m = calimero_context::group_store::MembershipRepository::new(store);
+        assert!(
+            m.is_member(&gid, &admin_a_pk).unwrap(),
+            "{label}: A present"
+        );
+        assert!(
+            m.is_member(&gid, &admin_c_pk).unwrap(),
+            "{label}: C present"
+        );
+        assert!(
+            m.is_member(&gid, &new_member_d).unwrap(),
+            "{label}: D added"
+        );
+        assert!(
+            m.is_member(&gid, &new_member_e).unwrap(),
+            "{label}: E added"
+        );
+    }
+
+    // `compute_state_hash` sorts members by pubkey, so the converged hashes match
+    // — order-independent convergence, the property the old reject actively broke.
+    let final_b = MetaRepository::new(&node_b)
+        .compute_state_hash(&gid)
+        .unwrap();
+    let final_c = MetaRepository::new(&node_c)
+        .compute_state_hash(&gid)
+        .unwrap();
+    assert_eq!(
+        final_b, final_c,
+        "nodes converge to identical state regardless of apply order"
     );
 }
 

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -1288,28 +1288,36 @@ pub fn apply_local_signed_group_op_at_cut(
 
     let zero_hash = [0u8; 32];
     if op.state_hash != zero_hash {
-        // Mirror the namespace receive-side bypass (apply_group_op_inner): if
-        // the subgroup meta row hasn't been written yet — e.g. a group op
-        // buffered/replayed before its GroupCreated lands — there is no state
-        // to hash. `compute_state_hash` would raise GroupNotFoundForHash and
-        // strand the op forever (#2848). Treat absent meta as a bypass;
-        // signature and nonce checks remain in force.
+        // Staleness telemetry, NOT an apply gate (cutover C5.S3a). This is the
+        // `DeltaApplier::apply` body for the group governance DAG, so concurrent
+        // same-subgroup ops from different nodes routinely land here: A and B each
+        // sign against their then-current view and the second to reach C has
+        // already drifted. `bail!`-ing on that mismatch rejects a legitimate
+        // concurrent sibling the DAG would otherwise merge, forcing recovery onto
+        // anchor-sync reconcile — a multi-node convergence hazard. `scope_root` is
+        // now the authoritative convergence signal and CRDT merge handles the
+        // concurrency, so we recompute and WARN on disagreement but apply anyway —
+        // matching the namespace-wrapped path (`apply_group_op_inner`), whose own
+        // comment already documents this trade-off (PR #2500 caveat). Signature
+        // and nonce-window checks remain the real safety/anti-replay gates.
+        //
+        // Absent-meta bypass: if the subgroup meta row hasn't been written yet —
+        // e.g. a group op buffered/replayed before its GroupCreated lands — there
+        // is no state to hash. `compute_state_hash` would raise
+        // GroupNotFoundForHash and strand the op forever (#2848). Treat absent meta
+        // as a bypass; GroupCreated's apply re-drives this op once meta exists.
         let repo = MetaRepository::new(store);
         if repo.load(&group_id)?.is_some() {
             let current_state_hash = repo.compute_state_hash(&group_id)?;
             if op.state_hash != current_state_hash {
-                tracing::debug!(
+                tracing::warn!(
                     group_id = %hex::encode(group_id.to_bytes()),
                     expected = %hex::encode(op.state_hash),
                     actual = %hex::encode(current_state_hash),
                     nonce = op.nonce,
                     signer = %op.signer,
-                    "rejecting op: state_hash mismatch (signed against stale state)"
-                );
-                bail!(
-                    "state_hash mismatch: op was signed against {}, current state is {}",
-                    hex::encode(op.state_hash),
-                    hex::encode(current_state_hash)
+                    "local group op state_hash mismatch (signed against stale state; \
+                     applying anyway — see PR #2500 caveat)"
                 );
             }
         }

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -1286,6 +1286,25 @@ pub fn apply_local_signed_group_op_at_cut(
         .map_err(|e| eyre::eyre!("signed group op: {e}"))?;
     let group_id = ContextGroupId::from(op.group_id);
 
+    // Anti-replay / dedup runs FIRST: a replayed op whose nonce is already in the
+    // window returns here without mutating, so it must short-circuit BEFORE the
+    // state_hash telemetry below — otherwise a pure replay would emit a misleading
+    // "applying anyway" warn even though nothing is applied. Mirrors the ordering
+    // the namespace path (`apply_group_op_inner`) already documents.
+    let mut nonce_window = load_nonce_window(store, &group_id, &op.signer)?;
+    if nonce_window.contains(op.nonce) {
+        tracing::debug!(
+            nonce = op.nonce,
+            floor = nonce_window.floor(),
+            signer = %op.signer,
+            "ignoring op with already-processed nonce"
+        );
+        return Ok(());
+    }
+
+    // C5.S3b: remove this entire block once `state_hash` is dropped from the wire
+    // format (the flag-day op-id change). Until then it stays as staleness
+    // telemetry only.
     let zero_hash = [0u8; 32];
     if op.state_hash != zero_hash {
         // Staleness telemetry, NOT an apply gate (cutover C5.S3a). This is the
@@ -1299,7 +1318,8 @@ pub fn apply_local_signed_group_op_at_cut(
         // concurrency, so we recompute and WARN on disagreement but apply anyway —
         // matching the namespace-wrapped path (`apply_group_op_inner`), whose own
         // comment already documents this trade-off (PR #2500 caveat). Signature
-        // and nonce-window checks remain the real safety/anti-replay gates.
+        // and the nonce window (checked above) remain the real safety/anti-replay
+        // gates.
         //
         // Absent-meta bypass: if the subgroup meta row hasn't been written yet —
         // e.g. a group op buffered/replayed before its GroupCreated lands — there
@@ -1312,6 +1332,10 @@ pub fn apply_local_signed_group_op_at_cut(
             if op.state_hash != current_state_hash {
                 tracing::warn!(
                     group_id = %hex::encode(group_id.to_bytes()),
+                    // Log the variant so operators can tell an expected concurrent
+                    // MemberAdded apart from a stale-hash op on a sensitive variant
+                    // (e.g. MemberRemoved) when diagnosing real divergence.
+                    op = ?op.op,
                     expected = %hex::encode(op.state_hash),
                     actual = %hex::encode(current_state_hash),
                     nonce = op.nonce,
@@ -1321,17 +1345,6 @@ pub fn apply_local_signed_group_op_at_cut(
                 );
             }
         }
-    }
-
-    let mut nonce_window = load_nonce_window(store, &group_id, &op.signer)?;
-    if nonce_window.contains(op.nonce) {
-        tracing::debug!(
-            nonce = op.nonce,
-            floor = nonce_window.floor(),
-            signer = %op.signer,
-            "ignoring op with already-processed nonce"
-        );
-        return Ok(());
     }
 
     let (handled, _divergence, pending_events) = apply_group_op_mutations(


### PR DESCRIPTION
## What

First sub-slice of **C5.S3** (retire op-level `state_hash` as an apply gate). One-site change: the local group-op apply path now **warns** on a `state_hash` mismatch instead of hard-`bail!`ing.

## Why

`apply_local_signed_group_op_at_cut` (`crates/governance-store/src/lib.rs:1290`) is the `DeltaApplier::apply` body for the **group governance DAG**, so concurrent same-subgroup ops from different nodes routinely land here — A and B each sign against their then-current view, and the second to reach C has already drifted. `bail!`ing on that mismatch **rejects a legitimate concurrent sibling the DAG would otherwise merge**, forcing recovery onto anchor-sync reconcile — a real multi-node convergence hazard.

The namespace-wrapped sibling path (`apply_group_op_inner`, `namespace/governance.rs:1452`) **already** downgraded this to warn-and-apply (the PR #2500 caveat), and its comment explicitly calls out the local path as the lone surviving hard-bail. This brings the local path into that same symmetry: now that `scope_root` is the authoritative convergence signal and CRDT merge handles concurrency, the recomputed `state_hash` is **staleness telemetry, not an apply gate**.

Signature verification and the **nonce window** remain the real safety / anti-replay gates; the absent-meta bypass (#2848) is unchanged.

## Scope

- **No wire or schema change.** The `state_hash` field stays on `SignableGroupOp` and in the content hash, so **op ids are stable** — no re-bootstrap. The flag-day field removal + `SCHEMA_VERSION` bump is the separate later **C5.S3b**.
- Replaces the now-obsolete `state_hash_prevents_concurrent_op_divergence` test (which pinned the reject semantics this PR removes) with `state_hash_mismatch_does_not_reject_concurrent_ops`: two admins concurrently add *independent* members against the same genesis state; both nodes converge to the identical member set regardless of apply order (`compute_state_hash` sorts members, so the converged hashes match). Independent adds avoid the authorization-order confound of the old admin-removes-admin scenario.
- fmt + clippy (`-D warnings`) clean; the 3 `state_hash_*` convergence tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes group governance DAG apply behavior for concurrent ops (previously rejected ops now mutate state), which affects multi-node convergence but keeps signature and nonce gates; scope is localized to the local apply path with no wire format change.
> 
> **Overview**
> **C5.S3a** aligns the **local** signed group-op apply path with the namespace path: a signed `state_hash` that no longer matches the store is **staleness telemetry** (warn + continue), not a hard reject.
> 
> In `apply_local_signed_group_op_at_cut`, mismatches no longer `bail!`; they emit a structured `warn` (including the op variant) and the op still applies. **Anti-replay runs first**: the per-signer nonce window is checked before any `state_hash` logic so replays return early without a misleading “applying anyway” warning. Signature verification and the absent-meta bypass are unchanged; no wire/schema change.
> 
> The integration test is renamed and rewritten: concurrent independent `MemberAdded` ops from two admins against the same genesis state must apply on both nodes in either order, converge on membership and `compute_state_hash`, and replay via nonce dedup without duplicate rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd5bcd1a0983c1d2845e0f19d525051049113fea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->