### PR TITLE
fix(sdk,sys,abi): correctness fixes across ABI/SDK macros and host glue

### DIFF
--- a/crates/governance-store/src/membership/status.rs
+++ b/crates/governance-store/src/membership/status.rs
@@ -11,18 +11,15 @@
 use calimero_primitives::context::GroupMemberRole;
 
 /// Map the `invited_role: u8` byte from `GroupInvitationFromAdmin` to the typed
-/// [`GroupMemberRole`]. The encoding is documented at the source struct
-/// (0 = Admin, 1 = Member, 2 = ReadOnly).
+/// [`GroupMemberRole`], used by the `MemberJoined` apply path in
+/// `namespace/membership.rs`.
 ///
-/// Used by the `MemberJoined` apply path in `namespace/membership.rs`. Unknown
-/// values default to `Member` (least-privilege) rather than `Admin`, so an
-/// attacker injecting an out-of-range value cannot silently escalate.
+/// Thin alias for the canonical [`GroupMemberRole::from_invited_role`] so this
+/// apply path and the op-adapter share one decoding and cannot drift. The
+/// canonical mapping documents the encoding (0 = Admin, 1 = Member, 2 = ReadOnly)
+/// and the least-privilege default for unknown bytes.
 pub(crate) fn role_from_invited_role(value: u8) -> GroupMemberRole {
-    match value {
-        0 => GroupMemberRole::Admin,
-        2 => GroupMemberRole::ReadOnly,
-        _ => GroupMemberRole::Member,
-    }
+    GroupMemberRole::from_invited_role(value)
 }
 
 #[cfg(test)]

--- a/crates/op-adapter/src/lib.rs
+++ b/crates/op-adapter/src/lib.rs
@@ -55,17 +55,6 @@ pub fn set_writers_payload(object: Id, entry: &RotationLogEntry) -> OpPayload {
     }
 }
 
-/// Map an invitation's `invited_role` byte (0 = Admin, 2 = ReadOnly, else
-/// Member) to a [`GroupMemberRole`] — the same mapping governance-store uses
-/// (reimplemented here so the adapter doesn't depend on a `pub(crate)` helper).
-fn role_from_invited_role(value: u8) -> GroupMemberRole {
-    match value {
-        0 => GroupMemberRole::Admin,
-        2 => GroupMemberRole::ReadOnly,
-        _ => GroupMemberRole::Member,
-    }
-}
-
 /// Encode a per-group governance op ([`GroupOp`], already decrypted) as an
 /// [`OpPayload`] for `group`.
 ///
@@ -203,7 +192,7 @@ pub fn payload_from_root_op(op: &RootOp, signer: PublicKey) -> Option<OpPayload>
         } => Some(OpPayload::MemberAdded {
             group: signed_invitation.invitation.group_id,
             member: *member,
-            role: role_from_invited_role(signed_invitation.invitation.invited_role),
+            role: GroupMemberRole::from_invited_role(signed_invitation.invitation.invited_role),
         }),
         RootOp::MemberJoinedOpen { member, group_id } => Some(OpPayload::MemberAdded {
             group: ContextGroupId::from(*group_id),

--- a/crates/primitives/src/context.rs
+++ b/crates/primitives/src/context.rs
@@ -293,6 +293,25 @@ pub enum GroupMemberRole {
     ReadOnlyTee,
 }
 
+impl GroupMemberRole {
+    /// Map an invitation's `invited_role: u8` byte to a role. This is the single
+    /// canonical decoding of the on-the-wire invitation encoding
+    /// (`0 = Admin`, `1 = Member`, `2 = ReadOnly`); both the governance apply
+    /// path and the op-adapter route through it so the two cannot drift.
+    ///
+    /// Unknown/out-of-range values default to [`GroupMemberRole::Member`]
+    /// (least privilege) rather than `Admin`, so a malformed or hostile byte
+    /// cannot silently escalate.
+    #[must_use]
+    pub fn from_invited_role(value: u8) -> Self {
+        match value {
+            0 => Self::Admin,
+            2 => Self::ReadOnly,
+            _ => Self::Member,
+        }
+    }
+}
+
 /// A serialized and encoded payload for inviting a user to join a Context Group.
 ///
 /// Internally Borsh-serialized for compact, deterministic representation and

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -187,7 +187,7 @@ impl VMHostFunctions<'_> {
         let location =
             unsafe { self.read_guest_memory_typed::<sys::Location<'_>>(src_location_ptr)? };
 
-        let file = self.read_guest_memory_str(&location.file())?.to_owned();
+        let file = self.read_guest_memory_str(location.file())?.to_owned();
         let line = location.line();
         let column = location.column();
 
@@ -240,7 +240,7 @@ impl VMHostFunctions<'_> {
             unsafe { self.read_guest_memory_typed::<sys::Location<'_>>(src_location_ptr)? };
 
         let panic_message = self.read_guest_memory_str(&panic_message_buf)?.to_owned();
-        let file = self.read_guest_memory_str(&location.file())?.to_owned();
+        let file = self.read_guest_memory_str(location.file())?.to_owned();
         let line = location.line();
         let column = location.column();
 

--- a/crates/sdk/macros/src/event.rs
+++ b/crates/sdk/macros/src/event.rs
@@ -38,21 +38,61 @@ impl ToTokens for EventImpl<'_> {
             #orig
 
             impl #impl_generics ::calimero_sdk::event::AppEvent for #ident #ty_generics #where_clause {
+                // `kind` and `data` are read off the serde-tagged object so the
+                // wire names honour any `#[serde(rename/rename_all)]` the variant
+                // carries — deriving them from the raw variant identifier here
+                // would silently diverge from how the event actually serializes.
                 fn kind(&self) -> ::std::borrow::Cow<str> {
-                    // todo! revisit quick
                     match ::calimero_sdk::serde_json::to_value(self) {
-                        Ok(data) => ::std::borrow::Cow::Owned(data["kind"].as_str().expect("Failed to get event kind").to_string()),
-                        Err(err) => ::calimero_sdk::env::panic_str(
-                            &format!("Failed to serialize event: {:?}", err)
+                        ::core::result::Result::Ok(
+                            ::calimero_sdk::serde_json::Value::Object(mut __obj)
+                        ) => match __obj.remove("kind") {
+                            ::core::option::Option::Some(
+                                ::calimero_sdk::serde_json::Value::String(__k)
+                            ) => ::std::borrow::Cow::Owned(__k),
+                            _ => ::calimero_sdk::env::panic_str(
+                                "event did not serialize with a string `kind` tag",
+                            ),
+                        },
+                        ::core::result::Result::Ok(_) => ::calimero_sdk::env::panic_str(
+                            "event did not serialize to a `{ kind, data }` object",
+                        ),
+                        ::core::result::Result::Err(__err) => ::calimero_sdk::env::panic_str(
+                            &::std::format!("Failed to serialize event: {:?}", __err)
                         ),
                     }
                 }
                 fn data(&self) -> ::std::borrow::Cow<[u8]> {
-                    // todo! revisit quick
                     match ::calimero_sdk::serde_json::to_value(self) {
-                        Ok(data) => ::std::borrow::Cow::Owned(::calimero_sdk::serde_json::to_vec(&data["data"]).expect("Failed to serialize event data")),
-                        Err(err) => ::calimero_sdk::env::panic_str(
-                            &format!("Failed to serialize event: {:?}", err)
+                        ::core::result::Result::Ok(
+                            ::calimero_sdk::serde_json::Value::Object(__obj)
+                        ) => match __obj.get("data") {
+                            // A unit variant carries no `content`, so serde omits
+                            // `data` (or leaves it null). Emit an empty payload —
+                            // not the 4-byte JSON literal `null` the old
+                            // round-trip produced.
+                            ::core::option::Option::None
+                            | ::core::option::Option::Some(
+                                ::calimero_sdk::serde_json::Value::Null
+                            ) => ::std::borrow::Cow::Borrowed(&[][..]),
+                            ::core::option::Option::Some(__data) => {
+                                match ::calimero_sdk::serde_json::to_vec(__data) {
+                                    ::core::result::Result::Ok(__bytes) =>
+                                        ::std::borrow::Cow::Owned(__bytes),
+                                    ::core::result::Result::Err(__err) =>
+                                        ::calimero_sdk::env::panic_str(
+                                            &::std::format!(
+                                                "Failed to serialize event data: {:?}", __err
+                                            )
+                                        ),
+                                }
+                            }
+                        },
+                        ::core::result::Result::Ok(_) => ::calimero_sdk::env::panic_str(
+                            "event did not serialize to a `{ kind, data }` object",
+                        ),
+                        ::core::result::Result::Err(__err) => ::calimero_sdk::env::panic_str(
+                            &::std::format!("Failed to serialize event: {:?}", __err)
                         ),
                     }
                 }
@@ -141,5 +181,53 @@ impl<'a> TryFrom<EventImplInput<'a>> for EventImpl<'a> {
             generics,
             orig: input.item,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::ToTokens;
+    use syn::parse_quote;
+
+    use super::*;
+
+    fn render(item: syn::ItemEnum) -> String {
+        // Validation consults the reserved-ident table; initialize it first.
+        crate::reserved::init();
+        let item = StructOrEnumItem::Enum(item);
+        EventImpl::try_from(EventImplInput { item: &item })
+            .map_err(|_| "event impl should build for a valid enum")
+            .unwrap()
+            .to_token_stream()
+            .to_string()
+    }
+
+    #[test]
+    fn event_data_emits_empty_payload_for_unit_variants_and_drops_expect() {
+        let rendered = render(parse_quote! {
+            pub enum Event {
+                Ping,
+                Tick { count: u32 },
+            }
+        });
+
+        // A unit variant must no longer serialize to the 4-byte JSON literal
+        // `null`: `data()` returns an empty borrowed payload for a null/absent
+        // `data` field.
+        assert!(
+            rendered.contains("Null"),
+            "data() must special-case a null/absent `data` field, got:\n{rendered}",
+        );
+        assert!(
+            rendered.contains("Borrowed"),
+            "data() must return an empty borrowed payload for unit variants, got:\n{rendered}",
+        );
+
+        // The brittle `.expect(...)` that aborted the whole instance on a
+        // malformed value is gone.
+        assert!(
+            !rendered.contains(". expect ("),
+            "kind()/data() must not use `.expect`, got:\n{rendered}",
+        );
     }
 }

--- a/crates/sdk/macros/src/lib.rs
+++ b/crates/sdk/macros/src/lib.rs
@@ -353,9 +353,16 @@ pub fn emit(input: TokenStream) -> TokenStream {
             let event = &parsed.elems[0];
             quote!(::calimero_sdk::event::emit(#event)).into()
         } else {
-            // Fallback to regular emit if not 1 or 2 arguments
-            let event = &parsed.elems[0];
-            quote!(::calimero_sdk::event::emit(#event)).into()
+            // Zero elements (`emit!(())`) or three+ — neither is a valid event.
+            // Indexing `elems[0]` here would panic the proc macro ("proc macro
+            // panicked") with no useful span; emit a clear spanned error instead.
+            syn::Error::new_spanned(
+                &parsed,
+                "`app::emit!` expects an event, optionally with a handler: \
+                 `emit!(event)` or `emit!((event, \"handler\"))`",
+            )
+            .to_compile_error()
+            .into()
         }
     } else {
         // Simple case - just the event (not a tuple)

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -22,6 +22,14 @@ pub enum LogicMethod<'a> {
 /// macro rejects it. Add to this list if codegen introduces new prefixes.
 const RESERVED_METHOD_PREFIXES: &[&str] = &["__calimero"];
 
+/// Exact method names the SDK emits as its own `#[no_mangle]` wasm exports.
+/// Unlike the reserved *prefixes* above, these carry no `__calimero` marker, so
+/// an app method sharing one of these names would silently produce a duplicate
+/// export symbol — a confusing linker error far from the cause. Reserving them
+/// here surfaces a clear, spanned diagnostic at the offending method instead.
+/// Kept in sync with the exports generated in `state.rs`.
+const RESERVED_METHOD_NAMES: &[&str] = &["migrate_my_entries", "count_my_pending"];
+
 pub enum Modifer {
     Init,
     /// `#[app::view]` — app author declares the method read-only. Stored in
@@ -538,6 +546,7 @@ impl<'a, 'b> TryFrom<LogicMethodImplInput<'a, 'b>> for LogicMethod<'a> {
         if RESERVED_METHOD_PREFIXES
             .iter()
             .any(|prefix| name_str.starts_with(prefix))
+            || RESERVED_METHOD_NAMES.contains(&name_str.as_str())
         {
             errors.subsume(SynError::new_spanned(name, ParseError::ReservedMethodName));
         }

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -944,13 +944,34 @@ fn generate_test_state_impl(
     }
 }
 
+/// The final path-segment identifier of a field type, e.g. `UnorderedMap` for
+/// `calimero_storage::collections::UnorderedMap<K, V>`, or `Option` for
+/// `Option<UnorderedMap<K, V>>`. Returns `None` for non-path types (references,
+/// tuples, …).
+///
+/// Classification keys off this exact identifier rather than a substring of the
+/// stringified type. Substring matching misfires on both ends: `RateCounter`
+/// contains `Counter` (a false positive that would emit a `reassign` call the
+/// type can't answer), and a wrapper like `Option<UnorderedMap<…>>` contains
+/// `UnorderedMap` (another false positive — `Option` has no such method). Either
+/// produces a hard compile error or, worse, an id that diverges across nodes.
+fn outer_type_ident(ty: &Type) -> Option<String> {
+    match ty {
+        Type::Path(path) => path.path.segments.last().map(|seg| seg.ident.to_string()),
+        _ => None,
+    }
+}
+
 /// Whether a field type is a single-owner identity-gated collection that the
 /// one-tap `migrate_my_entries()` sweeps. Matches `AuthoredMap`/`AuthoredVector`
 /// only. `SharedStorage` (group writer-set) is deliberately excluded: its value
 /// converts via the organic writer-write substrate, and a batch re-write would
 /// force a `T: Clone` bound on every shared value type.
-fn is_identity_gated_collection(type_str: &str) -> bool {
-    type_str.contains("AuthoredMap") || type_str.contains("AuthoredVector")
+fn is_identity_gated_collection(ty: &Type) -> bool {
+    matches!(
+        outer_type_ident(ty).as_deref(),
+        Some("AuthoredMap" | "AuthoredVector")
+    )
 }
 
 /// Generate the one-tap `migrate_my_entries()` wasm export + its inherent
@@ -975,10 +996,10 @@ fn generate_migrate_my_entries_impl(
     let mut count_loops: Vec<TokenStream> = Vec::new();
     for (idx, field) in fields.iter().enumerate() {
         let field_type = &field.ty;
-        let type_str = quote! { #field_type }.to_string();
-        if !is_identity_gated_collection(&type_str) {
+        if !is_identity_gated_collection(field_type) {
             continue;
         }
+        let is_authored_map = outer_type_ident(field_type).as_deref() == Some("AuthoredMap");
 
         let access = if let Some(name) = &field.ident {
             quote! { self.#name }
@@ -989,7 +1010,7 @@ fn generate_migrate_my_entries_impl(
 
         // Count-only twin of the migrate loop: tally the caller's still-stale
         // owned entries without re-writing them (read-only, no signed delta).
-        let count_body = if type_str.contains("AuthoredMap") {
+        let count_body = if is_authored_map {
             quote! {
                 let __keys: ::std::vec::Vec<_> = match #access.entries() {
                     ::core::result::Result::Ok(__it) => __it.map(|(__k, _)| __k).collect(),
@@ -1019,9 +1040,8 @@ fn generate_migrate_my_entries_impl(
         };
         count_loops.push(count_body);
 
-        // `AuthoredVector` also contains the substring "Vector"; check the map
-        // first, then fall to the vector shape (keyed-by-index vs keyed-by-key).
-        let loop_body = if type_str.contains("AuthoredMap") {
+        // Map shape (keyed-by-key) vs vector shape (keyed-by-index).
+        let loop_body = if is_authored_map {
             quote! {
                 // Collect into an owned Vec in its own statement so the immutable
                 // `entries()` borrow is fully released before the mutable owner
@@ -1207,44 +1227,36 @@ fn generate_assign_deterministic_ids_impl(
         }
     };
 
-    // Helper function to check if a type is a collection that needs ID assignment
-    fn is_collection_type(type_str: &str) -> bool {
-        type_str.contains("UnorderedMap")
-            // `SortedMap` is NOT a substring of any other entry, so it must be
-            // listed explicitly — otherwise a top-level `SortedMap` state field
-            // keeps its `Id::random()` and diverges across nodes (CIP I9).
-            || type_str.contains("SortedMap")
-            || type_str.contains("Vector")
-            || type_str.contains("UnorderedSet")
-            // `SortedSet` is NOT a substring of any other entry (same reason as
-            // `SortedMap`): list it explicitly or its id stays random and diverges.
-            || type_str.contains("SortedSet")
-            || type_str.contains("Counter")
-            || type_str.contains("ReplicatedGrowableArray")
-            || type_str.contains("UserStorage")
-            || type_str.contains("FrozenStorage")
-            || type_str.contains("SharedStorage")
-            // `PermissionedStorage` and its `Ownable` alias wrap a
-            // `SharedStorage`; their `reassign_deterministic_id` delegates to it,
-            // so the inner wrapper gets the field-derived id and converges. Both
-            // must be listed: a field written as `Ownable<_>` shows the `Ownable`
-            // token (alias is not resolved here), and `PermissionedStorage` is not
-            // a substring of `SharedStorage`.
-            || type_str.contains("PermissionedStorage")
-            || type_str.contains("Ownable")
-            // `AccessControl` wraps a single guarded storage; its
-            // `reassign_deterministic_id` delegates to it. The macro does not
-            // recurse into nested structs, so without this its inner storage
-            // keeps a random id and diverges across nodes.
-            || type_str.contains("AccessControl")
-            // `AuthoredVector` is already matched by the `"Vector"` substring above;
-            // `AuthoredMap` is NOT a substring of any entry, so it must be listed
-            // explicitly or its outer wrapper id stays `Id::random()` and a
-            // freshly-constructed map (in `init`/`migrate`) diverges across nodes.
-            // Safe: the inner map is built with a deterministic id, so its
-            // `reassign` is an idempotent no-op (no clear+reinsert), and only the
-            // wrapper's id is canonicalised — owner stamps are preserved.
-            || type_str.contains("AuthoredMap")
+    // Whether a top-level state field is a CRDT collection whose deterministic
+    // id must be (re)assigned from its field name (CIP Invariant I9). Keyed off
+    // the type's final path-segment identifier — matched exactly, never as a
+    // substring. `AuthoredVector` and `AuthoredMap` are listed in their own right
+    // (exact-match does not treat `AuthoredVector` as `Vector`), and a wrapper
+    // such as `Option<UnorderedMap<…>>` is correctly excluded (its outer ident is
+    // `Option`, which has no `reassign_deterministic_id`). `Ownable` is the alias
+    // for `PermissionedStorage` and is listed because the alias is not resolved
+    // at macro time; both delegate `reassign` to the inner `SharedStorage`.
+    fn is_collection_type(ty: &Type) -> bool {
+        matches!(
+            outer_type_ident(ty).as_deref(),
+            Some(
+                "UnorderedMap"
+                    | "SortedMap"
+                    | "Vector"
+                    | "AuthoredVector"
+                    | "UnorderedSet"
+                    | "SortedSet"
+                    | "Counter"
+                    | "ReplicatedGrowableArray"
+                    | "UserStorage"
+                    | "FrozenStorage"
+                    | "SharedStorage"
+                    | "PermissionedStorage"
+                    | "Ownable"
+                    | "AccessControl"
+                    | "AuthoredMap"
+            )
+        )
     }
 
     // Generate reassign calls for each collection field
@@ -1253,9 +1265,8 @@ fn generate_assign_deterministic_ids_impl(
         .enumerate()
         .filter_map(|(idx, field)| {
             let field_type = &field.ty;
-            let type_str = quote! { #field_type }.to_string();
 
-            if !is_collection_type(&type_str) {
+            if !is_collection_type(field_type) {
                 return None;
             }
 
@@ -1375,6 +1386,45 @@ mod tests {
         let generics = item.generics.clone();
         let orig = StructOrEnumItem::Struct(item);
         generate_migrate_my_entries_impl(&ident, &generics, &orig).to_string()
+    }
+
+    /// Helper: render the generated deterministic-id assignment block.
+    fn render_assign(item: syn::ItemStruct) -> String {
+        let ident = item.ident.clone();
+        let generics = item.generics.clone();
+        let orig = StructOrEnumItem::Struct(item);
+        generate_assign_deterministic_ids_impl(&ident, &generics, &orig).to_string()
+    }
+
+    /// Classification keys off the type's outer ident, not a substring, so a
+    /// non-collection whose name merely *contains* a collection name
+    /// (`RateCounter` ⊃ `Counter`) and a wrapper around a collection
+    /// (`Option<UnorderedMap<…>>`) are both excluded — only genuine top-level
+    /// collections get a `reassign_deterministic_id` call. Substring matching
+    /// used to emit calls for both, producing a hard compile error or a
+    /// divergent id.
+    #[test]
+    fn assign_ids_skips_lookalikes_and_wrappers() {
+        let rendered = render_assign(parse_quote! {
+            pub struct AppRoot {
+                pub real: UnorderedMap<String, u64>,
+                pub rate: RateCounter,
+                pub maybe: Option<UnorderedMap<String, u64>>,
+            }
+        });
+
+        assert!(
+            rendered.contains("self . real . reassign_deterministic_id"),
+            "a genuine top-level collection must be (re)assigned, got:\n{rendered}",
+        );
+        assert!(
+            !rendered.contains("self . rate"),
+            "`RateCounter` is not a `Counter` — must NOT be reassigned, got:\n{rendered}",
+        );
+        assert!(
+            !rendered.contains("self . maybe"),
+            "`Option<UnorderedMap<…>>` is a wrapper — must NOT be reassigned, got:\n{rendered}",
+        );
     }
 
     #[test]

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -234,11 +234,15 @@ pub fn register_len(register_id: RegisterId) -> Option<usize> {
 pub fn read_register(register_id: RegisterId) -> Option<Vec<u8>> {
     let len = register_len(register_id)?;
 
-    let mut buffer = Vec::with_capacity(len);
+    // Zero-initialize rather than `with_capacity` + `set_len`: the host fills the
+    // buffer during the call below, but the `BufferMut` descriptor must already
+    // advertise `len` bytes for the host to write into. Exposing uninitialized
+    // capacity as the live slice (via `set_len`) before the host writes is UB if
+    // the host writes fewer bytes than advertised and still reports success —
+    // the unwritten tail would be read as initialized. `vec![0; len]` is sound.
+    let mut buffer = vec![0_u8; len];
 
     let succeed: bool = unsafe {
-        buffer.set_len(len);
-
         sys::read_register(register_id, Ref::new(&BufferMut::new(&mut buffer)))
             .try_into()
             .unwrap_or_else(expected_boolean)
@@ -834,17 +838,26 @@ fn decode_index_pairs(buf: &[u8]) -> Vec<(Vec<u8>, Vec<u8>)> {
         let Some(klen) = take_u32(buf, &mut pos) else {
             break;
         };
-        let Some(key) = buf.get(pos..pos + klen).map(<[u8]>::to_vec) else {
+        // `pos + klen` can overflow `usize` on a 32-bit (wasm32) host for a
+        // hostile/corrupt length prefix; `checked_add` makes that a clean stop
+        // rather than a wrapping read or a debug-build panic before `.get`.
+        let Some(kend) = pos.checked_add(klen) else {
             break;
         };
-        pos += klen;
+        let Some(key) = buf.get(pos..kend).map(<[u8]>::to_vec) else {
+            break;
+        };
+        pos = kend;
         let Some(vlen) = take_u32(buf, &mut pos) else {
             break;
         };
-        let Some(value) = buf.get(pos..pos + vlen).map(<[u8]>::to_vec) else {
+        let Some(vend) = pos.checked_add(vlen) else {
             break;
         };
-        pos += vlen;
+        let Some(value) = buf.get(pos..vend).map(<[u8]>::to_vec) else {
+            break;
+        };
+        pos = vend;
         out.push((key, value));
     }
     out
@@ -1068,6 +1081,17 @@ pub fn ed25519_verify(signature: &[u8; 64], public_key: &[u8; 32], message: &[u8
 // STREAMING BLOB API
 // ========================================
 
+/// Narrow a public `u64` blob file descriptor to the pointer-sized integer the
+/// host ABI expects. On a 32-bit (wasm32) host a plain `as usize` would silently
+/// truncate the high bits, potentially aliasing a *different*, live descriptor.
+/// A value that doesn't fit (one the host could never have issued) instead
+/// collapses to an all-ones sentinel the host rejects as invalid.
+#[cfg(target_arch = "wasm32")]
+#[inline]
+fn blob_fd(fd: u64) -> PtrSizedInt {
+    PtrSizedInt::new(usize::try_from(fd).unwrap_or(usize::MAX))
+}
+
 /// Create a new blob write handle for streaming data.
 /// Returns a file descriptor that can be used with blob_write() and blob_close().
 pub fn blob_create() -> u64 {
@@ -1097,13 +1121,7 @@ pub fn blob_open(blob_id: &[u8; 32]) -> u64 {
 pub fn blob_read(fd: u64, buffer: &mut [u8]) -> u64 {
     #[cfg(target_arch = "wasm32")]
     {
-        unsafe {
-            sys::blob_read(
-                PtrSizedInt::new(fd as usize),
-                Ref::new(&BufferMut::new(buffer)),
-            )
-        }
-        .as_usize() as u64
+        unsafe { sys::blob_read(blob_fd(fd), Ref::new(&BufferMut::new(buffer))) }.as_usize() as u64
     }
     #[cfg(not(target_arch = "wasm32"))]
     host::blob_read(fd, buffer)
@@ -1114,8 +1132,7 @@ pub fn blob_read(fd: u64, buffer: &mut [u8]) -> u64 {
 pub fn blob_write(fd: u64, data: &[u8]) -> u64 {
     #[cfg(target_arch = "wasm32")]
     {
-        unsafe { sys::blob_write(PtrSizedInt::new(fd as usize), Ref::new(&Buffer::from(data))) }
-            .as_usize() as u64
+        unsafe { sys::blob_write(blob_fd(fd), Ref::new(&Buffer::from(data))) }.as_usize() as u64
     }
     #[cfg(not(target_arch = "wasm32"))]
     host::blob_write(fd, data)
@@ -1131,11 +1148,7 @@ pub fn blob_close(fd: u64) -> [u8; 32] {
     {
         let mut blob_id_buf = [0_u8; 32];
         let success: bool = unsafe {
-            sys::blob_close(
-                PtrSizedInt::new(fd as usize),
-                Ref::new(&BufferMut::new(&mut blob_id_buf)),
-            )
-            .try_into()
+            sys::blob_close(blob_fd(fd), Ref::new(&BufferMut::new(&mut blob_id_buf))).try_into()
         }
         .unwrap_or_else(expected_boolean);
 

--- a/crates/storage-macros/src/lib.rs
+++ b/crates/storage-macros/src/lib.rs
@@ -67,9 +67,9 @@ use syn::{parse_macro_input, Data, DeriveInput, Fields, Type};
 /// */
 /// ```
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics at compile time if:
+/// Emits a compile error (with a span pointing at the offending item) if:
 /// - Applied to non-struct types (enums, unions)
 /// - Struct has unnamed fields
 /// - Missing `#[storage]` attribute
@@ -89,21 +89,37 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
 
     let fields = match &input.data {
         Data::Struct(data) => &data.fields,
-        Data::Enum(_) | Data::Union(_) => panic!("AtomicUnit can only be derived for structs"),
+        Data::Enum(_) | Data::Union(_) => {
+            return syn::Error::new_spanned(name, "AtomicUnit can only be derived for structs")
+                .to_compile_error()
+                .into();
+        }
     };
 
     let named_fields = match fields {
         Fields::Named(fields) => &fields.named,
         Fields::Unnamed(_) | Fields::Unit => {
-            panic!("AtomicUnit can only be derived for structs with named fields")
+            return syn::Error::new_spanned(
+                fields,
+                "AtomicUnit can only be derived for structs with named fields",
+            )
+            .to_compile_error()
+            .into();
         }
     };
 
     // Find the field marked with the #[storage] attribute
-    let storage_field = named_fields
+    let Some(storage_field) = named_fields
         .iter()
         .find(|f| f.attrs.iter().any(|attr| attr.path().is_ident("storage")))
-        .expect("You must designate one field with #[storage] for the Element");
+    else {
+        return syn::Error::new_spanned(
+            name,
+            "AtomicUnit requires exactly one field annotated with #[storage] to hold the Element",
+        )
+        .to_compile_error()
+        .into();
+    };
 
     let storage_ident = storage_field.ident.as_ref().unwrap();
 
@@ -129,9 +145,9 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
 
     let expanded = quote! {
         impl #impl_generics calimero_storage::entities::Data for #name #ty_generics #serde_where_clause {
-            fn collections(&self) -> std::collections::BTreeMap<String, Vec<calimero_storage::entities::ChildInfo>> {
+            fn collections(&self) -> ::std::collections::BTreeMap<::std::string::String, ::std::vec::Vec<calimero_storage::entities::ChildInfo>> {
                 use calimero_storage::entities::Collection;
-                let mut collections = std::collections::BTreeMap::new();
+                let mut collections = ::std::collections::BTreeMap::new();
                 #(
                     collections.insert(
                         stringify!(#collection_fields).to_owned(),
@@ -199,12 +215,11 @@ pub fn atomic_unit_derive(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// # Panics
+/// # Errors
 ///
-/// This macro will panic during compilation if:
+/// This macro emits a compile error (with a span on the offending item) if:
 ///
 ///   - It is applied to anything other than a struct
-///   - The struct has unnamed fields
 ///   - The `#[children(Type)]` attribute is missing or invalid
 ///
 /// # See also
@@ -218,30 +233,54 @@ pub fn collection_derive(input: TokenStream) -> TokenStream {
     let name = &input.ident;
     let where_clause = input.generics.make_where_clause().clone();
     let (impl_generics, ty_generics, _) = input.generics.split_for_impl();
-    let child_type = input
+    let Some(children_attr) = input
         .attrs
         .iter()
         .find(|attr| attr.path().is_ident("children"))
-        .and_then(|attr| attr.parse_args::<Type>().ok())
-        .expect("Collection derive requires #[children(Type)] attribute");
+    else {
+        return syn::Error::new_spanned(
+            &input.ident,
+            "Collection derive requires a `#[children(Type)]` attribute naming the child Data type",
+        )
+        .to_compile_error()
+        .into();
+    };
+    let child_type = match children_attr.parse_args::<Type>() {
+        Ok(ty) => ty,
+        Err(err) => return err.to_compile_error().into(),
+    };
 
     let fields = match input.data {
         Data::Struct(data) => data.fields,
-        Data::Enum(_) | Data::Union(_) => panic!("Collection can only be derived for structs"),
+        Data::Enum(_) | Data::Union(_) => {
+            return syn::Error::new_spanned(
+                &input.ident,
+                "Collection can only be derived for structs",
+            )
+            .to_compile_error()
+            .into();
+        }
     };
 
+    // A Collection is a pure grouping handle: its entries live as child elements
+    // in storage, never inline. So it (de)serializes to exactly zero bytes. The
+    // serialize/deserialize pair is symmetric (both touch no bytes), which keeps
+    // the surrounding struct's borsh stream in lock-step — the writer emits
+    // nothing for this field and the reader consumes nothing for it. Any inline
+    // fields the struct carries are reconstructed via `Default` on decode, so the
+    // type must not rely on them surviving a round-trip.
     let deserialize_impl = quote! {
         impl #impl_generics calimero_sdk::borsh::BorshDeserialize for #name #ty_generics #where_clause {
-            fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
-                Ok(Self::default())
+            fn deserialize_reader<R: ::std::io::Read>(_reader: &mut R) -> ::std::io::Result<Self> {
+                ::core::result::Result::Ok(<Self as ::core::default::Default>::default())
             }
         }
     };
 
     let serialize_impl = quote! {
         impl #impl_generics calimero_sdk::borsh::BorshSerialize for #name #ty_generics #where_clause {
-            fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-                Ok(())
+            fn serialize<W: ::std::io::Write>(&self, _writer: &mut W) -> ::std::io::Result<()> {
+                ::core::result::Result::Ok(())
             }
         }
     };
@@ -250,7 +289,7 @@ pub fn collection_derive(input: TokenStream) -> TokenStream {
         .iter()
         .map(|field| {
             let ident = field.ident.as_ref().unwrap();
-            quote! { #ident: Default::default(), }
+            quote! { #ident: ::core::default::Default::default(), }
         })
         .collect::<Vec<_>>();
 

--- a/crates/sys/src/types.rs
+++ b/crates/sys/src/types.rs
@@ -16,8 +16,11 @@ pub use r#ref::*;
 pub use register::*;
 pub use xcall::*;
 
+// Not `Copy`/`Clone`: it wraps a move-only `Buffer` (see `buffer.rs` for why the
+// descriptor must be move-only). It is only ever borrowed (`Ref::new(&…)`) or
+// destructured by value, so neither is needed.
 #[repr(C, u64)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ValueReturn<'a> {
     Ok(Buffer<'a>),
     Err(Buffer<'a>),

--- a/crates/sys/src/types/buffer.rs
+++ b/crates/sys/src/types/buffer.rs
@@ -10,8 +10,15 @@ mod guest;
 #[cfg(not(target_arch = "wasm32"))]
 mod host;
 
+// Deliberately NOT `Copy`/`Clone`. The descriptor owns a raw pointer plus a
+// lifetime, and `as_mut_slice` hands out `&mut [T]` over that pointer. If the
+// descriptor were duplicable, safe code could copy it and call `as_mut_slice`
+// on each copy to obtain two independent `&mut [T]` aliasing the same memory
+// (or a shared `into_slice` alongside a `&mut`) — UB the per-borrow lifetimes
+// alone cannot prevent. Being move-only makes "I hold this descriptor" unique,
+// so the borrow checker can actually serialize access through it.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Slice<'a, T> {
     ptr: Pointer<T>,
     len: u64,
@@ -20,6 +27,16 @@ pub struct Slice<'a, T> {
 
 pub type Buffer<'a> = Slice<'a, u8>;
 pub type BufferMut<'a> = Buffer<'a>;
+
+impl Buffer<'_> {
+    /// Borrow the buffer's bytes as a UTF-8 `str`, tied to this borrow of
+    /// `self`. The sound replacement for the by-value `TryFrom<Buffer> for &str`
+    /// when you only have a `&Buffer` (e.g. a field of `Event`/`Location`).
+    #[inline]
+    pub fn as_str(&self) -> Result<&str, Utf8Error> {
+        from_utf8(self.as_slice())
+    }
+}
 
 impl<T> AsRef<[T]> for Slice<'_, T> {
     #[inline]
@@ -69,9 +86,11 @@ impl<'a> TryFrom<Buffer<'a>> for &'a str {
     type Error = Utf8Error;
 
     fn try_from(buf: Buffer<'a>) -> Result<Self, Self::Error> {
-        // The descriptor is consumed by value, so the `'a` slice cannot alias a
-        // live borrow of `buf`. `into_slice` is the only path that hands out the
-        // full `'a` lifetime; the borrowing accessors stay tied to `self`.
+        // Sound because `Slice` is move-only: consuming `buf` by value leaves no
+        // other live descriptor that could hand out a `&mut` aliasing this `'a`
+        // slice. `into_slice` is the only path that yields the full `'a`
+        // lifetime; the borrowing accessors stay tied to `self`. For a `&Buffer`
+        // (no ownership to consume), use [`Buffer::as_str`] instead.
         from_utf8(buf.into_slice())
     }
 }

--- a/crates/sys/src/types/buffer.rs
+++ b/crates/sys/src/types/buffer.rs
@@ -21,16 +21,16 @@ pub struct Slice<'a, T> {
 pub type Buffer<'a> = Slice<'a, u8>;
 pub type BufferMut<'a> = Buffer<'a>;
 
-impl<'a, T> AsRef<[T]> for Slice<'a, T> {
+impl<T> AsRef<[T]> for Slice<'_, T> {
     #[inline]
-    fn as_ref(&self) -> &'a [T] {
+    fn as_ref(&self) -> &[T] {
         self.as_slice()
     }
 }
 
-impl<'a, T> AsMut<[T]> for Slice<'a, T> {
+impl<T> AsMut<[T]> for Slice<'_, T> {
     #[inline]
-    fn as_mut(&mut self) -> &'a mut [T] {
+    fn as_mut(&mut self) -> &mut [T] {
         self.as_mut_slice()
     }
 }
@@ -49,18 +49,18 @@ impl<'a, T> From<&'a mut [T]> for Slice<'a, T> {
     }
 }
 
-impl<'a, T> Deref for Slice<'a, T> {
+impl<T> Deref for Slice<'_, T> {
     type Target = [T];
 
     #[inline]
-    fn deref(&self) -> &'a Self::Target {
+    fn deref(&self) -> &Self::Target {
         self.as_slice()
     }
 }
 
-impl<'a, T> DerefMut for Slice<'a, T> {
+impl<T> DerefMut for Slice<'_, T> {
     #[inline]
-    fn deref_mut(&mut self) -> &'a mut Self::Target {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         self.as_mut_slice()
     }
 }
@@ -69,6 +69,9 @@ impl<'a> TryFrom<Buffer<'a>> for &'a str {
     type Error = Utf8Error;
 
     fn try_from(buf: Buffer<'a>) -> Result<Self, Self::Error> {
-        from_utf8(buf.as_slice())
+        // The descriptor is consumed by value, so the `'a` slice cannot alias a
+        // live borrow of `buf`. `into_slice` is the only path that hands out the
+        // full `'a` lifetime; the borrowing accessors stay tied to `self`.
+        from_utf8(buf.into_slice())
     }
 }

--- a/crates/sys/src/types/buffer/guest.rs
+++ b/crates/sys/src/types/buffer/guest.rs
@@ -29,14 +29,27 @@ impl<'a, T> Slice<'a, T> {
         self.len as usize
     }
 
+    // The borrowing accessors deliberately tie the returned slice to the borrow
+    // of `self`, NOT to `'a`. Returning `&'a`/`&'a mut` here would let safe SDK
+    // code mint two aliasing `&mut [T]` (two `as_mut` calls), or a `&[T]` and a
+    // `&mut [T]` over the same bytes (`as_ref` then `as_mut`) — instant UB. With
+    // the borrow tied to `self`, the borrow checker serialises those accesses.
     #[inline]
-    pub(crate) fn as_slice(&self) -> &'a [T] {
+    pub(crate) fn as_slice(&self) -> &[T] {
         unsafe { from_raw_parts(self.ptr.as_ptr(), self.len()) }
     }
 
     #[inline]
-    pub(crate) fn as_mut_slice(&mut self) -> &'a mut [T] {
+    pub(crate) fn as_mut_slice(&mut self) -> &mut [T] {
         unsafe { from_raw_parts_mut(self.ptr.as_mut_ptr(), self.len()) }
+    }
+
+    // Consumes the descriptor to yield the full-`'a` (shared, read-only) slice.
+    // Sound because it takes `self` by value and only ever hands out a shared
+    // reference — the one place that genuinely needs the `'a` lifetime.
+    #[inline]
+    pub(crate) fn into_slice(self) -> &'a [T] {
+        unsafe { from_raw_parts(self.ptr.as_ptr(), self.len()) }
     }
 }
 

--- a/crates/sys/src/types/buffer/guest.rs
+++ b/crates/sys/src/types/buffer/guest.rs
@@ -29,6 +29,12 @@ impl<'a, T> Slice<'a, T> {
         self.len as usize
     }
 
+    #[inline]
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
     // The borrowing accessors deliberately tie the returned slice to the borrow
     // of `self`, NOT to `'a`. Returning `&'a`/`&'a mut` here would let safe SDK
     // code mint two aliasing `&mut [T]` (two `as_mut` calls), or a `&[T]` and a
@@ -37,19 +43,28 @@ impl<'a, T> Slice<'a, T> {
     // serialises every access through the one live descriptor.
     #[inline]
     pub(crate) fn as_slice(&self) -> &[T] {
-        // SAFETY: a `Slice` is only ever constructed from a live `&[T]`/`&mut [T]`
-        // (`Slice::new`/`From`) or the empty/null descriptor, so `ptr` is non-null
-        // and valid for `len` elements; the returned borrow is tied to `self`, so
-        // it cannot outlive that backing storage.
+        // The empty descriptor (`Slice::empty`) carries a null `ptr`, and
+        // `from_raw_parts` is UB on a null pointer even for `len == 0`, so a
+        // zero-length slice returns the canonical empty slice without touching it.
+        if self.is_empty() {
+            return &[];
+        }
+        // SAFETY: a non-empty `Slice` is only ever constructed from a live
+        // `&[T]`/`&mut [T]` (`Slice::new`/`From`), so `ptr` is non-null and valid
+        // for `len` elements; the returned borrow is tied to `self`, so it cannot
+        // outlive that backing storage.
         unsafe { from_raw_parts(self.ptr.as_ptr(), self.len()) }
     }
 
     #[inline]
     pub(crate) fn as_mut_slice(&mut self) -> &mut [T] {
-        // SAFETY: as in `as_slice`, `ptr` is valid for `len` elements; the
-        // descriptor was built from a `&mut [T]` so the bytes are uniquely owned,
-        // and `&mut self` (on a move-only `Slice`) guarantees this is the only
-        // live handle, so the returned `&mut` does not alias.
+        if self.is_empty() {
+            return &mut [];
+        }
+        // SAFETY: as in `as_slice`, `ptr` is non-null and valid for `len`
+        // elements; the descriptor was built from a `&mut [T]` so the bytes are
+        // uniquely owned, and `&mut self` (on a move-only `Slice`) guarantees this
+        // is the only live handle, so the returned `&mut` does not alias.
         unsafe { from_raw_parts_mut(self.ptr.as_mut_ptr(), self.len()) }
     }
 
@@ -59,8 +74,12 @@ impl<'a, T> Slice<'a, T> {
     // out — the one place that genuinely needs the `'a` lifetime.
     #[inline]
     pub(crate) fn into_slice(self) -> &'a [T] {
-        // SAFETY: same validity invariant as `as_slice`; `self` is consumed, so
-        // the `'a` borrow it yields cannot coexist with any other handle.
+        if self.is_empty() {
+            return &[];
+        }
+        // SAFETY: same validity invariant as `as_slice` (non-null, valid for
+        // `len`); `self` is consumed, so the `'a` borrow it yields cannot coexist
+        // with any other handle.
         unsafe { from_raw_parts(self.ptr.as_ptr(), self.len()) }
     }
 }

--- a/crates/sys/src/types/buffer/guest.rs
+++ b/crates/sys/src/types/buffer/guest.rs
@@ -33,22 +33,34 @@ impl<'a, T> Slice<'a, T> {
     // of `self`, NOT to `'a`. Returning `&'a`/`&'a mut` here would let safe SDK
     // code mint two aliasing `&mut [T]` (two `as_mut` calls), or a `&[T]` and a
     // `&mut [T]` over the same bytes (`as_ref` then `as_mut`) — instant UB. With
-    // the borrow tied to `self`, the borrow checker serialises those accesses.
+    // the borrow tied to `self` AND `Slice` being move-only, the borrow checker
+    // serialises every access through the one live descriptor.
     #[inline]
     pub(crate) fn as_slice(&self) -> &[T] {
+        // SAFETY: a `Slice` is only ever constructed from a live `&[T]`/`&mut [T]`
+        // (`Slice::new`/`From`) or the empty/null descriptor, so `ptr` is non-null
+        // and valid for `len` elements; the returned borrow is tied to `self`, so
+        // it cannot outlive that backing storage.
         unsafe { from_raw_parts(self.ptr.as_ptr(), self.len()) }
     }
 
     #[inline]
     pub(crate) fn as_mut_slice(&mut self) -> &mut [T] {
+        // SAFETY: as in `as_slice`, `ptr` is valid for `len` elements; the
+        // descriptor was built from a `&mut [T]` so the bytes are uniquely owned,
+        // and `&mut self` (on a move-only `Slice`) guarantees this is the only
+        // live handle, so the returned `&mut` does not alias.
         unsafe { from_raw_parts_mut(self.ptr.as_mut_ptr(), self.len()) }
     }
 
     // Consumes the descriptor to yield the full-`'a` (shared, read-only) slice.
-    // Sound because it takes `self` by value and only ever hands out a shared
-    // reference — the one place that genuinely needs the `'a` lifetime.
+    // Sound because `Slice` is move-only: taking `self` by value leaves no other
+    // live descriptor over the same memory, and only a shared reference is handed
+    // out — the one place that genuinely needs the `'a` lifetime.
     #[inline]
     pub(crate) fn into_slice(self) -> &'a [T] {
+        // SAFETY: same validity invariant as `as_slice`; `self` is consumed, so
+        // the `'a` borrow it yields cannot coexist with any other handle.
         unsafe { from_raw_parts(self.ptr.as_ptr(), self.len()) }
     }
 }

--- a/crates/sys/src/types/buffer/host.rs
+++ b/crates/sys/src/types/buffer/host.rs
@@ -29,12 +29,17 @@ impl<'a, T> Slice<'a, T> {
     }
 
     #[inline]
-    pub(crate) fn as_slice(&self) -> &'a [T] {
+    pub(crate) fn as_slice(&self) -> &[T] {
         unimplemented!("Slice construction is only permitted in wasm32")
     }
 
     #[inline]
-    pub(crate) fn as_mut_slice(&mut self) -> &'a mut [T] {
+    pub(crate) fn as_mut_slice(&mut self) -> &mut [T] {
+        unimplemented!("Slice construction is only permitted in wasm32")
+    }
+
+    #[inline]
+    pub(crate) fn into_slice(self) -> &'a [T] {
         unimplemented!("Slice construction is only permitted in wasm32")
     }
 }

--- a/crates/sys/src/types/event/guest.rs
+++ b/crates/sys/src/types/event/guest.rs
@@ -13,7 +13,7 @@ impl<'a> Event<'a> {
     #[inline]
     pub fn kind(&self) -> &str {
         self.kind
-            .try_into()
+            .as_str()
             .expect("this should always be a valid utf8 string") // todo! test if this pulls in format code
     }
 

--- a/crates/sys/src/types/location/guest.rs
+++ b/crates/sys/src/types/location/guest.rs
@@ -22,7 +22,7 @@ impl Location<'_> {
     #[inline]
     pub fn file(&self) -> &str {
         self.file
-            .try_into()
+            .as_str()
             .expect("this should always be a valid utf8 string") // todo! test if this pulls in format code
     }
 }

--- a/crates/sys/src/types/location/host.rs
+++ b/crates/sys/src/types/location/host.rs
@@ -1,7 +1,7 @@
 use core::panic;
 
 use super::Location;
-use crate::Slice;
+use crate::Buffer;
 
 impl Location<'_> {
     #[inline]
@@ -22,9 +22,11 @@ impl Location<'_> {
         unimplemented!("Slice construction is only permitted in wasm32")
     }
 
+    // Returns a borrow (not an owned descriptor): `Slice` is move-only, so the
+    // field cannot be copied out of `&self`.
     #[inline]
-    pub fn file(&self) -> Slice<'_, u8> {
-        self.file
+    pub fn file(&self) -> &Buffer<'_> {
+        &self.file
     }
 }
 

--- a/crates/sys/src/types/xcall/guest.rs
+++ b/crates/sys/src/types/xcall/guest.rs
@@ -21,7 +21,7 @@ impl<'a> XCall<'a> {
     #[inline]
     pub fn function(&self) -> &str {
         self.function
-            .try_into()
+            .as_str()
             .expect("function should always be a valid utf8 string")
     }
 

--- a/crates/wasm-abi/src/embed.rs
+++ b/crates/wasm-abi/src/embed.rs
@@ -37,6 +37,13 @@ impl std::error::Error for EmbedError {
 /// Read the embedded state-schema `Manifest`, or `None` if the section is absent
 /// or malformed (drives fail-open at the upgrade gate).
 ///
+/// Note: a section tagged with an unsupported *future* major (`wasm-abi/2`)
+/// fails `validate_manifest` and is therefore also read as `None` here — i.e. it
+/// fails open like an absent section. Distinguishing "schema present but from a
+/// newer toolchain" from "no schema" at the downgrade gate would require
+/// threading [`crate::validate::ValidationError::UnsupportedSchemaVersion`] up
+/// to the caller and is intentionally left to a focused change on that gate.
+///
 /// Returns the *last* parseable `calimero_abi_v1` section. The writer emits
 /// exactly one (appended last), so this is normally unambiguous; on the off
 /// chance a stale earlier section co-exists, last-wins matches the writer's

--- a/crates/wasm-abi/src/validate.rs
+++ b/crates/wasm-abi/src/validate.rs
@@ -5,11 +5,32 @@ use crate::schema::{
     Variant,
 };
 
+/// The `schema_version` tag prefix every manifest carries.
+const SCHEMA_PREFIX: &str = "wasm-abi/";
+
+/// The ABI schema major version this build understands. A manifest tagged with
+/// this major (any minor) validates; a *different* major is a known-but-
+/// unsupported schema, surfaced distinctly from a tag that isn't a
+/// `wasm-abi/<major>` string at all. Matching the major (rather than the whole
+/// `"wasm-abi/1"` string) means a forward-compatible minor bump (`wasm-abi/1.1`)
+/// still validates instead of being silently rejected as "no schema".
+const SUPPORTED_SCHEMA_MAJOR: u32 = 1;
+
+/// Parse the major version out of a `wasm-abi/<major>[.<minor>]` tag. `None` if
+/// the string lacks the prefix or the major isn't an integer.
+fn schema_major(version: &str) -> Option<u32> {
+    let rest = version.strip_prefix(SCHEMA_PREFIX)?;
+    let major = rest.split('.').next().unwrap_or(rest);
+    major.parse::<u32>().ok()
+}
+
 /// Validation error types
 #[derive(Debug, thiserror::Error)]
 pub enum ValidationError {
     #[error("invalid schema version: {0}")]
     InvalidSchemaVersion(String),
+    #[error("unsupported schema major version: {0} (this build understands wasm-abi/{SUPPORTED_SCHEMA_MAJOR})")]
+    UnsupportedSchemaVersion(String),
     #[error("invalid type reference: {ref_name} at {path}")]
     InvalidTypeReference { ref_name: String, path: String },
     #[error("invalid bytes size: {size} at {path}")]
@@ -24,11 +45,22 @@ pub enum ValidationError {
 
 /// Validate a manifest
 pub fn validate_manifest(manifest: &Manifest) -> Result<(), ValidationError> {
-    // Check schema version
-    if manifest.schema_version != "wasm-abi/1" {
-        return Err(ValidationError::InvalidSchemaVersion(
-            manifest.schema_version.clone(),
-        ));
+    // Check schema version by major. A future major (e.g. wasm-abi/2) is
+    // reported as `UnsupportedSchemaVersion` — distinct from a malformed tag —
+    // so callers can tell "schema present but from a newer toolchain" apart from
+    // "no/garbled schema" rather than collapsing both to a generic rejection.
+    match schema_major(&manifest.schema_version) {
+        Some(SUPPORTED_SCHEMA_MAJOR) => {}
+        Some(_) => {
+            return Err(ValidationError::UnsupportedSchemaVersion(
+                manifest.schema_version.clone(),
+            ));
+        }
+        None => {
+            return Err(ValidationError::InvalidSchemaVersion(
+                manifest.schema_version.clone(),
+            ));
+        }
     }
 
     // Check that methods are sorted
@@ -324,7 +356,42 @@ mod tests {
         let mut manifest = Manifest::new();
         manifest.schema_version = "invalid".to_owned();
 
-        assert!(validate_manifest(&manifest).is_err());
+        assert!(matches!(
+            validate_manifest(&manifest),
+            Err(ValidationError::InvalidSchemaVersion(_))
+        ));
+    }
+
+    #[test]
+    fn test_unsupported_future_major_is_distinct() {
+        let mut manifest = Manifest::new();
+        manifest.schema_version = "wasm-abi/2".to_owned();
+
+        // A well-formed tag from a newer toolchain is surfaced distinctly from a
+        // malformed one, so callers can treat "newer schema" ≠ "no schema".
+        assert!(matches!(
+            validate_manifest(&manifest),
+            Err(ValidationError::UnsupportedSchemaVersion(_))
+        ));
+    }
+
+    #[test]
+    fn test_forward_compatible_minor_accepted() {
+        let mut manifest = Manifest::new();
+        manifest.schema_version = "wasm-abi/1.3".to_owned();
+
+        // Same major, newer minor: still our schema, must validate.
+        assert!(validate_manifest(&manifest).is_ok());
+    }
+
+    #[test]
+    fn schema_major_parsing() {
+        assert_eq!(schema_major("wasm-abi/1"), Some(1));
+        assert_eq!(schema_major("wasm-abi/1.4"), Some(1));
+        assert_eq!(schema_major("wasm-abi/2"), Some(2));
+        assert_eq!(schema_major("wasm-abi/"), None);
+        assert_eq!(schema_major("nope/1"), None);
+        assert_eq!(schema_major("invalid"), None);
     }
 
     #[test]


### PR DESCRIPTION
A batch of correctness fixes across the ABI/SDK surface, each scoped and independently testable. Built in a dedicated worktree off `master`.

## Fixes

| Sev | Issue | Fix |
|---|---|---|
| **H** | `Buffer::as_mut_slice` returns a slice whose lifetime is decoupled from `&mut self` → two `as_mut` (or `as_ref`+`as_mut`) calls yield aliasing slices, reachable as UB from safe SDK code | Tie `as_slice`/`as_mut_slice` (and `AsRef`/`AsMut`/`Deref`/`DerefMut`) to the `self` borrow; add by-value `into_slice` for the one legitimate `'a` consumer (`TryFrom<Buffer> for &str`) |
| **M** | `Collection` derive Borsh, non-absolute paths, `panic!`/`.unwrap` on bad input | Symmetric zero-byte borsh documented as an invariant; `panic!`/`.expect` → spanned `compile_error!`; `std`/`core`/`Default` made absolute |
| **M** | state-field classification by token-string substring — `RateCounter` (⊃ `Counter`) and `Option<UnorderedMap<…>>` misclassified → wrong codegen / id divergence | Match the type's exact outer path-segment ident instead of a substring |
| **M** | Generated `#[no_mangle]` exports (`migrate_my_entries`, `count_my_pending`) not reserved → an app method of the same name produces a duplicate symbol | Reserve those exact export names → clear spanned diagnostic instead of a linker error |
| **M** | Event macro `Value` round-trip emits `b"null"` for unit variants and `.expect()` aborts the instance | Unit variants emit an empty payload; controlled `panic_str`; serde-driven `kind` retained (honours `#[serde(rename)]`) |
| **M** | `read_register` calls `set_len` before the host fills the buffer → uninitialized memory observable as init bytes | Zero-initialize with `vec![0; len]` |
| **L** | Unchecked `pos + klen`/`pos + vlen` in `decode_index_pairs` | `checked_add` |
| **L** | `u64 → usize` blob fd truncation on wasm32 | `blob_fd` helper guards the conversion (out-of-range → invalid-fd sentinel) |
| **L** | ABI schema version matched as exact string → an unknown future major reads as "no schema" | Match by major-version prefix; surface an unknown major distinctly as `UnsupportedSchemaVersion` |
| **L** | `app::emit!(())` panics the proc macro with an OOB index | Spanned `compile_error!` for 0- and 3+-element tuples |
| **L** | `role_from_invited_role` reimplemented in op-adapter | Single canonical `GroupMemberRole::from_invited_role`; both call sites delegate |

## Tests
New regression tests for field classification (`RateCounter`/`Option` exclusion), the event unit-variant payload, and ABI version handling. Full workspace `cargo check` clean; all affected suites green (storage, sdk, runtime, wasm-abi, sdk-macros, governance-store); `team-metrics-macro` + `blobs` example apps build for `wasm32`.

## Two deliberate scope decisions
- **storage-macros crate paths stay non-absolute.** The storage crate consumes its own derives via `use crate as calimero_storage`, so `::calimero_storage` breaks intra-crate expansion (`E0433`). The meaningful shadowing fix (`::std`/`::core`/`Default`) is applied; crate names stay on the self-alias form.
- **ABI fail-open at the downgrade gate left as-is.** `validate.rs` now distinguishes a future-major schema, but `read_embedded_state_schema` still returns `None` for it (fails open like an absent section). Threading `UnsupportedSchemaVersion` through the identity-downgrade gate in `upgrade_group.rs` is a security-semantics change that deserves its own focused review — documented inline rather than changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)