### PR TITLE
fix(meroctl): bind loopback OAuth callback to a single-use state nonce

### DIFF
--- a/crates/meroctl/src/auth.rs
+++ b/crates/meroctl/src/auth.rs
@@ -130,6 +130,17 @@ async fn start_callback_server(
                     // another local process from injecting tokens into our
                     // loopback callback (login-CSRF).
                     if params.get("state").map(String::as_str) != Some(expected_state.as_str()) {
+                        // Wake the waiting CLI with an error instead of dropping
+                        // the request silently — otherwise it blocks until the
+                        // 2-minute auth timeout.
+                        if let Ok(mut guard) = tx.lock() {
+                            if let Some(sender) = guard.take() {
+                                drop(sender.send(Err(
+                                    "authentication state mismatch (possible CSRF); rejected"
+                                        .to_owned(),
+                                )));
+                            }
+                        }
                         return STATE_MISMATCH_HTML;
                     }
                     let callback = AuthCallback {

--- a/crates/meroctl/src/auth.rs
+++ b/crates/meroctl/src/auth.rs
@@ -12,6 +12,7 @@ use axum::routing::get;
 use axum::Router;
 use calimero_client::{auth, get_session_cache, AuthMode, JwtToken};
 use eyre::{bail, eyre, OptionExt, Result};
+use rand::RngCore;
 use serde::Deserialize;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -41,10 +42,15 @@ pub async fn authenticate(api_url: &Url, output: Output) -> Result<JwtToken> {
         bail!("Server does not require authentication");
     }
 
-    // Set up callback server
-    let (callback_port, callback_rx) = start_callback_server().await?;
+    // A single-use, unguessable state nonce binds the browser round-trip to
+    // this CLI invocation. Without it, any local process that can reach the
+    // loopback callback port could inject its own tokens (login-CSRF).
+    let state = generate_state();
 
-    let auth_url = build_auth_url(api_url, callback_port)?;
+    // Set up callback server
+    let (callback_port, callback_rx) = start_callback_server(state.clone()).await?;
+
+    let auth_url = build_auth_url(api_url, callback_port, &state)?;
 
     output.write(&InfoLine(
         "Opening browser for authentication — you have 2 minutes to complete sign-in.",
@@ -80,9 +86,12 @@ pub async fn authenticate(api_url: &Url, output: Output) -> Result<JwtToken> {
     }
 }
 
-async fn start_callback_server() -> Result<(u16, oneshot::Receiver<Result<AuthCallback, String>>)> {
+async fn start_callback_server(
+    expected_state: String,
+) -> Result<(u16, oneshot::Receiver<Result<AuthCallback, String>>)> {
     let (tx, rx) = oneshot::channel();
     let tx = Arc::new(Mutex::new(Some(tx)));
+    let expected_state = Arc::new(expected_state);
 
     let (start_port, end_port) = (9080u16, 9090u16);
 
@@ -112,9 +121,17 @@ async fn start_callback_server() -> Result<(u16, oneshot::Receiver<Result<AuthCa
         "/callback",
         get({
             let tx = Arc::clone(&tx);
+            let expected_state = Arc::clone(&expected_state);
             move |Query(params): Query<HashMap<String, String>>| async move {
                 // Check if we have tokens as query parameters
                 if params.contains_key("access_token") {
+                    // Reject any callback whose `state` does not match the
+                    // single-use nonce minted for this flow. This is what stops
+                    // another local process from injecting tokens into our
+                    // loopback callback (login-CSRF).
+                    if params.get("state").map(String::as_str) != Some(expected_state.as_str()) {
+                        return STATE_MISMATCH_HTML;
+                    }
                     let callback = AuthCallback {
                         access_token: params.get("access_token").cloned(),
                         refresh_token: params.get("refresh_token").cloned(),
@@ -258,6 +275,10 @@ async fn start_callback_server() -> Result<(u16, oneshot::Receiver<Result<AuthCa
                 const q = new URLSearchParams();
                 q.set('access_token', accessToken);
                 if (refreshToken) q.set('refresh_token', refreshToken);
+                // Preserve the state nonce from the callback URL's query so the
+                // server-side handler can verify it before accepting the tokens.
+                const state = new URLSearchParams(window.location.search).get('state');
+                if (state) q.set('state', state);
                 window.location.href = window.location.origin + window.location.pathname + '?' + q.toString();
             } else {
                 document.querySelector('.spinner').style.display = 'none';
@@ -291,20 +312,38 @@ async fn start_callback_server() -> Result<(u16, oneshot::Receiver<Result<AuthCa
     Ok((bound_port, rx))
 }
 
-fn build_auth_url(api_url: &Url, callback_port: u16) -> Result<Url> {
+/// Generate a single-use, unguessable state nonce (256 bits, hex-encoded).
+fn generate_state() -> String {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+fn build_auth_url(api_url: &Url, callback_port: u16, state: &str) -> Result<Url> {
     let mut auth_url = api_url.clone();
     auth_url.set_path("/auth/login");
+    // Carry the state nonce in the callback URL itself; the server echoes the
+    // callback URL back to the browser, so the nonce round-trips without any
+    // server-side support and is verified in the callback handler.
+    let callback = format!("http://127.0.0.1:{callback_port}/callback?state={state}");
     let _ = auth_url
         .query_pairs_mut()
-        .append_pair(
-            "callback-url",
-            &format!("http://127.0.0.1:{callback_port}/callback"),
-        )
+        .append_pair("callback-url", &callback)
         .append_pair("app-url", api_url.as_str().trim_end_matches('/'))
         .append_pair("permissions", "admin");
 
     Ok(auth_url)
 }
+
+/// Page shown when a callback arrives with a missing/incorrect state nonce.
+const STATE_MISMATCH_HTML: Html<&'static str> = Html(
+    r#"<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><title>Authentication rejected</title></head>
+<body style="font-family:sans-serif;background:#111;color:#fff;text-align:center;padding-top:4rem">
+<h1>Authentication rejected</h1>
+<p>The sign-in response did not match this session. Please close this window and run the command again.</p>
+</body></html>"#,
+);
 
 /// Helper function to authenticate against a URL if required
 /// Returns Some(tokens) if authentication was needed and successful, None if no auth required
@@ -494,10 +533,14 @@ impl calimero_client::ClientAuthenticator for MeroctlAuthenticator {
             "Opening browser for authentication — you have 2 minutes to complete sign-in.",
         );
 
-        // Set up callback server
-        let (callback_port, callback_rx) = start_callback_server().await?;
+        // Single-use state nonce binds this browser round-trip to this flow,
+        // preventing another local process from injecting tokens (login-CSRF).
+        let state = generate_state();
 
-        let auth_url = build_auth_url(api_url, callback_port)?;
+        // Set up callback server
+        let (callback_port, callback_rx) = start_callback_server(state.clone()).await?;
+
+        let auth_url = build_auth_url(api_url, callback_port, &state)?;
 
         // Open the OAuth URL in the browser
         if let Err(e) = self.output.open_browser(&auth_url) {
@@ -649,8 +692,31 @@ mod tests {
     use camino::Utf8PathBuf;
     use url::Url;
 
+    use super::{build_auth_url, generate_state};
     use crate::config::{Config, NodeConnection};
     use crate::storage::JwtToken;
+
+    #[test]
+    fn generate_state_is_unguessable_hex_and_unique() {
+        let a = generate_state();
+        let b = generate_state();
+        assert_eq!(a.len(), 64, "32 bytes hex-encoded");
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a, b, "each invocation must produce a fresh nonce");
+    }
+
+    #[test]
+    fn build_auth_url_embeds_state_in_callback() {
+        let api = Url::parse("https://node.example/").unwrap();
+        let url = build_auth_url(&api, 9080, "abc123").unwrap();
+        let callback = url
+            .query_pairs()
+            .find(|(k, _)| k == "callback-url")
+            .map(|(_, v)| v.into_owned())
+            .expect("callback-url present");
+        assert_eq!(callback, "http://127.0.0.1:9080/callback?state=abc123");
+        assert!(url.query_pairs().any(|(k, _)| k == "permissions"));
+    }
 
     fn make_tokens(access: &str) -> JwtToken {
         JwtToken {


### PR DESCRIPTION
## Problem

`meroctl`'s browser login spins up a loopback HTTP server on a port in `9080-9090` and treats **any** request carrying an `access_token` as the authentication result:

```rust
// before — auth.rs callback handler
if params.contains_key("access_token") {
    // …send these tokens back to the CLI, no questions asked…
}
```

The auth URL carried no `state`/nonce, so any other local process (or a malicious page able to issue a request to `127.0.0.1:<port>/callback?access_token=…`) could **inject its own tokens** into the CLI's session — a classic login-CSRF. The CLI would then persist and use attacker-controlled credentials.

## Fix

Mint a single-use, unguessable **256-bit `state` nonce** per login and require it on the callback:

1. `generate_state()` → 32 random bytes, hex-encoded.
2. The nonce is embedded in the **callback URL itself** (`…/callback?state=<nonce>`). The auth server echoes the callback URL back to the browser, so the nonce round-trips with **no server-side changes required**.
3. The token-extracting JS preserves `state` when it reconstructs the redirect.
4. The callback handler **rejects** any request whose `state` doesn't match the nonce minted for this flow — showing a rejection page and never delivering tokens.

```rust
// after
if params.contains_key("access_token") {
    if params.get("state").map(String::as_str) != Some(expected_state.as_str()) {
        return STATE_MISMATCH_HTML; // reject — no tokens delivered
    }
    …
}
```

A 256-bit nonce is infeasible to guess, so a foreign process can no longer complete the callback.

## Changes
- `crates/meroctl/src/auth.rs`: `generate_state`, `build_auth_url(…, state)`, `start_callback_server(expected_state)` + handler validation, state-preserving callback JS, rejection page. Applied to **both** auth entry points (`authenticate` and the `ClientAuthenticator` impl).
- Unit tests: nonce is hex/unique; callback URL embeds the nonce.

## Validation
- `cargo build -p meroctl`, `cargo clippy -p meroctl` clean.
- `cargo test -p meroctl` — new `auth::tests` pass. Login e2e covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)