### PR TITLE
fix(context): refuse code-only upgrades to an opaque (unsupported-version) target

### DIFF
--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -821,6 +821,29 @@ pub(crate) fn select_intermediate_rungs(
     Ok(rungs)
 }
 
+/// Read a target service's embedded schema for migration planning, refusing an
+/// *opaque* target: one whose schema is tagged with a major this build does not
+/// understand. Such a target reads as "no schema" through the plain `Option`
+/// reader, which would let it proceed as a code-only swap — and a code-only swap
+/// installs new bytecode over existing state with no migration. If that new code
+/// reinterprets identity-gated entries as plain, it is exactly the downgrade the
+/// L1 gate exists to forbid, except the gate never runs because no migration was
+/// detected. We cannot evaluate an unsupported schema, so we refuse rather than
+/// install it blind. (`Absent` — genuinely no/legacy ABI — stays code-only, as
+/// before; the L1 gate's documented fail-open owns that case.)
+fn classify_target_schema(bytes: &[u8]) -> eyre::Result<Option<Manifest>> {
+    match read_embedded_state_schema_versioned(bytes) {
+        EmbeddedSchema::Supported(manifest) => Ok(Some(manifest)),
+        EmbeddedSchema::UnsupportedVersion(version) => eyre::bail!(
+            "the target bytecode embeds an unsupported ABI schema version '{version}' that this \
+             node cannot evaluate — refusing the upgrade rather than installing it blind (a \
+             code-only swap to an unreadable schema could silently reinterpret existing state). \
+             Upgrade this node to a build that understands it first"
+        ),
+        EmbeddedSchema::Absent => Ok(None),
+    }
+}
+
 pub(crate) async fn resolve_upgrade_from_abis(
     node_client: &calimero_node_primitives::client::NodeClient,
     current_app_key: [u8; 32],
@@ -863,7 +886,12 @@ pub(crate) async fn resolve_upgrade_from_abis(
             .application_bytes_from_blob(&target_blob_id, service.as_deref())
             .await
         {
-            Ok(Some(bytes)) => read_embedded_state_schema(&bytes),
+            Ok(Some(bytes)) => classify_target_schema(&bytes).map_err(|err| {
+                eyre::eyre!(
+                    "service '{}': {err}",
+                    service.as_deref().unwrap_or("<single>")
+                )
+            })?,
             _ => None,
         };
 
@@ -1925,6 +1953,44 @@ mod tests {
         // Unsupported takes precedence even when the other side is absent.
         assert!(
             super::verify_no_identity_downgrade(&unsupported(), &EmbeddedSchema::Absent).is_err()
+        );
+    }
+
+    /// Embed a manifest into a minimal valid wasm module.
+    fn embed_manifest(manifest: &calimero_wasm_abi::schema::Manifest) -> Vec<u8> {
+        let empty_module = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+        calimero_wasm_abi::embed::write_embedded_state_schema(&empty_module, manifest)
+            .expect("embed")
+    }
+
+    #[test]
+    fn target_schema_supported_resolves_to_some() {
+        let wasm = embed_manifest(&dg_manifest(DG_PLAIN));
+        assert!(super::classify_target_schema(&wasm)
+            .expect("a supported schema is not an error")
+            .is_some());
+    }
+
+    #[test]
+    fn target_schema_absent_resolves_to_none() {
+        // A module with no `calimero_abi_v1` section stays code-only-eligible.
+        let bare_module = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+        assert!(super::classify_target_schema(&bare_module)
+            .expect("an absent schema is not an error")
+            .is_none());
+    }
+
+    #[test]
+    fn target_schema_refuses_unsupported_future_major() {
+        // The code-only bypass: an opaque target must be refused outright rather
+        // than read as "no schema" and waved through as code-only.
+        let mut manifest = dg_manifest(DG_PLAIN);
+        manifest.schema_version = "wasm-abi/2".to_owned();
+        let wasm = embed_manifest(&manifest);
+        let err = super::classify_target_schema(&wasm).unwrap_err();
+        assert!(
+            err.to_string().contains("unsupported ABI schema version"),
+            "{err}"
         );
     }
 


### PR DESCRIPTION
Follow-up to #3062 (which closed #3060). Completes the unsupported-schema hardening of the upgrade path by closing the **code-only** bypass.

## Problem

The L1 identity-downgrade gate (`verify_no_identity_downgrade`) runs only when a migration is detected (`if has_migration`). Migration detection happens in `resolve_upgrade_from_abis`, which read the **target** ABI through the plain `Option` reader (`read_embedded_state_schema`). A target whose schema is tagged with a major this build cannot evaluate (`wasm-abi/2`) read back as `None` — "no schema" — so:

- no migration was detected → `has_migration = false` → the gate was **skipped**;
- the upgrade proceeded **code-only** (new bytecode over existing state, no migration).

If that new code reinterprets identity-gated entries as plain, it is exactly the downgrade the gate exists to forbid — but the gate never ran. #3062 made the gate fail closed *when it runs*; this closes the path where it never runs.

## Fix

Resolve the target schema with the version-aware reader and refuse outright when it is `UnsupportedVersion`, via a small pure helper `classify_target_schema`:

| Target schema | Action |
|---|---|
| `Supported` | plan as today |
| `UnsupportedVersion` | **bail** — "upgrade this node first" |
| `Absent` (genuinely no/legacy ABI) | code-only-eligible as before (the gate's documented fail-open owns this) |

Placed at the single chokepoint both upgrade flows funnel through, so it is **fail-safe at every caller**:
- admin emission paths (`?`) propagate the error → the upgrade is never proposed network-wide;
- the receiver actuation path (`execute`) marks the migration failed → the context stays on its current version, stranded for operator resync.

## Tests

Unit tests for `classify_target_schema`: `Supported -> Some`, `Absent -> None`, `UnsupportedVersion -> refused` (the bypass). Existing `upgrade_group` tests (incl. the #3062 gate tests) still pass.

Full workspace `cargo clippy --all-targets -D warnings` clean; `calimero-context` (203) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)