### PR TITLE
fix(store): copy iterator keys/values instead of extending lifetimes

### DIFF
--- a/crates/store/impl/rocksdb/src/tests.rs
+++ b/crates/store/impl/rocksdb/src/tests.rs
@@ -210,6 +210,40 @@ fn test_rocksdb_entries_survive_collection() {
     for (key, bytes) in collected_keys.iter().zip(&expected) {
         assert_eq!(key.as_ref(), &bytes[..], "collected key was invalidated");
     }
+
+    // Directly model the use-after-free: retain entry N, advance to N+1, then
+    // read the retained N. The underlying RocksDB cursor has moved on by then,
+    // so an unowned slice would be reading overwritten buffer memory.
+    let mut iter = db.iter(Column::Identity).expect("iter should succeed");
+    let mut entries = iter.entries();
+    let mut prev: Option<(Slice<'_>, Slice<'_>, [u8; 2])> = None;
+    for bytes in &expected {
+        let (key, value) = entries
+            .next()
+            .map(|(k, v)| {
+                (
+                    k.expect("key should be valid"),
+                    v.expect("value should be valid"),
+                )
+            })
+            .expect("entry should exist");
+
+        // Assert the *previous* entry (retained across this advance) is intact.
+        if let Some((prev_key, prev_value, prev_bytes)) = &prev {
+            assert_eq!(
+                prev_key.as_ref(),
+                &prev_bytes[..],
+                "retained key was invalidated by the next advance"
+            );
+            assert_eq!(
+                prev_value.as_ref(),
+                &prev_bytes[..],
+                "retained value was invalidated by the next advance"
+            );
+        }
+
+        prev = Some((key, value, *bytes));
+    }
 }
 
 #[test]

--- a/crates/store/impl/rocksdb/src/tests.rs
+++ b/crates/store/impl/rocksdb/src/tests.rs
@@ -150,6 +150,69 @@ fn test_rocksdb_iter() {
 }
 
 #[test]
+fn test_rocksdb_entries_survive_collection() {
+    // Regression test: keys/values yielded by `entries()`/`keys()` must remain
+    // valid after subsequent `next()` calls. The underlying RocksDB iterator
+    // hands out slices borrowing its internal buffer, which is overwritten on
+    // each advance. Because `Iterator::next` does not tie its item to the
+    // `&mut self` borrow, collecting the items into a `Vec` (or otherwise
+    // retaining them) must not expose freed/overwritten memory.
+    let dir = TempDir::new("_calimero_store_collect").expect("tempdir should be created");
+    let dir_path = dir
+        .path()
+        .to_owned()
+        .try_into()
+        .expect("path conversion should succeed");
+    let config = StoreConfig::new(dir_path);
+    let db = RocksDB::open(&config).expect("db should open");
+
+    let mut expected = Vec::new();
+    for b1 in 0..10 {
+        for b2 in 0..10 {
+            let bytes = [b1, b2];
+            db.put(
+                Column::Identity,
+                Slice::from(&bytes[..]),
+                Slice::from(&bytes[..]),
+            )
+            .expect("put should succeed");
+            expected.push([b1, b2]);
+        }
+    }
+
+    // Collect every entry up front, holding each yielded slice across the
+    // `next()` calls that follow it.
+    let mut iter = db.iter(Column::Identity).expect("iter should succeed");
+    let collected: Vec<(Slice<'_>, Slice<'_>)> = iter
+        .entries()
+        .map(|(k, v)| {
+            (
+                k.expect("key should be valid"),
+                v.expect("value should be valid"),
+            )
+        })
+        .collect();
+
+    assert_eq!(collected.len(), expected.len());
+    for ((key, value), bytes) in collected.iter().zip(&expected) {
+        assert_eq!(key.as_ref(), &bytes[..], "collected key was invalidated");
+        assert_eq!(value.as_ref(), &bytes[..], "collected value was invalidated");
+    }
+
+    // Same expectation for `keys()`.
+    let mut iter = db.iter(Column::Identity).expect("iter should succeed");
+    let collected_keys: Vec<Slice<'_>> = iter
+        .keys()
+        .map(|k| k.expect("key should be valid"))
+        .collect();
+
+    assert_eq!(collected_keys.len(), expected.len());
+    for (key, bytes) in collected_keys.iter().zip(&expected) {
+        assert_eq!(key.as_ref(), &bytes[..], "collected key was invalidated");
+    }
+}
+
+#[test]
 fn test_data_persistence() {
     // Test that data persists across open/close cycles
     let dir = TempDir::new("_calimero_store_persistence").expect("tempdir should be created");

--- a/crates/store/impl/rocksdb/src/tests.rs
+++ b/crates/store/impl/rocksdb/src/tests.rs
@@ -183,6 +183,10 @@ fn test_rocksdb_entries_survive_collection() {
     // Collect every entry up front, holding each yielded slice across the
     // `next()` calls that follow it.
     let mut iter = db.iter(Column::Identity).expect("iter should succeed");
+    // NB: the items are typed `Slice<'_>` (the iterator's `Item` carries the
+    // iterator's lifetime), not `Slice<'static>` — even though the fix backs
+    // them with owned `Box<[u8]>` at runtime. Annotating `'static` here would
+    // wrongly require `db` to be borrowed for `'static` and fail to compile.
     let collected: Vec<(Slice<'_>, Slice<'_>)> = iter
         .entries()
         .map(|(k, v)| {

--- a/crates/store/impl/rocksdb/src/tests.rs
+++ b/crates/store/impl/rocksdb/src/tests.rs
@@ -200,7 +200,11 @@ fn test_rocksdb_entries_survive_collection() {
     assert_eq!(collected.len(), expected.len());
     for ((key, value), bytes) in collected.iter().zip(&expected) {
         assert_eq!(key.as_ref(), &bytes[..], "collected key was invalidated");
-        assert_eq!(value.as_ref(), &bytes[..], "collected value was invalidated");
+        assert_eq!(
+            value.as_ref(),
+            &bytes[..],
+            "collected value was invalidated"
+        );
     }
 
     // Same expectation for `keys()`.

--- a/crates/store/src/iter.rs
+++ b/crates/store/src/iter.rs
@@ -2,7 +2,6 @@ use core::convert::Infallible;
 use core::fmt;
 use core::fmt::{Debug, Formatter};
 use core::marker::PhantomData;
-use core::mem::transmute;
 
 use calimero_primitives::reflect::Reflect;
 use eyre::{Report, Result as EyreResult};
@@ -262,8 +261,13 @@ where
         while !self.iter.done {
             match self.iter.inner.next() {
                 Ok(Some(key)) => {
-                    // safety: key only needs to live as long as the iterator, not it's reference
-                    let key = unsafe { transmute::<Slice<'_>, Slice<'_>>(key) };
+                    // The slice yielded by the underlying iterator borrows its
+                    // internal buffer, which the next `next()` call invalidates.
+                    // `Iterator::next` does not tie the yielded item to the
+                    // `&mut self` borrow, so callers may retain it across
+                    // iterations (e.g. `collect`). Copy into an owned buffer to
+                    // sever that aliasing — see the module note on `Slice`.
+                    let key: Slice<'b> = key.into_boxed().into();
                     match K::try_into_key(key) {
                         Ok(key) => return Some(Ok(key)),
                         // Skip keys with mismatched sizes (different key type in same column)
@@ -324,8 +328,11 @@ where
 
                 match self.iter.inner.next() {
                     Ok(Some(raw_key)) => {
-                        // safety: key only needs to live as long as the iterator, not it's reference
-                        let raw_key = unsafe { transmute::<Slice<'_>, Slice<'_>>(raw_key) };
+                        // Copy into an owned buffer before yielding: the borrowed
+                        // slice points into the underlying iterator's buffer, which
+                        // is invalidated by the next `next()`/`read()` call. See the
+                        // matching note in `IterKeys::next`.
+                        let raw_key: Slice<'b> = raw_key.into_boxed().into();
                         match K::try_into_key(raw_key) {
                             Ok(key) => break key,
                             // Skip keys with mismatched sizes (different key type in same column)
@@ -357,8 +364,11 @@ where
                 }
             };
 
-            // safety: value only needs to live as long as the iterator, not it's reference
-            let value = unsafe { transmute::<Slice<'_>, Slice<'_>>(value) };
+            // Copy into an owned buffer before yielding: the borrowed slice
+            // points into the underlying iterator's buffer, which is invalidated
+            // by the next `next()`/`read()` call. See the matching note in
+            // `IterKeys::next`.
+            let value: Slice<'b> = value.into_boxed().into();
 
             V::try_into_value(value).map_err(Into::into)
         };

--- a/crates/store/src/iter.rs
+++ b/crates/store/src/iter.rs
@@ -267,7 +267,7 @@ where
                     // `&mut self` borrow, so callers may retain it across
                     // iterations (e.g. `collect`). Copy into an owned buffer to
                     // sever that aliasing — see the module note on `Slice`.
-                    let key: Slice<'b> = key.into_boxed().into();
+                    let key: Slice<'static> = key.into_boxed().into();
                     match K::try_into_key(key) {
                         Ok(key) => return Some(Ok(key)),
                         // Skip keys with mismatched sizes (different key type in same column)
@@ -332,7 +332,7 @@ where
                         // slice points into the underlying iterator's buffer, which
                         // is invalidated by the next `next()`/`read()` call. See the
                         // matching note in `IterKeys::next`.
-                        let raw_key: Slice<'b> = raw_key.into_boxed().into();
+                        let raw_key: Slice<'static> = raw_key.into_boxed().into();
                         match K::try_into_key(raw_key) {
                             Ok(key) => break key,
                             // Skip keys with mismatched sizes (different key type in same column)
@@ -368,7 +368,7 @@ where
             // points into the underlying iterator's buffer, which is invalidated
             // by the next `next()`/`read()` call. See the matching note in
             // `IterKeys::next`.
-            let value: Slice<'b> = value.into_boxed().into();
+            let value: Slice<'static> = value.into_boxed().into();
 
             V::try_into_value(value).map_err(Into::into)
         };

--- a/crates/store/src/iter.rs
+++ b/crates/store/src/iter.rs
@@ -79,10 +79,28 @@ impl<'a, K, V> Iter<'a, K, V> {
         }
     }
 
+    /// Returns an iterator over the keys.
+    ///
+    /// # Allocation
+    ///
+    /// Each yielded key is copied into an owned buffer so it stays valid after
+    /// the iterator advances (the backend hands out slices that borrow its
+    /// internal cursor buffer, which the next step overwrites). This means one
+    /// allocation per item — for backends that yield already-owned buffers the
+    /// copy is elided, but for the RocksDB backend (borrowed slices) it is not.
+    /// Callers that only need each key transiently within a single loop
+    /// iteration still pay this cost; a zero-copy streaming variant would
+    /// require a lending iterator (GAT) and is not currently provided.
     pub const fn keys(&mut self) -> IterKeys<'_, 'a, K, V> {
         IterKeys { iter: self }
     }
 
+    /// Returns an iterator over the key-value entries.
+    ///
+    /// # Allocation
+    ///
+    /// Each yielded key and value is copied into an owned buffer; see
+    /// [`Iter::keys`] for the rationale and cost.
     pub const fn entries(&mut self) -> IterEntries<'_, 'a, K, V> {
         IterEntries { iter: self }
     }


### PR DESCRIPTION
## Description

This PR fixes a critical lifetime bug in the RocksDB iterator implementation where borrowed slices from the underlying iterator's internal buffer were being unsafely transmuted to extend their lifetime beyond the iterator's mutable borrow.

The issue: RocksDB's iterator yields slices that borrow its internal buffer, which gets overwritten on each `next()` call. The previous code used `unsafe { transmute }` to extend these slice lifetimes, allowing callers to collect them into a `Vec` or retain them across iterations. This created use-after-free bugs when the collected slices were accessed after the iterator advanced.

The fix: Instead of transmuting lifetimes, we now copy borrowed slices into owned `Box`ed buffers before yielding them. This severs the aliasing relationship with the iterator's internal buffer, making it safe for callers to retain slices across iterations.

Changes:
- Removed unsafe `transmute` calls in `IterKeys::next()`, `IterEntries::next()`, and `IterEntries::read()`
- Replaced with `into_boxed().into()` to copy slices into owned buffers
- Updated comments to explain the lifetime safety rationale
- Added comprehensive regression test `test_rocksdb_entries_survive_collection()` that verifies slices remain valid after collection and subsequent iterator advances

## Test plan

Added `test_rocksdb_entries_survive_collection()` which:
1. Inserts 100 key-value pairs into RocksDB
2. Collects all entries via `entries()` into a `Vec`, holding each slice across subsequent `next()` calls
3. Verifies all collected slices remain valid and contain correct data
4. Repeats the same test for `keys()`

This test would have caught the original bug by triggering use-after-free when accessing collected slices.

## Wire contract (SDK gate)

N/A — no HTTP wire DTOs or routes changed.

## Documentation update

N/A — internal implementation detail.

https://claude.ai/code/session_01JyxQo68oGgb6VkMao1FA3k