### PR TITLE
fix(auth,network,server,context,storage): secret/logging/error-handling hygiene

### DIFF
--- a/crates/auth/src/api/handlers/auth.rs
+++ b/crates/auth/src/api/handlers/auth.rs
@@ -451,7 +451,7 @@ pub async fn validate_handler(
             // Add error type header for better client handling
             if matches!(err, AuthError::TokenExpired) {
                 error_headers.insert("X-Auth-Error", "token_expired".parse().unwrap());
-            } else if err.to_string().contains("revoked") {
+            } else if matches!(err, AuthError::TokenRevoked) {
                 error_headers.insert("X-Auth-Error", "token_revoked".parse().unwrap());
             } else {
                 error_headers.insert("X-Auth-Error", "invalid_token".parse().unwrap());

--- a/crates/auth/src/auth/middleware.rs
+++ b/crates/auth/src/auth/middleware.rs
@@ -9,6 +9,7 @@ use tracing::{debug, info, warn};
 
 use crate::auth::permissions::PermissionValidator;
 use crate::server::AppState;
+use crate::utils::sanitize_for_log;
 use crate::AuthError;
 
 /// Permissions of the authenticated caller.
@@ -41,14 +42,18 @@ pub async fn auth_middleware(
     // Extract request details for logging
     let method = request.method().clone();
     let path = request.uri().path().to_string();
+    // Sanitized copy used for every log line below; `path` itself stays raw for
+    // routing logic. `method` is an `http::Method` (validated token, no control
+    // chars), so only `path` needs escaping.
+    let safe_path = sanitize_for_log(&path);
     let start_time = std::time::Instant::now();
 
     // Skip authentication for public endpoints
     if path.starts_with("/public") {
-        info!("Skipping auth for public endpoint {} {}", method, path);
+        info!(method = %method, path = %safe_path, "Skipping auth for public endpoint");
         let response = next.run(request).await;
         let duration = start_time.elapsed();
-        debug!("Request {} {} completed in {:?}", method, path, duration);
+        debug!(method = %method, path = %safe_path, ?duration, "Request completed");
         return Ok(response);
     }
 
@@ -57,8 +62,10 @@ pub async fn auth_middleware(
     match state.auth_service.verify_token_from_headers(&headers).await {
         Ok(auth_response) => {
             debug!(
-                "Successful authentication for {} {} by user {}",
-                method, path, auth_response.key_id
+                method = %method,
+                path = %safe_path,
+                user = %auth_response.key_id,
+                "Successful authentication"
             );
 
             let validator = PermissionValidator::new();
@@ -70,8 +77,11 @@ pub async fn auth_middleware(
 
             if !has_permission {
                 warn!(
-                    "Permission denied for {} {} - required: {:?}, had: {:?}",
-                    method, path, required_permissions, auth_response.permissions
+                    method = %method,
+                    path = %safe_path,
+                    ?required_permissions,
+                    had = ?auth_response.permissions,
+                    "Permission denied"
                 );
                 let mut headers = HeaderMap::new();
                 headers.insert(
@@ -90,14 +100,15 @@ pub async fn auth_middleware(
 
             let mut response = next.run(request).await;
             let duration = start_time.elapsed();
-            debug!("Request {} {} completed in {:?}", method, path, duration);
+            debug!(method = %method, path = %safe_path, ?duration, "Request completed");
 
             if let Ok(user_value) = HeaderValue::from_str(&auth_response.key_id) {
                 response.headers_mut().insert("X-Auth-User", user_value);
             } else {
                 warn!(
-                    "Skipping X-Auth-User header: key_id is not a valid header value for {} {}",
-                    method, path
+                    method = %method,
+                    path = %safe_path,
+                    "Skipping X-Auth-User header: key_id is not a valid header value"
                 );
             }
 
@@ -109,8 +120,9 @@ pub async fn auth_middleware(
                         .insert("X-Auth-Permissions", permissions_value);
                 } else {
                     warn!(
-                        "Skipping X-Auth-Permissions header: invalid header value for {} {}",
-                        method, path
+                        method = %method,
+                        path = %safe_path,
+                        "Skipping X-Auth-Permissions header: invalid header value"
                     );
                 }
             }
@@ -123,33 +135,36 @@ pub async fn auth_middleware(
 
             match err {
                 AuthError::TokenExpired => {
-                    warn!(
-                        "Token expired for {} {} (took {:?})",
-                        method, path, duration
-                    );
+                    warn!(method = %method, path = %safe_path, ?duration, "Token expired");
                     headers.insert("X-Auth-Error", HeaderValue::from_static("token_expired"));
                     Err((StatusCode::UNAUTHORIZED, headers))
                 }
-                AuthError::InvalidToken(msg) if msg.contains("revoked") => {
-                    warn!(
-                        "Token revoked for {} {} (took {:?})",
-                        method, path, duration
-                    );
+                // Decided by the error *type*, not a substring match on the
+                // message — renaming the message can never downgrade a revoked
+                // token to 401.
+                AuthError::TokenRevoked => {
+                    warn!(method = %method, path = %safe_path, ?duration, "Token revoked");
                     headers.insert("X-Auth-Error", HeaderValue::from_static("token_revoked"));
                     Err((StatusCode::FORBIDDEN, headers))
                 }
                 AuthError::InvalidRequest(_) => {
                     warn!(
-                        "Invalid request for {} {}: {} (took {:?})",
-                        method, path, err, duration
+                        method = %method,
+                        path = %safe_path,
+                        error = %err,
+                        ?duration,
+                        "Invalid request"
                     );
                     headers.insert("X-Auth-Error", HeaderValue::from_static("invalid_request"));
                     Err((StatusCode::BAD_REQUEST, headers))
                 }
                 _ => {
                     warn!(
-                        "Authentication failed for {} {}: {} (took {:?})",
-                        method, path, err, duration
+                        method = %method,
+                        path = %safe_path,
+                        error = %err,
+                        ?duration,
+                        "Authentication failed"
                     );
                     headers.insert("X-Auth-Error", HeaderValue::from_static("invalid_token"));
                     Err((StatusCode::UNAUTHORIZED, headers))
@@ -719,14 +734,11 @@ mod tests {
     #[tokio::test]
     async fn test_error_response_revoked_token_format() {
         // Verify that revoked token errors produce correct header format
-        let err = crate::AuthError::InvalidToken("Key has been revoked".to_string());
+        let err = crate::AuthError::TokenRevoked;
 
         let mut headers = HeaderMap::new();
-        match &err {
-            crate::AuthError::InvalidToken(msg) if msg.contains("revoked") => {
-                headers.insert("X-Auth-Error", "token_revoked".parse().unwrap());
-            }
-            _ => {}
+        if let crate::AuthError::TokenRevoked = &err {
+            headers.insert("X-Auth-Error", "token_revoked".parse().unwrap());
         }
 
         assert_eq!(
@@ -757,13 +769,10 @@ mod tests {
         let err = crate::AuthError::InvalidToken("Some other error".to_string());
 
         let mut headers = HeaderMap::new();
-        match &err {
-            // Expiry is now its own variant, so the generic arm no longer needs
-            // to exclude "expired" messages.
-            crate::AuthError::InvalidToken(msg) if !msg.contains("revoked") => {
-                headers.insert("X-Auth-Error", "invalid_token".parse().unwrap());
-            }
-            _ => {}
+        // Revocation and expiry are now their own variants, so a generic
+        // `InvalidToken` needs no message-substring exclusions.
+        if let crate::AuthError::InvalidToken(_) = &err {
+            headers.insert("X-Auth-Error", "invalid_token".parse().unwrap());
         }
 
         assert_eq!(
@@ -785,9 +794,9 @@ mod tests {
         assert_eq!(status, StatusCode::UNAUTHORIZED);
 
         // Revoked token -> 403 Forbidden
-        let revoked_err = crate::AuthError::InvalidToken("Key has been revoked".to_string());
+        let revoked_err = crate::AuthError::TokenRevoked;
         let status = match &revoked_err {
-            crate::AuthError::InvalidToken(msg) if msg.contains("revoked") => StatusCode::FORBIDDEN,
+            crate::AuthError::TokenRevoked => StatusCode::FORBIDDEN,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
         assert_eq!(status, StatusCode::FORBIDDEN);
@@ -803,11 +812,9 @@ mod tests {
         // Generic invalid token -> 401 Unauthorized
         let generic_err = crate::AuthError::InvalidToken("Malformed".to_string());
         let status = match &generic_err {
-            // Expiry is now its own variant, so the generic arm no longer needs
-            // to exclude "expired" messages.
-            crate::AuthError::InvalidToken(msg) if !msg.contains("revoked") => {
-                StatusCode::UNAUTHORIZED
-            }
+            // Revocation and expiry are now their own variants, so a generic
+            // `InvalidToken` maps straight to 401.
+            crate::AuthError::InvalidToken(_) => StatusCode::UNAUTHORIZED,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
         assert_eq!(status, StatusCode::UNAUTHORIZED);
@@ -1027,11 +1034,11 @@ mod tests {
             crate::AuthError::AuthenticationFailed("test".to_string()),
             crate::AuthError::AuthorizationFailed("test".to_string()),
             crate::AuthError::InvalidToken("test".to_string()),
-            crate::AuthError::StorageError("test".to_string()),
+            crate::AuthError::StorageError("test".into()),
             crate::AuthError::ProviderError("test".to_string()),
             crate::AuthError::SignatureVerificationFailed("test".to_string()),
             crate::AuthError::KeyOwnershipFailed("test".to_string()),
-            crate::AuthError::TokenGenerationFailed("test".to_string()),
+            crate::AuthError::TokenGenerationFailed("test".into()),
             crate::AuthError::InvalidRequest("test".to_string()),
             crate::AuthError::ServiceUnavailable("test".to_string()),
         ];
@@ -1060,22 +1067,17 @@ mod tests {
     }
 
     #[test]
-    fn test_revoked_token_message_variations() {
-        // Test various messages that indicate revocation
-        let revoked_messages = vec![
-            "Key has been revoked",
-            "revoked",
-            "token revoked",
-            "key revoked",
-        ];
+    fn test_revoked_token_detected_by_variant_not_message() {
+        // Revocation is now identified by the dedicated `TokenRevoked` variant,
+        // not by substring-matching an error message — so renaming the message
+        // can never silently downgrade a revoked token's 403 to a 401.
+        let revoked = crate::AuthError::TokenRevoked;
+        assert!(matches!(&revoked, crate::AuthError::TokenRevoked));
 
-        for msg in revoked_messages {
-            let contains_revoked = msg.to_lowercase().contains("revoked");
-            assert!(
-                contains_revoked,
-                "Message '{msg}' should be detected as revoked"
-            );
-        }
+        // A generic `InvalidToken` whose message merely mentions "revoked" must
+        // NOT be treated as a revocation.
+        let lookalike = crate::AuthError::InvalidToken("looks revoked but isn't".to_string());
+        assert!(!matches!(&lookalike, crate::AuthError::TokenRevoked));
     }
 
     // ==========================================================================

--- a/crates/auth/src/auth/token/jwt.rs
+++ b/crates/auth/src/auth/token/jwt.rs
@@ -193,7 +193,7 @@ impl TokenManager {
             .secret_manager
             .get_jwt_auth_secret()
             .await
-            .map_err(|e| AuthError::TokenGenerationFailed(e.to_string()))?;
+            .map_err(|e| AuthError::TokenGenerationFailed(e.into()))?;
 
         let header = Header::new(Algorithm::HS256);
         encode(
@@ -201,7 +201,7 @@ impl TokenManager {
             &claims,
             &EncodingKey::from_secret(secret.as_bytes()),
         )
-        .map_err(|e| AuthError::TokenGenerationFailed(e.to_string()))
+        .map_err(|e| AuthError::TokenGenerationFailed(e.into()))
     }
 
     /// Generate a pair of JWT tokens without key validation.
@@ -270,11 +270,11 @@ impl TokenManager {
             .key_manager
             .get_key(&key_id)
             .await
-            .map_err(|e| AuthError::StorageError(e.to_string()))?
+            .map_err(|e| AuthError::StorageError(e.into()))?
             .ok_or_else(|| AuthError::InvalidToken("Key not found".to_string()))?;
 
         if !key.is_valid() {
-            return Err(AuthError::InvalidToken("Key has been revoked".to_string()));
+            return Err(AuthError::TokenRevoked);
         }
 
         let access_expiry = Duration::seconds(self.config.access_token_expiry as i64);
@@ -312,7 +312,7 @@ impl TokenManager {
             .secret_manager
             .get_jwt_auth_secret()
             .await
-            .map_err(|e| AuthError::TokenGenerationFailed(e.to_string()))?;
+            .map_err(|e| AuthError::TokenGenerationFailed(e.into()))?;
 
         let mut validation = Validation::new(Algorithm::HS256);
         validation.validate_exp = true;
@@ -374,11 +374,11 @@ impl TokenManager {
             .key_manager
             .get_key(&claims.sub)
             .await
-            .map_err(|e| AuthError::StorageError(e.to_string()))?
+            .map_err(|e| AuthError::StorageError(e.into()))?
             .ok_or_else(|| AuthError::InvalidToken("Key not found".to_string()))?;
 
         if !key.is_valid() {
-            return Err(AuthError::InvalidToken("Key has been revoked".to_string()));
+            return Err(AuthError::TokenRevoked);
         }
 
         Ok(AuthResponse {
@@ -425,7 +425,7 @@ impl TokenManager {
             .key_manager
             .get_key(key_id)
             .await
-            .map_err(|e| AuthError::StorageError(e.to_string()))?
+            .map_err(|e| AuthError::StorageError(e.into()))?
             .ok_or_else(|| AuthError::InvalidToken("Key not found".to_string()))?;
 
         // Revoke the key
@@ -435,7 +435,7 @@ impl TokenManager {
         self.key_manager
             .set_key(key_id, &key)
             .await
-            .map_err(|e| AuthError::StorageError(format!("Failed to update key: {e}")))?;
+            .map_err(|e| AuthError::StorageError(format!("Failed to update key: {e}").into()))?;
 
         Ok(())
     }
@@ -449,7 +449,7 @@ impl TokenManager {
             .key_manager
             .get_key(key_id)
             .await
-            .map_err(|e| AuthError::StorageError(e.to_string()))?;
+            .map_err(|e| AuthError::StorageError(e.into()))?;
         Ok(key.and_then(|k| k.public_key))
     }
 
@@ -480,7 +480,7 @@ impl TokenManager {
             .await
             .map_err(|e| {
                 tracing::error!("Storage error while getting key {}: {}", claims.sub, e);
-                AuthError::StorageError(e.to_string())
+                AuthError::StorageError(e.into())
             })?
             .ok_or_else(|| {
                 tracing::error!("Key not found: {}", claims.sub);
@@ -505,10 +505,12 @@ impl TokenManager {
                 hasher.update(format!("refresh:{}:{}", claims.sub, timestamp).as_bytes());
                 let new_client_id = hex::encode(hasher.finalize());
 
+                // Log only short id prefixes; the full client key ids are
+                // sensitive and add noise to debug logs.
                 tracing::debug!(
-                    "Rotating client key from {} to {}",
-                    claims.sub,
-                    new_client_id
+                    from = claims.sub.get(..8).unwrap_or(claims.sub.as_str()),
+                    to = new_client_id.get(..8).unwrap_or(new_client_id.as_str()),
+                    "Rotating client key (ids truncated)"
                 );
 
                 // Generate tokens FIRST, before any key mutations.
@@ -537,9 +539,9 @@ impl TokenManager {
                     );
                     // Token generation succeeded but key storage failed.
                     // Return error - user's old key is still valid, so no lockout.
-                    return Err(AuthError::StorageError(format!(
-                        "Failed to store new client key during rotation: {e}"
-                    )));
+                    return Err(AuthError::StorageError(
+                        format!("Failed to store new client key during rotation: {e}").into(),
+                    ));
                 }
 
                 tracing::debug!("Successfully stored new client key: {}", new_client_id);
@@ -573,7 +575,7 @@ impl TokenManager {
         // Generate a secure random nonce
         let mut nonce_bytes = [0u8; 32];
         rand::thread_rng().try_fill(&mut nonce_bytes).map_err(|e| {
-            AuthError::TokenGenerationFailed(format!("Failed to generate nonce: {e}"))
+            AuthError::TokenGenerationFailed(format!("Failed to generate nonce: {e}").into())
         })?;
         let nonce = base64::engine::general_purpose::STANDARD.encode(nonce_bytes);
 
@@ -589,7 +591,7 @@ impl TokenManager {
             .secret_manager
             .get_jwt_challenge_secret()
             .await
-            .map_err(|e| AuthError::TokenGenerationFailed(e.to_string()))?;
+            .map_err(|e| AuthError::TokenGenerationFailed(e.into()))?;
 
         let header = Header::new(Algorithm::HS256);
         let challenge = encode(
@@ -597,7 +599,7 @@ impl TokenManager {
             &claims,
             &EncodingKey::from_secret(secret.as_bytes()),
         )
-        .map_err(|e| AuthError::TokenGenerationFailed(e.to_string()))?;
+        .map_err(|e| AuthError::TokenGenerationFailed(e.into()))?;
 
         Ok(ChallengeResponse { challenge, nonce })
     }
@@ -616,7 +618,7 @@ impl TokenManager {
             .secret_manager
             .get_jwt_challenge_secret()
             .await
-            .map_err(|e| AuthError::TokenGenerationFailed(e.to_string()))?;
+            .map_err(|e| AuthError::TokenGenerationFailed(e.into()))?;
 
         let mut validation = Validation::new(Algorithm::HS256);
         validation.validate_exp = true;

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -37,8 +37,14 @@ pub enum AuthError {
     InvalidToken(String),
     #[error("Token has expired")]
     TokenExpired,
+    /// The presented token's key has been revoked. Kept distinct from
+    /// [`InvalidToken`](AuthError::InvalidToken) so the HTTP layer maps it to
+    /// `403 Forbidden` via the type, not a substring match on the message
+    /// (renaming the message must never silently downgrade revoked → `401`).
+    #[error("Token has been revoked")]
+    TokenRevoked,
     #[error("Storage error: {0}")]
-    StorageError(String),
+    StorageError(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("Provider error: {0}")]
     ProviderError(String),
     #[error("Signature verification failed: {0}")]
@@ -46,7 +52,7 @@ pub enum AuthError {
     #[error("Key ownership verification failed: {0}")]
     KeyOwnershipFailed(String),
     #[error("Token generation failed: {0}")]
-    TokenGenerationFailed(String),
+    TokenGenerationFailed(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("Invalid request: {0}")]
     InvalidRequest(String),
     #[error("Service unavailable: {0}")]

--- a/crates/auth/src/providers/impls/user_password.rs
+++ b/crates/auth/src/providers/impls/user_password.rs
@@ -176,8 +176,9 @@ impl UserPasswordProvider {
             // Existing user - return their key ID and permissions
             let permissions = root_key.permissions.clone();
             debug!(
-                "Existing user authenticated: {} with permissions: {:?}",
-                username, permissions
+                user = %crate::utils::sanitize_for_log(username),
+                ?permissions,
+                "Existing user authenticated"
             );
             return Ok((key_id, permissions));
         }
@@ -191,7 +192,10 @@ impl UserPasswordProvider {
         if existing_keys.is_empty() {
             // Bootstrap case - create the first root key
             let (key_id, root_key) = self.create_root_key(username, password).await?;
-            debug!("Bootstrap: Created first root key for user: {}", username);
+            debug!(
+                user = %crate::utils::sanitize_for_log(username),
+                "Bootstrap: created first root key"
+            );
             Ok((key_id, root_key.permissions))
         } else {
             // Root keys exist but credentials are invalid

--- a/crates/auth/src/secrets.rs
+++ b/crates/auth/src/secrets.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -66,7 +67,7 @@ impl Default for SecretRotationConfig {
 }
 
 /// A versioned secret with metadata
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct VersionedSecret {
     /// The secret value (base64 encoded)
     pub value: String,
@@ -80,6 +81,22 @@ pub struct VersionedSecret {
     pub is_primary: bool,
     /// The type of secret
     pub secret_type: SecretType,
+}
+
+// Manual `Debug` so the cleartext signing secret in `value` is never dumped by
+// a `{:?}` (e.g. when a containing struct is logged). Everything else is
+// non-sensitive metadata and is shown to keep the impl useful.
+impl fmt::Debug for VersionedSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VersionedSecret")
+            .field("value", &"<redacted>")
+            .field("version", &self.version)
+            .field("created_at", &self.created_at)
+            .field("expires_at", &self.expires_at)
+            .field("is_primary", &self.is_primary)
+            .field("secret_type", &self.secret_type)
+            .finish()
+    }
 }
 
 impl VersionedSecret {

--- a/crates/auth/src/utils.rs
+++ b/crates/auth/src/utils.rs
@@ -17,14 +17,17 @@ pub(crate) fn sanitize_for_log(input: &str) -> String {
     const MAX_LEN: usize = 256;
 
     let mut out = String::with_capacity(input.len().min(MAX_LEN));
-    for ch in input.chars().take(MAX_LEN) {
+    let mut chars = input.chars();
+    for ch in chars.by_ref().take(MAX_LEN) {
         if ch.is_control() {
             out.extend(ch.escape_default());
         } else {
             out.push(ch);
         }
     }
-    if input.chars().nth(MAX_LEN).is_some() {
+    // `chars` resumes right after the `take(MAX_LEN)`, so a remaining char means
+    // the input was longer than the cap — O(1), no second scan of the input.
+    if chars.next().is_some() {
         out.push('…');
     }
     out

--- a/crates/auth/src/utils.rs
+++ b/crates/auth/src/utils.rs
@@ -5,6 +5,31 @@ use std::time::Instant;
 
 use tokio::sync::RwLock;
 
+/// Escape control characters from a possibly user-controlled string before it
+/// reaches a log line.
+///
+/// Values such as a request path, a method token, or a username are user
+/// input. Logged raw, a crafted value can inject CR/LF (forging fake log
+/// records) or ANSI escape sequences (rewriting a terminal that reads the
+/// logs). Control characters are rendered in escaped form and the output is
+/// length-bounded so an oversized value can't flood the log sink.
+pub(crate) fn sanitize_for_log(input: &str) -> String {
+    const MAX_LEN: usize = 256;
+
+    let mut out = String::with_capacity(input.len().min(MAX_LEN));
+    for ch in input.chars().take(MAX_LEN) {
+        if ch.is_control() {
+            out.extend(ch.escape_default());
+        } else {
+            out.push(ch);
+        }
+    }
+    if input.chars().nth(MAX_LEN).is_some() {
+        out.push('…');
+    }
+    out
+}
+
 /// Basic metrics collector for auth operations
 #[derive(Debug, Clone)]
 pub struct AuthMetrics {

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -53,8 +53,8 @@ use crate::local_governance::AckRouter;
 use crate::messages::{
     AcquireContextLockRequest, ApplySignedGroupOpRequest, ApplySignedNamespaceOpRequest,
     ContextMessage, CreateContextRequest, CreateContextResponse, DeleteContextRequest,
-    DeleteContextResponse, ExecuteError, ExecuteRequest, ExecuteResponse, MigrationParams,
-    NamespaceApplyOutcome, UpdateApplicationRequest,
+    DeleteContextResponse, ExecuteError, ExecuteRequest, ExecuteResponse, InternalErrorKind,
+    MigrationParams, NamespaceApplyOutcome, UpdateApplicationRequest,
 };
 use crate::{ContextAtomic, ContextAtomicKey};
 
@@ -1543,12 +1543,16 @@ impl ContextClient {
             .await
             .map_err(|err| {
                 tracing::error!(%err, "context manager mailbox closed during execute");
-                ExecuteError::InternalError
+                ExecuteError::InternalError {
+                    kind: InternalErrorKind::Ipc,
+                }
             })?;
 
         receiver.await.map_err(|err| {
             tracing::error!(%err, "context manager dropped the execute response channel");
-            ExecuteError::InternalError
+            ExecuteError::InternalError {
+                kind: InternalErrorKind::Ipc,
+            }
         })?
     }
 
@@ -1623,7 +1627,9 @@ impl ContextClient {
                 %err,
                 "merge_root_state: failed to serialize MergeRootStateRequest"
             );
-            ExecuteError::InternalError
+            ExecuteError::InternalError {
+                kind: InternalErrorKind::Merge,
+            }
         })?;
 
         let response = self
@@ -1644,7 +1650,9 @@ impl ContextClient {
                     %context_id,
                     "merge_root_state: WASM export returned no bytes"
                 );
-                return Err(ExecuteError::InternalError);
+                return Err(ExecuteError::InternalError {
+                    kind: InternalErrorKind::Merge,
+                });
             }
             Err(err) => {
                 tracing::error!(
@@ -1652,7 +1660,9 @@ impl ContextClient {
                     ?err,
                     "merge_root_state: WASM export reported a function-call error"
                 );
-                return Err(ExecuteError::InternalError);
+                return Err(ExecuteError::InternalError {
+                    kind: InternalErrorKind::Merge,
+                });
             }
         };
 
@@ -1663,7 +1673,9 @@ impl ContextClient {
                     %err,
                     "merge_root_state: failed to deserialize MergeRootStateResponse"
                 );
-                ExecuteError::InternalError
+                ExecuteError::InternalError {
+                    kind: InternalErrorKind::Merge,
+                }
             })?;
 
         match response {
@@ -1674,7 +1686,9 @@ impl ContextClient {
                     error = %msg,
                     "merge_root_state: WASM Mergeable::merge returned an error"
                 );
-                Err(ExecuteError::InternalError)
+                Err(ExecuteError::InternalError {
+                    kind: InternalErrorKind::Merge,
+                })
             }
         }
     }

--- a/crates/context/primitives/src/messages.rs
+++ b/crates/context/primitives/src/messages.rs
@@ -127,6 +127,30 @@ impl Message for AcquireContextLockRequest {
     type Result = Option<ContextAtomicKey>;
 }
 
+/// Coarse, stable category attached to [`ExecuteError::InternalError`] so a
+/// caller can tell *which class* of internal failure occurred without parsing
+/// log text. The detailed cause is always logged server-side at the failure
+/// site; this only classifies it on the wire.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum InternalErrorKind {
+    /// Loading or resolving the context, its config, or its identity failed.
+    Context,
+    /// Loading or resolving group / cascade-upgrade metadata failed.
+    Group,
+    /// Resolving or loading a state-delta encryption key failed.
+    Encryption,
+    /// The WASM runtime / execution task failed.
+    Runtime,
+    /// A root-state CRDT merge round-trip (serialize/execute/deserialize) failed.
+    Merge,
+    /// An internal actor channel/mailbox was closed or dropped.
+    Ipc,
+    /// Any other internal failure.
+    Other,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, ThisError)]
 #[serde(tag = "type", content = "data")]
 #[non_exhaustive]
@@ -142,8 +166,8 @@ pub enum ExecuteError {
     Uninitialized,
     #[error("application not installed: '{application_id}'")]
     ApplicationNotInstalled { application_id: ApplicationId },
-    #[error("internal error")]
-    InternalError,
+    #[error("internal error ({kind:?})")]
+    InternalError { kind: InternalErrorKind },
     #[error("error resolving identity alias '{alias}'")]
     AliasResolutionFailed { alias: Alias<PublicKey> },
     /// Group-context execute attempted before its `KeyDelivery` op

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -11,7 +11,7 @@ use actix::{
 use calimero_context_client::client::crypto::ContextIdentity;
 use calimero_context_client::client::ContextClient;
 use calimero_context_client::messages::{
-    ExecuteError, ExecuteEvent, ExecuteRequest, ExecuteResponse, MigrationParams,
+    ExecuteError, ExecuteEvent, ExecuteRequest, ExecuteResponse, InternalErrorKind, MigrationParams,
 };
 use calimero_context_client::{ContextAtomic, ContextAtomicKey, ContextGuard};
 use calimero_context_config::types::{ContextGroupId, GovernanceParentEdge};
@@ -170,9 +170,11 @@ impl Handler<ExecuteRequest> for ContextManager {
             Ok(Some(context)) => context,
             Ok(None) => return ActorResponse::reply(Err(ExecuteError::ContextNotFound)),
             Err(err) => {
-                error!(%err, "failed to execute request");
+                error!(%err, "failed to fetch context");
 
-                return ActorResponse::reply(Err(ExecuteError::InternalError));
+                return ActorResponse::reply(Err(ExecuteError::InternalError {
+                    kind: InternalErrorKind::Context,
+                }));
             }
         };
 
@@ -249,7 +251,9 @@ impl Handler<ExecuteRequest> for ContextManager {
                             %err,
                             "cascade gate: failed to load GroupUpgradeStatus"
                         );
-                        return ActorResponse::reply(Err(ExecuteError::InternalError));
+                        return ActorResponse::reply(Err(ExecuteError::InternalError {
+                            kind: InternalErrorKind::Group,
+                        }));
                     }
                 }
             }
@@ -262,7 +266,9 @@ impl Handler<ExecuteRequest> for ContextManager {
                     %err,
                     "cascade gate: failed to resolve owning group"
                 );
-                return ActorResponse::reply(Err(ExecuteError::InternalError));
+                return ActorResponse::reply(Err(ExecuteError::InternalError {
+                    kind: InternalErrorKind::Group,
+                }));
             }
         }
 
@@ -288,12 +294,16 @@ impl Handler<ExecuteRequest> for ContextManager {
             Ok(None) => {
                 error!(%context_id, "missing context config for context");
 
-                return ActorResponse::reply(Err(ExecuteError::InternalError));
+                return ActorResponse::reply(Err(ExecuteError::InternalError {
+                    kind: InternalErrorKind::Context,
+                }));
             }
             Err(err) => {
-                error!(%err, "failed to execute request");
+                error!(%err, "failed to load context config");
 
-                return ActorResponse::reply(Err(ExecuteError::InternalError));
+                return ActorResponse::reply(Err(ExecuteError::InternalError {
+                    kind: InternalErrorKind::Context,
+                }));
             }
         }
 
@@ -311,9 +321,11 @@ impl Handler<ExecuteRequest> for ContextManager {
                 }))
             }
             Err(err) => {
-                error!(%err, "failed to execute request");
+                error!(%err, "failed to load context identity");
 
-                return ActorResponse::reply(Err(ExecuteError::InternalError));
+                return ActorResponse::reply(Err(ExecuteError::InternalError {
+                    kind: InternalErrorKind::Context,
+                }));
             }
         };
 
@@ -357,7 +369,9 @@ impl Handler<ExecuteRequest> for ContextManager {
                                 %err,
                                 "state-delta encryption: resolve_namespace failed",
                             );
-                            return ActorResponse::reply(Err(ExecuteError::InternalError));
+                            return ActorResponse::reply(Err(ExecuteError::InternalError {
+                                kind: InternalErrorKind::Encryption,
+                            }));
                         }
                     };
                     let key_group_id = match CapabilitiesRepository::new(&self.datastore)
@@ -373,7 +387,9 @@ impl Handler<ExecuteRequest> for ContextManager {
                                 %err,
                                 "state-delta encryption: is_open_chain_to_namespace failed",
                             );
-                            return ActorResponse::reply(Err(ExecuteError::InternalError));
+                            return ActorResponse::reply(Err(ExecuteError::InternalError {
+                                kind: InternalErrorKind::Encryption,
+                            }));
                         }
                     };
                     // Group-context branch: the group/namespace key is the
@@ -418,7 +434,9 @@ impl Handler<ExecuteRequest> for ContextManager {
                                 %err,
                                 "state-delta encryption: load_current_group_key failed",
                             );
-                            return ActorResponse::reply(Err(ExecuteError::InternalError));
+                            return ActorResponse::reply(Err(ExecuteError::InternalError {
+                                kind: InternalErrorKind::Encryption,
+                            }));
                         }
                     }
                 }
@@ -428,7 +446,9 @@ impl Handler<ExecuteRequest> for ContextManager {
                     if let Some(sk) = identity.sender_key {
                         (sk, [0u8; 32])
                     } else {
-                        return ActorResponse::reply(Err(ExecuteError::InternalError));
+                        return ActorResponse::reply(Err(ExecuteError::InternalError {
+                            kind: InternalErrorKind::Encryption,
+                        }));
                     }
                 }
                 Err(err) => {
@@ -437,7 +457,9 @@ impl Handler<ExecuteRequest> for ContextManager {
                         %err,
                         "state-delta encryption: get_group_for_context failed",
                     );
-                    return ActorResponse::reply(Err(ExecuteError::InternalError));
+                    return ActorResponse::reply(Err(ExecuteError::InternalError {
+                        kind: InternalErrorKind::Encryption,
+                    }));
                 }
             };
 
@@ -1284,7 +1306,9 @@ impl Handler<ExecuteRequest> for ContextManager {
             .map_err(|err, _act, _ctx| {
                 err.downcast::<ExecuteError>().unwrap_or_else(|err| {
                     debug!(?err, "an error occurred while executing request");
-                    ExecuteError::InternalError
+                    ExecuteError::InternalError {
+                        kind: InternalErrorKind::Runtime,
+                    }
                 })
             })
             .map_ok(
@@ -2406,7 +2430,12 @@ fn substitute_aliases_in_payload(
 
             let public_key = node_client
                 .resolve_alias(*alias, Some(context_id))
-                .map_err(|_| ExecuteError::InternalError)?
+                .map_err(|err| {
+                    error!(%err, ?alias, "failed to resolve alias during substitution");
+                    ExecuteError::InternalError {
+                        kind: InternalErrorKind::Context,
+                    }
+                })?
                 .ok_or(ExecuteError::AliasResolutionFailed { alias: *alias })?;
 
             // Substitution hot path: bs58-encode the 32-byte key into a

--- a/crates/network/src/handlers/stream/swarm/gossipsub.rs
+++ b/crates/network/src/handlers/stream/swarm/gossipsub.rs
@@ -1,7 +1,6 @@
 use calimero_network_primitives::messages::NetworkEvent;
 use libp2p::gossipsub::Event;
 use libp2p_metrics::Recorder;
-use owo_colors::OwoColorize;
 use tracing::{debug, warn};
 
 use super::{EventHandler, NetworkManager};
@@ -9,7 +8,6 @@ use super::{EventHandler, NetworkManager};
 impl EventHandler<Event> for NetworkManager {
     fn handle(&mut self, event: Event) {
         self.metrics.record(&event);
-        debug!("{}: {:?}", "gossipsub".yellow(), event);
 
         match event {
             Event::Message {
@@ -17,6 +15,17 @@ impl EventHandler<Event> for NetworkManager {
                 message,
                 ..
             } => {
+                // Log only non-sensitive metadata. The previous `{:?}` of the
+                // whole event dumped the raw `message.data` payload on a hot
+                // path (data leak) and injected ANSI color codes into the logs.
+                debug!(
+                    target: "network::gossipsub",
+                    message_id = ?id,
+                    source = ?message.source,
+                    topic = ?message.topic,
+                    payload_len = message.data.len(),
+                    "gossipsub message received"
+                );
                 if !self
                     .event_dispatcher
                     .dispatch(NetworkEvent::Message { id, message })
@@ -25,6 +34,7 @@ impl EventHandler<Event> for NetworkManager {
                 }
             }
             Event::Subscribed { peer_id, topic } => {
+                debug!(target: "network::gossipsub", %peer_id, ?topic, "subscribed");
                 if !self
                     .event_dispatcher
                     .dispatch(NetworkEvent::Subscribed { peer_id, topic })
@@ -33,6 +43,7 @@ impl EventHandler<Event> for NetworkManager {
                 }
             }
             Event::Unsubscribed { peer_id, topic } => {
+                debug!(target: "network::gossipsub", %peer_id, ?topic, "unsubscribed");
                 if !self
                     .event_dispatcher
                     .dispatch(NetworkEvent::Unsubscribed { peer_id, topic })

--- a/crates/server/src/admin/handlers/groups.rs
+++ b/crates/server/src/admin/handlers/groups.rs
@@ -77,13 +77,20 @@ fn upgrade_info_to_api_data(info: &GroupUpgradeInfo) -> GroupUpgradeStatusApiDat
 }
 
 pub fn parse_group_id(s: &str) -> Result<ContextGroupId, ApiError> {
-    let bytes = hex::decode(s).map_err(|_| ApiError {
-        status_code: StatusCode::BAD_REQUEST,
-        message: "Invalid group id format: expected hex-encoded 32 bytes".into(),
+    let bytes = hex::decode(s).map_err(|e| {
+        // Keep the client message generic but preserve the parse cause server-side.
+        tracing::debug!(error = %e, "parse_group_id: hex decode failed");
+        ApiError {
+            status_code: StatusCode::BAD_REQUEST,
+            message: "Invalid group id format: expected hex-encoded 32 bytes".into(),
+        }
     })?;
-    let arr: [u8; 32] = bytes.try_into().map_err(|_| ApiError {
-        status_code: StatusCode::BAD_REQUEST,
-        message: "Invalid group id: must be exactly 32 bytes".into(),
+    let arr: [u8; 32] = bytes.try_into().map_err(|bytes: Vec<u8>| {
+        tracing::debug!(len = bytes.len(), "parse_group_id: wrong byte length");
+        ApiError {
+            status_code: StatusCode::BAD_REQUEST,
+            message: "Invalid group id: must be exactly 32 bytes".into(),
+        }
     })?;
     Ok(ContextGroupId::from(arr))
 }
@@ -93,13 +100,19 @@ pub(crate) fn parse_context_id(s: &str) -> Result<ContextId, ApiError> {
         return Ok(context_id);
     }
 
-    let bytes = hex::decode(s).map_err(|_| ApiError {
-        status_code: StatusCode::BAD_REQUEST,
-        message: "Invalid context id format: expected base58 or hex-encoded 32 bytes".into(),
+    let bytes = hex::decode(s).map_err(|e| {
+        tracing::debug!(error = %e, "parse_context_id: hex decode failed");
+        ApiError {
+            status_code: StatusCode::BAD_REQUEST,
+            message: "Invalid context id format: expected base58 or hex-encoded 32 bytes".into(),
+        }
     })?;
-    let arr: [u8; 32] = bytes.try_into().map_err(|_| ApiError {
-        status_code: StatusCode::BAD_REQUEST,
-        message: "Invalid context id: must be exactly 32 bytes".into(),
+    let arr: [u8; 32] = bytes.try_into().map_err(|bytes: Vec<u8>| {
+        tracing::debug!(len = bytes.len(), "parse_context_id: wrong byte length");
+        ApiError {
+            status_code: StatusCode::BAD_REQUEST,
+            message: "Invalid context id: must be exactly 32 bytes".into(),
+        }
     })?;
     Ok(ContextId::from(arr))
 }

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -507,7 +507,10 @@ fn serve_file(file: EmbeddedFile) -> Result<impl IntoResponse, StatusCode> {
         .status(StatusCode::OK)
         .header("Content-Type", file.metadata.mimetype())
         .body(Body::from(content))
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to build file response");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
@@ -612,12 +615,11 @@ async fn is_authed_handler() -> impl IntoResponse {
 }
 
 async fn certificate_handler(Extension(state): Extension<Arc<AdminState>>) -> impl IntoResponse {
-    #[expect(clippy::print_stderr, reason = "Acceptable for CLI")]
     let certificate = match get_ssl(&state.store) {
         Ok(Some(cert)) => Some(cert),
         Ok(None) => None,
         Err(err) => {
-            eprintln!("Failed to get the certificate: {err}");
+            tracing::error!(error = %err, "Failed to get the certificate");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed to get the certificate",

--- a/crates/storage/src/env.rs
+++ b/crates/storage/src/env.rs
@@ -803,9 +803,12 @@ mod mocked {
             .unwrap_or_else(|| EXECUTOR_ID.with(|id| id.get()))
     }
 
-    /// Prints the log
+    /// Routes the log line through `tracing` (this is the host/native build, so
+    /// a subscriber is present) rather than raw stdout, so guest/app logs carry
+    /// the process's structured formatting and can be filtered and redirected
+    /// like every other log instead of bypassing it onto stdout.
     pub(super) fn log(message: &str) {
-        println!("{message}");
+        tracing::info!(target: "calimero_storage::guest", "{message}");
     }
 
     /// Sets the thread-local executor ID. Only callable from this crate


### PR DESCRIPTION
Addresses a batch of secret-handling, log-injection/PII, and error-context findings across auth, network, server, context, and storage. Full workspace CI clippy (`--all-targets -D warnings`) is clean; auth (68) and context-client (27) test suites pass.

## Findings addressed

**Secrets / High**
- **`VersionedSecret` leaked its cleartext signing secret via derived `Debug`** — replaced with a manual `Debug` that redacts `value` and keeps the non-sensitive metadata.
- **403-vs-401 decided by substring-matching the error message** — added a typed `AuthError::TokenRevoked`. Revoked tokens now map to 403 by *type*; renaming any message can't silently downgrade a revoked token to 401. Updated the emit sites (`jwt.rs`), the middleware, the token-validation handler, and the tests.

**Log injection / PII**
- **Unescaped user-controlled path/method on every auth failure** (CRLF/ANSI injection + flood) — sanitize control chars and switch to structured fields via a shared `utils::sanitize_for_log` (length-bounded).
- **Username logged unescaped** (`user_password`) — same sanitizer + structured field.
- **Gossipsub `{:?}`-dumped the raw message payload** (+ ANSI color) on a hot path — now logs only `message_id`/`source`/`topic`/`payload_len`.
- **Client key ids in a rotation debug log** — trimmed to short prefixes.
- **Guest-log host path wrote to raw stdout** — routed through `tracing` (the wasm path already goes through the host log syscall).
- **`eprintln!` in the certificate HTTP handler** — routed through `tracing::error!`.

**Error context**
- **`AuthError` variants discarded the source** — the error-wrapping variants (`StorageError`, `TokenGenerationFailed`) now carry a real `#[source]` instead of stringifying the cause.
- **Parse/`http::Error` causes dropped at the API boundary** (`map_err(|_| …)`) — hex/length causes are now logged server-side (client message kept generic), and the dropped `http::Error` on the file-response path is logged.
- **~20 distinct execute failures collapsed to one opaque `InternalError`** — added a static `InternalErrorKind` category (`Context`/`Group`/`Encryption`/`Runtime`/`Merge`/`Ipc`/`Other`) carried on the wire variant, so callers can distinguish failure classes. Each site already logs its distinct cause; a couple of duplicate `"failed to execute request"` messages were made specific.

## Scoping notes (proportionate calls, flagged for review)

1. **`AuthError` `#[source]`** was added to the variants that genuinely wrap a foreign error (storage / token-gen), not to the leaf-message variants (`InvalidToken`, `InvalidRequest`, `TokenExpired`, …) which have no nested cause. The wrapping sites use `e.into()` to box the real error (`Box<dyn Error + Send + Sync>`), preserving the typed chain.
2. **`InternalErrorKind`** is a coarse, server-internal category, not a full per-failure error enum. It changes the serde wire shape of `InternalError` (now `{ kind }`); acceptable pre-1.0 and the enum is `#[non_exhaustive]`. No code matches the variant, so nothing breaks.
3. **Log flood / rate-limiting** for the auth-failure path: sanitization removes the injection vector; rate-limiting/sampling is left to the tracing-subscriber layer rather than a bespoke limiter in the middleware (wrong layer for a clean fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)