### PR TITLE
fix(concurrency): task-leak, panic, and unbounded-map hardening

### DIFF
--- a/crates/node/src/dag_compactor.rs
+++ b/crates/node/src/dag_compactor.rs
@@ -75,8 +75,13 @@ impl DagCompactor {
         let config = self.config;
         let in_progress = self.sweep_in_progress.clone();
         actix::spawn(async move {
+            // Clear the in-progress flag on the way out via RAII, so a panic
+            // inside `compact_all` (e.g. a bug in DAG pruning) still releases the
+            // guard. A plain post-await `store(false)` would be skipped on unwind,
+            // leaving `sweep_in_progress` stuck `true` and silently disabling all
+            // future compaction sweeps for the process lifetime.
+            let _guard = SweepGuard(in_progress);
             DagCompactor::compact_all(delta_stores, config).await;
-            in_progress.store(false, Ordering::Release);
         });
     }
 
@@ -118,6 +123,17 @@ impl DagCompactor {
         }
 
         total_pruned
+    }
+}
+
+/// RAII guard that clears [`DagCompactor::sweep_in_progress`] when the sweep
+/// task finishes — whether it returns normally or unwinds on panic — so a
+/// failed sweep can never permanently wedge the compactor.
+struct SweepGuard(Arc<AtomicBool>);
+
+impl Drop for SweepGuard {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
     }
 }
 

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -891,35 +891,108 @@ impl Handler<ApplyBeaconLocal> for ReadinessManager {
 /// going through the actor mailbox.
 #[derive(Debug, Default)]
 pub struct ReadinessCacheNotify {
-    waiters: Mutex<HashMap<[u8; 32], Arc<tokio::sync::Notify>>>,
+    waiters: Mutex<HashMap<[u8; 32], WaiterSlot>>,
+}
+
+/// One namespace's wake handle plus a count of the in-flight
+/// [`ReadinessCache::await_first_fresh_beacon`] calls holding it. The slot is
+/// removed once the count reaches zero, so the map stays bounded by the number
+/// of namespaces with a waiter *right now* rather than every namespace the node
+/// has ever waited on.
+#[derive(Debug)]
+struct WaiterSlot {
+    notify: Arc<tokio::sync::Notify>,
+    refs: usize,
+}
+
+/// RAII handle for an active waiter registration. Holds the namespace's
+/// `Notify` for use across `.await` points, and drops the namespace's refcount
+/// (evicting the slot at zero) when the awaiting call finishes or is cancelled.
+///
+/// Private and only constructed by [`ReadinessCacheNotify::acquire_waiter`],
+/// which releases the `waiters` mutex before handing the guard back. `drop`
+/// re-acquires that same non-reentrant `ReadinessCacheNotify::waiters` mutex,
+/// so a guard must never be dropped while the caller already holds it — none of
+/// the internal call sites do (the guard is only ever held as a local across
+/// `.await`s).
+struct WaiterGuard<'a> {
+    registry: &'a ReadinessCacheNotify,
+    ns: [u8; 32],
+    notify: Arc<tokio::sync::Notify>,
+}
+
+impl WaiterGuard<'_> {
+    /// The namespace's shared `Notify`, for creating per-iteration `Notified`
+    /// futures. Named `notifier` (not `notify`) to avoid colliding with
+    /// [`ReadinessCacheNotify::notify`], which *fires* a wake rather than
+    /// returning the primitive.
+    fn notifier(&self) -> &tokio::sync::Notify {
+        &self.notify
+    }
+}
+
+impl Drop for WaiterGuard<'_> {
+    fn drop(&mut self) {
+        let mut g = self.registry.waiters_lock();
+        // A live guard's slot must still be present with refs >= 1: guards are
+        // minted by `acquire_waiter` (refs += 1), aren't Clone, and only the
+        // last guard's drop removes the slot. Assert both invariants in
+        // debug/test builds rather than papering over an accounting bug (a
+        // silent no-op on a missing slot, or a saturating decrement on zero).
+        // Both `debug_assert!`s compile out entirely in release.
+        debug_assert!(
+            g.contains_key(&self.ns),
+            "WaiterGuard dropped but its namespace slot was already gone"
+        );
+        if let std::collections::hash_map::Entry::Occupied(mut e) = g.entry(self.ns) {
+            let slot = e.get_mut();
+            debug_assert!(
+                slot.refs > 0,
+                "WaiterGuard dropped more times than acquired"
+            );
+            slot.refs -= 1;
+            if slot.refs == 0 {
+                let _ = e.remove();
+            }
+        }
+    }
 }
 
 impl ReadinessCacheNotify {
     /// Acquire the waiters map, recovering from a poisoned mutex.
     /// See [`ReadinessCache::entries_lock`] for rationale (mirrors
     /// `AckRouter::lock` from PR #2264).
-    fn waiters_lock(
-        &self,
-    ) -> std::sync::MutexGuard<'_, HashMap<[u8; 32], Arc<tokio::sync::Notify>>> {
+    fn waiters_lock(&self) -> std::sync::MutexGuard<'_, HashMap<[u8; 32], WaiterSlot>> {
         self.waiters
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
-    /// Get-or-create the per-namespace `Notify`. Cloned so the caller
-    /// holds it across `.await` points without keeping the registry
-    /// lock.
-    pub fn waiter_for(&self, ns: [u8; 32]) -> Arc<tokio::sync::Notify> {
+    /// Register a waiter for `ns`, returning a guard that keeps the namespace's
+    /// `Notify` alive in the map for as long as the guard is held. Because the
+    /// slot exists for the entire lifetime of the guard, any [`Self::notify`]
+    /// fired during that window reaches this waiter; the slot is evicted only
+    /// once no waiters remain.
+    fn acquire_waiter(&self, ns: [u8; 32]) -> WaiterGuard<'_> {
         let mut g = self.waiters_lock();
-        g.entry(ns)
-            .or_insert_with(|| Arc::new(tokio::sync::Notify::new()))
-            .clone()
+        let slot = g.entry(ns).or_insert_with(|| WaiterSlot {
+            notify: Arc::new(tokio::sync::Notify::new()),
+            refs: 0,
+        });
+        slot.refs += 1;
+        let notify = Arc::clone(&slot.notify);
+        drop(g);
+        WaiterGuard {
+            registry: self,
+            ns,
+            notify,
+        }
     }
 
     pub fn notify(&self, ns: [u8; 32]) {
         let g = self.waiters_lock();
-        if let Some(n) = g.get(&ns) {
-            n.notify_waiters();
+        if let Some(slot) = g.get(&ns) {
+            slot.notify.notify_waiters();
         }
     }
 }
@@ -948,12 +1021,16 @@ impl ReadinessCache {
         ttl: Duration,
         deadline: Duration,
     ) -> Option<(PublicKey, CacheEntry)> {
-        let waiter = notify.waiter_for(ns);
+        // Held for the whole call, so the namespace's slot stays in the waiters
+        // map until we return and any `notify()` in between reaches us. Dropping
+        // it (return or cancellation) releases the refcount and evicts the slot
+        // when we were the last waiter, keeping the map bounded.
+        let waiter = notify.acquire_waiter(ns);
         let timeout_fut = tokio::time::sleep(deadline);
         tokio::pin!(timeout_fut);
         loop {
             // 1. Create + pin a fresh Notified for this iteration.
-            let notified = waiter.notified();
+            let notified = waiter.notifier().notified();
             tokio::pin!(notified);
             // 2. Register without polling. From here on, any
             //    `notify_waiters()` is guaranteed to wake us, even if

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -3641,12 +3641,38 @@ impl SyncManager {
     fn should_attempt_stage(&self, context_id: ContextId, blob: [u8; 32]) -> bool {
         const RETRY_AFTER: std::time::Duration = std::time::Duration::from_secs(300);
         const MAX_ATTEMPTS: u32 = 12; // ~1h of retries, then give up
+
+        // Cap on tracked (context, blob) pairs. Entries parked at MAX_ATTEMPTS
+        // are never cleared by `clear_stage_attempt` (only successes clear), so
+        // without a bound a node that meets many never-resolving pairs would
+        // grow this memo for its whole lifetime. The memo is a best-effort
+        // backoff, not a correctness invariant: an evicted pair simply restarts
+        // its backoff, costing at most a few extra doomed BlobShares.
+        const MAX_TRACKED: usize = 4096;
+
         let mut memo = self
             .stale_blob_attempts
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let now = Instant::now();
-        let entry = memo.entry((context_id, blob)).or_insert((None, 0));
+        let key = (context_id, blob);
+        if !memo.contains_key(&key) && memo.len() >= MAX_TRACKED {
+            // Evict the least-recently-attempted entry (a never-attempted `None`
+            // sorts first, then the oldest timestamp) to make room. This is an
+            // O(MAX_TRACKED) scan, but it runs only on a cap-boundary miss (a
+            // new key while already at 4096 entries), not on the common
+            // already-tracked path, so the amortised cost stays negligible. If
+            // this map ever grows much larger or the miss rate climbs, switch to
+            // an O(1)-eviction structure (e.g. an LRU cache).
+            if let Some(oldest) = memo
+                .iter()
+                .min_by_key(|(_, (last, _))| *last)
+                .map(|(k, _)| *k)
+            {
+                let _ = memo.remove(&oldest);
+            }
+        }
+        let entry = memo.entry(key).or_insert((None, 0));
         if entry.1 >= MAX_ATTEMPTS {
             return false;
         }

--- a/crates/server/src/sse/handlers.rs
+++ b/crates/server/src/sse/handlers.rs
@@ -51,7 +51,7 @@ use serde_json::to_string as to_json_string;
 use std::collections::hash_map::Entry;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, info, warn};
 
@@ -180,30 +180,37 @@ pub async fn handle_subscription(
                 session_id, ctxs
             );
 
-            let sessions = state.sessions.read().await;
+            // Clone the session handle out of the map and release the map lock
+            // immediately — the map read-lock must not span the store write below.
+            let session = state.sessions.read().await.get(&session_id).cloned();
 
-            if let Some(session) = sessions.get(&session_id) {
-                let mut inner = session.inner.write().await;
-                if !owner_allows_access(&inner.owner, &caller) {
-                    drop(inner);
-                    drop(sessions);
-                    warn!(%session_id, "SSE subscribe denied: caller is not the session owner");
-                    return forbidden();
-                }
-                for ctx in &ctxs.context_ids {
-                    let _ = inner.subscriptions.insert(*ctx);
-                }
-                inner.touch();
+            if let Some(session) = session {
+                // Serialize persistence for this session so concurrent
+                // subscribe/unsubscribe commit to the store in mutation order.
+                // The data lock (`inner`) is taken only to mutate + snapshot
+                // (no I/O) and released before the blocking `save_session`, so a
+                // slow store write can't stall event delivery, which reads
+                // `inner`. Lock order is persist-guard → `inner`.
+                let _persist = session.persist_guard().await;
 
-                // Persist to store
-                let persisted = inner.to_persisted();
-                drop(inner);
-                drop(sessions);
+                let persisted = {
+                    let mut inner = session.inner.write().await;
+                    if !owner_allows_access(&inner.owner, &caller) {
+                        warn!(%session_id, "SSE subscribe denied: caller is not the session owner");
+                        return forbidden();
+                    }
+                    for ctx in &ctxs.context_ids {
+                        let _ = inner.subscriptions.insert(*ctx);
+                    }
+                    inner.touch();
+                    inner.to_persisted()
+                };
 
                 let mut store = state.store.clone();
                 if let Err(err) = save_session(&mut store, session_id, &persisted) {
                     error!(%session_id, %err, "Failed to persist session subscriptions");
                 }
+                drop(_persist);
 
                 (
                     StatusCode::OK,
@@ -231,36 +238,36 @@ pub async fn handle_subscription(
                 session_id, ctxs
             );
 
-            let sessions = state.sessions.read().await;
-            if let Some(session) = sessions.get(&session_id) {
-                let mut inner = session.inner.write().await;
-                if !owner_allows_access(&inner.owner, &caller) {
-                    drop(inner);
-                    drop(sessions);
-                    warn!(%session_id, "SSE unsubscribe denied: caller is not the session owner");
-                    return forbidden();
-                }
+            let session = state.sessions.read().await.get(&session_id).cloned();
+            if let Some(session) = session {
+                // See the subscribe path: serialize persistence per session and
+                // keep the store write off the data lock.
+                let _persist = session.persist_guard().await;
+
                 let mut unsubscribed = Vec::new();
-
-                // Remove contexts that were actually subscribed
-                // This is an idempotent operation - attempting to unsubscribe from
-                // a context that wasn't subscribed is not an error
-                for ctx in &ctxs.context_ids {
-                    if inner.subscriptions.remove(ctx) {
-                        unsubscribed.push(*ctx);
+                let persisted = {
+                    let mut inner = session.inner.write().await;
+                    if !owner_allows_access(&inner.owner, &caller) {
+                        warn!(%session_id, "SSE unsubscribe denied: caller is not the session owner");
+                        return forbidden();
                     }
-                }
-                inner.touch();
 
-                // Persist to store
-                let persisted = inner.to_persisted();
-                drop(inner);
-                drop(sessions);
+                    // Remove contexts that were actually subscribed. Idempotent:
+                    // unsubscribing from a context that wasn't subscribed is fine.
+                    for ctx in &ctxs.context_ids {
+                        if inner.subscriptions.remove(ctx) {
+                            unsubscribed.push(*ctx);
+                        }
+                    }
+                    inner.touch();
+                    inner.to_persisted()
+                };
 
                 let mut store = state.store.clone();
                 if let Err(err) = save_session(&mut store, session_id, &persisted) {
                     error!(%session_id, %err, "Failed to persist session after unsubscribe");
                 }
+                drop(_persist);
 
                 // Idempotent operation - always return OK with info about what was unsubscribed
                 // Response includes:
@@ -386,11 +393,8 @@ pub async fn sse_handler(
                     } else {
                         info!(%existing_session_id, "Client reconnecting to persisted session");
                         // Restore session from storage
-                        let session_state = SessionState {
-                            inner: Arc::new(RwLock::new(SessionStateInner::from_persisted(
-                                persisted_data,
-                            ))),
-                        };
+                        let session_state =
+                            SessionState::new(SessionStateInner::from_persisted(persisted_data));
                         // Add to in-memory cache
                         drop(
                             state
@@ -508,12 +512,17 @@ pub async fn sse_handler(
     // makes `command_sender.closed()` resolve and the handler exit. (axum streams
     // the SSE body lazily via `Sse::new`, so the receiver is not held alive by the
     // handler future itself.)
-    drop(tokio::spawn(handle_node_events(
+    // Bind the task to the session, aborting any task a previous connection
+    // left running for the same session. Two live tasks would share this
+    // session's `event_counter` and each bump it per broadcast event, corrupting
+    // event IDs and double-delivering events.
+    let event_task = tokio::spawn(handle_node_events(
         session_id,
         Arc::clone(&state),
         session_state.clone(),
         commands_sender,
-    )));
+    ));
+    session_state.bind_event_task(event_task.abort_handle());
 
     // Build response with session ID in header for easy client access
     let sse_response = Sse::new(stream).keep_alive(KeepAlive::default());
@@ -674,9 +683,7 @@ async fn create_new_session(
         match sessions.entry(session_id) {
             Entry::Occupied(_) => continue,
             Entry::Vacant(entry) => {
-                let session_state = SessionState {
-                    inner: Arc::new(RwLock::new(SessionStateInner::with_owner(owner.clone()))),
-                };
+                let session_state = SessionState::new(SessionStateInner::with_owner(owner.clone()));
                 let _ = entry.insert(session_state.clone());
 
                 // Persist new session to store

--- a/crates/server/src/sse/session.rs
+++ b/crates/server/src/sse/session.rs
@@ -49,7 +49,12 @@ impl Default for SessionStateInner {
     fn default() -> Self {
         Self {
             subscriptions: HashSet::new(),
-            event_counter: AtomicU64::new(0),
+            // Event IDs start at 1. The connection's initial "connect" event is
+            // emitted with the reserved id `{session_id}-0`, so the first real
+            // event must not also be `-0` (`fetch_add` returns the pre-increment
+            // value). Starting at 1 keeps every real event id distinct from the
+            // connect frame.
+            event_counter: AtomicU64::new(1),
             last_activity: AtomicU64::new(now_secs()),
             owner: None,
         }
@@ -105,6 +110,87 @@ impl SessionStateInner {
 #[derive(Clone, Debug)]
 pub struct SessionState {
     pub inner: Arc<RwLock<SessionStateInner>>,
+    /// Abort handle for the node-event task currently bound to this session.
+    ///
+    /// A session outlives the individual SSE connections that use it (it
+    /// persists across reconnects). Each connection spawns its own node-event
+    /// task that forwards matching broadcast events into that connection's
+    /// command channel, and the connection's response stream stamps each
+    /// forwarded event with the next value of the shared `event_counter`. When a
+    /// new connection (re)binds to this session, the task from the previous
+    /// connection must be aborted: otherwise two live connections drain the
+    /// broadcast stream in parallel and their response streams both bump the one
+    /// shared `event_counter`, corrupting event IDs and delivering each event
+    /// more than once.
+    ///
+    /// Aborting the prior task cannot bump-without-deliver: the counter is
+    /// incremented in the response stream as an event is emitted, not by the
+    /// task being aborted (which only forwards commands), so a killed task drops
+    /// only events it had not yet forwarded — no phantom gap beyond the
+    /// skip-on-disconnect gaps the session already tolerates. `None` until the
+    /// first task is bound.
+    ///
+    /// Private on purpose: the abort-before-replace invariant only holds if
+    /// every mutation goes through [`SessionState::bind_event_task`], so callers
+    /// must not touch the handle directly.
+    ///
+    /// Dropping a `SessionState` does not abort the task. `SessionState` is
+    /// `Clone` (several clones coexist — in the session map, in the request
+    /// handler, and inside the task itself), so a `Drop` impl here would abort
+    /// on every transient clone drop, not on eviction. Eviction-time
+    /// cancellation is instead deferred to the task noticing its connection's
+    /// command channel has closed; this handle exists only to cancel a
+    /// superseded task when a new connection rebinds the same session.
+    event_task: Arc<std::sync::Mutex<Option<tokio::task::AbortHandle>>>,
+    /// Serializes persistence of this session's state (the subscribe/unsubscribe
+    /// store writes) so concurrent mutations of the *same* session commit to the
+    /// store in the order they mutated the in-memory state.
+    ///
+    /// Held (via [`SessionState::persist_guard`]) across the blocking
+    /// `save_session` call, but deliberately kept separate from `inner`: event
+    /// delivery only reads `inner`, so a slow store write serializes persists
+    /// without stalling the broadcast fan-out. Lock order is always
+    /// persist-guard → `inner`; nothing acquires them the other way.
+    persist_lock: Arc<tokio::sync::Mutex<()>>,
+}
+
+impl SessionState {
+    /// Wrap freshly-built session state, with no node-event task bound yet.
+    #[must_use]
+    pub fn new(inner: SessionStateInner) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(inner)),
+            event_task: Arc::new(std::sync::Mutex::new(None)),
+            persist_lock: Arc::new(tokio::sync::Mutex::new(())),
+        }
+    }
+
+    /// Acquire this session's persistence guard. Hold it across a `save_session`
+    /// call so concurrent subscribe/unsubscribe requests persist in mutation
+    /// order. Snapshot `inner` (a brief write-lock, no I/O) and drop that lock
+    /// before the store write, so event delivery — which reads `inner` — is
+    /// never blocked on the store.
+    pub async fn persist_guard(&self) -> tokio::sync::MutexGuard<'_, ()> {
+        self.persist_lock.lock().await
+    }
+
+    /// Bind a newly-spawned node-event task to this session, aborting any task
+    /// bound by a previous connection. Aborting an already-finished task is a
+    /// no-op, so a normally-closed prior connection costs nothing here.
+    pub fn bind_event_task(&self, handle: tokio::task::AbortHandle) {
+        // Swap the handle under the lock, then release the lock before calling
+        // `abort()` — never hold this std::sync::Mutex across external code.
+        let prev = {
+            let mut slot = self
+                .event_task
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            slot.replace(handle)
+        };
+        if let Some(prev) = prev {
+            prev.abort();
+        }
+    }
 }
 
 /// Get current timestamp in seconds since UNIX epoch

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -28,7 +28,7 @@ use serde_json::{
     to_value as to_json_value, Value,
 };
 use tokio::spawn;
-use tokio::sync::{mpsc, RwLock, Semaphore};
+use tokio::sync::{mpsc, oneshot, RwLock, Semaphore};
 use tokio::time::interval;
 use tracing::{debug, error, field, info, info_span, warn, Instrument};
 use uuid::Uuid;
@@ -274,10 +274,20 @@ async fn handle_socket(
 
     debug!(%connection_id, "Client connection established");
 
+    // Cancellation signal for the node-event task. The sender lives on this
+    // stack frame; when the read loop below ends and `handle_socket` returns,
+    // dropping it resolves the receiver and stops the task. Without it, on a
+    // quiet node the task would park in `events.next()` indefinitely, holding a
+    // broadcast-receiver subscription and a `command_sender` clone long after
+    // the client disconnected — a per-disconnect leak that also delays shutdown.
+    let (events_shutdown_tx, events_shutdown_rx) = oneshot::channel::<()>();
+
     drop(spawn(handle_node_events(
         connection_id,
         Arc::clone(&state),
+        connection_state.clone(),
         commands_sender.clone(),
+        events_shutdown_rx,
     )));
 
     let (socket_sender, mut socket_receiver) = socket.split();
@@ -360,6 +370,11 @@ async fn handle_socket(
 
     debug!(%connection_id, "Client connection terminated");
 
+    // Stop the node-event task now rather than at the end of scope, so it
+    // releases its broadcast subscription promptly even if the client went quiet
+    // long before disconnecting.
+    drop(events_shutdown_tx);
+
     let mut state = state.connections.write().await;
     drop(state.remove(&connection_id));
 }
@@ -367,17 +382,34 @@ async fn handle_socket(
 async fn handle_node_events(
     connection_id: ConnectionId,
     state: Arc<ServiceState>,
+    connection_state: ConnectionState,
     command_sender: mpsc::Sender<Command>,
+    mut shutdown: oneshot::Receiver<()>,
 ) {
     let events = state.node_client.receive_events();
 
     let mut events = pin!(events);
 
-    while let Some(event) = events.next().await {
-        let Some(connection_state) = state.connections.read().await.get(&connection_id).cloned()
-        else {
-            error!(%connection_id, "Unexpected state, client_id not found in client state map");
-            return;
+    loop {
+        let event = tokio::select! {
+            // Poll cancellation first so a disconnected connection stops this
+            // task promptly even under a steady event stream.
+            biased;
+            // Resolves as soon as `handle_socket` drops the shutdown sender at
+            // connection teardown (whether the client sent frames recently or
+            // not). This is what lets a quiet-node connection stop parking in
+            // `events.next()` and release its broadcast subscription.
+            _ = &mut shutdown => {
+                debug!(%connection_id, "WS connection closed, stopping event handler");
+                break;
+            }
+            maybe_event = events.next() => match maybe_event {
+                Some(event) => event,
+                None => {
+                    debug!(%connection_id, "Node event stream ended, stopping event handler");
+                    break;
+                }
+            },
         };
 
         debug!(
@@ -416,11 +448,15 @@ async fn handle_node_events(
         let response = Response { id: None, body };
 
         if let Err(err) = command_sender.send(Command::Send(response)).await {
-            error!(
+            // The command receiver is gone (connection tearing down), so stop
+            // instead of logging an error for every subsequent event until the
+            // shutdown signal arrives.
+            debug!(
                 %connection_id,
                 %err,
-                "Failed to send WsCommand::Send",
+                "Failed to send WsCommand::Send (connection closed), stopping event handler",
             );
+            break;
         };
     }
 }

--- a/crates/store/src/db/memory/raw.rs
+++ b/crates/store/src/db/memory/raw.rs
@@ -169,11 +169,20 @@ impl<K: Ord, V> Drop for InMemoryIterInner<'_, K, V> {
             return;
         };
 
+        // Hold the arena write lock across the whole drain so each
+        // `strong_count == 1` check and its matching `remove` are one atomic
+        // step against other arena mutations. The previous per-entry
+        // lock/unlock left a window where a concurrent operation could observe
+        // or resurrect an index between the count check and the removal.
+        let Ok(mut arena) = self.arena.write() else {
+            return;
+        };
         while let Some((_, idx)) = column.pop_first() {
+            // This iterator's clone is the sole remaining holder of the index —
+            // the live column already dropped its copy — so the arena slot is
+            // now unreachable and safe to reclaim.
             if Arc::strong_count(&idx) == 1 {
-                if let Ok(mut value) = self.arena.write() {
-                    drop(value.remove(*idx));
-                }
+                drop(arena.remove(*idx));
             }
         }
     }


### PR DESCRIPTION
## Summary

A batch of concurrency-hardening fixes across the server, node, and store crates — event-task leaks/duplication, a panic that permanently wedges a background sweep, unordered persistence, and a few unbounded maps.

Note: the SSE code was reworked since these were first reported, so the old *connection-registry insert/cleanup race* is already gone (the `active_connections` registry no longer exists). Its symptom — a reconnecting client getting nothing / duplicated events — is covered by the abort-handle fix below.

## Fixes

**High**
- **SSE duplicate event task** — a session outlives individual connections, and each connection spawned a node-event task that increments the session's shared `event_counter`. Two live tasks (e.g. a reconnect while the old connection lingers) both drained the broadcast and bumped the counter, corrupting event IDs and double-delivering. Now `SessionState` carries a per-session `AbortHandle`; binding a new task aborts the prior one.

**Medium**
- **SSE persist TOCTOU** — subscribe/unsubscribe now call `save_session` while holding the per-session write guard, so concurrent requests commit to the store in the order they mutated in-memory state.
- **WS lingering event task** — `handle_node_events` now `select!`s the event stream against a `oneshot` cancellation dropped at connection teardown. On a quiet node it previously parked in `events.next()` indefinitely, leaking the broadcast-receiver subscription and a `command_sender` clone per disconnect.
- **dag_compactor stuck flag** — `sweep_in_progress` is now cleared by an RAII guard, so a panic inside a sweep can't leave it stuck `true` and silently disable all future compaction.
- **readiness waiters map** — per-namespace waiter slots are ref-counted and evicted at zero, bounding the map to namespaces waiting *now* rather than every namespace ever waited on. Late-arrival race semantics preserved.
- **sync stale-blob memo** — capped at 4096 entries, evicting the least-recently-attempted pair on insert; parked (never-cleared) pairs can no longer grow it unbounded. The memo is best-effort backoff, so an evicted pair simply restarts.
- **store in-memory GC** — `InMemoryIterInner::drop` now holds the arena write lock across the whole drain, making each `strong_count` check and its removal atomic.

**Minor**
- **SSE `…-0` id collision** — event counter starts at 1 so the first real event no longer collides with the reserved `{session}-0` connect frame.

## Testing

- `cargo check` / `cargo clippy` clean on `calimero-server`, `calimero-node`, `calimero-store`
- Test suites pass, including the readiness late-arrival race test (`await_first_fresh_beacon_resolves_on_late_arrival`) and the WS lifecycle/event tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)