### PR TITLE
fix: prevent privilege escalation in key permission updates

### DIFF
--- a/crates/auth/src/api/handlers/permissions.rs
+++ b/crates/auth/src/api/handlers/permissions.rs
@@ -4,10 +4,12 @@ use axum::extract::{Extension, Path};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde::{Deserialize, Serialize};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use validator::Validate;
 
 use crate::api::handlers::auth::{error_response, success_response};
+use crate::auth::middleware::CallerPermissions;
+use crate::auth::permissions::{Permission, PermissionValidator};
 use crate::auth::validation::{sanitize_string, ValidatedJson};
 use crate::server::AppState;
 use crate::storage::StorageError;
@@ -69,6 +71,40 @@ pub async fn get_key_permissions_handler(
     }
 }
 
+/// Reason a requested permission grant was denied.
+#[derive(Debug, PartialEq, Eq)]
+enum GrantDenial {
+    /// The permission string could not be parsed into a known permission.
+    InvalidFormat(String),
+    /// The caller does not hold a permission that satisfies the requested one.
+    Escalation(String),
+}
+
+/// Ensure the caller is only granting permissions they themselves hold.
+///
+/// For every permission in `add`, the caller must hold a permission that
+/// satisfies it (`admin` satisfies everything; scoped permissions follow the
+/// usual hierarchy). Permissions that fail to parse are rejected so we never
+/// grant something we cannot reason about.
+fn validate_grantable_permissions(
+    caller_permissions: &[String],
+    add: &[String],
+) -> Result<(), GrantDenial> {
+    let validator = PermissionValidator::new();
+
+    for perm in add {
+        let parsed = perm
+            .parse::<Permission>()
+            .map_err(GrantDenial::InvalidFormat)?;
+
+        if !validator.validate_permissions(caller_permissions, std::slice::from_ref(&parsed)) {
+            return Err(GrantDenial::Escalation(perm.clone()));
+        }
+    }
+
+    Ok(())
+}
+
 /// Key permissions update handler
 ///
 /// This endpoint updates the permissions for a key.
@@ -85,6 +121,7 @@ pub async fn get_key_permissions_handler(
 /// * `impl IntoResponse` - The response
 pub async fn update_key_permissions_handler(
     state: Extension<Arc<AppState>>,
+    Extension(caller_permissions): Extension<CallerPermissions>,
     Path(key_id): Path<String>,
     ValidatedJson(mut request): ValidatedJson<UpdateKeyPermissionsRequest>,
 ) -> impl IntoResponse {
@@ -98,6 +135,37 @@ pub async fn update_key_permissions_handler(
         *remove = remove.iter().map(|p| sanitize_string(p)).collect();
         remove.retain(|p| !p.is_empty()); // Remove empty permissions after sanitization
     }
+
+    // Prevent privilege escalation: a caller may only grant permissions that
+    // they themselves hold. Without this check, any key with
+    // `keys:update_permissions` could add arbitrary permissions (including
+    // `admin`) to a key and escalate its own privileges.
+    //
+    // Only additions are restricted; removing permissions is always allowed.
+    if let Some(add) = &request.add {
+        match validate_grantable_permissions(&caller_permissions.0, add) {
+            Ok(()) => {}
+            Err(GrantDenial::InvalidFormat(e)) => {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    format!("Invalid permission format: {e}"),
+                    None,
+                );
+            }
+            Err(GrantDenial::Escalation(perm)) => {
+                warn!(
+                    "Privilege escalation blocked: caller attempted to grant '{}' to key '{}' without holding it",
+                    perm, key_id
+                );
+                return error_response(
+                    StatusCode::FORBIDDEN,
+                    "Cannot grant permissions that exceed your own",
+                    None,
+                );
+            }
+        }
+    }
+
     // Get current key
     let key_result = state.0.key_manager.get_key(&key_id).await;
 
@@ -201,5 +269,92 @@ pub async fn update_key_permissions_handler(
             error!("Failed to get key: {}", err);
             error_response(StatusCode::INTERNAL_SERVER_ERROR, "Failed to get key", None)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_grantable_permissions, GrantDenial};
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn non_admin_cannot_grant_admin() {
+        // A key that can only update permissions must not be able to grant
+        // `admin` (the core privilege-escalation vector).
+        let caller = strings(&["keys:permissions:update"]);
+        let result = validate_grantable_permissions(&caller, &strings(&["admin"]));
+        assert_eq!(result, Err(GrantDenial::Escalation("admin".to_string())));
+    }
+
+    #[test]
+    fn caller_cannot_grant_permission_it_does_not_hold() {
+        // Holding the update-permissions capability does not let the caller
+        // hand out unrelated permissions such as creating keys.
+        let caller = strings(&["keys:permissions:update", "keys:list"]);
+        let result = validate_grantable_permissions(&caller, &strings(&["keys:create"]));
+        assert_eq!(
+            result,
+            Err(GrantDenial::Escalation("keys:create".to_string()))
+        );
+    }
+
+    #[test]
+    fn admin_can_grant_anything() {
+        let caller = strings(&["admin"]);
+        assert_eq!(
+            validate_grantable_permissions(
+                &caller,
+                &strings(&["admin", "keys:create", "context:execute"])
+            ),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn caller_can_grant_permission_it_holds() {
+        let caller = strings(&["keys:permissions:update", "keys:create", "keys:list"]);
+        assert_eq!(
+            validate_grantable_permissions(&caller, &strings(&["keys:create", "keys:list"])),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn caller_can_grant_narrower_scope_than_it_holds() {
+        // A caller holding a global-scoped permission may grant the same
+        // permission scoped to a specific resource (a subset of its own).
+        let caller = strings(&["context:list"]);
+        assert_eq!(
+            validate_grantable_permissions(&caller, &strings(&["context:list[ctx-1]"])),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn caller_cannot_widen_scope_beyond_what_it_holds() {
+        // The reverse is not allowed: a caller scoped to one resource cannot
+        // grant a global-scoped permission.
+        let caller = strings(&["context:list[ctx-1]"]);
+        let result = validate_grantable_permissions(&caller, &strings(&["context:list"]));
+        assert_eq!(
+            result,
+            Err(GrantDenial::Escalation("context:list".to_string()))
+        );
+    }
+
+    #[test]
+    fn unparseable_permission_is_rejected() {
+        let caller = strings(&["admin"]);
+        let result = validate_grantable_permissions(&caller, &strings(&["not-a-real-permission"]));
+        assert!(matches!(result, Err(GrantDenial::InvalidFormat(_))));
+    }
+
+    #[test]
+    fn empty_add_list_is_allowed() {
+        let caller = strings(&["keys:permissions:update"]);
+        assert_eq!(validate_grantable_permissions(&caller, &[]), Ok(()));
     }
 }

--- a/crates/auth/src/auth/middleware.rs
+++ b/crates/auth/src/auth/middleware.rs
@@ -11,6 +11,15 @@ use crate::auth::permissions::PermissionValidator;
 use crate::server::AppState;
 use crate::AuthError;
 
+/// Permissions of the authenticated caller.
+///
+/// Injected into the request extensions by [`auth_middleware`] so that
+/// downstream handlers can perform fine-grained, caller-aware authorization
+/// (for example, preventing a caller from granting permissions they do not
+/// themselves hold).
+#[derive(Debug, Clone)]
+pub struct CallerPermissions(pub Vec<String>);
+
 /// Authentication middleware for protected routes
 ///
 /// This middleware validates JWT tokens and enforces permissions for protected API endpoints.
@@ -26,7 +35,7 @@ use crate::AuthError;
 /// * `Result<Response, (StatusCode, HeaderMap)>` - The response or error with headers
 pub async fn auth_middleware(
     state: Extension<Arc<AppState>>,
-    request: Request<Body>,
+    mut request: Request<Body>,
     next: Next,
 ) -> Result<Response, (StatusCode, HeaderMap)> {
     // Extract request details for logging
@@ -68,6 +77,13 @@ pub async fn auth_middleware(
                 headers.insert("X-Auth-Error", "permission_denied".parse().unwrap());
                 return Err((StatusCode::FORBIDDEN, headers));
             }
+
+            // Make the caller's permissions available to downstream handlers
+            // so they can enforce caller-aware authorization (e.g. preventing
+            // privilege escalation when updating another key's permissions).
+            request
+                .extensions_mut()
+                .insert(CallerPermissions(auth_response.permissions.clone()));
 
             let mut response = next.run(request).await;
             let duration = start_time.elapsed();


### PR DESCRIPTION
## Description

This PR adds authorization checks to prevent privilege escalation when updating key permissions. Previously, any key with `keys:update_permissions` could grant arbitrary permissions (including `admin`) to itself or other keys, bypassing the intended permission hierarchy.

The fix introduces:

1. **`validate_grantable_permissions()` function**: Validates that a caller can only grant permissions they themselves hold. This respects the permission hierarchy where:
   - `admin` satisfies all permissions
   - Scoped permissions (e.g., `context:list[ctx-1]`) can be narrowed but not widened
   - Unparseable permissions are rejected to prevent granting unknown capabilities

2. **`CallerPermissions` extension**: A new type injected into request extensions by the auth middleware, making the authenticated caller's permissions available to downstream handlers for fine-grained authorization decisions.

3. **Updated `update_key_permissions_handler()`**: Now validates all permissions in the `add` list before applying updates. Permission removals are unrestricted. Invalid or escalating permissions are rejected with appropriate HTTP status codes (400 for invalid format, 403 for escalation attempts).

The change is backward compatible—only additions are restricted; existing permission removal functionality is unchanged.

## Test plan

Added comprehensive unit tests covering:
- Non-admin users cannot grant `admin` permission
- Callers cannot grant permissions they don't hold
- Admin users can grant any permission
- Callers can grant permissions they hold
- Scoped permissions can be narrowed but not widened
- Unparseable permissions are rejected
- Empty permission lists are allowed

All tests pass and validate the privilege escalation prevention logic.

## Wire contract (SDK gate)

- [x] No DTO changes (only internal authorization logic)
- [x] No route changes
- [x] No SDK updates needed

https://claude.ai/code/session_014vuBNRRMNdHEKLuAksCQtx