### PR TITLE
refactor(storage): replace reject_frozen bool with RemoveMode enum

### DIFF
--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -200,7 +200,6 @@ const fn nonce_check_disabled_for_testing() -> bool {
     false
 }
 
-/// The primary interface for the storage system.
 /// Why a child is being removed from its collection, selecting whether the
 /// Frozen-deletion guard applies.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -212,6 +211,7 @@ enum RemoveMode {
     Relocate,
 }
 
+/// The primary interface for the storage system.
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
 pub struct Interface<S: StorageAdaptor = MainStorage>(PhantomData<S>);

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -201,6 +201,17 @@ const fn nonce_check_disabled_for_testing() -> bool {
 }
 
 /// The primary interface for the storage system.
+/// Why a child is being removed from its collection, selecting whether the
+/// Frozen-deletion guard applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoveMode {
+    /// A genuine semantic deletion: reject `Frozen` children.
+    Delete,
+    /// A deterministic re-key relocation: the child is immediately re-inserted
+    /// under a new id, so `Frozen` children are relocated rather than rejected.
+    Relocate,
+}
+
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
 pub struct Interface<S: StorageAdaptor = MainStorage>(PhantomData<S>);
@@ -2659,7 +2670,7 @@ impl<S: StorageAdaptor> Interface<S> {
     /// `Frozen`.
     ///
     pub fn remove_child_from(parent_id: Id, child_id: Id) -> Result<bool, StorageError> {
-        Self::remove_child_from_inner(parent_id, child_id, true)
+        Self::remove_child_from_inner(parent_id, child_id, RemoveMode::Delete)
     }
 
     /// Removes a child from a collection as part of a deterministic re-key
@@ -2675,18 +2686,18 @@ impl<S: StorageAdaptor> Interface<S> {
     /// Returns error if parent or child doesn't exist.
     ///
     pub(crate) fn relocate_child_from(parent_id: Id, child_id: Id) -> Result<bool, StorageError> {
-        Self::remove_child_from_inner(parent_id, child_id, false)
+        Self::remove_child_from_inner(parent_id, child_id, RemoveMode::Relocate)
     }
 
     /// Shared implementation behind [`remove_child_from`](Self::remove_child_from)
     /// and [`relocate_child_from`](Self::relocate_child_from).
     ///
-    /// `reject_frozen` gates the Frozen-deletion guard: `true` for genuine
-    /// deletes, `false` for re-key relocations.
+    /// `mode` selects whether the Frozen-deletion guard applies: it does for
+    /// [`RemoveMode::Delete`], but not for [`RemoveMode::Relocate`] re-keys.
     fn remove_child_from_inner(
         parent_id: Id,
         child_id: Id,
-        reject_frozen: bool,
+        mode: RemoveMode,
     ) -> Result<bool, StorageError> {
         let child_exists = <Index<S>>::get_children_of(parent_id)?
             .iter()
@@ -2712,9 +2723,9 @@ impl<S: StorageAdaptor> Interface<S> {
         // Refusing here keeps the deleter consistent with its peers.
         //
         // The re-key relocation path (`relocate_child_from`) passes
-        // `reject_frozen == false`: it removes the entry only to re-insert it
+        // `RemoveMode::Relocate`: it removes the entry only to re-insert it
         // under a new deterministic id, so the frozen data is preserved.
-        if reject_frozen && matches!(metadata.storage_type, StorageType::Frozen) {
+        if mode == RemoveMode::Delete && matches!(metadata.storage_type, StorageType::Frozen) {
             return Err(StorageError::ActionNotAllowed(
                 "Frozen data cannot be deleted".to_owned(),
             ));


### PR DESCRIPTION
Follow-up to #3039 (Frozen-child deletion guard), addressing a review comment from that PR.

## Why

`remove_child_from_inner` took a bare `reject_frozen: bool`. The #3039 reviewers flagged this as boolean-blindness: `relocate_child_from` passes `false` to deliberately skip the Frozen guard, but nothing stops a future caller from passing the wrong literal and silently bypassing the split-brain protection.

## What

Replace the bool with a self-documenting enum:

```rust
enum RemoveMode { Delete, Relocate }
```

- `remove_child_from` → `RemoveMode::Delete`
- `relocate_child_from` → `RemoveMode::Relocate`
- guard reads `if mode == RemoveMode::Delete && matches!(.., Frozen)`

No behavior change — purely makes the contract explicit at the call site.

## Test plan

- `cargo clippy -p calimero-storage --all-targets --features testing -- -D warnings` — clean ✅
- `cargo test -p calimero-storage --features testing remove_child_from_rejects_frozen` — passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)