### PR TITLE
fix(sync): bound inbound blob stream and discard on hash mismatch

### DIFF
--- a/crates/node/src/constants.rs
+++ b/crates/node/src/constants.rs
@@ -16,6 +16,9 @@ pub const MAX_BLOB_CACHE_COUNT: usize = 100;
 /// The maximum size of the blob cache (in bytes).
 /// Currently, equals to 500 MiB.
 pub const MAX_BLOB_CACHE_SIZE_BYTES: usize = 500 * 1024 * 1024;
+/// Hard upper bound on a single inbound blob received over the sync stream.
+/// A peer advertising size==0 (unknown) is still capped at this limit.
+pub const MAX_BLOB_STREAM_SIZE_BYTES: u64 = 500 * 1024 * 1024;
 /// The period of eviction of old blobs (every 300 seconds) for the node (in seconds).
 pub const OLD_BLOBS_EVICTION_FREQUENCY_S: u64 = 300;
 

--- a/crates/node/src/constants.rs
+++ b/crates/node/src/constants.rs
@@ -18,6 +18,7 @@ pub const MAX_BLOB_CACHE_COUNT: usize = 100;
 pub const MAX_BLOB_CACHE_SIZE_BYTES: usize = 500 * 1024 * 1024;
 /// Hard upper bound on a single inbound blob received over the sync stream.
 /// A peer advertising size==0 (unknown) is still capped at this limit.
+/// u64 to match the wire-protocol `size: u64` field; usize would truncate on 32-bit targets.
 pub const MAX_BLOB_STREAM_SIZE_BYTES: u64 = 500 * 1024 * 1024;
 /// The period of eviction of old blobs (every 300 seconds) for the node (in seconds).
 pub const OLD_BLOBS_EVICTION_FREQUENCY_S: u64 = 300;

--- a/crates/node/src/sync/blobs.rs
+++ b/crates/node/src/sync/blobs.rs
@@ -11,9 +11,9 @@ use rand::{thread_rng, Rng};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 
-use crate::constants::MAX_BLOB_STREAM_SIZE_BYTES;
 use super::manager::SyncManager;
 use super::tracking::Sequencer;
+use crate::constants::MAX_BLOB_STREAM_SIZE_BYTES;
 
 impl SyncManager {
     pub(super) async fn initiate_blob_share_process(

--- a/crates/node/src/sync/blobs.rs
+++ b/crates/node/src/sync/blobs.rs
@@ -139,6 +139,12 @@ impl SyncManager {
         if received_blob_id != blob_id {
             // Discard the incorrectly-hashed blob before propagating the error
             // so we don't persist corrupt data.
+            warn!(
+                %blob_id,
+                %received_blob_id,
+                advertised_size = size,
+                "blob hash mismatch after receive; deleting stored blob",
+            );
             if let Err(err) = self.node_client.delete_blob(received_blob_id).await {
                 warn!(%received_blob_id, %err, "failed to delete mismatched blob");
             }

--- a/crates/node/src/sync/blobs.rs
+++ b/crates/node/src/sync/blobs.rs
@@ -11,6 +11,7 @@ use rand::{thread_rng, Rng};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 
+use crate::constants::MAX_BLOB_STREAM_SIZE_BYTES;
 use super::manager::SyncManager;
 use super::tracking::Sequencer;
 
@@ -86,10 +87,16 @@ impl SyncManager {
 
         let (tx, mut rx) = mpsc::channel(1);
 
-        let expected_size = if size > 0 { Some(size) } else { None };
+        // Always cap the inbound stream. A peer advertising size==0 (unknown)
+        // still gets a hard ceiling so a rogue sender cannot stream unbounded data.
+        let size_limit = if size > 0 {
+            size.min(MAX_BLOB_STREAM_SIZE_BYTES)
+        } else {
+            MAX_BLOB_STREAM_SIZE_BYTES
+        };
         let add_task = self.node_client.add_blob(
             poll_fn(|cx| rx.poll_recv(cx)).into_async_read(),
-            expected_size,
+            Some(size_limit),
             None,
         );
 
@@ -130,6 +137,11 @@ impl SyncManager {
         let ((received_blob_id, _), _) = tokio::try_join!(add_task, read_task)?;
 
         if received_blob_id != blob_id {
+            // Discard the incorrectly-hashed blob before propagating the error
+            // so we don't persist corrupt data.
+            if let Err(err) = self.node_client.delete_blob(received_blob_id).await {
+                warn!(%received_blob_id, %err, "failed to delete mismatched blob");
+            }
             bail!(
                 "unexpected blob id: expected {}, got {}",
                 blob_id,


### PR DESCRIPTION
When a peer advertises size==0, expected_size was None, leaving add_blob
with no upper bound on how much data it would accept from the stream.
A rogue sender could exploit this to push unbounded data.

- Always pass Some(size_limit) to add_blob: use the advertised size when
  > 0 (capped at MAX_BLOB_STREAM_SIZE_BYTES), or the cap itself when
  size==0 (unknown).
- On blob-id mismatch after full consume, delete the stored blob before
  bailing so corrupt/unexpected data is not persisted.
- Add MAX_BLOB_STREAM_SIZE_BYTES = 500 MiB constant to constants.rs.

Fixes: crates/node/src/sync/blobs.rs:89