### PR TITLE
fix(store): bound InMemoryDB Send/Sync on T instead of asserting unconditionally

### DIFF
--- a/crates/store/src/db/memory.rs
+++ b/crates/store/src/db/memory.rs
@@ -138,6 +138,10 @@ impl AsRef<[u8]> for ArcSlice<'_> {
     }
 }
 
+// The `Send + Sync` bounds are load-bearing: `Database` requires `Send + Sync +
+// 'static`, and `InMemoryDB<T>` is only `Send`/`Sync` when `T` is. They were
+// previously masked by an unconditional (unsound) `unsafe impl Send/Sync` — don't
+// drop them as "redundant with auto-derivation".
 impl<'a, T: InMemoryDBImpl<'a> + Debug + Send + Sync + 'static> Database<'a> for InMemoryDB<T>
 where
     T::Key: Ord + Clone + Borrow<[u8]>,

--- a/crates/store/src/db/memory.rs
+++ b/crates/store/src/db/memory.rs
@@ -68,16 +68,15 @@ impl<'a> InMemoryDBImpl<'a> for Owned {
 }
 
 #[derive(Debug)]
-// TODO: Remove this lint exception once the is multi-thread-capable.
-#[allow(clippy::non_send_fields_in_send_ty, reason = "TODO: This is temporary")]
 pub struct InMemoryDB<T> {
     inner: T,
 }
 
-// todo! vvvvv remove this once miraclx/slice/multi-thread-capable is merged in
-unsafe impl<T: Debug> Sync for InMemoryDB<T> {}
-unsafe impl<T: Debug> Send for InMemoryDB<T> {}
-// todo! ^^^^^ remove this once miraclx/slice/multi-thread-capable is merged in
+// `InMemoryDB<T>` is `Send`/`Sync` exactly when its sole field `T` is. We rely on
+// the auto-derived bounds rather than asserting them unconditionally: an
+// unconditional `unsafe impl` would falsely claim thread-safety for any `T`
+// (e.g. `Rc` or borrowed non-`Sync` data). Both `Ref` and `Owned` are thread-safe
+// because `Slice` and the underlying `Arc<RwLock<_>>` storage are.
 
 impl InMemoryDB<()> {
     #[must_use]
@@ -139,7 +138,7 @@ impl AsRef<[u8]> for ArcSlice<'_> {
     }
 }
 
-impl<'a, T: InMemoryDBImpl<'a> + Debug + 'static> Database<'a> for InMemoryDB<T>
+impl<'a, T: InMemoryDBImpl<'a> + Debug + Send + Sync + 'static> Database<'a> for InMemoryDB<T>
 where
     T::Key: Ord + Clone + Borrow<[u8]>,
     T::Value: 'static,


### PR DESCRIPTION
## Problem

`crates/store/src/db/memory.rs` had:

```rust
unsafe impl<T: Debug> Sync for InMemoryDB<T> {}
unsafe impl<T: Debug> Send for InMemoryDB<T> {}
```

This unconditionally claims `Send`/`Sync` for **any** `T: Debug` — including `Rc<…>` or borrowed non-`Sync` data — which is unsound. The `Debug` bound is unrelated to thread-safety; it was just an arbitrary marker left over from when `Slice` was not yet thread-capable (per the stale `miraclx/slice/multi-thread-capable` TODOs).

## Fix

`InMemoryDB<T>` has a single field `inner: T`, so the compiler's auto-derived bounds give `Send`/`Sync` **exactly** when `T` is — the sound result. So instead of bounding a redundant `unsafe impl`, the manual impls are removed entirely and auto-derivation enforces the correct bound (zero `unsafe`).

`Slice<'a>` is now genuinely `Send + Sync` (every `SliceInner` variant — `&[u8]`, `Arc<Box<[u8]>>`, and `Arc<dyn BufRef>` where `BufRef: Reflect + Send + Sync` — is thread-safe), so both `Ref` and `Owned` (each `Arc<RwLock<InMemoryDBInner<Slice, Slice>>>`) remain `Send + Sync`.

Also removed the now-moot `clippy::non_send_fields_in_send_ty` allow, and propagated `+ Send + Sync` onto the `Database<'a> for InMemoryDB<T>` impl — a bound the unconditional impl had been masking (`Database` requires `Send + Sync + 'static`).

## Verification

- `cargo check -p calimero-store` ✓
- `cargo test -p calimero-store` — 27 passed, 0 failed ✓
- `cargo clippy -p calimero-store` — clean ✓
- `cargo check --workspace --all-targets` — full workspace + all test targets compile ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)