### PR TITLE
fix(governance-store): validate namespace_id before side effects in apply_signed_op

### DIFF
--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -162,6 +162,14 @@ impl<'a> NamespaceGovernance<'a> {
         // idempotency guard's invariant ("op in the log ⟹ its head advance
         // already ran") intact: a wrong-namespace op is rejected before it can
         // touch anything.
+        //
+        // The public free-function entry points are safe by construction —
+        // `apply_signed_namespace_op_at_cut` builds the `NamespaceGovernance`
+        // handle with `op.namespace_id`, and the publisher path
+        // (`publish_post_gate`) signs with `self.namespace_id` — so this guard
+        // is dormant for them and exists to defend against direct misuse of the
+        // struct API (`NamespaceGovernance::new(store, X).apply_signed_op(op)`
+        // with `op.namespace_id != X`).
         if op.namespace_id != self.namespace_id {
             return Err(eyre::eyre!(
                 "namespace mismatch in apply_signed_op: handle={}, op={}",

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -153,6 +153,23 @@ impl<'a> NamespaceGovernance<'a> {
     }
 
     pub fn apply_signed_op(&self, op: &SignedNamespaceOp) -> EyreResult<ApplyNamespaceOpResult> {
+        // Validate the op's namespace BEFORE any side effects. The op-log write
+        // (`store_signed_operation`) already rejects a namespace mismatch, but
+        // it runs only *after* `advance_dag_head` and the per-op-kind side
+        // effects below — so a mismatched op would mutate state and advance the
+        // DAG head, then fail at store time, leaving the head advanced for an op
+        // that was never logged (and never can be). Checking here keeps the
+        // idempotency guard's invariant ("op in the log ⟹ its head advance
+        // already ran") intact: a wrong-namespace op is rejected before it can
+        // touch anything.
+        if op.namespace_id != self.namespace_id {
+            return Err(eyre::eyre!(
+                "namespace mismatch in apply_signed_op: handle={}, op={}",
+                hex::encode(self.namespace_id),
+                hex::encode(op.namespace_id)
+            ));
+        }
+
         op.verify_signature()
             .map_err(|e| eyre::eyre!("signed namespace op: {e}"))?;
 


### PR DESCRIPTION
apply_signed_op ran the per-op-kind side effects and advanced the DAG
head before the namespace_id was checked at store time in
store_signed_operation. A wrong-namespace op would mutate state and
advance the head, then fail at the store write, leaving the head
advanced for an op that was never logged.

Validate op.namespace_id at the top of apply_signed_op so a mismatched
op is rejected before any side effects, preserving the idempotency
guard's invariant that an op in the log implies its head advance ran.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dn8nTqykkewYZWwvya9gPz