### PR TITLE
fix(governance): clear deny-list on MemberJoined re-join

### DIFF
--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -261,11 +261,37 @@ impl<'a> NamespaceGovernance<'a> {
                             }
                         }
                     }
-                    RootOp::MemberJoined { .. } => {
+                    RootOp::MemberJoined {
+                        member,
+                        signed_invitation,
+                    }
+                    | RootOp::MemberJoinedAt {
+                        member,
+                        signed_invitation,
+                        ..
+                    } => {
                         // The joiner obtains the group key via the direct
                         // join response and the joiner-side pull
                         // (`recover_missing_group_keys`); no delivery is
                         // triggered from this apply path.
+                        //
+                        // Clear the deny-list on EVERY peer, not just the
+                        // local rejoiner — same rationale as the
+                        // `MemberJoinedOpen` arm below and the sibling
+                        // `MemberAdded` (`mod.rs:1215`) /
+                        // `MemberJoinedViaTeeAttestation` (`mod.rs:1502`)
+                        // arms. A prior `MemberLeft` (or `MemberRemoved`)
+                        // stamped this member on each peer's per-subgroup
+                        // deny-list; re-joining via an open invitation must
+                        // clear that stale `GroupDeniedMember` row, or peers
+                        // keep dropping the rejoiner's state-delta traffic at
+                        // the receive filter forever. `MemberJoined` /
+                        // `MemberJoinedAt` were the missing arms. Idempotent
+                        // on a member who was never denied. The group key is
+                        // the invitation's `group_id`, the subgroup the
+                        // joiner materialized a direct membership row in.
+                        let group_id = signed_invitation.invitation.group_id;
+                        DenyListRepository::new(self.store).clear(&group_id, member)?;
                     }
                     RootOp::MemberJoinedOpen { member, group_id } => {
                         // The joiner pulls the subgroup key directly from a

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -3820,6 +3820,105 @@ fn member_joined_open_clears_deny_list_and_restores_context_identity() {
 }
 
 #[test]
+fn member_joined_clears_deny_list_for_rejoiner() {
+    // An open-invitation re-join (`RootOp::MemberJoined`) must clear the
+    // per-group deny-list entry stamped by a prior `MemberLeft` /
+    // `MemberRemoved`, exactly like its sibling arms (`MemberAdded`,
+    // `MemberJoinedViaTeeAttestation`, `MemberJoinedOpen`). Pre-fix the
+    // `MemberJoined` arm was a no-op, so a rejoined member kept a stale
+    // `GroupDeniedMember` row and every peer permanently dropped the
+    // rejoiner's state-delta traffic at the receive filter.
+    use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
+    use calimero_context_config::types::{
+        GroupInvitationFromAdmin, SignedGroupOpenInvitation, SignerId,
+    };
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+    use sha2::{Digest, Sha256};
+
+    let mut rng = OsRng;
+    let store = test_store();
+
+    // namespace (root) ── subgroup; the member re-joins the subgroup via
+    // an admin-signed open invitation.
+    let ns_id = [0xB0u8; 32];
+    let ns_gid = ContextGroupId::from(ns_id);
+    let subgroup = ContextGroupId::from([0xB1u8; 32]);
+
+    let admin_sk = PrivateKey::random(&mut rng);
+    let admin_pk = admin_sk.public_key();
+    MetaRepository::new(&store)
+        .save(&subgroup, &sample_meta_with_admin(admin_pk))
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&subgroup, &admin_pk, GroupMemberRole::Admin)
+        .unwrap();
+    NamespaceRepository::new(&store)
+        .nest(&ns_gid, &subgroup)
+        .unwrap();
+
+    // Rejoiner: signs their own `MemberJoined` op, not yet a direct member.
+    let member_sk = PrivateKey::random(&mut rng);
+    let member_pk = member_sk.public_key();
+
+    // Pre-state from a prior `MemberLeft` / `MemberRemoved` cascade: the
+    // member is stamped on the subgroup deny-list.
+    DenyListRepository::new(&store)
+        .mark(&subgroup, &member_pk)
+        .unwrap();
+    assert!(DenyListRepository::new(&store)
+        .is_denied(&subgroup, &member_pk)
+        .unwrap());
+
+    // Admin-signed open invitation for the subgroup (no expiry).
+    let invitation = GroupInvitationFromAdmin {
+        inviter_identity: SignerId::from(*admin_pk.digest()),
+        group_id: subgroup,
+        expiration_timestamp: 0,
+        secret_salt: [0x42; 32],
+        invited_role: 1,
+    };
+    let inv_bytes = borsh::to_vec(&invitation).unwrap();
+    let inv_sig = admin_sk.sign(&Sha256::digest(&inv_bytes)).unwrap();
+    let signed_invitation = SignedGroupOpenInvitation {
+        invitation,
+        inviter_signature: hex::encode(inv_sig.to_bytes()),
+        application_id: None,
+        app_key: None,
+    };
+
+    let signed = SignedNamespaceOp::sign(
+        &member_sk,
+        ns_id,
+        vec![],
+        1,
+        NamespaceOp::Root(RootOp::MemberJoined {
+            member: member_pk,
+            signed_invitation,
+        }),
+    )
+    .unwrap();
+    apply_signed_namespace_op(&store, &signed).unwrap();
+
+    // The join materialized the joiner's direct membership row...
+    assert!(
+        MembershipRepository::new(&store)
+            .has_direct_member(&subgroup, &member_pk)
+            .unwrap(),
+        "MemberJoined must materialize the joiner's direct membership row"
+    );
+    // ...and cleared the stale deny-list entry so peers stop dropping the
+    // rejoiner's state-deltas at the receive filter.
+    assert!(
+        !DenyListRepository::new(&store)
+            .is_denied(&subgroup, &member_pk)
+            .unwrap(),
+        "MemberJoined apply MUST clear the per-group deny-list entry for \
+         the rejoiner so peers stop dropping their state-deltas"
+    );
+}
+
+#[test]
 fn member_added_does_nothing_for_non_rejoiner_peers() {
     // On peers whose local namespace identity is NOT the rejoiner,
     // applying MemberAdded must NOT create a ContextIdentity row for


### PR DESCRIPTION
Re-joining a subgroup via an open invitation (RootOp::MemberJoined / MemberJoinedAt) materialized the joiner's direct membership row but left the stale GroupDeniedMember row stamped by the prior MemberLeft / MemberRemoved untouched. As a result every peer kept dropping the rejoined member's state-delta traffic at the receive filter, so post- rejoin sync never converged.

Clear the per-group deny-list entry in the MemberJoined / MemberJoinedAt apply arm, matching the three sibling arms (MemberAdded, MemberJoinedViaTeeAttestation, MemberJoinedOpen) that already do this. The clear is idempotent on a member who was never denied.


Claude-Session: https://claude.ai/code/session_018vnXYSdSg4YN3RmW5ZqT4D

# [product] short description

## Description

Please include a short description of the change and which issue is fixed.
Please also include relevant motivation and context. List any dependencies that
are required for this change.

## Test plan

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Is it possible to add a test case to our
end-to-end tests with changes from this PR? Add screenshots or videos for
changes in the user-interface.

## Wire contract (SDK gate)

If this PR changes an HTTP wire DTO or route, the SDKs mirror it by hand — keep
them in sync or the contract gate goes red:

- [ ] Regenerated wire fixtures (if a DTO changed):
      `UPDATE_FIXTURES=1 cargo test -p calimero-server-primitives --test wire_fixtures`
- [ ] Updated `crates/server/endpoints.json` (if routes changed):
      `UPDATE_MANIFEST=1 cargo test -p calimero-server --test route_manifest`
- [ ] Linked the matching mero-js PR — a breaking wire change needs a paired SDK update

To run the live SDK e2e against your paired SDK branch, add a line to this body
(defaults to `master`):

```
sdk-ref: <your-mero-js-branch>
```

## Documentation update

Mention here what part (if any) of public or internal documentation should be
updated because of this PR. Documentation **has to be updated** no later than
**one day** after this PR has been merged.
