### PR TITLE
refactor(governance): typed id newtypes for key/app/namespace/group ids (#2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,6 +1374,7 @@ dependencies = [
  "calimero-storage",
  "ed25519-dalek",
  "rand 0.8.5",
+ "serde",
  "sha2 0.10.9",
  "thiserror 1.0.69",
 ]

--- a/crates/context/src/handlers/add_group_members.rs
+++ b/crates/context/src/handlers/add_group_members.rs
@@ -65,7 +65,7 @@ impl Handler<AddGroupMembersRequest> for ContextManager {
                         match GroupKeyring::wrap_for_member(&sk, identity, &group_key) {
                             Ok(envelope) => {
                                 let delivery_op = NamespaceOp::Root(RootOp::KeyDelivery {
-                                    group_id: group_id.to_bytes(),
+                                    group_id: group_id.to_bytes().into(),
                                     envelope,
                                 });
                                 // Recipient-specific: pass

--- a/crates/context/src/handlers/add_group_members.rs
+++ b/crates/context/src/handlers/add_group_members.rs
@@ -76,7 +76,7 @@ impl Handler<AddGroupMembersRequest> for ContextManager {
                                     &datastore,
                                     &node_client,
                                     &ack_router,
-                                    ns_id.to_bytes(),
+                                    ns_id.to_bytes().into(),
                                     &sk,
                                     delivery_op,
                                     Some(vec![*identity]),

--- a/crates/context/src/handlers/admit_tee_node.rs
+++ b/crates/context/src/handlers/admit_tee_node.rs
@@ -47,7 +47,7 @@ async fn deliver_group_key_to_member(
     let envelope = GroupKeyring::wrap_for_member(signer_sk, member, &group_key)?;
 
     let delivery_op = NamespaceOp::Root(RootOp::KeyDelivery {
-        group_id: group_id.to_bytes(),
+        group_id: group_id.to_bytes().into(),
         envelope,
     });
 

--- a/crates/context/src/handlers/admit_tee_node.rs
+++ b/crates/context/src/handlers/admit_tee_node.rs
@@ -59,7 +59,7 @@ async fn deliver_group_key_to_member(
         store,
         node_client,
         ack_router,
-        namespace_id.to_bytes(),
+        namespace_id.to_bytes().into(),
         signer_sk,
         delivery_op,
         Some(vec![*member]),

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -16,7 +16,7 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
         _ctx: &mut Self::Context,
     ) -> Self::Result {
         let namespace_id = op.namespace_id;
-        let dag = self.get_or_create_namespace_dag(&namespace_id);
+        let dag = self.get_or_create_namespace_dag(namespace_id.as_bytes());
         let datastore = self.datastore.clone();
         // Separate handle for the shadow-compare (the one above is moved into
         // the applier).
@@ -292,7 +292,7 @@ fn apply_auth_requirement(
 
     match &signed.op {
         NamespaceOp::Root(root) => {
-            let ns_root = ContextGroupId::from(signed.namespace_id);
+            let ns_root = ContextGroupId::from(signed.namespace_id.to_bytes());
             match root {
                 RootOp::AdminChanged { .. }
                 | RootOp::PolicyUpdated { .. }

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -68,7 +68,7 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                             &feed_store,
                             namespace_id,
                             calimero_context_config::types::ContextGroupId::from(*group_id),
-                            key_id,
+                            key_id.as_bytes(),
                             encrypted,
                         )
                         .map_err(|err| {

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -67,7 +67,7 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                         } => calimero_governance_store::decrypt_group_op(
                             &feed_store,
                             namespace_id,
-                            calimero_context_config::types::ContextGroupId::from(*group_id),
+                            *group_id,
                             key_id.as_bytes(),
                             encrypted,
                         )
@@ -298,7 +298,7 @@ fn apply_auth_requirement(
                 | RootOp::PolicyUpdated { .. }
                 | RootOp::GroupReparented { .. } => Some((ns_root, ApplyAuthReq::Admin)),
                 RootOp::GroupCreated { parent_id, .. } => Some((
-                    ContextGroupId::from(*parent_id),
+                    *parent_id,
                     ApplyAuthReq::AdminOrCap(Cap::CAN_CREATE_SUBGROUP.bits()),
                 )),
                 // GroupDeleted authorizes the subgroup OWNER or a
@@ -308,7 +308,7 @@ fn apply_auth_requirement(
             }
         }
         NamespaceOp::Group { group_id, .. } => {
-            let group = ContextGroupId::from(*group_id);
+            let group = *group_id;
             match decrypted? {
                 GroupOp::MemberAdded { .. } | GroupOp::MemberRemoved { .. } => {
                     Some((group, ApplyAuthReq::AdminOrCap(Cap::MANAGE_MEMBERS.bits())))

--- a/crates/context/src/handlers/create_group.rs
+++ b/crates/context/src/handlers/create_group.rs
@@ -251,8 +251,8 @@ impl Handler<CreateGroupRequest> for ContextManager {
                 // GroupMeta, which is exactly the gap #2474 closes.
                 if let Some(parent_id) = parent_group_id {
                     let create_op = NamespaceOp::Root(RootOp::GroupCreated {
-                        group_id: group_id.to_bytes(),
-                        parent_id: parent_id.to_bytes(),
+                        group_id: group_id.to_bytes().into(),
+                        parent_id: parent_id.to_bytes().into(),
                         restricted,
                     });
                     match calimero_governance_store::sign_apply_and_publish_namespace_op(

--- a/crates/context/src/handlers/create_group.rs
+++ b/crates/context/src/handlers/create_group.rs
@@ -259,7 +259,7 @@ impl Handler<CreateGroupRequest> for ContextManager {
                         &datastore,
                         &node_client,
                         &ack_router,
-                        namespace_id.to_bytes(),
+                        namespace_id.to_bytes().into(),
                         &signer_sk,
                         create_op,
                     )
@@ -285,7 +285,7 @@ impl Handler<CreateGroupRequest> for ContextManager {
                         &datastore,
                         &node_client,
                         &ack_router,
-                        namespace_id.to_bytes(),
+                        namespace_id.to_bytes().into(),
                         &signer_sk,
                         genesis_op,
                     )

--- a/crates/context/src/handlers/delete_group.rs
+++ b/crates/context/src/handlers/delete_group.rs
@@ -129,7 +129,7 @@ impl Handler<DeleteGroupRequest> for ContextManager {
                     &datastore,
                     &node_client,
                     &ack_router,
-                    namespace_id_bytes,
+                    namespace_id_bytes.into(),
                     &signer_sk,
                     op,
                 )

--- a/crates/context/src/handlers/delete_group.rs
+++ b/crates/context/src/handlers/delete_group.rs
@@ -120,9 +120,9 @@ impl Handler<DeleteGroupRequest> for ContextManager {
             async move {
                 let signer_sk = PrivateKey::from(signer_sk_bytes);
                 let op = NamespaceOp::Root(RootOp::GroupDeleted {
-                    root_group_id: group_id_bytes,
-                    cascade_group_ids,
-                    cascade_context_ids,
+                    root_group_id: group_id_bytes.into(),
+                    cascade_group_ids: cascade_group_ids.into_iter().map(Into::into).collect(),
+                    cascade_context_ids: cascade_context_ids.into_iter().map(Into::into).collect(),
                 });
 
                 let report = calimero_governance_store::sign_apply_and_publish_namespace_op(

--- a/crates/context/src/handlers/execute/governance_position.rs
+++ b/crates/context/src/handlers/execute/governance_position.rs
@@ -44,8 +44,10 @@ pub(super) fn compute_governance_position_for_context(
         }
     };
 
-    let dag =
-        calimero_governance_store::NamespaceDagService::new(datastore, namespace_id.to_bytes());
+    let dag = calimero_governance_store::NamespaceDagService::new(
+        datastore,
+        namespace_id.to_bytes().into(),
+    );
 
     // The parent edge is just the governance heads at sign time. There is no
     // embedded `group_state_hash` anymore, so the old double-read (which

--- a/crates/context/src/handlers/join_context.rs
+++ b/crates/context/src/handlers/join_context.rs
@@ -262,7 +262,7 @@ impl Handler<JoinContextRequest> for ContextManager {
                         &datastore,
                         &node_client,
                         &ack_router,
-                        ns_id.to_bytes(),
+                        ns_id.to_bytes().into(),
                         &signer_sk,
                         op,
                     )

--- a/crates/context/src/handlers/join_context.rs
+++ b/crates/context/src/handlers/join_context.rs
@@ -255,7 +255,7 @@ impl Handler<JoinContextRequest> for ContextManager {
                     let op = calimero_context_client::local_governance::NamespaceOp::Root(
                         calimero_context_client::local_governance::RootOp::MemberJoinedOpen {
                             member: joiner_identity,
-                            group_id: group_id.to_bytes(),
+                            group_id: group_id.to_bytes().into(),
                         },
                     );
                     if let Err(e) = calimero_governance_store::sign_apply_and_publish_namespace_op(

--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -314,7 +314,7 @@ impl Handler<JoinGroupRequest> for ContextManager {
                     &datastore,
                     &node_client,
                     &ack_router,
-                    namespace_id,
+                    namespace_id.into(),
                     &sk,
                     member_joined_op,
                     None,

--- a/crates/context/src/handlers/join_subgroup_inheritance.rs
+++ b/crates/context/src/handlers/join_subgroup_inheritance.rs
@@ -140,7 +140,7 @@ impl Handler<JoinSubgroupInheritanceRequest> for ContextManager {
                 // wouldn't know to retry.
                 let op = NamespaceOp::Root(RootOp::MemberJoinedOpen {
                     member: joiner_identity,
-                    group_id: group_id.to_bytes(),
+                    group_id: group_id.to_bytes().into(),
                 });
                 calimero_governance_store::sign_apply_and_publish_namespace_op(
                     &datastore,

--- a/crates/context/src/handlers/join_subgroup_inheritance.rs
+++ b/crates/context/src/handlers/join_subgroup_inheritance.rs
@@ -146,7 +146,7 @@ impl Handler<JoinSubgroupInheritanceRequest> for ContextManager {
                     &datastore,
                     &node_client,
                     &ack_router,
-                    ns_id.to_bytes(),
+                    ns_id.to_bytes().into(),
                     &signer_sk,
                     op,
                 )

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -216,7 +216,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                                 &group_id,
                                 &sk,
                                 GroupOp::TargetApplicationSet {
-                                    app_key: rung.app_key,
+                                    app_key: rung.app_key.into(),
                                     target_application_id,
                                 },
                             )
@@ -384,7 +384,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                     &group_id,
                     &sk,
                     GroupOp::TargetApplicationSet {
-                        app_key,
+                        app_key: app_key.into(),
                         target_application_id,
                     },
                 )
@@ -1669,8 +1669,8 @@ fn dispatch_cascade(
             &group_id,
             &sk,
             GroupOp::CascadeUpgrade {
-                from_app_key,
-                app_key: new_app_key,
+                from_app_key: from_app_key.into(),
+                app_key: new_app_key.into(),
                 target_application_id,
                 migration: migration_bytes_for_publish.clone(),
                 cascade_hlc,

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1052,7 +1052,7 @@ impl ScopeProjections {
                 } => calimero_governance_store::decrypt_group_op(
                     store,
                     namespace_id.into(),
-                    ContextGroupId::from(*group_id),
+                    *group_id,
                     key_id.as_bytes(),
                     encrypted,
                 )
@@ -1731,7 +1731,7 @@ mod tests {
                 signer,
                 RootOp::MemberJoinedOpen {
                     member,
-                    group_id: group,
+                    group_id: group.into(),
                 },
             ),
             None,
@@ -2116,7 +2116,7 @@ mod tests {
             signer,
             nonce: 0,
             op: NamespaceOp::Group {
-                group_id: group.to_bytes(),
+                group_id: group.to_bytes().into(),
                 key_id: [0u8; 32].into(),
                 encrypted: calimero_governance_types::EncryptedGroupOp {
                     nonce: [0u8; 12],

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -527,7 +527,7 @@ impl ScopeProjections {
             .resolve(&group)
             .ok()?
             .to_bytes();
-        NamespaceDagService::new(store, namespace_id)
+        NamespaceDagService::new(store, namespace_id.into())
             .read_head_record()
             .ok()
             .map(|head| head.parent_hashes)
@@ -569,7 +569,7 @@ impl ScopeProjections {
         // op advanced the head mid-rebuild, the new head's ancestry isn't fully
         // folded and `member_at_cut`'s completeness guard returns `None` (defer to
         // live) rather than deciding against a stale cut that predates a revocation.
-        let heads = NamespaceDagService::new(store, namespace_id)
+        let heads = NamespaceDagService::new(store, namespace_id.into())
             .read_head_record()
             .ok()?
             .parent_hashes;
@@ -817,7 +817,7 @@ impl ScopeProjections {
             return None;
         };
         proj.apply_backfill(namespace_id, ops);
-        let heads = NamespaceDagService::new(store, namespace_id)
+        let heads = NamespaceDagService::new(store, namespace_id.into())
             .read_head_record()
             .ok()?
             .parent_hashes;
@@ -994,7 +994,7 @@ impl ScopeProjections {
     /// [`apply_backfill`]: Self::apply_backfill
     #[must_use]
     pub fn collect_namespace_ops(store: &Store, namespace_id: [u8; 32]) -> Option<Vec<Op>> {
-        let dag = NamespaceDagService::new(store, namespace_id);
+        let dag = NamespaceDagService::new(store, namespace_id.into());
         let heads = match dag.read_head_record() {
             Ok(head) => head.parent_hashes,
             Err(err) => {
@@ -1003,7 +1003,7 @@ impl ScopeProjections {
             }
         };
 
-        let op_log = NamespaceOpLogService::new(store, namespace_id);
+        let op_log = NamespaceOpLogService::new(store, namespace_id.into());
         let mut visited: HashSet<[u8; 32]> = HashSet::new();
         let mut queue: std::collections::VecDeque<[u8; 32]> = heads.into_iter().collect();
         let mut ops = Vec::new();
@@ -1051,7 +1051,7 @@ impl ScopeProjections {
                     ..
                 } => calimero_governance_store::decrypt_group_op(
                     store,
-                    namespace_id,
+                    namespace_id.into(),
                     ContextGroupId::from(*group_id),
                     key_id.as_bytes(),
                     encrypted,
@@ -1679,7 +1679,7 @@ mod tests {
     fn signed_root(namespace_id: [u8; 32], signer: PublicKey, op: RootOp) -> SignedNamespaceOp {
         SignedNamespaceOp {
             version: 1,
-            namespace_id,
+            namespace_id: namespace_id.into(),
             parent_op_hashes: Vec::new(),
             signer,
             nonce: 0,
@@ -2111,7 +2111,7 @@ mod tests {
     ) -> SignedNamespaceOp {
         SignedNamespaceOp {
             version: 1,
-            namespace_id,
+            namespace_id: namespace_id.into(),
             parent_op_hashes: Vec::new(),
             signer,
             nonce: 0,

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1053,7 +1053,7 @@ impl ScopeProjections {
                     store,
                     namespace_id,
                     ContextGroupId::from(*group_id),
-                    key_id,
+                    key_id.as_bytes(),
                     encrypted,
                 )
                 .ok()
@@ -2117,7 +2117,7 @@ mod tests {
             nonce: 0,
             op: NamespaceOp::Group {
                 group_id: group.to_bytes(),
-                key_id: [0u8; 32],
+                key_id: [0u8; 32].into(),
                 encrypted: calimero_governance_types::EncryptedGroupOp {
                     nonce: [0u8; 12],
                     ciphertext: Vec::new(),

--- a/crates/context/src/self_purge.rs
+++ b/crates/context/src/self_purge.rs
@@ -2843,7 +2843,7 @@ mod tests {
             vec![],
             1,
             NamespaceOp::Group {
-                group_id: sub_gid.to_bytes(),
+                group_id: sub_gid.to_bytes().into(),
                 key_id: key_id.into(),
                 encrypted,
                 key_rotation: None,

--- a/crates/context/src/self_purge.rs
+++ b/crates/context/src/self_purge.rs
@@ -2840,7 +2840,7 @@ mod tests {
             1,
             NamespaceOp::Group {
                 group_id: sub_gid.to_bytes(),
-                key_id,
+                key_id: key_id.into(),
                 encrypted,
                 key_rotation: None,
             },

--- a/crates/context/src/self_purge.rs
+++ b/crates/context/src/self_purge.rs
@@ -574,7 +574,8 @@ fn redrive_stranded_ops_sweep(store: &Store) {
                 let mut pairs = Vec::new();
                 for ns_id in &namespaces {
                     match calimero_governance_store::namespace_groups_with_held_key_buffered_ops(
-                        store, *ns_id,
+                        store,
+                        (*ns_id).into(),
                     ) {
                         Ok(groups) => {
                             for group_id in groups {
@@ -598,8 +599,11 @@ fn redrive_stranded_ops_sweep(store: &Store) {
         for (ns_id, group_id) in pass_pairs {
             let ns_hex = hex::encode(ns_id);
             let group_hex = hex::encode(group_id);
-            match calimero_governance_store::redrive_buffered_ops_for_group(store, ns_id, group_id)
-            {
+            match calimero_governance_store::redrive_buffered_ops_for_group(
+                store,
+                ns_id.into(),
+                group_id,
+            ) {
                 Ok(0) => {
                     // Nothing applied this pass for this group (already
                     // drained, or its remaining ops still await a
@@ -2835,7 +2839,7 @@ mod tests {
         let encrypted = GroupKeyring::encrypt_op(&subgroup_key, &inner_op).expect("encrypt op");
         let ctx_registered_op = SignedNamespaceOp::sign(
             &owner_sk,
-            namespace_id,
+            namespace_id.into(),
             vec![],
             1,
             NamespaceOp::Group {

--- a/crates/context/src/tee_subgroup_admit.rs
+++ b/crates/context/src/tee_subgroup_admit.rs
@@ -59,7 +59,7 @@ pub(crate) fn admit_trigger(event: &OpEvent) -> Option<AdmitTrigger> {
             child_group_id,
             ..
         } => Some(AdmitTrigger::NewSubgroup {
-            namespace_id: *namespace_id,
+            namespace_id: namespace_id.to_bytes(),
             child_group_id: *child_group_id,
         }),
         OpEvent::TeeMemberAdmitted { group_id, member } => Some(AdmitTrigger::NewTeeMember {
@@ -425,7 +425,7 @@ mod dispatch_tests {
 
         assert_eq!(
             admit_trigger(&OpEvent::SubgroupCreated {
-                namespace_id: [1u8; 32],
+                namespace_id: [1u8; 32].into(),
                 parent_group_id: [2u8; 32],
                 child_group_id: [3u8; 32],
             }),

--- a/crates/context/src/tee_subgroup_admit.rs
+++ b/crates/context/src/tee_subgroup_admit.rs
@@ -29,6 +29,7 @@ use calimero_governance_store::{
     tee_admission_record, tee_admission_records, CapabilitiesRepository, GroupKeyring,
     MembershipRepository, NamespaceRepository, TeeAdmissionRecord,
 };
+use calimero_governance_types::NamespaceId;
 use calimero_primitives::context::GroupMemberRole;
 use calimero_primitives::identity::PublicKey;
 use calimero_store::Store;
@@ -39,7 +40,7 @@ use tracing::{debug, error, info, warn};
 pub(crate) enum AdmitTrigger {
     /// A new subgroup was created; admit the namespace's existing root TEE members.
     NewSubgroup {
-        namespace_id: [u8; 32],
+        namespace_id: NamespaceId,
         child_group_id: [u8; 32],
     },
     /// A TEE member was admitted somewhere; if it was the namespace root, fan it
@@ -59,7 +60,7 @@ pub(crate) fn admit_trigger(event: &OpEvent) -> Option<AdmitTrigger> {
             child_group_id,
             ..
         } => Some(AdmitTrigger::NewSubgroup {
-            namespace_id: namespace_id.to_bytes(),
+            namespace_id: *namespace_id,
             child_group_id: *child_group_id,
         }),
         OpEvent::TeeMemberAdmitted { group_id, member } => Some(AdmitTrigger::NewTeeMember {
@@ -225,10 +226,10 @@ async fn admit_member_into_subgroup(
 async fn handle_new_subgroup(
     store: &Store,
     context_client: &ContextClient,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     child_group_id: [u8; 32],
 ) {
-    let namespace_gid = ContextGroupId::from(namespace_id);
+    let namespace_gid = ContextGroupId::from(namespace_id.to_bytes());
     let child_gid = ContextGroupId::from(child_group_id);
 
     // Note on the same emit-before-persist race: unlike `handle_new_tee_member`,
@@ -241,7 +242,7 @@ async fn handle_new_subgroup(
 
     debug!(
         subgroup = %hex::encode(child_group_id),
-        namespace = %hex::encode(namespace_id),
+        namespace = %hex::encode(namespace_id.as_bytes()),
         "tee-subgroup-admit: new-subgroup trigger received"
     );
 
@@ -430,7 +431,7 @@ mod dispatch_tests {
                 child_group_id: [3u8; 32],
             }),
             Some(AdmitTrigger::NewSubgroup {
-                namespace_id: [1u8; 32],
+                namespace_id: [1u8; 32].into(),
                 child_group_id: [3u8; 32],
             })
         );

--- a/crates/context/tests/cascade_apply_walk.rs
+++ b/crates/context/tests/cascade_apply_walk.rs
@@ -121,8 +121,8 @@ fn cascade_target_application_set_updates_all_matching_descendants_and_skips_sib
         vec![],
         1,
         GroupOp::CascadeTargetApplicationSet {
-            from_app_key: APP_KEY_1,
-            app_key: APP_KEY_2,
+            from_app_key: APP_KEY_1.into(),
+            app_key: APP_KEY_2.into(),
             target_application_id: app_id_2(),
         },
     )

--- a/crates/context/tests/cascade_apply_walk.rs
+++ b/crates/context/tests/cascade_apply_walk.rs
@@ -117,7 +117,7 @@ fn cascade_target_application_set_updates_all_matching_descendants_and_skips_sib
     // Cascade op signed on R, targeting from_app_key=K1, new app_key=K2 + new target=APP_ID_2.
     let cascade_op = SignedGroupOp::sign(
         &admin_sk,
-        r.to_bytes(),
+        r.to_bytes().into(),
         vec![],
         1,
         GroupOp::CascadeTargetApplicationSet {

--- a/crates/context/tests/cascade_atomic_apply.rs
+++ b/crates/context/tests/cascade_atomic_apply.rs
@@ -97,8 +97,8 @@ fn cascade_upgrade_atomic_op_sets_target_app_key_and_migration_and_records_casca
         vec![],
         1,
         GroupOp::CascadeUpgrade {
-            from_app_key: APP_KEY_1,
-            app_key: APP_KEY_2,
+            from_app_key: APP_KEY_1.into(),
+            app_key: APP_KEY_2.into(),
             target_application_id: app_id_2(),
             migration: Some(b"migrate_v2".to_vec()),
             cascade_hlc: fence,
@@ -190,8 +190,8 @@ async fn cascade_upgrade_reverse_delivery_converges_atomically() {
         vec![op_p_hash],
         2,
         GroupOp::CascadeUpgrade {
-            from_app_key: APP_KEY_1,
-            app_key: APP_KEY_2,
+            from_app_key: APP_KEY_1.into(),
+            app_key: APP_KEY_2.into(),
             target_application_id: app_id_2(),
             migration: Some(b"migrate_v2".to_vec()),
             cascade_hlc: fence,
@@ -296,8 +296,8 @@ fn two_op_reverse_delivery_drops_migration_characterization() {
             vec![],
             1,
             GroupOp::CascadeTargetApplicationSet {
-                from_app_key: APP_KEY_1,
-                app_key: APP_KEY_2,
+                from_app_key: APP_KEY_1.into(),
+                app_key: APP_KEY_2.into(),
                 target_application_id: app_id_2(),
             },
         )
@@ -312,7 +312,7 @@ fn two_op_reverse_delivery_drops_migration_characterization() {
             vec![],
             2,
             GroupOp::CascadeGroupMigrationSet {
-                from_app_key: APP_KEY_1,
+                from_app_key: APP_KEY_1.into(),
                 migration: Some(b"migrate_v2".to_vec()),
             },
         )

--- a/crates/context/tests/cascade_atomic_apply.rs
+++ b/crates/context/tests/cascade_atomic_apply.rs
@@ -93,7 +93,7 @@ fn cascade_upgrade_atomic_op_sets_target_app_key_and_migration_and_records_casca
     let fence = calimero_storage::logical_clock::HybridTimestamp::zero();
     let op = SignedGroupOp::sign(
         &admin_sk,
-        r.to_bytes(),
+        r.to_bytes().into(),
         vec![],
         1,
         GroupOp::CascadeUpgrade {
@@ -172,7 +172,7 @@ async fn cascade_upgrade_reverse_delivery_converges_atomically() {
     // Op P: benign predecessor (genesis-parented). Causally first.
     let op_p = SignedGroupOp::sign(
         &admin_sk,
-        root.to_bytes(),
+        root.to_bytes().into(),
         vec![[0u8; 32]],
         1,
         GroupOp::GroupMetadataSet {
@@ -186,7 +186,7 @@ async fn cascade_upgrade_reverse_delivery_converges_atomically() {
     // Op C: the atomic CascadeUpgrade, causally AFTER op_p.
     let op_c = SignedGroupOp::sign(
         &admin_sk,
-        root.to_bytes(),
+        root.to_bytes().into(),
         vec![op_p_hash],
         2,
         GroupOp::CascadeUpgrade {
@@ -292,7 +292,7 @@ fn two_op_reverse_delivery_drops_migration_characterization() {
         &store,
         &SignedGroupOp::sign(
             &admin_sk,
-            r.to_bytes(),
+            r.to_bytes().into(),
             vec![],
             1,
             GroupOp::CascadeTargetApplicationSet {
@@ -308,7 +308,7 @@ fn two_op_reverse_delivery_drops_migration_characterization() {
         &store,
         &SignedGroupOp::sign(
             &admin_sk,
-            r.to_bytes(),
+            r.to_bytes().into(),
             vec![],
             2,
             GroupOp::CascadeGroupMigrationSet {

--- a/crates/context/tests/cascade_concurrent_safety.rs
+++ b/crates/context/tests/cascade_concurrent_safety.rs
@@ -130,7 +130,7 @@ async fn divergent_cascade_apply_order_converges_via_predicate_skip() {
     // Op A: cascade K1 -> K2 (genesis-parented). Causally first.
     let op_a = SignedGroupOp::sign(
         &admin_sk,
-        root.to_bytes(),
+        root.to_bytes().into(),
         vec![[0u8; 32]],
         1,
         GroupOp::CascadeTargetApplicationSet {
@@ -148,7 +148,7 @@ async fn divergent_cascade_apply_order_converges_via_predicate_skip() {
     // and the cascade arm hits the predicate-skip path.
     let op_b = SignedGroupOp::sign(
         &admin_sk,
-        root.to_bytes(),
+        root.to_bytes().into(),
         vec![op_a_hash],
         2,
         GroupOp::CascadeTargetApplicationSet {

--- a/crates/context/tests/cascade_concurrent_safety.rs
+++ b/crates/context/tests/cascade_concurrent_safety.rs
@@ -134,8 +134,8 @@ async fn divergent_cascade_apply_order_converges_via_predicate_skip() {
         vec![[0u8; 32]],
         1,
         GroupOp::CascadeTargetApplicationSet {
-            from_app_key: APP_KEY_1,
-            app_key: APP_KEY_2,
+            from_app_key: APP_KEY_1.into(),
+            app_key: APP_KEY_2.into(),
             target_application_id: app_id_2(),
         },
     )
@@ -152,8 +152,8 @@ async fn divergent_cascade_apply_order_converges_via_predicate_skip() {
         vec![op_a_hash],
         2,
         GroupOp::CascadeTargetApplicationSet {
-            from_app_key: APP_KEY_1,
-            app_key: APP_KEY_3,
+            from_app_key: APP_KEY_1.into(),
+            app_key: APP_KEY_3.into(),
             target_application_id: app_id_3(),
         },
     )

--- a/crates/context/tests/cascade_status_rpc.rs
+++ b/crates/context/tests/cascade_status_rpc.rs
@@ -90,8 +90,8 @@ fn collect_cascade_status_returns_entries_for_all_three_groups() {
         vec![],
         1,
         GroupOp::CascadeUpgrade {
-            from_app_key: APP_KEY_1,
-            app_key: APP_KEY_2,
+            from_app_key: APP_KEY_1.into(),
+            app_key: APP_KEY_2.into(),
             target_application_id: app_id_2(),
             migration: Some(b"migrate_v2".to_vec()),
             cascade_hlc: fence,

--- a/crates/context/tests/cascade_status_rpc.rs
+++ b/crates/context/tests/cascade_status_rpc.rs
@@ -86,7 +86,7 @@ fn collect_cascade_status_returns_entries_for_all_three_groups() {
     let fence = HybridTimestamp::zero();
     let op = SignedGroupOp::sign(
         &admin_sk,
-        r.to_bytes(),
+        r.to_bytes().into(),
         vec![],
         1,
         GroupOp::CascadeUpgrade {

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -133,7 +133,7 @@ fn two_nodes_converge_on_same_signed_op_sequence() {
 
     let op1 = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::MemberAdded {
@@ -160,8 +160,8 @@ fn two_nodes_converge_on_same_signed_op_sequence() {
             .unwrap()
     );
 
-    let op2 =
-        SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], 2, GroupOp::Noop).expect("sign op2");
+    let op2 = SignedGroupOp::sign(&admin_sk, gid_bytes.into(), vec![], 2, GroupOp::Noop)
+        .expect("sign op2");
     let payload2 = borsh_to_vec(&op2).expect("borsh encode op2");
 
     apply_wire_payload(&store_a, &payload2);
@@ -208,7 +208,7 @@ fn two_nodes_converge_on_target_application_and_migration() {
 
     let op1 = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::TargetApplicationSet {
@@ -220,7 +220,7 @@ fn two_nodes_converge_on_target_application_and_migration() {
 
     let op2 = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         2,
         GroupOp::GroupMigrationSet {
@@ -825,7 +825,7 @@ fn two_nodes_converge_on_context_alias_as_admin() {
 
     let op1 = SignedGroupOp::sign(
         &creator_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::ContextRegistered {
@@ -839,7 +839,7 @@ fn two_nodes_converge_on_context_alias_as_admin() {
     .expect("sign ContextRegistered");
     let op2 = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::ContextMetadataSet {
@@ -897,7 +897,7 @@ fn op_log_records_applied_ops_and_head_advances() {
     let new_member = PrivateKey::random(&mut rng).public_key();
     let op1 = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::MemberAdded {
@@ -919,8 +919,8 @@ fn op_log_records_applied_ops_and_head_advances() {
     let decoded: SignedGroupOp = borsh::from_slice(&log[0].1).unwrap();
     assert_eq!(decoded.nonce, op1.nonce);
 
-    let op2 =
-        SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], 2, GroupOp::Noop).expect("sign op2");
+    let op2 = SignedGroupOp::sign(&admin_sk, gid_bytes.into(), vec![], 2, GroupOp::Noop)
+        .expect("sign op2");
     apply_local_signed_group_op(&store, &op2).unwrap();
 
     let head2 = get_op_head(&store, &gid).unwrap().expect("head after op2");
@@ -950,7 +950,8 @@ fn duplicate_op_is_idempotent() {
         .add_member(&gid, &admin_pk, GroupMemberRole::Admin)
         .unwrap();
 
-    let op = SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], 1, GroupOp::Noop).expect("sign op");
+    let op = SignedGroupOp::sign(&admin_sk, gid_bytes.into(), vec![], 1, GroupOp::Noop)
+        .expect("sign op");
     let payload = borsh_to_vec(&op).expect("encode");
 
     apply_wire_payload(&store, &payload);
@@ -989,7 +990,7 @@ fn offline_node_replays_missed_ops_from_log() {
 
     let op1 = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![[0u8; 32]],
         1,
         GroupOp::MemberAdded {
@@ -1001,7 +1002,7 @@ fn offline_node_replays_missed_ops_from_log() {
     let op1_hash = op1.content_hash().unwrap();
     let op2 = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![op1_hash],
         2,
         GroupOp::MemberAdded {
@@ -1074,7 +1075,7 @@ async fn dag_applies_ops_in_causal_order() {
     // op1: add member1 (genesis parent)
     let op1 = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![[0u8; 32]],
         1,
         GroupOp::MemberAdded {
@@ -1089,7 +1090,7 @@ async fn dag_applies_ops_in_causal_order() {
     let op1_hash = op1.content_hash().unwrap();
     let op2 = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![op1_hash],
         2,
         GroupOp::MemberAdded {
@@ -1156,7 +1157,7 @@ async fn dag_concurrent_ops_create_two_heads() {
     // Two concurrent ops with genesis as parent
     let op_a = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![[0u8; 32]],
         1,
         GroupOp::MemberAdded {
@@ -1167,7 +1168,7 @@ async fn dag_concurrent_ops_create_two_heads() {
     .unwrap();
     let op_b = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![[0u8; 32]],
         2,
         GroupOp::MemberAdded {
@@ -1205,8 +1206,14 @@ async fn dag_concurrent_ops_create_two_heads() {
     // Merge op referencing both heads
     let hash_a = op_a.content_hash().unwrap();
     let hash_b = op_b.content_hash().unwrap();
-    let merge_op =
-        SignedGroupOp::sign(&admin_sk, gid_bytes, vec![hash_a, hash_b], 3, GroupOp::Noop).unwrap();
+    let merge_op = SignedGroupOp::sign(
+        &admin_sk,
+        gid_bytes.into(),
+        vec![hash_a, hash_b],
+        3,
+        GroupOp::Noop,
+    )
+    .unwrap();
     dag.add_delta(signed_op_to_delta(&merge_op).unwrap(), &applier)
         .await
         .unwrap();
@@ -1233,7 +1240,14 @@ async fn dag_duplicate_delta_is_idempotent() {
         .add_member(&gid, &admin_pk, GroupMemberRole::Admin)
         .unwrap();
 
-    let op = SignedGroupOp::sign(&admin_sk, gid_bytes, vec![[0u8; 32]], 1, GroupOp::Noop).unwrap();
+    let op = SignedGroupOp::sign(
+        &admin_sk,
+        gid_bytes.into(),
+        vec![[0u8; 32]],
+        1,
+        GroupOp::Noop,
+    )
+    .unwrap();
     let delta = signed_op_to_delta(&op).unwrap();
 
     let applier = GroupGovernanceApplier::new(store.clone());
@@ -1265,8 +1279,14 @@ async fn dag_deep_chain_with_out_of_order_delivery() {
     let mut ops = Vec::new();
     let mut prev_hash: Vec<[u8; 32]> = vec![[0u8; 32]];
     for i in 1..=5u64 {
-        let op =
-            SignedGroupOp::sign(&admin_sk, gid_bytes, prev_hash.clone(), i, GroupOp::Noop).unwrap();
+        let op = SignedGroupOp::sign(
+            &admin_sk,
+            gid_bytes.into(),
+            prev_hash.clone(),
+            i,
+            GroupOp::Noop,
+        )
+        .unwrap();
         prev_hash = vec![op.content_hash().unwrap()];
         ops.push(op);
     }
@@ -1329,7 +1349,8 @@ fn rejects_op_with_too_many_parents() {
             h
         })
         .collect();
-    let op_ok = SignedGroupOp::sign(&admin_sk, gid_bytes, parents_256, 1, GroupOp::Noop).unwrap();
+    let op_ok =
+        SignedGroupOp::sign(&admin_sk, gid_bytes.into(), parents_256, 1, GroupOp::Noop).unwrap();
     assert!(apply_local_signed_group_op(&store, &op_ok).is_ok());
 
     // 257 parents should be rejected
@@ -1341,7 +1362,8 @@ fn rejects_op_with_too_many_parents() {
             h
         })
         .collect();
-    let op_bad = SignedGroupOp::sign(&admin_sk, gid_bytes, parents_257, 2, GroupOp::Noop).unwrap();
+    let op_bad =
+        SignedGroupOp::sign(&admin_sk, gid_bytes.into(), parents_257, 2, GroupOp::Noop).unwrap();
     assert!(apply_local_signed_group_op(&store, &op_bad).is_err());
 }
 
@@ -1363,8 +1385,14 @@ fn dag_heads_are_capped_at_max() {
 
     // Create 70 concurrent ops (all with genesis parent) to exceed MAX_DAG_HEADS (64)
     for i in 1..=70u64 {
-        let op =
-            SignedGroupOp::sign(&admin_sk, gid_bytes, vec![[0u8; 32]], i, GroupOp::Noop).unwrap();
+        let op = SignedGroupOp::sign(
+            &admin_sk,
+            gid_bytes.into(),
+            vec![[0u8; 32]],
+            i,
+            GroupOp::Noop,
+        )
+        .unwrap();
         apply_local_signed_group_op(&store, &op).unwrap();
     }
 
@@ -1375,8 +1403,14 @@ fn dag_heads_are_capped_at_max() {
         head.dag_heads.len()
     );
     // The last op's hash should be present (not truncated)
-    let last_op =
-        SignedGroupOp::sign(&admin_sk, gid_bytes, vec![[0u8; 32]], 70, GroupOp::Noop).unwrap();
+    let last_op = SignedGroupOp::sign(
+        &admin_sk,
+        gid_bytes.into(),
+        vec![[0u8; 32]],
+        70,
+        GroupOp::Noop,
+    )
+    .unwrap();
     let last_hash = last_op.content_hash().unwrap();
     assert!(
         head.dag_heads.contains(&last_hash),
@@ -1437,7 +1471,7 @@ fn concurrent_independent_member_adds_converge() {
     // SAME genesis state (concurrent).
     let op_a = SignedGroupOp::sign(
         &admin_a_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![[0u8; 32]],
         1,
         GroupOp::MemberAdded {
@@ -1450,7 +1484,7 @@ fn concurrent_independent_member_adds_converge() {
     // nonce=1 — each signer has its own independent nonce window.
     let op_c = SignedGroupOp::sign(
         &admin_c_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![[0u8; 32]],
         1,
         GroupOp::MemberAdded {
@@ -1599,7 +1633,7 @@ fn cascade_removal_on_member_kick() {
 
     let op = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![[0u8; 32]],
         1,
         dummy_member_removed(member_pk),
@@ -1671,7 +1705,7 @@ fn cascade_removal_deterministic_across_nodes() {
 
     let op = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![[0u8; 32]],
         1,
         dummy_member_removed(member_pk),

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -212,7 +212,7 @@ fn two_nodes_converge_on_target_application_and_migration() {
         vec![],
         1,
         GroupOp::TargetApplicationSet {
-            app_key: [0x11; 32],
+            app_key: [0x11; 32].into(),
             target_application_id: new_target,
         },
     )

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -299,7 +299,7 @@ fn two_nodes_converge_on_namespace_member_joined() {
 
     let ns_op = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::MemberJoined {
@@ -349,7 +349,7 @@ fn member_joined_at_rejects_expired_invitation() {
 
     let ns_op = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::MemberJoinedAt {
@@ -400,7 +400,7 @@ fn member_joined_rejects_when_expiration_set_and_joined_at_absent() {
     let signed_invitation = sign_invitation(&admin_sk, gid, 9_999_999_999, 1);
     let ns_op = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::MemberJoined {
@@ -453,7 +453,7 @@ fn member_joined_at_accepts_in_window_invitation() {
     let signed_invitation = sign_invitation(&admin_sk, gid, 1_000_000, 1);
     let ns_op = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::MemberJoinedAt {
@@ -505,7 +505,7 @@ fn member_joined_at_backdated_joined_at_bypasses_apply_gate_documented_residual(
     let signed_invitation = sign_invitation(&admin_sk, gid, 1_000_000, 1);
     let ns_op = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::MemberJoinedAt {
@@ -556,7 +556,7 @@ fn member_joined_at_in_window_converges_when_expiration_already_past_wallclock()
     let signed_invitation = sign_invitation(&admin_sk, gid, 1_000_000, 1);
     let ns_op = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::MemberJoinedAt {
@@ -601,7 +601,7 @@ fn member_joined_at_ignores_zero_expiration() {
     let signed_invitation = sign_invitation(&admin_sk, gid, 0, 1);
     let ns_op = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::MemberJoinedAt {
@@ -678,7 +678,7 @@ fn recursive_invite_joins_all_descendant_groups() {
     for (i, (_gid, signed_inv)) in invitations.iter().enumerate() {
         let ns_op = SignedNamespaceOp::sign(
             &joiner_sk,
-            ns_id.to_bytes(),
+            ns_id.to_bytes().into(),
             vec![],
             (i + 1) as u64,
             NamespaceOp::Root(RootOp::MemberJoinedAt {
@@ -1825,7 +1825,7 @@ fn reapplying_namespace_op_keeps_dag_head_set_clean_and_position_embeddable() {
 
     let ns_op = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::MemberJoined {
@@ -1843,7 +1843,7 @@ fn reapplying_namespace_op_keeps_dag_head_set_clean_and_position_embeddable() {
     // replay (e.g. a counter-based dedup that tolerates one duplicate) is
     // still caught, not just the final state.
     let read_state = |label: &str| {
-        let (heads, _next_nonce) = NamespaceDagService::new(&store, ns_id)
+        let (heads, _next_nonce) = NamespaceDagService::new(&store, ns_id.into())
             .read_head()
             .expect("read namespace dag head");
         assert_eq!(

--- a/crates/context/tests/op_store_reconstruction.rs
+++ b/crates/context/tests/op_store_reconstruction.rs
@@ -101,7 +101,7 @@ fn op_store_reconstruction_recovers_late_decrypted_membership_after_key_delivery
         nonce: 1,
         op: NamespaceOp::Group {
             group_id: ns_bytes,
-            key_id,
+            key_id: key_id.into(),
             encrypted,
             key_rotation: None,
         },
@@ -189,7 +189,7 @@ fn completeness_gate_flags_governance_ops_missing_from_the_op_store() {
             nonce: u64::from(id),
             op: NamespaceOp::Group {
                 group_id: ns_bytes,
-                key_id: [0u8; 32],
+                key_id: [0u8; 32].into(),
                 encrypted: EncryptedGroupOp {
                     nonce: [0u8; 12],
                     ciphertext: Vec::new(),
@@ -260,7 +260,7 @@ fn locally_authored_op_lands_in_the_op_store_atomically() {
         nonce: 1,
         op: NamespaceOp::Group {
             group_id: ns_bytes,
-            key_id,
+            key_id: key_id.into(),
             encrypted,
             key_rotation: None,
         },

--- a/crates/context/tests/op_store_reconstruction.rs
+++ b/crates/context/tests/op_store_reconstruction.rs
@@ -95,7 +95,7 @@ fn op_store_reconstruction_recovers_late_decrypted_membership_after_key_delivery
     let encrypted = GroupKeyring::encrypt_op(&group_key, &inner).unwrap();
     let signed = SignedNamespaceOp {
         version: 1,
-        namespace_id: ns_bytes,
+        namespace_id: ns_bytes.into(),
         parent_op_hashes: Vec::new(),
         signer: admin,
         nonce: 1,
@@ -112,10 +112,10 @@ fn op_store_reconstruction_recovers_late_decrypted_membership_after_key_delivery
     // (1) The op lands in the governance DAG (op-log + frontier), exactly as a
     // received op does — this is what `collect_namespace_ops` walks. The group key
     // is present, so the read-time re-decrypt recovers the MemberAdded.
-    NamespaceOpLogService::new(&store, ns_bytes)
+    NamespaceOpLogService::new(&store, ns_bytes.into())
         .store_signed_operation(&signed)
         .unwrap();
-    NamespaceDagService::new(&store, ns_bytes)
+    NamespaceDagService::new(&store, ns_bytes.into())
         .advance_dag_head(delta_id, &[], 0)
         .unwrap();
 
@@ -183,7 +183,7 @@ fn completeness_gate_flags_governance_ops_missing_from_the_op_store() {
     let op = |id: u8| {
         let signed = SignedNamespaceOp {
             version: 1,
-            namespace_id: ns_bytes,
+            namespace_id: ns_bytes.into(),
             parent_op_hashes: Vec::new(),
             signer: admin,
             nonce: u64::from(id),
@@ -254,7 +254,7 @@ fn locally_authored_op_lands_in_the_op_store_atomically() {
     let encrypted = GroupKeyring::encrypt_op(&group_key, &inner).unwrap();
     let signed = SignedNamespaceOp {
         version: 1,
-        namespace_id: ns_bytes,
+        namespace_id: ns_bytes.into(),
         parent_op_hashes: Vec::new(),
         signer: admin,
         nonce: 1,
@@ -267,10 +267,10 @@ fn locally_authored_op_lands_in_the_op_store_atomically() {
         signature: [0u8; 64],
     };
     let delta_id = signed.content_hash().unwrap();
-    NamespaceOpLogService::new(&store, ns_bytes)
+    NamespaceOpLogService::new(&store, ns_bytes.into())
         .store_signed_operation(&signed)
         .unwrap();
-    NamespaceDagService::new(&store, ns_bytes)
+    NamespaceDagService::new(&store, ns_bytes.into())
         .advance_dag_head(delta_id, &[], 0)
         .unwrap();
 

--- a/crates/context/tests/op_store_reconstruction.rs
+++ b/crates/context/tests/op_store_reconstruction.rs
@@ -100,7 +100,7 @@ fn op_store_reconstruction_recovers_late_decrypted_membership_after_key_delivery
         signer: admin,
         nonce: 1,
         op: NamespaceOp::Group {
-            group_id: ns_bytes,
+            group_id: ns_bytes.into(),
             key_id: key_id.into(),
             encrypted,
             key_rotation: None,
@@ -188,7 +188,7 @@ fn completeness_gate_flags_governance_ops_missing_from_the_op_store() {
             signer: admin,
             nonce: u64::from(id),
             op: NamespaceOp::Group {
-                group_id: ns_bytes,
+                group_id: ns_bytes.into(),
                 key_id: [0u8; 32].into(),
                 encrypted: EncryptedGroupOp {
                     nonce: [0u8; 12],
@@ -259,7 +259,7 @@ fn locally_authored_op_lands_in_the_op_store_atomically() {
         signer: admin,
         nonce: 1,
         op: NamespaceOp::Group {
-            group_id: ns_bytes,
+            group_id: ns_bytes.into(),
             key_id: key_id.into(),
             encrypted,
             key_rotation: None,

--- a/crates/context/tests/projection_membership_equivalence.rs
+++ b/crates/context/tests/projection_membership_equivalence.rs
@@ -144,7 +144,7 @@ fn ns_group_envelope(
         nonce: 0,
         op: NamespaceOp::Group {
             group_id: group.to_bytes(),
-            key_id: [0u8; 32],
+            key_id: [0u8; 32].into(),
             encrypted: EncryptedGroupOp {
                 nonce: [0u8; 12],
                 ciphertext: Vec::new(),

--- a/crates/context/tests/projection_membership_equivalence.rs
+++ b/crates/context/tests/projection_membership_equivalence.rs
@@ -103,8 +103,8 @@ fn fold_subgroup_structure(
         signer: admin,
         nonce: 0,
         op: NamespaceOp::Root(RootOp::GroupCreated {
-            group_id: subgroup.to_bytes(),
-            parent_id: namespace,
+            group_id: subgroup.to_bytes().into(),
+            parent_id: namespace.into(),
             restricted: true,
         }),
         signature: [0u8; 64],
@@ -143,7 +143,7 @@ fn ns_group_envelope(
         signer,
         nonce: 0,
         op: NamespaceOp::Group {
-            group_id: group.to_bytes(),
+            group_id: group.to_bytes().into(),
             key_id: [0u8; 32].into(),
             encrypted: EncryptedGroupOp {
                 nonce: [0u8; 12],
@@ -225,7 +225,7 @@ fn projection_matches_live_across_inherited_join_and_root_removal() {
         2,
         NamespaceOp::Root(RootOp::MemberJoinedOpen {
             member: joiner,
-            group_id: subgroup.to_bytes(),
+            group_id: subgroup.to_bytes().into(),
         }),
     )
     .expect("sign join_sub");
@@ -381,7 +381,7 @@ fn projection_matches_live_across_leave_and_rejoin_inheritance() {
         2,
         NamespaceOp::Root(RootOp::MemberJoinedOpen {
             member: joiner,
-            group_id: subgroup.to_bytes(),
+            group_id: subgroup.to_bytes().into(),
         }),
     )
     .unwrap();
@@ -519,7 +519,7 @@ fn projection_defers_when_cut_ancestry_incomplete() {
         2,
         NamespaceOp::Root(RootOp::MemberJoinedOpen {
             member: joiner,
-            group_id: subgroup.to_bytes(),
+            group_id: subgroup.to_bytes().into(),
         }),
     )
     .unwrap();
@@ -627,7 +627,7 @@ fn refreshing_the_missing_ancestor_unblocks_the_authoritative_grant() {
         2,
         NamespaceOp::Root(RootOp::MemberJoinedOpen {
             member: joiner,
-            group_id: subgroup.to_bytes(),
+            group_id: subgroup.to_bytes().into(),
         }),
     )
     .unwrap();

--- a/crates/context/tests/projection_membership_equivalence.rs
+++ b/crates/context/tests/projection_membership_equivalence.rs
@@ -98,7 +98,7 @@ fn fold_subgroup_structure(
 ) -> [u8; 32] {
     let created = SignedNamespaceOp {
         version: 1,
-        namespace_id: namespace,
+        namespace_id: namespace.into(),
         parent_op_hashes: Vec::new(),
         signer: admin,
         nonce: 0,
@@ -138,7 +138,7 @@ fn ns_group_envelope(
 ) -> SignedNamespaceOp {
     SignedNamespaceOp {
         version: 1,
-        namespace_id: namespace,
+        namespace_id: namespace.into(),
         parent_op_hashes: Vec::new(),
         signer,
         nonce: 0,
@@ -203,7 +203,7 @@ fn projection_matches_live_across_inherited_join_and_root_removal() {
     // (1) joiner joins the namespace root via invitation — a DIRECT membership.
     let join_ns = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns.to_bytes(),
+        ns.to_bytes().into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::MemberJoined {
@@ -220,7 +220,7 @@ fn projection_matches_live_across_inherited_join_and_root_removal() {
     // live writes NO direct row; membership is re-derived from the anchor.
     let join_sub = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns.to_bytes(),
+        ns.to_bytes().into(),
         vec![],
         2,
         NamespaceOp::Root(RootOp::MemberJoinedOpen {
@@ -356,7 +356,7 @@ fn projection_matches_live_across_leave_and_rejoin_inheritance() {
     // join ns (nonce 1) + inherit subgroup (nonce 2).
     let join_ns = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns.to_bytes(),
+        ns.to_bytes().into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::MemberJoined {
@@ -376,7 +376,7 @@ fn projection_matches_live_across_leave_and_rejoin_inheritance() {
 
     let join_sub = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns.to_bytes(),
+        ns.to_bytes().into(),
         vec![],
         2,
         NamespaceOp::Root(RootOp::MemberJoinedOpen {
@@ -422,7 +422,7 @@ fn projection_matches_live_across_leave_and_rejoin_inheritance() {
     // REJOIN ns via invitation (direct root membership again).
     let rejoin_ns = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns.to_bytes(),
+        ns.to_bytes().into(),
         vec![],
         3,
         NamespaceOp::Root(RootOp::MemberJoined {
@@ -502,7 +502,7 @@ fn projection_defers_when_cut_ancestry_incomplete() {
     // live resolver authoritatively sees the joiner as an inherited member.
     let join_ns = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns.to_bytes(),
+        ns.to_bytes().into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::MemberJoined {
@@ -514,7 +514,7 @@ fn projection_defers_when_cut_ancestry_incomplete() {
     group_store::apply_signed_namespace_op(&store, &join_ns).unwrap();
     let join_sub = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns.to_bytes(),
+        ns.to_bytes().into(),
         vec![],
         2,
         NamespaceOp::Root(RootOp::MemberJoinedOpen {
@@ -610,7 +610,7 @@ fn refreshing_the_missing_ancestor_unblocks_the_authoritative_grant() {
     // after the backfill pull delivered them.
     let join_ns = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns.to_bytes(),
+        ns.to_bytes().into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::MemberJoined {
@@ -622,7 +622,7 @@ fn refreshing_the_missing_ancestor_unblocks_the_authoritative_grant() {
     group_store::apply_signed_namespace_op(&store, &join_ns).unwrap();
     let join_sub = SignedNamespaceOp::sign(
         &joiner_sk,
-        ns.to_bytes(),
+        ns.to_bytes().into(),
         vec![],
         2,
         NamespaceOp::Root(RootOp::MemberJoinedOpen {

--- a/crates/governance-store/src/governance_broadcast.rs
+++ b/crates/governance-store/src/governance_broadcast.rs
@@ -10,6 +10,7 @@
 //! Tasks 3.2 — 3.4 add `verify_ack`, `assert_transport_ready`, and
 //! `publish_and_await_ack` on top of this skeleton.
 use crate::MembershipRepository;
+use calimero_governance_types::NamespaceId;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -52,8 +53,8 @@ pub(crate) fn classify_network_publish_error(e: eyre::Report) -> BroadcastPublis
 /// Mirrors the format used by `NodeClient::publish_signed_namespace_op`
 /// and the receiver-side `network_event::namespace` handler.
 #[must_use]
-pub fn ns_topic(namespace_id: [u8; 32]) -> TopicHash {
-    TopicHash::from_raw(format!("ns/{}", hex::encode(namespace_id)))
+pub fn ns_topic(namespace_id: NamespaceId) -> TopicHash {
+    TopicHash::from_raw(format!("ns/{}", hex::encode(namespace_id.as_bytes())))
 }
 
 /// Per-op publish timeout for "cheap" governance ops — alias / metadata
@@ -153,7 +154,7 @@ pub enum GovernanceBroadcastError {
 ///    this node's local DAG view — non-members cannot ack.
 pub fn verify_ack(
     store: &Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     expected_op_hash: [u8; 32],
     ack: &SignedAck,
 ) -> bool {
@@ -526,7 +527,7 @@ pub async fn publish_and_await_ack_namespace(
     store: &Store,
     transport: &dyn BroadcastTransport,
     ack_router: &AckRouter,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     topic: TopicHash,
     op: SignedNamespaceOp,
     op_timeout: Duration,
@@ -579,7 +580,7 @@ pub async fn publish_and_await_ack_namespace(
         )));
     }
     let envelope = BroadcastMessage::NamespaceGovernanceDelta {
-        namespace_id,
+        namespace_id: namespace_id.to_bytes(),
         delta_id,
         parent_ids,
         payload: inner,

--- a/crates/governance-store/src/governance_broadcast/tests.rs
+++ b/crates/governance-store/src/governance_broadcast/tests.rs
@@ -125,8 +125,8 @@ fn timeout_classifier_assigns_per_op_kind() {
     // Member-change class: membership-table mutations, possible inheritance walks.
     assert_eq!(
         timeout_for_namespace_op(&NamespaceOp::Root(RootOp::GroupCreated {
-            group_id: [0u8; 32],
-            parent_id: [0u8; 32],
+            group_id: [0u8; 32].into(),
+            parent_id: [0u8; 32].into(),
             restricted: true,
         })),
         OP_ACK_MEMBER_CHANGE_TIMEOUT
@@ -135,7 +135,7 @@ fn timeout_classifier_assigns_per_op_kind() {
     // Heavy class: cascade deletes / KeyDelivery side-effects.
     assert_eq!(
         timeout_for_namespace_op(&NamespaceOp::Root(RootOp::GroupDeleted {
-            root_group_id: [0u8; 32],
+            root_group_id: [0u8; 32].into(),
             cascade_group_ids: Vec::new(),
             cascade_context_ids: Vec::new(),
         })),
@@ -146,7 +146,7 @@ fn timeout_classifier_assigns_per_op_kind() {
     // the inner GroupOp variant isn't visible without decrypting.
     assert_eq!(
         timeout_for_namespace_op(&NamespaceOp::Group {
-            group_id: [0u8; 32],
+            group_id: [0u8; 32].into(),
             key_id: [0u8; 32].into(),
             encrypted: calimero_context_client::local_governance::EncryptedGroupOp {
                 ciphertext: Vec::new(),

--- a/crates/governance-store/src/governance_broadcast/tests.rs
+++ b/crates/governance-store/src/governance_broadcast/tests.rs
@@ -146,7 +146,7 @@ fn timeout_classifier_assigns_per_op_kind() {
     assert_eq!(
         timeout_for_namespace_op(&NamespaceOp::Group {
             group_id: [0u8; 32],
-            key_id: [0u8; 32],
+            key_id: [0u8; 32].into(),
             encrypted: calimero_context_client::local_governance::EncryptedGroupOp {
                 ciphertext: Vec::new(),
                 nonce: [0u8; 12],

--- a/crates/governance-store/src/governance_broadcast/tests.rs
+++ b/crates/governance-store/src/governance_broadcast/tests.rs
@@ -1,3 +1,4 @@
+use calimero_governance_types::NamespaceId;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -48,7 +49,7 @@ async fn verify_ack_rejects_wrong_op_hash() {
     let sk = PrivateKey::random(&mut rand::thread_rng());
     let ack = signed_ack(&sk, [1u8; 32]);
     // Caller is waiting on a different op_hash than the ack carries.
-    assert!(!verify_ack(&store, [42u8; 32], [9u8; 32], &ack));
+    assert!(!verify_ack(&store, [42u8; 32].into(), [9u8; 32], &ack));
 }
 
 #[tokio::test]
@@ -57,7 +58,7 @@ async fn verify_ack_rejects_invalid_signature() {
     // dummy_ack uses [0u8; 64] — Ed25519 verification fails before we
     // ever consult the membership store.
     let ack = dummy_ack([1u8; 32]);
-    assert!(!verify_ack(&store, [42u8; 32], [1u8; 32], &ack));
+    assert!(!verify_ack(&store, [42u8; 32].into(), [1u8; 32], &ack));
 }
 
 #[tokio::test]
@@ -66,7 +67,7 @@ async fn verify_ack_rejects_non_member_signer() {
     // Properly-signed ack, but `store` has no namespace members at all.
     let sk = PrivateKey::random(&mut rand::thread_rng());
     let ack = signed_ack(&sk, [7u8; 32]);
-    assert!(!verify_ack(&store, [42u8; 32], [7u8; 32], &ack));
+    assert!(!verify_ack(&store, [42u8; 32].into(), [7u8; 32], &ack));
 }
 
 // ---------------------------------------------------------------------------
@@ -173,7 +174,7 @@ impl BroadcastTransport for StubTransport {
     }
 }
 
-fn mk_signed_op(sk: &PrivateKey, namespace_id: [u8; 32]) -> SignedNamespaceOp {
+fn mk_signed_op(sk: &PrivateKey, namespace_id: NamespaceId) -> SignedNamespaceOp {
     SignedNamespaceOp::sign(
         sk,
         namespace_id,
@@ -188,10 +189,10 @@ fn mk_signed_op(sk: &PrivateKey, namespace_id: [u8; 32]) -> SignedNamespaceOp {
 
 fn plant_namespace_member(
     store: &Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     pk: &calimero_primitives::identity::PublicKey,
 ) {
-    let gid = ContextGroupId::from(namespace_id);
+    let gid = ContextGroupId::from(namespace_id.to_bytes());
     MembershipRepository::new(store)
         .add_member(&gid, pk, GroupMemberRole::Member)
         .expect("plant");
@@ -210,13 +211,13 @@ async fn publish_and_await_ack_times_out_with_empty_acked_by() {
     let transport = StubTransport;
     let topic = TopicHash::from_raw("ns/test");
     let signer = PrivateKey::random(&mut rand::thread_rng());
-    let signed_op = mk_signed_op(&signer, [42u8; 32]);
+    let signed_op = mk_signed_op(&signer, [42u8; 32].into());
 
     let report = publish_and_await_ack_namespace(
         &store,
         &transport,
         &router,
-        [42u8; 32],
+        [42u8; 32].into(),
         topic,
         signed_op,
         Duration::from_millis(50),
@@ -243,10 +244,10 @@ async fn publish_and_await_ack_dedups_acks_from_same_signer() {
     // namespace member that acks.
     let publisher = PrivateKey::random(&mut rand::thread_rng());
     let alice = PrivateKey::random(&mut rand::thread_rng());
-    plant_namespace_member(&store, namespace_id, &publisher.public_key());
-    plant_namespace_member(&store, namespace_id, &alice.public_key());
+    plant_namespace_member(&store, namespace_id.into(), &publisher.public_key());
+    plant_namespace_member(&store, namespace_id.into(), &alice.public_key());
 
-    let signed_op = mk_signed_op(&publisher, namespace_id);
+    let signed_op = mk_signed_op(&publisher, namespace_id.into());
     let op_hash = calimero_context_client::local_governance::hash_scoped_namespace(
         topic.as_str().as_bytes(),
         &signed_op,
@@ -274,7 +275,7 @@ async fn publish_and_await_ack_dedups_acks_from_same_signer() {
         &store,
         &transport,
         &router,
-        namespace_id,
+        namespace_id.into(),
         topic,
         signed_op,
         Duration::from_millis(200),
@@ -304,11 +305,11 @@ async fn publish_and_await_ack_returns_ok_on_min_acks_satisfied() {
     let publisher = PrivateKey::random(&mut rand::thread_rng());
     let alice = PrivateKey::random(&mut rand::thread_rng());
     let bob = PrivateKey::random(&mut rand::thread_rng());
-    plant_namespace_member(&store, namespace_id, &publisher.public_key());
-    plant_namespace_member(&store, namespace_id, &alice.public_key());
-    plant_namespace_member(&store, namespace_id, &bob.public_key());
+    plant_namespace_member(&store, namespace_id.into(), &publisher.public_key());
+    plant_namespace_member(&store, namespace_id.into(), &alice.public_key());
+    plant_namespace_member(&store, namespace_id.into(), &bob.public_key());
 
-    let signed_op = mk_signed_op(&publisher, namespace_id);
+    let signed_op = mk_signed_op(&publisher, namespace_id.into());
     let op_hash = calimero_context_client::local_governance::hash_scoped_namespace(
         topic.as_str().as_bytes(),
         &signed_op,
@@ -338,7 +339,7 @@ async fn publish_and_await_ack_returns_ok_on_min_acks_satisfied() {
         &store,
         &transport,
         &router,
-        namespace_id,
+        namespace_id.into(),
         topic,
         signed_op,
         Duration::from_millis(500),
@@ -367,14 +368,14 @@ async fn publish_and_await_ack_returns_ok_immediately_when_min_acks_is_zero() {
     let transport = StubTransport;
     let topic = TopicHash::from_raw("ns/min-acks-zero");
     let signer = PrivateKey::random(&mut rand::thread_rng());
-    let signed_op = mk_signed_op(&signer, [42u8; 32]);
+    let signed_op = mk_signed_op(&signer, [42u8; 32].into());
 
     let started = std::time::Instant::now();
     let res = publish_and_await_ack_namespace(
         &store,
         &transport,
         &router,
-        [42u8; 32],
+        [42u8; 32].into(),
         topic,
         signed_op,
         Duration::from_secs(5),
@@ -408,7 +409,7 @@ async fn verify_ack_rejects_signature_without_domain_prefix() {
         signer_pubkey: sk.public_key(),
         signature,
     };
-    assert!(!verify_ack(&store, [42u8; 32], op_hash, &ack));
+    assert!(!verify_ack(&store, [42u8; 32].into(), op_hash, &ack));
 }
 
 /// Transport stub whose publish always returns the libp2p
@@ -438,13 +439,13 @@ async fn no_peers_with_min_acks_zero_returns_ok_empty() {
     let transport = NoPeersTransport;
     let topic = TopicHash::from_raw("ns/test-solo");
     let signer = PrivateKey::random(&mut rand::thread_rng());
-    let signed_op = mk_signed_op(&signer, [42u8; 32]);
+    let signed_op = mk_signed_op(&signer, [42u8; 32].into());
 
     let report = publish_and_await_ack_namespace(
         &store,
         &transport,
         &router,
-        [42u8; 32],
+        [42u8; 32].into(),
         topic,
         signed_op,
         Duration::from_millis(50),
@@ -480,13 +481,13 @@ async fn no_peers_with_min_acks_positive_returns_no_ack_received() {
     let transport = NoPeersTransport;
     let topic = TopicHash::from_raw("ns/test-multi");
     let signer = PrivateKey::random(&mut rand::thread_rng());
-    let signed_op = mk_signed_op(&signer, [42u8; 32]);
+    let signed_op = mk_signed_op(&signer, [42u8; 32].into());
 
     let res = publish_and_await_ack_namespace(
         &store,
         &transport,
         &router,
-        [42u8; 32],
+        [42u8; 32].into(),
         topic,
         signed_op,
         Duration::from_millis(50),
@@ -511,7 +512,7 @@ async fn no_peers_with_min_acks_positive_returns_no_ack_received() {
 /// payload from `wire.rs`.
 fn signed_beacon(
     sk: &PrivateKey,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     applied_through: u64,
     strong: bool,
 ) -> SignedReadinessBeacon {
@@ -536,9 +537,9 @@ async fn verify_readiness_beacon_accepts_signed_member_beacon() {
     let store = empty_store();
     let sk = PrivateKey::random(&mut rand::thread_rng());
     let ns_id = [42u8; 32];
-    plant_namespace_member(&store, ns_id, &sk.public_key());
+    plant_namespace_member(&store, ns_id.into(), &sk.public_key());
 
-    let beacon = signed_beacon(&sk, ns_id, 17, true);
+    let beacon = signed_beacon(&sk, ns_id.into(), 17, true);
     assert!(
         verify_readiness_beacon(&store, &beacon),
         "signed beacon from a member must verify"
@@ -554,7 +555,7 @@ async fn verify_readiness_beacon_rejects_non_member_signer() {
     let sk = PrivateKey::random(&mut rand::thread_rng());
     let ns_id = [42u8; 32];
     // No plant_namespace_member call.
-    let beacon = signed_beacon(&sk, ns_id, 17, true);
+    let beacon = signed_beacon(&sk, ns_id.into(), 17, true);
     assert!(!verify_readiness_beacon(&store, &beacon));
 }
 
@@ -568,9 +569,9 @@ async fn verify_readiness_beacon_rejects_bad_signature() {
     let store = empty_store();
     let sk = PrivateKey::random(&mut rand::thread_rng());
     let ns_id = [42u8; 32];
-    plant_namespace_member(&store, ns_id, &sk.public_key());
+    plant_namespace_member(&store, ns_id.into(), &sk.public_key());
 
-    let mut beacon = signed_beacon(&sk, ns_id, 17, true);
+    let mut beacon = signed_beacon(&sk, ns_id.into(), 17, true);
     beacon.signature = [0u8; 64]; // clobber the signature
     assert!(!verify_readiness_beacon(&store, &beacon));
 }
@@ -585,7 +586,7 @@ async fn verify_readiness_beacon_rejects_bad_signature() {
 /// payload from `wire.rs`.
 fn signed_heartbeat(
     sk: &PrivateKey,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     schema_version: u32,
     residue_identity: u64,
 ) -> SignedMigrationHeartbeat {
@@ -613,9 +614,9 @@ async fn verify_migration_heartbeat_accepts_signed_member_heartbeat() {
     let store = empty_store();
     let sk = PrivateKey::random(&mut rand::thread_rng());
     let ns_id = [42u8; 32];
-    plant_namespace_member(&store, ns_id, &sk.public_key());
+    plant_namespace_member(&store, ns_id.into(), &sk.public_key());
 
-    let hb = signed_heartbeat(&sk, ns_id, 2, 0);
+    let hb = signed_heartbeat(&sk, ns_id.into(), 2, 0);
     assert!(
         verify_migration_heartbeat(&store, &hb),
         "signed heartbeat from a member must verify"
@@ -631,7 +632,7 @@ async fn verify_migration_heartbeat_rejects_non_member_signer() {
     let sk = PrivateKey::random(&mut rand::thread_rng());
     let ns_id = [42u8; 32];
     // No plant_namespace_member call.
-    let hb = signed_heartbeat(&sk, ns_id, 2, 0);
+    let hb = signed_heartbeat(&sk, ns_id.into(), 2, 0);
     assert!(!verify_migration_heartbeat(&store, &hb));
 }
 
@@ -643,9 +644,9 @@ async fn verify_migration_heartbeat_rejects_bad_signature() {
     let store = empty_store();
     let sk = PrivateKey::random(&mut rand::thread_rng());
     let ns_id = [42u8; 32];
-    plant_namespace_member(&store, ns_id, &sk.public_key());
+    plant_namespace_member(&store, ns_id.into(), &sk.public_key());
 
-    let mut hb = signed_heartbeat(&sk, ns_id, 2, 5);
+    let mut hb = signed_heartbeat(&sk, ns_id.into(), 2, 5);
     hb.residue_identity = 0; // tamper after signing — sig no longer covers body
     assert!(!verify_migration_heartbeat(&store, &hb));
 }

--- a/crates/governance-store/src/governance_signer.rs
+++ b/crates/governance-store/src/governance_signer.rs
@@ -1,5 +1,6 @@
 use calimero_context_client::local_governance::{AckRouter, GroupOp, NamespaceOp};
 use calimero_context_config::types::ContextGroupId;
+use calimero_governance_types::NamespaceId;
 use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_store::Store;
 use eyre::Result as EyreResult;
@@ -55,7 +56,7 @@ impl<'a> GovernanceSigner<'a> {
 
     pub async fn publish_namespace_op(
         &self,
-        namespace_id: [u8; 32],
+        namespace_id: NamespaceId,
         signer_sk: &PrivateKey,
         op: NamespaceOp,
     ) -> EyreResult<DeliveryReport> {
@@ -66,7 +67,7 @@ impl<'a> GovernanceSigner<'a> {
 
     pub async fn publish_namespace_op_without_apply(
         &self,
-        namespace_id: [u8; 32],
+        namespace_id: NamespaceId,
         signer_sk: &PrivateKey,
         op: NamespaceOp,
         required_signers: Option<Vec<PublicKey>>,

--- a/crates/governance-store/src/group_governance_publisher.rs
+++ b/crates/governance-store/src/group_governance_publisher.rs
@@ -95,7 +95,7 @@ impl<'a> GroupGovernancePublisher<'a> {
         // and both are handed to `sign_and_publish_post_gate`.
         let namespace_id = NamespaceRepository::new(self.store).resolve(&self.group_id)?;
         let namespace_bytes = namespace_id.to_bytes();
-        let topic = ns_topic(namespace_bytes);
+        let topic = ns_topic(namespace_bytes.into());
         let mesh = self
             .node_client
             .mesh_peer_count_for_namespace(namespace_bytes)
@@ -271,7 +271,7 @@ impl<'a> GroupGovernancePublisher<'a> {
         // via sync. `sign_and_publish_post_gate` takes the `mesh` / `known`
         // snapshot directly and never runs `assert_transport_ready`, so
         // there is no gate that could reject after the local apply.
-        let mut report = NamespaceGovernance::new(self.store, namespace_bytes)
+        let mut report = NamespaceGovernance::new(self.store, namespace_bytes.into())
             .sign_and_publish_post_gate(
                 self.node_client,
                 ack_router,
@@ -282,7 +282,8 @@ impl<'a> GroupGovernancePublisher<'a> {
                 true,
             )
             .await?;
-        report.readiness = classify_report_readiness(self.store, namespace_bytes, &report, known);
+        report.readiness =
+            classify_report_readiness(self.store, namespace_bytes.into(), &report, known);
         tracing::debug!(
             op_kind,
             group_id = %hex::encode(self.group_id.to_bytes()),

--- a/crates/governance-store/src/group_governance_publisher.rs
+++ b/crates/governance-store/src/group_governance_publisher.rs
@@ -247,7 +247,7 @@ impl<'a> GroupGovernancePublisher<'a> {
 
         let namespace_op = NamespaceOp::Group {
             group_id: self.group_id.to_bytes(),
-            key_id: stored_key.key_id,
+            key_id: stored_key.key_id.into(),
             encrypted,
             key_rotation,
         };

--- a/crates/governance-store/src/group_governance_publisher.rs
+++ b/crates/governance-store/src/group_governance_publisher.rs
@@ -246,7 +246,7 @@ impl<'a> GroupGovernancePublisher<'a> {
         };
 
         let namespace_op = NamespaceOp::Group {
-            group_id: self.group_id.to_bytes(),
+            group_id: self.group_id.to_bytes().into(),
             key_id: stored_key.key_id.into(),
             encrypted,
             key_rotation,

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -306,7 +306,7 @@ impl<'a> GroupKeyring<'a> {
         }
 
         Ok(KeyRotation {
-            new_key_id,
+            new_key_id: new_key_id.into(),
             envelopes,
         })
     }

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -1316,7 +1316,7 @@ pub fn apply_local_signed_group_op_at_cut(
     }
     op.verify_signature()
         .map_err(|e| eyre::eyre!("signed group op: {e}"))?;
-    let group_id = ContextGroupId::from(op.group_id);
+    let group_id = op.group_id;
 
     // C5.S3b: the op-level `state_hash` staleness check was removed with the field.
     // It stopped being an apply gate in C5.S3a (`scope_root` is the convergence
@@ -1474,7 +1474,7 @@ pub fn sign_apply_local_group_op_borsh(
     let parent_hashes = get_op_head(store, group_id)?
         .map(|h| h.dag_heads.clone())
         .unwrap_or_default();
-    let signed = SignedGroupOp::sign(signer_sk, group_id.to_bytes(), parent_hashes, nonce, op)?;
+    let signed = SignedGroupOp::sign(signer_sk, *group_id, parent_hashes, nonce, op)?;
     let delta_id = signed
         .content_hash()
         .map_err(|e| eyre::eyre!("content_hash: {e}"))?;

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -13,6 +13,7 @@
 
 use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
 use calimero_context_config::types::ContextGroupId;
+use calimero_governance_types::NamespaceId;
 use calimero_primitives::context::{ContextId, GroupMemberRole};
 use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_primitives::metadata::MetadataRecord;
@@ -652,23 +653,24 @@ impl<'a> GroupHandle<'a> {
 /// A scoped handle for namespace-level operations (identity, DAG heads, governance ops).
 pub struct NamespaceHandle<'a> {
     store: &'a Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
 }
 
 impl<'a> NamespaceHandle<'a> {
-    pub fn new(store: &'a Store, namespace_id: [u8; 32]) -> Self {
+    pub fn new(store: &'a Store, namespace_id: NamespaceId) -> Self {
         Self {
             store,
             namespace_id,
         }
     }
 
-    pub fn namespace_id(&self) -> [u8; 32] {
+    pub fn namespace_id(&self) -> NamespaceId {
         self.namespace_id
     }
 
     pub fn get_identity(&self) -> EyreResult<Option<ResolvedIdentity>> {
-        NamespaceRepository::new(self.store).identity(&ContextGroupId::from(self.namespace_id))
+        NamespaceRepository::new(self.store)
+            .identity(&ContextGroupId::from(self.namespace_id.to_bytes()))
     }
 
     pub fn store_identity(
@@ -678,7 +680,7 @@ impl<'a> NamespaceHandle<'a> {
         sender: &[u8; 32],
     ) -> EyreResult<()> {
         NamespaceRepository::new(self.store).store_identity(
-            &ContextGroupId::from(self.namespace_id),
+            &ContextGroupId::from(self.namespace_id.to_bytes()),
             pk,
             sk,
             sender,
@@ -729,7 +731,7 @@ impl<'a> GroupStoreIndex<'a> {
         GroupHandle::new(self.store, group_id)
     }
 
-    pub fn namespace(&self, namespace_id: [u8; 32]) -> NamespaceHandle<'a> {
+    pub fn namespace(&self, namespace_id: NamespaceId) -> NamespaceHandle<'a> {
         NamespaceHandle::new(self.store, namespace_id)
     }
 

--- a/crates/governance-store/src/membership/core.rs
+++ b/crates/governance-store/src/membership/core.rs
@@ -1,5 +1,6 @@
 use crate::{CapabilitiesRepository, MetadataRepository};
 use crate::{DenyListRepository, MetaRepository, NamespaceRepository};
+use calimero_governance_types::NamespaceId;
 use std::collections::BTreeSet;
 
 use calimero_context_config::types::ContextGroupId;
@@ -474,8 +475,8 @@ impl<'a> MembershipRepository<'a> {
     /// Public-key-only view of the current member set for a namespace.
     /// Includes the meta `admin_identity` if not already in the member
     /// rows — see the original `namespace_member_pubkeys` doc.
-    pub fn namespace_pubkeys(&self, namespace_id: [u8; 32]) -> EyreResult<Vec<PublicKey>> {
-        let group_id = ContextGroupId::from(namespace_id);
+    pub fn namespace_pubkeys(&self, namespace_id: NamespaceId) -> EyreResult<Vec<PublicKey>> {
+        let group_id = ContextGroupId::from(namespace_id.to_bytes());
         let members = self.list(&group_id, 0, usize::MAX)?;
         let mut pubkeys: Vec<PublicKey> = members.into_iter().map(|(pk, _role)| pk).collect();
         if let Some(meta) = MetaRepository::new(self.store).load(&group_id)? {
@@ -512,10 +513,10 @@ impl<'a> MembershipRepository<'a> {
     /// admitted TEE node. See original `is_authoritative_namespace_identity`.
     pub fn is_authoritative_namespace_identity(
         &self,
-        namespace_id: [u8; 32],
+        namespace_id: NamespaceId,
         identity: &PublicKey,
     ) -> EyreResult<bool> {
-        let gid = ContextGroupId::from(namespace_id);
+        let gid = ContextGroupId::from(namespace_id.to_bytes());
 
         if let Some(meta) = MetaRepository::new(self.store).load(&gid)? {
             if *identity == meta.owner_identity {

--- a/crates/governance-store/src/membership/tests.rs
+++ b/crates/governance-store/src/membership/tests.rs
@@ -161,7 +161,7 @@ fn membership_policy_guards_last_admin_and_tee_paths() {
     let signer_sk = PrivateKey::random(&mut rng);
     let policy_op = SignedGroupOp::sign(
         &signer_sk,
-        gid.to_bytes(),
+        gid.to_bytes().into(),
         vec![],
         1,
         GroupOp::TeeAdmissionPolicySet {
@@ -2072,7 +2072,7 @@ fn is_authoritative_namespace_identity_recognizes_owner_admin_tee() {
     let signer_sk = PrivateKey::random(&mut rng);
     let tee_op = SignedGroupOp::sign(
         &signer_sk,
-        gid.to_bytes(),
+        gid.to_bytes().into(),
         vec![],
         1,
         GroupOp::MemberJoinedViaTeeAttestation {

--- a/crates/governance-store/src/membership/tests.rs
+++ b/crates/governance-store/src/membership/tests.rs
@@ -1356,7 +1356,7 @@ fn namespace_member_pubkeys_includes_meta_admin_without_member_row() {
     MetaRepository::new(&store).save(&gid, &meta).unwrap();
 
     let pks = MembershipRepository::new(&store)
-        .namespace_pubkeys(namespace_id)
+        .namespace_pubkeys(namespace_id.into())
         .unwrap();
     assert!(
         pks.contains(&admin),
@@ -1391,7 +1391,7 @@ fn namespace_member_pubkeys_dedups_admin_with_member_row() {
         .unwrap();
 
     let pks = MembershipRepository::new(&store)
-        .namespace_pubkeys(namespace_id)
+        .namespace_pubkeys(namespace_id.into())
         .unwrap();
     assert_eq!(pks.iter().filter(|p| **p == admin).count(), 1);
     assert!(pks.contains(&other));
@@ -1413,7 +1413,7 @@ fn namespace_member_pubkeys_includes_member_rows() {
         .unwrap();
 
     let pks = MembershipRepository::new(&store)
-        .namespace_pubkeys(namespace_id)
+        .namespace_pubkeys(namespace_id.into())
         .unwrap();
     assert!(pks.contains(&m1));
     assert!(pks.contains(&m2));
@@ -2091,18 +2091,18 @@ fn is_authoritative_namespace_identity_recognizes_owner_admin_tee() {
     append_op_log_entry(&store, &gid, 1, &borsh::to_vec(&tee_op).unwrap()).unwrap();
 
     assert!(MembershipRepository::new(&store)
-        .is_authoritative_namespace_identity(namespace_id, &owner)
+        .is_authoritative_namespace_identity(namespace_id.into(), &owner)
         .unwrap());
     assert!(MembershipRepository::new(&store)
-        .is_authoritative_namespace_identity(namespace_id, &admin_member)
+        .is_authoritative_namespace_identity(namespace_id.into(), &admin_member)
         .unwrap());
     assert!(MembershipRepository::new(&store)
-        .is_authoritative_namespace_identity(namespace_id, &tee_node)
+        .is_authoritative_namespace_identity(namespace_id.into(), &tee_node)
         .unwrap());
     assert!(!MembershipRepository::new(&store)
-        .is_authoritative_namespace_identity(namespace_id, &ordinary)
+        .is_authoritative_namespace_identity(namespace_id.into(), &ordinary)
         .unwrap());
     assert!(!MembershipRepository::new(&store)
-        .is_authoritative_namespace_identity(namespace_id, &stranger)
+        .is_authoritative_namespace_identity(namespace_id.into(), &stranger)
         .unwrap());
 }

--- a/crates/governance-store/src/namespace/dag.rs
+++ b/crates/governance-store/src/namespace/dag.rs
@@ -1,3 +1,4 @@
+use calimero_governance_types::NamespaceId;
 use std::collections::HashSet;
 
 use calimero_context_client::local_governance::SignedNamespaceOp;
@@ -22,11 +23,11 @@ impl NamespaceHead {
 /// Domain service for namespace DAG persistence and traversal.
 pub struct NamespaceDagService<'a> {
     store: &'a Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
 }
 
 impl<'a> NamespaceDagService<'a> {
-    pub fn new(store: &'a Store, namespace_id: [u8; 32]) -> Self {
+    pub fn new(store: &'a Store, namespace_id: NamespaceId) -> Self {
         Self {
             store,
             namespace_id,
@@ -44,7 +45,7 @@ impl<'a> NamespaceDagService<'a> {
     /// condition observable rather than silent.
     pub fn read_head_record(&self) -> EyreResult<NamespaceHead> {
         let handle = self.store.handle();
-        let key = calimero_store::key::NamespaceGovHead::new(self.namespace_id);
+        let key = calimero_store::key::NamespaceGovHead::new(self.namespace_id.to_bytes());
         let head = handle.get(&key)?;
         let raw_heads = head
             .as_ref()
@@ -54,7 +55,7 @@ impl<'a> NamespaceDagService<'a> {
         if let Some(h) = head.as_ref() {
             if h.dag_heads.len() != parent_hashes.len() {
                 tracing::warn!(
-                    namespace_id = %hex::encode(self.namespace_id),
+                    namespace_id = %hex::encode(self.namespace_id.as_bytes()),
                     stored = h.dag_heads.len(),
                     deduped = parent_hashes.len(),
                     "namespace governance DAG head set contained duplicates; \
@@ -89,7 +90,7 @@ impl<'a> NamespaceDagService<'a> {
         sequence: u64,
     ) -> EyreResult<()> {
         let handle = self.store.handle();
-        let ns_key = calimero_store::key::NamespaceGovHead::new(self.namespace_id);
+        let ns_key = calimero_store::key::NamespaceGovHead::new(self.namespace_id.to_bytes());
         let current = handle.get(&ns_key)?;
         drop(handle);
 

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -1,3 +1,5 @@
+use calimero_governance_types::NamespaceId;
+
 use crate::{
     CapabilitiesRepository, DenyListRepository, GroupKeyring, MembershipRepository, MetaRepository,
     NamespaceRepository,
@@ -66,7 +68,7 @@ pub(crate) fn min_acks_after_local_mutation(
 /// `GroupGovernancePublisher` (a sibling module — hence `pub(crate)`).
 pub(crate) fn classify_report_readiness(
     store: &Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     report: &DeliveryReport,
     known_subscribers: usize,
 ) -> PublishReadiness {
@@ -81,7 +83,7 @@ pub(crate) fn classify_report_readiness(
 /// Domain API for namespace DAG and governance operation lifecycle.
 pub struct NamespaceGovernance<'a> {
     store: &'a Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     /// The op's causal cut (its parent op hashes), threaded to the apply gates so
     /// they can authorize against the projection AS OF the op's parents. Empty for
     /// constructions outside the live apply path (sign/read/tests), which keep the
@@ -95,7 +97,7 @@ pub struct NamespaceGovernance<'a> {
 }
 
 impl<'a> NamespaceGovernance<'a> {
-    pub fn new(store: &'a Store, namespace_id: [u8; 32]) -> Self {
+    pub fn new(store: &'a Store, namespace_id: NamespaceId) -> Self {
         Self {
             store,
             namespace_id,
@@ -173,8 +175,8 @@ impl<'a> NamespaceGovernance<'a> {
         if op.namespace_id != self.namespace_id {
             return Err(eyre::eyre!(
                 "namespace mismatch in apply_signed_op: handle={}, op={}",
-                hex::encode(self.namespace_id),
-                hex::encode(op.namespace_id)
+                hex::encode(self.namespace_id.as_bytes()),
+                hex::encode(op.namespace_id.as_bytes())
             ));
         }
 
@@ -206,7 +208,7 @@ impl<'a> NamespaceGovernance<'a> {
         // `apply_signed_op`, and is bounded by the per-signer nonce check there.
         if NamespaceOpLogService::new(self.store, self.namespace_id).contains_op(delta_id)? {
             tracing::debug!(
-                namespace_id = %hex::encode(self.namespace_id),
+                namespace_id = %hex::encode(self.namespace_id.as_bytes()),
                 delta_id = %hex::encode(delta_id),
                 "namespace governance op already applied; skipping re-apply (#2327)"
             );
@@ -379,7 +381,7 @@ impl<'a> NamespaceGovernance<'a> {
                         // propagate.
                         let gid = *group_id;
                         let gid_typed = ContextGroupId::from(gid);
-                        let ns_typed = ContextGroupId::from(self.namespace_id);
+                        let ns_typed = ContextGroupId::from(self.namespace_id.to_bytes());
                         let holds_key = GroupKeyring::new(self.store, gid_typed)
                             .holds_any_key()
                             .unwrap_or(false)
@@ -427,7 +429,7 @@ impl<'a> NamespaceGovernance<'a> {
                 {
                     Some(k) => Some(k),
                     None => {
-                        let ns_id_typed = ContextGroupId::from(self.namespace_id);
+                        let ns_id_typed = ContextGroupId::from(self.namespace_id.to_bytes());
                         GroupKeyring::new(self.store, ns_id_typed)
                             .load_key_by_id(key_id.as_bytes())?
                     }
@@ -455,7 +457,7 @@ impl<'a> NamespaceGovernance<'a> {
                 }
 
                 if let Some(rotation) = key_rotation {
-                    let ns_id = ContextGroupId::from(op.namespace_id);
+                    let ns_id = ContextGroupId::from(op.namespace_id.to_bytes());
                     if let Some(identity) =
                         NamespaceRepository::new(self.store).identity_record(&ns_id)?
                     {
@@ -567,10 +569,10 @@ impl<'a> NamespaceGovernance<'a> {
         // *publishes* an op never observes its own monotonic advance and
         // the FSM stays at `Bootstrapping` forever. See
         // `notify_namespace_op_applied` for the cross-crate plumbing.
-        node_client.notify_namespace_op_applied(self.namespace_id);
+        node_client.notify_namespace_op_applied(self.namespace_id.to_bytes());
 
         let mesh = node_client
-            .mesh_peer_count_for_namespace(self.namespace_id)
+            .mesh_peer_count_for_namespace(self.namespace_id.to_bytes())
             .await;
         let known = node_client.known_subscribers(&topic);
         if observe_mesh {
@@ -598,7 +600,7 @@ impl<'a> NamespaceGovernance<'a> {
             Err(e) => {
                 tracing::debug!(
                     op_kind,
-                    namespace_id = %hex::encode(self.namespace_id),
+                    namespace_id = %hex::encode(self.namespace_id.as_bytes()),
                     error = %e,
                     "namespace governance op applied locally; publish did not \
                      confirm (best-effort) — will propagate via sync"
@@ -615,7 +617,7 @@ impl<'a> NamespaceGovernance<'a> {
         report.readiness = classify_report_readiness(self.store, self.namespace_id, &report, known);
         tracing::debug!(
             op_kind,
-            namespace_id = %hex::encode(self.namespace_id),
+            namespace_id = %hex::encode(self.namespace_id.as_bytes()),
             acks = report.acked_by.len(),
             readiness = report.readiness.label(),
             elapsed_ms = report.elapsed_ms,
@@ -635,7 +637,7 @@ impl<'a> NamespaceGovernance<'a> {
     ) -> EyreResult<DeliveryReport> {
         let topic = ns_topic(self.namespace_id);
         let mesh = node_client
-            .mesh_peer_count_for_namespace(self.namespace_id)
+            .mesh_peer_count_for_namespace(self.namespace_id.to_bytes())
             .await;
         let known = node_client.known_subscribers(&topic);
         assert_transport_ready(mesh, known, node_client.gossipsub_mesh_n_low())
@@ -756,7 +758,7 @@ impl<'a> NamespaceGovernance<'a> {
         // just advanced on the publisher path, so the readiness FSM needs
         // to be told. Both paths converge at `Handler<NamespaceOpApplied>`
         // on `ReadinessManager`, mirroring the gossipsub-receive route.
-        node_client.notify_namespace_op_applied(self.namespace_id);
+        node_client.notify_namespace_op_applied(self.namespace_id.to_bytes());
 
         if observe_mesh {
             record_governance_publish_mesh_peers(op_kind, mesh);
@@ -801,7 +803,7 @@ impl<'a> NamespaceGovernance<'a> {
             Err(e) if best_effort => {
                 tracing::debug!(
                     op_kind,
-                    namespace_id = %hex::encode(self.namespace_id),
+                    namespace_id = %hex::encode(self.namespace_id.as_bytes()),
                     error = %e,
                     "namespace governance op applied locally; publish did not \
                      confirm (best-effort) — will propagate via sync"
@@ -823,7 +825,7 @@ impl<'a> NamespaceGovernance<'a> {
         // the message accurate for both.
         tracing::debug!(
             op_kind,
-            namespace_id = %hex::encode(self.namespace_id),
+            namespace_id = %hex::encode(self.namespace_id.as_bytes()),
             acks = report.acked_by.len(),
             elapsed_ms = report.elapsed_ms,
             op_hash = %hex::encode(report.op_hash),
@@ -884,7 +886,7 @@ impl<'a> NamespaceGovernance<'a> {
         group_id: [u8; 32],
         founder: &PublicKey,
     ) -> EyreResult<()> {
-        if group_id != self.namespace_id {
+        if group_id != self.namespace_id.to_bytes() {
             return Ok(());
         }
         let gid = ContextGroupId::from(group_id);
@@ -1018,7 +1020,7 @@ impl<'a> NamespaceGovernance<'a> {
         requester: PublicKey,
     ) -> EyreResult<(Vec<u8>, PublicKey)> {
         let group_gid = ContextGroupId::from(group_id);
-        let ns_gid = ContextGroupId::from(self.namespace_id);
+        let ns_gid = ContextGroupId::from(self.namespace_id.to_bytes());
 
         // Cross-namespace pin: the requested group must belong to the
         // namespace the requester named, otherwise an attacker on namespace
@@ -1026,7 +1028,7 @@ impl<'a> NamespaceGovernance<'a> {
         // membership check, this is the full authorisation gate.
         let group_in_namespace = matches!(
             NamespaceRepository::new(self.store).resolve(&group_gid),
-            Ok(ns) if ns.to_bytes() == self.namespace_id
+            Ok(ns) if ns.to_bytes() == self.namespace_id.to_bytes()
         );
         if !group_in_namespace
             || !MembershipRepository::new(self.store).is_member(&group_gid, &requester)?
@@ -1042,7 +1044,7 @@ impl<'a> NamespaceGovernance<'a> {
         let Some(record) = NamespaceRepository::new(self.store).resolve_identity_record(&ns_gid)?
         else {
             tracing::warn!(
-                namespace_id = %hex::encode(self.namespace_id),
+                namespace_id = %hex::encode(self.namespace_id.as_bytes()),
                 "no namespace identity, cannot wrap group key"
             );
             return Ok((Vec::new(), requester));
@@ -1056,7 +1058,7 @@ impl<'a> NamespaceGovernance<'a> {
             )),
             Err(err) => {
                 tracing::warn!(
-                    namespace_id = %hex::encode(self.namespace_id),
+                    namespace_id = %hex::encode(self.namespace_id.as_bytes()),
                     group_id = %hex::encode(group_id),
                     %err,
                     "failed to wrap group key for requester"
@@ -1110,7 +1112,7 @@ impl<'a> NamespaceGovernance<'a> {
         envelope: &KeyEnvelope,
         responder_identity: PublicKey,
     ) -> EyreResult<Option<super::super::DivergenceReport>> {
-        let ns_id = ContextGroupId::from(self.namespace_id);
+        let ns_id = ContextGroupId::from(self.namespace_id.to_bytes());
 
         let Some(identity) = NamespaceRepository::new(self.store).identity_record(&ns_id)? else {
             return Ok(None);
@@ -1654,16 +1656,15 @@ pub fn apply_signed_namespace_op_at_cut(
 /// there is nothing to fold.
 pub fn decrypt_group_op(
     store: &Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     group_id: ContextGroupId,
     key_id: &[u8; 32],
     encrypted: &EncryptedGroupOp,
 ) -> EyreResult<Option<GroupOp>> {
     let resolved = match GroupKeyring::new(store, group_id).load_key_by_id(key_id)? {
         Some(k) => Some(k),
-        None => {
-            GroupKeyring::new(store, ContextGroupId::from(namespace_id)).load_key_by_id(key_id)?
-        }
+        None => GroupKeyring::new(store, ContextGroupId::from(namespace_id.to_bytes()))
+            .load_key_by_id(key_id)?,
     };
     match resolved {
         Some(group_key) => Ok(Some(GroupKeyring::decrypt_op(&group_key, encrypted)?)),
@@ -1676,7 +1677,7 @@ pub fn decrypt_group_op(
 /// [`NamespaceGovernance::build_group_key_delivery`].
 pub fn build_group_key_delivery(
     store: &Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     group_id: [u8; 32],
     requester: PublicKey,
 ) -> EyreResult<(Vec<u8>, PublicKey)> {
@@ -1688,7 +1689,7 @@ pub fn build_group_key_delivery(
 /// [`NamespaceGovernance::apply_received_group_key`].
 pub fn apply_received_group_key(
     store: &Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     group_id: [u8; 32],
     envelope_bytes: &[u8],
     responder_identity: PublicKey,
@@ -1709,7 +1710,7 @@ pub fn apply_received_group_key(
 /// in-tree caller and lands in a follow-up task.
 pub fn retry_encrypted_ops_for_group(
     store: &Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     group_id: [u8; 32],
 ) -> EyreResult<Option<super::super::DivergenceReport>> {
     NamespaceGovernance::new(store, namespace_id).retry_encrypted_ops_for_group(group_id)
@@ -1723,7 +1724,7 @@ pub fn retry_encrypted_ops_for_group(
 /// the keys to exactly these groups.
 pub fn namespace_groups_awaiting_key(
     store: &Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
 ) -> EyreResult<Vec<[u8; 32]>> {
     NamespaceRetryService::new(store, namespace_id).groups_awaiting_key()
 }
@@ -1735,7 +1736,7 @@ pub fn namespace_groups_awaiting_key(
 /// the live re-drive landed holds the key but has no future trigger.
 pub fn namespace_groups_with_held_key_buffered_ops(
     store: &Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
 ) -> EyreResult<Vec<[u8; 32]>> {
     NamespaceRetryService::new(store, namespace_id).groups_with_held_key_buffered_ops()
 }
@@ -1765,7 +1766,7 @@ pub fn known_namespace_identities(store: &Store) -> EyreResult<Vec<[u8; 32]>> {
 /// rather than ops actually recovered.
 pub fn redrive_buffered_ops_for_group(
     store: &Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     group_id: [u8; 32],
 ) -> EyreResult<usize> {
     NamespaceGovernance::new(store, namespace_id).redrive_encrypted_ops_for_group_counted(group_id)
@@ -1775,7 +1776,7 @@ pub async fn sign_apply_and_publish_namespace_op(
     store: &Store,
     node_client: &calimero_node_primitives::client::NodeClient,
     ack_router: &AckRouter,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     signer_sk: &PrivateKey,
     op: NamespaceOp,
 ) -> EyreResult<DeliveryReport> {
@@ -1788,7 +1789,7 @@ pub async fn sign_and_publish_namespace_op(
     store: &Store,
     node_client: &calimero_node_primitives::client::NodeClient,
     ack_router: &AckRouter,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     signer_sk: &PrivateKey,
     op: NamespaceOp,
     required_signers: Option<Vec<PublicKey>>,
@@ -1800,7 +1801,7 @@ pub async fn sign_and_publish_namespace_op(
 
 pub fn collect_skeleton_delta_ids_for_group(
     store: &Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     group_id: [u8; 32],
 ) -> EyreResult<Vec<[u8; 32]>> {
     NamespaceGovernance::new(store, namespace_id).collect_skeleton_delta_ids_for_group(group_id)

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -243,8 +243,11 @@ impl<'a> NamespaceGovernance<'a> {
                         // a failure here must not block the DAG (every later
                         // op would orphan), so errors are logged, not
                         // propagated.
-                        match self.apply_received_group_key_envelope(*group_id, envelope, op.signer)
-                        {
+                        match self.apply_received_group_key_envelope(
+                            group_id.to_bytes(),
+                            envelope,
+                            op.signer,
+                        ) {
                             Ok(retry_divergence) => {
                                 if retry_divergence.is_some() {
                                     result.divergence = retry_divergence;
@@ -252,12 +255,12 @@ impl<'a> NamespaceGovernance<'a> {
                             }
                             Err(e) => {
                                 tracing::warn!(
-                                    group_id = %hex::encode(group_id),
+                                    group_id = %hex::encode(group_id.to_bytes()),
                                     error = %e,
                                     "KeyDelivery side-effect failed; DAG apply continues"
                                 );
                                 result.key_unwrap_failures.push(KeyUnwrapFailure {
-                                    group_id: *group_id,
+                                    group_id: group_id.to_bytes(),
                                     reason: format!("KeyDelivery side-effect failed: {e}"),
                                 });
                             }
@@ -302,7 +305,7 @@ impl<'a> NamespaceGovernance<'a> {
                         // (we ran it via `apply_root_op` above before this
                         // match), so by the time we get here the path is
                         // confirmed Inherited.
-                        let group_id_typed = ContextGroupId::from(*group_id);
+                        let group_id_typed = *group_id;
                         // Clear deny-list on EVERY peer, not just the
                         // local rejoiner. A prior `MemberLeft` (or
                         // `MemberRemoved` followed by inheritance rejoin)
@@ -380,7 +383,7 @@ impl<'a> NamespaceGovernance<'a> {
                         // touching the op-log. Best-effort: log, never
                         // propagate.
                         let gid = *group_id;
-                        let gid_typed = ContextGroupId::from(gid);
+                        let gid_typed = gid;
                         let ns_typed = ContextGroupId::from(self.namespace_id.to_bytes());
                         let holds_key = GroupKeyring::new(self.store, gid_typed)
                             .holds_any_key()
@@ -389,7 +392,7 @@ impl<'a> NamespaceGovernance<'a> {
                                 .holds_any_key()
                                 .unwrap_or(false);
                         if holds_key {
-                            match self.retry_encrypted_ops_for_group(*group_id) {
+                            match self.retry_encrypted_ops_for_group(group_id.to_bytes()) {
                                 Ok(retry_divergence) => {
                                     if retry_divergence.is_some() {
                                         result.divergence = retry_divergence;
@@ -397,7 +400,7 @@ impl<'a> NamespaceGovernance<'a> {
                                 }
                                 Err(e) => tracing::warn!(
                                     ?e,
-                                    group_id = %hex::encode(group_id),
+                                    group_id = %hex::encode(group_id.to_bytes()),
                                     "retry after GroupCreated failed (#2848)"
                                 ),
                             }
@@ -412,7 +415,7 @@ impl<'a> NamespaceGovernance<'a> {
                 encrypted,
                 key_rotation,
             } => {
-                let group_id_typed = ContextGroupId::from(*group_id);
+                let group_id_typed = *group_id;
 
                 // Issue #2256: an `Open` subgroup is encrypted with the
                 // parent namespace's key (see `GroupGovernancePublisher`).
@@ -469,7 +472,7 @@ impl<'a> NamespaceGovernance<'a> {
                                         let _ = GroupKeyring::new(self.store, group_id_typed)
                                             .store_key(&new_key)?;
                                         tracing::info!(
-                                            group_id = %hex::encode(group_id),
+                                            group_id = %hex::encode(group_id.to_bytes()),
                                             "stored rotated group key"
                                         );
                                     }
@@ -479,7 +482,7 @@ impl<'a> NamespaceGovernance<'a> {
                                             "failed to unwrap key rotation envelope"
                                         );
                                         result.key_unwrap_failures.push(KeyUnwrapFailure {
-                                            group_id: *group_id,
+                                            group_id: group_id.to_bytes(),
                                             reason: format!("key rotation unwrap failed: {e}"),
                                         });
                                     }
@@ -1352,7 +1355,7 @@ impl<'a> NamespaceGovernance<'a> {
 
         let signed_group_op = SignedGroupOp {
             version: calimero_context_client::local_governance::SIGNED_GROUP_OP_SCHEMA_VERSION,
-            group_id: group_id.to_bytes(),
+            group_id: *group_id,
             parent_op_hashes: ns_op.parent_op_hashes.clone(),
             signer: ns_op.signer,
             nonce: ns_op.nonce,

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -422,14 +422,16 @@ impl<'a> NamespaceGovernance<'a> {
                 // saw `Open` but the receiver has already applied a flip
                 // to `Restricted`, the fallback still resolves the key
                 // because both keyrings persist their entries.
-                let resolved_key =
-                    match GroupKeyring::new(self.store, group_id_typed).load_key_by_id(key_id)? {
-                        Some(k) => Some(k),
-                        None => {
-                            let ns_id_typed = ContextGroupId::from(self.namespace_id);
-                            GroupKeyring::new(self.store, ns_id_typed).load_key_by_id(key_id)?
-                        }
-                    };
+                let resolved_key = match GroupKeyring::new(self.store, group_id_typed)
+                    .load_key_by_id(key_id.as_bytes())?
+                {
+                    Some(k) => Some(k),
+                    None => {
+                        let ns_id_typed = ContextGroupId::from(self.namespace_id);
+                        GroupKeyring::new(self.store, ns_id_typed)
+                            .load_key_by_id(key_id.as_bytes())?
+                    }
+                };
 
                 if let Some(group_key) = resolved_key {
                     // Surface any post-apply hash divergence reported by

--- a/crates/governance-store/src/namespace/membership.rs
+++ b/crates/governance-store/src/namespace/membership.rs
@@ -2,6 +2,7 @@ use crate::{MembershipRepository, NamespaceRepository};
 use calimero_context_config::types::ContextGroupId;
 use calimero_context_config::types::SignedGroupOpenInvitation;
 use calimero_context_config::MemberCapabilities;
+use calimero_governance_types::NamespaceId;
 use calimero_primitives::context::GroupMemberRole;
 use calimero_primitives::identity::PublicKey;
 use calimero_store::Store;
@@ -13,11 +14,11 @@ use super::super::membership::role_from_invited_role;
 /// Namespace-scoped service for handling `RootOp::MemberJoined`.
 pub struct NamespaceMembershipService<'a> {
     store: &'a Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
 }
 
 impl<'a> NamespaceMembershipService<'a> {
-    pub fn new(store: &'a Store, namespace_id: [u8; 32]) -> Self {
+    pub fn new(store: &'a Store, namespace_id: NamespaceId) -> Self {
         Self {
             store,
             namespace_id,
@@ -79,7 +80,7 @@ impl<'a> NamespaceMembershipService<'a> {
         }
 
         let resolved_ns = NamespaceRepository::new(self.store).resolve(&group_id)?;
-        if resolved_ns.to_bytes() != self.namespace_id {
+        if resolved_ns.to_bytes() != self.namespace_id.to_bytes() {
             bail!("group does not belong to this namespace");
         }
 
@@ -112,7 +113,7 @@ impl<'a> NamespaceMembershipService<'a> {
         self.verify_inviter_signature(signed_invitation)?;
 
         let resolved_ns = NamespaceRepository::new(self.store).resolve(&group_id)?;
-        if resolved_ns.to_bytes() != self.namespace_id {
+        if resolved_ns.to_bytes() != self.namespace_id.to_bytes() {
             bail!("group does not belong to this namespace");
         }
 

--- a/crates/governance-store/src/namespace/op_log.rs
+++ b/crates/governance-store/src/namespace/op_log.rs
@@ -1,6 +1,7 @@
 use calimero_context_client::local_governance::{
     NamespaceOp, OpaqueSkeleton, SignedNamespaceOp, StoredNamespaceEntry,
 };
+use calimero_governance_types::KeyId;
 use calimero_store::Store;
 use eyre::{bail, Result as EyreResult};
 
@@ -9,7 +10,7 @@ use crate::metrics::{record_namespace_decode_fallback, record_namespace_decode_i
 /// Typed namespace group entry decoded from the namespace op-log.
 pub struct StoredSignedGroupOp {
     pub signed_op: SignedNamespaceOp,
-    pub key_id: [u8; 32],
+    pub key_id: KeyId,
 }
 
 /// Service for persisting and reading namespace governance op-log entries.
@@ -143,7 +144,7 @@ impl<'a> NamespaceOpLogService<'a> {
                 self.store,
                 self.namespace_id,
                 calimero_context_config::types::ContextGroupId::from(*group_id),
-                key_id,
+                key_id.as_bytes(),
                 encrypted,
             )
             .ok()
@@ -321,7 +322,7 @@ impl<'a> NamespaceOpLogService<'a> {
                 ..
             } = signed_op.op
             {
-                seen.insert((op_group_id, key_id));
+                seen.insert((op_group_id, key_id.to_bytes()));
             }
         }
 

--- a/crates/governance-store/src/namespace/op_log.rs
+++ b/crates/governance-store/src/namespace/op_log.rs
@@ -144,7 +144,7 @@ impl<'a> NamespaceOpLogService<'a> {
             } => crate::decrypt_group_op(
                 self.store,
                 self.namespace_id,
-                calimero_context_config::types::ContextGroupId::from(*group_id),
+                *group_id,
                 key_id.as_bytes(),
                 encrypted,
             )
@@ -267,7 +267,7 @@ impl<'a> NamespaceOpLogService<'a> {
             else {
                 continue;
             };
-            if op_group_id != group_id {
+            if op_group_id.to_bytes() != group_id {
                 continue;
             }
             entries.push(StoredSignedGroupOp { signed_op, key_id });
@@ -325,7 +325,7 @@ impl<'a> NamespaceOpLogService<'a> {
                 ..
             } = signed_op.op
             {
-                seen.insert((op_group_id, key_id.to_bytes()));
+                seen.insert((op_group_id.to_bytes(), key_id.to_bytes()));
             }
         }
 
@@ -378,7 +378,7 @@ impl<'a> NamespaceOpLogService<'a> {
             let Some(skeleton) = decode_opaque_skeleton(&value.skeleton_bytes) else {
                 continue;
             };
-            if skeleton.group_id == group_id {
+            if skeleton.group_id.to_bytes() == group_id {
                 delta_ids.push(skeleton.delta_id);
             }
         }

--- a/crates/governance-store/src/namespace/op_log.rs
+++ b/crates/governance-store/src/namespace/op_log.rs
@@ -2,6 +2,7 @@ use calimero_context_client::local_governance::{
     NamespaceOp, OpaqueSkeleton, SignedNamespaceOp, StoredNamespaceEntry,
 };
 use calimero_governance_types::KeyId;
+use calimero_governance_types::NamespaceId;
 use calimero_store::Store;
 use eyre::{bail, Result as EyreResult};
 
@@ -16,11 +17,11 @@ pub struct StoredSignedGroupOp {
 /// Service for persisting and reading namespace governance op-log entries.
 pub struct NamespaceOpLogService<'a> {
     store: &'a Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
 }
 
 impl<'a> NamespaceOpLogService<'a> {
-    pub fn new(store: &'a Store, namespace_id: [u8; 32]) -> Self {
+    pub fn new(store: &'a Store, namespace_id: NamespaceId) -> Self {
         Self {
             store,
             namespace_id,
@@ -34,7 +35,7 @@ impl<'a> NamespaceOpLogService<'a> {
     /// without paying the cost of a full op-log scan.
     pub fn contains_op(&self, delta_id: [u8; 32]) -> EyreResult<bool> {
         let handle = self.store.handle();
-        let key = calimero_store::key::NamespaceGovOp::new(self.namespace_id, delta_id);
+        let key = calimero_store::key::NamespaceGovOp::new(self.namespace_id.to_bytes(), delta_id);
         handle
             .has(&key)
             .map_err(|e| eyre::eyre!("contains_op: {e}"))
@@ -55,7 +56,7 @@ impl<'a> NamespaceOpLogService<'a> {
     /// drops it with a misleading "permanently missing" log.
     pub fn get_signed_op(&self, delta_id: [u8; 32]) -> EyreResult<Option<SignedNamespaceOp>> {
         let handle = self.store.handle();
-        let key = calimero_store::key::NamespaceGovOp::new(self.namespace_id, delta_id);
+        let key = calimero_store::key::NamespaceGovOp::new(self.namespace_id.to_bytes(), delta_id);
         let value: calimero_store::key::NamespaceGovOpValue = match handle.get(&key) {
             Ok(Some(v)) => v,
             Ok(None) => return Ok(None),
@@ -75,15 +76,15 @@ impl<'a> NamespaceOpLogService<'a> {
         if op.namespace_id != self.namespace_id {
             bail!(
                 "namespace mismatch when storing op: handle={}, op={}",
-                hex::encode(self.namespace_id),
-                hex::encode(op.namespace_id)
+                hex::encode(self.namespace_id.as_bytes()),
+                hex::encode(op.namespace_id.as_bytes())
             );
         }
 
         let delta_id = op
             .content_hash()
             .map_err(|e| eyre::eyre!("content_hash: {e}"))?;
-        let key = calimero_store::key::NamespaceGovOp::new(self.namespace_id, delta_id);
+        let key = calimero_store::key::NamespaceGovOp::new(self.namespace_id.to_bytes(), delta_id);
         let value = calimero_store::key::NamespaceGovOpValue {
             skeleton_bytes: borsh::to_vec(&StoredNamespaceEntry::Signed(op.clone()))
                 .map_err(|e| eyre::eyre!("borsh: {e}"))?,
@@ -108,7 +109,7 @@ impl<'a> NamespaceOpLogService<'a> {
             // existing backfill/repersist paths. Logged, not propagated.
             tracing::warn!(
                 %err,
-                namespace_id = %hex::encode(self.namespace_id),
+                namespace_id = %hex::encode(self.namespace_id.as_bytes()),
                 delta_id = %hex::encode(delta_id),
                 "unified op-store: atomic op-store write failed; gov-DAG write kept"
             );
@@ -163,7 +164,7 @@ impl<'a> NamespaceOpLogService<'a> {
             &delta.parents,
         );
 
-        let scope = calimero_op::ScopeId::from(self.namespace_id);
+        let scope = calimero_op::ScopeId::from(self.namespace_id.to_bytes());
         let key = calimero_store::key::ScopeUnifiedOp::new(*scope.as_bytes(), unified_op.id());
         let bytes = borsh::to_vec(&unified_op).map_err(|e| eyre::eyre!("borsh op: {e}"))?;
         let value =
@@ -184,7 +185,8 @@ impl<'a> NamespaceOpLogService<'a> {
     ) -> EyreResult<Vec<StoredSignedGroupOp>> {
         let mut entries = Vec::new();
         let handle = self.store.handle();
-        let start = calimero_store::key::NamespaceGovOp::new(self.namespace_id, [0u8; 32]);
+        let start =
+            calimero_store::key::NamespaceGovOp::new(self.namespace_id.to_bytes(), [0u8; 32]);
         let mut iter = handle
             .iter::<calimero_store::key::NamespaceGovOp>()
             .map_err(|e| eyre::eyre!("iter::<NamespaceGovOp>: {e}"))?;
@@ -232,7 +234,7 @@ impl<'a> NamespaceOpLogService<'a> {
                     break;
                 }
             };
-            if key.namespace_id() != self.namespace_id {
+            if key.namespace_id() != self.namespace_id.to_bytes() {
                 break;
             }
             let value: calimero_store::key::NamespaceGovOpValue = match handle.get(&key) {
@@ -246,7 +248,7 @@ impl<'a> NamespaceOpLogService<'a> {
                     // valid retry candidates.
                     record_namespace_decode_invalid("signed_iter_value");
                     tracing::warn!(
-                        namespace_id = %hex::encode(self.namespace_id),
+                        namespace_id = %hex::encode(self.namespace_id.as_bytes()),
                         delta_id = %hex::encode(key.delta_id()),
                         error = %e,
                         "skipping undecodable NamespaceGovOpValue during retry walk"
@@ -286,7 +288,8 @@ impl<'a> NamespaceOpLogService<'a> {
     pub fn collect_buffered_group_op_keys(&self) -> EyreResult<Vec<([u8; 32], [u8; 32])>> {
         let mut seen = std::collections::BTreeSet::new();
         let handle = self.store.handle();
-        let start = calimero_store::key::NamespaceGovOp::new(self.namespace_id, [0u8; 32]);
+        let start =
+            calimero_store::key::NamespaceGovOp::new(self.namespace_id.to_bytes(), [0u8; 32]);
         let mut iter = handle
             .iter::<calimero_store::key::NamespaceGovOp>()
             .map_err(|e| eyre::eyre!("iter::<NamespaceGovOp>: {e}"))?;
@@ -302,7 +305,7 @@ impl<'a> NamespaceOpLogService<'a> {
                     break;
                 }
             };
-            if key.namespace_id() != self.namespace_id {
+            if key.namespace_id() != self.namespace_id.to_bytes() {
                 break;
             }
             let value: calimero_store::key::NamespaceGovOpValue = match handle.get(&key) {
@@ -335,7 +338,8 @@ impl<'a> NamespaceOpLogService<'a> {
     ) -> EyreResult<Vec<[u8; 32]>> {
         let mut delta_ids = Vec::new();
         let handle = self.store.handle();
-        let start = calimero_store::key::NamespaceGovOp::new(self.namespace_id, [0u8; 32]);
+        let start =
+            calimero_store::key::NamespaceGovOp::new(self.namespace_id.to_bytes(), [0u8; 32]);
         let mut iter = handle.iter::<calimero_store::key::NamespaceGovOp>()?;
         let first = iter.seek(start).transpose();
 
@@ -354,7 +358,7 @@ impl<'a> NamespaceOpLogService<'a> {
                     break;
                 }
             };
-            if key.namespace_id() != self.namespace_id {
+            if key.namespace_id() != self.namespace_id.to_bytes() {
                 break;
             }
             let value: calimero_store::key::NamespaceGovOpValue = match handle.get(&key) {
@@ -363,7 +367,7 @@ impl<'a> NamespaceOpLogService<'a> {
                 Err(e) => {
                     record_namespace_decode_invalid("opaque_iter_value");
                     tracing::warn!(
-                        namespace_id = %hex::encode(self.namespace_id),
+                        namespace_id = %hex::encode(self.namespace_id.as_bytes()),
                         delta_id = %hex::encode(key.delta_id()),
                         error = %e,
                         "skipping undecodable NamespaceGovOpValue during opaque walk"

--- a/crates/governance-store/src/namespace/retry.rs
+++ b/crates/governance-store/src/namespace/retry.rs
@@ -135,13 +135,13 @@ impl<'a> NamespaceRetryService<'a> {
             // may have been encrypted with the namespace key if the
             // subgroup was `Open` at publish time.
             let group_key = match GroupKeyring::new(self.store, gid_typed)
-                .load_key_by_id(&key_id)
+                .load_key_by_id(key_id.as_bytes())
                 .map_err(|e| eyre::eyre!("load_group_key_by_id(group): {e}"))?
             {
                 Some(k) => k,
                 None => {
                     let Some(k) = GroupKeyring::new(self.store, ns_typed)
-                        .load_key_by_id(&key_id)
+                        .load_key_by_id(key_id.as_bytes())
                         .map_err(|e| eyre::eyre!("load_group_key_by_id(namespace): {e}"))?
                     else {
                         continue;

--- a/crates/governance-store/src/namespace/retry.rs
+++ b/crates/governance-store/src/namespace/retry.rs
@@ -2,6 +2,7 @@ use super::op_log::NamespaceOpLogService;
 use crate::GroupKeyring;
 use calimero_context_client::local_governance::{NamespaceOp, SignedNamespaceOp};
 use calimero_context_config::types::ContextGroupId;
+use calimero_governance_types::NamespaceId;
 use calimero_store::Store;
 use eyre::Result as EyreResult;
 
@@ -15,11 +16,11 @@ pub struct RetryCandidate {
 /// Service for retrying deferred encrypted group operations after key delivery.
 pub struct NamespaceRetryService<'a> {
     store: &'a Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
 }
 
 impl<'a> NamespaceRetryService<'a> {
-    pub fn new(store: &'a Store, namespace_id: [u8; 32]) -> Self {
+    pub fn new(store: &'a Store, namespace_id: NamespaceId) -> Self {
         Self {
             store,
             namespace_id,
@@ -45,7 +46,7 @@ impl<'a> NamespaceRetryService<'a> {
         let op_keys = op_log
             .collect_buffered_group_op_keys()
             .map_err(|e| eyre::eyre!("op_log.collect_buffered_group_op_keys: {e}"))?;
-        let ns_typed = ContextGroupId::from(self.namespace_id);
+        let ns_typed = ContextGroupId::from(self.namespace_id.to_bytes());
 
         let mut awaiting = std::collections::BTreeSet::new();
         for (group_id, key_id) in op_keys {
@@ -93,7 +94,7 @@ impl<'a> NamespaceRetryService<'a> {
         let op_keys = op_log
             .collect_buffered_group_op_keys()
             .map_err(|e| eyre::eyre!("op_log.collect_buffered_group_op_keys: {e}"))?;
-        let ns_typed = ContextGroupId::from(self.namespace_id);
+        let ns_typed = ContextGroupId::from(self.namespace_id.to_bytes());
 
         let mut held = std::collections::BTreeSet::new();
         for (group_id, key_id) in op_keys {
@@ -122,7 +123,7 @@ impl<'a> NamespaceRetryService<'a> {
     ) -> EyreResult<Vec<RetryCandidate>> {
         let mut candidates = Vec::new();
         let gid_typed = ContextGroupId::from(group_id);
-        let ns_typed = ContextGroupId::from(self.namespace_id);
+        let ns_typed = ContextGroupId::from(self.namespace_id.to_bytes());
         let op_log = NamespaceOpLogService::new(self.store, self.namespace_id);
         let entries = op_log
             .collect_signed_group_ops_for_group(group_id)

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -288,7 +288,7 @@ fn namespace_dag_service_collects_skeleton_delta_ids_by_group() {
         skeleton_bytes: borsh::to_vec(&StoredNamespaceEntry::Opaque(OpaqueSkeleton {
             delta_id: delta_a,
             parent_op_hashes: vec![],
-            group_id: group_a.to_bytes(),
+            group_id: group_a.to_bytes().into(),
             signer,
         }))
         .unwrap(),
@@ -297,7 +297,7 @@ fn namespace_dag_service_collects_skeleton_delta_ids_by_group() {
         skeleton_bytes: borsh::to_vec(&StoredNamespaceEntry::Opaque(OpaqueSkeleton {
             delta_id: delta_b,
             parent_op_hashes: vec![delta_a],
-            group_id: group_b.to_bytes(),
+            group_id: group_b.to_bytes().into(),
             signer,
         }))
         .unwrap(),
@@ -307,7 +307,7 @@ fn namespace_dag_service_collects_skeleton_delta_ids_by_group() {
         skeleton_bytes: borsh::to_vec(&StoredNamespaceEntry::Opaque(OpaqueSkeleton {
             delta_id: delta_other_ns,
             parent_op_hashes: vec![],
-            group_id: group_a.to_bytes(),
+            group_id: group_a.to_bytes().into(),
             signer,
         }))
         .unwrap(),
@@ -344,7 +344,7 @@ fn namespace_op_log_service_reads_signed_and_skeleton_entries() {
         vec![],
         1,
         NamespaceOp::Group {
-            group_id: group_a.to_bytes(),
+            group_id: group_a.to_bytes().into(),
             key_id: [0x01; 32].into(),
             encrypted: GroupKeyring::encrypt_op(&[0xA1; 32], &GroupOp::Noop).unwrap(),
             key_rotation: None,
@@ -366,7 +366,7 @@ fn namespace_op_log_service_reads_signed_and_skeleton_entries() {
         skeleton_bytes: borsh::to_vec(&StoredNamespaceEntry::Opaque(OpaqueSkeleton {
             delta_id: skeleton_delta,
             parent_op_hashes: vec![],
-            group_id: group_b.to_bytes(),
+            group_id: group_b.to_bytes().into(),
             signer: signer_sk.public_key(),
         }))
         .unwrap(),
@@ -413,7 +413,7 @@ fn namespace_op_log_service_reads_tagged_and_legacy_rows() {
         vec![],
         1,
         NamespaceOp::Group {
-            group_id: group.to_bytes(),
+            group_id: group.to_bytes().into(),
             key_id: [0x12; 32].into(),
             encrypted: GroupKeyring::encrypt_op(&[0xAA; 32], &GroupOp::Noop).unwrap(),
             key_rotation: None,
@@ -430,7 +430,7 @@ fn namespace_op_log_service_reads_tagged_and_legacy_rows() {
     let legacy_skeleton = OpaqueSkeleton {
         delta_id: legacy_skeleton_delta,
         parent_op_hashes: vec![],
-        group_id: group.to_bytes(),
+        group_id: group.to_bytes().into(),
         signer: signer_sk.public_key(),
     };
 
@@ -489,7 +489,7 @@ fn namespace_op_log_service_collects_group_scoped_signed_ops() {
         vec![],
         1,
         NamespaceOp::Group {
-            group_id: group_a.to_bytes(),
+            group_id: group_a.to_bytes().into(),
             key_id: [0x11; 32].into(),
             encrypted: GroupKeyring::encrypt_op(&[0xAA; 32], &GroupOp::Noop).unwrap(),
             key_rotation: None,
@@ -503,7 +503,7 @@ fn namespace_op_log_service_collects_group_scoped_signed_ops() {
         vec![],
         2,
         NamespaceOp::Group {
-            group_id: group_b.to_bytes(),
+            group_id: group_b.to_bytes().into(),
             key_id: [0x22; 32].into(),
             encrypted: GroupKeyring::encrypt_op(&[0xBB; 32], &GroupOp::Noop).unwrap(),
             key_rotation: None,
@@ -565,7 +565,7 @@ fn namespace_retry_service_collects_only_retryable_group_ops() {
         vec![],
         1,
         NamespaceOp::Group {
-            group_id: group_a.to_bytes(),
+            group_id: group_a.to_bytes().into(),
             key_id: key_id.into(),
             encrypted: encrypted_a,
             key_rotation: None,
@@ -579,7 +579,7 @@ fn namespace_retry_service_collects_only_retryable_group_ops() {
         vec![],
         2,
         NamespaceOp::Group {
-            group_id: group_b.to_bytes(),
+            group_id: group_b.to_bytes().into(),
             key_id: key_id.into(),
             encrypted: encrypted_b,
             key_rotation: None,
@@ -610,7 +610,7 @@ fn namespace_retry_service_collects_only_retryable_group_ops() {
 
     assert_eq!(retryable.len(), 1, "expected only one retryable op");
     match &retryable[0].signed_op.op {
-        NamespaceOp::Group { group_id, .. } => assert_eq!(*group_id, group_a.to_bytes()),
+        NamespaceOp::Group { group_id, .. } => assert_eq!(*group_id, group_a.to_bytes().into()),
         _ => panic!("expected group op"),
     }
 }
@@ -672,7 +672,7 @@ fn namespace_retry_service_orders_candidates_by_signer_nonce() {
                     vec![],
                     nonce,
                     NamespaceOp::Group {
-                        group_id: group.to_bytes(),
+                        group_id: group.to_bytes().into(),
                         key_id: key_id.into(),
                         encrypted: GroupKeyring::encrypt_op(&group_key, &GroupOp::Noop).unwrap(),
                         key_rotation: None,
@@ -1077,7 +1077,7 @@ fn replica_applies_tee_policy_then_membership_via_namespace_governance() {
         vec![],
         1,
         NamespaceOp::Group {
-            group_id: namespace_id,
+            group_id: namespace_id.into(),
             key_id: key_id.into(),
             encrypted: policy_op,
             key_rotation: None,
@@ -1120,7 +1120,7 @@ fn replica_applies_tee_policy_then_membership_via_namespace_governance() {
         vec![],
         2,
         NamespaceOp::Group {
-            group_id: namespace_id,
+            group_id: namespace_id.into(),
             key_id: key_id.into(),
             encrypted: join_op,
             key_rotation: None,
@@ -1275,7 +1275,7 @@ fn tee_replica_seed_bootstrap_admits_tee_with_open_join_cap() {
         head.parent_hashes.clone(),
         head.next_nonce,
         NamespaceOp::Group {
-            group_id: namespace_id,
+            group_id: namespace_id.into(),
             key_id: key_id.into(),
             encrypted: policy_op,
             key_rotation: None,
@@ -1311,7 +1311,7 @@ fn tee_replica_seed_bootstrap_admits_tee_with_open_join_cap() {
         head.parent_hashes.clone(),
         head.next_nonce,
         NamespaceOp::Group {
-            group_id: namespace_id,
+            group_id: namespace_id.into(),
             key_id: key_id.into(),
             encrypted: join_op,
             key_rotation: None,
@@ -1463,8 +1463,8 @@ fn replica_genesis_founder_survives_non_owner_seed_and_applies_owner_ops() {
     );
     let subgroup_id = [0xC5u8; 32];
     let create_op = NamespaceOp::Root(RootOp::GroupCreated {
-        group_id: subgroup_id,
-        parent_id: namespace_id,
+        group_id: subgroup_id.into(),
+        parent_id: namespace_id.into(),
         restricted: true,
     });
     let signed = SignedNamespaceOp::sign(
@@ -2489,7 +2489,7 @@ fn replica_op_log_dedup_survives_head_pruning() {
     let group_op_content_hash = |ns_op: &SignedNamespaceOp, inner: &GroupOp| -> [u8; 32] {
         SignedGroupOp {
             version: SIGNED_GROUP_OP_SCHEMA_VERSION,
-            group_id: namespace_id,
+            group_id: namespace_id.into(),
             parent_op_hashes: ns_op.parent_op_hashes.clone(),
             signer: ns_op.signer,
             nonce: ns_op.nonce,
@@ -2518,7 +2518,7 @@ fn replica_op_log_dedup_survives_head_pruning() {
         vec![],
         1,
         NamespaceOp::Group {
-            group_id: namespace_id,
+            group_id: namespace_id.into(),
             key_id: key_id.into(),
             encrypted: GroupKeyring::encrypt_op(&group_key, &inner_a).unwrap(),
             key_rotation: None,
@@ -2545,7 +2545,7 @@ fn replica_op_log_dedup_survives_head_pruning() {
         vec![hash_a],
         2,
         NamespaceOp::Group {
-            group_id: namespace_id,
+            group_id: namespace_id.into(),
             key_id: key_id.into(),
             encrypted: GroupKeyring::encrypt_op(&group_key, &inner_b).unwrap(),
             key_rotation: None,
@@ -2646,7 +2646,7 @@ fn replica_concurrent_sibling_ops_apply_out_of_order_2516() {
             vec![],
             nonce,
             NamespaceOp::Group {
-                group_id: namespace_id,
+                group_id: namespace_id.into(),
                 key_id: key_id.into(),
                 encrypted: GroupKeyring::encrypt_op(&group_key, inner).unwrap(),
                 key_rotation: None,
@@ -2727,7 +2727,7 @@ fn replica_stale_head_does_not_overwrite_orphan_entry() {
     let group_op_content_hash = |ns_op: &SignedNamespaceOp, inner: &GroupOp| -> [u8; 32] {
         SignedGroupOp {
             version: SIGNED_GROUP_OP_SCHEMA_VERSION,
-            group_id: namespace_id,
+            group_id: namespace_id.into(),
             parent_op_hashes: ns_op.parent_op_hashes.clone(),
             signer: ns_op.signer,
             nonce: ns_op.nonce,
@@ -2756,7 +2756,7 @@ fn replica_stale_head_does_not_overwrite_orphan_entry() {
         vec![],
         1,
         NamespaceOp::Group {
-            group_id: namespace_id,
+            group_id: namespace_id.into(),
             key_id: key_id.into(),
             encrypted: GroupKeyring::encrypt_op(&group_key, &inner_a).unwrap(),
             key_rotation: None,
@@ -2781,7 +2781,7 @@ fn replica_stale_head_does_not_overwrite_orphan_entry() {
         vec![],
         2,
         NamespaceOp::Group {
-            group_id: namespace_id,
+            group_id: namespace_id.into(),
             key_id: key_id.into(),
             encrypted: GroupKeyring::encrypt_op(&group_key, &inner_b).unwrap(),
             key_rotation: None,
@@ -3281,8 +3281,8 @@ fn governance_group_reparented_via_signed_op() {
             vec![],
             (i + 1) as u64,
             NamespaceOp::Root(RootOp::GroupCreated {
-                group_id: *gid,
-                parent_id: *parent,
+                group_id: (*gid).into(),
+                parent_id: (*parent).into(),
                 restricted: true,
             }),
         )
@@ -3302,8 +3302,8 @@ fn governance_group_reparented_via_signed_op() {
         vec![],
         4,
         NamespaceOp::Root(RootOp::GroupReparented {
-            child_group_id: leaf_id,
-            new_parent_id,
+            child_group_id: leaf_id.into(),
+            new_parent_id: new_parent_id.into(),
         }),
     )
     .expect("sign reparent op");
@@ -3362,8 +3362,8 @@ fn governance_apply_signed_op_is_idempotent_on_replay() {
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
-            group_id: [0xC1; 32],
-            parent_id: ns_id,
+            group_id: [0xC1; 32].into(),
+            parent_id: ns_id.into(),
             restricted: true,
         }),
     )
@@ -3425,8 +3425,8 @@ fn governance_rejects_non_admin_signer() {
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
-            group_id: [0xBB; 32],
-            parent_id: ns_id,
+            group_id: [0xBB; 32].into(),
+            parent_id: ns_id.into(),
             restricted: true,
         }),
     )
@@ -3472,8 +3472,8 @@ fn governance_group_created_is_idempotent() {
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
-            group_id: new_group_id,
-            parent_id: ns_id,
+            group_id: new_group_id.into(),
+            parent_id: ns_id.into(),
             restricted: true,
         }),
     )
@@ -3489,8 +3489,8 @@ fn governance_group_created_is_idempotent() {
         vec![],
         2,
         NamespaceOp::Root(RootOp::GroupCreated {
-            group_id: new_group_id,
-            parent_id: ns_id,
+            group_id: new_group_id.into(),
+            parent_id: ns_id.into(),
             restricted: true,
         }),
     )
@@ -3547,8 +3547,8 @@ fn governance_group_created_writes_birth_visibility() {
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
-            group_id: open_group_id,
-            parent_id: ns_id,
+            group_id: open_group_id.into(),
+            parent_id: ns_id.into(),
             restricted: false,
         }),
     )
@@ -3569,8 +3569,8 @@ fn governance_group_created_writes_birth_visibility() {
         vec![],
         2,
         NamespaceOp::Root(RootOp::GroupCreated {
-            group_id: restricted_group_id,
-            parent_id: ns_id,
+            group_id: restricted_group_id.into(),
+            parent_id: ns_id.into(),
             restricted: true,
         }),
     )
@@ -3633,8 +3633,8 @@ fn governance_group_created_replay_does_not_reset_visibility() {
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
-            group_id,
-            parent_id: ns_id,
+            group_id: group_id.into(),
+            parent_id: ns_id.into(),
             restricted: false,
         }),
     )
@@ -3665,8 +3665,8 @@ fn governance_group_created_replay_does_not_reset_visibility() {
         vec![],
         2,
         NamespaceOp::Root(RootOp::GroupCreated {
-            group_id,
-            parent_id: ns_id,
+            group_id: group_id.into(),
+            parent_id: ns_id.into(),
             restricted: false,
         }),
     )
@@ -3733,8 +3733,8 @@ fn governance_group_created_writes_parent_edge_even_when_meta_pre_populated() {
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
-            group_id: new_group_id,
-            parent_id: ns_id,
+            group_id: new_group_id.into(),
+            parent_id: ns_id.into(),
             restricted: true,
         }),
     )
@@ -3796,8 +3796,8 @@ fn execute_group_created_rejects_self_parent() {
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
-            group_id: ns_id,
-            parent_id: ns_id,
+            group_id: ns_id.into(),
+            parent_id: ns_id.into(),
             restricted: true,
         }),
     )
@@ -3860,8 +3860,8 @@ fn execute_group_created_inherits_app_key_and_application_from_parent() {
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
-            group_id: sub_id,
-            parent_id: ns_id,
+            group_id: sub_id.into(),
+            parent_id: ns_id.into(),
             restricted: true,
         }),
     )
@@ -3950,8 +3950,8 @@ fn execute_group_deleted_subset_check_allows_partial_retry() {
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupDeleted {
-            root_group_id: a_id,
-            cascade_group_ids,
+            root_group_id: a_id.into(),
+            cascade_group_ids: cascade_group_ids.into_iter().map(Into::into).collect(),
             cascade_context_ids: vec![],
         }),
     )
@@ -4020,8 +4020,8 @@ fn execute_group_deleted_ignores_payload_groups_outside_local_subtree() {
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupDeleted {
-            root_group_id: a_id,
-            cascade_group_ids: vec![b_id, x_id],
+            root_group_id: a_id.into(),
+            cascade_group_ids: vec![b_id.into(), x_id.into()],
             cascade_context_ids: vec![],
         }),
     )
@@ -4405,8 +4405,8 @@ fn governance_group_created_honors_can_create_subgroup_at_root_only() {
             vec![],
             nonce,
             NamespaceOp::Root(RootOp::GroupCreated {
-                group_id,
-                parent_id,
+                group_id: group_id.into(),
+                parent_id: parent_id.into(),
                 restricted: true,
             }),
         )
@@ -4572,7 +4572,7 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
             vec![],
             nonce,
             NamespaceOp::Root(RootOp::GroupDeleted {
-                root_group_id,
+                root_group_id: root_group_id.into(),
                 cascade_group_ids: vec![],
                 cascade_context_ids: vec![],
             }),
@@ -4694,8 +4694,8 @@ fn group_created_with_no_key_skips_retry() {
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
-            group_id: new_group_id,
-            parent_id: ns_id,
+            group_id: new_group_id.into(),
+            parent_id: ns_id.into(),
             restricted: true,
         }),
     )
@@ -4834,7 +4834,7 @@ fn groups_awaiting_key_reports_then_clears() {
         vec![],
         1,
         NamespaceOp::Group {
-            group_id,
+            group_id: group_id.into(),
             // Content-addressed id of the key the op is encrypted under, so
             // storing that exact key later resolves the op (awaiting clears).
             key_id: GroupKeyring::key_id_for(&[0xAA; 32]).into(),
@@ -4895,7 +4895,7 @@ fn restricted_subgroup_awaits_key_despite_holding_namespace_key() {
         vec![],
         1,
         NamespaceOp::Group {
-            group_id: subgroup_id,
+            group_id: subgroup_id.into(),
             key_id: GroupKeyring::key_id_for(&subgroup_key).into(),
             encrypted: GroupKeyring::encrypt_op(&subgroup_key, &GroupOp::Noop).unwrap(),
             key_rotation: None,
@@ -4990,7 +4990,7 @@ fn responder_delivery_round_trips_key_to_joiner_cross_store() {
         vec![],
         1,
         NamespaceOp::Group {
-            group_id: subgroup_id,
+            group_id: subgroup_id.into(),
             // Content-addressed id of `group_key`, so the retry path finds
             // the delivered key by id once it is stored.
             key_id: GroupKeyring::key_id_for(&group_key).into(),
@@ -5113,7 +5113,7 @@ fn responder_delivery_round_trips_key_to_read_only_tee_joiner() {
         vec![],
         1,
         NamespaceOp::Group {
-            group_id: subgroup_id,
+            group_id: subgroup_id.into(),
             // Content-addressed id of `group_key`, so the retry path finds
             // the delivered key by id once it is stored.
             key_id: GroupKeyring::key_id_for(&group_key).into(),
@@ -5278,7 +5278,7 @@ fn curative_sweep_redrives_stranded_context() {
         vec![],
         1,
         NamespaceOp::Group {
-            group_id: sub_gid.to_bytes(),
+            group_id: sub_gid.to_bytes().into(),
             key_id: key_id.into(),
             encrypted,
             key_rotation: None,
@@ -5383,7 +5383,7 @@ fn curative_sweep_redrives_stranded_context() {
         vec![],
         2,
         NamespaceOp::Group {
-            group_id: nokey_gid.to_bytes(),
+            group_id: nokey_gid.to_bytes().into(),
             key_id: GroupKeyring::key_id_for(&nokey_key).into(),
             encrypted: nokey_encrypted,
             key_rotation: None,

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -341,7 +341,7 @@ fn namespace_op_log_service_reads_signed_and_skeleton_entries() {
         1,
         NamespaceOp::Group {
             group_id: group_a.to_bytes(),
-            key_id: [0x01; 32],
+            key_id: [0x01; 32].into(),
             encrypted: GroupKeyring::encrypt_op(&[0xA1; 32], &GroupOp::Noop).unwrap(),
             key_rotation: None,
         },
@@ -381,7 +381,7 @@ fn namespace_op_log_service_reads_signed_and_skeleton_entries() {
         signed_delta,
         "signed op should be decoded with stable delta id",
     );
-    assert_eq!(decoded_signed[0].key_id, [0x01; 32]);
+    assert_eq!(decoded_signed[0].key_id.to_bytes(), [0x01; 32]);
 
     let decoded_skeleton = op_log
         .collect_opaque_skeleton_delta_ids_for_group(group_b.to_bytes())
@@ -410,7 +410,7 @@ fn namespace_op_log_service_reads_tagged_and_legacy_rows() {
         1,
         NamespaceOp::Group {
             group_id: group.to_bytes(),
-            key_id: [0x12; 32],
+            key_id: [0x12; 32].into(),
             encrypted: GroupKeyring::encrypt_op(&[0xAA; 32], &GroupOp::Noop).unwrap(),
             key_rotation: None,
         },
@@ -486,7 +486,7 @@ fn namespace_op_log_service_collects_group_scoped_signed_ops() {
         1,
         NamespaceOp::Group {
             group_id: group_a.to_bytes(),
-            key_id: [0x11; 32],
+            key_id: [0x11; 32].into(),
             encrypted: GroupKeyring::encrypt_op(&[0xAA; 32], &GroupOp::Noop).unwrap(),
             key_rotation: None,
         },
@@ -500,7 +500,7 @@ fn namespace_op_log_service_collects_group_scoped_signed_ops() {
         2,
         NamespaceOp::Group {
             group_id: group_b.to_bytes(),
-            key_id: [0x22; 32],
+            key_id: [0x22; 32].into(),
             encrypted: GroupKeyring::encrypt_op(&[0xBB; 32], &GroupOp::Noop).unwrap(),
             key_rotation: None,
         },
@@ -531,7 +531,7 @@ fn namespace_op_log_service_collects_group_scoped_signed_ops() {
         selected[0].signed_op.content_hash().unwrap(),
         op_a.content_hash().unwrap()
     );
-    assert_eq!(selected[0].key_id, [0x11; 32]);
+    assert_eq!(selected[0].key_id.to_bytes(), [0x11; 32]);
 }
 
 #[test]
@@ -562,7 +562,7 @@ fn namespace_retry_service_collects_only_retryable_group_ops() {
         1,
         NamespaceOp::Group {
             group_id: group_a.to_bytes(),
-            key_id,
+            key_id: key_id.into(),
             encrypted: encrypted_a,
             key_rotation: None,
         },
@@ -576,7 +576,7 @@ fn namespace_retry_service_collects_only_retryable_group_ops() {
         2,
         NamespaceOp::Group {
             group_id: group_b.to_bytes(),
-            key_id,
+            key_id: key_id.into(),
             encrypted: encrypted_b,
             key_rotation: None,
         },
@@ -669,7 +669,7 @@ fn namespace_retry_service_orders_candidates_by_signer_nonce() {
                     nonce,
                     NamespaceOp::Group {
                         group_id: group.to_bytes(),
-                        key_id,
+                        key_id: key_id.into(),
                         encrypted: GroupKeyring::encrypt_op(&group_key, &GroupOp::Noop).unwrap(),
                         key_rotation: None,
                     },
@@ -1074,7 +1074,7 @@ fn replica_applies_tee_policy_then_membership_via_namespace_governance() {
         1,
         NamespaceOp::Group {
             group_id: namespace_id,
-            key_id,
+            key_id: key_id.into(),
             encrypted: policy_op,
             key_rotation: None,
         },
@@ -1117,7 +1117,7 @@ fn replica_applies_tee_policy_then_membership_via_namespace_governance() {
         2,
         NamespaceOp::Group {
             group_id: namespace_id,
-            key_id,
+            key_id: key_id.into(),
             encrypted: join_op,
             key_rotation: None,
         },
@@ -1271,7 +1271,7 @@ fn tee_replica_seed_bootstrap_admits_tee_with_open_join_cap() {
         head.next_nonce,
         NamespaceOp::Group {
             group_id: namespace_id,
-            key_id,
+            key_id: key_id.into(),
             encrypted: policy_op,
             key_rotation: None,
         },
@@ -1307,7 +1307,7 @@ fn tee_replica_seed_bootstrap_admits_tee_with_open_join_cap() {
         head.next_nonce,
         NamespaceOp::Group {
             group_id: namespace_id,
-            key_id,
+            key_id: key_id.into(),
             encrypted: join_op,
             key_rotation: None,
         },
@@ -2486,7 +2486,7 @@ fn replica_op_log_dedup_survives_head_pruning() {
         1,
         NamespaceOp::Group {
             group_id: namespace_id,
-            key_id,
+            key_id: key_id.into(),
             encrypted: GroupKeyring::encrypt_op(&group_key, &inner_a).unwrap(),
             key_rotation: None,
         },
@@ -2513,7 +2513,7 @@ fn replica_op_log_dedup_survives_head_pruning() {
         2,
         NamespaceOp::Group {
             group_id: namespace_id,
-            key_id,
+            key_id: key_id.into(),
             encrypted: GroupKeyring::encrypt_op(&group_key, &inner_b).unwrap(),
             key_rotation: None,
         },
@@ -2614,7 +2614,7 @@ fn replica_concurrent_sibling_ops_apply_out_of_order_2516() {
             nonce,
             NamespaceOp::Group {
                 group_id: namespace_id,
-                key_id,
+                key_id: key_id.into(),
                 encrypted: GroupKeyring::encrypt_op(&group_key, inner).unwrap(),
                 key_rotation: None,
             },
@@ -2724,7 +2724,7 @@ fn replica_stale_head_does_not_overwrite_orphan_entry() {
         1,
         NamespaceOp::Group {
             group_id: namespace_id,
-            key_id,
+            key_id: key_id.into(),
             encrypted: GroupKeyring::encrypt_op(&group_key, &inner_a).unwrap(),
             key_rotation: None,
         },
@@ -2749,7 +2749,7 @@ fn replica_stale_head_does_not_overwrite_orphan_entry() {
         2,
         NamespaceOp::Group {
             group_id: namespace_id,
-            key_id,
+            key_id: key_id.into(),
             encrypted: GroupKeyring::encrypt_op(&group_key, &inner_b).unwrap(),
             key_rotation: None,
         },
@@ -4804,7 +4804,7 @@ fn groups_awaiting_key_reports_then_clears() {
             group_id,
             // Content-addressed id of the key the op is encrypted under, so
             // storing that exact key later resolves the op (awaiting clears).
-            key_id: GroupKeyring::key_id_for(&[0xAA; 32]),
+            key_id: GroupKeyring::key_id_for(&[0xAA; 32]).into(),
             encrypted: GroupKeyring::encrypt_op(&[0xAA; 32], &GroupOp::Noop).unwrap(),
             key_rotation: None,
         },
@@ -4863,7 +4863,7 @@ fn restricted_subgroup_awaits_key_despite_holding_namespace_key() {
         1,
         NamespaceOp::Group {
             group_id: subgroup_id,
-            key_id: GroupKeyring::key_id_for(&subgroup_key),
+            key_id: GroupKeyring::key_id_for(&subgroup_key).into(),
             encrypted: GroupKeyring::encrypt_op(&subgroup_key, &GroupOp::Noop).unwrap(),
             key_rotation: None,
         },
@@ -4955,7 +4955,7 @@ fn responder_delivery_round_trips_key_to_joiner_cross_store() {
             group_id: subgroup_id,
             // Content-addressed id of `group_key`, so the retry path finds
             // the delivered key by id once it is stored.
-            key_id: GroupKeyring::key_id_for(&group_key),
+            key_id: GroupKeyring::key_id_for(&group_key).into(),
             encrypted: GroupKeyring::encrypt_op(&group_key, &GroupOp::Noop).unwrap(),
             key_rotation: None,
         },
@@ -5071,7 +5071,7 @@ fn responder_delivery_round_trips_key_to_read_only_tee_joiner() {
             group_id: subgroup_id,
             // Content-addressed id of `group_key`, so the retry path finds
             // the delivered key by id once it is stored.
-            key_id: GroupKeyring::key_id_for(&group_key),
+            key_id: GroupKeyring::key_id_for(&group_key).into(),
             encrypted: GroupKeyring::encrypt_op(&group_key, &GroupOp::Noop).unwrap(),
             key_rotation: None,
         },
@@ -5232,7 +5232,7 @@ fn curative_sweep_redrives_stranded_context() {
         1,
         NamespaceOp::Group {
             group_id: sub_gid.to_bytes(),
-            key_id,
+            key_id: key_id.into(),
             encrypted,
             key_rotation: None,
         },
@@ -5335,7 +5335,7 @@ fn curative_sweep_redrives_stranded_context() {
         2,
         NamespaceOp::Group {
             group_id: nokey_gid.to_bytes(),
-            key_id: GroupKeyring::key_id_for(&nokey_key),
+            key_id: GroupKeyring::key_id_for(&nokey_key).into(),
             encrypted: nokey_encrypted,
             key_rotation: None,
         },

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -7,6 +7,8 @@
 //! `group_store::test_fixtures` module. Namespace-only inline helpers
 //! (`raw_namespace_dag_heads`) came along with the move.
 
+use calimero_governance_types::NamespaceId;
+
 use crate::{
     CapabilitiesRepository, GroupDeletedRejection, GroupKeyring, MembershipRepository,
     MetaRepository, NamespaceRepository,
@@ -37,7 +39,7 @@ fn namespace_dag_service_store_operation_rejects_namespace_mismatch() {
 
     let signed = SignedNamespaceOp::sign(
         &signer_sk,
-        op_ns,
+        op_ns.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::PolicyUpdated {
@@ -46,7 +48,7 @@ fn namespace_dag_service_store_operation_rejects_namespace_mismatch() {
     )
     .unwrap();
 
-    let err = NamespaceDagService::new(&store, governance_ns)
+    let err = NamespaceDagService::new(&store, governance_ns.into())
         .store_operation(&signed)
         .unwrap_err();
     assert!(
@@ -100,7 +102,7 @@ fn validate_open_invitation_rejects_expired() {
         .unwrap();
 
     let signed = test_signed_invitation(&admin_sk, gid, 1_000_000);
-    let svc = NamespaceMembershipService::new(&store, ns_id);
+    let svc = NamespaceMembershipService::new(&store, ns_id.into());
 
     assert!(
         svc.validate_open_invitation(&signed, 2_000_000).is_err(),
@@ -140,7 +142,7 @@ fn validate_open_invitation_rejects_forged_inviter_signature() {
 
     let mut signed = test_signed_invitation(&admin_sk, gid, 9_999_999_999);
     signed.inviter_signature = hex::encode([0u8; 64]);
-    let svc = NamespaceMembershipService::new(&store, ns_id);
+    let svc = NamespaceMembershipService::new(&store, ns_id.into());
 
     assert!(
         svc.validate_open_invitation(&signed, 1_000).is_err(),
@@ -166,7 +168,7 @@ fn validate_open_invitation_rejects_unauthorized_inviter() {
         .unwrap();
 
     let signed = test_signed_invitation(&stranger_sk, gid, 9_999_999_999);
-    let svc = NamespaceMembershipService::new(&store, ns_id);
+    let svc = NamespaceMembershipService::new(&store, ns_id.into());
 
     assert!(
         svc.validate_open_invitation(&signed, 1_000).is_err(),
@@ -178,7 +180,7 @@ fn validate_open_invitation_rejects_unauthorized_inviter() {
 fn namespace_dag_service_advance_dag_head_prunes_parent_hashes() {
     let store = test_store();
     let namespace_id = [0x73; 32];
-    let dag = NamespaceDagService::new(&store, namespace_id);
+    let dag = NamespaceDagService::new(&store, namespace_id.into());
 
     let delta_a = [0xA1; 32];
     let delta_b = [0xB2; 32];
@@ -197,7 +199,7 @@ fn namespace_dag_service_advance_dag_head_prunes_parent_hashes() {
 fn namespace_dag_service_advance_dag_head_is_idempotent_for_same_delta() {
     let store = test_store();
     let namespace_id = [0x77; 32];
-    let dag = NamespaceDagService::new(&store, namespace_id);
+    let dag = NamespaceDagService::new(&store, namespace_id.into());
 
     let delta_a = [0xA1; 32];
     let delta_b = [0xB2; 32];
@@ -209,7 +211,7 @@ fn namespace_dag_service_advance_dag_head_is_idempotent_for_same_delta() {
     dag.advance_dag_head(delta_b, &[], 2).unwrap();
     dag.advance_dag_head(delta_b, &[], 2).unwrap();
 
-    let raw = raw_namespace_dag_heads(&store, namespace_id);
+    let raw = raw_namespace_dag_heads(&store, namespace_id.into());
     assert_eq!(
         raw,
         vec![delta_a, delta_b],
@@ -240,7 +242,7 @@ fn namespace_dag_service_heals_pre_existing_duplicate_heads() {
     drop(handle);
 
     // Read de-dups on the fly (preserving first-seen order).
-    let dag = NamespaceDagService::new(&store, namespace_id);
+    let dag = NamespaceDagService::new(&store, namespace_id.into());
     let head = dag.read_head_record().unwrap();
     assert_eq!(head.parent_hashes, vec![delta_a, delta_b]);
     assert_eq!(head.next_nonce, 6);
@@ -248,14 +250,16 @@ fn namespace_dag_service_heals_pre_existing_duplicate_heads() {
     // The next governance op heals the persisted value too: it supersedes
     // `delta_b` (a parent) and appends `delta_c` exactly once.
     dag.advance_dag_head(delta_c, &[delta_b], 6).unwrap();
-    let raw = raw_namespace_dag_heads(&store, namespace_id);
+    let raw = raw_namespace_dag_heads(&store, namespace_id.into());
     assert_eq!(raw, vec![delta_a, delta_c]);
 }
 
-fn raw_namespace_dag_heads(store: &Store, namespace_id: [u8; 32]) -> Vec<[u8; 32]> {
+fn raw_namespace_dag_heads(store: &Store, namespace_id: NamespaceId) -> Vec<[u8; 32]> {
     store
         .handle()
-        .get(&calimero_store::key::NamespaceGovHead::new(namespace_id))
+        .get(&calimero_store::key::NamespaceGovHead::new(
+            namespace_id.to_bytes(),
+        ))
         .unwrap()
         .map(|h| h.dag_heads)
         .unwrap_or_default()
@@ -269,7 +273,7 @@ fn namespace_dag_service_collects_skeleton_delta_ids_by_group() {
     let namespace_id = [0x74; 32];
     let group_a = ContextGroupId::from([0x75; 32]);
     let group_b = ContextGroupId::from([0x76; 32]);
-    let dag = NamespaceDagService::new(&store, namespace_id);
+    let dag = NamespaceDagService::new(&store, namespace_id.into());
     let delta_a = [0xA1; 32];
     let delta_b = [0xB2; 32];
     let delta_other_ns = [0xC3; 32];
@@ -336,7 +340,7 @@ fn namespace_op_log_service_reads_signed_and_skeleton_entries() {
 
     let signed_group = SignedNamespaceOp::sign(
         &signer_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         1,
         NamespaceOp::Group {
@@ -370,7 +374,7 @@ fn namespace_op_log_service_reads_signed_and_skeleton_entries() {
     handle.put(&key_skeleton, &val_skeleton).unwrap();
     drop(handle);
 
-    let op_log = NamespaceOpLogService::new(&store, namespace_id);
+    let op_log = NamespaceOpLogService::new(&store, namespace_id.into());
 
     let decoded_signed = op_log
         .collect_signed_group_ops_for_group(group_a.to_bytes())
@@ -405,7 +409,7 @@ fn namespace_op_log_service_reads_tagged_and_legacy_rows() {
 
     let tagged_signed = SignedNamespaceOp::sign(
         &signer_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         1,
         NamespaceOp::Group {
@@ -453,7 +457,7 @@ fn namespace_op_log_service_reads_tagged_and_legacy_rows() {
         .unwrap();
     drop(handle);
 
-    let op_log = NamespaceOpLogService::new(&store, namespace_id);
+    let op_log = NamespaceOpLogService::new(&store, namespace_id.into());
     let signed = op_log
         .collect_signed_group_ops_for_group(group.to_bytes())
         .unwrap();
@@ -481,7 +485,7 @@ fn namespace_op_log_service_collects_group_scoped_signed_ops() {
 
     let op_a = SignedNamespaceOp::sign(
         &signer_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         1,
         NamespaceOp::Group {
@@ -495,7 +499,7 @@ fn namespace_op_log_service_collects_group_scoped_signed_ops() {
 
     let op_b = SignedNamespaceOp::sign(
         &signer_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         2,
         NamespaceOp::Group {
@@ -509,7 +513,7 @@ fn namespace_op_log_service_collects_group_scoped_signed_ops() {
 
     let root = SignedNamespaceOp::sign(
         &signer_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         3,
         NamespaceOp::Root(RootOp::PolicyUpdated {
@@ -518,7 +522,7 @@ fn namespace_op_log_service_collects_group_scoped_signed_ops() {
     )
     .unwrap();
 
-    let op_log = NamespaceOpLogService::new(&store, namespace_id);
+    let op_log = NamespaceOpLogService::new(&store, namespace_id.into());
     op_log.store_signed_operation(&op_a).unwrap();
     op_log.store_signed_operation(&op_b).unwrap();
     op_log.store_signed_operation(&root).unwrap();
@@ -557,7 +561,7 @@ fn namespace_retry_service_collects_only_retryable_group_ops() {
 
     let group_a_op = SignedNamespaceOp::sign(
         &signer_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         1,
         NamespaceOp::Group {
@@ -571,7 +575,7 @@ fn namespace_retry_service_collects_only_retryable_group_ops() {
 
     let group_b_op = SignedNamespaceOp::sign(
         &signer_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         2,
         NamespaceOp::Group {
@@ -585,7 +589,7 @@ fn namespace_retry_service_collects_only_retryable_group_ops() {
 
     let root_op = SignedNamespaceOp::sign(
         &signer_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         3,
         NamespaceOp::Root(RootOp::PolicyUpdated {
@@ -594,12 +598,12 @@ fn namespace_retry_service_collects_only_retryable_group_ops() {
     )
     .unwrap();
 
-    let governance = NamespaceGovernance::new(&store, namespace_id);
+    let governance = NamespaceGovernance::new(&store, namespace_id.into());
     governance.store_operation(&group_a_op).unwrap();
     governance.store_operation(&group_b_op).unwrap();
     governance.store_operation(&root_op).unwrap();
 
-    let retry = NamespaceRetryService::new(&store, namespace_id);
+    let retry = NamespaceRetryService::new(&store, namespace_id.into());
     let retryable = retry
         .collect_retry_candidates_for_group(group_a.to_bytes())
         .unwrap();
@@ -664,7 +668,7 @@ fn namespace_retry_service_orders_candidates_by_signer_nonce() {
             .map(|nonce| {
                 SignedNamespaceOp::sign(
                     &signer_sk,
-                    namespace_id,
+                    namespace_id.into(),
                     vec![],
                     nonce,
                     NamespaceOp::Group {
@@ -697,11 +701,11 @@ fn namespace_retry_service_orders_candidates_by_signer_nonce() {
         // sibling test (`NamespaceGovernance::store_operation`), then
         // confirm the raw op-log iteration actually came back in the
         // predicted not-nonce-order — i.e. the bug path is reachable.
-        let governance = NamespaceGovernance::new(&store, namespace_id);
+        let governance = NamespaceGovernance::new(&store, namespace_id.into());
         for op in &signed_ops {
             governance.store_operation(op).unwrap();
         }
-        raw_nonces = NamespaceOpLogService::new(&store, namespace_id)
+        raw_nonces = NamespaceOpLogService::new(&store, namespace_id.into())
             .collect_signed_group_ops_for_group(group.to_bytes())
             .unwrap()
             .iter()
@@ -723,7 +727,7 @@ fn namespace_retry_service_orders_candidates_by_signer_nonce() {
          sort from a missing sort, so this test would silently pass on a regression."
     );
 
-    let retry = NamespaceRetryService::new(&store, namespace_id);
+    let retry = NamespaceRetryService::new(&store, namespace_id.into());
     let candidates = retry
         .collect_retry_candidates_for_group(group.to_bytes())
         .unwrap();
@@ -1040,7 +1044,7 @@ fn replica_applies_tee_policy_then_membership_via_namespace_governance() {
         .store_key(&group_key)
         .unwrap();
 
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     // Sanity: before any op is applied the replica has no policy and the TEE
     // node is not yet a member.
@@ -1069,7 +1073,7 @@ fn replica_applies_tee_policy_then_membership_via_namespace_governance() {
     .unwrap();
     let policy_ns_op = SignedNamespaceOp::sign(
         &verifier_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         1,
         NamespaceOp::Group {
@@ -1112,7 +1116,7 @@ fn replica_applies_tee_policy_then_membership_via_namespace_governance() {
     .unwrap();
     let join_ns_op = SignedNamespaceOp::sign(
         &verifier_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         2,
         NamespaceOp::Group {
@@ -1197,7 +1201,7 @@ fn tee_replica_seed_bootstrap_admits_tee_with_open_join_cap() {
     let ns_gid = ContextGroupId::from(namespace_id);
     let open_child = ContextGroupId::from([0xB5u8; 32]);
 
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     // ---- Genesis establishes the founder as the authoritative namespace admin
     // (#2474: this used to come from the bootstrap seed's KeyDelivery-signer
@@ -1207,8 +1211,9 @@ fn tee_replica_seed_bootstrap_admits_tee_with_open_join_cap() {
     {
         use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
         let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-        let signed_genesis = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 0, genesis)
-            .expect("sign genesis");
+        let signed_genesis =
+            SignedNamespaceOp::sign(&founder_sk, namespace_id.into(), vec![], 0, genesis)
+                .expect("sign genesis");
         gov.apply_signed_op(&signed_genesis)
             .expect("genesis NamespaceCreated establishes the founding admin");
     }
@@ -1266,7 +1271,7 @@ fn tee_replica_seed_bootstrap_admits_tee_with_open_join_cap() {
     );
     let policy_ns_op = SignedNamespaceOp::sign(
         &founder_sk,
-        namespace_id,
+        namespace_id.into(),
         head.parent_hashes.clone(),
         head.next_nonce,
         NamespaceOp::Group {
@@ -1302,7 +1307,7 @@ fn tee_replica_seed_bootstrap_admits_tee_with_open_join_cap() {
     let head = gov.read_head_record().expect("read head after policy op");
     let join_ns_op = SignedNamespaceOp::sign(
         &founder_sk,
-        namespace_id,
+        namespace_id.into(),
         head.parent_hashes.clone(),
         head.next_nonce,
         NamespaceOp::Group {
@@ -1395,7 +1400,7 @@ fn replica_genesis_founder_survives_non_owner_seed_and_applies_owner_ops() {
     let namespace_id = [0xC4u8; 32];
     let ns_gid = ContextGroupId::from(namespace_id);
 
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     // ---- Step 1: the GENESIS op the backfill replays FIRST. Signed by the true
     // owner with NO parents (the defining genesis invariant) — exactly what
@@ -1404,8 +1409,9 @@ fn replica_genesis_founder_survives_non_owner_seed_and_applies_owner_ops() {
     // an arbitrary placeholder the apply path does not consult for ordering.)
     // This establishes the founding admin authoritatively. ----
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder: owner });
-    let signed_genesis = SignedNamespaceOp::sign(&owner_sk, namespace_id, vec![], 0, genesis)
-        .expect("owner signs NamespaceCreated genesis");
+    let signed_genesis =
+        SignedNamespaceOp::sign(&owner_sk, namespace_id.into(), vec![], 0, genesis)
+            .expect("owner signs NamespaceCreated genesis");
     gov.apply_signed_op(&signed_genesis)
         .expect("genesis NamespaceCreated must apply on the bare replica");
 
@@ -1463,7 +1469,7 @@ fn replica_genesis_founder_survives_non_owner_seed_and_applies_owner_ops() {
     });
     let signed = SignedNamespaceOp::sign(
         &owner_sk,
-        namespace_id,
+        namespace_id.into(),
         head.parent_hashes.clone(),
         head.next_nonce,
         create_op,
@@ -1512,11 +1518,11 @@ fn namespace_created_genesis_on_bare_store_and_anti_hijack() {
         let store = test_store();
         let namespace_id = [0xA1u8; 32];
         let ns_gid = ContextGroupId::from(namespace_id);
-        let gov = NamespaceGovernance::new(&store, namespace_id);
+        let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
         let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
         let signed =
-            SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 0, genesis).unwrap();
+            SignedNamespaceOp::sign(&founder_sk, namespace_id.into(), vec![], 0, genesis).unwrap();
         gov.apply_signed_op(&signed)
             .expect("bare-store genesis applies");
 
@@ -1540,7 +1546,7 @@ fn namespace_created_genesis_on_bare_store_and_anti_hijack() {
         // ---- (b) anti-hijack: a second, forged genesis is a no-op ----
         let forged = NamespaceOp::Root(RootOp::NamespaceCreated { founder: attacker });
         let signed_forged =
-            SignedNamespaceOp::sign(&attacker_sk, namespace_id, vec![], 1, forged).unwrap();
+            SignedNamespaceOp::sign(&attacker_sk, namespace_id.into(), vec![], 1, forged).unwrap();
         gov.apply_signed_op(&signed_forged)
             .expect("forged second genesis applies as a no-op (no error)");
 
@@ -1562,7 +1568,7 @@ fn namespace_created_genesis_on_bare_store_and_anti_hijack() {
         let store = test_store();
         let namespace_id = [0xA2u8; 32];
         let ns_gid = ContextGroupId::from(namespace_id);
-        let gov = NamespaceGovernance::new(&store, namespace_id);
+        let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
         // A non-owner seed runs first, writing placeholder meta (admin == zero).
         gov.seed_bootstrap_admin_if_absent(namespace_id, &attacker)
@@ -1583,7 +1589,7 @@ fn namespace_created_genesis_on_bare_store_and_anti_hijack() {
         // Genesis then lands and fills in the real founder over the placeholder.
         let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
         let signed =
-            SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 0, genesis).unwrap();
+            SignedNamespaceOp::sign(&founder_sk, namespace_id.into(), vec![], 0, genesis).unwrap();
         gov.apply_signed_op(&signed)
             .expect("genesis applies over the placeholder seed meta");
         let meta = MetaRepository::new(&store).load(&ns_gid).unwrap().unwrap();
@@ -1607,13 +1613,13 @@ fn namespace_created_genesis_on_bare_store_and_anti_hijack() {
         let store = test_store();
         let namespace_id = [0xA3u8; 32];
         let ns_gid = ContextGroupId::from(namespace_id);
-        let gov = NamespaceGovernance::new(&store, namespace_id);
+        let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
         // Attacker signs the genuine FIRST op (nonce=0, empty parents) but names
         // the founder as someone else (here: `founder`).
         let forged = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
         let signed =
-            SignedNamespaceOp::sign(&attacker_sk, namespace_id, vec![], 0, forged).unwrap();
+            SignedNamespaceOp::sign(&attacker_sk, namespace_id.into(), vec![], 0, forged).unwrap();
         assert!(
             gov.apply_signed_op(&signed).is_err(),
             "nonce-0 forged genesis (signer != founder) must be REJECTED by the \
@@ -1663,7 +1669,7 @@ fn namespace_created_genesis_proceeds_when_only_admin_is_placeholder() {
     let store = test_store();
     let namespace_id = [0xA4u8; 32];
     let ns_gid = ContextGroupId::from(namespace_id);
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     // Construct a partial-write state: admin_identity is still the placeholder
     // sentinel (no real admin), but owner_identity is a real (non-placeholder)
@@ -1675,7 +1681,7 @@ fn namespace_created_genesis_proceeds_when_only_admin_is_placeholder() {
     MetaRepository::new(&store).save(&ns_gid, &partial).unwrap();
 
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 0, genesis)
+    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id.into(), vec![], 0, genesis)
         .expect("founder signs NamespaceCreated genesis");
     gov.apply_signed_op(&signed)
         .expect("genesis proceeds when admin_identity is still the placeholder");
@@ -1719,7 +1725,7 @@ fn namespace_created_genesis_upgrades_seeded_member_founder_to_admin() {
     let store = test_store();
     let namespace_id = [0xD9u8; 32];
     let ns_gid = ContextGroupId::from(namespace_id);
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     // ---- Seed FIRST, for the founder's OWN identity (the deliverer happens to
     // be the founder). The seed writes placeholder meta + the founder as a
@@ -1743,7 +1749,7 @@ fn namespace_created_genesis_upgrades_seeded_member_founder_to_admin() {
 
     // ---- Genesis lands and must UPGRADE the founder Member row to Admin. ----
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 0, genesis)
+    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id.into(), vec![], 0, genesis)
         .expect("founder signs NamespaceCreated genesis");
     gov.apply_signed_op(&signed)
         .expect("genesis applies over the founder's seeded Member placeholder");
@@ -1792,7 +1798,7 @@ fn namespace_created_genesis_ensures_member_row_for_established_founder() {
     let store = test_store();
     let namespace_id = [0xE3u8; 32];
     let ns_gid = ContextGroupId::from(namespace_id);
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     // Pre-establish the root meta with admin == owner == founder but write NO
     // member row — simulating a path that set a real `admin_identity` before
@@ -1811,7 +1817,7 @@ fn namespace_created_genesis_ensures_member_row_for_established_founder() {
     // Genesis arrives for the SAME founder. The established gate short-circuits
     // the meta rewrite but must still ensure the Admin member row.
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 0, genesis)
+    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id.into(), vec![], 0, genesis)
         .expect("founder signs NamespaceCreated genesis");
     gov.apply_signed_op(&signed)
         .expect("genesis applies as an idempotent same-founder re-arrival");
@@ -1865,7 +1871,7 @@ fn namespace_created_genesis_same_founder_rearrival_does_not_downgrade_admin() {
     let store = test_store();
     let namespace_id = [0xF1u8; 32];
     let ns_gid = ContextGroupId::from(namespace_id);
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     // Pre-establish the namespace fully: meta admin == owner == founder AND an
     // explicit Admin member row for the founder.
@@ -1885,7 +1891,7 @@ fn namespace_created_genesis_same_founder_rearrival_does_not_downgrade_admin() {
 
     // A parentless same-founder genesis re-arrives (e.g. via sync backfill).
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 0, genesis)
+    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id.into(), vec![], 0, genesis)
         .expect("founder signs NamespaceCreated genesis");
     gov.apply_signed_op(&signed)
         .expect("parentless same-founder genesis is an idempotent re-arrival no-op");
@@ -1927,11 +1933,12 @@ fn namespace_created_genesis_signer_must_equal_founder() {
     let store = test_store();
     let namespace_id = [0xB7u8; 32];
     let ns_gid = ContextGroupId::from(namespace_id);
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     // Attacker declares the victim as founder but signs with their OWN key.
     let forged = NamespaceOp::Root(RootOp::NamespaceCreated { founder: victim });
-    let signed = SignedNamespaceOp::sign(&attacker_sk, namespace_id, vec![], 0, forged).unwrap();
+    let signed =
+        SignedNamespaceOp::sign(&attacker_sk, namespace_id.into(), vec![], 0, forged).unwrap();
 
     let res = gov.apply_signed_op(&signed);
     assert!(
@@ -1986,14 +1993,19 @@ fn namespace_created_with_parents_is_rejected_as_non_genesis() {
     // independent under any future shared-store refactor.
     let namespace_id = [0xDAu8; 32];
     let ns_gid = ContextGroupId::from(namespace_id);
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     // Self-consistent (signer == founder) but PARENTED genesis: a fabricated
     // parent op-hash makes this not the DAG root.
     let parented = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed =
-        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![[0x11u8; 32]], 2, parented)
-            .unwrap();
+    let signed = SignedNamespaceOp::sign(
+        &founder_sk,
+        namespace_id.into(),
+        vec![[0x11u8; 32]],
+        2,
+        parented,
+    )
+    .unwrap();
 
     let res = gov.apply_signed_op(&signed);
     assert!(
@@ -2017,7 +2029,7 @@ fn namespace_created_with_parents_is_rejected_as_non_genesis() {
     // Sanity: the REAL genesis path (no parents, same founder) still applies.
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
     let signed_genesis =
-        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 1, genesis).unwrap();
+        SignedNamespaceOp::sign(&founder_sk, namespace_id.into(), vec![], 1, genesis).unwrap();
     gov.apply_signed_op(&signed_genesis)
         .expect("parentless genesis (the DAG root) still applies");
     assert!(
@@ -2055,7 +2067,7 @@ fn namespace_created_parented_on_bare_ns_errs_and_does_not_advance_head() {
     let store = test_store();
     let namespace_id = [0xDBu8; 32];
     let ns_gid = ContextGroupId::from(namespace_id);
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     // Precondition: a brand-new namespace has an EMPTY head.
     let head_before = gov.read_head_record().expect("read head on bare namespace");
@@ -2066,9 +2078,14 @@ fn namespace_created_parented_on_bare_ns_errs_and_does_not_advance_head() {
 
     // Parented (non-genesis) NamespaceCreated on the bare namespace.
     let parented = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed =
-        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![[0x22u8; 32]], 2, parented)
-            .unwrap();
+    let signed = SignedNamespaceOp::sign(
+        &founder_sk,
+        namespace_id.into(),
+        vec![[0x22u8; 32]],
+        2,
+        parented,
+    )
+    .unwrap();
     let res = gov.apply_signed_op(&signed);
     assert!(
         res.is_err(),
@@ -2090,7 +2107,7 @@ fn namespace_created_parented_on_bare_ns_errs_and_does_not_advance_head() {
     // establishes the founder (it would be impossible if the head had advanced).
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
     let signed_genesis =
-        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 1, genesis).unwrap();
+        SignedNamespaceOp::sign(&founder_sk, namespace_id.into(), vec![], 1, genesis).unwrap();
     gov.apply_signed_op(&signed_genesis).expect(
         "the parentless genesis still applies because the rejected parented op did not \
          advance the head",
@@ -2124,12 +2141,12 @@ fn namespace_created_parented_on_established_namespace_is_noop_not_err() {
     let store = test_store();
     let namespace_id = [0xC4u8; 32];
     let ns_gid = ContextGroupId::from(namespace_id);
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     // Establish the namespace via a clean parentless genesis.
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
     let signed_genesis =
-        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 1, genesis).unwrap();
+        SignedNamespaceOp::sign(&founder_sk, namespace_id.into(), vec![], 1, genesis).unwrap();
     gov.apply_signed_op(&signed_genesis)
         .expect("parentless genesis establishes the namespace");
     let meta_before = MetaRepository::new(&store).load(&ns_gid).unwrap().unwrap();
@@ -2141,9 +2158,14 @@ fn namespace_created_parented_on_established_namespace_is_noop_not_err() {
     // A PARENTED `NamespaceCreated` (same founder) now arrives late on the
     // established namespace. It must be a NO-OP, returning Ok — not Err.
     let parented = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed_parented =
-        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![[0x22u8; 32]], 2, parented)
-            .unwrap();
+    let signed_parented = SignedNamespaceOp::sign(
+        &founder_sk,
+        namespace_id.into(),
+        vec![[0x22u8; 32]],
+        2,
+        parented,
+    )
+    .unwrap();
     let res = gov.apply_signed_op(&signed_parented);
     assert!(
         res.is_ok(),
@@ -2181,7 +2203,7 @@ fn namespace_created_parented_same_founder_on_established_ns_does_no_repair() {
     let store = test_store();
     let namespace_id = [0xC6u8; 32];
     let ns_gid = ContextGroupId::from(namespace_id);
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     // Pre-establish meta DIRECTLY (not via genesis): admin == founder
     // (established) but owner DIVERGED, and crucially NO Admin member row and
@@ -2212,9 +2234,14 @@ fn namespace_created_parented_same_founder_on_established_ns_does_no_repair() {
 
     // PARENTED same-founder `NamespaceCreated` arrives on the established ns.
     let parented = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed_parented =
-        SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![[0x33u8; 32]], 2, parented)
-            .unwrap();
+    let signed_parented = SignedNamespaceOp::sign(
+        &founder_sk,
+        namespace_id.into(),
+        vec![[0x33u8; 32]],
+        2,
+        parented,
+    )
+    .unwrap();
     gov.apply_signed_op(&signed_parented)
         .expect("parented same-founder op on an established namespace is a no-op (Ok), per #591");
 
@@ -2264,7 +2291,7 @@ fn namespace_created_same_founder_repairs_diverged_owner_identity() {
     let store = test_store();
     let namespace_id = [0xC5u8; 32];
     let ns_gid = ContextGroupId::from(namespace_id);
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     // Pre-establish meta: admin == founder (established), but owner DIVERGED to
     // a stray non-founder key. Use `sample_meta_with_admin` so other fields
@@ -2278,7 +2305,7 @@ fn namespace_created_same_founder_repairs_diverged_owner_identity() {
 
     // Same-founder genesis re-arrives (parentless idempotent re-arrival).
     let genesis = NamespaceOp::Root(RootOp::NamespaceCreated { founder });
-    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id, vec![], 0, genesis)
+    let signed = SignedNamespaceOp::sign(&founder_sk, namespace_id.into(), vec![], 0, genesis)
         .expect("founder signs idempotent genesis");
     gov.apply_signed_op(&signed)
         .expect("idempotent same-founder re-arrival applies as a no-op-with-repair");
@@ -2353,7 +2380,7 @@ fn genesis_apply_failure_leaves_namespace_head_unadvanced() {
 
     let store = test_store();
     let namespace_id = [0xDBu8; 32];
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     // Pre-genesis head is empty / absent: no heads, next_nonce starts at 1.
     let before = gov.read_head_record().unwrap();
@@ -2374,7 +2401,7 @@ fn genesis_apply_failure_leaves_namespace_head_unadvanced() {
         founder: real_founder,
     });
     let signed_bad =
-        SignedNamespaceOp::sign(&attacker_sk, namespace_id, vec![], 1, bad_genesis).unwrap();
+        SignedNamespaceOp::sign(&attacker_sk, namespace_id.into(), vec![], 1, bad_genesis).unwrap();
 
     let res = gov.apply_signed_op(&signed_bad);
     assert!(
@@ -2399,8 +2426,14 @@ fn genesis_apply_failure_leaves_namespace_head_unadvanced() {
     let good_genesis = NamespaceOp::Root(RootOp::NamespaceCreated {
         founder: real_founder,
     });
-    let signed_good =
-        SignedNamespaceOp::sign(&real_founder_sk, namespace_id, vec![], 1, good_genesis).unwrap();
+    let signed_good = SignedNamespaceOp::sign(
+        &real_founder_sk,
+        namespace_id.into(),
+        vec![],
+        1,
+        good_genesis,
+    )
+    .unwrap();
     gov.apply_signed_op(&signed_good)
         .expect("clean parentless genesis applies after a prior failed attempt");
 
@@ -2449,7 +2482,7 @@ fn replica_op_log_dedup_survives_head_pruning() {
         .store_key(&group_key)
         .unwrap();
 
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     // Helper: build the SignedGroupOp exactly as `decrypt_and_apply_group_op`
     // reconstructs it from a namespace op, so we can compute its content hash.
@@ -2481,7 +2514,7 @@ fn replica_op_log_dedup_survives_head_pruning() {
     let inner_a = make_policy_op("mA");
     let op_a = SignedNamespaceOp::sign(
         &signer_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         1,
         NamespaceOp::Group {
@@ -2508,7 +2541,7 @@ fn replica_op_log_dedup_survives_head_pruning() {
     let inner_b = make_policy_op("mB");
     let op_b = SignedNamespaceOp::sign(
         &signer_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![hash_a],
         2,
         NamespaceOp::Group {
@@ -2593,7 +2626,7 @@ fn replica_concurrent_sibling_ops_apply_out_of_order_2516() {
         .store_key(&group_key)
         .unwrap();
 
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     let make_policy_op = |mrtd: &str| GroupOp::TeeAdmissionPolicySet {
         allowed_mrtd: vec![mrtd.to_owned()],
@@ -2609,7 +2642,7 @@ fn replica_concurrent_sibling_ops_apply_out_of_order_2516() {
     let sign_sibling = |inner: &GroupOp, nonce: u64| {
         SignedNamespaceOp::sign(
             &signer_sk,
-            namespace_id,
+            namespace_id.into(),
             vec![],
             nonce,
             NamespaceOp::Group {
@@ -2689,7 +2722,7 @@ fn replica_stale_head_does_not_overwrite_orphan_entry() {
         .store_key(&group_key)
         .unwrap();
 
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     let group_op_content_hash = |ns_op: &SignedNamespaceOp, inner: &GroupOp| -> [u8; 32] {
         SignedGroupOp {
@@ -2719,7 +2752,7 @@ fn replica_stale_head_does_not_overwrite_orphan_entry() {
     let inner_a = make_policy_op("mA");
     let op_a = SignedNamespaceOp::sign(
         &signer_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         1,
         NamespaceOp::Group {
@@ -2744,7 +2777,7 @@ fn replica_stale_head_does_not_overwrite_orphan_entry() {
     let inner_b = make_policy_op("mB");
     let op_b = SignedNamespaceOp::sign(
         &signer_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         2,
         NamespaceOp::Group {
@@ -3234,7 +3267,7 @@ fn governance_group_reparented_via_signed_op() {
         .store_identity(&ns_gid, &admin_pk, &admin_sk_bytes, &[0u8; 32])
         .unwrap();
 
-    let gov = NamespaceGovernance::new(&store, ns_id);
+    let gov = NamespaceGovernance::new(&store, ns_id.into());
 
     // Create three subgroups via GroupCreated ops (atomic create+nest):
     // namespace → mid, namespace → new_parent, mid → leaf.
@@ -3244,7 +3277,7 @@ fn governance_group_reparented_via_signed_op() {
     {
         let op = SignedNamespaceOp::sign(
             &admin_sk,
-            ns_id,
+            ns_id.into(),
             vec![],
             (i + 1) as u64,
             NamespaceOp::Root(RootOp::GroupCreated {
@@ -3265,7 +3298,7 @@ fn governance_group_reparented_via_signed_op() {
     // Reparent leaf from mid to new_parent.
     let reparent_op = SignedNamespaceOp::sign(
         &admin_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         4,
         NamespaceOp::Root(RootOp::GroupReparented {
@@ -3321,11 +3354,11 @@ fn governance_apply_signed_op_is_idempotent_on_replay() {
         .store_identity(&ns_gid, &admin_pk, &admin_sk_bytes, &[0u8; 32])
         .unwrap();
 
-    let gov = NamespaceGovernance::new(&store, ns_id);
+    let gov = NamespaceGovernance::new(&store, ns_id.into());
 
     let op = SignedNamespaceOp::sign(
         &admin_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
@@ -3339,7 +3372,7 @@ fn governance_apply_signed_op_is_idempotent_on_replay() {
 
     gov.apply_signed_op(&op).expect("first apply");
     assert_eq!(
-        raw_namespace_dag_heads(&store, ns_id),
+        raw_namespace_dag_heads(&store, ns_id.into()),
         vec![delta_id],
         "head set after first apply"
     );
@@ -3348,7 +3381,7 @@ fn governance_apply_signed_op_is_idempotent_on_replay() {
     let replay = gov.apply_signed_op(&op).expect("replay apply");
     assert!(replay.key_unwrap_failures.is_empty());
     assert_eq!(
-        raw_namespace_dag_heads(&store, ns_id),
+        raw_namespace_dag_heads(&store, ns_id.into()),
         vec![delta_id],
         "head set must stay duplicate-free after replay"
     );
@@ -3383,12 +3416,12 @@ fn governance_rejects_non_admin_signer() {
         .store_identity(&ns_gid, &admin_pk, &admin_sk_bytes, &[0u8; 32])
         .unwrap();
 
-    let gov = NamespaceGovernance::new(&store, ns_id);
+    let gov = NamespaceGovernance::new(&store, ns_id.into());
 
     // Non-admin tries to create a group
     let op = SignedNamespaceOp::sign(
         &intruder_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
@@ -3431,11 +3464,11 @@ fn governance_group_created_is_idempotent() {
         .store_identity(&ns_gid, &admin_pk, &admin_sk_bytes, &[0u8; 32])
         .unwrap();
 
-    let gov = NamespaceGovernance::new(&store, ns_id);
+    let gov = NamespaceGovernance::new(&store, ns_id.into());
 
     let op1 = SignedNamespaceOp::sign(
         &admin_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
@@ -3452,7 +3485,7 @@ fn governance_group_created_is_idempotent() {
     // Apply same op again (different nonce but same group_id)
     let op2 = SignedNamespaceOp::sign(
         &admin_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         2,
         NamespaceOp::Root(RootOp::GroupCreated {
@@ -3504,13 +3537,13 @@ fn governance_group_created_writes_birth_visibility() {
         .store_identity(&ns_gid, &admin_pk, &admin_sk_bytes, &[0u8; 32])
         .unwrap();
 
-    let gov = NamespaceGovernance::new(&store, ns_id);
+    let gov = NamespaceGovernance::new(&store, ns_id.into());
     let caps = CapabilitiesRepository::new(&store);
 
     // Born-Open: restricted = false ⇒ visibility key written as Open.
     let open_op = SignedNamespaceOp::sign(
         &admin_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
@@ -3532,7 +3565,7 @@ fn governance_group_created_writes_birth_visibility() {
     // Born-Restricted: restricted = true ⇒ Restricted.
     let restricted_op = SignedNamespaceOp::sign(
         &admin_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         2,
         NamespaceOp::Root(RootOp::GroupCreated {
@@ -3590,13 +3623,13 @@ fn governance_group_created_replay_does_not_reset_visibility() {
         .store_identity(&ns_gid, &admin_pk, &admin_sk_bytes, &[0u8; 32])
         .unwrap();
 
-    let gov = NamespaceGovernance::new(&store, ns_id);
+    let gov = NamespaceGovernance::new(&store, ns_id.into());
     let caps = CapabilitiesRepository::new(&store);
 
     // 1. Create the subgroup born-Open.
     let create_op = SignedNamespaceOp::sign(
         &admin_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
@@ -3628,7 +3661,7 @@ fn governance_group_created_replay_does_not_reset_visibility() {
     // 3. Replay the SAME GroupCreated op (different nonce, same group_id).
     let replay_op = SignedNamespaceOp::sign(
         &admin_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         2,
         NamespaceOp::Root(RootOp::GroupCreated {
@@ -3693,10 +3726,10 @@ fn governance_group_created_writes_parent_edge_even_when_meta_pre_populated() {
         .unwrap();
 
     // Now apply the GroupCreated op — idempotency must NOT skip the edges.
-    let gov = NamespaceGovernance::new(&store, ns_id);
+    let gov = NamespaceGovernance::new(&store, ns_id.into());
     let op = SignedNamespaceOp::sign(
         &admin_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
@@ -3759,7 +3792,7 @@ fn execute_group_created_rejects_self_parent() {
     // Attempt to emit GroupCreated with group_id == parent_id (the bug).
     let op = SignedNamespaceOp::sign(
         &admin_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
@@ -3770,7 +3803,7 @@ fn execute_group_created_rejects_self_parent() {
     )
     .expect("sign op");
 
-    let gov = NamespaceGovernance::new(&store, ns_id);
+    let gov = NamespaceGovernance::new(&store, ns_id.into());
     let err = gov.apply_signed_op(&op).unwrap_err();
     assert!(
         matches!(
@@ -3823,7 +3856,7 @@ fn execute_group_created_inherits_app_key_and_application_from_parent() {
 
     let op = SignedNamespaceOp::sign(
         &admin_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
@@ -3834,7 +3867,7 @@ fn execute_group_created_inherits_app_key_and_application_from_parent() {
     )
     .expect("sign op");
 
-    let gov = NamespaceGovernance::new(&store, ns_id);
+    let gov = NamespaceGovernance::new(&store, ns_id.into());
     gov.apply_signed_op(&op).expect("apply group_created");
 
     let sub_meta = MetaRepository::new(&store)
@@ -3910,10 +3943,10 @@ fn execute_group_deleted_subset_check_allows_partial_retry() {
     // Now the retry: cascade op has payload [B], but local subtree of A is
     // empty (B already gone). Subset check: local {} ⊆ payload {B} ✓ → apply
     // proceeds. Exact-match check would have rejected here — that's the bug.
-    let gov = NamespaceGovernance::new(&store, ns_id);
+    let gov = NamespaceGovernance::new(&store, ns_id.into());
     let op = SignedNamespaceOp::sign(
         &admin_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupDeleted {
@@ -3980,10 +4013,10 @@ fn execute_group_deleted_ignores_payload_groups_outside_local_subtree() {
     // Hostile payload: deletes A (authorized) but also lists the unrelated
     // X. Local subtree of A is {B}, so {B} ⊆ {B, X} — the subset check
     // passes and X is a payload extra.
-    let gov = NamespaceGovernance::new(&store, ns_id);
+    let gov = NamespaceGovernance::new(&store, ns_id.into());
     let op = SignedNamespaceOp::sign(
         &admin_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupDeleted {
@@ -4359,7 +4392,7 @@ fn governance_group_created_honors_can_create_subgroup_at_root_only() {
         .store_identity(&ns_gid, &admin_pk, &admin_sk_bytes, &[0u8; 32])
         .unwrap();
 
-    let gov = NamespaceGovernance::new(&store, ns_id);
+    let gov = NamespaceGovernance::new(&store, ns_id.into());
     // `nonce` is informational only — `apply_signed_op` advances the DAG head
     // from `read_head_record().next_nonce`, not from `op.nonce`, and a rejected
     // op never advances the head or gets stored. Distinct `group_id`s already
@@ -4368,7 +4401,7 @@ fn governance_group_created_honors_can_create_subgroup_at_root_only() {
     let create = |sk: &PrivateKey, group_id: [u8; 32], parent_id: [u8; 32], nonce: u64| {
         SignedNamespaceOp::sign(
             sk,
-            ns_id,
+            ns_id.into(),
             vec![],
             nonce,
             NamespaceOp::Root(RootOp::GroupCreated {
@@ -4527,7 +4560,7 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
     let (s2, s2_gid) = mk_subgroup(0xC2);
     let (s3, s3_gid) = mk_subgroup(0xC3);
 
-    let gov = NamespaceGovernance::new(&store, ns_id);
+    let gov = NamespaceGovernance::new(&store, ns_id.into());
     // `nonce` here is informational only — `apply_signed_op` advances the DAG
     // head from `read_head_record().next_nonce`, not from `op.nonce`; distinct
     // `root_group_id`s already give each op a distinct content hash. We still
@@ -4535,7 +4568,7 @@ fn governance_group_deleted_owner_admin_or_cap_only() {
     let del = |sk: &PrivateKey, root_group_id: [u8; 32], nonce: u64| {
         SignedNamespaceOp::sign(
             sk,
-            ns_id,
+            ns_id.into(),
             vec![],
             nonce,
             NamespaceOp::Root(RootOp::GroupDeleted {
@@ -4657,7 +4690,7 @@ fn group_created_with_no_key_skips_retry() {
 
     let op = SignedNamespaceOp::sign(
         &admin_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
@@ -4668,7 +4701,7 @@ fn group_created_with_no_key_skips_retry() {
     )
     .unwrap();
 
-    let gov = NamespaceGovernance::new(&store, ns_id);
+    let gov = NamespaceGovernance::new(&store, ns_id.into());
     let result = gov
         .apply_signed_op(&op)
         .expect("GroupCreated with no held key must apply cleanly (cheap no-op retry gate)");
@@ -4722,7 +4755,7 @@ fn apply_received_group_key_stores_key_for_recipient() {
 
     apply_received_group_key(
         &store,
-        namespace_id,
+        namespace_id.into(),
         group_id,
         &envelope_bytes,
         sender_sk.public_key(),
@@ -4768,7 +4801,7 @@ fn apply_received_group_key_ignores_envelope_for_other_recipient() {
     // Not addressed to us: benign no-op, no key stored.
     let divergence = apply_received_group_key(
         &store,
-        namespace_id,
+        namespace_id.into(),
         group_id,
         &envelope_bytes,
         sender_sk.public_key(),
@@ -4797,7 +4830,7 @@ fn groups_awaiting_key_reports_then_clears() {
     // Buffer an encrypted group op for `group_id` whose key we don't hold.
     let op = SignedNamespaceOp::sign(
         &signer_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         1,
         NamespaceOp::Group {
@@ -4810,19 +4843,19 @@ fn groups_awaiting_key_reports_then_clears() {
         },
     )
     .unwrap();
-    NamespaceOpLogService::new(&store, namespace_id)
+    NamespaceOpLogService::new(&store, namespace_id.into())
         .store_signed_operation(&op)
         .unwrap();
 
     // Keyless: the group is reported as awaiting a key.
-    let awaiting = namespace_groups_awaiting_key(&store, namespace_id).unwrap();
+    let awaiting = namespace_groups_awaiting_key(&store, namespace_id.into()).unwrap();
     assert_eq!(awaiting, vec![group_id]);
 
     // Once the op's key is stored locally, the group drops out of the set.
     GroupKeyring::new(&store, group_gid)
         .store_key(&[0xAA; 32])
         .unwrap();
-    let awaiting = namespace_groups_awaiting_key(&store, namespace_id).unwrap();
+    let awaiting = namespace_groups_awaiting_key(&store, namespace_id.into()).unwrap();
     assert!(awaiting.is_empty());
 }
 
@@ -4858,7 +4891,7 @@ fn restricted_subgroup_awaits_key_despite_holding_namespace_key() {
     // key, which the node does NOT hold.
     let op = SignedNamespaceOp::sign(
         &signer_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         1,
         NamespaceOp::Group {
@@ -4869,13 +4902,13 @@ fn restricted_subgroup_awaits_key_despite_holding_namespace_key() {
         },
     )
     .unwrap();
-    NamespaceOpLogService::new(&store, namespace_id)
+    NamespaceOpLogService::new(&store, namespace_id.into())
         .store_signed_operation(&op)
         .unwrap();
 
     // The subgroup must still be reported as awaiting its key.
     assert_eq!(
-        namespace_groups_awaiting_key(&store, namespace_id).unwrap(),
+        namespace_groups_awaiting_key(&store, namespace_id.into()).unwrap(),
         vec![subgroup_id],
         "holding the namespace key must not mask a Restricted subgroup awaiting its own key"
     );
@@ -4933,8 +4966,13 @@ fn responder_delivery_round_trips_key_to_joiner_cross_store() {
         .unwrap();
 
     // Responder builds the delivery for the joiner (the `GroupKeyResponse`).
-    let (envelope_bytes, responder_identity) =
-        build_group_key_delivery(&responder_store, namespace_id, subgroup_id, joiner_pk).unwrap();
+    let (envelope_bytes, responder_identity) = build_group_key_delivery(
+        &responder_store,
+        namespace_id.into(),
+        subgroup_id,
+        joiner_pk,
+    )
+    .unwrap();
     assert!(
         !envelope_bytes.is_empty(),
         "responder holding the key must deliver it to a member"
@@ -4948,7 +4986,7 @@ fn responder_delivery_round_trips_key_to_joiner_cross_store() {
         .unwrap();
     let buffered = SignedNamespaceOp::sign(
         &responder_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         1,
         NamespaceOp::Group {
@@ -4961,20 +4999,20 @@ fn responder_delivery_round_trips_key_to_joiner_cross_store() {
         },
     )
     .unwrap();
-    NamespaceOpLogService::new(&joiner_store, namespace_id)
+    NamespaceOpLogService::new(&joiner_store, namespace_id.into())
         .store_signed_operation(&buffered)
         .unwrap();
 
     // Precondition: joiner awaits the key and holds none.
     assert_eq!(
-        namespace_groups_awaiting_key(&joiner_store, namespace_id).unwrap(),
+        namespace_groups_awaiting_key(&joiner_store, namespace_id.into()).unwrap(),
         vec![subgroup_id]
     );
 
     // Joiner applies the responder's delivery (the wire payload).
     apply_received_group_key(
         &joiner_store,
-        namespace_id,
+        namespace_id.into(),
         subgroup_id,
         &envelope_bytes,
         responder_identity,
@@ -4991,9 +5029,11 @@ fn responder_delivery_round_trips_key_to_joiner_cross_store() {
             .map(|(_, k)| k),
         Some(group_key)
     );
-    assert!(namespace_groups_awaiting_key(&joiner_store, namespace_id)
-        .unwrap()
-        .is_empty());
+    assert!(
+        namespace_groups_awaiting_key(&joiner_store, namespace_id.into())
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[test]
@@ -5049,8 +5089,13 @@ fn responder_delivery_round_trips_key_to_read_only_tee_joiner() {
         .unwrap();
 
     // Responder builds the delivery for the joiner (the `GroupKeyResponse`).
-    let (envelope_bytes, responder_identity) =
-        build_group_key_delivery(&responder_store, namespace_id, subgroup_id, joiner_pk).unwrap();
+    let (envelope_bytes, responder_identity) = build_group_key_delivery(
+        &responder_store,
+        namespace_id.into(),
+        subgroup_id,
+        joiner_pk,
+    )
+    .unwrap();
     assert!(
         !envelope_bytes.is_empty(),
         "responder holding the key must deliver it to a ReadOnlyTee member"
@@ -5064,7 +5109,7 @@ fn responder_delivery_round_trips_key_to_read_only_tee_joiner() {
         .unwrap();
     let buffered = SignedNamespaceOp::sign(
         &responder_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         1,
         NamespaceOp::Group {
@@ -5077,20 +5122,20 @@ fn responder_delivery_round_trips_key_to_read_only_tee_joiner() {
         },
     )
     .unwrap();
-    NamespaceOpLogService::new(&joiner_store, namespace_id)
+    NamespaceOpLogService::new(&joiner_store, namespace_id.into())
         .store_signed_operation(&buffered)
         .unwrap();
 
     // Precondition: joiner awaits the key and holds none.
     assert_eq!(
-        namespace_groups_awaiting_key(&joiner_store, namespace_id).unwrap(),
+        namespace_groups_awaiting_key(&joiner_store, namespace_id.into()).unwrap(),
         vec![subgroup_id]
     );
 
     // Joiner applies the responder's delivery (the wire payload).
     apply_received_group_key(
         &joiner_store,
-        namespace_id,
+        namespace_id.into(),
         subgroup_id,
         &envelope_bytes,
         responder_identity,
@@ -5106,9 +5151,11 @@ fn responder_delivery_round_trips_key_to_read_only_tee_joiner() {
             .map(|(_, k)| k),
         Some(group_key)
     );
-    assert!(namespace_groups_awaiting_key(&joiner_store, namespace_id)
-        .unwrap()
-        .is_empty());
+    assert!(
+        namespace_groups_awaiting_key(&joiner_store, namespace_id.into())
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[test]
@@ -5147,7 +5194,7 @@ fn responder_refuses_delivery_to_non_member() {
     // The requester is NOT a member of the subgroup → empty envelope: no key
     // wrapped, and no membership oracle leaked (same reply as "key not held").
     let (envelope_bytes, _responder_identity) =
-        build_group_key_delivery(&store, namespace_id, subgroup_id, stranger_pk).unwrap();
+        build_group_key_delivery(&store, namespace_id.into(), subgroup_id, stranger_pk).unwrap();
     assert!(
         envelope_bytes.is_empty(),
         "responder must not wrap a key for a non-member"
@@ -5227,7 +5274,7 @@ fn curative_sweep_redrives_stranded_context() {
     let encrypted = GroupKeyring::encrypt_op(&subgroup_key, &inner_op).unwrap();
     let ctx_registered_op = SignedNamespaceOp::sign(
         &owner_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         1,
         NamespaceOp::Group {
@@ -5248,7 +5295,7 @@ fn curative_sweep_redrives_stranded_context() {
         "buffered ContextRegistered must be effect-skipped before the key arrives"
     );
     assert!(
-        namespace_groups_with_held_key_buffered_ops(&store, namespace_id)
+        namespace_groups_with_held_key_buffered_ops(&store, namespace_id.into())
             .unwrap()
             .is_empty(),
         "no group should be enumerated while the key is still absent (awaiting-key state)"
@@ -5272,7 +5319,8 @@ fn curative_sweep_redrives_stranded_context() {
     nest_for_test(&store, &ns_gid, &sub_gid);
 
     // ---- Enumerator: exactly the stranded subgroup is returned -------------
-    let enumerated = namespace_groups_with_held_key_buffered_ops(&store, namespace_id).unwrap();
+    let enumerated =
+        namespace_groups_with_held_key_buffered_ops(&store, namespace_id.into()).unwrap();
     assert_eq!(
         enumerated,
         vec![sub_gid.to_bytes()],
@@ -5286,7 +5334,7 @@ fn curative_sweep_redrives_stranded_context() {
     );
 
     // ---- Re-drive: the buffered op applies ---------------------------------
-    let applied = redrive_buffered_ops_for_group(&store, namespace_id, sub_gid.to_bytes())
+    let applied = redrive_buffered_ops_for_group(&store, namespace_id.into(), sub_gid.to_bytes())
         .expect("re-drive must not error");
     assert_eq!(
         applied, 1,
@@ -5302,8 +5350,9 @@ fn curative_sweep_redrives_stranded_context() {
     // (The namespace op-log is append-only, so the group stays ENUMERATED, but
     // a re-drive of an already-applied op is a nonce-deduped no-op — this is
     // the sweep's convergence signal: applied-count drops to zero.)
-    let applied_again = redrive_buffered_ops_for_group(&store, namespace_id, sub_gid.to_bytes())
-        .expect("second re-drive must not error");
+    let applied_again =
+        redrive_buffered_ops_for_group(&store, namespace_id.into(), sub_gid.to_bytes())
+            .expect("second re-drive must not error");
     assert_eq!(
         applied_again, 0,
         "re-driving an already-applied group must apply nothing (idempotent no-op)"
@@ -5330,7 +5379,7 @@ fn curative_sweep_redrives_stranded_context() {
     let nokey_encrypted = GroupKeyring::encrypt_op(&nokey_key, &nokey_inner).unwrap();
     let nokey_op = SignedNamespaceOp::sign(
         &owner_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         2,
         NamespaceOp::Group {
@@ -5344,7 +5393,7 @@ fn curative_sweep_redrives_stranded_context() {
     apply_signed_namespace_op(&store, &nokey_op).expect("buffer no-key op (effect-skipped)");
 
     let enumerated_after =
-        namespace_groups_with_held_key_buffered_ops(&store, namespace_id).unwrap();
+        namespace_groups_with_held_key_buffered_ops(&store, namespace_id.into()).unwrap();
     assert!(
         !enumerated_after.contains(&nokey_gid.to_bytes()),
         "a no-key (deleted/never-keyed) group must NOT be enumerated by the curative sweep"
@@ -5360,7 +5409,7 @@ fn curative_sweep_redrives_stranded_context() {
 
     // Sanity: the no-key group IS in the awaiting-key set (the strict inverse).
     // The held-key subgroup is NOT (its key is held).
-    let awaiting = namespace_groups_awaiting_key(&store, namespace_id).unwrap();
+    let awaiting = namespace_groups_awaiting_key(&store, namespace_id.into()).unwrap();
     assert_eq!(
         awaiting,
         vec![nokey_gid.to_bytes()],

--- a/crates/governance-store/src/op_events.rs
+++ b/crates/governance-store/src/op_events.rs
@@ -15,6 +15,7 @@
 //! specialized for `ContextRegistered`; this module is its general-
 //! purpose peer covering all op variants that downstream handlers care
 //! about.
+use calimero_governance_types::NamespaceId;
 use std::sync::OnceLock;
 
 use calimero_primitives::context::{ContextId, GroupMemberRole};
@@ -39,7 +40,7 @@ pub enum OpEvent {
     /// nested under `parent_group_id`. Replaces the old SubgroupNested event,
     /// fired during create flows.
     SubgroupCreated {
-        namespace_id: [u8; 32],
+        namespace_id: NamespaceId,
         parent_group_id: [u8; 32],
         child_group_id: [u8; 32],
     },
@@ -47,7 +48,7 @@ pub enum OpEvent {
     /// another atomically. Replaces the old SubgroupNested/SubgroupUnnested
     /// pair (orphan state is no longer expressible).
     SubgroupReparented {
-        namespace_id: [u8; 32],
+        namespace_id: NamespaceId,
         old_parent_group_id: [u8; 32],
         new_parent_group_id: [u8; 32],
         child_group_id: [u8; 32],

--- a/crates/governance-store/src/ops/group.rs
+++ b/crates/governance-store/src/ops/group.rs
@@ -89,7 +89,7 @@ pub(crate) fn dispatch(ctx: &mut GroupApplyCtx<'_>, op: &GroupOp) -> EyreResult<
         GroupOp::TargetApplicationSet {
             app_key,
             target_application_id,
-        } => target_application_set::apply(ctx, app_key, target_application_id)?,
+        } => target_application_set::apply(ctx, &app_key.to_bytes(), target_application_id)?,
         GroupOp::ContextRegistered {
             context_id,
             application_id,
@@ -160,14 +160,14 @@ pub(crate) fn dispatch(ctx: &mut GroupApplyCtx<'_>, op: &GroupOp) -> EyreResult<
             target_application_id,
         } => cascade_target_application_set::apply(
             ctx,
-            from_app_key,
-            app_key,
+            &from_app_key.to_bytes(),
+            &app_key.to_bytes(),
             target_application_id,
         )?,
         GroupOp::CascadeGroupMigrationSet {
             from_app_key,
             migration,
-        } => cascade_group_migration_set::apply(ctx, from_app_key, migration)?,
+        } => cascade_group_migration_set::apply(ctx, &from_app_key.to_bytes(), migration)?,
         GroupOp::CascadeUpgrade {
             from_app_key,
             app_key,
@@ -176,8 +176,8 @@ pub(crate) fn dispatch(ctx: &mut GroupApplyCtx<'_>, op: &GroupOp) -> EyreResult<
             cascade_hlc,
         } => cascade_upgrade::apply(
             ctx,
-            from_app_key,
-            app_key,
+            &from_app_key.to_bytes(),
+            &app_key.to_bytes(),
             target_application_id,
             migration,
             *cascade_hlc,

--- a/crates/governance-store/src/ops/namespace.rs
+++ b/crates/governance-store/src/ops/namespace.rs
@@ -41,22 +41,34 @@ pub(crate) fn dispatch_root_op(
             group_id,
             parent_id,
             restricted,
-        } => group_created::apply(ctx, op, *group_id, *parent_id, *restricted),
+        } => group_created::apply(
+            ctx,
+            op,
+            group_id.to_bytes(),
+            parent_id.to_bytes(),
+            *restricted,
+        ),
         RootOp::GroupDeleted {
             root_group_id,
             cascade_group_ids,
             cascade_context_ids,
-        } => group_deleted::apply(
-            ctx,
-            op,
-            *root_group_id,
-            cascade_group_ids,
-            cascade_context_ids,
-        ),
+        } => {
+            let cascade_group_ids: Vec<[u8; 32]> =
+                cascade_group_ids.iter().map(|g| g.to_bytes()).collect();
+            let cascade_context_ids: Vec<[u8; 32]> =
+                cascade_context_ids.iter().map(|c| *c.as_ref()).collect();
+            group_deleted::apply(
+                ctx,
+                op,
+                root_group_id.to_bytes(),
+                &cascade_group_ids,
+                &cascade_context_ids,
+            )
+        }
         RootOp::GroupReparented {
             child_group_id,
             new_parent_id,
-        } => group_reparented::apply(ctx, op, *child_group_id, *new_parent_id),
+        } => group_reparented::apply(ctx, op, child_group_id.to_bytes(), new_parent_id.to_bytes()),
         RootOp::AdminChanged { new_admin } => admin_changed::apply(ctx, op, *new_admin),
         RootOp::PolicyUpdated { .. } => policy_updated::apply(ctx, op),
         RootOp::MemberJoined {
@@ -69,7 +81,7 @@ pub(crate) fn dispatch_root_op(
             joined_at,
         } => member_joined::apply(ctx, op, member, signed_invitation, Some(*joined_at)),
         RootOp::MemberJoinedOpen { member, group_id } => {
-            member_joined_open::apply(ctx, op, *member, *group_id)
+            member_joined_open::apply(ctx, op, *member, group_id.to_bytes())
         }
         // Self-authorizing namespace genesis. SECURITY residual (#2932): a
         // self-consistent forged genesis on a BARE namespace is not blocked here

--- a/crates/governance-store/src/ops/namespace.rs
+++ b/crates/governance-store/src/ops/namespace.rs
@@ -56,7 +56,7 @@ pub(crate) fn dispatch_root_op(
             let cascade_group_ids: Vec<[u8; 32]> =
                 cascade_group_ids.iter().map(|g| g.to_bytes()).collect();
             let cascade_context_ids: Vec<[u8; 32]> =
-                cascade_context_ids.iter().map(|c| *c.as_ref()).collect();
+                cascade_context_ids.iter().map(|c| *c.digest()).collect();
             group_deleted::apply(
                 ctx,
                 op,

--- a/crates/governance-store/src/ops/namespace/admin_changed.rs
+++ b/crates/governance-store/src/ops/namespace/admin_changed.rs
@@ -14,7 +14,7 @@ pub(crate) fn apply(
     new_admin: PublicKey,
 ) -> EyreResult<()> {
     ctx.require_namespace_admin(&op.signer)?;
-    let ns_gid = ContextGroupId::from(ctx.namespace_id());
+    let ns_gid = ContextGroupId::from(ctx.namespace_id().to_bytes());
     let meta_repo = MetaRepository::new(ctx.store());
     let mut meta = meta_repo
         .load(&ns_gid)?

--- a/crates/governance-store/src/ops/namespace/context.rs
+++ b/crates/governance-store/src/ops/namespace/context.rs
@@ -10,13 +10,14 @@
 use crate::authorizer::AtCutAuthorizer;
 use crate::{MembershipError, MembershipRepository};
 use calimero_context_config::types::ContextGroupId;
+use calimero_governance_types::NamespaceId;
 use calimero_primitives::identity::PublicKey;
 use calimero_store::Store;
 use eyre::{bail, Result as EyreResult};
 
 pub(crate) struct NamespaceApplyCtx<'a> {
     store: &'a Store,
-    namespace_id: [u8; 32],
+    namespace_id: NamespaceId,
     /// The applied op's causal cut (parent op hashes), for at-cut authorization
     /// (F5 #28). Empty outside the live apply path.
     parents: &'a [[u8; 32]],
@@ -34,7 +35,7 @@ pub(crate) struct NamespaceApplyCtx<'a> {
 impl<'a> NamespaceApplyCtx<'a> {
     pub(crate) fn new(
         store: &'a Store,
-        namespace_id: [u8; 32],
+        namespace_id: NamespaceId,
         parents: &'a [[u8; 32]],
         authorizer: &'a dyn AtCutAuthorizer,
     ) -> Self {
@@ -51,7 +52,7 @@ impl<'a> NamespaceApplyCtx<'a> {
         self.store
     }
 
-    pub(crate) fn namespace_id(&self) -> [u8; 32] {
+    pub(crate) fn namespace_id(&self) -> NamespaceId {
         self.namespace_id
     }
 
@@ -79,7 +80,7 @@ impl<'a> NamespaceApplyCtx<'a> {
     /// `None`, so the live path is byte-identical until a projection-backed
     /// authorizer is injected.
     pub(crate) fn require_namespace_admin(&self, signer: &PublicKey) -> EyreResult<()> {
-        let ns_gid = ContextGroupId::from(self.namespace_id);
+        let ns_gid = ContextGroupId::from(self.namespace_id.to_bytes());
         let authorized = match self
             .authorizer
             .is_admin_at_cut(&ns_gid, signer, self.parents)
@@ -89,7 +90,7 @@ impl<'a> NamespaceApplyCtx<'a> {
         };
         if !authorized {
             bail!(MembershipError::NotAdmin {
-                group_id: hex::encode(self.namespace_id),
+                group_id: hex::encode(self.namespace_id.as_bytes()),
                 identity: format!("{signer}"),
             });
         }

--- a/crates/governance-store/src/ops/namespace/group_created.rs
+++ b/crates/governance-store/src/ops/namespace/group_created.rs
@@ -39,9 +39,9 @@ pub(crate) fn apply(
     // because every peer applying this op must be able to verify the
     // creator's authority, and only the root group's capability rows are
     // readable by all namespace members (see the capability's doc).
-    let ns_gid = ContextGroupId::from(namespace_id);
+    let ns_gid = ContextGroupId::from(namespace_id.to_bytes());
     let authorized = MembershipRepository::new(store).is_admin(&ns_gid, &op.signer)?
-        || (parent_id == namespace_id
+        || (parent_id == namespace_id.to_bytes()
             && MembershipRepository::new(store).is_admin_or_has_capability(
                 &ns_gid,
                 &op.signer,
@@ -51,7 +51,7 @@ pub(crate) fn apply(
         bail!(ApplyError::GroupCreatedRejected(
             GroupCreatedRejection::Unauthorized {
                 signer: format!("{}", op.signer),
-                namespace: hex::encode(namespace_id),
+                namespace: hex::encode(namespace_id.as_bytes()),
             }
         ));
     }

--- a/crates/governance-store/src/ops/namespace/group_deleted.rs
+++ b/crates/governance-store/src/ops/namespace/group_deleted.rs
@@ -21,7 +21,7 @@ pub(crate) fn apply(
     let store = ctx.store();
     let namespace_id = ctx.namespace_id();
     let root_gid = ContextGroupId::from(root_group_id);
-    if root_group_id == namespace_id {
+    if root_group_id == namespace_id.to_bytes() {
         eyre::bail!(NamespaceError::CannotDeleteRoot(format!("{root_gid:?}")));
     }
 
@@ -48,7 +48,7 @@ pub(crate) fn apply(
     // finds the root meta already gone — the op was authorized on the
     // first pass, so we skip the auth check here and let the (idempotent)
     // cascade finish any remaining cleanup.
-    let ns_gid = ContextGroupId::from(namespace_id);
+    let ns_gid = ContextGroupId::from(namespace_id.to_bytes());
     if let Some(root_meta) = MetaRepository::new(store).load(&root_gid)? {
         if root_meta.owner_identity != op.signer {
             if let Err(e) =

--- a/crates/governance-store/src/ops/namespace/member_joined_open.rs
+++ b/crates/governance-store/src/ops/namespace/member_joined_open.rs
@@ -50,12 +50,12 @@ pub(crate) fn apply(
     // namespace — matches the implicit assumption in the sibling
     // `MemberJoined` apply path.
     let resolved_ns = NamespaceRepository::new(store).resolve(&gid)?;
-    if resolved_ns.to_bytes() != namespace_id {
+    if resolved_ns.to_bytes() != namespace_id.to_bytes() {
         eyre::bail!(ApplyError::MemberJoinedOpenRejected(
             MemberJoinedOpenRejection::WrongNamespace {
                 gid: format!("{gid:?}"),
                 resolved_ns: format!("{resolved_ns:?}"),
-                this_ns: format!("{:?}", ContextGroupId::from(namespace_id)),
+                this_ns: format!("{:?}", ContextGroupId::from(namespace_id.to_bytes())),
             }
         ));
     }

--- a/crates/governance-store/src/ops/namespace/namespace_created.rs
+++ b/crates/governance-store/src/ops/namespace/namespace_created.rs
@@ -89,7 +89,7 @@ pub(crate) fn apply(
 ) -> EyreResult<()> {
     let store = ctx.store();
     let namespace_id = ctx.namespace_id();
-    let ns_gid = ContextGroupId::from(namespace_id);
+    let ns_gid = ContextGroupId::from(namespace_id.to_bytes());
 
     // ---- Load the root meta and decide established-ness FIRST. ----
     // The established check (NOT the structural parents/signer checks) is the
@@ -150,7 +150,7 @@ pub(crate) fn apply(
                 // stall), we simply do not act on a non-genesis-shaped op.
                 if !op.parent_op_hashes.is_empty() {
                     tracing::debug!(
-                        namespace_id = %hex::encode(namespace_id),
+                        namespace_id = %hex::encode(namespace_id.as_bytes()),
                         %founder,
                         parent_count = op.parent_op_hashes.len(),
                         "NamespaceCreated: same-founder PARENTED op on an established \
@@ -204,7 +204,7 @@ pub(crate) fn apply(
                     repaired.owner_identity = founder;
                     MetaRepository::new(store).save(&ns_gid, &repaired)?;
                     tracing::debug!(
-                        namespace_id = %hex::encode(namespace_id),
+                        namespace_id = %hex::encode(namespace_id.as_bytes()),
                         %founder,
                         prior_owner = %meta.owner_identity,
                         "NamespaceCreated: same-founder re-arrival repaired diverged \
@@ -223,7 +223,7 @@ pub(crate) fn apply(
                     )?;
                 }
                 tracing::debug!(
-                    namespace_id = %hex::encode(namespace_id),
+                    namespace_id = %hex::encode(namespace_id.as_bytes()),
                     %founder,
                     "NamespaceCreated: founder already established; ensured Admin member row \
                      (genesis-shaped idempotent re-arrival)"
@@ -235,7 +235,7 @@ pub(crate) fn apply(
             // would grant its declared founder state on a namespace they do not
             // own. That is the anti-hijack guarantee.
             tracing::debug!(
-                namespace_id = %hex::encode(namespace_id),
+                namespace_id = %hex::encode(namespace_id.as_bytes()),
                 established_admin = %meta.admin_identity,
                 established_owner = %meta.owner_identity,
                 %founder,
@@ -400,7 +400,7 @@ pub(crate) fn apply(
     }
 
     tracing::info!(
-        namespace_id = %hex::encode(namespace_id),
+        namespace_id = %hex::encode(namespace_id.as_bytes()),
         %founder,
         "NamespaceCreated genesis applied: founder established as namespace admin/owner"
     );

--- a/crates/governance-store/src/tee.rs
+++ b/crates/governance-store/src/tee.rs
@@ -256,7 +256,7 @@ mod tests {
     ) -> SignedGroupOp {
         SignedGroupOp::sign(
             signer_sk,
-            ns_gid.to_bytes(),
+            ns_gid,
             vec![],
             nonce,
             GroupOp::MemberJoinedViaTeeAttestation {
@@ -286,7 +286,7 @@ mod tests {
         let signer_sk = PrivateKey::random(&mut rng);
         let tee_op = SignedGroupOp::sign(
             &signer_sk,
-            ns_gid.to_bytes(),
+            ns_gid,
             vec![],
             1,
             GroupOp::MemberJoinedViaTeeAttestation {

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -423,7 +423,7 @@ fn apply_local_signed_group_op_nonce_and_admin() {
 
     let op1 = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::MemberAdded {
@@ -437,13 +437,14 @@ fn apply_local_signed_group_op_nonce_and_admin() {
         .is_member(&gid, &member_pk)
         .unwrap());
 
-    let op_dup_nonce = SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], 1, GroupOp::Noop).unwrap();
+    let op_dup_nonce =
+        SignedGroupOp::sign(&admin_sk, gid_bytes.into(), vec![], 1, GroupOp::Noop).unwrap();
     assert!(
         apply_local_signed_group_op(&store, &op_dup_nonce).is_ok(),
         "duplicate nonce should be silently accepted (idempotent)"
     );
 
-    let op2 = SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], 2, GroupOp::Noop).unwrap();
+    let op2 = SignedGroupOp::sign(&admin_sk, gid_bytes.into(), vec![], 2, GroupOp::Noop).unwrap();
     apply_local_signed_group_op(&store, &op2).unwrap();
 
     let non_admin_sk = PrivateKey::random(&mut rng);
@@ -452,7 +453,7 @@ fn apply_local_signed_group_op_nonce_and_admin() {
         .unwrap();
     let op_bad = SignedGroupOp::sign(
         &non_admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::MemberAdded {
@@ -499,7 +500,7 @@ fn apply_local_signed_group_op_out_of_order_siblings_2516() {
     // The HIGHER-nonce sibling (nonce 2) is delivered first.
     let op_high = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         2,
         GroupOp::MemberAdded {
@@ -523,7 +524,7 @@ fn apply_local_signed_group_op_out_of_order_siblings_2516() {
     // would have dropped it as `1 <= last(=2)`; the window applies it.
     let op_low = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::MemberAdded {
@@ -600,7 +601,7 @@ fn apply_local_signed_group_op_replay_does_not_duplicate_log_entry() {
     let member = PrivateKey::random(&mut rng).public_key();
     let op = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::MemberAdded {
@@ -725,7 +726,7 @@ fn reject_read_only_tee_via_member_added() {
     let tee_pk = PrivateKey::random(&mut rng).public_key();
     let op = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::MemberAdded {
@@ -768,7 +769,7 @@ fn reject_read_only_tee_via_member_role_set() {
 
     let op = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::MemberRoleSet {
@@ -814,7 +815,7 @@ fn apply_local_member_alias_member_signer_or_admin() {
 
     let op = SignedGroupOp::sign(
         &member_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::MemberMetadataSet {
@@ -837,7 +838,7 @@ fn apply_local_member_alias_member_signer_or_admin() {
     let other_sk = PrivateKey::random(&mut rng);
     let op_bad = SignedGroupOp::sign(
         &other_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::MemberMetadataSet {
@@ -851,7 +852,7 @@ fn apply_local_member_alias_member_signer_or_admin() {
 
     let admin_op = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::MemberMetadataSet {
@@ -909,7 +910,7 @@ fn apply_local_context_alias_admin_or_creator() {
 
     let op_reg = SignedGroupOp::sign(
         &creator_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::ContextRegistered {
@@ -925,7 +926,7 @@ fn apply_local_context_alias_admin_or_creator() {
 
     let op_creator_alias = SignedGroupOp::sign(
         &creator_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         2,
         GroupOp::ContextMetadataSet {
@@ -942,7 +943,7 @@ fn apply_local_context_alias_admin_or_creator() {
 
     let op_admin = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::ContextMetadataSet {
@@ -993,7 +994,7 @@ fn apply_local_signed_group_op_capabilities_upgrade_policy_and_delete() {
 
     let op_caps = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::MemberCapabilitySet {
@@ -1013,7 +1014,7 @@ fn apply_local_signed_group_op_capabilities_upgrade_policy_and_delete() {
 
     let op_policy = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         2,
         GroupOp::UpgradePolicySet {
@@ -1032,7 +1033,7 @@ fn apply_local_signed_group_op_capabilities_upgrade_policy_and_delete() {
     );
 
     let op_del =
-        SignedGroupOp::sign(&admin_sk, gid_bytes, vec![], 3, GroupOp::GroupDelete).unwrap();
+        SignedGroupOp::sign(&admin_sk, gid_bytes.into(), vec![], 3, GroupOp::GroupDelete).unwrap();
     apply_local_signed_group_op(&store, &op_del).unwrap();
     assert!(MetaRepository::new(&store).load(&gid).unwrap().is_none());
 }
@@ -1059,7 +1060,7 @@ fn apply_local_signed_group_op_rejects_last_admin_removal() {
 
     let op_bad = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         dummy_member_removed_op(admin_pk),
@@ -1117,7 +1118,7 @@ fn transfer_ownership_rejects_non_owner_signer() {
 
     let op = SignedGroupOp::sign(
         &other_admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::TransferOwnership {
@@ -1174,7 +1175,7 @@ fn transfer_ownership_rejects_new_owner_not_admin() {
 
     let op = SignedGroupOp::sign(
         &owner_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::TransferOwnership {
@@ -1229,7 +1230,7 @@ fn transfer_ownership_rejects_new_owner_not_member() {
 
     let op = SignedGroupOp::sign(
         &owner_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::TransferOwnership {
@@ -1291,7 +1292,7 @@ fn transfer_ownership_moves_admin_identity_to_new_owner() {
 
     let op = SignedGroupOp::sign(
         &owner_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::TransferOwnership {
@@ -1361,7 +1362,7 @@ fn context_capability_granted_rejects_unauthorized_signer() {
 
     let op = SignedGroupOp::sign(
         &member_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::ContextCapabilityGranted {
@@ -1427,7 +1428,7 @@ fn context_capability_revoked_rejects_unauthorized_signer() {
 
     let op = SignedGroupOp::sign(
         &member_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::ContextCapabilityRevoked {
@@ -2542,7 +2543,8 @@ fn local_state_join_tracking_and_delete_group_rows_cleanup() {
 
     let mut rng = OsRng;
     let signer_sk = PrivateKey::random(&mut rng);
-    let op = SignedGroupOp::sign(&signer_sk, gid.to_bytes(), vec![], 1, GroupOp::Noop).unwrap();
+    let op =
+        SignedGroupOp::sign(&signer_sk, gid.to_bytes().into(), vec![], 1, GroupOp::Noop).unwrap();
     let op_bytes = borsh::to_vec(&op).unwrap();
     append_op_log_entry(&store, &gid, 1, &op_bytes).unwrap();
     set_op_head(&store, &gid, 1, vec![[0x11; 32]]).unwrap();
@@ -2634,7 +2636,7 @@ fn tee_policy_and_quote_hash_scan_latest_and_match() {
     let signer_sk = PrivateKey::random(&mut rng);
     let policy_1 = SignedGroupOp::sign(
         &signer_sk,
-        gid.to_bytes(),
+        gid.to_bytes().into(),
         vec![],
         1,
         GroupOp::TeeAdmissionPolicySet {
@@ -2652,7 +2654,7 @@ fn tee_policy_and_quote_hash_scan_latest_and_match() {
 
     let joined = SignedGroupOp::sign(
         &signer_sk,
-        gid.to_bytes(),
+        gid.to_bytes().into(),
         vec![],
         2,
         GroupOp::MemberJoinedViaTeeAttestation {
@@ -2672,7 +2674,7 @@ fn tee_policy_and_quote_hash_scan_latest_and_match() {
 
     let policy_2 = SignedGroupOp::sign(
         &signer_sk,
-        gid.to_bytes(),
+        gid.to_bytes().into(),
         vec![],
         3,
         GroupOp::TeeAdmissionPolicySet {
@@ -2845,7 +2847,7 @@ fn append_tee_policy_op(store: &Store, group: &ContextGroupId, seq: u64, mrtd: &
     let signer_sk = PrivateKey::random(&mut rng);
     let op = SignedGroupOp::sign(
         &signer_sk,
-        group.to_bytes(),
+        group.to_bytes().into(),
         vec![],
         seq,
         GroupOp::TeeAdmissionPolicySet {
@@ -2952,7 +2954,7 @@ fn apply_tee_policy_op_on_subgroup_rejected() {
 
     let op = SignedGroupOp::sign(
         &admin_sk,
-        child.to_bytes(),
+        child.to_bytes().into(),
         vec![],
         1,
         GroupOp::TeeAdmissionPolicySet {
@@ -3612,7 +3614,7 @@ fn member_added_after_remove_restores_context_identity_for_local_rejoiner() {
 
     let removed = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         dummy_member_removed_op(member_pk),
@@ -3634,7 +3636,7 @@ fn member_added_after_remove_restores_context_identity_for_local_rejoiner() {
     // restore on the local rejoiner.
     let readded = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         2,
         GroupOp::MemberAdded {
@@ -3735,7 +3737,7 @@ fn member_added_after_remove_restores_context_identity_for_subgroup_with_real_na
     }
     let removed = SignedGroupOp::sign(
         &admin_sk,
-        subgroup.to_bytes(),
+        subgroup.to_bytes().into(),
         vec![],
         1,
         dummy_member_removed_op(member_pk),
@@ -3754,7 +3756,7 @@ fn member_added_after_remove_restores_context_identity_for_subgroup_with_real_na
     // match — only then does the restore run.
     let readded = SignedGroupOp::sign(
         &admin_sk,
-        subgroup.to_bytes(),
+        subgroup.to_bytes().into(),
         vec![],
         2,
         GroupOp::MemberAdded {
@@ -3867,7 +3869,7 @@ fn member_joined_open_clears_deny_list_and_restores_context_identity() {
         1,
         NamespaceOp::Root(RootOp::MemberJoinedOpen {
             member: member_pk,
-            group_id: subgroup.to_bytes(),
+            group_id: subgroup.to_bytes().into(),
         }),
     )
     .unwrap();
@@ -4035,7 +4037,7 @@ fn member_added_does_nothing_for_non_rejoiner_peers() {
 
     let added = SignedGroupOp::sign(
         &admin_sk,
-        gid.to_bytes(),
+        gid.to_bytes().into(),
         vec![],
         1,
         GroupOp::MemberAdded {
@@ -4696,7 +4698,7 @@ fn deny_list_member_added_op_clears_existing_entry() {
     // Apply MemberAdded for target_pk.
     let op = SignedGroupOp::sign(
         &admin_sk,
-        gid.to_bytes(),
+        gid.to_bytes().into(),
         vec![],
         1,
         GroupOp::MemberAdded {
@@ -4747,7 +4749,7 @@ fn deny_list_member_removed_op_marks_entry() {
 
     let op = SignedGroupOp::sign(
         &admin_sk,
-        gid.to_bytes(),
+        gid.to_bytes().into(),
         vec![],
         1,
         dummy_member_removed_op(target_pk),
@@ -4786,7 +4788,7 @@ fn deny_list_remove_then_readd_clears_entry_via_apply_path() {
     // Remove.
     let rm = SignedGroupOp::sign(
         &admin_sk,
-        gid.to_bytes(),
+        gid.to_bytes().into(),
         vec![],
         1,
         dummy_member_removed_op(target_pk),
@@ -4800,7 +4802,7 @@ fn deny_list_remove_then_readd_clears_entry_via_apply_path() {
     // Re-add.
     let add = SignedGroupOp::sign(
         &admin_sk,
-        gid.to_bytes(),
+        gid.to_bytes().into(),
         vec![rm.content_hash().unwrap()],
         2,
         GroupOp::MemberAdded {
@@ -4880,7 +4882,7 @@ fn metadata_set_does_not_change_group_state_hash() {
 
     let op = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::GroupMetadataSet {
@@ -4947,7 +4949,7 @@ fn member_metadata_self_set_allowed_others_gated() {
     // Alice sets her own metadata — allowed.
     let op = SignedGroupOp::sign(
         &alice_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::MemberMetadataSet {
@@ -4962,7 +4964,7 @@ fn member_metadata_self_set_allowed_others_gated() {
     // Alice tries to set Bob's metadata — rejected (no CAN_MANAGE_METADATA).
     let op_bad = SignedGroupOp::sign(
         &alice_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         2,
         GroupOp::MemberMetadataSet {
@@ -4977,7 +4979,7 @@ fn member_metadata_self_set_allowed_others_gated() {
     // Group-level metadata by a bare member — rejected.
     let op_group = SignedGroupOp::sign(
         &alice_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         3,
         GroupOp::GroupMetadataSet {
@@ -4998,7 +5000,7 @@ fn member_metadata_self_set_allowed_others_gated() {
         .unwrap();
     let op_ok = SignedGroupOp::sign(
         &alice_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         4,
         GroupOp::GroupMetadataSet {
@@ -5353,7 +5355,7 @@ fn apply_with_precomputed_real_hashes_matches_post_apply_view() {
 
     let signed = SignedGroupOp::sign(
         &admin_sk,
-        gid.to_bytes(),
+        gid.to_bytes().into(),
         vec![],
         1,
         GroupOp::MemberRemoved {
@@ -5695,7 +5697,7 @@ fn is_tee_admitted_identity_matches_tee_joined_member() {
     let signer_sk = PrivateKey::random(&mut rng);
     let tee_op = SignedGroupOp::sign(
         &signer_sk,
-        gid.to_bytes(),
+        gid.to_bytes().into(),
         vec![],
         1,
         GroupOp::MemberJoinedViaTeeAttestation {
@@ -5760,7 +5762,7 @@ mod auto_follow_tests {
 
         let op = SignedGroupOp::sign(
             &admin_sk,
-            gid_bytes,
+            gid_bytes.into(),
             vec![],
             1,
             GroupOp::MemberSetAutoFollow {
@@ -5787,7 +5789,7 @@ mod auto_follow_tests {
 
         let op = SignedGroupOp::sign(
             &member_sk,
-            gid_bytes,
+            gid_bytes.into(),
             vec![],
             1,
             GroupOp::MemberSetAutoFollow {
@@ -5824,7 +5826,7 @@ mod auto_follow_tests {
 
         let op = SignedGroupOp::sign(
             &member_sk,
-            gid_bytes,
+            gid_bytes.into(),
             vec![],
             1,
             GroupOp::MemberSetAutoFollow {
@@ -5865,7 +5867,7 @@ mod auto_follow_tests {
 
         let op = SignedGroupOp::sign(
             &admin_sk,
-            gid_bytes,
+            gid_bytes.into(),
             vec![],
             1,
             GroupOp::MemberSetAutoFollow {
@@ -5900,7 +5902,7 @@ mod auto_follow_tests {
         // Member turns on contexts
         let op1 = SignedGroupOp::sign(
             &member_sk,
-            gid_bytes,
+            gid_bytes.into(),
             vec![],
             1,
             GroupOp::MemberSetAutoFollow {
@@ -5915,7 +5917,7 @@ mod auto_follow_tests {
         // Admin changes role — flags must survive
         let op2 = SignedGroupOp::sign(
             &admin_sk,
-            gid_bytes,
+            gid_bytes.into(),
             vec![],
             1,
             GroupOp::MemberRoleSet {
@@ -5960,7 +5962,7 @@ mod auto_follow_tests {
         // 1. MemberSetAutoFollow on self
         let set_flags = SignedGroupOp::sign(
             &member_sk,
-            gid_bytes,
+            gid_bytes.into(),
             vec![],
             1,
             GroupOp::MemberSetAutoFollow {
@@ -5984,7 +5986,7 @@ mod auto_follow_tests {
         let context_id = ContextId::from([0x77; 32]);
         let register = SignedGroupOp::sign(
             &admin_sk,
-            gid_bytes,
+            gid_bytes.into(),
             vec![],
             1,
             GroupOp::ContextRegistered {
@@ -6066,7 +6068,7 @@ mod auto_follow_tests {
 
         let op = SignedGroupOp::sign(
             &admin_sk,
-            gid_bytes,
+            gid_bytes.into(),
             vec![],
             1,
             GroupOp::MemberAdded {
@@ -6165,7 +6167,7 @@ mod auto_follow_tests {
             &store,
             &SignedGroupOp::sign(
                 &admin_sk,
-                gid_bytes,
+                gid_bytes.into(),
                 vec![],
                 1,
                 GroupOp::MemberAdded {
@@ -6182,7 +6184,7 @@ mod auto_follow_tests {
             &store,
             &SignedGroupOp::sign(
                 &target_sk,
-                gid_bytes,
+                gid_bytes.into(),
                 vec![],
                 1,
                 GroupOp::MemberSetAutoFollow {
@@ -6242,7 +6244,7 @@ mod auto_follow_tests {
 
         let op = SignedGroupOp::sign(
             &admin_sk,
-            gid_bytes,
+            gid_bytes.into(),
             vec![],
             1,
             GroupOp::MemberAdded {
@@ -6353,7 +6355,7 @@ mod auto_follow_tests {
 
         let op = SignedGroupOp::sign(
             &admin_sk,
-            gid_bytes,
+            gid_bytes.into(),
             vec![],
             1,
             GroupOp::MemberAdded {
@@ -6457,8 +6459,8 @@ mod auto_follow_tests {
             vec![],
             1,
             NamespaceOp::Root(RootOp::GroupCreated {
-                group_id: new_group_id,
-                parent_id: ns_id,
+                group_id: new_group_id.into(),
+                parent_id: ns_id.into(),
                 restricted: true,
             }),
         )
@@ -6706,7 +6708,7 @@ mod tee_member_removed_event_tests {
 
         let op = SignedGroupOp::sign(
             &admin_sk,
-            gid.to_bytes(),
+            gid.to_bytes().into(),
             vec![],
             1,
             dummy_member_removed_op(tee_pk),
@@ -6755,7 +6757,7 @@ mod tee_member_removed_event_tests {
 
         let op = SignedGroupOp::sign(
             &admin_sk,
-            gid.to_bytes(),
+            gid.to_bytes().into(),
             vec![],
             1,
             dummy_member_removed_op(target_pk),
@@ -6825,7 +6827,7 @@ mod tee_member_removed_event_tests {
         // Root admin removes the TEE at the namespace root.
         let op = SignedGroupOp::sign(
             &admin_sk,
-            ns_gid.to_bytes(),
+            ns_gid.to_bytes().into(),
             vec![],
             1,
             dummy_member_removed_op(tee_pk),
@@ -6941,7 +6943,7 @@ mod tee_member_removed_event_tests {
 
         let op = SignedGroupOp::sign(
             &admin_sk,
-            ns_gid.to_bytes(),
+            ns_gid.to_bytes().into(),
             vec![],
             1,
             dummy_member_removed_op(tee_pk),
@@ -7019,7 +7021,7 @@ mod tee_member_removed_event_tests {
 
         let op = SignedGroupOp::sign(
             &admin_sk,
-            ns_gid.to_bytes(),
+            ns_gid.to_bytes().into(),
             vec![],
             1,
             dummy_member_removed_op(member_pk),
@@ -7095,7 +7097,7 @@ mod tee_member_removed_event_tests {
 
             let op = SignedGroupOp::sign(
                 &tee_sk,
-                gid.to_bytes(),
+                gid.to_bytes().into(),
                 vec![],
                 1,
                 GroupOp::MemberLeft {
@@ -7141,7 +7143,7 @@ mod tee_member_removed_event_tests {
 
             let op = SignedGroupOp::sign(
                 &leaver_sk,
-                gid.to_bytes(),
+                gid.to_bytes().into(),
                 vec![],
                 1,
                 GroupOp::MemberLeft {

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -2796,7 +2796,7 @@ fn seed_bootstrap_admin_repairs_missing_member_row() {
     let namespace_id = [0xC6u8; 32];
     let ns_gid = ContextGroupId::from(namespace_id);
 
-    let gov = NamespaceGovernance::new(&store, namespace_id);
+    let gov = NamespaceGovernance::new(&store, namespace_id.into());
 
     // ---- First seed: both meta and the (non-authoritative) member row are
     // written. #2474: the member row is `Member`, not `Admin`. ----
@@ -3862,7 +3862,7 @@ fn member_joined_open_clears_deny_list_and_restores_context_identity() {
     // Sign + apply a fresh `MemberJoinedOpen` for the rejoiner.
     let signed = SignedNamespaceOp::sign(
         &member_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::MemberJoinedOpen {
@@ -3973,7 +3973,7 @@ fn member_joined_clears_deny_list_for_rejoiner() {
 
     let signed = SignedNamespaceOp::sign(
         &member_sk,
-        ns_id,
+        ns_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::MemberJoined {
@@ -6453,7 +6453,7 @@ mod auto_follow_tests {
 
         let op = SignedNamespaceOp::sign(
             &admin_sk,
-            ns_id,
+            ns_id.into(),
             vec![],
             1,
             NamespaceOp::Root(RootOp::GroupCreated {
@@ -6497,12 +6497,12 @@ mod auto_follow_tests {
                         namespace_id,
                         parent_group_id,
                         child_group_id,
-                    }) if namespace_id == ns_id
+                    }) if namespace_id == ns_id.into()
                         && parent_group_id == ns_id
                         && child_group_id == new_group_id =>
                     {
                         return Some(
-                            NamespaceOpLogService::new(&observer_store, ns_id)
+                            NamespaceOpLogService::new(&observer_store, ns_id.into())
                                 .contains_op(delta_id)
                                 .unwrap(),
                         );
@@ -6526,7 +6526,7 @@ mod auto_follow_tests {
 
         // Release the observer and immediately apply.
         barrier.wait();
-        NamespaceGovernance::new(&store, ns_id)
+        NamespaceGovernance::new(&store, ns_id.into())
             .apply_signed_op(&op)
             .unwrap();
 

--- a/crates/governance-store/src/unified_op_decode.rs
+++ b/crates/governance-store/src/unified_op_decode.rs
@@ -100,7 +100,7 @@ pub fn op_from_namespace_op(
     };
     build_op(
         id,
-        ScopeId::from(signed.namespace_id),
+        ScopeId::from(signed.namespace_id.to_bytes()),
         signed.signer,
         hlc,
         parents,

--- a/crates/governance-store/src/unified_op_decode.rs
+++ b/crates/governance-store/src/unified_op_decode.rs
@@ -9,7 +9,6 @@
 //! existing projection callers keep compiling unchanged.
 
 use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
-use calimero_context_config::types::ContextGroupId;
 use calimero_dag::CausalDelta;
 use calimero_op::{Op, OpPayload, ScopeId};
 use calimero_op_adapter::{payload_from_group_op, payload_from_root_op};
@@ -91,7 +90,7 @@ pub fn op_from_namespace_op(
             payload_from_root_op(root, signed.signer).unwrap_or(OpPayload::Noop)
         }
         NamespaceOp::Group { group_id, .. } => decrypted_group_op
-            .and_then(|g| payload_from_group_op(ContextGroupId::from(*group_id), g))
+            .and_then(|g| payload_from_group_op(*group_id, g))
             .unwrap_or(OpPayload::Noop),
         // `NamespaceOp` is `#[non_exhaustive]`; an unknown future op folds as a
         // `Noop` graph node (same as an undecryptable/unfoldable op above),

--- a/crates/governance-types/Cargo.toml
+++ b/crates/governance-types/Cargo.toml
@@ -18,6 +18,7 @@ publish = true
 blake3.workspace = true
 borsh = { workspace = true, features = ["derive"] }
 ed25519-dalek.workspace = true
+serde = { workspace = true, features = ["derive"] }
 sha2.workspace = true
 thiserror.workspace = true
 

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -24,7 +24,7 @@ use std::collections::BTreeMap;
 use std::io;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use calimero_context_config::types::SignedGroupOpenInvitation;
+use calimero_context_config::types::{AppKey, SignedGroupOpenInvitation};
 use calimero_context_config::{MemberCapabilities, VisibilityMode};
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::{ContextId, GroupMemberRole, UpgradePolicy};
@@ -297,7 +297,7 @@ pub enum GroupOp {
     UpgradePolicySet { policy: UpgradePolicy },
     /// Update target application and app key in group metadata.
     TargetApplicationSet {
-        app_key: [u8; 32],
+        app_key: AppKey,
         target_application_id: ApplicationId,
     },
     /// Register a context index under this group (must match `ContextGroupRef` invariants).
@@ -424,8 +424,8 @@ pub enum GroupOp {
     /// `#[deprecated]` because the enum's derived borsh/Debug impls reference
     /// every variant and would warn at the derive site.)
     CascadeTargetApplicationSet {
-        from_app_key: [u8; 32],
-        app_key: [u8; 32],
+        from_app_key: AppKey,
+        app_key: AppKey,
         target_application_id: ApplicationId,
     },
     /// Cascade variant of [`Self::GroupMigrationSet`]: emitted alongside
@@ -438,7 +438,7 @@ pub enum GroupOp {
     /// DEPRECATED: superseded by [`Self::CascadeUpgrade`] (see that variant).
     /// Do NOT emit; apply arm retained for one release for wire-compat.
     CascadeGroupMigrationSet {
-        from_app_key: [u8; 32],
+        from_app_key: AppKey,
         migration: Option<Vec<u8>>,
     },
     /// Atomic namespace cascade upgrade. Applies target_application_id, app_key,
@@ -453,8 +453,8 @@ pub enum GroupOp {
     /// timestamp predates this value is rejected post-`Completed` to prevent
     /// offline-writer stale-schema state from overwriting migrated state.
     CascadeUpgrade {
-        from_app_key: [u8; 32],
-        app_key: [u8; 32],
+        from_app_key: AppKey,
+        app_key: AppKey,
         target_application_id: ApplicationId,
         migration: Option<Vec<u8>>,
         cascade_hlc: HybridTimestamp,

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -24,7 +24,7 @@ use std::collections::BTreeMap;
 use std::io;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use calimero_context_config::types::{AppKey, SignedGroupOpenInvitation};
+use calimero_context_config::types::{AppKey, ContextGroupId, SignedGroupOpenInvitation};
 use calimero_context_config::{MemberCapabilities, VisibilityMode};
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::{ContextId, GroupMemberRole, UpgradePolicy};
@@ -520,7 +520,7 @@ pub enum NamespaceOp {
     /// cleartext so non-members can store the skeleton; the payload is only
     /// readable by holders of the group key identified by `key_id`.
     Group {
-        group_id: [u8; 32],
+        group_id: ContextGroupId,
         /// `sha256(group_key)` — identifies which group key encrypted this op.
         key_id: KeyId,
         encrypted: EncryptedGroupOp,
@@ -551,8 +551,8 @@ pub enum RootOp {
     /// `ReadOnlyTee` row that the old Restricted-then-flip path produced.
     /// Visibility can still be changed later via `SubgroupVisibilitySet`.
     GroupCreated {
-        group_id: [u8; 32],
-        parent_id: [u8; 32],
+        group_id: ContextGroupId,
+        parent_id: ContextGroupId,
         restricted: bool,
     },
     /// Atomically move `child_group_id` from its current parent to
@@ -564,8 +564,8 @@ pub enum RootOp {
     /// Replaces the old `GroupNested` + `GroupUnnested` two-op pattern;
     /// orphan state is no longer expressible.
     GroupReparented {
-        child_group_id: [u8; 32],
-        new_parent_id: [u8; 32],
+        child_group_id: ContextGroupId,
+        new_parent_id: ContextGroupId,
     },
     /// Delete `root_group_id` AND its entire subtree AND all contained
     /// contexts in one op. The signer pre-computes `cascade_group_ids`
@@ -575,9 +575,9 @@ pub enum RootOp {
     /// with their state — deterministic-application check that catches
     /// silent divergence.
     GroupDeleted {
-        root_group_id: [u8; 32],
-        cascade_group_ids: Vec<[u8; 32]>,
-        cascade_context_ids: Vec<[u8; 32]>,
+        root_group_id: ContextGroupId,
+        cascade_group_ids: Vec<ContextGroupId>,
+        cascade_context_ids: Vec<ContextId>,
     },
     /// The namespace administrator was changed.
     AdminChanged { new_admin: PublicKey },
@@ -620,7 +620,7 @@ pub enum RootOp {
     /// (`recover_missing_group_keys`) is the durable retry that covers a
     /// member who misses this delivery.
     KeyDelivery {
-        group_id: [u8; 32],
+        group_id: ContextGroupId,
         envelope: KeyEnvelope,
     },
     /// A namespace member just self-joined an `Open` subgroup whose
@@ -643,7 +643,7 @@ pub enum RootOp {
     /// it. See `handlers/join_context.rs`.
     MemberJoinedOpen {
         member: PublicKey,
-        group_id: [u8; 32],
+        group_id: ContextGroupId,
     },
     /// Invitation-based join carrying the joiner's claimed redemption
     /// time (`joined_at`, unix seconds, covered by the joiner's
@@ -891,7 +891,7 @@ impl SignedNamespaceOp {
 
     /// Extract the group_id if this is a group-scoped op.
     #[must_use]
-    pub fn group_id(&self) -> Option<[u8; 32]> {
+    pub fn group_id(&self) -> Option<ContextGroupId> {
         match &self.op {
             NamespaceOp::Group { group_id, .. } => Some(*group_id),
             NamespaceOp::Root(_) => None,
@@ -905,7 +905,7 @@ impl SignedNamespaceOp {
 pub struct OpaqueSkeleton {
     pub delta_id: [u8; 32],
     pub parent_op_hashes: Vec<[u8; 32]>,
-    pub group_id: [u8; 32],
+    pub group_id: ContextGroupId,
     pub signer: PublicKey,
 }
 
@@ -931,7 +931,7 @@ pub enum StoredNamespaceEntry {
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct SignableGroupOp {
     pub version: u8,
-    pub group_id: [u8; 32],
+    pub group_id: ContextGroupId,
     pub parent_op_hashes: Vec<[u8; 32]>,
     pub signer: PublicKey,
     pub nonce: u64,
@@ -946,7 +946,7 @@ pub struct SignableGroupOp {
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct SignedGroupOp {
     pub version: u8,
-    pub group_id: [u8; 32],
+    pub group_id: ContextGroupId,
     pub parent_op_hashes: Vec<[u8; 32]>,
     pub signer: PublicKey,
     pub nonce: u64,
@@ -986,7 +986,7 @@ impl SignedGroupOp {
     /// latest applied ops). Empty vec for the first op in a group (genesis).
     pub fn sign(
         sk: &PrivateKey,
-        group_id: [u8; 32],
+        group_id: ContextGroupId,
         parent_op_hashes: Vec<[u8; 32]>,
         nonce: u64,
         op: GroupOp,

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -522,7 +522,7 @@ pub enum NamespaceOp {
     Group {
         group_id: [u8; 32],
         /// `sha256(group_key)` — identifies which group key encrypted this op.
-        key_id: [u8; 32],
+        key_id: KeyId,
         encrypted: EncryptedGroupOp,
         /// Present only on `MemberRemoved` ops: wraps a NEW group key for
         /// each remaining member. Lives outside the encrypted payload so
@@ -754,7 +754,7 @@ pub struct KeyEnvelope {
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct KeyRotation {
     /// `sha256(new_group_key)` — identifies the new epoch.
-    pub new_key_id: [u8; 32],
+    pub new_key_id: KeyId,
     /// One envelope per remaining member, each wrapping the new group key.
     pub envelopes: Vec<KeyEnvelope>,
 }

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -766,7 +766,7 @@ pub struct KeyRotation {
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct SignableNamespaceOp {
     pub version: u8,
-    pub namespace_id: [u8; 32],
+    pub namespace_id: NamespaceId,
     pub parent_op_hashes: Vec<[u8; 32]>,
     pub signer: PublicKey,
     pub nonce: u64,
@@ -777,7 +777,7 @@ pub struct SignableNamespaceOp {
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct SignedNamespaceOp {
     pub version: u8,
-    pub namespace_id: [u8; 32],
+    pub namespace_id: NamespaceId,
     pub parent_op_hashes: Vec<[u8; 32]>,
     pub signer: PublicKey,
     pub nonce: u64,
@@ -819,7 +819,7 @@ impl SignedNamespaceOp {
     /// Build and sign a new namespace operation.
     pub fn sign(
         sk: &PrivateKey,
-        namespace_id: [u8; 32],
+        namespace_id: NamespaceId,
         parent_op_hashes: Vec<[u8; 32]>,
         nonce: u64,
         op: NamespaceOp,

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -44,15 +44,19 @@ pub use wire::{
 // (they depend on `tokio::sync::broadcast` and connect actor mailboxes).
 // This crate is pure-data: types, signing, hashing, borsh layout.
 
-/// Define a 32-byte id newtype. Borsh-transparent (a derived `[u8; 32]`, no tag
-/// or length prefix) so it is byte-compatible with the bare `[u8; 32]` these
-/// ids used to be, while making the distinct id kinds non-interchangeable.
+/// Define a 32-byte id newtype. Borsh- and serde-transparent (a derived
+/// `[u8; 32]`, no tag or length prefix — a serde newtype struct serializes as
+/// its inner value) so it is byte-compatible with the bare `[u8; 32]` these ids
+/// used to be, while making the distinct id kinds non-interchangeable. Serde
+/// parity with `AppKey`/`ContextGroupId` keeps the ids usable across the JSON
+/// API surface, not just the borsh op wire.
 macro_rules! id_newtype {
     ($(#[$m:meta])* $name:ident) => {
         $(#[$m])*
         #[derive(
             Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash,
             BorshSerialize, BorshDeserialize,
+            serde::Serialize, serde::Deserialize,
         )]
         pub struct $name([u8; 32]);
 

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -44,6 +44,56 @@ pub use wire::{
 // (they depend on `tokio::sync::broadcast` and connect actor mailboxes).
 // This crate is pure-data: types, signing, hashing, borsh layout.
 
+/// Define a 32-byte id newtype. Borsh-transparent (a derived `[u8; 32]`, no tag
+/// or length prefix) so it is byte-compatible with the bare `[u8; 32]` these
+/// ids used to be, while making the distinct id kinds non-interchangeable.
+macro_rules! id_newtype {
+    ($(#[$m:meta])* $name:ident) => {
+        $(#[$m])*
+        #[derive(
+            Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash,
+            BorshSerialize, BorshDeserialize,
+        )]
+        pub struct $name([u8; 32]);
+
+        impl $name {
+            #[must_use]
+            pub const fn new(bytes: [u8; 32]) -> Self {
+                Self(bytes)
+            }
+            #[must_use]
+            pub const fn as_bytes(&self) -> &[u8; 32] {
+                &self.0
+            }
+            #[must_use]
+            pub const fn to_bytes(self) -> [u8; 32] {
+                self.0
+            }
+        }
+
+        impl From<[u8; 32]> for $name {
+            fn from(bytes: [u8; 32]) -> Self {
+                Self(bytes)
+            }
+        }
+
+        impl From<$name> for [u8; 32] {
+            fn from(id: $name) -> Self {
+                id.0
+            }
+        }
+    };
+}
+
+id_newtype! {
+    /// Stable id of a namespace (the root governance group of a DAG).
+    NamespaceId
+}
+id_newtype! {
+    /// Stable id of a group/namespace encryption key.
+    KeyId
+}
+
 /// Wire/schema version for [`SignedGroupOp`].
 ///
 /// v5: Drop the `cut: GovernanceParentEdge` field from `MemberRemoved` and

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -651,11 +651,11 @@ fn root_op_discriminants_are_golden() {
     );
 }
 
-fn sample_group_id() -> [u8; 32] {
+fn sample_group_id() -> ContextGroupId {
     let mut g = [0u8; 32];
     g[0] = 7;
     g[31] = 3;
-    g
+    g.into()
 }
 
 #[test]
@@ -771,7 +771,7 @@ fn signable_bytes_deterministic() {
     let pk = sk.public_key();
     let s = SignableGroupOp {
         version: SIGNED_GROUP_OP_SCHEMA_VERSION,
-        group_id: [1u8; 32],
+        group_id: [1u8; 32].into(),
         parent_op_hashes: vec![],
         signer: pk,
         nonce: 42,
@@ -804,7 +804,7 @@ fn namespace_op_sign_verify_root() {
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: sample_group_id(),
-            parent_id: sample_namespace_id().to_bytes(),
+            parent_id: sample_namespace_id().to_bytes().into(),
             restricted: true,
         }),
     )
@@ -874,7 +874,7 @@ fn namespace_op_content_hash_distinct() {
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: sample_group_id(),
-            parent_id: sample_namespace_id().to_bytes(),
+            parent_id: sample_namespace_id().to_bytes().into(),
             restricted: true,
         }),
     )
@@ -887,7 +887,7 @@ fn namespace_op_content_hash_distinct() {
         2,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: sample_group_id(),
-            parent_id: sample_namespace_id().to_bytes(),
+            parent_id: sample_namespace_id().to_bytes().into(),
             restricted: true,
         }),
     )
@@ -913,7 +913,7 @@ fn namespace_signable_bytes_deterministic() {
         nonce: 42,
         op: NamespaceOp::Root(RootOp::GroupCreated {
             group_id: sample_group_id(),
-            parent_id: sample_namespace_id().to_bytes(),
+            parent_id: sample_namespace_id().to_bytes().into(),
             restricted: true,
         }),
     };
@@ -1251,7 +1251,7 @@ fn pre_flag_day_namespace_op_version_is_rejected() {
     let signer = PrivateKey::random(&mut OsRng).public_key();
     let stale = SignedNamespaceOp {
         version: SIGNED_NAMESPACE_OP_SCHEMA_VERSION - 1,
-        namespace_id: sample_group_id().into(),
+        namespace_id: sample_group_id().to_bytes().into(),
         parent_op_hashes: vec![],
         signer,
         nonce: 1,
@@ -1295,7 +1295,7 @@ fn v7_borsh_layout_group_op_is_rejected_not_misparsed() {
     let signer = PrivateKey::random(&mut OsRng).public_key();
     let v7 = V7SignedGroupOp {
         version: SIGNED_GROUP_OP_SCHEMA_VERSION - 1,
-        group_id: sample_group_id(),
+        group_id: sample_group_id().to_bytes(),
         parent_op_hashes: vec![],
         state_hash: [0xAB; 32],
         signer,
@@ -1414,18 +1414,18 @@ mod governance_op_storage_roundtrip {
     fn every_root_op_roundtrips_through_stored_signed_entry() {
         let ops = [
             RootOp::GroupCreated {
-                group_id: [1; 32],
-                parent_id: [2; 32],
+                group_id: [1; 32].into(),
+                parent_id: [2; 32].into(),
                 restricted: true,
             },
             RootOp::GroupReparented {
-                child_group_id: [1; 32],
-                new_parent_id: [2; 32],
+                child_group_id: [1; 32].into(),
+                new_parent_id: [2; 32].into(),
             },
             RootOp::GroupDeleted {
-                root_group_id: [1; 32],
-                cascade_group_ids: vec![[3; 32]],
-                cascade_context_ids: vec![[4; 32]],
+                root_group_id: [1; 32].into(),
+                cascade_group_ids: vec![[3; 32].into()],
+                cascade_context_ids: vec![[4; 32].into()],
             },
             RootOp::AdminChanged {
                 new_admin: PrivateKey::random(&mut OsRng).public_key(),
@@ -1439,7 +1439,7 @@ mod governance_op_storage_roundtrip {
             },
             RootOp::MemberJoinedOpen {
                 member: PrivateKey::random(&mut OsRng).public_key(),
-                group_id: [7; 32],
+                group_id: [7; 32].into(),
             },
             RootOp::MemberJoinedAt {
                 member: PrivateKey::random(&mut OsRng).public_key(),

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -785,11 +785,11 @@ fn signable_bytes_deterministic() {
 
 // --- Namespace op tests ---
 
-fn sample_namespace_id() -> [u8; 32] {
+fn sample_namespace_id() -> NamespaceId {
     let mut ns = [0u8; 32];
     ns[0] = 0xAA;
     ns[31] = 0xBB;
-    ns
+    ns.into()
 }
 
 #[test]
@@ -804,7 +804,7 @@ fn namespace_op_sign_verify_root() {
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: sample_group_id(),
-            parent_id: sample_namespace_id(),
+            parent_id: sample_namespace_id().to_bytes(),
             restricted: true,
         }),
     )
@@ -874,7 +874,7 @@ fn namespace_op_content_hash_distinct() {
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: sample_group_id(),
-            parent_id: sample_namespace_id(),
+            parent_id: sample_namespace_id().to_bytes(),
             restricted: true,
         }),
     )
@@ -887,7 +887,7 @@ fn namespace_op_content_hash_distinct() {
         2,
         NamespaceOp::Root(RootOp::GroupCreated {
             group_id: sample_group_id(),
-            parent_id: sample_namespace_id(),
+            parent_id: sample_namespace_id().to_bytes(),
             restricted: true,
         }),
     )
@@ -913,7 +913,7 @@ fn namespace_signable_bytes_deterministic() {
         nonce: 42,
         op: NamespaceOp::Root(RootOp::GroupCreated {
             group_id: sample_group_id(),
-            parent_id: sample_namespace_id(),
+            parent_id: sample_namespace_id().to_bytes(),
             restricted: true,
         }),
     };
@@ -1251,7 +1251,7 @@ fn pre_flag_day_namespace_op_version_is_rejected() {
     let signer = PrivateKey::random(&mut OsRng).public_key();
     let stale = SignedNamespaceOp {
         version: SIGNED_NAMESPACE_OP_SCHEMA_VERSION - 1,
-        namespace_id: sample_group_id(),
+        namespace_id: sample_group_id().into(),
         parent_op_hashes: vec![],
         signer,
         nonce: 1,
@@ -1368,7 +1368,7 @@ mod governance_op_storage_roundtrip {
 
     fn signed(op: NamespaceOp) -> SignedNamespaceOp {
         let sk = PrivateKey::random(&mut OsRng);
-        SignedNamespaceOp::sign(&sk, [0x77; 32], vec![[0x01; 32], [0x02; 32]], 7, op)
+        SignedNamespaceOp::sign(&sk, [0x77; 32].into(), vec![[0x01; 32], [0x02; 32]], 7, op)
             .expect("sign namespace op")
     }
 

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -87,7 +87,7 @@ const GOLDEN_GROUP_OP_UPGRADE_POLICY_SET: &[u8] = &[
     1, // UpgradePolicy::LazyOnAccess (ordinal 1, the Default)
 ];
 
-/// GroupOp ordinal 8 — TargetApplicationSet { app_key: [0;32], target: [0;32] }
+/// GroupOp ordinal 8 — TargetApplicationSet { app_key: [0;32].into(), target: [0;32] }
 const GOLDEN_GROUP_OP_TARGET_APPLICATION_SET: &[u8] = &[
     8, // discriminant
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -220,7 +220,7 @@ const GOLDEN_GROUP_OP_TRANSFER_OWNERSHIP: &[u8] = &[
     0, // new_owner
 ];
 
-/// GroupOp ordinal 23 — CascadeTargetApplicationSet { from_app_key: [0;32], app_key: [0;32], target: [0;32] }
+/// GroupOp ordinal 23 — CascadeTargetApplicationSet { from_app_key: [0;32].into(), app_key: [0;32].into(), target: [0;32] }
 const GOLDEN_GROUP_OP_CASCADE_TARGET_APPLICATION_SET: &[u8] = &[
     23, // discriminant
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -231,7 +231,7 @@ const GOLDEN_GROUP_OP_CASCADE_TARGET_APPLICATION_SET: &[u8] = &[
     0, // target_application_id
 ];
 
-/// GroupOp ordinal 24 — CascadeGroupMigrationSet { from_app_key: [0;32], migration: None }
+/// GroupOp ordinal 24 — CascadeGroupMigrationSet { from_app_key: [0;32].into(), migration: None }
 const GOLDEN_GROUP_OP_CASCADE_GROUP_MIGRATION_SET: &[u8] = &[
     24, // discriminant
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -943,8 +943,8 @@ fn cascade_target_application_set_sign_verify() {
         vec![],
         1,
         GroupOp::CascadeTargetApplicationSet {
-            from_app_key: [9u8; 32],
-            app_key: [10u8; 32],
+            from_app_key: [9u8; 32].into(),
+            app_key: [10u8; 32].into(),
             target_application_id: sample_application_id(0x42),
         },
     )
@@ -969,7 +969,7 @@ fn cascade_group_migration_set_sign_verify() {
         vec![],
         1,
         GroupOp::CascadeGroupMigrationSet {
-            from_app_key: [9u8; 32],
+            from_app_key: [9u8; 32].into(),
             migration: Some(b"migrate_v1_to_v2".to_vec()),
         },
     )
@@ -999,7 +999,7 @@ fn cascade_target_distinct_from_single_group_target() {
         vec![],
         1,
         GroupOp::TargetApplicationSet {
-            app_key: new_app_key,
+            app_key: new_app_key.into(),
             target_application_id: target,
         },
     )
@@ -1011,8 +1011,8 @@ fn cascade_target_distinct_from_single_group_target() {
         vec![],
         1,
         GroupOp::CascadeTargetApplicationSet {
-            from_app_key: [9u8; 32],
-            app_key: new_app_key,
+            from_app_key: [9u8; 32].into(),
+            app_key: new_app_key.into(),
             target_application_id: target,
         },
     )
@@ -1047,8 +1047,8 @@ fn cascade_target_from_app_key_changes_hash() {
         vec![],
         1,
         GroupOp::CascadeTargetApplicationSet {
-            from_app_key: [9u8; 32],
-            app_key: new_app_key,
+            from_app_key: [9u8; 32].into(),
+            app_key: new_app_key.into(),
             target_application_id: target,
         },
     )
@@ -1060,8 +1060,8 @@ fn cascade_target_from_app_key_changes_hash() {
         vec![],
         1,
         GroupOp::CascadeTargetApplicationSet {
-            from_app_key: [8u8; 32], // only this differs
-            app_key: new_app_key,
+            from_app_key: [8u8; 32].into(), // only this differs
+            app_key: new_app_key.into(),
             target_application_id: target,
         },
     )
@@ -1085,8 +1085,8 @@ fn cascade_target_application_set_borsh_round_trip() {
     // op decodes as; this guards against that by asserting field
     // equality after a round trip.
     let original = GroupOp::CascadeTargetApplicationSet {
-        from_app_key: [9u8; 32],
-        app_key: [10u8; 32],
+        from_app_key: [9u8; 32].into(),
+        app_key: [10u8; 32].into(),
         target_application_id: sample_application_id(0x42),
     };
 
@@ -1099,8 +1099,8 @@ fn cascade_target_application_set_borsh_round_trip() {
             app_key,
             target_application_id,
         } => {
-            assert_eq!(from_app_key, [9u8; 32]);
-            assert_eq!(app_key, [10u8; 32]);
+            assert_eq!(from_app_key.to_bytes(), [9u8; 32]);
+            assert_eq!(app_key.to_bytes(), [10u8; 32]);
             assert_eq!(target_application_id, sample_application_id(0x42));
         }
         other => panic!("expected CascadeTargetApplicationSet, got {other:?}"),
@@ -1111,7 +1111,7 @@ fn cascade_target_application_set_borsh_round_trip() {
 fn cascade_group_migration_set_borsh_round_trip() {
     // Symmetric round-trip guard for the migration variant.
     let original = GroupOp::CascadeGroupMigrationSet {
-        from_app_key: [9u8; 32],
+        from_app_key: [9u8; 32].into(),
         migration: Some(b"migrate_v1_to_v2".to_vec()),
     };
 
@@ -1123,7 +1123,7 @@ fn cascade_group_migration_set_borsh_round_trip() {
             from_app_key,
             migration,
         } => {
-            assert_eq!(from_app_key, [9u8; 32]);
+            assert_eq!(from_app_key.to_bytes(), [9u8; 32]);
             assert_eq!(migration.as_deref(), Some(b"migrate_v1_to_v2".as_ref()));
         }
         other => panic!("expected CascadeGroupMigrationSet, got {other:?}"),
@@ -1131,7 +1131,7 @@ fn cascade_group_migration_set_borsh_round_trip() {
 
     // Also cover migration = None.
     let original_none = GroupOp::CascadeGroupMigrationSet {
-        from_app_key: [0u8; 32],
+        from_app_key: [0u8; 32].into(),
         migration: None,
     };
     let bytes_none = borsh::to_vec(&original_none).expect("serialize none");
@@ -1141,7 +1141,7 @@ fn cascade_group_migration_set_borsh_round_trip() {
             from_app_key,
             migration,
         } => {
-            assert_eq!(from_app_key, [0u8; 32]);
+            assert_eq!(from_app_key.to_bytes(), [0u8; 32]);
             assert!(migration.is_none());
         }
         other => panic!("expected CascadeGroupMigrationSet, got {other:?}"),
@@ -1166,8 +1166,8 @@ fn cascade_upgrade_back_compat_discriminant_fixed() {
     //
     // Golden encoding of:
     //   GroupOp::CascadeUpgrade {
-    //       from_app_key: [3u8; 32],
-    //       app_key: [4u8; 32],
+    //       from_app_key: [3u8; 32].into(),
+    //       app_key: [4u8; 32].into(),
     //       target_application_id: sample_application_id(5),
     //       migration: Some(b"migrate".to_vec()),
     //       cascade_hlc: HybridTimestamp::zero(),
@@ -1203,8 +1203,8 @@ fn cascade_upgrade_back_compat_discriminant_fixed() {
             migration,
             cascade_hlc,
         } => {
-            assert_eq!(from_app_key, [3u8; 32]);
-            assert_eq!(app_key, [4u8; 32]);
+            assert_eq!(from_app_key.to_bytes(), [3u8; 32]);
+            assert_eq!(app_key.to_bytes(), [4u8; 32]);
             assert_eq!(target_application_id, sample_application_id(5));
             assert_eq!(migration, Some(b"migrate".to_vec()));
             assert_eq!(cascade_hlc, HybridTimestamp::zero());

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -831,7 +831,7 @@ fn namespace_op_sign_verify_group() {
         1,
         NamespaceOp::Group {
             group_id: sample_group_id(),
-            key_id: [0u8; 32],
+            key_id: [0u8; 32].into(),
             encrypted,
             key_rotation: None,
         },

--- a/crates/governance-types/src/wire.rs
+++ b/crates/governance-types/src/wire.rs
@@ -15,7 +15,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_primitives::identity::PublicKey;
 
-use super::{GovernanceError, SignedGroupOp, SignedNamespaceOp};
+use super::{GovernanceError, NamespaceId, SignedGroupOp, SignedNamespaceOp};
 
 /// Domain separation prefix for [`SignedAck`] signatures.
 pub const ACK_SIGN_DOMAIN: &[u8] = b"calimero.ack.v1";
@@ -99,7 +99,7 @@ impl SignedAck {
 /// detected at verification time.
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct SignableReadinessBeacon {
-    pub namespace_id: [u8; 32],
+    pub namespace_id: NamespaceId,
     pub peer_pubkey: PublicKey,
     pub dag_head: [u8; 32],
     pub applied_through: u64,
@@ -116,7 +116,7 @@ pub struct SignableReadinessBeacon {
 /// cold-fleet deadlock without requiring a quorum.
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct SignedReadinessBeacon {
-    pub namespace_id: [u8; 32],
+    pub namespace_id: NamespaceId,
     pub peer_pubkey: PublicKey,
     pub dag_head: [u8; 32],
     pub applied_through: u64,
@@ -167,7 +167,7 @@ impl SignedReadinessBeacon {
 /// are detected at verification time.
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct SignableMigrationHeartbeat {
-    pub namespace_id: [u8; 32],
+    pub namespace_id: NamespaceId,
     pub peer_pubkey: PublicKey,
     /// Schema/binary version the publishing node has loaded.
     pub schema_version: u32,
@@ -197,7 +197,7 @@ pub struct SignableMigrationHeartbeat {
 // fail loudly on a desync — keep them in step.
 #[derive(Debug, Clone, BorshSerialize)]
 pub struct SignedMigrationHeartbeat {
-    pub namespace_id: [u8; 32],
+    pub namespace_id: NamespaceId,
     pub peer_pubkey: PublicKey,
     pub schema_version: u32,
     pub residue_auto: u64,
@@ -266,7 +266,7 @@ fn read_trailing<R: borsh::io::Read, const N: usize>(
 // go AFTER migration_failed (another trailing read) or behind a discriminant.
 impl BorshDeserialize for SignedMigrationHeartbeat {
     fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
-        let namespace_id = <[u8; 32]>::deserialize_reader(reader)?;
+        let namespace_id: NamespaceId = <[u8; 32]>::deserialize_reader(reader)?.into();
         let peer_pubkey = PublicKey::deserialize_reader(reader)?;
         let schema_version = u32::deserialize_reader(reader)?;
         let residue_auto = u64::deserialize_reader(reader)?;
@@ -335,7 +335,7 @@ impl SignedMigrationHeartbeat {
 /// the periodic beacon interval when waiting for `await_namespace_ready`.
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct ReadinessProbe {
-    pub namespace_id: [u8; 32],
+    pub namespace_id: NamespaceId,
     pub nonce: [u8; 16],
 }
 
@@ -395,14 +395,14 @@ mod tests {
     #[test]
     fn namespace_topic_msg_discriminates_kinds() {
         let probe = NamespaceTopicMsg::ReadinessProbe(ReadinessProbe {
-            namespace_id: [1u8; 32],
+            namespace_id: [1u8; 32].into(),
             nonce: [2u8; 16],
         });
         let bytes = borsh::to_vec(&probe).expect("ser");
         let parsed: NamespaceTopicMsg = borsh::from_slice(&bytes).expect("de");
         match parsed {
             NamespaceTopicMsg::ReadinessProbe(p) => {
-                assert_eq!(p.namespace_id, [1u8; 32]);
+                assert_eq!(p.namespace_id.to_bytes(), [1u8; 32]);
                 assert_eq!(p.nonce, [2u8; 16]);
             }
             other => panic!("wrong variant: {other:?}"),
@@ -412,7 +412,7 @@ mod tests {
     #[test]
     fn group_topic_msg_discriminates_kinds() {
         let beacon = GroupTopicMsg::ReadinessBeacon(SignedReadinessBeacon {
-            namespace_id: [3u8; 32],
+            namespace_id: [3u8; 32].into(),
             peer_pubkey: PrivateKey::random(&mut rand::thread_rng()).public_key(),
             dag_head: [4u8; 32],
             applied_through: 17,
@@ -424,7 +424,7 @@ mod tests {
         let parsed: GroupTopicMsg = borsh::from_slice(&bytes).expect("de");
         match parsed {
             GroupTopicMsg::ReadinessBeacon(b) => {
-                assert_eq!(b.namespace_id, [3u8; 32]);
+                assert_eq!(b.namespace_id.to_bytes(), [3u8; 32]);
                 assert_eq!(b.applied_through, 17);
                 assert!(b.strong);
             }
@@ -437,7 +437,7 @@ mod tests {
         let sk = PrivateKey::random(&mut rand::thread_rng());
         let op = SignedNamespaceOp::sign(
             &sk,
-            [0u8; 32],
+            [0u8; 32].into(),
             Vec::new(),
             0,
             super::super::NamespaceOp::Root(super::super::RootOp::AdminChanged {
@@ -503,7 +503,7 @@ mod tests {
     fn signed_readiness_beacon_verify_round_trip() {
         let sk = PrivateKey::random(&mut rand::thread_rng());
         let mut beacon = SignedReadinessBeacon {
-            namespace_id: [7u8; 32],
+            namespace_id: [7u8; 32].into(),
             peer_pubkey: sk.public_key(),
             dag_head: [9u8; 32],
             applied_through: 42,
@@ -524,7 +524,7 @@ mod tests {
         // must break the signature.
         let sk = PrivateKey::random(&mut rand::thread_rng());
         let mut beacon = SignedReadinessBeacon {
-            namespace_id: [7u8; 32],
+            namespace_id: [7u8; 32].into(),
             peer_pubkey: sk.public_key(),
             dag_head: [9u8; 32],
             applied_through: 42,
@@ -549,7 +549,7 @@ mod tests {
         // must break the signature.
         let sk = PrivateKey::random(&mut rand::thread_rng());
         let mut beacon = SignedReadinessBeacon {
-            namespace_id: [7u8; 32],
+            namespace_id: [7u8; 32].into(),
             peer_pubkey: sk.public_key(),
             dag_head: [9u8; 32],
             applied_through: 100,
@@ -572,7 +572,7 @@ mod tests {
     fn signed_migration_heartbeat_verify_round_trip() {
         let sk = PrivateKey::random(&mut rand::thread_rng());
         let mut hb = SignedMigrationHeartbeat {
-            namespace_id: [7u8; 32],
+            namespace_id: [7u8; 32].into(),
             peer_pubkey: sk.public_key(),
             schema_version: 2,
             residue_auto: 5,
@@ -596,7 +596,7 @@ mod tests {
         // fake a completed migration must break the signature.
         let sk = PrivateKey::random(&mut rand::thread_rng());
         let mut hb = SignedMigrationHeartbeat {
-            namespace_id: [7u8; 32],
+            namespace_id: [7u8; 32].into(),
             peer_pubkey: sk.public_key(),
             schema_version: 2,
             residue_auto: 0,
@@ -626,7 +626,7 @@ mod tests {
     fn migration_heartbeat_authored_remaining_unsigned_and_eof_tolerant() {
         let sk = PrivateKey::random(&mut rand::thread_rng());
         let mut hb = SignedMigrationHeartbeat {
-            namespace_id: [9u8; 32],
+            namespace_id: [9u8; 32].into(),
             peer_pubkey: sk.public_key(),
             schema_version: 2,
             residue_auto: 0,
@@ -678,7 +678,7 @@ mod tests {
     fn migration_heartbeat_migration_failed_unsigned_and_eof_tolerant() {
         let sk = PrivateKey::random(&mut rand::thread_rng());
         let mut hb = SignedMigrationHeartbeat {
-            namespace_id: [7u8; 32],
+            namespace_id: [7u8; 32].into(),
             peer_pubkey: sk.public_key(),
             schema_version: 2,
             residue_auto: 0,
@@ -726,7 +726,7 @@ mod tests {
         // domain prefix.
         let sk = PrivateKey::random(&mut rand::thread_rng());
         let hb_unsigned = SignableMigrationHeartbeat {
-            namespace_id: [7u8; 32],
+            namespace_id: [7u8; 32].into(),
             peer_pubkey: sk.public_key(),
             schema_version: 2,
             residue_auto: 0,
@@ -758,7 +758,7 @@ mod tests {
     fn namespace_topic_msg_migration_heartbeat_roundtrip() {
         let sk = PrivateKey::random(&mut rand::thread_rng());
         let envelope = NamespaceTopicMsg::MigrationHeartbeat(SignedMigrationHeartbeat {
-            namespace_id: [3u8; 32],
+            namespace_id: [3u8; 32].into(),
             peer_pubkey: sk.public_key(),
             schema_version: 2,
             residue_auto: 7,
@@ -773,7 +773,7 @@ mod tests {
         let parsed: NamespaceTopicMsg = borsh::from_slice(&bytes).expect("de");
         match parsed {
             NamespaceTopicMsg::MigrationHeartbeat(hb) => {
-                assert_eq!(hb.namespace_id, [3u8; 32]);
+                assert_eq!(hb.namespace_id.to_bytes(), [3u8; 32]);
                 assert_eq!(hb.schema_version, 2);
                 assert_eq!(hb.residue_auto, 7);
                 assert_eq!(hb.residue_identity, 1);

--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -63,7 +63,7 @@ pub(super) fn handle_namespace_governance_delta(
         // cache from a Y subscription. Mirrors the existing `Op` arm
         // check below.
         NamespaceTopicMsg::ReadinessBeacon(beacon) => {
-            if beacon.namespace_id != namespace_id {
+            if beacon.namespace_id != namespace_id.into() {
                 warn!("ReadinessBeacon namespace_id mismatch with topic; dropping");
                 return;
             }
@@ -71,7 +71,7 @@ pub(super) fn handle_namespace_governance_delta(
             return;
         }
         NamespaceTopicMsg::ReadinessProbe(probe) => {
-            if probe.namespace_id != namespace_id {
+            if probe.namespace_id != namespace_id.into() {
                 warn!("ReadinessProbe namespace_id mismatch with topic; dropping");
                 return;
             }
@@ -88,7 +88,7 @@ pub(super) fn handle_namespace_governance_delta(
         // rollup. The heartbeat is ephemeral telemetry, not governance state,
         // so there is no apply / ack / backfill — just the cache upsert.
         NamespaceTopicMsg::MigrationHeartbeat(heartbeat) => {
-            if heartbeat.namespace_id != namespace_id {
+            if heartbeat.namespace_id != namespace_id.into() {
                 warn!("MigrationHeartbeat namespace_id mismatch with topic; dropping");
                 return;
             }
@@ -97,14 +97,14 @@ pub(super) fn handle_namespace_governance_delta(
                 &heartbeat,
             ) {
                 debug!(
-                    namespace_id = %hex::encode(heartbeat.namespace_id),
+                    namespace_id = %hex::encode(heartbeat.namespace_id.as_bytes()),
                     "MigrationHeartbeat failed verification (sig/membership); dropping"
                 );
                 return;
             }
             this.migration_status_cache.insert(&heartbeat);
             debug!(
-                namespace_id = %hex::encode(heartbeat.namespace_id),
+                namespace_id = %hex::encode(heartbeat.namespace_id.as_bytes()),
                 peer = %heartbeat.peer_pubkey,
                 schema_version = heartbeat.schema_version,
                 residue_auto = heartbeat.residue_auto,
@@ -115,7 +115,7 @@ pub(super) fn handle_namespace_governance_delta(
         }
     };
 
-    if op.namespace_id != namespace_id {
+    if op.namespace_id != namespace_id.into() {
         warn!("NamespaceGovernanceDelta namespace_id mismatch with topic");
         return;
     }

--- a/crates/node/src/handlers/network_event/readiness.rs
+++ b/crates/node/src/handlers/network_event/readiness.rs
@@ -78,12 +78,12 @@ pub(super) fn handle_readiness_beacon(
 ) {
     if !verify_readiness_beacon(&manager.datastore, &beacon) {
         debug!(
-            namespace_id = %hex::encode(beacon.namespace_id),
+            namespace_id = %hex::encode(beacon.namespace_id.as_bytes()),
             "ReadinessBeacon failed verification; dropping"
         );
         return;
     }
-    let namespace_id = beacon.namespace_id;
+    let namespace_id = beacon.namespace_id.to_bytes();
     let peer_pubkey = beacon.peer_pubkey;
     let applied_through = beacon.applied_through;
     let strong = beacon.strong;
@@ -211,7 +211,7 @@ pub(super) fn handle_readiness_probe(
     // probe-driven amplification regardless of probe content.
     if let Some(addr) = &manager.readiness_addr {
         addr.do_send(EmitOutOfCycleBeacon {
-            namespace_id: probe.namespace_id,
+            namespace_id: probe.namespace_id.to_bytes(),
             requesting_peer: peer_id,
         });
     }

--- a/crates/node/src/join_namespace.rs
+++ b/crates/node/src/join_namespace.rs
@@ -197,7 +197,7 @@ pub async fn join_namespace(
     // the probe simply doesn't reach anyone, and `await_first_fresh_beacon`
     // below will time out with `NoReadyPeers`.
     let probe = ReadinessProbe {
-        namespace_id,
+        namespace_id: namespace_id.into(),
         nonce: rand::random(),
     };
     let inner = borsh::to_vec(&NamespaceTopicMsg::ReadinessProbe(probe))
@@ -214,7 +214,7 @@ pub async fn join_namespace(
         payload: inner,
     };
     let bytes = borsh::to_vec(&envelope).map_err(|e| JoinError::Transport(e.to_string()))?;
-    let topic = ns_topic(namespace_id);
+    let topic = ns_topic(namespace_id.into());
     if let Err(err) = node_client.network_client().publish(topic, bytes).await {
         debug!(
             ?err,
@@ -323,7 +323,7 @@ pub async fn await_namespace_ready(
         let mesh = node_client
             .mesh_peer_count_for_namespace(namespace_id)
             .await;
-        let topic = ns_topic(namespace_id);
+        let topic = ns_topic(namespace_id.into());
         let known = node_client.known_subscribers(&topic);
         let required = std::cmp::min(mesh_n_low, known);
         if mesh >= required {
@@ -366,7 +366,7 @@ pub async fn await_namespace_ready(
         signed_invitation: invitation,
         joined_at: now_secs,
     });
-    let report = NamespaceGovernance::new(store, namespace_id)
+    let report = NamespaceGovernance::new(store, namespace_id.into())
         .sign_and_publish_without_apply(node_client, ack_router, &signing_key, op, None)
         .await
         .map_err(|e| ReadyError::PublishMemberJoined(e.to_string()))?;
@@ -376,7 +376,7 @@ pub async fn await_namespace_ready(
     // store read fails we substitute defaults rather than fail the
     // whole join, since the caller's primary signal is `acked_by`.
     let members_learned = MembershipRepository::new(store)
-        .namespace_pubkeys(namespace_id)
+        .namespace_pubkeys(namespace_id.into())
         .map(|m| m.len())
         .unwrap_or(0);
 

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -1955,7 +1955,7 @@ async fn restricted_ctx_redriven_after_group_created() {
         1,
         NamespaceOp::Group {
             group_id: sub_gid.to_bytes(),
-            key_id,
+            key_id: key_id.into(),
             encrypted,
             key_rotation: None,
         },
@@ -2183,7 +2183,7 @@ async fn open_ctx_redriven_after_group_created_via_namespace_key() {
         1,
         NamespaceOp::Group {
             group_id: sub_gid.to_bytes(),
-            key_id,
+            key_id: key_id.into(),
             encrypted,
             key_rotation: None,
         },
@@ -2548,7 +2548,7 @@ async fn tee_matrix_restricted_late_join() {
         2,
         NamespaceOp::Group {
             group_id: sub_gid.to_bytes(),
-            key_id,
+            key_id: key_id.into(),
             encrypted,
             key_rotation: None,
         },

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -1950,7 +1950,7 @@ async fn restricted_ctx_redriven_after_group_created() {
 
     let ctx_registered_op = SignedNamespaceOp::sign(
         &owner_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         1,
         NamespaceOp::Group {
@@ -1989,7 +1989,7 @@ async fn restricted_ctx_redriven_after_group_created() {
 
     let key_delivery_op = SignedNamespaceOp::sign(
         &owner_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         2,
         NamespaceOp::Root(RootOp::KeyDelivery {
@@ -2026,7 +2026,7 @@ async fn restricted_ctx_redriven_after_group_created() {
     // GroupCreated re-trigger the buffered-op retry.
     let group_created_op = SignedNamespaceOp::sign(
         &owner_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         3,
         NamespaceOp::Root(RootOp::GroupCreated {
@@ -2178,7 +2178,7 @@ async fn open_ctx_redriven_after_group_created_via_namespace_key() {
 
     let ctx_registered_op = SignedNamespaceOp::sign(
         &owner_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         1,
         NamespaceOp::Group {
@@ -2227,7 +2227,7 @@ async fn open_ctx_redriven_after_group_created_via_namespace_key() {
     // ---- Step 3: GroupCreated{restricted:false} applies → must re-drive ------
     let group_created_op = SignedNamespaceOp::sign(
         &owner_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         2,
         NamespaceOp::Root(RootOp::GroupCreated {
@@ -2506,7 +2506,7 @@ async fn tee_matrix_restricted_late_join() {
     // ---- Step 1 (late-join): the subgroup EXISTS first (GroupCreated) -------
     let group_created_op = SignedNamespaceOp::sign(
         &owner_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
@@ -2543,7 +2543,7 @@ async fn tee_matrix_restricted_late_join() {
     let encrypted = GroupKeyring::encrypt_op(&subgroup_key, &inner_op).expect("encrypt group op");
     let ctx_registered_op = SignedNamespaceOp::sign(
         &owner_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         2,
         NamespaceOp::Group {
@@ -2572,7 +2572,7 @@ async fn tee_matrix_restricted_late_join() {
         .expect("wrap subgroup key for receiver");
     let key_delivery_op = SignedNamespaceOp::sign(
         &owner_sk,
-        namespace_id,
+        namespace_id.into(),
         vec![],
         3,
         NamespaceOp::Root(RootOp::KeyDelivery {

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -310,7 +310,7 @@ async fn apply_signed_group_op_via_context_client() {
 
     let op = SignedGroupOp::sign(
         &admin_sk,
-        gid_bytes,
+        gid_bytes.into(),
         vec![],
         1,
         GroupOp::MemberAdded {
@@ -581,7 +581,7 @@ fn provision_tee_owner_with_sk(
     // Policy lives on the namespace governance op log; admin-signed.
     let policy_op = SignedGroupOp::sign(
         &owner_sk,
-        gid.to_bytes(),
+        gid.to_bytes().into(),
         vec![],
         1,
         GroupOp::TeeAdmissionPolicySet {
@@ -1367,7 +1367,7 @@ async fn integrated_tee_lifecycle_open_replication_and_scoped_root_cascade() {
         + 1;
     let remove_tee_op = SignedGroupOp::sign(
         &owner_sk,
-        ns_gid.to_bytes(),
+        ns_gid.to_bytes().into(),
         vec![],
         next_owner_nonce,
         GroupOp::MemberRemoved {
@@ -1954,7 +1954,7 @@ async fn restricted_ctx_redriven_after_group_created() {
         vec![],
         1,
         NamespaceOp::Group {
-            group_id: sub_gid.to_bytes(),
+            group_id: sub_gid.to_bytes().into(),
             key_id: key_id.into(),
             encrypted,
             key_rotation: None,
@@ -1993,7 +1993,7 @@ async fn restricted_ctx_redriven_after_group_created() {
         vec![],
         2,
         NamespaceOp::Root(RootOp::KeyDelivery {
-            group_id: sub_gid.to_bytes(),
+            group_id: sub_gid.to_bytes().into(),
             envelope,
         }),
     )
@@ -2030,8 +2030,8 @@ async fn restricted_ctx_redriven_after_group_created() {
         vec![],
         3,
         NamespaceOp::Root(RootOp::GroupCreated {
-            group_id: sub_gid.to_bytes(),
-            parent_id: namespace_id,
+            group_id: sub_gid.to_bytes().into(),
+            parent_id: namespace_id.into(),
             restricted: true,
         }),
     )
@@ -2182,7 +2182,7 @@ async fn open_ctx_redriven_after_group_created_via_namespace_key() {
         vec![],
         1,
         NamespaceOp::Group {
-            group_id: sub_gid.to_bytes(),
+            group_id: sub_gid.to_bytes().into(),
             key_id: key_id.into(),
             encrypted,
             key_rotation: None,
@@ -2231,8 +2231,8 @@ async fn open_ctx_redriven_after_group_created_via_namespace_key() {
         vec![],
         2,
         NamespaceOp::Root(RootOp::GroupCreated {
-            group_id: sub_gid.to_bytes(),
-            parent_id: namespace_id,
+            group_id: sub_gid.to_bytes().into(),
+            parent_id: namespace_id.into(),
             restricted: false,
         }),
     )
@@ -2510,8 +2510,8 @@ async fn tee_matrix_restricted_late_join() {
         vec![],
         1,
         NamespaceOp::Root(RootOp::GroupCreated {
-            group_id: sub_gid.to_bytes(),
-            parent_id: namespace_id,
+            group_id: sub_gid.to_bytes().into(),
+            parent_id: namespace_id.into(),
             restricted: true,
         }),
     )
@@ -2547,7 +2547,7 @@ async fn tee_matrix_restricted_late_join() {
         vec![],
         2,
         NamespaceOp::Group {
-            group_id: sub_gid.to_bytes(),
+            group_id: sub_gid.to_bytes().into(),
             key_id: key_id.into(),
             encrypted,
             key_rotation: None,
@@ -2576,7 +2576,7 @@ async fn tee_matrix_restricted_late_join() {
         vec![],
         3,
         NamespaceOp::Root(RootOp::KeyDelivery {
-            group_id: sub_gid.to_bytes(),
+            group_id: sub_gid.to_bytes().into(),
             envelope,
         }),
     )

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -164,7 +164,7 @@ impl MigrationStatusCache {
 
         let now = Instant::now();
         let mut g = self.entries_lock();
-        let key = (hb.namespace_id, hb.peer_pubkey);
+        let key = (hb.namespace_id.to_bytes(), hb.peer_pubkey);
         if let Some(existing) = g.get(&key) {
             // Drop the heartbeat if it's older or equal-clock-but-not-fresher.
             if hb.ts_millis < existing.ts_millis
@@ -182,7 +182,8 @@ impl MigrationStatusCache {
         // (filtered by per-call `ttl`) without competing against this prune.
         let evict_window = Duration::from_millis(MAX_HEARTBEAT_CLOCK_DRIFT_MS.saturating_mul(2));
         g.retain(|(ns, _), entry| {
-            *ns != hb.namespace_id || now.duration_since(entry.received_at) <= evict_window
+            *ns != hb.namespace_id.to_bytes()
+                || now.duration_since(entry.received_at) <= evict_window
         });
 
         let _ = g.insert(
@@ -689,7 +690,7 @@ pub fn build_signed_heartbeat(
 ) -> Result<SignedMigrationHeartbeat, calimero_context_client::local_governance::GovernanceError> {
     let peer_pubkey = signer_sk.public_key();
     let mut hb = SignedMigrationHeartbeat {
-        namespace_id,
+        namespace_id: namespace_id.into(),
         peer_pubkey,
         schema_version: facts.schema_version,
         residue_auto: facts.residue_auto,
@@ -845,7 +846,7 @@ impl MigrationEmitter {
             }
         };
 
-        let topic = calimero_context::governance_broadcast::ns_topic(ns_id);
+        let topic = calimero_context::governance_broadcast::ns_topic(ns_id.into());
         // Wrap in the `BroadcastMessage::NamespaceGovernanceDelta` envelope
         // the receiver decodes on `ns/<id>` topics, then borsh the inner
         // `NamespaceTopicMsg::MigrationHeartbeat`. delta_id/parent_ids are
@@ -917,7 +918,7 @@ mod tests {
     ) -> SignedMigrationHeartbeat {
         let peer_pubkey = sk.public_key();
         let body = SignableMigrationHeartbeat {
-            namespace_id: ns,
+            namespace_id: ns.into(),
             peer_pubkey,
             schema_version,
             residue_auto,
@@ -930,7 +931,7 @@ mod tests {
         signable.extend_from_slice(&borsh::to_vec(&body).unwrap());
         let signature = sk.sign(&signable).unwrap().to_bytes();
         SignedMigrationHeartbeat {
-            namespace_id: ns,
+            namespace_id: ns.into(),
             peer_pubkey,
             schema_version,
             residue_auto,

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -289,7 +289,7 @@ impl ReadinessCache {
 
         let now = Instant::now();
         let mut g = self.entries_lock();
-        let key = (beacon.namespace_id, beacon.peer_pubkey);
+        let key = (beacon.namespace_id.to_bytes(), beacon.peer_pubkey);
         if let Some(existing) = g.get(&key) {
             // Drop the beacon if it's older or equal-clock-but-not-fresher.
             if beacon.ts_millis < existing.ts_millis
@@ -309,7 +309,8 @@ impl ReadinessCache {
         // against this prune.
         let evict_window = Duration::from_millis(MAX_BEACON_CLOCK_DRIFT_MS.saturating_mul(2));
         g.retain(|(ns, _), entry| {
-            *ns != beacon.namespace_id || now.duration_since(entry.received_at) <= evict_window
+            *ns != beacon.namespace_id.to_bytes()
+                || now.duration_since(entry.received_at) <= evict_window
         });
 
         let _ = g.insert(
@@ -601,7 +602,7 @@ impl ReadinessManager {
         // Build with a placeholder signature, sign over the canonical
         // signable_bytes(), then write the real signature back.
         let mut beacon = SignedReadinessBeacon {
-            namespace_id: ns_id,
+            namespace_id: ns_id.into(),
             peer_pubkey,
             dag_head,
             applied_through: state.local_applied_through,
@@ -630,7 +631,7 @@ impl ReadinessManager {
         };
         beacon.signature = signature;
 
-        let topic = calimero_context::governance_broadcast::ns_topic(ns_id);
+        let topic = calimero_context::governance_broadcast::ns_topic(ns_id.into());
         // Wrap the NamespaceTopicMsg in the BroadcastMessage envelope used
         // on `ns/<id>` topics — the receiver-side dispatch in
         // `network_event::handle_namespace_governance_delta` unwraps

--- a/crates/node/src/readiness/tests.rs
+++ b/crates/node/src/readiness/tests.rs
@@ -149,7 +149,7 @@ fn applied_through_grace_prevents_thrashing() {
 
 fn make_beacon(pk: PublicKey, applied_through: u64, strong: bool) -> SignedReadinessBeacon {
     SignedReadinessBeacon {
-        namespace_id: [42u8; 32],
+        namespace_id: [42u8; 32].into(),
         peer_pubkey: pk,
         dag_head: [9u8; 32],
         applied_through,

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -468,7 +468,7 @@ impl SyncManager {
         // point-to-point, not folded governance state, so responders
         // disagreeing cannot diverge membership.
         let now_secs = calimero_context::group_store::now_secs();
-        if let Err(err) = NamespaceMembershipService::new(&store, namespace_id)
+        if let Err(err) = NamespaceMembershipService::new(&store, namespace_id.into())
             .validate_open_invitation(&invitation, now_secs)
         {
             let msg = StreamMessage::Message {
@@ -1350,7 +1350,7 @@ impl SyncManager {
 
         let awaiting = match calimero_context::group_store::namespace_groups_awaiting_key(
             &store,
-            namespace_id,
+            namespace_id.into(),
         ) {
             Ok(groups) => groups,
             Err(err) => {
@@ -1401,7 +1401,7 @@ impl SyncManager {
                 let store = self.context_client.datastore_handle().into_inner();
                 let outcome = calimero_context::group_store::apply_received_group_key(
                     &store,
-                    namespace_id,
+                    namespace_id.into(),
                     group_id,
                     &envelope_bytes,
                     responder_identity,
@@ -1552,7 +1552,7 @@ impl SyncManager {
         let (key_envelope_bytes, responder_identity) =
             match calimero_context::group_store::build_group_key_delivery(
                 &store,
-                namespace_id,
+                namespace_id.into(),
                 group_id,
                 requester_public_key,
             ) {

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -367,7 +367,7 @@ mod key_recovery_trigger {
         // steady state of a member that joined but never got its key.
         let op = SignedNamespaceOp::sign(
             &signer_sk,
-            namespace_id,
+            namespace_id.into(),
             vec![],
             1,
             NamespaceOp::Group {
@@ -378,7 +378,7 @@ mod key_recovery_trigger {
             },
         )
         .unwrap();
-        NamespaceOpLogService::new(&store, namespace_id)
+        NamespaceOpLogService::new(&store, namespace_id.into())
             .store_signed_operation(&op)
             .unwrap();
 
@@ -390,7 +390,7 @@ mod key_recovery_trigger {
         // Key recovery still has work to do: the group is awaiting a key.
         // The interval tick drives `recover_missing_group_keys` on this
         // signal, decoupled from the gate above.
-        let awaiting = namespace_groups_awaiting_key(&store, namespace_id).unwrap();
+        let awaiting = namespace_groups_awaiting_key(&store, namespace_id.into()).unwrap();
         assert_eq!(
             awaiting,
             vec![group_id],
@@ -401,7 +401,7 @@ mod key_recovery_trigger {
         GroupKeyring::new(&store, group_gid)
             .store_key(&[0xAA; 32])
             .unwrap();
-        assert!(namespace_groups_awaiting_key(&store, namespace_id)
+        assert!(namespace_groups_awaiting_key(&store, namespace_id.into())
             .unwrap()
             .is_empty());
     }

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -372,7 +372,7 @@ mod key_recovery_trigger {
             1,
             NamespaceOp::Group {
                 group_id,
-                key_id: GroupKeyring::key_id_for(&[0xAA; 32]),
+                key_id: GroupKeyring::key_id_for(&[0xAA; 32]).into(),
                 encrypted: GroupKeyring::encrypt_op(&[0xAA; 32], &GroupOp::Noop).unwrap(),
                 key_rotation: None,
             },

--- a/crates/node/src/sync/manager/tests.rs
+++ b/crates/node/src/sync/manager/tests.rs
@@ -371,7 +371,7 @@ mod key_recovery_trigger {
             vec![],
             1,
             NamespaceOp::Group {
-                group_id,
+                group_id: group_id.into(),
                 key_id: GroupKeyring::key_id_for(&[0xAA; 32]).into(),
                 encrypted: GroupKeyring::encrypt_op(&[0xAA; 32], &GroupOp::Noop).unwrap(),
                 key_rotation: None,

--- a/crates/op-adapter/src/lib.rs
+++ b/crates/op-adapter/src/lib.rs
@@ -195,7 +195,7 @@ pub fn payload_from_root_op(op: &RootOp, signer: PublicKey) -> Option<OpPayload>
             role: GroupMemberRole::from_invited_role(signed_invitation.invitation.invited_role),
         }),
         RootOp::MemberJoinedOpen { member, group_id } => Some(OpPayload::MemberAdded {
-            group: ContextGroupId::from(*group_id),
+            group: *group_id,
             member: *member,
             role: GroupMemberRole::Member,
         }),
@@ -204,8 +204,8 @@ pub fn payload_from_root_op(op: &RootOp, signer: PublicKey) -> Option<OpPayload>
             parent_id,
             restricted,
         } => Some(OpPayload::SubgroupCreated {
-            child: ScopeId::from(*group_id),
-            parent: ScopeId::from(*parent_id),
+            child: ScopeId::from(group_id.to_bytes()),
+            parent: ScopeId::from(parent_id.to_bytes()),
             // Visibility is now carried atomically on the live op (#2771):
             // `restricted: true` = Restricted (default), `false` = born-Open.
             // This aligns the projection-plane `SubgroupCreated.restricted`
@@ -217,11 +217,11 @@ pub fn payload_from_root_op(op: &RootOp, signer: PublicKey) -> Option<OpPayload>
             child_group_id,
             new_parent_id,
         } => Some(OpPayload::SubgroupReparented {
-            child: ScopeId::from(*child_group_id),
-            new_parent: ScopeId::from(*new_parent_id),
+            child: ScopeId::from(child_group_id.to_bytes()),
+            new_parent: ScopeId::from(new_parent_id.to_bytes()),
         }),
         RootOp::GroupDeleted { root_group_id, .. } => Some(OpPayload::SubgroupDeleted {
-            scope: ScopeId::from(*root_group_id),
+            scope: ScopeId::from(root_group_id.to_bytes()),
         }),
         // Out-of-model: `KeyDelivery` is key transport, not authorization
         // state. (`RootOp` is `#[non_exhaustive]`, so a `_` arm is mandatory.)
@@ -523,7 +523,7 @@ mod tests {
             payload_from_root_op(
                 &RootOp::MemberJoinedOpen {
                     member: m,
-                    group_id: gid,
+                    group_id: gid.into(),
                 },
                 PublicKey::from([1u8; 32])
             ),
@@ -584,8 +584,8 @@ mod tests {
         assert_eq!(
             payload_from_root_op(
                 &RootOp::GroupCreated {
-                    group_id: gid,
-                    parent_id: parent,
+                    group_id: gid.into(),
+                    parent_id: parent.into(),
                     restricted: true,
                 },
                 PublicKey::from([1u8; 32])
@@ -601,8 +601,8 @@ mod tests {
         assert_eq!(
             payload_from_root_op(
                 &RootOp::GroupReparented {
-                    child_group_id: gid,
-                    new_parent_id: [9u8; 32],
+                    child_group_id: gid.into(),
+                    new_parent_id: [9u8; 32].into(),
                 },
                 PublicKey::from([1u8; 32])
             ),
@@ -614,7 +614,7 @@ mod tests {
         assert_eq!(
             payload_from_root_op(
                 &RootOp::GroupDeleted {
-                    root_group_id: gid,
+                    root_group_id: gid.into(),
                     cascade_group_ids: vec![],
                     cascade_context_ids: vec![],
                 },

--- a/crates/server/src/admin/handlers/groups/reparent_group.rs
+++ b/crates/server/src/admin/handlers/groups/reparent_group.rs
@@ -70,8 +70,8 @@ pub async fn handler(
 
     let signer_sk = PrivateKey::from(sk_bytes);
     let op = NamespaceOp::Root(RootOp::GroupReparented {
-        child_group_id: child_group_id.to_bytes(),
-        new_parent_id: new_parent_id.to_bytes(),
+        child_group_id: child_group_id.to_bytes().into(),
+        new_parent_id: new_parent_id.to_bytes().into(),
     });
 
     info!(child=%group_id_str, new_parent=%req.new_parent_id, "Reparenting subgroup");

--- a/crates/server/src/admin/handlers/groups/reparent_group.rs
+++ b/crates/server/src/admin/handlers/groups/reparent_group.rs
@@ -90,7 +90,7 @@ pub async fn handler(
         &state.store,
         &state.node_client,
         state.ctx_client.ack_router(),
-        namespace_id.to_bytes(),
+        namespace_id.to_bytes().into(),
         &signer_sk,
         op,
     )

--- a/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
@@ -162,7 +162,7 @@ pub async fn handler(
         &state.store,
         &state.node_client,
         state.ctx_client.ack_router(),
-        resolved_ns_id.to_bytes(),
+        resolved_ns_id.to_bytes().into(),
         &signer_sk,
         op,
     )

--- a/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
@@ -152,8 +152,8 @@ pub async fn handler(
     // docs/superpowers/specs/2026-04-22-strict-group-tree-and-cascade-delete.md
     let op = calimero_context_client::local_governance::NamespaceOp::Root(
         calimero_context_client::local_governance::RootOp::GroupCreated {
-            group_id,
-            parent_id: namespace_id.to_bytes(),
+            group_id: group_id.into(),
+            parent_id: namespace_id.to_bytes().into(),
             restricted,
         },
     );


### PR DESCRIPTION
Final finding of the type-safety & encapsulation batch (`#2`, id newtypes), following #3087 and #3093. Every 32-byte governance identifier that used to flow as a bare `[u8; 32]` — mutually indistinguishable at the type level — is now a distinct newtype, so the compiler rejects crossing one id kind with another at any construction or call site.

## What changed

Migrated four id families across governance-types, governance-store, context, node, server, and op-adapter:

| Field family | Was | Now |
|---|---|---|
| `key_id`, `new_key_id` | `[u8; 32]` | `KeyId` |
| `app_key`, `from_app_key` | `[u8; 32]` | `AppKey` |
| `namespace_id` (+ services) | `[u8; 32]` | `NamespaceId` |
| `group_id`, `parent_id`, `child_group_id`, `new_parent_id`, `root_group_id` | `[u8; 32]` | `ContextGroupId` |
| `cascade_group_ids` | `Vec<[u8; 32]>` | `Vec<ContextGroupId>` |
| `cascade_context_ids` | `Vec<[u8; 32]>` | `Vec<ContextId>` |

`NamespaceId` / `KeyId` are added via a small `id_newtype!` macro; `AppKey`, `ContextGroupId`, and `ContextId` already existed and were adopted at the op boundary.

## Wire compatibility

Every one of these newtypes is **borsh- and serde-transparent** over its inner `[u8; 32]` (they either derive borsh directly over a bare array or wrap `Identity([u8; 32])`), so on-disk and on-wire encodings are **byte-identical** to the previous bare arrays. No data migration, no schema bump.

## Strategy

- The `NamespaceId` services (dag / op-log / governance / membership) carry the newtype end-to-end.
- For the other ids, conversion happens **at the op/wire boundary only** — internal storage-key / `ScopeId` plumbing and byte-keyed collections stay `[u8; 32]`, converting via `to_bytes()` / `into()` at the edge. This keeps the type-safety win where it matters (op fields can't be crossed) without churning every hashing/storage-key call.

## Verification

- `cargo check --workspace --all-targets`: clean
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings`: clean
- `cargo fmt --all --check`: clean

The migration was sliced by id-type (KeyId → AppKey → NamespaceId → ContextGroupId), each an independently-green commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
