### PR TITLE
feat(sync): P6.S3 — catch governance divergence pre-sync when entities agree

### DIFF
--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1233,7 +1233,9 @@ impl SyncManager {
                 .await?;
 
             match peer_state {
-                Some((peer_root_hash, _peer_dag_heads)) if *peer_root_hash != [0; 32] => {
+                Some((peer_root_hash, _peer_dag_heads, _peer_scope_root))
+                    if *peer_root_hash != [0; 32] =>
+                {
                     // Peer has state - use snapshot sync for efficient bootstrap
                     info!(
                         %context_id,
@@ -1423,7 +1425,7 @@ impl SyncManager {
             .query_peer_dag_state(context_id, chosen_peer, our_identity, stream)
             .await?;
 
-        if let Some((peer_root_hash, peer_dag_heads)) = peer_state {
+        if let Some((peer_root_hash, peer_dag_heads, peer_scope_root)) = peer_state {
             // Build handshakes for protocol selection (CIP §2.3)
             // Uses shared functions from calimero_node_primitives::sync::state_machine
             let local_hs = self.build_local_handshake(context);
@@ -1431,6 +1433,46 @@ impl SyncManager {
 
             // Select optimal sync protocol based on state comparison
             let selection = select_protocol(&local_hs, &remote_hs);
+
+            // P6.S3: `select_protocol` decides on the ENTITY plane only (root_hash +
+            // dag_heads), so when entities already agree it returns `None` — "nothing
+            // to sync". But a pure governance-plane divergence (rotation / ACL change
+            // the entity Merkle can't see, since governance lives outside it) is
+            // exactly that case: entities equal, `scope_root` differs. Without this
+            // check it would go uncorrected — the post-sync P6.S2 hook only fires
+            // when HC/LevelWise actually run, which a `None` selection skips. Compute
+            // the authoritative `scope_verdict` from the peer's wire-carried
+            // `scope_root` and, on a pre-sync `GovDiverged`, pull governance from the
+            // peer instead of doing nothing. Cold/non-group projections resolve
+            // `None` and fall back to the entity-root compare inside `scope_verdict`,
+            // so a partially-warmed node never raises a false governance divergence.
+            if matches!(selection.protocol, SyncProtocol::None) {
+                let local_root = *context.root_hash;
+                let local_scope_root = {
+                    let store = self.context_client.datastore_handle().into_inner();
+                    super::helpers::local_scope_root(&store, &context_id, local_root)
+                };
+                let verdict = super::helpers::scope_verdict(
+                    local_scope_root,
+                    peer_scope_root.map(|h| *h),
+                    local_root,
+                    *peer_root_hash,
+                );
+                if let super::helpers::ScopeVerdict::GovDiverged(local_sr, peer_sr) = verdict {
+                    info!(
+                        marker = "gov_divergence_pull_triggered",
+                        %context_id,
+                        %chosen_peer,
+                        local_scope_root = %hex::encode(&local_sr[..8]),
+                        peer_scope_root = %hex::encode(&peer_sr[..8]),
+                        "entities agree but scope_root differs pre-sync — pulling governance \
+                         from peer (no entity walk needed)"
+                    );
+                    self.pull_namespace_governance(context_id, chosen_peer)
+                        .await;
+                    return Ok(None);
+                }
+            }
 
             info!(
                 %context_id,
@@ -1481,17 +1523,29 @@ impl SyncManager {
         Ok(None)
     }
 
-    /// Query peer for their DAG state (root_hash and dag_heads) without triggering full sync.
+    /// Query peer for their DAG state (root_hash, dag_heads, and scope_root)
+    /// without triggering full sync.
     ///
-    /// Returns `Ok(Some((root_hash, dag_heads)))` if peer responded successfully,
-    /// `Ok(None)` if peer had no valid response or no state, or `Err` on communication error.
+    /// Returns `Ok(Some((root_hash, dag_heads, scope_root)))` if peer responded
+    /// successfully (`scope_root` is `None` when the peer couldn't fold one — cold
+    /// projection / non-group context), `Ok(None)` if peer had no valid response or
+    /// no state, or `Err` on communication error. The `scope_root` lets the caller
+    /// decide a pre-sync `scope_verdict` so a pure governance-plane divergence
+    /// (entities agree, ACL/membership differs) is caught even when the entity-root
+    /// compare would say "no sync needed" (cutover P6.S3).
     async fn query_peer_dag_state(
         &self,
         context_id: ContextId,
         chosen_peer: PeerId,
         our_identity: PublicKey,
         stream: &mut Stream,
-    ) -> eyre::Result<Option<(calimero_primitives::hash::Hash, Vec<[u8; DIGEST_SIZE]>)>> {
+    ) -> eyre::Result<
+        Option<(
+            calimero_primitives::hash::Hash,
+            Vec<[u8; DIGEST_SIZE]>,
+            Option<calimero_primitives::hash::Hash>,
+        )>,
+    > {
         let request_msg = StreamMessage::Init {
             context_id,
             party_id: our_identity,
@@ -1509,7 +1563,7 @@ impl SyncManager {
                     MessagePayload::DagHeadsResponse {
                         dag_heads,
                         root_hash,
-                        scope_root: _,
+                        scope_root,
                     },
                 ..
             }) => {
@@ -1520,13 +1574,34 @@ impl SyncManager {
                     peer_root_hash = %root_hash,
                     "Received peer DAG state for comparison"
                 );
-                Ok(Some((root_hash, dag_heads)))
+                Ok(Some((root_hash, dag_heads, scope_root)))
             }
             _ => {
                 debug!(%context_id, %chosen_peer, "Failed to get peer DAG state for comparison");
                 Ok(None)
             }
         }
+    }
+
+    /// Pull the namespace governance DAG for `context_id` from `peer`
+    /// (cutover P6.S2/S3). Resolves the namespace and issues a
+    /// `NamespaceBackfillRequest` — the same machinery as the pending-delta and
+    /// join backfills, edge-triggered on a `scope_root` governance divergence.
+    /// Best-effort: a no-op when the context has no resolvable namespace.
+    async fn pull_namespace_governance(&self, context_id: ContextId, peer: PeerId) {
+        let namespace_id = {
+            let store = self.context_client.datastore_handle().into_inner();
+            namespace_sync::resolve_namespace_id(&store, &context_id)
+        };
+        let Some(namespace_id) = namespace_id else {
+            debug!(
+                %context_id,
+                "scope_root governance pull: could not resolve namespace id; skipping"
+            );
+            return;
+        };
+        self.sync_namespace_from_peer(namespace_id, Some(peer))
+            .await;
     }
 
     async fn initiate_sync_inner(
@@ -3416,23 +3491,7 @@ impl super::protocol_selector::ProtocolDispatch for SyncManager {
     }
 
     async fn pull_namespace_governance(&self, context_id: ContextId, peer: PeerId) {
-        let namespace_id = {
-            let store = self.context_client.datastore_handle().into_inner();
-            namespace_sync::resolve_namespace_id(&store, &context_id)
-        };
-        let Some(namespace_id) = namespace_id else {
-            debug!(
-                %context_id,
-                "scope_root governance pull: could not resolve namespace id; skipping"
-            );
-            return;
-        };
-        // Pull the namespace governance DAG from the peer we just diverged
-        // from — it holds the rotation/ACL op our entity walk couldn't see.
-        // Same `NamespaceBackfillRequest` machinery as the pending-delta and
-        // join backfills, just edge-triggered on the scope_root verdict.
-        self.sync_namespace_from_peer(namespace_id, Some(peer))
-            .await;
+        SyncManager::pull_namespace_governance(self, context_id, peer).await
     }
 }
 

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1446,7 +1446,15 @@ impl SyncManager {
             // peer instead of doing nothing. Cold/non-group projections resolve
             // `None` and fall back to the entity-root compare inside `scope_verdict`,
             // so a partially-warmed node never raises a false governance divergence.
-            if matches!(selection.protocol, SyncProtocol::None) {
+            // Only a peer that folded its OWN scope_root can drive a governance
+            // divergence — `scope_verdict` reports `GovDiverged` only when both
+            // sides resolve one. When the peer's is `None` (cold / non-group) the
+            // verdict falls back to the entity-root compare, which already agreed
+            // here (selection == None). So short-circuit on `peer_scope_root` before
+            // touching the store, keeping the hot no-op path store-free.
+            if let (SyncProtocol::None, Some(peer_scope_root)) =
+                (&selection.protocol, peer_scope_root)
+            {
                 let local_root = *context.root_hash;
                 let local_scope_root = {
                     let store = self.context_client.datastore_handle().into_inner();
@@ -1454,7 +1462,7 @@ impl SyncManager {
                 };
                 let verdict = super::helpers::scope_verdict(
                     local_scope_root,
-                    peer_scope_root.map(|h| *h),
+                    Some(*peer_scope_root),
                     local_root,
                     *peer_root_hash,
                 );
@@ -1470,6 +1478,15 @@ impl SyncManager {
                     );
                     self.pull_namespace_governance(context_id, chosen_peer)
                         .await;
+                    // Completion marker so the e2e report (and operators) can
+                    // correlate the trigger with its outcome — the `Ok(None)` below
+                    // is otherwise indistinguishable from "entities already in sync".
+                    debug!(
+                        marker = "gov_divergence_pull_complete",
+                        %context_id,
+                        %chosen_peer,
+                        "pre-sync governance pull issued; convergence verified next session"
+                    );
                     return Ok(None);
                 }
             }


### PR DESCRIPTION
## What

First slice of **P6.S3** (route the data-plane/selection through the verdict). Closes the last hole in scope_root-driven governance convergence.

`select_protocol` decides on the **entity plane only** (root_hash + dag_heads), so when the entity Merkle already matches it returns `None` — "nothing to sync". But governance lives **outside** the entity Merkle, so a pure governance-plane divergence (a rotation / ACL change) is *exactly* the entities-agree case: `root_hash` equal, `scope_root` differs. The post-sync P6.S2 hook only fires when HC/LevelWise actually run — which a `None` selection skips — so that divergence went uncorrected tick after tick.

## How

- `query_peer_dag_state` now returns the peer's `scope_root` (already on `DagHeadsResponse`, previously discarded as `scope_root: _`).
- At the selection point, when `select_protocol` says `None`, compute the authoritative `scope_verdict`. On a pre-sync `GovDiverged` (entities equal, scope_root differs) → pull the namespace governance DAG from the peer (reusing the P6.S2 `pull_namespace_governance` path, refactored to an inherent method) and skip the pointless entity walk.
- **Cold / non-group projections** resolve `scope_root == None` and fall back to the entity-root compare inside `scope_verdict`, so a partially-warmed node never raises a false governance divergence.

Complements P6.S2: **pre-sync** handles "entities already agree", **post-sync** handles "entities diverge then converge". Logs the same `gov_divergence_pull_triggered` marker, so the existing informational e2e report step covers both.

## Scope / testing
- No wire change (`scope_root` was already on the response); no change to `select_protocol` or the HC/LevelWise/Snapshot decision tree; tombstone / frozen-leaf / authorization paths untouched (they live inside the entity walk, which this only *skips* when there's nothing to walk).
- fmt + clippy (`-D warnings`) clean; 39 manager sync unit tests pass. The pre-sync pull path is exercised by the partition e2e suites (same Stream-fixture gap as the selector keeps it out of unit tests); the verdict itself is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync orchestration on the common “already in sync” path with store reads and governance backfill when scope roots disagree; logic is gated on both sides resolving `scope_root` to avoid false positives on cold projections.
> 
> **Overview**
> **P6.S3** closes a gap where periodic sync treated “entity roots match” as fully in sync even when **governance** (`scope_root`) still diverged—because `select_protocol` only looks at entity `root_hash` and DAG heads and returns `SyncProtocol::None`, skipping HashComparison/LevelWise and the post-sync P6.S2 governance pull.
> 
> `query_peer_dag_state` now surfaces the peer’s **`scope_root`** from `DagHeadsResponse` (already on the wire; previously ignored). When protocol selection is **`None`** and the peer sent a resolved `scope_root`, the manager runs **`scope_verdict`**. On **`GovDiverged`** (entities equal, scope roots differ), it **pulls the namespace governance DAG** from that peer via the existing P6.S2 `pull_namespace_governance` path (refactored to an inherent `SyncManager` method) and returns without an entity walk. Peers with **`scope_root == None`** skip the store read on the hot path so cold/non-group nodes don’t false-trigger.
> 
> Logs **`gov_divergence_pull_triggered`** / **`gov_divergence_pull_complete`** for operators and e2e, complementing P6.S2’s post-sync hook when entities actually diverge first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55ea43b23611ef6b63c3541f1eaa704387eaa4a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->