### PR TITLE
fix(governance): replace unvalidated u8 discriminants with typed enums and bounds checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,6 +1337,7 @@ dependencies = [
  "calimero-context-config",
  "calimero-crypto",
  "calimero-dag",
+ "calimero-governance-types",
  "calimero-network-primitives",
  "calimero-node-primitives",
  "calimero-op",

--- a/crates/context/config/src/lib.rs
+++ b/crates/context/config/src/lib.rs
@@ -130,7 +130,17 @@ impl<'a> GroupRequest<'a> {
 ///
 /// The walk in `check_group_membership` stops at the first `Restricted`
 /// ancestor; a `Restricted` subgroup is a wall regardless of what sits above.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    borsh::BorshSerialize,
+    borsh::BorshDeserialize,
+)]
 pub enum VisibilityMode {
     Open,
     Restricted,

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use actix::Message;
 use calimero_context_config::types::{AppKey, ContextGroupId, SignedGroupOpenInvitation};
+use calimero_context_config::VisibilityMode;
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::{ContextId, GroupMemberRole, UpgradePolicy};
 use calimero_primitives::identity::PublicKey;
@@ -723,7 +724,7 @@ impl Message for SetSubgroupVisibilityRequest {
 #[derive(Debug)]
 pub struct StoreSubgroupVisibilityRequest {
     pub group_id: ContextGroupId,
-    pub mode: u8,
+    pub mode: VisibilityMode,
 }
 
 impl Message for StoreSubgroupVisibilityRequest {

--- a/crates/context/src/handlers/set_subgroup_visibility.rs
+++ b/crates/context/src/handlers/set_subgroup_visibility.rs
@@ -55,11 +55,6 @@ impl Handler<SetSubgroupVisibilityRequest> for ContextManager {
             return ActorResponse::reply(Err(err));
         }
 
-        let mode_u8 = match subgroup_visibility {
-            calimero_context_config::VisibilityMode::Open => 0u8,
-            calimero_context_config::VisibilityMode::Restricted => 1u8,
-        };
-
         let datastore = preflight.datastore.clone();
         let node_client = preflight.node_client.clone();
         let ack_router = Arc::clone(&self.ack_router);
@@ -73,7 +68,9 @@ impl Handler<SetSubgroupVisibilityRequest> for ContextManager {
                     &ack_router,
                     &group_id,
                     &sk,
-                    GroupOp::SubgroupVisibilitySet { mode: mode_u8 },
+                    GroupOp::SubgroupVisibilitySet {
+                        mode: subgroup_visibility,
+                    },
                 )
                 .await?;
                 report.observe("set_subgroup_visibility", "SubgroupVisibilitySet");

--- a/crates/context/src/handlers/store_subgroup_visibility.rs
+++ b/crates/context/src/handlers/store_subgroup_visibility.rs
@@ -1,6 +1,5 @@
 use actix::{ActorResponse, Handler, Message};
 use calimero_context_client::group::StoreSubgroupVisibilityRequest;
-use calimero_context_config::VisibilityMode;
 use calimero_governance_store::CapabilitiesRepository;
 
 use crate::ContextManager;
@@ -13,12 +12,8 @@ impl Handler<StoreSubgroupVisibilityRequest> for ContextManager {
         StoreSubgroupVisibilityRequest { group_id, mode }: StoreSubgroupVisibilityRequest,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
-        let visibility = match mode {
-            0 => VisibilityMode::Open,
-            _ => VisibilityMode::Restricted,
-        };
-        let result = CapabilitiesRepository::new(&self.datastore)
-            .set_subgroup_visibility(&group_id, visibility);
+        let result =
+            CapabilitiesRepository::new(&self.datastore).set_subgroup_visibility(&group_id, mode);
         ActorResponse::reply(result)
     }
 }

--- a/crates/context/tests/projection_membership_equivalence.rs
+++ b/crates/context/tests/projection_membership_equivalence.rs
@@ -119,7 +119,9 @@ fn fold_subgroup_structure(
     let vis = ns_group_envelope(namespace, admin, subgroup);
     proj.ingest_op(&op_from_namespace_op(
         &vis,
-        Some(&GroupOp::SubgroupVisibilitySet { mode: 0 }), // 0 = Open
+        Some(&GroupOp::SubgroupVisibilitySet {
+            mode: calimero_context_config::VisibilityMode::Open,
+        }),
         visibility_id,
         hlc(0),
         &[created_id],

--- a/crates/governance-store/Cargo.toml
+++ b/crates/governance-store/Cargo.toml
@@ -28,6 +28,7 @@ tracing.workspace = true
 
 calimero-context-config.workspace = true
 calimero-context-client.workspace = true
+calimero-governance-types.workspace = true
 calimero-crypto.workspace = true
 calimero-dag.workspace = true
 calimero-network-primitives.workspace = true

--- a/crates/governance-store/src/capabilities.rs
+++ b/crates/governance-store/src/capabilities.rs
@@ -199,6 +199,18 @@ impl<'a> CapabilitiesRepository<'a> {
         Ok(())
     }
 
+    pub fn delete_context_member(
+        &self,
+        group_id: &ContextGroupId,
+        context_id: &ContextId,
+        member: &PublicKey,
+    ) -> EyreResult<()> {
+        let mut handle = self.store.handle();
+        let key = GroupContextMemberCap::new(group_id.to_bytes(), *context_id, *member);
+        handle.delete(&key)?;
+        Ok(())
+    }
+
     pub fn set_context_member(
         &self,
         group_id: &ContextGroupId,

--- a/crates/governance-store/src/ops/group/context_capability_granted.rs
+++ b/crates/governance-store/src/ops/group/context_capability_granted.rs
@@ -3,6 +3,7 @@
 
 use super::context::GroupApplyCtx;
 use crate::CapabilitiesRepository;
+use calimero_governance_types::ContextCapabilityBits;
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
 use eyre::Result as EyreResult;
@@ -11,7 +12,7 @@ pub(crate) fn apply(
     ctx: &mut GroupApplyCtx<'_>,
     context_id: &ContextId,
     member: &PublicKey,
-    capability: &u8,
+    capability: &ContextCapabilityBits,
 ) -> EyreResult<()> {
     let signer = ctx.signer();
     let group_id = ctx.group_id();
@@ -23,6 +24,6 @@ pub(crate) fn apply(
     let current = caps
         .context_member_capability(group_id, context_id, member)?
         .unwrap_or(0);
-    caps.set_context_member(group_id, context_id, member, current | capability)?;
+    caps.set_context_member(group_id, context_id, member, current | capability.get())?;
     Ok(())
 }

--- a/crates/governance-store/src/ops/group/context_capability_revoked.rs
+++ b/crates/governance-store/src/ops/group/context_capability_revoked.rs
@@ -3,6 +3,7 @@
 
 use super::context::GroupApplyCtx;
 use crate::CapabilitiesRepository;
+use calimero_governance_types::ContextCapabilityBits;
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
 use eyre::Result as EyreResult;
@@ -11,7 +12,7 @@ pub(crate) fn apply(
     ctx: &mut GroupApplyCtx<'_>,
     context_id: &ContextId,
     member: &PublicKey,
-    capability: &u8,
+    capability: &ContextCapabilityBits,
 ) -> EyreResult<()> {
     let signer = ctx.signer();
     let group_id = ctx.group_id();
@@ -23,6 +24,11 @@ pub(crate) fn apply(
     let current = caps
         .context_member_capability(group_id, context_id, member)?
         .unwrap_or(0);
-    caps.set_context_member(group_id, context_id, member, current & !capability)?;
+    let new_caps = current & !capability.get();
+    if new_caps == 0 {
+        caps.delete_context_member(group_id, context_id, member)?;
+    } else {
+        caps.set_context_member(group_id, context_id, member, new_caps)?;
+    }
     Ok(())
 }

--- a/crates/governance-store/src/ops/group/subgroup_visibility_set.rs
+++ b/crates/governance-store/src/ops/group/subgroup_visibility_set.rs
@@ -2,15 +2,11 @@
 //! `apply_group_op_mutations` in #2304.
 
 use super::context::GroupApplyCtx;
+use calimero_context_config::VisibilityMode;
 use eyre::Result as EyreResult;
 
-pub(crate) fn apply(ctx: &mut GroupApplyCtx<'_>, mode: &u8) -> EyreResult<()> {
+pub(crate) fn apply(ctx: &mut GroupApplyCtx<'_>, mode: &VisibilityMode) -> EyreResult<()> {
     let signer = ctx.signer();
-
-    let visibility = match *mode {
-        0 => calimero_context_config::VisibilityMode::Open,
-        _ => calimero_context_config::VisibilityMode::Restricted,
-    };
-    ctx.settings().set_subgroup_visibility(signer, visibility)?;
+    ctx.settings().set_subgroup_visibility(signer, *mode)?;
     Ok(())
 }

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -1289,7 +1289,8 @@ fn context_capability_granted_rejects_unauthorized_signer() {
         GroupOp::ContextCapabilityGranted {
             context_id,
             member: target_pk,
-            capability: 0b1,
+            capability: calimero_governance_types::ContextCapabilityBits::new(0b1)
+                .expect("capability bitmask is non-zero"),
         },
     )
     .unwrap();
@@ -1354,7 +1355,8 @@ fn context_capability_revoked_rejects_unauthorized_signer() {
         GroupOp::ContextCapabilityRevoked {
             context_id,
             member: target_pk,
-            capability: 0b1,
+            capability: calimero_governance_types::ContextCapabilityBits::new(0b1)
+                .expect("capability bitmask is non-zero"),
         },
     )
     .unwrap();

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -148,13 +148,14 @@ impl From<std::num::NonZeroU8> for ContextCapabilityBits {
 impl BorshDeserialize for ContextCapabilityBits {
     fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
         let bits = u8::deserialize_reader(reader)?;
-        if bits == 0 {
-            return Err(io::Error::new(
+        // Route through the canonical constructor so the zero-rejection
+        // invariant lives in exactly one place.
+        Self::new(bits).ok_or_else(|| {
+            io::Error::new(
                 io::ErrorKind::InvalidData,
                 "ContextCapabilityBits: capability bitmask must not be zero",
-            ));
-        }
-        Ok(Self(bits))
+            )
+        })
     }
 }
 

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -21,9 +21,11 @@
 //! group-scoped ops they cannot decrypt.
 
 use std::collections::BTreeMap;
+use std::io;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_context_config::types::SignedGroupOpenInvitation;
+use calimero_context_config::VisibilityMode;
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::{ContextId, GroupMemberRole, UpgradePolicy};
 use calimero_primitives::identity::{PrivateKey, PublicKey};
@@ -98,6 +100,63 @@ pub const SIGNED_GROUP_OP_SCHEMA_VERSION: u8 = 8;
 
 /// Domain separation prefix for Ed25519 signatures over group ops.
 pub const GROUP_GOVERNANCE_SIGN_DOMAIN: &[u8] = b"calimero.group.v1";
+
+/// A non-zero `u8` bitmask representing per-context member capabilities.
+///
+/// Validated at Borsh deserialization time: a zero value is rejected on the
+/// wire, making it impossible to construct an invalid capability op from
+/// received bytes.
+///
+/// Unknown bits are accepted without error (forward-compatible): nodes
+/// running older software will store ops with bits they do not recognise and
+/// replay them faithfully. Callers must mask against known capability
+/// constants before interpreting the value.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, BorshSerialize)]
+pub struct ContextCapabilityBits(u8);
+
+impl ContextCapabilityBits {
+    /// Construct from a raw bitmask, returning `None` if `bits == 0`.
+    #[must_use]
+    pub fn new(bits: u8) -> Option<Self> {
+        if bits == 0 {
+            None
+        } else {
+            Some(Self(bits))
+        }
+    }
+
+    #[must_use]
+    pub fn get(self) -> u8 {
+        self.0
+    }
+}
+
+impl TryFrom<u8> for ContextCapabilityBits {
+    type Error = &'static str;
+
+    fn try_from(bits: u8) -> Result<Self, Self::Error> {
+        Self::new(bits).ok_or("capability bitmask must not be zero")
+    }
+}
+
+impl From<std::num::NonZeroU8> for ContextCapabilityBits {
+    fn from(v: std::num::NonZeroU8) -> Self {
+        Self(v.get())
+    }
+}
+
+impl BorshDeserialize for ContextCapabilityBits {
+    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        let bits = u8::deserialize_reader(reader)?;
+        if bits == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "ContextCapabilityBits: capability bitmask must not be zero",
+            ));
+        }
+        Ok(Self(bits))
+    }
+}
 
 /// Group mutation for local governance (signed, gossip-replicated).
 ///
@@ -204,10 +263,10 @@ pub enum GroupOp {
     },
     /// Unregister a context from this group.
     ContextDetached { context_id: ContextId },
-    /// Subgroup visibility (`0` = Open, `1` = Restricted). When `Open`,
-    /// parent-group members holding `CAN_JOIN_OPEN_SUBGROUPS` are inherited
-    /// as members of this subgroup. See [`crate::group::SetSubgroupVisibilityRequest`].
-    SubgroupVisibilitySet { mode: u8 },
+    /// Subgroup visibility. When `Open`, parent-group members holding
+    /// `CAN_JOIN_OPEN_SUBGROUPS` are inherited as members of this subgroup.
+    /// See [`crate::group::SetSubgroupVisibilityRequest`].
+    SubgroupVisibilitySet { mode: VisibilityMode },
     /// Wholly replace the metadata record (name + opaque `data`) of the group
     /// itself (a namespace is a root group, so this covers it).
     /// **Signer:** group admin or holder of `CAN_MANAGE_METADATA`.
@@ -238,13 +297,13 @@ pub enum GroupOp {
     ContextCapabilityGranted {
         context_id: ContextId,
         member: PublicKey,
-        capability: u8,
+        capability: ContextCapabilityBits,
     },
     /// Revoke a capability from a member for a specific context.
     ContextCapabilityRevoked {
         context_id: ContextId,
         member: PublicKey,
-        capability: u8,
+        capability: ContextCapabilityBits,
     },
     /// TEE admission policy: defines which TEE nodes can auto-join the group.
     /// Only admins can set this policy.

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -156,14 +156,14 @@ const GOLDEN_GROUP_OP_GROUP_MIGRATION_SET: &[u8] = &[
     0,  // migration = None
 ];
 
-/// GroupOp ordinal 17 — ContextCapabilityGranted { context_id: [0;32], member: [0;32], capability: 0 }
+/// GroupOp ordinal 17 — ContextCapabilityGranted { context_id: [0;32], member: [0;32], capability: 1 }
 const GOLDEN_GROUP_OP_CONTEXT_CAPABILITY_GRANTED: &[u8] = &[
     17, // discriminant
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, // context_id
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, // member
-    0, // capability
+    1, // capability (must be non-zero: ContextCapabilityBits rejects 0 on the wire)
 ];
 
 /// GroupOp ordinal 18 — ContextCapabilityRevoked (same shape as Granted)
@@ -173,7 +173,7 @@ const GOLDEN_GROUP_OP_CONTEXT_CAPABILITY_REVOKED: &[u8] = &[
     0, // context_id
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, // member
-    0, // capability
+    1, // capability (must be non-zero: ContextCapabilityBits rejects 0 on the wire)
 ];
 
 /// GroupOp ordinal 19 — TeeAdmissionPolicySet (6 empty Vec<String> + accept_mock=false)

--- a/crates/op-adapter/src/lib.rs
+++ b/crates/op-adapter/src/lib.rs
@@ -148,7 +148,7 @@ pub fn payload_from_group_op(group: ContextGroupId, op: &GroupOp) -> Option<OpPa
         // Live mode byte: 0 = Open, anything else = Restricted.
         GroupOp::SubgroupVisibilitySet { mode } => Some(OpPayload::SubgroupVisibilitySet {
             scope: ScopeId::from(group.to_bytes()),
-            restricted: *mode != 0,
+            restricted: matches!(mode, calimero_context_config::VisibilityMode::Restricted),
         }),
         _ => None,
     }


### PR DESCRIPTION
Re-applies the typed-discriminant hardening from #2965 (reverted in #3032), with the build break that forced the revert fixed.

## What this does

- `GroupOp::SubgroupVisibilitySet.mode` becomes `VisibilityMode` instead of a raw `u8`, and `VisibilityMode` gains `BorshSerialize`/`BorshDeserialize`. The wire layout is unchanged — a two-unit-variant enum serializes as the same `0`/`1` discriminant byte.
- `ContextCapabilityGranted` / `ContextCapabilityRevoked.capability` become a validated `ContextCapabilityBits` newtype that **rejects a zero bitmask at Borsh deserialization**, so an invalid capability op cannot be constructed from received bytes. A revoke that clears the last bit now deletes the member-capability row instead of storing a zero.
- Removes the manual `u8` ↔ enum conversions in the visibility handlers and the apply op.

## Why the original (#2965) was reverted — and why this one is safe

The first attempt did not update two capability-op test sites in `governance-store/src/tests.rs` that still passed `capability: 0b1` (a raw integer). Those sites were added by a change that merged **concurrently** with #2965, so #2965 never saw them. Each was green in isolation; their combination failed to compile:

```
error[E0308]: mismatched types
    --> crates/governance-store/src/tests.rs:1292
     |     capability: 0b1,
     |                 ^^^ expected `ContextCapabilityBits`, found integer
```

This broke the test build, so #2965 was reverted in #3032. CI never built the two PRs together (each merged against a stale-green base). Those two sites now construct the value via `ContextCapabilityBits::new(0b1)`.

## Test plan

- `cargo build --workspace --all-targets --tests` — clean ✅ (the exact path that broke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)