### PR TITLE
fix(sync): harden wire formats & schemas against crafted/corrupt input

### DIFF
--- a/crates/dag/src/lib.rs
+++ b/crates/dag/src/lib.rs
@@ -88,6 +88,20 @@ pub struct CausalDelta<T> {
 }
 
 impl<T: BorshDeserialize> BorshDeserialize for CausalDelta<T> {
+    /// # Framing requirement
+    ///
+    /// The trailing-`kind` detection depends on the reader ending exactly at the
+    /// delta's last byte: end-of-input means "no `kind` present" (legacy delta →
+    /// `Regular`). So this impl is only correct when the reader is bounded to
+    /// exactly one delta — i.e. `borsh::from_slice` / `try_from_slice` over one
+    /// delta's bytes, or a length-delimited frame. Do **not** decode a
+    /// `CausalDelta` embedded mid-stream in a larger borsh aggregate (a field of
+    /// another struct, or an element of a `Vec<CausalDelta<_>>` with more
+    /// elements after it): there, the bytes that follow would be misread as the
+    /// `kind` discriminant. Today this holds — production never whole-borsh's a
+    /// `CausalDelta<T>` (the payload is serialized on its own and the other
+    /// fields live in separate store columns); if that changes, length-frame the
+    /// delta or promote `kind` to a non-trailing field.
     fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
         // Field order must match the derived `BorshSerialize` (declaration
         // order). `kind` is a backward-compatible trailing field: a pre-`kind`

--- a/crates/dag/src/lib.rs
+++ b/crates/dag/src/lib.rs
@@ -57,7 +57,14 @@ impl Default for DeltaKind {
 }
 
 /// A causal delta with parent references
-#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+///
+/// `kind` is a trailing field: it was added after the original wire format, so
+/// both the serde and borsh decoders tolerate its absence and default it to
+/// [`DeltaKind::Regular`]. serde gets this from `#[serde(default)]`; borsh — whose
+/// derive has no trailing-field tolerance — gets it from the hand-written
+/// [`BorshDeserialize`] below (the derive is intentionally omitted). Keep the two
+/// in step: a new trailing field needs the same treatment in both.
+#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, Serialize, Deserialize)]
 pub struct CausalDelta<T> {
     /// Unique delta ID (content hash)
     pub id: [u8; 32],
@@ -74,9 +81,57 @@ pub struct CausalDelta<T> {
     /// Expected root hash after applying this delta
     pub expected_root_hash: [u8; 32],
 
-    /// Kind of delta (regular or checkpoint)
+    /// Kind of delta (regular or checkpoint). Trailing field — see the struct
+    /// docs; absent on deltas produced before it existed.
     #[serde(default)]
     pub kind: DeltaKind,
+}
+
+impl<T: BorshDeserialize> BorshDeserialize for CausalDelta<T> {
+    fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
+        // Field order must match the derived `BorshSerialize` (declaration
+        // order). `kind` is a backward-compatible trailing field: a pre-`kind`
+        // delta stops cleanly after `expected_root_hash`, so a clean EOF at that
+        // boundary decodes as `DeltaKind::Regular`.
+        let id = <[u8; 32]>::deserialize_reader(reader)?;
+        let parents = Vec::<[u8; 32]>::deserialize_reader(reader)?;
+        let payload = T::deserialize_reader(reader)?;
+        let hlc = calimero_storage::logical_clock::HybridTimestamp::deserialize_reader(reader)?;
+        let expected_root_hash = <[u8; 32]>::deserialize_reader(reader)?;
+
+        // `DeltaKind` is a unit-variant enum, so its borsh encoding is a single
+        // discriminant byte: 0 = Regular, 1 = Checkpoint. Read it tolerating a
+        // clean EOF (legacy pre-`kind` delta) while retrying `Interrupted`.
+        let mut tag = [0u8; 1];
+        let kind = loop {
+            match reader.read(&mut tag) {
+                Ok(0) => break DeltaKind::Regular, // clean EOF: legacy delta
+                Ok(_) => {
+                    break match tag[0] {
+                        0 => DeltaKind::Regular,
+                        1 => DeltaKind::Checkpoint,
+                        other => {
+                            return Err(borsh::io::Error::new(
+                                borsh::io::ErrorKind::InvalidData,
+                                format!("invalid DeltaKind discriminant {other}"),
+                            ))
+                        }
+                    }
+                }
+                Err(e) if e.kind() == borsh::io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e),
+            }
+        };
+
+        Ok(Self {
+            id,
+            parents,
+            payload,
+            hlc,
+            expected_root_hash,
+            kind,
+        })
+    }
 }
 
 impl<T> CausalDelta<T> {

--- a/crates/dag/src/lib.rs
+++ b/crates/dag/src/lib.rs
@@ -100,12 +100,22 @@ impl<T: BorshDeserialize> BorshDeserialize for CausalDelta<T> {
         let expected_root_hash = <[u8; 32]>::deserialize_reader(reader)?;
 
         // `DeltaKind` is a unit-variant enum, so its borsh encoding is a single
-        // discriminant byte: 0 = Regular, 1 = Checkpoint. Read it tolerating a
-        // clean EOF (legacy pre-`kind` delta) while retrying `Interrupted`.
+        // discriminant byte: 0 = Regular, 1 = Checkpoint. A pre-`kind` delta
+        // omits it, so a clean EOF at this boundary must decode as Regular.
+        //
+        // We deliberately read the byte with a raw `read()` loop rather than
+        // `u8::deserialize_reader`: borsh's reader maps an at-EOF read to
+        // `ErrorKind::InvalidData` ("Unexpected length of input"), which is
+        // indistinguishable by kind from a genuine corrupt-data error — so it
+        // can't detect the trailing-field boundary. `read()` distinguishes them
+        // directly: `Ok(0)` is end-of-input (→ Regular), `Ok(1)` is a present
+        // discriminant, and `Interrupted` retries. This mirrors the existing
+        // `read_option_tag` helper used for the same trailing-field pattern in
+        // the sync types.
         let mut tag = [0u8; 1];
         let kind = loop {
             match reader.read(&mut tag) {
-                Ok(0) => break DeltaKind::Regular, // clean EOF: legacy delta
+                Ok(0) => break DeltaKind::Regular, // end of input: legacy delta
                 Ok(_) => {
                     break match tag[0] {
                         0 => DeltaKind::Regular,

--- a/crates/dag/src/tests.rs
+++ b/crates/dag/src/tests.rs
@@ -1323,3 +1323,39 @@ async fn test_prune_to_recent_never_prunes_pending() {
     assert_eq!(dag.pending_stats().count, 1);
     assert!(dag.has_delta(&[9; 32]));
 }
+
+#[test]
+fn causal_delta_kind_borsh_roundtrips_both_variants() {
+    for kind in [DeltaKind::Regular, DeltaKind::Checkpoint] {
+        let mut delta = CausalDelta::new_test([1; 32], vec![[0; 32]], TestPayload { value: 7 });
+        delta.kind = kind.clone();
+        delta.expected_root_hash = [3; 32];
+
+        let bytes = borsh::to_vec(&delta).expect("serialize");
+        let decoded: CausalDelta<TestPayload> = borsh::from_slice(&bytes).expect("deserialize");
+        assert_eq!(decoded, delta);
+        assert_eq!(decoded.kind, kind);
+    }
+}
+
+#[test]
+fn causal_delta_decodes_legacy_bytes_without_kind_as_regular() {
+    // A pre-`kind` peer serialized every field up to `expected_root_hash` and
+    // stopped. `kind` is a unit variant, so its encoding is a single trailing
+    // byte (0 for Regular); dropping it reproduces the legacy wire. The
+    // hand-written `BorshDeserialize` must tolerate that clean EOF and default
+    // `kind` to Regular rather than erroring.
+    let delta = CausalDelta::new_test([5; 32], vec![[4; 32]], TestPayload { value: 42 });
+    assert_eq!(delta.kind, DeltaKind::Regular);
+
+    let full = borsh::to_vec(&delta).expect("serialize");
+    // Trailing byte is the Regular discriminant (0).
+    assert_eq!(*full.last().unwrap(), 0);
+    let legacy = &full[..full.len() - 1];
+
+    let decoded: CausalDelta<TestPayload> =
+        borsh::from_slice(legacy).expect("legacy bytes must decode");
+    assert_eq!(decoded.kind, DeltaKind::Regular);
+    assert_eq!(decoded.id, delta.id);
+    assert_eq!(decoded.payload, delta.payload);
+}

--- a/crates/dag/src/tests.rs
+++ b/crates/dag/src/tests.rs
@@ -1339,6 +1339,16 @@ fn causal_delta_kind_borsh_roundtrips_both_variants() {
 }
 
 #[test]
+fn delta_kind_discriminants_are_pinned() {
+    // The trailing-field decode of `CausalDelta` relies on `DeltaKind` encoding
+    // to exactly one byte with `Regular == 0`. Pin both facts independently of
+    // the `CausalDelta` round-trip so a future variant reorder or encoding
+    // change fails here with a clear message.
+    assert_eq!(borsh::to_vec(&DeltaKind::Regular).unwrap(), vec![0u8]);
+    assert_eq!(borsh::to_vec(&DeltaKind::Checkpoint).unwrap(), vec![1u8]);
+}
+
+#[test]
 fn causal_delta_decodes_legacy_bytes_without_kind_as_regular() {
     // A pre-`kind` peer serialized every field up to `expected_root_hash` and
     // stopped. `kind` is a unit variant, so its encoding is a single trailing
@@ -1349,9 +1359,15 @@ fn causal_delta_decodes_legacy_bytes_without_kind_as_regular() {
     assert_eq!(delta.kind, DeltaKind::Regular);
 
     let full = borsh::to_vec(&delta).expect("serialize");
-    // Trailing byte is the Regular discriminant (0).
+    // `kind` must be exactly the one trailing byte we strip, and its Regular
+    // discriminant must be 0 — otherwise this test would strip the wrong byte.
     assert_eq!(*full.last().unwrap(), 0);
     let legacy = &full[..full.len() - 1];
+    assert_eq!(
+        full.len() - legacy.len(),
+        1,
+        "DeltaKind must be exactly 1 byte"
+    );
 
     let decoded: CausalDelta<TestPayload> =
         borsh::from_slice(legacy).expect("legacy bytes must decode");

--- a/crates/node/primitives/src/sync.rs
+++ b/crates/node/primitives/src/sync.rs
@@ -70,13 +70,14 @@ pub use delta::{
 // Hash comparison types
 pub use hash_comparison::{
     compare_tree_nodes, CrdtType, EntityDeletion, LeafMetadata, TreeCompareResult, TreeLeafData,
-    TreeNode, TreeNodeRequest, TreeNodeResponse, MAX_CHILDREN_PER_NODE, MAX_LEAF_VALUE_SIZE,
-    MAX_NODES_PER_RESPONSE, MAX_TREE_DEPTH,
+    TreeNode, TreeNodeRequest, TreeNodeResponse, MAX_ANCESTORS, MAX_CHILDREN_PER_NODE,
+    MAX_LEAF_VALUE_SIZE, MAX_NODES_PER_RESPONSE, MAX_TREE_DEPTH,
 };
 
 // Bloom filter types
 pub use bloom_filter::{
     BloomFilterRequest, BloomFilterResponse, DeltaIdBloomFilter, DEFAULT_BLOOM_FP_RATE,
+    MAX_MISSING_ENTITIES,
 };
 
 // Wire protocol types (used by all sync protocols)

--- a/crates/node/primitives/src/sync/bloom_filter.rs
+++ b/crates/node/primitives/src/sync/bloom_filter.rs
@@ -6,6 +6,15 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 use super::hash_comparison::TreeLeafData;
 
+/// Maximum number of leaves a single [`BloomFilterResponse`] may carry.
+///
+/// Mirrors the response caps on the sibling sync types (e.g.
+/// `MAX_NODES_PER_RESPONSE`). Each `TreeLeafData` can be up to ~1 MB, so an
+/// uncapped `missing_entities` vector is a memory-exhaustion vector; bound it
+/// and validate every leaf via [`BloomFilterResponse::is_valid`] after decoding
+/// from an untrusted peer.
+pub const MAX_MISSING_ENTITIES: usize = 1000;
+
 // =============================================================================
 // Constants
 // =============================================================================
@@ -308,34 +317,41 @@ impl DeltaIdBloomFilter {
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize)]
 pub struct BloomFilterRequest {
     /// Bloom filter containing initiator's entity IDs.
+    ///
+    /// The filter fully encodes its own parameters (`num_bits`, `num_hashes`,
+    /// `item_count`), so the false-positive rate is derivable from it and is not
+    /// carried separately. Keeping it out of the wire format also removes a
+    /// borsh `f64` field whose only non-canonical bit pattern (a crafted NaN)
+    /// would make the whole message fail to decode.
     pub filter: DeltaIdBloomFilter,
-
-    /// False positive rate used to build the filter.
-    /// Uses f64 for consistency with wire protocol.
-    pub false_positive_rate: f64,
 }
 
 impl BloomFilterRequest {
     /// Create a new Bloom filter request.
     #[must_use]
-    pub fn new(filter: DeltaIdBloomFilter, false_positive_rate: f64) -> Self {
-        Self {
-            filter,
-            false_positive_rate,
-        }
+    pub fn new(filter: DeltaIdBloomFilter) -> Self {
+        Self { filter }
     }
 
     /// Create a request by building a filter from entity IDs.
+    ///
+    /// `fp_rate` sizes the filter (clamped to the valid range) but is not stored
+    /// on the request — see the [`filter`](BloomFilterRequest::filter) field.
     #[must_use]
     pub fn from_ids(ids: &[[u8; 32]], fp_rate: f64) -> Self {
-        // Use the same clamped fp_rate that DeltaIdBloomFilter::new() uses
-        // to ensure metadata matches what was actually used to build the filter
         let clamped_fp_rate = DeltaIdBloomFilter::clamp_fp_rate(fp_rate);
         let mut filter = DeltaIdBloomFilter::new(ids.len(), clamped_fp_rate);
         for id in ids {
             filter.insert(id);
         }
-        Self::new(filter, clamped_fp_rate)
+        Self::new(filter)
+    }
+
+    /// The false-positive rate the filter was built for, recovered from the
+    /// filter's own parameters rather than carried on the wire.
+    #[must_use]
+    pub fn false_positive_rate(&self) -> f64 {
+        self.filter.estimated_fp_rate()
     }
 }
 
@@ -382,6 +398,18 @@ impl BloomFilterResponse {
     pub fn missing_count(&self) -> usize {
         self.missing_entities.len()
     }
+
+    /// Check if the response is within valid bounds.
+    ///
+    /// Call this after deserializing from untrusted sources to prevent memory
+    /// exhaustion: bounds the number of returned leaves to
+    /// [`MAX_MISSING_ENTITIES`] and validates each leaf (value + ancestor-chain
+    /// size). Mirrors `TreeNodeResponse::is_valid` on the sibling sync types.
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        self.missing_entities.len() <= MAX_MISSING_ENTITIES
+            && self.missing_entities.iter().all(TreeLeafData::is_valid)
+    }
 }
 
 // =============================================================================
@@ -391,7 +419,7 @@ impl BloomFilterResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sync::hash_comparison::{CrdtType, LeafMetadata};
+    use crate::sync::hash_comparison::{CrdtType, LeafMetadata, MAX_LEAF_VALUE_SIZE};
 
     #[test]
     fn test_bloom_filter_fnv1a_consistency() {
@@ -509,7 +537,6 @@ mod tests {
         assert!(request.filter.contains(&[2u8; 32]));
         assert!(request.filter.contains(&[3u8; 32]));
         assert!(!request.filter.contains(&[4u8; 32]));
-        assert_eq!(request.false_positive_rate, 0.01);
     }
 
     #[test]
@@ -555,6 +582,26 @@ mod tests {
         let decoded: BloomFilterResponse = borsh::from_slice(&encoded).expect("deserialize");
 
         assert_eq!(response, decoded);
+    }
+
+    #[test]
+    fn test_bloom_filter_response_is_valid() {
+        let metadata = LeafMetadata::new(CrdtType::lww_register("test"), 100, [5; 32]);
+
+        // Within bounds → valid.
+        let leaf = TreeLeafData::new([1; 32], vec![1, 2, 3], metadata.clone());
+        let ok = BloomFilterResponse::new(vec![leaf.clone()], 10);
+        assert!(ok.is_valid());
+        assert!(BloomFilterResponse::empty(0).is_valid());
+
+        // Too many leaves → invalid.
+        let over = BloomFilterResponse::new(vec![leaf; MAX_MISSING_ENTITIES + 1], 10);
+        assert!(!over.is_valid());
+
+        // A single oversized leaf → invalid (per-leaf validation).
+        let big_leaf = TreeLeafData::new([1; 32], vec![0u8; MAX_LEAF_VALUE_SIZE + 1], metadata);
+        let bad = BloomFilterResponse::new(vec![big_leaf], 10);
+        assert!(!bad.is_valid());
     }
 
     #[test]
@@ -836,37 +883,20 @@ mod tests {
     }
 
     #[test]
-    fn test_bloom_filter_from_ids_clamps_fp_rate() {
-        // Test that from_ids stores the clamped FP rate, not the original
-
-        // Test with NaN - should use DEFAULT_BLOOM_FP_RATE
+    fn test_bloom_filter_from_ids_clamps_fp_rate_for_sizing() {
+        // `fp_rate` is no longer stored on the request, but it must still be
+        // clamped internally so extreme/invalid values (NaN, negative, >0.5)
+        // produce a valid, usable filter rather than a degenerate one.
         let ids = [[1u8; 32], [2u8; 32]];
-        let request = BloomFilterRequest::from_ids(&ids, f64::NAN);
-        assert_eq!(
-            request.false_positive_rate, DEFAULT_BLOOM_FP_RATE,
-            "NaN should be clamped to DEFAULT_BLOOM_FP_RATE"
-        );
-
-        // Test with negative - should use MIN_FP_RATE
-        let request = BloomFilterRequest::from_ids(&ids, -1.0);
-        assert_eq!(
-            request.false_positive_rate, MIN_FP_RATE,
-            "Negative should be clamped to MIN_FP_RATE"
-        );
-
-        // Test with too high - should use MAX_FP_RATE
-        let request = BloomFilterRequest::from_ids(&ids, 0.99);
-        assert_eq!(
-            request.false_positive_rate, MAX_FP_RATE,
-            "Value > 0.5 should be clamped to MAX_FP_RATE"
-        );
-
-        // Test with valid value - should remain unchanged
-        let request = BloomFilterRequest::from_ids(&ids, 0.02);
-        assert_eq!(
-            request.false_positive_rate, 0.02,
-            "Valid FP rate should remain unchanged"
-        );
+        for fp_rate in [f64::NAN, -1.0, 0.0, 0.99, f64::INFINITY, 0.02] {
+            let request = BloomFilterRequest::from_ids(&ids, fp_rate);
+            assert!(
+                request.filter.is_valid(),
+                "from_ids with fp_rate {fp_rate} must build a valid filter"
+            );
+            assert!(request.filter.contains(&[1u8; 32]));
+            assert!(request.filter.contains(&[2u8; 32]));
+        }
     }
 
     #[test]

--- a/crates/node/primitives/src/sync/hash_comparison.rs
+++ b/crates/node/primitives/src/sync/hash_comparison.rs
@@ -36,6 +36,15 @@ pub const MAX_LEAF_VALUE_SIZE: usize = 1_048_576;
 /// extremely deep traversals. Most practical Merkle trees have depth < 32.
 pub const MAX_TREE_DEPTH: usize = 64;
 
+/// Maximum length of the `ancestors` chain carried in a leaf's metadata.
+///
+/// The chain runs from the immediate parent up to (excluding) the system root,
+/// so its natural bound is the tree depth. Each entry embeds a full `Metadata`,
+/// so without a cap a malicious peer could inflate a single leaf into a large
+/// allocation. Bounded to [`MAX_TREE_DEPTH`] for the same reason traversal depth
+/// is.
+pub const MAX_ANCESTORS: usize = MAX_TREE_DEPTH;
+
 // =============================================================================
 // Tree Node Request/Response
 // =============================================================================
@@ -312,10 +321,13 @@ impl TreeLeafData {
 
     /// Check if leaf data is within valid bounds.
     ///
-    /// Call this after deserializing from untrusted sources.
+    /// Call this after deserializing from untrusted sources. Bounds both the
+    /// leaf `value` and the metadata's `ancestors` chain — each ancestor embeds
+    /// a full `Metadata`, so an uncapped chain is its own memory-exhaustion
+    /// vector independent of the value size.
     #[must_use]
     pub fn is_valid(&self) -> bool {
-        self.value.len() <= MAX_LEAF_VALUE_SIZE
+        self.value.len() <= MAX_LEAF_VALUE_SIZE && self.metadata.ancestors.len() <= MAX_ANCESTORS
     }
 }
 
@@ -1279,6 +1291,27 @@ mod tests {
         let over_limit_value = vec![0u8; MAX_LEAF_VALUE_SIZE + 1];
         let over_limit = TreeLeafData::new([1; 32], over_limit_value, metadata);
         assert!(!over_limit.is_valid());
+    }
+
+    #[test]
+    fn test_tree_leaf_data_ancestors_bound() {
+        use calimero_storage::address::Id;
+        use calimero_storage::entities::{ChildInfo, Metadata};
+
+        let ancestor = || ChildInfo::new(Id::from([9u8; 32]), [0u8; 32], Metadata::new(1, 2));
+
+        // A short ancestor chain (within the depth bound) is valid.
+        let ok_meta = LeafMetadata::new(CrdtType::lww_register("test"), 100, [1; 32])
+            .with_ancestors((0..MAX_ANCESTORS).map(|_| ancestor()).collect());
+        let ok = TreeLeafData::new([1; 32], vec![1, 2, 3], ok_meta);
+        assert!(ok.is_valid());
+
+        // An over-long chain (each entry embeds a full Metadata) is rejected even
+        // though the value itself is tiny.
+        let bad_meta = LeafMetadata::new(CrdtType::lww_register("test"), 100, [1; 32])
+            .with_ancestors((0..=MAX_ANCESTORS).map(|_| ancestor()).collect());
+        let bad = TreeLeafData::new([1; 32], vec![1, 2, 3], bad_meta);
+        assert!(!bad.is_valid());
     }
 
     #[test]

--- a/crates/node/primitives/src/sync/protocol.rs
+++ b/crates/node/primitives/src/sync/protocol.rs
@@ -83,15 +83,17 @@ pub enum SyncProtocol {
     /// Bloom filter-based quick diff.
     ///
     /// Best for: Large trees with small diff (<10% divergence).
+    ///
+    /// The false-positive rate is intentionally not negotiated here: it is a
+    /// property of the actual [`DeltaIdBloomFilter`] exchanged during the sync,
+    /// derivable from that filter's parameters. Advertising it as a borsh `f64`
+    /// would also add a field whose only non-canonical bit pattern (a crafted
+    /// NaN) makes the whole handshake fail to decode.
+    ///
+    /// [`DeltaIdBloomFilter`]: super::bloom_filter::DeltaIdBloomFilter
     BloomFilter {
         /// Size of the bloom filter in bits.
         filter_size: u64,
-        /// Expected false positive rate (0.0 to 1.0).
-        ///
-        /// **Note**: Validation of bounds is performed when constructing the actual
-        /// bloom filter, not at protocol negotiation time. Invalid values will cause
-        /// filter construction to fail gracefully.
-        false_positive_rate: f64,
     },
 
     /// Subtree prefetch for deep localized changes.
@@ -259,7 +261,6 @@ pub fn select_protocol(local: &SyncHandshake, remote: &SyncHandshake) -> Protoco
             protocol: SyncProtocol::BloomFilter {
                 // ~10 bits per entity, max 10k; saturating to avoid overflow on huge counts
                 filter_size: remote.entity_count.saturating_mul(10).min(10_000),
-                false_positive_rate: 0.01,
             },
             reason: "large tree with small divergence, using bloom filter",
         };
@@ -355,10 +356,7 @@ mod tests {
                 compressed: true,
                 verified: false,
             },
-            SyncProtocol::BloomFilter {
-                filter_size: 1024,
-                false_positive_rate: 0.01,
-            },
+            SyncProtocol::BloomFilter { filter_size: 1024 },
             SyncProtocol::SubtreePrefetch {
                 subtree_roots: vec![[5; 32], [6; 32]],
             },
@@ -392,6 +390,60 @@ mod tests {
     }
 
     #[test]
+    fn test_sync_protocol_kind_discriminants_are_parallel() {
+        // SyncProtocol and SyncProtocolKind must list their variants in the same
+        // order: borsh encodes the variant index as the leading tag byte, and
+        // capability negotiation relies on `SyncProtocol::kind()` mapping a
+        // protocol to the kind with the *same* discriminant. This test pins that
+        // parity so inserting/reordering a variant in only one enum fails here
+        // rather than silently mis-advertising capabilities on the wire.
+        let pairs = [
+            (SyncProtocol::None, SyncProtocolKind::None),
+            (
+                SyncProtocol::DeltaSync {
+                    missing_delta_ids: vec![],
+                },
+                SyncProtocolKind::DeltaSync,
+            ),
+            (
+                SyncProtocol::HashComparison { root_hash: [0; 32] },
+                SyncProtocolKind::HashComparison,
+            ),
+            (
+                SyncProtocol::Snapshot {
+                    compressed: false,
+                    verified: false,
+                },
+                SyncProtocolKind::Snapshot,
+            ),
+            (
+                SyncProtocol::BloomFilter { filter_size: 0 },
+                SyncProtocolKind::BloomFilter,
+            ),
+            (
+                SyncProtocol::SubtreePrefetch {
+                    subtree_roots: vec![],
+                },
+                SyncProtocolKind::SubtreePrefetch,
+            ),
+            (
+                SyncProtocol::LevelWise { max_depth: 0 },
+                SyncProtocolKind::LevelWise,
+            ),
+        ];
+
+        for (protocol, kind) in pairs {
+            let protocol_tag = borsh::to_vec(&protocol).expect("serialize protocol")[0];
+            let kind_tag = borsh::to_vec(&kind).expect("serialize kind")[0];
+            assert_eq!(
+                protocol_tag, kind_tag,
+                "discriminant mismatch: {protocol:?} (tag {protocol_tag}) vs {kind:?} (tag {kind_tag})"
+            );
+            assert_eq!(protocol.kind(), kind, "kind() mapping must agree");
+        }
+    }
+
+    #[test]
     fn test_sync_protocol_kind_conversion() {
         // Test kind() method and From trait
         assert_eq!(SyncProtocol::None.kind(), SyncProtocolKind::None);
@@ -415,11 +467,7 @@ mod tests {
             SyncProtocolKind::Snapshot
         );
         assert_eq!(
-            SyncProtocol::BloomFilter {
-                filter_size: 1024,
-                false_positive_rate: 0.01
-            }
-            .kind(),
+            SyncProtocol::BloomFilter { filter_size: 1024 }.kind(),
             SyncProtocolKind::BloomFilter
         );
         assert_eq!(

--- a/crates/node/src/sync/tracking.rs
+++ b/crates/node/src/sync/tracking.rs
@@ -230,10 +230,7 @@ mod tests {
     /// Test that BloomFilter maps to SnapshotSync (fallback category)
     #[test]
     fn test_from_primitives_bloom_filter() {
-        let primitive = PrimitivesSyncProtocol::BloomFilter {
-            filter_size: 1000,
-            false_positive_rate: 0.01,
-        };
+        let primitive = PrimitivesSyncProtocol::BloomFilter { filter_size: 1000 };
         let tracking: SyncProtocol = (&primitive).into();
         assert!(matches!(tracking, SyncProtocol::SnapshotSync));
     }
@@ -271,10 +268,7 @@ mod tests {
                 compressed: false,
                 verified: false,
             },
-            PrimitivesSyncProtocol::BloomFilter {
-                filter_size: 0,
-                false_positive_rate: 0.0,
-            },
+            PrimitivesSyncProtocol::BloomFilter { filter_size: 0 },
             PrimitivesSyncProtocol::SubtreePrefetch {
                 subtree_roots: vec![],
             },

--- a/crates/op/src/lib.rs
+++ b/crates/op/src/lib.rs
@@ -91,6 +91,22 @@ pub struct Op {
 }
 
 /// The change an [`Op`] carries, across all four planes folded into one model.
+///
+/// **Append-only wire format.** An op's content-address [`id`](Op::id) is a hash
+/// over `borsh(payload)`, and borsh encodes an enum variant by its *positional*
+/// discriminant (declaration order → tag byte). Inserting a variant in the
+/// middle, removing one, or reordering therefore renumbers every later variant,
+/// which silently changes the id — and thus the signature — of every already
+/// stored/persisted op that used one of the shifted variants. New variants MUST
+/// be appended at the end only; existing variants must never be reordered or
+/// removed. [`op_payload_discriminants_are_pinned`] guards this.
+///
+/// This enum is intentionally *not* `#[non_exhaustive]`: `calimero-authz`
+/// authorizes ops with an exhaustive match over `OpPayload`, so a newly added
+/// variant should fail to compile there until it is explicitly given an
+/// authorization rule, rather than being swept into a catch-all arm.
+///
+/// [`op_payload_discriminants_are_pinned`]: tests::op_payload_discriminants_are_pinned
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize)]
 pub enum OpPayload {
     // ---- data plane ----
@@ -375,6 +391,100 @@ mod tests {
         assert_ne!(base, scope_root([1u8; 32], [0u8; 32], [0u8; 32]));
         assert_ne!(base, scope_root([0u8; 32], [1u8; 32], [0u8; 32]));
         assert_ne!(base, scope_root([0u8; 32], [0u8; 32], [1u8; 32]));
+    }
+
+    #[test]
+    fn op_payload_discriminants_are_pinned() {
+        use calimero_context_config::types::ContextGroupId;
+        use calimero_context_config::MemberCapabilities;
+        use calimero_primitives::context::GroupMemberRole;
+
+        let id = Id::new([1u8; 32]);
+        let pk = PublicKey::from([2u8; 32]);
+        let scope = ScopeId::from([3u8; 32]);
+        let group = ContextGroupId::from([4u8; 32]);
+        let caps = MemberCapabilities::empty();
+
+        // Every variant, paired with the borsh discriminant it MUST keep forever
+        // (see the append-only note on `OpPayload`). The exhaustive `match` below
+        // means adding a variant fails to compile until it is appended here with
+        // its own pinned tag — never inserted in the middle.
+        let all = [
+            OpPayload::Put {
+                entity: id,
+                value: vec![1],
+            },
+            OpPayload::Delete { entity: id },
+            OpPayload::SetWriters {
+                object: id,
+                writers: BTreeMap::new(),
+            },
+            OpPayload::MemberAdded {
+                group,
+                member: pk,
+                role: GroupMemberRole::Member,
+            },
+            OpPayload::MemberRemoved { group, member: pk },
+            OpPayload::AdminChanged { new_admin: pk },
+            OpPayload::PolicyUpdated {
+                policy_bytes: vec![],
+            },
+            OpPayload::SubgroupCreated {
+                child: scope,
+                parent: scope,
+                restricted: false,
+                admin: pk,
+            },
+            OpPayload::SubgroupReparented {
+                child: scope,
+                new_parent: scope,
+            },
+            OpPayload::SubgroupDeleted { scope },
+            OpPayload::SubgroupVisibilitySet {
+                scope,
+                restricted: true,
+            },
+            OpPayload::DefaultCapabilitiesSet {
+                group,
+                capabilities: caps,
+            },
+            OpPayload::MemberCapabilitySet {
+                group,
+                member: pk,
+                capabilities: caps,
+            },
+            OpPayload::Noop,
+        ];
+
+        // Exhaustive: a new variant forces a new arm here.
+        fn pinned_tag(p: &OpPayload) -> u8 {
+            match p {
+                OpPayload::Put { .. } => 0,
+                OpPayload::Delete { .. } => 1,
+                OpPayload::SetWriters { .. } => 2,
+                OpPayload::MemberAdded { .. } => 3,
+                OpPayload::MemberRemoved { .. } => 4,
+                OpPayload::AdminChanged { .. } => 5,
+                OpPayload::PolicyUpdated { .. } => 6,
+                OpPayload::SubgroupCreated { .. } => 7,
+                OpPayload::SubgroupReparented { .. } => 8,
+                OpPayload::SubgroupDeleted { .. } => 9,
+                OpPayload::SubgroupVisibilitySet { .. } => 10,
+                OpPayload::DefaultCapabilitiesSet { .. } => 11,
+                OpPayload::MemberCapabilitySet { .. } => 12,
+                OpPayload::Noop => 13,
+            }
+        }
+
+        assert_eq!(all.len(), 14, "every OpPayload variant must be listed");
+        for payload in &all {
+            let bytes = borsh::to_vec(payload).expect("serialize");
+            assert_eq!(
+                bytes[0],
+                pinned_tag(payload),
+                "borsh discriminant drifted for {payload:?} — variants must be append-only"
+            );
+        }
     }
 
     #[test]

--- a/crates/primitives/src/version.rs
+++ b/crates/primitives/src/version.rs
@@ -12,15 +12,23 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Maximum accepted length (in bytes) of any single [`Version`] string field
+/// when decoding from borsh. Version metadata (semver, git describe, commit,
+/// rustc) is short; this bound stops a peer from advertising a multi-gigabyte
+/// length prefix that would force a huge allocation during handshake.
+#[cfg(feature = "borsh")]
+pub const MAX_VERSION_STRING_LEN: usize = 256;
+
 /// Data structure for release version and build metadata (git describe, commit, rustc).
 ///
 /// Used for protocol version exchange and for constructing version strings in
 /// binaries from build-time env vars (e.g. `MEROD_VERSION`, `MEROD_BUILD`).
+///
+/// `BorshDeserialize` is hand-written (not derived) so each string field is
+/// length-capped on decode — see [`MAX_VERSION_STRING_LEN`]. The derive would
+/// trust an attacker-controlled length prefix.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-#[cfg_attr(
-    feature = "borsh",
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize))]
 pub struct Version {
     /// Release version (e.g. from Cargo.toml or git tag).
     pub version: String,
@@ -31,6 +39,39 @@ pub struct Version {
     /// Rustc version used to build.
     pub rustc_version: String,
 }
+
+#[cfg(feature = "borsh")]
+const _: () = {
+    use borsh::io::{Error, ErrorKind, Read};
+    use borsh::BorshDeserialize;
+
+    /// Read a borsh `String` (u32 length prefix + UTF-8 bytes) but reject a
+    /// length above [`MAX_VERSION_STRING_LEN`] before allocating.
+    fn read_capped_string<R: Read>(reader: &mut R) -> borsh::io::Result<String> {
+        let len = u32::deserialize_reader(reader)? as usize;
+        if len > MAX_VERSION_STRING_LEN {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "Version string exceeds maximum length",
+            ));
+        }
+        let mut buf = vec![0u8; len];
+        reader.read_exact(&mut buf)?;
+        String::from_utf8(buf)
+            .map_err(|_| Error::new(ErrorKind::InvalidData, "Version string is not valid UTF-8"))
+    }
+
+    impl BorshDeserialize for Version {
+        fn deserialize_reader<R: Read>(reader: &mut R) -> borsh::io::Result<Self> {
+            Ok(Self {
+                version: read_capped_string(reader)?,
+                build: read_capped_string(reader)?,
+                commit: read_capped_string(reader)?,
+                rustc_version: read_capped_string(reader)?,
+            })
+        }
+    }
+};
 
 impl Version {
     /// Build from build-time env vars (e.g. in binaries that set `MEROD_*` / `MEROCTL_*`).
@@ -76,5 +117,41 @@ mod tests {
             version.to_string(),
             "(release 1.2.3) (build v1.2.3-5-gabc123) (commit abc123) (rustc 1.88.0)"
         );
+    }
+
+    #[cfg(feature = "borsh")]
+    #[test]
+    fn borsh_roundtrips() {
+        let version = Version::from_build_env("1.2.3", "v1.2.3-5-gabc123", "abc123", "1.88.0");
+        let bytes = borsh::to_vec(&version).expect("serialize");
+        let decoded: Version = borsh::from_slice(&bytes).expect("deserialize");
+        assert_eq!(decoded.version, version.version);
+        assert_eq!(decoded.build, version.build);
+        assert_eq!(decoded.commit, version.commit);
+        assert_eq!(decoded.rustc_version, version.rustc_version);
+    }
+
+    #[cfg(feature = "borsh")]
+    #[test]
+    fn borsh_rejects_oversized_string_length_prefix() {
+        use super::MAX_VERSION_STRING_LEN;
+
+        // A crafted frame whose first field claims a huge length must be
+        // rejected at the length check, before allocating — no multi-GB alloc,
+        // no read of gigabytes that aren't there.
+        let mut bytes = Vec::new();
+        let huge = (MAX_VERSION_STRING_LEN as u32) + 1;
+        bytes.extend_from_slice(&huge.to_le_bytes());
+        // No payload bytes follow; the length check must fire first.
+
+        let result: Result<Version, _> = borsh::from_slice(&bytes);
+        assert!(result.is_err(), "oversized length prefix must be rejected");
+
+        // A string exactly at the cap is accepted.
+        let at_cap = "a".repeat(MAX_VERSION_STRING_LEN);
+        let version = Version::from_build_env(&at_cap, "", "", "");
+        let ok_bytes = borsh::to_vec(&version).expect("serialize");
+        let decoded: Version = borsh::from_slice(&ok_bytes).expect("deserialize at cap");
+        assert_eq!(decoded.version.len(), MAX_VERSION_STRING_LEN);
     }
 }

--- a/crates/primitives/src/version.rs
+++ b/crates/primitives/src/version.rs
@@ -47,6 +47,10 @@ const _: () = {
 
     /// Read a borsh `String` (u32 length prefix + UTF-8 bytes) but reject a
     /// length above [`MAX_VERSION_STRING_LEN`] before allocating.
+    ///
+    /// Contract: the length check MUST run before the `vec![0u8; len]`
+    /// allocation below — that ordering is the entire point of this helper (a
+    /// hostile length prefix must never drive an allocation). Do not reorder.
     fn read_capped_string<R: Read>(reader: &mut R) -> borsh::io::Result<String> {
         let len = u32::deserialize_reader(reader)? as usize;
         if len > MAX_VERSION_STRING_LEN {
@@ -55,6 +59,7 @@ const _: () = {
                 "Version string exceeds maximum length",
             ));
         }
+        // Length validated above; safe to allocate exactly `len` bytes.
         let mut buf = vec![0u8; len];
         reader.read_exact(&mut buf)?;
         String::from_utf8(buf)

--- a/crates/storage/src/delta.rs
+++ b/crates/storage/src/delta.rs
@@ -177,20 +177,38 @@ pub enum StorageDelta {
 
 impl BorshDeserialize for StorageDelta {
     fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-        let Ok(tag) = u8::deserialize_reader(reader) else {
-            return Ok(StorageDelta::Comparisons(vec![]));
-        };
-
-        match tag {
-            0 => Ok(StorageDelta::Actions(Vec::deserialize_reader(reader)?)),
-            1 => Ok(StorageDelta::Comparisons(Vec::deserialize_reader(reader)?)),
-            2 => Ok(StorageDelta::CausalActions {
+        // A genuinely-empty artifact (zero bytes) is the legacy "no-op" sentinel
+        // that `commit_root` emits when there are neither actions nor comparisons.
+        // Distinguish it explicitly from a *truncated* artifact: only a clean EOF
+        // on the very first byte maps to the no-op. Once a tag byte is present the
+        // remaining fields must decode in full — a short read there is an error,
+        // never a silently-accepted no-op.
+        let mut tag = [0u8; 1];
+        match read_tag_or_eof(reader, &mut tag)? {
+            None => Ok(StorageDelta::Comparisons(vec![])), // empty artifact: no-op
+            Some(0) => Ok(StorageDelta::Actions(Vec::deserialize_reader(reader)?)),
+            Some(1) => Ok(StorageDelta::Comparisons(Vec::deserialize_reader(reader)?)),
+            Some(2) => Ok(StorageDelta::CausalActions {
                 actions: Vec::deserialize_reader(reader)?,
                 delta_id: <[u8; 32]>::deserialize_reader(reader)?,
                 delta_hlc: HybridTimestamp::deserialize_reader(reader)?,
                 effective_writers: BTreeMap::deserialize_reader(reader)?,
             }),
-            _ => Err(io::Error::new(io::ErrorKind::InvalidData, "Invalid tag")),
+            Some(_) => Err(io::Error::new(io::ErrorKind::InvalidData, "Invalid tag")),
+        }
+    }
+}
+
+/// Read the leading tag byte, distinguishing a truly-empty stream (`Ok(None)`)
+/// from a present tag (`Ok(Some(byte))`). Retries on `Interrupted`. Any other
+/// I/O error propagates, so a partial/short read is never swallowed.
+fn read_tag_or_eof<R: io::Read>(reader: &mut R, buf: &mut [u8; 1]) -> io::Result<Option<u8>> {
+    loop {
+        match reader.read(buf) {
+            Ok(0) => return Ok(None),
+            Ok(_) => return Ok(Some(buf[0])),
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
         }
     }
 }
@@ -575,6 +593,30 @@ mod borsh_roundtrip_tests {
             ),
             "expected CausalActions with empty effective_writers, got {decoded:?}"
         );
+    }
+
+    #[test]
+    fn truncated_actions_artifact_errors_not_noop() {
+        // Tag 0 (Actions) present but the following Vec<Action> is missing: a
+        // truncated artifact must surface as an error, not be silently accepted
+        // as an empty no-op. Only a zero-byte stream is the no-op sentinel.
+        for truncated in [
+            vec![0_u8],          // Actions tag, no length prefix
+            vec![0_u8, 5, 0, 0], // Actions tag, partial (3/4-byte) length prefix
+            vec![2_u8],          // CausalActions tag, no body
+        ] {
+            let result: Result<StorageDelta, _> = from_slice(&truncated);
+            assert!(
+                result.is_err(),
+                "truncated artifact {truncated:?} must error, got {result:?}"
+            );
+        }
+
+        // The zero-byte no-op sentinel still decodes.
+        assert!(matches!(
+            from_slice::<StorageDelta>(&[]).unwrap(),
+            StorageDelta::Comparisons(v) if v.is_empty()
+        ));
     }
 
     #[test]

--- a/crates/storage/src/logical_clock.rs
+++ b/crates/storage/src/logical_clock.rs
@@ -194,13 +194,15 @@ impl BorshDeserialize for HybridTimestamp {
         let time_u64 = u64::deserialize_reader(reader)?;
         let id_u128 = u128::deserialize_reader(reader)?;
         let time = NTP64(time_u64);
-        let id = if id_u128 == 0 {
-            ID::from(DEFAULT_ID)
-        } else {
-            NonZeroU128::new(id_u128).map(ID::from).ok_or_else(|| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, "ID cannot be zero")
-            })?
-        };
+        // A serialized HLC id is always a NonZeroU128 (see `BorshSerialize`), so
+        // an on-wire `id == 0` can only come from corruption or a crafted frame.
+        // Reject it rather than coercing to `DEFAULT_ID`: coercion is
+        // non-injective — two distinct byte strings (`id == 0` and `id == 1`)
+        // would decode to the same timestamp, breaking the globally-unique-id
+        // invariant that HLC ordering and CRDT tiebreaks depend on.
+        let id = NonZeroU128::new(id_u128).map(ID::from).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "HLC id cannot be zero")
+        })?;
         Ok(Self(Timestamp::new(time, id)))
     }
 }
@@ -479,6 +481,28 @@ mod tests {
         let deserialized: HybridTimestamp = borsh::from_slice(&serialized).unwrap();
 
         assert_eq!(ts, deserialized);
+    }
+
+    #[test]
+    fn test_hybrid_timestamp_borsh_rejects_zero_id() {
+        // A crafted/corrupt frame with `id == 0` must be rejected, not coerced
+        // to id 1 — coercion would let two distinct byte strings decode to the
+        // same timestamp and collide otherwise-unique HLC ids.
+        let mut bytes = Vec::new();
+        0u64.serialize(&mut bytes).unwrap(); // time
+        0u128.serialize(&mut bytes).unwrap(); // id == 0 (invalid)
+
+        let result: Result<HybridTimestamp, _> = borsh::from_slice(&bytes);
+        assert!(
+            result.is_err(),
+            "id == 0 must fail to decode, got {result:?}"
+        );
+
+        // A valid non-zero id still decodes.
+        let mut ok = Vec::new();
+        0u64.serialize(&mut ok).unwrap();
+        1u128.serialize(&mut ok).unwrap();
+        assert!(borsh::from_slice::<HybridTimestamp>(&ok).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Hardens a batch of borsh wire-format and schema issues across the sync, DAG, op, storage, and version types. Each fix is defensive against crafted or corrupt input from an untrusted peer, plus targeted tests. Pre-1.0, so wire-format changes are made cleanly (no migration shims).

## Findings addressed

**[M] `false_positive_rate: f64` on the borsh wire** — a crafted NaN is non-canonical and makes borsh fail the whole message; the field was also redundant. Dropped it from both `BloomFilterRequest` and `SyncProtocol::BloomFilter` (the rate is derivable from the filter's own parameters). Kept a `BloomFilterRequest::false_positive_rate()` accessor.

**[M] `BloomFilterResponse.missing_entities` uncapped** — added `MAX_MISSING_ENTITIES` and a `BloomFilterResponse::is_valid()` that bounds the count and validates each leaf, mirroring `TreeNodeResponse::is_valid`.

**[M] `LeafMetadata.ancestors` decoded uncapped** — `TreeLeafData::is_valid()` now also bounds `metadata.ancestors.len()` (`MAX_ANCESTORS`); each ancestor embeds a full `Metadata`.

**[M] `CausalDelta.kind` serde/borsh forward-compat asymmetric** — hand-wrote a trailing-field-tolerant `BorshDeserialize` for `CausalDelta<T>` so a pre-`kind` delta decodes as `Regular`, matching the existing `#[serde(default)]`.

**[M] `HybridTimestamp` borsh coerced `id == 0` → 1 (non-injective)** — now returns `InvalidData` on `id == 0` instead of coercing, preserving the unique-id invariant (a valid serialize never emits 0).

**[L] `OpPayload` discriminant stability** — documented append-only variant discipline and pinned the borsh discriminants with an exhaustive golden test. Intentionally **not** `#[non_exhaustive]`: `calimero-authz` authorizes ops via an exhaustive match by design, and a wildcard arm would silently absorb new variants instead of failing to compile until they're explicitly authorized. The golden test is the guard.

**[L] `StorageDelta` empty/truncated decode** — only a zero-byte stream now maps to the `Comparisons(vec![])` no-op sentinel; a tag byte followed by a short read errors instead of being silently accepted.

**[L] `Version` strings uncapped + parallel sync enums** — hand-wrote a length-capping `BorshDeserialize` for `Version` (`MAX_VERSION_STRING_LEN`), and added an order-parity test pinning `SyncProtocol` and `SyncProtocolKind` to identical borsh discriminants.

## Testing
- `cargo check --workspace --all-targets` — clean
- `cargo test` on dag / op / storage / primitives / node-primitives — all pass, including new tests
- `cargo clippy` on the changed crates — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)