### PR TITLE
ci: supply-chain & image hardening (action pins, image digests, checksums, secret handling)

### DIFF
--- a/.github/actions/container-release-profiling/action.yml
+++ b/.github/actions/container-release-profiling/action.yml
@@ -67,13 +67,13 @@ runs:
         done
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -102,7 +102,7 @@ runs:
 
     - name: Extract metadata
       id: metadata
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
       env:
         LABELS: |
           org.opencontainers.image.description=Calimero Node with Profiling Tools
@@ -141,7 +141,7 @@ runs:
         fi
 
     - name: Build and push image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         context: .
         file: ${{ inputs.dockerfile }}

--- a/.github/actions/container-release/action.yml
+++ b/.github/actions/container-release/action.yml
@@ -75,13 +75,13 @@ runs:
         done
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -110,7 +110,7 @@ runs:
 
     - name: Extract metadata
       id: metadata
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
       env:
         LABELS: |
           org.opencontainers.image.description=Calimero Node
@@ -150,7 +150,7 @@ runs:
         fi
 
     - name: Build and push image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         context: .
         file: ${{ inputs.dockerfile }}

--- a/.github/actions/contributions/action.yml
+++ b/.github/actions/contributions/action.yml
@@ -23,7 +23,7 @@ runs:
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Apply Needs Attention Label
-      uses: hramos/needs-attention@v2.0.0
+      uses: hramos/needs-attention@d0eaa7f961c04d4da86466b1176b56e0d4089022 # v2.0.0
       with:
         repo-token: ${{ inputs.repo-token }}
         response-required-label: ${{ inputs.response-required-label }}

--- a/.github/actions/setup-rust-ci/action.yml
+++ b/.github/actions/setup-rust-ci/action.yml
@@ -43,14 +43,14 @@ runs:
         sudo apt-get install -y --no-install-recommends libclang-dev
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       with:
         toolchain: ${{ inputs.toolchain }}
         components: ${{ inputs.components }}
         targets: ${{ inputs.targets }}
 
     - name: Setup Rust cache
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         prefix-key: v0-rust
         shared-key: ${{ inputs.shared-key }}

--- a/.github/actions/style/action.yml
+++ b/.github/actions/style/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v45
+      uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45
 
     # Check for Markdown/MDX changes
     - name: Check for Markdown/MDX changes

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,12 @@ updates:
     groups:
       npm:
         patterns: ["*"]
+
+  # Dockerfile base images — keeps the @sha256 digest pins current.
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      docker:
+        patterns: ["*"]

--- a/.github/workflows/fuzzy-load-test.yml
+++ b/.github/workflows/fuzzy-load-test.yml
@@ -246,6 +246,8 @@ jobs:
 
       - name: Setup vmagent for metrics collection
         id: setup-vmagent
+        env:
+          VICTORIA_METRICS_BEARER_TOKEN: ${{ secrets.VICTORIA_LB_METRICS_BEARER_TOKEN }}
         run: |
           chmod +x scripts/setup-vmagent.sh
           COMMIT_HASH="${{ github.sha }}"
@@ -254,7 +256,6 @@ jobs:
             "kv-store" \
             "kv-store-${SHORT_COMMIT}" \
             "${{ github.run_id }}" \
-            "${{ secrets.VICTORIA_LB_METRICS_BEARER_TOKEN }}" \
             "8429" \
             "$COMMIT_HASH" \
             "${{ github.ref_name }}"
@@ -468,6 +469,8 @@ jobs:
 
       - name: Setup vmagent for metrics collection
         id: setup-vmagent-handlers
+        env:
+          VICTORIA_METRICS_BEARER_TOKEN: ${{ secrets.VICTORIA_LB_METRICS_BEARER_TOKEN }}
         run: |
           chmod +x scripts/setup-vmagent.sh
           COMMIT_HASH="${{ github.sha }}"
@@ -476,7 +479,6 @@ jobs:
             "kv-store-with-handlers" \
             "kv-store-with-handlers-${SHORT_COMMIT}" \
             "${{ github.run_id }}" \
-            "${{ secrets.VICTORIA_LB_METRICS_BEARER_TOKEN }}" \
             "8430" \
             "$COMMIT_HASH" \
             "${{ github.ref_name }}"
@@ -680,6 +682,8 @@ jobs:
 
       - name: Setup vmagent for metrics collection
         id: setup-vmagent-e2e
+        env:
+          VICTORIA_METRICS_BEARER_TOKEN: ${{ secrets.VICTORIA_LB_METRICS_BEARER_TOKEN }}
         run: |
           chmod +x scripts/setup-vmagent.sh
           COMMIT_HASH="${{ github.sha }}"
@@ -688,7 +692,6 @@ jobs:
             "scaffolding-e2e" \
             "scaffolding-e2e-${SHORT_COMMIT}" \
             "${{ github.run_id }}" \
-            "${{ secrets.VICTORIA_LB_METRICS_BEARER_TOKEN }}" \
             "8431" \
             "$COMMIT_HASH" \
             "${{ github.ref_name }}"
@@ -890,6 +893,8 @@ jobs:
 
       - name: Setup vmagent for metrics collection
         id: setup-vmagent-gov
+        env:
+          VICTORIA_METRICS_BEARER_TOKEN: ${{ secrets.VICTORIA_LB_METRICS_BEARER_TOKEN }}
         run: |
           chmod +x scripts/setup-vmagent.sh
           COMMIT_HASH="${{ github.sha }}"
@@ -898,7 +903,6 @@ jobs:
             "group-governance" \
             "group-governance-${SHORT_COMMIT}" \
             "${{ github.run_id }}" \
-            "${{ secrets.VICTORIA_LB_METRICS_BEARER_TOKEN }}" \
             "8432" \
             "$COMMIT_HASH" \
             "${{ github.ref_name }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ ARG RUST_VERSION=1.88.0
 # ^~~ keep this in sync with rust-toolchain.toml
 
 ################################################################################
-FROM rust:${RUST_VERSION}-slim-bookworm AS build
+# Digest pins the exact base image for reproducible builds. When bumping
+# RUST_VERSION, refresh this digest too (docker buildx imagetools inspect
+# rust:<version>-slim-bookworm) — the digest, not the tag, selects the image.
+FROM rust:${RUST_VERSION}-slim-bookworm@sha256:38bc5a86d998772d4aec2348656ed21438d20fcdce2795b56ca434cf21430d89 AS build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     clang \
@@ -42,7 +45,9 @@ RUN --mount=type=cache,target=/app/target/ \
     cp /app/target/release/merod /app/target/release/meroctl /usr/local/bin/
 
 ################################################################################
-FROM debian:bookworm-slim AS runtime
+# Digest-pinned runtime base; refresh with `docker buildx imagetools inspect
+# debian:bookworm-slim` when updating.
+FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df AS runtime
 
 LABEL org.opencontainers.image.description="Calimero Node" \
     org.opencontainers.image.licenses="MIT OR Apache-2.0" \

--- a/Dockerfile.auth
+++ b/Dockerfile.auth
@@ -73,9 +73,11 @@ RUN adduser \
     --uid "${UID}" \
     user
 
-# Copy to a fixed name so the entrypoint can use exec form (which does not do
-# variable expansion) — exec form makes the binary PID 1 and receive signals
-# directly, so SIGTERM/SIGINT propagate for a clean shutdown.
+# APP_NAME selects which crate binary the build stage produced; we always install
+# it under the fixed name mero-auth (regardless of APP_NAME) so the entrypoint can
+# use exec form, which does not do variable expansion. Exec form makes the binary
+# PID 1 and receive signals directly, so SIGTERM/SIGINT propagate for a clean
+# shutdown.
 COPY --from=build \
     /usr/local/bin/${APP_NAME} \
     /usr/local/bin/mero-auth

--- a/Dockerfile.auth
+++ b/Dockerfile.auth
@@ -6,7 +6,10 @@ ARG RUST_VERSION=1.88.0
 ARG APP_NAME=mero-auth
 
 ################################################################################
-FROM rust:${RUST_VERSION}-slim-bookworm AS build
+# Digest pins the exact base image for reproducible builds. When bumping
+# RUST_VERSION, refresh this digest too (docker buildx imagetools inspect
+# rust:<version>-slim-bookworm) — the digest, not the tag, selects the image.
+FROM rust:${RUST_VERSION}-slim-bookworm@sha256:38bc5a86d998772d4aec2348656ed21438d20fcdce2795b56ca434cf21430d89 AS build
 ARG APP_NAME
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -45,7 +48,9 @@ RUN --mount=type=cache,target=/app/target \
     cp target/release/${APP_NAME} /usr/local/bin/
 
 ################################################################################
-FROM debian:bookworm-slim AS runtime
+# Digest-pinned runtime base; refresh with `docker buildx imagetools inspect
+# debian:bookworm-slim` when updating.
+FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df AS runtime
 ARG APP_NAME
 
 LABEL org.opencontainers.image.description="Calimero Authentication Service" \
@@ -68,9 +73,12 @@ RUN adduser \
     --uid "${UID}" \
     user
 
+# Copy to a fixed name so the entrypoint can use exec form (which does not do
+# variable expansion) — exec form makes the binary PID 1 and receive signals
+# directly, so SIGTERM/SIGINT propagate for a clean shutdown.
 COPY --from=build \
     /usr/local/bin/${APP_NAME} \
-    /usr/local/bin/
+    /usr/local/bin/mero-auth
 COPY crates/auth/config/config.toml /etc/calimero/auth.toml
 
 USER user
@@ -79,5 +87,4 @@ WORKDIR /data
 VOLUME /data
 EXPOSE 3001
 
-ENV APP_NAME=${APP_NAME}
-ENTRYPOINT ${APP_NAME} --config /etc/calimero/auth.toml --verbose
+ENTRYPOINT ["/usr/local/bin/mero-auth", "--config", "/etc/calimero/auth.toml", "--verbose"]

--- a/crates/auth/config/config.toml
+++ b/crates/auth/config/config.toml
@@ -55,9 +55,14 @@ max_password_length = 128
 
 # Development/testing configuration
 [development]
-# Enable mock token endpoint for CI/testing (SECURITY: disabled by default)
-enable_mock_auth = true
+# Mock token endpoint that mints tokens without real authentication. The handler
+# and its route are additionally compiled out of release builds (see the
+# `#[cfg(debug_assertions)]` gates in the auth crate), so this must never be true
+# in a shipped image. Left false; enable it only in a local dev config and set
+# your own `mock_auth_header_value`.
+enable_mock_auth = false
 # Require authorization header for mock endpoint
 mock_auth_require_header = true
-# Authorization header value required for mock endpoint (set to enable)
-mock_auth_header_value = "Bearer test-auth-token" 
+# Authorization header value required for the mock endpoint. Empty by default so
+# no usable token is baked into the image; set it alongside enable_mock_auth.
+mock_auth_header_value = ""

--- a/scripts/download-contracts.sh
+++ b/scripts/download-contracts.sh
@@ -1,4 +1,5 @@
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 TAG=${CALIMERO_CONTRACTS_VERSION:-0.7.0}
 OUTPUT_DIR=${CALIMERO_CONTRACTS_DIR:-contracts}
@@ -14,10 +15,17 @@ else
   API_URL="https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/tags/$TAG"
 fi
 
-RELEASE_DATA=$(curl -s "$API_URL")
-ASSET_URLS=$(echo "$RELEASE_DATA" | jq -r '.assets[] | select(.name | endswith(".tar.gz")) | .browser_download_url')
+RELEASE_DATA=$(curl --fail --silent --show-error \
+  -H "Accept: application/vnd.github+json" "$API_URL")
 
-if [ -z "$ASSET_URLS" ]; then
+# Emit "<download-url>\t<sha256-digest>" per .tar.gz asset. The digest is the
+# hash GitHub computed for the stored asset and returns over TLS from the API;
+# we verify each download against it before extracting so a tampered or
+# truncated archive from the download CDN is rejected.
+ASSETS=$(echo "$RELEASE_DATA" \
+  | jq -r '.assets[] | select(.name | endswith(".tar.gz")) | [.browser_download_url, .digest] | @tsv')
+
+if [ -z "$ASSETS" ]; then
   echo "No .tar.gz assets found for ${TAG}"
   echo "API Response:"
   echo "$RELEASE_DATA" | jq '.'
@@ -26,20 +34,37 @@ fi
 
 mkdir -p "$OUTPUT_DIR"
 
-echo "$ASSET_URLS" | while read -r ASSET_URL; do
-  ARTIFACT_NAME=$(basename "$ASSET_URL" .tar.gz)
+while IFS=$'\t' read -r ASSET_URL ASSET_DIGEST; do
+  [ -n "$ASSET_URL" ] || continue
 
+  ARTIFACT_NAME=$(basename "$ASSET_URL" .tar.gz)
   ARTIFACT_DIR="$OUTPUT_DIR/$ARTIFACT_NAME"
+  TARBALL="$ARTIFACT_DIR/artifact.tar.gz"
 
   mkdir -p "$ARTIFACT_DIR"
 
   echo "Downloading $ARTIFACT_NAME from $ASSET_URL..."
-  curl -L "$ASSET_URL" -o "$ARTIFACT_DIR/artifact.tar.gz"
+  curl --fail --silent --show-error --location "$ASSET_URL" -o "$TARBALL"
+
+  EXPECTED="${ASSET_DIGEST#sha256:}"
+  if [ -z "$EXPECTED" ] || [ "$EXPECTED" = "null" ]; then
+    echo "ERROR: no sha256 digest published for $ARTIFACT_NAME; refusing to extract" >&2
+    exit 1
+  fi
+
+  ACTUAL=$(sha256sum "$TARBALL" | awk '{print $1}')
+  if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "ERROR: checksum mismatch for $ARTIFACT_NAME" >&2
+    echo "  expected: $EXPECTED" >&2
+    echo "  actual:   $ACTUAL" >&2
+    exit 1
+  fi
+  echo "Checksum verified for $ARTIFACT_NAME"
 
   echo "Extracting $ARTIFACT_NAME to $ARTIFACT_DIR..."
-  tar -xzf "$ARTIFACT_DIR/artifact.tar.gz" -C "$ARTIFACT_DIR"
+  tar -xzf "$TARBALL" -C "$ARTIFACT_DIR"
 
-  rm "$ARTIFACT_DIR/artifact.tar.gz"
-done
+  rm "$TARBALL"
+done <<< "$ASSETS"
 
 echo "All artifacts have been downloaded and extracted into $OUTPUT_DIR!"

--- a/scripts/download-contracts.sh
+++ b/scripts/download-contracts.sh
@@ -19,9 +19,12 @@ RELEASE_DATA=$(curl --fail --silent --show-error \
   -H "Accept: application/vnd.github+json" "$API_URL")
 
 # Emit "<download-url>\t<sha256-digest>" per .tar.gz asset. The digest is the
-# hash GitHub computed for the stored asset and returns over TLS from the API;
-# we verify each download against it before extracting so a tampered or
-# truncated archive from the download CDN is rejected.
+# hash GitHub itself computed for the stored asset, returned over TLS from
+# api.github.com; each download is verified against it before extracting.
+# Trust boundary: this rejects corruption or tampering between GitHub and us
+# (CDN / transit), but is only as trustworthy as the GitHub API response — it
+# does NOT defend against a compromised GitHub release. Defending against that
+# would require the contracts repo to publish a signed checksum manifest.
 ASSETS=$(echo "$RELEASE_DATA" \
   | jq -r '.assets[] | select(.name | endswith(".tar.gz")) | [.browser_download_url, .digest] | @tsv')
 

--- a/scripts/setup-vmagent.sh
+++ b/scripts/setup-vmagent.sh
@@ -23,6 +23,11 @@ fi
 # Configuration
 VMAGENT_VERSION="1.132.0"
 VMAGENT_ARCH="amd64"
+# SHA-256 of vmutils-linux-${VMAGENT_ARCH}-v${VMAGENT_VERSION}.tar.gz, pinned
+# here in-repo (taken from the upstream _checksums.txt) so the trust root is
+# this reviewed file rather than a checksums file fetched from the same host as
+# the archive. Refresh it whenever VMAGENT_VERSION or VMAGENT_ARCH changes.
+VMAGENT_SHA256="fd3eaa294050fc849931e8947212c736825a7a49e5509ee4555e288750861fc8"
 VMAGENT_DIR="/tmp/vmagent-${TEST_CASE}"
 VICTORIA_WRITE_URL="https://victoria-lb.apps.dev.p2p.aws.calimero.network/api/v1/write"
 VMAGENT_CONFIG="/tmp/vmagent_scrape_${TEST_CASE}.yml"
@@ -31,64 +36,42 @@ VMAGENT_LOG="/tmp/vmagent-${TEST_CASE}.log"
 VMAGENT_ASSET="vmutils-linux-${VMAGENT_ARCH}-v${VMAGENT_VERSION}.tar.gz"
 VMAGENT_BASE_URL="https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v${VMAGENT_VERSION}"
 TARBALL="/tmp/vmutils-${TEST_CASE}.tar.gz"
-CHECKSUMS="/tmp/vmutils-${TEST_CASE}_checksums.txt"
 
 # Create directories
 mkdir -p "$VMAGENT_DIR"
 
-# Download vmagent binary and its upstream-published checksums file
+# Download vmagent archive. wget exits non-zero on HTTP errors and `set -e`
+# aborts the script, so a failed download never reaches the checks below.
 echo "Downloading vmagent v${VMAGENT_VERSION}..."
 wget -q -O "$TARBALL" "${VMAGENT_BASE_URL}/${VMAGENT_ASSET}"
-wget -q -O "$CHECKSUMS" "${VMAGENT_BASE_URL}/${VMAGENT_ASSET%.tar.gz}_checksums.txt"
 
-if [ ! -f "$TARBALL" ]; then
-    echo "ERROR: Failed to download vmagent"
-    exit 1
-fi
-
-# Verify the archive against the upstream SHA-256 before extracting/executing.
-EXPECTED_SHA=$(awk -v f="$VMAGENT_ASSET" '$2 == f {print $1}' "$CHECKSUMS")
-if [ -z "$EXPECTED_SHA" ]; then
-    echo "ERROR: no checksum for $VMAGENT_ASSET found in checksums file" >&2
-    rm -f "$TARBALL" "$CHECKSUMS"
-    exit 1
-fi
+# Verify against the pinned SHA-256 before extracting/executing anything.
 ACTUAL_SHA=$(sha256sum "$TARBALL" | awk '{print $1}')
-if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+if [ "$ACTUAL_SHA" != "$VMAGENT_SHA256" ]; then
     echo "ERROR: vmagent archive checksum mismatch" >&2
-    echo "  expected: $EXPECTED_SHA" >&2
+    echo "  expected: $VMAGENT_SHA256" >&2
     echo "  actual:   $ACTUAL_SHA" >&2
-    rm -f "$TARBALL" "$CHECKSUMS"
+    rm -f "$TARBALL"
     exit 1
 fi
 echo "vmagent archive checksum verified"
 
-# Extract vmagent-prod binary from tar
-tar -xzf "$TARBALL" -C "$VMAGENT_DIR" vmagent-prod
-
-# Rename to vmagent
-mv "$VMAGENT_DIR/vmagent-prod" "$VMAGENT_DIR/vmagent"
-
-# Verify binary was extracted
-if [ ! -f "$VMAGENT_DIR/vmagent" ]; then
-    echo "ERROR: vmagent-prod binary not found in tar archive"
-    echo "Archive URL: ${VMAGENT_BASE_URL}/${VMAGENT_ASSET}"
-    echo "Archive contents:"
-    tar -tzf "$TARBALL" | head -10 || true
-    rm -f "$TARBALL" "$CHECKSUMS"
+# Extract vmagent-prod. Handle failure explicitly (rather than letting `set -e`
+# abort) so the archive contents can be printed for diagnosis while the tarball
+# still exists.
+if ! tar -xzf "$TARBALL" -C "$VMAGENT_DIR" vmagent-prod; then
+    echo "ERROR: vmagent-prod not found in $VMAGENT_ASSET" >&2
+    echo "Archive contents:" >&2
+    tar -tzf "$TARBALL" | head -10 >&2 || true
+    rm -f "$TARBALL"
     exit 1
 fi
 
-# Clean up downloaded files
-rm -f "$TARBALL" "$CHECKSUMS"
+# Rename to vmagent and clean up the archive
+mv "$VMAGENT_DIR/vmagent-prod" "$VMAGENT_DIR/vmagent"
+rm -f "$TARBALL"
 
 chmod +x "$VMAGENT_DIR/vmagent"
-
-# Verify binary exists
-if [ ! -f "$VMAGENT_DIR/vmagent" ]; then
-    echo "ERROR: Failed to extract vmagent binary"
-    exit 1
-fi
 
 # Save bearer token to file
 AUTH_ENABLED="false"

--- a/scripts/setup-vmagent.sh
+++ b/scripts/setup-vmagent.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
 # Setup and manage vmagent for Victoria Metrics collection
-# Usage: setup-vmagent.sh <test_case> <instance_name> <workflow_run_id> <bearer_token> <http_port>
+# Usage: setup-vmagent.sh <test_case> <instance_name> <workflow_run_id> <http_port> [commit_hash] [branch]
+# The bearer token is read from the VICTORIA_METRICS_BEARER_TOKEN environment
+# variable (never passed as an argument, so it can't leak via ps/procfs).
 
 set -euo pipefail
 
 TEST_CASE="${1:-}"
 INSTANCE_NAME="${2:-}"
 WORKFLOW_RUN_ID="${3:-}"
-BEARER_TOKEN="${4:-}"
-HTTP_PORT="${5:-8429}"
-COMMIT_HASH="${6:-}"
-BRANCH="${7:-}"
+HTTP_PORT="${4:-8429}"
+COMMIT_HASH="${5:-}"
+BRANCH="${6:-}"
+BEARER_TOKEN="${VICTORIA_METRICS_BEARER_TOKEN:-}"
 
 if [ -z "$TEST_CASE" ] || [ -z "$INSTANCE_NAME" ]; then
-    echo "Usage: $0 <test_case> <instance_name> <workflow_run_id> <bearer_token> <http_port> [commit_hash] [branch]"
+    echo "Usage: $0 <test_case> <instance_name> <workflow_run_id> <http_port> [commit_hash] [branch]"
+    echo "       (set VICTORIA_METRICS_BEARER_TOKEN in the environment for authenticated writes)"
     exit 1
 fi
 
@@ -25,21 +28,43 @@ VICTORIA_WRITE_URL="https://victoria-lb.apps.dev.p2p.aws.calimero.network/api/v1
 VMAGENT_CONFIG="/tmp/vmagent_scrape_${TEST_CASE}.yml"
 VMAGENT_LOG="/tmp/vmagent-${TEST_CASE}.log"
 
+VMAGENT_ASSET="vmutils-linux-${VMAGENT_ARCH}-v${VMAGENT_VERSION}.tar.gz"
+VMAGENT_BASE_URL="https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v${VMAGENT_VERSION}"
+TARBALL="/tmp/vmutils-${TEST_CASE}.tar.gz"
+CHECKSUMS="/tmp/vmutils-${TEST_CASE}_checksums.txt"
+
 # Create directories
 mkdir -p "$VMAGENT_DIR"
 
-# Download vmagent binary
+# Download vmagent binary and its upstream-published checksums file
 echo "Downloading vmagent v${VMAGENT_VERSION}..."
-wget -q -O "/tmp/vmutils-${TEST_CASE}.tar.gz" \
-    "https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v${VMAGENT_VERSION}/vmutils-linux-${VMAGENT_ARCH}-v${VMAGENT_VERSION}.tar.gz"
+wget -q -O "$TARBALL" "${VMAGENT_BASE_URL}/${VMAGENT_ASSET}"
+wget -q -O "$CHECKSUMS" "${VMAGENT_BASE_URL}/${VMAGENT_ASSET%.tar.gz}_checksums.txt"
 
-if [ ! -f "/tmp/vmutils-${TEST_CASE}.tar.gz" ]; then
+if [ ! -f "$TARBALL" ]; then
     echo "ERROR: Failed to download vmagent"
     exit 1
 fi
 
+# Verify the archive against the upstream SHA-256 before extracting/executing.
+EXPECTED_SHA=$(awk -v f="$VMAGENT_ASSET" '$2 == f {print $1}' "$CHECKSUMS")
+if [ -z "$EXPECTED_SHA" ]; then
+    echo "ERROR: no checksum for $VMAGENT_ASSET found in checksums file" >&2
+    rm -f "$TARBALL" "$CHECKSUMS"
+    exit 1
+fi
+ACTUAL_SHA=$(sha256sum "$TARBALL" | awk '{print $1}')
+if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+    echo "ERROR: vmagent archive checksum mismatch" >&2
+    echo "  expected: $EXPECTED_SHA" >&2
+    echo "  actual:   $ACTUAL_SHA" >&2
+    rm -f "$TARBALL" "$CHECKSUMS"
+    exit 1
+fi
+echo "vmagent archive checksum verified"
+
 # Extract vmagent-prod binary from tar
-tar -xzf "/tmp/vmutils-${TEST_CASE}.tar.gz" -C "$VMAGENT_DIR" vmagent-prod
+tar -xzf "$TARBALL" -C "$VMAGENT_DIR" vmagent-prod
 
 # Rename to vmagent
 mv "$VMAGENT_DIR/vmagent-prod" "$VMAGENT_DIR/vmagent"
@@ -47,15 +72,15 @@ mv "$VMAGENT_DIR/vmagent-prod" "$VMAGENT_DIR/vmagent"
 # Verify binary was extracted
 if [ ! -f "$VMAGENT_DIR/vmagent" ]; then
     echo "ERROR: vmagent-prod binary not found in tar archive"
-    echo "Archive URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v${VMAGENT_VERSION}/vmutils-linux-${VMAGENT_ARCH}-v${VMAGENT_VERSION}.tar.gz"
+    echo "Archive URL: ${VMAGENT_BASE_URL}/${VMAGENT_ASSET}"
     echo "Archive contents:"
-    tar -tzf "/tmp/vmutils-${TEST_CASE}.tar.gz" | head -10 || true
-    rm -f "/tmp/vmutils-${TEST_CASE}.tar.gz"
+    tar -tzf "$TARBALL" | head -10 || true
+    rm -f "$TARBALL" "$CHECKSUMS"
     exit 1
 fi
 
-# Clean up tar file
-rm -f "/tmp/vmutils-${TEST_CASE}.tar.gz"
+# Clean up downloaded files
+rm -f "$TARBALL" "$CHECKSUMS"
 
 chmod +x "$VMAGENT_DIR/vmagent"
 
@@ -87,4 +112,3 @@ OUTPUT_FILE="${GITHUB_OUTPUT:-/dev/stdout}"
     echo "vmagent_config=$VMAGENT_CONFIG"
     echo "vmagent_log=$VMAGENT_LOG"
 } >> "$OUTPUT_FILE"
-


### PR DESCRIPTION
## What

A CI/build/runtime hardening pass covering the items from a security/hygiene review that were **not** already handled by recent master work. About half the original review list was already fixed upstream (least-priv `pull_request_target`, `workflow_run` output-injection, per-crate AGPL scoping, dependabot, CI concurrency-cancel, `actions/cache` v6), and the advisory-scanning items landed separately in #3091 — this PR is the remaining, non-overlapping set. Branched from and rebased onto the latest master.

## Changes

**Supply chain — pin third-party actions to commit SHAs**
Remaining unpinned actions in the composite actions are now SHA-pinned (dependabot's `github-actions` ecosystem keeps them current):
- `setup-rust-ci`: `dtolnay/rust-toolchain`, `Swatinem/rust-cache`
- `contributions`: `hramos/needs-attention`
- `style`: `tj-actions/changed-files`
- `container-release` + `container-release-profiling`: `docker/*` (×5 each)

**Supply chain — pin Docker base images by digest**
- `Dockerfile` and `Dockerfile.auth` base images (rust build stage, debian runtime) pinned by `@sha256:` digest.
- Added a `docker` ecosystem to `dependabot.yml` so the digests stay maintained.

**Download integrity — verify before extract/execute**
- `download-contracts.sh`: verifies each release asset against the sha256 digest GitHub publishes via its API before extracting.
- `setup-vmagent.sh`: verifies the vmagent archive against VictoriaMetrics' upstream `_checksums.txt` before extracting/executing.

**Secret handling**
- `setup-vmagent.sh` reads the metrics bearer token from `VICTORIA_METRICS_BEARER_TOKEN` instead of argv (no longer visible via `ps`/`/proc`); the four callers in `fuzzy-load-test.yml` pass it via `env:`.

**Auth service**
- `crates/auth/config/config.toml`: `enable_mock_auth=false` and clear the hardcoded mock token. The mock endpoint is already compiled out of release builds via `#[cfg(debug_assertions)]`; this removes the misleading shipped default and the baked-in `Bearer test-auth-token`.
- `Dockerfile.auth`: exec-form `ENTRYPOINT` (fixed binary name) so the process is PID 1 and receives `SIGTERM`/`SIGINT` for clean shutdown.

## Deliberately not included
**Permissive CORS + `unsafe-inline`/`unsafe-eval` CSP** in the shipped auth config (`allow_all_origins`, `script_src`). Locking these down blindly would break the embedded auth UI and browser deployments — the correct origins/CSP depend on deployment, so this needs a product decision rather than a blind default.

## Validation
- `cargo deny check advisories bans licenses sources` → all ok
- All edited YAML/TOML parse; shell scripts pass `bash -n`
- No Rust code changed; no `Cargo.lock`/`Cargo.toml` changes (advisory lockfile bumps are owned by #3091)

🤖 Generated with [Claude Code](https://claude.com/claude-code)