### PR TITLE
fix(meroctl): request least-privilege token scope per command

### DIFF
--- a/crates/meroctl/src/auth.rs
+++ b/crates/meroctl/src/auth.rs
@@ -368,20 +368,36 @@ static REQUESTED_SCOPE: std::sync::OnceLock<TokenScope> = std::sync::OnceLock::n
 
 /// Record the token scope the current command needs. Called once at startup
 /// before any authentication happens.
+///
+/// The scope is stored in a process-global `OnceLock`, so only the first call
+/// takes effect. A second call would be silently discarded and let one
+/// command's scope bleed into another, so we `debug_assert` the invariant to
+/// catch accidental double-sets in debug/test builds.
 pub fn set_requested_scope(scope: TokenScope) {
+    debug_assert!(
+        REQUESTED_SCOPE.get().is_none(),
+        "set_requested_scope called more than once"
+    );
     let _ = REQUESTED_SCOPE.set(scope);
 }
 
 /// The scope to request at login. An explicit `MEROCTL_AUTH_SCOPE` env var
 /// (`admin` or `resource`, case-insensitive) overrides the per-command scope —
 /// an escape hatch in either direction if the command-derived scope is wrong
-/// for a particular server. An unrecognised value is ignored. Otherwise the
-/// scope recorded by [`set_requested_scope`] is used, defaulting to `Admin`.
+/// for a particular server. An unrecognised value is warned about and ignored.
+/// Otherwise the scope recorded by [`set_requested_scope`] is used, defaulting
+/// to `Admin`.
 fn requested_scope() -> TokenScope {
     if let Ok(raw) = std::env::var("MEROCTL_AUTH_SCOPE") {
         if let Some(scope) = TokenScope::parse_override(&raw) {
             return scope;
         }
+        // Make misconfiguration visible: an operator who fat-fingers the value
+        // (e.g. `resourc`) would otherwise silently get the per-command scope
+        // while believing they had overridden it.
+        eprintln!(
+            "warning: unrecognised MEROCTL_AUTH_SCOPE value {raw:?} (expected `admin` or `resource`); ignoring"
+        );
     }
     REQUESTED_SCOPE.get().copied().unwrap_or(TokenScope::Admin)
 }

--- a/crates/meroctl/src/auth.rs
+++ b/crates/meroctl/src/auth.rs
@@ -366,39 +366,46 @@ impl TokenScope {
 
 static REQUESTED_SCOPE: std::sync::OnceLock<TokenScope> = std::sync::OnceLock::new();
 
-/// Record the token scope the current command needs. Called once at startup
-/// before any authentication happens.
+/// Record the least-privilege token scope for the current command, applying the
+/// `MEROCTL_AUTH_SCOPE` override once. Called exactly once at startup, before any
+/// authentication happens.
 ///
-/// The scope is stored in a process-global `OnceLock`, so only the first call
-/// takes effect. A second call would be silently discarded and let one
-/// command's scope bleed into another, so we `debug_assert` the invariant to
-/// catch accidental double-sets in debug/test builds.
-pub fn set_requested_scope(scope: TokenScope) {
-    debug_assert!(
-        REQUESTED_SCOPE.get().is_none(),
-        "set_requested_scope called more than once"
-    );
-    let _ = REQUESTED_SCOPE.set(scope);
+/// The final scope is stored in a process-global `OnceLock`, so a second call
+/// can't change it. Rather than silently discard the repeat (which would let one
+/// command's scope bleed into another) we surface it: a warning in every build,
+/// plus a hard `debug_assert` failure in debug/test builds.
+pub fn set_requested_scope(command_scope: TokenScope) {
+    let scope = resolve_scope_override(command_scope);
+    if REQUESTED_SCOPE.set(scope).is_err() {
+        eprintln!("warning: token scope already set; ignoring repeated set_requested_scope call");
+        debug_assert!(false, "set_requested_scope called more than once");
+    }
 }
 
-/// The scope to request at login. An explicit `MEROCTL_AUTH_SCOPE` env var
-/// (`admin` or `resource`, case-insensitive) overrides the per-command scope —
-/// an escape hatch in either direction if the command-derived scope is wrong
-/// for a particular server. An unrecognised value is warned about and ignored.
-/// Otherwise the scope recorded by [`set_requested_scope`] is used, defaulting
-/// to `Admin`.
-fn requested_scope() -> TokenScope {
-    if let Ok(raw) = std::env::var("MEROCTL_AUTH_SCOPE") {
-        if let Some(scope) = TokenScope::parse_override(&raw) {
-            return scope;
-        }
+/// Apply the `MEROCTL_AUTH_SCOPE` env override (`admin`/`resource`,
+/// case-insensitive) to the command-derived scope — an escape hatch in either
+/// direction if the command-derived scope is wrong for a particular server. An
+/// unrecognised value is warned about and ignored. Read exactly once, from
+/// [`set_requested_scope`], so the env read and any warning happen a single time.
+fn resolve_scope_override(command_scope: TokenScope) -> TokenScope {
+    let Ok(raw) = std::env::var("MEROCTL_AUTH_SCOPE") else {
+        return command_scope;
+    };
+    TokenScope::parse_override(&raw).unwrap_or_else(|| {
         // Make misconfiguration visible: an operator who fat-fingers the value
         // (e.g. `resourc`) would otherwise silently get the per-command scope
         // while believing they had overridden it.
         eprintln!(
             "warning: unrecognised MEROCTL_AUTH_SCOPE value {raw:?} (expected `admin` or `resource`); ignoring"
         );
-    }
+        command_scope
+    })
+}
+
+/// The resolved scope to request at login, recorded by [`set_requested_scope`]
+/// (defaults to `Admin` when unset). A pure reader — deterministic across the
+/// multiple `build_auth_url` calls in a single command.
+fn requested_scope() -> TokenScope {
     REQUESTED_SCOPE.get().copied().unwrap_or(TokenScope::Admin)
 }
 

--- a/crates/meroctl/src/auth.rs
+++ b/crates/meroctl/src/auth.rs
@@ -330,6 +330,48 @@ fn generate_state() -> String {
     hex::encode(bytes)
 }
 
+/// The token scope a command requests at login.
+///
+/// Read-only commands no longer have to persist a full-`admin` token; they can
+/// request a narrower, non-admin scope so a leaked CLI token can do less.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TokenScope {
+    /// Full administrative access. Used for mutating/admin/node commands and any
+    /// command whose required permissions we do not conservatively narrow.
+    Admin,
+    /// Non-admin resource access (no `admin`, no `keys`): sufficient for
+    /// read-only resource commands (list/get/info/download).
+    Resource,
+}
+
+impl TokenScope {
+    /// The `permissions` value sent to `/auth/login` for this scope.
+    fn as_permissions(self) -> &'static str {
+        match self {
+            Self::Admin => "admin",
+            Self::Resource => "application,package,context,blob",
+        }
+    }
+}
+
+static REQUESTED_SCOPE: std::sync::OnceLock<TokenScope> = std::sync::OnceLock::new();
+
+/// Record the token scope the current command needs. Called once at startup
+/// before any authentication happens.
+pub fn set_requested_scope(scope: TokenScope) {
+    let _ = REQUESTED_SCOPE.set(scope);
+}
+
+/// The scope to request at login. Defaults to `Admin` when unset (safe), and an
+/// explicit `MEROCTL_AUTH_SCOPE=admin` always forces admin — an escape hatch if
+/// a narrowed scope ever proves insufficient against a particular server.
+fn requested_scope() -> TokenScope {
+    if matches!(std::env::var("MEROCTL_AUTH_SCOPE").as_deref(), Ok("admin")) {
+        return TokenScope::Admin;
+    }
+    REQUESTED_SCOPE.get().copied().unwrap_or(TokenScope::Admin)
+}
+
 fn build_auth_url(api_url: &Url, callback_port: u16, state: &str) -> Result<Url> {
     let mut auth_url = api_url.clone();
     auth_url.set_path("/auth/login");
@@ -341,7 +383,7 @@ fn build_auth_url(api_url: &Url, callback_port: u16, state: &str) -> Result<Url>
         .query_pairs_mut()
         .append_pair("callback-url", &callback)
         .append_pair("app-url", api_url.as_str().trim_end_matches('/'))
-        .append_pair("permissions", "admin");
+        .append_pair("permissions", requested_scope().as_permissions());
 
     Ok(auth_url)
 }
@@ -727,6 +769,16 @@ mod tests {
             .expect("callback-url present");
         assert_eq!(callback, "http://127.0.0.1:9080/callback?state=abc123");
         assert!(url.query_pairs().any(|(k, _)| k == "permissions"));
+    }
+
+    #[test]
+    fn token_scope_permission_strings() {
+        use super::TokenScope;
+        assert_eq!(TokenScope::Admin.as_permissions(), "admin");
+        // Resource scope never grants `admin` or `keys`.
+        let resource = TokenScope::Resource.as_permissions();
+        assert!(!resource.split(',').any(|p| p == "admin" || p == "keys"));
+        assert!(resource.split(',').any(|p| p == "context"));
     }
 
     fn make_tokens(access: &str) -> JwtToken {

--- a/crates/meroctl/src/auth.rs
+++ b/crates/meroctl/src/auth.rs
@@ -352,6 +352,16 @@ impl TokenScope {
             Self::Resource => "application,package,context,blob",
         }
     }
+
+    /// Parse an explicit scope override (e.g. from `MEROCTL_AUTH_SCOPE`),
+    /// case-insensitively. Unrecognised values return `None`.
+    fn parse_override(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "admin" => Some(Self::Admin),
+            "resource" => Some(Self::Resource),
+            _ => None,
+        }
+    }
 }
 
 static REQUESTED_SCOPE: std::sync::OnceLock<TokenScope> = std::sync::OnceLock::new();
@@ -362,12 +372,16 @@ pub fn set_requested_scope(scope: TokenScope) {
     let _ = REQUESTED_SCOPE.set(scope);
 }
 
-/// The scope to request at login. Defaults to `Admin` when unset (safe), and an
-/// explicit `MEROCTL_AUTH_SCOPE=admin` always forces admin — an escape hatch if
-/// a narrowed scope ever proves insufficient against a particular server.
+/// The scope to request at login. An explicit `MEROCTL_AUTH_SCOPE` env var
+/// (`admin` or `resource`, case-insensitive) overrides the per-command scope —
+/// an escape hatch in either direction if the command-derived scope is wrong
+/// for a particular server. An unrecognised value is ignored. Otherwise the
+/// scope recorded by [`set_requested_scope`] is used, defaulting to `Admin`.
 fn requested_scope() -> TokenScope {
-    if matches!(std::env::var("MEROCTL_AUTH_SCOPE").as_deref(), Ok("admin")) {
-        return TokenScope::Admin;
+    if let Ok(raw) = std::env::var("MEROCTL_AUTH_SCOPE") {
+        if let Some(scope) = TokenScope::parse_override(&raw) {
+            return scope;
+        }
     }
     REQUESTED_SCOPE.get().copied().unwrap_or(TokenScope::Admin)
 }
@@ -779,6 +793,21 @@ mod tests {
         let resource = TokenScope::Resource.as_permissions();
         assert!(!resource.split(',').any(|p| p == "admin" || p == "keys"));
         assert!(resource.split(',').any(|p| p == "context"));
+    }
+
+    #[test]
+    fn token_scope_override_parses_both_directions() {
+        use super::TokenScope;
+        assert_eq!(TokenScope::parse_override("admin"), Some(TokenScope::Admin));
+        assert_eq!(
+            TokenScope::parse_override("RESOURCE"),
+            Some(TokenScope::Resource)
+        );
+        assert_eq!(
+            TokenScope::parse_override(" resource "),
+            Some(TokenScope::Resource)
+        );
+        assert_eq!(TokenScope::parse_override("bogus"), None);
     }
 
     fn make_tokens(access: &str) -> JwtToken {

--- a/crates/meroctl/src/cli.rs
+++ b/crates/meroctl/src/cli.rs
@@ -166,16 +166,23 @@ impl SubCommands {
                 | AppSubCommands::ListPackages(_)
                 | AppSubCommands::ListVersions(_)
                 | AppSubCommands::GetLatestVersion(_) => TokenScope::Resource,
+                // Everything else (install/uninstall/watch) mutates. NOTE: a new
+                // read-only variant falls through here and safely over-scopes to
+                // Admin — add it to the Resource list above when introduced.
                 _ => TokenScope::Admin,
             },
             SubCommands::Blob(c) => match c.subcommand {
                 BlobSubCommands::List(_)
                 | BlobSubCommands::Info(_)
                 | BlobSubCommands::Download(_) => TokenScope::Resource,
+                // NOTE: new read-only Blob variants must be added to the Resource
+                // list above; otherwise they safely over-scope to Admin here.
                 _ => TokenScope::Admin,
             },
             SubCommands::Context(c) => match c.subcommand {
                 ContextSubCommands::List(_) | ContextSubCommands::Get(_) => TokenScope::Resource,
+                // NOTE: new read-only Context variants must be added to the
+                // Resource list above; otherwise they over-scope to Admin here.
                 _ => TokenScope::Admin,
             },
             // Everything else (mutations, key/node management, call, and the

--- a/crates/meroctl/src/cli.rs
+++ b/crates/meroctl/src/cli.rs
@@ -158,6 +158,10 @@ impl SubCommands {
         use crate::cli::blob::BlobSubCommands;
         use crate::cli::context::ContextSubCommands;
 
+        // The App/Blob/Context arms are matched *exhaustively* (no wildcard) so
+        // adding a new subcommand variant is a compile error until its scope is
+        // classified here — a new read-only variant can't silently over-scope to
+        // Admin, nor a new mutating one silently under-scope to Resource.
         match self {
             SubCommands::App(c) => match c.subcommand {
                 AppSubCommands::Get(_)
@@ -166,24 +170,27 @@ impl SubCommands {
                 | AppSubCommands::ListPackages(_)
                 | AppSubCommands::ListVersions(_)
                 | AppSubCommands::GetLatestVersion(_) => TokenScope::Resource,
-                // Everything else (install/uninstall/watch) mutates. NOTE: a new
-                // read-only variant falls through here and safely over-scopes to
-                // Admin — add it to the Resource list above when introduced.
-                _ => TokenScope::Admin,
+                AppSubCommands::Install(_)
+                | AppSubCommands::Uninstall(_)
+                | AppSubCommands::Watch(_) => TokenScope::Admin,
             },
             SubCommands::Blob(c) => match c.subcommand {
                 BlobSubCommands::List(_)
                 | BlobSubCommands::Info(_)
                 | BlobSubCommands::Download(_) => TokenScope::Resource,
-                // NOTE: new read-only Blob variants must be added to the Resource
-                // list above; otherwise they safely over-scope to Admin here.
-                _ => TokenScope::Admin,
+                BlobSubCommands::Upload(_) | BlobSubCommands::Delete(_) => TokenScope::Admin,
             },
             SubCommands::Context(c) => match c.subcommand {
                 ContextSubCommands::List(_) | ContextSubCommands::Get(_) => TokenScope::Resource,
-                // NOTE: new read-only Context variants must be added to the
-                // Resource list above; otherwise they over-scope to Admin here.
-                _ => TokenScope::Admin,
+                ContextSubCommands::Create(_)
+                | ContextSubCommands::InviteSpecializedNode(_)
+                | ContextSubCommands::Delete(_)
+                | ContextSubCommands::Watch(_)
+                | ContextSubCommands::Update(_)
+                | ContextSubCommands::Identity(_)
+                | ContextSubCommands::Alias(_)
+                | ContextSubCommands::Use(_)
+                | ContextSubCommands::Sync(_) => TokenScope::Admin,
             },
             // Everything else (mutations, key/node management, call, and the
             // network/peers/tee reads whose permissions are not in the Resource

--- a/crates/meroctl/src/cli.rs
+++ b/crates/meroctl/src/cli.rs
@@ -43,7 +43,7 @@ use node::NodeCommand;
 use peers::PeersCommand;
 use tee::TeeCommand;
 
-use crate::auth::{authenticate_with_session_cache, check_authentication};
+use crate::auth::{authenticate_with_session_cache, check_authentication, TokenScope};
 
 pub const EXAMPLES: &str = r"
   # List all applications
@@ -146,9 +146,53 @@ impl Environment {
     }
 }
 
+impl SubCommands {
+    /// Least-privilege token scope this command needs at login.
+    ///
+    /// Read-only resource commands request a narrow, non-admin scope so they no
+    /// longer persist a full-`admin` token. Anything that mutates, manages keys
+    /// or the node, or whose required permissions we cannot conservatively
+    /// narrow, requests `Admin`.
+    fn required_scope(&self) -> TokenScope {
+        use crate::cli::app::AppSubCommands;
+        use crate::cli::blob::BlobSubCommands;
+        use crate::cli::context::ContextSubCommands;
+
+        match self {
+            SubCommands::App(c) => match c.subcommand {
+                AppSubCommands::Get(_)
+                | AppSubCommands::List(_)
+                | AppSubCommands::Versions(_)
+                | AppSubCommands::ListPackages(_)
+                | AppSubCommands::ListVersions(_)
+                | AppSubCommands::GetLatestVersion(_) => TokenScope::Resource,
+                _ => TokenScope::Admin,
+            },
+            SubCommands::Blob(c) => match c.subcommand {
+                BlobSubCommands::List(_)
+                | BlobSubCommands::Info(_)
+                | BlobSubCommands::Download(_) => TokenScope::Resource,
+                _ => TokenScope::Admin,
+            },
+            SubCommands::Context(c) => match c.subcommand {
+                ContextSubCommands::List(_) | ContextSubCommands::Get(_) => TokenScope::Resource,
+                _ => TokenScope::Admin,
+            },
+            // Everything else (mutations, key/node management, call, and the
+            // network/peers/tee reads whose permissions are not in the Resource
+            // set) conservatively requests Admin.
+            _ => TokenScope::Admin,
+        }
+    }
+}
+
 impl RootCommand {
     pub async fn run(self) -> Result<(), CliError> {
         let output = Output::new(self.args.output_format);
+
+        // Record the least-privilege scope this command needs before any
+        // authentication (and token persistence) happens.
+        crate::auth::set_requested_scope(self.action.required_scope());
 
         // Some commands don't require a connection (like node commands)
         let needs_connection = !matches!(&self.action, SubCommands::Node(_));


### PR DESCRIPTION
## Problem

The browser-login flow hardcoded the requested scope to `admin`:

```rust
// before — auth.rs build_auth_url
.append_pair("permissions", "admin");
```

So **every** command — including pure reads like `context list`, `app get`, `blob info` — obtained and **persisted a full-admin token** to disk. If that token leaks, the attacker has full administrative access regardless of what the user was actually doing.

## Fix

Introduce a `TokenScope` and request the least scope each command needs, recorded once per invocation **before** any auth/token persistence happens:

| Scope | `permissions` requested | Used by |
|---|---|---|
| `Resource` | `application,package,context,blob` (no `admin`, no `keys`) | read-only resource commands |
| `Admin` | `admin` | mutations, key/node management, `call`, and anything not conservatively narrowable |

Read-only commands mapped to `Resource`:
- `app get/list/versions/list-packages/list-versions/get-latest-version`
- `blob list/info/download`
- `context get/list`

Everything else stays `Admin` (safe default). An explicit `MEROCTL_AUTH_SCOPE=admin` env var forces admin as an escape hatch if a narrowed scope is ever insufficient against a particular server.

### Before / After
```
# before: `meroctl context list` → persists an ADMIN token
# after:  `meroctl context list` → persists a resource-scoped token (no admin/keys)
```

## Changes
- `crates/meroctl/src/auth.rs`: `TokenScope` enum + `as_permissions()`, a process-global requested scope (`set_requested_scope`/`requested_scope`) with the env escape hatch; `build_auth_url` now uses it.
- `crates/meroctl/src/cli.rs`: `SubCommands::required_scope()` mapping; set once in `RootCommand::run`.
- Unit test asserts `Resource` never grants `admin`/`keys`.

## Notes for reviewers
The exact `Resource` permission set is intentionally conservative (resource categories, no admin/keys). If a deployed auth server maps a read route to a permission outside this set, that command can be moved back to `Admin` or the env escape hatch used. Finer per-route scoping is a natural follow-up.

## Validation
- `cargo build -p meroctl`, `cargo clippy -p meroctl` clean; unit test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)