### PR TITLE
feat(xcall): node-enforced caller policy for #[app::xcall] entry points

### DIFF
--- a/apps/xcall-example/src/lib.rs
+++ b/apps/xcall-example/src/lib.rs
@@ -49,16 +49,19 @@ impl XCallExample {
         self.xcall_to(target_context, &method)
     }
 
-    /// Receive a pong via `xcall`. Marked `#[app::xcall(from_same_app)]` so the
-    /// node only admits callers running this same application — ping and pong
-    /// are the same app — and rejects a same-namespace context running a
-    /// different app before this method even runs.
+    /// Receive a pong via `xcall`. Marked `#[app::xcall]` so other contexts in
+    /// the same namespace may invoke it.
     ///
-    /// The node-enforced policy is the trust boundary; the `env::xcall_origin()`
-    /// checks below are the remaining app-specific logic — rejecting direct
-    /// calls (no origin) and verifying the origin matches the self-reported
-    /// `from_context`.
-    #[app::xcall(from_same_app)]
+    /// A tighter, node-enforced caller policy is available —
+    /// `#[app::xcall(from_same_app)]` restricts callers to contexts running this
+    /// same application. It's deliberately not used here yet: emitting the new
+    /// `xcall_callers` ABI field requires the downstream `abi-codegen` tool to
+    /// understand it first, so the example adopts it once that ships.
+    ///
+    /// `env::xcall_origin()` is set by the node and can't be forged, so this
+    /// method rejects direct calls (no origin) and refuses any call where the
+    /// origin doesn't match the self-reported `from_context`.
+    #[app::xcall]
     pub fn pong(&mut self, from_context: ContextId) -> app::Result<()> {
         let origin = calimero_sdk::env::xcall_origin().map(ContextId::from);
 

--- a/apps/xcall-example/src/lib.rs
+++ b/apps/xcall-example/src/lib.rs
@@ -49,13 +49,16 @@ impl XCallExample {
         self.xcall_to(target_context, &method)
     }
 
-    /// Receive a pong via `xcall`. Marked `#[app::xcall]` so other contexts in
-    /// the same namespace may invoke it.
+    /// Receive a pong via `xcall`. Marked `#[app::xcall(from_same_app)]` so the
+    /// node only admits callers running this same application — ping and pong
+    /// are the same app — and rejects a same-namespace context running a
+    /// different app before this method even runs.
     ///
-    /// `env::xcall_origin()` is set by the node and can't be forged, so this
-    /// method rejects direct calls (no origin) and refuses any call where the
-    /// origin doesn't match the self-reported `from_context`.
-    #[app::xcall]
+    /// The node-enforced policy is the trust boundary; the `env::xcall_origin()`
+    /// checks below are the remaining app-specific logic — rejecting direct
+    /// calls (no origin) and verifying the origin matches the self-reported
+    /// `from_context`.
+    #[app::xcall(from_same_app)]
     pub fn pong(&mut self, from_context: ContextId) -> app::Result<()> {
         let origin = calimero_sdk::env::xcall_origin().map(ContextId::from);
 

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -39,7 +39,7 @@ use std::sync::Arc;
 
 use calimero_store::{key, types, Store};
 use calimero_utils_actix::global_runtime;
-use calimero_wasm_abi::schema::MethodIntent;
+use calimero_wasm_abi::schema::{MethodIntent, XCallCallers};
 use either::Either;
 use eyre::{bail, WrapErr};
 use futures_util::future::TryFutureExt;
@@ -756,22 +756,44 @@ impl Handler<ExecuteRequest> for ContextManager {
             let context_client = act.context_client.clone();
 
             // For an xcall, deny any method the target app didn't mark
-            // `#[app::xcall]`. No declared set ⇒ not gated. Keyed by the
-            // executing blob, like the read-only lookup above. Applies to every
-            // xcall-dispatched run, including internal methods like
-            // `__calimero_sync_next` — a guest must not reach those via xcall
-            // (they are never `#[app::xcall]`); the sync path itself carries no
-            // origin, so legitimate state ops are unaffected.
+            // `#[app::xcall]`, and any caller the entry point's policy doesn't
+            // admit. No declared set ⇒ not gated. Keyed by the executing blob,
+            // like the read-only lookup above. Applies to every xcall-dispatched
+            // run, including internal methods like `__calimero_sync_next` — a
+            // guest must not reach those via xcall (they are never
+            // `#[app::xcall]`); the sync path itself carries no origin, so
+            // legitimate state ops are unaffected.
             let xcall_blob = act.executing_blob_for_context(&context.id).or_else(|| {
                 act.applications
                     .get(&context.application_id)
                     .map(|app| app.blob.bytecode)
             });
+            // The calling context's application id, resolved once (xcall path
+            // only), so a `from_same_app` entry point can compare it to ours. A
+            // caller that can't be resolved is treated as a mismatch — fail
+            // closed rather than admitting an unknown source.
+            let xcall_source_app = xcall_origin.and_then(|origin| {
+                context_client
+                    .get_context(&origin)
+                    .ok()
+                    .flatten()
+                    .map(|ctx| ctx.application_id)
+            });
             let xcall_denied = xcall_origin.is_some()
                 && xcall_blob.is_some_and(|blob| {
+                    // A module that declares no xcall entry points stays ungated
+                    // (back-compat). Otherwise the method must be a declared
+                    // entry point AND the caller must satisfy its policy.
                     act.xcall_methods
                         .get(&(blob, context.service_name.clone()))
-                        .is_some_and(|set| !set.contains(method.as_str()))
+                        .is_some_and(|policies| {
+                            xcall_caller_denied(
+                                policies,
+                                method.as_str(),
+                                xcall_source_app,
+                                context.application_id,
+                            )
+                        })
                 });
 
             // Cheap (Arc-backed) clone kept past internal_execute (which moves
@@ -784,7 +806,7 @@ impl Handler<ExecuteRequest> for ContextManager {
                     warn!(
                         %context_id,
                         function = %method,
-                        "xcall denied: not an #[app::xcall] entry point"
+                        "xcall denied: not an #[app::xcall] entry point, or caller not permitted by its policy"
                     );
                     bail!(ExecuteError::XCallNotPermitted { context_id });
                 }
@@ -1588,18 +1610,22 @@ impl ContextManager {
                     // manifest is fine: read-only defaults to the write lock,
                     // and an absent xcall set just leaves the method ungated.
                     let read_only_set = extract_read_only_set(&bytecode);
-                    let xcall_set = extract_xcall_set(&bytecode);
+                    let xcall_policies = extract_xcall_policies(&bytecode);
                     let module = calimero_utils_actix::global_runtime()
                         .spawn_blocking(move || {
                             calimero_runtime::Engine::with_limits(vm_limits).compile(&bytecode)
                         })
                         .await
                         .wrap_err("WASM compilation task failed")??;
-                    Ok((module, read_only_set, xcall_set))
+                    Ok((module, read_only_set, xcall_policies))
                 }
                 .into_actor(act)
                 .map_ok(
-                    move |(module, read_only_set, xcall_set): (calimero_runtime::Module, _, _),
+                    move |(module, read_only_set, xcall_policies): (
+                        calimero_runtime::Module,
+                        _,
+                        _,
+                    ),
                           act,
                           _ctx| {
                         let _ = act.modules.insert(cache_key.clone(), module.clone());
@@ -1607,8 +1633,8 @@ impl ContextManager {
                             let _ = act.read_only_methods.insert(cache_key.clone(), set);
                         }
                         // Cached like read_only_methods, keyed by the same blob.
-                        if let Some(set) = xcall_set {
-                            let _ = act.xcall_methods.insert(cache_key, set);
+                        if let Some(policies) = xcall_policies {
+                            let _ = act.xcall_methods.insert(cache_key, policies);
                         }
                         module
                     },
@@ -2347,21 +2373,43 @@ fn extract_read_only_set(bytecode: &[u8]) -> Option<Arc<HashSet<String>>> {
     Some(Arc::new(set))
 }
 
-/// The `#[app::xcall]` method names declared in a module's embedded ABI, or
-/// `None` if the manifest is absent/unparseable or declares none (the method is
-/// then left ungated). A returned set is always non-empty.
-fn extract_xcall_set(bytecode: &[u8]) -> Option<Arc<HashSet<String>>> {
+/// Decides whether an xcall to `method` is denied, given the target module's
+/// declared entry points (`policies`), the caller's application id
+/// (`source_app`, `None` if it couldn't be resolved), and the target's
+/// application id (`target_app`).
+///
+/// Denied when the method is not a declared `#[app::xcall]` entry point, or its
+/// policy excludes the caller. A `SameApp` entry point with an unresolved
+/// caller is denied — fail closed.
+fn xcall_caller_denied(
+    policies: &crate::XCallPolicyMap,
+    method: &str,
+    source_app: Option<ApplicationId>,
+    target_app: ApplicationId,
+) -> bool {
+    match policies.get(method) {
+        None => true,
+        Some(XCallCallers::AnyInNamespace) => false,
+        Some(XCallCallers::SameApp) => source_app != Some(target_app),
+    }
+}
+
+/// The `#[app::xcall]` entry points declared in a module's embedded ABI mapped
+/// to their caller policy, or `None` if the manifest is absent/unparseable or
+/// declares none (the method is then left ungated). A returned map is always
+/// non-empty.
+fn extract_xcall_policies(bytecode: &[u8]) -> Option<Arc<crate::XCallPolicyMap>> {
     let manifest = calimero_wasm_abi::embed::read_embedded_state_schema(bytecode)?;
-    let set: HashSet<String> = manifest
+    let map: crate::XCallPolicyMap = manifest
         .methods
         .into_iter()
         .filter(|m| m.xcall_callable)
-        .map(|m| m.name)
+        .map(|m| (m.name, m.xcall_callers))
         .collect();
-    if set.is_empty() {
+    if map.is_empty() {
         None
     } else {
-        Some(Arc::new(set))
+        Some(Arc::new(map))
     }
 }
 
@@ -2441,9 +2489,12 @@ mod tests {
     use calimero_store::key::GroupMetaValue;
     use calimero_store::Store;
 
+    use std::collections::HashMap;
+
     use super::{
-        extract_xcall_set, resolve_namespace_for_context, resolve_producing_app_key, should_block,
-        upgrade_blocks_write, upgrade_rejects_committed_write,
+        extract_xcall_policies, resolve_namespace_for_context, resolve_producing_app_key,
+        should_block, upgrade_blocks_write, upgrade_rejects_committed_write, xcall_caller_denied,
+        XCallCallers,
     };
     use calimero_store::key::GroupUpgradeStatus;
 
@@ -2493,10 +2544,47 @@ mod tests {
     }
 
     #[test]
-    fn extract_xcall_set_none_on_non_wasm() {
+    fn xcall_caller_policy_decision() {
+        let app_a = ApplicationId::from([0xA1; 32]);
+        let app_b = ApplicationId::from([0xB2; 32]);
+        let mut policies = HashMap::new();
+        policies.insert("open".to_owned(), XCallCallers::AnyInNamespace);
+        policies.insert("restricted".to_owned(), XCallCallers::SameApp);
+
+        // A method not declared as an entry point is always denied.
+        assert!(xcall_caller_denied(
+            &policies,
+            "unknown",
+            Some(app_a),
+            app_a
+        ));
+
+        // AnyInNamespace admits any caller (including an unresolved one).
+        assert!(!xcall_caller_denied(&policies, "open", Some(app_b), app_a));
+        assert!(!xcall_caller_denied(&policies, "open", None, app_a));
+
+        // SameApp admits only a caller running the same application id.
+        assert!(!xcall_caller_denied(
+            &policies,
+            "restricted",
+            Some(app_a),
+            app_a
+        ));
+        assert!(xcall_caller_denied(
+            &policies,
+            "restricted",
+            Some(app_b),
+            app_a
+        ));
+        // An unresolved caller is denied for SameApp — fail closed.
+        assert!(xcall_caller_denied(&policies, "restricted", None, app_a));
+    }
+
+    #[test]
+    fn extract_xcall_policies_none_on_non_wasm() {
         // No embedded ABI manifest ⇒ None (method left ungated).
-        assert!(extract_xcall_set(b"not a wasm module").is_none());
-        assert!(extract_xcall_set(&[]).is_none());
+        assert!(extract_xcall_policies(b"not a wasm module").is_none());
+        assert!(extract_xcall_policies(&[]).is_none());
     }
 
     #[test]

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -3,7 +3,7 @@
 use calimero_governance_store::{
     MembershipRepository, MetaRepository, NamespaceRepository, SigningKeysRepository,
 };
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -21,6 +21,7 @@ use calimero_primitives::application::{Application, ApplicationId};
 use calimero_primitives::blobs::BlobId;
 use calimero_primitives::context::{Context, ContextId};
 use calimero_store::Store;
+use calimero_wasm_abi::schema::XCallCallers;
 use either::Either;
 use prometheus_client::registry::Registry;
 use tokio::sync::{Mutex, RwLock};
@@ -380,6 +381,14 @@ impl Evictable for calimero_runtime::Module {}
 /// embedded ABI manifest on the next compile cycle.
 impl Evictable for Arc<HashSet<String>> {}
 
+/// Per-method xcall caller policy (method name → who may call it), derived from
+/// a module's embedded ABI.
+pub(crate) type XCallPolicyMap = HashMap<String, XCallCallers>;
+
+/// The xcall caller-policy map has no live handle either; re-derived from the
+/// embedded ABI manifest on the next compile cycle, so always safe to evict.
+impl Evictable for Arc<XCallPolicyMap> {}
+
 /// A per-namespace governance DAG is lock-gated exactly like [`ContextMeta`]:
 /// an in-flight op holds the `Arc<Mutex<DagStore>>`, so the DAG is evictable
 /// only at `strong_count == 1`. Evicting a live DAG would split it across two
@@ -457,14 +466,16 @@ pub struct ContextManager {
     /// Size-capped to `MAX_CACHED_MODULES` (one entry per compiled module).
     read_only_methods: BoundedCache<(BlobId, Option<String>), Arc<HashSet<String>>>,
 
-    /// Per-blob set of method names declared `#[app::xcall]` in the module ABI.
-    /// An xcall to a method outside this set is denied; an absent entry (module
-    /// declares none, or not parsed yet) leaves the method ungated.
+    /// Per-blob map of method names declared `#[app::xcall]` in the module ABI
+    /// to their caller policy (`XCallCallers`). An xcall to a method outside this
+    /// map is denied; a method present is allowed only if the caller satisfies
+    /// its policy. An absent entry (module declares none, or not parsed yet)
+    /// leaves the method ungated.
     ///
     /// Keyed by `(BlobId, Option<String>)` like `modules` / `read_only_methods`
     /// (content-addressed, never stale), populated in `get_module_for_blob`.
     /// Size-capped to `MAX_CACHED_MODULES` (one entry per compiled module).
-    xcall_methods: BoundedCache<(BlobId, Option<String>), Arc<HashSet<String>>>,
+    xcall_methods: BoundedCache<(BlobId, Option<String>), Arc<XCallPolicyMap>>,
 
     /// Cumulative hit/miss counters for the `contexts` hot cache, driving the
     /// periodic effectiveness log (see [`ContextCacheStats`] and

--- a/crates/sdk/macros/src/lib.rs
+++ b/crates/sdk/macros/src/lib.rs
@@ -182,18 +182,31 @@ pub fn init(_args: TokenStream, input: TokenStream) -> TokenStream {
 /// Marks a method as a cross-context (`xcall`) entry point.
 ///
 /// A marker consumed by `#[app::logic]` and recorded in the ABI as
-/// `Method.xcall_callable`; on its own it does not modify the method. The node
-/// uses the flag to restrict `xcall` dispatch to declared entry points.
+/// `Method.xcall_callable` / `Method.xcall_callers`; on its own it does not
+/// modify the method. The node uses these to restrict `xcall` dispatch to
+/// declared entry points and to enforce who may call them.
 ///
 /// Must be a registered attribute so it resolves at the method site when
 /// `#[app::logic]` re-emits the impl verbatim (as `#[app::view]` also is).
 ///
 /// # Usage
 ///
-/// Apply `#[app::xcall]` to a public logic method to allow other contexts in
-/// the same namespace to invoke it via `env::xcall`. Mutually exclusive with
-/// `#[app::init]` and `#[app::view]` (xcall is fire-and-forget, so a read-only
-/// target's return value would go nowhere).
+/// Apply `#[app::xcall]` to a public logic method to allow other contexts to
+/// invoke it via `env::xcall`. Mutually exclusive with `#[app::init]` and
+/// `#[app::view]` (xcall is fire-and-forget, so a read-only target's return
+/// value would go nowhere).
+///
+/// # Caller policy
+///
+/// By default (`#[app::xcall]`) any context in the same namespace may call.
+/// Tighten it with:
+///
+/// - `#[app::xcall(from_same_app)]` — only contexts running the **same
+///   application id** as this one may call. The node enforces this, so it
+///   does not depend on the target also checking `env::xcall_origin()`.
+///
+/// `env::xcall_origin()` remains available for finer, data-dependent checks the
+/// declarative policy can't express.
 #[proc_macro_attribute]
 pub fn xcall(_args: TokenStream, input: TokenStream) -> TokenStream {
     // this is a no-op, the attribute is just a marker

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -449,6 +449,25 @@ impl<'a, 'b> TryFrom<LogicMethodImplInput<'a, 'b>> for LogicMethod<'a> {
                     }
                     "xcall" => {
                         modifiers.push(Modifer::XCall);
+                        // Validate the optional caller-policy arg so a typo is a
+                        // compile error rather than silently falling back to the
+                        // open `AnyInNamespace` default in the ABI emitter — a
+                        // fail-open on a security policy. A bare `#[app::xcall]`
+                        // is a path attribute (no list), so only inspect args
+                        // when they're present.
+                        if matches!(attr.meta, syn::Meta::List(_)) {
+                            if let Err(err) = attr.parse_nested_meta(|meta| {
+                                if meta.path.is_ident("from_same_app") {
+                                    Ok(())
+                                } else {
+                                    Err(meta.error(
+                                        "unknown `#[app::xcall]` argument; expected `from_same_app`",
+                                    ))
+                                }
+                            }) {
+                                errors.subsume(err);
+                            }
+                        }
                     }
                     _ => {}
                 }

--- a/crates/wasm-abi/src/emitter.rs
+++ b/crates/wasm-abi/src/emitter.rs
@@ -7,7 +7,7 @@ use syn::{Item, ItemEnum, ItemImpl, ItemStruct, Type};
 use crate::normalize::{normalize_type, ResolvedLocal, TypeResolver};
 use crate::schema::{
     Event, Field, Manifest, Method, MethodIntent, MigrationEdgeAbi, Parameter, ScalarType, TypeDef,
-    TypeRef, Variant,
+    TypeRef, Variant, XCallCallers,
 };
 
 /// ABI emitter that processes Rust source code
@@ -317,14 +317,32 @@ fn has_app_view_attribute(attrs: &[syn::Attribute]) -> bool {
     })
 }
 
-/// Returns `true` when the method carries `#[app::xcall]`, declaring it as a
-/// cross-context entry point — i.e. callable by another context via `xcall`.
-fn has_app_xcall_attribute(attrs: &[syn::Attribute]) -> bool {
-    attrs.iter().any(|attr| {
-        let path = attr.path();
-        let segments: Vec<_> = path.segments.iter().collect();
-        segments.len() == 2 && segments[0].ident == "app" && segments[1].ident == "xcall"
-    })
+/// Returns the caller policy if the method carries `#[app::xcall]`, declaring
+/// it as a cross-context entry point, or `None` if it is not one.
+///
+/// A bare `#[app::xcall]` yields [`XCallCallers::AnyInNamespace`] (the
+/// historical default); `#[app::xcall(from_same_app)]` yields
+/// [`XCallCallers::SameApp`]. Unknown args are ignored here (the SDK macro
+/// validates them) so a typo can't break ABI emission silently into a
+/// non-xcall method.
+fn app_xcall_policy(attrs: &[syn::Attribute]) -> Option<XCallCallers> {
+    for attr in attrs {
+        let segments: Vec<_> = attr.path().segments.iter().collect();
+        if segments.len() == 2 && segments[0].ident == "app" && segments[1].ident == "xcall" {
+            let mut policy = XCallCallers::AnyInNamespace;
+            // A bare `#[app::xcall]` is a path attribute with no args, so
+            // `parse_nested_meta` errors — ignore that and keep the default.
+            // Only `#[app::xcall(...)]` carries nested meta to inspect.
+            let _ = attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("from_same_app") {
+                    policy = XCallCallers::SameApp;
+                }
+                Ok(())
+            });
+            return Some(policy);
+        }
+    }
+    None
 }
 
 /// Parse `version = N` out of `#[app::state(version = N, …)]`. `None` if no version arg.
@@ -635,9 +653,15 @@ impl<'ast> Visit<'ast> for AbiEmitter {
                     };
 
                     // Cross-context entry point from #[app::xcall]; never on
-                    // init (an initializer is not an xcall target).
-                    let xcall_callable =
-                        method_name != "init" && has_app_xcall_attribute(&method.attrs);
+                    // init (an initializer is not an xcall target). The policy
+                    // (who may call) rides alongside the callable flag.
+                    let xcall_policy = if method_name == "init" {
+                        None
+                    } else {
+                        app_xcall_policy(&method.attrs)
+                    };
+                    let xcall_callable = xcall_policy.is_some();
+                    let xcall_callers = xcall_policy.unwrap_or_default();
 
                     // Create and store the method
                     let method = Method {
@@ -648,6 +672,7 @@ impl<'ast> Visit<'ast> for AbiEmitter {
                         errors: Vec::new(),
                         intent,
                         xcall_callable,
+                        xcall_callers,
                     };
 
                     self.methods.push(method);
@@ -910,6 +935,42 @@ mod xcall_tests {
         assert!(
             !plain.xcall_callable,
             "unannotated method must not be xcall_callable"
+        );
+    }
+
+    #[test]
+    fn emits_caller_policy_from_xcall_args() {
+        let lib = r#"
+            #[app::state(version = 1)]
+            pub struct State { x: u32 }
+            #[app::logic]
+            impl State {
+                #[app::init] pub fn init() -> State { State { x: 0 } }
+                #[app::xcall] pub fn open(&mut self) {}
+                #[app::xcall(from_same_app)] pub fn restricted(&mut self) {}
+                pub fn plain(&mut self) {}
+            }
+        "#;
+        let m = emit_manifest_from_crate(&[("lib.rs".to_owned(), lib.to_owned())]).unwrap();
+        let policy = |name: &str| {
+            m.methods
+                .iter()
+                .find(|mm| mm.name == name)
+                .map(|mm| mm.xcall_callers.clone())
+        };
+
+        // Bare `#[app::xcall]` keeps the historical open default.
+        assert_eq!(policy("open"), Some(XCallCallers::AnyInNamespace));
+        // `from_same_app` tightens it to same-application callers only.
+        assert_eq!(policy("restricted"), Some(XCallCallers::SameApp));
+        // A non-xcall method carries the default (and isn't callable).
+        assert_eq!(policy("plain"), Some(XCallCallers::AnyInNamespace));
+        assert!(
+            !m.methods
+                .iter()
+                .find(|mm| mm.name == "plain")
+                .unwrap()
+                .xcall_callable
         );
     }
 }

--- a/crates/wasm-abi/src/schema.rs
+++ b/crates/wasm-abi/src/schema.rs
@@ -123,6 +123,34 @@ impl MethodIntent {
     }
 }
 
+/// Who may invoke an `#[app::xcall]` entry point, declared by the app author.
+///
+/// The node enforces this at the xcall gate, so the trust boundary is
+/// declarative and fail-closed rather than relying on every target method to
+/// hand-check `env::xcall_origin()`.
+///
+/// Defaults to [`AnyInNamespace`](XCallCallers::AnyInNamespace) — the
+/// pre-policy behaviour — so a bare `#[app::xcall]` and every manifest compiled
+/// before this field existed keep working unchanged.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum XCallCallers {
+    /// Any context in the same namespace may call (the historical default).
+    #[default]
+    AnyInNamespace,
+    /// Only contexts running the SAME application id as the target may call
+    /// (`#[app::xcall(from_same_app)]`).
+    SameApp,
+}
+
+impl XCallCallers {
+    /// Returns `true` for the default so `serde` skips the field on manifests
+    /// that don't tighten the policy, keeping them round-trip identical.
+    fn is_any_in_namespace(&self) -> bool {
+        matches!(self, Self::AnyInNamespace)
+    }
+}
+
 /// Method definition
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Method {
@@ -144,6 +172,11 @@ pub struct Method {
     /// modules with none are not gated. Absent/false on pre-existing manifests.
     #[serde(default, skip_serializing_if = "is_false")]
     pub xcall_callable: bool,
+    /// Who may invoke this entry point (only meaningful when `xcall_callable`).
+    /// Absent on manifests compiled before this field existed; treated as
+    /// [`XCallCallers::AnyInNamespace`] so they keep their prior behaviour.
+    #[serde(default, skip_serializing_if = "XCallCallers::is_any_in_namespace")]
+    pub xcall_callers: XCallCallers,
 }
 
 /// `skip_serializing_if` predicate for a defaulted `bool` field. serde passes
@@ -738,6 +771,7 @@ mod tests {
             errors: Vec::new(),
             intent: MethodIntent::Unspecified,
             xcall_callable: false,
+            xcall_callers: Default::default(),
         });
 
         // Serialize and deserialize
@@ -767,6 +801,7 @@ mod tests {
             errors: Vec::new(),
             intent: MethodIntent::Unspecified,
             xcall_callable: false,
+            xcall_callers: Default::default(),
         });
 
         assert_eq!(manifest.schema_version, "wasm-abi/1");
@@ -786,6 +821,7 @@ mod tests {
             errors: vec![],
             intent: MethodIntent::ReadOnly,
             xcall_callable: false,
+            xcall_callers: Default::default(),
         };
         let json = serde_json::to_string(&m).unwrap();
         assert!(json.contains("read_only"), "expected 'read_only' in {json}");
@@ -801,6 +837,7 @@ mod tests {
             errors: vec![],
             intent: MethodIntent::Mutating,
             xcall_callable: false,
+            xcall_callers: Default::default(),
         };
         let json_mut = serde_json::to_string(&m_mut).unwrap();
         assert!(
@@ -819,6 +856,7 @@ mod tests {
             errors: vec![],
             intent: MethodIntent::Unspecified,
             xcall_callable: false,
+            xcall_callers: Default::default(),
         };
         let json2 = serde_json::to_string(&m2).unwrap();
         assert!(
@@ -843,6 +881,7 @@ mod tests {
             errors: vec![],
             intent: MethodIntent::Unspecified,
             xcall_callable: false,
+            xcall_callers: Default::default(),
         };
         let json = serde_json::to_string(&m).unwrap();
         assert!(
@@ -853,6 +892,7 @@ mod tests {
         // True serialises and round-trips; orthogonal to a Mutating intent.
         let m2 = Method {
             xcall_callable: true,
+            xcall_callers: Default::default(),
             intent: MethodIntent::Mutating,
             ..m.clone()
         };

--- a/crates/wasm-abi/src/validate.rs
+++ b/crates/wasm-abi/src/validate.rs
@@ -346,6 +346,7 @@ mod tests {
             errors: vec![],
             intent: MethodIntent::Unspecified,
             xcall_callable: false,
+            xcall_callers: Default::default(),
         });
 
         assert!(validate_manifest(&manifest).is_ok());
@@ -407,6 +408,7 @@ mod tests {
             errors: vec![],
             intent: MethodIntent::Unspecified,
             xcall_callable: false,
+            xcall_callers: Default::default(),
         });
 
         assert!(validate_manifest(&manifest).is_err());

--- a/crates/wasm-abi/tests/invariants.rs
+++ b/crates/wasm-abi/tests/invariants.rs
@@ -66,6 +66,7 @@ fn test_invariant_error_payload_structure() {
         }],
         intent: MethodIntent::Unspecified,
         xcall_callable: false,
+        xcall_callers: Default::default(),
     });
 
     // This should pass validation
@@ -94,6 +95,7 @@ fn test_invariant_variable_bytes_no_size() {
         errors: vec![],
         intent: MethodIntent::Unspecified,
         xcall_callable: false,
+        xcall_callers: Default::default(),
     });
 
     // This should pass validation
@@ -126,6 +128,7 @@ fn test_invariant_map_string_key() {
         errors: vec![],
         intent: MethodIntent::Unspecified,
         xcall_callable: false,
+        xcall_callers: Default::default(),
     });
 
     // This should pass validation
@@ -156,6 +159,7 @@ fn test_invariant_no_dangling_refs() {
         errors: vec![],
         intent: MethodIntent::Unspecified,
         xcall_callable: false,
+        xcall_callers: Default::default(),
     });
 
     // This should pass validation
@@ -181,6 +185,7 @@ fn test_invariant_detects_dangling_refs() {
         errors: vec![],
         intent: MethodIntent::Unspecified,
         xcall_callable: false,
+        xcall_callers: Default::default(),
     });
 
     // This should fail validation
@@ -219,6 +224,7 @@ fn test_invariant_detects_dangling_refs_in_inner_type() {
         errors: vec![],
         intent: MethodIntent::Unspecified,
         xcall_callable: false,
+        xcall_callers: Default::default(),
     });
 
     // This should fail validation because NonExistentType is referenced in inner_type
@@ -250,6 +256,7 @@ fn test_invariant_deterministic_ordering() {
         errors: vec![],
         intent: MethodIntent::Unspecified,
         xcall_callable: false,
+        xcall_callers: Default::default(),
     });
     manifest.methods.push(Method {
         name: "a_method".to_string(),
@@ -259,6 +266,7 @@ fn test_invariant_deterministic_ordering() {
         errors: vec![],
         intent: MethodIntent::Unspecified,
         xcall_callable: false,
+        xcall_callers: Default::default(),
     });
 
     // This should fail validation because methods are not sorted

--- a/crates/wasm-abi/tests/schema_validation.rs
+++ b/crates/wasm-abi/tests/schema_validation.rs
@@ -24,6 +24,7 @@ fn test_schema_validation_basic() {
         errors: vec![],
         intent: MethodIntent::Unspecified,
         xcall_callable: false,
+        xcall_callers: Default::default(),
     });
 
     // Serialize to JSON
@@ -101,6 +102,7 @@ fn test_schema_validation_shared_storage_crdt_type() {
         errors: vec![],
         intent: MethodIntent::Unspecified,
         xcall_callable: false,
+        xcall_callers: Default::default(),
     });
 
     let manifest_json = serde_json::to_value(&manifest).unwrap();

--- a/crates/wasm-abi/wasm-abi.schema.json
+++ b/crates/wasm-abi/wasm-abi.schema.json
@@ -397,6 +397,14 @@
         "xcall_callable": {
           "type": "boolean",
           "description": "Cross-context entry point declared via #[app::xcall]. Absent/false on modules compiled before this field existed. When any method in a module sets this, the node enforces that only such methods are reachable via xcall."
+        },
+        "xcall_callers": {
+          "type": "string",
+          "enum": [
+            "any_in_namespace",
+            "same_app"
+          ],
+          "description": "Who may invoke this xcall entry point, enforced by the node. 'any_in_namespace' (the default, and the value for manifests compiled before this field existed) keeps the historical behaviour; 'same_app' (#[app::xcall(from_same_app)]) restricts callers to contexts running the same application id."
         }
       }
     },


### PR DESCRIPTION
## Motivation

Today an `#[app::xcall]` entry point can be invoked by **any** context in the same namespace, and the only authorization is whatever the target method hand-codes with `env::xcall_origin()`. That's **fail-open**: forget the check (or get it wrong) and a different app in the namespace can drive your entry point under the node's identity in your context.

This came out of scoping the "xcall executes as `members.first()`" item. The scoping showed the executor *must* be a member the node owns (a synthetic non-member can't execute and its writes are discarded), so the real weakness isn't the identity — it's that **caller authorization is delegated to every app author** instead of declared and node-enforced. This PR fixes that.

## What this does

A declarative, node-enforced caller policy on xcall entry points:

```rust
#[app::xcall]                  // any context in the same namespace (unchanged default)
#[app::xcall(from_same_app)]   // only contexts running the SAME application id
pub fn pong(&mut self, …) { … }
```

The node enforces `from_same_app` at the existing xcall gate, so it does **not** rely on the target also checking the origin. `env::xcall_origin()` remains for finer, data-dependent checks the declarative policy can't express.

## How

- **ABI** (`wasm-abi`): new `Method.xcall_callers` (`XCallCallers` enum, default `AnyInNamespace`, serde-skipped when default). The emitter parses the `from_same_app` arg from the source attribute. Fully back-compat — manifests without the field deserialize as `AnyInNamespace`, and the existing `xcall_callable` bool is unchanged.
- **Node** (`context`): the per-blob xcall cache maps method → policy. At the gate the node resolves the **caller's** application id (from `xcall_origin`, via `context_client.get_context`) and denies a `SameApp` entry point unless it matches the target's app id. An unresolvable caller is denied — **fail closed**. Enforcement stays entirely in the context crate; no runtime/VMContext threading. The decision is factored into the pure `xcall_caller_denied` helper and unit-tested.
- **Macro** (`sdk-macros`): `#[app::xcall]` accepts `from_same_app` and **rejects unknown args at compile time**, so a policy typo can't silently fall back to the open default.
- **Example**: `xcall-example`'s `pong` now uses `#[app::xcall(from_same_app)]` (ping and pong are the same app), demonstrating the node-enforced boundary; its `env::xcall_origin()` checks become app-specific provenance logic on top.

## Tests

- emitter: `from_same_app` → `SameApp`, bare `#[app::xcall]` → `AnyInNamespace`
- node: `xcall_caller_policy_decision` covers not-an-entry-point (deny), `AnyInNamespace` (allow any incl. unresolved), `SameApp` same-app (allow) / different-app (deny) / unresolved (deny, fail-closed)
- example app tests + full `wasm-abi` (all bins) and `calimero-context` (200) suites green; `calimero-node` builds; clippy clean across touched crates.

## Scope / follow-ups

This is **layer 1**: app-to-app, declarative, in the manifest. A natural **layer 2** is a governance-managed ACL for specific **context-id** pairs (runtime entities can't live in a compile-time manifest) — a separate, larger change. Default stays `AnyInNamespace` for back-compat; flipping to default-deny is a possible future tightening now that the mechanism exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)