### PR TITLE
fix(governance-store): propagate cascade_seq store read error

### DIFF
--- a/crates/governance-store/src/ops/group/cascade_upgrade.rs
+++ b/crates/governance-store/src/ops/group/cascade_upgrade.rs
@@ -54,18 +54,14 @@ pub(crate) fn apply(
     // `synced_up_to_hlc` (see `MigrationEmitter::refresh_hlc`). The
     // migration-status rollup pins the cohort by comparing those two SEQUENCES
     // like-for-like; `cascade_hlc` (an NTP64 HLC) must never serve as that pin.
-    // Best-effort: a missing head or read error leaves `cascade_seq` `None`
-    // (no pin) rather than failing the apply.
-    let cascade_seq = NamespaceRepository::new(store)
-        .resolve(group_id)
-        .ok()
-        .and_then(|ns| {
-            store
-                .handle()
-                .get(&NamespaceGovHead::new(ns.to_bytes()))
-                .ok()
-                .flatten()
-        })
+    // A genuinely-absent head leaves `cascade_seq` `None` (no pin), but a read
+    // error MUST propagate: swallowing it with `.ok()` would let the same op
+    // pin `None` on a node that hit a transient store error while peers pinned
+    // `Some(seq)`, diverging the cohort comparison across the cluster.
+    let ns = NamespaceRepository::new(store).resolve(group_id)?;
+    let cascade_seq = store
+        .handle()
+        .get(&NamespaceGovHead::new(ns.to_bytes()))?
         .map(|head| head.sequence);
 
     // Pre-scan: verify the signer would pass the per-descendant


### PR DESCRIPTION
## Description

This PR fixes a critical error handling bug in the cascade upgrade logic that could cause cohort divergence across the cluster.

**The Problem:**
The code was using `.ok()` to swallow read errors when fetching the namespace governance head, treating transient store errors the same as genuinely-absent heads. This is unsafe because:
- If a node hits a transient store error, it would pin `cascade_seq` to `None`
- Peer nodes that successfully read the head would pin `cascade_seq` to `Some(seq)`
- This divergence in the migration-status rollup comparison would cause the cohort to split

**The Fix:**
Changed the error handling to propagate read errors with `?` while still allowing genuinely-absent heads to result in `None`. This ensures:
- Transient errors fail fast and are retried, keeping the cluster in sync
- Only truly missing heads result in `None` pins
- The cohort comparison remains consistent across all nodes

The refactoring also improves code clarity by separating the namespace resolution from the head lookup, making the error handling intent explicit.

## Test plan

Existing tests cover the cascade upgrade logic. The change is defensive—it prevents a failure mode rather than adding new functionality. CI should pass with no additional test changes needed.

## Wire contract (SDK gate)

N/A — no HTTP wire DTOs or routes changed.

## Documentation update

N/A — internal implementation detail.

https://claude.ai/code/session_011sjZkyNWU9gHaSjnVTfnaV