### PR TITLE
Revert "fix(governance): replace unvalidated u8 discriminants with typed enums and bounds checks"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,7 +1337,6 @@ dependencies = [
  "calimero-context-config",
  "calimero-crypto",
  "calimero-dag",
- "calimero-governance-types",
  "calimero-network-primitives",
  "calimero-node-primitives",
  "calimero-op",

--- a/crates/context/config/src/lib.rs
+++ b/crates/context/config/src/lib.rs
@@ -130,17 +130,7 @@ impl<'a> GroupRequest<'a> {
 ///
 /// The walk in `check_group_membership` stops at the first `Restricted`
 /// ancestor; a `Restricted` subgroup is a wall regardless of what sits above.
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    borsh::BorshSerialize,
-    borsh::BorshDeserialize,
-)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum VisibilityMode {
     Open,
     Restricted,

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 
 use actix::Message;
 use calimero_context_config::types::{AppKey, ContextGroupId, SignedGroupOpenInvitation};
-use calimero_context_config::VisibilityMode;
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::{ContextId, GroupMemberRole, UpgradePolicy};
 use calimero_primitives::identity::PublicKey;
@@ -724,7 +723,7 @@ impl Message for SetSubgroupVisibilityRequest {
 #[derive(Debug)]
 pub struct StoreSubgroupVisibilityRequest {
     pub group_id: ContextGroupId,
-    pub mode: VisibilityMode,
+    pub mode: u8,
 }
 
 impl Message for StoreSubgroupVisibilityRequest {

--- a/crates/context/src/handlers/set_subgroup_visibility.rs
+++ b/crates/context/src/handlers/set_subgroup_visibility.rs
@@ -55,6 +55,11 @@ impl Handler<SetSubgroupVisibilityRequest> for ContextManager {
             return ActorResponse::reply(Err(err));
         }
 
+        let mode_u8 = match subgroup_visibility {
+            calimero_context_config::VisibilityMode::Open => 0u8,
+            calimero_context_config::VisibilityMode::Restricted => 1u8,
+        };
+
         let datastore = preflight.datastore.clone();
         let node_client = preflight.node_client.clone();
         let ack_router = Arc::clone(&self.ack_router);
@@ -68,9 +73,7 @@ impl Handler<SetSubgroupVisibilityRequest> for ContextManager {
                     &ack_router,
                     &group_id,
                     &sk,
-                    GroupOp::SubgroupVisibilitySet {
-                        mode: subgroup_visibility,
-                    },
+                    GroupOp::SubgroupVisibilitySet { mode: mode_u8 },
                 )
                 .await?;
                 report.observe("set_subgroup_visibility", "SubgroupVisibilitySet");

--- a/crates/context/src/handlers/store_subgroup_visibility.rs
+++ b/crates/context/src/handlers/store_subgroup_visibility.rs
@@ -1,5 +1,6 @@
 use actix::{ActorResponse, Handler, Message};
 use calimero_context_client::group::StoreSubgroupVisibilityRequest;
+use calimero_context_config::VisibilityMode;
 use calimero_governance_store::CapabilitiesRepository;
 
 use crate::ContextManager;
@@ -12,8 +13,12 @@ impl Handler<StoreSubgroupVisibilityRequest> for ContextManager {
         StoreSubgroupVisibilityRequest { group_id, mode }: StoreSubgroupVisibilityRequest,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
-        let result =
-            CapabilitiesRepository::new(&self.datastore).set_subgroup_visibility(&group_id, mode);
+        let visibility = match mode {
+            0 => VisibilityMode::Open,
+            _ => VisibilityMode::Restricted,
+        };
+        let result = CapabilitiesRepository::new(&self.datastore)
+            .set_subgroup_visibility(&group_id, visibility);
         ActorResponse::reply(result)
     }
 }

--- a/crates/context/tests/projection_membership_equivalence.rs
+++ b/crates/context/tests/projection_membership_equivalence.rs
@@ -119,9 +119,7 @@ fn fold_subgroup_structure(
     let vis = ns_group_envelope(namespace, admin, subgroup);
     proj.ingest_op(&op_from_namespace_op(
         &vis,
-        Some(&GroupOp::SubgroupVisibilitySet {
-            mode: calimero_context_config::VisibilityMode::Open,
-        }),
+        Some(&GroupOp::SubgroupVisibilitySet { mode: 0 }), // 0 = Open
         visibility_id,
         hlc(0),
         &[created_id],

--- a/crates/governance-store/Cargo.toml
+++ b/crates/governance-store/Cargo.toml
@@ -28,7 +28,6 @@ tracing.workspace = true
 
 calimero-context-config.workspace = true
 calimero-context-client.workspace = true
-calimero-governance-types.workspace = true
 calimero-crypto.workspace = true
 calimero-dag.workspace = true
 calimero-network-primitives.workspace = true

--- a/crates/governance-store/src/capabilities.rs
+++ b/crates/governance-store/src/capabilities.rs
@@ -199,18 +199,6 @@ impl<'a> CapabilitiesRepository<'a> {
         Ok(())
     }
 
-    pub fn delete_context_member(
-        &self,
-        group_id: &ContextGroupId,
-        context_id: &ContextId,
-        member: &PublicKey,
-    ) -> EyreResult<()> {
-        let mut handle = self.store.handle();
-        let key = GroupContextMemberCap::new(group_id.to_bytes(), *context_id, *member);
-        handle.delete(&key)?;
-        Ok(())
-    }
-
     pub fn set_context_member(
         &self,
         group_id: &ContextGroupId,

--- a/crates/governance-store/src/ops/group/context_capability_granted.rs
+++ b/crates/governance-store/src/ops/group/context_capability_granted.rs
@@ -3,7 +3,6 @@
 
 use super::context::GroupApplyCtx;
 use crate::CapabilitiesRepository;
-use calimero_governance_types::ContextCapabilityBits;
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
 use eyre::Result as EyreResult;
@@ -12,7 +11,7 @@ pub(crate) fn apply(
     ctx: &mut GroupApplyCtx<'_>,
     context_id: &ContextId,
     member: &PublicKey,
-    capability: &ContextCapabilityBits,
+    capability: &u8,
 ) -> EyreResult<()> {
     let signer = ctx.signer();
     let group_id = ctx.group_id();
@@ -24,6 +23,6 @@ pub(crate) fn apply(
     let current = caps
         .context_member_capability(group_id, context_id, member)?
         .unwrap_or(0);
-    caps.set_context_member(group_id, context_id, member, current | capability.get())?;
+    caps.set_context_member(group_id, context_id, member, current | capability)?;
     Ok(())
 }

--- a/crates/governance-store/src/ops/group/context_capability_revoked.rs
+++ b/crates/governance-store/src/ops/group/context_capability_revoked.rs
@@ -3,7 +3,6 @@
 
 use super::context::GroupApplyCtx;
 use crate::CapabilitiesRepository;
-use calimero_governance_types::ContextCapabilityBits;
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
 use eyre::Result as EyreResult;
@@ -12,7 +11,7 @@ pub(crate) fn apply(
     ctx: &mut GroupApplyCtx<'_>,
     context_id: &ContextId,
     member: &PublicKey,
-    capability: &ContextCapabilityBits,
+    capability: &u8,
 ) -> EyreResult<()> {
     let signer = ctx.signer();
     let group_id = ctx.group_id();
@@ -24,11 +23,6 @@ pub(crate) fn apply(
     let current = caps
         .context_member_capability(group_id, context_id, member)?
         .unwrap_or(0);
-    let new_caps = current & !capability.get();
-    if new_caps == 0 {
-        caps.delete_context_member(group_id, context_id, member)?;
-    } else {
-        caps.set_context_member(group_id, context_id, member, new_caps)?;
-    }
+    caps.set_context_member(group_id, context_id, member, current & !capability)?;
     Ok(())
 }

--- a/crates/governance-store/src/ops/group/subgroup_visibility_set.rs
+++ b/crates/governance-store/src/ops/group/subgroup_visibility_set.rs
@@ -2,11 +2,15 @@
 //! `apply_group_op_mutations` in #2304.
 
 use super::context::GroupApplyCtx;
-use calimero_context_config::VisibilityMode;
 use eyre::Result as EyreResult;
 
-pub(crate) fn apply(ctx: &mut GroupApplyCtx<'_>, mode: &VisibilityMode) -> EyreResult<()> {
+pub(crate) fn apply(ctx: &mut GroupApplyCtx<'_>, mode: &u8) -> EyreResult<()> {
     let signer = ctx.signer();
-    ctx.settings().set_subgroup_visibility(signer, *mode)?;
+
+    let visibility = match *mode {
+        0 => calimero_context_config::VisibilityMode::Open,
+        _ => calimero_context_config::VisibilityMode::Restricted,
+    };
+    ctx.settings().set_subgroup_visibility(signer, visibility)?;
     Ok(())
 }

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -21,11 +21,9 @@
 //! group-scoped ops they cannot decrypt.
 
 use std::collections::BTreeMap;
-use std::io;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_context_config::types::SignedGroupOpenInvitation;
-use calimero_context_config::VisibilityMode;
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::{ContextId, GroupMemberRole, UpgradePolicy};
 use calimero_primitives::identity::{PrivateKey, PublicKey};
@@ -100,63 +98,6 @@ pub const SIGNED_GROUP_OP_SCHEMA_VERSION: u8 = 8;
 
 /// Domain separation prefix for Ed25519 signatures over group ops.
 pub const GROUP_GOVERNANCE_SIGN_DOMAIN: &[u8] = b"calimero.group.v1";
-
-/// A non-zero `u8` bitmask representing per-context member capabilities.
-///
-/// Validated at Borsh deserialization time: a zero value is rejected on the
-/// wire, making it impossible to construct an invalid capability op from
-/// received bytes.
-///
-/// Unknown bits are accepted without error (forward-compatible): nodes
-/// running older software will store ops with bits they do not recognise and
-/// replay them faithfully. Callers must mask against known capability
-/// constants before interpreting the value.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, BorshSerialize)]
-pub struct ContextCapabilityBits(u8);
-
-impl ContextCapabilityBits {
-    /// Construct from a raw bitmask, returning `None` if `bits == 0`.
-    #[must_use]
-    pub fn new(bits: u8) -> Option<Self> {
-        if bits == 0 {
-            None
-        } else {
-            Some(Self(bits))
-        }
-    }
-
-    #[must_use]
-    pub fn get(self) -> u8 {
-        self.0
-    }
-}
-
-impl TryFrom<u8> for ContextCapabilityBits {
-    type Error = &'static str;
-
-    fn try_from(bits: u8) -> Result<Self, Self::Error> {
-        Self::new(bits).ok_or("capability bitmask must not be zero")
-    }
-}
-
-impl From<std::num::NonZeroU8> for ContextCapabilityBits {
-    fn from(v: std::num::NonZeroU8) -> Self {
-        Self(v.get())
-    }
-}
-
-impl BorshDeserialize for ContextCapabilityBits {
-    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-        let bits = u8::deserialize_reader(reader)?;
-        if bits == 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "ContextCapabilityBits: capability bitmask must not be zero",
-            ));
-        }
-        Ok(Self(bits))
-    }
-}
 
 /// Group mutation for local governance (signed, gossip-replicated).
 ///
@@ -263,10 +204,10 @@ pub enum GroupOp {
     },
     /// Unregister a context from this group.
     ContextDetached { context_id: ContextId },
-    /// Subgroup visibility. When `Open`, parent-group members holding
-    /// `CAN_JOIN_OPEN_SUBGROUPS` are inherited as members of this subgroup.
-    /// See [`crate::group::SetSubgroupVisibilityRequest`].
-    SubgroupVisibilitySet { mode: VisibilityMode },
+    /// Subgroup visibility (`0` = Open, `1` = Restricted). When `Open`,
+    /// parent-group members holding `CAN_JOIN_OPEN_SUBGROUPS` are inherited
+    /// as members of this subgroup. See [`crate::group::SetSubgroupVisibilityRequest`].
+    SubgroupVisibilitySet { mode: u8 },
     /// Wholly replace the metadata record (name + opaque `data`) of the group
     /// itself (a namespace is a root group, so this covers it).
     /// **Signer:** group admin or holder of `CAN_MANAGE_METADATA`.
@@ -297,13 +238,13 @@ pub enum GroupOp {
     ContextCapabilityGranted {
         context_id: ContextId,
         member: PublicKey,
-        capability: ContextCapabilityBits,
+        capability: u8,
     },
     /// Revoke a capability from a member for a specific context.
     ContextCapabilityRevoked {
         context_id: ContextId,
         member: PublicKey,
-        capability: ContextCapabilityBits,
+        capability: u8,
     },
     /// TEE admission policy: defines which TEE nodes can auto-join the group.
     /// Only admins can set this policy.

--- a/crates/op-adapter/src/lib.rs
+++ b/crates/op-adapter/src/lib.rs
@@ -148,7 +148,7 @@ pub fn payload_from_group_op(group: ContextGroupId, op: &GroupOp) -> Option<OpPa
         // Live mode byte: 0 = Open, anything else = Restricted.
         GroupOp::SubgroupVisibilitySet { mode } => Some(OpPayload::SubgroupVisibilitySet {
             scope: ScopeId::from(group.to_bytes()),
-            restricted: matches!(mode, calimero_context_config::VisibilityMode::Restricted),
+            restricted: *mode != 0,
         }),
         _ => None,
     }


### PR DESCRIPTION
Reverts calimero-network/core#2965