### PR TITLE
feat(governance)!: C5.S3b — remove op-level state_hash field + bump schema (flag-day)

### DIFF
--- a/crates/context/src/governance_dag.rs
+++ b/crates/context/src/governance_dag.rs
@@ -50,7 +50,9 @@ pub fn signed_op_to_delta(op: &SignedGroupOp) -> Result<CausalDelta<SignedGroupO
     Ok(make_delta(
         op,
         op.parent_op_hashes.clone(),
-        op.state_hash,
+        // C5.S3b removed the op-level state_hash; the DAG delta carries no
+        // meaningful `expected_root_hash` from a governance op.
+        [0u8; 32],
         delta_id,
     ))
 }

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1678,7 +1678,6 @@ mod tests {
             version: 1,
             namespace_id,
             parent_op_hashes: Vec::new(),
-            state_hash: [0u8; 32],
             signer,
             nonce: 0,
             op: NamespaceOp::Root(op),
@@ -2127,7 +2126,6 @@ mod tests {
             version: 1,
             namespace_id,
             parent_op_hashes: Vec::new(),
-            state_hash: [0u8; 32],
             signer,
             nonce: 0,
             op: NamespaceOp::Group {

--- a/crates/context/src/self_purge.rs
+++ b/crates/context/src/self_purge.rs
@@ -2837,7 +2837,6 @@ mod tests {
             &owner_sk,
             namespace_id,
             vec![],
-            [0u8; 32],
             1,
             NamespaceOp::Group {
                 group_id: sub_gid.to_bytes(),

--- a/crates/context/tests/cascade_apply_walk.rs
+++ b/crates/context/tests/cascade_apply_walk.rs
@@ -119,7 +119,6 @@ fn cascade_target_application_set_updates_all_matching_descendants_and_skips_sib
         &admin_sk,
         r.to_bytes(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::CascadeTargetApplicationSet {
             from_app_key: APP_KEY_1,

--- a/crates/context/tests/cascade_atomic_apply.rs
+++ b/crates/context/tests/cascade_atomic_apply.rs
@@ -95,7 +95,6 @@ fn cascade_upgrade_atomic_op_sets_target_app_key_and_migration_and_records_casca
         &admin_sk,
         r.to_bytes(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::CascadeUpgrade {
             from_app_key: APP_KEY_1,
@@ -175,7 +174,6 @@ async fn cascade_upgrade_reverse_delivery_converges_atomically() {
         &admin_sk,
         root.to_bytes(),
         vec![[0u8; 32]],
-        [0u8; 32],
         1,
         GroupOp::GroupMetadataSet {
             name: Some("label".to_owned()),
@@ -190,7 +188,6 @@ async fn cascade_upgrade_reverse_delivery_converges_atomically() {
         &admin_sk,
         root.to_bytes(),
         vec![op_p_hash],
-        [0u8; 32],
         2,
         GroupOp::CascadeUpgrade {
             from_app_key: APP_KEY_1,
@@ -297,7 +294,6 @@ fn two_op_reverse_delivery_drops_migration_characterization() {
             &admin_sk,
             r.to_bytes(),
             vec![],
-            [0u8; 32],
             1,
             GroupOp::CascadeTargetApplicationSet {
                 from_app_key: APP_KEY_1,
@@ -314,7 +310,6 @@ fn two_op_reverse_delivery_drops_migration_characterization() {
             &admin_sk,
             r.to_bytes(),
             vec![],
-            [0u8; 32],
             2,
             GroupOp::CascadeGroupMigrationSet {
                 from_app_key: APP_KEY_1,

--- a/crates/context/tests/cascade_concurrent_safety.rs
+++ b/crates/context/tests/cascade_concurrent_safety.rs
@@ -132,7 +132,6 @@ async fn divergent_cascade_apply_order_converges_via_predicate_skip() {
         &admin_sk,
         root.to_bytes(),
         vec![[0u8; 32]],
-        [0u8; 32],
         1,
         GroupOp::CascadeTargetApplicationSet {
             from_app_key: APP_KEY_1,
@@ -151,7 +150,6 @@ async fn divergent_cascade_apply_order_converges_via_predicate_skip() {
         &admin_sk,
         root.to_bytes(),
         vec![op_a_hash],
-        [0u8; 32],
         2,
         GroupOp::CascadeTargetApplicationSet {
             from_app_key: APP_KEY_1,

--- a/crates/context/tests/cascade_status_rpc.rs
+++ b/crates/context/tests/cascade_status_rpc.rs
@@ -88,7 +88,6 @@ fn collect_cascade_status_returns_entries_for_all_three_groups() {
         &admin_sk,
         r.to_bytes(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::CascadeUpgrade {
             from_app_key: APP_KEY_1,

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -1329,21 +1329,17 @@ fn dag_heads_are_capped_at_max() {
 }
 
 #[test]
-fn state_hash_mismatch_does_not_reject_concurrent_ops() {
-    // Cutover C5.S3a: a group op's signed `state_hash` is staleness TELEMETRY,
-    // not an apply gate. Two admins concurrently sign INDEPENDENT ops against the
-    // same genesis state; whichever lands second carries a now-stale `state_hash`.
-    // The old behaviour hard-`bail!`ed on that mismatch, which stranded a
-    // legitimate concurrent sibling and broke multi-node convergence (the whole
-    // reason `apply_group_op_inner` already warns-not-bails). Now the local path
-    // matches: the mismatch only warns and the op applies, so both nodes converge
-    // regardless of apply order. `scope_root` + CRDT merge are the convergence
-    // mechanism; signature + nonce-window remain the real safety gates.
+fn concurrent_independent_member_adds_converge() {
+    // Two admins concurrently apply INDEPENDENT ops (each adds a different member)
+    // against the same genesis state. Both nodes must converge to the same member
+    // set regardless of apply order — the CRDT convergence property the cutover
+    // relies on (no op-level staleness gate rejects a legitimate concurrent
+    // sibling). Signature + the per-signer nonce window are the only apply gates.
     //
-    // Independent ADDS (not the old admin-removes-admin scenario) deliberately
-    // avoid an authorization-order confound: under the live-fallback authorizer a
-    // removed admin's later op would fail on *authorization*, not state_hash, which
-    // would mask the gate-removal this test pins down.
+    // Independent ADDS (not an admin-removes-admin scenario) deliberately avoid an
+    // authorization-order confound: under the live-fallback authorizer a removed
+    // admin's later op would fail on *authorization*, masking the convergence
+    // property this test pins down.
     let mut rng = OsRng;
     let gid = sample_group_id();
     let gid_bytes = gid.to_bytes();
@@ -1370,18 +1366,18 @@ fn state_hash_mismatch_does_not_reject_concurrent_ops() {
             .unwrap();
     }
 
-    let state_hash_b = MetaRepository::new(&node_b)
+    let meta_hash_b = MetaRepository::new(&node_b)
         .compute_state_hash(&gid)
         .unwrap();
-    let state_hash_c = MetaRepository::new(&node_c)
+    let meta_hash_c = MetaRepository::new(&node_c)
         .compute_state_hash(&gid)
         .unwrap();
     assert_eq!(
-        state_hash_b, state_hash_c,
-        "nodes start with identical state hash"
+        meta_hash_b, meta_hash_c,
+        "nodes start with identical group-meta hash"
     );
 
-    // A adds D; C adds E — independent, non-conflicting, both signed against the
+    // A adds D; C adds E — independent, non-conflicting, both authored against the
     // SAME genesis state (concurrent).
     let op_a = SignedGroupOp::sign(
         &admin_a_sk,
@@ -1408,24 +1404,23 @@ fn state_hash_mismatch_does_not_reject_concurrent_ops() {
     )
     .unwrap();
 
-    // Node B: op_a first, then op_c (op_c's state_hash is now stale).
+    // Node B applies op_a then op_c; node C applies them in the opposite order.
     assert!(
         apply_local_signed_group_op(&node_b, &op_a).is_ok(),
         "op_a applies on node_b"
     );
     assert!(
         apply_local_signed_group_op(&node_b, &op_c).is_ok(),
-        "op_c applies on node_b despite a stale state_hash (telemetry, not a gate)"
+        "concurrent op_c also applies on node_b (no staleness gate)"
     );
 
-    // Node C: op_c first, then op_a (op_a's state_hash is now stale).
     assert!(
         apply_local_signed_group_op(&node_c, &op_c).is_ok(),
         "op_c applies on node_c"
     );
     assert!(
         apply_local_signed_group_op(&node_c, &op_a).is_ok(),
-        "op_a applies on node_c despite a stale state_hash"
+        "concurrent op_a also applies on node_c"
     );
 
     // Both nodes converge to {A, C admins + D, E members}, regardless of order.
@@ -1450,7 +1445,7 @@ fn state_hash_mismatch_does_not_reject_concurrent_ops() {
     }
 
     // `compute_state_hash` sorts members by pubkey, so the converged hashes match
-    // — order-independent convergence, the property the old reject actively broke.
+    // — order-independent convergence.
     let final_b = MetaRepository::new(&node_b)
         .compute_state_hash(&gid)
         .unwrap();
@@ -1462,10 +1457,9 @@ fn state_hash_mismatch_does_not_reject_concurrent_ops() {
         "nodes converge to identical state regardless of apply order"
     );
 
-    // Replay safety is unaffected by dropping the state_hash gate: the per-signer
-    // NONCE WINDOW (not state_hash) is the anti-replay guard, and it is unchanged.
-    // Re-applying op_a (admin_a, nonce 1) is a no-op — the nonce is already in the
-    // window — so a DAG replay of a seen op cannot double-apply its mutation.
+    // The per-signer NONCE WINDOW is the anti-replay guard. Re-applying op_a
+    // (admin_a, nonce 1) is a no-op — the nonce is already in the window — so a DAG
+    // replay of a seen op cannot double-apply its mutation.
     let members_before_replay = MembershipRepository::new(&node_b)
         .list(&gid, 0, usize::MAX)
         .unwrap()
@@ -1653,95 +1647,6 @@ fn cascade_removal_deterministic_across_nodes() {
 // member_joined_context_op_propagates test removed:
 // MemberJoinedContext governance op was removed — context membership
 // is now derived from group membership + visibility.
-
-#[test]
-fn state_hash_allows_sequential_ops() {
-    let mut rng = OsRng;
-    let gid = sample_group_id();
-    let gid_bytes = gid.to_bytes();
-    let store = empty_store();
-
-    let admin_sk = PrivateKey::random(&mut rng);
-    let admin_pk = admin_sk.public_key();
-    MetaRepository::new(&store)
-        .save(&gid, &sample_meta(admin_pk))
-        .unwrap();
-    MembershipRepository::new(&store)
-        .add_member(&gid, &admin_pk, GroupMemberRole::Admin)
-        .unwrap();
-
-    let member1 = PrivateKey::random(&mut rng).public_key();
-    let member2 = PrivateKey::random(&mut rng).public_key();
-
-    // Op1: add member1, signed against initial state
-    let state1 = MetaRepository::new(&store)
-        .compute_state_hash(&gid)
-        .unwrap();
-    let op1 = SignedGroupOp::sign(
-        &admin_sk,
-        gid_bytes,
-        vec![[0u8; 32]],
-        1,
-        GroupOp::MemberAdded {
-            member: member1,
-            role: GroupMemberRole::Member,
-        },
-    )
-    .unwrap();
-    apply_local_signed_group_op(&store, &op1).unwrap();
-
-    // Op2: add member2, signed against state AFTER op1
-    let state2 = MetaRepository::new(&store)
-        .compute_state_hash(&gid)
-        .unwrap();
-    assert_ne!(
-        state1, state2,
-        "state hash should change after adding member1"
-    );
-    let op2 = SignedGroupOp::sign(
-        &admin_sk,
-        gid_bytes,
-        vec![op1.content_hash().unwrap()],
-        2,
-        GroupOp::MemberAdded {
-            member: member2,
-            role: GroupMemberRole::Member,
-        },
-    )
-    .unwrap();
-    apply_local_signed_group_op(&store, &op2).unwrap();
-
-    assert!(
-        calimero_context::group_store::MembershipRepository::new(&store)
-            .is_member(&gid, &member1)
-            .unwrap()
-    );
-    assert!(
-        calimero_context::group_store::MembershipRepository::new(&store)
-            .is_member(&gid, &member2)
-            .unwrap()
-    );
-}
-
-#[test]
-fn state_hash_zero_skips_validation() {
-    let mut rng = OsRng;
-    let gid = sample_group_id();
-    let gid_bytes = gid.to_bytes();
-    let store = empty_store();
-
-    let admin_sk = PrivateKey::random(&mut rng);
-    let admin_pk = admin_sk.public_key();
-    MetaRepository::new(&store)
-        .save(&gid, &sample_meta(admin_pk))
-        .unwrap();
-    MembershipRepository::new(&store)
-        .add_member(&gid, &admin_pk, GroupMemberRole::Admin)
-        .unwrap();
-
-    let op = SignedGroupOp::sign(&admin_sk, gid_bytes, vec![[0u8; 32]], 1, GroupOp::Noop).unwrap();
-    assert!(apply_local_signed_group_op(&store, &op).is_ok());
-}
 
 #[test]
 fn group_member_with_keys_persists_and_retrieves() {

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -135,7 +135,6 @@ fn two_nodes_converge_on_same_signed_op_sequence() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberAdded {
             member: new_member,
@@ -161,8 +160,8 @@ fn two_nodes_converge_on_same_signed_op_sequence() {
             .unwrap()
     );
 
-    let op2 = SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], [0u8; 32], 2, GroupOp::Noop)
-        .expect("sign op2");
+    let op2 =
+        SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], 2, GroupOp::Noop).expect("sign op2");
     let payload2 = borsh_to_vec(&op2).expect("borsh encode op2");
 
     apply_wire_payload(&store_a, &payload2);
@@ -211,7 +210,6 @@ fn two_nodes_converge_on_target_application_and_migration() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::TargetApplicationSet {
             app_key: [0x11; 32],
@@ -224,7 +222,6 @@ fn two_nodes_converge_on_target_application_and_migration() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         2,
         GroupOp::GroupMigrationSet {
             migration: Some(b"v1-migration".to_vec()),
@@ -304,7 +301,6 @@ fn two_nodes_converge_on_namespace_member_joined() {
         &joiner_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::MemberJoined {
             member: joiner_pk,
@@ -355,7 +351,6 @@ fn member_joined_at_rejects_expired_invitation() {
         &joiner_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::MemberJoinedAt {
             member: joiner_pk,
@@ -410,7 +405,6 @@ fn member_joined_at_accepts_in_window_invitation() {
         &joiner_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::MemberJoinedAt {
             member: joiner_pk,
@@ -463,7 +457,6 @@ fn member_joined_at_backdated_joined_at_bypasses_apply_gate_documented_residual(
         &joiner_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::MemberJoinedAt {
             member: joiner_pk,
@@ -515,7 +508,6 @@ fn member_joined_at_in_window_converges_when_expiration_already_past_wallclock()
         &joiner_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::MemberJoinedAt {
             member: joiner_pk,
@@ -561,7 +553,6 @@ fn member_joined_at_ignores_zero_expiration() {
         &joiner_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::MemberJoinedAt {
             member: joiner_pk,
@@ -638,7 +629,6 @@ fn recursive_invite_joins_all_descendant_groups() {
             &joiner_sk,
             ns_id.to_bytes(),
             vec![],
-            [0u8; 32],
             (i + 1) as u64,
             NamespaceOp::Root(RootOp::MemberJoined {
                 member: joiner_pk,
@@ -781,7 +771,6 @@ fn two_nodes_converge_on_context_alias_as_admin() {
         &creator_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::ContextRegistered {
             context_id,
@@ -796,7 +785,6 @@ fn two_nodes_converge_on_context_alias_as_admin() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::ContextMetadataSet {
             context_id,
@@ -855,7 +843,6 @@ fn op_log_records_applied_ops_and_head_advances() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberAdded {
             member: new_member,
@@ -876,8 +863,8 @@ fn op_log_records_applied_ops_and_head_advances() {
     let decoded: SignedGroupOp = borsh::from_slice(&log[0].1).unwrap();
     assert_eq!(decoded.nonce, op1.nonce);
 
-    let op2 = SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], [0u8; 32], 2, GroupOp::Noop)
-        .expect("sign op2");
+    let op2 =
+        SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], 2, GroupOp::Noop).expect("sign op2");
     apply_local_signed_group_op(&store, &op2).unwrap();
 
     let head2 = get_op_head(&store, &gid).unwrap().expect("head after op2");
@@ -907,8 +894,7 @@ fn duplicate_op_is_idempotent() {
         .add_member(&gid, &admin_pk, GroupMemberRole::Admin)
         .unwrap();
 
-    let op = SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], [0u8; 32], 1, GroupOp::Noop)
-        .expect("sign op");
+    let op = SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], 1, GroupOp::Noop).expect("sign op");
     let payload = borsh_to_vec(&op).expect("encode");
 
     apply_wire_payload(&store, &payload);
@@ -949,7 +935,6 @@ fn offline_node_replays_missed_ops_from_log() {
         &admin_sk,
         gid_bytes,
         vec![[0u8; 32]],
-        [0u8; 32],
         1,
         GroupOp::MemberAdded {
             member: member1,
@@ -962,7 +947,6 @@ fn offline_node_replays_missed_ops_from_log() {
         &admin_sk,
         gid_bytes,
         vec![op1_hash],
-        [0u8; 32],
         2,
         GroupOp::MemberAdded {
             member: member2,
@@ -1036,7 +1020,6 @@ async fn dag_applies_ops_in_causal_order() {
         &admin_sk,
         gid_bytes,
         vec![[0u8; 32]],
-        [0u8; 32],
         1,
         GroupOp::MemberAdded {
             member: member1,
@@ -1052,7 +1035,6 @@ async fn dag_applies_ops_in_causal_order() {
         &admin_sk,
         gid_bytes,
         vec![op1_hash],
-        [0u8; 32],
         2,
         GroupOp::MemberAdded {
             member: member2,
@@ -1120,7 +1102,6 @@ async fn dag_concurrent_ops_create_two_heads() {
         &admin_sk,
         gid_bytes,
         vec![[0u8; 32]],
-        [0u8; 32],
         1,
         GroupOp::MemberAdded {
             member: member1,
@@ -1132,7 +1113,6 @@ async fn dag_concurrent_ops_create_two_heads() {
         &admin_sk,
         gid_bytes,
         vec![[0u8; 32]],
-        [0u8; 32],
         2,
         GroupOp::MemberAdded {
             member: member2,
@@ -1169,15 +1149,8 @@ async fn dag_concurrent_ops_create_two_heads() {
     // Merge op referencing both heads
     let hash_a = op_a.content_hash().unwrap();
     let hash_b = op_b.content_hash().unwrap();
-    let merge_op = SignedGroupOp::sign(
-        &admin_sk,
-        gid_bytes,
-        vec![hash_a, hash_b],
-        [0u8; 32],
-        3,
-        GroupOp::Noop,
-    )
-    .unwrap();
+    let merge_op =
+        SignedGroupOp::sign(&admin_sk, gid_bytes, vec![hash_a, hash_b], 3, GroupOp::Noop).unwrap();
     dag.add_delta(signed_op_to_delta(&merge_op).unwrap(), &applier)
         .await
         .unwrap();
@@ -1204,15 +1177,7 @@ async fn dag_duplicate_delta_is_idempotent() {
         .add_member(&gid, &admin_pk, GroupMemberRole::Admin)
         .unwrap();
 
-    let op = SignedGroupOp::sign(
-        &admin_sk,
-        gid_bytes,
-        vec![[0u8; 32]],
-        [0u8; 32],
-        1,
-        GroupOp::Noop,
-    )
-    .unwrap();
+    let op = SignedGroupOp::sign(&admin_sk, gid_bytes, vec![[0u8; 32]], 1, GroupOp::Noop).unwrap();
     let delta = signed_op_to_delta(&op).unwrap();
 
     let applier = GroupGovernanceApplier::new(store.clone());
@@ -1244,15 +1209,8 @@ async fn dag_deep_chain_with_out_of_order_delivery() {
     let mut ops = Vec::new();
     let mut prev_hash: Vec<[u8; 32]> = vec![[0u8; 32]];
     for i in 1..=5u64 {
-        let op = SignedGroupOp::sign(
-            &admin_sk,
-            gid_bytes,
-            prev_hash.clone(),
-            [0u8; 32],
-            i,
-            GroupOp::Noop,
-        )
-        .unwrap();
+        let op =
+            SignedGroupOp::sign(&admin_sk, gid_bytes, prev_hash.clone(), i, GroupOp::Noop).unwrap();
         prev_hash = vec![op.content_hash().unwrap()];
         ops.push(op);
     }
@@ -1315,15 +1273,7 @@ fn rejects_op_with_too_many_parents() {
             h
         })
         .collect();
-    let op_ok = SignedGroupOp::sign(
-        &admin_sk,
-        gid_bytes,
-        parents_256,
-        [0u8; 32],
-        1,
-        GroupOp::Noop,
-    )
-    .unwrap();
+    let op_ok = SignedGroupOp::sign(&admin_sk, gid_bytes, parents_256, 1, GroupOp::Noop).unwrap();
     assert!(apply_local_signed_group_op(&store, &op_ok).is_ok());
 
     // 257 parents should be rejected
@@ -1335,15 +1285,7 @@ fn rejects_op_with_too_many_parents() {
             h
         })
         .collect();
-    let op_bad = SignedGroupOp::sign(
-        &admin_sk,
-        gid_bytes,
-        parents_257,
-        [0u8; 32],
-        2,
-        GroupOp::Noop,
-    )
-    .unwrap();
+    let op_bad = SignedGroupOp::sign(&admin_sk, gid_bytes, parents_257, 2, GroupOp::Noop).unwrap();
     assert!(apply_local_signed_group_op(&store, &op_bad).is_err());
 }
 
@@ -1365,15 +1307,8 @@ fn dag_heads_are_capped_at_max() {
 
     // Create 70 concurrent ops (all with genesis parent) to exceed MAX_DAG_HEADS (64)
     for i in 1..=70u64 {
-        let op = SignedGroupOp::sign(
-            &admin_sk,
-            gid_bytes,
-            vec![[0u8; 32]],
-            [0u8; 32],
-            i,
-            GroupOp::Noop,
-        )
-        .unwrap();
+        let op =
+            SignedGroupOp::sign(&admin_sk, gid_bytes, vec![[0u8; 32]], i, GroupOp::Noop).unwrap();
         apply_local_signed_group_op(&store, &op).unwrap();
     }
 
@@ -1384,15 +1319,8 @@ fn dag_heads_are_capped_at_max() {
         head.dag_heads.len()
     );
     // The last op's hash should be present (not truncated)
-    let last_op = SignedGroupOp::sign(
-        &admin_sk,
-        gid_bytes,
-        vec![[0u8; 32]],
-        [0u8; 32],
-        70,
-        GroupOp::Noop,
-    )
-    .unwrap();
+    let last_op =
+        SignedGroupOp::sign(&admin_sk, gid_bytes, vec![[0u8; 32]], 70, GroupOp::Noop).unwrap();
     let last_hash = last_op.content_hash().unwrap();
     assert!(
         head.dag_heads.contains(&last_hash),
@@ -1459,7 +1387,6 @@ fn state_hash_mismatch_does_not_reject_concurrent_ops() {
         &admin_a_sk,
         gid_bytes,
         vec![[0u8; 32]],
-        state_hash_b,
         1,
         GroupOp::MemberAdded {
             member: new_member_d,
@@ -1473,7 +1400,6 @@ fn state_hash_mismatch_does_not_reject_concurrent_ops() {
         &admin_c_sk,
         gid_bytes,
         vec![[0u8; 32]],
-        state_hash_c,
         1,
         GroupOp::MemberAdded {
             member: new_member_e,
@@ -1625,7 +1551,6 @@ fn cascade_removal_on_member_kick() {
         &admin_sk,
         gid_bytes,
         vec![[0u8; 32]],
-        [0u8; 32],
         1,
         dummy_member_removed(member_pk),
     )
@@ -1698,7 +1623,6 @@ fn cascade_removal_deterministic_across_nodes() {
         &admin_sk,
         gid_bytes,
         vec![[0u8; 32]],
-        [0u8; 32],
         1,
         dummy_member_removed(member_pk),
     )
@@ -1757,7 +1681,6 @@ fn state_hash_allows_sequential_ops() {
         &admin_sk,
         gid_bytes,
         vec![[0u8; 32]],
-        state1,
         1,
         GroupOp::MemberAdded {
             member: member1,
@@ -1779,7 +1702,6 @@ fn state_hash_allows_sequential_ops() {
         &admin_sk,
         gid_bytes,
         vec![op1.content_hash().unwrap()],
-        state2,
         2,
         GroupOp::MemberAdded {
             member: member2,
@@ -1817,15 +1739,7 @@ fn state_hash_zero_skips_validation() {
         .add_member(&gid, &admin_pk, GroupMemberRole::Admin)
         .unwrap();
 
-    let op = SignedGroupOp::sign(
-        &admin_sk,
-        gid_bytes,
-        vec![[0u8; 32]],
-        [0u8; 32],
-        1,
-        GroupOp::Noop,
-    )
-    .unwrap();
+    let op = SignedGroupOp::sign(&admin_sk, gid_bytes, vec![[0u8; 32]], 1, GroupOp::Noop).unwrap();
     assert!(apply_local_signed_group_op(&store, &op).is_ok());
 }
 
@@ -1952,7 +1866,6 @@ fn reapplying_namespace_op_keeps_dag_head_set_clean_and_position_embeddable() {
         &joiner_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::MemberJoined {
             member: joiner_pk,

--- a/crates/context/tests/op_store_reconstruction.rs
+++ b/crates/context/tests/op_store_reconstruction.rs
@@ -97,7 +97,6 @@ fn op_store_reconstruction_recovers_late_decrypted_membership_after_key_delivery
         version: 1,
         namespace_id: ns_bytes,
         parent_op_hashes: Vec::new(),
-        state_hash: [0u8; 32],
         signer: admin,
         nonce: 1,
         op: NamespaceOp::Group {
@@ -186,7 +185,6 @@ fn completeness_gate_flags_governance_ops_missing_from_the_op_store() {
             version: 1,
             namespace_id: ns_bytes,
             parent_op_hashes: Vec::new(),
-            state_hash: [0u8; 32],
             signer: admin,
             nonce: u64::from(id),
             op: NamespaceOp::Group {
@@ -258,7 +256,6 @@ fn locally_authored_op_lands_in_the_op_store_atomically() {
         version: 1,
         namespace_id: ns_bytes,
         parent_op_hashes: Vec::new(),
-        state_hash: [0u8; 32],
         signer: admin,
         nonce: 1,
         op: NamespaceOp::Group {

--- a/crates/context/tests/projection_membership_equivalence.rs
+++ b/crates/context/tests/projection_membership_equivalence.rs
@@ -101,7 +101,6 @@ fn fold_subgroup_structure(
         version: 1,
         namespace_id: namespace,
         parent_op_hashes: Vec::new(),
-        state_hash: [0u8; 32],
         signer: admin,
         nonce: 0,
         op: NamespaceOp::Root(RootOp::GroupCreated {
@@ -140,7 +139,6 @@ fn ns_group_envelope(
         version: 1,
         namespace_id: namespace,
         parent_op_hashes: Vec::new(),
-        state_hash: [0u8; 32],
         signer,
         nonce: 0,
         op: NamespaceOp::Group {
@@ -206,7 +204,6 @@ fn projection_matches_live_across_inherited_join_and_root_removal() {
         &joiner_sk,
         ns.to_bytes(),
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::MemberJoined {
             member: joiner,
@@ -224,7 +221,6 @@ fn projection_matches_live_across_inherited_join_and_root_removal() {
         &joiner_sk,
         ns.to_bytes(),
         vec![],
-        [0u8; 32],
         2,
         NamespaceOp::Root(RootOp::MemberJoinedOpen {
             member: joiner,
@@ -361,7 +357,6 @@ fn projection_matches_live_across_leave_and_rejoin_inheritance() {
         &joiner_sk,
         ns.to_bytes(),
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::MemberJoined {
             member: joiner,
@@ -382,7 +377,6 @@ fn projection_matches_live_across_leave_and_rejoin_inheritance() {
         &joiner_sk,
         ns.to_bytes(),
         vec![],
-        [0u8; 32],
         2,
         NamespaceOp::Root(RootOp::MemberJoinedOpen {
             member: joiner,
@@ -429,7 +423,6 @@ fn projection_matches_live_across_leave_and_rejoin_inheritance() {
         &joiner_sk,
         ns.to_bytes(),
         vec![],
-        [0u8; 32],
         3,
         NamespaceOp::Root(RootOp::MemberJoined {
             member: joiner,
@@ -510,7 +503,6 @@ fn projection_defers_when_cut_ancestry_incomplete() {
         &joiner_sk,
         ns.to_bytes(),
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::MemberJoined {
             member: joiner,
@@ -523,7 +515,6 @@ fn projection_defers_when_cut_ancestry_incomplete() {
         &joiner_sk,
         ns.to_bytes(),
         vec![],
-        [0u8; 32],
         2,
         NamespaceOp::Root(RootOp::MemberJoinedOpen {
             member: joiner,

--- a/crates/governance-store/src/governance_broadcast/tests.rs
+++ b/crates/governance-store/src/governance_broadcast/tests.rs
@@ -178,7 +178,6 @@ fn mk_signed_op(sk: &PrivateKey, namespace_id: [u8; 32]) -> SignedNamespaceOp {
         sk,
         namespace_id,
         Vec::new(),
-        [0u8; 32],
         0,
         NamespaceOp::Root(RootOp::AdminChanged {
             new_admin: sk.public_key(),

--- a/crates/governance-store/src/group_governance_publisher.rs
+++ b/crates/governance-store/src/group_governance_publisher.rs
@@ -102,24 +102,10 @@ impl<'a> GroupGovernancePublisher<'a> {
             .await;
         let known = self.node_client.known_subscribers(&topic);
 
-        // Capture the pre-apply state hash BEFORE the local mutation
-        // runs. The receiver's staleness check in
-        // `apply_group_op_inner` recomputes the subgroup's state hash
-        // against its own pre-apply view; if we sampled here AFTER the
-        // local apply, the value we sign would reflect the post-apply
-        // view and every member-mutating op would fail the receiver's
-        // check (#2134 high-severity finding). Mirrors the sign-side
-        // bypass on `state_hash_for_op`: a not-yet-bootstrapped group
-        // has no meta row, so the zero value is the documented signal.
-        let pre_apply_state_hash = {
-            let repo = MetaRepository::new(self.store);
-            if repo.load(&self.group_id)?.is_none() {
-                [0u8; 32]
-            } else {
-                repo.compute_state_hash(&self.group_id)?
-            }
-        };
-
+        // C5.S3b: the op-level pre-apply state_hash capture was removed with the
+        // field (`scope_root` is the convergence signal now). The `MemberRemoved` /
+        // `MemberLeft` `expected_group_state_hash` claims above are a SEPARATE
+        // post-apply convergence mechanism and are unaffected.
         let _output =
             sign_apply_local_group_op_borsh(self.store, &self.group_id, signer_sk, op.clone())?;
 
@@ -291,7 +277,6 @@ impl<'a> GroupGovernancePublisher<'a> {
                 ack_router,
                 &namespace_sk,
                 namespace_op,
-                pre_apply_state_hash,
                 mesh,
                 known,
                 true,

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -1319,11 +1319,9 @@ pub fn apply_local_signed_group_op_at_cut(
         .map_err(|e| eyre::eyre!("signed group op: {e}"))?;
     let group_id = ContextGroupId::from(op.group_id);
 
-    // Anti-replay / dedup runs FIRST: a replayed op whose nonce is already in the
-    // window returns here without mutating, so it must short-circuit BEFORE the
-    // state_hash telemetry below — otherwise a pure replay would emit a misleading
-    // "applying anyway" warn even though nothing is applied. Mirrors the ordering
-    // the namespace path (`apply_group_op_inner`) already documents.
+    // C5.S3b: the op-level `state_hash` staleness check was removed with the field.
+    // It stopped being an apply gate in C5.S3a (`scope_root` is the convergence
+    // signal); the per-signer nonce window below remains the anti-replay gate.
     let mut nonce_window = load_nonce_window(store, &group_id, &op.signer)?;
     if nonce_window.contains(op.nonce) {
         tracing::debug!(
@@ -1333,51 +1331,6 @@ pub fn apply_local_signed_group_op_at_cut(
             "ignoring op with already-processed nonce"
         );
         return Ok(());
-    }
-
-    // C5.S3b: remove this entire block once `state_hash` is dropped from the wire
-    // format (the flag-day op-id change). Until then it stays as staleness
-    // telemetry only.
-    let zero_hash = [0u8; 32];
-    if op.state_hash != zero_hash {
-        // Staleness telemetry, NOT an apply gate (cutover C5.S3a). This is the
-        // `DeltaApplier::apply` body for the group governance DAG, so concurrent
-        // same-subgroup ops from different nodes routinely land here: A and B each
-        // sign against their then-current view and the second to reach C has
-        // already drifted. `bail!`-ing on that mismatch rejects a legitimate
-        // concurrent sibling the DAG would otherwise merge, forcing recovery onto
-        // anchor-sync reconcile — a multi-node convergence hazard. `scope_root` is
-        // now the authoritative convergence signal and CRDT merge handles the
-        // concurrency, so we recompute and WARN on disagreement but apply anyway —
-        // matching the namespace-wrapped path (`apply_group_op_inner`), whose own
-        // comment already documents this trade-off (PR #2500 caveat). Signature
-        // and the nonce window (checked above) remain the real safety/anti-replay
-        // gates.
-        //
-        // Absent-meta bypass: if the subgroup meta row hasn't been written yet —
-        // e.g. a group op buffered/replayed before its GroupCreated lands — there
-        // is no state to hash. `compute_state_hash` would raise
-        // GroupNotFoundForHash and strand the op forever (#2848). Treat absent meta
-        // as a bypass; GroupCreated's apply re-drives this op once meta exists.
-        let repo = MetaRepository::new(store);
-        if repo.load(&group_id)?.is_some() {
-            let current_state_hash = repo.compute_state_hash(&group_id)?;
-            if op.state_hash != current_state_hash {
-                tracing::warn!(
-                    group_id = %hex::encode(group_id.to_bytes()),
-                    // Log the variant so operators can tell an expected concurrent
-                    // MemberAdded apart from a stale-hash op on a sensitive variant
-                    // (e.g. MemberRemoved) when diagnosing real divergence.
-                    op = ?op.op,
-                    expected = %hex::encode(op.state_hash),
-                    actual = %hex::encode(current_state_hash),
-                    nonce = op.nonce,
-                    signer = %op.signer,
-                    "local group op state_hash mismatch (signed against stale state; \
-                     applying anyway — see PR #2500 caveat)"
-                );
-            }
-        }
     }
 
     let (handled, _divergence, pending_events) = apply_group_op_mutations(
@@ -1522,15 +1475,7 @@ pub fn sign_apply_local_group_op_borsh(
     let parent_hashes = get_op_head(store, group_id)?
         .map(|h| h.dag_heads.clone())
         .unwrap_or_default();
-    let state_hash = MetaRepository::new(store).compute_state_hash(group_id)?;
-    let signed = SignedGroupOp::sign(
-        signer_sk,
-        group_id.to_bytes(),
-        parent_hashes,
-        state_hash,
-        nonce,
-        op,
-    )?;
+    let signed = SignedGroupOp::sign(signer_sk, group_id.to_bytes(), parent_hashes, nonce, op)?;
     let delta_id = signed
         .content_hash()
         .map_err(|e| eyre::eyre!("content_hash: {e}"))?;

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -341,9 +341,6 @@ impl<'a> GroupHandle<'a> {
     pub fn delete_meta(&self) -> EyreResult<()> {
         MetaRepository::new(self.store).delete(&self.group_id)
     }
-    pub fn compute_state_hash(&self) -> EyreResult<[u8; 32]> {
-        MetaRepository::new(self.store).compute_state_hash(&self.group_id)
-    }
 
     // --- Members ---
     pub fn add_member(&self, identity: &PublicKey, role: GroupMemberRole) -> EyreResult<()> {

--- a/crates/governance-store/src/membership/tests.rs
+++ b/crates/governance-store/src/membership/tests.rs
@@ -163,7 +163,6 @@ fn membership_policy_guards_last_admin_and_tee_paths() {
         &signer_sk,
         gid.to_bytes(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::TeeAdmissionPolicySet {
             allowed_mrtd: vec!["m1".to_owned()],
@@ -2049,7 +2048,6 @@ fn is_authoritative_namespace_identity_recognizes_owner_admin_tee() {
         &signer_sk,
         gid.to_bytes(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberJoinedViaTeeAttestation {
             member: tee_node,

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -1527,9 +1527,9 @@ impl<'a> NamespaceGovernance<'a> {
         root: &RootOp,
     ) -> EyreResult<Vec<crate::op_events::OpEvent>> {
         // C5.S3b removed the op-level state_hash staleness telemetry that used to
-        // run here for `root_op_commits_to_namespace_state` variants. `scope_root`
-        // is the convergence signal now; signature + the nonce window (applied by
-        // the caller) remain the safety gates.
+        // run here for state-committing root variants. `scope_root` is the
+        // convergence signal now; signature + the nonce window (applied by the
+        // caller) remain the safety gates.
 
         // Per-variant logic lives in `ops/namespace/<variant>.rs` (#2481). The
         // op's causal cut + the at-cut authorizer ride along so the gates can

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -152,77 +152,6 @@ impl<'a> NamespaceGovernance<'a> {
             .collect_skeleton_delta_ids_for_group(group_id)
     }
 
-    /// Convergence claim baked into `SignedNamespaceOp.state_hash` at sign time.
-    ///
-    /// `Group` commits to the wrapped group's current meta+member set — the
-    /// same input the receiver recomputes in `apply_group_op_inner` to detect
-    /// a stale signer (mirrors `apply_local_signed_group_op` in the group-op
-    /// path).
-    ///
-    /// `Root` commits to the namespace's own meta+member set, but only for
-    /// variants whose correctness depends on it — see
-    /// `root_op_commits_to_namespace_state`. Additive/idempotent variants
-    /// (`KeyDelivery`) and subgroup-scoped mutations
-    /// (`GroupCreated`/`GroupReparented`/`GroupDeleted`) pass the zero
-    /// bypass to avoid coarse over-rejection on unrelated concurrent
-    /// activity.
-    ///
-    /// Pre-bootstrap groups/namespaces have no meta row to hash, so we fall
-    /// through to the documented zero-value bypass that the receiver also
-    /// recognizes.
-    ///
-    /// # Zero-hash bypass extends to gated variants too
-    ///
-    /// The receiver checks `op.state_hash != [0u8; 32]` before recomputing,
-    /// which means a gated variant (e.g. `AdminChanged`, `PolicyUpdated`)
-    /// signed with `state_hash == [0u8; 32]` skips the staleness check.
-    /// This is deliberate: pre-fix on-disk ops (signed before this change
-    /// landed) carry the zero hash, and rejecting them on replay would
-    /// break a node's ability to apply its own backfilled history. Net
-    /// effect: post-fix peers sign and verify; pre-fix ops bypass — same
-    /// semantics as the existing v1/v2 deployment. The bypass closes once
-    /// every signer has rolled forward and stopped emitting zero hashes;
-    /// no schema bump needed.
-    ///
-    /// **Known limitation:** there is no runtime enforcement that a
-    /// signer post-upgrade cannot emit `[0u8; 32]` to skip the check.
-    /// Defending against that case is not the purpose of this guard —
-    /// signature verification and the per-op authorization checks
-    /// (`require_namespace_admin`, capability checks, membership
-    /// recompute on the receiver) remain in force regardless of the
-    /// hash value. The staleness guard is a convergence aid for
-    /// concurrent-signer races between *honest* signers, not a
-    /// defence against adversarial signers — those are caught at the
-    /// authorization layer.
-    ///
-    /// # TOCTOU window between sign and apply
-    ///
-    /// Callers compute this hash, then sign, then apply locally and
-    /// publish. Between the compute call and the local apply, another
-    /// op could land — but every governance signer in the codebase
-    /// runs through the same actor mailbox (the `NodeManager` actor for
-    /// node-issued ops, or a single per-namespace driver for receiver
-    /// paths), which serializes applies for a given namespace.
-    /// `read_head_record` + this hash compute + local apply therefore
-    /// run atomically with respect to other governance applies on the
-    /// same node. The window only matters for divergence *across* nodes,
-    /// which is exactly what the staleness check on the receive side is
-    /// for.
-    fn state_hash_for_op(&self, op: &NamespaceOp) -> EyreResult<[u8; 32]> {
-        let target_gid = match op {
-            NamespaceOp::Group { group_id, .. } => ContextGroupId::from(*group_id),
-            NamespaceOp::Root(root) if root_op_commits_to_namespace_state(root) => {
-                ContextGroupId::from(self.namespace_id)
-            }
-            NamespaceOp::Root(_) => return Ok([0u8; 32]),
-        };
-        let repo = MetaRepository::new(self.store);
-        if repo.load(&target_gid)?.is_none() {
-            return Ok([0u8; 32]);
-        }
-        repo.compute_state_hash(&target_gid)
-    }
-
     pub fn apply_signed_op(&self, op: &SignedNamespaceOp) -> EyreResult<ApplyNamespaceOpResult> {
         op.verify_signature()
             .map_err(|e| eyre::eyre!("signed namespace op: {e}"))?;
@@ -557,12 +486,10 @@ impl<'a> NamespaceGovernance<'a> {
         let observe_mesh = !matches!(op, NamespaceOp::Group { .. });
         let op_kind = op.op_kind_label();
         let op_timeout = timeout_for_namespace_op(&op);
-        let state_hash = self.state_hash_for_op(&op)?;
         let signed = SignedNamespaceOp::sign(
             signer_sk,
             self.namespace_id,
             head.parent_hashes,
-            state_hash,
             head.next_nonce,
             op,
         )?;
@@ -657,14 +584,6 @@ impl<'a> NamespaceGovernance<'a> {
         assert_transport_ready(mesh, known, node_client.gossipsub_mesh_n_low())
             .map_err(|e| eyre::eyre!(e))?;
 
-        // No-local-apply path: nothing has mutated state on this node yet,
-        // so the current `state_hash_for_op` value IS the pre-apply view
-        // every receiver will compare against. Capture it here (rather
-        // than inside `publish_post_gate`) so the call shape stays uniform
-        // with the apply-first path below, which must capture before its
-        // local mutation runs.
-        let state_hash = self.state_hash_for_op(&op)?;
-
         // Quorum / no-local-apply path: a publish that never reaches a
         // quorum is a genuine failure — nothing was applied locally to
         // fall back on. `best_effort = false` keeps the hard error.
@@ -673,7 +592,6 @@ impl<'a> NamespaceGovernance<'a> {
             ack_router,
             signer_sk,
             op,
-            state_hash,
             topic,
             mesh,
             known,
@@ -691,14 +609,6 @@ impl<'a> NamespaceGovernance<'a> {
     /// passes `best_effort = true`: it has no gate of its own (the local
     /// apply is unconditional), so a publish failure here is non-fatal and
     /// the op propagates via sync rather than diverging on a retry.
-    ///
-    /// `state_hash` MUST be the receiver-equivalent pre-apply hash —
-    /// i.e. computed BEFORE the caller ran
-    /// `sign_apply_local_group_op_borsh`. The apply-first path computes
-    /// the hash inside its own scope (where the pre-apply state is still
-    /// visible) and passes it in here. Recomputing inside this function
-    /// would shift the hash forward and every member-mutating op would
-    /// permanently bail on the receiver's staleness check.
     // Gossip-publish entry on the namespace governance path: transport handles,
     // the op, and ack/gate sizing are orthogonal with no cohesive grouping.
     #[allow(clippy::too_many_arguments, reason = "orthogonal broadcast-path args")]
@@ -708,7 +618,6 @@ impl<'a> NamespaceGovernance<'a> {
         ack_router: &AckRouter,
         signer_sk: &PrivateKey,
         op: NamespaceOp,
-        state_hash: [u8; 32],
         mesh: usize,
         known: usize,
         best_effort: bool,
@@ -719,7 +628,6 @@ impl<'a> NamespaceGovernance<'a> {
             ack_router,
             signer_sk,
             op,
-            state_hash,
             topic,
             mesh,
             known,
@@ -733,10 +641,6 @@ impl<'a> NamespaceGovernance<'a> {
     /// [`sign_and_publish_post_gate`]. Takes the caller's `mesh` snapshot
     /// to feed the metric; the subscriber count is re-sampled at publish
     /// time (see below) so transient peer departures don't skew `min_acks`.
-    ///
-    /// `state_hash` must be the pre-apply hash captured by the caller
-    /// before any local mutation. See `sign_and_publish_post_gate`'s doc
-    /// for the constraint and why we no longer recompute here.
     ///
     /// `best_effort` selects the failure mode of the publish:
     /// * `false` (quorum / no-local-apply path) — a publish that gathers
@@ -753,7 +657,6 @@ impl<'a> NamespaceGovernance<'a> {
         ack_router: &AckRouter,
         signer_sk: &PrivateKey,
         op: NamespaceOp,
-        state_hash: [u8; 32],
         topic: TopicHash,
         mesh: usize,
         known_at_gate: usize,
@@ -768,7 +671,6 @@ impl<'a> NamespaceGovernance<'a> {
             signer_sk,
             self.namespace_id,
             head.parent_hashes,
-            state_hash,
             head.next_nonce,
             op,
         )?;
@@ -1366,21 +1268,6 @@ impl<'a> NamespaceGovernance<'a> {
 
     /// Decrypt an encrypted group op and apply it via
     /// [`apply_group_op_inner`](Self::apply_group_op_inner).
-    ///
-    /// # Hash-domain invariant
-    ///
-    /// `ns_op.state_hash` is propagated unchanged into the synthesized
-    /// `SignedGroupOp.state_hash`. This is correct because callers
-    /// always invoke this for `NamespaceOp::Group { encrypted, .. }`,
-    /// and `NamespaceGovernance::state_hash_for_op` computes the hash
-    /// over the *subgroup* (not the namespace root) for that variant —
-    /// the same domain `apply_group_op_inner`'s staleness guard then
-    /// recomputes locally. A future refactor that calls this for a
-    /// `NamespaceOp::Root` variant would silently pass the wrong
-    /// domain in, so the precondition is documented here rather than
-    /// type-enforced (the param type is the wrapping `SignedNamespaceOp`
-    /// regardless of variant, and pulling the variant info upstream
-    /// would ripple through every receive path).
     fn decrypt_and_apply_group_op(
         &self,
         ns_op: &SignedNamespaceOp,
@@ -1394,7 +1281,6 @@ impl<'a> NamespaceGovernance<'a> {
             version: calimero_context_client::local_governance::SIGNED_GROUP_OP_SCHEMA_VERSION,
             group_id: group_id.to_bytes(),
             parent_op_hashes: ns_op.parent_op_hashes.clone(),
-            state_hash: ns_op.state_hash,
             signer: ns_op.signer,
             nonce: ns_op.nonce,
             op: inner_op,
@@ -1413,25 +1299,17 @@ impl<'a> NamespaceGovernance<'a> {
         let nonce = signed_group_op.nonce;
         let op = &signed_group_op.op;
 
-        // Nonce dedup MUST run before the staleness check below.
-        //
-        // `retry_encrypted_ops_for_group` (fires on every KeyDelivery) reads
-        // back the entire op log for the group and re-feeds each entry
-        // through `decrypt_and_apply_group_op` → `apply_group_op_inner`.
-        // Already-applied ops therefore arrive here a second (or third…)
-        // time with their original `state_hash` — which was the group state
-        // *before* this op landed, i.e. inevitably different from the
-        // current state once the op has been applied. Running the staleness
-        // check first would `bail!` on every such replay; running the nonce
-        // dedup first cleanly short-circuits them to `Ok(None)`.
-        // Windowed dedup: a nonce is a duplicate iff it's at or below the
-        // contiguous floor OR already in the above-floor set. This is what
-        // fixes #2516 — two concurrent same-signer ops are DAG siblings with
-        // consecutive nonces, so they can arrive in either order. The old
-        // `nonce <= last` guard advanced a single high-water mark on the
-        // first to land and then dropped the lower-nonce sibling forever; the
-        // window holds the higher one in `above` and still applies the lower
-        // one when it arrives.
+        // Windowed nonce dedup (the anti-replay gate; C5.S3b removed the op-level
+        // state_hash staleness check that used to follow it).
+        // `retry_encrypted_ops_for_group` (fires on every KeyDelivery) reads back
+        // the entire op log for the group and re-feeds each entry through
+        // `decrypt_and_apply_group_op` → `apply_group_op_inner`, so already-applied
+        // ops arrive again; the window short-circuits them to `Ok(None)`.
+        // A nonce is a duplicate iff it's at or below the contiguous floor OR
+        // already in the above-floor set. This is what fixes #2516 — two concurrent
+        // same-signer ops are DAG siblings with consecutive nonces and can arrive in
+        // either order; the window holds the higher one in `above` and still applies
+        // the lower one when it arrives.
         let mut nonce_window = load_nonce_window(self.store, group_id, signer)?;
         if nonce_window.contains(nonce) {
             tracing::debug!(
@@ -1441,48 +1319,6 @@ impl<'a> NamespaceGovernance<'a> {
                 "ignoring namespace group op with already-processed nonce"
             );
             return Ok(None);
-        }
-
-        // Staleness telemetry. `state_hash_for_op` commits to the wrapped
-        // group's pre-apply meta+member set; on receive we recompute and
-        // surface a structured warning when they disagree. We do NOT
-        // `bail!` on mismatch — that would reject legitimate concurrent
-        // ops in the multi-node case where peers A and B simultaneously
-        // sign against their (then-current) view and the second to land
-        // on peer C has already drifted. The local group-op equivalent
-        // (`apply_local_signed_group_op` in `group_store/mod.rs`) hard-
-        // bails because group state is per-subgroup and concurrent same-
-        // subgroup ops are rare; namespace-wrapped ops are shipped through
-        // the shared root DAG and concurrent contention is the norm —
-        // rejecting here breaks multi-node convergence in the
-        // scaffolding-e2e / group-3node suites. The PR caveat on #2500
-        // documents this trade-off: state_hash verification stays as a
-        // divergence signal, not an apply gate. Anchor-sync reconcile is
-        // the recovery path for genuinely diverged peers.
-        if signed_group_op.state_hash != [0u8; 32] {
-            // Mirror the root-op bypass (apply_signed_op): if the subgroup
-            // meta row hasn't been written yet — e.g. an encrypted
-            // ContextRegistered buffered before its GroupCreated lands and now
-            // re-driven — there is no state to hash. `compute_state_hash`
-            // would raise GroupNotFoundForHash and strand the op forever
-            // (#2848). Treat absent meta as a bypass; authorization and
-            // signature verification remain in force, and GroupCreated's apply
-            // re-drives this op once the meta exists.
-            let repo = MetaRepository::new(self.store);
-            if repo.load(group_id)?.is_some() {
-                let current = repo.compute_state_hash(group_id)?;
-                if signed_group_op.state_hash != current {
-                    tracing::warn!(
-                        group_id = %hex::encode(group_id.to_bytes()),
-                        expected = %hex::encode(signed_group_op.state_hash),
-                        actual = %hex::encode(current),
-                        nonce,
-                        signer = %signer,
-                        "namespace group op state_hash mismatch (signed against stale state; \
-                         applying anyway — see PR #2500 caveat)"
-                    );
-                }
-            }
         }
 
         if let GroupOp::ContextRegistered {
@@ -1690,48 +1526,10 @@ impl<'a> NamespaceGovernance<'a> {
         op: &SignedNamespaceOp,
         root: &RootOp,
     ) -> EyreResult<Vec<crate::op_events::OpEvent>> {
-        // Staleness telemetry for root ops whose correctness depends on
-        // the namespace's own meta+member set (`root_op_commits_to_
-        // namespace_state` whitelist). Same shape as the group-op branch
-        // in `apply_group_op_inner` — warn on mismatch, apply anyway.
-        // Hard-rejection would over-reject the namespace path because
-        // concurrent root ops (e.g. simultaneous joins or policy updates
-        // from different admins) are the common case. The PR #2500
-        // caveat documents this trade-off; anchor-sync reconcile remains
-        // the recovery path for genuinely diverged peers.
-        //
-        // `GroupCreated` / `GroupReparented` / `GroupDeleted` are NOT
-        // gated by `root_op_commits_to_namespace_state` and skip this
-        // check entirely. Their authoritative state lives on the
-        // affected subgroup, not the namespace root.
-        if root_op_commits_to_namespace_state(root) && op.state_hash != [0u8; 32] {
-            let ns_gid = ContextGroupId::from(self.namespace_id);
-            let repo = MetaRepository::new(self.store);
-            // Mirror the sign-side bypass: if the namespace meta row
-            // hasn't been seeded yet (cold-start, bootstrap, joiner
-            // catching up via backfill), there is no state to hash. The
-            // sign side falls through to `[0u8; 32]` for the same case,
-            // but a non-zero claim can still reach a node whose meta is
-            // not yet present (e.g. a peer that signed after their
-            // bootstrap finished but the joiner receives the op before
-            // applying the namespace genesis ops). Treat as a bypass —
-            // there is no honest claim we can refute. Authorization
-            // and signature verification remain in force.
-            if let Some(_meta) = repo.load(&ns_gid)? {
-                let current = repo.compute_state_hash(&ns_gid)?;
-                if op.state_hash != current {
-                    tracing::warn!(
-                        namespace_id = %hex::encode(self.namespace_id),
-                        expected = %hex::encode(op.state_hash),
-                        actual = %hex::encode(current),
-                        nonce = op.nonce,
-                        signer = %op.signer,
-                        "namespace root op state_hash mismatch (signed against stale state; \
-                         applying anyway — see PR #2500 caveat)"
-                    );
-                }
-            }
-        }
+        // C5.S3b removed the op-level state_hash staleness telemetry that used to
+        // run here for `root_op_commits_to_namespace_state` variants. `scope_root`
+        // is the convergence signal now; signature + the nonce window (applied by
+        // the caller) remain the safety gates.
 
         // Per-variant logic lives in `ops/namespace/<variant>.rs` (#2481). The
         // op's causal cut + the at-cut authorizer ride along so the gates can
@@ -1745,30 +1543,6 @@ impl<'a> NamespaceGovernance<'a> {
         super::super::ops::namespace::dispatch_root_op(&mut ctx, op, root)?;
         Ok(ctx.take_events())
     }
-}
-
-/// Whether a root op's correctness depends on the namespace's current
-/// meta+member set, and therefore should carry a non-zero `state_hash`
-/// committing to it.
-///
-/// Included: variants that mutate or read namespace authorization state —
-/// `AdminChanged` (admin identity), `PolicyUpdated` (policy bytes are
-/// authoritative state), `MemberJoined`/`MemberJoinedOpen` (member set).
-///
-/// Excluded: `KeyDelivery` (additive, idempotent — a stale delivery is
-/// still a valid delivery), and `GroupCreated`/`GroupReparented`/
-/// `GroupDeleted` (their authoritative state is on the affected subgroup,
-/// not on the namespace root). Gating those would over-reject on unrelated
-/// concurrent namespace activity.
-fn root_op_commits_to_namespace_state(op: &RootOp) -> bool {
-    matches!(
-        op,
-        RootOp::AdminChanged { .. }
-            | RootOp::PolicyUpdated { .. }
-            | RootOp::MemberJoined { .. }
-            | RootOp::MemberJoinedAt { .. }
-            | RootOp::MemberJoinedOpen { .. }
-    )
 }
 
 /// Apply a signed namespace op with the LIVE apply-auth gates (no causal cut).

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -38,7 +38,6 @@ fn namespace_dag_service_store_operation_rejects_namespace_mismatch() {
         &signer_sk,
         op_ns,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::PolicyUpdated {
             policy_bytes: vec![1, 2, 3],
@@ -338,7 +337,6 @@ fn namespace_op_log_service_reads_signed_and_skeleton_entries() {
         &signer_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Group {
             group_id: group_a.to_bytes(),
@@ -408,7 +406,6 @@ fn namespace_op_log_service_reads_tagged_and_legacy_rows() {
         &signer_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Group {
             group_id: group.to_bytes(),
@@ -485,7 +482,6 @@ fn namespace_op_log_service_collects_group_scoped_signed_ops() {
         &signer_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Group {
             group_id: group_a.to_bytes(),
@@ -500,7 +496,6 @@ fn namespace_op_log_service_collects_group_scoped_signed_ops() {
         &signer_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         2,
         NamespaceOp::Group {
             group_id: group_b.to_bytes(),
@@ -515,7 +510,6 @@ fn namespace_op_log_service_collects_group_scoped_signed_ops() {
         &signer_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         3,
         NamespaceOp::Root(RootOp::PolicyUpdated {
             policy_bytes: vec![1, 2, 3],
@@ -564,7 +558,6 @@ fn namespace_retry_service_collects_only_retryable_group_ops() {
         &signer_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Group {
             group_id: group_a.to_bytes(),
@@ -579,7 +572,6 @@ fn namespace_retry_service_collects_only_retryable_group_ops() {
         &signer_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         2,
         NamespaceOp::Group {
             group_id: group_b.to_bytes(),
@@ -594,7 +586,6 @@ fn namespace_retry_service_collects_only_retryable_group_ops() {
         &signer_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         3,
         NamespaceOp::Root(RootOp::PolicyUpdated {
             policy_bytes: vec![7, 8, 9],
@@ -674,7 +665,6 @@ fn namespace_retry_service_orders_candidates_by_signer_nonce() {
                     &signer_sk,
                     namespace_id,
                     vec![],
-                    [0u8; 32],
                     nonce,
                     NamespaceOp::Group {
                         group_id: group.to_bytes(),
@@ -1080,7 +1070,6 @@ fn replica_applies_tee_policy_then_membership_via_namespace_governance() {
         &verifier_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Group {
             group_id: namespace_id,
@@ -1124,7 +1113,6 @@ fn replica_applies_tee_policy_then_membership_via_namespace_governance() {
         &verifier_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         2,
         NamespaceOp::Group {
             group_id: namespace_id,
@@ -1218,9 +1206,8 @@ fn tee_replica_seed_bootstrap_admits_tee_with_open_join_cap() {
     {
         use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
         let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-        let signed_genesis =
-            SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], [0u8; 32], 0, genesis)
-                .expect("sign genesis");
+        let signed_genesis = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 0, genesis)
+            .expect("sign genesis");
         gov.apply_signed_op(&signed_genesis)
             .expect("genesis NamespaceCreated establishes the founding admin");
     }
@@ -1280,7 +1267,6 @@ fn tee_replica_seed_bootstrap_admits_tee_with_open_join_cap() {
         &founder_sk,
         namespace_id,
         head.parent_hashes.clone(),
-        [0u8; 32],
         head.next_nonce,
         NamespaceOp::Group {
             group_id: namespace_id,
@@ -1317,7 +1303,6 @@ fn tee_replica_seed_bootstrap_admits_tee_with_open_join_cap() {
         &founder_sk,
         namespace_id,
         head.parent_hashes.clone(),
-        [0u8; 32],
         head.next_nonce,
         NamespaceOp::Group {
             group_id: namespace_id,
@@ -1418,9 +1403,8 @@ fn replica_genesis_founder_survives_non_owner_seed_and_applies_owner_ops() {
     // an arbitrary placeholder the apply path does not consult for ordering.)
     // This establishes the founding admin authoritatively. ----
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder: owner });
-    let signed_genesis =
-        SignedNamespaceOp::sign(&owner_sk, namespace_id, vec![], [0u8; 32], 0, genesis)
-            .expect("owner signs NamespaceCreated genesis");
+    let signed_genesis = SignedNamespaceOp::sign(&owner_sk, namespace_id, vec![], 0, genesis)
+        .expect("owner signs NamespaceCreated genesis");
     gov.apply_signed_op(&signed_genesis)
         .expect("genesis NamespaceCreated must apply on the bare replica");
 
@@ -1480,7 +1464,6 @@ fn replica_genesis_founder_survives_non_owner_seed_and_applies_owner_ops() {
         &owner_sk,
         namespace_id,
         head.parent_hashes.clone(),
-        [0u8; 32],
         head.next_nonce,
         create_op,
     )
@@ -1532,8 +1515,7 @@ fn namespace_created_genesis_on_bare_store_and_anti_hijack() {
 
         let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
         let signed =
-            SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], [0u8; 32], 0, genesis)
-                .unwrap();
+            SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 0, genesis).unwrap();
         gov.apply_signed_op(&signed)
             .expect("bare-store genesis applies");
 
@@ -1557,8 +1539,7 @@ fn namespace_created_genesis_on_bare_store_and_anti_hijack() {
         // ---- (b) anti-hijack: a second, forged genesis is a no-op ----
         let forged = NamespaceOp::Root(RootOp::NamespaceCreated { founder: attacker });
         let signed_forged =
-            SignedNamespaceOp::sign(&attacker_sk, namespace_id, vec![], [0u8; 32], 1, forged)
-                .unwrap();
+            SignedNamespaceOp::sign(&attacker_sk, namespace_id, vec![], 1, forged).unwrap();
         gov.apply_signed_op(&signed_forged)
             .expect("forged second genesis applies as a no-op (no error)");
 
@@ -1601,8 +1582,7 @@ fn namespace_created_genesis_on_bare_store_and_anti_hijack() {
         // Genesis then lands and fills in the real founder over the placeholder.
         let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
         let signed =
-            SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], [0u8; 32], 0, genesis)
-                .unwrap();
+            SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 0, genesis).unwrap();
         gov.apply_signed_op(&signed)
             .expect("genesis applies over the placeholder seed meta");
         let meta = MetaRepository::new(&store).load(&ns_gid).unwrap().unwrap();
@@ -1632,8 +1612,7 @@ fn namespace_created_genesis_on_bare_store_and_anti_hijack() {
         // the founder as someone else (here: `founder`).
         let forged = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
         let signed =
-            SignedNamespaceOp::sign(&attacker_sk, namespace_id, vec![], [0u8; 32], 0, forged)
-                .unwrap();
+            SignedNamespaceOp::sign(&attacker_sk, namespace_id, vec![], 0, forged).unwrap();
         assert!(
             gov.apply_signed_op(&signed).is_err(),
             "nonce-0 forged genesis (signer != founder) must be REJECTED by the \
@@ -1695,7 +1674,7 @@ fn namespace_created_genesis_proceeds_when_only_admin_is_placeholder() {
     MetaRepository::new(&store).save(&ns_gid, &partial).unwrap();
 
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], [0u8; 32], 0, genesis)
+    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 0, genesis)
         .expect("founder signs NamespaceCreated genesis");
     gov.apply_signed_op(&signed)
         .expect("genesis proceeds when admin_identity is still the placeholder");
@@ -1763,7 +1742,7 @@ fn namespace_created_genesis_upgrades_seeded_member_founder_to_admin() {
 
     // ---- Genesis lands and must UPGRADE the founder Member row to Admin. ----
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], [0u8; 32], 0, genesis)
+    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 0, genesis)
         .expect("founder signs NamespaceCreated genesis");
     gov.apply_signed_op(&signed)
         .expect("genesis applies over the founder's seeded Member placeholder");
@@ -1831,7 +1810,7 @@ fn namespace_created_genesis_ensures_member_row_for_established_founder() {
     // Genesis arrives for the SAME founder. The established gate short-circuits
     // the meta rewrite but must still ensure the Admin member row.
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], [0u8; 32], 0, genesis)
+    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 0, genesis)
         .expect("founder signs NamespaceCreated genesis");
     gov.apply_signed_op(&signed)
         .expect("genesis applies as an idempotent same-founder re-arrival");
@@ -1905,7 +1884,7 @@ fn namespace_created_genesis_same_founder_rearrival_does_not_downgrade_admin() {
 
     // A parentless same-founder genesis re-arrives (e.g. via sync backfill).
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], [0u8; 32], 0, genesis)
+    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 0, genesis)
         .expect("founder signs NamespaceCreated genesis");
     gov.apply_signed_op(&signed)
         .expect("parentless same-founder genesis is an idempotent re-arrival no-op");
@@ -1951,8 +1930,7 @@ fn namespace_created_genesis_signer_must_equal_founder() {
 
     // Attacker declares the victim as founder but signs with their OWN key.
     let forged = NamespaceOp::Root(RootOp::NamespaceCreated { founder: victim });
-    let signed =
-        SignedNamespaceOp::sign(&attacker_sk, namespace_id, vec![], [0u8; 32], 0, forged).unwrap();
+    let signed = SignedNamespaceOp::sign(&attacker_sk, namespace_id, vec![], 0, forged).unwrap();
 
     let res = gov.apply_signed_op(&signed);
     assert!(
@@ -2012,15 +1990,9 @@ fn namespace_created_with_parents_is_rejected_as_non_genesis() {
     // Self-consistent (signer == founder) but PARENTED genesis: a fabricated
     // parent op-hash makes this not the DAG root.
     let parented = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed = SignedNamespaceOp::sign(
-        &founder_sk,
-        namespace_id,
-        vec![[0x11u8; 32]],
-        [0u8; 32],
-        2,
-        parented,
-    )
-    .unwrap();
+    let signed =
+        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![[0x11u8; 32]], 2, parented)
+            .unwrap();
 
     let res = gov.apply_signed_op(&signed);
     assert!(
@@ -2044,7 +2016,7 @@ fn namespace_created_with_parents_is_rejected_as_non_genesis() {
     // Sanity: the REAL genesis path (no parents, same founder) still applies.
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
     let signed_genesis =
-        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], [0u8; 32], 1, genesis).unwrap();
+        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 1, genesis).unwrap();
     gov.apply_signed_op(&signed_genesis)
         .expect("parentless genesis (the DAG root) still applies");
     assert!(
@@ -2093,15 +2065,9 @@ fn namespace_created_parented_on_bare_ns_errs_and_does_not_advance_head() {
 
     // Parented (non-genesis) NamespaceCreated on the bare namespace.
     let parented = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed = SignedNamespaceOp::sign(
-        &founder_sk,
-        namespace_id,
-        vec![[0x22u8; 32]],
-        [0u8; 32],
-        2,
-        parented,
-    )
-    .unwrap();
+    let signed =
+        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![[0x22u8; 32]], 2, parented)
+            .unwrap();
     let res = gov.apply_signed_op(&signed);
     assert!(
         res.is_err(),
@@ -2123,7 +2089,7 @@ fn namespace_created_parented_on_bare_ns_errs_and_does_not_advance_head() {
     // establishes the founder (it would be impossible if the head had advanced).
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
     let signed_genesis =
-        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], [0u8; 32], 1, genesis).unwrap();
+        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 1, genesis).unwrap();
     gov.apply_signed_op(&signed_genesis).expect(
         "the parentless genesis still applies because the rejected parented op did not \
          advance the head",
@@ -2162,7 +2128,7 @@ fn namespace_created_parented_on_established_namespace_is_noop_not_err() {
     // Establish the namespace via a clean parentless genesis.
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
     let signed_genesis =
-        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], [0u8; 32], 1, genesis).unwrap();
+        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 1, genesis).unwrap();
     gov.apply_signed_op(&signed_genesis)
         .expect("parentless genesis establishes the namespace");
     let meta_before = MetaRepository::new(&store).load(&ns_gid).unwrap().unwrap();
@@ -2174,15 +2140,9 @@ fn namespace_created_parented_on_established_namespace_is_noop_not_err() {
     // A PARENTED `NamespaceCreated` (same founder) now arrives late on the
     // established namespace. It must be a NO-OP, returning Ok — not Err.
     let parented = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed_parented = SignedNamespaceOp::sign(
-        &founder_sk,
-        namespace_id,
-        vec![[0x22u8; 32]],
-        [0u8; 32],
-        2,
-        parented,
-    )
-    .unwrap();
+    let signed_parented =
+        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![[0x22u8; 32]], 2, parented)
+            .unwrap();
     let res = gov.apply_signed_op(&signed_parented);
     assert!(
         res.is_ok(),
@@ -2251,15 +2211,9 @@ fn namespace_created_parented_same_founder_on_established_ns_does_no_repair() {
 
     // PARENTED same-founder `NamespaceCreated` arrives on the established ns.
     let parented = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed_parented = SignedNamespaceOp::sign(
-        &founder_sk,
-        namespace_id,
-        vec![[0x33u8; 32]],
-        [0u8; 32],
-        2,
-        parented,
-    )
-    .unwrap();
+    let signed_parented =
+        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![[0x33u8; 32]], 2, parented)
+            .unwrap();
     gov.apply_signed_op(&signed_parented)
         .expect("parented same-founder op on an established namespace is a no-op (Ok), per #591");
 
@@ -2323,7 +2277,7 @@ fn namespace_created_same_founder_repairs_diverged_owner_identity() {
 
     // Same-founder genesis re-arrives (parentless idempotent re-arrival).
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], [0u8; 32], 0, genesis)
+    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 0, genesis)
         .expect("founder signs idempotent genesis");
     gov.apply_signed_op(&signed)
         .expect("idempotent same-founder re-arrival applies as a no-op-with-repair");
@@ -2418,15 +2372,8 @@ fn genesis_apply_failure_leaves_namespace_head_unadvanced() {
     let bad_genesis = NamespaceOp::Root(RootOp::NamespaceCreated {
         founder: real_founder,
     });
-    let signed_bad = SignedNamespaceOp::sign(
-        &attacker_sk,
-        namespace_id,
-        vec![],
-        [0u8; 32],
-        1,
-        bad_genesis,
-    )
-    .unwrap();
+    let signed_bad =
+        SignedNamespaceOp::sign(&attacker_sk, namespace_id, vec![], 1, bad_genesis).unwrap();
 
     let res = gov.apply_signed_op(&signed_bad);
     assert!(
@@ -2451,15 +2398,8 @@ fn genesis_apply_failure_leaves_namespace_head_unadvanced() {
     let good_genesis = NamespaceOp::Root(RootOp::NamespaceCreated {
         founder: real_founder,
     });
-    let signed_good = SignedNamespaceOp::sign(
-        &real_founder_sk,
-        namespace_id,
-        vec![], // empty parents — read from the still-empty head on retry
-        [0u8; 32],
-        1,
-        good_genesis,
-    )
-    .unwrap();
+    let signed_good =
+        SignedNamespaceOp::sign(&real_founder_sk, namespace_id, vec![], 1, good_genesis).unwrap();
     gov.apply_signed_op(&signed_good)
         .expect("clean parentless genesis applies after a prior failed attempt");
 
@@ -2517,7 +2457,6 @@ fn replica_op_log_dedup_survives_head_pruning() {
             version: SIGNED_GROUP_OP_SCHEMA_VERSION,
             group_id: namespace_id,
             parent_op_hashes: ns_op.parent_op_hashes.clone(),
-            state_hash: ns_op.state_hash,
             signer: ns_op.signer,
             nonce: ns_op.nonce,
             op: inner.clone(),
@@ -2543,7 +2482,6 @@ fn replica_op_log_dedup_survives_head_pruning() {
         &signer_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Group {
             group_id: namespace_id,
@@ -2571,7 +2509,6 @@ fn replica_op_log_dedup_survives_head_pruning() {
         &signer_sk,
         namespace_id,
         vec![hash_a],
-        [0u8; 32],
         2,
         NamespaceOp::Group {
             group_id: namespace_id,
@@ -2673,7 +2610,6 @@ fn replica_concurrent_sibling_ops_apply_out_of_order_2516() {
             &signer_sk,
             namespace_id,
             vec![],
-            [0u8; 32],
             nonce,
             NamespaceOp::Group {
                 group_id: namespace_id,
@@ -2759,7 +2695,6 @@ fn replica_stale_head_does_not_overwrite_orphan_entry() {
             version: SIGNED_GROUP_OP_SCHEMA_VERSION,
             group_id: namespace_id,
             parent_op_hashes: ns_op.parent_op_hashes.clone(),
-            state_hash: ns_op.state_hash,
             signer: ns_op.signer,
             nonce: ns_op.nonce,
             op: inner.clone(),
@@ -2785,7 +2720,6 @@ fn replica_stale_head_does_not_overwrite_orphan_entry() {
         &signer_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Group {
             group_id: namespace_id,
@@ -2811,7 +2745,6 @@ fn replica_stale_head_does_not_overwrite_orphan_entry() {
         &signer_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         2,
         NamespaceOp::Group {
             group_id: namespace_id,
@@ -3308,7 +3241,6 @@ fn governance_group_reparented_via_signed_op() {
             &admin_sk,
             ns_id,
             vec![],
-            [0u8; 32],
             (i + 1) as u64,
             NamespaceOp::Root(RootOp::GroupCreated {
                 group_id: *gid,
@@ -3330,7 +3262,6 @@ fn governance_group_reparented_via_signed_op() {
         &admin_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         4,
         NamespaceOp::Root(RootOp::GroupReparented {
             child_group_id: leaf_id,
@@ -3391,7 +3322,6 @@ fn governance_apply_signed_op_is_idempotent_on_replay() {
         &admin_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: [0xC1; 32],
@@ -3455,7 +3385,6 @@ fn governance_rejects_non_admin_signer() {
         &intruder_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: [0xBB; 32],
@@ -3503,7 +3432,6 @@ fn governance_group_created_is_idempotent() {
         &admin_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: new_group_id,
@@ -3521,7 +3449,6 @@ fn governance_group_created_is_idempotent() {
         &admin_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         2,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: new_group_id,
@@ -3580,7 +3507,6 @@ fn governance_group_created_writes_birth_visibility() {
         &admin_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: open_group_id,
@@ -3603,7 +3529,6 @@ fn governance_group_created_writes_birth_visibility() {
         &admin_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         2,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: restricted_group_id,
@@ -3668,7 +3593,6 @@ fn governance_group_created_replay_does_not_reset_visibility() {
         &admin_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id,
@@ -3701,7 +3625,6 @@ fn governance_group_created_replay_does_not_reset_visibility() {
         &admin_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         2,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id,
@@ -3770,7 +3693,6 @@ fn governance_group_created_writes_parent_edge_even_when_meta_pre_populated() {
         &admin_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: new_group_id,
@@ -3834,7 +3756,6 @@ fn execute_group_created_rejects_self_parent() {
         &admin_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: ns_id,
@@ -3899,7 +3820,6 @@ fn execute_group_created_inherits_app_key_and_application_from_parent() {
         &admin_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: sub_id,
@@ -4005,7 +3925,6 @@ fn execute_group_deleted_subset_check_allows_partial_retry() {
         &admin_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::GroupDeleted {
             root_group_id: a_id,
@@ -4375,7 +4294,6 @@ fn governance_group_created_honors_can_create_subgroup_at_root_only() {
             sk,
             ns_id,
             vec![],
-            [0u8; 32],
             nonce,
             NamespaceOp::Root(RootOp::GroupCreated {
                 group_id,
@@ -4539,7 +4457,6 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
             sk,
             ns_id,
             vec![],
-            [0u8; 32],
             nonce,
             NamespaceOp::Root(RootOp::GroupDeleted {
                 root_group_id,
@@ -4621,218 +4538,6 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
     assert!(MetaRepository::new(&store).load(&s3_gid).unwrap().is_none());
 }
 
-/// Shared setup for the `state_hash` apply-path tests below. Builds a
-/// namespace with a signer admin and a wrapped subgroup that has its own
-/// meta + members + group key, ready for `NamespaceOp::Group` ops.
-fn setup_state_hash_test_fixture() -> (
-    Store,
-    PrivateKey,
-    [u8; 32],
-    ContextGroupId,
-    [u8; 32],
-    [u8; 32],
-) {
-    use rand::rngs::OsRng;
-
-    let store = test_store();
-    let mut rng = OsRng;
-
-    let signer_sk = PrivateKey::random(&mut rng);
-    let signer_pk = signer_sk.public_key();
-
-    let namespace_id = [0xE0u8; 32];
-    let ns_gid = ContextGroupId::from(namespace_id);
-    MetaRepository::new(&store)
-        .save(&ns_gid, &sample_meta_with_admin(signer_pk))
-        .unwrap();
-    MembershipRepository::new(&store)
-        .add_member(&ns_gid, &signer_pk, GroupMemberRole::Admin)
-        .unwrap();
-
-    let group_id_arr = [0xE1u8; 32];
-    let group_gid = ContextGroupId::from(group_id_arr);
-    MetaRepository::new(&store)
-        .save(&group_gid, &sample_meta_with_admin(signer_pk))
-        .unwrap();
-    MembershipRepository::new(&store)
-        .add_member(&group_gid, &signer_pk, GroupMemberRole::Admin)
-        .unwrap();
-
-    let group_key = [0x6Au8; 32];
-    let key_id = GroupKeyring::new(&store, group_gid)
-        .store_key(&group_key)
-        .unwrap();
-
-    (store, signer_sk, namespace_id, group_gid, group_key, key_id)
-}
-
-#[test]
-fn namespace_group_op_zero_state_hash_bypasses_check() {
-    use calimero_context_client::local_governance::{NamespaceOp, SignedNamespaceOp};
-
-    use super::NamespaceGovernance;
-
-    let (store, signer_sk, namespace_id, group_gid, group_key, key_id) =
-        setup_state_hash_test_fixture();
-
-    // Mutate the wrapped group's state AFTER picking up the (zero) state_hash
-    // so the recomputed hash would differ from any non-zero claim. The zero
-    // bypass must still apply cleanly — this is the documented backwards-
-    // compat path for pre-fix on-disk ops.
-    let other_pk = PrivateKey::random(&mut rand::rngs::OsRng).public_key();
-    MembershipRepository::new(&store)
-        .add_member(&group_gid, &other_pk, GroupMemberRole::Member)
-        .unwrap();
-
-    let op = SignedNamespaceOp::sign(
-        &signer_sk,
-        namespace_id,
-        vec![],
-        [0u8; 32],
-        1,
-        NamespaceOp::Group {
-            group_id: group_gid.to_bytes(),
-            key_id,
-            encrypted: GroupKeyring::encrypt_op(&group_key, &GroupOp::Noop).unwrap(),
-            key_rotation: None,
-        },
-    )
-    .unwrap();
-
-    let gov = NamespaceGovernance::new(&store, namespace_id);
-    gov.apply_signed_op(&op)
-        .expect("zero state_hash must bypass the staleness check");
-}
-
-#[test]
-fn namespace_group_op_with_current_state_hash_applies() {
-    use calimero_context_client::local_governance::{NamespaceOp, SignedNamespaceOp};
-
-    use super::NamespaceGovernance;
-
-    let (store, signer_sk, namespace_id, group_gid, group_key, key_id) =
-        setup_state_hash_test_fixture();
-
-    let current = MetaRepository::new(&store)
-        .compute_state_hash(&group_gid)
-        .expect("compute state hash");
-
-    let op = SignedNamespaceOp::sign(
-        &signer_sk,
-        namespace_id,
-        vec![],
-        current,
-        1,
-        NamespaceOp::Group {
-            group_id: group_gid.to_bytes(),
-            key_id,
-            encrypted: GroupKeyring::encrypt_op(&group_key, &GroupOp::Noop).unwrap(),
-            key_rotation: None,
-        },
-    )
-    .unwrap();
-
-    let gov = NamespaceGovernance::new(&store, namespace_id);
-    gov.apply_signed_op(&op)
-        .expect("op signed against current state must apply");
-}
-
-#[test]
-fn namespace_group_op_with_stale_state_hash_applies_with_warning() {
-    use calimero_context_client::local_governance::{NamespaceOp, SignedNamespaceOp};
-
-    use super::NamespaceGovernance;
-
-    let (store, signer_sk, namespace_id, group_gid, group_key, key_id) =
-        setup_state_hash_test_fixture();
-
-    // Snapshot the state hash, then mutate the group (a real concurrent op
-    // would do this between sign and apply). The pre-mutation hash is now
-    // stale relative to post-mutation state — but the namespace path
-    // applies anyway and only logs a warning. Hard-rejecting would
-    // over-reject the multi-node concurrent-op case; see the apply-path
-    // comment in `apply_group_op_inner` and the PR #2500 caveat.
-    let stale = MetaRepository::new(&store)
-        .compute_state_hash(&group_gid)
-        .expect("compute state hash");
-
-    let other_pk = PrivateKey::random(&mut rand::rngs::OsRng).public_key();
-    MembershipRepository::new(&store)
-        .add_member(&group_gid, &other_pk, GroupMemberRole::Member)
-        .unwrap();
-
-    let op = SignedNamespaceOp::sign(
-        &signer_sk,
-        namespace_id,
-        vec![],
-        stale,
-        1,
-        NamespaceOp::Group {
-            group_id: group_gid.to_bytes(),
-            key_id,
-            encrypted: GroupKeyring::encrypt_op(&group_key, &GroupOp::Noop).unwrap(),
-            key_rotation: None,
-        },
-    )
-    .unwrap();
-
-    let gov = NamespaceGovernance::new(&store, namespace_id);
-    gov.apply_signed_op(&op)
-        .expect("stale state_hash must apply with a warning, not reject");
-}
-
-/// #2848 Part B: a group op carrying a *non-zero* `state_hash` whose target
-/// subgroup has no meta row yet (e.g. an encrypted ContextRegistered buffered
-/// before its GroupCreated lands and now re-driven) must BYPASS the staleness
-/// check rather than blow up on `GroupNotFoundForHash`. Before the fix
-/// `compute_state_hash` was called unconditionally and this returned `Err`,
-/// stranding the op forever.
-#[test]
-fn group_op_with_stale_hash_and_absent_meta_applies() {
-    use calimero_context_client::local_governance::{NamespaceOp, SignedNamespaceOp};
-
-    use super::NamespaceGovernance;
-
-    let (store, signer_sk, namespace_id, group_gid, group_key, key_id) =
-        setup_state_hash_test_fixture();
-
-    // Drop the subgroup meta so it is absent on apply — but keep the group key
-    // so the op still decrypts and reaches the staleness check. A non-zero
-    // state_hash with absent meta is exactly the buffered-before-GroupCreated
-    // case.
-    MetaRepository::new(&store)
-        .delete(&group_gid)
-        .expect("delete subgroup meta");
-    assert!(
-        MetaRepository::new(&store)
-            .load(&group_gid)
-            .unwrap()
-            .is_none(),
-        "precondition: subgroup meta is absent"
-    );
-
-    let op = SignedNamespaceOp::sign(
-        &signer_sk,
-        namespace_id,
-        vec![],
-        [0x11u8; 32], // non-zero, would mismatch any recomputed hash
-        1,
-        NamespaceOp::Group {
-            group_id: group_gid.to_bytes(),
-            key_id,
-            encrypted: GroupKeyring::encrypt_op(&group_key, &GroupOp::Noop).unwrap(),
-            key_rotation: None,
-        },
-    )
-    .unwrap();
-
-    let gov = NamespaceGovernance::new(&store, namespace_id);
-    gov.apply_signed_op(&op).expect(
-        "non-zero state_hash with absent subgroup meta must bypass the staleness check, \
-         not error on GroupNotFoundForHash (#2848 Part B)",
-    );
-}
-
 /// #2848 Part A gate: a `GroupCreated` for a subgroup whose key the local node
 /// does NOT hold must be a cheap no-op on the retry path — the key-presence
 /// gate short-circuits before the full op-log scan. There are no buffered ops
@@ -4874,7 +4579,6 @@ fn group_created_with_no_key_skips_retry() {
         &admin_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: new_group_id,
@@ -4892,77 +4596,6 @@ fn group_created_with_no_key_skips_retry() {
         result.divergence.is_none(),
         "no buffered ops to re-drive, so no divergence should surface"
     );
-}
-
-#[test]
-fn namespace_root_op_with_current_state_hash_applies() {
-    use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
-
-    use super::NamespaceGovernance;
-
-    let (store, signer_sk, namespace_id, _group_gid, _group_key, _key_id) =
-        setup_state_hash_test_fixture();
-    let ns_gid = ContextGroupId::from(namespace_id);
-
-    let current = MetaRepository::new(&store)
-        .compute_state_hash(&ns_gid)
-        .expect("compute namespace state hash");
-
-    let op = SignedNamespaceOp::sign(
-        &signer_sk,
-        namespace_id,
-        vec![],
-        current,
-        1,
-        NamespaceOp::Root(RootOp::PolicyUpdated {
-            policy_bytes: vec![1, 2, 3],
-        }),
-    )
-    .unwrap();
-
-    let gov = NamespaceGovernance::new(&store, namespace_id);
-    gov.apply_signed_op(&op)
-        .expect("root op signed against current namespace state must apply");
-}
-
-#[test]
-fn namespace_root_op_with_stale_state_hash_applies_with_warning() {
-    use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
-
-    use super::NamespaceGovernance;
-
-    let (store, signer_sk, namespace_id, _group_gid, _group_key, _key_id) =
-        setup_state_hash_test_fixture();
-    let ns_gid = ContextGroupId::from(namespace_id);
-
-    let stale = MetaRepository::new(&store)
-        .compute_state_hash(&ns_gid)
-        .expect("compute namespace state hash");
-
-    // Move namespace state forward (admin adds a new namespace member),
-    // simulating a concurrent op landing between sign and apply. The
-    // root-op staleness check warns but does not reject — same shape as
-    // the group-op branch, same convergence-under-contention rationale.
-    let new_member_pk = PrivateKey::random(&mut rand::rngs::OsRng).public_key();
-    MembershipRepository::new(&store)
-        .add_member(&ns_gid, &new_member_pk, GroupMemberRole::Member)
-        .unwrap();
-
-    let op = SignedNamespaceOp::sign(
-        &signer_sk,
-        namespace_id,
-        vec![],
-        stale,
-        1,
-        NamespaceOp::Root(RootOp::PolicyUpdated {
-            policy_bytes: vec![9, 9, 9],
-        }),
-    )
-    .unwrap();
-
-    let gov = NamespaceGovernance::new(&store, namespace_id);
-    gov.apply_signed_op(&op)
-        .expect("stale root state_hash must apply with a warning, not reject");
 }
 
 // ---------------------------------------------------------------------------
@@ -5086,7 +4719,6 @@ fn groups_awaiting_key_reports_then_clears() {
         &signer_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Group {
             group_id,
@@ -5148,7 +4780,6 @@ fn restricted_subgroup_awaits_key_despite_holding_namespace_key() {
         &signer_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Group {
             group_id: subgroup_id,
@@ -5239,7 +4870,6 @@ fn responder_delivery_round_trips_key_to_joiner_cross_store() {
         &responder_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Group {
             group_id: subgroup_id,
@@ -5356,7 +4986,6 @@ fn responder_delivery_round_trips_key_to_read_only_tee_joiner() {
         &responder_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Group {
             group_id: subgroup_id,
@@ -5520,7 +5149,6 @@ fn curative_sweep_redrives_stranded_context() {
         &owner_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Group {
             group_id: sub_gid.to_bytes(),
@@ -5624,7 +5252,6 @@ fn curative_sweep_redrives_stranded_context() {
         &owner_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         2,
         NamespaceOp::Group {
             group_id: nokey_gid.to_bytes(),

--- a/crates/governance-store/src/tee.rs
+++ b/crates/governance-store/src/tee.rs
@@ -258,7 +258,6 @@ mod tests {
             signer_sk,
             ns_gid.to_bytes(),
             vec![],
-            [0u8; 32],
             nonce,
             GroupOp::MemberJoinedViaTeeAttestation {
                 member,
@@ -289,7 +288,6 @@ mod tests {
             &signer_sk,
             ns_gid.to_bytes(),
             vec![],
-            [0u8; 32],
             1,
             GroupOp::MemberJoinedViaTeeAttestation {
                 member: tee_pk,

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -423,7 +423,6 @@ fn apply_local_signed_group_op_nonce_and_admin() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberAdded {
             member: member_pk,
@@ -436,15 +435,13 @@ fn apply_local_signed_group_op_nonce_and_admin() {
         .is_member(&gid, &member_pk)
         .unwrap());
 
-    let op_dup_nonce =
-        SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], [0u8; 32], 1, GroupOp::Noop).unwrap();
+    let op_dup_nonce = SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], 1, GroupOp::Noop).unwrap();
     assert!(
         apply_local_signed_group_op(&store, &op_dup_nonce).is_ok(),
         "duplicate nonce should be silently accepted (idempotent)"
     );
 
-    let op2 =
-        SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], [0u8; 32], 2, GroupOp::Noop).unwrap();
+    let op2 = SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], 2, GroupOp::Noop).unwrap();
     apply_local_signed_group_op(&store, &op2).unwrap();
 
     let non_admin_sk = PrivateKey::random(&mut rng);
@@ -455,7 +452,6 @@ fn apply_local_signed_group_op_nonce_and_admin() {
         &non_admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberAdded {
             member: PrivateKey::random(&mut rng).public_key(),
@@ -503,7 +499,6 @@ fn apply_local_signed_group_op_out_of_order_siblings_2516() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         2,
         GroupOp::MemberAdded {
             member: member_high,
@@ -528,7 +523,6 @@ fn apply_local_signed_group_op_out_of_order_siblings_2516() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberAdded {
             member: member_low,
@@ -606,7 +600,6 @@ fn apply_local_signed_group_op_replay_does_not_duplicate_log_entry() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberAdded {
             member,
@@ -732,7 +725,6 @@ fn reject_read_only_tee_via_member_added() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberAdded {
             member: tee_pk,
@@ -776,7 +768,6 @@ fn reject_read_only_tee_via_member_role_set() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberRoleSet {
             member: member_pk,
@@ -823,7 +814,6 @@ fn apply_local_member_alias_member_signer_or_admin() {
         &member_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberMetadataSet {
             member: member_pk,
@@ -847,7 +837,6 @@ fn apply_local_member_alias_member_signer_or_admin() {
         &other_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberMetadataSet {
             member: member_pk,
@@ -862,7 +851,6 @@ fn apply_local_member_alias_member_signer_or_admin() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberMetadataSet {
             member: member_pk,
@@ -917,7 +905,6 @@ fn apply_local_context_alias_admin_or_creator() {
         &creator_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::ContextRegistered {
             context_id,
@@ -934,7 +921,6 @@ fn apply_local_context_alias_admin_or_creator() {
         &creator_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         2,
         GroupOp::ContextMetadataSet {
             context_id,
@@ -952,7 +938,6 @@ fn apply_local_context_alias_admin_or_creator() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::ContextMetadataSet {
             context_id,
@@ -1004,7 +989,6 @@ fn apply_local_signed_group_op_capabilities_upgrade_policy_and_delete() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberCapabilitySet {
             member: member_m,
@@ -1025,7 +1009,6 @@ fn apply_local_signed_group_op_capabilities_upgrade_policy_and_delete() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         2,
         GroupOp::UpgradePolicySet {
             policy: UpgradePolicy::Automatic,
@@ -1042,15 +1025,8 @@ fn apply_local_signed_group_op_capabilities_upgrade_policy_and_delete() {
         UpgradePolicy::Automatic
     );
 
-    let op_del = SignedGroupOp::sign(
-        &admin_sk,
-        gid_bytes,
-        vec![],
-        [0u8; 32],
-        3,
-        GroupOp::GroupDelete,
-    )
-    .unwrap();
+    let op_del =
+        SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], 3, GroupOp::GroupDelete).unwrap();
     apply_local_signed_group_op(&store, &op_del).unwrap();
     assert!(MetaRepository::new(&store).load(&gid).unwrap().is_none());
 }
@@ -1079,7 +1055,6 @@ fn apply_local_signed_group_op_rejects_last_admin_removal() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         dummy_member_removed_op(admin_pk),
     )
@@ -2168,15 +2143,7 @@ fn local_state_join_tracking_and_delete_group_rows_cleanup() {
 
     let mut rng = OsRng;
     let signer_sk = PrivateKey::random(&mut rng);
-    let op = SignedGroupOp::sign(
-        &signer_sk,
-        gid.to_bytes(),
-        vec![],
-        [0u8; 32],
-        1,
-        GroupOp::Noop,
-    )
-    .unwrap();
+    let op = SignedGroupOp::sign(&signer_sk, gid.to_bytes(), vec![], 1, GroupOp::Noop).unwrap();
     let op_bytes = borsh::to_vec(&op).unwrap();
     append_op_log_entry(&store, &gid, 1, &op_bytes).unwrap();
     set_op_head(&store, &gid, 1, vec![[0x11; 32]]).unwrap();
@@ -2270,7 +2237,6 @@ fn tee_policy_and_quote_hash_scan_latest_and_match() {
         &signer_sk,
         gid.to_bytes(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::TeeAdmissionPolicySet {
             allowed_mrtd: vec!["m1".to_owned()],
@@ -2289,7 +2255,6 @@ fn tee_policy_and_quote_hash_scan_latest_and_match() {
         &signer_sk,
         gid.to_bytes(),
         vec![],
-        [0u8; 32],
         2,
         GroupOp::MemberJoinedViaTeeAttestation {
             member: PublicKey::from([0xD3; 32]),
@@ -2310,7 +2275,6 @@ fn tee_policy_and_quote_hash_scan_latest_and_match() {
         &signer_sk,
         gid.to_bytes(),
         vec![],
-        [0u8; 32],
         3,
         GroupOp::TeeAdmissionPolicySet {
             allowed_mrtd: vec!["m2".to_owned()],
@@ -2484,7 +2448,6 @@ fn append_tee_policy_op(store: &Store, group: &ContextGroupId, seq: u64, mrtd: &
         &signer_sk,
         group.to_bytes(),
         vec![],
-        [0u8; 32],
         seq,
         GroupOp::TeeAdmissionPolicySet {
             allowed_mrtd: vec![mrtd.to_owned()],
@@ -2592,7 +2555,6 @@ fn apply_tee_policy_op_on_subgroup_rejected() {
         &admin_sk,
         child.to_bytes(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::TeeAdmissionPolicySet {
             allowed_mrtd: vec!["m".to_owned()],
@@ -3253,7 +3215,6 @@ fn member_added_after_remove_restores_context_identity_for_local_rejoiner() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         dummy_member_removed_op(member_pk),
     )
@@ -3276,7 +3237,6 @@ fn member_added_after_remove_restores_context_identity_for_local_rejoiner() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         2,
         GroupOp::MemberAdded {
             member: member_pk,
@@ -3378,7 +3338,6 @@ fn member_added_after_remove_restores_context_identity_for_subgroup_with_real_na
         &admin_sk,
         subgroup.to_bytes(),
         vec![],
-        [0u8; 32],
         1,
         dummy_member_removed_op(member_pk),
     )
@@ -3398,7 +3357,6 @@ fn member_added_after_remove_restores_context_identity_for_subgroup_with_real_na
         &admin_sk,
         subgroup.to_bytes(),
         vec![],
-        [0u8; 32],
         2,
         GroupOp::MemberAdded {
             member: member_pk,
@@ -3507,7 +3465,6 @@ fn member_joined_open_clears_deny_list_and_restores_context_identity() {
         &member_sk,
         ns_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::MemberJoinedOpen {
             member: member_pk,
@@ -3582,7 +3539,6 @@ fn member_added_does_nothing_for_non_rejoiner_peers() {
         &admin_sk,
         gid.to_bytes(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberAdded {
             member: rejoiner_pk,
@@ -4236,9 +4192,6 @@ fn deny_list_member_added_op_clears_existing_entry() {
         &admin_sk,
         gid.to_bytes(),
         vec![],
-        MetaRepository::new(&store)
-            .compute_state_hash(&gid)
-            .unwrap(),
         1,
         GroupOp::MemberAdded {
             member: target_pk,
@@ -4290,9 +4243,6 @@ fn deny_list_member_removed_op_marks_entry() {
         &admin_sk,
         gid.to_bytes(),
         vec![],
-        MetaRepository::new(&store)
-            .compute_state_hash(&gid)
-            .unwrap(),
         1,
         dummy_member_removed_op(target_pk),
     )
@@ -4332,9 +4282,6 @@ fn deny_list_remove_then_readd_clears_entry_via_apply_path() {
         &admin_sk,
         gid.to_bytes(),
         vec![],
-        MetaRepository::new(&store)
-            .compute_state_hash(&gid)
-            .unwrap(),
         1,
         dummy_member_removed_op(target_pk),
     )
@@ -4349,9 +4296,6 @@ fn deny_list_remove_then_readd_clears_entry_via_apply_path() {
         &admin_sk,
         gid.to_bytes(),
         vec![rm.content_hash().unwrap()],
-        MetaRepository::new(&store)
-            .compute_state_hash(&gid)
-            .unwrap(),
         2,
         GroupOp::MemberAdded {
             member: target_pk,
@@ -4428,7 +4372,6 @@ fn metadata_set_does_not_change_group_state_hash() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::GroupMetadataSet {
             name: Some("renamed".to_owned()),
@@ -4496,7 +4439,6 @@ fn member_metadata_self_set_allowed_others_gated() {
         &alice_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberMetadataSet {
             member: alice_pk,
@@ -4512,7 +4454,6 @@ fn member_metadata_self_set_allowed_others_gated() {
         &alice_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         2,
         GroupOp::MemberMetadataSet {
             member: bob_pk,
@@ -4528,7 +4469,6 @@ fn member_metadata_self_set_allowed_others_gated() {
         &alice_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         3,
         GroupOp::GroupMetadataSet {
             name: Some("nope".to_owned()),
@@ -4546,7 +4486,6 @@ fn member_metadata_self_set_allowed_others_gated() {
         &alice_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         4,
         GroupOp::GroupMetadataSet {
             name: Some("renamed".to_owned()),
@@ -4902,9 +4841,6 @@ fn apply_with_precomputed_real_hashes_matches_post_apply_view() {
         &admin_sk,
         gid.to_bytes(),
         vec![],
-        MetaRepository::new(&store)
-            .compute_state_hash(&gid)
-            .unwrap(),
         1,
         GroupOp::MemberRemoved {
             member: target_pk,
@@ -5247,7 +5183,6 @@ fn is_tee_admitted_identity_matches_tee_joined_member() {
         &signer_sk,
         gid.to_bytes(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberJoinedViaTeeAttestation {
             member: tee_node,
@@ -5313,7 +5248,6 @@ mod auto_follow_tests {
             &admin_sk,
             gid_bytes,
             vec![],
-            [0u8; 32],
             1,
             GroupOp::MemberSetAutoFollow {
                 target: member_sk.public_key(),
@@ -5341,7 +5275,6 @@ mod auto_follow_tests {
             &member_sk,
             gid_bytes,
             vec![],
-            [0u8; 32],
             1,
             GroupOp::MemberSetAutoFollow {
                 target: member_sk.public_key(),
@@ -5379,7 +5312,6 @@ mod auto_follow_tests {
             &member_sk,
             gid_bytes,
             vec![],
-            [0u8; 32],
             1,
             GroupOp::MemberSetAutoFollow {
                 target: other_sk.public_key(),
@@ -5421,7 +5353,6 @@ mod auto_follow_tests {
             &admin_sk,
             gid_bytes,
             vec![],
-            [0u8; 32],
             1,
             GroupOp::MemberSetAutoFollow {
                 target: stranger,
@@ -5457,7 +5388,6 @@ mod auto_follow_tests {
             &member_sk,
             gid_bytes,
             vec![],
-            [0u8; 32],
             1,
             GroupOp::MemberSetAutoFollow {
                 target: member_sk.public_key(),
@@ -5473,7 +5403,6 @@ mod auto_follow_tests {
             &admin_sk,
             gid_bytes,
             vec![],
-            [0u8; 32],
             1,
             GroupOp::MemberRoleSet {
                 member: member_sk.public_key(),
@@ -5519,7 +5448,6 @@ mod auto_follow_tests {
             &member_sk,
             gid_bytes,
             vec![],
-            [0u8; 32],
             1,
             GroupOp::MemberSetAutoFollow {
                 target: member_sk.public_key(),
@@ -5544,7 +5472,6 @@ mod auto_follow_tests {
             &admin_sk,
             gid_bytes,
             vec![],
-            [0u8; 32],
             1,
             GroupOp::ContextRegistered {
                 context_id,
@@ -5627,7 +5554,6 @@ mod auto_follow_tests {
             &admin_sk,
             gid_bytes,
             vec![],
-            [0u8; 32],
             1,
             GroupOp::MemberAdded {
                 member: new_member_pk,
@@ -5727,7 +5653,6 @@ mod auto_follow_tests {
                 &admin_sk,
                 gid_bytes,
                 vec![],
-                [0u8; 32],
                 1,
                 GroupOp::MemberAdded {
                     member: target_pk,
@@ -5745,7 +5670,6 @@ mod auto_follow_tests {
                 &target_sk,
                 gid_bytes,
                 vec![],
-                [0u8; 32],
                 1,
                 GroupOp::MemberSetAutoFollow {
                     target: target_pk,
@@ -5806,7 +5730,6 @@ mod auto_follow_tests {
             &admin_sk,
             gid_bytes,
             vec![],
-            [0u8; 32],
             1,
             GroupOp::MemberAdded {
                 member: new_member_pk,
@@ -5918,7 +5841,6 @@ mod auto_follow_tests {
             &admin_sk,
             gid_bytes,
             vec![],
-            [0u8; 32],
             1,
             GroupOp::MemberAdded {
                 member: new_member_pk,
@@ -6019,7 +5941,6 @@ mod auto_follow_tests {
             &admin_sk,
             ns_id,
             vec![],
-            [0u8; 32],
             1,
             NamespaceOp::Root(RootOp::GroupCreated {
                 group_id: new_group_id,
@@ -6273,9 +6194,6 @@ mod tee_member_removed_event_tests {
             &admin_sk,
             gid.to_bytes(),
             vec![],
-            MetaRepository::new(&store)
-                .compute_state_hash(&gid)
-                .unwrap(),
             1,
             dummy_member_removed_op(tee_pk),
         )
@@ -6325,9 +6243,6 @@ mod tee_member_removed_event_tests {
             &admin_sk,
             gid.to_bytes(),
             vec![],
-            MetaRepository::new(&store)
-                .compute_state_hash(&gid)
-                .unwrap(),
             1,
             dummy_member_removed_op(target_pk),
         )
@@ -6398,9 +6313,6 @@ mod tee_member_removed_event_tests {
             &admin_sk,
             ns_gid.to_bytes(),
             vec![],
-            MetaRepository::new(&store)
-                .compute_state_hash(&ns_gid)
-                .unwrap(),
             1,
             dummy_member_removed_op(tee_pk),
         )
@@ -6517,9 +6429,6 @@ mod tee_member_removed_event_tests {
             &admin_sk,
             ns_gid.to_bytes(),
             vec![],
-            MetaRepository::new(&store)
-                .compute_state_hash(&ns_gid)
-                .unwrap(),
             1,
             dummy_member_removed_op(tee_pk),
         )
@@ -6598,9 +6507,6 @@ mod tee_member_removed_event_tests {
             &admin_sk,
             ns_gid.to_bytes(),
             vec![],
-            MetaRepository::new(&store)
-                .compute_state_hash(&ns_gid)
-                .unwrap(),
             1,
             dummy_member_removed_op(member_pk),
         )
@@ -6677,9 +6583,6 @@ mod tee_member_removed_event_tests {
                 &tee_sk,
                 gid.to_bytes(),
                 vec![],
-                MetaRepository::new(&store)
-                    .compute_state_hash(&gid)
-                    .unwrap(),
                 1,
                 GroupOp::MemberLeft {
                     member: tee_pk,
@@ -6726,9 +6629,6 @@ mod tee_member_removed_event_tests {
                 &leaver_sk,
                 gid.to_bytes(),
                 vec![],
-                MetaRepository::new(&store)
-                    .compute_state_hash(&gid)
-                    .unwrap(),
                 1,
                 GroupOp::MemberLeft {
                     member: leaver_pk,

--- a/crates/governance-store/src/unified_op_decode.rs
+++ b/crates/governance-store/src/unified_op_decode.rs
@@ -120,6 +120,8 @@ pub fn signed_namespace_op_to_delta(
         op.parent_op_hashes.clone(),
         op.clone(),
         HybridTimestamp::default(),
-        op.state_hash,
+        // C5.S3b removed the op-level state_hash; the unified op-store delta has no
+        // meaningful `expected_root_hash` to carry from a governance op.
+        [0u8; 32],
     ))
 }

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -88,7 +88,13 @@ pub use wire::{
 /// the out-of-order apply window that existed between the two v6 ops.
 /// Variant ordinal is appended after the v6 variants; v6 ordinals are
 /// preserved.
-pub const SIGNED_GROUP_OP_SCHEMA_VERSION: u8 = 7;
+///
+/// v8 (cutover C5.S3b): dropped the vestigial `state_hash` field from the
+/// signable/​signed op. It stopped being an apply gate in C5.S3a (`scope_root`
+/// is the authoritative convergence signal now), so it was pure dead weight in
+/// the signed bytes. Removing it changes every op's content hash (the op id),
+/// hence the version bump and the flag-day re-bootstrap.
+pub const SIGNED_GROUP_OP_SCHEMA_VERSION: u8 = 8;
 
 /// Domain separation prefix for Ed25519 signatures over group ops.
 pub const GROUP_GOVERNANCE_SIGN_DOMAIN: &[u8] = b"calimero.group.v1";
@@ -647,17 +653,6 @@ pub struct SignableNamespaceOp {
     pub version: u8,
     pub namespace_id: [u8; 32],
     pub parent_op_hashes: Vec<[u8; 32]>,
-    /// Convergence claim about the group-meta state at sign-time.
-    ///
-    /// **Zero-value bypass**: `[0u8; 32]` disables the staleness
-    /// check on apply (used by genesis ops where there is no prior
-    /// state to claim against). Non-zero values are verified against
-    /// the receiver's locally-computed state hash and trigger a
-    /// rejection (group ops) or divergence warning (namespace ops)
-    /// on mismatch. Callers that aren't genesis MUST pass a real
-    /// hash — leaving `state_hash` zeroed for a mid-DAG op silently
-    /// bypasses convergence detection.
-    pub state_hash: [u8; 32],
     pub signer: PublicKey,
     pub nonce: u64,
     pub op: NamespaceOp,
@@ -669,17 +664,6 @@ pub struct SignedNamespaceOp {
     pub version: u8,
     pub namespace_id: [u8; 32],
     pub parent_op_hashes: Vec<[u8; 32]>,
-    /// Convergence claim about the group-meta state at sign-time.
-    ///
-    /// **Zero-value bypass**: `[0u8; 32]` disables the staleness
-    /// check on apply (used by genesis ops where there is no prior
-    /// state to claim against). Non-zero values are verified against
-    /// the receiver's locally-computed state hash and trigger a
-    /// rejection (group ops) or divergence warning (namespace ops)
-    /// on mismatch. Callers that aren't genesis MUST pass a real
-    /// hash — leaving `state_hash` zeroed for a mid-DAG op silently
-    /// bypasses convergence detection.
-    pub state_hash: [u8; 32],
     pub signer: PublicKey,
     pub nonce: u64,
     pub op: NamespaceOp,
@@ -687,7 +671,12 @@ pub struct SignedNamespaceOp {
 }
 
 /// Wire/schema version for [`SignedNamespaceOp`].
-pub const SIGNED_NAMESPACE_OP_SCHEMA_VERSION: u8 = 1;
+///
+/// v2 (cutover C5.S3b): dropped the vestigial `state_hash` field. It stopped
+/// being an apply gate in C5.S3a (`scope_root` is the convergence signal now);
+/// removing it from the signable/​signed structs changes every op id, hence the
+/// version bump and the flag-day re-bootstrap.
+pub const SIGNED_NAMESPACE_OP_SCHEMA_VERSION: u8 = 2;
 
 /// Domain separation prefix for Ed25519 signatures over namespace ops.
 pub const NAMESPACE_GOVERNANCE_SIGN_DOMAIN: &[u8] = b"calimero.namespace.v1";
@@ -718,7 +707,6 @@ impl SignedNamespaceOp {
         sk: &PrivateKey,
         namespace_id: [u8; 32],
         parent_op_hashes: Vec<[u8; 32]>,
-        state_hash: [u8; 32],
         nonce: u64,
         op: NamespaceOp,
     ) -> Result<Self, GovernanceError> {
@@ -727,7 +715,6 @@ impl SignedNamespaceOp {
             version: SIGNED_NAMESPACE_OP_SCHEMA_VERSION,
             namespace_id,
             parent_op_hashes,
-            state_hash,
             signer,
             nonce,
             op,
@@ -738,7 +725,6 @@ impl SignedNamespaceOp {
             version: signable.version,
             namespace_id: signable.namespace_id,
             parent_op_hashes: signable.parent_op_hashes,
-            state_hash: signable.state_hash,
             signer: signable.signer,
             nonce: signable.nonce,
             op: signable.op,
@@ -778,7 +764,6 @@ impl SignedNamespaceOp {
             version: self.version,
             namespace_id: self.namespace_id,
             parent_op_hashes: self.parent_op_hashes.clone(),
-            state_hash: self.state_hash,
             signer: self.signer,
             nonce: self.nonce,
             op: self.op.clone(),
@@ -834,17 +819,6 @@ pub struct SignableGroupOp {
     pub version: u8,
     pub group_id: [u8; 32],
     pub parent_op_hashes: Vec<[u8; 32]>,
-    /// Convergence claim about the group-meta state at sign-time.
-    ///
-    /// **Zero-value bypass**: `[0u8; 32]` disables the staleness
-    /// check on apply (used by genesis ops where there is no prior
-    /// state to claim against). Non-zero values are verified against
-    /// the receiver's locally-computed state hash and trigger a
-    /// rejection (group ops) or divergence warning (namespace ops)
-    /// on mismatch. Callers that aren't genesis MUST pass a real
-    /// hash — leaving `state_hash` zeroed for a mid-DAG op silently
-    /// bypasses convergence detection.
-    pub state_hash: [u8; 32],
     pub signer: PublicKey,
     pub nonce: u64,
     pub op: GroupOp,
@@ -860,17 +834,6 @@ pub struct SignedGroupOp {
     pub version: u8,
     pub group_id: [u8; 32],
     pub parent_op_hashes: Vec<[u8; 32]>,
-    /// Convergence claim about the group-meta state at sign-time.
-    ///
-    /// **Zero-value bypass**: `[0u8; 32]` disables the staleness
-    /// check on apply (used by genesis ops where there is no prior
-    /// state to claim against). Non-zero values are verified against
-    /// the receiver's locally-computed state hash and trigger a
-    /// rejection (group ops) or divergence warning (namespace ops)
-    /// on mismatch. Callers that aren't genesis MUST pass a real
-    /// hash — leaving `state_hash` zeroed for a mid-DAG op silently
-    /// bypasses convergence detection.
-    pub state_hash: [u8; 32],
     pub signer: PublicKey,
     pub nonce: u64,
     pub op: GroupOp,
@@ -912,7 +875,6 @@ impl SignedGroupOp {
         sk: &PrivateKey,
         group_id: [u8; 32],
         parent_op_hashes: Vec<[u8; 32]>,
-        state_hash: [u8; 32],
         nonce: u64,
         op: GroupOp,
     ) -> Result<Self, GovernanceError> {
@@ -921,7 +883,6 @@ impl SignedGroupOp {
             version: SIGNED_GROUP_OP_SCHEMA_VERSION,
             group_id,
             parent_op_hashes,
-            state_hash,
             signer,
             nonce,
             op,
@@ -932,7 +893,6 @@ impl SignedGroupOp {
             version: signable.version,
             group_id: signable.group_id,
             parent_op_hashes: signable.parent_op_hashes,
-            state_hash: signable.state_hash,
             signer: signable.signer,
             nonce: signable.nonce,
             op: signable.op,
@@ -970,7 +930,6 @@ impl SignedGroupOp {
             version: self.version,
             group_id: self.group_id,
             parent_op_hashes: self.parent_op_hashes.clone(),
-            state_hash: self.state_hash,
             signer: self.signer,
             nonce: self.nonce,
             op: self.op.clone(),

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use calimero_primitives::identity::PrivateKey;
+use calimero_primitives::identity::{PrivateKey, PublicKey};
 use rand::rngs::OsRng;
 
 fn sample_group_id() -> [u8; 32] {
@@ -565,5 +565,97 @@ fn cascade_upgrade_back_compat_discriminant_fixed() {
             "frozen CascadeUpgrade bytes (discriminant 25) decoded as {other:?}; a \
              variant was inserted mid-enum, shifting prior variant tags"
         ),
+    }
+}
+
+// C5.S3b flag-day boundary: an op signed under the OLD schema must be REJECTED on
+// the new build, never silently misparsed. The `version` field is the first borsh
+// field, so it survives the layout change and the version check fires before any
+// signable-bytes reconstruction. These tests pin that boundary so a future refactor
+// can't re-open the window.
+#[test]
+fn pre_flag_day_group_op_version_is_rejected() {
+    let signer = PrivateKey::random(&mut OsRng).public_key();
+    // A struct-shaped op carrying a prior schema version (here v7, the last version
+    // that still had `state_hash`). `verify_signature` must reject on the version
+    // check alone — before touching the (here bogus) signature.
+    let stale = SignedGroupOp {
+        version: SIGNED_GROUP_OP_SCHEMA_VERSION - 1,
+        group_id: sample_group_id(),
+        parent_op_hashes: vec![],
+        signer,
+        nonce: 1,
+        op: GroupOp::Noop,
+        signature: [0u8; 64],
+    };
+    assert!(
+        matches!(
+            stale.verify_signature(),
+            Err(GovernanceError::SchemaVersion { .. })
+        ),
+        "a prior-version group op must be rejected with SchemaVersion, got {:?}",
+        stale.verify_signature()
+    );
+}
+
+#[test]
+fn pre_flag_day_namespace_op_version_is_rejected() {
+    let signer = PrivateKey::random(&mut OsRng).public_key();
+    let stale = SignedNamespaceOp {
+        version: SIGNED_NAMESPACE_OP_SCHEMA_VERSION - 1,
+        namespace_id: sample_group_id(),
+        parent_op_hashes: vec![],
+        signer,
+        nonce: 1,
+        op: NamespaceOp::Root(RootOp::PolicyUpdated {
+            policy_bytes: vec![],
+        }),
+        signature: [0u8; 64],
+    };
+    assert!(
+        matches!(
+            stale.verify_signature(),
+            Err(GovernanceError::SchemaVersion { .. })
+        ),
+        "a prior-version namespace op must be rejected with SchemaVersion, got {:?}",
+        stale.verify_signature()
+    );
+}
+
+#[test]
+fn v7_borsh_layout_group_op_is_rejected_not_misparsed() {
+    // A v7-shaped op still carries the removed `state_hash` field in its borsh bytes.
+    // Decoding it as the v8 struct must NOT silently succeed with a v8-looking op:
+    // either borsh refuses the misaligned/trailing bytes, or it decodes a struct
+    // whose `version` (7) fails the v8 check — never a spurious Ok.
+    #[derive(::borsh::BorshSerialize)]
+    struct V7SignedGroupOp {
+        version: u8,
+        group_id: [u8; 32],
+        parent_op_hashes: Vec<[u8; 32]>,
+        state_hash: [u8; 32],
+        signer: PublicKey,
+        nonce: u64,
+        op: GroupOp,
+        signature: [u8; 64],
+    }
+    let signer = PrivateKey::random(&mut OsRng).public_key();
+    let v7 = V7SignedGroupOp {
+        version: SIGNED_GROUP_OP_SCHEMA_VERSION - 1,
+        group_id: sample_group_id(),
+        parent_op_hashes: vec![],
+        state_hash: [0xAB; 32],
+        signer,
+        nonce: 1,
+        op: GroupOp::Noop,
+        signature: [0u8; 64],
+    };
+    let bytes = ::borsh::to_vec(&v7).expect("encode v7");
+    match ::borsh::from_slice::<SignedGroupOp>(&bytes) {
+        Ok(op) => assert!(
+            op.verify_signature().is_err(),
+            "a v7-encoded op decoded to a SignedGroupOp must still fail verify_signature"
+        ),
+        Err(_) => { /* borsh-level rejection of the old layout is also acceptable */ }
     }
 }

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -20,7 +20,6 @@ fn sign_and_verify_round_trip() {
         &sk,
         sample_group_id(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberAdded {
             member,
@@ -43,7 +42,6 @@ fn wrong_key_fails() {
         &sk,
         sample_group_id(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberAdded {
             member,
@@ -68,7 +66,6 @@ fn tampered_op_fails() {
         &sk,
         sample_group_id(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberAdded {
             member,
@@ -91,7 +88,6 @@ fn replay_distinct_content_hash() {
         &sk,
         sample_group_id(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberAdded {
             member,
@@ -104,7 +100,6 @@ fn replay_distinct_content_hash() {
         &sk,
         sample_group_id(),
         vec![],
-        [0u8; 32],
         2,
         GroupOp::MemberAdded {
             member,
@@ -130,7 +125,6 @@ fn signable_bytes_deterministic() {
         version: SIGNED_GROUP_OP_SCHEMA_VERSION,
         group_id: [1u8; 32],
         parent_op_hashes: vec![],
-        state_hash: [0u8; 32],
         signer: pk,
         nonce: 42,
         op: GroupOp::Noop,
@@ -159,7 +153,6 @@ fn namespace_op_sign_verify_root() {
         &sk,
         sample_namespace_id(),
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: sample_group_id(),
@@ -187,7 +180,6 @@ fn namespace_op_sign_verify_group() {
         &sk,
         sample_namespace_id(),
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Group {
             group_id: sample_group_id(),
@@ -211,7 +203,6 @@ fn namespace_op_tampered_fails() {
         &sk,
         sample_namespace_id(),
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::AdminChanged {
             new_admin: sk.public_key(),
@@ -232,7 +223,6 @@ fn namespace_op_content_hash_distinct() {
         &sk,
         sample_namespace_id(),
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: sample_group_id(),
@@ -246,7 +236,6 @@ fn namespace_op_content_hash_distinct() {
         &sk,
         sample_namespace_id(),
         vec![],
-        [0u8; 32],
         2,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: sample_group_id(),
@@ -272,7 +261,6 @@ fn namespace_signable_bytes_deterministic() {
         version: SIGNED_NAMESPACE_OP_SCHEMA_VERSION,
         namespace_id: sample_namespace_id(),
         parent_op_hashes: vec![],
-        state_hash: [0u8; 32],
         signer: pk,
         nonce: 42,
         op: NamespaceOp::Root(RootOp::GroupCreated {
@@ -305,7 +293,6 @@ fn cascade_target_application_set_sign_verify() {
         &sk,
         sample_group_id(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::CascadeTargetApplicationSet {
             from_app_key: [9u8; 32],
@@ -332,7 +319,6 @@ fn cascade_group_migration_set_sign_verify() {
         &sk,
         sample_group_id(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::CascadeGroupMigrationSet {
             from_app_key: [9u8; 32],
@@ -363,7 +349,6 @@ fn cascade_target_distinct_from_single_group_target() {
         &sk,
         sample_group_id(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::TargetApplicationSet {
             app_key: new_app_key,
@@ -376,7 +361,6 @@ fn cascade_target_distinct_from_single_group_target() {
         &sk,
         sample_group_id(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::CascadeTargetApplicationSet {
             from_app_key: [9u8; 32],
@@ -413,7 +397,6 @@ fn cascade_target_from_app_key_changes_hash() {
         &sk,
         sample_group_id(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::CascadeTargetApplicationSet {
             from_app_key: [9u8; 32],
@@ -427,7 +410,6 @@ fn cascade_target_from_app_key_changes_hash() {
         &sk,
         sample_group_id(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::CascadeTargetApplicationSet {
             from_app_key: [8u8; 32], // only this differs

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -624,10 +624,15 @@ fn pre_flag_day_namespace_op_version_is_rejected() {
 
 #[test]
 fn v7_borsh_layout_group_op_is_rejected_not_misparsed() {
-    // A v7-shaped op still carries the removed `state_hash` field in its borsh bytes.
-    // Decoding it as the v8 struct must NOT silently succeed with a v8-looking op:
-    // either borsh refuses the misaligned/trailing bytes, or it decodes a struct
-    // whose `version` (7) fails the v8 check — never a spurious Ok.
+    // A v7-shaped op still carries the removed `state_hash` field in its borsh bytes,
+    // between `parent_op_hashes` and `signer`. borsh is a flat format with no field
+    // names, so decoding these bytes as the v8 struct will (most likely) SUCCEED —
+    // consuming the 32 `state_hash` bytes as the start of `signer` and shifting the
+    // rest into a garbage `signer`/`nonce`/`op`. That successful-but-garbage decode
+    // IS a misparse; the only thing that saves us is that `version` is the FIRST
+    // byte, read intact as the old value, so `verify_signature` rejects on the
+    // version check. This test pins exactly that: the old version survives in byte 0,
+    // and the decoded op is rejected with `SchemaVersion` rather than verifying.
     #[derive(::borsh::BorshSerialize)]
     struct V7SignedGroupOp {
         version: u8,
@@ -651,11 +656,34 @@ fn v7_borsh_layout_group_op_is_rejected_not_misparsed() {
         signature: [0u8; 64],
     };
     let bytes = ::borsh::to_vec(&v7).expect("encode v7");
+    // Deterministic: byte 0 is the version, untouched by the layout shift.
+    assert_eq!(
+        bytes[0],
+        SIGNED_GROUP_OP_SCHEMA_VERSION - 1,
+        "v7 bytes must begin with the old schema version"
+    );
     match ::borsh::from_slice::<SignedGroupOp>(&bytes) {
-        Ok(op) => assert!(
-            op.verify_signature().is_err(),
-            "a v7-encoded op decoded to a SignedGroupOp must still fail verify_signature"
-        ),
-        Err(_) => { /* borsh-level rejection of the old layout is also acceptable */ }
+        Ok(op) => {
+            // The decode misparsed the shifted bytes, but the version survived — make
+            // that dependency explicit so a future refactor that checks the signature
+            // before the version can't let this test pass while a real misparse slips
+            // through.
+            assert_eq!(
+                op.version,
+                SIGNED_GROUP_OP_SCHEMA_VERSION - 1,
+                "decoded version must be the old schema version (byte 0)"
+            );
+            assert!(
+                matches!(
+                    op.verify_signature(),
+                    Err(GovernanceError::SchemaVersion { .. })
+                ),
+                "a v7-decoded op must be rejected on the version check, got {:?}",
+                op.verify_signature()
+            );
+        }
+        // If borsh instead rejects the misaligned/trailing bytes outright, that's also
+        // a clean rejection of the old layout.
+        Err(_) => {}
     }
 }

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -662,28 +662,24 @@ fn v7_borsh_layout_group_op_is_rejected_not_misparsed() {
         SIGNED_GROUP_OP_SCHEMA_VERSION - 1,
         "v7 bytes must begin with the old schema version"
     );
-    match ::borsh::from_slice::<SignedGroupOp>(&bytes) {
-        Ok(op) => {
-            // The decode misparsed the shifted bytes, but the version survived — make
-            // that dependency explicit so a future refactor that checks the signature
-            // before the version can't let this test pass while a real misparse slips
-            // through.
-            assert_eq!(
-                op.version,
-                SIGNED_GROUP_OP_SCHEMA_VERSION - 1,
-                "decoded version must be the old schema version (byte 0)"
-            );
-            assert!(
-                matches!(
-                    op.verify_signature(),
-                    Err(GovernanceError::SchemaVersion { .. })
-                ),
-                "a v7-decoded op must be rejected on the version check, got {:?}",
-                op.verify_signature()
-            );
-        }
-        // If borsh instead rejects the misaligned/trailing bytes outright, that's also
-        // a clean rejection of the old layout.
-        Err(_) => {}
+    // If borsh decodes the misaligned bytes (the likely case — it doesn't validate
+    // field counts), the decode misparsed the shifted bytes but the version survived;
+    // assert that dependency explicitly so a future refactor checking the signature
+    // before the version can't let a real misparse slip through. If borsh instead
+    // rejects the old layout outright, that is also a clean rejection (nothing to do).
+    if let Ok(op) = ::borsh::from_slice::<SignedGroupOp>(&bytes) {
+        assert_eq!(
+            op.version,
+            SIGNED_GROUP_OP_SCHEMA_VERSION - 1,
+            "decoded version must be the old schema version (byte 0)"
+        );
+        assert!(
+            matches!(
+                op.verify_signature(),
+                Err(GovernanceError::SchemaVersion { .. })
+            ),
+            "a v7-decoded op must be rejected on the version check, got {:?}",
+            op.verify_signature()
+        );
     }
 }

--- a/crates/governance-types/src/wire.rs
+++ b/crates/governance-types/src/wire.rs
@@ -441,7 +441,6 @@ mod tests {
             &sk,
             [0u8; 32],
             Vec::new(),
-            [0u8; 32],
             0,
             super::super::NamespaceOp::Root(super::super::RootOp::AdminChanged {
                 new_admin: sk.public_key(),

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -312,7 +312,6 @@ async fn apply_signed_group_op_via_context_client() {
         &admin_sk,
         gid_bytes,
         vec![],
-        [0u8; 32],
         1,
         GroupOp::MemberAdded {
             member: new_member,
@@ -584,7 +583,6 @@ fn provision_tee_owner_with_sk(
         &owner_sk,
         gid.to_bytes(),
         vec![],
-        [0u8; 32],
         1,
         GroupOp::TeeAdmissionPolicySet {
             allowed_mrtd: vec![MOCK_MEASUREMENT_48_HEX.to_owned()],
@@ -1371,7 +1369,6 @@ async fn integrated_tee_lifecycle_open_replication_and_scoped_root_cascade() {
         &owner_sk,
         ns_gid.to_bytes(),
         vec![],
-        pre_hash,
         next_owner_nonce,
         GroupOp::MemberRemoved {
             member: tee_pk,
@@ -1935,7 +1932,6 @@ async fn restricted_ctx_redriven_after_group_created() {
     // DOES hold the subgroup meta and so signs a non-zero hash; this stand-in
     // reproduces that exact condition. (Any non-zero value reaches the meta load
     // before any hash comparison, so the precise bytes don't matter.)
-    let nonzero_state_hash = [0x11u8; 32];
 
     // ---- Subscribe to op-events BEFORE driving anything ----------------------
     // Process-global broadcast; `#[serial]` keeps cross-test events out, but we
@@ -1956,7 +1952,6 @@ async fn restricted_ctx_redriven_after_group_created() {
         &owner_sk,
         namespace_id,
         vec![],
-        nonzero_state_hash,
         1,
         NamespaceOp::Group {
             group_id: sub_gid.to_bytes(),
@@ -1996,7 +1991,6 @@ async fn restricted_ctx_redriven_after_group_created() {
         &owner_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         2,
         NamespaceOp::Root(RootOp::KeyDelivery {
             group_id: sub_gid.to_bytes(),
@@ -2034,7 +2028,6 @@ async fn restricted_ctx_redriven_after_group_created() {
         &owner_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         3,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: sub_gid.to_bytes(),
@@ -2167,7 +2160,6 @@ async fn open_ctx_redriven_after_group_created_via_namespace_key() {
     // ---- The Open subgroup (NOT yet created on the receiver) ------------------
     let sub_gid = ContextGroupId::from(*PrivateKey::random(&mut rng).public_key());
     let context_id = calimero_primitives::context::ContextId::from([0xC9u8; 32]);
-    let nonzero_state_hash = [0x22u8; 32];
 
     let mut events = calimero_governance_store::op_events::subscribe();
 
@@ -2188,7 +2180,6 @@ async fn open_ctx_redriven_after_group_created_via_namespace_key() {
         &owner_sk,
         namespace_id,
         vec![],
-        nonzero_state_hash,
         1,
         NamespaceOp::Group {
             group_id: sub_gid.to_bytes(),
@@ -2238,7 +2229,6 @@ async fn open_ctx_redriven_after_group_created_via_namespace_key() {
         &owner_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         2,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: sub_gid.to_bytes(),
@@ -2504,7 +2494,6 @@ async fn tee_matrix_restricted_late_join() {
     };
     let key_id = GroupKeyring::key_id_for(&subgroup_key);
     let context_id = calimero_primitives::context::ContextId::from([0xCAu8; 32]);
-    let nonzero_state_hash = [0x22u8; 32];
 
     // The TEE node whose membership the late join must end with. In the
     // late-join ordering the TEE row in the subgroup pre-exists the key (a
@@ -2519,7 +2508,6 @@ async fn tee_matrix_restricted_late_join() {
         &owner_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: sub_gid.to_bytes(),
@@ -2557,7 +2545,6 @@ async fn tee_matrix_restricted_late_join() {
         &owner_sk,
         namespace_id,
         vec![],
-        nonzero_state_hash,
         2,
         NamespaceOp::Group {
             group_id: sub_gid.to_bytes(),
@@ -2587,7 +2574,6 @@ async fn tee_matrix_restricted_late_join() {
         &owner_sk,
         namespace_id,
         vec![],
-        [0u8; 32],
         3,
         NamespaceOp::Root(RootOp::KeyDelivery {
             group_id: sub_gid.to_bytes(),

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -369,7 +369,6 @@ mod key_recovery_trigger {
             &signer_sk,
             namespace_id,
             vec![],
-            [0u8; 32],
             1,
             NamespaceOp::Group {
                 group_id,


### PR DESCRIPTION
## ⚠️ FLAG-DAY / re-bootstrap — no back-compat

Removing `state_hash` changes **every op's content hash (its id)** *and* bumps the wire schema, so **every node must be on this build** and pre-existing governance DAGs are not deserializable. This is the deliberate closing move of the unified-causal-log cutover.

## What

The op-level `state_hash` field stopped being an apply gate in **C5.S3a** (#2939) — `scope_root` is the authoritative cross-plane convergence signal now — leaving it pure dead weight in the signed op bytes. This removes it entirely:

- drop `state_hash` from all four op structs — `SignableGroupOp` / `SignedGroupOp` and `SignableNamespaceOp` / `SignedNamespaceOp` — and from `sign()` / `to_signable()`. Since the field was inside the signed/hashed bytes, every op id changes;
- bump **both** schema versions: `SIGNED_GROUP_OP_SCHEMA_VERSION` 7→8 and `SIGNED_NAMESPACE_OP_SCHEMA_VERSION` 1→2. Old-shape ops are rejected outright by `verify_signature`.

Cut the now-dead machinery:
- apply-time staleness checks (`apply_local_signed_group_op_at_cut`, `apply_group_op_inner`, `apply_root_op`);
- `state_hash_for_op`, the `state_hash` param threaded through `publish_post_gate` / `sign_and_publish_post_gate` / `sign_and_publish_without_apply`, and the publisher's `pre_apply_state_hash` capture;
- `root_op_commits_to_namespace_state` (only the staleness gate used it);
- the synthesized-op field + the `unified_op_decode` / `governance_dag` deltas that reused `state_hash` as `expected_root_hash` (now `[0u8; 32]`).

The **per-signer nonce window** remains the anti-replay gate.

## KEPT — a separate mechanism, do not confuse

`MemberRemoved` / `MemberLeft` carry `expected_group_state_hash` + `expected_context_state_hashes` (post-apply convergence claims that drive reconcile-on-mismatch) and `compute_state_hash` feeds them. Those are **unaffected** — this PR only removes the op-level `state_hash` that was part of the op id.

## Mechanics / testing

- Test call sites updated by a bracket-aware codemod (223 `sign()` sites, 4th positional arg dropped).
- 6 obsolete `state_hash`-staleness unit tests + their fixture deleted (they pinned behaviour this PR removes); the surviving concurrent-convergence test still passes (it asserts independent concurrent ops converge, which never depended on `state_hash`).
- Net **−956 LOC**. fmt + clippy (`-D warnings`) clean across the workspace; governance-store + context compile on master.
- Stacked work it builds on is all merged: #2935/#2936/#2939/#2941/#2944.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Flag-day wire/schema break on governance op IDs affects every node and invalidates existing DAGs; changes core apply/publish paths in governance-store and context.
> 
> **Overview**
> **Flag-day breaking change:** drops `state_hash` from `SignableGroupOp` / `SignedGroupOp` and `SignableNamespaceOp` / `SignedNamespaceOp`, bumps `SIGNED_GROUP_OP_SCHEMA_VERSION` to **8** and `SIGNED_NAMESPACE_OP_SCHEMA_VERSION` to **2**, and updates `sign()` so every op’s **content hash (id)** changes—old DAG history is not readable on this build.
> 
> Apply and publish paths no longer compute, thread, or warn on op-level staleness (`state_hash_for_op`, `pre_apply_state_hash`, `apply_local_signed_group_op` / `apply_group_op_inner` / `apply_root_op` telemetry, `root_op_commits_to_namespace_state`). **Anti-replay stays on the per-signer nonce window.** DAG helpers (`signed_op_to_delta`, unified decode) set `expected_root_hash` to `[0u8; 32]` because governance ops no longer carry a meaningful root claim.
> 
> **Unchanged:** `MemberRemoved` / `MemberLeft` still use `expected_group_state_hash` and `expected_context_state_hashes` (separate post-apply convergence mechanism); `compute_state_hash` for those claims remains.
> 
> Tests and call sites are updated to the shorter `sign()` API; obsolete `state_hash` staleness unit tests are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98fd082437622a91b3e33829f197440614599577. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->