### PR TITLE
fix(auth): fail closed when a node-bound token has no request host

### DIFF
--- a/crates/auth/src/auth/middleware.rs
+++ b/crates/auth/src/auth/middleware.rs
@@ -930,6 +930,80 @@ mod tests {
             .verify_token_from_headers(&headers_mismatch)
             .await;
         assert!(result.is_err(), "Token should fail with mismatched host");
+
+        // Test with NO host header at all: a node-bound token must fail closed,
+        // otherwise a client could strip Host/X-Forwarded-Host to bypass the
+        // node binding entirely.
+        let mut headers_no_host = HeaderMap::new();
+        headers_no_host.insert(
+            "Authorization",
+            HeaderValue::from_str(&format!("Bearer {access_token}")).unwrap(),
+        );
+
+        let result = token_manager
+            .verify_token_from_headers(&headers_no_host)
+            .await;
+        assert!(
+            result.is_err(),
+            "node-bound token must fail closed when the request carries no host header"
+        );
+
+        // X-Forwarded-Host (set by reverse proxies) is honoured too: a matching
+        // forwarded host with no `Host` header still validates.
+        let mut headers_fwd = HeaderMap::new();
+        headers_fwd.insert(
+            "Authorization",
+            HeaderValue::from_str(&format!("Bearer {access_token}")).unwrap(),
+        );
+        headers_fwd.insert(
+            "X-Forwarded-Host",
+            HeaderValue::from_static("node1.example.com"),
+        );
+
+        let result = token_manager.verify_token_from_headers(&headers_fwd).await;
+        assert!(
+            result.is_ok(),
+            "matching X-Forwarded-Host should validate even without a Host header"
+        );
+    }
+
+    /// A token that is NOT node-bound (no `node_url`) is unaffected by the
+    /// host check — it stays valid even with no host header present, so the
+    /// fail-closed guard only tightens node-bound tokens.
+    #[tokio::test]
+    async fn test_non_node_bound_token_unaffected_by_missing_host() {
+        let (storage, token_manager, _) = create_test_setup().await;
+
+        let key_manager = KeyManager::new(Arc::clone(&storage));
+        let key = crate::storage::models::Key::new_root_key_with_permissions(
+            "test_public_key".to_string(),
+            "test_method".to_string(),
+            vec!["admin".to_string()],
+            None,
+        );
+        key_manager.set_key("test_key_no_node", &key).await.unwrap();
+
+        let (access_token, _) = token_manager
+            .generate_mock_token_pair(
+                "test_key_no_node".to_string(),
+                vec!["admin".to_string()],
+                None,
+                Some(3600),
+            )
+            .await
+            .unwrap();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            HeaderValue::from_str(&format!("Bearer {access_token}")).unwrap(),
+        );
+
+        let result = token_manager.verify_token_from_headers(&headers).await;
+        assert!(
+            result.is_ok(),
+            "a token without node_url should validate regardless of host header"
+        );
     }
 
     #[tokio::test]

--- a/crates/auth/src/auth/token/jwt.rs
+++ b/crates/auth/src/auth/token/jwt.rs
@@ -120,25 +120,40 @@ impl TokenManager {
             .or_else(|| headers.get("host"))
             .and_then(|h| h.to_str().ok());
 
-        if let Some(request_host) = request_host {
-            // Skip validation if request is coming from internal auth service.
-            // Only allow exact "auth" hostname or "auth:" followed by a numeric port.
-            // This prevents bypass attacks using forged headers like "auth:malicious.com".
-            if Self::is_internal_auth_service(request_host) {
-                return Ok(());
-            }
+        // This is only reached for a node-bound token (the caller invokes it
+        // exactly when `node_url` is set). If the request carries no
+        // determinable host, we cannot prove it is addressed to the bound node
+        // — fail closed. Letting a `None` host fall through to `Ok(())` would
+        // let any client strip the `Host`/`X-Forwarded-Host` header and bypass
+        // node binding entirely.
+        let Some(request_host) = request_host else {
+            return Err(
+                "Token is node-bound but the request carries no Host or X-Forwarded-Host \
+                 header to validate against"
+                    .to_owned(),
+            );
+        };
 
-            // Extract the host from the token's node URL
-            if let Ok(token_url) = Url::parse(token_node_url) {
-                if let Some(token_host) = token_url.host_str() {
-                    // Compare the hosts (handle both with and without port)
-                    let request_host_without_port =
-                        request_host.split(':').next().unwrap_or(request_host);
-                    if request_host_without_port != token_host && request_host != token_host {
-                        return Err(format!(
-                            "Token is not valid for this host. Token is for '{token_host}' but request is to '{request_host}'"
-                        ));
-                    }
+        // Skip validation if request is coming from internal auth service.
+        // Only allow exact "auth" hostname or "auth:" followed by a numeric port.
+        // This prevents bypass attacks using forged headers like "auth:malicious.com".
+        if Self::is_internal_auth_service(request_host) {
+            return Ok(());
+        }
+
+        // Extract the host from the token's node URL. `node_url` is not always a
+        // URL (it can carry a client name), so an unparseable value is left to
+        // fall through rather than rejected here — the missing-request-host case
+        // above is the binding-bypass this guards.
+        if let Ok(token_url) = Url::parse(token_node_url) {
+            if let Some(token_host) = token_url.host_str() {
+                // Compare the hosts (handle both with and without port)
+                let request_host_without_port =
+                    request_host.split(':').next().unwrap_or(request_host);
+                if request_host_without_port != token_host && request_host != token_host {
+                    return Err(format!(
+                        "Token is not valid for this host. Token is for '{token_host}' but request is to '{request_host}'"
+                    ));
                 }
             }
         }


### PR DESCRIPTION
## Problem

`validate_node_host` returned `Ok(())` when the request carried **neither** a `Host` nor an `X-Forwarded-Host` header. The entire host-comparison block was wrapped in `if let Some(request_host)`, so a `None` host fell straight through to the trailing `Ok(())`:

```rust
let request_host = headers.get("X-Forwarded-Host").or_else(|| headers.get("host"))...;
if let Some(request_host) = request_host {
    // ...all the binding checks...
}
Ok(())   // <- reached when no host header is present
```

The caller only invokes this for a **node-bound** token (one carrying a `node_url`). So a client could simply omit the host header and bypass node binding entirely — presenting a token minted for node A against node B. A header-stripping proxy/MITM achieves the same.

## Fix

Fail closed: a missing/undeterminable request host is now an error for a node-bound token.

```rust
let Some(request_host) = request_host else {
    return Err("Token is node-bound but the request carries no Host or X-Forwarded-Host header to validate against".to_owned());
};
```

Deliberately **narrow**:
- The internal-auth-service bypass (`host == "auth"` / `"auth:<port>"`) is unchanged — those requests carry a host.
- The `X-Forwarded-Host` path (reverse proxies) is unchanged.
- The token-`node_url` parse is **left to fall through**: `node_url` is not always a URL (it can carry a client name, e.g. `auth.rs` sets it from `client_name`), so an unparseable value is not rejected here. Only the missing-request-host binding-bypass is tightened.

All three call sites (`verify_token_string`, the refresh handler, and the reverse-proxy `validate_handler`) are real HTTP flows where legitimate clients/proxies send a host, so this does not affect valid traffic.

## Tests

- node-bound token with **no host header** → now fails closed
- node-bound token with a matching **`X-Forwarded-Host`** (no `Host`) → still validates
- **non-node-bound** token (no `node_url`) → unaffected by a missing host
- existing matching/mismatched-host and internal-auth-bypass tests stay green

`cargo test -p mero-auth` (69 tests) green, `cargo clippy -p mero-auth` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)