### PR TITLE
fix(meroctl): exit non-zero on render failure, async blob fs, dispatch macro, capability tests

### DIFF
--- a/crates/meroctl/src/cli.rs
+++ b/crates/meroctl/src/cli.rs
@@ -45,6 +45,19 @@ use tee::TeeCommand;
 
 use crate::auth::{authenticate_with_session_cache, check_authentication};
 
+/// Dispatch a subcommand enum whose every variant wraps a command type that
+/// exposes `async fn run(self, &mut Environment) -> Result<...>`. Replaces the
+/// repetitive `match { V(cmd) => cmd.run(environment).await, ... }` blocks that
+/// were duplicated across ~10 command modules.
+macro_rules! dispatch_subcommands {
+    ($value:expr, $environment:expr, $( $variant:path ),+ $(,)?) => {
+        match $value {
+            $( $variant(cmd) => cmd.run($environment).await, )+
+        }
+    };
+}
+pub(crate) use dispatch_subcommands;
+
 pub const EXAMPLES: &str = r"
   # List all applications
   $ meroctl --node node1 app ls

--- a/crates/meroctl/src/cli/blob.rs
+++ b/crates/meroctl/src/cli/blob.rs
@@ -60,12 +60,14 @@ pub enum BlobSubCommands {
 
 impl BlobCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
-        match self.subcommand {
-            BlobSubCommands::Upload(upload) => upload.run(environment).await,
-            BlobSubCommands::Download(download) => download.run(environment).await,
-            BlobSubCommands::Delete(delete) => delete.run(environment).await,
-            BlobSubCommands::Info(info) => info.run(environment).await,
-            BlobSubCommands::List(list) => list.run(environment).await,
-        }
+        crate::cli::dispatch_subcommands!(
+            self.subcommand,
+            environment,
+            BlobSubCommands::Upload,
+            BlobSubCommands::Download,
+            BlobSubCommands::Delete,
+            BlobSubCommands::Info,
+            BlobSubCommands::List,
+        )
     }
 }

--- a/crates/meroctl/src/cli/blob/download.rs
+++ b/crates/meroctl/src/cli/blob/download.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::PathBuf;
 
 use calimero_primitives::blobs::BlobId;
@@ -53,14 +52,16 @@ impl DownloadCommand {
         // Get file size before writing
         let size = data.len() as u64;
 
-        // Write to file
-        fs::write(&self.output_path, data).map_err(|e| {
-            eyre!(
-                "Failed to write file '{}': {}",
-                self.output_path.display(),
-                e
-            )
-        })?;
+        // Write to file (async so we don't block the runtime worker thread).
+        tokio::fs::write(&self.output_path, data)
+            .await
+            .map_err(|e| {
+                eyre!(
+                    "Failed to write file '{}': {}",
+                    self.output_path.display(),
+                    e
+                )
+            })?;
 
         let response = BlobDownloadResponse {
             blob_id: self.blob_id,

--- a/crates/meroctl/src/cli/blob/upload.rs
+++ b/crates/meroctl/src/cli/blob/upload.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::PathBuf;
 
 use calimero_primitives::context::ContextId;
@@ -34,8 +33,9 @@ impl UploadCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
         let client = environment.client()?;
 
-        // Read the file
-        let data = fs::read(&self.file_path)
+        // Read the file (async so we don't block the runtime worker thread).
+        let data = tokio::fs::read(&self.file_path)
+            .await
             .map_err(|e| eyre!("Failed to read file '{}': {}", self.file_path.display(), e))?;
 
         // Upload the blob

--- a/crates/meroctl/src/cli/group.rs
+++ b/crates/meroctl/src/cli/group.rs
@@ -91,24 +91,26 @@ pub enum GroupSubCommands {
 
 impl GroupCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
-        match self.subcommand {
-            GroupSubCommands::Get(cmd) => cmd.run(environment).await,
-            GroupSubCommands::Delete(cmd) => cmd.run(environment).await,
-            GroupSubCommands::Update(cmd) => cmd.run(environment).await,
-            GroupSubCommands::Members(cmd) => cmd.run(environment).await,
-            GroupSubCommands::Contexts(cmd) => cmd.run(environment).await,
-            GroupSubCommands::Metadata(cmd) => cmd.run(environment).await,
-            GroupSubCommands::MemberMetadata(cmd) => cmd.run(environment).await,
-            GroupSubCommands::ContextMetadata(cmd) => cmd.run(environment).await,
-            GroupSubCommands::Reparent(cmd) => cmd.run(environment).await,
-            GroupSubCommands::Subgroups(cmd) => cmd.run(environment).await,
-            GroupSubCommands::SigningKey(cmd) => cmd.run(environment).await,
-            GroupSubCommands::Upgrade(cmd) => cmd.run(environment).await,
-            GroupSubCommands::Sync(cmd) => cmd.run(environment).await,
-            GroupSubCommands::JoinContext(cmd) => cmd.run(environment).await,
-            GroupSubCommands::LeaveContext(cmd) => cmd.run(environment).await,
-            GroupSubCommands::Leave(cmd) => cmd.run(environment).await,
-            GroupSubCommands::Settings(cmd) => cmd.run(environment).await,
-        }
+        crate::cli::dispatch_subcommands!(
+            self.subcommand,
+            environment,
+            GroupSubCommands::Get,
+            GroupSubCommands::Delete,
+            GroupSubCommands::Update,
+            GroupSubCommands::Members,
+            GroupSubCommands::Contexts,
+            GroupSubCommands::Metadata,
+            GroupSubCommands::MemberMetadata,
+            GroupSubCommands::ContextMetadata,
+            GroupSubCommands::Reparent,
+            GroupSubCommands::Subgroups,
+            GroupSubCommands::SigningKey,
+            GroupSubCommands::Upgrade,
+            GroupSubCommands::Sync,
+            GroupSubCommands::JoinContext,
+            GroupSubCommands::LeaveContext,
+            GroupSubCommands::Leave,
+            GroupSubCommands::Settings,
+        )
     }
 }

--- a/crates/meroctl/src/cli/group/members.rs
+++ b/crates/meroctl/src/cli/group/members.rs
@@ -57,15 +57,17 @@ pub enum MembersSubCommands {
 
 impl MembersCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
-        match self.subcommand {
-            MembersSubCommands::List(cmd) => cmd.run(environment).await,
-            MembersSubCommands::Add(cmd) => cmd.run(environment).await,
-            MembersSubCommands::Remove(cmd) => cmd.run(environment).await,
-            MembersSubCommands::SetRole(cmd) => cmd.run(environment).await,
-            MembersSubCommands::SetCapabilities(cmd) => cmd.run(environment).await,
-            MembersSubCommands::GetCapabilities(cmd) => cmd.run(environment).await,
-            MembersSubCommands::CheckAccess(cmd) => cmd.run(environment).await,
-        }
+        crate::cli::dispatch_subcommands!(
+            self.subcommand,
+            environment,
+            MembersSubCommands::List,
+            MembersSubCommands::Add,
+            MembersSubCommands::Remove,
+            MembersSubCommands::SetRole,
+            MembersSubCommands::SetCapabilities,
+            MembersSubCommands::GetCapabilities,
+            MembersSubCommands::CheckAccess,
+        )
     }
 }
 
@@ -259,28 +261,15 @@ pub struct SetCapabilitiesCommand {
 
 impl SetCapabilitiesCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
-        let mut capabilities: u32 = 0;
-        if self.can_create_context {
-            capabilities |= MemberCapabilities::CAN_CREATE_CONTEXT.bits();
-        }
-        if self.can_invite_members {
-            capabilities |= MemberCapabilities::CAN_INVITE_MEMBERS.bits();
-        }
-        if self.can_join_open_subgroups {
-            capabilities |= MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS.bits();
-        }
-        if self.can_create_subgroup {
-            capabilities |= MemberCapabilities::CAN_CREATE_SUBGROUP.bits();
-        }
-        if self.can_delete_subgroup {
-            capabilities |= MemberCapabilities::CAN_DELETE_SUBGROUP.bits();
-        }
-        if self.can_manage_visibility {
-            capabilities |= MemberCapabilities::CAN_MANAGE_VISIBILITY.bits();
-        }
-        if self.can_manage_metadata {
-            capabilities |= MemberCapabilities::CAN_MANAGE_METADATA.bits();
-        }
+        let capabilities = encode_capabilities(
+            self.can_create_context,
+            self.can_invite_members,
+            self.can_join_open_subgroups,
+            self.can_create_subgroup,
+            self.can_delete_subgroup,
+            self.can_manage_visibility,
+            self.can_manage_metadata,
+        );
 
         let identity_hex = hex::encode(self.identity.digest());
 
@@ -385,5 +374,87 @@ impl CheckAccessCommand {
         );
 
         Ok(())
+    }
+}
+
+/// Encode the seven member-capability flags into the `MemberCapabilities`
+/// bitmask sent to the node.
+fn encode_capabilities(
+    can_create_context: bool,
+    can_invite_members: bool,
+    can_join_open_subgroups: bool,
+    can_create_subgroup: bool,
+    can_delete_subgroup: bool,
+    can_manage_visibility: bool,
+    can_manage_metadata: bool,
+) -> u32 {
+    let mut capabilities: u32 = 0;
+    if can_create_context {
+        capabilities |= MemberCapabilities::CAN_CREATE_CONTEXT.bits();
+    }
+    if can_invite_members {
+        capabilities |= MemberCapabilities::CAN_INVITE_MEMBERS.bits();
+    }
+    if can_join_open_subgroups {
+        capabilities |= MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS.bits();
+    }
+    if can_create_subgroup {
+        capabilities |= MemberCapabilities::CAN_CREATE_SUBGROUP.bits();
+    }
+    if can_delete_subgroup {
+        capabilities |= MemberCapabilities::CAN_DELETE_SUBGROUP.bits();
+    }
+    if can_manage_visibility {
+        capabilities |= MemberCapabilities::CAN_MANAGE_VISIBILITY.bits();
+    }
+    if can_manage_metadata {
+        capabilities |= MemberCapabilities::CAN_MANAGE_METADATA.bits();
+    }
+    capabilities
+}
+
+#[cfg(test)]
+mod tests {
+    use super::encode_capabilities;
+    use calimero_context_config::MemberCapabilities;
+
+    #[test]
+    fn no_flags_encodes_to_zero() {
+        assert_eq!(
+            encode_capabilities(false, false, false, false, false, false, false),
+            0
+        );
+    }
+
+    #[test]
+    fn each_flag_maps_to_its_bit() {
+        assert_eq!(
+            encode_capabilities(true, false, false, false, false, false, false),
+            MemberCapabilities::CAN_CREATE_CONTEXT.bits()
+        );
+        assert_eq!(
+            encode_capabilities(false, true, false, false, false, false, false),
+            MemberCapabilities::CAN_INVITE_MEMBERS.bits()
+        );
+        assert_eq!(
+            encode_capabilities(false, false, false, false, false, false, true),
+            MemberCapabilities::CAN_MANAGE_METADATA.bits()
+        );
+    }
+
+    #[test]
+    fn all_flags_or_together() {
+        let all = encode_capabilities(true, true, true, true, true, true, true);
+        let expected = (MemberCapabilities::CAN_CREATE_CONTEXT
+            | MemberCapabilities::CAN_INVITE_MEMBERS
+            | MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS
+            | MemberCapabilities::CAN_CREATE_SUBGROUP
+            | MemberCapabilities::CAN_DELETE_SUBGROUP
+            | MemberCapabilities::CAN_MANAGE_VISIBILITY
+            | MemberCapabilities::CAN_MANAGE_METADATA)
+            .bits();
+        assert_eq!(all, expected);
+        // Every set bit is distinct (no two flags collide on a bit).
+        assert_eq!(all.count_ones(), 7);
     }
 }

--- a/crates/meroctl/src/cli/namespace.rs
+++ b/crates/meroctl/src/cli/namespace.rs
@@ -66,17 +66,19 @@ pub enum NamespaceSubCommands {
 
 impl NamespaceCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
-        match self.subcommand {
-            NamespaceSubCommands::Create(cmd) => cmd.run(environment).await,
-            NamespaceSubCommands::Get(cmd) => cmd.run(environment).await,
-            NamespaceSubCommands::Delete(cmd) => cmd.run(environment).await,
-            NamespaceSubCommands::Invite(cmd) => cmd.run(environment).await,
-            NamespaceSubCommands::Join(cmd) => cmd.run(environment).await,
-            NamespaceSubCommands::Leave(cmd) => cmd.run(environment).await,
-            NamespaceSubCommands::Groups(cmd) => cmd.run(environment).await,
-            NamespaceSubCommands::CreateGroup(cmd) => cmd.run(environment).await,
-            NamespaceSubCommands::List(cmd) => cmd.run(environment).await,
-            NamespaceSubCommands::Identity(cmd) => cmd.run(environment).await,
-        }
+        crate::cli::dispatch_subcommands!(
+            self.subcommand,
+            environment,
+            NamespaceSubCommands::Create,
+            NamespaceSubCommands::Get,
+            NamespaceSubCommands::Delete,
+            NamespaceSubCommands::Invite,
+            NamespaceSubCommands::Join,
+            NamespaceSubCommands::Leave,
+            NamespaceSubCommands::Groups,
+            NamespaceSubCommands::CreateGroup,
+            NamespaceSubCommands::List,
+            NamespaceSubCommands::Identity,
+        )
     }
 }

--- a/crates/meroctl/src/main.rs
+++ b/crates/meroctl/src/main.rs
@@ -27,6 +27,9 @@ async fn main() -> ExitCode {
 
     let command = cli::RootCommand::parse();
     match command.run().await {
+        // A command can succeed yet fail to render its output (e.g. a JSON
+        // serialization error); don't mask that with a success exit code.
+        Ok(()) if output::output_failed() => ExitCode::FAILURE,
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => err.into(),
     }

--- a/crates/meroctl/src/output.rs
+++ b/crates/meroctl/src/output.rs
@@ -19,6 +19,11 @@ use serde::Serialize;
 /// Set when an `Output::write` fails to render (e.g. JSON serialization error).
 /// `main` reads this to exit non-zero instead of masking the failure with a
 /// success code.
+///
+/// Accessed with `Ordering::Relaxed`: this is a standalone flag that guards no
+/// other memory, the meaningful read happens once in `main` after the command
+/// has fully returned (so the store has long since happened-before it), and a
+/// set is monotonic (never cleared). No stronger ordering is needed.
 static OUTPUT_FAILED: AtomicBool = AtomicBool::new(false);
 
 /// Whether any output render has failed during this process.

--- a/crates/meroctl/src/output.rs
+++ b/crates/meroctl/src/output.rs
@@ -8,11 +8,23 @@ pub mod groups;
 pub mod network;
 pub mod tee;
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 // Re-export common types
 pub use blobs::{BlobDownloadResponse, BlobUploadResponse};
 use clap::ValueEnum;
 pub use common::{ErrorLine, InfoLine, WarnLine};
 use serde::Serialize;
+
+/// Set when an `Output::write` fails to render (e.g. JSON serialization error).
+/// `main` reads this to exit non-zero instead of masking the failure with a
+/// success code.
+static OUTPUT_FAILED: AtomicBool = AtomicBool::new(false);
+
+/// Whether any output render has failed during this process.
+pub fn output_failed() -> bool {
+    OUTPUT_FAILED.load(Ordering::Relaxed)
+}
 
 #[derive(Clone, Copy, Debug, Default, ValueEnum)]
 pub enum Format {
@@ -41,7 +53,12 @@ impl Output {
         match self.format {
             Format::Json => match serde_json::to_string(&value) {
                 Ok(json) => println!("{json}"),
-                Err(err) => eprintln!("Failed to serialize to JSON: {err}"),
+                Err(err) => {
+                    // Record the failure so the process exits non-zero instead
+                    // of reporting success after producing no usable output.
+                    OUTPUT_FAILED.store(true, Ordering::Relaxed);
+                    eprintln!("Failed to serialize to JSON: {err}");
+                }
             },
             Format::Human => value.report(),
         }


### PR DESCRIPTION
## Problem

Four small robustness/cleanup issues from the audit:

1. **Silent render failure** — `Output::write` printed a JSON serialization error to stderr but returned normally, so the process **exited 0** despite producing no usable output (a JSON consumer sees success + empty/garbage).
2. **Blocking I/O in async** — `blob upload`/`download` used `std::fs::{read,write}` inside `async fn`s, blocking a runtime worker thread on file I/O.
3. **Boilerplate** — an identical `match { V(cmd) => cmd.run(environment).await, … }` dispatch was duplicated across ~10 command modules.
4. **No tests** for the member-capability flag→bitmask encoding.

## Fix

1. `Output::write` now records a process-global flag on serialize failure; `main` returns `ExitCode::FAILURE` when set:
   ```rust
   Ok(()) if output::output_failed() => ExitCode::FAILURE,
   ```
2. `blob upload`/`download` use `tokio::fs::{read,write}().await`.
3. New `dispatch_subcommands!` macro; applied to the `blob`, `group`, `namespace`, and `group members` dispatchers (the multi-arm ones). Remaining single-arm dispatchers are left as-is; rolling the macro out further is mechanical follow-up.
4. Extracted `encode_capabilities(..7 bools..) -> u32` + unit tests (no-flags → 0, each flag → its bit, all-flags → 7 distinct bits).

## Changes
- `crates/meroctl/src/output.rs`, `src/main.rs`: non-zero exit on render failure.
- `crates/meroctl/src/cli/blob/{upload,download}.rs`: `tokio::fs`.
- `crates/meroctl/src/cli.rs`: `dispatch_subcommands!` macro; applied in `cli/blob.rs`, `cli/group.rs`, `cli/namespace.rs`, `cli/group/members.rs`.
- `crates/meroctl/src/cli/group/members.rs`: `encode_capabilities` + tests.

## Validation
- `cargo build -p meroctl`, `cargo clippy -p meroctl`, `cargo fmt --check` clean; capability unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)