### PR TITLE
fix(store): key by entry.key() in merge, handle Delete ops

### DIFF
--- a/crates/store/src/tx.rs
+++ b/crates/store/src/tx.rs
@@ -78,13 +78,12 @@ impl<'a> Transaction<'a> {
     #[expect(clippy::use_self, reason = "Needed in order to specify a lifetime")]
     pub fn merge(&mut self, other: &Transaction<'a>) {
         for (entry, op) in other.iter() {
-            drop(self.cols.entry(entry.column).or_default().insert(
-                match op {
-                    Operation::Put { value } => value.clone(),
-                    Operation::Delete => unreachable!(),
-                },
-                op.clone(),
-            ));
+            drop(
+                self.cols
+                    .entry(entry.column)
+                    .or_default()
+                    .insert(Slice::from(entry.key().to_owned()), op.clone()),
+            );
         }
     }
 


### PR DESCRIPTION
## Description

This PR fixes a bug in the `Transaction::merge` method where the insert operation was incorrectly using the operation's value as the key instead of the actual entry key.

**Before:** The code was extracting the value from `Operation::Put` and using it as the map key, which is incorrect and would fail for `Operation::Delete` (marked as unreachable).

**After:** The code now correctly uses `entry.key()` as the map key and passes the full `Operation` as the value, which is the intended behavior for merging transactions.

This is a straightforward bug fix that corrects the logic to match the expected semantics of transaction merging.

## Test plan

Existing tests should cover this change. The fix ensures that transaction merging correctly uses entry keys rather than operation values, which would be caught by any tests exercising the merge functionality.

## Wire contract (SDK gate)

N/A - No HTTP wire DTOs or routes changed.

## Documentation update

N/A - No public API changes.

https://claude.ai/code/session_01MHXJQppfcpLc7ZfbXk1Dv1