### PR TITLE
fix(runtime): avoid aliasing &mut into guest memory (UB)

### DIFF
--- a/crates/runtime/MEMORY_MODEL.md
+++ b/crates/runtime/MEMORY_MODEL.md
@@ -250,12 +250,17 @@ impl VMHostFunctions<'_> {
         std::str::from_utf8(bytes).map_err(|_| HostError::BadUTF8.into())
     }
     
-    /// Get mutable slice for writing to guest memory
-    pub fn read_guest_memory_slice_mut<'a>(
-        &self, 
-        buf: &sys::BufferMut<'a>
-    ) -> VMLogicResult<&'a mut [u8]> {
-        // Similar to read, but returns mutable reference
+    /// Copy bytes out into a guest buffer (copy-out)
+    ///
+    /// Never hands out a `&mut [u8]` aliasing guest memory: that would overlap
+    /// the immutable views returned by `read_guest_memory_slice` (undefined
+    /// behaviour). Instead it copies via Wasmer's `MemoryView::write`.
+    pub fn write_guest_memory_slice(
+        &self,
+        buf: &sys::BufferMut<'_>,
+        data: &[u8],
+    ) -> VMLogicResult<()> {
+        // Bounds-check `buf`, ensure `data` fits, then `memory.write(ptr, data)`
     }
 }
 ```

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -563,37 +563,25 @@ impl VMHostFunctions<'_> {
         Ok(unsafe { &memory.data_unchecked()[ptr..end] })
     }
 
-    /// Reads a MUTABLE slice of guest memory.
-    /// This should only be used when the host needs to WRITE into a buffer
-    /// provided by the guest.
+    /// Validates that the guest memory region described by the mutable buffer
+    /// `slice` lies entirely within the bounds of guest memory.
+    ///
+    /// This performs the same bounds check that a write would, without copying
+    /// any data. It is useful when the caller needs to verify that a guest
+    /// buffer is writable before performing side effects, but does not yet have
+    /// the data to write.
     ///
     /// # Arguments
     ///
-    /// * `slice` - A `sys::Buffer` descriptor pointing to the buffer location and length in guest memory.
-    ///
-    /// # Returns
-    ///
-    /// * Mutable slice of the guest memory contents.
+    /// * `slice` - A `sys::BufferMut` descriptor pointing to the buffer location and length in guest memory.
     ///
     /// # Errors
     ///
     /// Returns `VMLogicError::HostError(HostError::InvalidMemoryAccess)` if the requested
     /// memory region (ptr + len) exceeds the bounds of guest memory.
-    #[expect(
-        clippy::mut_from_ref,
-        reason = "We are not modifying the self explicitly, only the underlying slice of the guest memory.\
-        Meantime we are required to have an immutable reference to self, hence the exception"
-    )]
-    fn read_guest_memory_slice_mut(&self, slice: &sys::BufferMut<'_>) -> VMLogicResult<&mut [u8]> {
+    fn check_guest_memory_bounds(&self, slice: &sys::BufferMut<'_>) -> VMLogicResult<()> {
         let ptr = slice.ptr().value().as_usize();
         let len = slice.len() as usize;
-
-        trace!(
-            target: "runtime::memory",
-            ptr,
-            len,
-            "read_guest_memory_slice_mut"
-        );
 
         let memory = self.borrow_memory();
         let memory_size = memory.data_size() as usize;
@@ -604,8 +592,66 @@ impl VMHostFunctions<'_> {
             return Err(HostError::InvalidMemoryAccess.into());
         }
 
-        // SAFETY: We have verified that ptr..ptr+len is within the memory bounds
-        Ok(unsafe { &mut memory.data_unchecked_mut()[ptr..end] })
+        Ok(())
+    }
+
+    /// Copies `data` into the guest memory region described by the mutable
+    /// buffer `slice` (a copy-out into guest memory).
+    ///
+    /// This should be used when the host needs to WRITE into a buffer provided
+    /// by the guest. It relies on [`wasmer::MemoryView::write`] to perform a
+    /// safe copy into guest memory. This deliberately avoids materializing a
+    /// `&mut [u8]` that aliases guest memory from a shared `&self`: doing so
+    /// would create a mutable reference overlapping the immutable views handed
+    /// out by [`Self::read_guest_memory_slice`], which is undefined behaviour.
+    ///
+    /// # Arguments
+    ///
+    /// * `slice` - A `sys::BufferMut` descriptor pointing to the buffer location and length in guest memory.
+    /// * `data` - The bytes to copy into the guest buffer. Must not be longer than the buffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns `VMLogicError::HostError(HostError::InvalidMemoryAccess)` if `data` is
+    /// longer than the buffer, if the requested memory region (ptr + len) exceeds the
+    /// bounds of guest memory, or if the underlying write fails.
+    fn write_guest_memory_slice(
+        &self,
+        slice: &sys::BufferMut<'_>,
+        data: &[u8],
+    ) -> VMLogicResult<()> {
+        let ptr = slice.ptr().value().as_usize();
+        let len = slice.len() as usize;
+
+        trace!(
+            target: "runtime::memory",
+            ptr,
+            len,
+            data_len = data.len(),
+            "write_guest_memory_slice"
+        );
+
+        // The data must fit within the guest-provided buffer.
+        if data.len() > len {
+            return Err(HostError::InvalidMemoryAccess.into());
+        }
+
+        let memory = self.borrow_memory();
+        let memory_size = memory.data_size() as usize;
+
+        // Check for potential overflow and bounds
+        let end = ptr.checked_add(len).ok_or(HostError::InvalidMemoryAccess)?;
+        if end > memory_size {
+            return Err(HostError::InvalidMemoryAccess.into());
+        }
+
+        // Safe copy-out: `MemoryView::write` copies the bytes into guest memory
+        // without exposing an aliasing mutable reference.
+        memory
+            .write(ptr as u64, data)
+            .map_err(|_| HostError::InvalidMemoryAccess)?;
+
+        Ok(())
     }
 
     /// Reads an immutable UTF-8 string slice from guest memory.
@@ -1128,10 +1174,10 @@ mod tests {
         ));
     }
 
-    /// Tests that `read_guest_memory_slice_mut` returns an error when the requested memory region
+    /// Tests that `check_guest_memory_bounds` returns an error when the requested memory region
     /// exceeds the bounds of guest memory.
     #[test]
-    fn test_read_guest_memory_slice_mut_out_of_bounds() {
+    fn test_check_guest_memory_bounds_out_of_bounds() {
         let mut storage = SimpleMockStorage::new();
         let limits = VMLimits::default();
         let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
@@ -1157,7 +1203,7 @@ mod tests {
                 .unwrap()
         };
 
-        let err = host.read_guest_memory_slice_mut(&buffer).unwrap_err();
+        let err = host.check_guest_memory_bounds(&buffer).unwrap_err();
         assert!(matches!(
             err,
             VMLogicError::HostError(HostError::InvalidMemoryAccess)
@@ -1179,7 +1225,7 @@ mod tests {
         };
 
         let err_beyond = host
-            .read_guest_memory_slice_mut(&buffer_beyond)
+            .check_guest_memory_bounds(&buffer_beyond)
             .unwrap_err();
         assert!(matches!(
             err_beyond,

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -1224,9 +1224,7 @@ mod tests {
                 .unwrap()
         };
 
-        let err_beyond = host
-            .check_guest_memory_bounds(&buffer_beyond)
-            .unwrap_err();
+        let err_beyond = host.check_guest_memory_bounds(&buffer_beyond).unwrap_err();
         assert!(matches!(
             err_beyond,
             VMLogicError::HostError(HostError::InvalidMemoryAccess)

--- a/crates/runtime/src/logic/host_functions/blobs.rs
+++ b/crates/runtime/src/logic/host_functions/blobs.rs
@@ -232,10 +232,7 @@ impl VMHostFunctions<'_> {
         // Validate guest memory bounds BEFORE removing the handle to avoid
         // orphaning the handle if the bounds check fails.
         // We need to drop the reference before calling with_logic_mut.
-        {
-            let _bounds_check = self.read_guest_memory_slice_mut(&guest_blob_id_ptr)?;
-            // Reference is dropped at end of this block
-        }
+        self.check_guest_memory_bounds(&guest_blob_id_ptr)?;
 
         let handle = self.with_logic_mut(|logic| {
             logic
@@ -259,10 +256,8 @@ impl VMHostFunctions<'_> {
             BlobHandle::Read(read_handle) => *read_handle.blob_id.as_ref(),
         };
 
-        // Now get the slice again and write the blob_id to it
-        let guest_blob_id_out_buf: &mut [u8] =
-            self.read_guest_memory_slice_mut(&guest_blob_id_ptr)?;
-        guest_blob_id_out_buf.copy_from_slice(&final_blob_id);
+        // Now write the blob_id into the guest buffer.
+        self.write_guest_memory_slice(&guest_blob_id_ptr, &final_blob_id)?;
 
         Ok(1)
     }
@@ -541,8 +536,7 @@ impl VMHostFunctions<'_> {
         if bytes_read > 0 {
             // Copy data from the local output buffer to destination buffer located in guest
             // memory. This can fail with InvalidMemoryAccess if bounds check fails.
-            self.read_guest_memory_slice_mut(&dest_data)?
-                .copy_from_slice(&output_buffer);
+            self.write_guest_memory_slice(&dest_data, &output_buffer)?;
         }
 
         // Only update position AFTER successfully writing to guest memory.

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -276,8 +276,7 @@ impl VMHostFunctions<'_> {
             return Ok(0);
         }
 
-        self.read_guest_memory_slice_mut(&dest_data)?
-            .copy_from_slice(data);
+        self.write_guest_memory_slice(&dest_data, data)?;
 
         trace!(
             target: "runtime::host::system",

--- a/crates/runtime/src/logic/host_functions/utility.rs
+++ b/crates/runtime/src/logic/host_functions/utility.rs
@@ -125,7 +125,13 @@ impl VMHostFunctions<'_> {
     pub fn random_bytes(&mut self, dest_ptr: u64) -> VMLogicResult<()> {
         let dest_buf = unsafe { self.read_guest_memory_typed::<sys::BufferMut<'_>>(dest_ptr)? };
 
-        rand::thread_rng().fill_bytes(self.read_guest_memory_slice_mut(&dest_buf)?);
+        // Validate the destination bounds before allocating a buffer sized from
+        // the guest-provided length.
+        self.check_guest_memory_bounds(&dest_buf)?;
+
+        let mut bytes = vec![0_u8; dest_buf.len() as usize];
+        rand::thread_rng().fill_bytes(&mut bytes);
+        self.write_guest_memory_slice(&dest_buf, &bytes)?;
 
         Ok(())
     }
@@ -170,8 +176,7 @@ impl VMHostFunctions<'_> {
             .as_nanos() as u64;
 
         // Record the time into the guest memory buffer
-        let guest_time_out_buf: &mut [u8] = self.read_guest_memory_slice_mut(&guest_time_ptr)?;
-        guest_time_out_buf.copy_from_slice(&now.to_le_bytes());
+        self.write_guest_memory_slice(&guest_time_ptr, &now.to_le_bytes())?;
 
         Ok(())
     }


### PR DESCRIPTION
read_guest_memory_slice_mut materialized a `&mut [u8]` into guest
memory from a shared `&self` via `data_unchecked_mut`. That mutable
reference overlapped the immutable `&[u8]` views handed out by
read_guest_memory_slice over the same backing store, violating Rust's
aliasing rules (undefined behaviour).

Replace it with safe copy-out semantics:
  - `write_guest_memory_slice` copies caller-owned bytes into guest
    memory via `MemoryView::write`, after bounds-checking the buffer
    and ensuring the data fits.
  - `check_guest_memory_bounds` validates a guest buffer's bounds
    without copying, for callers that must verify writability before
    performing side effects (blob_close).

All call sites (read_register, time_now, random_bytes, blob_close,
blob_read) updated accordingly. random_bytes now fills a host-side
buffer before copying out. The bounds-check test and MEMORY_MODEL.md
are updated to match.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P83DNyRogsA4jLiLReohyD