### PR TITLE
fix(primitives): gate PrivateKey raw access and zeroize via derive

### DIFF
--- a/crates/context/primitives/src/client/crypto.rs
+++ b/crates/context/primitives/src/client/crypto.rs
@@ -68,7 +68,7 @@ impl ContextClient {
         handle.put(
             &key::ContextIdentity::new(ContextId::zero(), public_key),
             &types::ContextIdentity {
-                private_key: Some(*private_key),
+                private_key: Some(*private_key.as_bytes()),
                 sender_key: None,
             },
         )?;
@@ -142,10 +142,18 @@ impl ContextClient {
             );
         };
 
-        identity.sender_key = new_identity.sender_key.as_deref().copied();
+        identity.sender_key = new_identity
+            .sender_key
+            .as_ref()
+            .map(PrivateKey::as_bytes)
+            .copied();
         // TODO: what we are updating the private key for? if we got here, the datastore already
         // has the `identity.private_key` set.
-        identity.private_key = new_identity.private_key.as_deref().copied();
+        identity.private_key = new_identity
+            .private_key
+            .as_ref()
+            .map(PrivateKey::as_bytes)
+            .copied();
 
         handle.put(&key, &identity)?;
 

--- a/crates/context/src/auto_follow.rs
+++ b/crates/context/src/auto_follow.rs
@@ -722,7 +722,7 @@ mod tests {
                 .save(&gid, &sample_meta(pk))
                 .expect("save_group_meta");
             NamespaceRepository::new(&store)
-                .store_identity(&gid, &pk, &sk, &[0u8; 32])
+                .store_identity(&gid, &pk, sk.as_bytes(), &[0u8; 32])
                 .expect("store_namespace_identity");
             MembershipRepository::new(&store)
                 .add_member(&gid, &pk, GroupMemberRole::Member)

--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -571,8 +571,8 @@ async fn create_context(
     handle.put(
         &key::ContextIdentity::new(context.id, identity),
         &types::ContextIdentity {
-            private_key: Some(*identity_secret),
-            sender_key: Some(*sender_key),
+            private_key: Some(*identity_secret.as_bytes()),
+            sender_key: Some(*sender_key.as_bytes()),
         },
     )?;
 
@@ -585,7 +585,7 @@ async fn create_context(
     // messages (e.g. RemoveGroupMembers), but the window is small and the
     // worst case is a single context associated with a since-removed member.
     {
-        let sk = PrivateKey::from(*identity_secret);
+        let sk = PrivateKey::from(*identity_secret.as_bytes());
         let report = calimero_governance_store::sign_apply_and_publish(
             &datastore,
             &node_client,
@@ -608,7 +608,7 @@ async fn create_context(
     node_client.subscribe_namespace(group_id.to_bytes()).await?;
 
     if let Some(ref name_str) = name {
-        let sk = PrivateKey::from(*identity_secret);
+        let sk = PrivateKey::from(*identity_secret.as_bytes());
         let report = calimero_governance_store::sign_apply_and_publish(
             &datastore,
             &node_client,

--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -585,13 +585,12 @@ async fn create_context(
     // messages (e.g. RemoveGroupMembers), but the window is small and the
     // worst case is a single context associated with a since-removed member.
     {
-        let sk = PrivateKey::from(*identity_secret.as_bytes());
         let report = calimero_governance_store::sign_apply_and_publish(
             &datastore,
             &node_client,
             &ack_router,
             &group_id,
-            &sk,
+            &identity_secret,
             GroupOp::ContextRegistered {
                 context_id: context.id,
                 application_id: context.application_id,
@@ -608,13 +607,12 @@ async fn create_context(
     node_client.subscribe_namespace(group_id.to_bytes()).await?;
 
     if let Some(ref name_str) = name {
-        let sk = PrivateKey::from(*identity_secret.as_bytes());
         let report = calimero_governance_store::sign_apply_and_publish(
             &datastore,
             &node_client,
             &ack_router,
             &group_id,
-            &sk,
+            &identity_secret,
             GroupOp::ContextMetadataSet {
                 context_id: context.id,
                 name: Some(name_str.clone()),

--- a/crates/context/src/handlers/issue_ownership_proof.rs
+++ b/crates/context/src/handlers/issue_ownership_proof.rs
@@ -340,7 +340,7 @@ mod tests {
             .add_member(&group_id, &signing_pub, GroupMemberRole::Admin)
             .expect("add admin");
         SigningKeysRepository::new(&store)
-            .store_key(&group_id, &signing_pub, &signing_priv)
+            .store_key(&group_id, &signing_pub, signing_priv.as_bytes())
             .expect("store signing key");
         calimero_governance_store::register_context_in_group(&store, &group_id, &context_id)
             .expect("register context");
@@ -503,7 +503,7 @@ mod tests {
             .add_member(&root, &signing_pub, GroupMemberRole::Admin)
             .expect("add admin");
         SigningKeysRepository::new(&store)
-            .store_key(&root, &signing_pub, &signing_priv)
+            .store_key(&root, &signing_pub, signing_priv.as_bytes())
             .expect("store signing key");
 
         // Context lives in `child`, which is nested under `root`.
@@ -591,7 +591,7 @@ mod tests {
             .add_member(&group_id, &node_identity, GroupMemberRole::Admin)
             .expect("add admin");
         SigningKeysRepository::new(&store)
-            .store_key(&group_id, &node_identity, &real_priv)
+            .store_key(&group_id, &node_identity, real_priv.as_bytes())
             .expect("store signing key keyed by node_identity");
         calimero_governance_store::register_context_in_group(&store, &group_id, &context_id)
             .expect("register context");
@@ -644,7 +644,7 @@ mod tests {
             .add_member(&group_id, &signing_pub, GroupMemberRole::Admin)
             .expect("add admin");
         SigningKeysRepository::new(&store)
-            .store_key(&group_id, &signing_pub, &signing_priv)
+            .store_key(&group_id, &signing_pub, signing_priv.as_bytes())
             .expect("store signing key");
 
         let out = build_namespace_ownership_proof(
@@ -722,7 +722,7 @@ mod tests {
             .add_member(&child, &signing_pub, GroupMemberRole::Admin)
             .expect("add admin at child");
         SigningKeysRepository::new(&store)
-            .store_key(&child, &signing_pub, &signing_priv)
+            .store_key(&child, &signing_pub, signing_priv.as_bytes())
             .expect("store signing key at child");
 
         // `child` is nested under the namespace root `root`, so

--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -471,7 +471,7 @@ impl Handler<JoinGroupRequest> for ContextManager {
                                     handle.put(
                                         &ci_key,
                                         &calimero_store::types::ContextIdentity {
-                                            private_key: Some(*sk),
+                                            private_key: Some(*sk.as_bytes()),
                                             sender_key: None,
                                         },
                                     )?;

--- a/crates/context/src/handlers/list_namespaces.rs
+++ b/crates/context/src/handlers/list_namespaces.rs
@@ -226,7 +226,7 @@ mod tests {
             .store_identity(
                 &group_id_with_membership,
                 &node_identity_pk,
-                &node_identity_sk,
+                node_identity_sk.as_bytes(),
                 &sender_key,
             )
             .expect("store namespace identity for first namespace");
@@ -234,7 +234,7 @@ mod tests {
             .store_identity(
                 &group_id_without_membership,
                 &node_identity_pk,
-                &node_identity_sk,
+                node_identity_sk.as_bytes(),
                 &sender_key,
             )
             .expect("store namespace identity for second namespace");

--- a/crates/context/src/self_purge.rs
+++ b/crates/context/src/self_purge.rs
@@ -2806,7 +2806,7 @@ mod tests {
             .add_member(&ns_gid, &owner_pk, GroupMemberRole::Admin)
             .expect("add owner admin");
         NamespaceRepository::new(&store)
-            .store_identity(&ns_gid, &member_pk, &member_sk, &[0u8; 32])
+            .store_identity(&ns_gid, &member_pk, member_sk.as_bytes(), &[0u8; 32])
             .expect("store our ns identity");
 
         // The stranded subgroup + its key + the context it registers.

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -1669,8 +1669,8 @@ fn group_member_with_keys_persists_and_retrieves() {
             &gid,
             &member_pk,
             GroupMemberRole::Member,
-            Some(*member_sk),
-            Some(*sender_sk),
+            Some(*member_sk.as_bytes()),
+            Some(*sender_sk.as_bytes()),
         )
         .unwrap();
 
@@ -1686,8 +1686,8 @@ fn group_member_with_keys_persists_and_retrieves() {
         .expect("member value should exist");
 
     assert_eq!(value.role, GroupMemberRole::Member);
-    assert_eq!(value.private_key, Some(*member_sk));
-    assert_eq!(value.sender_key, Some(*sender_sk));
+    assert_eq!(value.private_key, Some(*member_sk.as_bytes()));
+    assert_eq!(value.sender_key, Some(*sender_sk.as_bytes()));
 }
 
 #[test]

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -34,7 +34,7 @@ impl SharedKey {
             .ok_or(SharedKeyError::InvalidPublicKey)?;
 
         Ok(Self {
-            key: (SigningKey::from_bytes(sk).to_scalar() * decompressed)
+            key: (SigningKey::from_bytes(sk.as_bytes()).to_scalar() * decompressed)
                 .compress()
                 .to_bytes(),
         })
@@ -42,7 +42,9 @@ impl SharedKey {
 
     #[must_use]
     pub fn from_sk(sk: &PrivateKey) -> Self {
-        Self { key: **sk }
+        Self {
+            key: *sk.as_bytes(),
+        }
     }
 
     #[must_use]

--- a/crates/governance-store/src/namespace/core.rs
+++ b/crates/governance-store/src/namespace/core.rs
@@ -602,14 +602,19 @@ impl<'a> NamespaceRepository<'a> {
         let public_key = private_key.public_key();
         let sender_key = PrivateKey::random(&mut OsRng);
 
-        self.store_identity(&ns_id, &public_key, &private_key, &sender_key)?;
+        self.store_identity(
+            &ns_id,
+            &public_key,
+            private_key.as_bytes(),
+            sender_key.as_bytes(),
+        )?;
 
         Ok(ResolvedNamespaceIdentity {
             namespace_id: ns_id,
             identity: NamespaceIdentityRecord {
                 public_key,
-                private_key: *private_key,
-                sender_key: *sender_key,
+                private_key: *private_key.as_bytes(),
+                sender_key: *sender_key.as_bytes(),
             },
         })
     }

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -5119,7 +5119,7 @@ fn curative_sweep_redrives_stranded_context() {
     // This receiver node's namespace identity — makes the namespace a "known"
     // one for `iter_identities`/`known_namespace_identities`.
     NamespaceRepository::new(&store)
-        .store_identity(&ns_gid, &member_pk, &member_sk, &[0u8; 32])
+        .store_identity(&ns_gid, &member_pk, member_sk.as_bytes(), &[0u8; 32])
         .unwrap();
 
     // ---- The stranded subgroup: pick id + mint its key ---------------------

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -2027,8 +2027,8 @@ fn auto_group_node_identity_is_admin_member() {
             &auto_group_id,
             &node_pk,
             GroupMemberRole::Admin,
-            Some(*node_sk),
-            Some(*sender_key),
+            Some(*node_sk.as_bytes()),
+            Some(*sender_key.as_bytes()),
         )
         .unwrap();
 
@@ -3183,7 +3183,7 @@ fn member_added_after_remove_restores_context_identity_for_local_rejoiner() {
     );
     let member_sk = PrivateKey::random(&mut rng);
     let member_pk = member_sk.public_key();
-    let member_sk_bytes = *member_sk;
+    let member_sk_bytes = *member_sk.as_bytes();
     NamespaceRepository::new(&store)
         .store_identity(&gid, &member_pk, &member_sk_bytes, &[0u8; 32])
         .unwrap();
@@ -3310,7 +3310,7 @@ fn member_added_after_remove_restores_context_identity_for_subgroup_with_real_na
     // the namespace identity from there.
     let member_sk = PrivateKey::random(&mut rng);
     let member_pk = member_sk.public_key();
-    let member_sk_bytes: [u8; 32] = *member_sk;
+    let member_sk_bytes: [u8; 32] = *member_sk.as_bytes();
     NamespaceRepository::new(&store)
         .store_identity(&ns_gid, &member_pk, &member_sk_bytes, &[0u8; 32])
         .unwrap();
@@ -3430,7 +3430,7 @@ fn member_joined_open_clears_deny_list_and_restores_context_identity() {
     // not a direct subgroup member (post-leave / post-kick state).
     let member_sk = PrivateKey::random(&mut rng);
     let member_pk = member_sk.public_key();
-    let member_sk_bytes: [u8; 32] = *member_sk;
+    let member_sk_bytes: [u8; 32] = *member_sk.as_bytes();
     MembershipRepository::new(&store)
         .add_member(&ns_gid, &member_pk, GroupMemberRole::Member)
         .unwrap();
@@ -3526,7 +3526,7 @@ fn member_added_does_nothing_for_non_rejoiner_peers() {
 
     // This node IS the admin — its namespace identity is admin_pk, not
     // the rejoiner's pk.
-    let admin_sk_bytes = *admin_sk;
+    let admin_sk_bytes = *admin_sk.as_bytes();
     NamespaceRepository::new(&store)
         .store_identity(&gid, &admin_pk, &admin_sk_bytes, &[0u8; 32])
         .unwrap();
@@ -5916,7 +5916,7 @@ mod auto_follow_tests {
 
         let mut rng = OsRng;
         let admin_sk = PrivateKey::random(&mut rng);
-        let admin_sk_bytes: [u8; 32] = *admin_sk;
+        let admin_sk_bytes: [u8; 32] = *admin_sk.as_bytes();
         let admin_pk = admin_sk.public_key();
 
         let ns_id = [0xA0u8; 32];

--- a/crates/node/src/cascade_dispatch_e2e.rs
+++ b/crates/node/src/cascade_dispatch_e2e.rs
@@ -286,7 +286,7 @@ fn provision_namespace(
     // descendant `save_group_upgrade` writes don't need a per-group
     // signing key.
     SigningKeysRepository::new(store)
-        .store_key(&ns, &admin_pk, admin_sk)
+        .store_key(&ns, &admin_pk, admin_sk.as_bytes())
         .expect("store signing key");
 
     CascadeFixture {
@@ -831,7 +831,7 @@ async fn lazy_upgrade_emits_multi_hop_ladder() {
         UpgradePolicy::LazyOnAccess,
     );
     SigningKeysRepository::new(&node.store)
-        .store_key(&gid, &admin_pk, &admin_sk)
+        .store_key(&gid, &admin_pk, admin_sk.as_bytes())
         .expect("store signing key");
 
     let response = node
@@ -897,7 +897,7 @@ async fn lazy_upgrade_multi_hop_missing_intermediate_rejects_with_floor() {
     );
     register_context_for(&node.store, &gid, ContextId::from([0xC6; 32]), app_id);
     SigningKeysRepository::new(&node.store)
-        .store_key(&gid, &admin_pk, &admin_sk)
+        .store_key(&gid, &admin_pk, admin_sk.as_bytes())
         .expect("store signing key");
 
     let err = node

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -389,7 +389,7 @@ async fn set_member_auto_follow_handler_error_paths() {
     // Admin needs a signing key registered so preflight can resolve one
     // when admin acts as requester.
     calimero_context::group_store::SigningKeysRepository::new(&node.store)
-        .store_key(&gid, &admin_sk.public_key(), &admin_sk)
+        .store_key(&gid, &admin_sk.public_key(), admin_sk.as_bytes())
         .unwrap();
 
     // Case 1: unknown group — preflight bails before the membership
@@ -575,7 +575,7 @@ fn provision_tee_owner_with_sk(
     // identity AND signing key. Without it the handler bails with
     // "node has no configured group identity for TEE admission".
     calimero_context::group_store::NamespaceRepository::new(&node.store)
-        .store_identity(gid, &owner_pk, &owner_sk, &[0u8; 32])
+        .store_identity(gid, &owner_pk, owner_sk.as_bytes(), &[0u8; 32])
         .expect("store_namespace_identity");
 
     // Policy lives on the namespace governance op log; admin-signed.
@@ -1026,7 +1026,7 @@ async fn root_admitted_tee_auto_follows_open_subgroup_context() {
     //    `auto_follow.contexts = true` (set by `add_member` at admission), which
     //    the inheritance fall-through must honor via the root anchor.
     calimero_context::group_store::NamespaceRepository::new(&node.store)
-        .store_identity(&ns_gid, &tee_pk, &tee_sk, &[0u8; 32])
+        .store_identity(&ns_gid, &tee_pk, tee_sk.as_bytes(), &[0u8; 32])
         .expect("re-point namespace identity to the TEE");
 
     // 4) Bind the auto-follow handler to THIS node's store/client. Like
@@ -1277,7 +1277,7 @@ async fn integrated_tee_lifecycle_open_replication_and_scoped_root_cascade() {
     // is the inherited-only TEE (root anchor, no open_sub row) — the path Fix B
     // changed. (See `root_admitted_tee_auto_follows_open_subgroup_context`.)
     calimero_context::group_store::NamespaceRepository::new(&node.store)
-        .store_identity(&ns_gid, &tee_pk, &tee_sk, &[0u8; 32])
+        .store_identity(&ns_gid, &tee_pk, tee_sk.as_bytes(), &[0u8; 32])
         .expect("re-point namespace identity to T");
 
     // Rebind the process-global auto-follow handler to this node's store/client.
@@ -1664,7 +1664,7 @@ async fn born_open_subgroup_no_direct_tee_row_but_inherits_replication() {
     //    subgroup), bind the auto-follow handler, register a context in the
     //    born-Open subgroup, and assert the TEE auto-joins it via inheritance.
     calimero_context::group_store::NamespaceRepository::new(&node.store)
-        .store_identity(&ns_gid, &tee_pk, &tee_sk, &[0u8; 32])
+        .store_identity(&ns_gid, &tee_pk, tee_sk.as_bytes(), &[0u8; 32])
         .expect("re-point namespace identity to the TEE");
 
     calimero_context::auto_follow::shutdown();
@@ -1906,7 +1906,7 @@ async fn restricted_ctx_redriven_after_group_created() {
     // unwraps the `KeyDelivery` envelope with THIS key, so the envelope below
     // must be wrapped for `member_pk`.
     NamespaceRepository::new(&store)
-        .store_identity(&ns_gid, &member_pk, &member_sk, &[0u8; 32])
+        .store_identity(&ns_gid, &member_pk, member_sk.as_bytes(), &[0u8; 32])
         .expect("store receiver namespace identity");
 
     // ---- The Restricted subgroup (NOT yet created on the receiver) -----------
@@ -2136,7 +2136,7 @@ async fn open_ctx_redriven_after_group_created_via_namespace_key() {
         .add_member(&ns_gid, &owner_pk, GroupMemberRole::Admin)
         .expect("add owner as namespace-root admin");
     NamespaceRepository::new(&store)
-        .store_identity(&ns_gid, &member_pk, &member_sk, &[0u8; 32])
+        .store_identity(&ns_gid, &member_pk, member_sk.as_bytes(), &[0u8; 32])
         .expect("store receiver namespace identity");
 
     // ---- The namespace key: the receiver HOLDS it (delivered with its join) --
@@ -2480,7 +2480,7 @@ async fn tee_matrix_restricted_late_join() {
         .add_member(&ns_gid, &owner_pk, GroupMemberRole::Admin)
         .expect("add owner as namespace-root admin");
     NamespaceRepository::new(&store)
-        .store_identity(&ns_gid, &member_pk, &member_sk, &[0u8; 32])
+        .store_identity(&ns_gid, &member_pk, member_sk.as_bytes(), &[0u8; 32])
         .expect("store receiver namespace identity");
 
     // The Restricted subgroup: id + key minted owner-side. The receiver does
@@ -2774,7 +2774,7 @@ async fn drive_open_auto_follow_replication(
     // node's namespace identity; point it at the inherited-only TEE so the
     // inheritance fall-through (root anchor, no subgroup row) is exercised.
     calimero_context::group_store::NamespaceRepository::new(&node.store)
-        .store_identity(ns_gid, tee_pk, tee_sk, &[0u8; 32])
+        .store_identity(ns_gid, tee_pk, tee_sk.as_bytes(), &[0u8; 32])
         .expect("re-point namespace identity to the TEE");
 
     calimero_context::auto_follow::shutdown();

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -20,7 +20,7 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 url = { workspace = true, features = ["serde"] }
-zeroize.workspace = true
+zeroize = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 hex.workspace = true

--- a/crates/primitives/src/identity.rs
+++ b/crates/primitives/src/identity.rs
@@ -6,18 +6,28 @@ use core::str::FromStr;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use zeroize::Zeroize;
 
 use crate::context::ContextId;
 use crate::hash::{Hash, HashError};
 
 use ed25519_dalek::{Signature, SignatureError, Signer, SigningKey, Verifier, VerifyingKey};
 
-#[cfg_attr(
-    feature = "borsh",
-    derive(borsh::BorshDeserialize, borsh::BorshSerialize)
-)]
-pub struct PrivateKey(Hash);
+// NOTE: `PrivateKey` deliberately derives no serialization (Borsh, Serde, …).
+// Serializing would copy the secret into a buffer that is never zeroized,
+// silently defeating the zeroize-on-drop guarantee and making it trivial to
+// persist or transmit the secret. The raw bytes are reachable only through the
+// audited [`PrivateKey::as_bytes`] accessor; storage layers that must persist
+// key material take an explicit `[u8; 32]` copy at a reviewed call site.
+//
+// The inner type is a plain `[u8; 32]` (not `Hash`) so that the derived
+// `ZeroizeOnDrop` can zeroize the secret directly and safely. The previous
+// implementation reached the same goal with a hand-rolled `Drop` that cast a
+// `*mut Hash` to `*mut u8` over `size_of::<Hash>()`; that was fragile — any
+// padding or extra field added to `Hash` would have silently left key material
+// un-zeroized. `#[derive(ZeroizeOnDrop)]` over `[u8; 32]` removes the `unsafe`
+// and tracks the field layout automatically.
+#[derive(zeroize::ZeroizeOnDrop)]
+pub struct PrivateKey([u8; 32]);
 
 impl fmt::Debug for PrivateKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -25,49 +35,32 @@ impl fmt::Debug for PrivateKey {
     }
 }
 
-impl Drop for PrivateKey {
-    fn drop(&mut self) {
-        // Zeroize the key material to prevent it from remaining in memory.
-        //
-        // SAFETY:
-        // - The pointer is valid and properly aligned because it comes from a valid
-        //   mutable reference (`&mut self.0`).
-        // - The size is correct as we use `size_of::<Hash>()` on the actual type.
-        // - We have exclusive access to this memory via `&mut self`.
-        // - Hash doesn't expose `DerefMut` or implement `Zeroize`, so we use pointer
-        //   casting to get a mutable byte slice over the entire structure.
-        unsafe {
-            let hash_ptr = &mut self.0 as *mut Hash as *mut u8;
-            let hash_size = core::mem::size_of::<Hash>();
-            core::slice::from_raw_parts_mut(hash_ptr, hash_size).zeroize();
-        }
-    }
-}
-
 impl From<[u8; 32]> for PrivateKey {
     fn from(id: [u8; 32]) -> Self {
-        Self(id.into())
-    }
-}
-
-impl AsRef<[u8; 32]> for PrivateKey {
-    fn as_ref(&self) -> &[u8; 32] {
-        &self.0
-    }
-}
-
-impl Deref for PrivateKey {
-    type Target = [u8; 32];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+        Self(id)
     }
 }
 
 impl PrivateKey {
+    /// Returns a reference to the raw 32-byte secret key material.
+    ///
+    /// # Security
+    ///
+    /// This is the single audited entry point to the secret bytes. It exists
+    /// for in-place cryptographic use (signing, key agreement) and for the few
+    /// storage layers that must persist an explicit `[u8; 32]` copy. Callers
+    /// MUST NOT log, print, or otherwise leak the returned bytes, and should
+    /// keep any copy as short-lived and tightly scoped as possible — copies
+    /// made out of this reference are not covered by the zeroize-on-drop
+    /// guarantee. Every use should be obvious enough to review on sight.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
     #[must_use]
     pub fn public_key(&self) -> PublicKey {
-        SigningKey::from_bytes(self)
+        SigningKey::from_bytes(self.as_bytes())
             .verifying_key()
             .to_bytes()
             .into()
@@ -83,7 +76,7 @@ impl PrivateKey {
     }
 
     pub fn sign(&self, message: &[u8]) -> Result<Signature, SignatureError> {
-        SigningKey::from_bytes(self).try_sign(message)
+        SigningKey::from_bytes(self.as_bytes()).try_sign(message)
     }
 }
 
@@ -251,13 +244,13 @@ mod tests {
         let mut key = ManuallyDrop::new(PrivateKey::from(secret_bytes));
 
         // Verify the key contains the expected bytes before drop
-        assert_eq!(key.as_ref(), &secret_bytes);
+        assert_eq!(key.as_bytes(), &secret_bytes);
 
         // Get a raw pointer to the key's memory location before dropping
         let key_ptr = &*key as *const PrivateKey as *const u8;
-        let hash_size = core::mem::size_of::<Hash>();
+        let key_size = core::mem::size_of::<PrivateKey>();
 
-        // Manually drop the key, which will call our Drop implementation.
+        // Manually drop the key, which will call the derived Drop implementation.
         // SAFETY: The key was created with ManuallyDrop::new, so we need to
         // manually drop it. After this, the ManuallyDrop wrapper prevents
         // double-drop.
@@ -274,9 +267,9 @@ mod tests {
         // SAFETY: We're reading stack memory that was just zeroized. While this is
         // technically UB (the value has been invalidated by drop), it's acceptable
         // here for verifying the security-critical zeroization behavior.
-        let zeroed = unsafe { core::slice::from_raw_parts(key_ptr, hash_size) };
+        let zeroed = unsafe { core::slice::from_raw_parts(key_ptr, key_size) };
 
-        // Check that the entire Hash structure is zeroed, not just the key bytes
+        // Check that the entire key structure is zeroed, not just part of it
         assert!(
             zeroed.iter().all(|&b| b == 0),
             "Key material was not properly zeroized on drop"

--- a/crates/primitives/src/identity.rs
+++ b/crates/primitives/src/identity.rs
@@ -26,6 +26,11 @@ use ed25519_dalek::{Signature, SignatureError, Signer, SigningKey, Verifier, Ver
 // padding or extra field added to `Hash` would have silently left key material
 // un-zeroized. `#[derive(ZeroizeOnDrop)]` over `[u8; 32]` removes the `unsafe`
 // and tracks the field layout automatically.
+//
+// `Clone` and `Copy` are deliberately NOT derived: either would hand out a copy
+// of the secret that is not tracked by `ZeroizeOnDrop`, reintroducing exactly
+// the leak this type guards against. Code that genuinely needs the bytes goes
+// through `as_bytes` at a reviewed call site.
 #[derive(zeroize::ZeroizeOnDrop)]
 pub struct PrivateKey([u8; 32]);
 

--- a/crates/server/src/admin/handlers/usage.rs
+++ b/crates/server/src/admin/handlers/usage.rs
@@ -244,7 +244,7 @@ mod tests {
             .store_identity(
                 &namespace_id,
                 &node_identity_pk,
-                node_identity_sk,
+                node_identity_sk.as_bytes(),
                 &[0x44; 32],
             )
             .expect("store identity");


### PR DESCRIPTION
Two security issues in `PrivateKey` (crates/primitives/src/identity.rs):

1. Raw bytes were exposed via `Deref<Target=[u8;32]>`, `AsRef<[u8;32]>`
   and a derived `BorshSerialize`/`BorshDeserialize`. Any of these made it
   trivial to copy or serialize the secret into a buffer that is never
   zeroized, silently defeating the zeroize-on-drop guarantee.

   - Drop the blanket `Deref` and `AsRef` impls and the Borsh derives.
   - Gate raw access behind a single audited `as_bytes(&self) -> &[u8; 32]`
     accessor, documented as the one reviewed entry point to the secret.
   - Update all call sites: in-place crypto uses (`SigningKey::from_bytes`,
     `SharedKey`) and the storage layers that persist an explicit `[u8; 32]`
     copy now go through `as_bytes()`.

2. The `Drop` impl zeroized via an `unsafe` cast of `*mut Hash` to `*mut u8`
   over `size_of::<Hash>()`, which would silently miss key material if `Hash`
   ever gained padding or fields.

   - Change the inner type to a plain `[u8; 32]` and `#[derive(ZeroizeOnDrop)]`,
     removing the hand-rolled `unsafe` Drop and tracking field layout
     automatically. Enables zeroize's `derive` feature on calimero-primitives.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014gfW6RgRfT6z5VDPg4dXQW