### PR TITLE
fix(runtime): cap precompiled module deserialization size

### DIFF
--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -22,6 +22,11 @@ const MAX_LOGS_CEILING: u64 = 1_000_000;
 /// lines are never legitimately this large; a value above it is treated as a
 /// misconfiguration.
 const MAX_LOG_SIZE_CEILING: u64 = 10 * 1024 * 1024;
+/// Upper bound accepted for `max_precompiled_module_size`, in bytes (1 GiB).
+/// A precompiled artifact larger than this is far outside any legitimate range
+/// (source WASM is itself capped at a few MiB) and would defeat the purpose of
+/// the cap, so it is treated as a misconfiguration.
+const MAX_PRECOMPILED_MODULE_SIZE_CEILING: u64 = 1024 * 1024 * 1024;
 
 /// The `[runtime]` config section.
 ///
@@ -86,6 +91,14 @@ pub struct RuntimeLimitsConfig {
     /// `tracing` emits long lines.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_log_size: Option<u64>,
+    /// Override for [`VMLimits::max_precompiled_module_size`]: the maximum size,
+    /// in bytes, of a precompiled (serialized) module accepted by
+    /// `Engine::from_precompiled`. Bounds deserialization input as
+    /// defense-in-depth; lower it in memory-constrained deployments. Distinct
+    /// from the source-WASM `max_module_size`, which guards a separate path and
+    /// is not operator-tunable today.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_precompiled_module_size: Option<u64>,
 }
 
 impl RuntimeLimitsConfig {
@@ -98,6 +111,9 @@ impl RuntimeLimitsConfig {
         }
         if let Some(max_log_size) = self.max_log_size {
             base.max_log_size = max_log_size;
+        }
+        if let Some(max_precompiled_module_size) = self.max_precompiled_module_size {
+            base.max_precompiled_module_size = max_precompiled_module_size;
         }
         base
     }
@@ -120,6 +136,15 @@ impl RuntimeLimitsConfig {
                 bail!(
                     "runtime.limits.max_log_size = {max_log_size} exceeds the maximum of \
                      {MAX_LOG_SIZE_CEILING} bytes"
+                );
+            }
+        }
+        if let Some(max_precompiled_module_size) = self.max_precompiled_module_size {
+            if max_precompiled_module_size > MAX_PRECOMPILED_MODULE_SIZE_CEILING {
+                bail!(
+                    "runtime.limits.max_precompiled_module_size = \
+                     {max_precompiled_module_size} exceeds the maximum of \
+                     {MAX_PRECOMPILED_MODULE_SIZE_CEILING} bytes"
                 );
             }
         }
@@ -147,6 +172,7 @@ mod tests {
             limits: RuntimeLimitsConfig {
                 max_logs: Some(4096),
                 max_log_size: None,
+                max_precompiled_module_size: None,
             },
         };
         let resolved = cfg.vm_limits();
@@ -155,6 +181,22 @@ mod tests {
         assert_eq!(resolved.max_log_size, defaults.max_log_size);
         // Untouched limits are preserved.
         assert_eq!(resolved.max_events, defaults.max_events);
+    }
+
+    #[test]
+    fn precompiled_module_size_override_applies() {
+        let defaults = VMLimits::default();
+        let cfg = RuntimeConfig {
+            limits: RuntimeLimitsConfig {
+                max_logs: None,
+                max_log_size: None,
+                max_precompiled_module_size: Some(8 * 1024 * 1024),
+            },
+        };
+        let resolved = cfg.vm_limits();
+        assert_eq!(resolved.max_precompiled_module_size, 8 * 1024 * 1024);
+        // The source-WASM cap is independent and stays at its default.
+        assert_eq!(resolved.max_module_size, defaults.max_module_size);
     }
 
     #[test]
@@ -180,6 +222,7 @@ mod tests {
             limits: RuntimeLimitsConfig {
                 max_logs: Some(4096),
                 max_log_size: Some(64 * 1024),
+                max_precompiled_module_size: Some(64 * 1024 * 1024),
             },
         };
         cfg.validate().expect("reasonable overrides are valid");
@@ -191,6 +234,7 @@ mod tests {
             limits: RuntimeLimitsConfig {
                 max_logs: Some(u64::MAX),
                 max_log_size: None,
+                max_precompiled_module_size: None,
             },
         };
         let err = cfg.validate().unwrap_err().to_string();
@@ -200,10 +244,24 @@ mod tests {
             limits: RuntimeLimitsConfig {
                 max_logs: None,
                 max_log_size: Some(u64::MAX),
+                max_precompiled_module_size: None,
             },
         };
         let err = cfg.validate().unwrap_err().to_string();
         assert!(err.contains("max_log_size"), "unexpected error: {err}");
+
+        let cfg = RuntimeConfig {
+            limits: RuntimeLimitsConfig {
+                max_logs: None,
+                max_log_size: None,
+                max_precompiled_module_size: Some(u64::MAX),
+            },
+        };
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("max_precompiled_module_size"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/runtime/src/errors.rs
+++ b/crates/runtime/src/errors.rs
@@ -6,7 +6,7 @@ use core::panic::Location as PanicLocation;
 
 use serde::Serialize;
 use thiserror::Error as ThisError;
-use wasmer::{ExportError, InstantiationError, LinkError, RuntimeError};
+use wasmer::{DeserializeError, ExportError, InstantiationError, LinkError, RuntimeError};
 use wasmer_types::{CompileError, TrapCode};
 
 #[derive(Debug, ThisError)]
@@ -49,6 +49,32 @@ pub enum FunctionCallError {
     ExecutionError(Vec<u8>),
     #[error("module size limit (max_module_size) exceeded: {size} bytes > {max} bytes limit")]
     ModuleSizeLimitExceeded { size: u64, max: u64 },
+}
+
+/// Error returned by
+/// [`Engine::from_precompiled`](crate::Engine::from_precompiled).
+///
+/// Kept separate from [`FunctionCallError`] because deserializing a
+/// precompiled artifact is a distinct operation from compiling source WASM:
+/// it carries a wasmer [`DeserializeError`] (not a [`CompileError`]) and its
+/// own size cap. Not `Serialize` — it wraps `DeserializeError`, which is not
+/// serializable, and these failures are node-local, not surfaced to guests.
+#[derive(Debug, ThisError)]
+#[non_exhaustive]
+pub enum PrecompiledModuleError {
+    /// The serialized precompiled artifact is larger than the configured
+    /// `max_precompiled_module_size` cap. Checked before handing the bytes to
+    /// wasmer so a corrupt or oversized blob cannot drive unbounded
+    /// allocation during deserialization, even when the caller attests the
+    /// bytes are trusted.
+    #[error(
+        "precompiled module size limit (max_precompiled_module_size) exceeded: \
+         {size} bytes > {max} bytes limit"
+    )]
+    SizeLimitExceeded { size: u64, max: u64 },
+    /// Wasmer rejected the bytes (wrong format, version mismatch, corruption).
+    #[error(transparent)]
+    Deserialize(#[from] DeserializeError),
 }
 
 #[derive(Debug, Serialize, ThisError)]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -4,7 +4,7 @@ use calimero_node_primitives::client::NodeClient;
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
 use tracing::{debug, error, info};
-use wasmer::{DeserializeError, Instance, SerializeError, Store};
+use wasmer::{Instance, SerializeError, Store};
 
 // Profiling feature: Only compile these imports when profiling feature is enabled
 #[cfg(feature = "profiling")]
@@ -21,7 +21,9 @@ pub mod store;
 
 pub use config::{RuntimeConfig, RuntimeLimitsConfig};
 pub use constraint::Constraint;
-use errors::{FunctionCallError, HostError, Location, PanicContext, VMRuntimeError};
+use errors::{
+    FunctionCallError, HostError, Location, PanicContext, PrecompiledModuleError, VMRuntimeError,
+};
 use logic::{CallbackHandlerGuard, Outcome, VMContext, VMLimits, VMLogic, VMLogicError};
 use memory::WasmerTunables;
 use store::Storage;
@@ -210,24 +212,48 @@ impl Engine {
         })
     }
 
+    /// Deserialize a precompiled (serialized) module produced by
+    /// [`Module::to_bytes`].
+    ///
     /// # Safety
     ///
-    /// This function deserializes a precompiled WASM module. The caller must ensure
-    /// the bytes come from a trusted source (e.g., previously compiled by this engine).
+    /// `wasmer::Module::deserialize` trusts its input: it maps the bytes
+    /// straight into an executable artifact without re-validating them. Feeding
+    /// it attacker-controlled bytes is undefined behavior. The caller MUST
+    /// ensure `bytes` originate from a trusted source — the only sound
+    /// provenance is bytes this very node produced via [`Module::to_bytes`]
+    /// (e.g. its own on-disk compilation cache). The `unsafe` marker is the
+    /// provenance assertion: every call site must justify, at the point of
+    /// call, why its bytes are trusted.
     ///
-    /// # Security Note
+    /// # Size cap (defense-in-depth)
     ///
-    /// No size limit check is performed here. This is an accepted security trade-off because:
-    /// 1. Precompiled modules have already been validated during their original compilation
-    /// 2. The serialized format may differ significantly in size from the original WASM binary
-    /// 3. The `unsafe` marker already requires callers to ensure the bytes are from a trusted source
-    ///
-    /// **Audit requirement**: All call sites using this method should be reviewed to ensure
-    /// precompiled bytes originate from trusted sources only (e.g., the node's own compilation cache).
-    ///
-    /// If precompiled bytes could come from an untrusted source, callers should implement
-    /// their own size validation before calling this method.
-    pub unsafe fn from_precompiled(&self, bytes: &[u8]) -> Result<Module, DeserializeError> {
+    /// Unlike the original design, this method now enforces a configurable size
+    /// cap ([`VMLimits::max_precompiled_module_size`]) *before* handing the
+    /// bytes to wasmer. Trusted provenance does not preclude a truncated cache
+    /// entry or a corrupt-on-disk artifact, and deserialization allocates
+    /// proportionally to the input; the cap bounds that allocation regardless.
+    /// It is intentionally separate from (and larger than)
+    /// [`VMLimits::max_module_size`], since a serialized artifact is bigger than
+    /// the source WASM it came from.
+    pub unsafe fn from_precompiled(
+        &self,
+        bytes: &[u8],
+    ) -> Result<Module, PrecompiledModuleError> {
+        // Note: `as u64` is safe because usize <= u64 on all supported platforms.
+        let size = bytes.len() as u64;
+        if size > self.limits.max_precompiled_module_size {
+            tracing::warn!(
+                size,
+                max = self.limits.max_precompiled_module_size,
+                "precompiled WASM module size limit exceeded"
+            );
+            return Err(PrecompiledModuleError::SizeLimitExceeded {
+                size,
+                max: self.limits.max_precompiled_module_size,
+            });
+        }
+
         let module = wasmer::Module::deserialize(&self.engine, bytes)?;
 
         Ok(Module {
@@ -1298,6 +1324,91 @@ mod wasm_integration_tests {
             }
             Ok(_) => panic!("Empty bytes should not compile successfully"),
             Err(other) => panic!("Expected CompilationError for empty bytes, got: {other:?}"),
+        }
+    }
+
+    /// A precompiled artifact this engine produced round-trips back through
+    /// `from_precompiled` when it is within the configured cap.
+    #[test]
+    fn test_from_precompiled_round_trips_within_cap() {
+        let wat = r#"
+            (module
+                (memory (export "memory") 1)
+                (func (export "test_func"))
+            )
+        "#;
+        let wasm = wat::parse_str(wat).expect("Failed to parse WAT");
+
+        let engine = Engine::default();
+        let module = engine.compile(&wasm).expect("Failed to compile module");
+        let precompiled = module.to_bytes().expect("Failed to serialize module");
+
+        // SAFETY: bytes were just produced by this same engine via `to_bytes`.
+        let restored = unsafe { engine.from_precompiled(&precompiled) };
+        assert!(
+            restored.is_ok(),
+            "Expected precompiled round-trip to succeed, got: {restored:?}"
+        );
+    }
+
+    /// `from_precompiled` enforces `max_precompiled_module_size` before handing
+    /// the bytes to wasmer, independent of the source-WASM `max_module_size`.
+    #[test]
+    fn test_from_precompiled_size_limit_exceeded() {
+        use crate::logic::VMLimits;
+
+        let wat = r#"
+            (module
+                (memory (export "memory") 1)
+                (func (export "test_func"))
+            )
+        "#;
+        let wasm = wat::parse_str(wat).expect("Failed to parse WAT");
+
+        // Compile with a generous engine, then serialize.
+        let precompiled = Engine::default()
+            .compile(&wasm)
+            .expect("Failed to compile module")
+            .to_bytes()
+            .expect("Failed to serialize module");
+
+        // A second engine whose precompiled cap is smaller than the artifact.
+        let limits = VMLimits {
+            max_precompiled_module_size: 1, // 1 byte - far below any artifact
+            ..Default::default()
+        };
+        let engine = Engine::new(wasmer::Engine::default(), limits);
+
+        // SAFETY: bytes came from a trusted compile above; we are exercising the
+        // size cap, which must reject before deserialization is attempted.
+        let result = unsafe { engine.from_precompiled(&precompiled) };
+        match result {
+            Err(PrecompiledModuleError::SizeLimitExceeded { size, max }) => {
+                assert_eq!(max, 1);
+                assert!(size > 1, "artifact should be larger than the cap");
+            }
+            Ok(_) => panic!("Expected SizeLimitExceeded, but deserialization succeeded"),
+            Err(other) => panic!("Expected SizeLimitExceeded, got: {other:?}"),
+        }
+    }
+
+    /// Bytes within the cap but not a valid artifact surface as a `Deserialize`
+    /// error, not a size error — the cap check is separate from validation.
+    #[test]
+    fn test_from_precompiled_invalid_bytes_surface_deserialize_error() {
+        let engine = Engine::default();
+        let garbage = vec![0u8; 1024];
+
+        // SAFETY: test-only bytes; here we assert the error path, not soundness.
+        let result = unsafe { engine.from_precompiled(&garbage) };
+        match result {
+            Err(PrecompiledModuleError::Deserialize(_)) => {
+                // Expected - within cap, but wasmer rejects the bytes.
+            }
+            Err(PrecompiledModuleError::SizeLimitExceeded { .. }) => {
+                panic!("1 KiB is within the default cap; should not be a size error")
+            }
+            Ok(_) => panic!("garbage bytes should not deserialize into a module"),
         }
     }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1411,4 +1411,45 @@ mod wasm_integration_tests {
             Ok(_) => panic!("garbage bytes should not deserialize into a module"),
         }
     }
+
+    /// Edge case mirroring `test_wasm_module_size_limit_zero` for the
+    /// precompiled path: with `max_precompiled_module_size = 0`, any non-empty
+    /// slice is rejected by the cap, while an empty slice passes the size check
+    /// (`0 > 0` is false) and surfaces as a deserialization error instead.
+    #[test]
+    fn test_from_precompiled_size_limit_zero() {
+        use crate::logic::VMLimits;
+
+        let limits = VMLimits {
+            max_precompiled_module_size: 0,
+            ..Default::default()
+        };
+        let engine = Engine::new(wasmer::Engine::default(), limits);
+
+        // Any non-empty slice is rejected by the cap before reaching wasmer.
+        // SAFETY: test-only bytes; the cap rejects before deserialization.
+        let non_empty = unsafe { engine.from_precompiled(&[0u8; 8]) };
+        match non_empty {
+            Err(PrecompiledModuleError::SizeLimitExceeded { size, max }) => {
+                assert_eq!(max, 0);
+                assert!(size > 0, "non-empty slice should exceed a cap of 0");
+            }
+            Ok(_) => panic!("Expected SizeLimitExceeded with max_precompiled_module_size=0"),
+            Err(other) => panic!("Expected SizeLimitExceeded, got: {other:?}"),
+        }
+
+        // An empty slice passes the size check (0 is not > 0) and fails in
+        // wasmer's deserialize instead.
+        // SAFETY: test-only bytes; asserting the error path, not soundness.
+        let empty = unsafe { engine.from_precompiled(&[]) };
+        match empty {
+            Err(PrecompiledModuleError::Deserialize(_)) => {
+                // Expected - empty slice passes the cap but cannot deserialize.
+            }
+            Err(PrecompiledModuleError::SizeLimitExceeded { .. }) => {
+                panic!("empty slice should pass the size check (0 is not > 0)")
+            }
+            Ok(_) => panic!("empty slice should not deserialize into a module"),
+        }
+    }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -236,10 +236,7 @@ impl Engine {
     /// It is intentionally separate from (and larger than)
     /// [`VMLimits::max_module_size`], since a serialized artifact is bigger than
     /// the source WASM it came from.
-    pub unsafe fn from_precompiled(
-        &self,
-        bytes: &[u8],
-    ) -> Result<Module, PrecompiledModuleError> {
+    pub unsafe fn from_precompiled(&self, bytes: &[u8]) -> Result<Module, PrecompiledModuleError> {
         // Note: `as u64` is safe because usize <= u64 on all supported platforms.
         let size = bytes.len() as u64;
         if size > self.limits.max_precompiled_module_size {

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -242,7 +242,11 @@ pub struct VMLimits {
     /// Even though `from_precompiled` callers attest (via `unsafe`) that the
     /// bytes are trusted, this cap is a defense-in-depth bound so a corrupt or
     /// unexpectedly large artifact cannot drive unbounded allocation. Setting
-    /// it to 0 rejects all non-empty precompiled modules.
+    /// it to 0 rejects all non-empty precompiled modules. An empty slice (0
+    /// bytes) always passes the size check regardless of this setting (the
+    /// check is `size > limit`, so `0 > 0` is false) and surfaces as a
+    /// deserialization error instead, matching the behavior of
+    /// [`max_module_size`](Self::max_module_size).
     pub max_precompiled_module_size: u64,
 }
 

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -164,6 +164,13 @@ const DEFAULT_MAX_MODULE_SIZE_MIB: u64 = 20;
 /// `max_storage_value_size` single-value cap — so a max-size value committed as
 /// an artifact still fits — while staying well under the guest-memory ceiling.
 const DEFAULT_MAX_ARTIFACT_SIZE_MIB: u64 = 16;
+/// Default maximum *precompiled* (serialized) module size in MiB (256 MiB).
+///
+/// Generously larger than [`DEFAULT_MAX_MODULE_SIZE_MIB`] because a serialized
+/// artifact (native code + relocations + metadata) is materially bigger than
+/// the source WASM it was compiled from. This is a defense-in-depth ceiling on
+/// deserialization input, not a tight functional limit.
+const DEFAULT_MAX_PRECOMPILED_MODULE_SIZE_MIB: u64 = 256;
 
 /// Defines the resource limits for a VM instance.
 ///
@@ -226,6 +233,17 @@ pub struct VMLimits {
     /// (~64 MiB). Exceeding it traps the execution with
     /// `HostError::ArtifactSizeOverflow`.
     pub max_artifact_size: u64,
+    /// The maximum size, in bytes, of a *precompiled* (serialized) module
+    /// accepted by [`Engine::from_precompiled`](crate::Engine::from_precompiled).
+    ///
+    /// Distinct from [`max_module_size`](Self::max_module_size): that bounds
+    /// source WASM before compilation, whereas this bounds the larger
+    /// serialized artifact (native code + metadata) before deserialization.
+    /// Even though `from_precompiled` callers attest (via `unsafe`) that the
+    /// bytes are trusted, this cap is a defense-in-depth bound so a corrupt or
+    /// unexpectedly large artifact cannot drive unbounded allocation. Setting
+    /// it to 0 rejects all non-empty precompiled modules.
+    pub max_precompiled_module_size: u64,
 }
 
 impl Default for VMLimits {
@@ -262,6 +280,8 @@ impl Default for VMLimits {
             max_method_name_length: DEFAULT_MAX_METHOD_NAME_LENGTH,
             max_module_size: DEFAULT_MAX_MODULE_SIZE_MIB * u64::from(ONE_MIB),
             max_artifact_size: DEFAULT_MAX_ARTIFACT_SIZE_MIB * u64::from(ONE_MIB),
+            max_precompiled_module_size: DEFAULT_MAX_PRECOMPILED_MODULE_SIZE_MIB
+                * u64::from(ONE_MIB),
         }
     }
 }


### PR DESCRIPTION
## Description

This PR adds a configurable size limit to `Engine::from_precompiled()` as a defense-in-depth measure against unbounded allocation during deserialization of precompiled (serialized) WASM modules.

### Changes

1. **New error type**: `PrecompiledModuleError` in `errors.rs` to distinguish deserialization failures from compilation errors. It carries both a `SizeLimitExceeded` variant (checked before wasmer) and a `Deserialize` variant (from wasmer).

2. **Size cap enforcement**: `Engine::from_precompiled()` now checks the serialized artifact size against `VMLimits::max_precompiled_module_size` before handing bytes to wasmer. This prevents corrupt or unexpectedly large cache entries from driving unbounded allocation, even though callers attest (via `unsafe`) that bytes are trusted.

3. **New limit field**: `VMLimits::max_precompiled_module_size` (default 256 MiB) — intentionally larger than `max_module_size` (20 MiB) because serialized artifacts (native code + relocations + metadata) are materially bigger than source WASM.

4. **Configuration support**: `RuntimeLimitsConfig::max_precompiled_module_size` allows operators to tune the cap in memory-constrained deployments. Includes validation against a 1 GiB ceiling to catch misconfiguration.

5. **Improved documentation**: Clarified the safety contract for `from_precompiled()` — bytes must originate from a trusted source (e.g., the node's own compilation cache), and the size cap is a separate defense-in-depth layer independent of that provenance assertion.

6. **Removed unused import**: `DeserializeError` was removed from the top-level import in `lib.rs` and re-added to `errors.rs` where it's actually used.

### Motivation

Precompiled modules are deserialized without re-validation (for performance), so the size cap bounds allocation proportionally to input size as a safeguard against corrupt or truncated cache entries. This is separate from (and larger than) the source-WASM cap because the serialized format is inherently bigger.

## Test plan

Added three unit tests in `wasm_integration_tests`:
- `test_from_precompiled_round_trips_within_cap`: Verifies a module compiled and serialized by the engine deserializes successfully when within the cap.
- `test_from_precompiled_size_limit_exceeded`: Confirms the size cap is enforced before deserialization, rejecting artifacts larger than the configured limit.
- `test_from_precompiled_invalid_bytes_surface_deserialize_error`: Ensures invalid bytes within the cap surface as a `Deserialize` error, not a size error, confirming the cap check is separate from validation.

Configuration tests in `config.rs` verify the override applies correctly and validation rejects oversized limits.

## Wire contract (SDK gate)

N/A — no HTTP wire DTOs or routes changed.

## Documentation update

The safety documentation for `Engine::from_precompiled()` has been significantly expanded inline. No external documentation updates required at this time.

https://claude.ai/code/session_01PDDB4G36xx8nLwKsfLJBKy