### PR TITLE
fix(runtime): bound commit artifact size with max_artifact_size limit

### DIFF
--- a/crates/runtime/src/errors.rs
+++ b/crates/runtime/src/errors.rs
@@ -128,6 +128,8 @@ pub enum HostError {
     XCallFunctionSizeOverflow,
     #[error("xcall params size overflow")]
     XCallParamsSizeOverflow,
+    #[error("commit artifact size overflow (size: {size}, max: {max})")]
+    ArtifactSizeOverflow { size: u64, max: u64 },
     #[error("blob operations not supported (NodeClient not available)")]
     BlobsNotSupported,
     #[error("invalid blob handle")]

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -155,6 +155,15 @@ const DEFAULT_MAX_BLOB_CHUNK_SIZE_MIB: u64 = 10;
 const DEFAULT_MAX_METHOD_NAME_LENGTH: u64 = 256;
 /// Default maximum WASM module size in MiB (20 MiB).
 const DEFAULT_MAX_MODULE_SIZE_MIB: u64 = 20;
+/// Default maximum commit-artifact size in MiB (16 MiB).
+///
+/// Bounds the binary artifact a guest hands to `env::commit`. The artifact is
+/// read out of guest memory and copied onto the host `Outcome` (then broadcast
+/// in receipts), so without a cap a contract could force a copy as large as
+/// guest memory itself (~64 MiB). 16 MiB sits above the 10 MiB
+/// `max_storage_value_size` single-value cap — so a max-size value committed as
+/// an artifact still fits — while staying well under the guest-memory ceiling.
+const DEFAULT_MAX_ARTIFACT_SIZE_MIB: u64 = 16;
 
 /// Defines the resource limits for a VM instance.
 ///
@@ -211,6 +220,12 @@ pub struct VMLimits {
     /// The default of 10 MiB accommodates most applications while preventing memory
     /// exhaustion. Consider reducing for memory-constrained environments.
     pub max_module_size: u64,
+    /// The maximum size, in bytes, of the binary artifact a guest may commit via
+    /// `env::commit`. The artifact is copied out of guest memory onto the
+    /// `Outcome`; without this cap the only bound is guest memory itself
+    /// (~64 MiB). Exceeding it traps the execution with
+    /// `HostError::ArtifactSizeOverflow`.
+    pub max_artifact_size: u64,
 }
 
 impl Default for VMLimits {
@@ -246,6 +261,7 @@ impl Default for VMLimits {
             max_blob_chunk_size: DEFAULT_MAX_BLOB_CHUNK_SIZE_MIB * u64::from(ONE_MIB),
             max_method_name_length: DEFAULT_MAX_METHOD_NAME_LENGTH,
             max_module_size: DEFAULT_MAX_MODULE_SIZE_MIB * u64::from(ONE_MIB),
+            max_artifact_size: DEFAULT_MAX_ARTIFACT_SIZE_MIB * u64::from(ONE_MIB),
         }
     }
 }
@@ -873,6 +889,7 @@ mod tests {
         assert_eq!(limits.max_blob_handles, 100);
         assert_eq!(limits.max_blob_chunk_size, 10 << 20); // 10 MiB
         assert_eq!(limits.max_method_name_length, 256);
+        assert_eq!(limits.max_artifact_size, 16 << 20); // 16 MiB
     }
 
     /// A smoke test for the successful path of the `finish` method.

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -811,11 +811,24 @@ impl VMHostFunctions<'_> {
     ///
     /// * `HostError::InvalidMemoryAccess` if this function is called more than once or if memory
     ///   access fails for descriptor buffers.
+    /// * `HostError::ArtifactSizeOverflow` if the artifact exceeds `max_artifact_size`.
     pub fn commit(&mut self, src_root_hash_ptr: u64, src_artifact_ptr: u64) -> VMLogicResult<()> {
         let root_hash =
             unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_root_hash_ptr)? };
         let artifact =
             unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_artifact_ptr)? };
+
+        // Bound the artifact before copying it out of guest memory: the copy
+        // lands on the host `Outcome`, so without this cap the only limit is
+        // guest memory itself (~64 MiB).
+        let max_artifact_size = self.borrow_logic().limits.max_artifact_size;
+        if artifact.len() > max_artifact_size {
+            return Err(HostError::ArtifactSizeOverflow {
+                size: artifact.len(),
+                max: max_artifact_size,
+            }
+            .into());
+        }
 
         let root_hash = *self.read_guest_memory_sized::<DIGEST_SIZE>(&root_hash)?;
         let artifact = self.read_guest_memory_slice(&artifact)?.to_vec();
@@ -1712,5 +1725,51 @@ mod tests {
         // Verify the host successfully stored the root hash and artifact in the `VMLogic` state.
         assert_eq!(host.borrow_logic().root_hash, Some(root_hash));
         assert_eq!(host.borrow_logic().artifact, artifact);
+    }
+
+    /// Tests that `commit()` rejects an artifact larger than `max_artifact_size`
+    /// instead of copying it onto the `Outcome`.
+    #[test]
+    fn test_commit_artifact_size_overflow() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits {
+            max_artifact_size: 4,
+            ..VMLimits::default()
+        };
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        let root_hash = [1u8; DIGEST_SIZE];
+        let artifact = vec![1, 2, 3, 4, 5]; // 5 bytes > 4-byte limit
+        let root_hash_ptr = 200u64;
+        let artifact_ptr = 300u64;
+        host.borrow_memory()
+            .write(root_hash_ptr, &root_hash)
+            .unwrap();
+        host.borrow_memory().write(artifact_ptr, &artifact).unwrap();
+
+        let root_hash_buf_ptr = 16u64;
+        let artifact_buf_ptr = 32u64;
+        prepare_guest_buf_descriptor(
+            &host,
+            root_hash_buf_ptr,
+            root_hash_ptr,
+            root_hash.len() as u64,
+        );
+        prepare_guest_buf_descriptor(&host, artifact_buf_ptr, artifact_ptr, artifact.len() as u64);
+
+        let err = host
+            .commit(root_hash_buf_ptr, artifact_buf_ptr)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            VMLogicError::HostError(HostError::ArtifactSizeOverflow { size: 5, max: 4 })
+        ));
+
+        // The over-large artifact must not have been copied onto the state, and
+        // the commit must not be marked as completed.
+        assert!(host.borrow_logic().artifact.is_empty());
+        assert_eq!(host.borrow_logic().root_hash, None);
+        assert!(!host.borrow_logic().commit_called);
     }
 }

--- a/docs-site/src/content/docs/protocol/limits.mdx
+++ b/docs-site/src/content/docs/protocol/limits.mdx
@@ -35,6 +35,7 @@ These bound a single WASM execution. Defaults live in `crates/runtime/src/logic.
 | `max_blob_chunk_size` | **10 MiB** | Per read/write chunk against a blob. |
 | `max_method_name_length` | **256 bytes** | Entrypoint method name. |
 | `max_module_size` | **20 MiB** | WASM module size before compilation (anti-DoS). |
+| `max_artifact_size` | **16 MiB** | Commit artifact copied out of guest memory onto the `Outcome` (anti-DoS); over-size traps with `ArtifactSizeOverflow`. |
 
 ## Wire limits
 


### PR DESCRIPTION
## Description

This PR adds a configurable `max_artifact_size` limit to prevent denial-of-service attacks where a malicious contract could force the host to copy arbitrarily large artifacts from guest memory onto the `Outcome` (which is then broadcast in receipts).

### Changes

- **New limit**: `max_artifact_size` (default 16 MiB) bounds the binary artifact passed to `env::commit()`
- **Validation**: The `commit()` host function now checks artifact size before copying from guest memory and returns `HostError::ArtifactSizeOverflow` if exceeded
- **Error type**: Added `ArtifactSizeOverflow { size, max }` variant to `HostError`
- **Documentation**: Updated limits documentation and added detailed comments explaining the rationale (16 MiB sits above the 10 MiB `max_storage_value_size` cap while staying well under the ~64 MiB guest memory ceiling)

### Rationale

Without this cap, the only bound on artifact size is guest memory itself (~64 MiB). By validating before the copy operation, we prevent a contract from forcing the host to allocate and broadcast oversized artifacts in receipts.

## Test plan

Added comprehensive unit test `test_commit_artifact_size_overflow()` that verifies:
- `commit()` rejects artifacts exceeding `max_artifact_size`
- The error variant contains correct size and max values
- The over-large artifact is not copied onto the state
- The commit is not marked as completed on rejection

Existing `test_commit()` test continues to pass, confirming normal operation is unaffected.

## Wire contract (SDK gate)

- [x] No wire DTO or route changes

## Documentation update

Updated `docs-site/src/content/docs/protocol/limits.mdx` to document the new `max_artifact_size` limit.

https://claude.ai/code/session_01QRaypqnDoQdDRzX9u5FFNC