### PR TITLE
ci: supply-chain & workflow hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  # Rust crates (workspace root).
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      cargo:
+        patterns: ["*"]
+
+  # GitHub Actions — also keeps the SHA-pinned `uses:` refs current.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # Docs site (npm).
+  - package-ecosystem: npm
+    directory: "/docs-site"
+    schedule:
+      interval: weekly
+    groups:
+      npm:
+        patterns: ["*"]

--- a/.github/workflows/abi-contract.yml
+++ b/.github/workflows/abi-contract.yml
@@ -63,7 +63,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
 

--- a/.github/workflows/abi-guard.yml
+++ b/.github/workflows/abi-guard.yml
@@ -25,14 +25,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
         
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           target: wasm32-unknown-unknown
           override: true
           
       - name: Cache Rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -20,6 +20,11 @@ env:
 permissions:
   contents: read
 
+# Cancel superseded PR runs; never cancel a master run.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   rust:
     name: Rust
@@ -77,4 +82,4 @@ jobs:
         run: |
           # Pin cargo-deny to 0.16.3 for compatibility with Rust 1.88.0 (from rust-toolchain.toml)
           cargo install cargo-deny --version 0.16.3 --locked
-          cargo deny check licenses sources
+          cargo deny check bans licenses sources

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -11,6 +11,13 @@ on:
     types:
       - completed
 
+# Least-privilege: runs in the base-repo context (workflow_run); only needs to read
+# the triggering run's artifacts and post a PR comment.
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
 jobs:
   submit:
     name: Submit
@@ -40,17 +47,27 @@ jobs:
       - name: Extract payload
         id: payload
         if: ${{ steps.download.outcome == 'success' }}
+        # payload.json comes from a fork-influenced workflow artifact. Emit each value
+        # with a unique random heredoc delimiter so its contents cannot forge extra
+        # workflow outputs (output injection).
         run: |
-          cat payload.json
-
-          echo "pr=$(jq '.pr' payload.json)" >> $GITHUB_OUTPUT
-          echo "tag=$(jq '.tag' payload.json)" >> $GITHUB_OUTPUT
-          echo "mode=$(jq '.mode' payload.json)" >> $GITHUB_OUTPUT
-          echo "message=$(jq '.message' payload.json)" >> $GITHUB_OUTPUT
+          emit() {
+            local delim
+            delim="EOF_$(openssl rand -hex 16)"
+            {
+              printf '%s<<%s\n' "$1" "$delim"
+              jq "$2" payload.json
+              printf '%s\n' "$delim"
+            } >> "$GITHUB_OUTPUT"
+          }
+          emit pr '.pr'
+          emit tag '.tag'
+          emit mode '.mode'
+          emit message '.message'
 
       - name: Apply pull request comment
         if: ${{ steps.download.outcome == 'success' }}
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@65f9e5c9a1f2cd378bd74b2e057c9736982a8e74 # v3
         with:
           pr-number: ${{ fromJson(steps.payload.outputs.pr) }}
           comment-tag: ${{ fromJson(steps.payload.outputs.tag) }}

--- a/.github/workflows/new-issue-or-pr.yml
+++ b/.github/workflows/new-issue-or-pr.yml
@@ -8,16 +8,17 @@ on:
     branches:
       - master # Trigger when PRs are opened or reopened targeting the master branch
 
+# Runs under pull_request_target (privileged token). Restrict it to exactly what the
+# labeling jobs need; everything else defaults to no access.
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   labelIssuePR:
     name: Apply Label to Issues and PRs
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
       - name: Add Label to Issue or PR
         uses: actions/github-script@v7
         with:
@@ -143,7 +144,7 @@ jobs:
           fi
 
       - name: Notify external contribution
-        uses: "ravsamhq/notify-slack-action@2.5.0"
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # 2.5.0
         with:
           status: failure
           notification_title: "New external contribution in <${{ github.server_url }}/${{ github.repository }}/${{ github.ref_name }}|${{ github.repository }}>"

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -34,7 +34,7 @@ jobs:
         2. Allowed type values are: build, ci, docs, feat, fix, perf, refactor, test.
 
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         id: lint_pr_title
 
       - name: Create PR Comment Payload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: release
 
@@ -259,7 +259,7 @@ jobs:
           path: artifacts/
 
       - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: artifacts/*
@@ -277,7 +277,7 @@ jobs:
 
     steps:
       - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
 
@@ -288,13 +288,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned to a commit SHA (supply-chain hygiene); comment tracks the tag.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Verify Rust installation
         run: rustc --version
 
       - name: Setup rust cache (publish)
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: release
 

--- a/.github/workflows/sdk-e2e.yml
+++ b/.github/workflows/sdk-e2e.yml
@@ -10,6 +10,11 @@ name: SDK E2E (paired)
 permissions:
   contents: read
 
+# Cancel superseded PR runs; never cancel a master run.
+concurrency:
+  group: sdk-e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 on:
   pull_request:
     paths:
@@ -42,7 +47,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/tidy-docker.yml
+++ b/.github/workflows/tidy-docker.yml
@@ -45,7 +45,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cleanup non-persistent images, except open PRs
-        uses: dataaxiom/ghcr-cleanup-action@v1
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1
         with:
           dry-run: ${{ github.event.inputs.dry-run }}
           package: ${{ env.PACKAGES }}
@@ -72,7 +72,7 @@ jobs:
           echo "active_prs=$expr" >> $GITHUB_OUTPUT
 
       - name: Cleanup closed PR images
-        uses: dataaxiom/ghcr-cleanup-action@v1
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1
         with:
           dry-run: ${{ github.event.inputs.dry-run }}
           package: ${{ env.PACKAGES }}

--- a/.github/workflows/wire-contract.yml
+++ b/.github/workflows/wire-contract.yml
@@ -37,7 +37,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/deny.toml
+++ b/deny.toml
@@ -28,14 +28,22 @@ allow = [
     "CC0-1.0",
     "BSL-1.0",
     "MPL-2.0",
-    "AGPL-3.0",
-    "GPL-3.0",
-    "LGPL-3.0",
     "0BSD",
     "Unlicense",
     "Apache-2.0 WITH LLVM-exception",
     "CDLA-Permissive-2.0",
 ]
+
+# AGPL-3.0 is not blanket-allowed (MIT/Apache project). These two TEE/TDX
+# attestation crates (pulled in via Dstack-TEE/dstack) are the only permitted
+# exceptions; a new accidental copyleft dependency still fails the check.
+[[licenses.exceptions]]
+name = "configfs-tsm"
+allow = ["AGPL-3.0"]
+
+[[licenses.exceptions]]
+name = "tdx-quote"
+allow = ["AGPL-3.0"]
 
 # Add exceptions for packages with complex licensing
 [[licenses.clarify]]


### PR DESCRIPTION
Hardening pass over CI workflows and supply-chain policy. From the Round-2 audit, **Supply Chain / CI / Container Hygiene** (§9); finding numbers below are audit IDs, not issue links. All changes are config-as-code with **no runtime/product behavior change**, and the supply-chain checks were run locally against the pinned `cargo-deny 0.16.3` (= CI's version, on Rust 1.88.0) before pushing.

## What's in this PR (verified green)

| Audit | Change |
|-------|--------|
| `F103` | SHA-pin **all** third-party actions (comment keeps the tag), matching the existing `dtolnay/rust-toolchain` pin. 10 actions across 6 workflows + `release.yml`'s stray `dtolnay/rust-toolchain@stable`. |
| `F102` | `new-issue-or-pr.yml` (`pull_request_target`): add least-priv `permissions:` + drop the unused untrusted PR-head checkout. |
| `F107` | `comment.yml` (`workflow_run`): add least-priv `permissions:` + write fork-influenced artifact values to `$GITHUB_OUTPUT` via random-delimiter heredocs (output-injection safe). |
| `F112` | `concurrency:` groups on `ci-checks.yml` + `sdk-e2e.yml` (cancel superseded PR runs, never master); bump deprecated `actions/cache@v3 → v4`; add `.github/dependabot.yml` (cargo, github-actions, npm/docs-site). |
| `F106` | `deny.toml`: drop blanket `AGPL-3.0`/`GPL-3.0`/`LGPL-3.0` from the allow-list; add **per-crate AGPL exceptions** for the two attestation crates that actually need it. |
| `F104` (partial) | Add the `bans` check to the `cargo deny` invocation. |

### Note on F106 — there is real AGPL in the tree
Removing the blanket allow surfaced two **AGPL-3.0** crates pulled in via `Dstack-TEE/dstack`: `configfs-tsm` and `tdx-quote` (TEE/TDX attestation). Confirmed they are **not** behind a feature flag — `tdx-quote` is an unconditional dep of `calimero-tee-attestation` + `calimero-server-primitives` (in `merod`/`meroctl`/`server` on every platform), and `configfs-tsm` is included on every Linux build (`cfg(target_os = "linux")`). They're scoped as explicit per-crate exceptions, so they keep working while a *new* accidental copyleft dependency now fails the check. Flagged separately for a licensing decision.

## Deferred to a follow-up — F104/F105 (advisories / CVE scanning)
CI has **no CVE/advisory scanning today**. Enabling it needs two things that don't belong in a hygiene PR:

1. **Tool bump:** pinned `cargo-deny 0.16.3` can't parse the modern advisory DB (a 2026 advisory uses CVSS 4.0). Verified that `0.19.9` fixes this and installs cleanly on **Rust 1.88.0** (CI's version).
2. **Triage:** with advisories enabled, the tree currently trips ~15 advisories that each need an upgrade or a documented `ignore`:
   - **Vulnerabilities:** RUSTSEC-2026-0044 / -0048 (AWS-LC X.509/CRL), RUSTSEC-2026-0118 / -0119 (DNS DoS), a CRL-parse reachable panic.
   - **Unmaintained/yanked:** `backoff`, `core2` (yanked), `instant`, `number_prefix`, `paste`, `proc-macro-error`/`-error2`, `serde_cbor`, `tempdir`.

I'll open that as a separate PR (bump cargo-deny + triage the list).

## Not in scope (other §9 items — separate surfaces)
- **F101** mock-auth in the image — **already fixed** by PR #2961 (`#[cfg(debug_assertions)]`); the route isn't compiled into the `--release` image.
- **F108** Docker base-image digest pinning, **F109/F110** script checksums + token-as-argv, **F111** auth CORS/CSP, **F112** shell-form `ENTRYPOINT` — touch the shipped image / runtime config / scripts, not CI.

## Observed but intentionally not touched
`new-issue-or-pr.yml` checks `eventName === 'pull_request'` under a `pull_request_target` trigger, so the PR-labeling branch is dead. It's a functional bug, not hardening — left for a separate change to keep this PR behavior-neutral.