### PR TITLE
fix(storage): reject Frozen child deletion at remove_child_from

### DIFF
--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -609,8 +609,9 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
 
         // Drop the old random-id children, move the collection to its
         // deterministic id, then re-insert each child under
-        // `compute_id(parent, index)`.
-        self.clear().expect("clear for reindex");
+        // `compute_id(parent, index)`. Uses the re-key clear so `Frozen`
+        // children are relocated (re-inserted below) rather than rejected.
+        self.clear_for_rekey().expect("clear for reindex");
         self.reassign_deterministic_id_under(parent_id, field_name, crdt_type);
 
         let parent = self.id();
@@ -749,6 +750,20 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         let mut collection = CollectionMut::new(self);
 
         collection.clear()?;
+
+        Ok(())
+    }
+
+    /// Clears the collection as part of a deterministic re-key relocation.
+    ///
+    /// Identical to [`clear`](Self::clear) except it removes children via
+    /// [`Interface::relocate_child_from`], which does not reject `Frozen`
+    /// children — a re-key re-inserts every entry under a new id, so frozen
+    /// data is preserved rather than deleted.
+    fn clear_for_rekey(&mut self) -> StoreResult<()> {
+        let mut collection = CollectionMut::new(self);
+
+        collection.clear_for_rekey()?;
 
         Ok(())
     }
@@ -896,6 +911,19 @@ where
 
         for child in children.drain(..) {
             let _ = <Interface<S>>::remove_child_from(self.collection.id(), child)?;
+        }
+
+        Ok(())
+    }
+
+    /// Clears the collection for a deterministic re-key relocation, removing
+    /// children via [`Interface::relocate_child_from`] so `Frozen` entries are
+    /// relocated rather than rejected. See [`Collection::clear_for_rekey`].
+    fn clear_for_rekey(&mut self) -> StoreResult<()> {
+        let children = self.collection.children_cache()?;
+
+        for child in children.drain(..) {
+            let _ = <Interface<S>>::relocate_child_from(self.collection.id(), child)?;
         }
 
         Ok(())

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -227,7 +227,11 @@ where
             .collect();
 
         // Clear the collection (removes old entries with old IDs).
-        self.inner.clear().expect("failed to clear for re-key");
+        // Uses the re-key clear so `Frozen` entries are relocated (re-inserted
+        // below under their new id) rather than rejected as deletions.
+        self.inner
+            .clear_for_rekey()
+            .expect("failed to clear for re-key");
 
         // Reassign the collection's ID (Collection's `_with_crdt_type` is itself
         // just `_under(None, ..)`, so this single call covers both variants).

--- a/crates/storage/src/collections/sorted_set.rs
+++ b/crates/storage/src/collections/sorted_set.rs
@@ -88,9 +88,7 @@ where
             .iter_unordered()
             .expect("read set elements for re-key")
             .collect();
-        self.inner
-            .clear_for_rekey()
-            .expect("clear set for re-key");
+        self.inner.clear_for_rekey().expect("clear set for re-key");
         self.inner.reassign_deterministic_id_under(
             Some(parent_id),
             "__sorted_set",

--- a/crates/storage/src/collections/sorted_set.rs
+++ b/crates/storage/src/collections/sorted_set.rs
@@ -88,7 +88,9 @@ where
             .iter_unordered()
             .expect("read set elements for re-key")
             .collect();
-        self.inner.clear().expect("clear set for re-key");
+        self.inner
+            .clear_for_rekey()
+            .expect("clear set for re-key");
         self.inner.reassign_deterministic_id_under(
             Some(parent_id),
             "__sorted_set",
@@ -158,7 +160,9 @@ where
             .iter_unordered()
             .expect("failed to read elements for migration")
             .collect();
-        self.inner.clear().expect("failed to clear for migration");
+        self.inner
+            .clear_for_rekey()
+            .expect("failed to clear for migration");
         self.inner.reassign_deterministic_id_with_crdt_type(
             field_name,
             CrdtType::sorted_set(std::any::type_name::<V>()),

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -233,7 +233,11 @@ where
             .expect("failed to read entries for re-key");
 
         // Clear the collection (removes old entries with old IDs).
-        self.inner.clear().expect("failed to clear for re-key");
+        // Uses the re-key clear so `Frozen` entries are relocated (re-inserted
+        // below under their new id) rather than rejected as deletions.
+        self.inner
+            .clear_for_rekey()
+            .expect("failed to clear for re-key");
 
         // Reassign the collection's ID (Collection's `_with_crdt_type` is itself
         // just `_under(None, ..)`, so this single call covers both variants).

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -68,7 +68,9 @@ where
             .inner
             .entries_with_storage_type()
             .expect("read set elements for re-key");
-        self.inner.clear().expect("clear set for re-key");
+        self.inner
+            .clear_for_rekey()
+            .expect("clear set for re-key");
         self.inner.reassign_deterministic_id_under(
             Some(parent_id),
             "__set",
@@ -183,8 +185,12 @@ where
             .entries_with_storage_type()
             .expect("failed to read elements for migration");
 
-        // Clear the collection (removes old entries with old IDs)
-        self.inner.clear().expect("failed to clear for migration");
+        // Clear the collection (removes old entries with old IDs).
+        // Uses the re-key clear so `Frozen` entries are relocated (re-inserted
+        // below under their new id) rather than rejected as deletions.
+        self.inner
+            .clear_for_rekey()
+            .expect("failed to clear for migration");
 
         // Now reassign the collection's ID
         self.inner.reassign_deterministic_id_with_crdt_type(

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -68,9 +68,7 @@ where
             .inner
             .entries_with_storage_type()
             .expect("read set elements for re-key");
-        self.inner
-            .clear_for_rekey()
-            .expect("clear set for re-key");
+        self.inner.clear_for_rekey().expect("clear set for re-key");
         self.inner.reassign_deterministic_id_under(
             Some(parent_id),
             "__set",

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2673,10 +2673,50 @@ impl<S: StorageAdaptor> Interface<S> {
     ///
     /// Deletes the child entity and generates sync actions automatically.
     ///
+    /// Rejects deletion of `Frozen` children — frozen data is immutable and
+    /// every peer rejects an incoming `DeleteRef` for it (see the
+    /// `StorageType::Frozen` arm in [`apply_action`](Self::apply_action)), so
+    /// a local delete would diverge the deleter from the rest of the network.
+    /// The re-key migration that relocates entries under new deterministic ids
+    /// must use [`relocate_child_from`](Self::relocate_child_from) instead.
+    ///
+    /// # Errors
+    /// Returns error if parent or child doesn't exist, or if the child is
+    /// `Frozen`.
+    ///
+    pub fn remove_child_from(parent_id: Id, child_id: Id) -> Result<bool, StorageError> {
+        Self::remove_child_from_inner(parent_id, child_id, true)
+    }
+
+    /// Removes a child from a collection as part of a deterministic re-key
+    /// relocation (the entry is immediately re-inserted under a new id).
+    ///
+    /// Unlike [`remove_child_from`](Self::remove_child_from) this does **not**
+    /// reject `Frozen` children: a re-key is a local relocation, not a
+    /// semantic deletion, so the frozen data is preserved (re-inserted under
+    /// its new deterministic id by the caller). Used only by the collection
+    /// re-key paths (`reassign_deterministic_id_*`).
+    ///
     /// # Errors
     /// Returns error if parent or child doesn't exist.
     ///
-    pub fn remove_child_from(parent_id: Id, child_id: Id) -> Result<bool, StorageError> {
+    pub(crate) fn relocate_child_from(
+        parent_id: Id,
+        child_id: Id,
+    ) -> Result<bool, StorageError> {
+        Self::remove_child_from_inner(parent_id, child_id, false)
+    }
+
+    /// Shared implementation behind [`remove_child_from`](Self::remove_child_from)
+    /// and [`relocate_child_from`](Self::relocate_child_from).
+    ///
+    /// `reject_frozen` gates the Frozen-deletion guard: `true` for genuine
+    /// deletes, `false` for re-key relocations.
+    fn remove_child_from_inner(
+        parent_id: Id,
+        child_id: Id,
+        reject_frozen: bool,
+    ) -> Result<bool, StorageError> {
         let child_exists = <Index<S>>::get_children_of(parent_id)?
             .iter()
             .any(|child| child.id() == child_id);
@@ -2690,6 +2730,24 @@ impl<S: StorageAdaptor> Interface<S> {
         // Get metadata before removing index
         let mut metadata =
             <Index<S>>::get_metadata(child_id)?.ok_or(StorageError::IndexNotFound(child_id))?;
+
+        // Reject deletion of Frozen data locally, before mutating any state.
+        //
+        // The receiving side rejects every `DeleteRef` for Frozen data (see
+        // the `StorageType::Frozen` arm in `apply_action`). If we let the
+        // local delete proceed it would tombstone the child and broadcast a
+        // `DeleteRef` that every peer rejects, leaving the deleter
+        // permanently diverged from the rest of the network (split-brain).
+        // Refusing here keeps the deleter consistent with its peers.
+        //
+        // The re-key relocation path (`relocate_child_from`) passes
+        // `reject_frozen == false`: it removes the entry only to re-insert it
+        // under a new deterministic id, so the frozen data is preserved.
+        if reject_frozen && matches!(metadata.storage_type, StorageType::Frozen) {
+            return Err(StorageError::ActionNotAllowed(
+                "Frozen data cannot be deleted".to_owned(),
+            ));
+        }
 
         // If this is a local user action, set the nonce
         if let StorageType::User { owner, .. } = metadata.storage_type {

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2700,10 +2700,7 @@ impl<S: StorageAdaptor> Interface<S> {
     /// # Errors
     /// Returns error if parent or child doesn't exist.
     ///
-    pub(crate) fn relocate_child_from(
-        parent_id: Id,
-        child_id: Id,
-    ) -> Result<bool, StorageError> {
+    pub(crate) fn relocate_child_from(parent_id: Id, child_id: Id) -> Result<bool, StorageError> {
         Self::remove_child_from_inner(parent_id, child_id, false)
     }
 

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -2130,6 +2130,49 @@ mod frozen_storage_verification {
         }
     }
 
+    /// A local delete of a Frozen child must be rejected at
+    /// `remove_child_from`, before any state mutation.
+    ///
+    /// Regression test for the split-brain: previously the local delete
+    /// tombstoned the child and broadcast a `DeleteRef` that every peer
+    /// rejects (see `frozen_delete_is_rejected`), leaving the deleter
+    /// permanently diverged from the rest of the network.
+    #[test]
+    fn remove_child_from_rejects_frozen_child() {
+        env::reset_for_testing();
+
+        // Parent under root.
+        let mut page = Page::new_from_element("Parent", Element::root());
+        assert!(MainInterface::save(&mut page).unwrap());
+
+        // Frozen child registered under the parent.
+        let mut child_element = Element::new(None);
+        child_element.set_frozen_domain();
+        let mut para = Paragraph::new_from_element("Frozen child", child_element);
+        assert!(MainInterface::add_child_to(page.id(), &mut para).unwrap());
+
+        // Local delete must be refused.
+        let result = MainInterface::remove_child_from(page.id(), para.id());
+        match result {
+            Err(StorageError::ActionNotAllowed(msg)) => {
+                assert!(
+                    msg.contains("Frozen") && msg.contains("deleted"),
+                    "Error should mention Frozen and deleted: {msg}"
+                );
+            }
+            other => panic!("Expected ActionNotAllowed error, got {other:?}"),
+        }
+
+        // The child must still be present — no tombstone, no divergence.
+        assert!(
+            MainInterface::children_of::<Paragraph>(page.id())
+                .unwrap()
+                .iter()
+                .any(|child| child.id() == para.id()),
+            "Frozen child must remain after a rejected delete"
+        );
+    }
+
     #[test]
     fn frozen_blob_too_small_fails() {
         env::reset_for_testing();

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -2139,6 +2139,8 @@ mod frozen_storage_verification {
     /// permanently diverged from the rest of the network.
     #[test]
     fn remove_child_from_rejects_frozen_child() {
+        use crate::delta::{commit_causal_delta, reset_delta_context};
+
         env::reset_for_testing();
 
         // Parent under root.
@@ -2150,6 +2152,10 @@ mod frozen_storage_verification {
         child_element.set_frozen_domain();
         let mut para = Paragraph::new_from_element("Frozen child", child_element);
         assert!(MainInterface::add_child_to(page.id(), &mut para).unwrap());
+
+        // Discard the actions emitted by the setup above — the assertion
+        // below is only about what the rejected delete contributes.
+        reset_delta_context();
 
         // Local delete must be refused.
         let result = MainInterface::remove_child_from(page.id(), para.id());
@@ -2171,6 +2177,21 @@ mod frozen_storage_verification {
                 .any(|child| child.id() == para.id()),
             "Frozen child must remain after a rejected delete"
         );
+
+        // The rejected delete must not have broadcast a `DeleteRef`: that is
+        // the split-brain this guards against — every peer rejects a Frozen
+        // `DeleteRef`, leaving only the deleter diverged. The guard fires
+        // before any state is mutated, so no action should reach the delta.
+        if let Some(delta) = commit_causal_delta(&[0; 32]).unwrap() {
+            assert!(
+                !delta
+                    .actions
+                    .iter()
+                    .any(|a| matches!(a, Action::DeleteRef { id, .. } if *id == para.id())),
+                "rejected Frozen delete must not emit a DeleteRef, got: {:?}",
+                delta.actions
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
A local delete of a Frozen child tombstoned the child and broadcast a DeleteRef that every receiver rejects (Frozen data cannot be deleted), leaving the deleter permanently diverged from all peers (split-brain).

Reject the deletion locally in remove_child_from, mirroring the receiver-side guard, so no state is mutated and no DeleteRef is emitted.

The deterministic re-key migration (reassign_deterministic_id_*) removes entries only to re-insert them under new ids, which is a relocation, not a deletion. Route those clears through a new relocate_child_from / clear_for_rekey path that skips the Frozen guard so frozen data is preserved across re-key.


Claude-Session: https://claude.ai/code/session_01JfRnTT2hCCKXHirnDNZmcr

# [product] short description

## Description

Please include a short description of the change and which issue is fixed.
Please also include relevant motivation and context. List any dependencies that
are required for this change.

## Test plan

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Is it possible to add a test case to our
end-to-end tests with changes from this PR? Add screenshots or videos for
changes in the user-interface.

## Wire contract (SDK gate)

If this PR changes an HTTP wire DTO or route, the SDKs mirror it by hand — keep
them in sync or the contract gate goes red:

- [ ] Regenerated wire fixtures (if a DTO changed):
      `UPDATE_FIXTURES=1 cargo test -p calimero-server-primitives --test wire_fixtures`
- [ ] Updated `crates/server/endpoints.json` (if routes changed):
      `UPDATE_MANIFEST=1 cargo test -p calimero-server --test route_manifest`
- [ ] Linked the matching mero-js PR — a breaking wire change needs a paired SDK update

To run the live SDK e2e against your paired SDK branch, add a line to this body
(defaults to `master`):

```
sdk-ref: <your-mero-js-branch>
```

## Documentation update

Mention here what part (if any) of public or internal documentation should be
updated because of this PR. Documentation **has to be updated** no later than
**one day** after this PR has been merged.
