### PR TITLE
fix(runtime): guard encode_index_pairs against u32 length truncation

### DIFF
--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -543,7 +543,7 @@ impl VMHostFunctions<'_> {
             "storage_index_scan"
         );
 
-        let encoded = encode_index_pairs(&pairs);
+        let encoded = encode_index_pairs(&pairs)?;
         self.with_logic_mut(|logic| logic.registers.set(logic.limits, register_id, encoded))?;
         Ok(1)
     }
@@ -581,7 +581,7 @@ impl VMHostFunctions<'_> {
             "storage_index_last"
         );
 
-        let encoded = encode_index_pairs(&pairs);
+        let encoded = encode_index_pairs(&pairs)?;
         self.with_logic_mut(|logic| logic.registers.set(logic.limits, register_id, encoded))?;
         Ok(1)
     }
@@ -590,16 +590,19 @@ impl VMHostFunctions<'_> {
 /// Encode ordered-index scan results into the length-prefixed wire format the
 /// guest (`calimero_sdk::env`) decodes: `count:u32`, then per pair
 /// `key_len:u32, key, value_len:u32, value` — all little-endian.
-fn encode_index_pairs(pairs: &[(Vec<u8>, Vec<u8>)]) -> Vec<u8> {
+fn encode_index_pairs(pairs: &[(Vec<u8>, Vec<u8>)]) -> VMLogicResult<Vec<u8>> {
     let mut out = Vec::new();
-    out.extend_from_slice(&(pairs.len() as u32).to_le_bytes());
+    let count = u32::try_from(pairs.len()).map_err(|_| HostError::IntegerOverflow)?;
+    out.extend_from_slice(&count.to_le_bytes());
     for (key, value) in pairs {
-        out.extend_from_slice(&(key.len() as u32).to_le_bytes());
+        let key_len = u32::try_from(key.len()).map_err(|_| HostError::IntegerOverflow)?;
+        out.extend_from_slice(&key_len.to_le_bytes());
         out.extend_from_slice(key);
-        out.extend_from_slice(&(value.len() as u32).to_le_bytes());
+        let value_len = u32::try_from(value.len()).map_err(|_| HostError::IntegerOverflow)?;
+        out.extend_from_slice(&value_len.to_le_bytes());
         out.extend_from_slice(value);
     }
-    out
+    Ok(out)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Replace `len() as u32` casts with `u32::try_from(...).map_err(IntegerOverflow)`
so a future storage-limit bump that allows lengths past u32::MAX surfaces an
error instead of silently corrupting the length prefixes in the wire format.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016Ess2FvLzJZHzQu9tSsjHJ