### PR TITLE
fix(node): refresh projection from op-store before governance-pending drain authorizes

### DIFF
--- a/crates/context/tests/projection_membership_equivalence.rs
+++ b/crates/context/tests/projection_membership_equivalence.rs
@@ -562,3 +562,123 @@ fn projection_defers_when_cut_ancestry_incomplete() {
         "projection must DEFER to live (None) on a partially-folded cut, not deny"
     );
 }
+
+/// The governance-pending drain authorizes a buffered delta with
+/// `member_at_cut_authoritative` against the in-memory projection. That
+/// projection can lag the durable op-store: the apply path folds an op into the
+/// projection only on a real `Applied`, not on the "already applied" dedup path,
+/// and ops arriving via the namespace-governance backfill pull take that dedup
+/// path. So the author's membership op can be durably present in the op-store
+/// yet absent from the projection — the drain then reads `None` ("cut ancestry
+/// not fully folded") on every pass and eventually drops a valid delta.
+///
+/// The fix refreshes the projection from the op-store at the cut before
+/// authorizing (`refresh_projection_for_cut`, the same step the gossip path runs
+/// via `resolve_cut_membership`). This test pins the mechanism that refresh
+/// relies on: with the author's root-membership ancestor missing from the
+/// projection the authoritative resolver abstains, and folding that ancestor —
+/// exactly what a refresh-from-store does — flips the verdict to a grant.
+#[test]
+fn refreshing_the_missing_ancestor_unblocks_the_authoritative_grant() {
+    let store = store();
+    let admin_sk = PrivateKey::random(&mut OsRng);
+    let admin = admin_sk.public_key();
+    let joiner_sk = PrivateKey::random(&mut OsRng);
+    let joiner = joiner_sk.public_key();
+
+    let ns = ContextGroupId::from([0x51; 32]);
+    let subgroup = ContextGroupId::from([0x52; 32]);
+
+    // Genesis base state (store seeds, as `create_group` writes).
+    for g in [&ns, &subgroup] {
+        MetaRepository::new(&store).save(g, &meta(admin)).unwrap();
+        MembershipRepository::new(&store)
+            .add_member(g, &admin, GroupMemberRole::Admin)
+            .unwrap();
+    }
+    NamespaceRepository::new(&store)
+        .nest(&ns, &subgroup)
+        .unwrap();
+    CapabilitiesRepository::new(&store)
+        .set_subgroup_visibility(&subgroup, VisibilityMode::Open)
+        .unwrap();
+    CapabilitiesRepository::new(&store)
+        .set_default_capabilities(&ns, MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS)
+        .unwrap();
+
+    // Both join ops are durably applied to the op-store — the state a node holds
+    // after the backfill pull delivered them.
+    let join_ns = SignedNamespaceOp::sign(
+        &joiner_sk,
+        ns.to_bytes(),
+        vec![],
+        1,
+        NamespaceOp::Root(RootOp::MemberJoined {
+            member: joiner,
+            signed_invitation: sign_invitation(&admin_sk, ns, 1),
+        }),
+    )
+    .unwrap();
+    group_store::apply_signed_namespace_op(&store, &join_ns).unwrap();
+    let join_sub = SignedNamespaceOp::sign(
+        &joiner_sk,
+        ns.to_bytes(),
+        vec![],
+        2,
+        NamespaceOp::Root(RootOp::MemberJoinedOpen {
+            member: joiner,
+            group_id: subgroup.to_bytes(),
+        }),
+    )
+    .unwrap();
+    group_store::apply_signed_namespace_op(&store, &join_sub).unwrap();
+
+    let id_root_join = [0x5A; 32];
+    let id_sub_join = [0x5B; 32];
+
+    // Stale projection: the subgroup structure and the joiner's subgroup-join are
+    // folded, but the joiner's ROOT-membership ancestor (`id_root_join`) is not —
+    // the drain's view when the backfill applied the ops via the dedup path.
+    let mut proj = ScopeProjections::new();
+    let s2 = fold_subgroup_structure(
+        &mut proj,
+        ns.to_bytes(),
+        admin,
+        subgroup,
+        [0x50; 32],
+        [0x5F; 32],
+    );
+    proj.ingest_op(&op_from_namespace_op(
+        &join_sub,
+        None,
+        id_sub_join,
+        hlc(2),
+        &[id_root_join], // parent is the root join — deliberately not folded yet
+    ));
+
+    // The drain's authorization fails: the cut's ancestry is incomplete, so it
+    // abstains and re-buffers — even though `join_ns` is durable in the store.
+    assert_eq!(
+        proj.member_at_cut_authoritative(&store, subgroup, &joiner, &[id_sub_join]),
+        None,
+        "stale projection: authoritative resolver must abstain while the ancestor is unfolded"
+    );
+
+    // Refresh folds the missing ancestor from the op-store (what
+    // `refresh_projection_for_cut` does before the drain authorizes).
+    proj.ingest_op(&op_from_namespace_op(
+        &join_ns,
+        None,
+        id_root_join,
+        hlc(1),
+        &[s2],
+    ));
+
+    // Now the cut's ancestry is complete and the inherited membership resolves —
+    // the drain authorizes and re-applies the delta instead of dropping it.
+    assert_eq!(
+        proj.member_at_cut_authoritative(&store, subgroup, &joiner, &[id_sub_join]),
+        Some(true),
+        "after refreshing the durable ancestor, the authoritative resolver must grant"
+    );
+}

--- a/crates/node/src/handlers/state_delta/buffering.rs
+++ b/crates/node/src/handlers/state_delta/buffering.rs
@@ -12,8 +12,8 @@ use eyre::Result;
 use tracing::{debug, info, warn};
 
 use super::{
-    apply_authorized_state_delta, choose_owned_identity, state_delta_message_from_buffered,
-    StateDeltaContext,
+    apply_authorized_state_delta, choose_owned_identity, refresh_projection_for_cut,
+    state_delta_message_from_buffered, StateDeltaContext,
 };
 
 /// Drain the governance-pending buffer for `context_id`, re-evaluating each
@@ -136,6 +136,27 @@ pub(super) async fn drain_governance_pending(input: &StateDeltaContext, context_
         //
         // F5 #29b: the drain is fully projection-sourced now — the last live
         // `acl_view_at` read (which only named the drop metric label) is gone.
+        //
+        // Refresh the projection from the durable op-store at this cut BEFORE
+        // authorizing — mirroring the gossip path (`resolve_cut_membership` →
+        // `refresh_projection_for_cut`). A governance op can be present in the
+        // op-store yet absent from the in-memory projection: the apply path
+        // folds an op into the projection only on `AddDeltaOutcome::Applied`,
+        // not on the "already applied" dedup path — and ops arriving via the
+        // namespace-governance backfill pull take exactly that dedup path. The
+        // drain runs after such a pull (`drain_governance_pending_after_sync`),
+        // so without this refresh it reads a stale projection and
+        // `member_at_cut_authoritative` returns `None` ("cut ancestry not fully
+        // folded") on every pass — re-buffering then permanently dropping a
+        // delta whose cited ancestry is in fact durably present. The refresh is
+        // cheap in steady state (a point lookup + a folded-head set check; the
+        // DAG re-walk runs only when the cut actually cites an unfolded head).
+        refresh_projection_for_cut(
+            &input.node_state,
+            datastore,
+            owning_group,
+            &pos.governance_dag_heads,
+        );
         let proj = input
             .node_state
             .read_scope_projections()


### PR DESCRIPTION
## Problem

The governance-pending drain authorizes each buffered state delta with `member_at_cut_authoritative` against the **in-memory** scope projection. Unlike the gossip path — which always runs `refresh_projection_for_cut` first (via `resolve_cut_membership`) — the drain read the projection **without refreshing it from the durable op-store**.

That projection can lag the op-store:
- the apply path folds an op into the projection only on a real `AddDeltaOutcome::Applied` (`apply_signed_namespace_op.rs`), **not** on the "already applied; skipping re-apply" dedup path;
- governance ops arriving via the namespace-governance backfill pull take exactly that dedup path;
- the drain runs immediately after such a pull (`drain_governance_pending_after_sync`).

So a buffered delta's cited governance ancestor can be **durably present in the op-store yet unfolded in the projection** the drain reads. `member_at_cut_authoritative` then returns `None` ("cut ancestry not fully folded") on every pass, and the delta is eventually dropped as "permanently missing" — silent loss of a valid, authorized write.

## Fix

Refresh the projection at the buffered delta's cut **before** authorizing, exactly as the gossip path does. Cheap in steady state: a point lookup + a folded-head set check; the DAG re-walk runs only when the cut actually cites an unfolded head.

```rust
refresh_projection_for_cut(&input.node_state, datastore, owning_group, &pos.governance_dag_heads);
let proj = input.node_state.read_scope_projections().member_at_cut_authoritative(...);
```

## Test

Adds a deterministic projection-level test (`refreshing_the_missing_ancestor_unblocks_the_authoritative_grant`) that pins the mechanism the fix relies on: with the author's root-membership ancestor durable in the op-store but missing from the projection, `member_at_cut_authoritative` abstains (`None`); folding that ancestor — what the refresh performs — flips the verdict to a grant (`Some(true)`).

## Scope & honesty

This was found while investigating the `32-authored-migrate-ux` e2e convergence stall, where a node permanently buffered then dropped a peer's delta for a missing governance ancestor. This fix closes a **proven** authorization-vs-recovery asymmetry that produces exactly that "cut ancestry not fully folded → drop" symptom.

It is **not** claimed to be the sole root cause of that flaky e2e: the upstream trigger (a membership op that lost its acks to a mesh-readiness race and then wasn't re-delivered) is timing-dependent and tracked separately. This PR makes the drain's authorization consistent with the gossip path — a standalone correctness fix that hardens recovery regardless of that trigger.

## Verification

- `cargo test -p calimero-context --test projection_membership_equivalence` — 4 passed.
- `cargo test -p calimero-node state_delta` — passed.
- `cargo clippy -p calimero-node -p calimero-context --all-targets` — clean.
- `cargo fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)