### PR TITLE
fix(soundness): close lint-suppressed hazards across storage/context/runtime

### DIFF
--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -112,12 +112,14 @@ pub struct RootSelfDump {
 /// and [`ContextRegistry::dump_root`] to decode the index without pulling
 /// in the full `calimero-storage` types (which would force a dep cycle).
 ///
-/// **SYNC NOTE**: When `calimero_storage::index::EntityIndex` or its
-/// transitively-borshed children change, update these mirrors *and*
-/// `calimero-storage/src/tests/index.rs::minimal_struct_layout_compat`.
-/// A missed update produces silent misdeserialization on a diagnostic
-/// path that fires only during rare divergence events — exactly when
-/// correct output matters most.
+/// **SYNC NOTE**: These structs mirror the canonical types by hand. The
+/// [`borsh_layout_round_trip`] test module below serialises the *real*
+/// `calimero_storage` types and decodes them through these mirrors, so a
+/// field-type or field-order drift fails the test run rather than silently
+/// misdeserialising on the rare divergence-diagnostic path (which is exactly
+/// when correct output matters most). When you change `EntityIndex` or its
+/// borshed children, update these mirrors; the test will flag a child layout
+/// that drifted.
 mod borsh_layout {
     use borsh::BorshDeserialize;
     use calimero_primitives::crdt::CrdtType;
@@ -189,6 +191,162 @@ mod borsh_layout {
         pub(super) signature: [u8; 64],
         pub(super) nonce: u64,
         pub(super) signer: Option<[u8; 32]>,
+    }
+}
+
+/// Mechanically guards the hand-written mirrors in [`borsh_layout`] against
+/// silent drift from the canonical `calimero_storage` types. The mirrors decode
+/// `EntityIndex` on a rare diagnostic path, so a layout mismatch would
+/// mis-deserialise precisely during divergence events. Each test serialises a
+/// *real* `ChildInfo` (the drift-prone, previously-broken part: its embedded
+/// `Metadata`/`StorageType`/`SignatureData`) with borsh and decodes it through
+/// the production mirror, asserting the bytes round-trip and are fully consumed.
+#[cfg(test)]
+mod borsh_layout_round_trip {
+    use std::collections::BTreeMap;
+
+    use borsh::BorshDeserialize;
+    use calimero_primitives::crdt::CrdtType;
+    use calimero_primitives::identity::PublicKey;
+    use calimero_storage::address::Id;
+    use calimero_storage::entities::{ChildInfo, Metadata, OpMask, SignatureData, StorageType};
+
+    use super::borsh_layout;
+
+    fn metadata_with(storage_type: StorageType) -> Metadata {
+        let mut md = Metadata::new(1000, 2000);
+        md.storage_type = storage_type;
+        md.crdt_type = Some(CrdtType::LwwRegister {
+            inner_type: "u64".to_owned(),
+        });
+        md.field_name = Some("field".to_owned());
+        md.schema_version = Some(7);
+        md
+    }
+
+    /// Serialise a canonical `ChildInfo` carrying `storage_type` and decode it
+    /// through the production mirror. Asserts the scalar fields survive and the
+    /// whole byte stream is consumed — a width/order drift either errors or
+    /// leaves trailing bytes.
+    fn round_trip(storage_type: StorageType) -> borsh_layout::ChildInfo {
+        let id = [0xAB; 32];
+        let merkle_hash = [0xCD; 32];
+        let child = ChildInfo::new(Id::new(id), merkle_hash, metadata_with(storage_type));
+
+        let bytes = borsh::to_vec(&child).expect("serialize canonical ChildInfo");
+        let mut reader: &[u8] = &bytes;
+        let decoded = borsh_layout::ChildInfo::deserialize_reader(&mut reader)
+            .expect("mirror failed to decode canonical ChildInfo — borsh layout drifted");
+        assert!(
+            reader.is_empty(),
+            "mirror left {} trailing byte(s) — borsh layout drifted",
+            reader.len()
+        );
+
+        assert_eq!(decoded.id, id);
+        assert_eq!(decoded.merkle_hash, merkle_hash);
+        assert_eq!(decoded.metadata.created_at, 1000);
+        assert_eq!(decoded.metadata.updated_at, 2000);
+        assert_eq!(decoded.metadata.field_name.as_deref(), Some("field"));
+        assert_eq!(decoded.metadata.schema_version, Some(7));
+        decoded
+    }
+
+    #[test]
+    fn public_round_trips() {
+        let decoded = round_trip(StorageType::Public);
+        assert!(matches!(
+            decoded.metadata.storage_type,
+            borsh_layout::StorageType::Public
+        ));
+    }
+
+    #[test]
+    fn frozen_round_trips() {
+        let decoded = round_trip(StorageType::Frozen);
+        assert!(matches!(
+            decoded.metadata.storage_type,
+            borsh_layout::StorageType::Frozen
+        ));
+    }
+
+    #[test]
+    fn user_round_trips() {
+        let owner = [0x11; 32];
+        let decoded = round_trip(StorageType::User {
+            owner: PublicKey::from(owner),
+            signature_data: Some(SignatureData {
+                signature: [0x22; 64],
+                nonce: 42,
+                signer: Some(PublicKey::from([0x33; 32])),
+            }),
+        });
+        match decoded.metadata.storage_type {
+            borsh_layout::StorageType::User {
+                owner: decoded_owner,
+                signature_data,
+            } => {
+                assert_eq!(decoded_owner, owner);
+                let sig = signature_data.expect("signature_data present");
+                assert_eq!(sig.nonce, 42);
+                assert_eq!(sig.signer, Some([0x33; 32]));
+            }
+            _ => panic!("expected User variant"),
+        }
+    }
+
+    #[test]
+    fn shared_writers_map_round_trips() {
+        // Previously-broken case: `writers` is `BTreeMap<PublicKey, OpMask>`
+        // (32-byte key + 1-byte mask), not `BTreeSet<[u8; 32]>`. A set-shaped
+        // mirror under-reads one byte per writer and misaligns everything after.
+        let mut writers: BTreeMap<PublicKey, OpMask> = BTreeMap::new();
+        let _ = writers.insert(PublicKey::from([0x44; 32]), OpMask::FULL);
+        let _ = writers.insert(PublicKey::from([0x55; 32]), OpMask::WRITE);
+
+        let decoded = round_trip(StorageType::Shared {
+            writers,
+            signature_data: None,
+        });
+        match decoded.metadata.storage_type {
+            borsh_layout::StorageType::Shared {
+                writers: decoded_writers,
+                signature_data,
+            } => {
+                assert_eq!(decoded_writers.len(), 2);
+                assert_eq!(
+                    decoded_writers.get(&[0x44; 32]).copied(),
+                    Some(OpMask::FULL.bits())
+                );
+                assert_eq!(
+                    decoded_writers.get(&[0x55; 32]).copied(),
+                    Some(OpMask::WRITE.bits())
+                );
+                assert!(signature_data.is_none());
+            }
+            _ => panic!("expected Shared variant"),
+        }
+    }
+
+    #[test]
+    fn shared_member_round_trips() {
+        // Previously-broken case: the mirror was missing this variant entirely,
+        // so any root with a member child failed to decode (cold-join failure).
+        let anchor = [0x66; 32];
+        let decoded = round_trip(StorageType::SharedMember {
+            anchor: Id::new(anchor),
+            signature_data: None,
+        });
+        match decoded.metadata.storage_type {
+            borsh_layout::StorageType::SharedMember {
+                anchor: decoded_anchor,
+                signature_data,
+            } => {
+                assert_eq!(decoded_anchor, anchor);
+                assert!(signature_data.is_none());
+            }
+            _ => panic!("expected SharedMember variant"),
+        }
     }
 }
 

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -249,6 +249,14 @@ mod borsh_layout_round_trip {
         assert_eq!(decoded.metadata.updated_at, 2000);
         assert_eq!(decoded.metadata.field_name.as_deref(), Some("field"));
         assert_eq!(decoded.metadata.schema_version, Some(7));
+        // The mirror decodes `crdt_type` as the canonical `CrdtType`, so this
+        // also guards the `CrdtType` borsh layout against drift.
+        assert_eq!(
+            decoded.metadata.crdt_type,
+            Some(CrdtType::LwwRegister {
+                inner_type: "u64".to_owned()
+            })
+        );
         decoded
     }
 

--- a/crates/context/src/handlers/execute/storage.rs
+++ b/crates/context/src/handlers/execute/storage.rs
@@ -2,6 +2,7 @@
 
 use core::cell::RefCell;
 use core::mem;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use calimero_primitives::context::ContextId;
@@ -27,8 +28,14 @@ pub struct ContextStorage {
     #[covariant]
     #[borrows(mut store)]
     inner: Temporal<'this, 'static, Store>,
-    // todo! unideal, will revisit the shape of WriteLayer to own keys (since they are now fixed-sized)
-    keys: RefCell<Vec<Arc<key::ContextState>>>,
+    // Interned state keys, keyed by their padded 32-byte form. The temporal
+    // layer above borrows keys with a `'static` lifetime (see `state_key`), so
+    // their backing allocations must live as long as `Self` and cannot be
+    // cleared mid-life. Interning bounds this to one `Arc` per *distinct* key
+    // rather than one per storage operation (which previously grew unbounded
+    // for read-heavy contexts).
+    // todo! revisit the shape of WriteLayer to own keys (since they are now fixed-sized)
+    keys: RefCell<HashMap<[u8; 32], Arc<key::ContextState>>>,
 }
 
 /// The exclusive upper bound for a byte prefix (smallest key not starting with
@@ -57,7 +64,9 @@ pub struct ContextPrivateStorage {
     #[covariant]
     #[borrows(mut store)]
     inner: Temporal<'this, 'static, Store>,
-    keys: RefCell<Vec<Arc<key::ContextPrivateState>>>,
+    // Interned like `ContextStorage::keys` — bounded by distinct keys, not by
+    // operation count.
+    keys: RefCell<HashMap<[u8; 32], Arc<key::ContextPrivateState>>>,
 }
 
 // safety: ContextStorage is constructed exclusively for the runtime
@@ -113,15 +122,21 @@ impl ContextStorage {
 
         let context_id = self.borrow_context_id();
 
-        keys.push(Arc::new(key::ContextState::new(*context_id, state_key)));
+        // Intern by the padded 32-byte key. The context id is fixed for a given
+        // storage instance, so the key bytes alone identify the entry; repeated
+        // accesses reuse the same `Arc` instead of leaking a new one each call.
+        let interned = keys
+            .entry(state_key)
+            .or_insert_with(|| Arc::new(key::ContextState::new(*context_id, state_key)));
 
-        // safety: TemporalStore lives as long as Self, so the reference will hold
-        //         plus, we never return a reference to the keys externally
-        unsafe {
-            mem::transmute::<Option<&key::ContextState>, Option<&'static key::ContextState>>(
-                keys.last().map(|x| &**x),
-            )
-        }
+        // safety: the interned `Arc` lives in `self`'s `keys` map for as long as
+        //         `Self` (the temporal layer that borrows it is also a field of
+        //         `Self`), and its heap payload keeps a stable address across
+        //         later map inserts/rehashes. We never hand a key reference out
+        //         past `Self`.
+        Some(unsafe {
+            mem::transmute::<&key::ContextState, &'static key::ContextState>(&**interned)
+        })
     }
 
     pub fn commit(mut self) -> eyre::Result<Store> {
@@ -296,19 +311,20 @@ impl ContextPrivateStorage {
 
         let context_id = self.borrow_context_id();
 
-        keys.push(Arc::new(key::ContextPrivateState::new(
-            *context_id,
-            state_key,
-        )));
+        // Intern by the padded 32-byte key — see `ContextStorage::state_key`.
+        let interned = keys
+            .entry(state_key)
+            .or_insert_with(|| Arc::new(key::ContextPrivateState::new(*context_id, state_key)));
 
-        // safety: TemporalStore lives as long as Self, so the reference will hold
-        //         plus, we never return a reference to the keys externally
-        unsafe {
-            mem::transmute::<
-                Option<&key::ContextPrivateState>,
-                Option<&'static key::ContextPrivateState>,
-            >(keys.last().map(|x| &**x))
-        }
+        // safety: the interned `Arc` lives in `self`'s `keys` map for as long as
+        //         `Self`, and its heap payload keeps a stable address across
+        //         later map inserts/rehashes. We never hand a key reference out
+        //         past `Self`.
+        Some(unsafe {
+            mem::transmute::<&key::ContextPrivateState, &'static key::ContextPrivateState>(
+                &**interned,
+            )
+        })
     }
 
     pub fn commit(mut self) -> eyre::Result<Store> {

--- a/crates/context/src/handlers/execute/storage.rs
+++ b/crates/context/src/handlers/execute/storage.rs
@@ -132,8 +132,12 @@ impl ContextStorage {
         // safety: the interned `Arc` lives in `self`'s `keys` map for as long as
         //         `Self` (the temporal layer that borrows it is also a field of
         //         `Self`), and its heap payload keeps a stable address across
-        //         later map inserts/rehashes. We never hand a key reference out
-        //         past `Self`.
+        //         later map inserts/rehashes — taking the reference through the
+        //         `Arc` (`&**interned`), not into the `HashMap`, so a rehash does
+        //         not invalidate it. `Self` is an `ouroboros` self-referential
+        //         struct, so it is pinned in place: a move cannot invalidate the
+        //         temporal layer's borrow of these keys. We never hand a key
+        //         reference out past `Self`.
         Some(unsafe {
             mem::transmute::<&key::ContextState, &'static key::ContextState>(&**interned)
         })
@@ -316,10 +320,13 @@ impl ContextPrivateStorage {
             .entry(state_key)
             .or_insert_with(|| Arc::new(key::ContextPrivateState::new(*context_id, state_key)));
 
-        // safety: the interned `Arc` lives in `self`'s `keys` map for as long as
-        //         `Self`, and its heap payload keeps a stable address across
-        //         later map inserts/rehashes. We never hand a key reference out
-        //         past `Self`.
+        // safety: same as `ContextStorage::state_key` — the interned `Arc` lives
+        //         in `self`'s `keys` map for as long as `Self`, its heap payload
+        //         keeps a stable address across map rehashes (the reference goes
+        //         through the `Arc`, not the `HashMap`), and `Self` is an
+        //         `ouroboros`-pinned self-referential struct so a move cannot
+        //         invalidate the temporal layer's borrow. We never hand a key
+        //         reference out past `Self`.
         Some(unsafe {
             mem::transmute::<&key::ContextPrivateState, &'static key::ContextPrivateState>(
                 &**interned,

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -18,7 +18,6 @@
 //! `event!`) appears inside. Use explicit counters or eager
 //! instrumentation *outside* the hot path instead.
 #![allow(single_use_lifetimes, unused_lifetimes, reason = "False positive")]
-#![allow(clippy::mem_forget, reason = "Safe for now")]
 
 use core::mem::MaybeUninit;
 use core::num::NonZeroU64;
@@ -551,6 +550,13 @@ impl VMLogic<'_> {
 /// This structure is necessary to safely provide guest access to host functions,
 /// hold the reference to guest memory (`MemoryView`) simultaneously. The `ouroboros`
 /// crate ensures that the lifetimes are managed correctly.
+// ouroboros' generated constructor/`into_heads` glue calls `mem::forget`;
+// scope the lint allow to this one self-referential struct rather than blanket
+// it across the whole module (where any future genuine leak would slip by).
+#[allow(
+    clippy::mem_forget,
+    reason = "ouroboros-generated self-referential glue uses mem::forget"
+)]
 #[self_referencing]
 pub struct VMHostFunctions<'a> {
     logic: &'a mut VMLogic<'a>,
@@ -560,6 +566,47 @@ pub struct VMHostFunctions<'a> {
     #[borrows(store)]
     memory: wasmer::MemoryView<'this>,
 }
+
+/// Marker for types that may be reinterpreted from raw guest memory bytes by
+/// [`VMHostFunctions::read_guest_memory_typed`].
+///
+/// That function copies `size_of::<T>()` bytes out of guest linear memory and
+/// `assume_init`s them as a `T`, so a `T` whose validity depends on its bit
+/// pattern (a `bool`, a non-`#[repr(C)]` enum with niches, a `NonNull`, an
+/// `enum` discriminant the guest could set out of range) would be instant UB.
+/// This trait is the compile-time allow-list: only the fixed set of
+/// host/guest ABI descriptor types defined in `calimero-sys` may be read this
+/// way, so adding a `read_guest_memory_typed::<SomethingElse>()` call fails to
+/// compile rather than silently introducing UB.
+///
+/// `bytemuck::Pod` would be the natural bound but is inapplicable here: every
+/// ABI descriptor carries a lifetime (`Buffer<'a>`, …) so cannot be `'static`,
+/// and `ValueReturn` is a `#[repr(C, u64)]` enum — both are disqualifying for
+/// `Pod`.
+///
+/// # Safety
+///
+/// Implementors are part of the stable `calimero-sys` host/guest ABI: they are
+/// `#[repr(C)]`/`#[repr(C, u64)]`, contain only `u64`-shaped fields
+/// (pointers/lengths/discriminants), and the guest SDK writes a well-formed
+/// instance at the descriptor offset before passing it. Reading is still
+/// bounds-checked by the underlying memory access; this trait asserts only that
+/// the *layout* is ABI-stable, not that an adversarial guest cannot supply an
+/// out-of-range discriminant (that remains the ABI's existing trust assumption,
+/// unchanged here).
+pub(crate) unsafe trait GuestAbiType {}
+
+// The `calimero-sys` ABI descriptor types read out of guest memory. The
+// orphan rule permits these because `GuestAbiType` is local to this crate.
+// SAFETY: each is a `#[repr(C)]` ABI descriptor of `u64`-shaped fields per the
+//         shared host/guest contract in `calimero-sys`.
+// `sys::Buffer` and `sys::BufferMut` are both aliases of `sys::Slice<'_, u8>`,
+// so a single impl covers every buffer read.
+unsafe impl GuestAbiType for sys::Buffer<'_> {}
+unsafe impl GuestAbiType for sys::Event<'_> {}
+unsafe impl GuestAbiType for sys::Location<'_> {}
+unsafe impl GuestAbiType for sys::ValueReturn<'_> {}
+unsafe impl GuestAbiType for sys::XCall<'_> {}
 
 // Private helper functions for memory access.
 impl VMHostFunctions<'_> {
@@ -756,8 +803,13 @@ impl VMHostFunctions<'_> {
     /// 1. It reads raw bytes from guest memory and interprets them as type `T`. The caller
     ///    must ensure that the bytes at `ptr` represent a valid instance of `T`.
     /// 2. It relies on `ptr` being a valid, aligned pointer within the guest memory.
+    ///
+    /// The `T: GuestAbiType` bound restricts `T` to the vetted `calimero-sys`
+    /// ABI descriptor types whose layout is valid to reinterpret from raw guest
+    /// bytes — see [`GuestAbiType`]. Without it, an `assume_init` of a type with
+    /// bit-pattern validity requirements would be UB.
     //TODO: refactor to use `sys::Buffer` instead of `ptr`.
-    unsafe fn read_guest_memory_typed<T>(&self, ptr: u64) -> VMLogicResult<T> {
+    unsafe fn read_guest_memory_typed<T: GuestAbiType>(&self, ptr: u64) -> VMLogicResult<T> {
         let mut value = MaybeUninit::<T>::uninit();
 
         let raw = slice::from_raw_parts_mut(value.as_mut_ptr().cast::<u8>(), size_of::<T>());

--- a/crates/runtime/src/logic/host_functions/blobs.rs
+++ b/crates/runtime/src/logic/host_functions/blobs.rs
@@ -146,6 +146,10 @@ impl VMHostFunctions<'_> {
     /// * `HostError::InvalidBlobHandle` if the `fd` is invalid or not a write handle.
     /// * `HostError::BlobWriteTooLarge` if the data chunk exceeds `max_blob_chunk_size`.
     pub fn blob_write(&mut self, fd: u64, src_data_ptr: u64) -> VMLogicResult<u64> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let data = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_data_ptr)? };
         let data_len = data.len();
 
@@ -218,6 +222,10 @@ impl VMHostFunctions<'_> {
     /// * `HostError::InvalidBlobHandle` if the `fd` is invalid.
     /// * `HostError::BlobsNotSupported` if the node client is not supported or upload operation fails.
     pub fn blob_close(&mut self, fd: u64, dest_blob_id_ptr: u64) -> VMLogicResult<u32> {
+        // SAFETY: `sys::BufferMut<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let guest_blob_id_ptr =
             unsafe { self.read_guest_memory_typed::<sys::BufferMut<'_>>(dest_blob_id_ptr)? };
 
@@ -291,7 +299,15 @@ impl VMHostFunctions<'_> {
             None => return Err(VMLogicError::HostError(HostError::BlobsNotSupported)),
         };
 
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let blob_id = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_blob_id_ptr)? };
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let context_id =
             unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_context_id_ptr)? };
 
@@ -335,6 +351,10 @@ impl VMHostFunctions<'_> {
     /// * `HostError::TooManyBlobHandles` if the maximum number of handles is exceeded.
     /// * `HostError::InvalidMemoryAccess` if memory access fails for a descriptor buffer.
     pub fn blob_open(&mut self, src_blob_id_ptr: u64) -> VMLogicResult<u64> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let blob_id = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_blob_id_ptr)? };
 
         if self.borrow_logic().node_client.is_none() {
@@ -403,6 +423,10 @@ impl VMHostFunctions<'_> {
     /// * `HostError::BlobBufferTooLarge` if the guest buffer exceeds `max_blob_chunk_size`.
     /// * `HostError::InvalidMemoryAccess` if memory access fails for a descriptor buffer.
     pub fn blob_read(&mut self, fd: u64, dest_data_ptr: u64) -> VMLogicResult<u64> {
+        // SAFETY: `sys::BufferMut<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let dest_data =
             unsafe { self.read_guest_memory_typed::<sys::BufferMut<'_>>(dest_data_ptr)? };
         let data_len = dest_data.len();

--- a/crates/runtime/src/logic/host_functions/js_collections.rs
+++ b/crates/runtime/src/logic/host_functions/js_collections.rs
@@ -1375,6 +1375,10 @@ impl VMHostFunctions<'_> {
     }
 
     fn read_map_id(&mut self, map_id_ptr: u64) -> VMLogicResult<Result<Id, String>> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let buffer = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(map_id_ptr)? };
         let data = self.read_guest_memory_slice(&buffer)?;
 
@@ -1392,6 +1396,10 @@ impl VMHostFunctions<'_> {
     }
 
     fn read_buffer(&mut self, ptr: u64) -> VMLogicResult<Vec<u8>> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let buffer = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(ptr)? };
         Ok(self.read_guest_memory_slice(&buffer)?.to_vec())
     }

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -25,6 +25,10 @@ impl VMHostFunctions<'_> {
     /// * `HostError::KeyLengthOverflow` if the key size exceeds the configured limit.
     /// * `HostError::InvalidMemoryAccess` if memory access fails for a descriptor buffer.
     pub fn storage_read(&mut self, src_key_ptr: u64, dest_register_id: u64) -> VMLogicResult<u32> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let key = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_key_ptr)? };
 
         let logic = self.borrow_logic();
@@ -95,6 +99,10 @@ impl VMHostFunctions<'_> {
         src_key_ptr: u64,
         dest_register_id: u64,
     ) -> VMLogicResult<u32> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let key = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_key_ptr)? };
 
         let logic = self.borrow_logic();
@@ -171,7 +179,15 @@ impl VMHostFunctions<'_> {
         src_value_ptr: u64,
         dest_register_id: u64,
     ) -> VMLogicResult<u32> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let key = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_key_ptr)? };
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let value = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_value_ptr)? };
 
         let logic = self.borrow_logic();
@@ -249,6 +265,10 @@ impl VMHostFunctions<'_> {
         src_key_ptr: u64,
         dest_register_id: u64,
     ) -> VMLogicResult<u32> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let key = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_key_ptr)? };
 
         let logic = self.borrow_logic();
@@ -323,6 +343,10 @@ impl VMHostFunctions<'_> {
         src_key_ptr: u64,
         dest_register_id: u64,
     ) -> VMLogicResult<u32> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let key = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_key_ptr)? };
 
         let logic = self.borrow_logic();
@@ -394,7 +418,15 @@ impl VMHostFunctions<'_> {
         src_key_ptr: u64,
         src_value_ptr: u64,
     ) -> VMLogicResult<u32> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let key = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_key_ptr)? };
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let value = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_value_ptr)? };
 
         let logic = self.borrow_logic();
@@ -458,7 +490,15 @@ impl VMHostFunctions<'_> {
     /// write was persisted, `0` otherwise (so the guest can skip stamping its
     /// index-validity marker and rebuild instead).
     pub fn storage_index_set(&mut self, key_ptr: u64, value_ptr: u64) -> VMLogicResult<u32> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let key = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(key_ptr)? };
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let value = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(value_ptr)? };
         // Bound guest-supplied sizes like `storage_write` does, so a buggy/hostile
         // guest can't drive unbounded host allocation through the index path.
@@ -478,6 +518,10 @@ impl VMHostFunctions<'_> {
 
     /// Remove `key` from the ordered index. Returns `1` if persisted, else `0`.
     pub fn storage_index_remove(&mut self, key_ptr: u64) -> VMLogicResult<u32> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let key = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(key_ptr)? };
         if key.len() > self.borrow_logic().limits.max_storage_key_size.get() {
             return Err(HostError::KeyLengthOverflow.into());
@@ -491,6 +535,10 @@ impl VMHostFunctions<'_> {
     /// Remove every ordered-index key beginning with `prefix`. Returns `1` if
     /// persisted, else `0`.
     pub fn storage_index_remove_prefix(&mut self, prefix_ptr: u64) -> VMLogicResult<u32> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let prefix = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(prefix_ptr)? };
         if prefix.len() > self.borrow_logic().limits.max_storage_key_size.get() {
             return Err(HostError::KeyLengthOverflow.into());
@@ -515,7 +563,15 @@ impl VMHostFunctions<'_> {
         limit: u64,
         register_id: u64,
     ) -> VMLogicResult<u32> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let lo = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(lo_ptr)? };
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let hi = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(hi_ptr)? };
         // The bounds are index keys; cap them like any other storage key.
         let max_key = self.borrow_logic().limits.max_storage_key_size.get();
@@ -557,7 +613,15 @@ impl VMHostFunctions<'_> {
         hi_ptr: u64,
         register_id: u64,
     ) -> VMLogicResult<u32> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let lo = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(lo_ptr)? };
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let hi = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(hi_ptr)? };
         let max_key = self.borrow_logic().limits.max_storage_key_size.get();
         if lo.len() > max_key || hi.len() > max_key {

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -184,6 +184,10 @@ impl VMHostFunctions<'_> {
     /// * `HostError::Panic` if the panic action was successfully executed.
     /// * `HostError::InvalidMemoryAccess` if memory access fails for a descriptor buffer.
     pub fn panic(&mut self, src_location_ptr: u64) -> VMLogicResult<()> {
+        // SAFETY: `sys::Location<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let location =
             unsafe { self.read_guest_memory_typed::<sys::Location<'_>>(src_location_ptr)? };
 
@@ -234,8 +238,16 @@ impl VMHostFunctions<'_> {
             src_location_ptr,
             "panic_utf8 invoked"
         );
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let panic_message_buf =
             unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_panic_msg_ptr)? };
+        // SAFETY: `sys::Location<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let location =
             unsafe { self.read_guest_memory_typed::<sys::Location<'_>>(src_location_ptr)? };
 
@@ -306,6 +318,10 @@ impl VMHostFunctions<'_> {
     /// * `HostError::InvalidRegisterId` if the register does not exist.
     /// * `HostError::InvalidMemoryAccess` if memory access fails for a descriptor buffer.
     pub fn read_register(&self, register_id: u64, dest_data_ptr: u64) -> VMLogicResult<u32> {
+        // SAFETY: `sys::BufferMut<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let dest_data =
             unsafe { self.read_guest_memory_typed::<sys::BufferMut<'_>>(dest_data_ptr)? };
 
@@ -508,6 +524,10 @@ impl VMHostFunctions<'_> {
     ///
     /// * `HostError::InvalidMemoryAccess` if memory access fails for descriptor buffers.
     pub fn value_return(&mut self, src_value_ptr: u64) -> VMLogicResult<()> {
+        // SAFETY: `sys::ValueReturn<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let result =
             unsafe { self.read_guest_memory_typed::<sys::ValueReturn<'_>>(src_value_ptr)? };
 
@@ -548,6 +568,10 @@ impl VMHostFunctions<'_> {
     /// * `HostError::ValueLengthOverflow` if the witness exceeds the value-size limit.
     /// * `HostError::InvalidMemoryAccess` if memory access fails for the buffer descriptor.
     pub fn emit_migration_witness(&mut self, src_ptr: u64) -> VMLogicResult<()> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let src_buf = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_ptr)? };
         let bytes = self.read_guest_memory_slice(&src_buf)?.to_vec();
 
@@ -588,6 +612,10 @@ impl VMHostFunctions<'_> {
             "log_utf8 invoked"
         );
 
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let src_log_buf =
             match unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_log_ptr) } {
                 Ok(buf) => buf,
@@ -660,6 +688,10 @@ impl VMHostFunctions<'_> {
     /// * `HostError::EventsOverflow` if the maximum number of events has been reached.
     /// * `HostError::InvalidMemoryAccess` if memory access fails for descriptor buffers.
     pub fn emit(&mut self, src_event_ptr: u64) -> VMLogicResult<()> {
+        // SAFETY: `sys::Event<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let event = unsafe { self.read_guest_memory_typed::<sys::Event<'_>>(src_event_ptr)? };
 
         let kind_len = event.kind().len();
@@ -732,6 +764,10 @@ impl VMHostFunctions<'_> {
         src_event_ptr: u64,
         src_handler_ptr: u64,
     ) -> VMLogicResult<()> {
+        // SAFETY: `sys::Event<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let event = unsafe { self.read_guest_memory_typed::<sys::Event<'_>>(src_event_ptr)? };
 
         let kind_len = event.kind().len();
@@ -761,6 +797,10 @@ impl VMHostFunctions<'_> {
             None
         } else {
             // Read the handler buffer from guest memory
+            // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+            //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+            //         it is sound; the guest SDK wrote a well-formed instance at this
+            //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
             let handler_buffer =
                 unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_handler_ptr)? };
             match self.read_guest_memory_str(&handler_buffer) {
@@ -800,6 +840,10 @@ impl VMHostFunctions<'_> {
     /// * `HostError::XCallsOverflow` if the maximum number of xcalls has been reached.
     /// * `HostError::InvalidMemoryAccess` if memory access fails for descriptor buffers.
     pub fn xcall(&mut self, src_xcall_ptr: u64) -> VMLogicResult<()> {
+        // SAFETY: `sys::XCall<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let xcall = unsafe { self.read_guest_memory_typed::<sys::XCall<'_>>(src_xcall_ptr)? };
 
         let function_len = xcall.function().len();
@@ -859,8 +903,16 @@ impl VMHostFunctions<'_> {
     ///   access fails for descriptor buffers.
     /// * `HostError::ArtifactSizeOverflow` if the artifact exceeds `max_artifact_size`.
     pub fn commit(&mut self, src_root_hash_ptr: u64, src_artifact_ptr: u64) -> VMLogicResult<()> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let root_hash =
             unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_root_hash_ptr)? };
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let artifact =
             unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_artifact_ptr)? };
 
@@ -908,6 +960,10 @@ impl VMHostFunctions<'_> {
         created_at: u64,
         updated_at: u64,
     ) -> VMLogicResult<()> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let buffer = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_doc_ptr)? };
         let payload = self.read_guest_memory_slice(&buffer)?.to_vec();
 
@@ -1021,6 +1077,10 @@ impl VMHostFunctions<'_> {
     /// will deserialize the actions and feed them into the storage interface so that
     /// CRDT entities and the root document are updated atomically.
     pub fn apply_storage_delta(&mut self, src_delta_ptr: u64) -> VMLogicResult<()> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let buffer = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_delta_ptr)? };
         let payload = self.read_guest_memory_slice(&buffer)?.to_vec();
         let delta_len = payload.len();

--- a/crates/runtime/src/logic/host_functions/utility.rs
+++ b/crates/runtime/src/logic/host_functions/utility.rs
@@ -68,9 +68,25 @@ impl VMHostFunctions<'_> {
             return Ok(1);
         }
 
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let url = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_url_ptr)? };
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let method = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_method_ptr)? };
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let headers = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_headers_ptr)? };
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let body = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_body_ptr)? };
 
         let url = self.read_guest_memory_str(&url)?;
@@ -123,6 +139,10 @@ impl VMHostFunctions<'_> {
     ///
     /// * `HostError::InvalidMemoryAccess` if memory access fails for a descriptor buffer.
     pub fn random_bytes(&mut self, dest_ptr: u64) -> VMLogicResult<()> {
+        // SAFETY: `sys::BufferMut<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let dest_buf = unsafe { self.read_guest_memory_typed::<sys::BufferMut<'_>>(dest_ptr)? };
 
         // Validate the destination bounds before allocating a buffer sized from
@@ -163,6 +183,10 @@ impl VMHostFunctions<'_> {
         reason = "Effectively infallible here"
     )]
     pub fn time_now(&mut self, dest_ptr: u64) -> VMLogicResult<()> {
+        // SAFETY: `sys::BufferMut<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let guest_time_ptr =
             unsafe { self.read_guest_memory_typed::<sys::BufferMut<'_>>(dest_ptr)? };
 
@@ -206,10 +230,22 @@ impl VMHostFunctions<'_> {
         src_message_ptr: u64,
     ) -> VMLogicResult<u32> {
         // Read buffer descriptors from guest memory
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let signature_buf =
             unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_signature_ptr)? };
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let public_key_buf =
             unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_public_key_ptr)? };
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
         let message_buf =
             unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_message_ptr)? };
 

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -1,6 +1,7 @@
 //! High-level data structures for storage.
 
 use core::cell::RefCell;
+use core::cmp::Ordering;
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
 use core::{fmt, ptr};
@@ -980,38 +981,93 @@ where
     }
 }
 
+/// Total equality over two fallible collection reads.
+///
+/// `PartialEq`/`Ord`/`Debug` on these collections have to read from the
+/// store, which can fail. The impls used to `.unwrap()` that read and panic
+/// mid-comparison — e.g. inside a `BTreeMap` lookup or a `tracing` log — on a
+/// transient or corrupt store. Instead we degrade to a *total* result: two
+/// unreadable collections compare equal, and a readable one never equals an
+/// unreadable one. No comparison can panic.
+pub(crate) fn fallible_iter_eq<I, T, E>(l: Result<I, E>, r: Result<I, E>) -> bool
+where
+    I: Iterator<Item = T>,
+    T: PartialEq,
+{
+    match (l, r) {
+        (Ok(l), Ok(r)) => l.eq(r),
+        (Err(_), Err(_)) => true,
+        _ => false,
+    }
+}
+
+/// Total ordering over two fallible collection reads (see
+/// [`fallible_iter_eq`]). An unreadable collection sorts before a readable
+/// one; two unreadable collections compare equal. Keeps `Ord` total and
+/// consistent with [`fallible_iter_partial_cmp`] rather than panicking.
+pub(crate) fn fallible_iter_cmp<I, T, E>(l: Result<I, E>, r: Result<I, E>) -> Ordering
+where
+    I: Iterator<Item = T>,
+    T: Ord,
+{
+    match (l, r) {
+        (Ok(l), Ok(r)) => l.cmp(r),
+        (Err(_), Ok(_)) => Ordering::Less,
+        (Ok(_), Err(_)) => Ordering::Greater,
+        (Err(_), Err(_)) => Ordering::Equal,
+    }
+}
+
+/// Total partial-ordering over two fallible collection reads, matching the
+/// read-failure ordering of [`fallible_iter_cmp`] so `PartialOrd` stays
+/// consistent with `Ord`. Returns `None` only for genuinely incomparable
+/// elements, never for a store fault.
+pub(crate) fn fallible_iter_partial_cmp<I, T, E>(
+    l: Result<I, E>,
+    r: Result<I, E>,
+) -> Option<Ordering>
+where
+    I: Iterator<Item = T>,
+    T: PartialOrd,
+{
+    match (l, r) {
+        (Ok(l), Ok(r)) => l.partial_cmp(r),
+        (Err(_), Ok(_)) => Some(Ordering::Less),
+        (Ok(_), Err(_)) => Some(Ordering::Greater),
+        (Err(_), Err(_)) => Some(Ordering::Equal),
+    }
+}
+
 impl<T: Eq + BorshSerialize + BorshDeserialize, S: StorageAdaptor> Eq for Collection<T, S> {}
 
 impl<T: PartialEq + BorshSerialize + BorshDeserialize, S: StorageAdaptor> PartialEq
     for Collection<T, S>
 {
-    #[expect(clippy::unwrap_used, reason = "'tis fine")]
     fn eq(&self, other: &Self) -> bool {
-        let l = self.entries().unwrap().flatten();
-        let r = other.entries().unwrap().flatten();
-
-        l.eq(r)
+        fallible_iter_eq(
+            self.entries().map(Iterator::flatten),
+            other.entries().map(Iterator::flatten),
+        )
     }
 }
 
 impl<T: Ord + BorshSerialize + BorshDeserialize, S: StorageAdaptor> Ord for Collection<T, S> {
-    #[expect(clippy::unwrap_used, reason = "'tis fine")]
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let l = self.entries().unwrap().flatten();
-        let r = other.entries().unwrap().flatten();
-
-        l.cmp(r)
+    fn cmp(&self, other: &Self) -> Ordering {
+        fallible_iter_cmp(
+            self.entries().map(Iterator::flatten),
+            other.entries().map(Iterator::flatten),
+        )
     }
 }
 
 impl<T: PartialOrd + BorshSerialize + BorshDeserialize, S: StorageAdaptor> PartialOrd
     for Collection<T, S>
 {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        let l = self.entries().ok()?.flatten();
-        let r = other.entries().ok()?.flatten();
-
-        l.partial_cmp(r)
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        fallible_iter_partial_cmp(
+            self.entries().map(Iterator::flatten),
+            other.entries().map(Iterator::flatten),
+        )
     }
 }
 

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -981,6 +981,24 @@ where
     }
 }
 
+/// Logged when a fallible collection comparison hits a store read error. The
+/// comparison still returns a total result (it never panics), but the fault is
+/// surfaced so it is not silently swallowed — in particular two unreadable
+/// collections compare *equal*, which a caller must not mistake for "converged".
+/// These `PartialEq`/`Ord` impls are not on the sync/merkle convergence path
+/// (that compares hashes, not whole collections), so a masked difference here
+/// cannot hide replication divergence; the warning keeps the fault observable
+/// regardless.
+#[cold]
+fn warn_collection_compare_read_error() {
+    tracing::warn!(
+        target: "storage::collections",
+        "store read error during collection comparison/format; degraded to a \
+         total fallback instead of panicking — any difference between the \
+         unreadable sides is not observed by this comparison"
+    );
+}
+
 /// Total equality over two fallible collection reads.
 ///
 /// `PartialEq`/`Ord`/`Debug` on these collections have to read from the
@@ -988,7 +1006,8 @@ where
 /// mid-comparison — e.g. inside a `BTreeMap` lookup or a `tracing` log — on a
 /// transient or corrupt store. Instead we degrade to a *total* result: two
 /// unreadable collections compare equal, and a readable one never equals an
-/// unreadable one. No comparison can panic.
+/// unreadable one. No comparison can panic; a read error is logged via
+/// [`warn_collection_compare_read_error`] so the fault stays observable.
 pub(crate) fn fallible_iter_eq<I, T, E>(l: Result<I, E>, r: Result<I, E>) -> bool
 where
     I: Iterator<Item = T>,
@@ -996,8 +1015,14 @@ where
 {
     match (l, r) {
         (Ok(l), Ok(r)) => l.eq(r),
-        (Err(_), Err(_)) => true,
-        _ => false,
+        (Err(_), Err(_)) => {
+            warn_collection_compare_read_error();
+            true
+        }
+        _ => {
+            warn_collection_compare_read_error();
+            false
+        }
     }
 }
 
@@ -1012,9 +1037,18 @@ where
 {
     match (l, r) {
         (Ok(l), Ok(r)) => l.cmp(r),
-        (Err(_), Ok(_)) => Ordering::Less,
-        (Ok(_), Err(_)) => Ordering::Greater,
-        (Err(_), Err(_)) => Ordering::Equal,
+        (Err(_), Ok(_)) => {
+            warn_collection_compare_read_error();
+            Ordering::Less
+        }
+        (Ok(_), Err(_)) => {
+            warn_collection_compare_read_error();
+            Ordering::Greater
+        }
+        (Err(_), Err(_)) => {
+            warn_collection_compare_read_error();
+            Ordering::Equal
+        }
     }
 }
 
@@ -1032,9 +1066,18 @@ where
 {
     match (l, r) {
         (Ok(l), Ok(r)) => l.partial_cmp(r),
-        (Err(_), Ok(_)) => Some(Ordering::Less),
-        (Ok(_), Err(_)) => Some(Ordering::Greater),
-        (Err(_), Err(_)) => Some(Ordering::Equal),
+        (Err(_), Ok(_)) => {
+            warn_collection_compare_read_error();
+            Some(Ordering::Less)
+        }
+        (Ok(_), Err(_)) => {
+            warn_collection_compare_read_error();
+            Some(Ordering::Greater)
+        }
+        (Err(_), Err(_)) => {
+            warn_collection_compare_read_error();
+            Some(Ordering::Equal)
+        }
     }
 }
 

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -15,9 +15,8 @@
 //! any single inner `Mergeable::merge`.
 
 use core::fmt;
-use std::cell::RefCell;
+use std::cell::OnceCell;
 use std::ops::{Deref, DerefMut};
-use std::ptr;
 
 use super::{Collection, ROOT_ENTRY_ID, ROOT_ID};
 use crate::address::Id;
@@ -32,7 +31,13 @@ use tracing::info;
 /// A set collection that stores unqiue values once.
 pub struct Root<T, S: StorageAdaptor = MainStorage> {
     inner: Collection<T, S>,
-    value: RefCell<Option<T>>,
+    // Lazily-materialised cache of the single root value. A `OnceCell`
+    // (not a `RefCell`) is load-bearing for soundness: it hands out `&T`
+    // references tied to `&self` directly, so `Deref` needs no `unsafe`
+    // pointer laundering. The cell is populated exactly once (on first
+    // access or at construction) and is only ever mutated through
+    // `&mut self` via `get_mut`, so no aliasing `&mut` can be produced.
+    value: OnceCell<T>,
     dirty: bool,
 }
 
@@ -105,10 +110,14 @@ where
             .insert_with_field_name(id, f(), "root")
             .expect("fatal: Root<T> entry insert failed");
 
+        let cache = OnceCell::new();
+        // The cell is freshly created, so `set` cannot fail here.
+        let _ = cache.set(value);
+
         Self {
             inner,
             dirty: false,
-            value: RefCell::new(Some(value)),
+            value: cache,
         }
     }
 
@@ -121,49 +130,134 @@ where
         ROOT_ENTRY_ID
     }
 
-    #[expect(clippy::mut_from_ref, reason = "'tis fine")]
-    #[expect(clippy::unwrap_used, reason = "fatal error if it happens")]
-    fn get(&self) -> &mut T {
-        let mut value = self.value.borrow_mut();
+    /// Returns a shared reference to the (lazily materialised) root value.
+    ///
+    /// The value is read from storage on first access and cached in the
+    /// `OnceCell`; later calls hand out further shared references to the
+    /// same cached value. This is sound precisely because the cell is
+    /// populated once and never mutated through a shared reference — the
+    /// previous implementation laundered a `RefCell` guard into a `&mut T`
+    /// via `ptr::from_mut`, which let two `get()` calls alias the same
+    /// `&mut T` (UB).
+    ///
+    /// `get` is bound by [`Deref::deref`], whose signature is infallible,
+    /// so a storage-read error has nowhere to propagate: we log the cause
+    /// (so node logs carry it before any WASM abort) and panic. A missing
+    /// entry is treated the same way — a `Root<T>` always writes its single
+    /// entry at construction, so its absence means a corrupt store.
+    #[expect(
+        clippy::panic,
+        reason = "Deref::deref is infallible; a store fault here is fatal, but \
+                  log the cause first so it reaches node logs before the abort"
+    )]
+    fn get(&self) -> &T {
+        self.value.get_or_init(|| {
+            let id = Self::entry_id();
+            match self.inner.get(id) {
+                Ok(Some(value)) => value,
+                Ok(None) => {
+                    tracing::error!(
+                        target: "storage::root",
+                        %id,
+                        "Root<T> entry missing from store — cannot materialise root value"
+                    );
+                    panic!("fatal: Root<T> entry missing from store");
+                }
+                Err(e) => {
+                    tracing::error!(
+                        target: "storage::root",
+                        %id,
+                        error = %e,
+                        "Root<T> entry read failed — cannot materialise root value"
+                    );
+                    panic!("fatal: Root<T> entry read failed: {e}");
+                }
+            }
+        })
+    }
 
-        let id = Self::entry_id();
-
-        let value = value.get_or_insert_with(|| self.inner.get(id).unwrap().unwrap());
-
-        #[expect(unsafe_code, reason = "necessary for caching")]
-        let value = unsafe { &mut *ptr::from_mut(value) };
-
-        value
+    /// Returns an exclusive reference to the (lazily materialised) root value.
+    ///
+    /// Requires `&mut self`, so there is no aliasing to reason about. It
+    /// populates the cache via [`Self::get`] (a shared borrow that ends
+    /// before the `get_mut` below) and then hands out the unique reference.
+    #[expect(
+        clippy::expect_used,
+        reason = "the cache is populated by the get() call immediately above"
+    )]
+    fn get_mut(&mut self) -> &mut T {
+        // Ensure the cache is populated; the shared borrow ends at the `;`.
+        let _: &T = self.get();
+        self.value
+            .get_mut()
+            .expect("root value cache populated by get() above")
     }
 
     /// Fetches the root collection.
+    ///
+    /// Returns `None` when no root has been written yet. A storage-read
+    /// fault (as opposed to "not present") is fatal and has nowhere to
+    /// propagate through this `Option`-returning signature, so it is logged
+    /// and then panics — keeping the cause in node logs before any abort.
     #[expect(
-        clippy::unwrap_used,
-        clippy::unwrap_in_result,
-        reason = "fatal error if it happens"
+        clippy::panic,
+        reason = "Option signature can't carry a store fault; log then abort"
     )]
     pub fn fetch() -> Option<Self> {
-        let inner = <Interface<S>>::root().unwrap()?;
+        let inner = match <Interface<S>>::root() {
+            Ok(inner) => inner?,
+            Err(e) => {
+                tracing::error!(
+                    target: "storage::root",
+                    error = %e,
+                    "Root::fetch: reading root collection failed"
+                );
+                panic!("fatal: Root::fetch failed: {e}");
+            }
+        };
 
         Some(Self {
             inner,
             dirty: false,
-            value: RefCell::new(None),
+            value: OnceCell::new(),
         })
     }
 
     /// Commits the root collection.
-    #[expect(clippy::unwrap_used, reason = "fatal error if it happens")]
+    ///
+    /// Storage faults while writing back the cached value or committing the
+    /// root are fatal; they are logged with their cause and then panic so
+    /// the reason survives in node logs before the WASM abort, rather than
+    /// surfacing as an opaque `unreachable` trap.
+    #[expect(
+        clippy::panic,
+        reason = "store write faults here are fatal; log the cause before aborting"
+    )]
     pub fn commit(mut self) {
         if self.dirty {
             if let Some(value) = self.value.into_inner() {
-                if let Some(mut entry) = self.inner.get_mut(Self::entry_id()).unwrap() {
+                let entry = self.inner.get_mut(Self::entry_id()).unwrap_or_else(|e| {
+                    tracing::error!(
+                        target: "storage::root",
+                        error = %e,
+                        "Root::commit: reading root entry for write-back failed"
+                    );
+                    panic!("fatal: Root::commit entry read failed: {e}");
+                });
+                if let Some(mut entry) = entry {
                     *entry = value;
                 }
             }
         }
 
-        <Interface<S>>::commit_root(Some(self.inner)).unwrap();
+        <Interface<S>>::commit_root(Some(self.inner)).unwrap_or_else(|e| {
+            tracing::error!(
+                target: "storage::root",
+                error = %e,
+                "Root::commit: commit_root failed"
+            );
+            panic!("fatal: Root::commit failed: {e}");
+        });
     }
 
     /// Commits the root collection without an instance of the root state.
@@ -487,6 +581,6 @@ where
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.dirty = true;
 
-        self.get()
+        self.get_mut()
     }
 }

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -156,12 +156,21 @@ where
             match self.inner.get(id) {
                 Ok(Some(value)) => value,
                 Ok(None) => {
+                    // The root collection was loaded (we have `self.inner`) but
+                    // its single entry is absent. That entry is written
+                    // atomically at construction, and `fetch` returning `Some`
+                    // guarantees it exists, so reaching here means a partial
+                    // write / store corruption — never a normal "empty root".
                     tracing::error!(
                         target: "storage::root",
                         %id,
-                        "Root<T> entry missing from store — cannot materialise root value"
+                        "Root<T> collection present but its single entry is absent — \
+                         partial write or store corruption, not an empty root"
                     );
-                    panic!("fatal: Root<T> entry missing from store");
+                    panic!(
+                        "fatal: Root<T> entry missing from store (collection present, \
+                         entry absent — store corruption)"
+                    );
                 }
                 Err(e) => {
                     tracing::error!(
@@ -242,6 +251,15 @@ where
         reason = "store write faults here are fatal; log the cause before aborting"
     )]
     pub fn commit(mut self) {
+        // `dirty` is only ever set by `DerefMut`, which populates the cache
+        // before flipping the flag, so a dirty `Root` always has a cached
+        // value. Guard the invariant: if it ever breaks (e.g. a future API
+        // change), the write-back below would be silently skipped.
+        debug_assert!(
+            !self.dirty || self.value.get().is_some(),
+            "Root marked dirty but its value cache is empty — write-back would be skipped"
+        );
+
         if self.dirty {
             if let Some(value) = self.value.into_inner() {
                 let entry = self.inner.get_mut(Self::entry_id()).unwrap_or_else(|e| {
@@ -587,6 +605,10 @@ where
     S: StorageAdaptor,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
+        // Materialise the cache first. If the lazy load panics on a store
+        // fault, `dirty` stays unset — so a failed load can never leave a
+        // dirty-but-unloaded `Root` that `commit` would try to write back.
+        let _: &T = self.get();
         self.dirty = true;
 
         self.get_mut()

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -195,7 +195,15 @@ where
 
     /// Fetches the root collection.
     ///
-    /// Returns `None` when no root has been written yet. A storage-read
+    /// Returns `None` when no root has been written yet. A returned
+    /// `Some(root)` guarantees the single inner entry exists — it is written
+    /// atomically alongside the root at construction (see [`Self::new_internal`])
+    /// — so a *missing* entry observed later by [`Self::get`] is always store
+    /// corruption (or a partial write from a previous crash), never a normal
+    /// "empty root" state. That is why `get` panics rather than returning `None`
+    /// for the absent-entry case.
+    ///
+    /// A storage-read
     /// fault (as opposed to "not present") is fatal and has nowhere to
     /// propagate through this `Option`-returning signature, so it is logged
     /// and then panics — keeping the cause in node logs before any abort.

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -923,12 +923,8 @@ where
     V: PartialEq + BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    #[expect(clippy::unwrap_used, reason = "'tis fine")]
     fn eq(&self, other: &Self) -> bool {
-        let l = self.entries().unwrap();
-        let r = other.entries().unwrap();
-
-        l.eq(r)
+        super::fallible_iter_eq(self.entries(), other.entries())
     }
 }
 
@@ -938,12 +934,8 @@ where
     V: Ord + BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    #[expect(clippy::unwrap_used, reason = "'tis fine")]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let l = self.entries().unwrap();
-        let r = other.entries().unwrap();
-
-        l.cmp(r)
+        super::fallible_iter_cmp(self.entries(), other.entries())
     }
 }
 
@@ -964,14 +956,17 @@ where
     V: fmt::Debug + BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    #[expect(clippy::unwrap_used, clippy::unwrap_in_result, reason = "'tis fine")]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
             f.debug_struct("SortedMap")
                 .field("entries", &self.inner)
                 .finish()
         } else {
-            f.debug_map().entries(self.entries().unwrap()).finish()
+            // A store fault while reading must not panic a Debug format.
+            match self.entries() {
+                Ok(entries) => f.debug_map().entries(entries).finish(),
+                Err(e) => f.debug_struct("SortedMap").field("read_error", &e).finish(),
+            }
         }
     }
 }

--- a/crates/storage/src/collections/sorted_set.rs
+++ b/crates/storage/src/collections/sorted_set.rs
@@ -539,9 +539,8 @@ where
     V: Ord + AsRef<[u8]> + BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    #[expect(clippy::unwrap_used, reason = "'tis fine")]
     fn eq(&self, other: &Self) -> bool {
-        self.iter().unwrap().eq(other.iter().unwrap())
+        super::fallible_iter_eq(self.iter(), other.iter())
     }
 }
 
@@ -550,9 +549,8 @@ where
     V: Ord + AsRef<[u8]> + BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    #[expect(clippy::unwrap_used, reason = "'tis fine")]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.iter().unwrap().cmp(other.iter().unwrap())
+        super::fallible_iter_cmp(self.iter(), other.iter())
     }
 }
 
@@ -571,14 +569,17 @@ where
     V: Ord + AsRef<[u8]> + fmt::Debug + BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    #[expect(clippy::unwrap_used, clippy::unwrap_in_result, reason = "'tis fine")]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
             f.debug_struct("SortedSet")
                 .field("items", &self.inner)
                 .finish()
         } else {
-            f.debug_set().entries(self.iter().unwrap()).finish()
+            // A store fault while reading must not panic a Debug format.
+            match self.iter() {
+                Ok(iter) => f.debug_set().entries(iter).finish(),
+                Err(e) => f.debug_struct("SortedSet").field("read_error", &e).finish(),
+            }
         }
     }
 }

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -604,12 +604,8 @@ where
     V: PartialEq + BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    #[expect(clippy::unwrap_used, reason = "'tis fine")]
     fn eq(&self, other: &Self) -> bool {
-        let l = self.entries().unwrap();
-        let r = other.entries().unwrap();
-
-        l.eq(r)
+        super::fallible_iter_eq(self.entries(), other.entries())
     }
 }
 
@@ -619,12 +615,8 @@ where
     V: Ord + BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    #[expect(clippy::unwrap_used, reason = "'tis fine")]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let l = self.entries().unwrap();
-        let r = other.entries().unwrap();
-
-        l.cmp(r)
+        super::fallible_iter_cmp(self.entries(), other.entries())
     }
 }
 
@@ -635,10 +627,7 @@ where
     S: StorageAdaptor,
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        let l = self.entries().ok()?;
-        let r = other.entries().ok()?;
-
-        l.partial_cmp(r)
+        super::fallible_iter_partial_cmp(self.entries(), other.entries())
     }
 }
 
@@ -648,14 +637,20 @@ where
     V: fmt::Debug + BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    #[expect(clippy::unwrap_used, clippy::unwrap_in_result, reason = "'tis fine")]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
             f.debug_struct("UnorderedMap")
                 .field("entries", &self.inner)
                 .finish()
         } else {
-            f.debug_map().entries(self.entries().unwrap()).finish()
+            // A store fault while reading must not panic a Debug format.
+            match self.entries() {
+                Ok(entries) => f.debug_map().entries(entries).finish(),
+                Err(e) => f
+                    .debug_struct("UnorderedMap")
+                    .field("read_error", &e)
+                    .finish(),
+            }
         }
     }
 }

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -354,12 +354,8 @@ where
     V: PartialEq + BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    #[expect(clippy::unwrap_used, reason = "'tis fine")]
     fn eq(&self, other: &Self) -> bool {
-        let l = self.iter().unwrap();
-        let r = other.iter().unwrap();
-
-        l.eq(r)
+        super::fallible_iter_eq(self.iter(), other.iter())
     }
 }
 
@@ -368,12 +364,8 @@ where
     V: Ord + BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    #[expect(clippy::unwrap_used, reason = "'tis fine")]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let l = self.iter().unwrap();
-        let r = other.iter().unwrap();
-
-        l.cmp(r)
+        super::fallible_iter_cmp(self.iter(), other.iter())
     }
 }
 
@@ -383,10 +375,7 @@ where
     S: StorageAdaptor,
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        let l = self.iter().ok()?;
-        let r = other.iter().ok()?;
-
-        l.partial_cmp(r)
+        super::fallible_iter_partial_cmp(self.iter(), other.iter())
     }
 }
 
@@ -395,14 +384,20 @@ where
     V: fmt::Debug + BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    #[expect(clippy::unwrap_used, clippy::unwrap_in_result, reason = "'tis fine")]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
             f.debug_struct("UnorderedSet")
                 .field("items", &self.inner)
                 .finish()
         } else {
-            f.debug_set().entries(self.iter().unwrap()).finish()
+            // A store fault while reading must not panic a Debug format.
+            match self.iter() {
+                Ok(iter) => f.debug_set().entries(iter).finish(),
+                Err(e) => f
+                    .debug_struct("UnorderedSet")
+                    .field("read_error", &e)
+                    .finish(),
+            }
         }
     }
 }

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -424,12 +424,8 @@ where
     V: PartialEq + BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    #[expect(clippy::unwrap_used, reason = "'tis fine")]
     fn eq(&self, other: &Self) -> bool {
-        let l = self.iter().unwrap();
-        let r = other.iter().unwrap();
-
-        l.eq(r)
+        super::fallible_iter_eq(self.iter(), other.iter())
     }
 }
 
@@ -438,12 +434,8 @@ where
     V: Ord + BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    #[expect(clippy::unwrap_used, reason = "'tis fine")]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let l = self.iter().unwrap();
-        let r = other.iter().unwrap();
-
-        l.cmp(r)
+        super::fallible_iter_cmp(self.iter(), other.iter())
     }
 }
 
@@ -453,10 +445,7 @@ where
     S: StorageAdaptor,
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        let l = self.iter().ok()?;
-        let r = other.iter().ok()?;
-
-        l.partial_cmp(r)
+        super::fallible_iter_partial_cmp(self.iter(), other.iter())
     }
 }
 
@@ -465,14 +454,18 @@ where
     V: fmt::Debug + BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    #[expect(clippy::unwrap_used, clippy::unwrap_in_result, reason = "'tis fine")]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
             f.debug_struct("Vector")
                 .field("items", &self.inner)
                 .finish()
         } else {
-            f.debug_list().entries(self.iter().unwrap()).finish()
+            // A store fault while reading entries must not panic a Debug
+            // format (e.g. inside a log); render the error instead.
+            match self.iter() {
+                Ok(iter) => f.debug_list().entries(iter).finish(),
+                Err(e) => f.debug_struct("Vector").field("read_error", &e).finish(),
+            }
         }
     }
 }

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -1070,16 +1070,19 @@ impl<S: StorageAdaptor> Index<S> {
     /// println!("Garbage collected {} tombstones", collected);
     /// ```
     ///
-    /// # Future Enhancements
+    /// # Errors
     ///
-    /// - Add metrics/logging for GC operations
-    /// - Support batched deletion for large tombstone counts
-    /// - [ ] Consider partial GC (limit number of items per run to avoid blocking)
-    /// - [ ] Add GC scheduling mechanism (auto-run periodically)
-    /// - [ ] Add GC configuration (min age, batch size, etc.)
+    /// Returns [`StorageError`] if an index entry cannot be loaded while
+    /// scanning. Failure to remove an individual tombstone key is ignored so a
+    /// single bad key does not abort the whole sweep.
     ///
-    #[allow(dead_code, reason = "planned feature for tombstone cleanup")]
-    pub(crate) fn garbage_collect_tombstones(retention_nanos: u64) -> Result<usize, StorageError>
+    /// # Scheduling
+    ///
+    /// This is a manually-invoked maintenance operation: it performs one full
+    /// pass over the index keys and returns. It is intentionally not
+    /// auto-scheduled — when and how often to reclaim tombstones (and any
+    /// batching or rate-limiting) is a policy decision left to the caller.
+    pub fn garbage_collect_tombstones(retention_nanos: u64) -> Result<usize, StorageError>
     where
         S: IterableStorage,
     {


### PR DESCRIPTION
Fixes a batch of lint-suppression / soundness-hazard findings. Each removed an `#[allow]`/`#[expect]` that was masking a real hazard. Full workspace CI clippy (`--all-targets -D warnings`) is clean and all storage tests pass (632 lib + integration + 5 new borsh tests).

## Findings addressed

**Soundness**
- **`Root::get` aliasing-`&mut` UB** — the `RefCell` guard was laundered into `&mut T` via `ptr::from_mut`, so two `get()` calls produced two aliasing `&mut` (UB). Replaced with a `OnceCell` cache: `Deref` yields `&T` tied to `&self`, `DerefMut` uses a new `get_mut(&mut self)`. **All `unsafe` + `mut_from_ref` removed.**
- **`read_guest_memory_typed` had no compile-time guard** — soundness rested on every `T` being POD. `bytemuck::Pod` is inapplicable (every ABI type carries a lifetime; `ValueReturn` is `#[repr(C, u64)]`), so added a sealed `unsafe trait GuestAbiType` implemented only for the 6 vetted `calimero-sys` descriptors and bounded the function — reading any un-vetted type is now a **compile error**. Plus SAFETY comments at all 48 call sites.

**Panic-safety**
- **Collection `eq`/`cmp`/`Debug`** no longer `unwrap()`-panic on a store fault mid-merge/log — shared *total*-comparison helpers; `partial_cmp` made consistent with `Ord`.
- **`Root::get`/`fetch`/`commit`** log the cause then panic (matching `commit_headless`) instead of an opaque WASM `unreachable`.

**Resource / correctness**
- **`state_key`** interns keys in `HashMap<[u8;32], Arc<…>>`; growth is bounded by *distinct* keys instead of one leaked `Arc` per storage op.
- **borsh layout mirrors** now have a round-trip test pinning the production `borsh_layout` mirror to the canonical `calimero_storage` types across all 5 `StorageType` variants (covers the two historical cold-join drift bugs).
- **`garbage_collect_tombstones`** is now `pub` (dead-code allow dropped) and documented as a manually-invoked op (no auto-scheduling); the existing test covers it.
- **crate-wide `clippy::mem_forget` allow** narrowed to the one `ouroboros` self-referential struct (verified with `-W clippy::mem_forget`: 3 → 0).

(The `ArcSlice::new` lifetime-launder finding was already fixed upstream in #3024 — no change needed.)

## Two scoping decisions worth a look

1. **`Root::fetch`/`commit` keep their signatures** rather than returning `Result`. Propagating would touch 70+ call sites, every production caller is guest code that panics regardless, and `get()` is `Deref`-bound so *cannot* return `Result`. The fix delivers the real value (cause in logs before abort).
2. **`#8` uses a marker trait instead of `bytemuck::Pod`** (the ABI types can't satisfy `Pod`). The residual ABI trust assumption (an adversarial guest writing an out-of-range `ValueReturn` discriminant) is pre-existing and unchanged — closing it needs validated decoding, a larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)