### PR TITLE
fix(storage): stop add-wins map/set merges from resurrecting deleted entries

### DIFF
--- a/crates/storage/src/collections/crdt_impls.rs
+++ b/crates/storage/src/collections/crdt_impls.rs
@@ -1110,7 +1110,9 @@ mod mapset_tombstone_merge_tests {
                 .unwrap(),
         );
 
-        // Precondition: the resurrection scenario is real.
+        // Precondition: the resurrection scenario is real. `b` must hold "k"
+        // live, else the merge is a no-op and the test passes vacuously.
+        assert!(b.get("k").unwrap().is_some());
         let entry = a.entry_id("k");
         assert!(a.get("k").unwrap().is_none());
         assert!(Index::<S>::is_deleted(entry).unwrap());
@@ -1162,6 +1164,8 @@ mod mapset_tombstone_merge_tests {
         let mut b = UnorderedSet::<String, S>::new_with_field_name("b_set");
         let _ = b.insert("x".to_owned()).unwrap();
 
+        // `b` must hold "x" live, else the merge is a no-op (vacuous pass).
+        assert!(b.contains("x").unwrap());
         let entry = a.entry_id("x");
         assert!(Index::<S>::is_deleted(entry).unwrap());
         let parent = Index::<S>::get_parent_id(entry).unwrap().unwrap();

--- a/crates/storage/src/collections/crdt_impls.rs
+++ b/crates/storage/src/collections/crdt_impls.rs
@@ -336,6 +336,7 @@ where
             {
                 // Add-wins, but a key we tombstoned must not be resurrected by
                 // other's live copy (delete wins; mirrors rga merge_chars_from).
+                // entry_id is self's: the tombstone lives in self's namespace.
                 drop(self.insert(key, other_value)?);
             }
         }
@@ -1081,11 +1082,8 @@ mod tests {
 }
 
 /// Add-wins map/set merges must not resurrect a key/value this replica
-/// tombstoned. Mirrors the RGA `tombstone_merge_tests`: `self` deletes an
-/// entry, a peer (a different collection id, same key) holds it live, and
-/// merging the peer in must leave the deletion intact. Resurrection shows up
-/// on the parent (`deleted_children` / `full_hash`), since the merge re-keys
-/// under `self`'s id; the child's own `deleted_at` is checked too.
+/// tombstoned: `self` deletes an entry, a peer holds it live, and merging the
+/// peer in must leave the deletion intact. Mirrors the RGA `tombstone_merge_tests`.
 #[cfg(test)]
 mod mapset_tombstone_merge_tests {
     use crate::collections::crdt_meta::Mergeable;
@@ -1100,7 +1098,8 @@ mod mapset_tombstone_merge_tests {
     fn map_merge_does_not_resurrect_locally_deleted_key() {
         type S = MockedStorage<861>;
 
-        // `a` tombstones "k"; `b` (a different map id) holds "k" live.
+        // `a` tombstones "k"; `b` is a separate replica (different collection id)
+        // holding "k" live. The guard checks `a`'s own id, so `a`'s delete wins.
         let mut a = UnorderedMap::<String, Reg, S>::new_with_field_name("a_map");
         drop(a.insert("k".to_owned(), Reg::new("v".to_owned())).unwrap());
         drop(a.remove("k").unwrap());

--- a/crates/storage/src/collections/crdt_impls.rs
+++ b/crates/storage/src/collections/crdt_impls.rs
@@ -16,6 +16,7 @@ use super::{
 };
 #[cfg(test)]
 use super::{GCounter, PNCounter};
+use crate::collections::error::StoreError;
 use crate::store::StorageAdaptor;
 
 // ============================================================================
@@ -330,8 +331,11 @@ where
                 // This is where nested CRDT merging happens!
                 our_value.merge(&other_value)?;
                 drop(self.insert(key, our_value)?);
-            } else {
-                // Key only in other - add it (add-wins semantics)
+            } else if !crate::index::Index::<S>::is_deleted(self.entry_id(&key))
+                .map_err(StoreError::from)?
+            {
+                // Add-wins, but a key we tombstoned must not be resurrected by
+                // other's live copy (delete wins; mirrors rga merge_chars_from).
                 drop(self.insert(key, other_value)?);
             }
         }
@@ -387,7 +391,10 @@ where
             if let Some(mut our_value) = self.get(&key)?.map(ValueRef::into_inner) {
                 our_value.merge(&other_value)?;
                 drop(self.insert(key, our_value)?);
-            } else {
+            } else if !crate::index::Index::<S>::is_deleted(self.entry_id(&key))
+                .map_err(StoreError::from)?
+            {
+                // See UnorderedMap::merge — local tombstone wins over add.
                 drop(self.insert(key, other_value)?);
             }
         }
@@ -449,8 +456,13 @@ where
         let other_values = other.iter()?;
 
         for value in other_values {
-            // Insert returns true if new, false if already exists
-            // We don't care - idempotent add-wins semantics
+            // Add-wins, but never resurrect a value we tombstoned (delete wins;
+            // see UnorderedMap::merge / rga merge_chars_from).
+            if crate::index::Index::<S>::is_deleted(self.entry_id(&value))
+                .map_err(StoreError::from)?
+            {
+                continue;
+            }
             let _ = self.insert(value)?;
         }
 
@@ -495,6 +507,12 @@ where
     /// element-ordered. Order falls out of `T: Ord`, so convergence is inherited.
     fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
         for value in other.iter()? {
+            // See UnorderedSet::merge — local tombstone wins over add.
+            if crate::index::Index::<S>::is_deleted(self.entry_id(&value))
+                .map_err(StoreError::from)?
+            {
+                continue;
+            }
             let _ = self.insert(value)?;
         }
         Ok(())
@@ -1059,5 +1077,125 @@ mod tests {
         // Test AsRef with bool
         let reg3 = LwwRegister::new(true);
         assert_eq!(reg3.as_ref(), &true);
+    }
+}
+
+/// Add-wins map/set merges must not resurrect a key/value this replica
+/// tombstoned. Mirrors the RGA `tombstone_merge_tests`: `self` deletes an
+/// entry, a peer (a different collection id, same key) holds it live, and
+/// merging the peer in must leave the deletion intact. Resurrection shows up
+/// on the parent (`deleted_children` / `full_hash`), since the merge re-keys
+/// under `self`'s id; the child's own `deleted_at` is checked too.
+#[cfg(test)]
+mod mapset_tombstone_merge_tests {
+    use crate::collections::crdt_meta::Mergeable;
+    use crate::collections::{LwwRegister, UnorderedMap, UnorderedSet};
+    use crate::index::Index;
+    use crate::store::MockedStorage;
+
+    // Map values must be a CRDT; `LwwRegister` is the simplest Mergeable value.
+    type Reg = LwwRegister<String>;
+
+    #[test]
+    fn map_merge_does_not_resurrect_locally_deleted_key() {
+        type S = MockedStorage<861>;
+
+        // `a` tombstones "k"; `b` (a different map id) holds "k" live.
+        let mut a = UnorderedMap::<String, Reg, S>::new_with_field_name("a_map");
+        drop(a.insert("k".to_owned(), Reg::new("v".to_owned())).unwrap());
+        drop(a.remove("k").unwrap());
+
+        let mut b = UnorderedMap::<String, Reg, S>::new_with_field_name("b_map");
+        drop(
+            b.insert("k".to_owned(), Reg::new("from_b".to_owned()))
+                .unwrap(),
+        );
+
+        // Precondition: the resurrection scenario is real.
+        let entry = a.entry_id("k");
+        assert!(a.get("k").unwrap().is_none());
+        assert!(Index::<S>::is_deleted(entry).unwrap());
+        let parent = Index::<S>::get_parent_id(entry).unwrap().unwrap();
+        let pre = Index::<S>::get_index(parent).unwrap().unwrap();
+        let pre_hash = pre.full_hash();
+        assert!(pre.deleted_children().contains(&entry));
+
+        Mergeable::merge(&mut a, &b).unwrap();
+
+        let post = Index::<S>::get_index(parent).unwrap().unwrap();
+        assert!(
+            a.get("k").unwrap().is_none(),
+            "merge resurrected a deleted key"
+        );
+        assert!(
+            post.deleted_children().contains(&entry),
+            "merge dropped the key from the deleted-children advertisement"
+        );
+        assert_eq!(post.full_hash(), pre_hash, "merge diverged the parent hash");
+    }
+
+    #[test]
+    fn map_merge_still_adds_unseen_key() {
+        type S = MockedStorage<862>;
+        let mut a = UnorderedMap::<String, Reg, S>::new_with_field_name("a_map2");
+        let mut b = UnorderedMap::<String, Reg, S>::new_with_field_name("b_map2");
+        drop(
+            b.insert("new".to_owned(), Reg::new("v".to_owned()))
+                .unwrap(),
+        );
+
+        Mergeable::merge(&mut a, &b).unwrap();
+
+        assert!(
+            a.get("new").unwrap().is_some(),
+            "merge dropped a genuinely new key"
+        );
+    }
+
+    #[test]
+    fn set_merge_does_not_resurrect_locally_deleted_value() {
+        type S = MockedStorage<863>;
+
+        let mut a = UnorderedSet::<String, S>::new_with_field_name("a_set");
+        let _ = a.insert("x".to_owned()).unwrap();
+        let _ = a.remove("x").unwrap();
+
+        let mut b = UnorderedSet::<String, S>::new_with_field_name("b_set");
+        let _ = b.insert("x".to_owned()).unwrap();
+
+        let entry = a.entry_id("x");
+        assert!(Index::<S>::is_deleted(entry).unwrap());
+        let parent = Index::<S>::get_parent_id(entry).unwrap().unwrap();
+        let pre = Index::<S>::get_index(parent).unwrap().unwrap();
+        let pre_hash = pre.full_hash();
+        assert!(pre.deleted_children().contains(&entry));
+
+        Mergeable::merge(&mut a, &b).unwrap();
+
+        let post = Index::<S>::get_index(parent).unwrap().unwrap();
+        assert!(
+            !a.contains("x").unwrap(),
+            "merge resurrected a deleted value"
+        );
+        assert!(
+            post.deleted_children().contains(&entry),
+            "merge dropped the value from the deleted-children advertisement"
+        );
+        assert_eq!(post.full_hash(), pre_hash, "merge diverged the parent hash");
+    }
+
+    #[test]
+    fn set_merge_still_adds_unseen_value() {
+        type S = MockedStorage<864>;
+        let mut a = UnorderedSet::<String, S>::new_with_field_name("a_set2");
+        let mut b = UnorderedSet::<String, S>::new_with_field_name("b_set2");
+        let _ = b.insert("new".to_owned()).unwrap();
+
+        Mergeable::merge(&mut a, &b).unwrap();
+
+        assert!(
+            a.contains("new").unwrap(),
+            "merge dropped a genuinely new value"
+        );
     }
 }

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -500,6 +500,17 @@ where
         self.inner.contains(id)
     }
 
+    /// The deterministic storage entity id this `key` maps to — lets the
+    /// add-wins merge consult `Index::is_deleted` without re-deriving
+    /// `compute_id`. See [`UnorderedMap::entry_id`](super::UnorderedMap::entry_id).
+    pub(crate) fn entry_id<Q>(&self, key: &Q) -> Id
+    where
+        K: Borrow<Q>,
+        Q: AsRef<[u8]> + ?Sized,
+    {
+        compute_id(self.inner.id(), key.as_ref())
+    }
+
     /// Remove a key from the map, returning the value if it previously existed.
     ///
     /// # Errors

--- a/crates/storage/src/collections/sorted_set.rs
+++ b/crates/storage/src/collections/sorted_set.rs
@@ -243,6 +243,17 @@ where
         self.inner.contains(id)
     }
 
+    /// The deterministic storage entity id this `value` maps to — lets the
+    /// add-wins merge consult `Index::is_deleted` without re-deriving
+    /// `compute_id`. See [`UnorderedSet::entry_id`](super::UnorderedSet::entry_id).
+    pub(crate) fn entry_id<Q>(&self, value: &Q) -> Id
+    where
+        V: Borrow<Q>,
+        Q: AsRef<[u8]> + ?Sized,
+    {
+        compute_id(self.inner.id(), value.as_ref())
+    }
+
     /// Remove `value`, returning `true` if it was present.
     ///
     /// # Errors

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -35,6 +35,7 @@ use serde::ser::SerializeSeq;
 use serde::Serialize;
 
 use super::{compute_id, Collection, CrdtType, StorageKey};
+use crate::address::Id;
 use crate::collections::error::StoreError;
 use crate::entities::Data;
 use crate::store::{MainStorage, StorageAdaptor};
@@ -233,6 +234,17 @@ where
         let _ignored = self.inner.insert(Some(id), value)?;
 
         Ok(true)
+    }
+
+    /// The deterministic storage entity id this `value` maps to. Lets the
+    /// add-wins merge consult `Index::is_deleted` without re-deriving
+    /// `compute_id` and drifting from the set's own keying.
+    pub(crate) fn entry_id<Q>(&self, value: &Q) -> Id
+    where
+        V: Borrow<Q>,
+        Q: AsRef<[u8]> + ?Sized,
+    {
+        compute_id(self.inner.id(), value.as_ref())
     }
 
     /// Get an iterator over the items in the set.


### PR DESCRIPTION
## Problem

The root-level `Mergeable::merge` for `UnorderedMap`, `SortedMap`, `UnorderedSet`, and `SortedSet` was pure add-wins: it re-inserted any entry present in the peer that wasn't in `self`'s live set — **without checking whether `self` had tombstoned it**.

So if replica A deleted key `K` (tombstone set) while replica B still held `K` live, merging B into A re-inserted `K`, clearing A's tombstone, re-adding it as a live child of the parent, and diverging the parent's `full_hash` from every peer that observed the delete. This is the entity-index sibling of the RGA resurrection bug fixed in #2950 (`merge_chars_from`), one collection layer up.

## Fix

Guard each add-wins insert with `Index::is_deleted(entry_id)` (delete wins), mirroring the RGA `merge_chars_from` pattern. A locally-tombstoned key/value is skipped instead of resurrected.

**Scope is non-resurrection only**, exactly as in the RGA fix: `entries()` / `iter()` already exclude the peer's tombstoned entries, so this merge cannot learn about the peer's deletes — full cross-node delete convergence continues to ride the `DeleteRef` / element-DAG sync path. The guard only prevents *this* replica from un-deleting what it already tombstoned.

Supporting change: added a `pub(crate) entry_id` helper to `UnorderedSet`, `SortedMap`, and `SortedSet` (the map already had one) so the merge can address the deterministic entity id without re-deriving `compute_id`.

## Tests

New `mapset_tombstone_merge_tests` module:
- `map`/`set` resurrection blocked — `self` tombstones an entry, a peer (different collection id, same key) holds it live, merge leaves the tombstone intact (asserted at the parent's `deleted_children` + `full_hash`, since a resurrecting insert re-keys under `self`'s id).
- `map`/`set` genuinely-new entries are still added (the guard doesn't over-suppress).

Verified **discriminating**: temporarily reverting the guards makes both resurrection tests fail at the parent-level assertions.

## Verification

- `cargo test -p calimero-storage` — all green, 0 failed
- `cargo clippy -p calimero-storage --all-targets` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)