### PR TITLE
fix(store): remove aliasing UB in FusedIter::next

### DIFF
--- a/crates/store/src/iter.rs
+++ b/crates/store/src/iter.rs
@@ -1,9 +1,8 @@
 use core::convert::Infallible;
+use core::fmt;
 use core::fmt::{Debug, Formatter};
-use core::hint::unreachable_unchecked;
 use core::marker::PhantomData;
-use core::mem::{replace, transmute};
-use core::{fmt, ptr};
+use core::mem::transmute;
 
 use calimero_primitives::reflect::Reflect;
 use eyre::{Report, Result as EyreResult};
@@ -460,44 +459,43 @@ impl<'a> TryIntoValue<'a> for Unstructured {
 }
 
 #[derive(Debug)]
-enum FusedIter<I> {
-    Active(I),
-    Interregnum,
-    Expended(I),
+struct FusedIter<I> {
+    iter: I,
+    /// Set once the underlying iterator is exhausted, so subsequent
+    /// `seek`/`next`/`read` calls don't touch the spent iterator.
+    expended: bool,
 }
 
 impl<I: DBIter> FusedIter<I> {
     fn seek(&mut self, key: Key<'_>) -> EyreResult<Option<Key<'_>>> {
-        if let Self::Active(iter) = self {
-            return iter.seek(key);
+        if self.expended {
+            return Ok(None);
         }
 
-        Ok(None)
+        self.iter.seek(key)
     }
 
     fn next(&mut self) -> EyreResult<Option<Key<'_>>> {
-        let this = unsafe { &mut *ptr::from_mut::<Self>(self) };
-
-        if let Self::Active(iter) = this {
-            if let Some(key) = iter.next()? {
+        if !self.expended {
+            // `self.iter` and `self.expended` are disjoint fields, so returning
+            // a key borrowed from `self.iter` in one branch while writing
+            // `self.expended` in the other is sound without any reborrowing.
+            if let Some(key) = self.iter.next()? {
                 return Ok(Some(key));
             }
 
-            match replace(self, Self::Interregnum) {
-                Self::Active(iter) => *self = Self::Expended(iter),
-                Self::Expended(_) | Self::Interregnum => unsafe { unreachable_unchecked() },
-            }
+            self.expended = true;
         }
 
         Ok(None)
     }
 
     fn read(&self) -> EyreResult<Option<Value<'_>>> {
-        if let Self::Active(iter) = self {
-            return iter.read().map(Some);
+        if self.expended {
+            return Ok(None);
         }
 
-        Ok(None)
+        self.iter.read().map(Some)
     }
 }
 
@@ -506,7 +504,13 @@ pub struct IterPair<A, B>(FusedIter<A>, B);
 
 impl<A, B> IterPair<A, B> {
     pub const fn new(iter: A, other: B) -> Self {
-        Self(FusedIter::Active(iter), other)
+        Self(
+            FusedIter {
+                iter,
+                expended: false,
+            },
+            other,
+        )
     }
 }
 


### PR DESCRIPTION
FusedIter::next created a second `&mut Self` via
`&mut *ptr::from_mut(self)` and kept it (and a borrow derived from it)
live across a `replace(self, ...)` call, producing two aliasing mutable
references — undefined behavior. The reborrow existed only to work around
the borrow checker's inability to prove that the exhaustion transition in
the `None` branch doesn't conflict with the key returned in the `Some`
branch (NLL problem case #3).

Replace the `Active`/`Interregnum`/`Expended` enum with a struct holding
the iterator and an `expended` flag. The transition then becomes a write
to the disjoint `expended` field, which the borrow checker accepts without
any reborrowing — the same split-borrow pattern already used by the
sibling `Iter::next`. This drops the unsafe block entirely along with the
now-unused `ptr`, `replace`, and `unreachable_unchecked` imports.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ENkAQmget6Yusiefe9TUXx