### PR TITLE
feat(sync): P6.S3 — centralise post-sync governance reconciliation for all backends

### DIFF
--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -142,16 +142,6 @@ pub struct HashComparisonStats {
     /// merge did not converge the two peers — see #2407 for the
     /// failure mode this guards against.
     pub root_hash_verified: bool,
-    /// Whether the convergence verdict was `GovDiverged` — the entity
-    /// roots agreed but the authoritative `scope_root` differed, i.e. a
-    /// pure ACL/governance-plane divergence that the entity Merkle walk
-    /// can't reconcile (governance lives outside the storage Merkle).
-    /// The caller (`ProtocolSelector`) reacts by pulling the namespace
-    /// governance DAG from the same peer (P6.S2) — without it, a node
-    /// with no stuck deltas would otherwise just warn and never converge
-    /// the governance plane. Distinct from `root_hash_verified == false`,
-    /// which also covers data-plane divergence.
-    pub gov_divergence_detected: bool,
     /// Root-state byte blobs the DFS encountered on remote leaves
     /// that the host can't merge by itself (separate-address-space
     /// merge registry — see [`crate::sync::helpers::apply_leaf_with_crdt_merge`]).
@@ -729,16 +719,13 @@ async fn run_initiator_impl<T: SyncTransport>(
         peer_current_root,
     );
     stats.root_hash_verified = verdict.converged();
-    stats.gov_divergence_detected =
-        matches!(verdict, super::helpers::ScopeVerdict::GovDiverged(..));
 
     // Surface the case the entity root hides: entities AGREE but `scope_root` differs
     // ⇒ the divergence is purely in the ACL/governance plane. HC's entity tree-walk
     // has nothing to reconcile here (the entities already match) — governance ops
-    // live outside the storage Merkle. The selector reacts to
-    // `gov_divergence_detected` by pulling the namespace governance DAG from this
-    // same peer (P6.S2); distinct marker so a governance-plane divergence is legible
-    // apart from a data-plane one.
+    // live outside the storage Merkle. This is observability only; the corrective
+    // governance pull is centralised post-sync in the manager (P6.S3), so it covers
+    // Snapshot / DeltaSync syncs too, not just HC / LevelWise.
     if let super::helpers::ScopeVerdict::GovDiverged(local_scope_root, peer_scope_root) = verdict {
         warn!(
             marker = "scope_root_governance_divergence",

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -145,11 +145,6 @@ pub struct LevelWiseStats {
     pub requests_sent: u64,
     /// Whether final root hash was verified against expected.
     pub root_hash_verified: bool,
-    /// Whether the convergence verdict was `GovDiverged` (entity roots
-    /// agreed, authoritative `scope_root` differed). Same meaning and
-    /// caller reaction as [`crate::sync::hash_comparison_protocol::HashComparisonStats::gov_divergence_detected`]:
-    /// the selector pulls the namespace governance DAG from this peer (P6.S2).
-    pub gov_divergence_detected: bool,
     /// Whether parent_ids were truncated due to `MAX_PARENTS_PER_REQUEST`.
     ///
     /// If true, the sync may be incomplete and a follow-up sync might be needed.
@@ -621,14 +616,12 @@ async fn run_initiator_impl<T: SyncTransport>(
         peer_current_root,
     );
     stats.root_hash_verified = verdict.converged();
-    stats.gov_divergence_detected =
-        matches!(verdict, super::helpers::ScopeVerdict::GovDiverged(..));
 
     if !stats.root_hash_verified {
         // Entities agree but scope_root differs ⇒ pure ACL/governance divergence
-        // (the case the entity root hides); distinct marker, parity with HC. The
-        // selector reacts to `gov_divergence_detected` by pulling governance from
-        // the peer (P6.S2).
+        // (the case the entity root hides); observability only — the corrective
+        // governance pull is centralised post-sync in the manager (P6.S3), covering
+        // all data backends, not just HC / LevelWise.
         if let super::helpers::ScopeVerdict::GovDiverged(local_scope_root, peer_scope_root) =
             verdict
         {

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1426,6 +1426,11 @@ impl SyncManager {
             .await?;
 
         if let Some((peer_root_hash, peer_dag_heads, peer_scope_root)) = peer_state {
+            // Normalise the peer's wire-carried scope_root to bytes once; it feeds
+            // both the pre-sync and post-sync governance-divergence checks below
+            // (`[u8; 32]` is `Copy`, so each check reads it independently).
+            let peer_scope_root = peer_scope_root.map(|h| *h);
+
             // Build handshakes for protocol selection (CIP §2.3)
             // Uses shared functions from calimero_node_primitives::sync::state_machine
             let local_hs = self.build_local_handshake(context);
@@ -1462,7 +1467,7 @@ impl SyncManager {
                 };
                 let verdict = super::helpers::scope_verdict(
                     local_scope_root,
-                    Some(*peer_scope_root),
+                    Some(peer_scope_root),
                     local_root,
                     *peer_root_hash,
                 );
@@ -1476,15 +1481,19 @@ impl SyncManager {
                         "entities agree but scope_root differs pre-sync — pulling governance \
                          from peer (no entity walk needed)"
                     );
-                    self.pull_namespace_governance(context_id, chosen_peer)
+                    let ops_pulled = self
+                        .pull_namespace_governance(context_id, chosen_peer)
                         .await;
                     // Completion marker so the e2e report (and operators) can
-                    // correlate the trigger with its outcome — the `Ok(None)` below
-                    // is otherwise indistinguishable from "entities already in sync".
+                    // correlate the trigger with its outcome — `ops_pulled == 0`
+                    // flags a pull that delivered nothing (best-effort failure or an
+                    // already-converged peer), which the `Ok(None)` below would
+                    // otherwise hide as "entities already in sync".
                     debug!(
                         marker = "gov_divergence_pull_complete",
                         %context_id,
                         %chosen_peer,
+                        ops_pulled,
                         "pre-sync governance pull issued; convergence verified next session"
                     );
                     return Ok(None);
@@ -1521,7 +1530,7 @@ impl SyncManager {
                     })
                 });
 
-            return self
+            let exec_result = self
                 .protocol_selector
                 .execute(
                     self,
@@ -1535,6 +1544,61 @@ impl SyncManager {
                     stream,
                 )
                 .await;
+
+            // P6.S3: centralised post-sync governance reconciliation. After ANY data
+            // backend runs (HashComparison / LevelWise / Snapshot / DeltaSync), the
+            // entity plane may have converged while governance still differs —
+            // governance lives outside the storage Merkle, so no entity walk reaches
+            // it. Recompute the verdict against the peer's handshake scope_root using
+            // the POST-sync local root (entities may have merged); on `GovDiverged`,
+            // pull governance. This replaces the per-protocol hooks that only fired
+            // for HC / LevelWise, so a snapshot/delta sync converges its governance
+            // plane too. Gated on `peer_scope_root` so the no-divergence path stays
+            // store-free; runs only on a successful sync (a failure retries next
+            // tick, re-checking then).
+            if exec_result.is_ok() {
+                if let Some(peer_scope_root) = peer_scope_root {
+                    let local_root = self
+                        .context_client
+                        .get_context(&context_id)
+                        .ok()
+                        .flatten()
+                        .map_or(*context.root_hash, |c| *c.root_hash);
+                    let local_scope_root = {
+                        let store = self.context_client.datastore_handle().into_inner();
+                        super::helpers::local_scope_root(&store, &context_id, local_root)
+                    };
+                    let verdict = super::helpers::scope_verdict(
+                        local_scope_root,
+                        Some(peer_scope_root),
+                        local_root,
+                        *peer_root_hash,
+                    );
+                    if let super::helpers::ScopeVerdict::GovDiverged(local_sr, peer_sr) = verdict {
+                        info!(
+                            marker = "gov_divergence_pull_triggered",
+                            %context_id,
+                            %chosen_peer,
+                            local_scope_root = %hex::encode(&local_sr[..8]),
+                            peer_scope_root = %hex::encode(&peer_sr[..8]),
+                            "entities converged but scope_root differs post-sync — pulling \
+                             governance from peer"
+                        );
+                        let ops_pulled = self
+                            .pull_namespace_governance(context_id, chosen_peer)
+                            .await;
+                        debug!(
+                            marker = "gov_divergence_pull_complete",
+                            %context_id,
+                            %chosen_peer,
+                            ops_pulled,
+                            "post-sync governance pull issued; convergence verified next session"
+                        );
+                    }
+                }
+            }
+
+            return exec_result;
         }
 
         Ok(None)
@@ -1604,8 +1668,10 @@ impl SyncManager {
     /// (cutover P6.S2/S3). Resolves the namespace and issues a
     /// `NamespaceBackfillRequest` — the same machinery as the pending-delta and
     /// join backfills, edge-triggered on a `scope_root` governance divergence.
-    /// Best-effort: a no-op when the context has no resolvable namespace.
-    async fn pull_namespace_governance(&self, context_id: ContextId, peer: PeerId) {
+    /// Returns the number of governance ops the backfill delivered (`0` when the
+    /// namespace can't be resolved or the best-effort pull came back empty), so the
+    /// divergence-correction caller can log the outcome rather than discarding it.
+    async fn pull_namespace_governance(&self, context_id: ContextId, peer: PeerId) -> usize {
         let namespace_id = {
             let store = self.context_client.datastore_handle().into_inner();
             namespace_sync::resolve_namespace_id(&store, &context_id)
@@ -1615,10 +1681,10 @@ impl SyncManager {
                 %context_id,
                 "scope_root governance pull: could not resolve namespace id; skipping"
             );
-            return;
+            return 0;
         };
         self.sync_namespace_from_peer(namespace_id, Some(peer))
-            .await;
+            .await
     }
 
     async fn initiate_sync_inner(
@@ -3506,10 +3572,6 @@ impl super::protocol_selector::ProtocolDispatch for SyncManager {
     ) -> eyre::Result<SyncProtocol> {
         SyncManager::fallback_to_snapshot_sync(self, context_id, our_identity, chosen_peer).await
     }
-
-    async fn pull_namespace_governance(&self, context_id: ContextId, peer: PeerId) {
-        SyncManager::pull_namespace_governance(self, context_id, peer).await
-    }
 }
 
 // Driver-dispatch back into `SyncManager` for the cross-actor message
@@ -3518,7 +3580,7 @@ impl super::protocol_selector::ProtocolDispatch for SyncManager {
 #[async_trait::async_trait(?Send)]
 impl super::driver::SyncDriverDispatch for SyncManager {
     async fn sync_namespace_from_peer(&self, namespace_id: [u8; 32]) {
-        SyncManager::sync_namespace_from_peer(self, namespace_id, None).await
+        let _ops = SyncManager::sync_namespace_from_peer(self, namespace_id, None).await;
     }
 
     async fn initiate_namespace_join(

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1549,51 +1549,66 @@ impl SyncManager {
             // backend runs (HashComparison / LevelWise / Snapshot / DeltaSync), the
             // entity plane may have converged while governance still differs —
             // governance lives outside the storage Merkle, so no entity walk reaches
-            // it. Recompute the verdict against the peer's handshake scope_root using
-            // the POST-sync local root (entities may have merged); on `GovDiverged`,
-            // pull governance. This replaces the per-protocol hooks that only fired
-            // for HC / LevelWise, so a snapshot/delta sync converges its governance
-            // plane too. Gated on `peer_scope_root` so the no-divergence path stays
-            // store-free; runs only on a successful sync (a failure retries next
-            // tick, re-checking then).
+            // it. This replaces the per-protocol hooks that only fired for HC /
+            // LevelWise, so a snapshot/delta sync converges its governance plane too.
+            //
+            // The decision is a DIRECT scope_root inequality, not a
+            // GovDiverged-vs-DataDiverged sub-classification. The manager only holds
+            // the peer's HANDSHAKE entity root — the peer may have advanced during the
+            // sync — so an entity-root compare here could misclassify a real
+            // governance divergence as "data" and SKIP the pull, which is the
+            // dangerous direction: a permanent governance stall. A governance pull is
+            // idempotent and returns 0 ops when governance is already in sync, so
+            // pulling whenever the authoritative scope_root still differs over-pulls
+            // at worst during a still-converging data plane — harmless and
+            // self-limiting (once scope_roots agree the pull stops). Runs only on a
+            // successful sync; gated on `peer_scope_root` so the no-divergence path
+            // stays store-free.
             if exec_result.is_ok() {
                 if let Some(peer_scope_root) = peer_scope_root {
-                    let local_root = self
-                        .context_client
-                        .get_context(&context_id)
-                        .ok()
-                        .flatten()
-                        .map_or(*context.root_hash, |c| *c.root_hash);
-                    let local_scope_root = {
-                        let store = self.context_client.datastore_handle().into_inner();
-                        super::helpers::local_scope_root(&store, &context_id, local_root)
+                    // Re-read the POST-sync local root (entities may have merged). On a
+                    // store fault, SKIP rather than fold a verdict against a stale
+                    // pre-sync root — the next tick re-checks against fresh state.
+                    let local_root = match self.context_client.get_context(&context_id) {
+                        Ok(Some(ctx)) => Some(*ctx.root_hash),
+                        Ok(None) => {
+                            warn!(%context_id, "post-sync gov check: context vanished; skipping");
+                            None
+                        }
+                        Err(err) => {
+                            warn!(%context_id, %err, "post-sync gov check: get_context failed; skipping");
+                            None
+                        }
                     };
-                    let verdict = super::helpers::scope_verdict(
-                        local_scope_root,
-                        Some(peer_scope_root),
-                        local_root,
-                        *peer_root_hash,
-                    );
-                    if let super::helpers::ScopeVerdict::GovDiverged(local_sr, peer_sr) = verdict {
-                        info!(
-                            marker = "gov_divergence_pull_triggered",
-                            %context_id,
-                            %chosen_peer,
-                            local_scope_root = %hex::encode(&local_sr[..8]),
-                            peer_scope_root = %hex::encode(&peer_sr[..8]),
-                            "entities converged but scope_root differs post-sync — pulling \
-                             governance from peer"
-                        );
-                        let ops_pulled = self
-                            .pull_namespace_governance(context_id, chosen_peer)
-                            .await;
-                        debug!(
-                            marker = "gov_divergence_pull_complete",
-                            %context_id,
-                            %chosen_peer,
-                            ops_pulled,
-                            "post-sync governance pull issued; convergence verified next session"
-                        );
+                    if let Some(local_root) = local_root {
+                        let local_scope_root = {
+                            let store = self.context_client.datastore_handle().into_inner();
+                            super::helpers::local_scope_root(&store, &context_id, local_root)
+                        };
+                        // `None` (cold / incomplete fold) abstains — same as the
+                        // verdict's cold-fallback: never pull on an unresolved scope.
+                        if let Some(local_sr) = local_scope_root {
+                            if local_sr != peer_scope_root {
+                                info!(
+                                    marker = "gov_divergence_pull_triggered",
+                                    %context_id,
+                                    %chosen_peer,
+                                    local_scope_root = %hex::encode(&local_sr[..8]),
+                                    peer_scope_root = %hex::encode(&peer_scope_root[..8]),
+                                    "scope_root still differs post-sync — pulling governance from peer"
+                                );
+                                let ops_pulled = self
+                                    .pull_namespace_governance(context_id, chosen_peer)
+                                    .await;
+                                debug!(
+                                    marker = "gov_divergence_pull_complete",
+                                    %context_id,
+                                    %chosen_peer,
+                                    ops_pulled,
+                                    "post-sync governance pull issued; convergence verified next session"
+                                );
+                            }
+                        }
                     }
                 }
             }

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1564,7 +1564,13 @@ impl SyncManager {
             // self-limiting (once scope_roots agree the pull stops). Runs only on a
             // successful sync; gated on `peer_scope_root` so the no-divergence path
             // stays store-free.
-            if exec_result.is_ok() {
+            //
+            // `Ok(Some(_))` not `is_ok()`: a data backend must have actually RUN.
+            // `execute` returns `Ok(None)` for the `SyncProtocol::None` selection
+            // (entities already in sync) — which the pre-sync `GovDiverged` check
+            // above already handled — so running the post-sync block on `Ok(None)`
+            // would just repeat a store read + fold on every converged tick.
+            if matches!(exec_result, Ok(Some(_))) {
                 if let Some(peer_scope_root) = peer_scope_root {
                     // Re-read the POST-sync local root (entities may have merged). On a
                     // store fault, SKIP rather than fold a verdict against a stale

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -1115,11 +1115,16 @@ impl SyncManager {
     /// [`StoredNamespaceEntry::Opaque`] skeleton and `extract_signed_op`
     /// returns `None` for it — backfilling from such a peer yields nothing for
     /// group ops and would never release a governance-pending delta.
+    /// Pull the namespace governance DAG from `peer` (or a mesh peer when `None`).
+    /// Returns the number of governance ops received in the backfill response — `0`
+    /// on any best-effort failure (no peer, stream/​send/​recv error, unexpected
+    /// response), so a caller correcting a divergence can tell whether the pull
+    /// actually delivered anything rather than treating it as a silent no-op.
     pub(super) async fn sync_namespace_from_peer(
         &self,
         namespace_id: [u8; 32],
         peer: Option<PeerId>,
-    ) {
+    ) -> usize {
         use calimero_node_primitives::sync::{InitPayload, MessagePayload, StreamMessage};
 
         let peer = match peer {
@@ -1135,7 +1140,7 @@ impl SyncManager {
                         namespace_id = %hex::encode(namespace_id),
                         "no mesh peers for namespace sync"
                     );
-                    return;
+                    return 0;
                 };
                 p
             }
@@ -1143,7 +1148,7 @@ impl SyncManager {
 
         let Ok(mut stream) = self.sync_network.open_stream(peer).await else {
             debug!("failed to open stream for namespace sync");
-            return;
+            return 0;
         };
 
         let msg = StreamMessage::Init {
@@ -1161,7 +1166,7 @@ impl SyncManager {
 
         if let Err(err) = crate::sync::stream::send(&mut stream, &msg, None).await {
             debug!(%err, "failed to send NamespaceBackfillRequest");
-            return;
+            return 0;
         }
 
         match crate::sync::stream::recv(&mut stream, None, self.sync_config.timeout).await {
@@ -1295,9 +1300,11 @@ impl SyncManager {
                 // permanently locked out of group decryption.
                 self.recover_missing_group_keys(namespace_id, Some(peer))
                     .await;
+                ops_received
             }
             _ => {
                 debug!("unexpected response to namespace sync request");
+                0
             }
         }
     }

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -71,17 +71,6 @@ pub(crate) trait ProtocolDispatch {
         our_identity: PublicKey,
         chosen_peer: PeerId,
     ) -> Result<SyncProtocol>;
-
-    /// Pull the namespace governance DAG for `context_id` from `peer`
-    /// (P6.S2). Called when a data-plane sync (HashComparison /
-    /// LevelWise) reports `gov_divergence_detected` — the entity Merkle
-    /// converged but the authoritative `scope_root` did not, so the
-    /// divergence is purely in the ACL/governance plane, which lives
-    /// outside the storage Merkle and is never pulled by the entity
-    /// tree-walk. The manager resolves the namespace for the context
-    /// and issues a `NamespaceBackfillRequest` to the peer. Best-effort:
-    /// a no-op when the context has no resolvable namespace.
-    async fn pull_namespace_governance(&self, context_id: ContextId, peer: PeerId);
 }
 
 /// Protocol-dispatch component.
@@ -277,24 +266,12 @@ impl ProtocolSelector {
                             .await;
                         }
 
-                        // P6.S2: entities converged but the authoritative
-                        // `scope_root` did not ⇒ pure governance-plane
-                        // divergence the entity walk can't reach. Pull the
-                        // namespace governance DAG from this same peer so the
-                        // rotation/ACL change propagates; the next session
-                        // re-reads an agreeing `scope_root`.
-                        if stats.gov_divergence_detected {
-                            info!(
-                                marker = "gov_divergence_pull_triggered",
-                                %context_id,
-                                %chosen_peer,
-                                "scope_root governance divergence — pulling namespace governance from peer"
-                            );
-                            dispatch
-                                .pull_namespace_governance(context_id, chosen_peer)
-                                .await;
-                        }
-
+                        // P6.S3: the post-sync governance-divergence pull moved to
+                        // a single check in the manager (`handle_dag_sync`, after
+                        // `execute` returns) so it covers EVERY data backend —
+                        // Snapshot / DeltaSync as well as HC / LevelWise — not just
+                        // the two that compute the verdict here. The selector stays
+                        // a pure data-transfer step.
                         Ok(Some(SyncProtocol::HashComparison { root_hash }))
                     }
                     Err(e) => {
@@ -431,21 +408,9 @@ impl ProtocolSelector {
                             .await;
                         }
 
-                        // P6.S2: governance-plane divergence the entity BFS
-                        // can't reach — pull the namespace governance from this
-                        // peer. Parity with the HashComparison arm above.
-                        if stats.gov_divergence_detected {
-                            info!(
-                                marker = "gov_divergence_pull_triggered",
-                                %context_id,
-                                %chosen_peer,
-                                "scope_root governance divergence — pulling namespace governance from peer"
-                            );
-                            dispatch
-                                .pull_namespace_governance(context_id, chosen_peer)
-                                .await;
-                        }
-
+                        // P6.S3: post-sync governance pull centralised in the
+                        // manager (covers all data backends); see the HashComparison
+                        // arm above.
                         Ok(Some(SyncProtocol::LevelWise { max_depth }))
                     }
                     Err(e) => {


### PR DESCRIPTION
## What

Completes **P6.S3**, building on #2941 (P6.S2/S3a, merged). Closes a real gap and centralises the governance-divergence control to a single place.

### The gap
The post-sync governance pull was bolted onto only the two data backends that compute the `scope_root` verdict internally — **HashComparison** and **LevelWise** — via a per-protocol `gov_divergence_detected` stat plus a hook in each `ProtocolSelector::execute` arm. The other backends (**Snapshot, DeltaSync, BloomFilter, SubtreePrefetch**) never checked the verdict. So a node that converged its entities via a snapshot/delta sync while its governance plane still differed would **never** pull the missing rotation/ACL op.

### The fix
Move the post-sync check to **one place in the manager** (`handle_dag_sync`, right after `execute` returns), so it covers **every** backend uniformly: recompute the verdict against the peer's handshake `scope_root` using the **post-sync** local root (entities may have merged); on `GovDiverged`, pull governance.

The selector and the two protocols go back to pure data-transfer + observability:
- removed `gov_divergence_detected` from `HashComparisonStats` / `LevelWiseStats` and the two pull hooks in `ProtocolSelector::execute`;
- removed the now-dead `ProtocolDispatch::pull_namespace_governance` trait method (the manager calls the inherent method directly);
- HC / LevelWise keep computing the verdict for `root_hash_verified` and the `scope_root_governance_divergence` warn (unchanged observability).

This makes the architecture explicit: **one control protocol (the scope_root verdict) with two transfer backends (governance pull + entity data sync)**.

## Folds in an unaddressed #2941 review finding
`sync_namespace_from_peer` / `pull_namespace_governance` now **return the number of governance ops** the backfill delivered, and both `gov_divergence_pull_complete` markers log `ops_pulled`. A pull that came back empty (best-effort failure or already-converged peer) is no longer indistinguishable from a normal no-op sync (the reviewer's "silently discarded result" point).

Two #2941 findings remain explicit follow-ups, noted here rather than rushed:
- **Ephemeral `scope_root` fold cost** — the fold has a `cut_ancestry_complete` guard the maintained projection's raw `scope_root_for` lacks, so swapping to the maintained projection is a separate, correctness-sensitive slice (it would risk false divergence on a partially-warmed node).
- **`resolve_namespace_id` sharing** with `backfill_governance_for_pending_deltas` — trivial; the two paths differ in peer-selection policy.

## Scope / testing
- No wire/op-id change. The HC-internal re-queried-root precision (for `root_hash_verified`) is untouched; the centralised gov check uses the handshake `scope_root` as its reference (the next session re-checks, so a peer changing governance mid-sync self-corrects).
- fmt + clippy (`-D warnings`) clean; 239 node sync unit tests pass. The post-sync pull path is exercised by the partition e2e suites; same `gov_divergence_pull_triggered` / `_complete` markers feed the existing informational e2e report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync convergence behavior for Snapshot/DeltaSync and broadens when governance pulls run; logic is intentionally conservative (idempotent pulls) but touches authorization-adjacent `scope_root` handling in the sync manager hot path.
> 
> **Overview**
> **Governance reconciliation** no longer runs inside HashComparison / LevelWise only. The manager now owns **pre-sync** (`GovDiverged` when protocol is `None`) and **post-sync** (after any successful `execute`) checks that pull namespace governance when `scope_root` still disagrees with the peer—using a direct inequality on folded `scope_root`, not per-protocol stats.
> 
> **Removed** `gov_divergence_detected` from HC/LevelWise stats, the `ProtocolDispatch::pull_namespace_governance` hook, and selector-side pulls after those protocols. HC/LevelWise still compute `scope_verdict` for `root_hash_verified` and `scope_root_governance_divergence` warnings only.
> 
> **Observability:** `sync_namespace_from_peer` / `pull_namespace_governance` return **op counts**; `gov_divergence_pull_complete` logs `ops_pulled` so empty backfills are visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8787be68184999bea33a4730677de885e4add943. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->