### PR TITLE
fix(primitives): zeroize local seed buffer in PrivateKey::random

### DIFF
--- a/crates/primitives/src/identity.rs
+++ b/crates/primitives/src/identity.rs
@@ -79,7 +79,13 @@ impl PrivateKey {
 
         csprng.fill_bytes(&mut secret);
 
-        Self::from(secret)
+        let key = Self::from(secret);
+
+        // Zeroize the local copy of the seed so it doesn't linger on the stack
+        // after being moved into the key.
+        secret.zeroize();
+
+        key
     }
 
     pub fn sign(&self, message: &[u8]) -> Result<Signature, SignatureError> {


### PR DESCRIPTION
The local [u8;32] secret buffer was filled with key material and moved
into the PrivateKey, but the stack copy was left un-zeroized. Zeroize it
after constructing the key so the seed does not linger in memory.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W9KHEfpGFsSaJ6XTnHoFoM