### PR TITLE
refactor(meroctl): use shared MemberCapabilities consts for capability bits

### DIFF
--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -1494,9 +1494,10 @@ fn capability_zero_means_no_permissions() {
         .unwrap();
     assert_eq!(caps, 0);
     // All capability bits are off
-    assert_eq!(caps & (1 << 0), 0); // CAN_CREATE_CONTEXT
-    assert_eq!(caps & (1 << 1), 0); // CAN_INVITE_MEMBERS
-    assert_eq!(caps & (1 << 2), 0); // CAN_JOIN_OPEN_SUBGROUPS
+    use calimero_context_config::MemberCapabilities;
+    assert_eq!(caps & MemberCapabilities::CAN_CREATE_CONTEXT, 0);
+    assert_eq!(caps & MemberCapabilities::CAN_INVITE_MEMBERS, 0);
+    assert_eq!(caps & MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS, 0);
 }
 
 #[test]

--- a/crates/meroctl/src/cli/group/members.rs
+++ b/crates/meroctl/src/cli/group/members.rs
@@ -1,3 +1,4 @@
+use calimero_context_config::MemberCapabilities;
 use calimero_primitives::context::GroupMemberRole;
 use calimero_primitives::identity::PublicKey;
 use calimero_server_primitives::admin::{
@@ -260,25 +261,25 @@ impl SetCapabilitiesCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
         let mut capabilities: u32 = 0;
         if self.can_create_context {
-            capabilities |= 1 << 0;
+            capabilities |= MemberCapabilities::CAN_CREATE_CONTEXT;
         }
         if self.can_invite_members {
-            capabilities |= 1 << 1;
+            capabilities |= MemberCapabilities::CAN_INVITE_MEMBERS;
         }
         if self.can_join_open_subgroups {
-            capabilities |= 1 << 2;
+            capabilities |= MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS;
         }
         if self.can_create_subgroup {
-            capabilities |= 1 << 5;
+            capabilities |= MemberCapabilities::CAN_CREATE_SUBGROUP;
         }
         if self.can_delete_subgroup {
-            capabilities |= 1 << 6;
+            capabilities |= MemberCapabilities::CAN_DELETE_SUBGROUP;
         }
         if self.can_manage_visibility {
-            capabilities |= 1 << 7;
+            capabilities |= MemberCapabilities::CAN_MANAGE_VISIBILITY;
         }
         if self.can_manage_metadata {
-            capabilities |= 1 << 8;
+            capabilities |= MemberCapabilities::CAN_MANAGE_METADATA;
         }
 
         let identity_hex = hex::encode(self.identity.digest());
@@ -356,59 +357,31 @@ impl CheckAccessCommand {
         println!("Role:                    {role}");
         println!(
             "CAN_CREATE_CONTEXT:      {}",
-            if caps & (1 << 0) != 0 {
-                "true"
-            } else {
-                "false"
-            }
+            caps & MemberCapabilities::CAN_CREATE_CONTEXT != 0
         );
         println!(
             "CAN_INVITE_MEMBERS:      {}",
-            if caps & (1 << 1) != 0 {
-                "true"
-            } else {
-                "false"
-            }
+            caps & MemberCapabilities::CAN_INVITE_MEMBERS != 0
         );
         println!(
             "CAN_JOIN_OPEN_SUBGROUPS: {}",
-            if caps & (1 << 2) != 0 {
-                "true"
-            } else {
-                "false"
-            }
+            caps & MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS != 0
         );
         println!(
             "CAN_CREATE_SUBGROUP:     {}",
-            if caps & (1 << 5) != 0 {
-                "true"
-            } else {
-                "false"
-            }
+            caps & MemberCapabilities::CAN_CREATE_SUBGROUP != 0
         );
         println!(
             "CAN_DELETE_SUBGROUP:     {}",
-            if caps & (1 << 6) != 0 {
-                "true"
-            } else {
-                "false"
-            }
+            caps & MemberCapabilities::CAN_DELETE_SUBGROUP != 0
         );
         println!(
             "CAN_MANAGE_VISIBILITY:   {}",
-            if caps & (1 << 7) != 0 {
-                "true"
-            } else {
-                "false"
-            }
+            caps & MemberCapabilities::CAN_MANAGE_VISIBILITY != 0
         );
         println!(
             "CAN_MANAGE_METADATA:     {}",
-            if caps & (1 << 8) != 0 {
-                "true"
-            } else {
-                "false"
-            }
+            caps & MemberCapabilities::CAN_MANAGE_METADATA != 0
         );
 
         Ok(())

--- a/crates/meroctl/src/cli/group/settings.rs
+++ b/crates/meroctl/src/cli/group/settings.rs
@@ -1,3 +1,4 @@
+use calimero_context_config::MemberCapabilities;
 use calimero_primitives::identity::PublicKey;
 use calimero_server_primitives::admin::{
     SetDefaultCapabilitiesApiRequest, SetSubgroupVisibilityApiRequest,
@@ -71,7 +72,7 @@ impl SettingsGetCommand {
         let _ = table.add_row(vec!["Subgroup Visibility", vis.as_str()]);
         let _ = table.add_row(vec![
             "CAN_CREATE_CONTEXT",
-            if caps & (1 << 0) != 0 {
+            if caps & MemberCapabilities::CAN_CREATE_CONTEXT != 0 {
                 "true"
             } else {
                 "false"
@@ -79,7 +80,7 @@ impl SettingsGetCommand {
         ]);
         let _ = table.add_row(vec![
             "CAN_INVITE_MEMBERS",
-            if caps & (1 << 1) != 0 {
+            if caps & MemberCapabilities::CAN_INVITE_MEMBERS != 0 {
                 "true"
             } else {
                 "false"
@@ -87,7 +88,7 @@ impl SettingsGetCommand {
         ]);
         let _ = table.add_row(vec![
             "CAN_JOIN_OPEN_SUBGROUPS",
-            if caps & (1 << 2) != 0 {
+            if caps & MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS != 0 {
                 "true"
             } else {
                 "false"
@@ -125,13 +126,13 @@ impl SetDefaultCapabilitiesCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
         let mut capabilities: u32 = 0;
         if self.can_create_context {
-            capabilities |= 1 << 0;
+            capabilities |= MemberCapabilities::CAN_CREATE_CONTEXT;
         }
         if self.can_invite_members {
-            capabilities |= 1 << 1;
+            capabilities |= MemberCapabilities::CAN_INVITE_MEMBERS;
         }
         if self.can_join_open_subgroups {
-            capabilities |= 1 << 2;
+            capabilities |= MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS;
         }
 
         let request = SetDefaultCapabilitiesApiRequest {

--- a/crates/meroctl/src/output/groups.rs
+++ b/crates/meroctl/src/output/groups.rs
@@ -1,3 +1,4 @@
+use calimero_context_config::MemberCapabilities;
 use calimero_server_primitives::admin::{
     AddGroupMembersApiResponse, CreateGroupApiResponse, CreateGroupInvitationApiResponse,
     CreateNamespaceApiResponse, DeleteGroupApiResponse, DeleteNamespaceApiResponse,
@@ -502,15 +503,30 @@ impl Report for GetMemberCapabilitiesApiResponse {
         ]);
         let _ = table.add_row(vec![
             "CAN_CREATE_CONTEXT".to_owned(),
-            if caps & (1 << 0) != 0 { "yes" } else { "no" }.to_owned(),
+            if caps & MemberCapabilities::CAN_CREATE_CONTEXT != 0 {
+                "yes"
+            } else {
+                "no"
+            }
+            .to_owned(),
         ]);
         let _ = table.add_row(vec![
             "CAN_INVITE_MEMBERS".to_owned(),
-            if caps & (1 << 1) != 0 { "yes" } else { "no" }.to_owned(),
+            if caps & MemberCapabilities::CAN_INVITE_MEMBERS != 0 {
+                "yes"
+            } else {
+                "no"
+            }
+            .to_owned(),
         ]);
         let _ = table.add_row(vec![
             "CAN_JOIN_OPEN_SUBGROUPS".to_owned(),
-            if caps & (1 << 2) != 0 { "yes" } else { "no" }.to_owned(),
+            if caps & MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS != 0 {
+                "yes"
+            } else {
+                "no"
+            }
+            .to_owned(),
         ]);
         let _ = table.add_row(vec![
             "Raw value".to_owned(),


### PR DESCRIPTION
Capability bit positions were hand-written as raw `1 << N` literals in
the meroctl CLI encode/decode paths (cli/group/members.rs,
cli/group/settings.rs, output/groups.rs) and one governance-store test.
These could silently drift from the canonical definitions in
`calimero_context_config::MemberCapabilities` and corrupt capabilities.

Replace all hand-written bit positions with references to the existing
`MemberCapabilities` constants, which are already the single source of
truth used by the governance store's permission checks. No behavioral
change — output and encoding are identical.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018TBbXpokzNamujdmXq1KRd