### PR TITLE
refactor(types): type-safety & encapsulation pass (9 of 11 findings)

### DIFF
--- a/crates/authz/src/lib.rs
+++ b/crates/authz/src/lib.rs
@@ -515,16 +515,15 @@ mod tests {
     }
 
     fn op_with(author: PublicKey, payload: OpPayload) -> Op {
-        Op {
-            id: [0u8; 32],
-            scope: ScopeId::from([0u8; 32]),
-            parents: vec![],
+        Op::new(
+            ScopeId::from([0u8; 32]),
+            vec![],
             author,
-            hlc: hlc0(),
+            hlc0(),
             payload,
-            expected_scope_root: [0u8; 32],
-            signature: [0u8; 64],
-        }
+            [0u8; 32],
+            [0u8; 64],
+        )
     }
 
     fn view_with_writer(entity: Id, who: PublicKey, mask: OpMask) -> AclView {

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -130,7 +130,7 @@ where
     }
 
     pub fn api_url(&self) -> &Url {
-        &self.connection.api_url
+        self.connection.api_url()
     }
 
     /// The WebSocket endpoint URL (`ws(s)://…/ws`) for this connection, derived
@@ -141,7 +141,7 @@ where
     /// unexpected scheme errors rather than silently degrading to cleartext
     /// `ws://`, which would leak the bearer token attached to the handshake.
     pub fn ws_url(&self) -> Result<Url> {
-        let mut url = self.connection.api_url.clone();
+        let mut url = self.connection.api_url().clone();
 
         let scheme = match url.scheme() {
             "http" => "ws",

--- a/crates/client/src/connection.rs
+++ b/crates/client/src/connection.rs
@@ -41,11 +41,16 @@ where
     A: ClientAuthenticator + Clone + Send + Sync,
     S: ClientStorage + Clone + Send + Sync,
 {
-    pub api_url: Url,
-    pub client: Client,
-    pub node_name: Option<String>,
-    pub authenticator: A,
-    pub client_storage: S,
+    // Private: the HTTP transport (`client`), the `authenticator` (holds
+    // credentials), and `client_storage` must not leak out of the connection,
+    // and none of the fields may be swapped mid-flight by a caller. Access the
+    // non-sensitive bits through the accessors below; everything else goes
+    // through the request methods.
+    api_url: Url,
+    client: Client,
+    node_name: Option<String>,
+    authenticator: A,
+    client_storage: S,
 }
 
 impl<A, S> ConnectionInfo<A, S>
@@ -66,6 +71,18 @@ where
             authenticator,
             client_storage,
         }
+    }
+
+    /// The base API URL this connection targets.
+    #[must_use]
+    pub fn api_url(&self) -> &Url {
+        &self.api_url
+    }
+
+    /// The configured node name, if any.
+    #[must_use]
+    pub fn node_name(&self) -> Option<&str> {
+        self.node_name.as_deref()
     }
 
     pub async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T> {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -295,6 +295,7 @@ fn default_kms_attestation_tcb_statuses() -> Vec<String> {
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct SyncConfig {
     #[serde(rename = "timeout_ms", with = "serde_duration")]
     pub timeout: Duration,
@@ -314,6 +315,26 @@ pub struct SyncConfig {
     pub interval: Duration,
     #[serde(rename = "frequency_ms", with = "serde_duration")]
     pub frequency: Duration,
+}
+
+impl SyncConfig {
+    /// Construct a [`SyncConfig`]. `SyncConfig` is `#[non_exhaustive]`, so
+    /// external crates build it through this constructor rather than a struct
+    /// literal — adding a field then stays source-compatible here.
+    #[must_use]
+    pub const fn new(
+        timeout: Duration,
+        session_deadline: Duration,
+        interval: Duration,
+        frequency: Duration,
+    ) -> Self {
+        Self {
+            timeout,
+            session_deadline,
+            interval,
+            frequency,
+        }
+    }
 }
 
 fn default_sync_session_deadline() -> Duration {

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -2524,7 +2524,9 @@ mod get_context_version_tests {
                     &key::GroupContextMetadata::new(gid, cid),
                     &calimero_primitives::metadata::MetadataRecord {
                         name: Some("docs-workspace".to_owned()),
-                        ..Default::default()
+                        data: Default::default(),
+                        updated_at: 0,
+                        updated_by: calimero_primitives::identity::PublicKey::from([1_u8; 32]),
                     },
                 )
                 .expect("seed context metadata");

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -77,6 +77,9 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                         .ok()
                         .flatten(),
                         calimero_governance_types::NamespaceOp::Root(_) => None,
+                        // `NamespaceOp` is `#[non_exhaustive]`; an unknown future
+                        // op has nothing to decrypt and folds as `Noop`.
+                        _ => None,
                     };
                     let shadow_op = crate::scope_projection::op_from_namespace_op(
                         &signed_op,
@@ -321,5 +324,8 @@ fn apply_auth_requirement(
                 _ => None,
             }
         }
+        // `NamespaceOp` is `#[non_exhaustive]`; an unknown future op authorizes
+        // nothing here (secure default — no admin/cap requirement is granted).
+        _ => None,
     }
 }

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -117,7 +117,7 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                                         &shadow_op.scope,
                                         &g,
                                         &m,
-                                        &[shadow_op.id],
+                                        &[shadow_op.id()],
                                     )
                                 });
                                 (true, role)

--- a/crates/context/src/handlers/create_group.rs
+++ b/crates/context/src/handlers/create_group.rs
@@ -202,9 +202,9 @@ impl Handler<CreateGroupRequest> for ContextManager {
                             &group_id,
                             &calimero_primitives::metadata::MetadataRecord {
                                 name: name.clone(),
+                                data: std::collections::BTreeMap::new(),
                                 updated_at: calimero_governance_store::now_millis(),
                                 updated_by: admin_identity,
-                                ..Default::default()
                             },
                         )?,
                         Err(e) => {

--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -447,7 +447,7 @@ impl Handler<JoinGroupRequest> for ContextManager {
                     && MetadataRepository::new(&datastore).group_metadata(&group_id)?.is_none()
                 {
                     MetadataRepository::new(&datastore).set_group(&group_id, &calimero_primitives::metadata::MetadataRecord {
-                            name: group_name.clone(), updated_at: calimero_governance_store::now_millis(), updated_by: joiner_identity, ..Default::default()
+                            name: group_name.clone(), data: std::collections::BTreeMap::new(), updated_at: calimero_governance_store::now_millis(), updated_by: joiner_identity,
                         }, )?;
                 }
 

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1059,6 +1059,9 @@ impl ScopeProjections {
                 .ok()
                 .flatten(),
                 calimero_governance_types::NamespaceOp::Root(_) => None,
+                // `NamespaceOp` is `#[non_exhaustive]`; an unknown future op has
+                // nothing to decrypt and folds as `Noop`.
+                _ => None,
             };
             ops.push(op_from_namespace_op(
                 &signed,

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -74,16 +74,16 @@ fn build_op(
     parents: &[[u8; 32]],
     payload: OpPayload,
 ) -> Op {
-    Op {
+    Op::from_parts(
         id,
         scope,
-        parents: parents.to_vec(),
+        parents.to_vec(),
         author,
         hlc,
         payload,
-        expected_scope_root: [0u8; 32],
-        signature: [0u8; 64],
-    }
+        [0u8; 32],
+        [0u8; 64],
+    )
 }
 
 /// Convert a writer-set rotation ([`RotationLogEntry`]) into the unified
@@ -257,7 +257,7 @@ impl ScopeProjections {
     pub fn ingest_op(&mut self, op: &Op) {
         self.states.entry(op.scope).or_default().apply(op);
         // O(1) dedup: `insert` is true only for a not-yet-seen id.
-        if self.seen.entry(op.scope).or_default().insert(op.id) {
+        if self.seen.entry(op.scope).or_default().insert(op.id()) {
             let log = self.logs.entry(op.scope).or_default();
             if matches!(op.payload, OpPayload::Noop) {
                 // Remember where this still-undecrypted op sits so a later decrypted
@@ -266,11 +266,11 @@ impl ScopeProjections {
                     .noop_log_pos
                     .entry(op.scope)
                     .or_default()
-                    .insert(op.id, log.len());
+                    .insert(op.id(), log.len());
             }
             log.push(op.clone());
         } else if !matches!(op.payload, OpPayload::Noop) {
-            // Already seen, but `op.id` is the SIGNED op's content hash, not the decoded
+            // Already seen, but `op.id()` is the SIGNED op's content hash, not the decoded
             // payload's — so an encrypted op first folded as `Noop` (applied before its
             // group key arrived) shares an id with its later, decrypted form. The op-log
             // is what the at-cut auth view (`acl_view_at` → `member_at_cut`) folds, so a
@@ -283,7 +283,7 @@ impl ScopeProjections {
             if let Some(idx) = self
                 .noop_log_pos
                 .get_mut(&op.scope)
-                .and_then(|m| m.remove(&op.id))
+                .and_then(|m| m.remove(&op.id()))
             {
                 if let Some(entry) = self.logs.get_mut(&op.scope).and_then(|l| l.get_mut(idx)) {
                     *entry = op.clone();
@@ -1102,7 +1102,7 @@ impl ScopeProjections {
                 Err(err) => tracing::warn!(
                     %err,
                     namespace = ?namespace_id,
-                    op = ?op.id,
+                    op = ?op.id(),
                     "op-store: failed to re-persist governance op after key delivery"
                 ),
             }
@@ -1152,7 +1152,7 @@ impl ScopeProjections {
         let scope = ScopeId::from(namespace_id);
         let store_ids: HashSet<[u8; 32]> =
             match crate::unified_op_store::load_scope_ops(store, &scope) {
-                Ok(ops) => ops.iter().map(|op| op.id).collect(),
+                Ok(ops) => ops.iter().map(|op| op.id()).collect(),
                 Err(err) => {
                     // A load fault must NOT read as "complete": CI treats no
                     // `op_store_incomplete` as a clean op-store, so a store error would
@@ -1171,7 +1171,7 @@ impl ScopeProjections {
             };
         let missing: Vec<[u8; 32]> = dag_ops
             .iter()
-            .map(|op| op.id)
+            .map(|op| op.id())
             .filter(|id| !store_ids.contains(id))
             .collect();
         if !missing.is_empty() {
@@ -1545,7 +1545,7 @@ impl ScopeProjections {
         let log_len = log.map_or(0, Vec::len);
         let heads_in_log = match log {
             Some(l) => {
-                let ids: HashSet<[u8; 32]> = l.iter().map(|o| o.id).collect();
+                let ids: HashSet<[u8; 32]> = l.iter().map(|o| o.id()).collect();
                 heads.iter().filter(|h| ids.contains(*h)).count()
             }
             None => 0,
@@ -1740,7 +1740,7 @@ mod tests {
             &[[0x88; 32]],
         );
 
-        assert_eq!(op.id, [0x99; 32], "op still occupies its DAG node");
+        assert_eq!(op.id(), [0x99; 32], "op still occupies its DAG node");
         assert_eq!(op.scope, ScopeId::from(ns));
         assert_eq!(op.parents, vec![[0x88; 32]], "with its real parents");
         assert_eq!(
@@ -1831,7 +1831,7 @@ mod tests {
             OpPayload::Noop,
             "undecryptable group op is a Noop node"
         );
-        assert_eq!(op.id, [0x99; 32], "but it still occupies its DAG node");
+        assert_eq!(op.id(), [0x99; 32], "but it still occupies its DAG node");
         assert_eq!(op.parents, vec![[0x88; 32]], "with its real parents");
     }
 
@@ -1876,17 +1876,7 @@ mod tests {
 
         let build = |ns: u64, parents: Vec<[u8; 32]>, payload: OpPayload| -> Op {
             let h = hlc(ns);
-            let id = Op::compute_id(scope, &parents, &admin, &h, &payload);
-            Op {
-                id,
-                scope,
-                parents,
-                author: admin,
-                hlc: h,
-                payload,
-                expected_scope_root: [0u8; 32],
-                signature: [0u8; 64],
-            }
+            Op::new(scope, parents, admin, h, payload, [0u8; 32], [0u8; 64])
         };
 
         let add = build(
@@ -1898,7 +1888,11 @@ mod tests {
                 role: GroupMemberRole::Member,
             },
         );
-        let remove = build(20, vec![add.id], OpPayload::MemberRemoved { group, member });
+        let remove = build(
+            20,
+            vec![add.id()],
+            OpPayload::MemberRemoved { group, member },
+        );
 
         let mut reg = ScopeProjections::new();
         reg.ingest_op(&add);
@@ -1906,19 +1900,19 @@ mod tests {
 
         // Cut at the add (pre-removal ancestry): the member is present — a write
         // authored here stays authorized even though we've since seen the remove.
-        let pre = reg.acl_view_at(&scope, &[add.id]).expect("scope fed");
+        let pre = reg.acl_view_at(&scope, &[add.id()]).expect("scope fed");
         assert_eq!(
             pre.groups.get(&group).and_then(|m| m.get(&member)),
             Some(&GroupMemberRole::Member),
         );
 
         // Cut at the remove (its ancestry includes both): the member is gone.
-        let post = reg.acl_view_at(&scope, &[remove.id]).expect("scope fed");
+        let post = reg.acl_view_at(&scope, &[remove.id()]).expect("scope fed");
         assert_eq!(post.groups.get(&group).and_then(|m| m.get(&member)), None);
 
         // Unknown scope ⇒ no view.
         assert!(reg
-            .acl_view_at(&ScopeId::from([0xEE; 32]), &[add.id])
+            .acl_view_at(&ScopeId::from([0xEE; 32]), &[add.id()])
             .is_none());
     }
 
@@ -1934,17 +1928,7 @@ mod tests {
 
         let build = |ns: u64, parents: Vec<[u8; 32]>, payload: OpPayload| -> Op {
             let h = hlc(ns);
-            let id = Op::compute_id(scope, &parents, &admin, &h, &payload);
-            Op {
-                id,
-                scope,
-                parents,
-                author: admin,
-                hlc: h,
-                payload,
-                expected_scope_root: [0u8; 32],
-                signature: [0u8; 64],
-            }
+            Op::new(scope, parents, admin, h, payload, [0u8; 32], [0u8; 64])
         };
 
         // An unfolded scope can't be compared — None, never a false divergence.
@@ -1964,7 +1948,7 @@ mod tests {
         // MemberAdded is a causal child of the prior op, not a sibling at genesis).
         reg.ingest_op(&build(
             20,
-            vec![admin_op.id],
+            vec![admin_op.id()],
             OpPayload::MemberAdded {
                 group,
                 member,
@@ -2038,7 +2022,7 @@ mod tests {
             add.scope, ns_scope,
             "group ops key under the namespace scope"
         );
-        assert_eq!(add.id, [0xAB; 32], "op carries the namespace delta id");
+        assert_eq!(add.id(), [0xAB; 32], "op carries the namespace delta id");
 
         let mut reg = ScopeProjections::new();
         reg.ingest_op(&add);

--- a/crates/context/src/unified_applier.rs
+++ b/crates/context/src/unified_applier.rs
@@ -118,23 +118,13 @@ mod tests {
     fn op(scope: ScopeId, ns: u64, parents: Vec<[u8; 32]>, payload: OpPayload) -> Op {
         let author = PublicKey::from([7u8; 32]);
         let h = hlc(ns);
-        let id = Op::compute_id(scope, &parents, &author, &h, &payload);
-        Op {
-            id,
-            scope,
-            parents,
-            author,
-            hlc: h,
-            payload,
-            expected_scope_root: [0u8; 32],
-            signature: [0u8; 64],
-        }
+        Op::new(scope, parents, author, h, payload, [0u8; 32], [0u8; 64])
     }
 
     fn delta(op: &Op) -> CausalDelta<Op> {
         // The unified delta IS the op: mirror id/parents so the DAG's causal model
         // matches the op's own parent set.
-        CausalDelta::new(op.id, op.parents.clone(), op.clone(), op.hlc, [0u8; 32])
+        CausalDelta::new(op.id(), op.parents.clone(), op.clone(), op.hlc, [0u8; 32])
     }
 
     /// Fold a causal chain of mixed-plane ops (admin → member → writers → data)
@@ -159,7 +149,7 @@ mod tests {
         let op_member = op(
             scope,
             20,
-            vec![op_admin.id],
+            vec![op_admin.id()],
             OpPayload::MemberAdded {
                 group,
                 member,
@@ -169,7 +159,7 @@ mod tests {
         let op_writers = op(
             scope,
             30,
-            vec![op_member.id],
+            vec![op_member.id()],
             OpPayload::SetWriters {
                 object: Id::new([9u8; 32]),
                 writers: [(member, OpMask::FULL)].into_iter().collect(),
@@ -178,7 +168,7 @@ mod tests {
         let op_put = op(
             scope,
             40,
-            vec![op_writers.id],
+            vec![op_writers.id()],
             OpPayload::Put {
                 entity: Id::new([9u8; 32]),
                 value: b"v1".to_vec(),
@@ -215,7 +205,7 @@ mod tests {
             }
             // Every op must have applied (none stuck pending) regardless of order.
             for op in ops {
-                assert!(dag.is_applied(&op.id), "op {order:?} left unapplied");
+                assert!(dag.is_applied(&op.id()), "op {order:?} left unapplied");
             }
             let got = applier
                 .projection()

--- a/crates/context/src/unified_op_store.rs
+++ b/crates/context/src/unified_op_store.rs
@@ -1,7 +1,7 @@
 //! Persistence for the unified causal-log op-store (cutover plan C2.1).
 //!
 //! Writes each unified [`Op`] to its own keyspace — one borsh row per op, keyed
-//! `[op.scope ‖ op.id]` in [`Column::UnifiedOp`](calimero_store::db::Column) — so
+//! `[op.scope ‖ op.id()]` in [`Column::UnifiedOp`](calimero_store::db::Column) — so
 //! the op-stream that backs the projection is durable. During the dual-write
 //! transition this lives **alongside** the legacy stores and is **observe-only**:
 //! nothing reads it for a sync/auth decision yet. The per-plane flips (C2.2+)
@@ -21,7 +21,7 @@ use calimero_store::types::ScopeUnifiedOp as ScopeUnifiedOpValue;
 use calimero_store::Store;
 use eyre::Result as EyreResult;
 
-/// Persist one unified [`Op`] under `[op.scope ‖ op.id]` — keyed by the op's
+/// Persist one unified [`Op`] under `[op.scope ‖ op.id()]` — keyed by the op's
 /// **scope**, so a scope's whole op-log is one contiguous key range (governance
 /// ops are namespace-scoped and shared across that namespace's contexts, so a
 /// single context id is the wrong partition). Idempotent — re-persisting the same
@@ -30,7 +30,7 @@ pub fn persist_op(store: &Store, op: &Op) -> EyreResult<()> {
     let bytes = borsh::to_vec(op)?;
     let mut handle = store.handle();
     handle.put(
-        &ScopeUnifiedOpKey::new(scope_bytes(&op.scope), op.id),
+        &ScopeUnifiedOpKey::new(scope_bytes(&op.scope), op.id()),
         &ScopeUnifiedOpValue::from(calimero_store::slice::Slice::from(bytes)),
     )?;
     Ok(())
@@ -117,26 +117,16 @@ mod tests {
     fn op(scope: ScopeId, ns: u64, parents: Vec<[u8; 32]>, payload: OpPayload) -> Op {
         let author = PublicKey::from([7u8; 32]);
         let h = hlc(ns);
-        let id = Op::compute_id(scope, &parents, &author, &h, &payload);
         // `expected_scope_root` and `signature` are zeroed: this is a
         // persistence/replay round-trip test, and neither the op-store nor the
         // projection fold verifies them (the projection folds already-verified ops
         // on content alone). If a signature or root check is ever added to that
         // path, this helper must produce valid values rather than zeros.
-        Op {
-            id,
-            scope,
-            parents,
-            author,
-            hlc: h,
-            payload,
-            expected_scope_root: [0u8; 32],
-            signature: [0u8; 64],
-        }
+        Op::new(scope, parents, author, h, payload, [0u8; 32], [0u8; 64])
     }
 
     fn delta(op: &Op) -> calimero_dag::CausalDelta<Op> {
-        calimero_dag::CausalDelta::new(op.id, op.parents.clone(), op.clone(), op.hlc, [0u8; 32])
+        calimero_dag::CausalDelta::new(op.id(), op.parents.clone(), op.clone(), op.hlc, [0u8; 32])
     }
 
     /// Persist a causal chain of mixed-plane ops, reload it from a fresh handle,
@@ -161,7 +151,7 @@ mod tests {
         let op_member = op(
             scope,
             20,
-            vec![op_admin.id],
+            vec![op_admin.id()],
             OpPayload::MemberAdded {
                 group,
                 member,
@@ -171,7 +161,7 @@ mod tests {
         let op_writers = op(
             scope,
             30,
-            vec![op_member.id],
+            vec![op_member.id()],
             OpPayload::SetWriters {
                 object: Id::new([9u8; 32]),
                 writers: [(member, OpMask::FULL)].into_iter().collect(),
@@ -222,7 +212,7 @@ mod tests {
             dag.add_delta(delta(op), &applier).await.expect("add_delta");
         }
         for op in ops {
-            assert!(dag.is_applied(&op.id), "reloaded op left unapplied");
+            assert!(dag.is_applied(&op.id()), "reloaded op left unapplied");
         }
 
         let got = applier

--- a/crates/context/tests/op_store_reconstruction.rs
+++ b/crates/context/tests/op_store_reconstruction.rs
@@ -210,7 +210,7 @@ fn completeness_gate_flags_governance_ops_missing_from_the_op_store() {
 
     assert_eq!(
         ScopeProjections::check_op_store_completeness(&store, ns_bytes, &dag_ops),
-        Some(vec![op3.id]),
+        Some(vec![op3.id()]),
         "the gate must flag exactly the op missing from the op-store"
     );
 
@@ -283,7 +283,7 @@ fn locally_authored_op_lands_in_the_op_store_atomically() {
         load_scope_ops(&store, &ScopeId::from(ns_bytes))
             .unwrap()
             .iter()
-            .map(|op| op.id)
+            .map(|op| op.id())
             .collect::<Vec<_>>(),
         vec![delta_id],
         "store_signed_operation must persist the op atomically with the gov-DAG write"
@@ -297,7 +297,7 @@ fn locally_authored_op_lands_in_the_op_store_atomically() {
     // of the op-store sees `member` (proves the payload landed, not just the id).
     let store_ops = load_scope_ops(&store, &ScopeId::from(ns_bytes)).unwrap();
     assert_eq!(
-        store_ops.iter().map(|op| op.id).collect::<Vec<_>>(),
+        store_ops.iter().map(|op| op.id()).collect::<Vec<_>>(),
         vec![delta_id],
         "the authored op must now be in the op-store"
     );

--- a/crates/governance-store/src/governance_broadcast.rs
+++ b/crates/governance-store/src/governance_broadcast.rs
@@ -106,6 +106,9 @@ pub fn timeout_for_namespace_op(op: &NamespaceOp) -> Duration {
             OP_ACK_HEAVY_TIMEOUT
         }
         NamespaceOp::Group { .. } => OP_ACK_MEMBER_CHANGE_TIMEOUT,
+        // `NamespaceOp` is `#[non_exhaustive]`; a future op type gets the
+        // conservative member-change timeout until classified explicitly.
+        _ => OP_ACK_MEMBER_CHANGE_TIMEOUT,
     }
 }
 

--- a/crates/governance-store/src/membership/tests.rs
+++ b/crates/governance-store/src/membership/tests.rs
@@ -1418,7 +1418,9 @@ fn remove_group_member_clears_member_metadata() {
             &member,
             &MetadataRecord {
                 name: Some("departing".to_owned()),
-                ..Default::default()
+                data: Default::default(),
+                updated_at: 0,
+                updated_by: [1_u8; 32].into(),
             },
         )
         .unwrap();

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -486,6 +486,10 @@ impl<'a> NamespaceGovernance<'a> {
                     }
                 }
             }
+            // `NamespaceOp` is `#[non_exhaustive]`; an unknown future op type
+            // contributes nothing to apply (it folds as a `Noop` in decode),
+            // so there is no state to mutate here.
+            _ => {}
         }
 
         // Ordering: advance the head first, then write the op to the log —

--- a/crates/governance-store/src/namespace/op_log.rs
+++ b/crates/governance-store/src/namespace/op_log.rs
@@ -149,6 +149,9 @@ impl<'a> NamespaceOpLogService<'a> {
             .ok()
             .flatten(),
             NamespaceOp::Root(_) => None,
+            // `NamespaceOp` is `#[non_exhaustive]`; nothing to decrypt for an
+            // unknown future op variant.
+            _ => None,
         };
 
         let unified_op = crate::unified_op_decode::op_from_namespace_op(

--- a/crates/governance-store/src/namespace/op_log.rs
+++ b/crates/governance-store/src/namespace/op_log.rs
@@ -163,13 +163,17 @@ impl<'a> NamespaceOpLogService<'a> {
         );
 
         let scope = calimero_op::ScopeId::from(self.namespace_id);
-        let key = calimero_store::key::ScopeUnifiedOp::new(*scope.as_bytes(), unified_op.id);
+        let key = calimero_store::key::ScopeUnifiedOp::new(*scope.as_bytes(), unified_op.id());
         let bytes = borsh::to_vec(&unified_op).map_err(|e| eyre::eyre!("borsh op: {e}"))?;
         let value =
             calimero_store::types::ScopeUnifiedOp::from(calimero_store::slice::Slice::from(bytes));
         handle.put(&key, &value)?;
         // Sanity: the op-store and the gov-DAG must key the same op identity.
-        debug_assert_eq!(unified_op.id, delta_id, "unified op id != gov-DAG delta id");
+        debug_assert_eq!(
+            unified_op.id(),
+            delta_id,
+            "unified op id != gov-DAG delta id"
+        );
         Ok(())
     }
 

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -168,7 +168,9 @@ fn group_settings_service_enforces_permissions_and_persists_values() {
             &gid,
             &calimero_primitives::metadata::MetadataRecord {
                 name: Some("group-main".to_owned()),
-                ..Default::default()
+                data: Default::default(),
+                updated_at: 0,
+                updated_by: [1_u8; 32].into(),
             },
         )
         .unwrap();
@@ -2501,7 +2503,9 @@ fn local_state_join_tracking_and_delete_group_rows_cleanup() {
             &gid,
             &calimero_primitives::metadata::MetadataRecord {
                 name: Some("g-alias".to_owned()),
-                ..Default::default()
+                data: Default::default(),
+                updated_at: 0,
+                updated_by: [1_u8; 32].into(),
             },
         )
         .unwrap();
@@ -2518,7 +2522,9 @@ fn local_state_join_tracking_and_delete_group_rows_cleanup() {
             &member2,
             &calimero_primitives::metadata::MetadataRecord {
                 name: Some("member2".to_owned()),
-                ..Default::default()
+                data: Default::default(),
+                updated_at: 0,
+                updated_by: [1_u8; 32].into(),
             },
         )
         .unwrap();

--- a/crates/governance-store/src/unified_op_decode.rs
+++ b/crates/governance-store/src/unified_op_decode.rs
@@ -34,16 +34,16 @@ fn build_op(
     parents: &[[u8; 32]],
     payload: OpPayload,
 ) -> Op {
-    Op {
+    Op::from_parts(
         id,
         scope,
-        parents: parents.to_vec(),
+        parents.to_vec(),
         author,
         hlc,
         payload,
-        expected_scope_root: [0u8; 32],
-        signature: [0u8; 64],
-    }
+        [0u8; 32],
+        [0u8; 64],
+    )
 }
 
 /// Convert a namespace governance op into the unified [`Op`] graph node it

--- a/crates/governance-store/src/unified_op_decode.rs
+++ b/crates/governance-store/src/unified_op_decode.rs
@@ -93,6 +93,10 @@ pub fn op_from_namespace_op(
         NamespaceOp::Group { group_id, .. } => decrypted_group_op
             .and_then(|g| payload_from_group_op(ContextGroupId::from(*group_id), g))
             .unwrap_or(OpPayload::Noop),
+        // `NamespaceOp` is `#[non_exhaustive]`; an unknown future op folds as a
+        // `Noop` graph node (same as an undecryptable/unfoldable op above),
+        // preserving causal structure without inventing a payload.
+        _ => OpPayload::Noop,
     };
     build_op(
         id,

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -462,6 +462,7 @@ impl GroupOp {
 /// - `Group` ops have a cleartext `group_id` tag (for topic routing and
 ///   skeleton storage) but the actual mutation is encrypted.
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+#[non_exhaustive]
 pub enum NamespaceOp {
     /// Cleartext namespace-wide administrative operation.
     Root(RootOp),
@@ -481,6 +482,10 @@ pub enum NamespaceOp {
 }
 
 /// Cleartext administrative operations that affect the entire namespace.
+// Intentionally NOT #[non_exhaustive]: `RootOp` is dispatched by a central
+// exhaustive `match root` (governance op-apply) that must fail to compile when
+// a variant is added so the new op gets a handler, rather than silently
+// hitting a `_` arm and being dropped from application.
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub enum RootOp {
     /// A new group was created AND atomically nested under `parent_id`.
@@ -745,8 +750,7 @@ pub const NAMESPACE_GOVERNANCE_SIGN_DOMAIN: &[u8] = b"calimero.namespace.v1";
 pub fn namespace_signable_bytes(
     signable: &SignableNamespaceOp,
 ) -> Result<Vec<u8>, GovernanceError> {
-    let mut body =
-        borsh::to_vec(signable).map_err(|e| GovernanceError::BorshSerialize(e.to_string()))?;
+    let mut body = borsh::to_vec(signable)?;
     let mut out = Vec::with_capacity(NAMESPACE_GOVERNANCE_SIGN_DOMAIN.len() + body.len());
     out.extend_from_slice(NAMESPACE_GOVERNANCE_SIGN_DOMAIN);
     out.append(&mut body);
@@ -907,13 +911,12 @@ pub enum GovernanceError {
     #[error("signature verification failed: {0}")]
     Signature(#[from] SignatureError),
     #[error("borsh serialization failed: {0}")]
-    BorshSerialize(String),
+    BorshSerialize(#[from] std::io::Error),
 }
 
 /// Bytes that are hashed/signed: `GROUP_GOVERNANCE_SIGN_DOMAIN` || `borsh(SignableGroupOp)`.
 pub fn signable_bytes(signable: &SignableGroupOp) -> Result<Vec<u8>, GovernanceError> {
-    let mut body =
-        borsh::to_vec(signable).map_err(|e| GovernanceError::BorshSerialize(e.to_string()))?;
+    let mut body = borsh::to_vec(signable)?;
     let mut out = Vec::with_capacity(GROUP_GOVERNANCE_SIGN_DOMAIN.len() + body.len());
     out.extend_from_slice(GROUP_GOVERNANCE_SIGN_DOMAIN);
     out.append(&mut body);

--- a/crates/governance-types/src/wire.rs
+++ b/crates/governance-types/src/wire.rs
@@ -38,7 +38,7 @@ pub fn hash_scoped_namespace(
 ) -> Result<[u8; 32], GovernanceError> {
     let mut hasher = blake3::Hasher::new();
     hasher.update(topic_id);
-    let body = borsh::to_vec(op).map_err(|e| GovernanceError::BorshSerialize(e.to_string()))?;
+    let body = borsh::to_vec(op)?;
     hasher.update(&body);
     Ok(*hasher.finalize().as_bytes())
 }
@@ -49,7 +49,7 @@ pub fn hash_scoped_namespace(
 pub fn hash_scoped_group(topic_id: &[u8], op: &SignedGroupOp) -> Result<[u8; 32], GovernanceError> {
     let mut hasher = blake3::Hasher::new();
     hasher.update(topic_id);
-    let body = borsh::to_vec(op).map_err(|e| GovernanceError::BorshSerialize(e.to_string()))?;
+    let body = borsh::to_vec(op)?;
     hasher.update(&body);
     Ok(*hasher.finalize().as_bytes())
 }
@@ -142,8 +142,7 @@ impl SignedReadinessBeacon {
     /// Canonical bytes that the beacon signature covers:
     /// [`READINESS_BEACON_SIGN_DOMAIN`] || `borsh(SignableReadinessBeacon)`.
     pub fn signable_bytes(&self) -> Result<Vec<u8>, GovernanceError> {
-        let body = borsh::to_vec(&self.to_signable())
-            .map_err(|e| GovernanceError::BorshSerialize(e.to_string()))?;
+        let body = borsh::to_vec(&self.to_signable())?;
         let mut out = Vec::with_capacity(READINESS_BEACON_SIGN_DOMAIN.len() + body.len());
         out.extend_from_slice(READINESS_BEACON_SIGN_DOMAIN);
         out.extend_from_slice(&body);
@@ -313,8 +312,7 @@ impl SignedMigrationHeartbeat {
     /// Canonical bytes that the heartbeat signature covers:
     /// [`MIGRATION_HEARTBEAT_SIGN_DOMAIN`] || `borsh(SignableMigrationHeartbeat)`.
     pub fn signable_bytes(&self) -> Result<Vec<u8>, GovernanceError> {
-        let body = borsh::to_vec(&self.to_signable())
-            .map_err(|e| GovernanceError::BorshSerialize(e.to_string()))?;
+        let body = borsh::to_vec(&self.to_signable())?;
         let mut out = Vec::with_capacity(MIGRATION_HEARTBEAT_SIGN_DOMAIN.len() + body.len());
         out.extend_from_slice(MIGRATION_HEARTBEAT_SIGN_DOMAIN);
         out.extend_from_slice(&body);

--- a/crates/meroctl/src/cli/dev.rs
+++ b/crates/meroctl/src/cli/dev.rs
@@ -196,9 +196,8 @@ impl StartCommand {
 
         let signer_display = app
             .as_ref()
-            .map(|a| &a.signer_id)
-            .filter(|s| !s.is_empty())
-            .map_or_else(|| "<none>".to_owned(), |s| s.clone());
+            .and_then(|a| a.signer_id.as_ref())
+            .map_or_else(|| "<none>".to_owned(), |s| s.as_str().to_owned());
 
         eprintln!();
         eprintln!("  Dev session ready");

--- a/crates/meroctl/src/cli/group/metadata.rs
+++ b/crates/meroctl/src/cli/group/metadata.rs
@@ -68,20 +68,28 @@ impl SetOpts {
     /// pairs become the whole map and `--unset` is rejected at the CLI layer).
     fn into_request(
         self,
-        current: calimero_primitives::metadata::MetadataRecord,
+        current: Option<calimero_primitives::metadata::MetadataRecord>,
     ) -> SetMetadataApiRequest {
+        // Only the existing name/data seed the request; the signer
+        // (`updated_by`) is set server-side on apply, so `MetadataRecord`
+        // intentionally has no `Default` to fabricate one here.
+        let (current_name, current_data) = match current {
+            Some(record) => (record.name, record.data),
+            None => (None, std::collections::BTreeMap::new()),
+        };
+
         let name = if self.clear_name {
             None
         } else if self.name.is_some() {
             self.name
         } else {
-            current.name
+            current_name
         };
 
         let mut data = if self.replace_data {
             std::collections::BTreeMap::new()
         } else {
-            current.data
+            current_data
         };
         for (k, v) in self.set {
             let _ = data.insert(k, v);
@@ -132,11 +140,7 @@ impl MetadataCommand {
                 environment.output.write(&response);
             }
             MetadataSubCommands::Set { group_id, opts } => {
-                let current = client
-                    .get_group_metadata(&group_id)
-                    .await?
-                    .data
-                    .unwrap_or_default();
+                let current = client.get_group_metadata(&group_id).await?.data;
                 let response = client
                     .set_group_metadata(&group_id, opts.into_request(current))
                     .await?;
@@ -192,8 +196,7 @@ impl MemberMetadataCommand {
                 let current = client
                     .get_member_metadata(&group_id, &identity_hex)
                     .await?
-                    .data
-                    .unwrap_or_default();
+                    .data;
                 let response = client
                     .set_member_metadata(&group_id, &identity_hex, opts.into_request(current))
                     .await?;
@@ -250,11 +253,7 @@ impl ContextMetadataCommand {
                 opts,
             } => {
                 let cid = context_id.to_string();
-                let current = client
-                    .get_context_metadata(&group_id, &cid)
-                    .await?
-                    .data
-                    .unwrap_or_default();
+                let current = client.get_context_metadata(&group_id, &cid).await?.data;
                 let response = client
                     .set_context_metadata(&group_id, &cid, opts.into_request(current))
                     .await?;

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -363,12 +363,12 @@ impl InitCommand {
                 ),
                 server_config,
             ),
-            SyncConfig {
-                timeout: DEFAULT_SYNC_TIMEOUT,
-                session_deadline: DEFAULT_SYNC_SESSION_DEADLINE,
-                interval: DEFAULT_SYNC_INTERVAL,
-                frequency: DEFAULT_SYNC_FREQUENCY,
-            },
+            SyncConfig::new(
+                DEFAULT_SYNC_TIMEOUT,
+                DEFAULT_SYNC_SESSION_DEADLINE,
+                DEFAULT_SYNC_INTERVAL,
+                DEFAULT_SYNC_FREQUENCY,
+            ),
             StoreConfigFile::new("data".into()),
             BlobStoreConfig::new("blobs".into()),
             ContextConfig {

--- a/crates/node/primitives/src/client/application.rs
+++ b/crates/node/primitives/src/client/application.rs
@@ -448,7 +448,11 @@ impl NodeClient {
                 // Raw-wasm apps carry no manifest; the row's metadata is the
                 // only version identity available.
                 versions.push(ApplicationVersionInfo {
-                    version: app.version.clone(),
+                    version: app
+                        .version
+                        .as_ref()
+                        .map(|v| v.as_str().to_owned())
+                        .unwrap_or_default(),
                     blob_id,
                     size,
                     package: app.package.clone(),

--- a/crates/node/src/sync/manager/blob_fetch.rs
+++ b/crates/node/src/sync/manager/blob_fetch.rs
@@ -207,8 +207,10 @@ impl SyncManager {
                 context_id: *context_id,
                 payload: ContextEventPayload::AppVersionChanged(AppVersionChangedPayload {
                     from_version: self.application_version(old_app_id),
-                    to_version: Some(installed_application.version.clone())
-                        .filter(|v| !v.is_empty()),
+                    to_version: installed_application
+                        .version
+                        .as_ref()
+                        .map(|v| v.as_str().to_owned()),
                 }),
             });
             let _ = self.node_client.send_event(event);

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -1222,6 +1222,8 @@ impl SyncManager {
                                         calimero_context_client::local_governance::NamespaceOp::Group { .. } => {
                                             "Group".to_owned()
                                         }
+                                        // `NamespaceOp` is `#[non_exhaustive]`.
+                                        _ => "Unknown".to_owned(),
                                     };
                                     warn!(
                                         namespace_id = %hex::encode(namespace_id),

--- a/crates/op-adapter/src/lib.rs
+++ b/crates/op-adapter/src/lib.rs
@@ -342,16 +342,9 @@ mod tests {
             };
             let parents: Vec<[u8; 32]> = prev_id.into_iter().collect();
             let id = Op::compute_id(scope, &parents, &admin, &h, &payload);
-            ops.push(Op {
-                id,
-                scope,
-                parents,
-                author: admin,
-                hlc: h,
-                payload,
-                expected_scope_root: [0u8; 32],
-                signature: [0u8; 64],
-            });
+            ops.push(Op::from_parts(
+                id, scope, parents, admin, h, payload, [0u8; 32], [0u8; 64],
+            ));
             prev_id = Some(id);
         }
 
@@ -399,17 +392,15 @@ mod tests {
             writers_nonce: 1,
         };
         let payload = set_writers_payload(object, &entry);
-        let id = Op::compute_id(scope, &[], &admin, &entry.delta_hlc, &payload);
-        let op = Op {
-            id,
+        let op = Op::new(
             scope,
-            parents: vec![],
-            author: admin,
-            hlc: entry.delta_hlc,
+            vec![],
+            admin,
+            entry.delta_hlc,
             payload,
-            expected_scope_root: [0u8; 32],
-            signature: [0u8; 64],
-        };
+            [0u8; 32],
+            [0u8; 64],
+        );
 
         let resolved = ScopeState::from_ops([&op])
             .acl_view()
@@ -640,17 +631,7 @@ mod tests {
 
         let build = |ns: u64, payload: OpPayload| -> Op {
             let h = hlc(ns);
-            let id = Op::compute_id(scope, &[], &admin, &h, &payload);
-            Op {
-                id,
-                scope,
-                parents: vec![],
-                author: admin,
-                hlc: h,
-                payload,
-                expected_scope_root: [0u8; 32],
-                signature: [0u8; 64],
-            }
+            Op::new(scope, vec![], admin, h, payload, [0u8; 32], [0u8; 64])
         };
 
         // Add(Member)@10 → Remove@20 → Add(Admin)@30 → present as Admin.

--- a/crates/op/src/lib.rs
+++ b/crates/op/src/lib.rs
@@ -29,7 +29,7 @@ use calimero_storage::logical_clock::HybridTimestamp;
 #[derive(
     Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, BorshSerialize, BorshDeserialize,
 )]
-pub struct ScopeId(pub [u8; 32]);
+pub struct ScopeId([u8; 32]);
 
 impl ScopeId {
     #[must_use]
@@ -54,7 +54,10 @@ impl From<[u8; 32]> for ScopeId {
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize)]
 pub struct Op {
     /// `compute_id(scope, parents, author, hlc, payload)` — content address.
-    pub id: [u8; 32],
+    /// **Private** and computed by [`Op::new`] so a caller can't desync the id
+    /// from the content it addresses; read it via [`Op::id`] and re-check it
+    /// with [`Op::verify`].
+    id: [u8; 32],
     /// The scope this op belongs to.
     pub scope: ScopeId,
     /// Causal predecessors (may cross scopes — see the struct docs).
@@ -169,6 +172,102 @@ pub enum OpPayload {
 }
 
 impl Op {
+    /// Build an op, computing its content-address [`id`](Op::id) from the
+    /// content so the two can never disagree. `signature` is the author's
+    /// Ed25519 signature over that id (see the [`signature`](Op::signature)
+    /// field docs); callers sign `Op::compute_id(...)` with the author key.
+    #[must_use]
+    pub fn new(
+        scope: ScopeId,
+        parents: Vec<[u8; 32]>,
+        author: PublicKey,
+        hlc: HybridTimestamp,
+        payload: OpPayload,
+        expected_scope_root: [u8; 32],
+        signature: [u8; 64],
+    ) -> Self {
+        let id = Self::compute_id(scope, &parents, &author, &hlc, &payload);
+        Self {
+            id,
+            scope,
+            parents,
+            author,
+            hlc,
+            payload,
+            expected_scope_root,
+            signature,
+        }
+    }
+
+    /// Build an op from an **explicit** `id` rather than recomputing it from the
+    /// content.
+    ///
+    /// This exists only for the unified-op *bridge*: a [`SignedNamespaceOp`] /
+    /// rotation entry is already a node in the governance DAG with its own
+    /// identity (`content_hash` / `delta_id`), and the unified `Op` mirrors that
+    /// node verbatim — keyed in the op-store by that same id — rather than by
+    /// `Op::compute_id` of the projected payload. These bridge ops are internal,
+    /// unsigned projections of already-verified governance ops, so they are not
+    /// passed through [`Op::verify`]. Fresh, independently-signed ops must use
+    /// [`Op::new`] instead, so their id is a true content address.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "one parameter per Op field (incl. the explicit id); a builder \
+                  would obscure the deliberate 1:1 field mapping for the bridge"
+    )]
+    #[must_use]
+    pub fn from_parts(
+        id: [u8; 32],
+        scope: ScopeId,
+        parents: Vec<[u8; 32]>,
+        author: PublicKey,
+        hlc: HybridTimestamp,
+        payload: OpPayload,
+        expected_scope_root: [u8; 32],
+        signature: [u8; 64],
+    ) -> Self {
+        Self {
+            id,
+            scope,
+            parents,
+            author,
+            hlc,
+            payload,
+            expected_scope_root,
+            signature,
+        }
+    }
+
+    /// Content address of this op.
+    #[must_use]
+    pub const fn id(&self) -> [u8; 32] {
+        self.id
+    }
+
+    /// Verify this op end-to-end: the cached [`id`](Op::id) actually addresses
+    /// the content, **and** the signature is a valid Ed25519 signature over
+    /// that id by [`author`](Op::author).
+    ///
+    /// `calimero-projection`/`calimero-authz` assume already-verified ops, so
+    /// every op crossing a trust boundary (deserialized, received from a peer)
+    /// MUST pass this before being folded.
+    #[must_use]
+    pub fn verify(&self) -> bool {
+        let recomputed = Self::compute_id(
+            self.scope,
+            &self.parents,
+            &self.author,
+            &self.hlc,
+            &self.payload,
+        );
+        if recomputed != self.id {
+            return false;
+        }
+        self.author
+            .verify_raw_signature(&self.id, &self.signature)
+            .is_ok()
+    }
+
     /// Content address of an op: `Sha256(scope ‖ sorted(parents) ‖ author ‖
     /// hlc ‖ borsh(payload))`. Parents are sorted so the id is independent of
     /// the order a builder happened to list them in.

--- a/crates/primitives/src/alias.rs
+++ b/crates/primitives/src/alias.rs
@@ -70,6 +70,10 @@ impl<T> Alias<T> {
     ///
     /// Panics if the string exceeds `MAX_ALIAS_LEN`.
     #[must_use]
+    #[deprecated(
+        note = "panics on aliases longer than MAX_ALIAS_LEN; use `Alias::try_from_str` \
+                (or `str::parse`) and handle `InvalidAlias` instead"
+    )]
     pub fn new(s: &str) -> Self {
         s.parse().expect("alias too long")
     }

--- a/crates/primitives/src/application.rs
+++ b/crates/primitives/src/application.rs
@@ -421,6 +421,73 @@ pub struct ApplicationBlob {
     pub compiled: BlobId,
 }
 
+/// A validated application version (`major.minor.patch` semver core, with an
+/// optional `-prerelease` / `+build` suffix). A newtype so a raw, unvalidated
+/// string can't masquerade as a version.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd, Serialize)]
+pub struct Version(Box<str>);
+
+/// Error returned when constructing an invalid [`Version`].
+#[derive(Clone, Debug, ThisError)]
+#[non_exhaustive]
+pub enum InvalidVersion {
+    /// The string is not `major.minor.patch` semver.
+    #[error("version must be semver `major.minor.patch`, got `{0}`")]
+    NotSemver(String),
+}
+
+impl Version {
+    /// Parse and validate a semver version string.
+    ///
+    /// # Errors
+    /// Returns [`InvalidVersion::NotSemver`] if `s` is not three dot-separated
+    /// numeric components (optionally followed by a `-pre`/`+build` suffix).
+    pub fn new(s: impl Into<Box<str>>) -> Result<Self, InvalidVersion> {
+        let s = s.into();
+        let core = s.split(['-', '+']).next().unwrap_or(&s);
+        let mut parts = core.split('.');
+        let numeric = |p: Option<&str>| {
+            p.is_some_and(|x| !x.is_empty() && x.bytes().all(|b| b.is_ascii_digit()))
+        };
+        let valid = numeric(parts.next())
+            && numeric(parts.next())
+            && numeric(parts.next())
+            && parts.next().is_none();
+        if valid {
+            Ok(Self(s))
+        } else {
+            Err(InvalidVersion::NotSemver(s.into_string()))
+        }
+    }
+
+    /// The version as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.pad(&self.0)
+    }
+}
+
+impl FromStr for Version {
+    type Err = InvalidVersion;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for Version {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = <String as Deserialize>::deserialize(deserializer)?;
+        Self::new(s).map_err(SerdeError::custom)
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Application {
@@ -429,12 +496,12 @@ pub struct Application {
     pub size: u64,
     pub source: ApplicationSource,
     pub metadata: Vec<u8>,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub signer_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signer_id: Option<SignerId>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub package: String,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<Version>,
     /// Named services. Key = service name, value = WASM blob.
     /// Empty for single-service apps (use `blob` field instead).
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -456,9 +523,9 @@ impl Application {
             size,
             source,
             metadata,
-            signer_id: String::new(),
+            signer_id: None,
             package: String::new(),
-            version: String::new(),
+            version: None,
             services: BTreeMap::new(),
         }
     }
@@ -476,9 +543,13 @@ impl Application {
 
     #[must_use]
     pub fn with_bundle_info(mut self, signer_id: String, package: String, version: String) -> Self {
-        self.signer_id = signer_id;
+        // An empty or invalid signer id becomes `None` rather than being stored
+        // as an unvalidated string.
+        self.signer_id = SignerId::new(signer_id).ok();
         self.package = package;
-        self.version = version;
+        // Validate the version; an empty or non-semver string becomes `None`
+        // rather than silently storing an invalid version.
+        self.version = Version::new(version).ok();
         self
     }
 }

--- a/crates/primitives/src/application.rs
+++ b/crates/primitives/src/application.rs
@@ -198,7 +198,9 @@ impl BorshSerialize for SignerId {
     fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
         // Serialize as length-prefixed bytes
         let bytes = self.0.as_bytes();
-        let len = bytes.len() as u32;
+        let len = u32::try_from(bytes.len()).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidData, "SignerId too long to encode")
+        })?;
         BorshSerialize::serialize(&len, writer)?;
         writer.write_all(bytes)
     }
@@ -348,7 +350,12 @@ impl BorshSerialize for AppKey {
     fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
         // Serialize app_id as length-prefixed bytes
         let app_id_bytes = self.app_id.as_bytes();
-        let app_id_len = app_id_bytes.len() as u32;
+        let app_id_len = u32::try_from(app_id_bytes.len()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "AppKey app_id too long to encode",
+            )
+        })?;
         BorshSerialize::serialize(&app_id_len, writer)?;
         writer.write_all(app_id_bytes)?;
 

--- a/crates/primitives/src/context.rs
+++ b/crates/primitives/src/context.rs
@@ -285,6 +285,10 @@ const _: () = {
     feature = "borsh",
     derive(borsh::BorshDeserialize, borsh::BorshSerialize)
 )]
+// Intentionally NOT #[non_exhaustive]: `calimero-projection::role_byte` maps
+// every role to a stable byte that feeds the consensus groups-root hash, and
+// must fail to compile (not silently hit a `_` arm) when a role is added so a
+// distinct hash byte is assigned. Exhaustive matching here is the safety net.
 pub enum GroupMemberRole {
     Admin,
     Member,

--- a/crates/primitives/src/context.rs
+++ b/crates/primitives/src/context.rs
@@ -364,11 +364,32 @@ impl TryFrom<&str> for GroupInvitationPayload {
     }
 }
 
+/// The constituent parts of a [`GroupInvitationPayload`].
+///
+/// A named struct rather than a 7-positional `new(...)` / a 7-tuple `parts()`:
+/// the payload carries two distinct 32-byte ids and three integers, which are
+/// trivially transposable when passed positionally.
+#[derive(Clone, Debug)]
+pub struct GroupInvitationParts {
+    /// The group the invitation is for.
+    pub group_id: [u8; DIGEST_SIZE],
+    /// Identity of the inviting member.
+    pub inviter_identity: crate::identity::PublicKey,
+    /// The specific invitee, if the invitation is targeted.
+    pub invitee_identity: Option<crate::identity::PublicKey>,
+    /// Optional expiration (semantics owned by the caller).
+    pub expiration: Option<u64>,
+    /// The inviter's signature over the invitation.
+    pub inviter_signature: String,
+    /// Per-invitation secret salt.
+    pub secret_salt: [u8; 32],
+    /// Absolute expiration timestamp.
+    pub expiration_timestamp: u64,
+}
+
 #[cfg(feature = "borsh")]
 const _: () = {
     use borsh::{BorshDeserialize, BorshSerialize};
-
-    use crate::identity::PublicKey;
 
     #[derive(BorshSerialize, BorshDeserialize)]
     struct GroupInvitationInner {
@@ -382,54 +403,35 @@ const _: () = {
     }
 
     impl GroupInvitationPayload {
-        /// Creates a new, serialized group invitation payload.
-        #[allow(clippy::too_many_arguments)]
-        pub fn new(
-            group_id: [u8; DIGEST_SIZE],
-            inviter_identity: PublicKey,
-            invitee_identity: Option<PublicKey>,
-            expiration: Option<u64>,
-            inviter_signature: String,
-            secret_salt: [u8; 32],
-            expiration_timestamp: u64,
-        ) -> io::Result<Self> {
+        /// Creates a new, serialized group invitation payload from its
+        /// [`GroupInvitationParts`].
+        pub fn new(parts: GroupInvitationParts) -> io::Result<Self> {
             let payload = GroupInvitationInner {
-                group_id,
-                inviter_identity: *inviter_identity,
-                invitee_identity: invitee_identity.map(|pk| *pk),
-                expiration,
-                inviter_signature,
-                secret_salt,
-                expiration_timestamp,
+                group_id: parts.group_id,
+                inviter_identity: *parts.inviter_identity,
+                invitee_identity: parts.invitee_identity.map(|pk| *pk),
+                expiration: parts.expiration,
+                inviter_signature: parts.inviter_signature,
+                secret_salt: parts.secret_salt,
+                expiration_timestamp: parts.expiration_timestamp,
             };
 
             borsh::to_vec(&payload).map(Self)
         }
 
-        /// Deserializes the payload and extracts its constituent parts.
-        #[allow(clippy::type_complexity)]
-        pub fn parts(
-            &self,
-        ) -> io::Result<(
-            [u8; DIGEST_SIZE],
-            PublicKey,
-            Option<PublicKey>,
-            Option<u64>,
-            String,
-            [u8; 32],
-            u64,
-        )> {
+        /// Deserializes the payload into its [`GroupInvitationParts`].
+        pub fn parts(&self) -> io::Result<GroupInvitationParts> {
             let payload: GroupInvitationInner = borsh::from_slice(&self.0)?;
 
-            Ok((
-                payload.group_id,
-                payload.inviter_identity.into(),
-                payload.invitee_identity.map(Into::into),
-                payload.expiration,
-                payload.inviter_signature,
-                payload.secret_salt,
-                payload.expiration_timestamp,
-            ))
+            Ok(GroupInvitationParts {
+                group_id: payload.group_id,
+                inviter_identity: payload.inviter_identity.into(),
+                invitee_identity: payload.invitee_identity.map(Into::into),
+                expiration: payload.expiration,
+                inviter_signature: payload.inviter_signature,
+                secret_salt: payload.secret_salt,
+                expiration_timestamp: payload.expiration_timestamp,
+            })
         }
     }
 };
@@ -473,15 +475,15 @@ mod tests {
         let invitee = PublicKey::from([5; DIGEST_SIZE]);
         let salt = [9u8; 32];
 
-        let payload = GroupInvitationPayload::new(
+        let payload = GroupInvitationPayload::new(GroupInvitationParts {
             group_id,
-            inviter,
-            Some(invitee),
-            Some(1_700_000_000),
-            "abcd1234".to_string(),
-            salt,
-            999_999_999,
-        )
+            inviter_identity: inviter,
+            invitee_identity: Some(invitee),
+            expiration: Some(1_700_000_000),
+            inviter_signature: "abcd1234".to_string(),
+            secret_salt: salt,
+            expiration_timestamp: 999_999_999,
+        })
         .expect("Payload creation should succeed");
 
         let encoded = payload.to_string();
@@ -490,15 +492,14 @@ mod tests {
         let decoded =
             GroupInvitationPayload::from_str(&encoded).expect("Payload decoding should succeed");
 
-        let (g, inv, invitee_out, exp, sig, decoded_salt, exp_ts) =
-            decoded.parts().expect("Parts extraction should succeed");
-        assert_eq!(g, group_id);
-        assert_eq!(inv, inviter);
-        assert_eq!(invitee_out, Some(invitee));
-        assert_eq!(exp, Some(1_700_000_000));
-        assert_eq!(sig, "abcd1234");
-        assert_eq!(decoded_salt, salt);
-        assert_eq!(exp_ts, 999_999_999);
+        let parts = decoded.parts().expect("Parts extraction should succeed");
+        assert_eq!(parts.group_id, group_id);
+        assert_eq!(parts.inviter_identity, inviter);
+        assert_eq!(parts.invitee_identity, Some(invitee));
+        assert_eq!(parts.expiration, Some(1_700_000_000));
+        assert_eq!(parts.inviter_signature, "abcd1234");
+        assert_eq!(parts.secret_salt, salt);
+        assert_eq!(parts.expiration_timestamp, 999_999_999);
     }
 
     #[test]
@@ -507,30 +508,29 @@ mod tests {
         let inviter = PublicKey::from([7; DIGEST_SIZE]);
         let salt = [10u8; 32];
 
-        let payload = GroupInvitationPayload::new(
+        let payload = GroupInvitationPayload::new(GroupInvitationParts {
             group_id,
-            inviter,
-            None,
-            None,
-            "sig_hex".to_string(),
-            salt,
-            1_000_000_000,
-        )
+            inviter_identity: inviter,
+            invitee_identity: None,
+            expiration: None,
+            inviter_signature: "sig_hex".to_string(),
+            secret_salt: salt,
+            expiration_timestamp: 1_000_000_000,
+        })
         .expect("Payload creation should succeed");
 
         let encoded = payload.to_string();
         let decoded =
             GroupInvitationPayload::from_str(&encoded).expect("Payload decoding should succeed");
 
-        let (g, inv, invitee_out, exp, sig, decoded_salt, exp_ts) =
-            decoded.parts().expect("Parts extraction should succeed");
-        assert_eq!(g, group_id);
-        assert_eq!(inv, inviter);
-        assert_eq!(invitee_out, None);
-        assert_eq!(exp, None);
-        assert_eq!(sig, "sig_hex");
-        assert_eq!(decoded_salt, salt);
-        assert_eq!(exp_ts, 1_000_000_000);
+        let parts = decoded.parts().expect("Parts extraction should succeed");
+        assert_eq!(parts.group_id, group_id);
+        assert_eq!(parts.inviter_identity, inviter);
+        assert_eq!(parts.invitee_identity, None);
+        assert_eq!(parts.expiration, None);
+        assert_eq!(parts.inviter_signature, "sig_hex");
+        assert_eq!(parts.secret_salt, salt);
+        assert_eq!(parts.expiration_timestamp, 1_000_000_000);
     }
 
     #[test]

--- a/crates/primitives/src/metadata.rs
+++ b/crates/primitives/src/metadata.rs
@@ -38,16 +38,10 @@ pub struct MetadataRecord {
     pub updated_by: PublicKey,
 }
 
-impl Default for MetadataRecord {
-    fn default() -> Self {
-        Self {
-            name: None,
-            data: BTreeMap::new(),
-            updated_at: 0,
-            updated_by: PublicKey::from([0_u8; 32]),
-        }
-    }
-}
+// Deliberately no `Default` impl: a `MetadataRecord` always has a real signer
+// (`updated_by`), and a `Default` would have to fabricate an all-zero
+// `PublicKey` — an invalid signer that silently looks authentic. Construct one
+// explicitly with the actual signer instead.
 
 /// Max length of [`MetadataRecord::name`], in bytes.
 pub const MAX_METADATA_NAME_LEN: usize = 64;
@@ -142,8 +136,15 @@ mod tests {
     }
 
     #[test]
-    fn default_is_empty() {
-        let rec = MetadataRecord::default();
+    fn empty_record_has_real_signer() {
+        // There is intentionally no `Default`; a record always carries a real
+        // signer rather than a fabricated all-zero key.
+        let rec = MetadataRecord {
+            name: None,
+            data: BTreeMap::new(),
+            updated_at: 0,
+            updated_by: [7_u8; 32].into(),
+        };
         assert!(rec.name.is_none());
         assert!(rec.data.is_empty());
         assert_eq!(rec.updated_at, 0);

--- a/crates/projection/src/lib.rs
+++ b/crates/projection/src/lib.rs
@@ -119,7 +119,7 @@ impl ScopeState {
 
     /// Apply one op with an explicit causal `generation` for its LWW stamp.
     pub fn apply_with_generation(&mut self, op: &Op, generation: u32) {
-        let stamp: Stamp = (op.hlc, generation, op.id);
+        let stamp: Stamp = (op.hlc, generation, op.id());
         match &op.payload {
             OpPayload::Put { entity, value } => {
                 if wins(stamp, self.data_clock.get(entity)) {
@@ -289,7 +289,7 @@ impl ScopeState {
     /// fully-materialized ancestry.
     #[must_use]
     pub fn acl_view_at(log: &[Op], parents: &[[u8; 32]]) -> AclView {
-        let by_id: HashMap<[u8; 32], &Op> = log.iter().map(|op| (op.id, op)).collect();
+        let by_id: HashMap<[u8; 32], &Op> = log.iter().map(|op| (op.id(), op)).collect();
         let mut visited: HashSet<[u8; 32]> = HashSet::new();
         let mut queue: VecDeque<[u8; 32]> = parents.iter().copied().collect();
         let mut ancestry: Vec<&Op> = Vec::new();
@@ -310,13 +310,13 @@ impl ScopeState {
         // It orders causally-related governance ops (whose `hlc` is all `0`) so a
         // re-add beats an earlier remove. Iterative post-order over the DAG (no
         // cycles), so deep chains can't blow the stack.
-        let anc_by_id: HashMap<[u8; 32], &Op> = ancestry.iter().map(|op| (op.id, *op)).collect();
+        let anc_by_id: HashMap<[u8; 32], &Op> = ancestry.iter().map(|op| (op.id(), *op)).collect();
         let mut generation: HashMap<[u8; 32], u32> = HashMap::new();
         for &start in &ancestry {
-            if generation.contains_key(&start.id) {
+            if generation.contains_key(&start.id()) {
                 continue;
             }
-            let mut stack = vec![start.id];
+            let mut stack = vec![start.id()];
             while let Some(&top) = stack.last() {
                 let Some(top_op) = anc_by_id.get(&top) else {
                     let _ = generation.insert(top, 0);
@@ -350,7 +350,7 @@ impl ScopeState {
 
         let mut state = Self::default();
         for &op in &ancestry {
-            state.apply_with_generation(op, generation.get(&op.id).copied().unwrap_or(0));
+            state.apply_with_generation(op, generation.get(&op.id()).copied().unwrap_or(0));
         }
         state.acl_view()
     }
@@ -366,7 +366,7 @@ impl ScopeState {
     /// grant can abstain (defer to live) unless it has the whole history.
     #[must_use]
     pub fn cut_ancestry_complete(log: &[Op], parents: &[[u8; 32]]) -> bool {
-        let by_id: HashMap<[u8; 32], &Op> = log.iter().map(|op| (op.id, op)).collect();
+        let by_id: HashMap<[u8; 32], &Op> = log.iter().map(|op| (op.id(), op)).collect();
         let mut visited: HashSet<[u8; 32]> = HashSet::new();
         let mut queue: VecDeque<[u8; 32]> = parents.iter().copied().collect();
         while let Some(id) = queue.pop_front() {
@@ -529,17 +529,7 @@ mod tests {
         let scope = ScopeId::from([0u8; 32]);
         let author = PublicKey::from([1u8; 32]);
         let h = hlc(hlc_ns);
-        let id = Op::compute_id(scope, &[], &author, &h, &payload);
-        Op {
-            id,
-            scope,
-            parents: vec![],
-            author,
-            hlc: h,
-            payload,
-            expected_scope_root: [0u8; 32],
-            signature: [0u8; 64],
-        }
+        Op::new(scope, vec![], author, h, payload, [0u8; 32], [0u8; 64])
     }
 
     fn sample_ops() -> Vec<Op> {
@@ -730,17 +720,15 @@ mod tests {
                         .collect(),
                 },
             };
-            let id = Op::compute_id(scope, &[], &author, &h, &payload);
-            ops.push(Op {
-                id,
+            ops.push(Op::new(
                 scope,
-                parents: vec![],
+                vec![],
                 author,
-                hlc: h,
+                h,
                 payload,
-                expected_scope_root: [0u8; 32],
-                signature: [0u8; 64],
-            });
+                [0u8; 32],
+                [0u8; 64],
+            ));
         }
 
         // The model must converge + isolate across many delivery orders.
@@ -797,19 +785,19 @@ mod tests {
                 writers: BTreeMap::new(),
             },
         );
-        revoke.parents = vec![genesis.id];
+        revoke.parents = vec![genesis.id()];
 
         let log = vec![genesis.clone(), revoke.clone()];
 
         // View at the cut [genesis] (pre-revoke) still sees the owner.
-        let pre = ScopeState::acl_view_at(&log, &[genesis.id]);
+        let pre = ScopeState::acl_view_at(&log, &[genesis.id()]);
         assert!(
             pre.is_owner(&owner, object),
             "pre-revoke cut keeps the owner"
         );
 
         // View at the cut [revoke] (post) does not.
-        let post = ScopeState::acl_view_at(&log, &[revoke.id]);
+        let post = ScopeState::acl_view_at(&log, &[revoke.id()]);
         assert!(
             !post.is_owner(&owner, object),
             "post-revoke cut drops the owner"
@@ -828,17 +816,7 @@ mod tests {
         let author = PublicKey::from([1u8; 32]);
         let zero = hlc(0);
         let mk = |parents: Vec<[u8; 32]>, payload: OpPayload| -> Op {
-            let id = Op::compute_id(scope, &parents, &author, &zero, &payload);
-            Op {
-                id,
-                scope,
-                parents,
-                author,
-                hlc: zero,
-                payload,
-                expected_scope_root: [0u8; 32],
-                signature: [0u8; 64],
-            }
+            Op::new(scope, parents, author, zero, payload, [0u8; 32], [0u8; 64])
         };
         let add = mk(
             vec![],
@@ -848,9 +826,9 @@ mod tests {
                 role: GroupMemberRole::Member,
             },
         );
-        let remove = mk(vec![add.id], OpPayload::MemberRemoved { group, member });
+        let remove = mk(vec![add.id()], OpPayload::MemberRemoved { group, member });
         let readd = mk(
-            vec![remove.id],
+            vec![remove.id()],
             OpPayload::MemberAdded {
                 group,
                 member,
@@ -860,7 +838,7 @@ mod tests {
         let log = vec![add.clone(), remove.clone(), readd.clone()];
 
         // At the re-add cut: present as Admin (generation readd > remove > add).
-        let at_readd = ScopeState::acl_view_at(&log, &[readd.id]);
+        let at_readd = ScopeState::acl_view_at(&log, &[readd.id()]);
         assert_eq!(
             at_readd.groups.get(&group).and_then(|m| m.get(&member)),
             Some(&GroupMemberRole::Admin),
@@ -868,7 +846,7 @@ mod tests {
         );
 
         // At the remove cut: absent.
-        let at_remove = ScopeState::acl_view_at(&log, &[remove.id]);
+        let at_remove = ScopeState::acl_view_at(&log, &[remove.id()]);
         assert_eq!(
             at_remove.groups.get(&group).and_then(|m| m.get(&member)),
             None,
@@ -888,17 +866,7 @@ mod tests {
         let author = PublicKey::from([1u8; 32]);
         let zero = hlc(0);
         let mk = |parents: Vec<[u8; 32]>, payload: OpPayload| -> Op {
-            let id = Op::compute_id(scope, &parents, &author, &zero, &payload);
-            Op {
-                id,
-                scope,
-                parents,
-                author,
-                hlc: zero,
-                payload,
-                expected_scope_root: [0u8; 32],
-                signature: [0u8; 64],
-            }
+            Op::new(scope, parents, author, zero, payload, [0u8; 32], [0u8; 64])
         };
         let add = mk(
             vec![],
@@ -908,18 +876,21 @@ mod tests {
                 role: GroupMemberRole::Member,
             },
         );
-        let remove = mk(vec![add.id], OpPayload::MemberRemoved { group, member });
+        let remove = mk(vec![add.id()], OpPayload::MemberRemoved { group, member });
 
         // Complete log: ancestry of [remove] = {remove, add}, both present.
         let complete = vec![add.clone(), remove.clone()];
-        assert!(ScopeState::cut_ancestry_complete(&complete, &[remove.id]));
+        assert!(ScopeState::cut_ancestry_complete(&complete, &[remove.id()]));
 
         // Missing the mid-ancestry `add` (remove's parent) → truncated → false.
         let truncated = vec![remove.clone()];
-        assert!(!ScopeState::cut_ancestry_complete(&truncated, &[remove.id]));
+        assert!(!ScopeState::cut_ancestry_complete(
+            &truncated,
+            &[remove.id()]
+        ));
 
         // A cited head absent from the log → also incomplete.
-        assert!(!ScopeState::cut_ancestry_complete(&[], &[remove.id]));
+        assert!(!ScopeState::cut_ancestry_complete(&[], &[remove.id()]));
     }
 
     #[test]

--- a/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
@@ -192,9 +192,9 @@ pub async fn handler(
                     &group_id,
                     &calimero_primitives::metadata::MetadataRecord {
                         name: body.group_name.clone(),
+                        data: std::collections::BTreeMap::new(),
                         updated_at: calimero_context::group_store::now_millis(),
                         updated_by: signer_pk,
-                        ..Default::default()
                     },
                 ) {
                     warn!(


### PR DESCRIPTION
Type-safety / encapsulation hardening across `op`, `primitives`, `governance-types`, `config`, and `client`. Each commit landed only after a full green `cargo check --workspace --all-targets`; the whole branch passes the CI clippy gate (`--all-targets -D warnings`).

## Findings addressed (9/11)

- **#1 Op id encapsulation (H):** `Op::id` is now private and computed by `Op::new` from the content, so a caller can't desync the id from what it addresses. Added `Op::verify` (recompute id + Ed25519-check the signature over it). `Op::from_parts` is the explicit-id constructor for the unified-op *bridge* (a `SignedNamespaceOp`/rotation entry already has a DAG identity the unified `Op` mirrors and keys storage by) — documented as not verify-able. Migrated ~20 constructions + ~40 `op.id` reads.
- **#3 (H):** deprecated panicking `Alias::new` in favor of fallible `try_from_str`/`parse`.
- **#5 (M):** `#[non_exhaustive]` on `NamespaceOp` and `config::SyncConfig` (+ `SyncConfig::new`). Deliberately **not** on `RootOp`/`GroupMemberRole` — both are dispatched/hashed by central exhaustive matches (`role_byte` feeds the consensus groups-root hash; `match root` dispatches op-apply) that should fail to compile when a variant is added rather than silently hit a `_` arm. Documented inline.
- **#6 (M):** `GovernanceError::BorshSerialize` carries `#[from] std::io::Error` instead of a stringified message.
- **#6b (M):** `Application.version` → validated `Version` semver newtype; `signer_id` → `Option<SignerId>` (was raw `String`s).
- **#7 (M):** `GroupInvitationPayload` uses a named `GroupInvitationParts` struct instead of 7 positional args / a 7-tuple.
- **#8 (M):** dropped `MetadataRecord: Default` (it fabricated an all-zero signer); all sites construct with a real `updated_by`.
- **#9 (M):** `ConnectionInfo` fields private (hides the reqwest client, authenticator, storage) + `api_url()`/`node_name()` accessors.
- **#11 (L, partial):** `ScopeId` inner `[u8;32]` made private (use `as_bytes()`/`From`); `u32::try_from` guards replace truncating `len() as u32` casts in `SignerId`/`AppKey` borsh.

## Deferred to a follow-up (with rationale)

- **#2 (H) — full id-newtype migration (`GroupId`/`NamespaceId`/`KeyId`):** ~200 sites across ~8 crates, an all-or-nothing change touching nearly every governance/context call site. Best done as its own focused PR.
- **#4 (M) — `GroupCapabilities` bitflags:** the `SubgroupVisibility` enum (`VisibilityMode`) and `ContextCapabilityBits` parts already exist upstream; what remains is typing the `capabilities: u32` **borsh wire fields** in `GroupOp`/`OpPayload`, a wire-format-sensitive change with ~38-site ripple.
- **#11 (L) — `DeltaId` newtype** for context `dag_heads` (the cast/encapsulation parts are done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)