### PR TITLE
fix: unify equal-HLC delete-vs-update tiebreak across storage types

### DIFF
--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -1674,15 +1674,29 @@ impl<S: StorageAdaptor> Interface<S> {
                                 // leaks current-nonce state to
                                 // unauthenticated probers).
                                 //
-                                // DeleteRef keeps the strict `Err` on
-                                // `<=` (unlike upsert's silent skip)
-                                // because a stale delete being
-                                // silently accepted vs dropped
-                                // carries different semantics than
-                                // a stale upsert, and rare-by-design
-                                // deletes don't drive the
-                                // post-divergence convergence problem
-                                // upsert silent-skip fixes.
+                                // DeleteRef rejects only STRICTLY stale
+                                // nonces (`<`) with a hard `Err` — unlike
+                                // upsert's silent skip — because a stale
+                                // delete dropped vs accepted carries
+                                // different semantics than a stale upsert,
+                                // and rare-by-design deletes don't drive
+                                // the post-divergence convergence problem
+                                // the upsert silent-skip fixes.
+                                //
+                                // The EQUAL-nonce case (`==`) is NOT
+                                // rejected here: it falls through to
+                                // `apply_delete_ref_action`, whose tiebreak
+                                // (`deleted_at < updated_at` ⇒ delete loses,
+                                // so equal ⇒ delete WINS) resolves the
+                                // delete-vs-update tie deterministically and
+                                // identically for every storage type. The
+                                // previous `<=` rejected equal-HLC deletes
+                                // for signed types only, while `Public` (no
+                                // nonce gate) and the apply path both let
+                                // equal through — so signed vs `Public`
+                                // diverged on the equal-HLC delete-vs-update
+                                // tie. Using `<` here unifies the tiebreak
+                                // across all storage types.
                                 let payload = action.payload_for_signing();
                                 let verification_result = crate::env::ed25519_verify(
                                     &sig_data.signature,
@@ -1699,7 +1713,7 @@ impl<S: StorageAdaptor> Interface<S> {
                                 // the index.
                                 let new_nonce = sig_data.nonce;
                                 let last_nonce = *existing_metadata.updated_at;
-                                if new_nonce <= last_nonce {
+                                if new_nonce < last_nonce {
                                     return Err(StorageError::NonceReplay(Box::new((
                                         *owner, new_nonce,
                                     ))));
@@ -1742,10 +1756,14 @@ impl<S: StorageAdaptor> Interface<S> {
                                 // `NonceReplay` (which leaks
                                 // current-nonce state).
                                 //
-                                // DeleteRef keeps the strict `Err` on
-                                // `<=` (unlike upsert's silent skip)
-                                // — see the User DeleteRef arm for
-                                // rationale.
+                                // DeleteRef rejects only STRICTLY stale
+                                // nonces (`<`) with a hard `Err` (unlike
+                                // upsert's silent skip); the equal-nonce
+                                // case falls through to the apply-path
+                                // tiebreak so the equal-HLC delete-vs-update
+                                // resolution is identical across storage
+                                // types — see the User DeleteRef arm for
+                                // the full rationale.
                                 //
                                 // Identify the signer.
                                 // Fast path: if the action carries a `signer` hint and that
@@ -1781,19 +1799,21 @@ impl<S: StorageAdaptor> Interface<S> {
 
                                 // Replay protection (per-entity monotonic nonce).
                                 //
-                                // Strict `<=` Err, symmetric with the
+                                // Strict `<` Err, symmetric with the
                                 // User DeleteRef arm above and matching
                                 // the rationale documented there: stale
                                 // delete semantics differ from upsert
-                                // silent-skip, and DeleteRef tests do
-                                // not opt into the test-only bypass.
-                                // Removing the previously-speculative
+                                // silent-skip, the equal-HLC case falls
+                                // through to the unified apply-path
+                                // tiebreak, and DeleteRef tests do not
+                                // opt into the test-only bypass. Removing
+                                // the previously-speculative
                                 // `nonce_check_disabled_for_testing`
                                 // guard here so the two delete arms
                                 // behave identically.
                                 let new_nonce = sig_data.nonce;
                                 let last_nonce = *existing_metadata.updated_at;
-                                if new_nonce <= last_nonce {
+                                if new_nonce < last_nonce {
                                     let placeholder = existing_writers
                                         .keys()
                                         .copied()
@@ -1880,10 +1900,12 @@ impl<S: StorageAdaptor> Interface<S> {
                                 // Operation-granularity gate: deletes need DELETE.
                                 Self::enforce_op_mask(&signer, OpMask::DELETE, &existing_writers)?;
 
-                                // Replay protection (strict `<=` Err, as Shared).
+                                // Replay protection (strict `<` Err, as Shared:
+                                // equal-HLC falls through to the unified
+                                // apply-path delete-vs-update tiebreak).
                                 let new_nonce = sig_data.nonce;
                                 let last_nonce = *existing_metadata.updated_at;
-                                if new_nonce <= last_nonce {
+                                if new_nonce < last_nonce {
                                     let placeholder = existing_writers
                                         .keys()
                                         .copied()
@@ -2315,7 +2337,16 @@ impl<S: StorageAdaptor> Interface<S> {
             return Ok(());
         };
 
-        // Guard: Local update is newer, deletion loses
+        // Guard: Local update is newer, deletion loses.
+        //
+        // This is the SINGLE canonical equal-HLC delete-vs-update tiebreak
+        // for every storage type. The strict `<` means a STRICTLY older
+        // delete loses, while an equal-HLC delete (`deleted_at ==
+        // updated_at`) WINS. The signed-type verify arms (User/Shared/
+        // SharedMember) reject only strictly-stale nonces (`<`) and let
+        // equal-HLC deletes fall through to here, and `Public` has no nonce
+        // gate at all — so all four types resolve the equal-HLC tie
+        // identically rather than signed types rejecting it earlier.
         if deleted_at < *metadata.updated_at {
             // Local update wins, ignore older deletion
             return Ok(());

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -1000,9 +1000,12 @@ mod user_storage_replay_protection {
         // post-divergence sync convergence.
         //
         // Strict rejection semantics remain for STRICTLY-LOWER
-        // nonces (see `replay_with_lower_nonce_fails` below) and
-        // for `DeleteRef` (where same-nonce delete is destructive
-        // and shouldn't occur in legitimate flows).
+        // nonces (see `replay_with_lower_nonce_fails` below). The
+        // `DeleteRef` arms now reject only strictly-lower nonces too
+        // and let the EQUAL-nonce case fall through to the unified
+        // apply-path tiebreak (`apply_delete_ref_action`: equal-HLC
+        // ⇒ delete wins) so signed types and `Public` resolve the
+        // equal-HLC delete-vs-update tie identically.
         //
         // **Why this test constructs the action manually** instead
         // of using `create_signed_user_add_action`: that helper
@@ -1102,7 +1105,10 @@ mod user_storage_replay_protection {
         // nonce)` and verify still runs.
         //
         // The DeleteRef path keeps the strict `Err(NonceReplay)` on
-        // `<=` — see `tombstone_replay_with_lower_nonce_fails`.
+        // STRICTLY-lower nonces (`<`); the equal-nonce case falls
+        // through to the unified apply-path tiebreak — see
+        // `user_delete_replay_protection` (strictly-stale) and
+        // `equal_nonce_delete_wins_like_public` (equal-HLC).
         env::reset_for_testing();
 
         let (signing_key, owner) = create_test_keypair();
@@ -2699,6 +2705,97 @@ mod storage_type_edge_cases {
         // Entity should still exist
         let retrieved = MainInterface::find_by_id::<Page>(page.id()).unwrap();
         assert!(retrieved.is_some());
+    }
+
+    #[test]
+    fn equal_nonce_delete_wins_like_public() {
+        // Unified equal-HLC delete-vs-update tiebreak: a signed
+        // `DeleteRef` whose nonce EQUALS the stored `updated_at` must
+        // be ACCEPTED and win (delete-wins-on-equal), exactly as a
+        // `Public` delete is. Before unification the signed verify
+        // arms rejected this case with `NonceReplay` (the `<=`
+        // boundary) while the apply path and `Public` (no nonce gate)
+        // both accepted it — so signed types and `Public` diverged on
+        // the equal-HLC tie. The verify arms now reject only
+        // STRICTLY-lower nonces (`<`) and let the equal case fall
+        // through to `apply_delete_ref_action`'s tiebreak
+        // (`deleted_at < updated_at` ⇒ delete loses, so equal ⇒ delete
+        // wins). Contrast `user_delete_replay_protection`, which keeps
+        // the strict `NonceReplay` on a STRICTLY-lower delete nonce.
+        crate::tests::common::register_test_merge_functions();
+        env::reset_for_testing();
+
+        let (signing_key, owner) = create_test_keypair();
+
+        let mut element = Element::root();
+        element.set_user_domain(owner);
+        let page = Page::new_from_element("Page", element);
+        let serialized = to_vec(&page).unwrap();
+
+        let nonce1 = env::time_now();
+        let action1 =
+            create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce1);
+        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
+
+        // The stored replay nonce after the add. Build a delete whose
+        // signed nonce AND `deleted_at` both equal it — mirroring the
+        // production invariant that both come from the same HLC — so
+        // the equal-HLC path is exercised in BOTH the verify and apply
+        // stages.
+        let stored = *<Index<MainStorage>>::get_metadata(page.id())
+            .unwrap()
+            .unwrap()
+            .updated_at;
+
+        let metadata = Metadata {
+            created_at: 0,
+            updated_at: stored.into(),
+            storage_type: StorageType::User {
+                owner,
+                signature_data: Some(SignatureData {
+                    signature: [0; 64],
+                    nonce: stored,
+                    signer: None,
+                }),
+            },
+            crdt_type: None,
+            field_name: None,
+            schema_version: None,
+        };
+        let mut delete_action = Action::DeleteRef {
+            id: page.id(),
+            deleted_at: stored,
+            metadata,
+        };
+        let signature = sign_action(&delete_action, &signing_key);
+        if let Action::DeleteRef {
+            metadata: ref mut m,
+            ..
+        } = delete_action
+        {
+            if let StorageType::User {
+                signature_data: ref mut sd,
+                ..
+            } = m.storage_type
+            {
+                *sd = Some(SignatureData {
+                    signature,
+                    nonce: stored,
+                    signer: None,
+                });
+            }
+        }
+
+        // Equal-HLC delete is accepted (not `NonceReplay`) and wins.
+        let result = MainInterface::apply_action(delete_action, &ApplyContext::empty());
+        assert!(
+            result.is_ok(),
+            "equal-HLC signed delete must be accepted (delete-wins), got {result:?}"
+        );
+        assert!(
+            MainInterface::find_by_id::<Page>(page.id()).unwrap().is_none(),
+            "equal-HLC delete must win, removing the entity"
+        );
     }
 }
 

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -2793,7 +2793,9 @@ mod storage_type_edge_cases {
             "equal-HLC signed delete must be accepted (delete-wins), got {result:?}"
         );
         assert!(
-            MainInterface::find_by_id::<Page>(page.id()).unwrap().is_none(),
+            MainInterface::find_by_id::<Page>(page.id())
+                .unwrap()
+                .is_none(),
             "equal-HLC delete must win, removing the entity"
         );
     }


### PR DESCRIPTION
## Description

This PR fixes a divergence in how signed storage types (User, Shared, SharedMember) and Public storage types handle delete operations when the delete nonce equals the stored update timestamp (equal-HLC case).

**The Problem:**
- Signed types were rejecting equal-HLC deletes with `NonceReplay` error (using `<=` boundary)
- Public type and the apply-path tiebreak were accepting equal-HLC deletes (no nonce gate)
- This caused signed vs Public to diverge on the equal-HLC delete-vs-update tie

**The Solution:**
- Change the nonce check boundary from `<=` to `<` in all three signed-type DeleteRef arms (User, Shared, SharedMember)
- This rejects only STRICTLY-stale nonces while letting equal-HLC deletes fall through
- The unified tiebreak in `apply_delete_ref_action` (`deleted_at < updated_at` ⇒ delete loses, so equal ⇒ delete wins) now handles the equal case identically for all storage types
- Maintains strict replay protection for strictly-lower nonces while achieving deterministic behavior across all types

**Changes:**
- Modified nonce comparison in three DeleteRef verify arms from `new_nonce <= last_nonce` to `new_nonce < last_nonce`
- Updated `apply_delete_ref_action` guard comment to document this as the canonical equal-HLC tiebreak
- Added comprehensive test `equal_nonce_delete_wins_like_public` to verify the unified behavior
- Updated all related comments to clarify the new semantics

## Test plan

The change is covered by:
1. New test `equal_nonce_delete_wins_like_public` - verifies that equal-HLC signed deletes are accepted and win, matching Public behavior
2. Existing test `user_delete_replay_protection` - continues to verify strict rejection of strictly-lower nonces
3. All existing replay protection tests pass with the stricter boundary

The test constructs a DeleteRef action with nonce and `deleted_at` both equal to the stored `updated_at`, verifying it's accepted (not `NonceReplay`) and successfully deletes the entity.

## Wire contract (SDK gate)

N/A - No HTTP wire DTOs or routes changed.

## Documentation update

N/A - This is an internal storage consistency fix with no public API changes.

https://claude.ai/code/session_014VGKcsjuFcDbj1YGU4kqSZ