### PR TITLE
fix(meroctl): await get_application in dev summary instead of nested block_on

### DIFF
--- a/crates/meroctl/src/cli/dev.rs
+++ b/crates/meroctl/src/cli/dev.rs
@@ -13,7 +13,6 @@ use clap::{Parser, Subcommand};
 use eyre::{bail, Result};
 use notify::event::ModifyKind;
 use notify::{EventKind, RecursiveMode, Watcher};
-use tokio::runtime::Handle;
 use tokio::sync::mpsc;
 
 use crate::cli::Environment;
@@ -91,7 +90,8 @@ impl StartCommand {
             .await?;
 
         // Step 4: Print summary
-        self.print_summary(environment, application_id, context_id, member_public_key)?;
+        self.print_summary(environment, application_id, context_id, member_public_key)
+            .await?;
 
         // Step 5: Watch loop (blocks until ctrl-c)
         if self.watch {
@@ -173,7 +173,7 @@ impl StartCommand {
         Ok((application_id, context_id, member_public_key))
     }
 
-    fn print_summary(
+    async fn print_summary(
         &self,
         environment: &Environment,
         application_id: ApplicationId,
@@ -183,9 +183,7 @@ impl StartCommand {
         let client = environment.client()?;
         let node_url = client.api_url();
 
-        let app_response = tokio::task::block_in_place(|| {
-            Handle::current().block_on(client.get_application(&application_id))
-        })?;
+        let app_response = client.get_application(&application_id).await?;
         let app = app_response.data.application;
 
         let package_display = app


### PR DESCRIPTION
## Problem

`DevCommand::print_summary` was a **synchronous** method called from the async `dev` command, and it reached back into the runtime to do an HTTP call:

```rust
// before — cli/dev.rs
let app_response = tokio::task::block_in_place(|| {
    Handle::current().block_on(client.get_application(&application_id))
})?;
```

`block_in_place` **panics on a current-thread runtime**, and nesting `block_on` inside an already-async context is a footgun (deadlock/panic risk depending on the runtime flavor).

## Fix

Make `print_summary` `async` and `.await` the call directly; the caller now `.await`s it.

```rust
// after
async fn print_summary(&self, …) -> Result<()> {
    let app_response = client.get_application(&application_id).await?;
    …
}
```

The now-unused `tokio::runtime::Handle` import is removed.

## Changes
- `crates/meroctl/src/cli/dev.rs`: `print_summary` is async; caller awaits; dropped `block_in_place`/`block_on` and the `Handle` import.

## Validation
- `cargo build -p meroctl`, `cargo clippy -p meroctl` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)