### PR TITLE
refactor(storage): replace opaque HlcDriftError with typed ClockUpdateError

### DIFF
--- a/crates/storage/src/env.rs
+++ b/crates/storage/src/env.rs
@@ -7,7 +7,7 @@ use mocked as imp;
 
 use std::cell::Cell;
 
-use crate::logical_clock::HybridTimestamp;
+use crate::logical_clock::{ClockUpdateError, HybridTimestamp};
 use crate::store::Key;
 
 // ============================================================================
@@ -353,14 +353,12 @@ pub fn hlc_timestamp() -> HybridTimestamp {
 ///
 /// # Errors
 ///
-/// Error returned by [`update_hlc`] when a remote timestamp is too far in the
-/// future to accept (drift protection).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct HlcDriftError;
-
-/// Returns [`HlcDriftError`] if the remote timestamp is >5s in the future (drift protection).
-pub fn update_hlc(remote_ts: &HybridTimestamp) -> Result<(), HlcDriftError> {
-    imp::update_hlc(remote_ts).map_err(|()| HlcDriftError)
+/// Returns a [`ClockUpdateError`] describing why the remote timestamp was
+/// rejected — currently [`ClockUpdateError::Drift`] when it is more than 5s in
+/// the future (drift protection). The typed reason is preserved from the clock
+/// itself rather than being flattened into an opaque failure.
+pub fn update_hlc(remote_ts: &HybridTimestamp) -> Result<(), ClockUpdateError> {
+    imp::update_hlc(remote_ts)
 }
 
 /// Reset for testing.
@@ -442,7 +440,7 @@ mod calimero_vm {
 
     use calimero_sdk::env;
 
-    use crate::logical_clock::{HybridTimestamp, LogicalClock};
+    use crate::logical_clock::{ClockUpdateError, HybridTimestamp, LogicalClock};
     use crate::store::Key;
 
     thread_local! {
@@ -581,7 +579,7 @@ mod calimero_vm {
     }
 
     /// Update HLC with remote timestamp
-    pub(super) fn update_hlc(remote_ts: &HybridTimestamp) -> Result<(), ()> {
+    pub(super) fn update_hlc(remote_ts: &HybridTimestamp) -> Result<(), ClockUpdateError> {
         ensure_hlc_initialized();
         WASM_HLC.with(|hlc_cell| {
             hlc_cell
@@ -610,7 +608,7 @@ mod mocked {
     use rand::RngCore;
 
     use super::RuntimeEnv;
-    use crate::logical_clock::{HybridTimestamp, LogicalClock};
+    use crate::logical_clock::{ClockUpdateError, HybridTimestamp, LogicalClock};
     use crate::store::{Key, MockedStorage, StorageAdaptor};
 
     thread_local! {
@@ -871,7 +869,7 @@ mod mocked {
     }
 
     /// Update HLC with remote timestamp
-    pub(super) fn update_hlc(remote_ts: &HybridTimestamp) -> Result<(), ()> {
+    pub(super) fn update_hlc(remote_ts: &HybridTimestamp) -> Result<(), ClockUpdateError> {
         NATIVE_HLC.with(|hlc| hlc.borrow_mut().update(remote_ts, time_now))
     }
 

--- a/crates/storage/src/logical_clock.rs
+++ b/crates/storage/src/logical_clock.rs
@@ -54,6 +54,7 @@ use core::fmt;
 use core::num::NonZeroU128;
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use thiserror::Error as ThisError;
 
 /// NTP64 timestamp (64-bit: 32-bit seconds + 32-bit fraction).
 #[derive(
@@ -237,6 +238,35 @@ pub fn logical_counter(ts: &HybridTimestamp) -> u32 {
     (ts.0.get_time().as_u64() & COUNTER_MASK) as u32
 }
 
+/// Why [`LogicalClock::update`] rejected a remote timestamp.
+///
+/// `update` returns this typed error rather than `()` so callers — and the
+/// public [`crate::env::update_hlc`] wrapper — can tell *why* an update was
+/// refused instead of collapsing every failure into a single opaque unit. The
+/// only rejection today is clock drift, but the enum is `#[non_exhaustive]` so
+/// future, non-drift reasons can be added without callers silently mislabeling
+/// them as drift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ThisError)]
+#[non_exhaustive]
+pub enum ClockUpdateError {
+    /// The remote timestamp's physical time is more than the drift tolerance
+    /// (5s) ahead of the local wall clock. Accepting it would let clock skew
+    /// drag the local clock arbitrarily far into the future, so the remote
+    /// operation's causality is not absorbed.
+    #[error(
+        "remote timestamp physical time {remote_phys} exceeds drift tolerance \
+         (max accepted: {max_accepted})"
+    )]
+    Drift {
+        /// Remote physical time (NTP64, counter bits masked off) that was
+        /// rejected.
+        remote_phys: u64,
+        /// Largest remote physical time that would have been accepted: the
+        /// local wall-clock physical time plus the 5s drift tolerance.
+        max_accepted: u64,
+    },
+}
+
 /// Hybrid Logical Clock implementation.
 ///
 /// Implements the HLC algorithm with custom time/random sources for WASM compatibility.
@@ -337,7 +367,7 @@ impl LogicalClock {
         &mut self,
         remote_ts: &HybridTimestamp,
         time_now_fn: F,
-    ) -> Result<(), ()>
+    ) -> Result<(), ClockUpdateError>
     where
         F: FnOnce() -> u64,
     {
@@ -361,7 +391,10 @@ impl LogicalClock {
         let drift_ntp = local_ntp + (DRIFT_TOLERANCE_SECS << 32);
 
         if remote_phys > drift_ntp {
-            return Err(());
+            return Err(ClockUpdateError::Drift {
+                remote_phys,
+                max_accepted: drift_ntp,
+            });
         }
 
         // Full Hybrid Logical Clock update rule. Advance to the greatest
@@ -601,8 +634,17 @@ mod tests {
         let now = hlc.new_timestamp(|| time.load(Ordering::Relaxed));
 
         let future = remote_ts(now.get_time().as_u64() + (10_u64 << 32), 0);
-        assert!(hlc
+        let err = hlc
             .update(&future, || time.load(Ordering::Relaxed))
-            .is_err());
+            .expect_err("far-future timestamp must be rejected");
+
+        // The rejection reason is preserved as a typed variant, not flattened
+        // into an opaque error, and reports the offending vs accepted bounds.
+        let ClockUpdateError::Drift {
+            remote_phys,
+            max_accepted,
+        } = err;
+        assert_eq!(remote_phys, future.get_time().as_u64() & PHYSICAL_MASK);
+        assert!(remote_phys > max_accepted);
     }
 }


### PR DESCRIPTION
## Description

This PR replaces the opaque `HlcDriftError` unit type with a new `ClockUpdateError` enum that preserves detailed rejection reasons from the hybrid logical clock implementation.

### Changes

- **New `ClockUpdateError` enum** in `logical_clock.rs`:
  - `#[non_exhaustive]` to allow future rejection reasons without breaking callers
  - `Drift` variant includes both the rejected `remote_phys` timestamp and the `max_accepted` bound
  - Derives `ThisError` for ergonomic error handling
  - Comprehensive documentation explaining the rejection semantics

- **Updated `LogicalClock::update()` signature**:
  - Returns `Result<(), ClockUpdateError>` instead of `Result<(), ()>`
  - Populates error details when rejecting timestamps due to drift

- **Simplified public API** in `env.rs`:
  - Removed opaque `HlcDriftError` struct
  - `update_hlc()` now returns `Result<(), ClockUpdateError>` directly
  - Callers can pattern-match on `ClockUpdateError::Drift` to inspect rejection bounds

- **Updated test coverage**:
  - Enhanced drift rejection test to verify typed error details
  - Asserts that `remote_phys > max_accepted` to validate bounds

### Motivation

Previously, callers could only detect that an HLC update failed without knowing why. This change enables better error diagnostics and future extensibility — if new rejection reasons are added (e.g., clock regression), callers can distinguish them via the enum rather than treating all failures identically.

## Test plan

Existing unit tests in `logical_clock.rs` verify the drift rejection behavior and now additionally validate that the error contains correct physical time bounds. The test confirms that rejected timestamps have `remote_phys > max_accepted`, ensuring the error details are accurate.

## Wire contract (SDK gate)

N/A — this is an internal storage crate change with no HTTP wire DTOs or routes affected.

## Documentation update

N/A — the change is self-documenting via the `#[non_exhaustive]` enum and inline doc comments explaining the rejection semantics.

https://claude.ai/code/session_011abuWNVxvTo6ysDJafMCAb