### PR TITLE
fix(storage): tombstone whole subtree on delete so GC can reclaim it

### DIFF
--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -906,25 +906,107 @@ impl<S: StorageAdaptor> Index<S> {
 
     /// Removes and deletes a child from a collection.
     ///
-    /// Uses tombstone-based deletion. To move a child to a different parent,
-    /// just add it to the new parent instead.
-    pub(crate) fn remove_child_from(parent_id: Id, child_id: Id) -> Result<(), StorageError> {
+    /// Uses tombstone-based deletion. Deleting a child also tombstones its
+    /// entire subtree (see [`tombstone_descendants_of`](Self::tombstone_descendants_of)):
+    /// a non-recursive delete would leave descendant index rows live, so they
+    /// could never be reclaimed by tombstone GC and would linger as orphans
+    /// under a tombstoned parent.
+    ///
+    /// `deleted_at` is the caller's tombstone nonce — the same value carried on
+    /// the `DeleteRef` wire action — so the child, every descendant, and the
+    /// remote replicas that replay the `DeleteRef` all stamp the subtree with
+    /// one identical timestamp and converge.
+    ///
+    /// To move a child to a different parent, add it to the new parent instead.
+    pub(crate) fn remove_child_from(
+        parent_id: Id,
+        child_id: Id,
+        deleted_at: u64,
+    ) -> Result<(), StorageError> {
         let _mutation_guard = index_mutation_guard();
-        Self::delete_entity_and_create_tombstone(child_id)?;
+        // Tombstone the subtree first (while `child_id`'s `children` are still
+        // readable), then the child itself, then detach it from its parent.
+        Self::tombstone_descendants_of(child_id, deleted_at)?;
+        Self::delete_entity_and_create_tombstone(child_id, deleted_at)?;
         Self::update_parent_after_child_removal(parent_id, child_id)?;
         Self::recalculate_ancestor_hashes_for(parent_id)?;
         Ok(())
     }
 
-    /// Deletes entity data and creates tombstone marker.
+    /// Deletes entity data and creates a tombstone marker for a single entity.
     ///
     /// Step 1 of deletion: Remove actual data, keep index for CRDT sync.
-    fn delete_entity_and_create_tombstone(id: Id) -> Result<(), StorageError> {
+    fn delete_entity_and_create_tombstone(id: Id, deleted_at: u64) -> Result<(), StorageError> {
         // Delete the actual entity data immediately (save storage space)
         let _ignored = S::storage_remove(Key::Entry(id));
 
         // Mark child index as deleted (tombstone for CRDT sync)
-        Self::mark_deleted(id, time_now())
+        Self::mark_deleted(id, deleted_at)
+    }
+
+    /// Tombstones every descendant of `root_id` at `deleted_at`.
+    ///
+    /// Deleting an entity detaches its whole subtree from the live Merkle tree
+    /// (the root is dropped from its parent's `children`), but the descendant
+    /// index rows remain. Without tombstoning them they keep `deleted_at =
+    /// None` forever, so tombstone GC can never reclaim them and they leak. This
+    /// walks the subtree via each node's `children` and tombstones the rows.
+    ///
+    /// Each descendant is resolved with the SAME canonical delete-vs-update
+    /// tiebreak that [`apply_delete_ref_action`] uses for a directly-deleted
+    /// entity: a descendant whose own `updated_at` is STRICTLY newer than
+    /// `deleted_at` (a concurrent update that causally follows the delete) keeps
+    /// its data — only strictly-older state is tombstoned. Running the identical
+    /// rule here and on the `DeleteRef` replay path means every replica stamps
+    /// the subtree the same way and converges, including the live-update-wins
+    /// "zombie" case (a surviving entity under a tombstoned ancestor), which is
+    /// the existing single-level concurrent add/update-vs-delete semantics
+    /// applied transitively.
+    ///
+    /// Internal subtree parent-lists and hashes are intentionally NOT
+    /// recomputed: the whole subtree is detached at the root, so none of it
+    /// feeds a live hash. Only the root's removal from its parent (done by the
+    /// caller) touches the live tree.
+    ///
+    /// [`apply_delete_ref_action`]: crate::interface::Interface::apply_delete_ref_action
+    pub(crate) fn tombstone_descendants_of(
+        root_id: Id,
+        deleted_at: u64,
+    ) -> Result<(), StorageError> {
+        let _mutation_guard = index_mutation_guard();
+
+        // Collect the descendant ids up front (depth-first over `children`) so
+        // the per-node tombstone writes below don't mutate the structure we are
+        // still traversing.
+        let mut stack = vec![root_id];
+        let mut descendants = Vec::new();
+        while let Some(id) = stack.pop() {
+            let Some(index) = Self::get_index(id)? else {
+                continue;
+            };
+            if let Some(children) = index.children {
+                for child in children {
+                    let child_id = child.id();
+                    descendants.push(child_id);
+                    stack.push(child_id);
+                }
+            }
+        }
+
+        for id in descendants {
+            let Some(index) = Self::get_index(id)? else {
+                continue;
+            };
+            // Strictly-newer local state wins (a concurrent update that
+            // causally follows this delete); equal or older is tombstoned. Same
+            // `<` tiebreak as `apply_delete_ref_action`.
+            if deleted_at < *index.metadata.updated_at {
+                continue;
+            }
+            Self::delete_entity_and_create_tombstone(id, deleted_at)?;
+        }
+
+        Ok(())
     }
 
     /// Removes a child reference from a parent without creating a tombstone.

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -956,17 +956,23 @@ impl<S: StorageAdaptor> Index<S> {
     /// tiebreak that [`apply_delete_ref_action`] uses for a directly-deleted
     /// entity: a descendant whose own `updated_at` is STRICTLY newer than
     /// `deleted_at` (a concurrent update that causally follows the delete) keeps
-    /// its data — only strictly-older state is tombstoned. Running the identical
-    /// rule here and on the `DeleteRef` replay path means every replica stamps
-    /// the subtree the same way and converges, including the live-update-wins
-    /// "zombie" case (a surviving entity under a tombstoned ancestor), which is
-    /// the existing single-level concurrent add/update-vs-delete semantics
-    /// applied transitively.
+    /// its data; equal-or-older state is tombstoned — so `deleted_at ==
+    /// updated_at` tombstones the descendant (delete wins on the tie), matching
+    /// the single-level rule. Running the identical rule here and on the
+    /// `DeleteRef` replay path means every replica stamps the subtree the same
+    /// way and converges, including the live-update-wins "zombie" case (a
+    /// surviving entity under a tombstoned ancestor), which is the existing
+    /// single-level concurrent add/update-vs-delete semantics applied
+    /// transitively.
     ///
     /// Internal subtree parent-lists and hashes are intentionally NOT
     /// recomputed: the whole subtree is detached at the root, so none of it
     /// feeds a live hash. Only the root's removal from its parent (done by the
     /// caller) touches the live tree.
+    ///
+    /// Acquires the reentrant index-mutation guard internally and holds it for
+    /// the whole walk, so it is safe to call whether or not a caller already
+    /// holds it (`remove_child_from` does; `apply_delete_ref_action` does not).
     ///
     /// [`apply_delete_ref_action`]: crate::interface::Interface::apply_delete_ref_action
     pub(crate) fn tombstone_descendants_of(
@@ -975,31 +981,29 @@ impl<S: StorageAdaptor> Index<S> {
     ) -> Result<(), StorageError> {
         let _mutation_guard = index_mutation_guard();
 
-        // Collect the descendant ids up front (depth-first over `children`) so
-        // the per-node tombstone writes below don't mutate the structure we are
-        // still traversing.
+        // Single depth-first pass: read each node's index once, descend via the
+        // `children` read BEFORE tombstoning it, then tombstone the node itself
+        // — except the root, which the caller tombstones. The guard is held for
+        // the whole walk, so a concurrent native writer can't insert a child
+        // that the traversal would miss.
         let mut stack = vec![root_id];
-        let mut descendants = Vec::new();
         while let Some(id) = stack.pop() {
             let Some(index) = Self::get_index(id)? else {
                 continue;
             };
-            if let Some(children) = index.children {
+            if let Some(children) = &index.children {
                 for child in children {
-                    let child_id = child.id();
-                    descendants.push(child_id);
-                    stack.push(child_id);
+                    stack.push(child.id());
                 }
             }
-        }
-
-        for id in descendants {
-            let Some(index) = Self::get_index(id)? else {
+            // The root is tombstoned by the caller; only its descendants here.
+            if id == root_id {
                 continue;
-            };
-            // Strictly-newer local state wins (a concurrent update that
-            // causally follows this delete); equal or older is tombstoned. Same
-            // `<` tiebreak as `apply_delete_ref_action`.
+            }
+            // Strictly-newer local state wins (a concurrent update that causally
+            // follows this delete); equal-or-older is tombstoned (`deleted_at ==
+            // updated_at` ⇒ delete wins). Same `<` tiebreak as
+            // `apply_delete_ref_action`.
             if deleted_at < *index.metadata.updated_at {
                 continue;
             }

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2309,6 +2309,14 @@ impl<S: StorageAdaptor> Interface<S> {
         // Get parent ID BEFORE deleting - we need it to update the Merkle tree
         let parent_id = <Index<S>>::get_parent_id(id)?;
 
+        // Tombstone the subtree BEFORE removing this entity, while its
+        // `children` are still readable. The originating node tombstoned the
+        // whole subtree under `id`; replay the same recursion here, with the
+        // same `deleted_at`, so this replica reclaims the descendant rows too
+        // and converges (otherwise they would leak as un-tombstoned orphans
+        // under a tombstoned ancestor).
+        <Index<S>>::tombstone_descendants_of(id, deleted_at)?;
+
         // Deletion wins - apply it
         let _ignored = S::storage_remove(Key::Entry(id));
         let _ignored = <Index<S>>::mark_deleted(id, deleted_at);
@@ -2808,7 +2816,7 @@ impl<S: StorageAdaptor> Interface<S> {
             };
         }
 
-        <Index<S>>::remove_child_from(parent_id, child_id)?;
+        <Index<S>>::remove_child_from(parent_id, child_id, deleted_at)?;
 
         // Use DeleteRef for efficient tombstone-based deletion.
         // More efficient than Delete: only sends ID + timestamp + metadata vs full ancestor tree.

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -590,7 +590,7 @@ mod index__public_methods {
             ChildInfo::new(child_id, child_own_hash, Metadata::default()),
         )
         .is_ok());
-        assert!(<Index<MainStorage>>::remove_child_from(root_id, child_id).is_ok());
+        assert!(<Index<MainStorage>>::remove_child_from(root_id, child_id, time_now()).is_ok());
 
         let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         // After removal, children should be None
@@ -725,6 +725,122 @@ mod index__private_methods {
         assert!(<Index<TestStorage>>::get_index(child3_id)
             .unwrap()
             .is_some()); // Not deleted
+    }
+}
+
+#[cfg(test)]
+mod subtree_tombstoning {
+    use super::*;
+    use crate::env::time_now;
+    use crate::store::MockedStorage;
+
+    /// Builds a linear chain root -> a -> b -> c under a fresh root and
+    /// returns the four ids. Each level is a child of the previous, so the
+    /// subtree under `a` is {b, c}.
+    fn build_chain<S: crate::store::StorageAdaptor>() -> (Id, Id, Id, Id) {
+        let root = Id::random();
+        let a = Id::random();
+        let b = Id::random();
+        let c = Id::random();
+        <Index<S>>::add_root(ChildInfo::new(root, [1; 32], Metadata::default())).unwrap();
+        <Index<S>>::add_child_to(root, ChildInfo::new(a, [2; 32], Metadata::default())).unwrap();
+        <Index<S>>::add_child_to(a, ChildInfo::new(b, [3; 32], Metadata::default())).unwrap();
+        <Index<S>>::add_child_to(b, ChildInfo::new(c, [4; 32], Metadata::default())).unwrap();
+        (root, a, b, c)
+    }
+
+    /// Deleting a node tombstones its WHOLE subtree, not just the node. The
+    /// pre-fix behaviour tombstoned only `a`, leaving `b` and `c` live as
+    /// orphans under a tombstoned ancestor (and so unreclaimable by GC).
+    #[test]
+    fn remove_child_from_tombstones_whole_subtree() {
+        let (root, a, b, c) = build_chain::<MainStorage>();
+
+        <Index<MainStorage>>::remove_child_from(root, a, time_now()).unwrap();
+
+        assert!(<Index<MainStorage>>::is_deleted(a).unwrap(), "root child");
+        assert!(<Index<MainStorage>>::is_deleted(b).unwrap(), "grandchild");
+        assert!(
+            <Index<MainStorage>>::is_deleted(c).unwrap(),
+            "great-grandchild"
+        );
+    }
+
+    /// `tombstone_descendants_of` tombstones every descendant but leaves the
+    /// root itself untouched (the caller tombstones the root).
+    #[test]
+    fn tombstone_descendants_of_skips_root_tombstones_rest() {
+        let (_root, a, b, c) = build_chain::<MainStorage>();
+
+        <Index<MainStorage>>::tombstone_descendants_of(a, time_now()).unwrap();
+
+        assert!(
+            !<Index<MainStorage>>::is_deleted(a).unwrap(),
+            "root untouched"
+        );
+        assert!(<Index<MainStorage>>::is_deleted(b).unwrap());
+        assert!(<Index<MainStorage>>::is_deleted(c).unwrap());
+    }
+
+    /// A descendant whose own `updated_at` is strictly newer than the delete
+    /// nonce survives as a "zombie" (live entity under a tombstoned ancestor),
+    /// matching the canonical delete-vs-update tiebreak `apply_delete_ref_action`
+    /// uses. This is what keeps concurrent update-into-a-deleted-subtree
+    /// convergent rather than letting an unconditional tombstone clobber a
+    /// causally-newer update.
+    #[test]
+    fn newer_update_on_descendant_wins_tiebreak() {
+        let (root, a, b, c) = build_chain::<MainStorage>();
+        let deleted_at = time_now();
+
+        // `c` received an update that causally follows the delete.
+        let mut c_index = <Index<MainStorage>>::get_index(c).unwrap().unwrap();
+        *c_index.metadata.updated_at = deleted_at + 1_000;
+        <Index<MainStorage>>::save_index(&c_index).unwrap();
+
+        <Index<MainStorage>>::remove_child_from(root, a, deleted_at).unwrap();
+
+        assert!(<Index<MainStorage>>::is_deleted(a).unwrap());
+        assert!(<Index<MainStorage>>::is_deleted(b).unwrap());
+        assert!(
+            !<Index<MainStorage>>::is_deleted(c).unwrap(),
+            "strictly-newer update on a descendant must survive the subtree delete"
+        );
+    }
+
+    /// The point of the fix: once the subtree is tombstoned, GC reclaims the
+    /// WHOLE subtree after retention — not just the directly-deleted node.
+    #[test]
+    fn gc_reclaims_full_subtree_after_retention() {
+        type TestStorage = MockedStorage<2100>;
+
+        let (root, a, b, c) = build_chain::<TestStorage>();
+
+        // Delete two days ago so a one-day-retention GC reclaims the subtree.
+        let two_days = 2 * 86_400_000_000_000_u64;
+        let deleted_at = time_now() - two_days;
+        <Index<TestStorage>>::remove_child_from(root, a, deleted_at).unwrap();
+
+        // All three subtree rows are tombstoned (root stays live).
+        for id in [a, b, c] {
+            assert!(
+                <Index<TestStorage>>::is_deleted(id).unwrap(),
+                "subtree row should be tombstoned before GC"
+            );
+        }
+
+        let one_day = 86_400_000_000_000_u64;
+        let collected = <Index<TestStorage>>::garbage_collect_tombstones(one_day).unwrap();
+
+        assert_eq!(collected, 3, "GC should reclaim all three subtree rows");
+        for id in [a, b, c] {
+            assert!(
+                <Index<TestStorage>>::get_index(id).unwrap().is_none(),
+                "subtree row should be reclaimed by GC"
+            );
+        }
+        // The (live) root survives.
+        assert!(<Index<TestStorage>>::get_index(root).unwrap().is_some());
     }
 }
 

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -754,32 +754,30 @@ mod subtree_tombstoning {
     /// orphans under a tombstoned ancestor (and so unreclaimable by GC).
     #[test]
     fn remove_child_from_tombstones_whole_subtree() {
-        let (root, a, b, c) = build_chain::<MainStorage>();
+        // Isolated per-test store (not the shared `MainStorage`) so a panic in
+        // one test can't leak tombstones into another.
+        type S = MockedStorage<2101>;
+        let (root, a, b, c) = build_chain::<S>();
 
-        <Index<MainStorage>>::remove_child_from(root, a, time_now()).unwrap();
+        <Index<S>>::remove_child_from(root, a, time_now()).unwrap();
 
-        assert!(<Index<MainStorage>>::is_deleted(a).unwrap(), "root child");
-        assert!(<Index<MainStorage>>::is_deleted(b).unwrap(), "grandchild");
-        assert!(
-            <Index<MainStorage>>::is_deleted(c).unwrap(),
-            "great-grandchild"
-        );
+        assert!(<Index<S>>::is_deleted(a).unwrap(), "root child");
+        assert!(<Index<S>>::is_deleted(b).unwrap(), "grandchild");
+        assert!(<Index<S>>::is_deleted(c).unwrap(), "great-grandchild");
     }
 
     /// `tombstone_descendants_of` tombstones every descendant but leaves the
     /// root itself untouched (the caller tombstones the root).
     #[test]
     fn tombstone_descendants_of_skips_root_tombstones_rest() {
-        let (_root, a, b, c) = build_chain::<MainStorage>();
+        type S = MockedStorage<2102>;
+        let (_root, a, b, c) = build_chain::<S>();
 
-        <Index<MainStorage>>::tombstone_descendants_of(a, time_now()).unwrap();
+        <Index<S>>::tombstone_descendants_of(a, time_now()).unwrap();
 
-        assert!(
-            !<Index<MainStorage>>::is_deleted(a).unwrap(),
-            "root untouched"
-        );
-        assert!(<Index<MainStorage>>::is_deleted(b).unwrap());
-        assert!(<Index<MainStorage>>::is_deleted(c).unwrap());
+        assert!(!<Index<S>>::is_deleted(a).unwrap(), "root untouched");
+        assert!(<Index<S>>::is_deleted(b).unwrap());
+        assert!(<Index<S>>::is_deleted(c).unwrap());
     }
 
     /// A descendant whose own `updated_at` is strictly newer than the delete
@@ -790,20 +788,21 @@ mod subtree_tombstoning {
     /// causally-newer update.
     #[test]
     fn newer_update_on_descendant_wins_tiebreak() {
-        let (root, a, b, c) = build_chain::<MainStorage>();
+        type S = MockedStorage<2103>;
+        let (root, a, b, c) = build_chain::<S>();
         let deleted_at = time_now();
 
         // `c` received an update that causally follows the delete.
-        let mut c_index = <Index<MainStorage>>::get_index(c).unwrap().unwrap();
+        let mut c_index = <Index<S>>::get_index(c).unwrap().unwrap();
         *c_index.metadata.updated_at = deleted_at + 1_000;
-        <Index<MainStorage>>::save_index(&c_index).unwrap();
+        <Index<S>>::save_index(&c_index).unwrap();
 
-        <Index<MainStorage>>::remove_child_from(root, a, deleted_at).unwrap();
+        <Index<S>>::remove_child_from(root, a, deleted_at).unwrap();
 
-        assert!(<Index<MainStorage>>::is_deleted(a).unwrap());
-        assert!(<Index<MainStorage>>::is_deleted(b).unwrap());
+        assert!(<Index<S>>::is_deleted(a).unwrap());
+        assert!(<Index<S>>::is_deleted(b).unwrap());
         assert!(
-            !<Index<MainStorage>>::is_deleted(c).unwrap(),
+            !<Index<S>>::is_deleted(c).unwrap(),
             "strictly-newer update on a descendant must survive the subtree delete"
         );
     }

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -3312,3 +3312,64 @@ mod owner_driven_convert {
         );
     }
 }
+
+/// Subtree tombstoning must converge: the node that performs a local delete
+/// and a replica that replays the resulting `DeleteRef` must end with the same
+/// tombstone state across the whole subtree — not just the directly-deleted
+/// node. The replica only ever receives ONE `DeleteRef` (for the subtree root);
+/// it reconstructs the descendant tombstones by replaying the same recursion
+/// with the same `deleted_at`.
+#[cfg(test)]
+mod subtree_tombstone_convergence {
+    use super::*;
+    use crate::entities::ChildInfo;
+
+    fn build_chain<S: crate::store::StorageAdaptor>(root: Id, a: Id, b: Id, c: Id) {
+        <Index<S>>::add_root(ChildInfo::new(root, [1; 32], Metadata::default())).unwrap();
+        <Index<S>>::add_child_to(root, ChildInfo::new(a, [2; 32], Metadata::default())).unwrap();
+        <Index<S>>::add_child_to(a, ChildInfo::new(b, [3; 32], Metadata::default())).unwrap();
+        <Index<S>>::add_child_to(b, ChildInfo::new(c, [4; 32], Metadata::default())).unwrap();
+    }
+
+    #[test]
+    fn local_delete_and_remote_delete_ref_converge_on_whole_subtree() {
+        // Two independent stores with an identical root -> a -> b -> c chain.
+        type Local = MockedStorage<2200>;
+        type Remote = MockedStorage<2201>;
+
+        // Same ids on both stores so the chains are identical.
+        let root = Id::random();
+        let a = Id::random();
+        let b = Id::random();
+        let c = Id::random();
+        build_chain::<Local>(root, a, b, c);
+        build_chain::<Remote>(root, a, b, c);
+
+        // One shared delete nonce — exactly what the originator stamps locally
+        // and carries on the `DeleteRef` wire.
+        let deleted_at = time_now();
+
+        // Originator: local delete of `a`.
+        <Index<Local>>::remove_child_from(root, a, deleted_at).unwrap();
+
+        // Replica: replay the single `DeleteRef` for the subtree root `a`.
+        let action = Action::DeleteRef {
+            id: a,
+            deleted_at,
+            metadata: Metadata::default(),
+        };
+        Interface::<Remote>::apply_action(action, &ApplyContext::empty()).unwrap();
+
+        // Both stores converged to the same tombstone state across the subtree.
+        for id in [a, b, c] {
+            assert!(
+                <Index<Local>>::is_deleted(id).unwrap(),
+                "originator must tombstone {id:?}"
+            );
+            assert!(
+                <Index<Remote>>::is_deleted(id).unwrap(),
+                "replica must tombstone {id:?} after replaying the root DeleteRef"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Deleting an entity only tombstoned the entity itself. `Index::remove_child_from` tombstoned the **direct** child and never descended into its subtree, and the receive path (`apply_delete_ref_action`) tombstoned only the directly-deleted id.

Consequence: a deleted node's descendants kept `deleted_at = None` **forever**. They were left as live orphans under a tombstoned ancestor, and tombstone GC — which only reclaims index rows that have `deleted_at` set — could never collect them. An unbounded index leak, and the reason `garbage_collect_tombstones` "can't reclaim subtrees."

## Fix

Add `Index::tombstone_descendants_of(root, deleted_at)`: a depth-first walk over the index `children` that tombstones every descendant, resolving each with the **same** canonical delete-vs-update tiebreak `apply_delete_ref_action` already uses for a directly-deleted entity — a descendant whose own `updated_at` is strictly newer than the delete nonce survives (the live-update-wins "zombie" case, applied transitively).

Called from **both** delete paths with one shared `deleted_at` (the nonce carried on the `DeleteRef` wire):
- local delete → `Index::remove_child_from`
- remote replay → `apply_delete_ref_action`

This symmetry is what guarantees convergence: the replica only ever receives a single `DeleteRef` (for the subtree root) and reconstructs the descendant tombstones by replaying the identical recursion with the identical `deleted_at`. Internal subtree parent-lists/hashes are intentionally not recomputed — the whole subtree detaches at the root, so none of it feeds a live hash.

### Relocate / re-key interaction (checked carefully)

`remove_child_from` is shared with the collection re-key path (`relocate_child_from`), so relocate now also tombstones the abandoned old subtree. This is **correct** and fixes a latent leak there: re-key moves data to **new deterministic ids** — recursively, which is the whole point of the `RekeyTarget` supertrait ("a `Mergeable` type that nests a collection must re-key it deterministically or it diverges permanently"). The old subtree is genuinely abandoned, and the re-key snapshot is captured **before** relocation, so no data is lost. Confirmed by the existing `reassign_deterministic_id_preserves_entries`, `converge`, and `rekey_record` integration tests, which all stay green.

## Tests

New (`tests/index.rs`, `tests/interface.rs`):
- local delete tombstones a full `root → a → b → c` chain
- `tombstone_descendants_of` tombstones descendants but leaves the root
- a descendant with a strictly-newer `updated_at` survives the subtree delete (tiebreak)
- GC reclaims all three subtree rows after retention (the live root survives)
- **two-store convergence**: originator's local delete and replica's single-`DeleteRef` replay reach identical subtree tombstone state

Full suite: `cargo test -p calimero-storage` (647 lib + integration) green, including re-key/reassign/converge/rekey_record. `cargo clippy -p calimero-storage --all-targets` clean.

## Scope

Subtree tombstoning is the prerequisite that makes tombstone GC *meaningful*. Wiring `garbage_collect_tombstones` into a production maintenance schedule is a separate concern (it remains a manually-invoked operation, by design) and is intentionally **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)