### PR TITLE
fix(context,wasm-abi): fail the identity-downgrade gate closed on unsupported ABI schema

### DIFF
--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -13,6 +13,7 @@ use calimero_primitives::context::{ContextId, UpgradePolicy};
 use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_store::key::{self, GroupUpgradeStatus, GroupUpgradeValue};
 use calimero_wasm_abi::downgrade::identity_downgrades;
+use calimero_wasm_abi::embed::{read_embedded_state_schema_versioned, EmbeddedSchema};
 use calimero_wasm_abi::schema::Manifest;
 use eyre::bail;
 use tracing::{debug, error, info, warn};
@@ -187,10 +188,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                         for rung in &rungs {
                             let next_schema = resolve_blob_schema(&node_client, rung.app_key).await;
                             if rung.migration.is_some() {
-                                verify_no_identity_downgrade(
-                                    prev_schema.as_ref(),
-                                    next_schema.as_ref(),
-                                )?;
+                                verify_no_identity_downgrade(&prev_schema, &next_schema)?;
                             }
                             prev_schema = next_schema;
                         }
@@ -559,11 +557,29 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
 /// to deserialize rather than silently re-interpreting identity-gated entries as
 /// plain. Extending the gate to code-only app swaps is a possible defence-in-depth
 /// follow-up (tracked under #2587).
-fn verify_no_identity_downgrade(
-    old: Option<&Manifest>,
-    new: Option<&Manifest>,
-) -> eyre::Result<()> {
-    let (Some(old), Some(new)) = (old, new) else {
+fn verify_no_identity_downgrade(old: &EmbeddedSchema, new: &EmbeddedSchema) -> eyre::Result<()> {
+    // A schema present but tagged with a newer major than this build understands
+    // is opaque: we cannot enumerate its identity-gated fields, so we cannot
+    // prove the upgrade is not an identity downgrade. Fail CLOSED rather than
+    // waving it through as if no schema were present (which is what collapsing it
+    // to `None` would do).
+    for (side, schema) in [("current", old), ("target", new)] {
+        if let EmbeddedSchema::UnsupportedVersion(version) = schema {
+            tracing::warn!(
+                side, %version,
+                "L1 identity-downgrade gate: refusing upgrade — app carries an unsupported future ABI schema version this node cannot evaluate"
+            );
+            eyre::bail!(
+                "identity-downgrade gate: the {side} app embeds an unsupported ABI schema version \
+                 '{version}' that this node cannot evaluate; refusing the migration upgrade \
+                 (upgrade this node to a build that understands it first)"
+            );
+        }
+    }
+
+    let (EmbeddedSchema::Supported(old), EmbeddedSchema::Supported(new)) = (old, new) else {
+        // One side has no embedded ABI (absent / malformed / legacy app): keep
+        // the documented fail-open — there is nothing to compare against.
         tracing::warn!(
             "L1 identity-downgrade gate: skipped (one side has no embedded ABI / legacy app); allowing upgrade"
         );
@@ -583,8 +599,10 @@ fn verify_no_identity_downgrade(
     Ok(())
 }
 
-/// Read a context application's embedded state schema, or None if unavailable
-/// (no blob, no embedded section, or a read error — all fail-open).
+/// Read a context application's embedded state schema as an [`EmbeddedSchema`].
+/// `Absent` if unavailable (no blob, no embedded section, or a read error — all
+/// fail-open); `UnsupportedVersion` if the section is from a newer toolchain (the
+/// gate fails closed on that).
 /// "From" side of the L1 gate. An in-place (same-id) bundle install leaves
 /// the application row already on the NEW wasm — comparing row-to-row would
 /// diff a manifest against itself and wave a downgrade through. The group's
@@ -596,11 +614,11 @@ async fn resolve_pre_upgrade_schema(
     node_client: &calimero_node_primitives::client::NodeClient,
     current_app_key: [u8; 32],
     current_application_id: &ApplicationId,
-) -> Option<Manifest> {
+) -> EmbeddedSchema {
     if current_app_key != [0u8; 32] {
         let blob = calimero_primitives::blobs::BlobId::from(current_app_key);
         match node_client.application_bytes_from_blob(&blob, None).await {
-            Ok(Some(bytes)) => return calimero_wasm_abi::embed::read_embedded_state_schema(&bytes),
+            Ok(Some(bytes)) => return read_embedded_state_schema_versioned(&bytes),
             Ok(None) => {}
             Err(err) => {
                 tracing::warn!(
@@ -658,19 +676,21 @@ async fn blob_max_state_version(
     max_sv
 }
 
-/// The blob's embedded manifest (single/first service), for the per-rung
-/// identity-downgrade gate.
+/// The blob's embedded schema (single/first service), for the per-rung
+/// identity-downgrade gate. `Absent` when the blob is missing/unreadable.
 async fn resolve_blob_schema(
     node_client: &calimero_node_primitives::client::NodeClient,
     blob: [u8; 32],
-) -> Option<Manifest> {
+) -> EmbeddedSchema {
     use calimero_primitives::blobs::BlobId;
 
-    let bytes = node_client
+    let Ok(Some(bytes)) = node_client
         .application_bytes_from_blob(&BlobId::from(blob), None)
         .await
-        .ok()??;
-    calimero_wasm_abi::embed::read_embedded_state_schema(&bytes)
+    else {
+        return EmbeddedSchema::Absent;
+    };
+    read_embedded_state_schema_versioned(&bytes)
 }
 
 /// Resolve the full emission ladder current -> target. Code-only, one-hop
@@ -988,19 +1008,19 @@ pub(crate) async fn resolve_upgrade_from_abis(
 async fn resolve_embedded_schema(
     node_client: &calimero_node_primitives::client::NodeClient,
     application_id: &ApplicationId,
-) -> Option<Manifest> {
+) -> EmbeddedSchema {
     match node_client
         .get_application_bytes(application_id, None)
         .await
     {
-        Ok(Some(bytes)) => calimero_wasm_abi::embed::read_embedded_state_schema(&bytes),
-        Ok(None) => None,
+        Ok(Some(bytes)) => read_embedded_state_schema_versioned(&bytes),
+        Ok(None) => EmbeddedSchema::Absent,
         Err(err) => {
             tracing::warn!(
                 %application_id, error = %err,
                 "L1 gate: failed to fetch application bytes; treating as no embedded ABI (fail-open)"
             );
-            None
+            EmbeddedSchema::Absent
         }
     }
 }
@@ -1609,7 +1629,7 @@ fn dispatch_cascade(
             .await;
             let new =
                 resolve_embedded_schema(&node_client_for_publish, &target_application_id).await;
-            verify_no_identity_downgrade(old.as_ref(), new.as_ref())?;
+            verify_no_identity_downgrade(&old, &new)?;
         }
 
         let sk = PrivateKey::from(effective_signing_key);
@@ -1834,6 +1854,12 @@ mod tests {
     };
     use calimero_context_config::types::ContextGroupId;
     use calimero_primitives::context::UpgradePolicy;
+    use calimero_wasm_abi::embed::EmbeddedSchema;
+
+    /// Wrap a downgrade-test manifest as a supported embedded schema.
+    fn supported(fields: &str) -> EmbeddedSchema {
+        EmbeddedSchema::Supported(dg_manifest(fields))
+    }
 
     fn gid(b: u8) -> ContextGroupId {
         ContextGroupId::from([b; 32])
@@ -1849,27 +1875,57 @@ mod tests {
 
     #[test]
     fn gate_refuses_identity_downgrade() {
-        let err = super::verify_no_identity_downgrade(
-            Some(&dg_manifest(DG_AUTH)),
-            Some(&dg_manifest(DG_PLAIN)),
-        )
-        .unwrap_err();
+        let err = super::verify_no_identity_downgrade(&supported(DG_AUTH), &supported(DG_PLAIN))
+            .unwrap_err();
         let s = err.to_string();
         assert!(s.contains("identity downgrade forbidden"), "{s}");
         assert!(s.contains("wiki"), "{s}");
     }
     #[test]
     fn gate_allows_carry_through() {
-        assert!(super::verify_no_identity_downgrade(
-            Some(&dg_manifest(DG_AUTH)),
-            Some(&dg_manifest(DG_AUTH))
-        )
-        .is_ok());
+        assert!(
+            super::verify_no_identity_downgrade(&supported(DG_AUTH), &supported(DG_AUTH)).is_ok()
+        );
     }
     #[test]
     fn gate_fails_open_when_schema_absent() {
-        assert!(super::verify_no_identity_downgrade(None, Some(&dg_manifest(DG_PLAIN))).is_ok());
-        assert!(super::verify_no_identity_downgrade(Some(&dg_manifest(DG_AUTH)), None).is_ok());
+        assert!(
+            super::verify_no_identity_downgrade(&EmbeddedSchema::Absent, &supported(DG_PLAIN))
+                .is_ok()
+        );
+        assert!(
+            super::verify_no_identity_downgrade(&supported(DG_AUTH), &EmbeddedSchema::Absent)
+                .is_ok()
+        );
+    }
+    #[test]
+    fn gate_fails_closed_on_unsupported_future_version() {
+        // A newer-major schema on EITHER side is opaque, so the gate must refuse
+        // the upgrade rather than fail open as it would for an absent schema.
+        let unsupported = || EmbeddedSchema::UnsupportedVersion("wasm-abi/2".to_owned());
+
+        let target_err =
+            super::verify_no_identity_downgrade(&supported(DG_AUTH), &unsupported()).unwrap_err();
+        assert!(
+            target_err
+                .to_string()
+                .contains("unsupported ABI schema version"),
+            "{target_err}"
+        );
+
+        let current_err =
+            super::verify_no_identity_downgrade(&unsupported(), &supported(DG_PLAIN)).unwrap_err();
+        assert!(
+            current_err
+                .to_string()
+                .contains("unsupported ABI schema version"),
+            "{current_err}"
+        );
+
+        // Unsupported takes precedence even when the other side is absent.
+        assert!(
+            super::verify_no_identity_downgrade(&unsupported(), &EmbeddedSchema::Absent).is_err()
+        );
     }
 
     #[test]

--- a/crates/wasm-abi/src/embed.rs
+++ b/crates/wasm-abi/src/embed.rs
@@ -86,11 +86,16 @@ pub fn read_embedded_state_schema(wasm: &[u8]) -> Option<Manifest> {
 /// an unsupported future major fails *closed* instead of being mistaken for "no
 /// schema".
 ///
-/// Returns the *last* `calimero_abi_v1` section that parses as a `Manifest`. The
-/// writer emits exactly one (appended last), so this is normally unambiguous;
-/// last-wins matches the writer's append semantics. A structurally-valid
-/// supported manifest always wins; failing that, a present unsupported-version
-/// section is reported over `Absent`; a malformed/invalid section is ignored.
+/// The writer emits exactly one section, but this is robust to several. The
+/// resolution rules, in priority order:
+///   - a `Supported` section is **never** overwritten by an `UnsupportedVersion`
+///     one, so a usable schema always wins over an opaque one *regardless of
+///     order* — the security property the gate relies on;
+///   - among multiple `Supported` sections the last wins (matches the writer's
+///     append/replace semantics);
+///   - an `UnsupportedVersion` is reported only when no `Supported` section
+///     exists (last unsupported wins among themselves);
+///   - a malformed / structurally-invalid section is ignored entirely.
 #[must_use]
 pub fn read_embedded_state_schema_versioned(wasm: &[u8]) -> EmbeddedSchema {
     let mut found = EmbeddedSchema::Absent;
@@ -295,6 +300,44 @@ mod tests {
         assert!(matches!(
             read_embedded_state_schema_versioned(&empty_module()),
             EmbeddedSchema::Absent
+        ));
+    }
+
+    /// Build a module with two raw `calimero_abi_v1` sections in the given JSON
+    /// order, bypassing the writer's dedup (which would keep only one).
+    fn module_with_two_sections(first: &Manifest, second: &Manifest) -> Vec<u8> {
+        let mut wasm = empty_module();
+        wasm.extend_from_slice(&encode_custom_section(
+            SECTION_NAME,
+            &serde_json::to_vec(first).unwrap(),
+        ));
+        wasm.extend_from_slice(&encode_custom_section(
+            SECTION_NAME,
+            &serde_json::to_vec(second).unwrap(),
+        ));
+        wasm
+    }
+
+    #[test]
+    fn versioned_supported_wins_over_a_later_unsupported_section() {
+        // Supported first, UnsupportedVersion appended after: the supported one
+        // must still win. This is the security property — an opaque section can
+        // never demote a usable one — so it is pinned in both orderings.
+        let wasm = module_with_two_sections(&sample_manifest(), &future_major_manifest());
+        assert!(matches!(
+            read_embedded_state_schema_versioned(&wasm),
+            EmbeddedSchema::Supported(_)
+        ));
+    }
+
+    #[test]
+    fn versioned_later_supported_wins_over_earlier_unsupported_section() {
+        // UnsupportedVersion first, Supported appended after: last-wins for a
+        // usable schema, so the result is still Supported.
+        let wasm = module_with_two_sections(&future_major_manifest(), &sample_manifest());
+        assert!(matches!(
+            read_embedded_state_schema_versioned(&wasm),
+            EmbeddedSchema::Supported(_)
         ));
     }
 

--- a/crates/wasm-abi/src/embed.rs
+++ b/crates/wasm-abi/src/embed.rs
@@ -4,8 +4,42 @@
 use wasmparser::{Parser, Payload};
 
 use crate::schema::Manifest;
+use crate::validate::ValidationError;
 
 const SECTION_NAME: &str = "calimero_abi_v1";
+
+/// Outcome of reading the embedded state-schema section. The three cases the
+/// identity-downgrade gate must treat differently: a usable schema, a schema
+/// present but from a newer toolchain than this build understands, and nothing
+/// usable at all.
+#[derive(Debug)]
+pub enum EmbeddedSchema {
+    /// A present, structurally-valid manifest of a schema major this build
+    /// supports.
+    Supported(Manifest),
+    /// A section is present and parses as a `Manifest`, but its `schema_version`
+    /// names a major this build does not understand (e.g. `wasm-abi/2`). The
+    /// node cannot enumerate its identity-gated fields, so a security gate must
+    /// treat it as "present but opaque" — NOT as "absent".
+    UnsupportedVersion(String),
+    /// No `calimero_abi_v1` section, or one that is malformed / structurally
+    /// invalid (bad JSON, dangling refs, …) — indistinguishable from no schema.
+    Absent,
+}
+
+impl EmbeddedSchema {
+    /// The manifest when present and supported, else `None`. Collapses both
+    /// `Absent` and `UnsupportedVersion` to "no usable schema" — for readers that
+    /// only consume a schema they can understand and are NOT making a security
+    /// (identity-downgrade) decision.
+    #[must_use]
+    pub fn into_manifest(self) -> Option<Manifest> {
+        match self {
+            EmbeddedSchema::Supported(manifest) => Some(manifest),
+            EmbeddedSchema::UnsupportedVersion(_) | EmbeddedSchema::Absent => None,
+        }
+    }
+}
 
 /// Error from [`write_embedded_state_schema`]. The read path stays infallible
 /// (`Option`) for fail-open; the write path is build-time tooling and fails
@@ -34,32 +68,51 @@ impl std::error::Error for EmbedError {
     }
 }
 
-/// Read the embedded state-schema `Manifest`, or `None` if the section is absent
-/// or malformed (drives fail-open at the upgrade gate).
+/// Read the embedded state-schema `Manifest`, or `None` if the section is absent,
+/// malformed, or tagged with a schema major this build does not support.
 ///
-/// Note: a section tagged with an unsupported *future* major (`wasm-abi/2`)
-/// fails `validate_manifest` and is therefore also read as `None` here — i.e. it
-/// fails open like an absent section. Distinguishing "schema present but from a
-/// newer toolchain" from "no schema" at the downgrade gate would require
-/// threading [`crate::validate::ValidationError::UnsupportedSchemaVersion`] up
-/// to the caller and is intentionally left to a focused change on that gate.
-///
-/// Returns the *last* parseable `calimero_abi_v1` section. The writer emits
-/// exactly one (appended last), so this is normally unambiguous; on the off
-/// chance a stale earlier section co-exists, last-wins matches the writer's
-/// append semantics.
+/// This collapses "unsupported future version" into `None` — fine for readers
+/// that only consume a schema they can understand. The identity-downgrade gate
+/// must NOT use this: a future-major schema read as `None` would fail open like
+/// an absent section. That gate uses [`read_embedded_state_schema_versioned`],
+/// which surfaces [`EmbeddedSchema::UnsupportedVersion`] so it can fail closed.
 pub fn read_embedded_state_schema(wasm: &[u8]) -> Option<Manifest> {
-    let mut found = None;
+    read_embedded_state_schema_versioned(wasm).into_manifest()
+}
+
+/// Read the embedded state-schema section as a three-way [`EmbeddedSchema`],
+/// distinguishing a usable manifest, a present-but-unsupported-version section,
+/// and an absent/malformed one. Security gates (identity downgrade) use this so
+/// an unsupported future major fails *closed* instead of being mistaken for "no
+/// schema".
+///
+/// Returns the *last* `calimero_abi_v1` section that parses as a `Manifest`. The
+/// writer emits exactly one (appended last), so this is normally unambiguous;
+/// last-wins matches the writer's append semantics. A structurally-valid
+/// supported manifest always wins; failing that, a present unsupported-version
+/// section is reported over `Absent`; a malformed/invalid section is ignored.
+#[must_use]
+pub fn read_embedded_state_schema_versioned(wasm: &[u8]) -> EmbeddedSchema {
+    let mut found = EmbeddedSchema::Absent;
     for payload in Parser::new(0).parse_all(wasm).flatten() {
         if let Payload::CustomSection(reader) = payload {
             if reader.name() == SECTION_NAME {
-                // Accept only a structurally VALID manifest. A well-formed-JSON
-                // but semantically invalid section (dangling refs, bad
-                // state_root, …) is treated as absent — deserialization alone
-                // does not vouch for validity, only that the bytes parse.
+                // Deserialization alone does not vouch for validity, only that
+                // the bytes parse — `validate_manifest` decides usability and
+                // separates an unsupported version from genuine malformation.
                 if let Ok(manifest) = serde_json::from_slice::<Manifest>(reader.data()) {
-                    if crate::validate::validate_manifest(&manifest).is_ok() {
-                        found = Some(manifest);
+                    match crate::validate::validate_manifest(&manifest) {
+                        Ok(()) => found = EmbeddedSchema::Supported(manifest),
+                        // A newer toolchain's schema: present but opaque. Record
+                        // it unless we already hold a usable (supported) one.
+                        Err(ValidationError::UnsupportedSchemaVersion(version)) => {
+                            if !matches!(found, EmbeddedSchema::Supported(_)) {
+                                found = EmbeddedSchema::UnsupportedVersion(version);
+                            }
+                        }
+                        // Malformed / structurally invalid → treat as absent
+                        // (leave any prior find untouched).
+                        Err(_) => {}
                     }
                 }
             }
@@ -205,6 +258,53 @@ mod tests {
 
     fn empty_module() -> Vec<u8> {
         vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]
+    }
+
+    /// A manifest tagged with a schema major this build does not support.
+    /// `write_embedded_state_schema` does not validate, so it embeds fine; the
+    /// reader is what rejects it.
+    fn future_major_manifest() -> Manifest {
+        serde_json::from_str(
+            r#"{"schema_version":"wasm-abi/2","types":{"Root":{"kind":"record","fields":[]}},"methods":[],"events":[],"state_root":"Root"}"#,
+        ).unwrap()
+    }
+
+    #[test]
+    fn versioned_reads_supported() {
+        let wasm = write_embedded_state_schema(&empty_module(), &sample_manifest()).expect("embed");
+        assert!(matches!(
+            read_embedded_state_schema_versioned(&wasm),
+            EmbeddedSchema::Supported(_)
+        ));
+    }
+
+    #[test]
+    fn versioned_surfaces_unsupported_future_major() {
+        let wasm =
+            write_embedded_state_schema(&empty_module(), &future_major_manifest()).expect("embed");
+        // The gate-facing reader keeps the section visible as opaque-but-present,
+        // so the gate can fail closed rather than mistake it for "no schema".
+        match read_embedded_state_schema_versioned(&wasm) {
+            EmbeddedSchema::UnsupportedVersion(v) => assert_eq!(v, "wasm-abi/2"),
+            other => panic!("expected UnsupportedVersion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn versioned_absent_for_module_without_section() {
+        assert!(matches!(
+            read_embedded_state_schema_versioned(&empty_module()),
+            EmbeddedSchema::Absent
+        ));
+    }
+
+    #[test]
+    fn option_reader_collapses_unsupported_to_none() {
+        // The convenience `Option` reader still hides the unsupported section
+        // (fail-open) — which is exactly why the gate must use the versioned one.
+        let wasm =
+            write_embedded_state_schema(&empty_module(), &future_major_manifest()).expect("embed");
+        assert!(read_embedded_state_schema(&wasm).is_none());
     }
 
     #[test]

--- a/crates/wasm-abi/tests/identity_downgrade_real_scenarios.rs
+++ b/crates/wasm-abi/tests/identity_downgrade_real_scenarios.rs
@@ -4,9 +4,16 @@
 //! by the merobox workflow `21-scenario-identity-downgrade`.
 
 use calimero_wasm_abi::downgrade::identity_downgrades;
-use calimero_wasm_abi::embed::{read_embedded_state_schema, write_embedded_state_schema};
+use calimero_wasm_abi::embed::{
+    read_embedded_state_schema, read_embedded_state_schema_versioned, write_embedded_state_schema,
+    EmbeddedSchema,
+};
 use calimero_wasm_abi::emitter::emit_manifest;
 use calimero_wasm_abi::schema::Manifest;
+
+fn empty_module() -> Vec<u8> {
+    vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]
+}
 
 const V1_SRC: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
@@ -27,8 +34,7 @@ fn state_schema(src: &str) -> Manifest {
 /// Embed a schema into a minimal valid module, then read it back — exercising the
 /// real wasm-section round-trip the node uses at upgrade time.
 fn embed_then_read(schema: &Manifest) -> Manifest {
-    let empty_module = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
-    let wasm = write_embedded_state_schema(&empty_module, schema).expect("embed");
+    let wasm = write_embedded_state_schema(&empty_module(), schema).expect("embed");
     read_embedded_state_schema(&wasm).expect("calimero_abi_v1 section present after embed")
 }
 
@@ -67,4 +73,24 @@ fn real_carry_through_is_not_a_downgrade() {
         identity_downgrades(&v1, &v1).is_empty(),
         "v1 -> v1 (carry-through) must not be flagged"
     );
+}
+
+/// A module whose embedded schema is from a NEWER toolchain (`wasm-abi/2`) must
+/// read as present-but-opaque, not as "no schema". This is the property the
+/// identity-downgrade gate relies on to fail *closed* instead of waving the
+/// upgrade through. (The gate decision itself is unit-tested in
+/// `calimero-context`; here we pin the wasm-section read that feeds it.)
+#[test]
+fn future_major_schema_reads_as_unsupported_not_absent() {
+    let mut schema = state_schema(V2_SRC);
+    schema.schema_version = "wasm-abi/2".to_owned();
+    let wasm = write_embedded_state_schema(&empty_module(), &schema).expect("embed");
+
+    match read_embedded_state_schema_versioned(&wasm) {
+        EmbeddedSchema::UnsupportedVersion(v) => assert_eq!(v, "wasm-abi/2"),
+        other => panic!("expected UnsupportedVersion, got {other:?}"),
+    }
+    // The convenience Option reader still collapses it to None — exactly the
+    // fail-open trap the gate avoids by using the versioned reader.
+    assert!(read_embedded_state_schema(&wasm).is_none());
 }


### PR DESCRIPTION
Closes #3060. Follow-up to #3056.

## Problem

A wasm module whose embedded state schema is tagged with a newer major than this build understands (`wasm-abi/2`) fails `validate_manifest`, so `read_embedded_state_schema` returns `None` — indistinguishable from "no embedded schema". The L1 identity-downgrade gate treats either side being `None` as fail-open, so a future-major-tagged module slips past the gate exactly like a legacy app with no ABI.

## Fix

Thread the version distinction up to the gate and **fail closed** on it:

- **wasm-abi** — new `read_embedded_state_schema_versioned(wasm) -> EmbeddedSchema` with three states:
  - `Supported(Manifest)` — present, structurally valid, supported major;
  - `UnsupportedVersion(String)` — present and parses, but a major this build can't evaluate;
  - `Absent` — no section, or malformed/structurally invalid.
  `read_embedded_state_schema` stays an `Option<Manifest>` wrapper (`.into_manifest()`), so every non-gate reader (execute, migration planner, `blob_max_state_version`) is unchanged.

- **context** — the gate's schema resolvers (`resolve_pre_upgrade_schema`, `resolve_blob_schema`, `resolve_embedded_schema`) now return `EmbeddedSchema`, and `verify_no_identity_downgrade`:
  - **fails closed** when either side is `UnsupportedVersion` — we can't enumerate its identity-gated fields, so we can't prove the upgrade isn't a downgrade; refuse and tell the operator to upgrade the node;
  - keeps the documented **fail-open** for `Absent` (legacy / no ABI / malformed);
  - runs the real `identity_downgrades` check only when **both** sides are `Supported`.

## Scope

This hardens the gate, which runs on **migration** upgrades. A code-only swap to an unsupported-version target (no typed migration is readable) is unchanged and still backed by borsh-deserialize failure — extending the gate to code-only swaps is the defence-in-depth follow-up already tracked in #2587.

## Tests

- `verify_no_identity_downgrade` unit tests: new `gate_fails_closed_on_unsupported_future_version` (target side, current side, and unsupported-vs-absent), existing fail-open / carry-through / refusal cases ported to `EmbeddedSchema`.
- `wasm-abi/embed.rs`: versioned reader returns Supported / UnsupportedVersion / Absent; the `Option` wrapper still collapses unsupported → `None`.
- `identity_downgrade_real_scenarios.rs`: a real scenario manifest re-tagged `wasm-abi/2` reads back as `UnsupportedVersion` (not `Absent`).

Full workspace `cargo clippy --all-targets -D warnings` clean; `calimero-context` (200+) and `calimero-wasm-abi` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)