### PR TITLE
fix(store): close lifetime-laundering transmute in ArcSlice::new

### DIFF
--- a/crates/store/src/db/memory.rs
+++ b/crates/store/src/db/memory.rs
@@ -119,11 +119,16 @@ struct ArcSlice<'this> {
     inner: Arc<Slice<'this>>,
 }
 
-impl ArcSlice<'_> {
-    fn new<'a, T: CastsTo<Slice<'a>>>(value: Arc<T>) -> Self {
+impl<'this> ArcSlice<'this> {
+    fn new<T: CastsTo<Slice<'this>> + 'this>(value: Arc<T>) -> Self {
         Self {
-            // safety: T: CastsTo<Slice>
-            inner: unsafe { transmute::<Arc<T>, Arc<Slice<'_>>>(value) },
+            // safety: `T: CastsTo<Slice<'this>>` guarantees layout compatibility,
+            // and the `T: 'this` bound guarantees the borrowed data behind `T`
+            // outlives `'this`. Together they make this transmute sound: the
+            // output `Slice<'this>` cannot outlive the data it points at, so a
+            // borrowed slice can no longer be laundered into a longer-lived
+            // (e.g. 'static) one and smuggled across threads.
+            inner: unsafe { transmute::<Arc<T>, Arc<Slice<'this>>>(value) },
         }
     }
 }
@@ -137,6 +142,7 @@ impl AsRef<[u8]> for ArcSlice<'_> {
 impl<'a, T: InMemoryDBImpl<'a> + Debug + 'static> Database<'a> for InMemoryDB<T>
 where
     T::Key: Ord + Clone + Borrow<[u8]>,
+    T::Value: 'static,
 {
     fn open(_config: &StoreConfig) -> EyreResult<Self> {
         todo!("phase this out, please. it's not even worth writing an accomodation for")
@@ -151,7 +157,13 @@ where
             return Ok(None);
         };
 
-        Ok(Some(Slice::from_owned(ArcSlice::new(value))))
+        // The impl requires `T::Value: 'static`, so the cloned `Arc` owns data
+        // valid for `'static`. Build a `'static`-backed slice and let it coerce
+        // to the (shorter) return lifetime — rather than laundering the stored
+        // value's lifetime into an unconstrained one.
+        let value: ArcSlice<'static> = ArcSlice::new(value);
+
+        Ok(Some(Slice::from_owned(value)))
     }
 
     fn put(&self, col: Column, key: Slice<'a>, value: Slice<'a>) -> EyreResult<()> {

--- a/crates/store/src/db/memory/raw.rs
+++ b/crates/store/src/db/memory/raw.rs
@@ -16,8 +16,13 @@ pub trait CastsTo<This> {}
 impl CastsTo<Slice<'_>> for Slice<'_> {}
 
 pub trait InMemoryDBImpl<'a> {
-    type Key: AsRef<[u8]> + CastsTo<Slice<'a>>;
-    type Value: CastsTo<Slice<'a>>;
+    // The `for<'x>` bound makes the cast lifetime-agnostic (it holds for every
+    // `'x` already, via `impl CastsTo<Slice<'_>> for Slice<'_>`). This lets the
+    // database impl recover the value as a `Slice<'static>` when it owns it,
+    // instead of being pinned to `'a`, which is what made `ArcSlice::new`'s
+    // lifetime laundering necessary in the first place.
+    type Key: AsRef<[u8]> + for<'x> CastsTo<Slice<'x>>;
+    type Value: for<'x> CastsTo<Slice<'x>>;
 
     fn db(&self) -> &RwLock<InMemoryDBInner<Self::Key, Self::Value>>;
 


### PR DESCRIPTION
## Description

This PR fixes lifetime safety issues in the in-memory database implementation by:

1. **Tightening `ArcSlice::new` lifetime bounds**: Added explicit `'this` lifetime parameter to the impl block and constrained the generic type `T` with `T: 'this` to ensure borrowed data outlives the slice. This prevents lifetime laundering where a slice could be coerced to a longer lifetime (e.g., `'static`) and unsafely shared across threads.

2. **Making `CastsTo` bounds lifetime-agnostic**: Changed `InMemoryDBImpl` trait bounds from `CastsTo<Slice<'a>>` to `for<'x> CastsTo<Slice<'x>>`. This allows the database to recover owned values as `Slice<'static>` rather than being pinned to the query lifetime `'a`, eliminating the need for unsafe lifetime coercion in the first place.

3. **Adding `T::Value: 'static` bound**: Added explicit `'static` bound to `InMemoryDB<T>` impl to clarify that stored values are owned and valid for the entire program lifetime.

4. **Improving safety documentation**: Enhanced comments explaining the safety invariants of the transmute operation and the lifetime coercion strategy.

These changes maintain the same runtime behavior while making the lifetime safety properties explicit and verifiable by the type system, reducing reliance on unsafe code.

## Test plan

Existing tests pass. The changes are purely type-system refinements that don't alter runtime behavior — the code compiles and functions identically, but with stronger lifetime guarantees that prevent potential safety violations.

## Wire contract (SDK gate)

N/A — no HTTP wire DTOs or routes changed.

## Documentation update

N/A — internal implementation detail.

https://claude.ai/code/session_014cREtd2tSq4AvHEm6rYBe1