### PR TITLE
fix(network): resolve dropped-sender panic and pending_dial leak on dial

### DIFF
--- a/crates/network/src/handlers/commands/dial.rs
+++ b/crates/network/src/handlers/commands/dial.rs
@@ -21,6 +21,13 @@ impl Handler<Dial> for NetworkManager {
         match self.pending_dial.entry(peer_id) {
             Entry::Occupied(_) => {
                 // todo! await the existing receiver
+                //
+                // NB: this `Ok(())` means "a dial to this peer is already in
+                // flight", not "the dial succeeded". The in-flight dial owns
+                // the only sender, so we can't subscribe to its result here
+                // without a broadcast/clone; until that's wired up, a caller
+                // hitting this branch gets a spurious success even if the
+                // real dial later fails.
                 return Response::reply(Ok(()));
             }
             Entry::Vacant(entry) => {

--- a/crates/network/src/handlers/commands/dial.rs
+++ b/crates/network/src/handlers/commands/dial.rs
@@ -41,6 +41,16 @@ impl Handler<Dial> for NetworkManager {
             }
         }
 
-        Response::fut(async { receiver.await.expect("Sender not to be dropped.") })
+        Response::fut(async move {
+            // The sender lives in `pending_dial` and is normally either fired
+            // by `ConnectionEstablished`/`OutgoingConnectionError` or carried
+            // until then. If it is dropped without sending — e.g. the manager
+            // is shutting down and tears down the swarm — `recv` errors out.
+            // Surface that as a dial error rather than panicking the actor.
+            match receiver.await {
+                Ok(result) => result,
+                Err(_) => Err(eyre!("dial cancelled before completion")),
+            }
+        })
     }
 }

--- a/crates/network/src/handlers/stream/swarm.rs
+++ b/crates/network/src/handlers/stream/swarm.rs
@@ -110,7 +110,12 @@ impl StreamHandler<FromSwarm> for NetworkManager {
                 self.record_connected_addr(peer_id, cache_addr);
 
                 // Resolve any pending dial for this peer on *any* established
-                // connection, not just the `Dialer` endpoint. A dial we
+                // connection, not just the `Dialer` endpoint. `pending_dial`
+                // is only ever populated by the `Dial` handler when we call
+                // `swarm.dial()`, so resolving on any endpoint is safe: a
+                // purely inbound connection cannot carry a `pending_dial`
+                // entry unless we also initiated a dial to that peer (the
+                // simultaneous-open case this fix targets). A dial we
                 // initiated can complete as a `Listener` endpoint (e.g. a
                 // simultaneous-open / hole-punched connection where the peer's
                 // SYN wins the race), in which case scoping the clear to

--- a/crates/network/src/handlers/stream/swarm.rs
+++ b/crates/network/src/handlers/stream/swarm.rs
@@ -1,7 +1,6 @@
 use actix::{AsyncContext, StreamHandler};
 use calimero_network_primitives::messages::NetworkEvent;
 use eyre::eyre;
-use libp2p::core::ConnectedPoint;
 use libp2p::swarm::{DialError, SwarmEvent};
 use libp2p::PeerId;
 use multiaddr::{Multiaddr, Protocol};
@@ -110,10 +109,17 @@ impl StreamHandler<FromSwarm> for NetworkManager {
                 let cache_addr = remote.clone();
                 self.record_connected_addr(peer_id, cache_addr);
 
-                if let ConnectedPoint::Dialer { .. } = endpoint {
-                    if let Some(sender) = self.pending_dial.remove(&peer_id) {
-                        let _ignored = sender.send(Ok(()));
-                    }
+                // Resolve any pending dial for this peer on *any* established
+                // connection, not just the `Dialer` endpoint. A dial we
+                // initiated can complete as a `Listener` endpoint (e.g. a
+                // simultaneous-open / hole-punched connection where the peer's
+                // SYN wins the race), in which case scoping the clear to
+                // `Dialer` would strand the `pending_dial` entry — and its
+                // oneshot sender — until shutdown. That leak both wedges the
+                // awaiting `Dial` future indefinitely and, when the swarm is
+                // finally torn down, drops the sender and surfaces as a panic.
+                if let Some(sender) = self.pending_dial.remove(&peer_id) {
+                    let _ignored = sender.send(Ok(()));
                 }
             }
             SwarmEvent::ConnectionClosed {


### PR DESCRIPTION
## Description

This PR fixes a critical bug where pending dial futures could be indefinitely wedged when connections complete as `Listener` endpoints instead of `Dialer` endpoints.

### The Problem

When initiating a dial to a peer, the code stores a oneshot sender in `pending_dial` and waits for either:
1. `ConnectionEstablished` event to fire the sender
2. `OutgoingConnectionError` to fire the sender

However, the `ConnectionEstablished` handler only cleared the pending dial when the connection endpoint was `Dialer`. In simultaneous-open scenarios (e.g., hole-punched connections where both peers dial each other), the connection can complete as a `Listener` endpoint even though we initiated the dial. This caused the pending dial entry to never be cleared, leaving the awaiting `Dial` future permanently blocked.

When the swarm shuts down, it drops the sender without sending a value, causing the receiver to error. The original code would panic on this error with `.expect()`, crashing the actor.

### The Solution

1. **Remove the endpoint check**: Clear pending dials on *any* established connection for the peer, not just `Dialer` endpoints. This handles simultaneous-open scenarios correctly.

2. **Handle sender drops gracefully**: Change the receiver await from `.expect()` to a `match` that converts sender drops into a proper `DialError` instead of panicking.

3. **Add clarifying comments**: Document why this behavior is necessary to prevent future regressions.

## Test plan

Existing tests pass. The fix is defensive — it handles an edge case that would previously cause actor panics during shutdown or in simultaneous-open connection scenarios. Manual verification would require triggering simultaneous-open connections or swarm shutdown during pending dials, which is difficult to reproduce deterministically.

## Wire contract (SDK gate)

N/A — no HTTP wire DTOs or routes changed.

## Documentation update

N/A — internal implementation detail.

https://claude.ai/code/session_01LBMy3RSGzbVrRoN8ML6mgS