### PR TITLE
fix(meroctl): honour --output-format json in the interactive call shell

### DIFF
--- a/crates/meroctl/src/cli/call.rs
+++ b/crates/meroctl/src/cli/call.rs
@@ -17,7 +17,7 @@ use tokio::io::{stdin, AsyncBufReadExt, BufReader};
 use crate::cli::validation::non_empty_string;
 use crate::cli::Environment;
 use crate::client::Client;
-use crate::output::InfoLine;
+use crate::output::{Format, InfoLine};
 use crate::ws::WsSession;
 
 pub const EXAMPLES: &str = r#"
@@ -157,6 +157,7 @@ async fn run_shell(
     seed_args: Option<Value>,
     timeout: Option<Duration>,
 ) -> Result<()> {
+    let format = environment.output.format();
     let mut context_id = resolve_context(client, context).await?;
     let mut session = WsSession::connect(client).await?;
 
@@ -173,8 +174,16 @@ async fn run_shell(
     // start, so a transport failure ends it.
     if let Some(method) = seed_method {
         let args = seed_args.unwrap_or_else(|| json!({}));
-        if let CallOutcome::Closed(err) =
-            run_call(&mut session, timeout, context_id, &substitute, method, args).await
+        if let CallOutcome::Closed(err) = run_call(
+            &mut session,
+            timeout,
+            context_id,
+            &substitute,
+            method,
+            args,
+            format,
+        )
+        .await
         {
             eprintln!("Connection closed: {err}");
             return Ok(());
@@ -250,7 +259,17 @@ async fn run_shell(
             None => json!({}),
         };
 
-        match run_call(&mut session, timeout, context_id, &substitute, method, args).await {
+        match run_call(
+            &mut session,
+            timeout,
+            context_id,
+            &substitute,
+            method,
+            args,
+            format,
+        )
+        .await
+        {
             CallOutcome::Done => {}
             CallOutcome::TimedOut(dur) => eprintln!(
                 "No response within {}s; the call may still be running on the node.",
@@ -288,6 +307,7 @@ async fn run_call(
     substitute: &[Alias<PublicKey>],
     method: String,
     args: Value,
+    format: Format,
 ) -> CallOutcome {
     let request = ExecutionRequest::new(context_id, method, args, substitute.to_vec());
 
@@ -301,14 +321,25 @@ async fn run_call(
 
     match result {
         Ok(response) => {
-            print_response(&response);
+            print_response(&response, format);
             CallOutcome::Done
         }
         Err(err) => CallOutcome::Closed(err),
     }
 }
 
-fn print_response(response: &Response) {
+fn print_response(response: &Response, format: Format) {
+    // JSON mode: emit the whole response as one machine-readable line on stdout
+    // (results and handler errors alike) so `call -i` output is parseable, just
+    // like the non-interactive path honours --output-format.
+    if matches!(format, Format::Json) {
+        match serde_json::to_string(response) {
+            Ok(json) => println!("{json}"),
+            Err(err) => eprintln!("Failed to serialize response to JSON: {err}"),
+        }
+        return;
+    }
+
     match &response.body {
         ResponseBody::Result(ResponseBodyResult(value)) => {
             let rendered =

--- a/crates/meroctl/src/output.rs
+++ b/crates/meroctl/src/output.rs
@@ -37,6 +37,11 @@ impl Output {
         }
     }
 
+    /// The configured output format (`--output-format`).
+    pub const fn format(&self) -> Format {
+        self.format
+    }
+
     pub fn write<T: Serialize + Report>(&self, value: &T) {
         match self.format {
             Format::Json => match serde_json::to_string(&value) {


### PR DESCRIPTION
## Problem

The interactive shell (`call -i`) always printed responses as human-pretty text with `println!`, **ignoring `--output-format json`**:

```rust
// before — cli/call.rs
fn print_response(response: &Response) {
    match &response.body {
        ResponseBody::Result(ResponseBodyResult(value)) => {
            let rendered = serde_json::to_string_pretty(value)…;
            println!("{rendered}");   // always human, even with --output-format json
        }
        …
    }
}
```

A script driving `meroctl call -i --output-format json` got pretty-printed/decorated output it couldn't parse — inconsistent with the non-interactive path, which already honours the format.

## Fix

Thread the configured `Format` into the shell's printer:

- **JSON** → emit each response (result *or* handler error) as **one machine-readable JSON line on stdout**, so consumers can parse line-by-line.
- **Human** → unchanged (pretty value to stdout, errors to stderr) — preserving the nice interactive UX.

Adds a small `Output::format()` accessor.

```
$ meroctl call -i --output-format json --context c   # now emits parseable JSON per call
```

## Changes
- `crates/meroctl/src/output.rs`: `Output::format()` accessor.
- `crates/meroctl/src/cli/call.rs`: thread `Format` through `run_shell`→`run_call`→`print_response`; JSON branch.

## Validation
- `cargo build -p meroctl`, `cargo clippy -p meroctl` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)