### PR TITLE
fix(governance): move admin_identity to new owner on TransferOwnership

### DIFF
--- a/crates/governance-store/src/ops/group/transfer_ownership.rs
+++ b/crates/governance-store/src/ops/group/transfer_ownership.rs
@@ -45,7 +45,20 @@ pub(crate) fn apply(ctx: &mut GroupApplyCtx<'_>, new_owner: &PublicKey) -> EyreR
         ))),
     }
 
+    // Move BOTH the owner pin and the meta admin pin to the successor.
+    //
+    // `is_admin` treats `meta.admin_identity` as an always-admin that no
+    // member-row change can revoke (see `MembershipRepository::is_admin`).
+    // At group/namespace genesis the creator is written as
+    // `admin_identity == owner_identity`, so leaving `admin_identity` on
+    // the old owner here would let a former owner keep permanent,
+    // unrevokable admin after handing ownership over. Re-pinning it to the
+    // new owner preserves the genesis invariant (owner is the meta admin)
+    // and demotes the former owner to whatever revokable member row they
+    // still hold (an explicit Admin row, if any — which can now be removed
+    // or demoted like any other).
     meta.owner_identity = *new_owner;
+    meta.admin_identity = *new_owner;
     MetaRepository::new(store).save(group_id, &meta)?;
     Ok(())
 }

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -1249,6 +1249,78 @@ fn transfer_ownership_rejects_new_owner_not_member() {
     );
 }
 
+/// `TransferOwnership` must move the meta `admin_identity` pin to the
+/// successor, not just `owner_identity`. `is_admin` honors
+/// `meta.admin_identity` as an always-admin that no member-row change can
+/// revoke, so leaving it on the old owner would grant the former owner
+/// permanent, unrevokable admin after handover. This pins the fix: after a
+/// transfer the former owner's admin authority is only as durable as their
+/// member row, so removing that row revokes their admin entirely.
+#[test]
+fn transfer_ownership_moves_admin_identity_to_new_owner() {
+    use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let mut rng = OsRng;
+    let store = test_store();
+    let gid = test_group_id();
+    let gid_bytes = gid.to_bytes();
+
+    // Genesis shape: creator is owner_identity == admin_identity, with an
+    // explicit Admin member row (mirrors `GroupCreated`/namespace genesis).
+    let owner_sk = PrivateKey::random(&mut rng);
+    let owner_pk = owner_sk.public_key();
+    let successor_pk = PrivateKey::random(&mut rng).public_key();
+
+    MetaRepository::new(&store)
+        .save(&gid, &sample_meta_with_admin(owner_pk))
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&gid, &owner_pk, GroupMemberRole::Admin)
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&gid, &successor_pk, GroupMemberRole::Admin)
+        .unwrap();
+
+    let op = SignedGroupOp::sign(
+        &owner_sk,
+        gid_bytes,
+        vec![],
+        1,
+        GroupOp::TransferOwnership {
+            new_owner: successor_pk,
+        },
+    )
+    .unwrap();
+    apply_local_signed_group_op(&store, &op).unwrap();
+
+    // Both pins moved to the successor.
+    let meta = MetaRepository::new(&store).load(&gid).unwrap().unwrap();
+    assert_eq!(meta.owner_identity, successor_pk, "owner moved");
+    assert_eq!(meta.admin_identity, successor_pk, "admin pin moved");
+
+    // The former owner's admin is now backed solely by their (revokable)
+    // member row — removing it strips their admin entirely. Before the fix
+    // the lingering `admin_identity` pin would keep them admin forever.
+    MembershipRepository::new(&store)
+        .remove_member(&gid, &owner_pk)
+        .unwrap();
+    assert!(
+        !MembershipRepository::new(&store)
+            .is_admin(&gid, &owner_pk)
+            .unwrap(),
+        "former owner must lose admin once their member row is removed"
+    );
+    // The successor remains admin (member row + meta pin).
+    assert!(
+        MembershipRepository::new(&store)
+            .is_admin(&gid, &successor_pk)
+            .unwrap(),
+        "successor must still be admin after the transfer"
+    );
+}
+
 /// `ContextCapabilityGranted` is gated by `require_manage_members`. A
 /// plain member without the `MANAGE_MEMBERS` capability (and not an
 /// admin) cannot grant a context capability — and the grant must not be


### PR DESCRIPTION
TransferOwnership only updated `owner_identity`, leaving `admin_identity` pinned to the former owner. Because `MembershipRepository::is_admin` treats `meta.admin_identity` as an always-admin that no member-row change can revoke, the former owner retained permanent, unrevokable admin after handing ownership over.

Re-pin `admin_identity` to the successor alongside `owner_identity`. This preserves the genesis invariant (the owner is the meta admin) and demotes the former owner to whatever revokable member row they still hold, so they can be removed or demoted like any other admin.

Add a regression test asserting both pins move and that removing the former owner's member row now strips their admin entirely.


Claude-Session: https://claude.ai/code/session_01V2x89maYb3JChLPWqRaexx

# [product] short description

## Description

Please include a short description of the change and which issue is fixed.
Please also include relevant motivation and context. List any dependencies that
are required for this change.

## Test plan

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Is it possible to add a test case to our
end-to-end tests with changes from this PR? Add screenshots or videos for
changes in the user-interface.

## Wire contract (SDK gate)

If this PR changes an HTTP wire DTO or route, the SDKs mirror it by hand — keep
them in sync or the contract gate goes red:

- [ ] Regenerated wire fixtures (if a DTO changed):
      `UPDATE_FIXTURES=1 cargo test -p calimero-server-primitives --test wire_fixtures`
- [ ] Updated `crates/server/endpoints.json` (if routes changed):
      `UPDATE_MANIFEST=1 cargo test -p calimero-server --test route_manifest`
- [ ] Linked the matching mero-js PR — a breaking wire change needs a paired SDK update

To run the live SDK e2e against your paired SDK branch, add a line to this body
(defaults to `master`):

```
sdk-ref: <your-mero-js-branch>
```

## Documentation update

Mention here what part (if any) of public or internal documentation should be
updated because of this PR. Documentation **has to be updated** no later than
**one day** after this PR has been merged.
