### PR TITLE
fix(meroctl): validate hex group IDs at parse time

### DIFF
--- a/crates/meroctl/src/cli/context/create.rs
+++ b/crates/meroctl/src/cli/context/create.rs
@@ -74,6 +74,7 @@ pub struct CreateCommand {
     #[clap(
         long,
         required = true,
+        value_parser = crate::cli::validation::group_id,
         help = "Group ID (hex) to attach this context to"
     )]
     pub group_id: String,

--- a/crates/meroctl/src/cli/group/members.rs
+++ b/crates/meroctl/src/cli/group/members.rs
@@ -72,7 +72,11 @@ impl MembersCommand {
 #[derive(Clone, Debug, Parser)]
 #[command(about = "List all members of a group")]
 pub struct ListMembersCommand {
-    #[clap(name = "GROUP_ID", help = "The hex-encoded group ID")]
+    #[clap(
+        name = "GROUP_ID",
+        value_parser = crate::cli::validation::group_id,
+        help = "The hex-encoded group ID"
+    )]
     pub group_id: String,
 }
 
@@ -90,7 +94,11 @@ impl ListMembersCommand {
 #[derive(Clone, Debug, Parser)]
 #[command(about = "Add a member to a group")]
 pub struct AddMembersCommand {
-    #[clap(name = "GROUP_ID", help = "The hex-encoded group ID")]
+    #[clap(
+        name = "GROUP_ID",
+        value_parser = crate::cli::validation::group_id,
+        help = "The hex-encoded group ID"
+    )]
     pub group_id: String,
 
     #[clap(name = "IDENTITY", help = "Public key of the identity to add")]
@@ -133,7 +141,11 @@ impl AddMembersCommand {
 #[derive(Clone, Debug, Parser)]
 #[command(about = "Remove members from a group")]
 pub struct RemoveMembersCommand {
-    #[clap(name = "GROUP_ID", help = "The hex-encoded group ID")]
+    #[clap(
+        name = "GROUP_ID",
+        value_parser = crate::cli::validation::group_id,
+        help = "The hex-encoded group ID"
+    )]
     pub group_id: String,
 
     #[clap(
@@ -169,7 +181,11 @@ impl RemoveMembersCommand {
 #[derive(Clone, Debug, Parser)]
 #[command(about = "Update the role of a group member")]
 pub struct SetRoleCommand {
-    #[clap(name = "GROUP_ID", help = "The hex-encoded group ID")]
+    #[clap(
+        name = "GROUP_ID",
+        value_parser = crate::cli::validation::group_id,
+        help = "The hex-encoded group ID"
+    )]
     pub group_id: String,
 
     #[clap(
@@ -211,7 +227,11 @@ impl SetRoleCommand {
 #[derive(Clone, Debug, Parser)]
 #[command(about = "Set capabilities for a group member")]
 pub struct SetCapabilitiesCommand {
-    #[clap(name = "GROUP_ID", help = "The hex-encoded group ID")]
+    #[clap(
+        name = "GROUP_ID",
+        value_parser = crate::cli::validation::group_id,
+        help = "The hex-encoded group ID"
+    )]
     pub group_id: String,
 
     #[clap(name = "IDENTITY", help = "Public key of the member")]
@@ -303,7 +323,11 @@ impl SetCapabilitiesCommand {
 #[derive(Clone, Debug, Parser)]
 #[command(about = "Get capabilities of a group member")]
 pub struct GetCapabilitiesCommand {
-    #[clap(name = "GROUP_ID", help = "The hex-encoded group ID")]
+    #[clap(
+        name = "GROUP_ID",
+        value_parser = crate::cli::validation::group_id,
+        help = "The hex-encoded group ID"
+    )]
     pub group_id: String,
 
     #[clap(name = "IDENTITY", help = "Public key of the member")]
@@ -328,7 +352,11 @@ impl GetCapabilitiesCommand {
 #[derive(Clone, Debug, Parser)]
 #[command(about = "Diagnostic: check an identity's role and capabilities in a group")]
 pub struct CheckAccessCommand {
-    #[clap(name = "GROUP_ID", help = "The hex-encoded group ID")]
+    #[clap(
+        name = "GROUP_ID",
+        value_parser = crate::cli::validation::group_id,
+        help = "The hex-encoded group ID"
+    )]
     pub group_id: String,
 
     #[clap(name = "IDENTITY", help = "Public key of the identity to check")]

--- a/crates/meroctl/src/cli/group/metadata.rs
+++ b/crates/meroctl/src/cli/group/metadata.rs
@@ -111,12 +111,20 @@ pub struct MetadataCommand {
 pub enum MetadataSubCommands {
     #[command(about = "Show the group's metadata record")]
     Get {
-        #[clap(name = "GROUP_ID", help = "Hex-encoded group ID")]
+        #[clap(
+            name = "GROUP_ID",
+            value_parser = crate::cli::validation::group_id,
+            help = "Hex-encoded group ID"
+        )]
         group_id: String,
     },
     #[command(about = "Update the group's metadata record (read-modify-write)")]
     Set {
-        #[clap(name = "GROUP_ID", help = "Hex-encoded group ID")]
+        #[clap(
+            name = "GROUP_ID",
+            value_parser = crate::cli::validation::group_id,
+            help = "Hex-encoded group ID"
+        )]
         group_id: String,
         #[command(flatten)]
         opts: SetOpts,
@@ -158,14 +166,22 @@ pub struct MemberMetadataCommand {
 pub enum MemberMetadataSubCommands {
     #[command(about = "Show a member's metadata record")]
     Get {
-        #[clap(name = "GROUP_ID", help = "Hex-encoded group ID")]
+        #[clap(
+            name = "GROUP_ID",
+            value_parser = crate::cli::validation::group_id,
+            help = "Hex-encoded group ID"
+        )]
         group_id: String,
         #[clap(name = "MEMBER", help = "Member public key")]
         member: PublicKey,
     },
     #[command(about = "Update a member's metadata record (read-modify-write)")]
     Set {
-        #[clap(name = "GROUP_ID", help = "Hex-encoded group ID")]
+        #[clap(
+            name = "GROUP_ID",
+            value_parser = crate::cli::validation::group_id,
+            help = "Hex-encoded group ID"
+        )]
         group_id: String,
         #[clap(name = "MEMBER", help = "Member public key")]
         member: PublicKey,
@@ -215,14 +231,22 @@ pub struct ContextMetadataCommand {
 pub enum ContextMetadataSubCommands {
     #[command(about = "Show a context's metadata record")]
     Get {
-        #[clap(name = "GROUP_ID", help = "Hex-encoded group ID")]
+        #[clap(
+            name = "GROUP_ID",
+            value_parser = crate::cli::validation::group_id,
+            help = "Hex-encoded group ID"
+        )]
         group_id: String,
         #[clap(name = "CONTEXT_ID", help = "Context ID")]
         context_id: ContextId,
     },
     #[command(about = "Update a context's metadata record (read-modify-write)")]
     Set {
-        #[clap(name = "GROUP_ID", help = "Hex-encoded group ID")]
+        #[clap(
+            name = "GROUP_ID",
+            value_parser = crate::cli::validation::group_id,
+            help = "Hex-encoded group ID"
+        )]
         group_id: String,
         #[clap(name = "CONTEXT_ID", help = "Context ID")]
         context_id: ContextId,

--- a/crates/meroctl/src/cli/group/settings.rs
+++ b/crates/meroctl/src/cli/group/settings.rs
@@ -51,7 +51,11 @@ impl SettingsCommand {
 #[derive(Clone, Debug, Parser)]
 #[command(about = "Get current default settings for a group")]
 pub struct SettingsGetCommand {
-    #[clap(name = "GROUP_ID", help = "The hex-encoded group ID")]
+    #[clap(
+        name = "GROUP_ID",
+        value_parser = crate::cli::validation::group_id,
+        help = "The hex-encoded group ID"
+    )]
     pub group_id: String,
 }
 
@@ -103,7 +107,11 @@ impl SettingsGetCommand {
 #[derive(Clone, Debug, Parser)]
 #[command(about = "Set default capabilities for new group members (admin-only)")]
 pub struct SetDefaultCapabilitiesCommand {
-    #[clap(name = "GROUP_ID", help = "The hex-encoded group ID")]
+    #[clap(
+        name = "GROUP_ID",
+        value_parser = crate::cli::validation::group_id,
+        help = "The hex-encoded group ID"
+    )]
     pub group_id: String,
 
     #[clap(long, help = "Allow new members to create contexts by default")]
@@ -159,7 +167,11 @@ impl SetDefaultCapabilitiesCommand {
              add_group_members"
 )]
 pub struct SetSubgroupVisibilityCommand {
-    #[clap(name = "GROUP_ID", help = "The hex-encoded group ID")]
+    #[clap(
+        name = "GROUP_ID",
+        value_parser = crate::cli::validation::group_id,
+        help = "The hex-encoded group ID"
+    )]
     pub group_id: String,
 
     #[clap(long, value_enum, help = "Subgroup visibility: open or restricted")]

--- a/crates/meroctl/src/cli/validation.rs
+++ b/crates/meroctl/src/cli/validation.rs
@@ -100,13 +100,15 @@ pub fn valid_node_name(s: &str) -> Result<String, String> {
 ///
 /// Can be used with `#[clap(value_parser = group_id)]`.
 pub fn group_id(s: &str) -> Result<String, String> {
+    // Validate and report on the same (trimmed) value so the error never refers
+    // to a different string than the one actually checked.
     let trimmed = s.trim();
     let bytes = hex::decode(trimmed).map_err(|_| {
-        format!("Invalid group id '{s}': expected hex-encoded 32 bytes (64 hex characters)")
+        format!("Invalid group id '{trimmed}': expected hex-encoded 32 bytes (64 hex characters)")
     })?;
     if bytes.len() != 32 {
         return Err(format!(
-            "Invalid group id '{s}': must be exactly 32 bytes (64 hex characters), got {} bytes",
+            "Invalid group id '{trimmed}': must be exactly 32 bytes (64 hex characters), got {} bytes",
             bytes.len()
         ));
     }

--- a/crates/meroctl/src/cli/validation.rs
+++ b/crates/meroctl/src/cli/validation.rs
@@ -92,6 +92,27 @@ pub fn valid_node_name(s: &str) -> Result<String, String> {
     Ok(s.to_string())
 }
 
+/// Clap value parser for hex-encoded group IDs.
+///
+/// A group ID is exactly 32 bytes, hex-encoded (64 hex characters). Validating
+/// at parse time turns an opaque post-round-trip server error into an immediate,
+/// actionable CLI error. Returns the normalised (lowercased) hex string.
+///
+/// Can be used with `#[clap(value_parser = group_id)]`.
+pub fn group_id(s: &str) -> Result<String, String> {
+    let trimmed = s.trim();
+    let bytes = hex::decode(trimmed).map_err(|_| {
+        format!("Invalid group id '{s}': expected hex-encoded 32 bytes (64 hex characters)")
+    })?;
+    if bytes.len() != 32 {
+        return Err(format!(
+            "Invalid group id '{s}': must be exactly 32 bytes (64 hex characters), got {} bytes",
+            bytes.len()
+        ));
+    }
+    Ok(trimmed.to_ascii_lowercase())
+}
+
 /// Clap value parser for valid URLs.
 ///
 /// Can be used with `#[arg(value_parser = valid_url)]`
@@ -177,5 +198,20 @@ mod tests {
     fn test_valid_url_parser() {
         assert!(valid_url("http://localhost:8080").is_ok());
         assert!(valid_url("not-a-url").is_err());
+    }
+
+    #[test]
+    fn test_group_id_parser() {
+        let valid = "a".repeat(64);
+        assert_eq!(group_id(&valid).unwrap(), valid);
+        // Uppercase is normalised to lowercase.
+        assert_eq!(group_id(&"A".repeat(64)).unwrap(), "a".repeat(64));
+        // Too short / too long.
+        assert!(group_id(&"ab".repeat(10)).is_err());
+        assert!(group_id(&"a".repeat(66)).is_err());
+        // Non-hex.
+        assert!(group_id(&"z".repeat(64)).is_err());
+        // Empty.
+        assert!(group_id("").is_err());
     }
 }


### PR DESCRIPTION
## Problem

Group-ID arguments were plain `String`s with no validation:

```rust
// before
#[clap(name = "GROUP_ID", help = "The hex-encoded group ID")]
pub group_id: String,
```

A malformed ID (wrong length, non-hex chars, trailing whitespace) sailed through the CLI and only failed **after** a server round-trip, surfacing as an opaque error like *"Invalid group id: must be exactly 32 bytes"* — long after the user could tell what went wrong locally.

## Fix

Add a `group_id` clap `value_parser` (mirroring the server's `parse_group_id`: exactly 32 bytes = 64 hex chars) that rejects bad input **before** any network call and normalises the value to lowercase:

```rust
#[clap(name = "GROUP_ID", value_parser = crate::cli::validation::group_id, help = "…")]
pub group_id: String,
```

```
$ meroctl group members ls deadbeef
error: invalid value 'deadbeef' for '<GROUP_ID>': Invalid group id 'deadbeef': must be exactly 32 bytes (64 hex characters), got 4 bytes
```

## Changes
- `crates/meroctl/src/cli/validation.rs`: `group_id` parser + unit test (valid/upper-case-normalised/short/long/non-hex/empty).
- Applied to `group members` (all subcommands), `group settings`, `group metadata`, and `context create` group-ID args.

## Validation
- `cargo build -p meroctl`, `cargo clippy -p meroctl` clean; unit test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)