### PR TITLE
fix(merod): restrict node home and datastore dirs to owner-only

### DIFF
--- a/architecture/crates/tools.html
+++ b/architecture/crates/tools.html
@@ -517,6 +517,7 @@ merod --home /data --node mynode init \
 </div>
 <p><span class="code">--group-governance local</span> is the default (and only) governance mode.</p>
 <p>For read-only nodes, add <span class="code">--mode read-only</span>.</p>
+<p>On Unix, <span class="code">init</span> runs under a restrictive <span class="code">umask</span> (<span class="code">0077</span>) so the node home, <span class="code">config.toml</span> (which holds the Ed25519 private key), and the datastore — including every RocksDB file — are created owner-only. <span class="code">config.toml</span> is pinned to <span class="code">0600</span> and the directories to <span class="code">0700</span>, keeping the key unreadable by other local users.</p>
 </div>
 </details>
 </div>

--- a/architecture/crates/tools.html
+++ b/architecture/crates/tools.html
@@ -517,7 +517,7 @@ merod --home /data --node mynode init \
 </div>
 <p><span class="code">--group-governance local</span> is the default (and only) governance mode.</p>
 <p>For read-only nodes, add <span class="code">--mode read-only</span>.</p>
-<p>On Unix, <span class="code">init</span> runs under a restrictive <span class="code">umask</span> (<span class="code">0077</span>) so the node home, <span class="code">config.toml</span> (which holds the Ed25519 private key), and the datastore — including every RocksDB file — are created owner-only. <span class="code">config.toml</span> is pinned to <span class="code">0600</span> and the directories to <span class="code">0700</span>, keeping the key unreadable by other local users.</p>
+<p>On Unix, <span class="code">init</span> hardens the node directory to owner-only permissions: the node home and datastore directories (and every RocksDB file beneath them) are set to <span class="code">0700</span>/<span class="code">0600</span>, and <span class="code">config.toml</span> — which holds the Ed25519 private key — is pinned to <span class="code">0600</span>, keeping the key unreadable by other local users.</p>
 </div>
 </details>
 </div>

--- a/crates/merod/Cargo.toml
+++ b/crates/merod/Cargo.toml
@@ -52,6 +52,9 @@ mero-auth = { path = "../auth" }
 sigstore = { version = "0.13.0", default-features = false, features = ["verify", "cosign", "sigstore-trust-root", "rustls-tls"] }
 x509-cert = "0.2.5"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [build-dependencies]
 calimero-build-utils.workspace = true
 

--- a/crates/merod/Cargo.toml
+++ b/crates/merod/Cargo.toml
@@ -52,9 +52,6 @@ mero-auth = { path = "../auth" }
 sigstore = { version = "0.13.0", default-features = false, features = ["verify", "cosign", "sigstore-trust-root", "rustls-tls"] }
 x509-cert = "0.2.5"
 
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
-
 [build-dependencies]
 calimero-build-utils.workspace = true
 

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -25,7 +25,7 @@ use mero_auth::config::{AuthConfig as EmbeddedAuthConfig, StorageConfig as AuthS
 use multiaddr::{Multiaddr, Protocol};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use tokio::fs::{self, create_dir_all};
+use tokio::fs;
 use tracing::{info, warn};
 
 use super::auth_mode::AuthModeArg;
@@ -83,6 +83,24 @@ async fn restrict_tree_to_owner(root: impl AsRef<Path>) -> EyreResult<()> {
 #[cfg(not(unix))]
 async fn restrict_tree_to_owner(_root: impl AsRef<Path>) -> EyreResult<()> {
     Ok(())
+}
+
+/// Create `path` and any missing parents, with directories created owner-only
+/// (`0700`) on Unix. Using the mode at creation time means the node home is
+/// never momentarily visible to other users with permissive bits — the window a
+/// create-then-`chmod` would leave open. Pre-existing components keep their mode.
+async fn create_dir_owner_only(path: impl AsRef<Path>) -> EyreResult<()> {
+    let path = path.as_ref();
+
+    let mut builder = fs::DirBuilder::new();
+    let _ = builder.recursive(true);
+    #[cfg(unix)]
+    let _ = builder.mode(0o700);
+
+    builder
+        .create(path)
+        .await
+        .wrap_err_with(|| format!("failed to create directory {path:?}"))
 }
 
 // Sync configuration - aggressive defaults for fast CRDT convergence
@@ -243,13 +261,11 @@ impl InitCommand {
         }
 
         if !path.exists() {
-            create_dir_all(&path)
-                .await
-                .wrap_err_with(|| format!("failed to create directory {path:?}"))?;
+            create_dir_owner_only(&path).await?;
         }
 
-        // Lock the node home down to owner-only before anything sensitive (the
-        // private key in config.toml, the datastore) is written into it.
+        // A freshly created home is already 0700 (above); tighten a pre-existing
+        // one so the private key and datastore land in an owner-only directory.
         restrict_to_owner(&path, 0o700).await?;
 
         let identity = Keypair::generate_ed25519();
@@ -367,13 +383,18 @@ impl InitCommand {
         // parent directory's permissions are ever loosened.
         restrict_to_owner(path.join(CONFIG_FILE), 0o600).await?;
 
+        // `config` is fully consumed below; `datastore_path` is cloned so the
+        // store's owned copy is independent.
         let datastore_path = path.join(&config.datastore.path);
         drop(Store::open::<RocksDB>(&StoreConfig::new(
             datastore_path.clone(),
         ))?);
 
-        // The store is now closed, so no writer races us: recursively make the
-        // datastore and all of RocksDB's files owner-only.
+        // RocksDB creates these files under the process umask, but they live
+        // inside the now-0700 node home, so they were never reachable by other
+        // users. With the store closed (no writer racing us), recursively pin the
+        // datastore and every RocksDB file to owner-only as defense in depth, so
+        // the contents stay private even if the home's mode is later loosened.
         restrict_tree_to_owner(&datastore_path).await?;
 
         info!("Initialized a node in {:?}", path);

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -31,48 +31,9 @@ use tracing::{info, warn};
 use super::auth_mode::AuthModeArg;
 use crate::cli;
 
-/// Forces a restrictive `umask` (`0077`) for the lifetime of the guard so every
-/// file and directory created during node initialization — the node home, the
-/// `config.toml` holding the Ed25519 private key, and the RocksDB datastore with
-/// all of its files and sub-directories — is owner-only from the moment it is
-/// created. This closes the window between creation and an after-the-fact
-/// `chmod`, and protects the contents even if a parent directory's permissions
-/// are later relaxed. `init` is a one-shot command that does no other concurrent
-/// filesystem work, so mutating the process-wide `umask` here is safe.
-#[cfg(unix)]
-struct OwnerOnlyUmask(libc::mode_t);
-
-#[cfg(unix)]
-impl OwnerOnlyUmask {
-    fn set() -> Self {
-        // SAFETY: `umask` only swaps the process file-creation mask and always
-        // succeeds, returning the previous mask.
-        Self(unsafe { libc::umask(0o077) })
-    }
-}
-
-#[cfg(unix)]
-impl Drop for OwnerOnlyUmask {
-    fn drop(&mut self) {
-        // SAFETY: restore the mask captured in `set`; same contract as above.
-        let _ = unsafe { libc::umask(self.0) };
-    }
-}
-
-#[cfg(not(unix))]
-struct OwnerOnlyUmask;
-
-#[cfg(not(unix))]
-impl OwnerOnlyUmask {
-    fn set() -> Self {
-        Self
-    }
-}
-
-/// Restrict an existing path to owner-only access. The restrictive `umask`
-/// covers everything created during init, but a directory that already existed
-/// keeps its old mode, so tighten those explicitly. No-op on non-Unix platforms,
-/// which lack POSIX mode bits.
+/// Restrict a single path to the given owner-only `mode` (`0700` for
+/// directories, `0600` for files). No-op on non-Unix platforms, which lack
+/// POSIX mode bits.
 #[cfg(unix)]
 async fn restrict_to_owner(path: impl AsRef<Path>, mode: u32) -> EyreResult<()> {
     use std::os::unix::fs::PermissionsExt;
@@ -85,6 +46,42 @@ async fn restrict_to_owner(path: impl AsRef<Path>, mode: u32) -> EyreResult<()> 
 
 #[cfg(not(unix))]
 async fn restrict_to_owner(_path: impl AsRef<Path>, _mode: u32) -> EyreResult<()> {
+    Ok(())
+}
+
+/// Recursively restrict a directory tree to owner-only access: `0700` for every
+/// directory and `0600` for every file. RocksDB creates the datastore's files
+/// and sub-directories with the process umask (typically world-readable), so
+/// walking the tree after the store is closed makes the raw data — and any
+/// content left by a previous partial init — unreadable to other local users
+/// rather than relying solely on the top-level directory's mode. Symlinks are
+/// left untouched (RocksDB creates none here).
+#[cfg(unix)]
+async fn restrict_tree_to_owner(root: impl AsRef<Path>) -> EyreResult<()> {
+    let mut stack = vec![root.as_ref().to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        restrict_to_owner(&dir, 0o700).await?;
+
+        let mut entries = fs::read_dir(&dir)
+            .await
+            .wrap_err_with(|| format!("failed to read directory {dir:?}"))?;
+
+        while let Some(entry) = entries.next_entry().await? {
+            let file_type = entry.file_type().await?;
+            if file_type.is_dir() {
+                stack.push(entry.path());
+            } else if file_type.is_file() {
+                restrict_to_owner(entry.path(), 0o600).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+async fn restrict_tree_to_owner(_root: impl AsRef<Path>) -> EyreResult<()> {
     Ok(())
 }
 
@@ -227,9 +224,6 @@ impl InitCommand {
 
         let path = root_args.home.join(root_args.node_name);
 
-        // Create everything below owner-only from the start; dropped at end of init.
-        let _umask = OwnerOnlyUmask::set();
-
         if ConfigFile::exists(&path) {
             if let Err(err) = ConfigFile::load(&path).await {
                 if self.force {
@@ -254,7 +248,8 @@ impl InitCommand {
                 .wrap_err_with(|| format!("failed to create directory {path:?}"))?;
         }
 
-        // The umask covers a freshly created home; tighten a pre-existing one too.
+        // Lock the node home down to owner-only before anything sensitive (the
+        // private key in config.toml, the datastore) is written into it.
         restrict_to_owner(&path, 0o700).await?;
 
         let identity = Keypair::generate_ed25519();
@@ -377,9 +372,9 @@ impl InitCommand {
             datastore_path.clone(),
         ))?);
 
-        // The umask keeps RocksDB's contents owner-only; tighten a pre-existing
-        // datastore directory too.
-        restrict_to_owner(&datastore_path, 0o700).await?;
+        // The store is now closed, so no writer races us: recursively make the
+        // datastore and all of RocksDB's files owner-only.
+        restrict_tree_to_owner(&datastore_path).await?;
 
         info!("Initialized a node in {:?}", path);
 

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -1,6 +1,6 @@
 use calimero_config::{
     BlobStoreConfig, ConfigFile, DataStoreConfig as StoreConfigFile, IdentityConfig, NetworkConfig,
-    NodeMode, ServerConfig, SyncConfig,
+    NodeMode, ServerConfig, SyncConfig, CONFIG_FILE,
 };
 use calimero_context::config::ContextConfig;
 use calimero_context_config::client_config::{ClientConfig, ClientSigner, LocalConfig};
@@ -31,22 +31,60 @@ use tracing::{info, warn};
 use super::auth_mode::AuthModeArg;
 use crate::cli;
 
-/// Restrict a directory to owner-only access (`0700`) so the Ed25519 private
-/// key in `config.toml` and the datastore underneath it are not readable or
-/// traversable by other local users. No-op on non-Unix platforms, which lack
-/// POSIX mode bits.
+/// Forces a restrictive `umask` (`0077`) for the lifetime of the guard so every
+/// file and directory created during node initialization — the node home, the
+/// `config.toml` holding the Ed25519 private key, and the RocksDB datastore with
+/// all of its files and sub-directories — is owner-only from the moment it is
+/// created. This closes the window between creation and an after-the-fact
+/// `chmod`, and protects the contents even if a parent directory's permissions
+/// are later relaxed. `init` is a one-shot command that does no other concurrent
+/// filesystem work, so mutating the process-wide `umask` here is safe.
 #[cfg(unix)]
-async fn restrict_dir_to_owner(dir: impl AsRef<Path>) -> EyreResult<()> {
-    use std::os::unix::fs::PermissionsExt;
+struct OwnerOnlyUmask(libc::mode_t);
 
-    let dir = dir.as_ref();
-    fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
-        .await
-        .wrap_err_with(|| format!("failed to restrict permissions on {dir:?}"))
+#[cfg(unix)]
+impl OwnerOnlyUmask {
+    fn set() -> Self {
+        // SAFETY: `umask` only swaps the process file-creation mask and always
+        // succeeds, returning the previous mask.
+        Self(unsafe { libc::umask(0o077) })
+    }
+}
+
+#[cfg(unix)]
+impl Drop for OwnerOnlyUmask {
+    fn drop(&mut self) {
+        // SAFETY: restore the mask captured in `set`; same contract as above.
+        let _ = unsafe { libc::umask(self.0) };
+    }
 }
 
 #[cfg(not(unix))]
-async fn restrict_dir_to_owner(_dir: impl AsRef<Path>) -> EyreResult<()> {
+struct OwnerOnlyUmask;
+
+#[cfg(not(unix))]
+impl OwnerOnlyUmask {
+    fn set() -> Self {
+        Self
+    }
+}
+
+/// Restrict an existing path to owner-only access. The restrictive `umask`
+/// covers everything created during init, but a directory that already existed
+/// keeps its old mode, so tighten those explicitly. No-op on non-Unix platforms,
+/// which lack POSIX mode bits.
+#[cfg(unix)]
+async fn restrict_to_owner(path: impl AsRef<Path>, mode: u32) -> EyreResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = path.as_ref();
+    fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+        .await
+        .wrap_err_with(|| format!("failed to restrict permissions on {path:?}"))
+}
+
+#[cfg(not(unix))]
+async fn restrict_to_owner(_path: impl AsRef<Path>, _mode: u32) -> EyreResult<()> {
     Ok(())
 }
 
@@ -189,6 +227,9 @@ impl InitCommand {
 
         let path = root_args.home.join(root_args.node_name);
 
+        // Create everything below owner-only from the start; dropped at end of init.
+        let _umask = OwnerOnlyUmask::set();
+
         if ConfigFile::exists(&path) {
             if let Err(err) = ConfigFile::load(&path).await {
                 if self.force {
@@ -213,8 +254,8 @@ impl InitCommand {
                 .wrap_err_with(|| format!("failed to create directory {path:?}"))?;
         }
 
-        // The node home holds the private key in config.toml; keep it owner-only.
-        restrict_dir_to_owner(&path).await?;
+        // The umask covers a freshly created home; tighten a pre-existing one too.
+        restrict_to_owner(&path, 0o700).await?;
 
         let identity = Keypair::generate_ed25519();
         info!("Generated identity: {:?}", identity.public().to_peer_id());
@@ -327,13 +368,18 @@ impl InitCommand {
 
         config.save(&path).await?;
 
+        // The file itself holds the private key; keep it owner-only even if its
+        // parent directory's permissions are ever loosened.
+        restrict_to_owner(path.join(CONFIG_FILE), 0o600).await?;
+
         let datastore_path = path.join(&config.datastore.path);
         drop(Store::open::<RocksDB>(&StoreConfig::new(
             datastore_path.clone(),
         ))?);
 
-        // RocksDB creates the datastore dir with the default umask; restrict it too.
-        restrict_dir_to_owner(&datastore_path).await?;
+        // The umask keeps RocksDB's contents owner-only; tighten a pre-existing
+        // datastore directory too.
+        restrict_to_owner(&datastore_path, 0o700).await?;
 
         info!("Initialized a node in {:?}", path);
 

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -24,12 +24,31 @@ use libp2p::identity::Keypair;
 use mero_auth::config::{AuthConfig as EmbeddedAuthConfig, StorageConfig as AuthStorageConfig};
 use multiaddr::{Multiaddr, Protocol};
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::fs::{self, create_dir_all};
 use tracing::{info, warn};
 
 use super::auth_mode::AuthModeArg;
 use crate::cli;
+
+/// Restrict a directory to owner-only access (`0700`) so the Ed25519 private
+/// key in `config.toml` and the datastore underneath it are not readable or
+/// traversable by other local users. No-op on non-Unix platforms, which lack
+/// POSIX mode bits.
+#[cfg(unix)]
+async fn restrict_dir_to_owner(dir: impl AsRef<Path>) -> EyreResult<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = dir.as_ref();
+    fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
+        .await
+        .wrap_err_with(|| format!("failed to restrict permissions on {dir:?}"))
+}
+
+#[cfg(not(unix))]
+async fn restrict_dir_to_owner(_dir: impl AsRef<Path>) -> EyreResult<()> {
+    Ok(())
+}
 
 // Sync configuration - aggressive defaults for fast CRDT convergence
 const DEFAULT_SYNC_TIMEOUT: Duration = Duration::from_secs(30);
@@ -194,6 +213,9 @@ impl InitCommand {
                 .wrap_err_with(|| format!("failed to create directory {path:?}"))?;
         }
 
+        // The node home holds the private key in config.toml; keep it owner-only.
+        restrict_dir_to_owner(&path).await?;
+
         let identity = Keypair::generate_ed25519();
         info!("Generated identity: {:?}", identity.public().to_peer_id());
 
@@ -305,9 +327,13 @@ impl InitCommand {
 
         config.save(&path).await?;
 
+        let datastore_path = path.join(&config.datastore.path);
         drop(Store::open::<RocksDB>(&StoreConfig::new(
-            path.join(config.datastore.path),
+            datastore_path.clone(),
         ))?);
+
+        // RocksDB creates the datastore dir with the default umask; restrict it too.
+        restrict_dir_to_owner(&datastore_path).await?;
 
         info!("Initialized a node in {:?}", path);
 


### PR DESCRIPTION
## Problem

`merod init` created both the node home directory (`crates/merod/src/cli/init.rs:191`) and the RocksDB datastore directory (`crates/merod/src/cli/init.rs:308`) using the default umask — typically `0755`, i.e. world-traversable.

The Ed25519 private key lives in `config.toml` under the node home. Even though the key file itself is hardened, the permissive parent directories let any other local user traverse into them, undermining that hardening.

## Fix

Added a `restrict_dir_to_owner` helper that sets a directory to `0700` after creation on Unix (no-op on non-Unix platforms, which lack POSIX mode bits). Applied to both the node home and the datastore directory.

## Verification

- `cargo check -p merod` and `cargo clippy -p merod` — clean
- Ran `merod init` end-to-end and confirmed with `stat`:
  - node home → `700`
  - `data/` → `700`
  - `config.toml` stays `0644` but is now unreachable to other local users via its owner-only parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)