### PR TITLE
fix(ci): label PRs under the pull_request_target trigger

### DIFF
--- a/.github/workflows/new-issue-or-pr.yml
+++ b/.github/workflows/new-issue-or-pr.yml
@@ -32,7 +32,7 @@ jobs:
                 issue_number: context.issue.number,
                 labels: ['needs-team-review']
               });
-            } else if (context.eventName === 'pull_request') {
+            } else if (context.eventName === 'pull_request_target') {
               // Add label to PR
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,


### PR DESCRIPTION
The auto-labeling script in `new-issue-or-pr.yml` branches on the event name:

```js
if (context.eventName === 'issues') { /* label issue */ }
else if (context.eventName === 'pull_request') { /* label PR */ }
```

But the workflow triggers on **`pull_request_target`**, so for a PR `context.eventName` is `"pull_request_target"` — never `"pull_request"`. The PR branch never executed: **opened/reopened PRs were silently never labeled** (`needs-team-review`). Issues were unaffected.

One-word fix: match the actual event name. No other behavior change.

(Spotted while auditing this workflow for #3086; kept separate to keep that PR behavior-neutral.)