### PR TITLE
fix(server,auth): abuse/DoS hardening — SSRF, traversal, callback XSS, login lockout, WS limits, SSE task leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,6 +1527,7 @@ dependencies = [
  "tokio-util",
  "toml 0.8.23",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/auth/src/api/handlers/auth.rs
+++ b/crates/auth/src/api/handlers/auth.rs
@@ -172,6 +172,12 @@ pub async fn token_handler(
     // used only as an opaque map key and is never logged. (See module docs for
     // the identity-rotation / IP-keying follow-up.)
     //
+    // Note the key is built from the RAW (pre-sanitization) values, while the
+    // rate-limit `warn!` below logs the SANITIZED `auth_method`. They can
+    // therefore differ; the raw value is deliberate for the bucket (so two
+    // distinct identities can't be collapsed by sanitization), and the
+    // sanitized value is deliberate for the log (low-cardinality, injection-safe).
+    //
     // Length-prefix the first component so the `|` separator is unambiguous:
     // raw, attacker-controlled values could otherwise inject a `|` to collide
     // two distinct identities into one bucket (e.g. lock out a victim by

--- a/crates/auth/src/api/handlers/auth.rs
+++ b/crates/auth/src/api/handlers/auth.rs
@@ -502,13 +502,36 @@ fn extract_token_from_forwarded_uri(headers: &HeaderMap) -> Option<&str> {
 /// # Returns
 ///
 /// * `impl IntoResponse` - HTML form for authentication
+/// Default callback URL used when none is supplied or the supplied one is
+/// rejected.
+const DEFAULT_CALLBACK: &str = "http://127.0.0.1:9080/callback";
+
+/// Turn an attacker-controlled `callback-url` query value into a JS string
+/// literal that is safe to embed in an inline `<script>`.
+///
+/// 1. Accept it only if it parses as an `http`/`https` URL (rejects
+///    `javascript:`, `data:`, and malformed values); otherwise fall back to the
+///    default. Re-serialising the parsed URL also percent-encodes HTML-unsafe
+///    characters such as `<`/`>`, so it cannot break out of the `<script>`.
+/// 2. JSON-encode the result, producing a quoted, fully-escaped JS string
+///    literal, so it cannot break out of the JS string context. This closes the
+///    `'{callback_url}'` → `';alert(1);//` injection.
+fn safe_callback_js(raw: Option<&str>) -> String {
+    let validated = raw
+        .and_then(|raw| url::Url::parse(raw).ok())
+        .filter(|u| matches!(u.scheme(), "http" | "https"))
+        .map_or_else(|| DEFAULT_CALLBACK.to_owned(), |u| u.to_string());
+    serde_json::to_string(&validated).unwrap_or_else(|_| format!("{DEFAULT_CALLBACK:?}"))
+}
+
 pub async fn callback_handler(
     _state: Extension<Arc<AppState>>,
     Query(params): Query<HashMap<String, String>>,
 ) -> impl IntoResponse {
-    // Extract the callback URL from query parameters
-    let default_callback = "http://127.0.0.1:9080/callback".to_string();
-    let callback_url = params.get("callback-url").unwrap_or(&default_callback);
+    // Extract the callback URL from query parameters. This value is
+    // attacker-controlled and is embedded into an inline <script>; see
+    // [`safe_callback_js`] for how it is sanitised.
+    let callback_url_js = safe_callback_js(params.get("callback-url").map(String::as_str));
 
     // Create a simple authentication form
     let html = format!(
@@ -652,7 +675,7 @@ pub async fn callback_handler(
                 const refreshToken = 'temp_refresh_token_' + Date.now();
                 
                 // Redirect back to meroctl with tokens
-                const callbackUrl = '{callback_url}';
+                const callbackUrl = {callback_url_js};
                 const redirectUrl = new URL(callbackUrl);
                 redirectUrl.searchParams.set('access_token', accessToken);
                 redirectUrl.searchParams.set('refresh_token', refreshToken);
@@ -945,5 +968,49 @@ pub async fn mock_token_handler(
                 None,
             )
         }
+    }
+}
+
+#[cfg(test)]
+mod callback_xss_tests {
+    use super::{safe_callback_js, DEFAULT_CALLBACK};
+
+    #[test]
+    fn malicious_callbacks_fall_back_to_default() {
+        for bad in [
+            Some("'; alert(1); //"),
+            Some("javascript:alert(1)"),
+            Some("data:text/html,<script>alert(1)</script>"),
+            Some("not a url"),
+            None,
+        ] {
+            let js = safe_callback_js(bad);
+            assert_eq!(
+                js,
+                format!("{DEFAULT_CALLBACK:?}"),
+                "malicious/invalid callback {bad:?} must fall back to the default",
+            );
+        }
+    }
+
+    #[test]
+    fn valid_callback_is_json_quoted_and_html_safe() {
+        // A valid http(s) URL is accepted, emitted as a quoted JS string literal.
+        let js = safe_callback_js(Some("https://app.example.com/cb?x=1"));
+        assert!(
+            js.starts_with('"') && js.ends_with('"'),
+            "must be a JS string literal: {js}"
+        );
+        assert!(js.contains("app.example.com"));
+
+        // Angle brackets that would break out of <script> are percent-encoded by
+        // URL normalisation, so the embedded literal contains no raw '<'/'>'.
+        let js = safe_callback_js(Some("http://x/</script><script>alert(1)</script>"));
+        assert!(
+            !js.contains('<') && !js.contains('>'),
+            "must not contain raw angle brackets: {js}"
+        );
+        // And it remains a single quoted JS string (no unescaped quote break-out).
+        assert!(js.starts_with('"') && js.ends_with('"'));
     }
 }

--- a/crates/auth/src/api/handlers/auth.rs
+++ b/crates/auth/src/api/handlers/auth.rs
@@ -164,6 +164,15 @@ pub async fn token_handler(
     // Extract node URL from client_name for node-specific token generation
     let node_url = Some(token_request.client_name.clone());
 
+    // Rate-limit key from the RAW identity, captured before sanitization so that
+    // two distinct identities cannot be collapsed into one bucket (which would
+    // let one identity lock out another). Keyed by (auth_method, public_key)
+    // only: `client_name` is fully attacker-controlled and adds no binding, and
+    // `public_key` is the field bound to the caller's identity. This value is
+    // used only as an opaque map key and is never logged. (See module docs for
+    // the identity-rotation / IP-keying follow-up.)
+    let rl_key = format!("{}|{}", token_request.auth_method, token_request.public_key);
+
     // Sanitize string inputs to prevent injection attacks
     token_request.auth_method = sanitize_identifier(&token_request.auth_method);
     token_request.public_key = sanitize_string(&token_request.public_key);
@@ -194,18 +203,15 @@ pub async fn token_handler(
         );
     }
 
-    // Brute-force throttle, keyed by the request identity. If this caller has
-    // exceeded the failed-attempt budget, reject with 429 + Retry-After before
-    // doing any credential work.
-    //
-    // Keyed by (auth_method, public_key) only. `client_name` is fully
-    // attacker-controlled and adds no binding — including it would let an
-    // attacker reset the bucket by rotating the name. `public_key` is the field
-    // bound to the caller's identity. (See module docs for the
-    // identity-rotation / IP-keying follow-up.)
-    let rl_key = format!("{}|{}", token_request.auth_method, token_request.public_key);
+    // Brute-force throttle: if this caller has exceeded the failed-attempt
+    // budget, reject with 429 + Retry-After before doing any credential work.
     if let Some(retry_after) = state.0.login_rate_limiter.check(&rl_key) {
-        warn!("Login rate limit exceeded for identity {rl_key}");
+        // Log only the sanitized, low-cardinality auth method — never the raw
+        // key (which holds the public key and could be a log-injection vector).
+        warn!(
+            auth_method = %token_request.auth_method,
+            "Login rate limit exceeded"
+        );
         let mut headers = HeaderMap::new();
         drop(
             headers.insert(

--- a/crates/auth/src/api/handlers/auth.rs
+++ b/crates/auth/src/api/handlers/auth.rs
@@ -176,11 +176,24 @@ pub async fn token_handler(
     // raw, attacker-controlled values could otherwise inject a `|` to collide
     // two distinct identities into one bucket (e.g. lock out a victim by
     // polluting their bucket).
+    //
+    // Cap each component before it enters the key: the raw fields are unbounded
+    // attacker input, and an oversized `public_key` (e.g. megabytes) would be
+    // allocated and stored verbatim as a map key — up to MAX_TRACKED_KEYS of
+    // them — turning the limiter into a memory-amplification sink. A real
+    // public key is well under this bound, so capping cannot collapse two
+    // legitimate identities; a forged >cap key only ever collides with another
+    // forged >cap key sharing the same prefix, which is the attacker's own
+    // bucket.
+    const MAX_RL_KEY_FIELD: usize = 256;
+    let cap_field = |s: &str| -> String { s.chars().take(MAX_RL_KEY_FIELD).collect() };
+    let rl_auth_method = cap_field(&token_request.auth_method);
+    let rl_public_key = cap_field(&token_request.public_key);
     let rl_key = format!(
         "{}|{}|{}",
-        token_request.auth_method.len(),
-        token_request.auth_method,
-        token_request.public_key
+        rl_auth_method.len(),
+        rl_auth_method,
+        rl_public_key
     );
 
     // Sanitize string inputs to prevent injection attacks

--- a/crates/auth/src/api/handlers/auth.rs
+++ b/crates/auth/src/api/handlers/auth.rs
@@ -197,17 +197,22 @@ pub async fn token_handler(
     // Brute-force throttle, keyed by the request identity. If this caller has
     // exceeded the failed-attempt budget, reject with 429 + Retry-After before
     // doing any credential work.
-    let rl_key = format!(
-        "{}|{}|{}",
-        token_request.auth_method, token_request.public_key, token_request.client_name
-    );
+    //
+    // Keyed by (auth_method, public_key) only. `client_name` is fully
+    // attacker-controlled and adds no binding — including it would let an
+    // attacker reset the bucket by rotating the name. `public_key` is the field
+    // bound to the caller's identity. (See module docs for the
+    // identity-rotation / IP-keying follow-up.)
+    let rl_key = format!("{}|{}", token_request.auth_method, token_request.public_key);
     if let Some(retry_after) = state.0.login_rate_limiter.check(&rl_key) {
         warn!("Login rate limit exceeded for identity {rl_key}");
         let mut headers = HeaderMap::new();
-        let _ = headers.insert(
-            "Retry-After",
-            HeaderValue::from_str(&retry_after.to_string())
-                .unwrap_or_else(|_| HeaderValue::from_static("60")),
+        drop(
+            headers.insert(
+                "Retry-After",
+                HeaderValue::from_str(&retry_after.to_string())
+                    .unwrap_or_else(|_| HeaderValue::from_static("60")),
+            ),
         );
         return error_response(
             StatusCode::TOO_MANY_REQUESTS,
@@ -516,21 +521,7 @@ fn extract_token_from_forwarded_uri(headers: &HeaderMap) -> Option<&str> {
         })
 }
 
-/// OAuth callback handler for meroctl authentication flow
-///
-/// This endpoint serves a simple authentication form that allows users
-/// to authenticate and then redirects back to the meroctl callback server.
-///
-/// # Arguments
-///
-/// * `state` - The application state
-/// * `Query(params)` - Query parameters including callback-url
-///
-/// # Returns
-///
-/// * `impl IntoResponse` - HTML form for authentication
-/// Default callback URL used when none is supplied or the supplied one is
-/// rejected.
+/// Default callback URL used when none is supplied or the supplied one is rejected.
 const DEFAULT_CALLBACK: &str = "http://127.0.0.1:9080/callback";
 
 /// Turn an attacker-controlled `callback-url` query value into a JS string
@@ -551,6 +542,19 @@ fn safe_callback_js(raw: Option<&str>) -> String {
     serde_json::to_string(&validated).unwrap_or_else(|_| format!("{DEFAULT_CALLBACK:?}"))
 }
 
+/// OAuth callback handler for meroctl authentication flow
+///
+/// This endpoint serves a simple authentication form that allows users
+/// to authenticate and then redirects back to the meroctl callback server.
+///
+/// # Arguments
+///
+/// * `state` - The application state
+/// * `Query(params)` - Query parameters including callback-url
+///
+/// # Returns
+///
+/// * `impl IntoResponse` - HTML form for authentication
 pub async fn callback_handler(
     _state: Extension<Arc<AppState>>,
     Query(params): Query<HashMap<String, String>>,

--- a/crates/auth/src/api/handlers/auth.rs
+++ b/crates/auth/src/api/handlers/auth.rs
@@ -194,6 +194,28 @@ pub async fn token_handler(
         );
     }
 
+    // Brute-force throttle, keyed by the request identity. If this caller has
+    // exceeded the failed-attempt budget, reject with 429 + Retry-After before
+    // doing any credential work.
+    let rl_key = format!(
+        "{}|{}|{}",
+        token_request.auth_method, token_request.public_key, token_request.client_name
+    );
+    if let Some(retry_after) = state.0.login_rate_limiter.check(&rl_key) {
+        warn!("Login rate limit exceeded for identity {rl_key}");
+        let mut headers = HeaderMap::new();
+        let _ = headers.insert(
+            "Retry-After",
+            HeaderValue::from_str(&retry_after.to_string())
+                .unwrap_or_else(|_| HeaderValue::from_static("60")),
+        );
+        return error_response(
+            StatusCode::TOO_MANY_REQUESTS,
+            "Too many failed login attempts; please try again later",
+            Some(headers),
+        );
+    }
+
     // Authenticate directly using the token request with node context
     let auth_response = match state
         .0
@@ -204,6 +226,7 @@ pub async fn token_handler(
         Ok(response) => response,
         Err(err) => {
             error!("Authentication failed: {}", err);
+            state.0.login_rate_limiter.record_failure(&rl_key);
             return error_response(
                 StatusCode::UNAUTHORIZED,
                 format!("Authentication failed: {err}"),
@@ -214,12 +237,16 @@ pub async fn token_handler(
 
     // Ensure authentication was successful
     if !auth_response.is_valid {
+        state.0.login_rate_limiter.record_failure(&rl_key);
         return error_response(
             StatusCode::UNAUTHORIZED,
             "Authentication failed: Invalid credentials",
             None,
         );
     }
+
+    // Successful authentication clears the failed-attempt counter.
+    state.0.login_rate_limiter.reset(&rl_key);
 
     let key_id = auth_response.key_id;
 

--- a/crates/auth/src/api/handlers/auth.rs
+++ b/crates/auth/src/api/handlers/auth.rs
@@ -171,7 +171,17 @@ pub async fn token_handler(
     // `public_key` is the field bound to the caller's identity. This value is
     // used only as an opaque map key and is never logged. (See module docs for
     // the identity-rotation / IP-keying follow-up.)
-    let rl_key = format!("{}|{}", token_request.auth_method, token_request.public_key);
+    //
+    // Length-prefix the first component so the `|` separator is unambiguous:
+    // raw, attacker-controlled values could otherwise inject a `|` to collide
+    // two distinct identities into one bucket (e.g. lock out a victim by
+    // polluting their bucket).
+    let rl_key = format!(
+        "{}|{}|{}",
+        token_request.auth_method.len(),
+        token_request.auth_method,
+        token_request.public_key
+    );
 
     // Sanitize string inputs to prevent injection attacks
     token_request.auth_method = sanitize_identifier(&token_request.auth_method);
@@ -206,6 +216,10 @@ pub async fn token_handler(
     // Brute-force throttle: if this caller has exceeded the failed-attempt
     // budget, reject with 429 + Retry-After before doing any credential work.
     if let Some(retry_after) = state.0.login_rate_limiter.check(&rl_key) {
+        // Count the rejected attempt too, so sustained hammering keeps the
+        // window rolling rather than letting the attacker wait out a fixed
+        // lockout while still probing.
+        state.0.login_rate_limiter.record_failure(&rl_key);
         // Log only the sanitized, low-cardinality auth method — never the raw
         // key (which holds the public key and could be a log-injection vector).
         warn!(

--- a/crates/auth/src/api/handlers/auth.rs
+++ b/crates/auth/src/api/handlers/auth.rs
@@ -195,10 +195,16 @@ pub async fn token_handler(
     let cap_field = |s: &str| -> String { s.chars().take(MAX_RL_KEY_FIELD).collect() };
     let rl_auth_method = cap_field(&token_request.auth_method);
     let rl_public_key = cap_field(&token_request.public_key);
+    // Length-prefix *both* fields so the key is unambiguous regardless of any
+    // `|` characters in either component: `len|auth_method|len|public_key`. A
+    // bare `|` separator would otherwise let an attacker who controls
+    // `public_key` smuggle a separator and collide with a different identity's
+    // bucket.
     let rl_key = format!(
-        "{}|{}|{}",
+        "{}|{}|{}|{}",
         rl_auth_method.len(),
         rl_auth_method,
+        rl_public_key.len(),
         rl_public_key
     );
 

--- a/crates/auth/src/auth/mod.rs
+++ b/crates/auth/src/auth/mod.rs
@@ -1,5 +1,6 @@
 pub mod middleware;
 pub mod permissions;
+pub mod rate_limit;
 pub mod security;
 pub mod service;
 pub mod token;

--- a/crates/auth/src/auth/rate_limit.rs
+++ b/crates/auth/src/auth/rate_limit.rs
@@ -169,6 +169,12 @@ impl LoginRateLimiter {
                         "Login rate-limiter at capacity; evicting oldest bucket (possible identity-rotation flood)"
                     );
                 } else {
+                    // Unreachable: the map is non-empty here (it just passed the
+                    // `>= MAX_TRACKED_KEYS` check) and reclaim only removes
+                    // entries, so `oldest_active_key` always finds a victim. Log
+                    // loudly and drop the record rather than panicking if that
+                    // invariant is ever violated, so the failure is visible.
+                    warn!("Login rate-limiter: no eviction victim on a full map; dropping failure record (unexpected)");
                     return;
                 }
             }

--- a/crates/auth/src/auth/rate_limit.rs
+++ b/crates/auth/src/auth/rate_limit.rs
@@ -8,6 +8,22 @@
 //! Time is passed in explicitly (`*_at(now_ms)`) so the behaviour is
 //! deterministic in tests; the public wrappers stamp the real clock.
 //!
+//! # Semantics
+//!
+//! `max_attempts` is the number of failures **allowed within the window before
+//! lockout**: the bucket locks once it holds `max_attempts` in-window failures.
+//! With the default of 5, the 5th failure trips the lockout. Callers
+//! `check()` before attempting and `record_failure()` after a failure, so the
+//! gate is a sliding window over recent failures, not a hard per-session count.
+//!
+//! Because `check()` and `record_failure()` take the lock separately, two
+//! concurrent requests for the same key can both pass `check()` at the
+//! threshold boundary and each record a failure — an inherent off-by-one in the
+//! check-then-act pattern. For a brute-force throttle this is immaterial (one
+//! extra attempt in a 60s window does not change the economics) and is not
+//! worth serialising every login behind a single `check_and_record` critical
+//! section.
+//!
 //! # Known limitations (intentionally out of scope; tracked follow-ups)
 //!
 //! - **In-memory / per-process**: counters live in the heap and reset on process
@@ -18,14 +34,23 @@
 //!   (`auth_method|public_key`). An attacker who rotates the public key gets a
 //!   fresh bucket; IP-based limiting (which closes that) needs `ConnectInfo`
 //!   wiring at the server.
+//! - **Wall-clock, not monotonic**: timestamps come from `SystemTime` so they
+//!   survive across the explicit-time API and tests. A forward clock jump can
+//!   retire an in-window failure early (shortening a lockout); a backward jump
+//!   only ever widens it. The effect is bounded by the 60s window and accepted
+//!   — a monotonic `Instant` doesn't serialise to the `u64` ms the API uses.
 //!
 //! To stop identity rotation from growing memory without bound, the tracked-key
-//! map is capped at [`MAX_TRACKED_KEYS`]: once full, failures for *new* keys are
-//! not tracked (existing buckets continue to lock out as normal).
+//! map is capped at [`MAX_TRACKED_KEYS`]. When full, [`record_failure_at`]
+//! first reclaims buckets whose failures have all aged out, then (if still
+//! full) evicts the least-recently-active bucket — so a new identity is always
+//! tracked rather than waved through unthrottled.
 
 use std::collections::HashMap;
 use std::sync::{Mutex, MutexGuard};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+use tracing::warn;
 
 /// Default: 5 failed attempts per 60s window before lockout.
 const DEFAULT_MAX_ATTEMPTS: u32 = 5;
@@ -83,9 +108,20 @@ impl LoginRateLimiter {
     }
 
     /// Lock the map, recovering from poisoning rather than disabling the
-    /// limiter: if a thread panicked while holding the lock, silently returning
-    /// "not locked" / dropping the failure would turn off brute-force protection
-    /// entirely. The inner map is still consistent, so reuse it.
+    /// limiter.
+    ///
+    /// Reuse — not clear — on poison recovery is the fail-*closed* choice here:
+    /// clearing the map would wipe every live lockout and let all in-progress
+    /// brute-force attempts start over (fail-open), which is exactly what this
+    /// limiter exists to prevent. Reusing preserves existing lockouts.
+    ///
+    /// Reuse is also safe in practice: every mutation under this lock is a
+    /// `push`, a `retain`, or a `remove` over `Vec<u64>`/`HashMap` — none of
+    /// which run user code that can panic, so the only realistic poison source
+    /// is a panic elsewhere on the thread, leaving the map structurally intact.
+    /// A worst-case partially-updated bucket can at most mis-time one
+    /// identity's lockout by a few failures, which the sliding window
+    /// self-heals on the next call.
     fn lock(&self) -> MutexGuard<'_, HashMap<String, Vec<u64>>> {
         self.inner
             .lock()
@@ -112,13 +148,41 @@ impl LoginRateLimiter {
 
     fn record_failure_at(&self, key: &str, now: u64) {
         let mut map = self.lock();
-        // Bound memory: once the cap is reached, do not start tracking new
-        // identities (existing buckets still record and lock out).
+        // Bound memory at the cap. Rather than silently dropping failures for
+        // every new identity once full — which would let an attacker first
+        // exhaust the key space with 100k throwaway identities and then
+        // brute-force any *new* identity completely unthrottled — make room:
+        //   1. Reclaim buckets whose failures have all aged out of the window.
+        //      Under normal churn this alone frees space and touches no live
+        //      lockout.
+        //   2. If every tracked identity still has an in-window failure (a
+        //      genuine 100k-distinct-identity flood), evict the least-recently-
+        //      active bucket so the new identity is still tracked. We log this
+        //      (no key material) so operators are alerted to map flooding.
         if !map.contains_key(key) && map.len() >= MAX_TRACKED_KEYS {
-            return;
+            reclaim_expired(&mut map, now, self.window_ms);
+            if map.len() >= MAX_TRACKED_KEYS {
+                if let Some(victim) = oldest_active_key(&map) {
+                    drop(map.remove(&victim));
+                    warn!(
+                        tracked_keys = map.len(),
+                        "Login rate-limiter at capacity; evicting oldest bucket (possible identity-rotation flood)"
+                    );
+                } else {
+                    return;
+                }
+            }
         }
         let failures = map.entry(key.to_owned()).or_default();
         prune(failures, now, self.window_ms);
+        // Cap per-key history. Once the bucket holds `max_attempts` in-window
+        // failures the caller is already locked out, and the unlock time is
+        // fixed by the *oldest* in-window failure (`failures[0]`), so further
+        // timestamps cannot extend or change the lockout — recording them would
+        // only grow the Vec without bound under a high-rate flood. Drop them.
+        if failures.len() >= self.max_attempts as usize {
+            return;
+        }
         failures.push(now);
     }
 }
@@ -127,6 +191,24 @@ impl LoginRateLimiter {
 fn prune(failures: &mut Vec<u64>, now: u64, window_ms: u64) {
     let cutoff = now.saturating_sub(window_ms);
     failures.retain(|&t| t >= cutoff);
+}
+
+/// Remove every bucket whose failures have all aged out of the window. Keeps
+/// the map bounded to identities with *live* lockouts.
+fn reclaim_expired(map: &mut HashMap<String, Vec<u64>>, now: u64, window_ms: u64) {
+    map.retain(|_, failures| {
+        prune(failures, now, window_ms);
+        !failures.is_empty()
+    });
+}
+
+/// The key of the least-recently-active bucket (smallest most-recent failure
+/// timestamp), used to pick an eviction victim when the map is full of live
+/// buckets. `None` only if the map is empty.
+fn oldest_active_key(map: &HashMap<String, Vec<u64>>) -> Option<String> {
+    map.iter()
+        .min_by_key(|(_, failures)| failures.iter().copied().max().unwrap_or(0))
+        .map(|(k, _)| k.clone())
 }
 
 #[cfg(test)]
@@ -179,5 +261,41 @@ mod tests {
         assert!(rl.check_at("a", 2).is_some());
         // A different identity is unaffected.
         assert_eq!(rl.check_at("b", 2), None);
+    }
+
+    #[test]
+    fn per_key_history_is_capped_under_flood() {
+        let rl = LoginRateLimiter::new(3, 60_000);
+        let key = "flooder";
+        // 50 failures, all inside the window: the bucket must not grow past
+        // `max_attempts`, since extra in-window failures cannot change the
+        // (oldest-failure-based) unlock time.
+        for t in 0..50 {
+            rl.record_failure_at(key, t);
+        }
+        let len = rl.lock().get(key).map(Vec::len).unwrap_or(0);
+        assert_eq!(len, 3, "bucket must be capped at max_attempts entries");
+        // Still correctly locked out.
+        assert!(rl.check_at(key, 100).is_some(), "flooded key stays locked");
+    }
+
+    #[test]
+    fn reclaim_expired_drops_only_aged_buckets() {
+        let mut map: HashMap<String, Vec<u64>> = HashMap::new();
+        let _ = map.insert("live".to_owned(), vec![50_000]);
+        let _ = map.insert("aged".to_owned(), vec![0, 100]);
+        // now=70_000, window=60_000 → cutoff 10_000: "aged" (<=100) is gone,
+        // "live" (50_000) survives.
+        reclaim_expired(&mut map, 70_000, 60_000);
+        assert!(map.contains_key("live"));
+        assert!(!map.contains_key("aged"));
+    }
+
+    #[test]
+    fn oldest_active_key_picks_least_recently_active() {
+        let mut map: HashMap<String, Vec<u64>> = HashMap::new();
+        let _ = map.insert("old".to_owned(), vec![10, 20]); // most recent = 20
+        let _ = map.insert("new".to_owned(), vec![100]); // most recent = 100
+        assert_eq!(oldest_active_key(&map).as_deref(), Some("old"));
     }
 }

--- a/crates/auth/src/auth/rate_limit.rs
+++ b/crates/auth/src/auth/rate_limit.rs
@@ -171,11 +171,12 @@ impl LoginRateLimiter {
                 } else {
                     // Unreachable: the map is non-empty here (it just passed the
                     // `>= MAX_TRACKED_KEYS` check) and reclaim only removes
-                    // entries, so `oldest_active_key` always finds a victim. Log
-                    // loudly and drop the record rather than panicking if that
-                    // invariant is ever violated, so the failure is visible.
-                    warn!("Login rate-limiter: no eviction victim on a full map; dropping failure record (unexpected)");
-                    return;
+                    // entries, so `oldest_active_key` always finds a victim. If
+                    // that invariant is ever violated, still record the failure
+                    // (the cap is a soft bound, transiently exceeded by one)
+                    // rather than dropping it — dropping would fail open for this
+                    // identity. Log loudly so the unexpected state is visible.
+                    warn!("Login rate-limiter: no eviction victim on a full map (unexpected); recording without eviction");
                 }
             }
         }

--- a/crates/auth/src/auth/rate_limit.rs
+++ b/crates/auth/src/auth/rate_limit.rs
@@ -8,18 +8,32 @@
 //! Time is passed in explicitly (`*_at(now_ms)`) so the behaviour is
 //! deterministic in tests; the public wrappers stamp the real clock.
 //!
-//! NOTE: keying is by request identity (auth method + public key + client
-//! name). IP-based limiting — which would also throttle attackers that rotate
-//! the request identity — requires `ConnectInfo` wiring at the server and is a
-//! tracked follow-up.
+//! # Known limitations (intentionally out of scope; tracked follow-ups)
+//!
+//! - **In-memory / per-process**: counters live in the heap and reset on process
+//!   restart (crash, OOM-kill, deliberate restart), so an attacker able to
+//!   restart the process can reset the lockout. Production hardening would
+//!   persist counts to the store.
+//! - **Identity-keyed, not IP-keyed**: the key is the request identity
+//!   (`auth_method|public_key`). An attacker who rotates the public key gets a
+//!   fresh bucket; IP-based limiting (which closes that) needs `ConnectInfo`
+//!   wiring at the server.
+//!
+//! To stop identity rotation from growing memory without bound, the tracked-key
+//! map is capped at [`MAX_TRACKED_KEYS`]: once full, failures for *new* keys are
+//! not tracked (existing buckets continue to lock out as normal).
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Default: 5 failed attempts per 60s window before lockout.
 const DEFAULT_MAX_ATTEMPTS: u32 = 5;
 const DEFAULT_WINDOW_MS: u64 = 60_000;
+
+/// Upper bound on distinct identities tracked at once, so an attacker rotating
+/// identities cannot grow the map without bound.
+const MAX_TRACKED_KEYS: usize = 100_000;
 
 /// Current wall-clock time in milliseconds since the UNIX epoch.
 fn now_ms() -> u64 {
@@ -65,35 +79,47 @@ impl LoginRateLimiter {
 
     /// Clear all recorded failures for `key` (call on successful auth).
     pub fn reset(&self, key: &str) {
-        if let Ok(mut map) = self.inner.lock() {
-            let _ = map.remove(key);
-        }
+        drop(self.lock().remove(key));
+    }
+
+    /// Lock the map, recovering from poisoning rather than disabling the
+    /// limiter: if a thread panicked while holding the lock, silently returning
+    /// "not locked" / dropping the failure would turn off brute-force protection
+    /// entirely. The inner map is still consistent, so reuse it.
+    fn lock(&self) -> MutexGuard<'_, HashMap<String, Vec<u64>>> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     fn check_at(&self, key: &str, now: u64) -> Option<u64> {
-        let mut map = self.inner.lock().ok()?;
+        let mut map = self.lock();
         let failures = map.get_mut(key)?;
         prune(failures, now, self.window_ms);
+
+        if failures.is_empty() {
+            drop(map.remove(key));
+            return None;
+        }
         if failures.len() as u32 >= self.max_attempts {
             // Locked until the oldest in-window failure ages out.
-            let oldest = *failures.first()?;
-            let unlock_at = oldest.saturating_add(self.window_ms);
+            let unlock_at = failures[0].saturating_add(self.window_ms);
             let retry_after_ms = unlock_at.saturating_sub(now);
-            Some(retry_after_ms.div_ceil(1000).max(1))
-        } else {
-            if failures.is_empty() {
-                let _ = map.remove(key);
-            }
-            None
+            return Some(retry_after_ms.div_ceil(1000).max(1));
         }
+        None
     }
 
     fn record_failure_at(&self, key: &str, now: u64) {
-        if let Ok(mut map) = self.inner.lock() {
-            let failures = map.entry(key.to_owned()).or_default();
-            prune(failures, now, self.window_ms);
-            failures.push(now);
+        let mut map = self.lock();
+        // Bound memory: once the cap is reached, do not start tracking new
+        // identities (existing buckets still record and lock out).
+        if !map.contains_key(key) && map.len() >= MAX_TRACKED_KEYS {
+            return;
         }
+        let failures = map.entry(key.to_owned()).or_default();
+        prune(failures, now, self.window_ms);
+        failures.push(now);
     }
 }
 
@@ -123,7 +149,7 @@ mod tests {
 
         // 3rd failure reached the limit → locked, with a positive retry-after.
         let retry = rl.check_at(key, 3_000).expect("must be locked");
-        assert!(retry >= 1 && retry <= 60, "retry-after seconds: {retry}");
+        assert!((1..=60).contains(&retry), "retry-after seconds: {retry}");
 
         // Still locked just before the window clears.
         assert!(rl.check_at(key, 59_000).is_some());

--- a/crates/auth/src/auth/rate_limit.rs
+++ b/crates/auth/src/auth/rate_limit.rs
@@ -175,13 +175,18 @@ impl LoginRateLimiter {
         }
         let failures = map.entry(key.to_owned()).or_default();
         prune(failures, now, self.window_ms);
-        // Cap per-key history. Once the bucket holds `max_attempts` in-window
-        // failures the caller is already locked out, and the unlock time is
-        // fixed by the *oldest* in-window failure (`failures[0]`), so further
-        // timestamps cannot extend or change the lockout — recording them would
-        // only grow the Vec without bound under a high-rate flood. Drop them.
+        // Bound the bucket at `max_attempts` entries while keeping the window
+        // rolling. When the bucket is already full, drop the oldest in-window
+        // failure before pushing the new one: this advances `failures[0]`,
+        // which fixes the unlock time, so sustained hammering keeps extending
+        // the lockout — matching the 429-path `record_failure` in
+        // `token_handler` — rather than letting an attacker wait out a lockout
+        // anchored to their very first failure. The Vec never exceeds
+        // `max_attempts` entries (a handful), so the `remove(0)` shift is cheap,
+        // and pruning above means a bucket that has fully aged out is refilled
+        // from empty rather than rolled.
         if failures.len() >= self.max_attempts as usize {
-            return;
+            let _ = failures.remove(0);
         }
         failures.push(now);
     }
@@ -205,6 +210,12 @@ fn reclaim_expired(map: &mut HashMap<String, Vec<u64>>, now: u64, window_ms: u64
 /// The key of the least-recently-active bucket (smallest most-recent failure
 /// timestamp), used to pick an eviction victim when the map is full of live
 /// buckets. `None` only if the map is empty.
+///
+/// This is an O(n) scan (n ≤ [`MAX_TRACKED_KEYS`]) that clones the victim key
+/// under the lock. It only runs on the rare full-map eviction path — i.e. a
+/// genuine ~100k-distinct-identity flood; the steady state never reaches it. A
+/// secondary last-active index (min-heap / ordered set) would make this
+/// O(log n) but is out of scope for this in-memory best-effort limiter.
 fn oldest_active_key(map: &HashMap<String, Vec<u64>>) -> Option<String> {
     map.iter()
         .min_by_key(|(_, failures)| failures.iter().copied().max().unwrap_or(0))
@@ -264,18 +275,20 @@ mod tests {
     }
 
     #[test]
-    fn per_key_history_is_capped_under_flood() {
+    fn per_key_history_caps_and_rolls_under_flood() {
         let rl = LoginRateLimiter::new(3, 60_000);
         let key = "flooder";
-        // 50 failures, all inside the window: the bucket must not grow past
-        // `max_attempts`, since extra in-window failures cannot change the
-        // (oldest-failure-based) unlock time.
+        // 50 failures at t=0..49, all inside the window.
         for t in 0..50 {
             rl.record_failure_at(key, t);
         }
-        let len = rl.lock().get(key).map(Vec::len).unwrap_or(0);
-        assert_eq!(len, 3, "bucket must be capped at max_attempts entries");
-        // Still correctly locked out.
+        let bucket = rl.lock().get(key).cloned().unwrap_or_default();
+        // Bounded at max_attempts entries — no unbounded Vec growth...
+        assert_eq!(bucket.len(), 3, "bucket capped at max_attempts entries");
+        // ...and the window rolled forward: the oldest retained failure is the
+        // (50 - 3)th, not the original t=0, so the lockout tracks recent
+        // hammering instead of staying anchored to the first failure.
+        assert_eq!(bucket[0], 47, "window rolled to the most recent failures");
         assert!(rl.check_at(key, 100).is_some(), "flooded key stays locked");
     }
 

--- a/crates/auth/src/auth/rate_limit.rs
+++ b/crates/auth/src/auth/rate_limit.rs
@@ -300,6 +300,30 @@ mod tests {
     }
 
     #[test]
+    fn retry_after_stays_at_least_one_second_across_cap_and_roll_cycles() {
+        // The rolling cap advances `failures[0]` (the lockout anchor) on every
+        // recorded failure once the bucket is full, so the reported retry-after
+        // is computed from the oldest *retained* failure rather than the first
+        // one ever seen. Regardless of how many cap-and-roll cycles happen, a
+        // locked key must always report a retry-after of at least 1 second (no
+        // zero/sub-second value that would invite an immediate retry).
+        let rl = LoginRateLimiter::new(3, 60_000);
+        let key = "sustained-flooder";
+        for t in 0..200u64 {
+            // Hammer once per second; each call past the cap rolls the window.
+            rl.record_failure_at(key, t * 1_000);
+            // Only assert once the bucket has reached `max_attempts` (3) entries
+            // and is therefore locked; the first two failures are still allowed.
+            if t + 1 >= 3 {
+                let retry = rl
+                    .check_at(key, t * 1_000)
+                    .expect("a full bucket must remain locked");
+                assert!(retry >= 1, "retry-after must stay >= 1s, got {retry}");
+            }
+        }
+    }
+
+    #[test]
     fn reclaim_expired_drops_only_aged_buckets() {
         let mut map: HashMap<String, Vec<u64>> = HashMap::new();
         let _ = map.insert("live".to_owned(), vec![50_000]);

--- a/crates/auth/src/auth/rate_limit.rs
+++ b/crates/auth/src/auth/rate_limit.rs
@@ -1,0 +1,157 @@
+//! Login brute-force throttling.
+//!
+//! A small in-memory sliding-window limiter that bounds failed authentication
+//! attempts per caller identity. After `max_attempts` failures within
+//! `window`, further attempts are rejected with a lockout until the window
+//! clears. A successful authentication resets the counter.
+//!
+//! Time is passed in explicitly (`*_at(now_ms)`) so the behaviour is
+//! deterministic in tests; the public wrappers stamp the real clock.
+//!
+//! NOTE: keying is by request identity (auth method + public key + client
+//! name). IP-based limiting — which would also throttle attackers that rotate
+//! the request identity — requires `ConnectInfo` wiring at the server and is a
+//! tracked follow-up.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Default: 5 failed attempts per 60s window before lockout.
+const DEFAULT_MAX_ATTEMPTS: u32 = 5;
+const DEFAULT_WINDOW_MS: u64 = 60_000;
+
+/// Current wall-clock time in milliseconds since the UNIX epoch.
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[derive(Debug)]
+pub struct LoginRateLimiter {
+    inner: Mutex<HashMap<String, Vec<u64>>>,
+    max_attempts: u32,
+    window_ms: u64,
+}
+
+impl Default for LoginRateLimiter {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_ATTEMPTS, DEFAULT_WINDOW_MS)
+    }
+}
+
+impl LoginRateLimiter {
+    #[must_use]
+    pub fn new(max_attempts: u32, window_ms: u64) -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+            max_attempts,
+            window_ms,
+        }
+    }
+
+    /// If `key` is currently locked out, return `Some(retry_after_secs)`.
+    /// Call this *before* attempting authentication.
+    pub fn check(&self, key: &str) -> Option<u64> {
+        self.check_at(key, now_ms())
+    }
+
+    /// Record a failed attempt for `key`.
+    pub fn record_failure(&self, key: &str) {
+        self.record_failure_at(key, now_ms());
+    }
+
+    /// Clear all recorded failures for `key` (call on successful auth).
+    pub fn reset(&self, key: &str) {
+        if let Ok(mut map) = self.inner.lock() {
+            let _ = map.remove(key);
+        }
+    }
+
+    fn check_at(&self, key: &str, now: u64) -> Option<u64> {
+        let mut map = self.inner.lock().ok()?;
+        let failures = map.get_mut(key)?;
+        prune(failures, now, self.window_ms);
+        if failures.len() as u32 >= self.max_attempts {
+            // Locked until the oldest in-window failure ages out.
+            let oldest = *failures.first()?;
+            let unlock_at = oldest.saturating_add(self.window_ms);
+            let retry_after_ms = unlock_at.saturating_sub(now);
+            Some(retry_after_ms.div_ceil(1000).max(1))
+        } else {
+            if failures.is_empty() {
+                let _ = map.remove(key);
+            }
+            None
+        }
+    }
+
+    fn record_failure_at(&self, key: &str, now: u64) {
+        if let Ok(mut map) = self.inner.lock() {
+            let failures = map.entry(key.to_owned()).or_default();
+            prune(failures, now, self.window_ms);
+            failures.push(now);
+        }
+    }
+}
+
+/// Drop failure timestamps older than the window.
+fn prune(failures: &mut Vec<u64>, now: u64, window_ms: u64) {
+    let cutoff = now.saturating_sub(window_ms);
+    failures.retain(|&t| t >= cutoff);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locks_out_after_max_attempts_and_recovers_after_window() {
+        let rl = LoginRateLimiter::new(3, 60_000);
+        let key = "user|pk|client";
+
+        // Not locked initially.
+        assert_eq!(rl.check_at(key, 0), None);
+
+        // First 3 failures within the window: still allowed up to the limit.
+        rl.record_failure_at(key, 0);
+        rl.record_failure_at(key, 1_000);
+        assert_eq!(rl.check_at(key, 2_000), None, "2 failures < 3 → allowed");
+        rl.record_failure_at(key, 2_000);
+
+        // 3rd failure reached the limit → locked, with a positive retry-after.
+        let retry = rl.check_at(key, 3_000).expect("must be locked");
+        assert!(retry >= 1 && retry <= 60, "retry-after seconds: {retry}");
+
+        // Still locked just before the window clears.
+        assert!(rl.check_at(key, 59_000).is_some());
+
+        // After the oldest failure ages out of the window, allowed again.
+        assert_eq!(rl.check_at(key, 61_001), None);
+    }
+
+    #[test]
+    fn success_resets_the_counter() {
+        let rl = LoginRateLimiter::new(3, 60_000);
+        let key = "k";
+        rl.record_failure_at(key, 0);
+        rl.record_failure_at(key, 1);
+        rl.record_failure_at(key, 2);
+        assert!(rl.check_at(key, 3).is_some(), "locked after 3 failures");
+
+        rl.reset(key);
+        assert_eq!(rl.check_at(key, 4), None, "reset clears the lockout");
+    }
+
+    #[test]
+    fn distinct_keys_are_independent() {
+        let rl = LoginRateLimiter::new(2, 60_000);
+        rl.record_failure_at("a", 0);
+        rl.record_failure_at("a", 1);
+        assert!(rl.check_at("a", 2).is_some());
+        // A different identity is unaffected.
+        assert_eq!(rl.check_at("b", 2), None);
+    }
+}

--- a/crates/auth/src/embedded.rs
+++ b/crates/auth/src/embedded.rs
@@ -82,6 +82,7 @@ pub async fn build_app(config: AuthConfig) -> Result<EmbeddedAuthApp> {
         token_generator: token_manager,
         config: config.clone(),
         metrics,
+        login_rate_limiter: Arc::new(crate::auth::rate_limit::LoginRateLimiter::default()),
     });
 
     let router = create_router(Arc::clone(&state), &config);

--- a/crates/auth/src/server.rs
+++ b/crates/auth/src/server.rs
@@ -25,6 +25,8 @@ pub struct AppState {
     pub config: AuthConfig,
     /// Metrics
     pub metrics: AuthMetrics,
+    /// Brute-force throttling for the login/token endpoint.
+    pub login_rate_limiter: Arc<crate::auth::rate_limit::LoginRateLimiter>,
 }
 
 /// Start the authentication service
@@ -54,6 +56,7 @@ pub async fn start_server(
         token_generator: auth_service.get_token_manager().clone(),
         config: config.clone(),
         metrics,
+        login_rate_limiter: Arc::new(crate::auth::rate_limit::LoginRateLimiter::default()),
     });
 
     // Create the session store

--- a/crates/node/primitives/Cargo.toml
+++ b/crates/node/primitives/Cargo.toml
@@ -25,6 +25,7 @@ reqwest = { workspace = true, features = ["stream"] }
 tokio = { workspace = true, features = ["sync"] }
 tokio-util.workspace = true
 tracing.workspace = true
+url.workspace = true
 
 calimero-context-config.workspace = true
 calimero-crypto.workspace = true

--- a/crates/node/primitives/src/client/application/install.rs
+++ b/crates/node/primitives/src/client/application/install.rs
@@ -33,16 +33,20 @@ const MAX_INSTALL_REDIRECTS: usize = 10;
 /// the synchronous check in `calimero-server-primitives` (the two crates do not
 /// share a dependency); applied here at fetch time so it also covers redirect
 /// hops, which the request-validation layer cannot see.
+///
+/// Uses the typed `Url::host()` rather than string parsing so IPv6 literals
+/// (including bracketed forms) are classified by the URL parser, not by manual
+/// bracket stripping.
 fn host_is_blocked(url: &Url) -> bool {
-    let Some(host) = url.host_str() else {
-        return true; // no host → refuse
-    };
-    let trimmed = host.trim_start_matches('[').trim_end_matches(']');
-    if let Ok(ip) = trimmed.parse::<std::net::IpAddr>() {
-        return ip_is_blocked(ip);
+    match url.host() {
+        Some(url::Host::Ipv4(ip)) => ip_is_blocked(std::net::IpAddr::V4(ip)),
+        Some(url::Host::Ipv6(ip)) => ip_is_blocked(std::net::IpAddr::V6(ip)),
+        Some(url::Host::Domain(domain)) => {
+            let domain = domain.trim_end_matches('.').to_ascii_lowercase();
+            domain == "localhost" || domain.ends_with(".localhost")
+        }
+        None => true, // no host → refuse
     }
-    let domain = host.trim_end_matches('.').to_ascii_lowercase();
-    domain == "localhost" || domain.ends_with(".localhost")
 }
 
 fn ip_is_blocked(ip: std::net::IpAddr) -> bool {

--- a/crates/node/primitives/src/client/application/install.rs
+++ b/crates/node/primitives/src/client/application/install.rs
@@ -29,10 +29,13 @@ const MAX_ERROR_BODY_LEN: usize = 256;
 const MAX_INSTALL_REDIRECTS: usize = 10;
 
 /// Whether a URL's host must be refused as an SSRF target: a literal
-/// loopback / private / link-local / unspecified IP, or `localhost`. Mirrors
-/// the synchronous check in `calimero-server-primitives` (the two crates do not
-/// share a dependency); applied here at fetch time so it also covers redirect
-/// hops, which the request-validation layer cannot see.
+/// loopback / private / link-local / unspecified IP, or `localhost`. Applied
+/// here at fetch time so it also covers redirect hops, which the
+/// request-validation layer cannot see.
+///
+/// SYNC(#3053): mirrors `calimero-server-primitives::validation::url_host_is_blocked`
+/// (the two crates do not share a dependency). Keep the blocked ranges in step
+/// with that copy until both are deduplicated into a shared crate (#3053).
 ///
 /// Uses the typed `Url::host()` rather than string parsing so IPv6 literals
 /// (including bracketed forms) are classified by the URL parser, not by manual

--- a/crates/node/primitives/src/client/application/install.rs
+++ b/crates/node/primitives/src/client/application/install.rs
@@ -55,11 +55,15 @@ fn host_is_blocked(url: &Url) -> bool {
 fn ip_is_blocked(ip: std::net::IpAddr) -> bool {
     match ip {
         std::net::IpAddr::V4(v4) => {
+            let o = v4.octets();
+            // 100.64.0.0/10 (RFC 6598, CGNAT). SYNC(#3053).
+            let is_cgnat = o[0] == 100 && (o[1] & 0xc0) == 0x40;
             v4.is_loopback()
                 || v4.is_private()
                 || v4.is_link_local()
                 || v4.is_unspecified()
                 || v4.is_broadcast()
+                || is_cgnat
         }
         std::net::IpAddr::V6(v6) => {
             if v6.is_loopback() || v6.is_unspecified() {

--- a/crates/node/primitives/src/client/application/install.rs
+++ b/crates/node/primitives/src/client/application/install.rs
@@ -25,6 +25,70 @@ use crate::client::NodeClient;
 
 const MAX_ERROR_BODY_LEN: usize = 256;
 
+/// Maximum redirects to follow when downloading an application.
+const MAX_INSTALL_REDIRECTS: usize = 10;
+
+/// Whether a URL's host must be refused as an SSRF target: a literal
+/// loopback / private / link-local / unspecified IP, or `localhost`. Mirrors
+/// the synchronous check in `calimero-server-primitives` (the two crates do not
+/// share a dependency); applied here at fetch time so it also covers redirect
+/// hops, which the request-validation layer cannot see.
+fn host_is_blocked(url: &Url) -> bool {
+    let Some(host) = url.host_str() else {
+        return true; // no host → refuse
+    };
+    let trimmed = host.trim_start_matches('[').trim_end_matches(']');
+    if let Ok(ip) = trimmed.parse::<std::net::IpAddr>() {
+        return ip_is_blocked(ip);
+    }
+    let domain = host.trim_end_matches('.').to_ascii_lowercase();
+    domain == "localhost" || domain.ends_with(".localhost")
+}
+
+fn ip_is_blocked(ip: std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+        }
+        std::net::IpAddr::V6(v6) => {
+            if v6.is_loopback() || v6.is_unspecified() {
+                return true;
+            }
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return ip_is_blocked(std::net::IpAddr::V4(v4));
+            }
+            let first = v6.segments()[0];
+            // fc00::/7 (unique-local) or fe80::/10 (link-local).
+            (first & 0xfe00) == 0xfc00 || (first & 0xffc0) == 0xfe80
+        }
+    }
+}
+
+/// Build an HTTP client that refuses to connect to non-public addresses, on the
+/// initial request and on every redirect hop (closes redirect-to-private SSRF).
+///
+/// Note: a public hostname whose DNS resolves to a private address (DNS
+/// rebinding) is not caught here — that needs a custom resolver and is tracked
+/// as a follow-up. The literal-IP and `localhost` cases, including via
+/// redirect, are covered.
+fn ssrf_guarded_client() -> reqwest::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            if host_is_blocked(attempt.url()) {
+                attempt.error("redirect to a non-public address is blocked")
+            } else if attempt.previous().len() >= MAX_INSTALL_REDIRECTS {
+                attempt.stop()
+            } else {
+                attempt.follow()
+            }
+        }))
+        .build()
+}
+
 impl NodeClient {
     pub fn install_raw_wasm(
         &self,
@@ -310,7 +374,19 @@ impl NodeClient {
     ) -> eyre::Result<ApplicationId> {
         let uri = url.as_str().parse()?;
 
-        let response = reqwest::Client::new().get(url.clone()).send().await?;
+        // SSRF guard: refuse non-http(s) schemes and literal non-public hosts
+        // before connecting; the client also re-checks every redirect hop.
+        if !matches!(url.scheme(), "http" | "https") {
+            bail!(
+                "unsupported URL scheme '{}'; only http and https are allowed",
+                url.scheme()
+            );
+        }
+        if host_is_blocked(&url) {
+            bail!("refusing to fetch from a non-public address: {}", url);
+        }
+
+        let response = ssrf_guarded_client()?.get(url.clone()).send().await?;
 
         if !response.status().is_success() {
             let status = response.status();
@@ -921,5 +997,41 @@ impl NodeClient {
         // In a real implementation, you might want to resolve the package/version to a URL
         let url = source.to_string().parse()?;
         self.install_application_from_url(url, metadata, None).await
+    }
+}
+
+#[cfg(test)]
+mod ssrf_tests {
+    use reqwest::Url;
+
+    use super::host_is_blocked;
+
+    #[test]
+    fn blocks_non_public_hosts() {
+        for bad in [
+            "http://169.254.169.254/latest/meta-data/",
+            "http://127.0.0.1/",
+            "http://localhost/",
+            "http://10.0.0.1/",
+            "http://192.168.0.1/",
+            "http://[::1]/",
+            "http://[fc00::1]/",
+            "http://[::ffff:127.0.0.1]/",
+        ] {
+            assert!(
+                host_is_blocked(&Url::parse(bad).unwrap()),
+                "{bad} must be blocked",
+            );
+        }
+    }
+
+    #[test]
+    fn allows_public_hosts() {
+        for ok in ["https://registry.example.com/", "http://93.184.216.34/"] {
+            assert!(
+                !host_is_blocked(&Url::parse(ok).unwrap()),
+                "{ok} must be allowed",
+            );
+        }
     }
 }

--- a/crates/node/primitives/src/client/application/install.rs
+++ b/crates/node/primitives/src/client/application/install.rs
@@ -82,7 +82,9 @@ fn ip_is_blocked(ip: std::net::IpAddr) -> bool {
 fn ssrf_guarded_client() -> reqwest::Result<reqwest::Client> {
     reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::custom(|attempt| {
-            if host_is_blocked(attempt.url()) {
+            if !matches!(attempt.url().scheme(), "http" | "https") {
+                attempt.error("redirect to a non-http(s) scheme is blocked")
+            } else if host_is_blocked(attempt.url()) {
                 attempt.error("redirect to a non-public address is blocked")
             } else if attempt.previous().len() >= MAX_INSTALL_REDIRECTS {
                 attempt.stop()

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1313,10 +1313,10 @@ impl TeeVerifyQuoteResponse {
 use crate::validation::{
     helpers::{
         validate_bytes_size, validate_hex_string, validate_optional_string_length,
-        validate_string_length, validate_url,
+        validate_safe_path, validate_string_length, validate_url,
     },
     Validate, ValidationError, MAX_INIT_PARAMS_SIZE, MAX_METADATA_SIZE, MAX_PACKAGE_NAME_LENGTH,
-    MAX_PATH_LENGTH, MAX_QUOTE_B64_LENGTH, MAX_VERSION_LENGTH,
+    MAX_QUOTE_B64_LENGTH, MAX_VERSION_LENGTH,
 };
 
 impl Validate for InstallApplicationRequest {
@@ -1351,12 +1351,8 @@ impl Validate for InstallDevApplicationRequest {
     fn validate(&self) -> Vec<ValidationError> {
         let mut errors = Vec::new();
 
-        if self.path.as_str().len() > MAX_PATH_LENGTH {
-            errors.push(ValidationError::StringTooLong {
-                field: "path",
-                max: MAX_PATH_LENGTH,
-                actual: self.path.as_str().len(),
-            });
+        if let Some(e) = validate_safe_path(self.path.as_str(), "path") {
+            errors.push(e);
         }
 
         if let Some(e) = validate_bytes_size(&self.metadata, "metadata", MAX_METADATA_SIZE) {

--- a/crates/server/primitives/src/validation.rs
+++ b/crates/server/primitives/src/validation.rs
@@ -262,18 +262,128 @@ pub mod helpers {
         }
     }
 
-    /// Validate URL length
+    /// Validate a URL the node will fetch from (e.g. application install).
+    ///
+    /// Beyond the length cap this is the first line of SSRF defense: it enforces
+    /// an `http`/`https` scheme and rejects URLs whose host is a literal
+    /// loopback / private / link-local / unspecified IP, or `localhost`. This
+    /// blocks the obvious metadata-service and internal-service targets
+    /// (`http://169.254.169.254/...`, `http://127.0.0.1`, `http://10.0.0.1`,
+    /// `http://[::1]`, `http://localhost`).
+    ///
+    /// It does NOT catch a public hostname that *resolves* to a private address
+    /// (DNS rebinding) or a redirect to a private address — those require
+    /// resolution at fetch time and are enforced separately by the download
+    /// path. Keep both layers.
     pub fn validate_url(value: &url::Url, field: &'static str) -> Option<ValidationError> {
         let url_str = value.as_str();
         if url_str.len() > MAX_URL_LENGTH {
-            Some(ValidationError::StringTooLong {
+            return Some(ValidationError::StringTooLong {
                 field,
                 max: MAX_URL_LENGTH,
                 actual: url_str.len(),
-            })
-        } else {
-            None
+            });
         }
+
+        match value.scheme() {
+            "http" | "https" => {}
+            other => {
+                return Some(ValidationError::InvalidFormat {
+                    field,
+                    reason: format!(
+                        "unsupported URL scheme '{other}'; only http and https are allowed"
+                    ),
+                });
+            }
+        }
+
+        match value.host() {
+            Some(host) if url_host_is_blocked(&host) => Some(ValidationError::InvalidFormat {
+                field,
+                reason:
+                    "URL host is a loopback, private, link-local, or otherwise non-public address"
+                        .to_owned(),
+            }),
+            Some(_) => None,
+            None => Some(ValidationError::InvalidFormat {
+                field,
+                reason: "URL has no host".to_owned(),
+            }),
+        }
+    }
+
+    /// Whether a URL host must be refused as an SSRF target (literal private/
+    /// loopback/link-local/unspecified IP, or a `localhost` domain).
+    pub fn url_host_is_blocked(host: &url::Host<&str>) -> bool {
+        match host {
+            url::Host::Ipv4(ip) => ipv4_is_blocked(*ip),
+            url::Host::Ipv6(ip) => ipv6_is_blocked(*ip),
+            url::Host::Domain(domain) => {
+                let domain = domain.trim_end_matches('.').to_ascii_lowercase();
+                domain == "localhost" || domain.ends_with(".localhost")
+            }
+        }
+    }
+
+    /// Blocked IPv4 ranges: loopback (127/8), private (10/8, 172.16/12,
+    /// 192.168/16), link-local (169.254/16 — incl. the cloud metadata IP),
+    /// unspecified (0.0.0.0), and broadcast.
+    fn ipv4_is_blocked(ip: std::net::Ipv4Addr) -> bool {
+        ip.is_loopback()
+            || ip.is_private()
+            || ip.is_link_local()
+            || ip.is_unspecified()
+            || ip.is_broadcast()
+    }
+
+    /// Blocked IPv6: loopback (::1), unspecified (::), unique-local (fc00::/7),
+    /// link-local (fe80::/10), and IPv4-mapped addresses whose embedded v4 is
+    /// blocked. (Avoids unstable `Ipv6Addr` helpers by checking segments.)
+    fn ipv6_is_blocked(ip: std::net::Ipv6Addr) -> bool {
+        if ip.is_loopback() || ip.is_unspecified() {
+            return true;
+        }
+        if let Some(v4) = ip.to_ipv4_mapped() {
+            return ipv4_is_blocked(v4);
+        }
+        let first = ip.segments()[0];
+        // fc00::/7 (unique-local) and fe80::/10 (link-local).
+        (first & 0xfe00) == 0xfc00 || (first & 0xffc0) == 0xfe80
+    }
+
+    /// Validate a local filesystem path supplied by a client (e.g. dev install).
+    ///
+    /// Rejects `..` traversal components, which are never legitimate and are the
+    /// classic way to escape an intended directory (e.g. `foo/../../etc/passwd`).
+    ///
+    /// Absolute paths are intentionally allowed: dev installs commonly point at
+    /// an absolute build-output path (`meroctl app install --path /abs/app.wasm`),
+    /// and the `install-dev-application` endpoint is node-owner/admin-only (the
+    /// permission gate denies non-admin tokens), so reading the owner's own
+    /// filesystem is not a privilege boundary. This check is defense-in-depth
+    /// against traversal tricks layered on top of that gate.
+    pub fn validate_safe_path(path: &str, field: &'static str) -> Option<ValidationError> {
+        use std::path::{Component, Path};
+
+        if path.len() > MAX_PATH_LENGTH {
+            return Some(ValidationError::StringTooLong {
+                field,
+                max: MAX_PATH_LENGTH,
+                actual: path.len(),
+            });
+        }
+
+        if Path::new(path)
+            .components()
+            .any(|c| matches!(c, Component::ParentDir))
+        {
+            return Some(ValidationError::InvalidFormat {
+                field,
+                reason: "path must not contain '..' traversal components".to_owned(),
+            });
+        }
+
+        None
     }
 
     /// Validate method name (checks for empty, length, and control characters)
@@ -368,5 +478,85 @@ pub mod helpers {
                 2 + content_size + comma_size
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod ssrf_and_path_tests {
+    use url::Url;
+
+    use super::helpers::{validate_safe_path, validate_url};
+    use super::ValidationError;
+
+    fn url(s: &str) -> Url {
+        Url::parse(s).unwrap()
+    }
+
+    #[test]
+    fn ssrf_targets_are_rejected() {
+        for bad in [
+            "http://169.254.169.254/latest/meta-data/", // cloud metadata
+            "http://127.0.0.1:6379",
+            "http://localhost:8080/admin",
+            "https://LOCALHOST/x",
+            "http://10.0.0.5/internal",
+            "http://172.16.3.4/",
+            "http://192.168.1.1/",
+            "http://0.0.0.0/",
+            "http://[::1]/",
+            "http://[fe80::1]/",
+            "http://[fc00::1]/",
+            "http://[::ffff:127.0.0.1]/", // IPv4-mapped loopback
+        ] {
+            assert!(
+                matches!(
+                    validate_url(&url(bad), "url"),
+                    Some(ValidationError::InvalidFormat { .. })
+                ),
+                "{bad} must be rejected as an SSRF target",
+            );
+        }
+    }
+
+    #[test]
+    fn non_http_schemes_are_rejected() {
+        for bad in ["file:///etc/passwd", "ftp://example.com/x", "gopher://x/"] {
+            assert!(matches!(
+                validate_url(&url(bad), "url"),
+                Some(ValidationError::InvalidFormat { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn public_urls_are_allowed() {
+        for ok in [
+            "https://registry.example.com/app.wasm",
+            "http://93.184.216.34/app.mpk", // public literal IP
+            "https://calimero.network/pkg/v1.mpk",
+        ] {
+            assert!(
+                validate_url(&url(ok), "url").is_none(),
+                "{ok} must be allowed",
+            );
+        }
+    }
+
+    #[test]
+    fn path_traversal_is_rejected_absolute_allowed() {
+        for bad in ["../../etc/passwd", "foo/../../bar", "a/../b/../../c"] {
+            assert!(
+                matches!(
+                    validate_safe_path(bad, "path"),
+                    Some(ValidationError::InvalidFormat { .. })
+                ),
+                "{bad} must be rejected for traversal",
+            );
+        }
+        // Absolute and plain relative paths are allowed (dev-install ergonomics;
+        // the endpoint is admin-only).
+        assert!(validate_safe_path("/abs/build/app.wasm", "path").is_none());
+        assert!(validate_safe_path("res/app.wasm", "path").is_none());
+        assert!(validate_safe_path("./res/app.wasm", "path").is_none());
     }
 }

--- a/crates/server/primitives/src/validation.rs
+++ b/crates/server/primitives/src/validation.rs
@@ -315,12 +315,12 @@ pub mod helpers {
     /// Whether a URL host must be refused as an SSRF target (literal private/
     /// loopback/link-local/unspecified IP, or a `localhost` domain).
     ///
-    /// NOTE: the same blocked-range logic is duplicated in
+    /// SYNC(#3053): the same blocked-range logic is duplicated in
     /// `calimero-node-primitives` (`client/application/install.rs::host_is_blocked`),
     /// which applies it at fetch time to also cover redirect hops. The two
     /// crates do not share a dependency; if you change the blocked ranges here
-    /// (e.g. add an RFC range or a new IPv6 special prefix), update that copy
-    /// too. A shared `net-utils` crate is the tracked follow-up.
+    /// (e.g. add CGNAT 100.64.0.0/10 or a new IPv6 special prefix), update that
+    /// copy too. Tracked for deduplication into a shared crate in #3053.
     pub fn url_host_is_blocked(host: &url::Host<&str>) -> bool {
         match host {
             url::Host::Ipv4(ip) => ipv4_is_blocked(*ip),

--- a/crates/server/primitives/src/validation.rs
+++ b/crates/server/primitives/src/validation.rs
@@ -314,6 +314,13 @@ pub mod helpers {
 
     /// Whether a URL host must be refused as an SSRF target (literal private/
     /// loopback/link-local/unspecified IP, or a `localhost` domain).
+    ///
+    /// NOTE: the same blocked-range logic is duplicated in
+    /// `calimero-node-primitives` (`client/application/install.rs::host_is_blocked`),
+    /// which applies it at fetch time to also cover redirect hops. The two
+    /// crates do not share a dependency; if you change the blocked ranges here
+    /// (e.g. add an RFC range or a new IPv6 special prefix), update that copy
+    /// too. A shared `net-utils` crate is the tracked follow-up.
     pub fn url_host_is_blocked(host: &url::Host<&str>) -> bool {
         match host {
             url::Host::Ipv4(ip) => ipv4_is_blocked(*ip),

--- a/crates/server/primitives/src/validation.rs
+++ b/crates/server/primitives/src/validation.rs
@@ -334,13 +334,19 @@ pub mod helpers {
 
     /// Blocked IPv4 ranges: loopback (127/8), private (10/8, 172.16/12,
     /// 192.168/16), link-local (169.254/16 — incl. the cloud metadata IP),
-    /// unspecified (0.0.0.0), and broadcast.
+    /// unspecified (0.0.0.0), broadcast, and CGNAT (100.64.0.0/10, RFC 6598 —
+    /// used by some cloud providers for internal/metadata reachability).
     fn ipv4_is_blocked(ip: std::net::Ipv4Addr) -> bool {
+        let o = ip.octets();
+        // 100.64.0.0/10: first octet 100, second octet 64..=127. `is_shared()`
+        // would cover this but is unstable, so check the prefix directly.
+        let is_cgnat = o[0] == 100 && (o[1] & 0xc0) == 0x40;
         ip.is_loopback()
             || ip.is_private()
             || ip.is_link_local()
             || ip.is_unspecified()
             || ip.is_broadcast()
+            || is_cgnat
     }
 
     /// Blocked IPv6: loopback (::1), unspecified (::), unique-local (fc00::/7),
@@ -509,6 +515,7 @@ mod ssrf_and_path_tests {
             "http://10.0.0.5/internal",
             "http://172.16.3.4/",
             "http://192.168.1.1/",
+            "http://100.64.0.1/", // CGNAT (RFC 6598)
             "http://0.0.0.0/",
             "http://[::1]/",
             "http://[fe80::1]/",

--- a/crates/server/src/sse/events.rs
+++ b/crates/server/src/sse/events.rs
@@ -36,6 +36,16 @@ use super::state::ServiceState;
 /// This design prioritizes simplicity and resource efficiency over guaranteed delivery.
 /// For critical state updates, clients should implement their own state reconciliation
 /// after reconnection.
+///
+/// # Lifecycle (no task leak)
+///
+/// This task is scoped to a single connection. It exits as soon as that
+/// connection's command channel closes (the client disconnected) — detected
+/// without waiting for the next node event via `closed()` in the `select!`.
+/// Previously it slept-and-looped forever when no connection was active, so
+/// every disconnect leaked a task, and a reconnect (which spawns a fresh task)
+/// produced duplicate delivery. The session state persists separately for
+/// reconnection.
 pub async fn handle_node_events(
     session_id: ConnectionId,
     state: Arc<ServiceState>,

--- a/crates/server/src/sse/events.rs
+++ b/crates/server/src/sse/events.rs
@@ -39,13 +39,14 @@ use super::state::ServiceState;
 ///
 /// # Lifecycle (no task leak)
 ///
-/// This task is scoped to a single connection. It exits as soon as that
-/// connection's command channel closes (the client disconnected) — detected
-/// without waiting for the next node event via `closed()` in the `select!`.
-/// Previously it slept-and-looped forever when no connection was active, so
-/// every disconnect leaked a task, and a reconnect (which spawns a fresh task)
-/// produced duplicate delivery. The session state persists separately for
-/// reconnection.
+/// This task is scoped to a single connection and writes directly to that
+/// connection's command channel (`commands_sender`). It exits **only** when the
+/// connection actually goes away — either `commands_sender.closed()` fires (the
+/// SSE stream's receiver was dropped) or a send fails for the same reason — or
+/// when the node event stream ends. It does not consult `active_connections`,
+/// so a transient miss there during a reconnect handoff cannot kill it.
+/// Previously it slept-and-looped forever when no connection was active, which
+/// leaked a task per disconnect.
 pub async fn handle_node_events(
     session_id: ConnectionId,
     state: Arc<ServiceState>,

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -28,7 +28,7 @@ use serde_json::{
     to_value as to_json_value, Value,
 };
 use tokio::spawn;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{mpsc, RwLock, Semaphore};
 use tokio::time::interval;
 use tracing::{debug, error, field, info, info_span, warn, Instrument};
 use uuid::Uuid;
@@ -238,7 +238,11 @@ async fn ws_handler(
             (None, true)
         }
     };
-    ws.on_upgrade(move |socket| handle_socket(socket, state, caller, node_owner))
+    // Cap inbound message/frame size so a single oversized frame cannot exhaust
+    // memory during JSON parsing (the connection is closed instead).
+    ws.max_message_size(WS_MAX_MESSAGE_BYTES)
+        .max_frame_size(WS_MAX_MESSAGE_BYTES)
+        .on_upgrade(move |socket| handle_socket(socket, state, caller, node_owner))
         .into_response()
 }
 
@@ -249,6 +253,10 @@ async fn handle_socket(
     node_owner: bool,
 ) {
     let (commands_sender, commands_receiver) = mpsc::channel(WS_COMMAND_CHANNEL_BUFFER_SIZE);
+
+    // Bounds the number of concurrently-processed text frames for this
+    // connection (see WS_MAX_CONCURRENT_MESSAGES).
+    let message_limiter = Arc::new(Semaphore::new(WS_MAX_CONCURRENT_MESSAGES));
 
     // Generate a globally unique connection ID. A UUID (vs a per-process
     // counter) stays unique across node restarts and when logs from multiple
@@ -300,11 +308,19 @@ async fn handle_socket(
 
         match message {
             Message::Text(message) => {
-                drop(spawn(handle_text_message(
-                    connection_id,
-                    Arc::clone(&state),
-                    message,
-                )));
+                // Acquire a permit before spawning. When all permits are in use
+                // this awaits — applying backpressure to the read loop instead
+                // of spawning unbounded handler tasks under a message flood.
+                let permit = match Arc::clone(&message_limiter).acquire_owned().await {
+                    Ok(permit) => permit,
+                    Err(_) => break, // semaphore closed — connection shutting down
+                };
+                let state = Arc::clone(&state);
+                drop(spawn(async move {
+                    // Held for the lifetime of the handler; released on completion.
+                    let _permit = permit;
+                    handle_text_message(connection_id, state, message).await;
+                }));
             }
             Message::Binary(_) => {
                 debug!("Received binary message");
@@ -697,6 +713,19 @@ use crate::config::ServerConfig;
 /// This controls how many WebSocket commands can be queued in the channel before
 /// the sender blocks. Should match SSE's COMMAND_CHANNEL_BUFFER_SIZE for consistency.
 const WS_COMMAND_CHANNEL_BUFFER_SIZE: usize = 32;
+
+/// Maximum number of text messages from a single connection being processed
+/// concurrently. Each text frame was previously `spawn`ed unconditionally, so a
+/// client flooding messages could spawn unbounded tasks (memory/CPU exhaustion).
+/// A per-connection permit pool bounds in-flight handlers and applies
+/// backpressure (the read loop awaits a permit before accepting the next frame).
+const WS_MAX_CONCURRENT_MESSAGES: usize = 32;
+
+/// Maximum size of a single inbound WebSocket message. Frames are JSON-parsed in
+/// full, so without a cap a single huge frame could exhaust memory. Oversized
+/// messages cause the connection to be closed by the WebSocket layer rather than
+/// buffered. 16 MiB comfortably covers legitimate execute payloads.
+const WS_MAX_MESSAGE_BYTES: usize = 16 * 1024 * 1024;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

**PR 2 of 2** of the Auth / HTTP / JSON-RPC / WS / SSE hardening. This is the abuse / DoS / injection battery. Guard numbers refer to **Section G** of the security audit.

> **Stacked on #3040** (base branch `feat/auth-default-deny-and-sse-idor`). Review/merge #3040 first; this PR's diff is only the 5 commits below. Rebase onto `master` once #3040 lands.

## What changed

### 🔴 #66 — SSRF on application-install URLs
`install-application` only length-checked the URL, and the downloader used a default reqwest client that follows redirects. Two layers:
- **Request validation** (`validate_url`): enforce `http`/`https` and reject a host that is a literal loopback / private / link-local / unspecified IP or `localhost` (blocks `169.254.169.254`, `127.0.0.1`, `10/172.16/192.168`, `::1`, `fc00::/7`, `fe80::/10`, IPv4-mapped, `localhost`).
- **Fetch time** (`install_application_from_url`): refuse non-http(s)/non-public hosts before connecting and re-validate **every redirect hop** (closes redirect-to-private).
- *Follow-up:* DNS rebinding (public name → private A record) needs a custom resolver; noted in code.

### 🔴 #67 — Path traversal on dev install
`install-dev` only length-checked the path. `validate_safe_path` now rejects `..` traversal components. Absolute paths stay allowed (legit `meroctl --path /abs` dev usage; the endpoint is node-owner/admin-only after #3040's permission gate, so this is defense-in-depth).

### 🔴 #9 — Callback-url XSS
`callback_handler` interpolated the `callback-url` query param raw into an inline `<script>` (`'{callback_url}'` → `';alert(1);//`). `safe_callback_js` now accepts only well-formed `http`/`https` URLs (URL normalisation percent-encodes `<`/`>`) and JSON-encodes the result into a quoted, escaped JS string literal.

### 🔴 #8 — Login brute-force lockout
`/auth/token` had no rate limiting. Added an in-memory sliding-window limiter (`LoginRateLimiter`, default 5 failures / 60s) → 429 + `Retry-After`; failures record, success resets. Keyed by request identity; IP-based limiting (via `ConnectInfo`) noted as a follow-up.

### 🟠 #61 / #62 — WebSocket resource limits
- #61: cap inbound WS message/frame size at 16 MiB (oversized frames close the connection instead of buffering for an unbounded JSON parse). HTTP JSON bodies are already bounded by axum's default limit.
- #62: per-frame `spawn` was unbounded; a per-connection `Semaphore` (32) now bounds in-flight handlers and applies backpressure.

### 🟠 #63 — SSE event-task leak on disconnect
`handle_node_events` never terminated on disconnect — it slept-and-looped forever, leaking a task per disconnect and causing duplicate delivery after reconnect. It now `select!`s on the connection's `closed()` signal and exits promptly. The exactly-once-replay half (buffer + replay) is a separate reliability feature, intentionally out of scope; skip-on-disconnect remains documented.

## Testing
New unit tests per fix: SSRF/scheme/path tables (server-primitives + node-primitives), callback XSS, login lockout (window + reset + key isolation), host-spoof; WS/SSE changes pass the existing round-trip/cleanup suites through the new bounded/cancellable paths.
- `cargo test -p mero-auth --lib` → **69 passed**
- `cargo test -p calimero-server --lib` → **39 passed**
- `cargo test -p calimero-server-primitives --lib` → **11 passed**
- `cargo test -p calimero-node-primitives --lib` (ssrf) → **2 passed**

## Deferred follow-ups (documented in code)
- #66: DNS-rebinding resolution guard (custom resolver).
- #8: IP-based rate-limit key (requires `ConnectInfo` wiring).
- #63: exactly-once event replay on reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)