### PR TITLE
feat(xcall-example): restrict pong to same-app callers via from_same_app

### DIFF
--- a/apps/xcall-example/src/lib.rs
+++ b/apps/xcall-example/src/lib.rs
@@ -49,19 +49,16 @@ impl XCallExample {
         self.xcall_to(target_context, &method)
     }
 
-    /// Receive a pong via `xcall`. Marked `#[app::xcall]` so other contexts in
-    /// the same namespace may invoke it.
+    /// Receive a pong via `xcall`. Marked `#[app::xcall(from_same_app)]` so the
+    /// node only admits callers running this same application — ping and pong
+    /// are the same app — and rejects a same-namespace context running a
+    /// different app before this method even runs.
     ///
-    /// A tighter, node-enforced caller policy is available —
-    /// `#[app::xcall(from_same_app)]` restricts callers to contexts running this
-    /// same application. It's deliberately not used here yet: emitting the new
-    /// `xcall_callers` ABI field requires the downstream `abi-codegen` tool to
-    /// understand it first, so the example adopts it once that ships.
-    ///
-    /// `env::xcall_origin()` is set by the node and can't be forged, so this
-    /// method rejects direct calls (no origin) and refuses any call where the
-    /// origin doesn't match the self-reported `from_context`.
-    #[app::xcall]
+    /// The node-enforced policy is the trust boundary; the `env::xcall_origin()`
+    /// checks below are the remaining app-specific logic — rejecting direct
+    /// calls (no origin) and verifying the origin matches the self-reported
+    /// `from_context`.
+    #[app::xcall(from_same_app)]
     pub fn pong(&mut self, from_context: ContextId) -> app::Result<()> {
         let origin = calimero_sdk::env::xcall_origin().map(ContextId::from);
 


### PR DESCRIPTION
Closes out the xcall caller-policy rollout: now that abi-codegen understands the `xcall_callers` ABI field (mero-devtools-js#36, shipped on `main`), the example can adopt the node-enforced policy.

## Change

`xcall-example`'s `pong` moves from `#[app::xcall]` to **`#[app::xcall(from_same_app)]`** — ping and pong are the same application, so the node now rejects a same-namespace context running a *different* app before `pong` runs. The `env::xcall_origin()` checks remain as app-specific provenance logic on top.

## Context

The node-side capability shipped in #3068; `xcall-example` was deliberately kept on the open default there so it wouldn't emit `xcall_callers` before the downstream tooling could parse it (that would fail the cross-repo ABI-contract check). The sequence is now complete:

1. #3068 — field + node enforcement (merged)
2. `0.11.0-rc.9` — released with the field
3. mero-devtools-js#36 — abi-codegen learns the field (merged to `main`)
4. **this PR** — example adopts `from_same_app`; its ABI-contract check passes against devtools `main`

The `from_same_app` parse path was already covered by the wasm-abi emitter unit test; this adds the end-to-end example.