### PR TITLE
fix(meroctl): resolve secrets from env/file/stdin instead of argv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6017,6 +6017,7 @@ dependencies = [
  "notify",
  "rand 0.8.5",
  "reqwest 0.12.28",
+ "rpassword",
  "semver",
  "serde",
  "serde_json",
@@ -8197,6 +8198,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8233,6 +8245,16 @@ dependencies = [
  "nix",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,6 +259,7 @@ rand = "0.8.5"
 reqwest = { version = "0.12.2", default-features = false, features = ["rustls-tls"] }
 ring = "0.17.8"
 rocksdb = { version = "0.24.0", default-features = false, features = ["bindgen-runtime"] }
+rpassword = "7.3"
 rust-embed = "8.5.0"
 rustc_version = "0.4"
 semver = "1.0.22"

--- a/crates/meroctl/Cargo.toml
+++ b/crates/meroctl/Cargo.toml
@@ -24,6 +24,7 @@ libp2p.workspace = true
 notify.workspace = true
 rand.workspace = true
 reqwest = { workspace = true, features = ["json"] }
+rpassword.workspace = true
 semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/meroctl/src/cli/context/create.rs
+++ b/crates/meroctl/src/cli/context/create.rs
@@ -210,10 +210,9 @@ pub async fn create_context(
         group_name,
     } = args;
 
-    // Resolve the identity secret from its source spec (env:/file:/-/prompt) so
-    // it never has to be passed verbatim on the command line.
-    let identity_secret =
-        crate::secret::resolve_optional_secret(identity_secret.as_deref(), "identity secret")?;
+    // Resolve the identity secret from its source spec (env:/file:/-) so it
+    // never has to be passed verbatim on the command line.
+    let identity_secret = crate::secret::resolve_optional_secret(identity_secret.as_deref())?;
 
     let response: GetApplicationResponse = client.get_application(&application_id).await?;
 

--- a/crates/meroctl/src/cli/context/create.rs
+++ b/crates/meroctl/src/cli/context/create.rs
@@ -78,7 +78,12 @@ pub struct CreateCommand {
     )]
     pub group_id: String,
 
-    #[clap(long, help = "Identity secret (hex) for signing group membership")]
+    #[clap(
+        long,
+        help = "Source of the identity secret (hex) for signing group membership: `env:NAME`, \
+                `file:PATH`, `-` (stdin), or the raw value (discouraged — exposed in shell \
+                history / ps / /proc)"
+    )]
     pub identity_secret: Option<String>,
 
     #[clap(
@@ -204,6 +209,12 @@ pub async fn create_context(
         identity_secret,
         group_name,
     } = args;
+
+    // Resolve the identity secret from its source spec (env:/file:/-/prompt) so
+    // it never has to be passed verbatim on the command line.
+    let identity_secret =
+        crate::secret::resolve_optional_secret(identity_secret.as_deref(), "identity secret")?;
+
     let response: GetApplicationResponse = client.get_application(&application_id).await?;
 
     if response.data.application.is_none() {

--- a/crates/meroctl/src/cli/group/signing_key.rs
+++ b/crates/meroctl/src/cli/group/signing_key.rs
@@ -33,16 +33,17 @@ pub struct RegisterSigningKeyCommand {
 
     #[clap(
         name = "SIGNING_KEY",
-        help = "The hex-encoded private signing key to register"
+        help = "Source of the hex-encoded private signing key: `env:NAME`, `file:PATH`, `-` \
+                (stdin), or the raw value (discouraged — exposed in shell history / ps / /proc)"
     )]
     pub signing_key: String,
 }
 
 impl RegisterSigningKeyCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
-        let request = RegisterGroupSigningKeyApiRequest {
-            signing_key: self.signing_key,
-        };
+        let signing_key =
+            crate::secret::resolve_required_secret(Some(&self.signing_key), "signing key")?;
+        let request = RegisterGroupSigningKeyApiRequest { signing_key };
 
         let client = environment.client()?;
         let response = client

--- a/crates/meroctl/src/cli/node.rs
+++ b/crates/meroctl/src/cli/node.rs
@@ -21,11 +21,14 @@ pub struct AddNodeCommand {
     /// URL of remote node or path to local node directory
     pub location: String,
 
-    /// Access token for authentication (skips automatic login)
+    /// Access token source (skips automatic login): `env:NAME`, `file:PATH`,
+    /// `-` (stdin), or the raw token (discouraged — exposed in shell history /
+    /// ps / /proc).
     #[arg(long)]
     pub access_token: Option<String>,
 
-    /// Refresh token for authentication (optional, used with access-token)
+    /// Refresh token source (used with --access-token): `env:NAME`,
+    /// `file:PATH`, `-` (stdin), or the raw token (discouraged).
     #[arg(long)]
     pub refresh_token: Option<String>,
 }
@@ -264,12 +267,18 @@ async fn determine_auth_tokens(
     node_description: &str,
     output: Output,
 ) -> Result<Option<JwtToken>> {
-    // If access token is provided, use direct JWT tokens (skip automatic auth)
-    if let Some(access_token) = &cmd.access_token {
-        return Ok(Some(if let Some(refresh) = &cmd.refresh_token {
-            JwtToken::with_refresh(access_token.clone(), refresh.clone())
+    // If access token is provided, use direct JWT tokens (skip automatic auth).
+    // The flag values are *source specs*, not the raw secret, so the token
+    // never has to appear in argv.
+    let access_token =
+        crate::secret::resolve_optional_secret(cmd.access_token.as_deref(), "access token")?;
+    if let Some(access_token) = access_token {
+        let refresh_token =
+            crate::secret::resolve_optional_secret(cmd.refresh_token.as_deref(), "refresh token")?;
+        return Ok(Some(if let Some(refresh) = refresh_token {
+            JwtToken::with_refresh(access_token, refresh)
         } else {
-            JwtToken::new(access_token.clone())
+            JwtToken::new(access_token)
         }));
     }
 

--- a/crates/meroctl/src/cli/node.rs
+++ b/crates/meroctl/src/cli/node.rs
@@ -270,11 +270,9 @@ async fn determine_auth_tokens(
     // If access token is provided, use direct JWT tokens (skip automatic auth).
     // The flag values are *source specs*, not the raw secret, so the token
     // never has to appear in argv.
-    let access_token =
-        crate::secret::resolve_optional_secret(cmd.access_token.as_deref(), "access token")?;
+    let access_token = crate::secret::resolve_optional_secret(cmd.access_token.as_deref())?;
     if let Some(access_token) = access_token {
-        let refresh_token =
-            crate::secret::resolve_optional_secret(cmd.refresh_token.as_deref(), "refresh token")?;
+        let refresh_token = crate::secret::resolve_optional_secret(cmd.refresh_token.as_deref())?;
         return Ok(Some(if let Some(refresh) = refresh_token {
             JwtToken::with_refresh(access_token, refresh)
         } else {

--- a/crates/meroctl/src/main.rs
+++ b/crates/meroctl/src/main.rs
@@ -11,6 +11,7 @@ mod connection;
 mod defaults;
 
 mod output;
+mod secret;
 mod storage;
 mod ws;
 

--- a/crates/meroctl/src/secret.rs
+++ b/crates/meroctl/src/secret.rs
@@ -1,0 +1,146 @@
+//! Resolve secret CLI inputs without exposing them in the process's argv.
+//!
+//! Passing a secret as a positional/inline CLI argument leaks it via shell
+//! history, `ps`, and `/proc/<pid>/cmdline`. Instead of taking the secret
+//! itself, secret-bearing flags take a *source spec* that this module resolves:
+//!
+//! - `env:NAME`  — read the value from environment variable `NAME`
+//! - `file:PATH` — read the value from `PATH` (trailing newline trimmed)
+//! - `-`         — read a single line from stdin
+//!
+//! A bare value (anything not matching the forms above) is still accepted for
+//! backwards compatibility, but emits a deprecation warning recommending the
+//! safe forms. When no value is supplied at all and stdin is a TTY, the user is
+//! prompted without echo.
+
+use std::env;
+use std::fs;
+use std::io::{self, BufRead, IsTerminal, Write};
+
+use eyre::{eyre, Result, WrapErr};
+
+/// Resolve an optional secret source spec into the secret value.
+///
+/// Returns `Ok(None)` only when `arg` is `None` and stdin is not a TTY (so a
+/// non-interactive run with no secret supplied stays "not provided" rather than
+/// blocking on a prompt). `prompt` labels the no-echo prompt.
+pub fn resolve_optional_secret(arg: Option<&str>, prompt: &str) -> Result<Option<String>> {
+    match arg {
+        Some(spec) => resolve_spec(spec).map(Some),
+        None => {
+            if io::stdin().is_terminal() {
+                prompt_hidden(prompt).map(Some)
+            } else {
+                Ok(None)
+            }
+        }
+    }
+}
+
+/// Resolve a required secret source spec into the secret value.
+///
+/// Like [`resolve_optional_secret`] but errors when nothing is supplied in a
+/// non-interactive context instead of returning `None`.
+pub fn resolve_required_secret(arg: Option<&str>, prompt: &str) -> Result<String> {
+    match resolve_optional_secret(arg, prompt)? {
+        Some(value) if !value.is_empty() => Ok(value),
+        Some(_) => Err(eyre!("{prompt}: resolved to an empty value")),
+        None => Err(eyre!(
+            "{prompt}: no value supplied. Provide one via `env:NAME`, `file:PATH`, `-` (stdin), or run interactively."
+        )),
+    }
+}
+
+fn resolve_spec(spec: &str) -> Result<String> {
+    if let Some(name) = spec.strip_prefix("env:") {
+        let value = env::var(name).wrap_err_with(|| {
+            format!("failed to read secret from environment variable `{name}`")
+        })?;
+        return Ok(value);
+    }
+
+    if let Some(path) = spec.strip_prefix("file:") {
+        let raw = fs::read_to_string(path)
+            .wrap_err_with(|| format!("failed to read secret from file `{path}`"))?;
+        // Trim a single trailing newline (and any \r) so `echo secret > f` works.
+        return Ok(raw.trim_end_matches(['\n', '\r']).to_owned());
+    }
+
+    if spec == "-" {
+        let mut line = String::new();
+        let n = io::stdin()
+            .lock()
+            .read_line(&mut line)
+            .wrap_err("failed to read secret from stdin")?;
+        if n == 0 {
+            return Err(eyre!("no secret received on stdin"));
+        }
+        return Ok(line.trim_end_matches(['\n', '\r']).to_owned());
+    }
+
+    // Bare literal: keep working, but warn — it is exposed in argv.
+    eprintln!(
+        "warning: passing a secret directly on the command line exposes it via shell history, \
+         `ps`, and /proc. Prefer `env:NAME`, `file:PATH`, or `-` (stdin)."
+    );
+    Ok(spec.to_owned())
+}
+
+fn prompt_hidden(prompt: &str) -> Result<String> {
+    // Write the prompt to stderr so it does not pollute machine-readable stdout.
+    let mut stderr = io::stderr();
+    write!(stderr, "{prompt}: ").wrap_err("failed to write prompt")?;
+    stderr.flush().ok();
+    let value = rpassword::read_password().wrap_err("failed to read secret from prompt")?;
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_spec_reads_environment_variable() {
+        // SAFETY: single-threaded test; unique var name avoids cross-test races.
+        env::set_var("MEROCTL_TEST_SECRET_ENV", "s3cr3t");
+        assert_eq!(
+            resolve_spec("env:MEROCTL_TEST_SECRET_ENV").unwrap(),
+            "s3cr3t"
+        );
+        env::remove_var("MEROCTL_TEST_SECRET_ENV");
+    }
+
+    #[test]
+    fn env_spec_errors_when_unset() {
+        assert!(resolve_spec("env:MEROCTL_TEST_DEFINITELY_UNSET").is_err());
+    }
+
+    #[test]
+    fn file_spec_reads_and_trims_trailing_newline() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("key");
+        fs::write(&path, "deadbeef\n").unwrap();
+        let spec = format!("file:{}", path.display());
+        assert_eq!(resolve_spec(&spec).unwrap(), "deadbeef");
+    }
+
+    #[test]
+    fn file_spec_errors_on_missing_file() {
+        assert!(resolve_spec("file:/no/such/meroctl/secret").is_err());
+    }
+
+    #[test]
+    fn bare_value_is_returned_verbatim() {
+        // (Emits a deprecation warning to stderr.)
+        assert_eq!(resolve_spec("literal-secret").unwrap(), "literal-secret");
+    }
+
+    #[test]
+    fn required_secret_errors_on_empty_resolution() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty");
+        fs::write(&path, "").unwrap();
+        let spec = format!("file:{}", path.display());
+        assert!(resolve_required_secret(Some(&spec), "test secret").is_err());
+    }
+}

--- a/crates/meroctl/src/secret.rs
+++ b/crates/meroctl/src/secret.rs
@@ -5,13 +5,18 @@
 //! itself, secret-bearing flags take a *source spec* that this module resolves:
 //!
 //! - `env:NAME`  — read the value from environment variable `NAME`
-//! - `file:PATH` — read the value from `PATH` (trailing newline trimmed)
-//! - `-`         — read a single line from stdin
+//! - `file:PATH` — read the value from `PATH` (trailing newlines trimmed)
+//! - `-`         — read one line from stdin (secrets here are single-line, e.g.
+//!   hex keys or JWTs)
 //!
 //! A bare value (anything not matching the forms above) is still accepted for
 //! backwards compatibility, but emits a deprecation warning recommending the
-//! safe forms. When no value is supplied at all and stdin is a TTY, the user is
-//! prompted without echo.
+//! safe forms.
+//!
+//! Only [`resolve_required_secret`] ever prompts (and only on a TTY); an
+//! *optional* secret that is simply omitted resolves to `None` without a
+//! prompt, so commands with optional secrets (e.g. `node add` tokens) are not
+//! interrupted.
 
 use std::env;
 use std::fs;
@@ -21,30 +26,37 @@ use eyre::{eyre, Result, WrapErr};
 
 /// Resolve an optional secret source spec into the secret value.
 ///
-/// Returns `Ok(None)` only when `arg` is `None` and stdin is not a TTY (so a
-/// non-interactive run with no secret supplied stays "not provided" rather than
-/// blocking on a prompt). `prompt` labels the no-echo prompt.
-pub fn resolve_optional_secret(arg: Option<&str>, prompt: &str) -> Result<Option<String>> {
+/// Returns `Ok(None)` when `arg` is `None` — an omitted optional secret stays
+/// "not provided" and never triggers a prompt. When a spec *is* given it is
+/// resolved (and a failure to resolve it is an error).
+pub fn resolve_optional_secret(arg: Option<&str>) -> Result<Option<String>> {
     match arg {
         Some(spec) => resolve_spec(spec).map(Some),
-        None => {
-            if io::stdin().is_terminal() {
-                prompt_hidden(prompt).map(Some)
-            } else {
-                Ok(None)
-            }
-        }
+        None => Ok(None),
     }
 }
 
 /// Resolve a required secret source spec into the secret value.
 ///
-/// Like [`resolve_optional_secret`] but errors when nothing is supplied in a
-/// non-interactive context instead of returning `None`.
+/// When a spec is given it is resolved (and rejected if it resolves to empty).
+/// When nothing is supplied, a TTY is prompted without echo; a non-interactive
+/// run errors rather than hanging.
 pub fn resolve_required_secret(arg: Option<&str>, prompt: &str) -> Result<String> {
-    match resolve_optional_secret(arg, prompt)? {
-        Some(value) if !value.is_empty() => Ok(value),
-        Some(_) => Err(eyre!("{prompt}: resolved to an empty value")),
+    match arg {
+        Some(spec) => {
+            let value = resolve_spec(spec)?;
+            if value.is_empty() {
+                return Err(eyre!("{prompt}: resolved to an empty value"));
+            }
+            Ok(value)
+        }
+        None if io::stdin().is_terminal() => {
+            let value = prompt_hidden(prompt)?;
+            if value.is_empty() {
+                return Err(eyre!("{prompt}: empty value entered"));
+            }
+            Ok(value)
+        }
         None => Err(eyre!(
             "{prompt}: no value supplied. Provide one via `env:NAME`, `file:PATH`, `-` (stdin), or run interactively."
         )),
@@ -62,7 +74,8 @@ fn resolve_spec(spec: &str) -> Result<String> {
     if let Some(path) = spec.strip_prefix("file:") {
         let raw = fs::read_to_string(path)
             .wrap_err_with(|| format!("failed to read secret from file `{path}`"))?;
-        // Trim a single trailing newline (and any \r) so `echo secret > f` works.
+        // Trim trailing newline(s)/CRs so `echo secret > f` works; a secret
+        // never legitimately ends in a newline.
         return Ok(raw.trim_end_matches(['\n', '\r']).to_owned());
     }
 
@@ -101,7 +114,10 @@ mod tests {
 
     #[test]
     fn env_spec_reads_environment_variable() {
-        // SAFETY: single-threaded test; unique var name avoids cross-test races.
+        // The test harness runs tests on multiple threads, so this mutates the
+        // process environment concurrently with other tests. That is sound on
+        // edition 2021 (`set_var` is safe) and race-free in practice here: the
+        // variable name is unique to this test and no other test reads it.
         env::set_var("MEROCTL_TEST_SECRET_ENV", "s3cr3t");
         assert_eq!(
             resolve_spec("env:MEROCTL_TEST_SECRET_ENV").unwrap(),


### PR DESCRIPTION
## Problem

`meroctl` accepted several **secrets as positional/inline CLI arguments**, which leak them via shell history, `ps`, and `/proc/<pid>/cmdline`:

| Command | Secret |
|---|---|
| `group signing-key register <GROUP_ID> <SIGNING_KEY>` | private signing key |
| `node add --access-token/--refresh-token <TOKEN>` | JWT tokens |
| `context create --identity-secret <HEX>` | identity secret |

### Before
```
meroctl group signing-key register <gid> 0xPRIVATEKEY     # key in argv → history/ps/proc
meroctl node add n https://… --access-token eyJ…          # token in argv
meroctl context create --application-id … --identity-secret 0xSECRET …
```
The raw secret is visible to any user who can read the process table or your shell history file.

## Fix

A new `secret` module resolves a secret from a **source spec** instead of taking the secret itself:

- `env:NAME` — read from environment variable `NAME`
- `file:PATH` — read from a file (trailing newline trimmed)
- `-` — read one line from stdin
- omitted on a TTY — no-echo prompt (`rpassword`)
- a bare value still works **but prints a deprecation warning** (backwards-compatible)

### After
```
meroctl group signing-key register <gid> file:./key.hex   # nothing sensitive in argv
MERO_TOK=eyJ… meroctl node add n https://… --access-token env:MERO_TOK
printf '%s' 0xSECRET | meroctl context create … --identity-secret -
```

## Changes
- `crates/meroctl/src/secret.rs` (new): `resolve_optional_secret` / `resolve_required_secret` + unit tests (env/file/stdin/bare/empty).
- Wired into `cli/group/signing_key.rs`, `cli/node.rs`, `cli/context/create.rs`; help text documents the safe forms.
- Adds `rpassword` (workspace dep) for the no-echo prompt.

## Validation
- `cargo build -p meroctl`, `cargo clippy -p meroctl` clean.
- `cargo test -p meroctl` — 6 new `secret::tests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)