### PR TITLE
fix(runtime): scope callback-handler thread-local per execution

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -22,7 +22,7 @@ pub mod store;
 pub use config::{RuntimeConfig, RuntimeLimitsConfig};
 pub use constraint::Constraint;
 use errors::{FunctionCallError, HostError, Location, PanicContext, VMRuntimeError};
-use logic::{Outcome, VMContext, VMLimits, VMLogic, VMLogicError};
+use logic::{CallbackHandlerGuard, Outcome, VMContext, VMLimits, VMLogic, VMLogicError};
 use memory::WasmerTunables;
 use store::Storage;
 
@@ -314,6 +314,13 @@ impl Module {
         context.xcall_origin = xcall_origin.map(|origin| *origin);
 
         let mut logic = VMLogic::new(storage, private_storage, context, &self.limits, node_client);
+
+        // Scope the callback-handler thread-local to this execution. The runtime
+        // reuses OS threads, so without this guard a handler name set while
+        // running one context could leak into a later execution and misattribute
+        // its events. The guard clears any stale value on entry and restores the
+        // prior one on drop (kept until the end of this fn, past `finish`).
+        let _callback_handler_scope = CallbackHandlerGuard::enter();
 
         let mut store = Store::new(self.engine.clone());
 

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -48,7 +48,7 @@ mod imports;
 mod registers;
 
 pub use errors::VMLogicError;
-pub use host_functions::{BlobHandle, Event, XCall};
+pub use host_functions::{BlobHandle, CallbackHandlerGuard, Event, XCall};
 use registers::Registers;
 
 /// A specialized `Result` type for VMLogic operations.

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -95,7 +95,43 @@ pub(super) fn build_runtime_env(
 thread_local! {
     /// The name of the callback handler method to call when emitting events with handlers.
     /// This is set temporarily by the SDK's `emit_with_handler` function and read by the runtime.
+    ///
+    /// The runtime reuses OS threads across executions, so this thread-local must
+    /// never be allowed to outlive the execution that set it: a value left behind
+    /// by a prior execution would be read by [`VMHostFunctions::emit`] during a
+    /// later one and misattribute that event to a handler from a different
+    /// context. [`CallbackHandlerGuard`] scopes it to a single execution.
     static CURRENT_CALLBACK_HANDLER: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+/// RAII guard that scopes [`CURRENT_CALLBACK_HANDLER`] to a single execution.
+///
+/// Entering clears any value left behind on this thread (stashing whatever was
+/// there) and dropping restores it. Because the runtime pools and reuses OS
+/// threads, holding this guard for the duration of an execution guarantees that
+/// a callback-handler name set while running one context can never leak into a
+/// later execution that happens to reuse the same thread. Save-and-restore
+/// (rather than unconditionally clearing) also keeps re-entrant executions
+/// correct: a nested run restores the outer run's value when it finishes.
+#[must_use = "the guard must be held for the duration of the execution"]
+pub struct CallbackHandlerGuard {
+    previous: Option<String>,
+}
+
+impl CallbackHandlerGuard {
+    /// Enters a fresh callback-handler scope for the current execution, clearing
+    /// (and stashing) any value left behind on this thread.
+    pub fn enter() -> Self {
+        let previous = CURRENT_CALLBACK_HANDLER.with(|name| name.borrow_mut().take());
+        Self { previous }
+    }
+}
+
+impl Drop for CallbackHandlerGuard {
+    fn drop(&mut self) {
+        let previous = self.previous.take();
+        CURRENT_CALLBACK_HANDLER.with(|name| *name.borrow_mut() = previous);
+    }
 }
 
 /// Represents a structured event emitted during the execution.
@@ -1128,6 +1164,58 @@ mod tests {
         },
         Cow, VMContext, VMLimits, VMLogic, VMLogicError, DIGEST_SIZE,
     };
+
+    use super::{CallbackHandlerGuard, CURRENT_CALLBACK_HANDLER};
+
+    fn current_handler() -> Option<String> {
+        CURRENT_CALLBACK_HANDLER.with(|name| name.borrow().clone())
+    }
+
+    /// The guard clears any value left behind on the thread when entered, so an
+    /// execution always starts with a fresh (empty) callback handler.
+    #[test]
+    fn test_callback_handler_guard_clears_stale_value_on_enter() {
+        // Simulate a value leaked from a "previous execution" on this thread.
+        CURRENT_CALLBACK_HANDLER.with(|name| *name.borrow_mut() = Some("stale".to_owned()));
+
+        {
+            let _scope = CallbackHandlerGuard::enter();
+            assert_eq!(
+                current_handler(),
+                None,
+                "entering a scope must clear a value left by a prior execution"
+            );
+        }
+    }
+
+    /// The guard restores the previous value on drop, so a re-entrant execution
+    /// does not clobber the outer execution's callback handler.
+    #[test]
+    fn test_callback_handler_guard_restores_previous_on_drop() {
+        let outer = CallbackHandlerGuard::enter();
+        CURRENT_CALLBACK_HANDLER.with(|name| *name.borrow_mut() = Some("outer".to_owned()));
+
+        {
+            // A nested execution enters its own scope...
+            let _inner = CallbackHandlerGuard::enter();
+            assert_eq!(current_handler(), None, "nested scope starts empty");
+            CURRENT_CALLBACK_HANDLER.with(|name| *name.borrow_mut() = Some("inner".to_owned()));
+        }
+
+        // ...and on drop the outer execution's value is back in place.
+        assert_eq!(
+            current_handler(),
+            Some("outer".to_owned()),
+            "dropping the nested scope must restore the outer value"
+        );
+
+        drop(outer);
+        assert_eq!(
+            current_handler(),
+            None,
+            "dropping the outermost scope must leave the thread-local empty"
+        );
+    }
 
     /// Tests the `input()`, `register_len()`, `read_register()` host functions.
     #[test]

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -113,6 +113,16 @@ thread_local! {
 /// later execution that happens to reuse the same thread. Save-and-restore
 /// (rather than unconditionally clearing) also keeps re-entrant executions
 /// correct: a nested run restores the outer run's value when it finishes.
+///
+/// # Usage
+///
+/// Multiple guards on the same thread must be released in strictly nested
+/// (LIFO) order, since each restores the value it observed at `enter()`. Held
+/// as ordinary locals — the way `Module::run` uses it — Rust's LIFO drop order
+/// guarantees this; restoring guards out of order would clobber the saved
+/// value. The value must also actually be held: `#[must_use]` flags the
+/// `enter();`-and-discard mistake, which would drop the guard immediately and
+/// leave nothing scoped.
 #[must_use = "the guard must be held for the duration of the execution"]
 pub struct CallbackHandlerGuard {
     previous: Option<String>,


### PR DESCRIPTION
## Description

This PR fixes a critical bug where callback handler names could leak across executions when the runtime reuses OS threads. The issue occurs because `CURRENT_CALLBACK_HANDLER` is a thread-local that persists across multiple executions on the same thread, potentially causing events from one execution to be misattributed to a handler from a different context.

The fix introduces `CallbackHandlerGuard`, an RAII guard that:
- Clears any stale callback handler value when entering a new execution
- Restores the previous value on drop, preserving correctness for re-entrant executions
- Is scoped to the duration of a single execution in `Module::run`

This ensures that callback handler state cannot leak between executions while maintaining correctness for nested/re-entrant execution scenarios.

## Test plan

Added comprehensive unit tests in `crates/runtime/src/logic/host_functions/system.rs`:
- `test_callback_handler_guard_clears_stale_value_on_enter`: Verifies that entering a guard scope clears values left behind by prior executions
- `test_callback_handler_guard_restores_previous_on_drop`: Verifies that dropping the guard restores the previous value, ensuring re-entrant executions work correctly

These tests validate the save-and-restore mechanism that prevents both inter-execution leakage and intra-execution corruption.

## Wire contract (SDK gate)

- [x] No wire contract changes

## Documentation update

No documentation updates needed — this is an internal runtime fix with no public API changes.

https://claude.ai/code/session_01J7Wyr9fdqiDm9KXUrX66ip