### PR TITLE
fix(network): libp2p resource-exhaustion & DHT hardening

### DIFF
--- a/crates/network/src/behaviour.rs
+++ b/crates/network/src/behaviour.rs
@@ -64,9 +64,13 @@ const KAD_RECORD_PUBLICATION_INTERVAL: Duration = Duration::from_secs(6 * 60 * 6
 // indefinitely.
 const KAD_QUERY_TIMEOUT: Duration = Duration::from_secs(60);
 // Records replicate to at most this many peers. Calimero clusters are small
-// (2–20 peers), so this both saturates availability within a real cluster and
-// bounds how far a single record fans out.
-const KAD_REPLICATION_FACTOR: NonZeroUsize = match NonZeroUsize::new(20) {
+// (2–20 peers); 10 still saturates a typical cluster with redundant copies of
+// each record — a record survives unless all 10 holders drop — while leaving
+// headroom below the libp2p default of 20 (K_VALUE). If the peer count
+// transiently spikes (e.g. a churny bootstrap phase), replication fan-out and
+// the write traffic it drives stay bounded at 10 instead of tracking the
+// cluster size upward.
+const KAD_REPLICATION_FACTOR: NonZeroUsize = match NonZeroUsize::new(10) {
     Some(factor) => factor,
     None => panic!("KAD_REPLICATION_FACTOR must be non-zero"),
 };

--- a/crates/network/src/behaviour.rs
+++ b/crates/network/src/behaviour.rs
@@ -66,17 +66,21 @@ const KAD_QUERY_TIMEOUT: Duration = Duration::from_secs(60);
 // Records replicate to at most this many peers. Calimero clusters are small
 // (2–20 peers), so this both saturates availability within a real cluster and
 // bounds how far a single record fans out.
-const KAD_REPLICATION_FACTOR: usize = 20;
+const KAD_REPLICATION_FACTOR: NonZeroUsize = match NonZeroUsize::new(20) {
+    Some(factor) => factor,
+    None => panic!("KAD_REPLICATION_FACTOR must be non-zero"),
+};
 
 // Kademlia in-memory store bounds — the resource ceiling for records this node
 // will hold on behalf of the network. Provider records are unused (we announce
 // via `put_record`, not `start_providing`), so the provider fields are kept
 // minimal. `max_value_bytes` is the load-bearing anti-abuse bound: a valid
 // blob-provider value is a peer id plus an 8-byte size (~50 bytes), so 256
-// bytes rejects any oversized forged record cheaply, before it ever reaches
-// the structural validation in the inbound-record handler.
+// bytes rejects any oversized forged record cheaply. The inbound-record
+// validator enforces the same ceiling directly (see the kad handler), so an
+// oversized record is dropped in our own code; the store bound is the backstop.
 const KAD_MAX_RECORDS: usize = 4096;
-const KAD_MAX_VALUE_BYTES: usize = 256;
+pub(crate) const KAD_MAX_VALUE_BYTES: usize = 256;
 const KAD_MAX_PROVIDERS_PER_KEY: usize = 20;
 const KAD_MAX_PROVIDED_KEYS: usize = 1024;
 
@@ -206,9 +210,7 @@ impl Behaviour {
                         let _ = kad_config
                             .set_publication_interval(Some(KAD_RECORD_PUBLICATION_INTERVAL));
                         let _ = kad_config.set_query_timeout(KAD_QUERY_TIMEOUT);
-                        if let Some(replication) = NonZeroUsize::new(KAD_REPLICATION_FACTOR) {
-                            let _ = kad_config.set_replication_factor(replication);
-                        }
+                        let _ = kad_config.set_replication_factor(KAD_REPLICATION_FACTOR);
 
                         let store = kad::store::MemoryStore::with_config(
                             peer_id,

--- a/crates/network/src/behaviour.rs
+++ b/crates/network/src/behaviour.rs
@@ -205,12 +205,11 @@ impl Behaviour {
                         // can validate its shape and size before it enters our
                         // store. Without this any server-mode node would store
                         // arbitrary forged records for any (context, blob).
-                        let _ = kad_config.set_record_filtering(kad::StoreInserts::FilterBoth);
-                        let _ = kad_config.set_record_ttl(Some(KAD_RECORD_TTL));
-                        let _ = kad_config
-                            .set_publication_interval(Some(KAD_RECORD_PUBLICATION_INTERVAL));
-                        let _ = kad_config.set_query_timeout(KAD_QUERY_TIMEOUT);
-                        let _ = kad_config.set_replication_factor(KAD_REPLICATION_FACTOR);
+                        kad_config.set_record_filtering(kad::StoreInserts::FilterBoth);
+                        kad_config.set_record_ttl(Some(KAD_RECORD_TTL));
+                        kad_config.set_publication_interval(Some(KAD_RECORD_PUBLICATION_INTERVAL));
+                        kad_config.set_query_timeout(KAD_QUERY_TIMEOUT);
+                        kad_config.set_replication_factor(KAD_REPLICATION_FACTOR);
 
                         let store = kad::store::MemoryStore::with_config(
                             peer_id,
@@ -384,7 +383,7 @@ impl Behaviour {
 /// cap instead of the library's 8192 default.
 fn bounded_yamux_config() -> yamux::Config {
     let mut cfg = yamux::Config::default();
-    let _ = cfg.set_max_num_streams(YAMUX_MAX_NUM_STREAMS);
+    cfg.set_max_num_streams(YAMUX_MAX_NUM_STREAMS);
     cfg
 }
 

--- a/crates/network/src/behaviour.rs
+++ b/crates/network/src/behaviour.rs
@@ -1,3 +1,4 @@
+use core::num::{NonZeroU8, NonZeroUsize};
 use core::time::Duration;
 
 use calimero_network_primitives::config::{
@@ -46,6 +47,76 @@ const MAX_ESTABLISHED_PER_PEER: u32 = 8;
 // still bounding total open sockets/FDs.
 const MAX_ESTABLISHED_TOTAL: u32 = 1024;
 
+// Kademlia record lifetime and refresh.
+//
+// The only records Calimero puts on the DHT are tiny blob-provider entries
+// (peer id + blob size, keyed by context+blob), announced on demand at
+// upgrade/admit time — never on a periodic schedule from the app. libp2p's
+// 48h default TTL therefore leaves forged or stale entries lingering far
+// longer than any real blob handoff needs. Bound the TTL to 12h and have the
+// original announcer re-publish every 6h, so a live blob's record is always
+// refreshed well before it expires while a one-off (or malicious) entry ages
+// out in half a day.
+const KAD_RECORD_TTL: Duration = Duration::from_secs(12 * 60 * 60);
+const KAD_RECORD_PUBLICATION_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+// Cap the wall-clock a single DHT query may burn before it is abandoned, so a
+// blob lookup against unresponsive closest-peers can't hang a caller
+// indefinitely.
+const KAD_QUERY_TIMEOUT: Duration = Duration::from_secs(60);
+// Records replicate to at most this many peers. Calimero clusters are small
+// (2–20 peers), so this both saturates availability within a real cluster and
+// bounds how far a single record fans out.
+const KAD_REPLICATION_FACTOR: usize = 20;
+
+// Kademlia in-memory store bounds — the resource ceiling for records this node
+// will hold on behalf of the network. Provider records are unused (we announce
+// via `put_record`, not `start_providing`), so the provider fields are kept
+// minimal. `max_value_bytes` is the load-bearing anti-abuse bound: a valid
+// blob-provider value is a peer id plus an 8-byte size (~50 bytes), so 256
+// bytes rejects any oversized forged record cheaply, before it ever reaches
+// the structural validation in the inbound-record handler.
+const KAD_MAX_RECORDS: usize = 4096;
+const KAD_MAX_VALUE_BYTES: usize = 256;
+const KAD_MAX_PROVIDERS_PER_KEY: usize = 20;
+const KAD_MAX_PROVIDED_KEYS: usize = 1024;
+
+// Gossipsub message-size ceiling. libp2p's hidden default is 64 KiB, which is
+// also the only inbound size guard on the receive path — and small enough that
+// a legitimate large state-delta broadcast is silently dropped. Set it
+// explicitly to 1 MiB: comfortably above real envelopes+deltas, matched to the
+// specialized-node-invite cap, and far below the transport stream limit so it
+// never conflicts with yamux framing. `flood_publish` fans each publish out to
+// every subscriber, so this doubles as the amplification bound and is kept
+// deliberately modest rather than pushed to the stream ceiling.
+const GOSSIPSUB_MAX_TRANSMIT_SIZE: usize = 1024 * 1024;
+
+// Inbound concurrency cap for the specialized-node-invite request-response
+// protocol. Each request carries a TEE attestation quote whose verification is
+// expensive; without a cap a peer can open many concurrent request streams and
+// turn cheap bytes into disproportionate CPU. The message size is already
+// bounded by the codec; this bounds how many verifications run at once.
+const SPECIALIZED_NODE_INVITE_MAX_CONCURRENT_STREAMS: usize = 8;
+
+// Addresses dialed in parallel per dial attempt (libp2p default is 8). Lowering
+// it curbs the socket burst when dialing a peer that advertises many
+// addresses — relevant at startup when redialing a large peer cache — while
+// still trying enough candidates to connect promptly.
+const DIAL_CONCURRENCY_FACTOR: u8 = 3;
+
+// Per-connection substream ceiling (libp2p yamux default is 8192). A handful of
+// concurrent substreams covers every Calimero protocol on one connection, so a
+// far lower cap bounds how much a single peer can allocate against us without
+// starving legitimate use.
+const YAMUX_MAX_NUM_STREAMS: usize = 256;
+
+// Liveness-probe cadence, pinned rather than left to the libp2p default. The
+// ping-failure watchdog (see the ping handler) sizes its force-close threshold
+// against a 15s interval / 20s timeout to land inside the sync-recovery budget;
+// pinning the values here keeps that math correct even if the library default
+// later changes.
+const PING_INTERVAL: Duration = Duration::from_secs(15);
+const PING_TIMEOUT: Duration = Duration::from_secs(20);
+
 #[expect(
     missing_debug_implementations,
     reason = "Swarm behaviours don't implement Debug"
@@ -89,10 +160,10 @@ impl Behaviour {
             .with_tcp(
                 tcp::Config::default(),
                 (tls::Config::new, noise::Config::new),
-                yamux::Config::default,
+                bounded_yamux_config,
             )?
             .with_quic()
-            .with_relay_client(noise::Config::new, yamux::Config::default)?
+            .with_relay_client(noise::Config::new, bounded_yamux_config)?
             .with_behaviour(|key, relay_behaviour| {
                 let mut behaviour = Self {
                     autonat: {
@@ -122,13 +193,34 @@ impl Behaviour {
                         .transpose()?
                         .into(),
                     kad: {
-                        let kad_config = kad::Config::new(CALIMERO_KAD_PROTO_NAME);
+                        let mut kad_config = kad::Config::new(CALIMERO_KAD_PROTO_NAME);
+                        // Reject auto-storing inbound records. With filtering
+                        // on, a replicated record from another peer is
+                        // surfaced as an `InboundRequest::PutRecord` event
+                        // instead of being written blind, so the kad handler
+                        // can validate its shape and size before it enters our
+                        // store. Without this any server-mode node would store
+                        // arbitrary forged records for any (context, blob).
+                        let _ = kad_config.set_record_filtering(kad::StoreInserts::FilterBoth);
+                        let _ = kad_config.set_record_ttl(Some(KAD_RECORD_TTL));
+                        let _ = kad_config
+                            .set_publication_interval(Some(KAD_RECORD_PUBLICATION_INTERVAL));
+                        let _ = kad_config.set_query_timeout(KAD_QUERY_TIMEOUT);
+                        if let Some(replication) = NonZeroUsize::new(KAD_REPLICATION_FACTOR) {
+                            let _ = kad_config.set_replication_factor(replication);
+                        }
 
-                        let mut kad = kad::Behaviour::with_config(
+                        let store = kad::store::MemoryStore::with_config(
                             peer_id,
-                            kad::store::MemoryStore::new(peer_id),
-                            kad_config,
+                            kad::store::MemoryStoreConfig {
+                                max_records: KAD_MAX_RECORDS,
+                                max_value_bytes: KAD_MAX_VALUE_BYTES,
+                                max_providers_per_key: KAD_MAX_PROVIDERS_PER_KEY,
+                                max_provided_keys: KAD_MAX_PROVIDED_KEYS,
+                            },
                         );
+
+                        let mut kad = kad::Behaviour::with_config(peer_id, store, kad_config);
 
                         for (peer_id, addr) in bootstrap_peers {
                             let _ = kad.add_address(&peer_id, addr);
@@ -195,12 +287,37 @@ impl Behaviour {
                             .mesh_n_high(GOSSIPSUB_MESH_N_HIGH)
                             .mesh_outbound_min(GOSSIPSUB_MESH_OUTBOUND_MIN)
                             .flood_publish(true)
+                            // Set the transmit size explicitly rather than
+                            // inheriting the hidden 64 KiB default, which also
+                            // silently caps the inbound receive path. See
+                            // `GOSSIPSUB_MAX_TRANSMIT_SIZE`.
+                            .max_transmit_size(GOSSIPSUB_MAX_TRANSMIT_SIZE)
+                            // Anti-churn backoffs (defaults 10s / 60s) are
+                            // deliberately cut to the 1s floor. They exist to
+                            // rate-limit GRAFT/PRUNE thrash between mutually
+                            // untrusted peers on a large permissionless mesh;
+                            // a long prune-backoff there stops a churning peer
+                            // from re-grafting instantly. Calimero's mesh is
+                            // small (2–20 peers) and admission-gated by signed
+                            // governance membership, so a peer worth meshing
+                            // with is already trusted and one that isn't is
+                            // rejected at the application layer regardless of
+                            // mesh state — the long backoff buys no protection
+                            // here and only slows legitimate re-grafting after
+                            // a transient drop (e.g. the ping-watchdog close),
+                            // which on a small mesh directly delays broadcast
+                            // recovery. The 1s floor keeps re-meshing prompt
+                            // while still collapsing a tight graft/prune loop.
                             .unsubscribe_backoff(1)
                             .prune_backoff(Duration::from_secs(1))
                             .build()
                             .map_err(|e| eyre::eyre!("invalid gossipsub config: {e}"))?,
                     )?,
-                    ping: ping::Behaviour::default(),
+                    ping: ping::Behaviour::new(
+                        ping::Config::new()
+                            .with_interval(PING_INTERVAL)
+                            .with_timeout(PING_TIMEOUT),
+                    ),
                     rendezvous: rendezvous::client::Behaviour::new(key.clone()),
                     relay: relay_behaviour,
                     stream: libp2p_stream::Behaviour::new(),
@@ -209,7 +326,9 @@ impl Behaviour {
                             CALIMERO_SPECIALIZED_NODE_INVITE_PROTOCOL,
                             ProtocolSupport::Full,
                         )],
-                        request_response::Config::default(),
+                        request_response::Config::default().with_max_concurrent_streams(
+                            SPECIALIZED_NODE_INVITE_MAX_CONCURRENT_STREAMS,
+                        ),
                     ),
                 };
 
@@ -237,7 +356,13 @@ impl Behaviour {
 
                 Ok(behaviour)
             })?
-            .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(30)))
+            .with_swarm_config(|cfg| {
+                let cfg = cfg.with_idle_connection_timeout(Duration::from_secs(30));
+                match NonZeroU8::new(DIAL_CONCURRENCY_FACTOR) {
+                    Some(factor) => cfg.with_dial_concurrency_factor(factor),
+                    None => cfg,
+                }
+            })
             .build();
 
         for addr in &config.swarm.listen {
@@ -248,6 +373,17 @@ impl Behaviour {
 
         Ok(swarm)
     }
+}
+
+/// Yamux muxer config with a bounded per-connection substream ceiling.
+///
+/// Passed by name to both `with_tcp` and `with_relay_client` so every
+/// connection — direct or relayed — inherits the same `YAMUX_MAX_NUM_STREAMS`
+/// cap instead of the library's 8192 default.
+fn bounded_yamux_config() -> yamux::Config {
+    let mut cfg = yamux::Config::default();
+    let _ = cfg.set_max_num_streams(YAMUX_MAX_NUM_STREAMS);
+    cfg
 }
 
 /// Peer-score configuration for membership-biased mesh maintenance

--- a/crates/network/src/handlers/stream/swarm/identify.rs
+++ b/crates/network/src/handlers/stream/swarm/identify.rs
@@ -1,10 +1,42 @@
 use libp2p::identify::{Event, Info};
 use libp2p_metrics::Recorder;
-use multiaddr::Protocol;
+use multiaddr::{Multiaddr, Protocol};
 use owo_colors::OwoColorize;
 use tracing::{debug, error};
 
 use super::{EventHandler, NetworkManager};
+
+/// Whether a peer-advertised (identify-pushed) address is worth keeping as a
+/// direct-dial candidate.
+///
+/// Rejects addresses no remote peer can legitimately be reachable at —
+/// loopback, unspecified (`0.0.0.0` / `::`), and link-local — since these are
+/// unverified, peer-controlled input. Private (RFC-1918) and IPv6 unique-local
+/// (`fc00::/7`) ranges are kept: they're valid for same-network / overlay
+/// deployments. Addresses with no IP component (e.g. a DNS multiaddr) pass
+/// through unchanged.
+fn is_dialable_advertised_addr(addr: &Multiaddr) -> bool {
+    for proto in addr.iter() {
+        match proto {
+            Protocol::Ip4(ip) => {
+                if ip.is_loopback() || ip.is_unspecified() || ip.is_link_local() {
+                    return false;
+                }
+            }
+            Protocol::Ip6(ip) => {
+                if ip.is_loopback() || ip.is_unspecified() {
+                    return false;
+                }
+                // Link-local fe80::/10 — never routable off-link.
+                if (ip.segments()[0] & 0xffc0) == 0xfe80 {
+                    return false;
+                }
+            }
+            _ => {}
+        }
+    }
+    true
+}
 
 impl EventHandler<Event> for NetworkManager {
     fn handle(&mut self, event: Event) {
@@ -39,9 +71,18 @@ impl EventHandler<Event> for NetworkManager {
             // loop would just waste attempts on them. Filter out our own
             // observed address (sometimes echoed back); it's about us, not
             // the peer.
+            //
+            // Also drop addresses a remote peer can never legitimately be
+            // reachable at — loopback, unspecified, and link-local. These are
+            // peer-controlled, unverified input: without the filter a
+            // malicious or misconfigured peer could push entries that seed our
+            // dial book with wasted attempts, or point dials at our own
+            // loopback/link-local interfaces. Private (RFC-1918) and IPv6
+            // unique-local ranges are kept — they're legitimate for
+            // same-network / overlay deployments.
             for addr in &listen_addrs {
                 let is_relayed = addr.iter().any(|p| matches!(p, Protocol::P2pCircuit));
-                if !is_relayed && addr != &observed_addr {
+                if !is_relayed && addr != &observed_addr && is_dialable_advertised_addr(addr) {
                     self.discovery.state.add_peer_addr(peer_id, addr);
                 }
             }
@@ -93,5 +134,36 @@ impl EventHandler<Event> for NetworkManager {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_dialable_advertised_addr;
+
+    fn dialable(s: &str) -> bool {
+        is_dialable_advertised_addr(&s.parse().expect("valid multiaddr"))
+    }
+
+    #[test]
+    fn keeps_routable_and_overlay_addresses() {
+        assert!(dialable("/ip4/203.0.113.7/tcp/2428"));
+        assert!(dialable("/ip6/2001:db8::1/tcp/2428"));
+        // Private / unique-local are legitimate for overlays.
+        assert!(dialable("/ip4/10.0.0.5/tcp/2428"));
+        assert!(dialable("/ip4/192.168.1.20/udp/2428/quic-v1"));
+        assert!(dialable("/ip6/fd00::1/tcp/2428"));
+        // No IP component (DNS) passes through.
+        assert!(dialable("/dns4/node.example.com/tcp/2428"));
+    }
+
+    #[test]
+    fn drops_unreachable_advertised_addresses() {
+        assert!(!dialable("/ip4/127.0.0.1/tcp/2428"));
+        assert!(!dialable("/ip4/0.0.0.0/tcp/2428"));
+        assert!(!dialable("/ip4/169.254.1.1/tcp/2428"));
+        assert!(!dialable("/ip6/::1/tcp/2428"));
+        assert!(!dialable("/ip6/::/tcp/2428"));
+        assert!(!dialable("/ip6/fe80::1/tcp/2428"));
     }
 }

--- a/crates/network/src/handlers/stream/swarm/identify.rs
+++ b/crates/network/src/handlers/stream/swarm/identify.rs
@@ -15,6 +15,12 @@ use super::{EventHandler, NetworkManager};
 /// (`fc00::/7`) ranges are kept: they're valid for same-network / overlay
 /// deployments. Addresses with no IP component (e.g. a DNS multiaddr) pass
 /// through unchanged.
+///
+/// Unlike `is_seedable_external_address` in `lib.rs`, this filter stays silent
+/// on private/unique-local ranges rather than warning. That counterpart vets
+/// *our own* operator-configured external address, where a private range is a
+/// likely misconfiguration worth flagging; here the addresses belong to other
+/// peers, so a per-peer warning would be noise, not an actionable signal.
 fn is_dialable_advertised_addr(addr: &Multiaddr) -> bool {
     for proto in addr.iter() {
         match proto {

--- a/crates/network/src/handlers/stream/swarm/kad.rs
+++ b/crates/network/src/handlers/stream/swarm/kad.rs
@@ -1,7 +1,8 @@
 use calimero_network_primitives::messages::NetworkEvent;
 use calimero_primitives::blobs::BlobId;
 use calimero_primitives::context::ContextId;
-use libp2p::kad::{Event, GetRecordError, GetRecordOk, QueryResult};
+use libp2p::kad::store::RecordStore;
+use libp2p::kad::{Event, GetRecordError, GetRecordOk, InboundRequest, QueryResult, Record};
 use libp2p::PeerId;
 use libp2p_metrics::Recorder;
 use owo_colors::OwoColorize;
@@ -106,13 +107,142 @@ impl EventHandler<Event> for NetworkManager {
                     let _ignored = sender.send(peers);
                 }
             }
-            Event::InboundRequest { .. }
-            | Event::OutboundQueryProgressed { .. }
+            // Record filtering is enabled (`StoreInserts::FilterBoth`), so a
+            // record replicated to us by another peer surfaces here as an
+            // inbound request rather than being written to our store blind.
+            // Validate its shape before admitting it; anything else is a
+            // routing/read request with nothing to store.
+            Event::InboundRequest { request } => match request {
+                InboundRequest::PutRecord {
+                    source,
+                    record: Some(record),
+                    ..
+                } => {
+                    if is_valid_blob_provider_record(&record) {
+                        match self.swarm.behaviour_mut().kad.store_mut().put(record) {
+                            Ok(()) => {
+                                debug!(%source, "stored validated inbound DHT record");
+                            }
+                            Err(err) => {
+                                debug!(%source, ?err, "rejected inbound DHT record: store put failed");
+                            }
+                        }
+                    } else {
+                        debug!(%source, "rejected malformed inbound DHT record");
+                    }
+                }
+                // We announce blobs via `put_record`, never `start_providing`,
+                // so this node holds no provider records — drop any a peer
+                // tries to add rather than storing on its behalf.
+                InboundRequest::AddProvider { .. } => {
+                    debug!("ignoring inbound AddProvider record (provider records unused)");
+                }
+                InboundRequest::FindNode { .. }
+                | InboundRequest::GetProvider { .. }
+                | InboundRequest::GetRecord { .. }
+                | InboundRequest::PutRecord { record: None, .. } => {}
+            },
+            Event::OutboundQueryProgressed { .. }
             | Event::ModeChanged { .. }
             | Event::PendingRoutablePeer { .. }
             | Event::RoutablePeer { .. }
             | Event::RoutingUpdated { .. }
             | Event::UnroutablePeer { .. } => {}
         }
+    }
+}
+
+/// Structural validation for an inbound blob-provider record before we admit
+/// it to our store.
+///
+/// With record filtering enabled every record another peer replicates to us
+/// arrives for inspection instead of being written blind. We can't authorize
+/// the *content* — these records are unsigned and the network layer has no
+/// view of context membership — but we can reject anything not shaped like the
+/// blob announcement this node itself produces (see the `AnnounceBlob`
+/// handler): a 64-byte key (context id + blob id) whose value is a parseable
+/// peer id followed by an 8-byte little-endian size. That drops malformed and
+/// garbage records cheaply; the store's own `max_value_bytes` / `max_records`
+/// bounds cap everything that passes.
+fn is_valid_blob_provider_record(record: &Record) -> bool {
+    /// context_id (32) + blob_id (32).
+    const EXPECTED_KEY_LEN: usize = 64;
+    /// Trailing little-endian `u64` blob size.
+    const SIZE_LEN: usize = 8;
+
+    if record.key.as_ref().len() != EXPECTED_KEY_LEN {
+        return false;
+    }
+
+    let Some(peer_id_bytes) = record
+        .value
+        .len()
+        .checked_sub(SIZE_LEN)
+        .map(|end| &record.value[..end])
+    else {
+        return false;
+    };
+
+    // A zero-length peer id can never be valid; `from_bytes` also rejects it,
+    // but bail explicitly so intent is clear.
+    !peer_id_bytes.is_empty() && PeerId::from_bytes(peer_id_bytes).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use libp2p::kad::RecordKey;
+
+    use super::*;
+
+    fn record(key: Vec<u8>, value: Vec<u8>) -> Record {
+        Record::new(RecordKey::new(&key), value)
+    }
+
+    fn valid_value() -> Vec<u8> {
+        let peer_id = PeerId::random();
+        let size: u64 = 4096;
+        [peer_id.to_bytes().as_slice(), &size.to_le_bytes()].concat()
+    }
+
+    #[test]
+    fn accepts_a_well_formed_blob_record() {
+        let rec = record(vec![7u8; 64], valid_value());
+        assert!(is_valid_blob_provider_record(&rec));
+    }
+
+    #[test]
+    fn rejects_wrong_key_length() {
+        // One byte short and one byte long — only exactly 64 is a blob key.
+        assert!(!is_valid_blob_provider_record(&record(
+            vec![7u8; 63],
+            valid_value()
+        )));
+        assert!(!is_valid_blob_provider_record(&record(
+            vec![7u8; 65],
+            valid_value()
+        )));
+    }
+
+    #[test]
+    fn rejects_value_too_short_for_a_size_suffix() {
+        // Fewer than the 8 trailing size bytes leaves no room for a peer id.
+        assert!(!is_valid_blob_provider_record(&record(
+            vec![7u8; 64],
+            vec![0u8; 8]
+        )));
+        assert!(!is_valid_blob_provider_record(&record(
+            vec![7u8; 64],
+            vec![0u8; 4]
+        )));
+    }
+
+    #[test]
+    fn rejects_unparseable_peer_id() {
+        // Right shape (>8 bytes) but the leading bytes aren't a valid peer id.
+        let value = [vec![0xffu8; 16], 1024u64.to_le_bytes().to_vec()].concat();
+        assert!(!is_valid_blob_provider_record(&record(
+            vec![7u8; 64],
+            value
+        )));
     }
 }

--- a/crates/network/src/handlers/stream/swarm/kad.rs
+++ b/crates/network/src/handlers/stream/swarm/kad.rs
@@ -6,7 +6,7 @@ use libp2p::kad::{Event, GetRecordError, GetRecordOk, InboundRequest, QueryResul
 use libp2p::PeerId;
 use libp2p_metrics::Recorder;
 use owo_colors::OwoColorize;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use super::{EventHandler, NetworkManager};
 
@@ -124,7 +124,12 @@ impl EventHandler<Event> for NetworkManager {
                                 debug!(%source, "stored validated inbound DHT record");
                             }
                             Err(err) => {
-                                debug!(%source, ?err, "rejected inbound DHT record: store put failed");
+                                // Surfaced at warn, not debug: the validator
+                                // already rejects oversized values, so a put
+                                // failure here is most likely the store hitting
+                                // its `max_records` ceiling — a capacity signal
+                                // an operator should see without debug logging.
+                                warn!(%source, ?err, "rejected inbound DHT record: store put failed (store may be full)");
                             }
                         }
                     } else {

--- a/crates/network/src/handlers/stream/swarm/kad.rs
+++ b/crates/network/src/handlers/stream/swarm/kad.rs
@@ -233,14 +233,22 @@ mod tests {
 
     #[test]
     fn rejects_value_too_short_for_a_size_suffix() {
-        // Fewer than the 8 trailing size bytes leaves no room for a peer id.
+        // At most 8 bytes (<= SIZE_LEN) leaves no room for a peer id: below 8
+        // the `checked_sub` fails, and exactly 8 yields an empty prefix caught
+        // by the `is_empty` guard.
+        assert!(!is_valid_blob_provider_record(&record(
+            vec![7u8; 64],
+            vec![0u8; 4]
+        )));
         assert!(!is_valid_blob_provider_record(&record(
             vec![7u8; 64],
             vec![0u8; 8]
         )));
+        // One byte past the size suffix is a non-empty prefix, so it clears the
+        // `is_empty` guard and must instead be rejected by the peer-id parse.
         assert!(!is_valid_blob_provider_record(&record(
             vec![7u8; 64],
-            vec![0u8; 4]
+            vec![0u8; 9]
         )));
     }
 

--- a/crates/network/src/handlers/stream/swarm/kad.rs
+++ b/crates/network/src/handlers/stream/swarm/kad.rs
@@ -161,9 +161,11 @@ impl EventHandler<Event> for NetworkManager {
 /// view of context membership — but we can reject anything not shaped like the
 /// blob announcement this node itself produces (see the `AnnounceBlob`
 /// handler): a 64-byte key (context id + blob id) whose value is a parseable
-/// peer id followed by an 8-byte little-endian size. That drops malformed and
-/// garbage records cheaply; the store's own `max_value_bytes` / `max_records`
-/// bounds cap everything that passes.
+/// peer id followed by an 8-byte little-endian size. We also enforce the
+/// store's `KAD_MAX_VALUE_BYTES` ceiling here, so an oversized value is dropped
+/// in our own code rather than relying on the store's `put` as the only guard.
+/// That drops malformed, oversized, and garbage records cheaply; the store's
+/// own `max_value_bytes` / `max_records` bounds are the backstop.
 fn is_valid_blob_provider_record(record: &Record) -> bool {
     /// context_id (32) + blob_id (32).
     const EXPECTED_KEY_LEN: usize = 64;
@@ -171,6 +173,12 @@ fn is_valid_blob_provider_record(record: &Record) -> bool {
     const SIZE_LEN: usize = 8;
 
     if record.key.as_ref().len() != EXPECTED_KEY_LEN {
+        return false;
+    }
+
+    // Reject anything larger than the store would accept, up front — a valid
+    // blob-provider value is ~50 bytes, far below this ceiling.
+    if record.value.len() > crate::behaviour::KAD_MAX_VALUE_BYTES {
         return false;
     }
 
@@ -240,6 +248,26 @@ mod tests {
     fn rejects_unparseable_peer_id() {
         // Right shape (>8 bytes) but the leading bytes aren't a valid peer id.
         let value = [vec![0xffu8; 16], 1024u64.to_le_bytes().to_vec()].concat();
+        assert!(!is_valid_blob_provider_record(&record(
+            vec![7u8; 64],
+            value
+        )));
+    }
+
+    #[test]
+    fn rejects_value_over_the_store_ceiling() {
+        // A parseable peer id + size suffix, but padded past the store's
+        // `max_value_bytes`: the validator drops it up front rather than
+        // leaving the store's `put` as the only guard.
+        let peer_id = PeerId::random();
+        let padding = vec![0u8; crate::behaviour::KAD_MAX_VALUE_BYTES];
+        let value = [
+            peer_id.to_bytes().as_slice(),
+            &padding,
+            &4096u64.to_le_bytes(),
+        ]
+        .concat();
+        assert!(value.len() > crate::behaviour::KAD_MAX_VALUE_BYTES);
         assert!(!is_valid_blob_provider_record(&record(
             vec![7u8; 64],
             value

--- a/crates/network/src/handlers/stream/swarm/kad.rs
+++ b/crates/network/src/handlers/stream/swarm/kad.rs
@@ -137,10 +137,19 @@ impl EventHandler<Event> for NetworkManager {
                 InboundRequest::AddProvider { .. } => {
                     debug!("ignoring inbound AddProvider record (provider records unused)");
                 }
+                // FilterBoth always attaches the record, so a PutRecord with no
+                // payload is an unexpected protocol state (or config drift) —
+                // log it so it's distinguishable from a routine routing event.
+                InboundRequest::PutRecord {
+                    source,
+                    record: None,
+                    ..
+                } => {
+                    debug!(%source, "received PutRecord with no record payload — ignoring");
+                }
                 InboundRequest::FindNode { .. }
                 | InboundRequest::GetProvider { .. }
-                | InboundRequest::GetRecord { .. }
-                | InboundRequest::PutRecord { record: None, .. } => {}
+                | InboundRequest::GetRecord { .. } => {}
             },
             Event::OutboundQueryProgressed { .. }
             | Event::ModeChanged { .. }

--- a/crates/network/tests/kad_record_filtering.rs
+++ b/crates/network/tests/kad_record_filtering.rs
@@ -30,7 +30,7 @@ impl KadOnly {
         let peer_id = k.public().to_peer_id();
         let mut config = kad::Config::new(kad::PROTOCOL_NAME);
         // Mirror production: never auto-store an inbound record.
-        let _ = config.set_record_filtering(StoreInserts::FilterBoth);
+        config.set_record_filtering(StoreInserts::FilterBoth);
         Self {
             kad: kad::Behaviour::with_config(peer_id, MemoryStore::new(peer_id), config),
         }

--- a/crates/network/tests/kad_record_filtering.rs
+++ b/crates/network/tests/kad_record_filtering.rs
@@ -1,0 +1,119 @@
+//! Locks the Kademlia record-filtering contract the blob-provider DHT flow
+//! depends on.
+//!
+//! Production configures `StoreInserts::FilterBoth` (see `behaviour.rs`), so a
+//! record another peer replicates to us is **not** written to our store blind:
+//! it surfaces as an `InboundRequest::PutRecord` carrying the record, and the
+//! kad handler validates its shape before storing it explicitly. This test
+//! reproduces that end-to-end with two real swarms — the replicated record
+//! stays absent from the receiver's store until the handler stores it. A
+//! future libp2p change that silently reverted to auto-storing, or dropped the
+//! record from the event, would fail here instead of quietly breaking blob
+//! discovery in production.
+
+use libp2p::identity::Keypair;
+use libp2p::kad::store::{MemoryStore, RecordStore};
+use libp2p::kad::{self, InboundRequest, Mode, Quorum, Record, RecordKey, StoreInserts};
+use libp2p::swarm::{NetworkBehaviour, SwarmEvent};
+use libp2p::{PeerId, Swarm};
+use libp2p_swarm_test::SwarmExt;
+
+#[derive(NetworkBehaviour)]
+struct KadOnly {
+    kad: kad::Behaviour<MemoryStore>,
+}
+
+impl KadOnly {
+    fn new(k: Keypair) -> Self {
+        let peer_id = k.public().to_peer_id();
+        let mut config = kad::Config::new(kad::PROTOCOL_NAME);
+        // Mirror production: never auto-store an inbound record.
+        let _ = config.set_record_filtering(StoreInserts::FilterBoth);
+        Self {
+            kad: kad::Behaviour::with_config(peer_id, MemoryStore::new(peer_id), config),
+        }
+    }
+}
+
+/// A record shaped like the blob announcement `AnnounceBlob` produces: a
+/// 64-byte key (context id + blob id) and a value of a peer id + 8-byte size.
+fn blob_record() -> Record {
+    let value = [
+        PeerId::random().to_bytes().as_slice(),
+        &4096_u64.to_le_bytes(),
+    ]
+    .concat();
+    Record::new(RecordKey::new(&vec![9_u8; 64]), value)
+}
+
+#[tokio::test]
+async fn filtered_inbound_record_is_not_stored_until_handler_stores_it() {
+    let mut announcer = Swarm::new_ephemeral_tokio(KadOnly::new);
+    let (announcer_addr, _) = announcer.listen().with_memory_addr_external().await;
+    let announcer_id = *announcer.local_peer_id();
+
+    let mut receiver = Swarm::new_ephemeral_tokio(KadOnly::new);
+    let (receiver_addr, _) = receiver.listen().with_memory_addr_external().await;
+    let receiver_id = *receiver.local_peer_id();
+
+    // Server mode so the receiver accepts inbound records; seed each side's
+    // routing table so the put actually routes between the two peers.
+    announcer.behaviour_mut().kad.set_mode(Some(Mode::Server));
+    receiver.behaviour_mut().kad.set_mode(Some(Mode::Server));
+    let _ = announcer
+        .behaviour_mut()
+        .kad
+        .add_address(&receiver_id, receiver_addr);
+    let _ = receiver
+        .behaviour_mut()
+        .kad
+        .add_address(&announcer_id, announcer_addr);
+
+    announcer.connect(&mut receiver).await;
+
+    let record = blob_record();
+    let key = record.key.clone();
+    let _query = announcer
+        .behaviour_mut()
+        .kad
+        .put_record(record, Quorum::One)
+        .expect("put_record should be accepted");
+
+    // Drive both swarms until the receiver surfaces the replicated record.
+    // Polling the announcer keeps its side of the connection making progress.
+    loop {
+        let event = tokio::select! {
+            _ = announcer.next_swarm_event() => continue,
+            event = receiver.next_swarm_event() => event,
+        };
+
+        if let SwarmEvent::Behaviour(KadOnlyEvent::Kad(kad::Event::InboundRequest {
+            request:
+                InboundRequest::PutRecord {
+                    record: Some(inbound),
+                    ..
+                },
+        })) = event
+        {
+            assert_eq!(inbound.key, key, "received the announced record");
+            // FilterBoth must have suppressed the blind auto-store.
+            assert!(
+                receiver.behaviour_mut().kad.store_mut().get(&key).is_none(),
+                "record must not be stored before the handler validates it",
+            );
+            // The handler's explicit store is what makes it retrievable.
+            receiver
+                .behaviour_mut()
+                .kad
+                .store_mut()
+                .put(inbound)
+                .expect("store put should succeed");
+            break;
+        }
+    }
+
+    assert!(
+        receiver.behaviour_mut().kad.store_mut().get(&key).is_some(),
+        "record is retrievable only after the handler stores it",
+    );
+}

--- a/crates/network/tests/kad_record_filtering.rs
+++ b/crates/network/tests/kad_record_filtering.rs
@@ -11,6 +11,8 @@
 //! record from the event, would fail here instead of quietly breaking blob
 //! discovery in production.
 
+use std::time::Duration;
+
 use libp2p::identity::Keypair;
 use libp2p::kad::store::{MemoryStore, RecordStore};
 use libp2p::kad::{self, InboundRequest, Mode, Quorum, Record, RecordKey, StoreInserts};
@@ -81,36 +83,41 @@ async fn filtered_inbound_record_is_not_stored_until_handler_stores_it() {
 
     // Drive both swarms until the receiver surfaces the replicated record.
     // Polling the announcer keeps its side of the connection making progress.
-    loop {
-        let event = tokio::select! {
-            _ = announcer.next_swarm_event() => continue,
-            event = receiver.next_swarm_event() => event,
-        };
+    // Bounded so a routing regression fails loudly instead of hanging forever.
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            let event = tokio::select! {
+                _ = announcer.next_swarm_event() => continue,
+                event = receiver.next_swarm_event() => event,
+            };
 
-        if let SwarmEvent::Behaviour(KadOnlyEvent::Kad(kad::Event::InboundRequest {
-            request:
-                InboundRequest::PutRecord {
-                    record: Some(inbound),
-                    ..
-                },
-        })) = event
-        {
-            assert_eq!(inbound.key, key, "received the announced record");
-            // FilterBoth must have suppressed the blind auto-store.
-            assert!(
-                receiver.behaviour_mut().kad.store_mut().get(&key).is_none(),
-                "record must not be stored before the handler validates it",
-            );
-            // The handler's explicit store is what makes it retrievable.
-            receiver
-                .behaviour_mut()
-                .kad
-                .store_mut()
-                .put(inbound)
-                .expect("store put should succeed");
-            break;
+            if let SwarmEvent::Behaviour(KadOnlyEvent::Kad(kad::Event::InboundRequest {
+                request:
+                    InboundRequest::PutRecord {
+                        record: Some(inbound),
+                        ..
+                    },
+            })) = event
+            {
+                assert_eq!(inbound.key, key, "received the announced record");
+                // FilterBoth must have suppressed the blind auto-store.
+                assert!(
+                    receiver.behaviour_mut().kad.store_mut().get(&key).is_none(),
+                    "record must not be stored before the handler validates it",
+                );
+                // The handler's explicit store is what makes it retrievable.
+                receiver
+                    .behaviour_mut()
+                    .kad
+                    .store_mut()
+                    .put(inbound)
+                    .expect("store put should succeed");
+                break;
+            }
         }
-    }
+    })
+    .await
+    .expect("timed out waiting for the receiver to surface the replicated record");
 
     assert!(
         receiver.behaviour_mut().kad.store_mut().get(&key).is_some(),


### PR DESCRIPTION
## Summary

Hardens the libp2p network behaviour against resource exhaustion and forged DHT records, building on the existing connection-limit / peer-scoring work already on master. Scoped from an audit list; findings already resolved on master were skipped, and two deliberately-documented design decisions (`flood_publish`, the short gossipsub backoffs) were kept per design intent — the latter now with an explicit justification comment.

## Kademlia
- **Record filtering (`StoreInserts::FilterBoth`)** — inbound replicated records are no longer written blind. They surface as `InboundRequest::PutRecord` and pass a structural validator (64-byte key + parseable peer id + 8-byte size) before `store_mut().put()`. Provider records are dropped (we announce via `put_record`, never `start_providing`).
- **Lifetimes & bounds** — record TTL 12h with 6h re-publication (was 48h), 60s query timeout, explicit replication factor, and a bounded `MemoryStoreConfig` (`max_records`, `max_value_bytes=256`, provider caps). The 256-byte value cap cheaply rejects oversized forged records — real blob-provider values are ~46 bytes.

## Behaviour tuning
- Gossipsub `max_transmit_size` set explicitly to 1 MiB (the hidden 64 KiB default is the only receive-path guard and silently drops large broadcasts).
- Specialized-node-invite `max_concurrent_streams` cap (bounds concurrent TEE-verify load; message size was already capped at 1 MB).
- Lower `dial_concurrency_factor`, bounded yamux `max_num_streams`, and pinned ping interval/timeout that the ping-failure watchdog's math assumes.
- Kept the 1s gossipsub backoffs and `flood_publish(true)` as-is; added a comment explaining why the short backoffs are safe on the admission-gated mesh.

## Identify
- Non-routable pushed listen addresses (loopback/unspecified/link-local) are filtered out before entering the dial book — peer-controlled input shouldn't seed our dial targets. Private/overlay ranges are kept.

## Testing
- Unit tests for the record validator and the address filter.
- New cross-node integration test (`kad_record_filtering.rs`) that locks the FilterBoth contract end-to-end: a replicated record stays out of the receiver's store until the handler stores it.
- `cargo build` / `clippy --all-targets` / `test` clean on `calimero-network` (97 tests pass); `calimero-node` builds unchanged (network public API is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)