### PR TITLE
fix(runtime): host-function safety hardening (UB, OOM, transmute, block_on)

### DIFF
--- a/crates/runtime/src/logic/host_functions/blobs.rs
+++ b/crates/runtime/src/logic/host_functions/blobs.rs
@@ -254,10 +254,14 @@ impl VMHostFunctions<'_> {
             BlobHandle::Write(write_handle) => {
                 let _ignored = write_handle.sender;
 
-                let (blob_id_, _size) = tokio::runtime::Handle::current()
-                    .block_on(write_handle.completion_handle)
-                    .map_err(|_| VMLogicError::HostError(HostError::BlobsNotSupported))?
-                    .map_err(|_| VMLogicError::HostError(HostError::BlobsNotSupported))?;
+                // `block_in_place` hands the blocking wait off the async worker;
+                // a bare `Handle::block_on` panics when called on a runtime
+                // thread.
+                let (blob_id_, _size) = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(write_handle.completion_handle)
+                })
+                .map_err(|_| VMLogicError::HostError(HostError::BlobsNotSupported))?
+                .map_err(|_| VMLogicError::HostError(HostError::BlobsNotSupported))?;
 
                 *blob_id_.as_ref()
             }
@@ -316,10 +320,13 @@ impl VMHostFunctions<'_> {
             ContextId::from(*self.read_guest_memory_sized::<DIGEST_SIZE>(&context_id)?);
 
         // Get blob metadata to get size
-        let blob_info = tokio::runtime::Handle::current()
-            .block_on(node_client.get_blob_info(blob_id))
-            .map_err(|_| VMLogicError::HostError(HostError::BlobsNotSupported))?
-            .ok_or(VMLogicError::HostError(HostError::BlobsNotSupported))?;
+        // `block_in_place` hands the blocking wait off the async worker; a bare
+        // `Handle::block_on` panics when called on a runtime thread.
+        let blob_info = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(node_client.get_blob_info(blob_id))
+        })
+        .map_err(|_| VMLogicError::HostError(HostError::BlobsNotSupported))?
+        .ok_or(VMLogicError::HostError(HostError::BlobsNotSupported))?;
 
         // Announce blob to network
         tokio::task::block_in_place(|| {
@@ -501,9 +508,14 @@ impl VMHostFunctions<'_> {
             }
 
             if read_handle.stream.is_none() {
-                let blob_stream = tokio::runtime::Handle::current()
-                    .block_on(node_client.get_blob(&read_handle.blob_id, None))
-                    .map_err(|_| VMLogicError::HostError(HostError::BlobsNotSupported))?;
+                // `block_in_place` hands the blocking wait off the async worker;
+                // a bare `Handle::block_on` panics when called on a runtime
+                // thread.
+                let blob_stream = tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current()
+                        .block_on(node_client.get_blob(&read_handle.blob_id, None))
+                })
+                .map_err(|_| VMLogicError::HostError(HostError::BlobsNotSupported))?;
 
                 if let Some(stream) = blob_stream {
                     let mapped_stream = stream.map(|result| {
@@ -519,37 +531,44 @@ impl VMHostFunctions<'_> {
             }
 
             if let Some(stream) = &mut read_handle.stream {
-                tokio::runtime::Handle::current().block_on(async {
-                    while output_buffer.len() < data_len {
-                        match stream.next().await {
-                            Some(Ok(chunk)) => {
-                                let chunk_bytes = chunk.as_ref();
+                // `block_in_place` hands the blocking wait off the async worker;
+                // a bare `Handle::block_on` panics when called on a runtime
+                // thread.
+                tokio::task::block_in_place(|| {
+                    tokio::runtime::Handle::current().block_on(async {
+                        while output_buffer.len() < data_len {
+                            match stream.next().await {
+                                Some(Ok(chunk)) => {
+                                    let chunk_bytes = chunk.as_ref();
 
-                                let remaining_needed = data_len
-                                    .checked_sub(output_buffer.len())
-                                    .ok_or(VMLogicError::HostError(HostError::IntegerOverflow))?;
+                                    let remaining_needed =
+                                        data_len.checked_sub(output_buffer.len()).ok_or(
+                                            VMLogicError::HostError(HostError::IntegerOverflow),
+                                        )?;
 
-                                if chunk_bytes.len() <= remaining_needed {
-                                    output_buffer.extend_from_slice(chunk_bytes);
-                                } else {
-                                    // Use part of chunk, save rest in cursor for next time
-                                    output_buffer
-                                        .extend_from_slice(&chunk_bytes[..remaining_needed]);
+                                    if chunk_bytes.len() <= remaining_needed {
+                                        output_buffer.extend_from_slice(chunk_bytes);
+                                    } else {
+                                        // Use part of chunk, save rest in cursor for next time
+                                        output_buffer
+                                            .extend_from_slice(&chunk_bytes[..remaining_needed]);
 
-                                    // Create cursor with remaining data
-                                    let remaining_data = chunk_bytes[remaining_needed..].to_vec();
-                                    read_handle.current_chunk_cursor =
-                                        Some(Cursor::new(remaining_data));
+                                        // Create cursor with remaining data
+                                        let remaining_data =
+                                            chunk_bytes[remaining_needed..].to_vec();
+                                        read_handle.current_chunk_cursor =
+                                            Some(Cursor::new(remaining_data));
 
+                                        break;
+                                    }
+                                }
+                                Some(Err(_)) | None => {
                                     break;
                                 }
                             }
-                            Some(Err(_)) | None => {
-                                break;
-                            }
                         }
-                    }
-                    Ok::<(), VMLogicError>(())
+                        Ok::<(), VMLogicError>(())
+                    })
                 })?;
             }
 

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -34,57 +34,61 @@ pub(super) fn build_runtime_env(
     context_id: [u8; DIGEST_SIZE],
     executor_id: [u8; DIGEST_SIZE],
 ) -> RuntimeEnv {
+    // Erase the borrow lifetime of the storage trait object so the callbacks
+    // can satisfy `RuntimeEnv`'s `'static` closure bound. Crucially we keep the
+    // trait-object pointer *intact* as a single fat pointer rather than
+    // splitting it into its (data, vtable) halves: that split relied on the
+    // unspecified internal layout of Rust trait-object pointers. `*mut dyn _`
+    // is `Copy`, so the fat pointer lives happily inside a `Cell`.
+    //
+    // SAFETY: the transmute only extends the lifetime of the trait object;
+    //         source and target are both `*mut dyn RuntimeStorage` fat pointers
+    //         with identical layout. The extended lifetime never actually
+    //         outlives `storage`: the pointer is only ever dereferenced while
+    //         this `RuntimeEnv` is installed via `with_runtime_env`, which
+    //         happens strictly within the host call that created it (see the
+    //         per-closure safety notes below).
     let raw_ptr: *mut dyn RuntimeStorage = storage;
-    let (data_ptr, vtable_ptr): (*mut (), *mut ()) = unsafe { mem::transmute(raw_ptr) };
-    let storage_cell = Rc::new(Cell::new((data_ptr as usize, vtable_ptr as usize)));
+    let raw_static: *mut (dyn RuntimeStorage + 'static) = unsafe { mem::transmute(raw_ptr) };
+    let storage_cell = Rc::new(Cell::new(raw_static));
 
     let reader_cell = Rc::clone(&storage_cell);
     let reader = Rc::new(move |key: &calimero_storage::store::Key| {
-        let (data_addr, vtable_addr) = reader_cell.get();
-        if data_addr == 0 {
-            return None;
-        }
-
+        let ptr = reader_cell.get();
         let key_vec = key.to_bytes().to_vec();
-        let raw = (data_addr as *mut (), vtable_addr as *mut ());
-        let ptr: *mut dyn RuntimeStorage = unsafe { mem::transmute(raw) };
+        // SAFETY: see `build_runtime_env`. While the host function is executing
+        //         the VM guarantees exclusivity over `logic.storage`, so it is
+        //         sound to dereference `ptr` here — the only place this closure
+        //         runs.
         unsafe { (&*ptr).get(&key_vec) }
     });
 
     let writer_cell = Rc::clone(&storage_cell);
     let writer = Rc::new(move |key: calimero_storage::store::Key, value: &[u8]| {
-        let (data_addr, vtable_addr) = writer_cell.get();
-        if data_addr == 0 {
-            return false;
-        }
-
+        let ptr = writer_cell.get();
         let key_vec = key.to_bytes().to_vec();
-        let raw = (data_addr as *mut (), vtable_addr as *mut ());
-        let ptr: *mut dyn RuntimeStorage = unsafe { mem::transmute(raw) };
+        // SAFETY: as above; exclusive access to `logic.storage` is guaranteed
+        //         for the duration of the host call.
         unsafe { (&mut *ptr).set(key_vec, value.to_vec()).is_some() }
     });
 
     let remover_cell = Rc::clone(&storage_cell);
     let remover = Rc::new(move |key: &calimero_storage::store::Key| {
-        let (data_addr, vtable_addr) = remover_cell.get();
-        if data_addr == 0 {
-            return false;
-        }
-
+        let ptr = remover_cell.get();
         let key_vec = key.to_bytes().to_vec();
-        let raw = (data_addr as *mut (), vtable_addr as *mut ());
-        let ptr: *mut dyn RuntimeStorage = unsafe { mem::transmute(raw) };
+        // SAFETY: as above; exclusive access to `logic.storage` is guaranteed
+        //         for the duration of the host call.
         unsafe { (&mut *ptr).remove(&key_vec).is_some() }
     });
 
     // Safety notes:
     //
-    // * The closures below capture the data and vtable pointers of `storage`
-    //   at the time `build_runtime_env` is called.  While the host function is
-    //   executing the VM guarantees exclusivity over `logic.storage`, so it is
-    //   safe to dereference those pointers inside the closures.
-    // * The pointers are stored in a `Cell` to keep the closures `Fn` (instead
-    //   of `FnMut`) which matches the storage crate’s expectations.
+    // * The closures above capture the (lifetime-erased) fat pointer to
+    //   `storage`. While the host function is executing the VM guarantees
+    //   exclusivity over `logic.storage`, so it is safe to dereference that
+    //   pointer inside the closures.
+    // * The pointer is stored in a `Cell` to keep the closures `Fn` (instead of
+    //   `FnMut`), which matches the storage crate’s expectations.
     // * When the host function returns the `RuntimeEnv` drops out of scope and
     //   the storage crate falls back to its default environment, so subsequent
     //   calls that do not install an override will continue to use the mock /
@@ -395,12 +399,28 @@ impl VMHostFunctions<'_> {
 
         let len = usize::try_from(message_len).map_err(|_| HostError::IntegerOverflow)?;
 
-        let mut bytes = vec![0u8; len];
-        if len > 0 {
-            self.borrow_memory()
-                .read(message_ptr, &mut bytes)
+        // Bound the guest-provided length against actual guest memory *before*
+        // allocating. Sizing `vec![0u8; len]` directly from an unchecked guest
+        // length lets the guest force an enormous host allocation (OOM); the
+        // read below would reject an out-of-bounds region, but only after the
+        // allocation had already happened.
+        let bytes = if len == 0 {
+            Vec::new()
+        } else {
+            let ptr = usize::try_from(message_ptr).map_err(|_| HostError::IntegerOverflow)?;
+            let memory = self.borrow_memory();
+            let memory_size = memory.data_size() as usize;
+            let end = ptr.checked_add(len).ok_or(HostError::InvalidMemoryAccess)?;
+            if end > memory_size {
+                return Err(HostError::InvalidMemoryAccess.into());
+            }
+
+            let mut buf = vec![0u8; len];
+            memory
+                .read(message_ptr, &mut buf)
                 .map_err(|_| HostError::InvalidMemoryAccess)?;
-        }
+            buf
+        };
 
         let message = String::from_utf8_lossy(&bytes).to_string();
         let max_len = {
@@ -524,16 +544,40 @@ impl VMHostFunctions<'_> {
     ///
     /// * `HostError::InvalidMemoryAccess` if memory access fails for descriptor buffers.
     pub fn value_return(&mut self, src_value_ptr: u64) -> VMLogicResult<()> {
-        // SAFETY: `sys::ValueReturn<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
-        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
-        //         it is sound; the guest SDK wrote a well-formed instance at this
-        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
-        let result =
-            unsafe { self.read_guest_memory_typed::<sys::ValueReturn<'_>>(src_value_ptr)? };
+        // `sys::ValueReturn` is a `#[repr(C, u64)]` enum: an 8-byte discriminant
+        // followed by a `Buffer` payload. The discriminant comes straight from
+        // guest memory, so reinterpreting the whole enum with `assume_init`
+        // would be undefined behaviour if the guest supplied an out-of-range
+        // tag. Read and validate the discriminant as a plain `u64` first, then
+        // read the `Buffer` payload separately — this never materializes a
+        // `ValueReturn` with an invalid discriminant.
+        let mut discriminant_bytes = [0u8; mem::size_of::<u64>()];
+        self.borrow_memory()
+            .read(src_value_ptr, &mut discriminant_bytes)?;
+        let discriminant = u64::from_le_bytes(discriminant_bytes);
 
-        let result = match result {
-            sys::ValueReturn::Ok(value) => Ok(self.read_guest_memory_slice(&value)?.to_vec()),
-            sys::ValueReturn::Err(value) => Err(self.read_guest_memory_slice(&value)?.to_vec()),
+        // The `Buffer` payload follows the 8-byte discriminant.
+        let payload_ptr = src_value_ptr
+            .checked_add(mem::size_of::<u64>() as u64)
+            .ok_or(HostError::InvalidMemoryAccess)?;
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the read is bounds-checked. See `read_guest_memory_typed`.
+        let value = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(payload_ptr)? };
+        let bytes = self.read_guest_memory_slice(&value)?.to_vec();
+
+        // Discriminant layout matches `sys::ValueReturn`: 0 = Ok, 1 = Err.
+        let result = match discriminant {
+            0 => Ok(bytes),
+            1 => Err(bytes),
+            other => {
+                warn!(
+                    target: "runtime::host::system",
+                    discriminant = other,
+                    "value_return got an out-of-range ValueReturn discriminant"
+                );
+                return Err(HostError::DeserializationError.into());
+            }
         };
 
         let result_len = match &result {


### PR DESCRIPTION
## Summary

Four targeted WASM runtime / host-function safety fixes. These are the clearly-scoped, low-risk items from a host-function safety audit; two protocol-behavior items were **intentionally deferred** (see below).

### Fixes

- **[H] UB: enum read from guest bytes via `assume_init`** (`system.rs::value_return`)
  `sys::ValueReturn` is a `#[repr(C, u64)]` enum read from raw guest memory. An out-of-range discriminant made `assume_init` undefined behaviour. Now the discriminant is read and validated as a plain `u64` (`0 = Ok`, `1 = Err`) *first*, then the `Buffer` payload is read separately — a `ValueReturn` with an invalid tag is never materialized. Out-of-range tags return `DeserializationError`.

- **[M] Guest-controlled length alloc before bounds check** (`system.rs::js_std_d_print`)
  `vec![0u8; len]` was sized from an unchecked guest length (OOM), with the bounds check only happening on the subsequent read. The length is now bounds-checked against actual guest memory (`ptr + len ≤ data_size`) before allocating.

- **[M] Unsafe fat-pointer transmute of trait object** (`system.rs::build_runtime_env`)
  Stopped decomposing `*mut dyn RuntimeStorage` into its `(data, vtable)` halves via `transmute`, which relied on the unspecified internal layout of trait-object pointers. The fat pointer is now kept intact; only its lifetime is erased to satisfy `RuntimeEnv`'s `'static` closure bound. No storage-crate change.

- **[M] `block_on` inside sync host call panics** (`blobs.rs`)
  Wrapped the remaining bare `Handle::current().block_on(...)` calls (blob close, announce `get_blob_info`, read `get_blob`, read stream loop) in `tokio::task::block_in_place`, matching the existing correct call site. A direct `block_on` panics on a runtime worker thread.

### Deferred (by design decision)

- Guest-callable `apply_storage_delta` writer verification (`ApplyContext::empty()`) — needs a protocol-level decision (gate the import vs. peer-delta verification).
- `time_now` / `random_bytes` determinism — making them deterministic changes guest-observable semantics; to be designed separately.

## Testing

- `cargo build -p calimero-runtime` — clean
- `cargo test -p calimero-runtime` — 105 lib + 21 CRDT + 2 tracing tests pass, 0 failures
- `cargo clippy -p calimero-runtime --all-targets` — clean
- `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)