### PR TITLE
fix(governance): security hardening for key delivery, rotation & namespace boundaries

### DIFF
--- a/crates/context/src/handlers/add_group_members.rs
+++ b/crates/context/src/handlers/add_group_members.rs
@@ -62,7 +62,12 @@ impl Handler<AddGroupMembersRequest> for ContextManager {
                         GroupKeyring::new(&datastore, group_id).load_current_key()?
                     {
                         let ns_id = NamespaceRepository::new(&datastore).resolve(&group_id)?;
-                        match GroupKeyring::wrap_for_member(&sk, identity, &group_key) {
+                        match GroupKeyring::wrap_for_member(
+                            &sk,
+                            identity,
+                            &group_id.to_bytes(),
+                            &group_key,
+                        ) {
                             Ok(envelope) => {
                                 let delivery_op = NamespaceOp::Root(RootOp::KeyDelivery {
                                     group_id: group_id.to_bytes().into(),

--- a/crates/context/src/handlers/admit_tee_node.rs
+++ b/crates/context/src/handlers/admit_tee_node.rs
@@ -44,7 +44,8 @@ async fn deliver_group_key_to_member(
         eyre::bail!("verifier has no group key for namespace; cannot deliver to admitted TEE node");
     };
 
-    let envelope = GroupKeyring::wrap_for_member(signer_sk, member, &group_key)?;
+    let envelope =
+        GroupKeyring::wrap_for_member(signer_sk, member, &group_id.to_bytes(), &group_key)?;
 
     let delivery_op = NamespaceOp::Root(RootOp::KeyDelivery {
         group_id: group_id.to_bytes().into(),

--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -169,7 +169,12 @@ impl Handler<JoinGroupRequest> for ContextManager {
                         borsh::from_slice(&join_result.key_envelope_bytes)
                             .map_err(|e| eyre::eyre!("failed to deserialize key envelope: {e}"))?;
 
-                    let group_key = GroupKeyring::unwrap_for_recipient(&sk, &envelope)?;
+                    let group_key = GroupKeyring::unwrap_for_recipient(
+                        &sk,
+                        &group_id.to_bytes(),
+                        None,
+                        &envelope,
+                    )?;
                     GroupKeyring::new(&datastore, group_id).store_key(&group_key)?;
                     info!("received group key via direct join response");
                 }

--- a/crates/context/src/handlers/join_subgroup_inheritance.rs
+++ b/crates/context/src/handlers/join_subgroup_inheritance.rs
@@ -113,7 +113,12 @@ impl Handler<JoinSubgroupInheritanceRequest> for ContextManager {
                         .await?;
                     let envelope: KeyEnvelope = borsh::from_slice(&envelope_bytes)
                         .map_err(|e| eyre::eyre!("decode KeyEnvelope from peer response: {e}"))?;
-                    let group_key = GroupKeyring::unwrap_for_recipient(&signer_sk, &envelope)?;
+                    let group_key = GroupKeyring::unwrap_for_recipient(
+                        &signer_sk,
+                        &group_id.to_bytes(),
+                        None,
+                        &envelope,
+                    )?;
                     let _key_id = GroupKeyring::new(&datastore, group_id).store_key(&group_key)?;
                 } else {
                     info!(

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -67,6 +67,7 @@ pub mod group_store {
         get_local_gov_nonce,
         get_op_head,
         is_currently_authorized_for_context,
+        namespace_group_keys_awaiting,
         namespace_groups_awaiting_key,
         now_millis,
         now_secs,

--- a/crates/governance-store/src/errors.rs
+++ b/crates/governance-store/src/errors.rs
@@ -236,6 +236,12 @@ pub enum NamespaceError {
     #[error("new parent group {0} not found in this namespace")]
     ReparentTargetMissing(String),
 
+    /// Reparent target exists but resolves to a DIFFERENT namespace than the
+    /// child. Reparenting across namespaces would splice the child's
+    /// crypto/access boundary into a foreign namespace.
+    #[error("reparent across namespaces: child {child} and new parent {new_parent} resolve to different namespaces")]
+    ReparentCrossNamespace { child: String, new_parent: String },
+
     /// Namespace root group not found at all.
     #[error("namespace root group not found")]
     RootMissing,
@@ -327,6 +333,12 @@ pub enum KeyringError {
     /// schema-mismatch between sender and receiver.
     #[error("borsh decode inner GroupOp: {0}")]
     InnerOpDecodeFailed(String),
+
+    /// A key envelope's authenticating signature did not verify against its
+    /// stated `sender`, or the sender is not the identity the caller required.
+    /// The envelope is forged, tampered, or replayed and MUST be rejected.
+    #[error("key envelope sender authentication failed: {0}")]
+    EnvelopeAuthFailed(String),
 }
 
 /// Errors raised by `MetaRepository` and the meta-row-touching
@@ -376,6 +388,20 @@ pub enum GroupCreatedRejection {
          holding CAN_CREATE_SUBGROUP at the namespace root"
     )]
     Unauthorized { signer: String, namespace: String },
+
+    /// The named parent group exists but resolves to a DIFFERENT namespace.
+    /// Meta rows are keyed by group id alone, so mere existence of the parent
+    /// does not prove same-namespace membership — grafting a subgroup under a
+    /// foreign namespace's group would splice this namespace's crypto/access
+    /// boundary into it.
+    #[error(
+        "parent {parent} belongs to namespace {parent_namespace}, not this namespace {namespace}"
+    )]
+    ParentCrossNamespace {
+        parent: String,
+        parent_namespace: String,
+        namespace: String,
+    },
 }
 
 /// Reasons `RootOp::NamespaceCreated` (the namespace GENESIS op, #2474) apply

--- a/crates/governance-store/src/group_governance_publisher.rs
+++ b/crates/governance-store/src/group_governance_publisher.rs
@@ -232,10 +232,29 @@ impl<'a> GroupGovernancePublisher<'a> {
         let key_rotation = if let Some(removed) = removed_member {
             if encrypting_group_id == self.group_id {
                 let new_group_key: [u8; 32] = OsRng.gen();
-                let _ = GroupKeyring::new(self.store, self.group_id).store_key(&new_group_key)?;
+                // Stamp the new key with the DAG sequence this op will occupy.
+                // `next_nonce` is strictly greater than the sequence of any
+                // already-applied op — including the one that introduced the key
+                // being superseded — so the fresh key deterministically outranks
+                // it in `load_current_key`, on this node and on every receiver
+                // (which stamps the same op with its own DAG sequence). Without
+                // this the publisher would keep the epoch-0/older key as
+                // "current" and re-encrypt for the removed member.
+                let rotation_epoch = NamespaceGovernance::new(self.store, namespace_bytes.into())
+                    .read_head_record()?
+                    .next_nonce;
+                let _ = GroupKeyring::new(self.store, self.group_id)
+                    .store_key_with_epoch(&new_group_key, rotation_epoch)?;
+                // Wrap with the NAMESPACE identity — the key that signs the
+                // outer namespace op below (`op.signer` on the receiver). The
+                // rotation-apply gate verifies each envelope's authenticated
+                // `sender` against that op signer, so the wrapper and the outer
+                // signer must be the same identity (the local per-group signing
+                // key used elsewhere can differ from the namespace identity).
+                let rotation_sender_sk = PrivateKey::from(namespace_identity.private_key);
                 Some(GroupKeyring::new(self.store, self.group_id).build_rotation(
                     &new_group_key,
-                    signer_sk,
+                    &rotation_sender_sk,
                     Some(removed),
                 )?)
             } else {

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -72,13 +72,24 @@ impl<'a> GroupKeyring<'a> {
     /// for the same fresh `key_id` could both observe an absent entry and the
     /// epoch-`0` put could land last, regressing the stored epoch to `0` and
     /// making the node pick a stale "current" key (the very divergence the epoch
-    /// exists to prevent). The lock makes the check-then-write atomic; group-key
-    /// writes are rare (rotations / deliveries) so contention is negligible.
+    /// exists to prevent). The lock makes the check-then-write atomic.
+    ///
+    /// Two properties make the lock sufficient without store-level snapshot
+    /// isolation: (1) `handle.put` is write-through to the shared DB, so a write
+    /// by one lock holder is visible to the next holder's freshly-opened
+    /// `handle.get`; and (2) `handle` is declared *after* `_guard`, so it drops
+    /// (flushing any layer buffering) *before* the lock is released — the next
+    /// holder can never observe a half-applied write. A single process-global
+    /// lock (rather than a per-group lock) is deliberate: group-key writes are
+    /// rare (rotations / deliveries), never on a hot path, so cross-group
+    /// contention is negligible and not worth a per-key lock map.
     pub fn store_key_with_epoch(&self, group_key: &[u8; 32], epoch: u64) -> EyreResult<[u8; 32]> {
         let key_id = Self::key_id_for(group_key);
         let entry = GroupKeyEntry::new(self.group_id.to_bytes(), key_id);
         // Serialize the read-modify-write; recover a poisoned lock (the guarded
         // state lives in the store, not the guard, so a prior panic is benign).
+        // NOTE: `_guard` is declared before `handle` on purpose — `handle` must
+        // drop first (see doc above).
         let _guard = GROUP_KEY_EPOCH_WRITE_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -128,6 +139,14 @@ impl<'a> GroupKeyring<'a> {
     /// the old wall-clock `created_at` ordering, two rotations within the same
     /// second or a skewed clock can no longer make two nodes pick different
     /// "current" keys (which caused decrypt divergence).
+    ///
+    /// The `key_id` tie-break is what makes two *concurrent* rotations (e.g. two
+    /// admins removing members on causally-unordered ops that land at the same
+    /// epoch) **converge** rather than diverge: once both keys are present, every
+    /// node picks the same one (larger `key_id` wins — a total order over a
+    /// sha256 hash). And the choice is safety-neutral either way, because both
+    /// concurrent rotations exclude the removed member(s) from their envelopes,
+    /// so whichever key wins, a removed member holds neither.
     pub fn load_current_key_record(&self) -> EyreResult<Option<StoredGroupKey>> {
         let gid = self.group_id.to_bytes();
         let keys = collect_keys_with_prefix(

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -74,22 +74,21 @@ impl<'a> GroupKeyring<'a> {
     /// making the node pick a stale "current" key (the very divergence the epoch
     /// exists to prevent). The lock makes the check-then-write atomic.
     ///
-    /// Two properties make the lock sufficient without store-level snapshot
-    /// isolation: (1) `handle.put` is write-through to the shared DB, so a write
-    /// by one lock holder is visible to the next holder's freshly-opened
-    /// `handle.get`; and (2) `handle` is declared *after* `_guard`, so it drops
-    /// (flushing any layer buffering) *before* the lock is released — the next
-    /// holder can never observe a half-applied write. A single process-global
-    /// lock (rather than a per-group lock) is deliberate: group-key writes are
-    /// rare (rotations / deliveries), never on a hot path, so cross-group
-    /// contention is negligible and not worth a per-key lock map.
+    /// The lock is sufficient without store-level snapshot isolation because a
+    /// base-`Store` `handle.put` is **write-through** to the shared DB (it calls
+    /// `db.put` directly; the layer's `commit` is a no-op, so there is no
+    /// per-handle write buffer). The write is therefore durable and visible the
+    /// instant `put` returns — before the lock is released — so the next lock
+    /// holder's freshly-opened `handle.get` always observes it. Correctness does
+    /// **not** depend on when `handle` is dropped. A single process-global lock
+    /// (rather than a per-group lock) is deliberate: group-key writes are rare
+    /// (rotations / deliveries), never on a hot path, so cross-group contention
+    /// is negligible and not worth a per-key lock map.
     pub fn store_key_with_epoch(&self, group_key: &[u8; 32], epoch: u64) -> EyreResult<[u8; 32]> {
         let key_id = Self::key_id_for(group_key);
         let entry = GroupKeyEntry::new(self.group_id.to_bytes(), key_id);
         // Serialize the read-modify-write; recover a poisoned lock (the guarded
         // state lives in the store, not the guard, so a prior panic is benign).
-        // NOTE: `_guard` is declared before `handle` on purpose — `handle` must
-        // drop first (see doc above).
         let _guard = GROUP_KEY_EPOCH_WRITE_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -40,18 +40,46 @@ impl<'a> GroupKeyring<'a> {
         hasher.finalize().into()
     }
 
+    /// Store a genesis / bootstrap group key at `epoch = 0`.
+    ///
+    /// Use [`store_key_with_epoch`](Self::store_key_with_epoch) for a key
+    /// introduced by a governance op (a rotation or an on-DAG delivery), whose
+    /// deterministic DAG sequence is the epoch that decides which key is
+    /// "current". A bare genesis key is always the oldest (`epoch 0`), so any
+    /// later rotation deterministically supersedes it.
     pub fn store_key(&self, group_key: &[u8; 32]) -> EyreResult<[u8; 32]> {
+        self.store_key_with_epoch(group_key, 0)
+    }
+
+    /// Store a group key stamped with an explicit deterministic `epoch` (the DAG
+    /// sequence of the op that introduced it).
+    ///
+    /// The epoch is stored **monotonically**: if this `key_id` is already
+    /// present with a higher epoch, the higher value is kept. That makes the
+    /// two orderings in which a key can arrive commute — e.g. a keyless joiner
+    /// that pulls the current key at `epoch 0` and later replays the rotation op
+    /// that minted it (real epoch) ends up with the real epoch either way — so
+    /// nodes never disagree on the "current" key from write-ordering alone.
+    pub fn store_key_with_epoch(&self, group_key: &[u8; 32], epoch: u64) -> EyreResult<[u8; 32]> {
         let key_id = Self::key_id_for(group_key);
         let entry = GroupKeyEntry::new(self.group_id.to_bytes(), key_id);
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
+        let mut handle = self.store.handle();
+        let epoch = match handle.get(&entry)? {
+            Some(existing) => {
+                let existing: GroupKeyValue = existing;
+                existing.epoch.max(epoch)
+            }
+            None => epoch,
+        };
         let value = GroupKeyValue {
             group_key: *group_key,
             created_at: now,
+            epoch,
         };
-        let mut handle = self.store.handle();
         handle.put(&entry, &value)?;
         Ok(key_id)
     }
@@ -76,7 +104,12 @@ impl<'a> GroupKeyring<'a> {
         Ok(())
     }
 
-    /// Returns the latest key by `created_at`.
+    /// Returns the "current" key: the one with the highest deterministic
+    /// `epoch` (the DAG sequence of the op that introduced it), breaking ties by
+    /// the larger `key_id`. This is fully deterministic across nodes — unlike
+    /// the old wall-clock `created_at` ordering, two rotations within the same
+    /// second or a skewed clock can no longer make two nodes pick different
+    /// "current" keys (which caused decrypt divergence).
     pub fn load_current_key_record(&self) -> EyreResult<Option<StoredGroupKey>> {
         let gid = self.group_id.to_bytes();
         let keys = collect_keys_with_prefix(
@@ -96,8 +129,15 @@ impl<'a> GroupKeyring<'a> {
                 key_id: key.key_id(),
                 group_key: val.group_key,
             };
-            if best.as_ref().is_none_or(|(_, ts)| val.created_at > *ts) {
-                best = Some((current, val.created_at));
+            let better = match best.as_ref() {
+                None => true,
+                Some((best_rec, best_epoch)) => {
+                    val.epoch > *best_epoch
+                        || (val.epoch == *best_epoch && current.key_id > best_rec.key_id)
+                }
+            };
+            if better {
+                best = Some((current, val.epoch));
             }
         }
 
@@ -233,14 +273,28 @@ impl<'a> GroupKeyring<'a> {
         })
     }
 
+    /// Wrap `group_key` for `recipient_pk`, authenticated by `sender_sk` and
+    /// bound to `group_id`.
+    ///
+    /// Forward secrecy: a fresh ephemeral keypair is generated per call and the
+    /// ECDH secret is derived from `SharedKey::new(ephemeral_sk, recipient_pk)`,
+    /// so a later compromise of `sender_sk` does not decrypt this envelope.
+    /// Authentication: `sender_sk` signs the canonical envelope bytes (see
+    /// [`KeyEnvelope::signing_payload`]) so a recipient can verify who wrapped
+    /// the key and reject forged / cross-group-replayed envelopes.
     pub fn wrap_for_member(
         sender_sk: &PrivateKey,
         recipient_pk: &PublicKey,
+        group_id: &[u8; 32],
         group_key: &[u8; 32],
     ) -> EyreResult<KeyEnvelope> {
         use calimero_crypto::SharedKey;
 
-        let shared = SharedKey::new(sender_sk, recipient_pk).map_err(|e| {
+        // Per-envelope ephemeral keypair — the source of forward secrecy.
+        let ephemeral_sk = PrivateKey::random(&mut rand::thread_rng());
+        let ephemeral_pk = ephemeral_sk.public_key();
+
+        let shared = SharedKey::new(&ephemeral_sk, recipient_pk).map_err(|e| {
             KeyringError::KeyAgreementFailed {
                 details: format!("{e:?}"),
             }
@@ -255,19 +309,70 @@ impl<'a> GroupKeyring<'a> {
             .encrypt(group_key.to_vec(), nonce)
             .ok_or(KeyringError::EncryptionFailed)?;
 
+        let sender = sender_sk.public_key();
+        let payload = KeyEnvelope::signing_payload(
+            group_id,
+            recipient_pk,
+            &sender,
+            &ephemeral_pk,
+            &nonce,
+            &ciphertext,
+        );
+        let signature = sender_sk
+            .sign(&payload)
+            .map_err(|e| KeyringError::EnvelopeAuthFailed(format!("sign: {e}")))?
+            .to_bytes();
+
         Ok(KeyEnvelope {
             recipient: *recipient_pk,
-            ephemeral_pk: sender_sk.public_key(),
+            sender,
+            ephemeral_pk,
             nonce,
             ciphertext,
+            signature,
         })
     }
 
+    /// Unwrap a [`KeyEnvelope`] addressed to `recipient_sk`, verifying the
+    /// sender's authenticating signature (bound to `group_id`) before
+    /// decrypting.
+    ///
+    /// When `expected_sender` is `Some`, the envelope's `sender` must equal it —
+    /// callers that know who is authorized to wrap (e.g. the admin who authored
+    /// a rotation) pass it to reject an otherwise-valid envelope minted by the
+    /// wrong identity. On success the (verified) sender is available on the
+    /// returned key's envelope; the raw group key is returned.
     pub fn unwrap_for_recipient(
         recipient_sk: &PrivateKey,
+        group_id: &[u8; 32],
+        expected_sender: Option<&PublicKey>,
         envelope: &KeyEnvelope,
     ) -> EyreResult<[u8; 32]> {
         use calimero_crypto::SharedKey;
+
+        if let Some(expected) = expected_sender {
+            if envelope.sender != *expected {
+                bail!(KeyringError::EnvelopeAuthFailed(format!(
+                    "sender {} is not the required {expected}",
+                    envelope.sender
+                )));
+            }
+        }
+
+        // Authenticate the sender before doing any ECDH/decrypt work: a forged
+        // or cross-group-replayed envelope fails here.
+        let payload = KeyEnvelope::signing_payload(
+            group_id,
+            &envelope.recipient,
+            &envelope.sender,
+            &envelope.ephemeral_pk,
+            &envelope.nonce,
+            &envelope.ciphertext,
+        );
+        envelope
+            .sender
+            .verify_raw_signature(&payload, &envelope.signature)
+            .map_err(|e| KeyringError::EnvelopeAuthFailed(format!("verify: {e}")))?;
 
         let shared = SharedKey::new(recipient_sk, &envelope.ephemeral_pk).map_err(|e| {
             KeyringError::KeyAgreementFailed {
@@ -295,6 +400,7 @@ impl<'a> GroupKeyring<'a> {
         excluded_member: Option<&PublicKey>,
     ) -> EyreResult<KeyRotation> {
         let members = MembershipRepository::new(self.store).list(&self.group_id, 0, usize::MAX)?;
+        let group_id = self.group_id.to_bytes();
         let new_key_id = Self::key_id_for(new_group_key);
         let mut envelopes = Vec::new();
 
@@ -302,7 +408,12 @@ impl<'a> GroupKeyring<'a> {
             if excluded_member == Some(member_pk) {
                 continue;
             }
-            envelopes.push(Self::wrap_for_member(sender_sk, member_pk, new_group_key)?);
+            envelopes.push(Self::wrap_for_member(
+                sender_sk,
+                member_pk,
+                &group_id,
+                new_group_key,
+            )?);
         }
 
         Ok(KeyRotation {
@@ -391,5 +502,117 @@ mod delete_tests {
         // After clearing, the ring is empty again.
         ring.delete_all_for_group().unwrap();
         assert!(!ring.holds_any_key().unwrap());
+    }
+
+    #[test]
+    fn envelope_roundtrips_and_authenticates_sender() {
+        let group_id = [0x11u8; 32];
+        let group_key = [0x22u8; 32];
+        let sender = PrivateKey::from([0x01u8; 32]);
+        let recipient = PrivateKey::from([0x02u8; 32]);
+
+        let env =
+            GroupKeyring::wrap_for_member(&sender, &recipient.public_key(), &group_id, &group_key)
+                .unwrap();
+
+        // Sender is authenticated, and the ephemeral key is NOT the sender's
+        // long-term key (forward secrecy).
+        assert_eq!(env.sender, sender.public_key());
+        assert_ne!(env.ephemeral_pk, sender.public_key());
+
+        // Round-trips for the addressed recipient.
+        assert_eq!(
+            GroupKeyring::unwrap_for_recipient(&recipient, &group_id, None, &env).unwrap(),
+            group_key
+        );
+
+        // `expected_sender` is enforced.
+        assert!(GroupKeyring::unwrap_for_recipient(
+            &recipient,
+            &group_id,
+            Some(&sender.public_key()),
+            &env
+        )
+        .is_ok());
+        let wrong = PrivateKey::from([0x09u8; 32]).public_key();
+        assert!(
+            GroupKeyring::unwrap_for_recipient(&recipient, &group_id, Some(&wrong), &env).is_err()
+        );
+    }
+
+    #[test]
+    fn envelope_rejects_tamper_forgery_and_cross_group_replay() {
+        let group_id = [0x11u8; 32];
+        let group_key = [0x22u8; 32];
+        let sender = PrivateKey::from([0x01u8; 32]);
+        let recipient = PrivateKey::from([0x02u8; 32]);
+        let env =
+            GroupKeyring::wrap_for_member(&sender, &recipient.public_key(), &group_id, &group_key)
+                .unwrap();
+
+        // Replaying the envelope under a different group_id fails: the
+        // signature is bound to the group.
+        let other_group = [0x33u8; 32];
+        assert!(GroupKeyring::unwrap_for_recipient(&recipient, &other_group, None, &env).is_err());
+
+        // A flipped signature byte fails verification.
+        let mut tampered = env.clone();
+        tampered.signature[0] ^= 0xFF;
+        assert!(
+            GroupKeyring::unwrap_for_recipient(&recipient, &group_id, None, &tampered).is_err()
+        );
+
+        // Claiming a different sender (without a matching signature) fails.
+        let mut spoofed = env.clone();
+        spoofed.sender = PrivateKey::from([0x07u8; 32]).public_key();
+        assert!(GroupKeyring::unwrap_for_recipient(&recipient, &group_id, None, &spoofed).is_err());
+    }
+
+    #[test]
+    fn current_key_selected_by_epoch_then_key_id() {
+        let store = test_store();
+        let gid = ContextGroupId::from([0x42u8; 32]);
+        let ring = GroupKeyring::new(&store, gid);
+
+        // Higher epoch wins regardless of key bytes.
+        let old = [0x01u8; 32];
+        let new = [0x02u8; 32];
+        ring.store_key_with_epoch(&old, 5).unwrap();
+        ring.store_key_with_epoch(&new, 9).unwrap();
+        assert_eq!(
+            ring.load_current_key_record().unwrap().unwrap().group_key,
+            new
+        );
+
+        // Epoch is monotonic: re-storing `new` at a LOWER epoch keeps epoch 9,
+        // so `new` is still current.
+        ring.store_key_with_epoch(&new, 0).unwrap();
+        assert_eq!(
+            ring.load_current_key_record().unwrap().unwrap().group_key,
+            new
+        );
+    }
+
+    #[test]
+    fn current_key_breaks_equal_epoch_tie_by_key_id_deterministically() {
+        let store = test_store();
+        let gid = ContextGroupId::from([0x43u8; 32]);
+        let ring = GroupKeyring::new(&store, gid);
+
+        let a = [0x01u8; 32];
+        let b = [0x02u8; 32];
+        ring.store_key_with_epoch(&a, 7).unwrap();
+        ring.store_key_with_epoch(&b, 7).unwrap();
+
+        // Deterministic tie-break: the larger key_id wins on every node.
+        let expected = if GroupKeyring::key_id_for(&a) > GroupKeyring::key_id_for(&b) {
+            a
+        } else {
+            b
+        };
+        assert_eq!(
+            ring.load_current_key_record().unwrap().unwrap().group_key,
+            expected
+        );
     }
 }

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -11,6 +11,11 @@ use sha2::{Digest, Sha256};
 
 use super::collect_keys_with_prefix;
 
+/// Serializes the read-check-write in [`GroupKeyring::store_key_with_epoch`]
+/// across all callers (governance apply and the sync-task pull/join paths),
+/// making the epoch monotonicity atomic without a store-level compare-and-swap.
+static GROUP_KEY_EPOCH_WRITE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StoredGroupKey {
     pub key_id: [u8; 32],
@@ -56,26 +61,28 @@ impl<'a> GroupKeyring<'a> {
     ///
     /// The epoch is stored **monotonically and never lowered**: a write only
     /// touches the store when the entry is absent or when it strictly *raises*
-    /// the epoch. This matters because `store_key` (epoch `0`) is also called
-    /// outside the per-namespace governance-apply lock — from the direct-pull
-    /// path (`apply_received_group_key`) and the join handlers — so an epoch-`0`
-    /// write could otherwise race a rotation's epoch-`N` write and clobber it.
-    /// Since a lowering (or equal) write is a no-op here, an epoch-`0` write can
-    /// never overwrite a higher stored epoch regardless of interleaving; the
-    /// only writes that hit the store are the absent-entry seed and genuine
-    /// epoch increases (a rotation), and those never contend for the same
-    /// `key_id` (`key_id = sha256(group_key)`, and each rotation mints a fresh
-    /// key, so a given key_id has exactly one "real" epoch — two writers raising
-    /// it to the same value are idempotent). Result: nodes converge on the same
-    /// "current" key without needing an atomic read-modify-write.
+    /// the epoch. A lower/equal write (e.g. an epoch-`0` pull for a key a
+    /// rotation already stored) is a no-op.
+    ///
+    /// The read-check-write is serialized by a process-global lock. The store
+    /// layer has no compare-and-swap, and `store_key` (epoch `0`) is called from
+    /// the direct-pull path (`apply_received_group_key`) and join handlers, which
+    /// run on sync tasks *outside* the per-namespace governance-apply actor lock.
+    /// Without serialization an epoch-`0` write and a rotation's epoch-`N` write
+    /// for the same fresh `key_id` could both observe an absent entry and the
+    /// epoch-`0` put could land last, regressing the stored epoch to `0` and
+    /// making the node pick a stale "current" key (the very divergence the epoch
+    /// exists to prevent). The lock makes the check-then-write atomic; group-key
+    /// writes are rare (rotations / deliveries) so contention is negligible.
     pub fn store_key_with_epoch(&self, group_key: &[u8; 32], epoch: u64) -> EyreResult<[u8; 32]> {
         let key_id = Self::key_id_for(group_key);
         let entry = GroupKeyEntry::new(self.group_id.to_bytes(), key_id);
+        // Serialize the read-modify-write; recover a poisoned lock (the guarded
+        // state lives in the store, not the guard, so a prior panic is benign).
+        let _guard = GROUP_KEY_EPOCH_WRITE_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let mut handle = self.store.handle();
-        // Only write when absent or strictly raising the epoch — a lower/equal
-        // epoch (e.g. an epoch-0 pull for a key a rotation already stored) is a
-        // no-op, so it can never regress a higher stored epoch even under a
-        // racing interleave with a concurrent writer.
         if let Some(existing) = handle.get(&entry)? {
             let existing: GroupKeyValue = existing;
             if epoch <= existing.epoch {
@@ -384,6 +391,17 @@ impl<'a> GroupKeyring<'a> {
             .sender
             .verify_raw_signature(&payload, &envelope.signature)
             .map_err(|e| KeyringError::EnvelopeAuthFailed(format!("verify: {e}")))?;
+
+        // The envelope must actually be addressed to us. Callers already filter
+        // by `recipient`, but checking here too means a misaddressed (e.g.
+        // replayed-from-another-delivery) envelope fails with a clear
+        // "wrong recipient" error instead of a downstream `DecryptionFailed`
+        // from ECDH-ing with the wrong key.
+        if envelope.recipient != recipient_sk.public_key() {
+            bail!(KeyringError::EnvelopeAuthFailed(
+                "envelope is not addressed to this recipient".to_owned()
+            ));
+        }
 
         let shared = SharedKey::new(recipient_sk, &envelope.ephemeral_pk).map_err(|e| {
             KeyringError::KeyAgreementFailed {

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -60,6 +60,17 @@ impl<'a> GroupKeyring<'a> {
     /// that pulls the current key at `epoch 0` and later replays the rotation op
     /// that minted it (real epoch) ends up with the real epoch either way — so
     /// nodes never disagree on the "current" key from write-ordering alone.
+    ///
+    /// The read-modify-write below (get the existing epoch, take the max, put)
+    /// is **not** an atomic store transaction, but it does not need to be: every
+    /// writer of a `GroupKeyEntry` runs inside the per-namespace governance
+    /// apply, which is serialized by the `DagStore` lock the `ContextManager`
+    /// actor holds (the same single-writer invariant `advance_dag_head` and
+    /// `delete_all_for_group` rely on). There is therefore no concurrent writer
+    /// for the same `(group_id, key_id)` to interleave between the get and the
+    /// put. `key_id = sha256(group_key)`, so any two writes for the same key_id
+    /// carry the identical `group_key`; only the `epoch`/`created_at` can differ,
+    /// and the monotonic-max keeps the write idempotent regardless.
     pub fn store_key_with_epoch(&self, group_key: &[u8; 32], epoch: u64) -> EyreResult<[u8; 32]> {
         let key_id = Self::key_id_for(group_key);
         let entry = GroupKeyEntry::new(self.group_id.to_bytes(), key_id);

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -54,38 +54,38 @@ impl<'a> GroupKeyring<'a> {
     /// Store a group key stamped with an explicit deterministic `epoch` (the DAG
     /// sequence of the op that introduced it).
     ///
-    /// The epoch is stored **monotonically**: if this `key_id` is already
-    /// present with a higher epoch, the higher value is kept. That makes the
-    /// two orderings in which a key can arrive commute — e.g. a keyless joiner
-    /// that pulls the current key at `epoch 0` and later replays the rotation op
-    /// that minted it (real epoch) ends up with the real epoch either way — so
-    /// nodes never disagree on the "current" key from write-ordering alone.
-    ///
-    /// The read-modify-write below (get the existing epoch, take the max, put)
-    /// is **not** an atomic store transaction, but it does not need to be: every
-    /// writer of a `GroupKeyEntry` runs inside the per-namespace governance
-    /// apply, which is serialized by the `DagStore` lock the `ContextManager`
-    /// actor holds (the same single-writer invariant `advance_dag_head` and
-    /// `delete_all_for_group` rely on). There is therefore no concurrent writer
-    /// for the same `(group_id, key_id)` to interleave between the get and the
-    /// put. `key_id = sha256(group_key)`, so any two writes for the same key_id
-    /// carry the identical `group_key`; only the `epoch`/`created_at` can differ,
-    /// and the monotonic-max keeps the write idempotent regardless.
+    /// The epoch is stored **monotonically and never lowered**: a write only
+    /// touches the store when the entry is absent or when it strictly *raises*
+    /// the epoch. This matters because `store_key` (epoch `0`) is also called
+    /// outside the per-namespace governance-apply lock — from the direct-pull
+    /// path (`apply_received_group_key`) and the join handlers — so an epoch-`0`
+    /// write could otherwise race a rotation's epoch-`N` write and clobber it.
+    /// Since a lowering (or equal) write is a no-op here, an epoch-`0` write can
+    /// never overwrite a higher stored epoch regardless of interleaving; the
+    /// only writes that hit the store are the absent-entry seed and genuine
+    /// epoch increases (a rotation), and those never contend for the same
+    /// `key_id` (`key_id = sha256(group_key)`, and each rotation mints a fresh
+    /// key, so a given key_id has exactly one "real" epoch — two writers raising
+    /// it to the same value are idempotent). Result: nodes converge on the same
+    /// "current" key without needing an atomic read-modify-write.
     pub fn store_key_with_epoch(&self, group_key: &[u8; 32], epoch: u64) -> EyreResult<[u8; 32]> {
         let key_id = Self::key_id_for(group_key);
         let entry = GroupKeyEntry::new(self.group_id.to_bytes(), key_id);
+        let mut handle = self.store.handle();
+        // Only write when absent or strictly raising the epoch — a lower/equal
+        // epoch (e.g. an epoch-0 pull for a key a rotation already stored) is a
+        // no-op, so it can never regress a higher stored epoch even under a
+        // racing interleave with a concurrent writer.
+        if let Some(existing) = handle.get(&entry)? {
+            let existing: GroupKeyValue = existing;
+            if epoch <= existing.epoch {
+                return Ok(key_id);
+            }
+        }
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-        let mut handle = self.store.handle();
-        let epoch = match handle.get(&entry)? {
-            Some(existing) => {
-                let existing: GroupKeyValue = existing;
-                existing.epoch.max(epoch)
-            }
-            None => epoch,
-        };
         let value = GroupKeyValue {
             group_key: *group_key,
             created_at: now,

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -377,6 +377,18 @@ impl<'a> GroupKeyring<'a> {
             }
         }
 
+        // Cheap identity gate first: the envelope must be addressed to us. This
+        // is checked against our own key (not a value we have to trust from the
+        // envelope), so it is safe to do before signature verification and gives
+        // a clear "wrong recipient" error instead of a downstream
+        // `DecryptionFailed` from ECDH-ing with the wrong key. Callers already
+        // filter by `recipient`; this is defense in depth.
+        if envelope.recipient != recipient_sk.public_key() {
+            bail!(KeyringError::EnvelopeAuthFailed(
+                "envelope is not addressed to this recipient".to_owned()
+            ));
+        }
+
         // Authenticate the sender before doing any ECDH/decrypt work: a forged
         // or cross-group-replayed envelope fails here.
         let payload = KeyEnvelope::signing_payload(
@@ -391,17 +403,6 @@ impl<'a> GroupKeyring<'a> {
             .sender
             .verify_raw_signature(&payload, &envelope.signature)
             .map_err(|e| KeyringError::EnvelopeAuthFailed(format!("verify: {e}")))?;
-
-        // The envelope must actually be addressed to us. Callers already filter
-        // by `recipient`, but checking here too means a misaddressed (e.g.
-        // replayed-from-another-delivery) envelope fails with a clear
-        // "wrong recipient" error instead of a downstream `DecryptionFailed`
-        // from ECDH-ing with the wrong key.
-        if envelope.recipient != recipient_sk.public_key() {
-            bail!(KeyringError::EnvelopeAuthFailed(
-                "envelope is not addressed to this recipient".to_owned()
-            ));
-        }
 
         let shared = SharedKey::new(recipient_sk, &envelope.ephemeral_pk).map_err(|e| {
             KeyringError::KeyAgreementFailed {

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -105,7 +105,7 @@ pub use self::namespace::MAX_NAMESPACE_DEPTH;
 pub use self::namespace::{
     apply_received_group_key, apply_signed_namespace_op, apply_signed_namespace_op_at_cut,
     build_group_key_delivery, collect_skeleton_delta_ids_for_group, decrypt_group_op,
-    known_namespace_identities, namespace_groups_awaiting_key,
+    known_namespace_identities, namespace_group_keys_awaiting, namespace_groups_awaiting_key,
     namespace_groups_with_held_key_buffered_ops, redrive_buffered_ops_for_group,
     retry_encrypted_ops_for_group, sign_and_publish_namespace_op,
     sign_apply_and_publish_namespace_op, ApplyNamespaceOpResult, CascadePayload, KeyUnwrapFailure,

--- a/crates/governance-store/src/namespace/core.rs
+++ b/crates/governance-store/src/namespace/core.rs
@@ -434,6 +434,17 @@ impl<'a> NamespaceRepository<'a> {
             )));
         }
 
+        // Both must live in the same namespace. Meta rows are keyed by group id
+        // alone, so the target-exists check above does not prove same-namespace;
+        // without this an admin of namespace A could reparent an A-group under a
+        // B-group, grafting A's crypto/access boundary into B.
+        if self.resolve(child)? != self.resolve(new_parent)? {
+            eyre::bail!(NamespaceError::ReparentCrossNamespace {
+                child: format!("{child:?}"),
+                new_parent: format!("{new_parent:?}"),
+            });
+        }
+
         if self.is_descendant_of(new_parent, child)? {
             eyre::bail!(NamespaceError::ReparentCycle {
                 new_parent: format!("{new_parent:?}"),

--- a/crates/governance-store/src/namespace/dag.rs
+++ b/crates/governance-store/src/namespace/dag.rs
@@ -94,7 +94,42 @@ impl<'a> NamespaceDagService<'a> {
         let current = handle.get(&ns_key)?;
         drop(handle);
 
-        let parent_set: HashSet<[u8; 32]> = parent_ids.iter().copied().collect();
+        let current_heads: HashSet<[u8; 32]> = current
+            .as_ref()
+            .map(|h| h.dag_heads.iter().copied().collect())
+            .unwrap_or_default();
+
+        // Validate cited parents are RESOLVABLE — either a current head or an
+        // op we have already applied and logged. A resolvable parent is trusted
+        // to advance the head frontier that `compute_governance_position`
+        // depends on; an unresolvable one (absent / fabricated) must not, or a
+        // crafted op could pad the frontier and desync every peer's position
+        // check. The in-memory DagStore already gates apply on parent
+        // availability (an op with absent parents is held `Pending` and its
+        // ancestors are back-filled first), so for ops arriving through the
+        // normal path every parent is resolvable here; this guard defends the
+        // governance-head write against a direct/edge caller that bypasses that
+        // gate, and makes the anomaly observable rather than silent.
+        let op_log = NamespaceOpLogService::new(self.store, self.namespace_id);
+        let mut resolvable_parents: HashSet<[u8; 32]> = HashSet::with_capacity(parent_ids.len());
+        for parent in parent_ids {
+            if current_heads.contains(parent) || op_log.contains_op(*parent)? {
+                let _ = resolvable_parents.insert(*parent);
+            } else {
+                tracing::warn!(
+                    namespace_id = %hex::encode(self.namespace_id.as_bytes()),
+                    delta_id = %hex::encode(delta_id),
+                    parent = %hex::encode(parent),
+                    "advance_dag_head: op cites an unresolvable parent (not a current \
+                     head nor a known applied op); ignoring it for head supersession"
+                );
+            }
+        }
+
+        // Only resolvable parents may supersede current heads. Unresolvable ones
+        // are dropped, so they can neither remove a real head nor otherwise
+        // influence the frontier.
+        let parent_set = resolvable_parents;
         // Drop the heads this op supersedes (its parents) and collapse any
         // pre-existing duplicates: a stored head set must be unique, otherwise
         // `compute_governance_position` refuses to embed a position and every

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -1454,6 +1454,14 @@ impl<'a> NamespaceGovernance<'a> {
             if envelope.recipient != recipient_pk {
                 continue;
             }
+            // Invariant: `op.signer` MUST be the same identity that wrapped the
+            // rotation envelopes. The publisher guarantees this by signing the
+            // outer namespace op and wrapping every envelope with the SAME
+            // namespace identity key (see `build_rotation` call in
+            // `group_governance_publisher`). If a future refactor ever signs the
+            // outer op with a different key than it wraps with, this
+            // `expected_sender` check will reject the rotation rather than
+            // silently accept a mismatched wrapper — fail-closed by design.
             match GroupKeyring::unwrap_for_recipient(
                 &recipient_sk,
                 &group_id.to_bytes(),

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -1428,12 +1428,17 @@ impl<'a> NamespaceGovernance<'a> {
         }
 
         // Authorized-rotator gate: only an admin at the op's cut may rotate.
-        // An incomplete fold / missing apply-auth context resolves to `false`
-        // here (fail closed) rather than aborting the whole apply.
+        // `is_admin` returns `Ok(false)` for a genuine non-admin (and for an
+        // incomplete fold / missing apply-auth context, via the live fallback),
+        // which we treat as "not authorized" and skip. A store *error* (e.g. I/O
+        // failure), by contrast, is propagated with `?` rather than swallowed as
+        // "not admin": swallowing it would silently drop a legitimate rotation
+        // and leave the node unable to decrypt subsequent ops. Propagating lets
+        // the apply fail and be retried; the inner op re-applies idempotently
+        // (per-signer nonce window) and the rotation is re-attempted.
         let signer_is_admin = PermissionChecker::new(self.store, *group_id)
             .with_apply_auth(&op.parent_op_hashes, self.authorizer)
-            .is_admin(&op.signer)
-            .unwrap_or(false);
+            .is_admin(&op.signer)?;
         if !signer_is_admin {
             tracing::warn!(
                 group_id = %hex::encode(group_id.to_bytes()),

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -2,11 +2,11 @@ use calimero_governance_types::NamespaceId;
 
 use crate::{
     CapabilitiesRepository, DenyListRepository, GroupKeyring, MembershipRepository, MetaRepository,
-    NamespaceRepository,
+    NamespaceRepository, PermissionChecker,
 };
 use calimero_context_client::local_governance::{
-    hash_scoped_namespace, AckRouter, EncryptedGroupOp, GroupOp, KeyEnvelope, NamespaceOp, RootOp,
-    SignedGroupOp, SignedNamespaceOp,
+    hash_scoped_namespace, AckRouter, EncryptedGroupOp, GroupOp, KeyEnvelope, KeyRotation,
+    NamespaceOp, RootOp, SignedGroupOp, SignedNamespaceOp,
 };
 use calimero_context_config::types::ContextGroupId;
 use calimero_context_config::MemberCapabilities;
@@ -219,6 +219,17 @@ impl<'a> NamespaceGovernance<'a> {
             // canonical dedup-tradeoff note in `apply_local_signed_group_op`.
             return Ok(ApplyNamespaceOpResult::default());
         }
+
+        // Deterministic epoch for any key this op introduces (a rotation): the
+        // DAG sequence this op will occupy. Read here — before the side-effect
+        // match — so the rotation arm can stamp the new key with it; the head is
+        // not mutated until `advance_dag_head` below, so this equals the value
+        // used there. Causally-ordered rotations (the normal case: an admin
+        // removes member A, later removes member B) get strictly increasing
+        // epochs on every node, since a descendant op is always applied after
+        // its ancestor — so all nodes deterministically agree which rotated key
+        // is "current", unlike the old wall-clock ordering.
+        let op_sequence = self.read_head_record()?.next_nonce;
 
         let mut result = ApplyNamespaceOpResult::default();
         let mut root_events: Vec<crate::op_events::OpEvent> = Vec::new();
@@ -438,6 +449,11 @@ impl<'a> NamespaceGovernance<'a> {
                     }
                 };
 
+                // Whether we hold the current key and could decrypt+apply the
+                // inner op. This doubles as the "am I a member of this group"
+                // signal for the rotation gate below: a node with no key for the
+                // group is not a member and must never process a rotation for it.
+                let inner_decrypted = resolved_key.is_some();
                 if let Some(group_key) = resolved_key {
                     // Surface any post-apply hash divergence reported by
                     // `MemberRemoved` / `MemberLeft` apply so the node
@@ -460,37 +476,14 @@ impl<'a> NamespaceGovernance<'a> {
                 }
 
                 if let Some(rotation) = key_rotation {
-                    let ns_id = ContextGroupId::from(op.namespace_id.to_bytes());
-                    if let Some(identity) =
-                        NamespaceRepository::new(self.store).identity_record(&ns_id)?
-                    {
-                        let recipient_sk = PrivateKey::from(identity.private_key);
-                        for envelope in &rotation.envelopes {
-                            if envelope.recipient == recipient_sk.public_key() {
-                                match GroupKeyring::unwrap_for_recipient(&recipient_sk, envelope) {
-                                    Ok(new_key) => {
-                                        let _ = GroupKeyring::new(self.store, group_id_typed)
-                                            .store_key(&new_key)?;
-                                        tracing::info!(
-                                            group_id = %hex::encode(group_id.to_bytes()),
-                                            "stored rotated group key"
-                                        );
-                                    }
-                                    Err(e) => {
-                                        tracing::warn!(
-                                            ?e,
-                                            "failed to unwrap key rotation envelope"
-                                        );
-                                        result.key_unwrap_failures.push(KeyUnwrapFailure {
-                                            group_id: group_id.to_bytes(),
-                                            reason: format!("key rotation unwrap failed: {e}"),
-                                        });
-                                    }
-                                }
-                                break;
-                            }
-                        }
-                    }
+                    self.apply_key_rotation(
+                        &group_id_typed,
+                        op,
+                        rotation,
+                        inner_decrypted,
+                        op_sequence,
+                        &mut result,
+                    )?;
                 }
             }
             // `NamespaceOp` is `#[non_exhaustive]`; an unknown future op type
@@ -1021,6 +1014,7 @@ impl<'a> NamespaceGovernance<'a> {
         &self,
         group_id: [u8; 32],
         requester: PublicKey,
+        requested_key_id: Option<[u8; 32]>,
     ) -> EyreResult<(Vec<u8>, PublicKey)> {
         let group_gid = ContextGroupId::from(group_id);
         let ns_gid = ContextGroupId::from(self.namespace_id.to_bytes());
@@ -1039,10 +1033,30 @@ impl<'a> NamespaceGovernance<'a> {
             return Ok((Vec::new(), requester));
         }
 
-        let Some((_key_id, group_key)) =
-            GroupKeyring::new(self.store, group_gid).load_current_key()?
-        else {
-            return Ok((Vec::new(), requester));
+        // Serve the EXACT key the requester named when it named one (a buffered
+        // op stranded on a specific — possibly rotated-out — epoch), else the
+        // current key (a keyless joiner bootstrapping). Scoping to a key_id also
+        // tightens the removed-member case: a removed member is not a `member`
+        // (rejected above on an up-to-date responder), and even against a
+        // lagging responder they can only name key_ids of ops they already
+        // saw — never the fresh post-removal key, which no op they hold cites.
+        let group_key = match requested_key_id {
+            Some(key_id) => {
+                let Some(group_key) =
+                    GroupKeyring::new(self.store, group_gid).load_key_by_id(&key_id)?
+                else {
+                    return Ok((Vec::new(), requester));
+                };
+                group_key
+            }
+            None => {
+                let Some((_key_id, group_key)) =
+                    GroupKeyring::new(self.store, group_gid).load_current_key()?
+                else {
+                    return Ok((Vec::new(), requester));
+                };
+                group_key
+            }
         };
         let Some(record) = NamespaceRepository::new(self.store).resolve_identity_record(&ns_gid)?
         else {
@@ -1054,7 +1068,7 @@ impl<'a> NamespaceGovernance<'a> {
         };
         let sender_sk = PrivateKey::from(record.private_key);
         let responder_identity = sender_sk.public_key();
-        match GroupKeyring::wrap_for_member(&sender_sk, &requester, &group_key) {
+        match GroupKeyring::wrap_for_member(&sender_sk, &requester, &group_id, &group_key) {
             Ok(envelope) => Ok((
                 borsh::to_vec(&envelope).unwrap_or_default(),
                 responder_identity,
@@ -1116,6 +1130,32 @@ impl<'a> NamespaceGovernance<'a> {
         responder_identity: PublicKey,
     ) -> EyreResult<Option<super::super::DivergenceReport>> {
         let ns_id = ContextGroupId::from(self.namespace_id.to_bytes());
+        let gid = ContextGroupId::from(group_id);
+
+        // Cross-namespace pin: reject a key for a group that is KNOWN to belong
+        // to a different namespace, so an attacker-served envelope can't store a
+        // chosen key under another namespace's group id (keyring pollution).
+        //
+        // "Known to belong elsewhere" means the group resolves UP a parent
+        // chain to a root that isn't this namespace. A group that resolves to
+        // itself (no parent edge yet) is NOT rejected: that is the legitimate
+        // stranded-delivery race where a subgroup's key arrives before its
+        // `GroupCreated` (which writes the parent edge) has been applied — the
+        // authenticated-sender gate below still bounds who may deliver it, and
+        // the key is keyed by (group_id, key_id) so a mismatched delivery is
+        // inert until a real op references it.
+        if let Ok(root) = NamespaceRepository::new(self.store).resolve(&gid) {
+            let root = root.to_bytes();
+            if root != self.namespace_id.to_bytes() && root != group_id {
+                tracing::warn!(
+                    namespace_id = %hex::encode(self.namespace_id.as_bytes()),
+                    group_id = %hex::encode(group_id),
+                    resolved_root = %hex::encode(root),
+                    "rejecting received group key: group belongs to a different namespace"
+                );
+                return Ok(None);
+            }
+        }
 
         let Some(identity) = NamespaceRepository::new(self.store).identity_record(&ns_id)? else {
             return Ok(None);
@@ -1129,7 +1169,15 @@ impl<'a> NamespaceGovernance<'a> {
             return Ok(None);
         }
 
-        let group_key = match GroupKeyring::unwrap_for_recipient(&recipient_sk, envelope) {
+        // Authenticate the envelope against the peer that served it: only a
+        // key-holding member of this namespace can mint a valid wrap, so the
+        // `sender` must be the `responder_identity` we transacted with.
+        let group_key = match GroupKeyring::unwrap_for_recipient(
+            &recipient_sk,
+            &group_id,
+            Some(&responder_identity),
+            envelope,
+        ) {
             Ok(k) => k,
             Err(e) => {
                 tracing::warn!(?e, "failed to unwrap received group key envelope");
@@ -1137,7 +1185,6 @@ impl<'a> NamespaceGovernance<'a> {
             }
         };
 
-        let gid = ContextGroupId::from(group_id);
         let key_id = GroupKeyring::new(self.store, gid)
             .store_key(&group_key)
             .map_err(|e| eyre::eyre!("store_group_key: {e}"))?;
@@ -1340,6 +1387,110 @@ impl<'a> NamespaceGovernance<'a> {
         }
 
         Ok(applied)
+    }
+
+    /// Process the plaintext `key_rotation` bundle attached to a group op.
+    ///
+    /// The bundle is NOT encrypted, so without gating any namespace participant
+    /// could attach a chosen key to any op and poison a group's keyring. Every
+    /// check below must pass before the rotated key is stored:
+    ///
+    /// 1. `inner_decrypted` — we hold the current key (i.e. are a member); a
+    ///    rotation for a group we don't belong to is ignored so it can't poison
+    ///    an arbitrary group's keyring.
+    /// 2. `op.signer` is an admin of the group **at the op's causal cut** — only
+    ///    an admin may remove a member and rotate the key. This is the missing
+    ///    "authorized rotator" check.
+    /// 3. the envelope is authenticated as coming from that same admin
+    ///    (`expected_sender = op.signer`), so an admin can't be impersonated.
+    /// 4. the unwrapped key hashes to the advertised `new_key_id` — that field
+    ///    is plaintext and trusted by every non-recipient peer, so binding it to
+    ///    the actual key stops a tampered id from splitting the keyring.
+    ///
+    /// The new key is stamped with this op's deterministic DAG `epoch` so all
+    /// nodes agree it supersedes the pre-rotation key.
+    fn apply_key_rotation(
+        &self,
+        group_id: &ContextGroupId,
+        op: &SignedNamespaceOp,
+        rotation: &KeyRotation,
+        inner_decrypted: bool,
+        epoch: u64,
+        result: &mut ApplyNamespaceOpResult,
+    ) -> EyreResult<()> {
+        if !inner_decrypted {
+            tracing::warn!(
+                group_id = %hex::encode(group_id.to_bytes()),
+                "ignoring key rotation: node holds no current key for this group \
+                 (not a member / could not decrypt the inner op)"
+            );
+            return Ok(());
+        }
+
+        // Authorized-rotator gate: only an admin at the op's cut may rotate.
+        // An incomplete fold / missing apply-auth context resolves to `false`
+        // here (fail closed) rather than aborting the whole apply.
+        let signer_is_admin = PermissionChecker::new(self.store, *group_id)
+            .with_apply_auth(&op.parent_op_hashes, self.authorizer)
+            .is_admin(&op.signer)
+            .unwrap_or(false);
+        if !signer_is_admin {
+            tracing::warn!(
+                group_id = %hex::encode(group_id.to_bytes()),
+                signer = %op.signer,
+                "ignoring key rotation: op signer is not an admin at the op's cut"
+            );
+            return Ok(());
+        }
+
+        let ns_id = ContextGroupId::from(op.namespace_id.to_bytes());
+        let Some(identity) = NamespaceRepository::new(self.store).identity_record(&ns_id)? else {
+            return Ok(());
+        };
+        let recipient_sk = PrivateKey::from(identity.private_key);
+        let recipient_pk = recipient_sk.public_key();
+
+        for envelope in &rotation.envelopes {
+            if envelope.recipient != recipient_pk {
+                continue;
+            }
+            match GroupKeyring::unwrap_for_recipient(
+                &recipient_sk,
+                &group_id.to_bytes(),
+                Some(&op.signer),
+                envelope,
+            ) {
+                Ok(new_key) => {
+                    if GroupKeyring::key_id_for(&new_key) != rotation.new_key_id.to_bytes() {
+                        tracing::warn!(
+                            group_id = %hex::encode(group_id.to_bytes()),
+                            "ignoring key rotation: unwrapped key does not match advertised new_key_id"
+                        );
+                        result.key_unwrap_failures.push(KeyUnwrapFailure {
+                            group_id: group_id.to_bytes(),
+                            reason: "new_key_id does not match unwrapped key".to_owned(),
+                        });
+                        return Ok(());
+                    }
+                    let _ = GroupKeyring::new(self.store, *group_id)
+                        .store_key_with_epoch(&new_key, epoch)?;
+                    tracing::info!(
+                        group_id = %hex::encode(group_id.to_bytes()),
+                        epoch,
+                        "stored rotated group key"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(?e, "failed to unwrap key rotation envelope");
+                    result.key_unwrap_failures.push(KeyUnwrapFailure {
+                        group_id: group_id.to_bytes(),
+                        reason: format!("key rotation unwrap failed: {e}"),
+                    });
+                }
+            }
+            break;
+        }
+        Ok(())
     }
 
     /// Decrypt an encrypted group op and apply it via
@@ -1683,8 +1834,23 @@ pub fn build_group_key_delivery(
     namespace_id: NamespaceId,
     group_id: [u8; 32],
     requester: PublicKey,
+    requested_key_id: Option<[u8; 32]>,
 ) -> EyreResult<(Vec<u8>, PublicKey)> {
-    NamespaceGovernance::new(store, namespace_id).build_group_key_delivery(group_id, requester)
+    NamespaceGovernance::new(store, namespace_id).build_group_key_delivery(
+        group_id,
+        requester,
+        requested_key_id,
+    )
+}
+
+/// Distinct `(group_id, key_id)` pairs the node is buffering an undecryptable
+/// group op for — the direct-pull requester asks a peer for each specific key
+/// epoch. See [`NamespaceRetryService::awaited_group_keys`].
+pub fn namespace_group_keys_awaiting(
+    store: &Store,
+    namespace_id: NamespaceId,
+) -> EyreResult<Vec<([u8; 32], [u8; 32])>> {
+    NamespaceRetryService::new(store, namespace_id).awaited_group_keys()
 }
 
 /// Apply a group key delivered out-of-band via the direct

--- a/crates/governance-store/src/namespace/mod.rs
+++ b/crates/governance-store/src/namespace/mod.rs
@@ -29,7 +29,7 @@ pub(crate) use self::governance::classify_report_readiness;
 pub use self::governance::{
     apply_received_group_key, apply_signed_namespace_op, apply_signed_namespace_op_at_cut,
     build_group_key_delivery, collect_skeleton_delta_ids_for_group, decrypt_group_op,
-    known_namespace_identities, namespace_groups_awaiting_key,
+    known_namespace_identities, namespace_group_keys_awaiting, namespace_groups_awaiting_key,
     namespace_groups_with_held_key_buffered_ops, redrive_buffered_ops_for_group,
     retry_encrypted_ops_for_group, sign_and_publish_namespace_op,
     sign_apply_and_publish_namespace_op, ApplyNamespaceOpResult, KeyUnwrapFailure,

--- a/crates/governance-store/src/namespace/retry.rs
+++ b/crates/governance-store/src/namespace/retry.rs
@@ -69,6 +69,39 @@ impl<'a> NamespaceRetryService<'a> {
         Ok(awaiting.into_iter().collect())
     }
 
+    /// Distinct `(group_id, key_id)` pairs the local node is buffering an
+    /// undecryptable op for — the same set [`groups_awaiting_key`] collapses to
+    /// group ids, but keeping the specific `key_id` each op needs. The
+    /// direct-pull requester uses this to ask a peer for the EXACT key epoch a
+    /// buffered op was encrypted under, instead of only the group's "current"
+    /// key: after a rotation the op it's stranded on may be under an older
+    /// epoch the peer has since rotated past, which a current-key request could
+    /// never deliver.
+    pub fn awaited_group_keys(&self) -> EyreResult<Vec<([u8; 32], [u8; 32])>> {
+        let op_log = NamespaceOpLogService::new(self.store, self.namespace_id);
+        let op_keys = op_log
+            .collect_buffered_group_op_keys()
+            .map_err(|e| eyre::eyre!("op_log.collect_buffered_group_op_keys: {e}"))?;
+        let ns_typed = ContextGroupId::from(self.namespace_id.to_bytes());
+
+        let mut awaiting = std::collections::BTreeSet::new();
+        for (group_id, key_id) in op_keys {
+            let gid_typed = ContextGroupId::from(group_id);
+            let resolvable = GroupKeyring::new(self.store, gid_typed)
+                .load_key_by_id(&key_id)
+                .map_err(|e| eyre::eyre!("load_key_by_id(group): {e}"))?
+                .is_some()
+                || GroupKeyring::new(self.store, ns_typed)
+                    .load_key_by_id(&key_id)
+                    .map_err(|e| eyre::eyre!("load_key_by_id(namespace): {e}"))?
+                    .is_some();
+            if !resolvable {
+                awaiting.insert((group_id, key_id));
+            }
+        }
+        Ok(awaiting.into_iter().collect())
+    }
+
     /// Distinct group ids that have at least one buffered encrypted op whose
     /// `key_id` the local node CAN already resolve — the exact INVERSE of
     /// [`groups_awaiting_key`](Self::groups_awaiting_key)'s filter.

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -3501,6 +3501,276 @@ fn governance_group_created_is_idempotent() {
         .expect("duplicate GroupCreated should be idempotent");
 }
 
+#[test]
+fn governance_group_created_rejects_cross_namespace_parent() {
+    use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    use super::NamespaceGovernance;
+    use crate::{ApplyError, GroupCreatedRejection};
+
+    let store = test_store();
+    let mut rng = OsRng;
+    let admin_sk_bytes: [u8; 32] = rand::Rng::gen(&mut rng);
+    let admin_sk = PrivateKey::from(admin_sk_bytes);
+    let admin_pk = admin_sk.public_key();
+
+    // Namespace A, where our admin has authority.
+    let ns_a = [0xA0u8; 32];
+    let ns_a_gid = ContextGroupId::from(ns_a);
+    MetaRepository::new(&store)
+        .save(&ns_a_gid, &sample_meta_with_admin(admin_pk))
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&ns_a_gid, &admin_pk, GroupMemberRole::Admin)
+        .unwrap();
+    NamespaceRepository::new(&store)
+        .store_identity(&ns_a_gid, &admin_pk, &admin_sk_bytes, &[0u8; 32])
+        .unwrap();
+
+    // A group that belongs to a DIFFERENT namespace B.
+    let root_b = ContextGroupId::from([0xB0u8; 32]);
+    let foreign = ContextGroupId::from([0xB1u8; 32]);
+    MetaRepository::new(&store)
+        .save(&root_b, &test_meta())
+        .unwrap();
+    MetaRepository::new(&store)
+        .save(&foreign, &test_meta())
+        .unwrap();
+    NamespaceRepository::new(&store)
+        .nest(&root_b, &foreign)
+        .unwrap();
+
+    // Namespace-A admin tries to graft a subgroup under namespace-B's group.
+    let new_group = [0xCCu8; 32];
+    let op = SignedNamespaceOp::sign(
+        &admin_sk,
+        ns_a.into(),
+        vec![],
+        1,
+        NamespaceOp::Root(RootOp::GroupCreated {
+            group_id: new_group.into(),
+            parent_id: foreign.to_bytes().into(),
+            restricted: true,
+        }),
+    )
+    .expect("sign GroupCreated");
+
+    let err = NamespaceGovernance::new(&store, ns_a.into())
+        .apply_signed_op(&op)
+        .expect_err("cross-namespace parent must be rejected");
+    assert!(
+        matches!(
+            err.downcast_ref::<ApplyError>(),
+            Some(ApplyError::GroupCreatedRejected(
+                GroupCreatedRejection::ParentCrossNamespace { .. }
+            ))
+        ),
+        "expected cross-namespace parent rejection, got: {err}"
+    );
+}
+
+/// Shared setup for the key-rotation apply tests: a namespace where `admin` is
+/// an Admin, `local` is the node under test (its namespace identity + a Member
+/// row), `removed` is a Member the rotation will exclude, and the local node
+/// already holds the pre-rotation ("old") key.
+#[cfg(test)]
+fn rotation_test_setup() -> (
+    Store,
+    ContextGroupId,
+    calimero_primitives::identity::PrivateKey, // admin (signs + wraps)
+    calimero_primitives::identity::PrivateKey, // local node identity
+    calimero_primitives::identity::PublicKey,  // removed member
+    [u8; 32],                                  // old_key_id
+) {
+    use calimero_primitives::identity::PrivateKey;
+    use rand::rngs::OsRng;
+
+    let store = test_store();
+    let mut rng = OsRng;
+
+    let ns_id = [0xA7u8; 32];
+    let ns_gid = ContextGroupId::from(ns_id);
+
+    let admin_sk = PrivateKey::random(&mut rng);
+    let admin_pk = admin_sk.public_key();
+    let local_sk_bytes: [u8; 32] = rand::Rng::gen(&mut rng);
+    let local_sk = PrivateKey::from(local_sk_bytes);
+    let local_pk = local_sk.public_key();
+    let removed_pk = PrivateKey::random(&mut rng).public_key();
+
+    MetaRepository::new(&store)
+        .save(&ns_gid, &sample_meta_with_admin(admin_pk))
+        .unwrap();
+    let m = MembershipRepository::new(&store);
+    m.add_member(&ns_gid, &admin_pk, GroupMemberRole::Admin)
+        .unwrap();
+    m.add_member(&ns_gid, &local_pk, GroupMemberRole::Member)
+        .unwrap();
+    m.add_member(&ns_gid, &removed_pk, GroupMemberRole::Member)
+        .unwrap();
+    NamespaceRepository::new(&store)
+        .store_identity(&ns_gid, &local_pk, &local_sk_bytes, &[0u8; 32])
+        .unwrap();
+
+    let old_key = [0x97u8; 32];
+    let old_key_id = GroupKeyring::new(&store, ns_gid)
+        .store_key(&old_key)
+        .unwrap();
+
+    (store, ns_gid, admin_sk, local_sk, removed_pk, old_key_id)
+}
+
+/// Build a `NamespaceOp::Group` carrying an encrypted `MemberRemoved` plus a
+/// key rotation, wrapped + signed by `signer_sk`.
+#[cfg(test)]
+fn build_rotation_op(
+    store: &Store,
+    ns_gid: ContextGroupId,
+    signer_sk: &calimero_primitives::identity::PrivateKey,
+    removed_pk: &calimero_primitives::identity::PublicKey,
+    old_key: &[u8; 32],
+    old_key_id: [u8; 32],
+    new_group_key: &[u8; 32],
+    tamper_new_key_id: bool,
+) -> calimero_context_client::local_governance::SignedNamespaceOp {
+    use calimero_context_client::local_governance::{NamespaceOp, SignedNamespaceOp};
+
+    let inner = GroupOp::MemberRemoved {
+        member: *removed_pk,
+        expected_group_state_hash: [0u8; 32],
+        expected_context_state_hashes: vec![],
+    };
+    let encrypted = GroupKeyring::encrypt_op(old_key, &inner).unwrap();
+    let mut rotation = GroupKeyring::new(store, ns_gid)
+        .build_rotation(new_group_key, signer_sk, Some(removed_pk))
+        .unwrap();
+    if tamper_new_key_id {
+        rotation.new_key_id = [0xFFu8; 32].into();
+    }
+    SignedNamespaceOp::sign(
+        signer_sk,
+        ns_gid.to_bytes().into(),
+        vec![],
+        1,
+        NamespaceOp::Group {
+            group_id: ns_gid.to_bytes().into(),
+            key_id: old_key_id.into(),
+            encrypted,
+            key_rotation: Some(rotation),
+        },
+    )
+    .unwrap()
+}
+
+#[test]
+fn rotation_apply_stores_key_for_authorized_admin() {
+    use super::NamespaceGovernance;
+
+    let (store, ns_gid, admin_sk, _local_sk, removed_pk, old_key_id) = rotation_test_setup();
+    let old_key = [0x97u8; 32];
+    let new_group_key = [0x42u8; 32];
+
+    let op = build_rotation_op(
+        &store,
+        ns_gid,
+        &admin_sk,
+        &removed_pk,
+        &old_key,
+        old_key_id,
+        &new_group_key,
+        false,
+    );
+    NamespaceGovernance::new(&store, ns_gid.to_bytes().into())
+        .apply_signed_op(&op)
+        .expect("authorized rotation must apply");
+
+    // The rotated key is stored (authorized admin, matching key_id).
+    let new_key_id = GroupKeyring::key_id_for(&new_group_key);
+    assert_eq!(
+        GroupKeyring::new(&store, ns_gid)
+            .load_key_by_id(&new_key_id)
+            .unwrap(),
+        Some(new_group_key),
+        "the rotated key must be stored for an authorized admin rotation"
+    );
+    // ...and it is the current key (higher DAG epoch than the genesis key).
+    assert_eq!(
+        GroupKeyring::new(&store, ns_gid)
+            .load_current_key()
+            .unwrap()
+            .map(|(_, k)| k),
+        Some(new_group_key),
+        "the rotated key must become current"
+    );
+}
+
+#[test]
+fn rotation_apply_rejects_new_key_id_mismatch() {
+    use super::NamespaceGovernance;
+
+    let (store, ns_gid, admin_sk, _local_sk, removed_pk, old_key_id) = rotation_test_setup();
+    let old_key = [0x97u8; 32];
+    let new_group_key = [0x42u8; 32];
+
+    // Same authorized admin, but the advertised `new_key_id` is a lie.
+    let op = build_rotation_op(
+        &store,
+        ns_gid,
+        &admin_sk,
+        &removed_pk,
+        &old_key,
+        old_key_id,
+        &new_group_key,
+        true,
+    );
+    NamespaceGovernance::new(&store, ns_gid.to_bytes().into())
+        .apply_signed_op(&op)
+        .expect("apply itself must not error (rotation is skipped, not fatal)");
+
+    assert!(
+        GroupKeyring::new(&store, ns_gid)
+            .load_key_by_id(&GroupKeyring::key_id_for(&new_group_key))
+            .unwrap()
+            .is_none(),
+        "a rotation whose unwrapped key does not match new_key_id must be ignored"
+    );
+}
+
+#[test]
+fn rotation_apply_ignored_when_signer_not_admin() {
+    use super::NamespaceGovernance;
+
+    let (store, ns_gid, _admin_sk, local_sk, removed_pk, old_key_id) = rotation_test_setup();
+    let old_key = [0x97u8; 32];
+    let new_group_key = [0x42u8; 32];
+
+    // The local node (a non-admin Member) signs + wraps its own rotation — the
+    // exact injection the authorized-rotator gate must block.
+    let op = build_rotation_op(
+        &store,
+        ns_gid,
+        &local_sk,
+        &removed_pk,
+        &old_key,
+        old_key_id,
+        &new_group_key,
+        false,
+    );
+    // Inner MemberRemoved by a non-admin fails authorization, so apply surfaces
+    // an error — but crucially the key must NOT have been stored either way.
+    let _ = NamespaceGovernance::new(&store, ns_gid.to_bytes().into()).apply_signed_op(&op);
+
+    assert!(
+        GroupKeyring::new(&store, ns_gid)
+            .load_key_by_id(&GroupKeyring::key_id_for(&new_group_key))
+            .unwrap()
+            .is_none(),
+        "a rotation from a non-admin signer must never poison the keyring"
+    );
+}
+
 /// #2771: `GroupCreated { restricted: false }` must write an Open visibility
 /// key at apply time (born-Open atomic create), and `restricted: true` must
 /// leave the subgroup Restricted. This is the store-level guard that the live
@@ -4139,9 +4409,15 @@ fn is_descendant_of_self_is_false() {
 #[test]
 fn reparent_group_swaps_parent_edge() {
     let store = test_store();
+    // Both parents live under a common namespace root, so the reparent stays
+    // within one namespace (the same-namespace guard requires this).
+    let root = ContextGroupId::from([0xEF; 32]);
     let old_parent = ContextGroupId::from([0xE0; 32]);
     let new_parent = ContextGroupId::from([0xE1; 32]);
     let child = ContextGroupId::from([0xE2; 32]);
+    MetaRepository::new(&store)
+        .save(&root, &test_meta())
+        .unwrap();
     MetaRepository::new(&store)
         .save(&old_parent, &test_meta())
         .unwrap();
@@ -4150,6 +4426,12 @@ fn reparent_group_swaps_parent_edge() {
         .unwrap();
     MetaRepository::new(&store)
         .save(&child, &test_meta())
+        .unwrap();
+    NamespaceRepository::new(&store)
+        .nest(&root, &old_parent)
+        .unwrap();
+    NamespaceRepository::new(&store)
+        .nest(&root, &new_parent)
         .unwrap();
     NamespaceRepository::new(&store)
         .nest(&old_parent, &child)
@@ -4201,6 +4483,38 @@ fn reparent_group_idempotent_on_same_parent() {
             .unwrap()
             .len(),
         1
+    );
+}
+
+#[test]
+fn reparent_rejects_cross_namespace() {
+    let store = test_store();
+    // Two independent namespace roots, each with a child group.
+    let root_a = ContextGroupId::from([0xA0; 32]);
+    let root_b = ContextGroupId::from([0xB0; 32]);
+    let child_a = ContextGroupId::from([0xA1; 32]);
+    let group_b = ContextGroupId::from([0xB1; 32]);
+    for g in [&root_a, &root_b, &child_a, &group_b] {
+        MetaRepository::new(&store).save(g, &test_meta()).unwrap();
+    }
+    NamespaceRepository::new(&store)
+        .nest(&root_a, &child_a)
+        .unwrap();
+    NamespaceRepository::new(&store)
+        .nest(&root_b, &group_b)
+        .unwrap();
+
+    // Reparenting a namespace-A group under a namespace-B group is rejected —
+    // it would graft A's crypto/access boundary into B.
+    let err = NamespaceRepository::new(&store)
+        .reparent(&child_a, &group_b)
+        .unwrap_err();
+    assert!(
+        matches!(
+            err.downcast_ref::<NamespaceError>(),
+            Some(NamespaceError::ReparentCrossNamespace { .. })
+        ),
+        "expected cross-namespace rejection, got: {err}"
     );
 }
 
@@ -4740,11 +5054,27 @@ fn apply_received_group_key_stores_key_for_recipient() {
         )
         .unwrap();
 
+    // Establish the subgroup's parent edge so it resolves to this namespace —
+    // in the real flow the subgroup's `GroupCreated` (which writes this edge)
+    // applies before any key delivery, and `apply_received_group_key` now
+    // requires the group to belong to this namespace (cross-namespace pin).
+    {
+        use calimero_store::key::GroupParentRef;
+        let mut h = store.handle();
+        h.put(&GroupParentRef::new(group_id), &namespace_id)
+            .unwrap();
+    }
+
     // A remote key-holder wraps the group key for us.
     let sender_sk = PrivateKey::from(rand::Rng::gen::<[u8; 32]>(&mut rng));
     let group_key = [0x6Au8; 32];
-    let envelope =
-        GroupKeyring::wrap_for_member(&sender_sk, &recipient_sk.public_key(), &group_key).unwrap();
+    let envelope = GroupKeyring::wrap_for_member(
+        &sender_sk,
+        &recipient_sk.public_key(),
+        &group_id,
+        &group_key,
+    )
+    .unwrap();
     let envelope_bytes = borsh::to_vec(&envelope).unwrap();
 
     // Precondition: we hold no key yet.
@@ -4791,11 +5121,21 @@ fn apply_received_group_key_ignores_envelope_for_other_recipient() {
         )
         .unwrap();
 
+    // Resolve the subgroup into this namespace so the cross-namespace pin
+    // passes and we actually exercise the recipient-mismatch path below.
+    {
+        use calimero_store::key::GroupParentRef;
+        let mut h = store.handle();
+        h.put(&GroupParentRef::new(group_id), &namespace_id)
+            .unwrap();
+    }
+
     // Envelope wrapped for somebody else entirely.
     let sender_sk = PrivateKey::from(rand::Rng::gen::<[u8; 32]>(&mut rng));
     let other_pk = PrivateKey::from(rand::Rng::gen::<[u8; 32]>(&mut rng)).public_key();
     let group_key = [0x6Bu8; 32];
-    let envelope = GroupKeyring::wrap_for_member(&sender_sk, &other_pk, &group_key).unwrap();
+    let envelope =
+        GroupKeyring::wrap_for_member(&sender_sk, &other_pk, &group_id, &group_key).unwrap();
     let envelope_bytes = borsh::to_vec(&envelope).unwrap();
 
     // Not addressed to us: benign no-op, no key stored.
@@ -4971,6 +5311,7 @@ fn responder_delivery_round_trips_key_to_joiner_cross_store() {
         namespace_id.into(),
         subgroup_id,
         joiner_pk,
+        None,
     )
     .unwrap();
     assert!(
@@ -5094,6 +5435,7 @@ fn responder_delivery_round_trips_key_to_read_only_tee_joiner() {
         namespace_id.into(),
         subgroup_id,
         joiner_pk,
+        None,
     )
     .unwrap();
     assert!(
@@ -5194,7 +5536,8 @@ fn responder_refuses_delivery_to_non_member() {
     // The requester is NOT a member of the subgroup → empty envelope: no key
     // wrapped, and no membership oracle leaked (same reply as "key not held").
     let (envelope_bytes, _responder_identity) =
-        build_group_key_delivery(&store, namespace_id.into(), subgroup_id, stranger_pk).unwrap();
+        build_group_key_delivery(&store, namespace_id.into(), subgroup_id, stranger_pk, None)
+            .unwrap();
     assert!(
         envelope_bytes.is_empty(),
         "responder must not wrap a key for a non-member"

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -3625,6 +3625,7 @@ fn rotation_test_setup() -> (
 /// Build a `NamespaceOp::Group` carrying an encrypted `MemberRemoved` plus a
 /// key rotation, wrapped + signed by `signer_sk`.
 #[cfg(test)]
+#[allow(clippy::too_many_arguments)]
 fn build_rotation_op(
     store: &Store,
     ns_gid: ContextGroupId,

--- a/crates/governance-store/src/ops/namespace/group_created.rs
+++ b/crates/governance-store/src/ops/namespace/group_created.rs
@@ -5,7 +5,7 @@ use super::context::NamespaceApplyCtx;
 use crate::op_events::OpEvent;
 use crate::{
     ApplyError, CapabilitiesRepository, GroupCreatedRejection, MembershipRepository,
-    MetaRepository, NamespaceError,
+    MetaRepository, NamespaceError, NamespaceRepository,
 };
 use calimero_context_client::local_governance::SignedNamespaceOp;
 use calimero_context_config::types::ContextGroupId;
@@ -62,6 +62,24 @@ pub(crate) fn apply(
         .ok_or_else(|| {
             eyre::eyre!("GroupCreated rejected: parent_id '{parent_gid:?}' not found in namespace")
         })?;
+
+    // Meta rows are keyed by group id alone, so an existing `parent_meta` proves
+    // only that the parent exists SOMEWHERE — not that it belongs to THIS
+    // namespace. Without this check an admin of namespace A could graft a
+    // subgroup under a group of namespace B, splicing A's crypto/access boundary
+    // into B. Require the parent to resolve to this namespace's root.
+    let parent_ns = NamespaceRepository::new(store)
+        .resolve(&parent_gid)
+        .map_err(|e| eyre::eyre!("GroupCreated rejected: cannot resolve parent namespace: {e}"))?;
+    if parent_ns.to_bytes() != namespace_id.to_bytes() {
+        bail!(ApplyError::GroupCreatedRejected(
+            GroupCreatedRejection::ParentCrossNamespace {
+                parent: format!("{parent_gid:?}"),
+                parent_namespace: hex::encode(parent_ns.to_bytes()),
+                namespace: hex::encode(namespace_id.as_bytes()),
+            }
+        ));
+    }
 
     // The originating node's `create_group` handler pre-populates
     // `GroupMeta` (and related state) BEFORE publishing this op, so a

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -733,21 +733,62 @@ pub struct EncryptedGroupOp {
     pub ciphertext: Vec<u8>,
 }
 
-/// ECDH-wrapped group key for a specific recipient.
+/// Domain separation prefix for the Ed25519 signature that authenticates a
+/// [`KeyEnvelope`]'s sender. Distinct from the op-signing domains so an
+/// envelope signature can never be replayed as an op signature or vice versa.
+pub const KEY_ENVELOPE_SIGN_DOMAIN: &[u8] = b"calimero.keyenvelope.v1";
+
+/// Authenticated, forward-secret ECDH-wrapped group key for a recipient.
 ///
-/// The sender encrypts the group key using a shared secret derived from
-/// `SharedKey::new(sender_sk, recipient_pk)`. The recipient decrypts with
-/// `SharedKey::new(recipient_sk, ephemeral_pk)`.
+/// The sender generates a fresh ephemeral keypair per envelope and encrypts the
+/// group key under `SharedKey::new(ephemeral_sk, recipient_pk)`; the recipient
+/// decrypts with `SharedKey::new(recipient_sk, ephemeral_pk)`. Because the
+/// ephemeral key is discarded after wrapping, compromising the sender's
+/// long-term key does not retroactively decrypt past envelopes. The `signature`
+/// authenticates `sender` over the whole envelope (bound to a `group_id`), so a
+/// recipient rejects forged or cross-group-replayed envelopes.
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct KeyEnvelope {
     /// Recipient's namespace identity public key.
     pub recipient: PublicKey,
-    /// Sender's public key used for ECDH key agreement.
+    /// Identity that wrapped this key, authenticated by `signature`.
+    pub sender: PublicKey,
+    /// Per-envelope ephemeral public key used for ECDH key agreement. Fresh for
+    /// every wrap — this is what gives the wrap forward secrecy.
     pub ephemeral_pk: PublicKey,
     /// 12-byte AES-GCM nonce.
     pub nonce: [u8; 12],
     /// `AES-256-GCM(group_key)` using the ECDH shared secret.
     pub ciphertext: Vec<u8>,
+    /// Ed25519 signature by `sender` over [`KeyEnvelope::signing_payload`].
+    pub signature: [u8; 64],
+}
+
+impl KeyEnvelope {
+    /// Canonical bytes signed by `sender` to authenticate an envelope. Binds
+    /// the wrap to `group_id` (preventing cross-group replay) and every
+    /// envelope field except the signature itself. Callers on both the wrap and
+    /// unwrap sides must build the payload identically.
+    #[must_use]
+    pub fn signing_payload(
+        group_id: &[u8; 32],
+        recipient: &PublicKey,
+        sender: &PublicKey,
+        ephemeral_pk: &PublicKey,
+        nonce: &[u8; 12],
+        ciphertext: &[u8],
+    ) -> Vec<u8> {
+        let mut out =
+            Vec::with_capacity(KEY_ENVELOPE_SIGN_DOMAIN.len() + 32 * 4 + 12 + ciphertext.len());
+        out.extend_from_slice(KEY_ENVELOPE_SIGN_DOMAIN);
+        out.extend_from_slice(group_id);
+        out.extend_from_slice(recipient.as_ref());
+        out.extend_from_slice(sender.as_ref());
+        out.extend_from_slice(ephemeral_pk.as_ref());
+        out.extend_from_slice(nonce);
+        out.extend_from_slice(ciphertext);
+        out
+    }
 }
 
 /// Key rotation bundle attached to a `MemberRemoved` governance op.
@@ -795,7 +836,12 @@ pub struct SignedNamespaceOp {
 /// being an apply gate in C5.S3a (`scope_root` is the convergence signal now);
 /// removing it from the signable/​signed structs changes every op id, hence the
 /// version bump and the flag-day re-bootstrap.
-pub const SIGNED_NAMESPACE_OP_SCHEMA_VERSION: u8 = 2;
+///
+/// v3: the `KeyEnvelope` carried in a `NamespaceOp::Group` key rotation gained
+/// authenticated `sender` + `signature` fields (and its `ephemeral_pk` became a
+/// true per-envelope ephemeral). That changes the borsh layout of every group
+/// op that carries a rotation, so every op id changes — another flag-day.
+pub const SIGNED_NAMESPACE_OP_SCHEMA_VERSION: u8 = 3;
 
 /// Domain separation prefix for Ed25519 signatures over namespace ops.
 pub const NAMESPACE_GOVERNANCE_SIGN_DOMAIN: &[u8] = b"calimero.namespace.v1";

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -521,6 +521,9 @@ const GOLDEN_ROOT_OP_MEMBER_JOINED: &[u8] = &[
 ];
 
 /// NamespaceOp::Root(RootOp::KeyDelivery) — RootOp ordinal 6
+///
+/// `KeyEnvelope` field order: recipient, sender, ephemeral_pk, nonce,
+/// ciphertext, signature (the authenticated + forward-secret envelope).
 const GOLDEN_ROOT_OP_KEY_DELIVERY: &[u8] = &[
     0, // NamespaceOp::Root
     6, // RootOp::KeyDelivery discriminant
@@ -528,11 +531,15 @@ const GOLDEN_ROOT_OP_KEY_DELIVERY: &[u8] = &[
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, // envelope.recipient [0u8;32]:
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, // envelope.sender [0u8;32]:
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, // envelope.ephemeral_pk [0u8;32]:
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, // envelope.nonce [0u8;12]:
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // envelope.ciphertext vec len = 0:
-    0, 0, 0, 0,
+    0, 0, 0, 0, // envelope.signature [0u8;64]:
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 ];
 
 /// NamespaceOp::Root(RootOp::MemberJoinedOpen) — RootOp ordinal 7

--- a/crates/node/primitives/src/sync/wire.rs
+++ b/crates/node/primitives/src/sync/wire.rs
@@ -286,6 +286,12 @@ pub enum InitPayload {
         /// The requester's namespace identity public key, used both for
         /// the membership check and as the ECDH wrap recipient.
         requester_public_key: PublicKey,
+        /// The specific key epoch the requester needs (the `key_id` of a
+        /// buffered op it can't decrypt), or `None` to ask for the group's
+        /// current key (a keyless joiner bootstrapping). Serving the exact
+        /// epoch lets a member recover a rotated-out key its stranded op was
+        /// encrypted under, which a current-key-only responder could not.
+        key_id: Option<[u8; 32]>,
     },
 }
 

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -1984,8 +1984,9 @@ async fn restricted_ctx_redriven_after_group_created() {
     // ---- Step 2: KeyDelivery → retry fires, fails meta-absent (stranded) -----
     // Wrap the subgroup key for the receiver's namespace identity (member_pk),
     // exactly as `admit_tee_node` / `add_group_members` would.
-    let envelope = GroupKeyring::wrap_for_member(&owner_sk, &member_pk, &subgroup_key)
-        .expect("wrap subgroup key for receiver");
+    let envelope =
+        GroupKeyring::wrap_for_member(&owner_sk, &member_pk, &sub_gid.to_bytes(), &subgroup_key)
+            .expect("wrap subgroup key for receiver");
 
     let key_delivery_op = SignedNamespaceOp::sign(
         &owner_sk,
@@ -2568,8 +2569,9 @@ async fn tee_matrix_restricted_late_join() {
     // retry on apply_received_group_key must re-drive the buffered op; because
     // the subgroup meta already exists (GroupCreated applied in step 1), the
     // staleness check passes and the context registers.
-    let envelope = GroupKeyring::wrap_for_member(&owner_sk, &member_pk, &subgroup_key)
-        .expect("wrap subgroup key for receiver");
+    let envelope =
+        GroupKeyring::wrap_for_member(&owner_sk, &member_pk, &sub_gid.to_bytes(), &subgroup_key)
+            .expect("wrap subgroup key for receiver");
     let key_delivery_op = SignedNamespaceOp::sign(
         &owner_sk,
         namespace_id.into(),

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -3313,12 +3313,14 @@ impl SyncManager {
             namespace_id,
             group_id,
             requester_public_key,
+            key_id,
         } = &payload
         {
             self.handle_group_key_request(
                 *namespace_id,
                 *group_id,
                 *requester_public_key,
+                *key_id,
                 stream,
                 nonce,
             )

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -493,6 +493,7 @@ impl SyncManager {
                         match GroupKeyring::wrap_for_member(
                             &sender_sk,
                             &joiner_public_key,
+                            &group_id.to_bytes(),
                             &group_key,
                         ) {
                             Ok(envelope) => borsh::to_vec(&envelope).unwrap_or_default(),
@@ -678,6 +679,7 @@ impl SyncManager {
                         match GroupKeyring::wrap_for_member(
                             &sender_sk,
                             &joiner_public_key,
+                            &subgroup_gid.to_bytes(),
                             &group_key,
                         ) {
                             Ok(envelope) => borsh::to_vec(&envelope).unwrap_or_default(),
@@ -1348,13 +1350,16 @@ impl SyncManager {
             }
         };
 
-        let awaiting = match calimero_context::group_store::namespace_groups_awaiting_key(
+        // `(group_id, key_id)` pairs we're stranded on — we ask each peer for
+        // the EXACT key epoch a buffered op needs, so a rotated-out key can be
+        // recovered (a current-key-only request could not deliver it).
+        let awaiting = match calimero_context::group_store::namespace_group_keys_awaiting(
             &store,
             namespace_id.into(),
         ) {
-            Ok(groups) => groups,
+            Ok(pairs) => pairs,
             Err(err) => {
-                debug!(%err, "failed to enumerate groups awaiting key");
+                debug!(%err, "failed to enumerate group keys awaiting");
                 return;
             }
         };
@@ -1381,7 +1386,7 @@ impl SyncManager {
             return;
         }
 
-        for group_id in awaiting {
+        for (group_id, key_id) in awaiting {
             for peer in &candidates {
                 let Some((envelope_bytes, responder_identity)) = self
                     .request_group_key_from_peer(
@@ -1389,6 +1394,7 @@ impl SyncManager {
                         namespace_id,
                         group_id,
                         requester_public_key,
+                        Some(key_id),
                     )
                     .await
                 else {
@@ -1479,6 +1485,7 @@ impl SyncManager {
         namespace_id: [u8; 32],
         group_id: [u8; 32],
         requester_public_key: PublicKey,
+        key_id: Option<[u8; 32]>,
     ) -> Option<(Vec<u8>, PublicKey)> {
         use calimero_node_primitives::sync::{InitPayload, MessagePayload, StreamMessage};
 
@@ -1497,6 +1504,7 @@ impl SyncManager {
                 namespace_id,
                 group_id,
                 requester_public_key,
+                key_id,
             },
             next_nonce: {
                 use rand::Rng;
@@ -1543,6 +1551,7 @@ impl SyncManager {
         namespace_id: [u8; 32],
         group_id: [u8; 32],
         requester_public_key: PublicKey,
+        requested_key_id: Option<[u8; 32]>,
         stream: &mut Stream,
         nonce: Nonce,
     ) -> eyre::Result<()> {
@@ -1555,6 +1564,7 @@ impl SyncManager {
                 namespace_id.into(),
                 group_id,
                 requester_public_key,
+                requested_key_id,
             ) {
                 Ok(pair) => pair,
                 Err(err) => {

--- a/crates/store/src/key/group/mod.rs
+++ b/crates/store/src/key/group/mod.rs
@@ -2023,13 +2023,20 @@ impl Debug for GroupDeniedMember {
     }
 }
 
-/// Value for [`GroupKeyEntry`]. The raw 32-byte AES-256 group key plus a
-/// creation timestamp used to determine "current" (latest) key for encryption.
+/// Value for [`GroupKeyEntry`]. The raw 32-byte AES-256 group key plus its
+/// ordering metadata.
+///
+/// `epoch` is the deterministic, DAG-derived sequence of the governance op that
+/// introduced this key (or `0` for a genesis / bootstrap key). It — not the
+/// wall-clock `created_at` — is what selects the "current" (latest) key for
+/// encryption, so all nodes agree even under clock skew or two rotations within
+/// the same second. `created_at` is retained for diagnostics only.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct GroupKeyValue {
     pub group_key: [u8; 32],
     pub created_at: u64,
+    pub epoch: u64,
 }
 
 /// Durable pending-self-purge marker, keyed by `namespace_id` (the root


### PR DESCRIPTION
## Governance security hardening (10 findings)

Hardens the group-governance / key-delivery / cascade subsystem against a batch of
security-review findings (4 High, 4 Medium, 2 Low) spanning key-rotation
authorization, cross-namespace boundary enforcement, wrapped-key forward secrecy +
sender authentication, deterministic key selection, and DAG head hygiene.

Calimero is pre-1.0, so wire/schema changes ship as a flag-day (no migration shim):
`KeyEnvelope` gains `sender` + `signature`, `GroupKeyValue` gains `epoch`,
`GroupKeyRequest` gains an optional `key_id`, and `SIGNED_NAMESPACE_OP_SCHEMA_VERSION`
bumps 2 → 3.

### Fixes

| Sev | Finding | Fix |
|---|---|---|
| H | Key-rotation arm stored an attacker-chosen key with no signer check | `apply_key_rotation` gates on: node holds the current key (member), `op.signer` is admin **at the op's cut**, envelope `sender` authenticated == `op.signer`, and `key_id_for(new_key) == new_key_id` |
| H | `GroupCreated` didn't verify the parent is in this namespace | assert `resolve(parent) == namespace_id` (new `GroupCreatedRejection::ParentCrossNamespace`) |
| H | Reparent didn't verify same-namespace target | assert `resolve(child) == resolve(new_parent)` (new `NamespaceError::ReparentCrossNamespace`) |
| H | Group-key wrap used the long-term key as "ephemeral" + unauthenticated sender | per-envelope ephemeral keypair (forward secrecy) + Ed25519 `sender` signature bound to `group_id` (rejects tamper / forgery / cross-group replay) |
| M | "Current key" chosen by wall-clock → divergence | order by a deterministic DAG-derived `epoch`, tie-break by `key_id`; `epoch` stored monotonically |
| M | Rotation processed even when node isn't a member / couldn't decrypt | gated on `inner_decrypted` (holds the current key) |
| M | Key delivery served the rotated key to a just-removed member | serve **by `key_id`** + live-member gate — a removed member can only name key_ids of ops they already saw, never the fresh post-removal key |
| M | `apply_received_group_key` didn't check group ∈ namespace | reject a key for a group that resolves **up a parent chain** to a different namespace (still allows the legitimate "key arrives before `GroupCreated`" race) |
| L | `advance_dag_head` didn't validate cited parents | unresolvable cited parents (not a current head nor a known applied op) are dropped from head-supersession and logged |
| L | Rotation envelopes only re-deliverable as "current" | `GroupKeyRequest` carries an optional `key_id`; the direct-pull requester asks for the exact epoch a stranded op needs |

### Notes on two design refinements
- The rotation envelope is now wrapped with the **namespace identity** (the key that
  signs the outer namespace op), so `envelope.sender == op.signer` and the
  authorized-rotator binding holds regardless of the local per-group signing key.
- The `apply_received_group_key` cross-namespace pin rejects only groups that resolve
  *up a parent chain* to a foreign namespace; a group that resolves to itself (no
  parent edge yet) is allowed, preserving the stranded-delivery race where a
  subgroup's key legitimately arrives before its `GroupCreated`.

### Tests
New coverage in `group_keys.rs` (envelope round-trip / auth, tamper + forgery +
cross-group-replay reject, epoch ordering + tie-break) and `namespace/tests.rs`
(cross-namespace `GroupCreated` + reparent reject; rotation-apply authorized-store,
`new_key_id`-mismatch reject, non-admin reject).

- `calimero-governance-store`: 398 passing
- `calimero-context`: passing
- `calimero-node`: 414 unit + 314 e2e passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
