### PR TITLE
fix(meroctl): confirm destructive commands (TTY prompt or --yes)

### DIFF
--- a/crates/meroctl/src/cli/blob/delete.rs
+++ b/crates/meroctl/src/cli/blob/delete.rs
@@ -3,6 +3,8 @@ use clap::Parser;
 use eyre::Result;
 
 use crate::cli::Environment;
+use crate::confirm::confirm;
+use crate::output::InfoLine;
 
 #[derive(Copy, Clone, Debug, Parser)]
 #[command(about = "Delete a blob by its ID")]
@@ -14,10 +16,21 @@ pub struct DeleteCommand {
         help = "ID of the blob to delete"
     )]
     pub blob_id: BlobId,
+
+    #[clap(long, short = 'y', help = "Skip the confirmation prompt")]
+    pub yes: bool,
 }
 
 impl DeleteCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
+        if !confirm(
+            &format!("Delete blob '{}'? This cannot be undone.", self.blob_id),
+            self.yes,
+        )? {
+            environment.output.write(&InfoLine("Aborted."));
+            return Ok(());
+        }
+
         let client = environment.client()?;
 
         let response = client.delete_blob(&self.blob_id).await?;

--- a/crates/meroctl/src/cli/context/delete.rs
+++ b/crates/meroctl/src/cli/context/delete.rs
@@ -5,6 +5,8 @@ use clap::Parser;
 use eyre::{OptionExt, Result};
 
 use crate::cli::Environment;
+use crate::confirm::confirm;
+use crate::output::InfoLine;
 
 #[derive(Clone, Debug, Parser)]
 #[command(about = "Delete a context")]
@@ -17,10 +19,21 @@ pub struct DeleteCommand {
         help = "Identity (public key) of the requester. Required when deleting a group context; must be a group admin."
     )]
     pub requester: Option<PublicKey>,
+
+    #[clap(long, short = 'y', help = "Skip the confirmation prompt")]
+    pub yes: bool,
 }
 
 impl DeleteCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
+        if !confirm(
+            &format!("Delete context '{}'? This cannot be undone.", self.context),
+            self.yes,
+        )? {
+            environment.output.write(&InfoLine("Aborted."));
+            return Ok(());
+        }
+
         let client = environment.client()?;
 
         let context_id = client

--- a/crates/meroctl/src/cli/group/delete.rs
+++ b/crates/meroctl/src/cli/group/delete.rs
@@ -4,6 +4,8 @@ use clap::Parser;
 use eyre::Result;
 
 use crate::cli::Environment;
+use crate::confirm::confirm;
+use crate::output::InfoLine;
 
 #[derive(Clone, Debug, Parser)]
 #[command(about = "Delete a group")]
@@ -16,10 +18,24 @@ pub struct DeleteCommand {
         help = "Public key of the requester (group admin). Auto-resolved from node group identity if omitted"
     )]
     pub requester: Option<PublicKey>,
+
+    #[clap(long, short = 'y', help = "Skip the confirmation prompt")]
+    pub yes: bool,
 }
 
 impl DeleteCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
+        if !confirm(
+            &format!(
+                "Delete group '{}'? This cascades to its subgroups and cannot be undone.",
+                self.group_id
+            ),
+            self.yes,
+        )? {
+            environment.output.write(&InfoLine("Aborted."));
+            return Ok(());
+        }
+
         let request = DeleteGroupApiRequest {
             requester: self.requester,
         };

--- a/crates/meroctl/src/cli/group/leave.rs
+++ b/crates/meroctl/src/cli/group/leave.rs
@@ -2,6 +2,8 @@ use clap::Parser;
 use eyre::Result;
 
 use crate::cli::Environment;
+use crate::confirm::confirm;
+use crate::output::InfoLine;
 
 #[derive(Clone, Debug, Parser)]
 #[command(about = "Voluntarily leave a group (publishes MemberLeft). \
@@ -10,10 +12,18 @@ use crate::cli::Environment;
 pub struct LeaveCommand {
     #[clap(name = "GROUP_ID", help = "The hex-encoded group ID to leave")]
     pub group_id: String,
+
+    #[clap(long, short = 'y', help = "Skip the confirmation prompt")]
+    pub yes: bool,
 }
 
 impl LeaveCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
+        if !confirm(&format!("Leave group '{}'?", self.group_id), self.yes)? {
+            environment.output.write(&InfoLine("Aborted."));
+            return Ok(());
+        }
+
         let client = environment.client()?;
         let response = client.leave_group(&self.group_id).await?;
 

--- a/crates/meroctl/src/cli/group/members.rs
+++ b/crates/meroctl/src/cli/group/members.rs
@@ -9,6 +9,8 @@ use clap::{Parser, Subcommand, ValueEnum};
 use eyre::Result;
 
 use crate::cli::Environment;
+use crate::confirm::confirm;
+use crate::output::InfoLine;
 
 #[derive(Clone, Debug, ValueEnum)]
 pub enum MemberRoleArg {
@@ -148,10 +150,25 @@ pub struct RemoveMembersCommand {
         help = "Public key of the requester (group admin). Auto-resolved from node group identity if omitted"
     )]
     pub requester: Option<PublicKey>,
+
+    #[clap(long, short = 'y', help = "Skip the confirmation prompt")]
+    pub yes: bool,
 }
 
 impl RemoveMembersCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
+        if !confirm(
+            &format!(
+                "Remove {} member(s) from group '{}'?",
+                self.identities.len(),
+                self.group_id
+            ),
+            self.yes,
+        )? {
+            environment.output.write(&InfoLine("Aborted."));
+            return Ok(());
+        }
+
         let request = RemoveGroupMembersApiRequest {
             members: self.identities,
             requester: self.requester,

--- a/crates/meroctl/src/confirm.rs
+++ b/crates/meroctl/src/confirm.rs
@@ -1,0 +1,63 @@
+//! Interactive confirmation for destructive commands.
+//!
+//! Destructive operations (deleting a context/group/blob, removing members,
+//! leaving a group) should not run silently. [`confirm`] gates them behind a
+//! TTY prompt, with a `--yes` escape hatch for scripts.
+
+use std::io::{self, BufRead, IsTerminal, Write};
+
+use eyre::{eyre, Result};
+
+/// Ask the user to confirm a destructive action.
+///
+/// - `assume_yes` (wired to a command's `--yes`) skips the prompt and proceeds.
+/// - On an interactive terminal, prints `prompt [y/N]:` and returns whether the
+///   user typed an affirmative answer (`y`/`yes`, case-insensitive).
+/// - In a **non-interactive** session without `--yes`, returns an error rather
+///   than silently proceeding — so a piped/CI invocation can't destroy data by
+///   accident.
+pub fn confirm(prompt: &str, assume_yes: bool) -> Result<bool> {
+    if assume_yes {
+        return Ok(true);
+    }
+
+    if !io::stdin().is_terminal() {
+        return Err(eyre!(
+            "{prompt}: refusing to proceed without confirmation in a non-interactive session. \
+             Re-run with --yes to confirm."
+        ));
+    }
+
+    let mut stderr = io::stderr();
+    write!(stderr, "{prompt} [y/N]: ").map_err(|e| eyre!("failed to write prompt: {e}"))?;
+    stderr.flush().ok();
+
+    let mut line = String::new();
+    io::stdin()
+        .lock()
+        .read_line(&mut line)
+        .map_err(|e| eyre!("failed to read confirmation: {e}"))?;
+
+    Ok(matches!(
+        line.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::confirm;
+
+    #[test]
+    fn assume_yes_skips_prompt_and_proceeds() {
+        // With --yes we must proceed without touching stdin (works in CI/non-TTY).
+        assert!(confirm("delete everything?", true).unwrap());
+    }
+
+    #[test]
+    fn non_interactive_without_yes_refuses() {
+        // Tests run with a non-TTY stdin, so this must error rather than block
+        // or silently proceed.
+        assert!(confirm("delete everything?", false).is_err());
+    }
+}

--- a/crates/meroctl/src/main.rs
+++ b/crates/meroctl/src/main.rs
@@ -7,6 +7,7 @@ pub mod cli;
 mod client;
 mod common;
 mod config;
+mod confirm;
 mod connection;
 mod defaults;
 


### PR DESCRIPTION
## Problem

Several destructive `meroctl` commands ran immediately, with **no confirmation**:

- `context delete`
- `group delete` (cascades to subgroups)
- `group leave`
- `group members remove`
- `blob delete`

A mistyped ID, a stray shell-history recall, or a wrong active node could irreversibly destroy data with no chance to abort.

## Fix

A shared `confirm` helper + a `--yes/-y` flag on each destructive command:

- **`--yes`** → proceed without prompting (scripts/CI).
- **Interactive TTY** → prompt `… [y/N]:`; proceed only on `y`/`yes`.
- **Non-interactive, no `--yes`** → **refuse with an error** instead of silently destroying data.

```
$ meroctl context delete my-ctx
Delete context 'my-ctx'? This cannot be undone. [y/N]: n
Aborted.

$ meroctl context delete my-ctx --yes      # scripted, no prompt
```

## Changes
- `crates/meroctl/src/confirm.rs` (new): `confirm(prompt, assume_yes)` + unit tests.
- `--yes/-y` + a confirm gate added to `context/delete.rs`, `group/delete.rs`, `group/leave.rs`, `group/members.rs` (remove), `blob/delete.rs`.

## Validation
- `cargo build -p meroctl`, `cargo clippy -p meroctl` clean; `confirm` unit tests pass (assume-yes proceeds; non-TTY-without-yes errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)