### PR TITLE
fix(storage): remove unimplemented Interface::validate stub

### DIFF
--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -3708,17 +3708,6 @@ impl<S: StorageAdaptor> Interface<S> {
         Ok(Some(full_hash))
     }
 
-    /// Validates Merkle tree integrity.
-    ///
-    /// **Note**: Not yet implemented.
-    ///
-    /// # Errors
-    /// Currently panics (unimplemented).
-    ///
-    pub fn validate() -> Result<(), StorageError> {
-        unimplemented!()
-    }
-
     /// Helper to verify an upsert (`Add` or `Update`) action against the
     /// receiver's currently-stored entity.
     ///

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -142,12 +142,6 @@ mod interface__public_methods {
         // TODO: This is best done when there's data
         todo!()
     }
-
-    #[test]
-    #[ignore]
-    fn validate() {
-        todo!()
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`Interface::validate()` was an `unimplemented!()` stub documented as a merkle-integrity check. It had no production callers and only an `#[ignore]`d `todo!()` test, so it was dead today and would panic the node on any future call. Remove the method and its test stub rather than ship a false "validates merkle tree integrity" claim backed by a panic.


Claude-Session: https://claude.ai/code/session_01S2ddi6fGFfrG7Xge1taT9G

# [product] short description

## Description

Please include a short description of the change and which issue is fixed.
Please also include relevant motivation and context. List any dependencies that
are required for this change.

## Test plan

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Is it possible to add a test case to our
end-to-end tests with changes from this PR? Add screenshots or videos for
changes in the user-interface.

## Wire contract (SDK gate)

If this PR changes an HTTP wire DTO or route, the SDKs mirror it by hand — keep
them in sync or the contract gate goes red:

- [ ] Regenerated wire fixtures (if a DTO changed):
      `UPDATE_FIXTURES=1 cargo test -p calimero-server-primitives --test wire_fixtures`
- [ ] Updated `crates/server/endpoints.json` (if routes changed):
      `UPDATE_MANIFEST=1 cargo test -p calimero-server --test route_manifest`
- [ ] Linked the matching mero-js PR — a breaking wire change needs a paired SDK update

To run the live SDK e2e against your paired SDK branch, add a line to this body
(defaults to `master`):

```
sdk-ref: <your-mero-js-branch>
```

## Documentation update

Mention here what part (if any) of public or internal documentation should be
updated because of this PR. Documentation **has to be updated** no later than
**one day** after this PR has been merged.
