### PR TITLE
fix(blobstore): delete metadata row in BlobManager::delete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,6 +1145,7 @@ dependencies = [
  "futures-util",
  "serde",
  "sha2 0.10.9",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",

--- a/crates/store/blobs/Cargo.toml
+++ b/crates/store/blobs/Cargo.toml
@@ -27,6 +27,8 @@ calimero-primitives.workspace = true
 calimero-store = { workspace = true, features = ["datatypes"] }
 
 [dev-dependencies]
+tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }
 tokio-util.workspace = true
 
 [features]

--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -119,7 +119,17 @@ impl BlobManager {
     }
 
     pub async fn delete(&self, id: BlobId) -> EyreResult<bool> {
-        self.blob_store.delete(id).await
+        let key = BlobMetaKey::new(id);
+
+        // Remove the metadata row alongside the chunk file. Without this, `has`
+        // keeps reporting the blob as present (it only checks metadata) while
+        // `get` fails because the underlying file is gone.
+        let had_meta = self.data_store.handle().has(&key)?;
+        self.data_store.handle().delete(&key)?;
+
+        let had_file = self.blob_store.delete(id).await?;
+
+        Ok(had_meta || had_file)
     }
 
     pub async fn put<T>(&self, stream: T) -> EyreResult<(BlobId, Hash, u64)>
@@ -486,4 +496,47 @@ impl BlobRepository for FileSystem {
 #[cfg(test)]
 mod integration_tests_package_usage {
     use tokio_util as _;
+}
+
+#[cfg(test)]
+mod delete_tests {
+    use std::path::Path;
+    use std::sync::Arc;
+
+    use calimero_store::db::InMemoryDB;
+    use calimero_store::Store as DataStore;
+    use camino::Utf8PathBuf;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    async fn manager(root: &Path) -> BlobManager {
+        let data_store = DataStore::new(Arc::new(InMemoryDB::owned()));
+        let config =
+            BlobStoreConfig::new(Utf8PathBuf::from_path_buf(root.to_path_buf()).unwrap());
+        let blob_store = FileSystem::new(&config).await.unwrap();
+        BlobManager::new(data_store, blob_store)
+    }
+
+    #[tokio::test]
+    async fn delete_removes_metadata_so_has_stays_consistent() {
+        let dir = tempdir().unwrap();
+        let mgr = manager(dir.path()).await;
+
+        let data = b"hello blob world";
+        let (id, _hash, _size) = mgr.put(&data[..]).await.unwrap();
+
+        assert!(mgr.has(id).unwrap());
+        assert!(mgr.get(id).unwrap().is_some());
+
+        assert!(mgr.delete(id).await.unwrap());
+
+        // The metadata row must be gone too; otherwise `has` keeps reporting the
+        // blob as present while `get` can no longer read it.
+        assert!(!mgr.has(id).unwrap());
+        assert!(mgr.get(id).unwrap().is_none());
+
+        // A second delete has nothing left to remove.
+        assert!(!mgr.delete(id).await.unwrap());
+    }
 }

--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -545,8 +545,7 @@ mod delete_tests {
 
     async fn manager(root: &Path) -> BlobManager {
         let data_store = DataStore::new(Arc::new(InMemoryDB::owned()));
-        let config =
-            BlobStoreConfig::new(Utf8PathBuf::from_path_buf(root.to_path_buf()).unwrap());
+        let config = BlobStoreConfig::new(Utf8PathBuf::from_path_buf(root.to_path_buf()).unwrap());
         let blob_store = FileSystem::new(&config).await.unwrap();
         BlobManager::new(data_store, blob_store)
     }


### PR DESCRIPTION
BlobManager::delete only removed the chunk file, leaving the BlobMeta row behind. Because has() consults the metadata store, it kept reporting the blob as present while get() failed to read the now-missing file.

Remove the BlobMeta row alongside the file so has()/get() stay consistent, and return whether the blob existed at all (metadata or file). Add a regression test covering the has()/get() contract after delete.


Claude-Session: https://claude.ai/code/session_01RKxCK91W6X3m2AEh1gDKCW

# [product] short description

## Description

Please include a short description of the change and which issue is fixed.
Please also include relevant motivation and context. List any dependencies that
are required for this change.

## Test plan

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Is it possible to add a test case to our
end-to-end tests with changes from this PR? Add screenshots or videos for
changes in the user-interface.

## Wire contract (SDK gate)

If this PR changes an HTTP wire DTO or route, the SDKs mirror it by hand — keep
them in sync or the contract gate goes red:

- [ ] Regenerated wire fixtures (if a DTO changed):
      `UPDATE_FIXTURES=1 cargo test -p calimero-server-primitives --test wire_fixtures`
- [ ] Updated `crates/server/endpoints.json` (if routes changed):
      `UPDATE_MANIFEST=1 cargo test -p calimero-server --test route_manifest`
- [ ] Linked the matching mero-js PR — a breaking wire change needs a paired SDK update

To run the live SDK e2e against your paired SDK branch, add a line to this body
(defaults to `master`):

```
sdk-ref: <your-mero-js-branch>
```

## Documentation update

Mention here what part (if any) of public or internal documentation should be
updated because of this PR. Documentation **has to be updated** no later than
**one day** after this PR has been merged.
