### PR TITLE
test(governance-store): cover governance-op rejection paths

### DIFF
--- a/crates/governance-store/src/errors.rs
+++ b/crates/governance-store/src/errors.rs
@@ -52,6 +52,7 @@
 //! the variant matches); callers that just bubble errors stay unchanged.
 //! See #2305 issue discussion.
 
+use calimero_primitives::context::GroupMemberRole;
 use thiserror::Error;
 
 /// Errors raised by `MembershipRepository` and the membership-policy
@@ -158,6 +159,25 @@ pub enum MembershipError {
     /// Only the current owner can transfer ownership of a group.
     #[error("only the current owner of group {0} can transfer ownership")]
     OnlyOwnerCanTransfer(String),
+
+    /// `TransferOwnership` target is a member but not an Admin. The
+    /// successor must already hold the Admin tier — Owner carries all
+    /// Admin privileges, so a plain-Member owner would be a confusing
+    /// "owner with reduced capabilities". Promote, then transfer.
+    #[error(
+        "new owner of group {group} must be an Admin, but is currently {role:?}; \
+         promote them to Admin before transferring ownership"
+    )]
+    TransferTargetNotAdmin {
+        group: String,
+        role: GroupMemberRole,
+    },
+
+    /// `TransferOwnership` target is not a member of the group at all —
+    /// transferring would create an absentee owner. Invite and promote
+    /// them first.
+    #[error("new owner is not a member of group {0}; invite and promote them first")]
+    TransferTargetNotMember(String),
 
     /// Only the current owner can delete a group. Distinct from
     /// [`OnlyOwnerCanTransfer`] so callers can route delete-rejection

--- a/crates/governance-store/src/ops/group/transfer_ownership.rs
+++ b/crates/governance-store/src/ops/group/transfer_ownership.rs
@@ -36,16 +36,13 @@ pub(crate) fn apply(ctx: &mut GroupApplyCtx<'_>, new_owner: &PublicKey) -> EyreR
     //     promote then transfer if needed.
     match MembershipRepository::new(store).role_of(group_id, new_owner)? {
         Some(GroupMemberRole::Admin) => {}
-        Some(other) => bail!(
-            "new owner of group {} must be an Admin, but is currently {:?}; \
-             promote them to Admin before transferring ownership",
-            hex::encode(group_id.to_bytes()),
-            other
-        ),
-        None => bail!(
-            "new owner is not a member of group {}; invite and promote them first",
-            hex::encode(group_id.to_bytes())
-        ),
+        Some(other) => bail!(MembershipError::TransferTargetNotAdmin {
+            group: hex::encode(group_id.to_bytes()),
+            role: other,
+        }),
+        None => bail!(MembershipError::TransferTargetNotMember(hex::encode(
+            group_id.to_bytes()
+        ))),
     }
 
     meta.owner_identity = *new_owner;

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -1063,6 +1063,300 @@ fn apply_local_signed_group_op_rejects_last_admin_removal() {
 }
 
 // -----------------------------------------------------------------------
+// Governance-op rejection paths
+//
+// These pin the authorization gates of the per-op apply handlers
+// (`ops/group/transfer_ownership.rs`, `context_capability_{granted,
+// revoked}.rs`). There is no top-level admin gate in
+// `apply_local_signed_group_op` — every op carries its own check — so
+// these tests drive the full signed-op path and assert both that the
+// op is rejected AND that it is rejected for the intended reason.
+// -----------------------------------------------------------------------
+
+/// `TransferOwnership` is owner-only. An admin who is *not* the current
+/// owner cannot transfer ownership, even though they otherwise pass
+/// every member-management gate.
+#[test]
+fn transfer_ownership_rejects_non_owner_signer() {
+    use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let mut rng = OsRng;
+    let store = test_store();
+    let gid = test_group_id();
+    let gid_bytes = gid.to_bytes();
+
+    let owner_sk = PrivateKey::random(&mut rng);
+    let owner_pk = owner_sk.public_key();
+    // A second admin — privileged, but not the owner.
+    let other_admin_sk = PrivateKey::random(&mut rng);
+    let other_admin_pk = other_admin_sk.public_key();
+    // A third admin standing by as a valid successor, so the op fails on
+    // the owner check rather than the new-owner-role check.
+    let successor_pk = PrivateKey::random(&mut rng).public_key();
+
+    MetaRepository::new(&store)
+        .save(&gid, &sample_meta_with_admin(owner_pk))
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&gid, &owner_pk, GroupMemberRole::Admin)
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&gid, &other_admin_pk, GroupMemberRole::Admin)
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&gid, &successor_pk, GroupMemberRole::Admin)
+        .unwrap();
+
+    let op = SignedGroupOp::sign(
+        &other_admin_sk,
+        gid_bytes,
+        vec![],
+        1,
+        GroupOp::TransferOwnership {
+            new_owner: successor_pk,
+        },
+    )
+    .unwrap();
+    let err = apply_local_signed_group_op(&store, &op).unwrap_err();
+    assert!(
+        err.to_string().contains("can transfer ownership"),
+        "expected owner-only rejection, got: {err}"
+    );
+    // Ownership is unchanged.
+    assert_eq!(
+        MetaRepository::new(&store)
+            .load(&gid)
+            .unwrap()
+            .unwrap()
+            .owner_identity,
+        owner_pk
+    );
+}
+
+/// `TransferOwnership` requires the successor to already be an Admin.
+/// Transferring to a plain Member is rejected (the handler refuses to
+/// create an "owner with reduced capabilities" state).
+#[test]
+fn transfer_ownership_rejects_new_owner_not_admin() {
+    use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let mut rng = OsRng;
+    let store = test_store();
+    let gid = test_group_id();
+    let gid_bytes = gid.to_bytes();
+
+    let owner_sk = PrivateKey::random(&mut rng);
+    let owner_pk = owner_sk.public_key();
+    let plain_member_pk = PrivateKey::random(&mut rng).public_key();
+
+    MetaRepository::new(&store)
+        .save(&gid, &sample_meta_with_admin(owner_pk))
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&gid, &owner_pk, GroupMemberRole::Admin)
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&gid, &plain_member_pk, GroupMemberRole::Member)
+        .unwrap();
+
+    let op = SignedGroupOp::sign(
+        &owner_sk,
+        gid_bytes,
+        vec![],
+        1,
+        GroupOp::TransferOwnership {
+            new_owner: plain_member_pk,
+        },
+    )
+    .unwrap();
+    let err = apply_local_signed_group_op(&store, &op).unwrap_err();
+    assert!(
+        err.to_string().contains("must be an Admin"),
+        "expected new-owner-not-admin rejection, got: {err}"
+    );
+    assert_eq!(
+        MetaRepository::new(&store)
+            .load(&gid)
+            .unwrap()
+            .unwrap()
+            .owner_identity,
+        owner_pk
+    );
+}
+
+/// `TransferOwnership` rejects a successor who is not a member of the
+/// group at all (would otherwise create an absentee owner).
+#[test]
+fn transfer_ownership_rejects_new_owner_not_member() {
+    use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let mut rng = OsRng;
+    let store = test_store();
+    let gid = test_group_id();
+    let gid_bytes = gid.to_bytes();
+
+    let owner_sk = PrivateKey::random(&mut rng);
+    let owner_pk = owner_sk.public_key();
+    let outsider_pk = PrivateKey::random(&mut rng).public_key();
+
+    MetaRepository::new(&store)
+        .save(&gid, &sample_meta_with_admin(owner_pk))
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&gid, &owner_pk, GroupMemberRole::Admin)
+        .unwrap();
+
+    let op = SignedGroupOp::sign(
+        &owner_sk,
+        gid_bytes,
+        vec![],
+        1,
+        GroupOp::TransferOwnership {
+            new_owner: outsider_pk,
+        },
+    )
+    .unwrap();
+    let err = apply_local_signed_group_op(&store, &op).unwrap_err();
+    assert!(
+        err.to_string().contains("not a member"),
+        "expected new-owner-not-member rejection, got: {err}"
+    );
+    assert_eq!(
+        MetaRepository::new(&store)
+            .load(&gid)
+            .unwrap()
+            .unwrap()
+            .owner_identity,
+        owner_pk
+    );
+}
+
+/// `ContextCapabilityGranted` is gated by `require_manage_members`. A
+/// plain member without the `MANAGE_MEMBERS` capability (and not an
+/// admin) cannot grant a context capability — and the grant must not be
+/// written.
+#[test]
+fn context_capability_granted_rejects_unauthorized_signer() {
+    use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let mut rng = OsRng;
+    let store = test_store();
+    let gid = test_group_id();
+    let gid_bytes = gid.to_bytes();
+
+    let admin_sk = PrivateKey::random(&mut rng);
+    let admin_pk = admin_sk.public_key();
+    let member_sk = PrivateKey::random(&mut rng);
+    let member_pk = member_sk.public_key();
+    let context_id = ContextId::from([0x44; 32]);
+    let target_pk = PrivateKey::random(&mut rng).public_key();
+
+    MetaRepository::new(&store)
+        .save(&gid, &sample_meta_with_admin(admin_pk))
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&gid, &admin_pk, GroupMemberRole::Admin)
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&gid, &member_pk, GroupMemberRole::Member)
+        .unwrap();
+
+    let op = SignedGroupOp::sign(
+        &member_sk,
+        gid_bytes,
+        vec![],
+        1,
+        GroupOp::ContextCapabilityGranted {
+            context_id,
+            member: target_pk,
+            capability: 0b1,
+        },
+    )
+    .unwrap();
+    let err = apply_local_signed_group_op(&store, &op).unwrap_err();
+    assert!(
+        err.to_string().contains("grant context capability"),
+        "expected unauthorized-signer rejection, got: {err}"
+    );
+    // Nothing was granted.
+    assert_eq!(
+        CapabilitiesRepository::new(&store)
+            .context_member_capability(&gid, &context_id, &target_pk)
+            .unwrap(),
+        None
+    );
+}
+
+/// `ContextCapabilityRevoked` shares the same `require_manage_members`
+/// gate. A plain member cannot revoke a context capability, and an
+/// existing grant must survive the rejected op untouched.
+#[test]
+fn context_capability_revoked_rejects_unauthorized_signer() {
+    use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let mut rng = OsRng;
+    let store = test_store();
+    let gid = test_group_id();
+    let gid_bytes = gid.to_bytes();
+
+    let admin_sk = PrivateKey::random(&mut rng);
+    let admin_pk = admin_sk.public_key();
+    let member_sk = PrivateKey::random(&mut rng);
+    let member_pk = member_sk.public_key();
+    let context_id = ContextId::from([0x55; 32]);
+    let target_pk = PrivateKey::random(&mut rng).public_key();
+
+    MetaRepository::new(&store)
+        .save(&gid, &sample_meta_with_admin(admin_pk))
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&gid, &admin_pk, GroupMemberRole::Admin)
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&gid, &member_pk, GroupMemberRole::Member)
+        .unwrap();
+    // Pre-existing grant that the unauthorized revoke must not disturb.
+    CapabilitiesRepository::new(&store)
+        .set_context_member(&gid, &context_id, &target_pk, 0b11)
+        .unwrap();
+
+    let op = SignedGroupOp::sign(
+        &member_sk,
+        gid_bytes,
+        vec![],
+        1,
+        GroupOp::ContextCapabilityRevoked {
+            context_id,
+            member: target_pk,
+            capability: 0b1,
+        },
+    )
+    .unwrap();
+    let err = apply_local_signed_group_op(&store, &op).unwrap_err();
+    assert!(
+        err.to_string().contains("revoke context capability"),
+        "expected unauthorized-signer rejection, got: {err}"
+    );
+    // The grant is untouched — the rejected op wrote nothing.
+    assert_eq!(
+        CapabilitiesRepository::new(&store)
+            .context_member_capability(&gid, &context_id, &target_pk)
+            .unwrap(),
+        Some(0b11)
+    );
+}
+
+// -----------------------------------------------------------------------
 // Signing key tests
 // -----------------------------------------------------------------------
 

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -1121,8 +1121,11 @@ fn transfer_ownership_rejects_non_owner_signer() {
     .unwrap();
     let err = apply_local_signed_group_op(&store, &op).unwrap_err();
     assert!(
-        err.to_string().contains("can transfer ownership"),
-        "expected owner-only rejection, got: {err}"
+        matches!(
+            err.downcast_ref::<MembershipError>(),
+            Some(MembershipError::OnlyOwnerCanTransfer(_))
+        ),
+        "expected OnlyOwnerCanTransfer, got: {err}"
     );
     // Ownership is unchanged.
     assert_eq!(
@@ -1175,8 +1178,14 @@ fn transfer_ownership_rejects_new_owner_not_admin() {
     .unwrap();
     let err = apply_local_signed_group_op(&store, &op).unwrap_err();
     assert!(
-        err.to_string().contains("must be an Admin"),
-        "expected new-owner-not-admin rejection, got: {err}"
+        matches!(
+            err.downcast_ref::<MembershipError>(),
+            Some(MembershipError::TransferTargetNotAdmin {
+                role: GroupMemberRole::Member,
+                ..
+            })
+        ),
+        "expected TransferTargetNotAdmin(Member), got: {err}"
     );
     assert_eq!(
         MetaRepository::new(&store)
@@ -1224,8 +1233,11 @@ fn transfer_ownership_rejects_new_owner_not_member() {
     .unwrap();
     let err = apply_local_signed_group_op(&store, &op).unwrap_err();
     assert!(
-        err.to_string().contains("not a member"),
-        "expected new-owner-not-member rejection, got: {err}"
+        matches!(
+            err.downcast_ref::<MembershipError>(),
+            Some(MembershipError::TransferTargetNotMember(_))
+        ),
+        "expected TransferTargetNotMember, got: {err}"
     );
     assert_eq!(
         MetaRepository::new(&store)
@@ -1283,8 +1295,12 @@ fn context_capability_granted_rejects_unauthorized_signer() {
     .unwrap();
     let err = apply_local_signed_group_op(&store, &op).unwrap_err();
     assert!(
-        err.to_string().contains("grant context capability"),
-        "expected unauthorized-signer rejection, got: {err}"
+        matches!(
+            err.downcast_ref::<CapabilitiesError>(),
+            Some(CapabilitiesError::Unauthorized { operation, .. })
+                if operation == "grant context capability"
+        ),
+        "expected Unauthorized(grant context capability), got: {err}"
     );
     // Nothing was granted.
     assert_eq!(
@@ -1344,8 +1360,12 @@ fn context_capability_revoked_rejects_unauthorized_signer() {
     .unwrap();
     let err = apply_local_signed_group_op(&store, &op).unwrap_err();
     assert!(
-        err.to_string().contains("revoke context capability"),
-        "expected unauthorized-signer rejection, got: {err}"
+        matches!(
+            err.downcast_ref::<CapabilitiesError>(),
+            Some(CapabilitiesError::Unauthorized { operation, .. })
+                if operation == "revoke context capability"
+        ),
+        "expected Unauthorized(revoke context capability), got: {err}"
     );
     // The grant is untouched — the rejected op wrote nothing.
     assert_eq!(


### PR DESCRIPTION
Add negative-path unit tests for three per-op apply handlers whose
authorization gates were previously untested:

- transfer_ownership: reject a non-owner signer, a successor who is a
  plain Member (not Admin), and a successor who is not a group member.
- context_capability_granted / context_capability_revoked: reject a
  signer lacking MANAGE_MEMBERS (a plain member), asserting the store
  is left untouched (no grant written / existing grant preserved).

Each test drives the full signed-op path (apply_local_signed_group_op)
and asserts both rejection and the intended rejection reason, since
authorization lives entirely in the per-op handlers (no top-level gate).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RQnhNsCjGBeh5Hh45gbeHZ