### PR TITLE
fix(storage): never regress tombstone nonce in mark_deleted

### DIFF
--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -721,11 +721,19 @@ impl<S: StorageAdaptor> Index<S> {
     pub(crate) fn mark_deleted(id: Id, deleted_at: u64) -> Result<(), StorageError> {
         let _mutation_guard = index_mutation_guard();
         if let Some(mut index) = Self::get_index(id)? {
+            // The tombstone time is a LWW CRDT nonce: never regress it. An
+            // out-of-order, older `DeleteRef` must not roll back a newer
+            // tombstone, which would also weaken replay protection via the
+            // `updated_at` nonce below. Keep the latest of the two.
+            let deleted_at = index
+                .deleted_at
+                .map_or(deleted_at, |existing| existing.max(deleted_at));
             index.deleted_at = Some(deleted_at);
 
-            // Also update the `updated_at` timestamp to this nonce.
-            // This is critical for replay protection on delete actions.
-            *index.metadata.updated_at = deleted_at;
+            // Also advance the `updated_at` timestamp toward this nonce.
+            // This is critical for replay protection on delete actions, and is
+            // likewise monotonic — an older delete never lowers it.
+            *index.metadata.updated_at = (*index.metadata.updated_at).max(deleted_at);
 
             Self::save_index(&index)?;
         }

--- a/crates/storage/src/tests/crdt.rs
+++ b/crates/storage/src/tests/crdt.rs
@@ -191,6 +191,33 @@ fn tombstone_allows_newer_update() {
 }
 
 #[test]
+fn tombstone_does_not_regress_on_out_of_order_delete() {
+    let mut page = Page::new_from_element("Test Page", Element::root());
+    let id = page.id();
+
+    assert!(TestInterface::save(&mut page).unwrap());
+
+    // Apply a newer tombstone first.
+    let newer = time_now();
+    let older = newer - 1_000_000_000; // 1s earlier nonce
+    Index::<TestStorage>::mark_deleted(id, newer).unwrap();
+
+    // An out-of-order, OLDER DeleteRef must not roll the tombstone back.
+    Index::<TestStorage>::mark_deleted(id, older).unwrap();
+
+    let index = Index::<TestStorage>::get_index(id).unwrap().unwrap();
+    assert_eq!(
+        index.deleted_at,
+        Some(newer),
+        "older delete must not regress the tombstone nonce"
+    );
+    assert_eq!(
+        *index.metadata.updated_at, newer,
+        "older delete must not regress the updated_at nonce (replay protection)"
+    );
+}
+
+#[test]
 fn delete_vs_update_conflict() {
     // Test LWW conflict resolution between delete and update
     let mut page = Page::new_from_element("Test Page", Element::root());


### PR DESCRIPTION
mark_deleted unconditionally overwrote both `deleted_at` and the `updated_at` replay-protection nonce with the incoming value. An out-of-order, older DeleteRef would therefore roll the tombstone time backward, causing updated_at divergence across nodes and weakening replay protection on delete actions.

Make both writes monotonic via max(), so a later tombstone is never regressed by an older one. This is the correct LWW behavior and fixes both apply_delete_ref_action call sites, which both delegate the write to mark_deleted.

Adds a regression test asserting an older delete does not lower either nonce.


## Wire contract (SDK gate)

If this PR changes an HTTP wire DTO or route, the SDKs mirror it by hand — keep
them in sync or the contract gate goes red:

- [ ] Regenerated wire fixtures (if a DTO changed):
      `UPDATE_FIXTURES=1 cargo test -p calimero-server-primitives --test wire_fixtures`
- [ ] Updated `crates/server/endpoints.json` (if routes changed):
      `UPDATE_MANIFEST=1 cargo test -p calimero-server --test route_manifest`
- [ ] Linked the matching mero-js PR — a breaking wire change needs a paired SDK update

To run the live SDK e2e against your paired SDK branch, add a line to this body
(defaults to `master`):

```
sdk-ref: <your-mero-js-branch>
```

