### PR TITLE
fix(network): add connection limits and cap the startup dial burst

### DIFF
--- a/crates/network/src/behaviour.rs
+++ b/crates/network/src/behaviour.rs
@@ -12,8 +12,8 @@ use libp2p::request_response::{self, ProtocolSupport};
 use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::swarm::{NetworkBehaviour, Swarm};
 use libp2p::{
-    dcutr, gossipsub, identify, kad, mdns, noise, ping, relay, rendezvous, tcp, tls, yamux,
-    StreamProtocol, SwarmBuilder,
+    connection_limits, dcutr, gossipsub, identify, kad, mdns, noise, ping, relay, rendezvous, tcp,
+    tls, yamux, StreamProtocol, SwarmBuilder,
 };
 use multiaddr::Protocol;
 use tracing::warn;
@@ -23,6 +23,29 @@ use crate::autonat;
 const PROTOCOL_VERSION: &str = concat!("/", env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 const CALIMERO_KAD_PROTO_NAME: StreamProtocol = StreamProtocol::new("/calimero/kad/1.0.0");
 
+// Connection-count ceilings, enforced by `connection_limits::Behaviour`.
+//
+// These are a resource-exhaustion backstop, not a tuning knob: Calimero
+// clusters are small (2–20 collaborating peers) plus a handful of
+// bootstrap/rendezvous/relay links, so the ceilings sit far above any
+// healthy steady state and only bite under abuse — e.g. a poisoned peer
+// cache trying to dial thousands of stale addresses at startup, or an inbound
+// handshake flood. Without them a single bad input can exhaust file
+// descriptors and take the node down.
+//
+// `max_pending_outgoing` is the dial-storm cap: excess concurrent dials are
+// denied (not queued) rather than opening an unbounded number of sockets. The
+// startup cache redial also caps how many it issues at the source.
+const MAX_PENDING_INCOMING: u32 = 128;
+const MAX_PENDING_OUTGOING: u32 = 128;
+// A peer legitimately holds a few simultaneous connections (TCP + QUIC, plus a
+// relayed circuit upgrading to a direct one via DCUtR), so allow headroom
+// while still bounding a single misbehaving peer.
+const MAX_ESTABLISHED_PER_PEER: u32 = 8;
+// Total established ceiling — generous headroom over any real cluster while
+// still bounding total open sockets/FDs.
+const MAX_ESTABLISHED_TOTAL: u32 = 1024;
+
 #[expect(
     missing_debug_implementations,
     reason = "Swarm behaviours don't implement Debug"
@@ -30,6 +53,7 @@ const CALIMERO_KAD_PROTO_NAME: StreamProtocol = StreamProtocol::new("/calimero/k
 #[derive(NetworkBehaviour)]
 pub struct Behaviour {
     pub autonat: autonat::Behaviour,
+    pub connection_limits: connection_limits::Behaviour,
     pub dcutr: dcutr::Behaviour,
     pub gossipsub: gossipsub::Behaviour,
     pub identify: identify::Behaviour,
@@ -78,6 +102,13 @@ impl Behaviour {
                                 .with_probe_interval(config.discovery.autonat.probe_interval),
                         )
                     },
+                    connection_limits: connection_limits::Behaviour::new(
+                        connection_limits::ConnectionLimits::default()
+                            .with_max_pending_incoming(Some(MAX_PENDING_INCOMING))
+                            .with_max_pending_outgoing(Some(MAX_PENDING_OUTGOING))
+                            .with_max_established_per_peer(Some(MAX_ESTABLISHED_PER_PEER))
+                            .with_max_established(Some(MAX_ESTABLISHED_TOTAL)),
+                    ),
                     dcutr: dcutr::Behaviour::new(peer_id),
                     identify: identify::Behaviour::new(
                         identify::Config::new(PROTOCOL_VERSION.to_owned(), key.public())

--- a/crates/network/src/discovery.rs
+++ b/crates/network/src/discovery.rs
@@ -28,6 +28,13 @@ pub mod state;
 /// aging out peers that have genuinely left.
 const PEER_CACHE_TTL_SECS: u64 = 24 * 60 * 60;
 
+/// Most-recently-seen cached peers to dial in the startup reconnect burst.
+/// The cache can hold thousands of entries; reconnect only needs the few
+/// peers we last collaborated with (rendezvous rediscovers the rest), so this
+/// bounds the startup dial fan-out well below `connection_limits` rather than
+/// emitting a dial storm from a full or poisoned cache.
+const MAX_STARTUP_CACHE_DIALS: usize = 32;
+
 /// Fixed node-local datastore key for the single peer-cache blob. The
 /// whole relevant-peer set is stored as one value under this key in the
 /// `Generic` column (raw-bytes codec).
@@ -265,8 +272,19 @@ impl NetworkManager {
         };
         self.peer_cache = PeerAddrCache::from_persisted(records, now, PEER_CACHE_TTL_SECS);
 
-        let candidates = self.peer_cache.dial_candidates(now, PEER_CACHE_TTL_SECS);
-        let count = candidates.len();
+        // Cap the startup dial burst. The cache holds up to
+        // `MAX_PEER_CACHE_ENTRIES` (4096) peers; firing a dial at every one
+        // at once — e.g. when the cache is full of stale/unreachable
+        // addresses — is a self-inflicted dial storm that can exhaust file
+        // descriptors before `connection_limits` even denies the overflow.
+        // Reconnect only needs the handful of peers we most recently
+        // collaborated with (most-recent-first are the likeliest still
+        // reachable), so dial those and let rendezvous rediscover the rest.
+        let total = self.peer_cache.fresh_count(now, PEER_CACHE_TTL_SECS);
+        let candidates =
+            self.peer_cache
+                .startup_dial_set(now, PEER_CACHE_TTL_SECS, MAX_STARTUP_CACHE_DIALS);
+        let dialed = candidates.len();
         for candidate in candidates {
             let opts = DialOpts::peer_id(candidate.peer_id)
                 .condition(PeerCondition::DisconnectedAndNotDialing)
@@ -276,8 +294,13 @@ impl NetworkManager {
                 debug!(peer_id = %candidate.peer_id, ?err, "peer-cache startup dial skipped");
             }
         }
-        if count > 0 {
-            info!(count, "dialing cached peers on startup for fast reconnect");
+        if total > 0 {
+            info!(
+                dialed,
+                total,
+                dropped = total.saturating_sub(dialed),
+                "dialing cached peers on startup for fast reconnect (most-recent-first, capped)"
+            );
         }
     }
 

--- a/crates/network/src/discovery/peer_cache.rs
+++ b/crates/network/src/discovery/peer_cache.rs
@@ -196,7 +196,10 @@ impl PeerAddrCache {
         out
     }
 
-    /// All currently-cached, still-fresh peers — the dial-on-startup set.
+    /// All currently-cached, still-fresh peers, sorted by `peer_id`. A
+    /// test-only inspection helper for the cache contents; production dials the
+    /// recency-capped [`startup_dial_set`](Self::startup_dial_set) instead.
+    #[cfg(test)]
     pub(crate) fn dial_candidates(&self, now_secs: u64, ttl_secs: u64) -> Vec<CachedPeer> {
         let mut out: Vec<CachedPeer> = self
             .peers
@@ -205,6 +208,42 @@ impl PeerAddrCache {
             .cloned()
             .collect();
         out.sort_by(|a, b| a.peer_id.cmp(&b.peer_id));
+        out
+    }
+
+    /// Count of currently-cached, still-fresh peers (the full reconnect set
+    /// before the startup dial cap is applied). Used only for logging how many
+    /// of the fresh candidates were dropped by the cap.
+    pub(crate) fn fresh_count(&self, now_secs: u64, ttl_secs: u64) -> usize {
+        self.peers
+            .values()
+            .filter(|p| is_fresh(p.last_seen_secs, now_secs, ttl_secs))
+            .count()
+    }
+
+    /// The startup reconnect dial set: at most `max` fresh peers, ordered
+    /// most-recently-seen first (ties broken by `peer_id` for determinism).
+    ///
+    /// Bounds the startup dial burst so a full or poisoned cache can't trigger
+    /// a dial storm; the dropped peers are simply rediscovered via rendezvous.
+    pub(crate) fn startup_dial_set(
+        &self,
+        now_secs: u64,
+        ttl_secs: u64,
+        max: usize,
+    ) -> Vec<CachedPeer> {
+        let mut out: Vec<CachedPeer> = self
+            .peers
+            .values()
+            .filter(|p| is_fresh(p.last_seen_secs, now_secs, ttl_secs))
+            .cloned()
+            .collect();
+        out.sort_by(|a, b| {
+            b.last_seen_secs
+                .cmp(&a.last_seen_secs)
+                .then_with(|| a.peer_id.cmp(&b.peer_id))
+        });
+        out.truncate(max);
         out
     }
 
@@ -335,6 +374,43 @@ mod tests {
         );
         // within TTL → kept.
         assert_eq!(c.dial_candidates(900, 1000).len(), 1);
+    }
+
+    #[test]
+    fn startup_dial_set_caps_to_most_recent_and_excludes_stale() {
+        let mut c = PeerAddrCache::default();
+        // Five fresh peers (last_seen 910..=950) and one stale (800).
+        c.record(peer(1), addr("/ip4/1.0.0.1/tcp/1"), 910);
+        c.record(peer(2), addr("/ip4/1.0.0.2/tcp/1"), 920);
+        c.record(peer(3), addr("/ip4/1.0.0.3/tcp/1"), 930);
+        c.record(peer(4), addr("/ip4/1.0.0.4/tcp/1"), 940);
+        c.record(peer(5), addr("/ip4/1.0.0.5/tcp/1"), 950);
+        c.record(peer(6), addr("/ip4/1.0.0.6/tcp/1"), 800);
+
+        // now=1000, ttl=100 → fresh iff last_seen >= 900, so peer(6) is stale.
+        let now = 1000;
+        let ttl = 100;
+        assert_eq!(c.fresh_count(now, ttl), 5, "stale peer excluded from count");
+
+        // Cap of 3 → the three most-recently-seen, most-recent-first.
+        let set = c.startup_dial_set(now, ttl, 3);
+        let ids: Vec<PeerId> = set.iter().map(|p| p.peer_id).collect();
+        assert_eq!(
+            ids,
+            vec![peer(5), peer(4), peer(3)],
+            "most-recently-seen three, newest first"
+        );
+        // Ordering is strictly descending by last_seen.
+        assert!(set
+            .windows(2)
+            .all(|w| w[0].last_seen_secs >= w[1].last_seen_secs));
+        // The stale peer is never dialed regardless of the cap.
+        assert!(
+            !c.startup_dial_set(now, ttl, 100)
+                .iter()
+                .any(|p| p.peer_id == peer(6)),
+            "stale peer must not be in the dial set even when the cap is not reached"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The swarm `Behaviour` had **no connection limits**, and `load_peer_cache_and_dial` (`discovery.rs`) fired a `swarm.dial()` at **every** fresh cached peer at once:

```rust
let candidates = self.peer_cache.dial_candidates(now, PEER_CACHE_TTL_SECS); // up to 4096
for candidate in candidates {
    self.swarm.dial(...);   // no throttle, no cap
}
```

The cache holds up to `MAX_PEER_CACHE_ENTRIES` (4096) entries. A full or **poisoned** cache turns startup into a self-inflicted dial storm that can exhaust file descriptors before the node is even useful — and nothing bounded total established connections either. (Pairs with the cache-size cap from #315/#322, which limited the *explosion* but not the unthrottled dials.)

## Fix — two layers

**1. `connection_limits::Behaviour` on the swarm** (`behaviour.rs`), with resource-exhaustion ceilings:

| limit | value | purpose |
|---|---|---|
| `max_pending_outgoing` | 128 | **dial-storm cap** — overflow dials are *denied*, not queued/opened |
| `max_pending_incoming` | 128 | inbound handshake-flood cap |
| `max_established_per_peer` | 8 | headroom for TCP+QUIC+relay→DCUtR, bounds one bad peer |
| `max_established` (total) | 1024 | bounds total open sockets/FDs |

These sit far above any healthy Calimero cluster (2–20 collaborating peers + a few bootstrap/rendezvous/relay links) and only bite under abuse. (`connection_limits` is part of libp2p-swarm core — no new Cargo feature needed.)

**2. Cap the startup cache redial at the source** (`discovery.rs` + `peer_cache.rs`): dial only the `MAX_STARTUP_CACHE_DIALS` (32) **most-recently-seen** peers (most-recent-first — the likeliest still reachable) via a new `PeerAddrCache::startup_dial_set`, logging how many candidates were dropped. Reconnect only needs the handful of peers we last collaborated with; rendezvous rediscovers the rest. The former `dial_candidates` becomes a test-only inspection helper.

## Tests

`startup_dial_set` caps to the most-recently-seen N, orders most-recent-first, and never includes a stale (past-TTL) peer. Full `calimero-network` suite (82) green, `cargo clippy --all-targets` clean, downstream `calimero-node` builds (the derived `BehaviourEvent` gains a no-op `connection_limits` variant — `connection_limits::Behaviour` never emits events).

## Note on configurability

The ceilings are intentionally fixed constants — a safety backstop, not a tuning knob. `SwarmConfig` is `#[non_exhaustive]`, so promoting them to config later is non-breaking if an infra node (bootstrap/relay) ever needs higher limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)