### PR TITLE
fix(store): use T::KIND in Alias::scope instead of hardcoded PublicKey::KIND

### DIFF
--- a/crates/store/src/key/alias.rs
+++ b/crates/store/src/key/alias.rs
@@ -183,7 +183,7 @@ impl Alias {
     pub fn scope<T: Aliasable<Scope: StoreScopeCompat>>(&self) -> Option<T::Scope> {
         let bytes = self.0.as_bytes();
 
-        (bytes[0] == PublicKey::KIND).then_some(())?;
+        (bytes[0] == T::KIND).then_some(())?;
 
         let mut scope = [0; SCOPE_SIZE];
 


### PR DESCRIPTION
## Description

Fixed a bug in `Alias::scope()` where the scope kind check was hardcoded to `PublicKey::KIND` instead of using the generic type parameter `T::KIND`. This caused the method to incorrectly validate aliases for non-PublicKey types.

The change allows the method to properly work with any `Aliasable` type by checking against the correct kind for the generic type being used.

## Test plan

Existing tests should cover this change. The fix ensures that `Alias::scope()` correctly validates aliases for all `Aliasable` types, not just `PublicKey`.

## Wire contract (SDK gate)

N/A - This is an internal store API change with no wire contract implications.

## Documentation update

N/A

https://claude.ai/code/session_01Kb2bva1xjc8NrRcQ5FVbd8