### PR TITLE
fix: replace InMemoryDB::open todo with proper error handling

### DIFF
--- a/crates/store/src/db/memory.rs
+++ b/crates/store/src/db/memory.rs
@@ -139,7 +139,14 @@ where
     T::Key: Ord + Clone + Borrow<[u8]>,
 {
     fn open(_config: &StoreConfig) -> EyreResult<Self> {
-        todo!("phase this out, please. it's not even worth writing an accomodation for")
+        // `InMemoryDB` has no on-disk representation to open and is never
+        // constructed through the generic `Database::open` path in practice.
+        // Return a recoverable error (rather than panicking) so generic
+        // callers don't crash, and point them at the real constructors.
+        Err(eyre!(
+            "InMemoryDB cannot be opened via `Database::open`; \
+             use `InMemoryDB::owned()` or `InMemoryDB::referenced()` instead"
+        ))
     }
 
     fn has(&self, col: Column, key: Slice<'_>) -> EyreResult<bool> {


### PR DESCRIPTION
## Description

Replace the `todo!()` panic in `InMemoryDB::open` with a recoverable error that provides helpful guidance to callers. 

`InMemoryDB` has no on-disk representation and is never constructed through the generic `Database::open` path in practice. Rather than panicking, this change returns a descriptive `eyre::Error` that directs users to the appropriate constructors (`InMemoryDB::owned()` or `InMemoryDB::referenced()`). This allows generic callers that may invoke `open` to fail gracefully instead of crashing.

## Test plan

N/A — This is a straightforward error handling improvement. The change converts a panic path into a recoverable error, which is inherently safer. Existing tests that don't call `InMemoryDB::open` directly are unaffected.

## Wire contract (SDK gate)

Not applicable — no HTTP wire DTOs or routes changed.

## Documentation update

Not applicable — this is an internal implementation detail.

https://claude.ai/code/session_01NFfwxcSvSVTeeaEmujBKK2