### PR TITLE
fix(storage): reject undefined OpMask bits to close signature malleability

### DIFF
--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -16,6 +16,7 @@ mod tests;
 use calimero_primitives::identity::PublicKey;
 use core::fmt::{self, Debug, Display, Formatter};
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read};
 use std::ops::{Deref, DerefMut};
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -516,16 +517,16 @@ impl Default for OpMask {
 }
 
 impl BorshDeserialize for OpMask {
-    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+    fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self, IoError> {
         let bits = u8::deserialize_reader(reader)?;
         // Reject any byte carrying bits outside the defined set. Accepting them
         // would admit multiple encodings that are equal under `contains` but
         // differ in `bits()`, which feeds the signed authorization payload and
         // the derived id — a signature-malleability vector. `FULL` is the union
         // of every defined bit.
-        if bits & !Self::FULL.0 != 0 {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
+        if (bits & !Self::FULL.0) != 0 {
+            return Err(IoError::new(
+                IoErrorKind::InvalidData,
                 "OpMask has undefined bits set",
             ));
         }

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -456,12 +456,17 @@ pub struct SignatureData {
 /// not a compatibility one), so a single [`WRITE`] bit covers all upserts until
 /// that lands.
 ///
+/// Only the three defined bits may ever be set on the wire: the byte is part
+/// of the signed authorization payload (committed via [`bits`](OpMask::bits)),
+/// so an undefined high bit would be semantically identical under
+/// [`contains`](OpMask::contains) yet change the signed bytes and the derived
+/// id. To keep the encoding canonical, [`BorshDeserialize`] is hand-written to
+/// reject any byte with bits outside [`FULL`] rather than deriving it.
+///
 /// [`WRITE`]: OpMask::WRITE
 /// [`FULL`]: OpMask::FULL
 /// [`contains`]: OpMask::contains
-#[derive(
-    BorshDeserialize, BorshSerialize, Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash,
-)]
+#[derive(BorshSerialize, Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct OpMask(u8);
 
 impl OpMask {
@@ -507,6 +512,24 @@ pub fn full_mask(keys: BTreeSet<PublicKey>) -> BTreeMap<PublicKey, OpMask> {
 impl Default for OpMask {
     fn default() -> Self {
         Self::FULL
+    }
+}
+
+impl BorshDeserialize for OpMask {
+    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let bits = u8::deserialize_reader(reader)?;
+        // Reject any byte carrying bits outside the defined set. Accepting them
+        // would admit multiple encodings that are equal under `contains` but
+        // differ in `bits()`, which feeds the signed authorization payload and
+        // the derived id — a signature-malleability vector. `FULL` is the union
+        // of every defined bit.
+        if bits & !Self::FULL.0 != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "OpMask has undefined bits set",
+            ));
+        }
+        Ok(Self(bits))
     }
 }
 

--- a/crates/storage/src/tests/entities.rs
+++ b/crates/storage/src/tests/entities.rs
@@ -537,7 +537,7 @@ mod op_mask__borsh {
         // Every encoding with a bit outside FULL must fail to deserialize, so a
         // peer cannot smuggle a non-canonical byte that is equal under
         // `contains` but alters the signed authorization payload and id.
-        for bits in (0u8..=u8::MAX).filter(|b| b & !OpMask::FULL.bits() != 0) {
+        for bits in (0u8..=u8::MAX).filter(|b| (b & !OpMask::FULL.bits()) != 0) {
             assert!(
                 OpMask::try_from_slice(&[bits]).is_err(),
                 "byte {bits:#010b} with undefined bits should be rejected"

--- a/crates/storage/src/tests/entities.rs
+++ b/crates/storage/src/tests/entities.rs
@@ -511,3 +511,37 @@ mod metadata__needs_owner_convert {
         assert!(!needs_owner_convert(&user_meta(None), 0));
     }
 }
+
+mod op_mask__borsh {
+    use borsh::{from_slice, to_vec, BorshDeserialize};
+
+    use crate::entities::OpMask;
+
+    #[test]
+    fn defined_masks_round_trip() {
+        for mask in [
+            OpMask::NONE,
+            OpMask::WRITE,
+            OpMask::DELETE,
+            OpMask::ADMIN,
+            OpMask::FULL,
+            OpMask::WRITE.union(OpMask::DELETE),
+        ] {
+            let bytes = to_vec(&mask).unwrap();
+            assert_eq!(from_slice::<OpMask>(&bytes).unwrap(), mask);
+        }
+    }
+
+    #[test]
+    fn undefined_high_bits_are_rejected() {
+        // Every encoding with a bit outside FULL must fail to deserialize, so a
+        // peer cannot smuggle a non-canonical byte that is equal under
+        // `contains` but alters the signed authorization payload and id.
+        for bits in (0u8..=u8::MAX).filter(|b| b & !OpMask::FULL.bits() != 0) {
+            assert!(
+                OpMask::try_from_slice(&[bits]).is_err(),
+                "byte {bits:#010b} with undefined bits should be rejected"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`OpMask(u8)` derived `BorshDeserialize`, so **any** byte deserialized successfully — including ones with undefined high bits (bits 3–7). `OpMask::contains()` only tests the three defined bits via masking, so `0b0000_0001` and `0b1000_0001` are behaviorally identical at the merge check.

But `mask.bits()` returns the raw byte, and that byte is committed verbatim into the signed authorization payload (`action.rs:291`, `hasher.update([mask.bits()])`) which feeds `compute_id`. A peer could flip an undefined bit to mint a distinct signed payload / id for a semantically-identical mask — **signature malleability**.

## Fix

Drop `BorshDeserialize` from the derive and hand-write it to **reject** any byte with bits outside `FULL` (`0b0000_0111`, the union of all defined bits), keeping the encoding canonical. Rejecting (rather than silently masking) treats a non-canonical byte as malformed input and fails loudly with `InvalidData`. `BorshSerialize` stays derived.

## Verification

- New tests: defined masks round-trip; all 248 bytes with an undefined bit are rejected.
- Full `calimero-storage` suite passes (626 unit + integration tests).
- `cargo clippy -p calimero-storage --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)