### PR TITLE
ci: pin dtolnay/rust-toolchain to a commit SHA (supply-chain hygiene)

### DIFF
--- a/.github/workflows/sdk-e2e.yml
+++ b/.github/workflows/sdk-e2e.yml
@@ -38,7 +38,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned to a commit SHA (supply-chain hygiene); comment tracks the tag.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust dependencies
         uses: actions/cache@v3

--- a/.github/workflows/wire-contract.yml
+++ b/.github/workflows/wire-contract.yml
@@ -33,7 +33,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned to a commit SHA (supply-chain hygiene); comment tracks the tag.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust dependencies
         uses: actions/cache@v3


### PR DESCRIPTION
Addresses the reviewer flag on the contract-gate workflows: `dtolnay/rust-toolchain@stable` is a mutable ref. Pins it to a commit SHA (`29eef33`, the current `stable`) in `wire-contract.yml` and `sdk-e2e.yml`, with a `# stable` comment tracking the tag.

The SHA pins the **action code**, not the Rust toolchain — `stable` Rust is still resolved at runtime, so this doesn't freeze the compiler version.

> Note: `release.yml` also uses `dtolnay/rust-toolchain@stable` (pre-existing, not part of the contract gate) — left as-is here; a repo-wide action-pinning pass would be a separate hygiene PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)