### PR TITLE
fix(storage): propagate fallible reads instead of panicking in WASM path

### DIFF
--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -316,6 +316,22 @@ struct ContextStorageApplier {
     apply_lock_slot: std::sync::Mutex<Option<ContextAtomicKey>>,
 }
 
+impl ContextStorageApplier {
+    /// Lock the apply-lock relay slot, recovering the guard if a prior holder
+    /// panicked.
+    ///
+    /// The slot only ever holds an `Option<ContextAtomicKey>` that every access
+    /// takes or replaces wholesale, so a poisoned guard never exposes a torn
+    /// value. Recovering it (rather than `.expect()`-ing) keeps a transient
+    /// panic in one apply from poisoning the mutex and turning every later
+    /// apply on this context into a crash.
+    fn lock_apply_slot(&self) -> std::sync::MutexGuard<'_, Option<ContextAtomicKey>> {
+        self.apply_lock_slot
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
 #[async_trait::async_trait]
 impl DeltaApplier<Vec<Action>> for ContextStorageApplier {
     async fn apply(&self, delta: &CausalDelta<Vec<Action>>) -> Result<(), ApplyError> {
@@ -425,17 +441,10 @@ impl DeltaApplier<Vec<Action>> for ContextStorageApplier {
             .retain_apply_lock
             .load(std::sync::atomic::Ordering::Acquire);
         let atomic = if retain_lock {
-            Some(
-                match self
-                    .apply_lock_slot
-                    .lock()
-                    .expect("apply_lock_slot poisoned")
-                    .take()
-                {
-                    Some(key) => ContextAtomic::Held(key),
-                    None => ContextAtomic::Lock,
-                },
-            )
+            Some(match self.lock_apply_slot().take() {
+                Some(key) => ContextAtomic::Held(key),
+                None => ContextAtomic::Lock,
+            })
         } else {
             None
         };
@@ -470,10 +479,7 @@ impl DeltaApplier<Vec<Action>> for ContextStorageApplier {
         // completed, so the slot stays empty and the caller commits heads
         // unlocked — safe, because a failed apply advances no heads.
         if retain_lock {
-            *self
-                .apply_lock_slot
-                .lock()
-                .expect("apply_lock_slot poisoned") = outcome.atomic.take();
+            *self.lock_apply_slot() = outcome.atomic.take();
         }
 
         let wasm_elapsed_ms = wasm_start.elapsed().as_secs_f64() * 1000.0;
@@ -1700,12 +1706,7 @@ impl DeltaStore {
             .store(false, std::sync::atomic::Ordering::Release);
         // Take the retained guard (if any apply acquired one) to hold across the
         // `dag_heads` commit below; dropped right after the persist.
-        let batch_apply_lock_guard = self
-            .applier
-            .apply_lock_slot
-            .lock()
-            .expect("apply_lock_slot poisoned")
-            .take();
+        let batch_apply_lock_guard = self.applier.lock_apply_slot().take();
 
         let heads = dag.get_heads();
         let heads_count = heads.len();
@@ -2189,12 +2190,7 @@ impl DeltaStore {
         // committed by then, which is all a concurrent local write needs to
         // observe. While held, the only work is the direct-datastore head
         // persist (no executor re-entry), so holding it cannot deadlock.
-        let apply_lock_guard = self
-            .applier
-            .apply_lock_slot
-            .lock()
-            .expect("apply_lock_slot poisoned")
-            .take();
+        let apply_lock_guard = self.applier.lock_apply_slot().take();
         let result = add_outcome?;
 
         // Update context's dag_heads after the DAG has been updated

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -325,6 +325,12 @@ impl ContextStorageApplier {
     /// value. Recovering it (rather than `.expect()`-ing) keeps a transient
     /// panic in one apply from poisoning the mutex and turning every later
     /// apply on this context into a crash.
+    ///
+    /// If a holder panicked after `take()`-ing the key but before replacing it,
+    /// the recovered slot is observed empty, so the next apply acquires a fresh
+    /// `ContextAtomic::Lock` instead of reusing a held one. That is safe and
+    /// leaks nothing: the panicked holder's `ContextAtomicKey` is an owned
+    /// `RwLock` guard, so it was dropped during unwind and its lock released.
     fn lock_apply_slot(&self) -> std::sync::MutexGuard<'_, Option<ContextAtomicKey>> {
         self.apply_lock_slot
             .lock()

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -308,9 +308,12 @@ where
             let loaded = self.inner.get(self.value_id())?.unwrap_or_default();
             *slot = Some(loaded);
         }
-        // The slot is populated above, so this closure never runs — it only
-        // hands back the cached `&mut T` while keeping the borrow checker happy
-        // without a panicking `unwrap`.
+        // The slot is `Some` by the line above, so `get_or_insert_with` never
+        // calls `T::default` — it is just the panic-free way to obtain `&mut T`
+        // from a now-populated slot (a borrow-checker-clean alternative to
+        // `as_mut().unwrap()` that needs no `clippy::expect_used` waiver). A
+        // bare `expect`/`unwrap` would reintroduce a panic on the hot read path
+        // this change exists to remove.
         let value = slot.get_or_insert_with(T::default);
         #[expect(unsafe_code, reason = "necessary for caching, mirrors Root::get")]
         let value = unsafe { &mut *core::ptr::from_mut(value) };

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -298,22 +298,23 @@ where
     /// so a later call does not collide with a still-held `RefCell` borrow.
     /// Sound because storage values are never aliased (each read deserializes a
     /// fresh copy) and execution is single-threaded WASM.
-    #[expect(
-        clippy::mut_from_ref,
-        clippy::expect_used,
-        reason = "lazy cache, mirrors Root::get"
-    )]
-    fn load_value(&self) -> &mut T {
+    #[expect(clippy::mut_from_ref, reason = "lazy cache, mirrors Root::get")]
+    fn load_value(&self) -> Result<&mut T, StoreError> {
         let mut slot = self.value.borrow_mut();
-        let value = slot.get_or_insert_with(|| {
-            self.inner
-                .get(self.value_id())
-                .expect("read WriterSetCell value")
-                .unwrap_or_default()
-        });
+        // The lazy initializer reads storage and is fallible, so this can't use
+        // `Option::get_or_insert_with`. `load_value` runs on *every* `get`, so a
+        // transient store error must propagate as a `Result` rather than panic.
+        if slot.is_none() {
+            let loaded = self.inner.get(self.value_id())?.unwrap_or_default();
+            *slot = Some(loaded);
+        }
+        // The slot is populated above, so this closure never runs — it only
+        // hands back the cached `&mut T` while keeping the borrow checker happy
+        // without a panicking `unwrap`.
+        let value = slot.get_or_insert_with(T::default);
         #[expect(unsafe_code, reason = "necessary for caching, mirrors Root::get")]
         let value = unsafe { &mut *core::ptr::from_mut(value) };
-        value
+        Ok(value)
     }
 }
 
@@ -334,10 +335,10 @@ where
     /// edited via [`insert`](WriterSetCell::insert) instead.
     ///
     /// # Errors
-    /// Currently infallible; the `Result` is preserved for forward compatibility.
+    /// Returns any underlying storage error from loading the value entry.
     pub fn get_mut(&mut self) -> Result<&mut T, StoreError> {
         let anchor = self.inner.id();
-        let value = self.load_value();
+        let value = self.load_value()?;
         // Stamp the value-collection element as a member anchored to the
         // wrapper. `Collection::insert` clones this element's `storage_type`
         // onto every entry, so all entries (at any depth) inherit the SAME
@@ -361,9 +362,9 @@ where
     /// Get a reference to the current value (anyone can read).
     ///
     /// # Errors
-    /// Currently infallible; the `Result` is preserved for forward compatibility.
+    /// Returns any underlying storage error from loading the value entry.
     pub fn get(&self) -> Result<&T, StoreError> {
-        Ok(self.load_value())
+        self.load_value().map(|value| &*value)
     }
 
     /// Returns the value entry's stamped `schema_version`, or `None` if no value

--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -90,12 +90,18 @@ impl BlobManager {
     }
 
     /// Get the package directory path
-    pub fn package_path(&self, package: &str) -> Utf8PathBuf {
+    ///
+    /// # Errors
+    /// Returns an error if `package` is not a safe path component.
+    pub fn package_path(&self, package: &str) -> EyreResult<Utf8PathBuf> {
         self.blob_store.package_path(package)
     }
 
     /// Get the version directory path
-    pub fn version_path(&self, package: &str, version: &str) -> Utf8PathBuf {
+    ///
+    /// # Errors
+    /// Returns an error if `package` or `version` is not a safe path component.
+    pub fn version_path(&self, package: &str, version: &str) -> EyreResult<Utf8PathBuf> {
         self.blob_store.version_path(package, version)
     }
 
@@ -105,7 +111,15 @@ impl BlobManager {
     }
 
     /// Get the path for a blob stored in a package/version directory
-    pub fn application_blob_path(&self, package: &str, version: &str, id: BlobId) -> Utf8PathBuf {
+    ///
+    /// # Errors
+    /// Returns an error if `package` or `version` is not a safe path component.
+    pub fn application_blob_path(
+        &self,
+        package: &str,
+        version: &str,
+        id: BlobId,
+    ) -> EyreResult<Utf8PathBuf> {
         self.blob_store.application_blob_path(package, version, id)
     }
 
@@ -424,30 +438,45 @@ impl FileSystem {
     }
 
     /// Get the path for a blob stored in a package/version directory
-    pub fn application_blob_path(&self, package: &str, version: &str, id: BlobId) -> Utf8PathBuf {
-        utils::validate_path_component(package, Some("package"));
-        utils::validate_path_component(version, Some("version"));
+    ///
+    /// # Errors
+    /// Returns an error if `package` or `version` is not a safe path component.
+    pub fn application_blob_path(
+        &self,
+        package: &str,
+        version: &str,
+        id: BlobId,
+    ) -> EyreResult<Utf8PathBuf> {
+        utils::validate_path_component(package, Some("package"))?;
+        utils::validate_path_component(version, Some("version"))?;
 
-        self.root
+        Ok(self
+            .root
             .join("applications")
             .join(package)
             .join(version)
             .join("blobs")
-            .join(id.to_string())
+            .join(id.to_string()))
     }
 
     /// Get the package directory path
-    pub fn package_path(&self, package: &str) -> Utf8PathBuf {
-        utils::validate_path_component(package, Some("package"));
+    ///
+    /// # Errors
+    /// Returns an error if `package` is not a safe path component.
+    pub fn package_path(&self, package: &str) -> EyreResult<Utf8PathBuf> {
+        utils::validate_path_component(package, Some("package"))?;
 
-        self.root.join("applications").join(package)
+        Ok(self.root.join("applications").join(package))
     }
 
     /// Get the version directory path
-    pub fn version_path(&self, package: &str, version: &str) -> Utf8PathBuf {
-        utils::validate_path_component(version, Some("version"));
+    ///
+    /// # Errors
+    /// Returns an error if `package` or `version` is not a safe path component.
+    pub fn version_path(&self, package: &str, version: &str) -> EyreResult<Utf8PathBuf> {
+        utils::validate_path_component(version, Some("version"))?;
 
-        self.package_path(package).join(version)
+        Ok(self.package_path(package)?.join(version))
     }
 
     /// Get the root/base path of the blobstore

--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -474,9 +474,13 @@ impl FileSystem {
     /// # Errors
     /// Returns an error if `package` or `version` is not a safe path component.
     pub fn version_path(&self, package: &str, version: &str) -> EyreResult<Utf8PathBuf> {
+        // Validate both components explicitly so the path-traversal contract is
+        // self-contained here, rather than leaning on `package_path` to guard
+        // `package` indirectly (matches `application_blob_path`).
+        utils::validate_path_component(package, Some("package"))?;
         utils::validate_path_component(version, Some("version"))?;
 
-        Ok(self.package_path(package)?.join(version))
+        Ok(self.root.join("applications").join(package).join(version))
     }
 
     /// Get the root/base path of the blobstore

--- a/crates/store/blobs/src/utils.rs
+++ b/crates/store/blobs/src/utils.rs
@@ -5,7 +5,7 @@
 ///
 /// # Allowed format
 ///
-/// * Alphanumeric characters (`a-z`, `A-Z`, `0-9`);
+/// * ASCII alphanumeric characters (`a-z`, `A-Z`, `0-9`);
 /// * Hyphens (`-`);
 /// * Single dots (`.`), but not at the start or end of the string.
 ///
@@ -15,126 +15,161 @@
 /// * `component_label`: An optional description of what is being validated (e.g., "package name", "version name").
 ///   Used for error messaging. If `None`, the default value "component" will be used for errors.
 ///
-/// # Panics
+/// # Errors
 ///
-/// This function panics if the `component`:
+/// Returns an error if the `component`:
 /// * Is empty;
-/// * Contains characters other than alphanumeric, hyphens, or dots (blocks `/`, `\`, etc.);
+/// * Contains characters other than ASCII alphanumeric, hyphens, or dots (blocks `/`, `\`, etc.);
 /// * Contains consecutive dots (`..`);
 /// * Starts or ends with a dot.
-pub fn validate_path_component(component: &str, component_label: Option<&str>) {
+pub fn validate_path_component(
+    component: &str,
+    component_label: Option<&str>,
+) -> eyre::Result<()> {
     let component_label = component_label.unwrap_or("component");
 
     // Ensure the component is not empty.
     if component.is_empty() {
-        panic!("{component_label} cannot be empty");
+        eyre::bail!("{component_label} cannot be empty");
     }
 
     // Prevent path traversal.
     if component.contains("..") {
-        panic!("{component_label} cannot contain '..': '{component}'");
+        eyre::bail!("{component_label} cannot contain '..': '{component}'");
     }
 
-    // Allow only alphanumeric characters, hyphen, and dot.
+    // Allow only ASCII alphanumeric characters, hyphen, and dot. The check is
+    // deliberately ASCII-restricted: a Unicode-aware `is_alphanumeric` would
+    // admit homoglyphs and full-width digits that can confuse path handling.
     if component
         .chars()
-        .any(|c| !c.is_alphanumeric() && c != '-' && c != '.')
+        .any(|c| !c.is_ascii_alphanumeric() && c != '-' && c != '.')
     {
-        panic!(
-            "invalid character in {component_label}: '{component}'. Only alphanumeric, '-', and '.' are allowed.",
+        eyre::bail!(
+            "invalid character in {component_label}: '{component}'. Only ASCII alphanumeric, '-', and '.' are allowed.",
         );
     }
 
     // Forbid using dots at boundaries.
     if component.starts_with('.') || component.ends_with('.') {
-        panic!("{component_label} cannot start or end with '.': '{component}'");
+        eyre::bail!("{component_label} cannot start or end with '.': '{component}'");
     }
+
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Asserts the component is rejected and the error message contains `needle`.
+    fn assert_rejected(component: &str, label: Option<&str>, needle: &str) {
+        let err = validate_path_component(component, label)
+            .expect_err("expected component to be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains(needle),
+            "error {msg:?} should contain {needle:?}",
+        );
+    }
+
     #[test]
     fn test_validate_path_component_success() {
         // Valid cases
-        validate_path_component("calimero", None);
-        validate_path_component("calimero-network", Some("package"));
-        validate_path_component("v1.0.0", Some("version"));
-        validate_path_component("1.2.3", None);
-        validate_path_component("calimero.world-controller-app", None);
-        validate_path_component("0123456789", None);
+        validate_path_component("calimero", None).unwrap();
+        validate_path_component("calimero-network", Some("package")).unwrap();
+        validate_path_component("v1.0.0", Some("version")).unwrap();
+        validate_path_component("1.2.3", None).unwrap();
+        validate_path_component("calimero.world-controller-app", None).unwrap();
+        validate_path_component("0123456789", None).unwrap();
     }
 
     #[test]
-    #[should_panic(expected = "package cannot be empty")]
     fn test_validate_path_component_empty_package() {
-        validate_path_component("", Some("package"));
+        assert_rejected("", Some("package"), "package cannot be empty");
     }
 
     #[test]
-    #[should_panic(expected = "version cannot be empty")]
     fn test_validate_path_component_empty_version() {
-        validate_path_component("", Some("version"));
+        assert_rejected("", Some("version"), "version cannot be empty");
     }
 
     #[test]
-    #[should_panic(expected = "component cannot be empty")]
     fn test_validate_path_component_empty_default() {
-        validate_path_component("", None);
+        assert_rejected("", None, "component cannot be empty");
     }
 
     #[test]
-    #[should_panic(expected = "invalid character in package name")]
     fn test_validate_path_component_slash() {
-        validate_path_component("calimero/network", Some("package name"));
+        assert_rejected(
+            "calimero/network",
+            Some("package name"),
+            "invalid character in package name",
+        );
     }
 
     #[test]
-    #[should_panic(expected = "invalid character")]
     fn test_validate_path_component_backslash() {
-        validate_path_component("calimero\\network", None);
+        assert_rejected("calimero\\network", None, "invalid character");
     }
 
     #[test]
-    #[should_panic(expected = "invalid character")]
     fn test_validate_path_component_space() {
-        validate_path_component("calimero network", None);
+        assert_rejected("calimero network", None, "invalid character");
     }
 
     #[test]
-    #[should_panic(expected = "invalid character")]
     fn test_validate_path_component_special_chars() {
-        validate_path_component("calimero@network", None);
+        assert_rejected("calimero@network", None, "invalid character");
     }
 
     #[test]
-    #[should_panic(expected = "package name cannot contain '..'")]
+    fn test_validate_path_component_non_ascii_alphanumeric() {
+        // Unicode alphanumerics (e.g. full-width digits, accented letters) are
+        // ASCII-restricted out, where the old `is_alphanumeric` check let them
+        // through.
+        assert_rejected("ｃalimero", None, "invalid character");
+        assert_rejected("café", None, "invalid character");
+    }
+
+    #[test]
     fn test_validate_path_component_traversal() {
-        validate_path_component("../etc", Some("package name"));
+        assert_rejected("../etc", Some("package name"), "package name cannot contain '..'");
     }
 
     #[test]
-    #[should_panic(expected = "version name cannot contain '..'")]
     fn test_validate_path_component_double_dot_middle() {
-        validate_path_component("calimero..network", Some("version name"));
+        assert_rejected(
+            "calimero..network",
+            Some("version name"),
+            "version name cannot contain '..'",
+        );
     }
 
     #[test]
-    #[should_panic(expected = "version name cannot contain '..'")]
     fn test_validate_path_component_multiple_dots() {
-        validate_path_component("calimero...network", Some("version name"));
+        assert_rejected(
+            "calimero...network",
+            Some("version name"),
+            "version name cannot contain '..'",
+        );
     }
 
     #[test]
-    #[should_panic(expected = "package name cannot start or end with '.'")]
     fn test_validate_path_component_start_dot() {
-        validate_path_component(".calimero", Some("package name"));
+        assert_rejected(
+            ".calimero",
+            Some("package name"),
+            "package name cannot start or end with '.'",
+        );
     }
 
     #[test]
-    #[should_panic(expected = "version name cannot start or end with '.'")]
     fn test_validate_path_component_end_dot() {
-        validate_path_component("calimero.", Some("version name"));
+        assert_rejected(
+            "calimero.",
+            Some("version name"),
+            "version name cannot start or end with '.'",
+        );
     }
 }

--- a/crates/store/blobs/src/utils.rs
+++ b/crates/store/blobs/src/utils.rs
@@ -33,7 +33,11 @@ pub fn validate_path_component(
         eyre::bail!("{component_label} cannot be empty");
     }
 
-    // Prevent path traversal.
+    // Belt-and-suspenders guard against literal `..` traversal sequences. The
+    // PRIMARY traversal defense is the ASCII allowlist below, which rejects path
+    // separators (`/`, `\`) outright; this `..` check is an additional guard.
+    // Keep the allowlist even if this check is ever reordered or removed — they
+    // are not independent.
     if component.contains("..") {
         eyre::bail!("{component_label} cannot contain '..': '{component}'");
     }

--- a/crates/store/blobs/src/utils.rs
+++ b/crates/store/blobs/src/utils.rs
@@ -22,10 +22,7 @@
 /// * Contains characters other than ASCII alphanumeric, hyphens, or dots (blocks `/`, `\`, etc.);
 /// * Contains consecutive dots (`..`);
 /// * Starts or ends with a dot.
-pub fn validate_path_component(
-    component: &str,
-    component_label: Option<&str>,
-) -> eyre::Result<()> {
+pub fn validate_path_component(component: &str, component_label: Option<&str>) -> eyre::Result<()> {
     let component_label = component_label.unwrap_or("component");
 
     // Ensure the component is not empty.
@@ -138,7 +135,11 @@ mod tests {
 
     #[test]
     fn test_validate_path_component_traversal() {
-        assert_rejected("../etc", Some("package name"), "package name cannot contain '..'");
+        assert_rejected(
+            "../etc",
+            Some("package name"),
+            "package name cannot contain '..'",
+        );
     }
 
     #[test]

--- a/crates/store/blobs/src/utils.rs
+++ b/crates/store/blobs/src/utils.rs
@@ -30,11 +30,12 @@ pub fn validate_path_component(component: &str, component_label: Option<&str>) -
         eyre::bail!("{component_label} cannot be empty");
     }
 
-    // Belt-and-suspenders guard against literal `..` traversal sequences. The
-    // PRIMARY traversal defense is the ASCII allowlist below, which rejects path
-    // separators (`/`, `\`) outright; this `..` check is an additional guard.
-    // Keep the allowlist even if this check is ever reordered or removed — they
-    // are not independent.
+    // Reject interior `..` traversal sequences. This check is LOAD-BEARING, not
+    // merely redundant: the ASCII allowlist below permits `.`, and the
+    // dot-boundary check only rejects leading/trailing dots, so an interior
+    // `..` (e.g. `a..b`) is caught ONLY here. The allowlist independently blocks
+    // path separators (`/`, `\`). The two guards cover different cases and
+    // neither subsumes the other — do not drop this one when refactoring.
     if component.contains("..") {
         eyre::bail!("{component_label} cannot contain '..': '{component}'");
     }


### PR DESCRIPTION
## Description

This PR converts the `validate_path_component` function and related path methods from panic-based error handling to returning `Result` types, improving error handling throughout the blob store and delta store modules.

### Key Changes

1. **Path validation refactoring** (`crates/store/blobs/src/utils.rs`):
   - Changed `validate_path_component` to return `eyre::Result<()>` instead of panicking
   - Replaced `panic!` calls with `eyre::bail!` for all validation errors
   - Added clarifying comment explaining why ASCII-only alphanumeric validation is used (prevents homoglyphs and full-width digits)
   - Updated all tests to use a new `assert_rejected` helper that checks error messages instead of `#[should_panic]`
   - Added new test cases for non-ASCII alphanumeric characters (e.g., full-width digits, accented letters)

2. **Blob manager API updates** (`crates/store/blobs/src/lib.rs`):
   - `BlobManager::package_path()` now returns `EyreResult<Utf8PathBuf>`
   - `BlobManager::version_path()` now returns `EyreResult<Utf8PathBuf>`
   - `BlobManager::application_blob_path()` now returns `EyreResult<Utf8PathBuf>`
   - `FileSystem` implementations updated to propagate validation errors with `?` operator
   - Added documentation for error conditions

3. **Delta store improvements** (`crates/node/src/delta_store.rs`):
   - Extracted `lock_apply_slot()` helper method to safely recover from poisoned mutexes instead of panicking with `.expect()`
   - Replaced three instances of `.expect("apply_lock_slot poisoned")` with calls to the new helper
   - Improves resilience by preventing transient panics from poisoning the mutex

4. **Storage collection error handling** (`crates/storage/src/collections/shared.rs`):
   - Changed `WriterSetCell::load_value()` to return `Result<&mut T, StoreError>` instead of panicking
   - Replaced `.expect()` with proper error propagation
   - Updated `get_mut()` and `get()` to propagate storage errors
   - Improved documentation to reflect that errors can now occur during lazy initialization

## Test Plan

- Existing unit tests in `crates/store/blobs/src/utils.rs` have been updated and now verify error messages instead of panic behavior
- New test cases added for non-ASCII alphanumeric characters to ensure the ASCII-only restriction works correctly
- All validation tests pass with the new error-based approach
- No manual testing needed; changes are covered by existing and new unit tests

## Wire contract (SDK gate)

N/A — No HTTP wire DTOs or routes changed.

## Documentation update

N/A — Changes are internal error handling improvements with no public API documentation impact.

https://claude.ai/code/session_01DWZsAV51GqqGS4TXiZDGpg