### PR TITLE
fix(storage): clear child tombstone on re-add; tombstone before data removal

### DIFF
--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -454,6 +454,11 @@ impl<S: StorageAdaptor> Index<S> {
         child_index.own_hash = child.merkle_hash();
         child_index.full_hash =
             Self::calculate_full_hash_for_children(child_index.own_hash, &child_index.children)?;
+        // Adding a child means it is live: clear any tombstone, else find_by_id
+        // keeps hiding an entity whose hash the parent now counts (a winning
+        // upsert on a tombstoned id → hash divergence). Pairs with the
+        // deleted_children.retain below, which clears the parent-side advert.
+        child_index.deleted_at = None;
         Self::save_index(&child_index)?;
 
         // Insert into parent's children list, keeping it sorted by `ChildInfo`'s
@@ -937,11 +942,12 @@ impl<S: StorageAdaptor> Index<S> {
     ///
     /// Step 1 of deletion: Remove actual data, keep index for CRDT sync.
     fn delete_entity_and_create_tombstone(id: Id, deleted_at: u64) -> Result<(), StorageError> {
-        // Delete the actual entity data immediately (save storage space)
+        // Tombstone first, then drop the data: if mark_deleted fails the entry
+        // is left intact and the delete can be retried, instead of leaving the
+        // data gone with no tombstone while the parent still lists it live.
+        Self::mark_deleted(id, deleted_at)?;
         let _ignored = S::storage_remove(Key::Entry(id));
-
-        // Mark child index as deleted (tombstone for CRDT sync)
-        Self::mark_deleted(id, deleted_at)
+        Ok(())
     }
 
     /// Tombstones every descendant of `root_id` at `deleted_at`.

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -455,9 +455,8 @@ impl<S: StorageAdaptor> Index<S> {
         child_index.full_hash =
             Self::calculate_full_hash_for_children(child_index.own_hash, &child_index.children)?;
         // Adding a child means it is live: clear any tombstone, else find_by_id
-        // keeps hiding an entity whose hash the parent now counts (a winning
-        // upsert on a tombstoned id → hash divergence). Pairs with the
-        // deleted_children.retain below, which clears the parent-side advert.
+        // hides an entity the parent hash now counts (upsert-on-tombstone
+        // divergence). Pairs with the deleted_children.retain below.
         child_index.deleted_at = None;
         Self::save_index(&child_index)?;
 

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -251,6 +251,59 @@ mod index__public_methods {
     }
 
     #[test]
+    fn readd_clears_child_tombstone() {
+        // A winning upsert on a tombstoned id re-adds it via `add_child_to`. The
+        // child's own tombstone must clear, or `find_by_id` keeps hiding an
+        // entity whose hash the parent now counts — resurrection hash divergence.
+        type S = MockedStorage<970>;
+        let root_id = Id::random();
+        assert!(
+            <Index<S>>::add_root(ChildInfo::new(root_id, [1; 32], Metadata::default())).is_ok()
+        );
+
+        let child_id = Id::random();
+        assert!(<Index<S>>::add_child_to(
+            root_id,
+            ChildInfo::new(child_id, [2; 32], Metadata::default())
+        )
+        .is_ok());
+
+        // Tombstone the child.
+        assert!(<Index<S>>::remove_child_from(root_id, child_id, 100).is_ok());
+        assert!(<Index<S>>::is_deleted(child_id).unwrap());
+        assert!(<Index<S>>::get_index(root_id)
+            .unwrap()
+            .unwrap()
+            .deleted_children()
+            .contains(&child_id));
+
+        // Re-add (resurrect) the child via a winning upsert.
+        assert!(<Index<S>>::add_child_to(
+            root_id,
+            ChildInfo::new(child_id, [3; 32], Metadata::default())
+        )
+        .is_ok());
+
+        // The child must no longer be tombstoned, nor advertised as deleted.
+        assert!(
+            !<Index<S>>::is_deleted(child_id).unwrap(),
+            "re-add left the child tombstoned"
+        );
+        let parent = <Index<S>>::get_index(root_id).unwrap().unwrap();
+        assert!(
+            !parent.deleted_children().contains(&child_id),
+            "re-add left the child in the parent's deleted-children advert"
+        );
+        assert!(
+            parent
+                .children()
+                .map(|c| c.iter().any(|ci| ci.id() == child_id))
+                .unwrap_or(false),
+            "re-add did not relink the child as a live child"
+        );
+    }
+
+    #[test]
     fn add_root() {
         let root_id = Id::random();
         let root_hash = [1_u8; 32];

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -276,6 +276,7 @@ mod index__public_methods {
             .unwrap()
             .deleted_children()
             .contains(&child_id));
+        let tombstoned_hash = <Index<S>>::get_index(root_id).unwrap().unwrap().full_hash();
 
         // Re-add (resurrect) the child via a winning upsert.
         assert!(<Index<S>>::add_child_to(
@@ -300,6 +301,13 @@ mod index__public_methods {
                 .map(|c| c.iter().any(|ci| ci.id() == child_id))
                 .unwrap_or(false),
             "re-add did not relink the child as a live child"
+        );
+        // The resurrected child is re-folded into the parent hash — the other
+        // symptom of the bug, and the value a peer that never deleted it carries.
+        assert_ne!(
+            parent.full_hash(),
+            tombstoned_hash,
+            "re-add did not re-fold the child into the parent hash"
         );
     }
 


### PR DESCRIPTION
Two small, independent delete-semantics fixes in the storage index. Both route through shared functions, so the diff is tiny.

## Upsert resurrection — child tombstone not cleared on re-add

A winning `Action::Update` on a tombstoned id re-links the child and re-counts it in the parent's `full_hash` (via `add_child_to`), and already clears the **parent-side** advert (`deleted_children.retain`). But it never cleared the **child's own** `deleted_at`. So `find_by_id` kept returning `None` for an entity whose hash the parent now counts — a peer that never tombstoned it sees the same parent hash but reads the entity as live, and any later local op recomputes a hash off a child the deleter's reads claim doesn't exist.

Fix: `add_child_to` now clears `child_index.deleted_at` on (re-)add — a child being added is, by definition, live. One line, beside the existing parent-side clear. This is the entity-index sibling of the RGA / map-set resurrection fixes (consult/clear the tombstone on a winning live write).

## Delete ordering — data removed before tombstone

`delete_entity_and_create_tombstone` removed the entry data first and **swallowed** the `storage_remove` result, then called `mark_deleted` (which does an index read-modify-write that *can* fail). If `mark_deleted` errored, the entry bytes were already gone with no tombstone, while the parent still listed the id as a live child — an unrecoverable half-delete.

Fix: reorder to tombstone-first. If `mark_deleted` fails, the entry is left intact and the delete can be retried, instead of losing data with no deletion record. (`mark_deleted` only touches the index, never the entry data, so the reorder is behavior-preserving on the happy path.)

## Tests

- `readd_clears_child_tombstone` — tombstone a child, re-add it, assert the tombstone clears on both the child and the parent advert and the child is relinked live. **Verified discriminating**: reverting the one-line fix makes it fail at `re-add left the child tombstoned`.
- The delete-ordering fix's behavior only differs under a `mark_deleted` storage failure, which needs fault-injection infrastructure that doesn't exist in this crate; the existing delete suite covers the happy path (confirming the reorder doesn't regress normal deletion).

## Verification

- `cargo test -p calimero-storage` — all green, 0 failed
- `cargo clippy -p calimero-storage --all-targets` — clean
- `cargo fmt --check` — clean

## Note

These are the two remaining open items from the storage delete-semantics cluster (#281/#282/#285/#286 already landed on master). Scoped deliberately small and kept separate from the Map/Set merge fix in the sibling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)