### PR TITLE
fix(server/sse): stop leaking node-event task per SSE connection

### DIFF
--- a/crates/server/src/sse/events.rs
+++ b/crates/server/src/sse/events.rs
@@ -3,7 +3,6 @@ use calimero_server_primitives::sse::{
     Command, ConnectionId, Response, ResponseBody, ResponseBodyError, ServerResponseError,
 };
 use core::pin::pin;
-use core::time::Duration;
 use futures_util::StreamExt;
 use serde_json::to_value as to_json_value;
 use std::sync::Arc;
@@ -15,10 +14,21 @@ use super::state::ServiceState;
 
 /// Handle incoming node events and forward to subscribed clients
 ///
+/// # Lifetime
+///
+/// This task is bound to a single SSE connection via `command_sender`. It runs
+/// for as long as that connection is open and **exits as soon as the connection
+/// closes** (the SSE stream's receiver is dropped) or the node's event stream
+/// ends. Exiting promptly is important: the task holds a broadcast receiver
+/// subscription obtained from [`NodeClient::receive_events`], so a task that
+/// outlived its connection would leak that subscription — and the spawned task
+/// itself — for the remaining lifetime of the process. On reconnection, a fresh
+/// task is spawned and bound to the new connection.
+///
 /// # Event Delivery Behavior
 ///
 /// This handler uses a **skip-on-disconnect** model:
-/// - Events are only delivered to currently active connections
+/// - Events are only delivered while the connection is active
 /// - Events that occur during disconnection are **not buffered** and will be skipped
 /// - When a client reconnects, they resume from the current event counter
 /// - Clients should handle gaps in event IDs and re-query application state if needed
@@ -30,23 +40,30 @@ pub async fn handle_node_events(
     session_id: ConnectionId,
     state: Arc<ServiceState>,
     session_state: SessionState,
+    command_sender: mpsc::Sender<Command>,
 ) {
     let events = state.node_client.receive_events();
 
     let mut events = pin!(events);
 
-    while let Some(event) = events.next().await {
-        // Check if there's an active connection for this session
-        let active_connections = state.active_connections.read().await;
-        let Some(active_conn) = active_connections.get(&session_id).cloned() else {
-            debug!(%session_id, "No active connection, skipping event (no buffering)");
-            drop(active_connections);
-
-            // Wait a bit before checking again (connection might be reconnecting)
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            continue;
+    loop {
+        let event = tokio::select! {
+            // Stop as soon as the connection goes away so we don't leak the
+            // broadcast receiver subscription (and this task) for the process
+            // lifetime. The session itself persists for reconnection; a new
+            // task is spawned when the client reconnects.
+            () = command_sender.closed() => {
+                debug!(%session_id, "SSE connection closed, stopping event handler");
+                break;
+            }
+            maybe_event = events.next() => match maybe_event {
+                Some(event) => event,
+                None => {
+                    debug!(%session_id, "Node event stream ended, stopping event handler");
+                    break;
+                }
+            },
         };
-        drop(active_connections);
 
         let subscriptions = session_state.inner.read().await.subscriptions.clone();
 
@@ -76,27 +93,15 @@ pub async fn handle_node_events(
 
         let response = Response { body };
 
-        if let Err(err) = active_conn.commands.send(Command::Send(response)).await {
+        if let Err(err) = command_sender.send(Command::Send(response)).await {
+            // The receiver is gone, so the connection has closed. Stop here
+            // rather than spinning; the session persists for reconnection.
             debug!(
                 %session_id,
                 %err,
-                "Failed to send event (connection closed, event skipped - no buffering)",
+                "Failed to send event (connection closed), stopping event handler",
             );
-            // Don't break - session persists for reconnection, but this event is lost
+            break;
         };
     }
-}
-
-/// Clean up connection when SSE stream closes
-pub async fn handle_connection_cleanup(
-    session_id: ConnectionId,
-    state: Arc<ServiceState>,
-    command_sender: mpsc::Sender<Command>,
-) {
-    command_sender.closed().await;
-
-    // Remove active connection but keep session for reconnection
-    drop(state.active_connections.write().await.remove(&session_id));
-
-    debug!(%session_id, "Active SSE connection closed (session persists for reconnection)");
 }

--- a/crates/server/src/sse/events.rs
+++ b/crates/server/src/sse/events.rs
@@ -48,6 +48,11 @@ pub async fn handle_node_events(
 
     loop {
         let event = tokio::select! {
+            // Poll the close branch first so a closed connection is detected
+            // promptly even when the event stream is producing faster than the
+            // channel drains; otherwise random branch selection could keep
+            // starving the close branch and delay task exit.
+            biased;
             // Stop as soon as the connection goes away so we don't leak the
             // broadcast receiver subscription (and this task) for the process
             // lifetime. The session itself persists for reconnection; a new

--- a/crates/server/src/sse/handlers.rs
+++ b/crates/server/src/sse/handlers.rs
@@ -376,6 +376,14 @@ pub async fn sse_handler(
     // Spawn event handler (after stream setup to ensure command channel is ready).
     // The handler is bound to this connection's command channel and exits on its
     // own when the connection closes, so there is no separate cleanup task to spawn.
+    //
+    // `commands_sender` is moved (not cloned) into the task on purpose: the only
+    // remaining sender then lives inside the handler, while the receiver is owned
+    // by the SSE response stream (`command_stream` above). When the client
+    // disconnects, axum drops the response body and therefore the receiver, which
+    // makes `command_sender.closed()` resolve and the handler exit. (axum streams
+    // the SSE body lazily via `Sse::new`, so the receiver is not held alive by the
+    // handler future itself.)
     drop(tokio::spawn(handle_node_events(
         session_id,
         Arc::clone(&state),

--- a/crates/server/src/sse/handlers.rs
+++ b/crates/server/src/sse/handlers.rs
@@ -56,8 +56,8 @@ use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, info, warn};
 
 use super::config::{retry_timeout, COMMAND_CHANNEL_BUFFER_SIZE, SESSION_EXPIRY_SECS};
-use super::events::{handle_connection_cleanup, handle_node_events};
-use super::session::{now_secs, ActiveConnection, SessionState, SessionStateInner};
+use super::events::handle_node_events;
+use super::session::{now_secs, SessionState, SessionStateInner};
 use super::state::ServiceState;
 use super::storage::{delete_session, load_session, save_session};
 
@@ -293,16 +293,6 @@ pub async fn sse_handler(
         create_new_session(&state).await
     };
 
-    // Register active connection
-    let mut active_connections = state.active_connections.write().await;
-    drop(active_connections.insert(
-        session_id,
-        ActiveConnection {
-            commands: commands_sender.clone(),
-        },
-    ));
-    drop(active_connections);
-
     if is_reconnect {
         info!(%session_id, "Client reconnected, subscriptions restored");
     } else {
@@ -383,18 +373,14 @@ pub async fn sse_handler(
 
     let stream = initial_stream.chain(command_stream);
 
-    // Spawn event handler (after stream setup to ensure command channel is ready)
+    // Spawn event handler (after stream setup to ensure command channel is ready).
+    // The handler is bound to this connection's command channel and exits on its
+    // own when the connection closes, so there is no separate cleanup task to spawn.
     drop(tokio::spawn(handle_node_events(
         session_id,
         Arc::clone(&state),
         session_state.clone(),
-    )));
-
-    // Spawn cleanup handler
-    drop(tokio::spawn(handle_connection_cleanup(
-        session_id,
-        Arc::clone(&state),
-        commands_sender.clone(),
+        commands_sender,
     )));
 
     // Build response with session ID in header for easy client access

--- a/crates/server/src/sse/session.rs
+++ b/crates/server/src/sse/session.rs
@@ -1,11 +1,10 @@
 use calimero_primitives::context::ContextId;
-use calimero_server_primitives::sse::Command;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::RwLock;
 
 use super::config::SESSION_EXPIRY_SECS;
 
@@ -83,12 +82,6 @@ impl SessionStateInner {
 #[derive(Clone, Debug)]
 pub struct SessionState {
     pub inner: Arc<RwLock<SessionStateInner>>,
-}
-
-/// Active SSE connection
-#[derive(Clone, Debug)]
-pub struct ActiveConnection {
-    pub commands: mpsc::Sender<Command>,
 }
 
 /// Get current timestamp in seconds since UNIX epoch

--- a/crates/server/src/sse/state.rs
+++ b/crates/server/src/sse/state.rs
@@ -4,7 +4,7 @@ use calimero_store::Store;
 use std::collections::HashMap;
 use tokio::sync::RwLock;
 
-use super::session::{ActiveConnection, SessionState};
+use super::session::SessionState;
 
 /// Global SSE service state
 pub struct ServiceState {
@@ -12,8 +12,6 @@ pub struct ServiceState {
     pub store: Store,
     /// Session state persists across reconnections (in-memory cache)
     pub sessions: RwLock<HashMap<ConnectionId, SessionState>>,
-    /// Active connections track current SSE streams
-    pub active_connections: RwLock<HashMap<ConnectionId, ActiveConnection>>,
 }
 
 impl ServiceState {
@@ -24,7 +22,6 @@ impl ServiceState {
             node_client,
             store,
             sessions: RwLock::default(),
-            active_connections: RwLock::default(),
         }
     }
 }


### PR DESCRIPTION
## Description

This PR refactors the SSE event handler to eliminate unnecessary complexity in connection lifecycle management. The key changes are:

1. **Remove active connection tracking**: Deleted the `active_connections` map and `ActiveConnection` struct that tracked current SSE streams. This was redundant since the event handler can directly monitor its own connection state.

2. **Simplify event handler lifecycle**: Modified `handle_node_events` to:
   - Accept `command_sender` directly as a parameter
   - Use `tokio::select!` to monitor both the event stream and the connection status
   - Exit immediately when the connection closes (via `command_sender.closed()`) or the event stream ends
   - Remove the polling loop with 100ms sleep that checked `active_connections`

3. **Remove cleanup task**: Deleted the separate `handle_connection_cleanup` task since the event handler now manages its own cleanup by exiting when the connection closes.

4. **Improve documentation**: Enhanced the docstring to clarify the task's lifetime, the importance of exiting promptly to avoid leaking broadcast receiver subscriptions, and the skip-on-disconnect event delivery model.

The refactoring maintains the same behavior (skip-on-disconnect event delivery, session persistence across reconnections) while reducing code complexity and eliminating the need for shared mutable state tracking active connections.

## Test plan

Existing tests should cover this change. The refactoring preserves the event delivery semantics and connection handling behavior. Manual verification would involve:
- Establishing an SSE connection and verifying events are delivered
- Disconnecting and reconnecting to verify session persistence
- Confirming no resource leaks occur during repeated connect/disconnect cycles

## Wire contract (SDK gate)

No HTTP wire DTOs or routes were changed.

- [ ] N/A — no wire contract changes

https://claude.ai/code/session_01GnRSmJB2628Uk5pUeyM8iC