### PR TITLE
fix(apps,sdk): correct silent failures across example apps and SDK

### DIFF
--- a/apps/blobs/README.md
+++ b/apps/blobs/README.md
@@ -43,7 +43,7 @@ Stores metadata about each uploaded file:
 
 ```rust
 pub struct FileRecord {
-    pub id: String,              // Unique file ID (e.g., "file_0")
+    pub id: String,              // Unique file ID, namespaced by uploader (e.g. "<uploader-base58>_0")
     pub name: String,            // Human-readable name
     pub blob_id: BlobId,         // Blob ID (base58 string in JSON via the SDK newtype)
     pub size: u64,               // File size in bytes
@@ -248,7 +248,7 @@ const response = await contractApi.upload_file(
 
 ```typescript
 // 1. CLIENT: Get blob ID from contract using file ID
-const fileId = "file_0"; // File ID returned from upload
+const fileId = uploadedFileId; // File ID returned from upload (e.g. "<uploader-base58>_0")
 
 // Option A: Get just the blob ID
 const blobId = await contractApi.get_blob_id_b58(fileId);

--- a/apps/blobs/src/lib.rs
+++ b/apps/blobs/src/lib.rs
@@ -26,7 +26,8 @@ const BYTES_PER_MB: f64 = BYTES_PER_KB * 1024.0;
 #[borsh(crate = "calimero_sdk::borsh")]
 #[serde(crate = "calimero_sdk::serde")]
 pub struct FileRecord {
-    /// Unique file identifier (e.g., "file_0", "file_1")
+    /// Unique file identifier, namespaced by the uploader's identity to stay
+    /// collision-free across replicas (e.g. "<uploader-base58>_0").
     pub id: String,
 
     /// Human-readable file name (e.g., "document.pdf", "image.png")
@@ -81,7 +82,7 @@ pub struct FileShareState {
     pub owner: LwwRegister<String>,
 
     /// Map of file ID to file metadata records.
-    /// Key: file ID (e.g., "file_0"), Value: FileRecord.
+    /// Key: file ID (e.g. "<uploader-base58>_0"), Value: FileRecord.
     pub files: UnorderedMap<String, FileRecord>,
 
     /// Monotonic counter used to generate unique file IDs.
@@ -93,7 +94,7 @@ pub struct FileShareState {
 pub enum FileShareEvent {
     /// Emitted when a file is successfully uploaded
     FileUploaded {
-        /// Unique file identifier (e.g., "file_0")
+        /// Unique file identifier (e.g. "<uploader-base58>_0")
         id: String,
         /// File name
         name: String,
@@ -144,7 +145,8 @@ impl FileShareState {
     /// * `mime_type` - MIME type (e.g., "application/pdf", "image/png")
     ///
     /// # Returns
-    /// * `Ok(String)` - The generated file ID (e.g., "file_0", "file_1")
+    /// * `Ok(String)` - The generated file ID, namespaced by uploader identity
+    ///   (e.g. "<uploader-base58>_0")
     /// * `Err(app::Error)` - Error if storage operation fails
     pub fn upload_file(
         &mut self,
@@ -153,15 +155,18 @@ impl FileShareState {
         size: u64,
         mime_type: String,
     ) -> app::Result<String> {
-        // Counter is a monotonic CRDT — it converges across replicas (taking
-        // the per-source max on merge). Using its current value as the file ID
-        // means concurrent uploads on different nodes can still pick the same
-        // ID; that limitation existed with the previous bare `u64` too.
+        // File IDs must be unique across replicas. The counter alone is not
+        // enough: it's a CRDT whose value converges, so two nodes uploading
+        // concurrently both read the same value and would mint the same ID,
+        // and one upload would overwrite the other on merge. Namespacing the
+        // ID with the uploader's identity makes it collision-free — each node
+        // has a distinct executor key, so `<uploader>_<counter>` is globally
+        // unique even when counters coincide.
+        let uploader = PublicKey::from(env::executor_id()).to_string();
         let next_id = self.file_counter.value()?;
-        let file_id = format!("file_{next_id}");
+        let file_id = format!("{uploader}_{next_id}");
         self.file_counter.increment()?;
 
-        let uploader = PublicKey::from(env::executor_id()).to_string();
         let timestamp = env::time_now();
 
         // BLOB API: Announce blob to network for peer discovery
@@ -207,7 +212,7 @@ impl FileShareState {
     /// currently expose blob deletion methods.
     ///
     /// # Arguments
-    /// * `file_id` - The ID of the file to delete (e.g., "file_0")
+    /// * `file_id` - The ID of the file to delete (e.g. "<uploader-base58>_0")
     ///
     /// # Returns
     /// * `Ok(())` - File metadata successfully deleted
@@ -256,7 +261,7 @@ impl FileShareState {
     /// Get a specific file by ID
     ///
     /// # Arguments
-    /// * `file_id` - The ID of the file to retrieve (e.g., "file_0")
+    /// * `file_id` - The ID of the file to retrieve (e.g. "<uploader-base58>_0")
     ///
     /// # Returns
     /// * `Ok(FileRecord)` - Complete file record with all metadata
@@ -275,7 +280,7 @@ impl FileShareState {
     /// via `blobClient.downloadBlob(blob_id, context_id)`.
     ///
     /// # Arguments
-    /// * `file_id` - The ID of the file (e.g., "file_0")
+    /// * `file_id` - The ID of the file (e.g. "<uploader-base58>_0")
     ///
     /// # Returns
     /// * `Ok(BlobId)` - The blob ID (base58 string over the wire, e.g.
@@ -321,7 +326,9 @@ impl FileShareState {
         let mut total_size = 0u64;
 
         for (_, file_record) in self.files.entries()? {
-            total_size += file_record.size;
+            // Saturate rather than overflow: adversarial or corrupt sizes
+            // would otherwise panic in debug and wrap in release.
+            total_size = total_size.saturating_add(file_record.size);
         }
 
         Ok(total_size)
@@ -411,5 +418,70 @@ mod tests {
             app.view(|s| s.search_files("nope".into())).unwrap().len(),
             0
         );
+    }
+
+    #[test]
+    fn distinct_uploaders_get_distinct_file_ids() {
+        let mut app = TestHost::new(FileShareState::init);
+
+        let id_a = app
+            .call_as([1u8; 32], |s| {
+                s.upload_file("a.txt".into(), blob_id(), 1, "text/plain".into())
+            })
+            .unwrap();
+        let id_b = app
+            .call_as([2u8; 32], |s| {
+                s.upload_file("b.txt".into(), blob_id(), 1, "text/plain".into())
+            })
+            .unwrap();
+
+        // IDs are namespaced by the uploader's identity, so two uploaders never
+        // mint a colliding ID even when the converging counter coincides.
+        assert_ne!(id_a, id_b);
+        assert!(id_a.starts_with(&PublicKey::from([1u8; 32]).to_string()));
+        assert!(id_b.starts_with(&PublicKey::from([2u8; 32]).to_string()));
+        assert_eq!(app.view(|s| s.list_files()).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn total_size_saturates_instead_of_overflowing() {
+        let mut app = TestHost::new(FileShareState::init);
+
+        app.call(|s| {
+            s.upload_file(
+                "big".into(),
+                blob_id(),
+                u64::MAX,
+                "application/octet-stream".into(),
+            )
+        })
+        .unwrap();
+        app.call(|s| {
+            s.upload_file(
+                "more".into(),
+                blob_id(),
+                10,
+                "application/octet-stream".into(),
+            )
+        })
+        .unwrap();
+
+        // u64::MAX + 10 saturates to u64::MAX rather than wrapping or panicking.
+        assert_eq!(app.view(|s| s.get_total_files_size()).unwrap(), u64::MAX);
+    }
+
+    #[test]
+    fn upload_survives_announce_failure() {
+        let mut app = TestHost::new(FileShareState::init);
+
+        // The harness can now drive the announce-failure branch real WASM hits.
+        app.set_blob_announce_should_fail(true);
+
+        app.call(|s| s.upload_file("f.txt".into(), blob_id(), 3, "text/plain".into()))
+            .unwrap();
+
+        // A failed announce is logged, not fatal: the file is still recorded.
+        assert_eq!(app.view(|s| s.list_files()).unwrap().len(), 1);
+        assert!(app.logs().iter().any(|l| l.contains("Failed to announce")));
     }
 }

--- a/apps/collaborative-editor/src/lib.rs
+++ b/apps/collaborative-editor/src/lib.rs
@@ -94,8 +94,16 @@ impl EditorState {
         app::log!("Initializing collaborative editor: {} by {}", title, owner);
 
         let mut metadata = UnorderedMap::new();
-        let _ = metadata.insert("title".to_string(), title.clone().into());
-        let _ = metadata.insert("owner".to_string(), owner.clone().into());
+        // `#[app::init]` must return `Self`, so it can't propagate a failure
+        // with `?`. Surface a storage error loudly rather than silently
+        // dropping the write (which would leave the document with no title or
+        // owner recorded).
+        metadata
+            .insert("title".to_string(), title.clone().into())
+            .expect("failed to write initial title metadata");
+        metadata
+            .insert("owner".to_string(), owner.clone().into())
+            .expect("failed to write initial owner metadata");
 
         let state = EditorState {
             document: ReplicatedGrowableArray::new(),
@@ -208,7 +216,7 @@ impl EditorState {
         let editor_id = env::executor_id();
         let editor = encode_identity(&editor_id);
 
-        let old_title = self.get_title();
+        let old_title = self.get_title()?;
 
         self.metadata
             .insert("title".to_string(), new_title.clone().into())?;
@@ -232,14 +240,20 @@ impl EditorState {
     /// Get the document title
     ///
     /// # Returns
-    /// * `String` - The current document title
-    pub fn get_title(&self) -> String {
-        self.metadata
-            .get("title")
-            .ok()
-            .flatten()
+    /// * `Ok(String)` - The current document title (the default
+    ///   "Untitled Document" if no title has been set yet)
+    /// * `Err(app::Error)` - Error if the metadata read fails
+    ///
+    /// A storage read failure is propagated rather than collapsed into the
+    /// default: callers like `set_title` record the returned value as the
+    /// `old_title` of a `TitleChanged` event, so a fabricated default would be
+    /// silently written into the event history.
+    pub fn get_title(&self) -> app::Result<String> {
+        Ok(self
+            .metadata
+            .get("title")?
             .map(|v| v.get().clone())
-            .unwrap_or_else(|| "Untitled Document".to_string())
+            .unwrap_or_else(|| "Untitled Document".to_string()))
     }
 
     /// Get document statistics
@@ -260,12 +274,10 @@ impl EditorState {
         let length = self.get_length()?;
         let total_edits = self.edit_count.value()?;
 
-        let title = self.get_title();
+        let title = self.get_title()?;
         let owner = self
             .metadata
-            .get("owner")
-            .ok()
-            .flatten()
+            .get("owner")?
             .map(|v| v.get().clone())
             .unwrap_or_else(|| "Unknown".to_string());
 
@@ -363,6 +375,6 @@ mod tests {
         let mut app = TestHost::new(EditorState::init);
 
         app.call(|s| s.set_title("My Doc".into())).unwrap();
-        assert_eq!(app.view(|s| s.get_title()), "My Doc");
+        assert_eq!(app.view(|s| s.get_title()).unwrap(), "My Doc");
     }
 }

--- a/apps/kv-store/src/lib.rs
+++ b/apps/kv-store/src/lib.rs
@@ -161,7 +161,7 @@ impl KvStore {
 
         // Only emit `Cleared` when the map had entries, and only after the
         // clear succeeds.
-        let was_non_empty = self.items.len()? > 0;
+        let was_non_empty = !self.items.is_empty()?;
         self.items.clear()?;
         if was_non_empty {
             app::emit!(Event::Cleared);

--- a/apps/kv-store/src/lib.rs
+++ b/apps/kv-store/src/lib.rs
@@ -146,17 +146,28 @@ impl KvStore {
     pub fn remove(&mut self, key: &str) -> app::Result<Option<String>> {
         app::log!("Removing key: {:?}", key);
 
-        app::emit!(Event::Removed { key });
+        // Only emit `Removed` when a value was actually present — emitting for
+        // an absent key would broadcast a change that never happened.
+        let removed = self.items.remove(key)?.map(|v| v.get().clone());
+        if removed.is_some() {
+            app::emit!(Event::Removed { key });
+        }
 
-        Ok(self.items.remove(key)?.map(|v| v.get().clone()))
+        Ok(removed)
     }
 
     pub fn clear(&mut self) -> app::Result<()> {
         app::log!("Clearing all entries");
 
-        app::emit!(Event::Cleared);
+        // Only emit `Cleared` when the map had entries, and only after the
+        // clear succeeds.
+        let was_non_empty = self.items.len()? > 0;
+        self.items.clear()?;
+        if was_non_empty {
+            app::emit!(Event::Cleared);
+        }
 
-        self.items.clear().map_err(Into::into)
+        Ok(())
     }
 }
 
@@ -228,5 +239,34 @@ mod tests {
 
         app.call(|s| s.set("k".into(), "v".into())).unwrap();
         assert_eq!(app.events().len(), 1);
+    }
+
+    #[test]
+    fn remove_absent_and_clear_empty_emit_nothing() {
+        let mut app = TestHost::new(KvStore::init);
+
+        // Removing a key that was never set must not broadcast a change.
+        assert_eq!(app.call(|s| s.remove("missing")).unwrap(), None);
+        assert!(app.events().is_empty());
+
+        // Clearing an already-empty store likewise emits nothing.
+        app.call(|s| s.clear()).unwrap();
+        assert!(app.events().is_empty());
+
+        // A real removal still emits exactly one `Removed` event.
+        app.call(|s| s.set("k".into(), "v".into())).unwrap();
+        let _ = app.take_events();
+        assert_eq!(app.call(|s| s.remove("k")).unwrap(), Some("v".to_owned()));
+        let events = app.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "Removed");
+
+        // And a real clear (non-empty store) emits exactly one `Cleared`.
+        app.call(|s| s.set("k".into(), "v".into())).unwrap();
+        let _ = app.take_events();
+        app.call(|s| s.clear()).unwrap();
+        let events = app.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "Cleared");
     }
 }

--- a/apps/private_data/src/lib.rs
+++ b/apps/private_data/src/lib.rs
@@ -227,18 +227,15 @@ impl SecretGame {
     /// matches the stored hash. `who` is derived from the executor
     /// identity rather than passed as an argument.
     ///
-    /// Takes `&self` because the *public* `SecretGame` state isn't
-    /// mutated here — only this node's private `Secrets`. The two
-    /// persistence paths are:
-    ///
-    /// - Tree-backed `attempted_games` / `guess_log` write each new
-    ///   entry through `PrivateStorage` immediately on
-    ///   `insert` / `push` (no save call needed).
-    /// - The borsh-blob field `last_guess` is persisted by the
-    ///   `EntryMut` `Drop` impl when `secrets_mut` goes out of scope.
-    ///   Early `?`-returns still drop the guard, so the blob saves
-    ///   whether we exit normally or via error propagation.
-    pub fn add_guess(&self, game_id: &str, guess: String) -> app::Result<bool> {
+    /// Takes `&mut self` even though only this node's private
+    /// `Secrets` is written and the public `SecretGame` is left
+    /// untouched. The runtime flushes private storage as part of
+    /// committing a method's state transition, and only `&mut self`
+    /// methods produce that commit — a `&self` method is treated as a
+    /// read-only view whose writes are never persisted. Any method
+    /// that writes private state must therefore take `&mut self`, or
+    /// the writes are silently discarded.
+    pub fn add_guess(&mut self, game_id: &str, guess: String) -> app::Result<bool> {
         let Some(public_hash_hex) = self.games.get(game_id)?.map(|v| v.get().clone()) else {
             app::bail!(Error::NoHash);
         };
@@ -270,21 +267,31 @@ impl SecretGame {
     }
 
     /// Toggle the "remember last guess" UX flag (private state).
-    pub fn set_remember_last_guess(&self, value: bool) -> app::Result<()> {
+    ///
+    /// Takes `&mut self` so the runtime commits and flushes the
+    /// private write — see [`SecretGame::add_guess`] for why a `&self`
+    /// method's private writes would be discarded.
+    pub fn set_remember_last_guess(&mut self, value: bool) -> app::Result<()> {
         let mut secrets = Secrets::private_load_or_default()?;
         secrets.as_mut().remember_last_guess = value;
         Ok(())
     }
 
     /// Attach a private note to a game (private state).
-    pub fn set_note(&self, game_id: String, note: String) -> app::Result<()> {
+    ///
+    /// `&mut self` for the same reason as
+    /// [`SecretGame::set_remember_last_guess`].
+    pub fn set_note(&mut self, game_id: String, note: String) -> app::Result<()> {
         let mut secrets = Secrets::private_load_or_default()?;
         secrets.as_mut().notes.insert(game_id, note);
         Ok(())
     }
 
     /// Add a private user-defined tag.
-    pub fn add_tag(&self, tag: String) -> app::Result<()> {
+    ///
+    /// `&mut self` for the same reason as
+    /// [`SecretGame::set_remember_last_guess`].
+    pub fn add_tag(&mut self, tag: String) -> app::Result<()> {
         let mut secrets = Secrets::private_load_or_default()?;
         secrets.as_mut().tags.insert(tag);
         Ok(())

--- a/apps/sorted-kv-store/src/lib.rs
+++ b/apps/sorted-kv-store/src/lib.rs
@@ -90,17 +90,28 @@ impl SortedKvStore {
     pub fn remove(&mut self, key: &str) -> app::Result<Option<String>> {
         app::log!("Removing key: {:?}", key);
 
-        app::emit!(Event::Removed { key });
+        // Only emit `Removed` when a value was actually present — emitting for
+        // an absent key would broadcast a change that never happened.
+        let removed = self.items.remove(key)?.map(|v| v.get().clone());
+        if removed.is_some() {
+            app::emit!(Event::Removed { key });
+        }
 
-        Ok(self.items.remove(key)?.map(|v| v.get().clone()))
+        Ok(removed)
     }
 
     pub fn clear(&mut self) -> app::Result<()> {
         app::log!("Clearing all entries");
 
-        app::emit!(Event::Cleared);
+        // Only emit `Cleared` when the map had entries, and only after the
+        // clear succeeds.
+        let was_non_empty = !self.items.is_empty()?;
+        self.items.clear()?;
+        if was_non_empty {
+            app::emit!(Event::Cleared);
+        }
 
-        self.items.clear().map_err(Into::into)
+        Ok(())
     }
 
     /// The number of entries in the map.
@@ -176,5 +187,56 @@ impl SortedKvStore {
             key,
             value: v.get().clone(),
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use calimero_sdk::testing::TestHost;
+
+    use super::*;
+
+    #[test]
+    fn set_get_and_ordered_entries() {
+        let mut app = TestHost::new(SortedKvStore::init);
+
+        app.call(|s| s.set("b".into(), "2".into())).unwrap();
+        app.call(|s| s.set("a".into(), "1".into())).unwrap();
+
+        assert_eq!(app.view(|s| s.get("a")).unwrap(), Some("1".to_owned()));
+
+        // BTreeMap collects in ascending key order — the headline guarantee.
+        let entries = app.view(|s| s.entries()).unwrap();
+        let keys: Vec<_> = entries.keys().cloned().collect();
+        assert_eq!(keys, vec!["a".to_owned(), "b".to_owned()]);
+    }
+
+    #[test]
+    fn remove_absent_and_clear_empty_emit_nothing() {
+        let mut app = TestHost::new(SortedKvStore::init);
+
+        // Removing a key that was never set must not broadcast a change.
+        assert_eq!(app.call(|s| s.remove("missing")).unwrap(), None);
+        assert!(app.events().is_empty());
+
+        // Clearing an already-empty store likewise emits nothing.
+        app.call(|s| s.clear()).unwrap();
+        assert!(app.events().is_empty());
+
+        // A real removal still emits exactly one `Removed` event.
+        app.call(|s| s.set("k".into(), "v".into())).unwrap();
+        let _ = app.take_events();
+        assert_eq!(app.call(|s| s.remove("k")).unwrap(), Some("v".to_owned()));
+        let events = app.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "Removed");
+
+        // And a real clear (non-empty store) emits exactly one `Cleared`.
+        app.call(|s| s.set("k".into(), "v".into())).unwrap();
+        let _ = app.take_events();
+        app.call(|s| s.clear()).unwrap();
+        let events = app.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "Cleared");
     }
 }

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -1200,8 +1200,10 @@ pub fn blob_announce_to_context(blob_id: &[u8; 32], target_context_id: &[u8; 32]
     #[cfg(not(target_arch = "wasm32"))]
     {
         // The in-process host has no network; the announce is a no-op that
-        // succeeds once the (already-checked) context match holds.
+        // succeeds once the (already-checked) context match holds — unless a
+        // test opted into failure via the harness so it can exercise the
+        // announce-failure branch (see `TestHost::set_blob_announce_should_fail`).
         let _ = blob_id;
-        true
+        !host::blob_announce_should_fail()
     }
 }

--- a/crates/sdk/src/env/ext.rs
+++ b/crates/sdk/src/env/ext.rs
@@ -30,12 +30,18 @@ pub unsafe fn fetch(
     }
     .try_into()
     .unwrap_or_else(expected_boolean);
-    let data = read_register(DATA_REGISTER).unwrap_or_else(expected_register);
+
     if failed {
+        // On failure the host writes the error message into the register; read
+        // it only on this branch. If the host signalled failure without a
+        // payload, surface an empty message rather than aborting with the
+        // misleading "Expected a register" panic.
+        let data = read_register(DATA_REGISTER).unwrap_or_default();
         return Err(String::from_utf8(data).unwrap_or_else(|_| {
             panic_str("Fetch failed with an error but the error is an invalid UTF-8 string.")
         }));
     }
 
+    let data = read_register(DATA_REGISTER).unwrap_or_else(expected_register);
     Ok(data)
 }

--- a/crates/sdk/src/env/ext.rs
+++ b/crates/sdk/src/env/ext.rs
@@ -34,12 +34,15 @@ pub unsafe fn fetch(
     if failed {
         // On failure the host writes the error message into the register; read
         // it only on this branch. If the host signalled failure without a
-        // payload, surface an empty message rather than aborting with the
+        // payload, surface an actionable message rather than aborting with the
         // misleading "Expected a register" panic.
-        let data = read_register(DATA_REGISTER).unwrap_or_default();
-        return Err(String::from_utf8(data).unwrap_or_else(|_| {
-            panic_str("Fetch failed with an error but the error is an invalid UTF-8 string.")
-        }));
+        let err = match read_register(DATA_REGISTER) {
+            Some(data) => String::from_utf8(data).unwrap_or_else(|_| {
+                panic_str("Fetch failed with an error but the error is an invalid UTF-8 string.")
+            }),
+            None => "Fetch failed but the host provided no error payload".to_owned(),
+        };
+        return Err(err);
     }
 
     let data = read_register(DATA_REGISTER).unwrap_or_else(expected_register);

--- a/crates/sdk/src/env/host.rs
+++ b/crates/sdk/src/env/host.rs
@@ -68,6 +68,9 @@ struct MockHost {
     blob_read_handles: BTreeMap<u64, ([u8; 32], Vec<u8>, usize)>,
     /// Next file descriptor to hand out. Starts at 1 so 0 stays "not found".
     next_fd: u64,
+    /// When `true`, `blob_announce_to_context` reports failure so tests can
+    /// exercise the announce-failure branch app code hits under real WASM.
+    blob_announce_should_fail: bool,
 }
 
 impl Default for MockHost {
@@ -85,6 +88,7 @@ impl Default for MockHost {
             blob_write_handles: BTreeMap::new(),
             blob_read_handles: BTreeMap::new(),
             next_fd: 1,
+            blob_announce_should_fail: false,
         }
     }
 }
@@ -137,6 +141,17 @@ pub(crate) fn set_executor_id(id: [u8; 32]) {
 /// Overrides the context identity the mock host reports to app logic.
 pub(crate) fn set_context_id(id: [u8; 32]) {
     with(|h| h.context_id = id);
+}
+
+/// Makes [`crate::env::blob_announce_to_context`] report failure (`false`) so
+/// tests can drive the announce-failure branch.
+pub(crate) fn set_blob_announce_should_fail(fail: bool) {
+    with(|h| h.blob_announce_should_fail = fail);
+}
+
+/// Whether the mock host should report a blob announce as failed.
+pub(crate) fn blob_announce_should_fail() -> bool {
+    with(|h| h.blob_announce_should_fail)
 }
 
 /// Writes `value` directly into the SDK host storage map at `key`.

--- a/crates/sdk/src/event.rs
+++ b/crates/sdk/src/event.rs
@@ -141,10 +141,27 @@ pub struct EncodedAppEvent<'a> {
     pub data: Cow<'a, [u8]>,
 }
 
+/// Default emitter installed before [`register`] runs.
+///
+/// Emitting before the event system is registered means `emit` was reached
+/// outside the normal app entrypoint — typically a direct unit test or
+/// setup-time code path. Rather than abort the guest with an opaque panic, log
+/// an actionable message and drop the event so the caller keeps running.
+fn unregistered_emitter(_event: Box<dyn AppEventExt>) {
+    env::log(
+        "app event emitted before the event system was registered; the event was dropped. \
+         This usually means `emit` ran outside the app entrypoint (e.g. a unit test or \
+         setup code) before `register` was called.",
+    );
+}
+
 thread_local! {
     /// The event emission function that processes events through the runtime.
     /// This is set during app initialization and used by the `emit` function.
-    static EVENT_EMITTER: RefCell<fn(Box<dyn AppEventExt>)> = panic!("uninitialized event emitter");
+    /// Until [`register`] runs it points at [`unregistered_emitter`], which
+    /// logs and drops the event instead of panicking.
+    static EVENT_EMITTER: RefCell<fn(Box<dyn AppEventExt>)> =
+        RefCell::new(unregistered_emitter);
 
     /// The name of the callback handler method to call when emitting events with handlers.
     /// This is set temporarily by `emit_with_handler` and read by the runtime.

--- a/crates/sdk/src/private_storage.rs
+++ b/crates/sdk/src/private_storage.rs
@@ -299,8 +299,15 @@ impl<T> EntryRef<T> {
         let data = borsh::to_vec(&self.data)
             .map_err(|e| crate::types::Error::msg(format!("Failed to serialize state: {e}")))?;
 
-        // Use private storage functions (node-local, NOT synchronized)
-        let _ = env::private_storage_write(self.key, &data);
+        // Use private storage functions (node-local, NOT synchronized).
+        // A `false` return means the write did not land (private storage
+        // unavailable on this node); surface it instead of silently
+        // reporting success.
+        if !env::private_storage_write(self.key, &data) {
+            return Err(crate::types::Error::msg(
+                "Failed to write private storage state",
+            ));
+        }
         Ok(())
     }
 }

--- a/crates/sdk/src/state.rs
+++ b/crates/sdk/src/state.rs
@@ -93,14 +93,19 @@ pub fn read_raw() -> Option<Vec<u8>> {
     // The storage layer stores entities as Entry<T> = borsh(T) ++ borsh(Element.id).
     // Element only serializes its `id: Id` field ([u8; 32]), all other fields are
     // #[borsh(skip)]. Strip this 32-byte suffix so migration code sees only the
-    // user's state struct bytes. Use >= so that when user state is 0 bytes (entry
-    // is exactly 32 bytes) we strip the suffix and return an empty Vec, not the id.
+    // user's state struct bytes.
     const ELEMENT_SUFFIX_LEN: usize = 32;
-    if bytes.len() >= ELEMENT_SUFFIX_LEN {
-        Some(bytes[..bytes.len() - ELEMENT_SUFFIX_LEN].to_vec())
-    } else {
-        Some(bytes)
+    if bytes.len() < ELEMENT_SUFFIX_LEN {
+        // A valid Entry<T> always carries the 32-byte Element.id suffix, so a
+        // shorter blob is corrupt storage — not user data. Returning these
+        // bytes would hand the truncated id back to migration code as if it
+        // were state; fail loudly instead. (Exactly 32 bytes is the legitimate
+        // "0-byte user state" case and falls through to an empty Vec below.)
+        crate::env::panic_str(
+            "root state entry is smaller than the 32-byte Element.id suffix; storage is corrupt",
+        );
     }
+    Some(bytes[..bytes.len() - ELEMENT_SUFFIX_LEN].to_vec())
 }
 
 #[cfg(test)]
@@ -127,5 +132,34 @@ mod tests {
             remaining: 2,
         };
         assert!(!pending.is_complete());
+    }
+
+    #[test]
+    fn read_raw_strips_element_id_suffix() {
+        // User data "hi" (2 bytes) followed by the 32-byte Element.id suffix.
+        let mut entry = b"hi".to_vec();
+        entry.extend_from_slice(&[0u8; 32]);
+        crate::env::__test_seed_root(entry);
+
+        assert_eq!(super::read_raw(), Some(b"hi".to_vec()));
+    }
+
+    #[test]
+    fn read_raw_returns_empty_for_zero_byte_user_state() {
+        // Exactly the suffix length: 0 bytes of user state, stripped to empty.
+        crate::env::__test_seed_root(vec![0u8; 32]);
+
+        assert_eq!(super::read_raw(), Some(Vec::new()));
+    }
+
+    #[test]
+    #[should_panic(expected = "storage is corrupt")]
+    fn read_raw_panics_on_truncated_entry() {
+        // Fewer than 32 bytes can't carry the Element.id suffix, so the entry
+        // is corrupt — `read_raw` must fail loudly rather than hand the id
+        // fragment back as if it were user state.
+        crate::env::__test_seed_root(vec![0u8; 10]);
+
+        let _ = super::read_raw();
     }
 }

--- a/crates/sdk/src/state.rs
+++ b/crates/sdk/src/state.rs
@@ -85,6 +85,15 @@ impl MigrateMyEntriesSummary {
 ///
 /// * `Some(Vec<u8>)` - The raw serialized state bytes (user data only) if state exists
 /// * `None` - If no state has been stored yet
+///
+/// # Panics
+///
+/// Panics (aborting the guest) if the stored root entry is shorter than the
+/// 32-byte `Element.id` suffix. That is structurally impossible for a valid
+/// `Entry<T>`, so it indicates corrupt storage — an unrecoverable condition,
+/// not a "no state yet" (`None`) one. Migration is the only caller and cannot
+/// meaningfully proceed from a corrupt root, so this aborts rather than handing
+/// back the truncated id bytes as if they were user state.
 #[must_use]
 pub fn read_raw() -> Option<Vec<u8>> {
     let root_key = root_storage_key();
@@ -99,12 +108,13 @@ pub fn read_raw() -> Option<Vec<u8>> {
         // A valid Entry<T> always carries the 32-byte Element.id suffix, so a
         // shorter blob is corrupt storage — not user data. Returning these
         // bytes would hand the truncated id back to migration code as if it
-        // were state; fail loudly instead. (Exactly 32 bytes is the legitimate
-        // "0-byte user state" case and falls through to an empty Vec below.)
+        // were state; abort instead (see the `# Panics` section).
         crate::env::panic_str(
             "root state entry is smaller than the 32-byte Element.id suffix; storage is corrupt",
         );
     }
+    // When len == ELEMENT_SUFFIX_LEN the slice is empty, yielding `Some(vec![])`
+    // — the legitimate "0-byte user state" case.
     Some(bytes[..bytes.len() - ELEMENT_SUFFIX_LEN].to_vec())
 }
 

--- a/crates/sdk/src/testing.rs
+++ b/crates/sdk/src/testing.rs
@@ -339,6 +339,14 @@ where
         host::set_context_id(id);
     }
 
+    /// Makes [`env::blob_announce_to_context`](crate::env::blob_announce_to_context)
+    /// report failure (`false`) for subsequent calls, so a test can exercise
+    /// the announce-failure branch app code hits under real WASM. Pass `false`
+    /// to restore the default (announce succeeds).
+    pub fn set_blob_announce_should_fail(&mut self, fail: bool) {
+        host::set_blob_announce_should_fail(fail);
+    }
+
     /// Returns the current executor identity.
     #[must_use]
     pub fn executor_id(&self) -> [u8; 32] {


### PR DESCRIPTION
Fixes a batch of correctness bugs found across the example apps and the supporting SDK surface they exercise. All affected crates' tests pass, `cargo clippy --all-targets` is clean, and `cargo check --workspace` succeeds.

## Apps

- **[H] private_data — discarded private writes.** `add_guess`, `set_remember_last_guess`, `set_note`, `add_tag` now take `&mut self`. The runtime flushes private storage only when a method commits a state transition (gated on `&mut self`); a `&self` method is treated as a read-only view, so its private writes were silently discarded under real WASM. `TestHost` hid this by persisting immediately. Corrected the doc that claimed `&self` was fine. (Also resolves the related `:215` issue — `add_secret`'s siblings no longer rely on its incidental public write.)
- **[M] kv-store / sorted-kv-store — events before a real change.** `remove` emits `Removed` only when a value was present; `clear` emits `Cleared` only when the map was non-empty and after the clear succeeds — matching the correct sorted-set-store pattern. These are the most-copied starters, so the pattern matters. Added regression tests (sorted-kv-store had none).
- **[M] blobs — file-id collision.** IDs were minted from `Counter::value()`, so concurrent uploads on different replicas could pick the same id and overwrite each other on convergence. IDs are now namespaced `{uploader}_{counter}`, collision-free across nodes.
- **[L] blobs — total size overflow.** `get_total_files_size` uses `saturating_add` so adversarial sizes can't panic (debug) or wrap (release).
- **[L] collaborative-editor — swallowed storage errors.** `get_title` now returns `app::Result<String>` and propagates read failures rather than collapsing them into a fabricated default that gets recorded into a `TitleChanged` event; `get_stats`'s owner read propagates too. `init` can't return `Result` (the `#[app::init]` macro requires `Self`), so its metadata writes now `.expect(...)` loudly instead of `let _ =`.

## SDK

- **[M] `EntryRef::save`** returns `Err` when `private_storage_write` reports `false`, instead of silently `Ok` (the `Drop` impl already panicked on the same `false`).
- **[M] Event emitter** thread-local now defaults to an `unregistered_emitter` that logs an actionable message and drops the event, instead of `panic!`-ing — so emitting before `register` (unit tests, setup code) no longer aborts the guest opaquely.
- **[L] `fetch`** reads `DATA_REGISTER` only after branching on `failed`; a host failure with no payload no longer aborts with the misleading "Expected a register".
- **[L] `state::read_raw`** treats a sub-32-byte root entry as corrupt (fails loudly) instead of returning the truncated `Element.id` bytes as if they were user state.
- **[L] blob-announce harness** — added `TestHost::set_blob_announce_should_fail(bool)` (backed by the mock host) so tests can drive the announce-failure branch real WASM hits; previously the in-process host always returned `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)