### PR TITLE
fix(governance-store): add visited set to subtree cascade walk

### DIFF
--- a/crates/governance-store/src/namespace/core.rs
+++ b/crates/governance-store/src/namespace/core.rs
@@ -388,9 +388,14 @@ impl<'a> NamespaceRepository<'a> {
         )?);
 
         let mut dfs_preorder: Vec<ContextGroupId> = Vec::new();
+        let mut visited = std::collections::HashSet::new();
+        visited.insert(*root);
         let mut stack = vec![*root];
         while let Some(g) = stack.pop() {
             for child in self.list_children(&g)? {
+                if !visited.insert(child) {
+                    continue;
+                }
                 dfs_preorder.push(child);
                 stack.push(child);
                 contexts.extend(super::super::enumerate_group_contexts(


### PR DESCRIPTION
## Description

This PR fixes a potential infinite loop in the `NamespaceRepository::list_all_contexts` method by adding cycle detection to the depth-first search traversal of context groups.

The issue occurs when traversing a hierarchy of context groups using a stack-based DFS. Without tracking visited nodes, if there are any cycles in the group hierarchy (either direct self-references or circular references between groups), the traversal would loop indefinitely.

The fix introduces a `HashSet` to track visited `ContextGroupId`s. Before processing a child group, we check if it has already been visited. If it has, we skip it; otherwise, we mark it as visited and continue processing.

## Test plan

Existing tests should pass. The change is defensive and maintains the same traversal order for acyclic graphs while preventing infinite loops in the presence of cycles.

## Wire contract (SDK gate)

N/A - No HTTP wire DTOs or routes changed.

## Documentation update

N/A - Internal implementation detail.

https://claude.ai/code/session_01Byc6CqEsxSyLMuRR7srD3r