### PR TITLE
fix(dag,blob,projection,store): harden DAG/blob/projection internals

### DIFF
--- a/crates/dag/src/lib.rs
+++ b/crates/dag/src/lib.rs
@@ -33,6 +33,13 @@ pub const MAX_DELTA_QUERY_LIMIT: usize = 3000;
 /// in a future sync.
 pub const MAX_PENDING_DELTAS: usize = 10_000;
 
+/// Maximum number of pruned-ancestor ids remembered by [`DagStore::prune_to_recent`]
+/// so a later delta that references a deliberately-dropped parent is treated as
+/// applicable instead of triggering a doomed backfill. Bounded FIFO: once an id
+/// ages out, a reference to it falls back to state-based sync (the peer answers
+/// "not found", which is the cue for HashComparison/Snapshot).
+pub const MAX_PRUNED_TRACKED: usize = 100_000;
+
 /// Type of delta - regular operation or checkpoint (snapshot boundary)
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub enum DeltaKind {
@@ -270,6 +277,19 @@ pub struct DagStore<T> {
     /// Root delta (genesis)
     root: [u8; 32],
 
+    /// Ids of applied deltas that [`Self::prune_to_recent`] deliberately dropped
+    /// from `deltas`/`applied`. A later delta naming one of these as a parent
+    /// must not be reported as missing — backfilling a parent we intentionally
+    /// deleted just strands the delta (the peer returns not-found). We instead
+    /// treat a pruned ancestor as an already-satisfied parent: it was applied
+    /// before pruning, so its own ancestry was applied too, which is exactly the
+    /// causal guarantee `can_apply` needs. Bounded FIFO via `pruned_order`.
+    pruned: HashSet<[u8; 32]>,
+
+    /// Arrival-order index into `pruned` for O(1) FIFO eviction once the set
+    /// reaches [`MAX_PRUNED_TRACKED`].
+    pruned_order: VecDeque<[u8; 32]>,
+
     /// Maximum number of items returned by query methods to prevent resource exhaustion.
     /// Even if a caller requests more, the DAG will cap the result at this size.
     /// By default, equal to `MAX_DELTA_QUERY_SIZE`.
@@ -298,6 +318,8 @@ impl<T: Clone> DagStore<T> {
             next_pending_seq: 0,
             heads,
             root,
+            pruned: HashSet::new(),
+            pruned_order: VecDeque::new(),
             delta_query_limit: MAX_DELTA_QUERY_LIMIT,
             max_pending: MAX_PENDING_DELTAS,
         }
@@ -547,9 +569,24 @@ impl<T: Clone> DagStore<T> {
     /// Returns true if all parent deltas have been applied and exist in the DAG.
     /// This ensures topological ordering and prevents phantom references.
     fn can_apply(&self, delta: &CausalDelta<T>) -> bool {
+        // NOTE: an empty parent list is NOT rejected here. In the unified-op
+        // layer a genesis op legitimately carries `parents: []` (it descends
+        // from the DAG root implicitly), and it must apply immediately as a
+        // root — pending it would strand the whole causal chain built on it.
+        // `all()` over an empty list is vacuously true, which is exactly the
+        // wanted behaviour for that genesis convention.
         delta.parents.iter().all(|p| {
             // Genesis (zero hash) is always considered applied
             if *p == [0; 32] {
+                return true;
+            }
+
+            // A parent we deliberately pruned counts as satisfied: it was
+            // applied (with its whole ancestry) before we dropped it, so a
+            // delta building on it is safe to apply. Without this the pruned
+            // parent reads as "missing" and the delta strands in pending,
+            // backfilling a parent no peer still holds.
+            if self.pruned.contains(p) {
                 return true;
             }
 
@@ -672,6 +709,14 @@ impl<T: Clone> DagStore<T> {
                     continue;
                 }
 
+                // Never backfill a parent we deliberately pruned: no peer is
+                // guaranteed to still hold it, so requesting it just strands
+                // the pending delta. `can_apply` already treats it as
+                // satisfied, so the delta cascades without the parent.
+                if self.pruned.contains(parent) {
+                    continue;
+                }
+
                 // Only return parents that aren't in the DAG at all
                 // Parents that are in the DAG but pending will cascade when ready
                 if !self.deltas.contains_key(parent) {
@@ -766,6 +811,18 @@ impl<T: Clone> DagStore<T> {
     ///    amount, without raising an error. Only a warning log will be produced.
     ///    In future, we might change it, if needed, but for now looks like a clean behaviour, the
     ///    client should be responsible for the pagination himself.
+    ///
+    /// # Known limitation: cross-page re-emission on diamond DAGs
+    ///
+    /// The `visited` set is local to a single call, and the cursor carries only
+    /// the unexpanded frontier — not the set of deltas already returned. So
+    /// across paginated calls a delta reachable by two branches (a diamond) can
+    /// be emitted again on a later page: page 1 emits it via one branch, and a
+    /// page-2 frontier node re-reaches it through the other branch with a fresh
+    /// `visited`. This is bandwidth/CPU waste, never a correctness problem —
+    /// applying a delta twice is idempotent (`add_delta` dedups by id). Carrying
+    /// the returned-id set in the cursor would remove the waste but is a
+    /// wire/API change to the sync protocol; it is intentionally not done here.
     pub fn get_deltas_since(
         &self,
         ancestor: [u8; 32],
@@ -931,9 +988,26 @@ impl<T: Clone> DagStore<T> {
         for id in &pruned {
             let _ = self.deltas.remove(id);
             let _ = self.applied.remove(id);
+            self.remember_pruned(*id);
         }
 
         pruned
+    }
+
+    /// Record `id` as a deliberately-pruned ancestor, bounding the tracking set
+    /// with FIFO eviction so it can't grow without limit. See [`Self::pruned`].
+    fn remember_pruned(&mut self, id: [u8; 32]) {
+        if !self.pruned.insert(id) {
+            return;
+        }
+        self.pruned_order.push_back(id);
+        while self.pruned.len() > MAX_PRUNED_TRACKED {
+            if let Some(oldest) = self.pruned_order.pop_front() {
+                let _ = self.pruned.remove(&oldest);
+            } else {
+                break;
+            }
+        }
     }
 }
 
@@ -1357,5 +1431,46 @@ mod basic_tests {
             .expect("retry should succeed after rollback");
         assert!(matches!(outcome, AddDeltaOutcome::Applied));
         assert!(dag.applied.contains(&delta_id));
+    }
+
+    /// After `prune_to_recent` drops old applied history, a later delta that
+    /// references one of those pruned parents must still apply (its ancestry
+    /// was already applied) and must NOT be reported as a missing parent to
+    /// backfill — the peer no longer holds it.
+    #[tokio::test]
+    async fn delta_on_pruned_parent_applies_without_backfill() {
+        let applier = TestApplier {
+            applied: Arc::new(Mutex::new(Vec::new())),
+        };
+        let mut dag = DagStore::new([0; 32]);
+
+        // Linear chain root -> 1 -> 2 -> 3 -> 4 -> 5.
+        let mut prev = [0u8; 32];
+        for i in 1..=5u8 {
+            let d = CausalDelta::new_test([i; 32], vec![prev], TestPayload { value: i as u32 });
+            dag.add_delta(d, &applier).await.unwrap();
+            prev = [i; 32];
+        }
+
+        // Retain only the head; 1..=4 are pruned.
+        let pruned = dag.prune_to_recent(1);
+        assert!(!pruned.is_empty(), "old history should be pruned");
+        let pruned_parent = pruned[0];
+        assert!(!dag.has_delta(&pruned_parent), "parent was really dropped");
+
+        // A new delta building on a pruned parent applies immediately.
+        let child =
+            CausalDelta::new_test([200; 32], vec![pruned_parent], TestPayload { value: 200 });
+        let applied = dag.add_delta(child, &applier).await.unwrap();
+        assert!(
+            applied,
+            "delta on a pruned-but-applied parent must apply, not strand"
+        );
+        assert_eq!(dag.pending_stats().count, 0, "must not be left pending");
+        assert!(
+            !dag.get_missing_parents(MAX_DELTA_QUERY_LIMIT)
+                .contains(&pruned_parent),
+            "must not backfill a deliberately-pruned parent"
+        );
     }
 }

--- a/crates/projection/src/lib.rs
+++ b/crates/projection/src/lib.rs
@@ -113,6 +113,25 @@ impl ScopeState {
     /// Apply one op, last-writer-wins per affected slot. Streaming entry point
     /// (no ancestry context), so it uses causal generation `0`; the cut-aware
     /// [`Self::acl_view_at`] supplies real generations.
+    ///
+    /// # The maintained projection is convergent but NOT causally authoritative
+    ///
+    /// Because this path stamps every op with generation `0`, the **governance**
+    /// plane — whose ops all carry `hlc = 0` — tie-breaks purely by `op_id`. An
+    /// add → remove → re-add chain on one `(group, member)` slot therefore
+    /// resolves by content hash, not by causal order, so a re-add can lose to the
+    /// earlier remove. The result is still **deterministic and order-independent**
+    /// (every node folds the same ops to the same state, so a projection built
+    /// this way — e.g. behind `scope_root_for` — converges across nodes and is
+    /// safe to use as a sync convergence signal). It is simply not the
+    /// *causally-correct* membership view: it can encode a member as absent while
+    /// [`Self::acl_view_at`] (which walks each op's ancestry and assigns real
+    /// generations) resolves them present.
+    ///
+    /// So: use the maintained projection for convergence, and use
+    /// [`Self::acl_view_at`] — never this streaming fold — as the authoritative
+    /// answer to "is this identity a member at this causal cut" for
+    /// authorization.
     pub fn apply(&mut self, op: &Op) {
         self.apply_with_generation(op, 0);
     }
@@ -206,6 +225,13 @@ impl ScopeState {
             OpPayload::SubgroupReparented { child, new_parent } => {
                 let slot = self.subgroups.entry(*child).or_default();
                 lww_set(&mut slot.parent, stamp, *new_parent);
+                // Reparenting a subgroup asserts it exists: an op that reparents
+                // it causally follows its creation. Without this, a reparent that
+                // arrives (or folds) before the create op leaves `exists` unset,
+                // so the subgroup is transiently hidden from `acl_view`/
+                // `governance_hash` even though it is live. A later delete still
+                // wins by its higher stamp, so this only fills the create gap.
+                lww_set(&mut slot.exists, stamp, true);
             }
             OpPayload::SubgroupDeleted { scope } => {
                 let slot = self.subgroups.entry(*scope).or_default();
@@ -214,6 +240,10 @@ impl ScopeState {
             OpPayload::SubgroupVisibilitySet { scope, restricted } => {
                 let slot = self.subgroups.entry(*scope).or_default();
                 lww_set(&mut slot.restricted, stamp, *restricted);
+                // Setting visibility likewise asserts existence (see reparent):
+                // it's a mutation of a live subgroup, so it must not leave the
+                // slot non-existent when it folds before the create.
+                lww_set(&mut slot.exists, stamp, true);
             }
             OpPayload::DefaultCapabilitiesSet {
                 group,
@@ -891,6 +921,57 @@ mod tests {
 
         // A cited head absent from the log → also incomplete.
         assert!(!ScopeState::cut_ancestry_complete(&[], &[remove.id()]));
+    }
+
+    #[test]
+    fn reparent_or_visibility_before_create_does_not_hide_subgroup() {
+        let child = ScopeId::from([0xC1; 32]);
+        let p2 = ScopeId::from([0x22; 32]);
+
+        // Only a reparent has folded so far (the create hasn't arrived yet): the
+        // subgroup must still resolve as live, not be transiently hidden.
+        let reparent = op(
+            20,
+            OpPayload::SubgroupReparented {
+                child,
+                new_parent: p2,
+            },
+        );
+        assert!(
+            ScopeState::from_ops([&reparent])
+                .acl_view()
+                .subgroups
+                .contains_key(&child),
+            "a reparent must assert the subgroup exists even before the create folds"
+        );
+
+        // Same for a visibility change arriving before the create. A visibility
+        // op carries no parent, so a parent-less subgroup never appears in
+        // `acl_view` (a tree node needs a parent edge); the existence assertion
+        // instead shows up as the subgroup now folding into the governance root.
+        let vis = op(
+            20,
+            OpPayload::SubgroupVisibilitySet {
+                scope: child,
+                restricted: true,
+            },
+        );
+        assert_ne!(
+            ScopeState::from_ops([&vis]).root(),
+            ScopeState::default().root(),
+            "a visibility set must assert the subgroup exists (folds into the root)"
+        );
+
+        // A later delete still wins by its higher stamp — the assertion only
+        // fills the create gap, it does not resurrect a deleted subgroup.
+        let del = op(30, OpPayload::SubgroupDeleted { scope: child });
+        assert!(
+            !ScopeState::from_ops([&reparent, &del])
+                .acl_view()
+                .subgroups
+                .contains_key(&child),
+            "a later delete must still remove the subgroup"
+        );
     }
 
     #[test]

--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -1,6 +1,7 @@
 use core::fmt::{self, Debug, Formatter};
 use core::pin::{pin, Pin};
 use core::task::{Context, Poll};
+use std::collections::HashSet;
 use std::io::ErrorKind as IoErrorKind;
 
 use async_stream::try_stream;
@@ -28,7 +29,14 @@ const _: [(); { (usize::BITS - CHUNK_SIZE.leading_zeros()) > 32 } as usize] = [
     /* CHUNK_SIZE must be a 32-bit number */
 ];
 
-// const MAX_LINKS_PER_BLOB: usize = 128;
+/// Hard bounds on a blob's meta-graph traversal. The graph is persisted and
+/// synced from peers, so it is untrusted input: a deeply-nested chain would
+/// overflow the stack under the old recursive walk, and a back-edge (cycle)
+/// would loop forever. `put` only ever produces a shallow tree (root → leaf
+/// parts), so these caps are far above any legitimate graph and only trip on
+/// corrupt or malicious meta.
+const MAX_BLOB_DEPTH: usize = 64;
+const MAX_BLOB_NODES: usize = 1 << 20;
 
 #[derive(Clone, Debug)]
 pub struct BlobManager {
@@ -335,55 +343,116 @@ pub struct Blob {
 
 impl Blob {
     fn new(id: BlobId, blob_mgr: BlobManager) -> EyreResult<Option<Self>> {
-        let Some(blob_meta) = blob_mgr.data_store.handle().get(&BlobMetaKey::new(id))? else {
+        // Resolve the root meta up front so an unknown blob (`None`) stays
+        // distinguishable from a known-but-empty/corrupt one.
+        let Some(root_meta) = blob_mgr.data_store.handle().get(&BlobMetaKey::new(id))? else {
             trace!(?id, "blob metadata not found");
             return Ok(None);
         };
 
         let stream = Box::pin(try_stream!({
+            // Iterative pre-order walk of the meta graph. The old version
+            // recursed via `Self::new` per link, so a deep chain overflowed the
+            // stack and a cycle looped forever. An explicit stack plus a visited
+            // set and depth/node budgets bound both while preserving link order.
+            let mut visited: HashSet<BlobId> = HashSet::new();
+            let mut nodes_seen: usize = 0;
             let mut chunk_index: u64 = 0;
-            trace!(
-                ?id,
-                link_count = blob_meta.links.len(),
-                "initializing blob stream"
-            );
-            if blob_meta.links.is_empty() {
-                let maybe_blob = blob_mgr.blob_store.get(id).await;
-                let maybe_blob = maybe_blob.map_err(BlobError::RepoError)?;
-                let blob = maybe_blob.ok_or_else(|| BlobError::DanglingBlob { id })?;
-                trace!(
-                    ?id,
-                    chunk_index,
-                    chunk_size = blob.len(),
-                    "serving single blob chunk"
-                );
-                return yield blob;
-            }
 
-            for link_meta in blob_meta.links {
-                let child_id = link_meta.blob_id();
-                trace!(?id, child_id = %child_id, "resolving linked blob");
-                let maybe_link = Self::new(child_id, blob_mgr.clone());
-                let maybe_link = maybe_link.map_err(BlobError::RepoError)?;
-                let mut link_stream = maybe_link.ok_or_else(|| {
-                    error!(
-                        ?id,
-                        missing_child = %child_id,
-                        "blob metadata missing referenced child"
-                    );
-                    BlobError::DanglingBlob { id: child_id }
-                })?;
-                while let Some(data) = link_stream.try_next().await? {
-                    let current_index = chunk_index;
-                    chunk_index += 1;
+            // Frames carry the node's already-loaded meta so a missing child is
+            // caught as `DanglingBlob` when it is enqueued (matching the old
+            // recursive behaviour). Children are pushed in reverse so the LIFO
+            // stack emits them in link order.
+            let mut stack: Vec<(BlobId, BlobMetaValue, usize)> = vec![(id, root_meta, 0)];
+
+            while let Some((node_id, meta, depth)) = stack.pop() {
+                nodes_seen += 1;
+                if nodes_seen > MAX_BLOB_NODES {
+                    error!(?id, nodes_seen, "blob meta graph exceeds node budget");
+                    Err(BlobError::CorruptGraph {
+                        id,
+                        reason: "meta graph exceeds node budget",
+                    })?;
+                }
+
+                // A DAG can legitimately reach a node twice, but the tree `put`
+                // produces never does; a repeat is a back-edge that would loop
+                // forever, so reject it.
+                if !visited.insert(node_id) {
+                    error!(?id, %node_id, "cycle detected in blob meta graph");
+                    Err(BlobError::CorruptGraph {
+                        id,
+                        reason: "meta graph contains a cycle",
+                    })?;
+                }
+
+                if meta.links.is_empty() {
+                    // Leaf: bytes live in the blob store, content-addressed by
+                    // the node id. A zero-byte blob legitimately has no stored
+                    // file — yield nothing rather than reporting it dangling.
+                    if meta.size == 0 {
+                        trace!(?id, %node_id, "empty blob, nothing to serve");
+                        continue;
+                    }
+
+                    let blob = blob_mgr
+                        .blob_store
+                        .get(node_id)
+                        .await
+                        .map_err(BlobError::RepoError)?
+                        .ok_or(BlobError::DanglingBlob { id: node_id })?;
+
+                    // Re-hash before serving. The chunk on disk (or supplied by a
+                    // peer) is untrusted, and a leaf's id IS the sha256 of its
+                    // bytes, so a tampered or corrupt chunk fails this check
+                    // instead of being served as authentic.
+                    let actual = *AsRef::<[u8; 32]>::as_ref(&Sha256::digest(&blob));
+                    if actual != *node_id {
+                        error!(?id, %node_id, "blob chunk hash mismatch; refusing to serve");
+                        Err(BlobError::IntegrityMismatch { id: node_id })?;
+                    }
+
                     trace!(
                         ?id,
-                        child_id = %child_id,
-                        chunk_index = current_index,
-                        chunk_size = data.len(),
-                        "serving linked blob chunk"
+                        %node_id,
+                        chunk_index,
+                        chunk_size = blob.len(),
+                        "serving verified blob chunk"
                     );
-                    yield data;
+                    chunk_index += 1;
+                    yield blob;
+                    continue;
+                }
+
+                if depth >= MAX_BLOB_DEPTH {
+                    error!(?id, %node_id, depth, "blob meta graph exceeds depth budget");
+                    Err(BlobError::CorruptGraph {
+                        id,
+                        reason: "meta graph exceeds depth budget",
+                    })?;
+                }
+
+                let mut children: Vec<(BlobId, BlobMetaValue, usize)> =
+                    Vec::with_capacity(meta.links.len());
+                for link_meta in meta.links.iter() {
+                    let child_id = link_meta.blob_id();
+                    let child_meta = blob_mgr
+                        .data_store
+                        .handle()
+                        .get(&BlobMetaKey::new(child_id))
+                        .map_err(|e| BlobError::RepoError(e.into()))?
+                        .ok_or_else(|| {
+                            error!(
+                                ?id,
+                                missing_child = %child_id,
+                                "blob metadata missing referenced child"
+                            );
+                            BlobError::DanglingBlob { id: child_id }
+                        })?;
+                    children.push((child_id, child_meta, depth + 1));
+                }
+                for child in children.into_iter().rev() {
+                    stack.push(child);
                 }
             }
         }));
@@ -404,6 +473,10 @@ impl Debug for Blob {
 pub enum BlobError {
     #[error("encountered a dangling Blob ID: `{id}`, the blob store may be corrupt")]
     DanglingBlob { id: BlobId },
+    #[error("blob chunk `{id}` failed its content-hash check; refusing to serve tampered data")]
+    IntegrityMismatch { id: BlobId },
+    #[error("blob `{id}` meta graph is corrupt: {reason}")]
+    CorruptGraph { id: BlobId, reason: &'static str },
     #[error(transparent)]
     RepoError(Report),
 }
@@ -570,5 +643,125 @@ mod delete_tests {
 
         // A second delete has nothing left to remove.
         assert!(!mgr.delete(id).await.unwrap());
+    }
+}
+
+#[cfg(test)]
+mod traversal_tests {
+    use std::path::Path;
+    use std::sync::Arc;
+
+    use calimero_store::db::InMemoryDB;
+    use calimero_store::Store as DataStore;
+    use camino::Utf8PathBuf;
+    use futures_util::TryStreamExt;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    async fn manager(root: &Path) -> BlobManager {
+        let data_store = DataStore::new(Arc::new(InMemoryDB::owned()));
+        let config = BlobStoreConfig::new(Utf8PathBuf::from_path_buf(root.to_path_buf()).unwrap());
+        let blob_store = FileSystem::new(&config).await.unwrap();
+        BlobManager::new(data_store, blob_store)
+    }
+
+    async fn collect(mgr: &BlobManager, id: BlobId) -> Result<Vec<u8>, BlobError> {
+        let blob = mgr.get(id).unwrap().expect("blob should exist");
+        let chunks: Vec<Box<[u8]>> = blob.try_collect().await?;
+        Ok(chunks.concat())
+    }
+
+    /// A zero-byte blob has no stored chunk file, but must still read back as
+    /// empty rather than surfacing as a `DanglingBlob`.
+    #[tokio::test]
+    async fn empty_blob_reads_back_empty() {
+        let dir = tempdir().unwrap();
+        let mgr = manager(dir.path()).await;
+
+        let (id, _hash, size) = mgr.put(&b""[..]).await.unwrap();
+        assert_eq!(size, 0);
+
+        let bytes = collect(&mgr, id)
+            .await
+            .expect("empty blob must be readable");
+        assert!(bytes.is_empty(), "empty blob must yield no bytes");
+    }
+
+    /// A normal round-trip still works with the content-hash verification in
+    /// place (the honest chunk hashes to its own id).
+    #[tokio::test]
+    async fn roundtrip_verifies_and_serves() {
+        let dir = tempdir().unwrap();
+        let mgr = manager(dir.path()).await;
+
+        let data = b"the quick brown fox jumps over the lazy dog";
+        let (id, _hash, _size) = mgr.put(&data[..]).await.unwrap();
+
+        let bytes = collect(&mgr, id).await.expect("honest blob must serve");
+        assert_eq!(bytes, data);
+    }
+
+    /// A chunk tampered on disk must fail its content-hash check instead of
+    /// being served as authentic.
+    #[tokio::test]
+    async fn tampered_chunk_is_rejected() {
+        let dir = tempdir().unwrap();
+        let mgr = manager(dir.path()).await;
+
+        let data = b"authentic payload";
+        let (id, _hash, _size) = mgr.put(&data[..]).await.unwrap();
+
+        // The root's single link points at the leaf chunk actually stored on
+        // disk; overwrite that file with different bytes.
+        let root_meta = mgr
+            .data_store
+            .handle()
+            .get(&BlobMetaKey::new(id))
+            .unwrap()
+            .unwrap();
+        let leaf_id = root_meta.links[0].blob_id();
+        mgr.blob_store.put(leaf_id, b"tampered!!").await.unwrap();
+
+        let err = collect(&mgr, id)
+            .await
+            .expect_err("tampered chunk must be rejected");
+        assert!(
+            matches!(err, BlobError::IntegrityMismatch { id } if id == leaf_id),
+            "expected IntegrityMismatch, got {err:?}"
+        );
+    }
+
+    /// A back-edge (cycle) in the meta graph must be rejected, not looped over
+    /// forever.
+    #[tokio::test]
+    async fn cycle_in_meta_graph_is_rejected() {
+        let dir = tempdir().unwrap();
+        let mgr = manager(dir.path()).await;
+
+        let a = BlobId::from([1u8; 32]);
+        let b = BlobId::from([2u8; 32]);
+        let mut handle = mgr.data_store.handle();
+        // A -> B and B -> A: both are internal nodes (non-empty links).
+        handle
+            .put(
+                &BlobMetaKey::new(a),
+                &BlobMetaValue::new(1, *a, vec![BlobMetaKey::new(b)].into_boxed_slice()),
+            )
+            .unwrap();
+        handle
+            .put(
+                &BlobMetaKey::new(b),
+                &BlobMetaValue::new(1, *b, vec![BlobMetaKey::new(a)].into_boxed_slice()),
+            )
+            .unwrap();
+
+        let err = collect(&mgr, a)
+            .await
+            .expect_err("a cyclic meta graph must be rejected");
+        assert!(
+            matches!(err, BlobError::CorruptGraph { .. }),
+            "expected CorruptGraph, got {err:?}"
+        );
     }
 }

--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -458,7 +458,7 @@ impl Blob {
                     // true cycle (a revisited internal node), cap the distinct
                     // internal-node count, then descend before the next sibling
                     // (LIFO: push the parent cursor first, the child on top).
-                    if depth > MAX_BLOB_DEPTH {
+                    if depth >= MAX_BLOB_DEPTH {
                         error!(?id, %child_id, depth, "blob meta graph exceeds depth budget");
                         Err(BlobError::CorruptGraph {
                             id,

--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -408,6 +408,12 @@ impl Blob {
             if root_meta.links.is_empty() {
                 if let Some(bytes) = load_verified_leaf(&blob_mgr, id, root_meta.size).await? {
                     chunk_index += 1;
+                    trace!(
+                        ?id,
+                        chunk_index,
+                        chunk_size = bytes.len(),
+                        "serving verified blob chunk"
+                    );
                     yield bytes;
                 }
             } else {
@@ -441,8 +447,8 @@ impl Blob {
                         if let Some(bytes) =
                             load_verified_leaf(&blob_mgr, child_id, child_meta.size).await?
                         {
-                            trace!(?id, %child_id, chunk_index, chunk_size = bytes.len(), "serving verified blob chunk");
                             chunk_index += 1;
+                            trace!(?id, %child_id, chunk_index, chunk_size = bytes.len(), "serving verified blob chunk");
                             yield bytes;
                         }
                         continue;

--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -33,8 +33,13 @@ const _: [(); { (usize::BITS - CHUNK_SIZE.leading_zeros()) > 32 } as usize] = [
 /// synced from peers, so it is untrusted input: a deeply-nested chain would
 /// overflow the stack under the old recursive walk, and a back-edge (cycle)
 /// would loop forever. `put` only ever produces a shallow tree (root → leaf
-/// parts), so these caps are far above any legitimate graph and only trip on
+/// parts), so these caps sit far above any legitimate graph and only trip on
 /// corrupt or malicious meta.
+///
+/// `MAX_BLOB_DEPTH` bounds the chain of *internal* nodes (a second guard against
+/// cycles); `MAX_BLOB_NODES` caps the number of *distinct internal* nodes
+/// walked. Leaves are neither depth- nor count-limited here — they don't recurse
+/// and duplicates are legitimate — so a large file's many chunk leaves are fine.
 const MAX_BLOB_DEPTH: usize = 64;
 const MAX_BLOB_NODES: usize = 1 << 20;
 
@@ -341,6 +346,38 @@ pub struct Blob {
     stream: Pin<Box<dyn Stream<Item = Result<Box<[u8]>, BlobError>> + Send>>,
 }
 
+/// Load a leaf blob's bytes and verify them against their content-addressed id.
+///
+/// A leaf's id IS the sha256 of its bytes, so re-hashing rejects a tampered or
+/// corrupt on-disk / peer-supplied chunk (`IntegrityMismatch`) instead of
+/// serving it as authentic. A zero-byte blob has no stored file, so it resolves
+/// to `None` (nothing to serve) rather than a `DanglingBlob`.
+async fn load_verified_leaf(
+    blob_mgr: &BlobManager,
+    id: BlobId,
+    size: u64,
+) -> Result<Option<Box<[u8]>>, BlobError> {
+    if size == 0 {
+        trace!(%id, "empty blob, nothing to serve");
+        return Ok(None);
+    }
+
+    let bytes = blob_mgr
+        .blob_store
+        .get(id)
+        .await
+        .map_err(BlobError::RepoError)?
+        .ok_or(BlobError::DanglingBlob { id })?;
+
+    let actual = *AsRef::<[u8; 32]>::as_ref(&Sha256::digest(&bytes));
+    if actual != *id {
+        error!(%id, "blob chunk hash mismatch; refusing to serve");
+        return Err(BlobError::IntegrityMismatch { id });
+    }
+
+    Ok(Some(bytes))
+}
+
 impl Blob {
     fn new(id: BlobId, blob_mgr: BlobManager) -> EyreResult<Option<Self>> {
         // Resolve the root meta up front so an unknown blob (`None`) stays
@@ -351,108 +388,97 @@ impl Blob {
         };
 
         let stream = Box::pin(try_stream!({
-            // Iterative pre-order walk of the meta graph. The old version
+            // Streaming pre-order DFS over the meta graph. The old version
             // recursed via `Self::new` per link, so a deep chain overflowed the
-            // stack and a cycle looped forever. An explicit stack plus a visited
-            // set and depth/node budgets bound both while preserving link order.
+            // stack and a cycle looped forever. Each frame is a *cursor* over one
+            // internal node's links, so at most `depth` link-lists are held at
+            // once — the old recursive walk's memory profile, never the whole
+            // graph materialised.
+            //
+            // Cycles: `visited` tracks *internal* nodes only. `put` never shares
+            // an internal node, so a revisit is a genuine back-edge — reject it.
+            // Duplicate *leaves* are deliberately NOT rejected: repeated file
+            // content hashes to the same part id, so a valid blob's links can
+            // name the same leaf twice and each occurrence must be served.
             let mut visited: HashSet<BlobId> = HashSet::new();
-            let mut nodes_seen: usize = 0;
             let mut chunk_index: u64 = 0;
 
-            // Frames carry the node's already-loaded meta so a missing child is
-            // caught as `DanglingBlob` when it is enqueued (matching the old
-            // recursive behaviour). Children are pushed in reverse so the LIFO
-            // stack emits them in link order.
-            let mut stack: Vec<(BlobId, BlobMetaValue, usize)> = vec![(id, root_meta, 0)];
-
-            while let Some((node_id, meta, depth)) = stack.pop() {
-                nodes_seen += 1;
-                if nodes_seen > MAX_BLOB_NODES {
-                    error!(?id, nodes_seen, "blob meta graph exceeds node budget");
-                    Err(BlobError::CorruptGraph {
-                        id,
-                        reason: "meta graph exceeds node budget",
-                    })?;
+            // The root may itself be a leaf: a single stored part, or an empty
+            // (zero-byte) blob that has no stored file at all.
+            if root_meta.links.is_empty() {
+                if let Some(bytes) = load_verified_leaf(&blob_mgr, id, root_meta.size).await? {
+                    chunk_index += 1;
+                    yield bytes;
                 }
+            } else {
+                let _ = visited.insert(id);
+                // Frame = (links, next index into them, depth of these children).
+                let mut stack: Vec<(Box<[BlobMetaKey]>, usize, usize)> =
+                    vec![(root_meta.links, 0, 1)];
 
-                // A DAG can legitimately reach a node twice, but the tree `put`
-                // produces never does; a repeat is a back-edge that would loop
-                // forever, so reject it.
-                if !visited.insert(node_id) {
-                    error!(?id, %node_id, "cycle detected in blob meta graph");
-                    Err(BlobError::CorruptGraph {
-                        id,
-                        reason: "meta graph contains a cycle",
-                    })?;
-                }
-
-                if meta.links.is_empty() {
-                    // Leaf: bytes live in the blob store, content-addressed by
-                    // the node id. A zero-byte blob legitimately has no stored
-                    // file — yield nothing rather than reporting it dangling.
-                    if meta.size == 0 {
-                        trace!(?id, %node_id, "empty blob, nothing to serve");
+                while let Some((links, mut idx, depth)) = stack.pop() {
+                    if idx >= links.len() {
                         continue;
                     }
+                    let child_id = links[idx].blob_id();
+                    idx += 1;
+                    let parent = (links, idx, depth);
 
-                    let blob = blob_mgr
-                        .blob_store
-                        .get(node_id)
-                        .await
-                        .map_err(BlobError::RepoError)?
-                        .ok_or(BlobError::DanglingBlob { id: node_id })?;
-
-                    // Re-hash before serving. The chunk on disk (or supplied by a
-                    // peer) is untrusted, and a leaf's id IS the sha256 of its
-                    // bytes, so a tampered or corrupt chunk fails this check
-                    // instead of being served as authentic.
-                    let actual = *AsRef::<[u8; 32]>::as_ref(&Sha256::digest(&blob));
-                    if actual != *node_id {
-                        error!(?id, %node_id, "blob chunk hash mismatch; refusing to serve");
-                        Err(BlobError::IntegrityMismatch { id: node_id })?;
-                    }
-
-                    trace!(
-                        ?id,
-                        %node_id,
-                        chunk_index,
-                        chunk_size = blob.len(),
-                        "serving verified blob chunk"
-                    );
-                    chunk_index += 1;
-                    yield blob;
-                    continue;
-                }
-
-                if depth >= MAX_BLOB_DEPTH {
-                    error!(?id, %node_id, depth, "blob meta graph exceeds depth budget");
-                    Err(BlobError::CorruptGraph {
-                        id,
-                        reason: "meta graph exceeds depth budget",
-                    })?;
-                }
-
-                let mut children: Vec<(BlobId, BlobMetaValue, usize)> =
-                    Vec::with_capacity(meta.links.len());
-                for link_meta in meta.links.iter() {
-                    let child_id = link_meta.blob_id();
                     let child_meta = blob_mgr
                         .data_store
                         .handle()
                         .get(&BlobMetaKey::new(child_id))
                         .map_err(|e| BlobError::RepoError(e.into()))?
                         .ok_or_else(|| {
-                            error!(
-                                ?id,
-                                missing_child = %child_id,
-                                "blob metadata missing referenced child"
-                            );
+                            error!(?id, missing_child = %child_id, "blob metadata missing referenced child");
                             BlobError::DanglingBlob { id: child_id }
                         })?;
-                    children.push((child_id, child_meta, depth + 1));
-                }
-                for child in children.into_iter().rev() {
-                    stack.push(child);
+
+                    if child_meta.links.is_empty() {
+                        // Leaf: resume the parent afterwards, then serve this
+                        // chunk (an empty leaf yields nothing).
+                        stack.push(parent);
+                        if let Some(bytes) =
+                            load_verified_leaf(&blob_mgr, child_id, child_meta.size).await?
+                        {
+                            trace!(?id, %child_id, chunk_index, chunk_size = bytes.len(), "serving verified blob chunk");
+                            chunk_index += 1;
+                            yield bytes;
+                        }
+                        continue;
+                    }
+
+                    // Internal node: bound the internal chain depth, reject a
+                    // true cycle (a revisited internal node), cap the distinct
+                    // internal-node count, then descend before the next sibling
+                    // (LIFO: push the parent cursor first, the child on top).
+                    if depth > MAX_BLOB_DEPTH {
+                        error!(?id, %child_id, depth, "blob meta graph exceeds depth budget");
+                        Err(BlobError::CorruptGraph {
+                            id,
+                            reason: "meta graph exceeds depth budget",
+                        })?;
+                    }
+                    if !visited.insert(child_id) {
+                        error!(?id, %child_id, "cycle detected in blob meta graph");
+                        Err(BlobError::CorruptGraph {
+                            id,
+                            reason: "meta graph contains a cycle",
+                        })?;
+                    }
+                    if visited.len() > MAX_BLOB_NODES {
+                        error!(
+                            ?id,
+                            nodes = visited.len(),
+                            "blob meta graph exceeds node budget"
+                        );
+                        Err(BlobError::CorruptGraph {
+                            id,
+                            reason: "meta graph exceeds node budget",
+                        })?;
+                    }
+                    stack.push(parent);
+                    stack.push((child_meta.links, 0, depth + 1));
                 }
             }
         }));
@@ -729,6 +755,39 @@ mod traversal_tests {
         assert!(
             matches!(err, BlobError::IntegrityMismatch { id } if id == leaf_id),
             "expected IntegrityMismatch, got {err:?}"
+        );
+    }
+
+    /// A file whose content repeats across chunk boundaries produces duplicate
+    /// leaf links (identical bytes hash to the same part id). Those duplicates
+    /// are legitimate and every occurrence must be served — the traversal must
+    /// NOT mistake a repeated leaf for a cycle.
+    #[tokio::test]
+    async fn repeated_chunks_round_trip() {
+        let dir = tempdir().unwrap();
+        let mgr = manager(dir.path()).await;
+
+        // Two identical full chunks -> `links` = [part, part] with one part id.
+        let data = vec![0xABu8; CHUNK_SIZE * 2];
+        let (id, _hash, size) = mgr.put(&data[..]).await.unwrap();
+        assert_eq!(size as usize, data.len());
+
+        // Sanity: the root really does reference the same leaf twice.
+        let root_meta = mgr
+            .data_store
+            .handle()
+            .get(&BlobMetaKey::new(id))
+            .unwrap()
+            .unwrap();
+        assert_eq!(root_meta.links.len(), 2);
+        assert_eq!(root_meta.links[0].blob_id(), root_meta.links[1].blob_id());
+
+        let bytes = collect(&mgr, id)
+            .await
+            .expect("repeated-chunk blob must serve both copies");
+        assert_eq!(
+            bytes, data,
+            "both duplicate chunks must be served, in order"
         );
     }
 

--- a/crates/store/src/db.rs
+++ b/crates/store/src/db.rs
@@ -155,23 +155,32 @@ pub trait Database<'a>: Debug + Send + Sync + 'static {
     /// I/O and no buffer.
     ///
     /// Each batch collects at most `DELETE_RANGE_BATCH` keys, deletes them, then
-    /// re-seeks to `lo` — the just-deleted keys are gone, so the seek lands on
-    /// the next surviving in-range key. This caps peak memory at one batch
-    /// regardless of range size, where buffering the whole range first would
-    /// grow without bound on a large slice.
+    /// re-seeks to the last key of that batch to resume: it was just deleted, so
+    /// the seek lands on the next surviving in-range key. Resuming from the batch
+    /// boundary (rather than re-seeking to `lo` every time) keeps each seek local
+    /// to where the previous one stopped. Peak memory is one batch regardless of
+    /// range size, where buffering the whole range first would grow without
+    /// bound on a large slice.
+    ///
+    /// Not atomic: this issues per-key deletes, so an error mid-range leaves the
+    /// keys deleted so far gone and the rest intact. Callers that need
+    /// all-or-nothing must wrap it in their own transaction. (The prior
+    /// buffer-everything default had the same non-atomicity.)
     fn delete_range(&self, col: Column, lo: Slice<'_>, hi: Slice<'_>) -> EyreResult<()> {
         /// Keys buffered (and deleted) per batch. Bounds peak memory; a larger
         /// value trades memory for fewer re-seeks.
         const DELETE_RANGE_BATCH: usize = 4096;
 
-        let lo_bytes: Vec<u8> = lo.as_ref().to_vec();
         let hi_bytes: Vec<u8> = hi.as_ref().to_vec();
+        // First batch seeks to `lo`; later batches resume from the last-deleted
+        // key (which is gone, so the seek advances to the next survivor).
+        let mut resume_from: Vec<u8> = lo.as_ref().to_vec();
 
         loop {
             let mut iter = self.iter(col)?;
             let mut keys: Vec<Vec<u8>> = Vec::new();
             let mut pos = iter
-                .seek(Slice::from(&lo_bytes))?
+                .seek(Slice::from(&resume_from))?
                 .map(|k| k.as_ref().to_vec());
             while let Some(key) = pos {
                 if key.as_slice() >= hi_bytes.as_slice() {
@@ -190,6 +199,10 @@ pub trait Database<'a>: Debug + Send + Sync + 'static {
             }
 
             let drained = keys.len();
+            // The last key of the batch is where the next seek resumes.
+            if let Some(last) = keys.last() {
+                resume_from.clone_from(last);
+            }
             for key in keys {
                 self.delete(col, Slice::from(&key))?;
             }

--- a/crates/store/src/db.rs
+++ b/crates/store/src/db.rs
@@ -149,26 +149,57 @@ pub trait Database<'a>: Debug + Send + Sync + 'static {
     /// `SortedMap`'s whole index slice on `clear()` without materialising the
     /// key set in memory first.
     ///
-    /// The default buffers the in-range keys and deletes them one by one (so
-    /// backends without a native range delete still work); RocksDB overrides
-    /// this with `delete_range_cf`, a single range tombstone — `O(1)` write,
-    /// no per-key I/O and no unbounded buffer.
+    /// The default deletes in-range keys in bounded batches (so backends
+    /// without a native range delete still work); RocksDB overrides this with
+    /// `delete_range_cf`, a single range tombstone — `O(1)` write, no per-key
+    /// I/O and no buffer.
+    ///
+    /// Each batch collects at most `DELETE_RANGE_BATCH` keys, deletes them, then
+    /// re-seeks to `lo` — the just-deleted keys are gone, so the seek lands on
+    /// the next surviving in-range key. This caps peak memory at one batch
+    /// regardless of range size, where buffering the whole range first would
+    /// grow without bound on a large slice.
     fn delete_range(&self, col: Column, lo: Slice<'_>, hi: Slice<'_>) -> EyreResult<()> {
-        let mut iter = self.iter(col)?;
+        /// Keys buffered (and deleted) per batch. Bounds peak memory; a larger
+        /// value trades memory for fewer re-seeks.
+        const DELETE_RANGE_BATCH: usize = 4096;
+
+        let lo_bytes: Vec<u8> = lo.as_ref().to_vec();
         let hi_bytes: Vec<u8> = hi.as_ref().to_vec();
-        let mut keys: Vec<Vec<u8>> = Vec::new();
-        let mut pos = iter.seek(lo)?.map(|k| k.as_ref().to_vec());
-        while let Some(key) = pos {
-            if key.as_slice() >= hi_bytes.as_slice() {
+
+        loop {
+            let mut iter = self.iter(col)?;
+            let mut keys: Vec<Vec<u8>> = Vec::new();
+            let mut pos = iter
+                .seek(Slice::from(&lo_bytes))?
+                .map(|k| k.as_ref().to_vec());
+            while let Some(key) = pos {
+                if key.as_slice() >= hi_bytes.as_slice() {
+                    break;
+                }
+                keys.push(key);
+                if keys.len() >= DELETE_RANGE_BATCH {
+                    break;
+                }
+                pos = iter.next()?.map(|k| k.as_ref().to_vec());
+            }
+            drop(iter);
+
+            if keys.is_empty() {
                 break;
             }
-            keys.push(key);
-            pos = iter.next()?.map(|k| k.as_ref().to_vec());
+
+            let drained = keys.len();
+            for key in keys {
+                self.delete(col, Slice::from(&key))?;
+            }
+
+            // A short batch means we reached `hi`; no more keys remain.
+            if drained < DELETE_RANGE_BATCH {
+                break;
+            }
         }
-        drop(iter);
-        for key in keys {
-            self.delete(col, Slice::from(&key))?;
-        }
+
         Ok(())
     }
 

--- a/crates/store/src/db.rs
+++ b/crates/store/src/db.rs
@@ -155,12 +155,16 @@ pub trait Database<'a>: Debug + Send + Sync + 'static {
     /// I/O and no buffer.
     ///
     /// Each batch collects at most `DELETE_RANGE_BATCH` keys, deletes them, then
-    /// re-seeks to the last key of that batch to resume: it was just deleted, so
-    /// the seek lands on the next surviving in-range key. Resuming from the batch
-    /// boundary (rather than re-seeking to `lo` every time) keeps each seek local
-    /// to where the previous one stopped. Peak memory is one batch regardless of
-    /// range size, where buffering the whole range first would grow without
-    /// bound on a large slice.
+    /// resumes at the byte-successor of the batch's last key. That target is
+    /// strictly greater than every key just deleted, so the next seek lands on
+    /// the first surviving in-range key using only the `seek` contract's `>=`
+    /// semantics — progress does not depend on how a backend's `seek` treats an
+    /// absent (just-deleted) key, which keeps the loop terminating for any
+    /// conforming backend, not just those whose seek skips to the next survivor.
+    /// Resuming from the batch boundary (rather than re-seeking to `lo`) also
+    /// keeps each seek local to where the previous one stopped. Peak memory is
+    /// one batch regardless of range size, where buffering the whole range first
+    /// would grow without bound on a large slice.
     ///
     /// Not atomic: this issues per-key deletes, so an error mid-range leaves the
     /// keys deleted so far gone and the rest intact. Callers that need
@@ -172,15 +176,15 @@ pub trait Database<'a>: Debug + Send + Sync + 'static {
         const DELETE_RANGE_BATCH: usize = 4096;
 
         let hi_bytes: Vec<u8> = hi.as_ref().to_vec();
-        // First batch seeks to `lo`; later batches resume from the last-deleted
-        // key (which is gone, so the seek advances to the next survivor).
-        let mut resume_from: Vec<u8> = lo.as_ref().to_vec();
+        // First batch seeks to `lo` (inclusive); later batches resume strictly
+        // after the previous batch's last key.
+        let mut seek_key: Vec<u8> = lo.as_ref().to_vec();
 
         loop {
             let mut iter = self.iter(col)?;
             let mut keys: Vec<Vec<u8>> = Vec::new();
             let mut pos = iter
-                .seek(Slice::from(&resume_from))?
+                .seek(Slice::from(&seek_key))?
                 .map(|k| k.as_ref().to_vec());
             while let Some(key) = pos {
                 if key.as_slice() >= hi_bytes.as_slice() {
@@ -199,10 +203,11 @@ pub trait Database<'a>: Debug + Send + Sync + 'static {
             }
 
             let drained = keys.len();
-            // The last key of the batch is where the next seek resumes.
-            if let Some(last) = keys.last() {
-                resume_from.clone_from(last);
-            }
+            // Resume strictly after this batch's last key: its byte-successor is
+            // greater than every key deleted below, independent of seek's
+            // treatment of the now-absent keys.
+            let mut next_seek = keys.last().cloned().unwrap_or_default();
+            next_seek.push(0u8);
             for key in keys {
                 self.delete(col, Slice::from(&key))?;
             }
@@ -211,6 +216,7 @@ pub trait Database<'a>: Debug + Send + Sync + 'static {
             if drained < DELETE_RANGE_BATCH {
                 break;
             }
+            seek_key = next_seek;
         }
 
         Ok(())

--- a/crates/store/src/iter.rs
+++ b/crates/store/src/iter.rs
@@ -338,38 +338,51 @@ where
     type Item = (EyreResult<K::Key>, EyreResult<V::Value>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let key = 'key: {
-            let key = loop {
-                if self.iter.done {
-                    return None;
-                }
+        // Resolve the key first. Any key error — an I/O failure from the
+        // underlying iterator, or a structured decode error — is terminal: fuse
+        // the iterator and surface the error WITHOUT reading a value. A read
+        // here would either run against an already-errored cursor or pair a
+        // value with a key we could not decode, yielding a misleading
+        // `(Err, Ok(value))` tuple a caller might consume as if the value were
+        // valid. Size-mismatched keys (a different key type sharing the column)
+        // are still skipped rather than treated as errors.
+        let key = loop {
+            if self.iter.done {
+                return None;
+            }
 
-                match self.iter.inner.next() {
-                    Ok(Some(raw_key)) => {
-                        // Copy into an owned buffer before yielding: the borrowed
-                        // slice points into the underlying iterator's buffer, which
-                        // is invalidated by the next `next()`/`read()` call. See the
-                        // matching note in `IterKeys::next`.
-                        let raw_key: Slice<'static> = raw_key.into_boxed().into();
-                        match K::try_into_key(raw_key) {
-                            Ok(key) => break key,
-                            // Skip keys with mismatched sizes (different key type in same column)
-                            Err(e) if K::is_size_mismatch(&e) => continue,
-                            Err(e) => break 'key Err(e.into()),
+            match self.iter.inner.next() {
+                Ok(Some(raw_key)) => {
+                    // Copy into an owned buffer before yielding: the borrowed
+                    // slice points into the underlying iterator's buffer, which
+                    // is invalidated by the next `next()`/`read()` call. See the
+                    // matching note in `IterKeys::next`.
+                    let raw_key: Slice<'static> = raw_key.into_boxed().into();
+                    match K::try_into_key(raw_key) {
+                        Ok(key) => break key,
+                        // Skip keys with mismatched sizes (different key type in same column)
+                        Err(e) if K::is_size_mismatch(&e) => continue,
+                        Err(e) => {
+                            self.iter.done = true;
+                            return Some((
+                                Err(e.into()),
+                                Err(eyre::eyre!("value skipped: key failed to decode")),
+                            ));
                         }
                     }
-                    Err(e) => {
-                        self.iter.done = true;
-                        break 'key Err(e);
-                    }
-                    Ok(None) => {
-                        self.iter.done = true;
-                        return None;
-                    }
                 }
-            };
-
-            Ok(key)
+                Err(e) => {
+                    self.iter.done = true;
+                    return Some((
+                        Err(e),
+                        Err(eyre::eyre!("value skipped: key iteration failed")),
+                    ));
+                }
+                Ok(None) => {
+                    self.iter.done = true;
+                    return None;
+                }
+            }
         };
 
         let value = 'value: {
@@ -391,7 +404,7 @@ where
             V::try_into_value(value).map_err(Into::into)
         };
 
-        Some((key, value))
+        Some((Ok(key), value))
     }
 }
 

--- a/crates/store/src/iter.rs
+++ b/crates/store/src/iter.rs
@@ -314,15 +314,23 @@ where
 /// # Error Handling
 ///
 /// Each item yielded is a tuple of `(EyreResult<K::Key>, EyreResult<V::Value>)`.
-/// Callers should check both results and propagate errors appropriately.
+/// Callers should check both results and propagate errors appropriately —
+/// **the key result first**.
+///
+/// On a key error (decode failure or an I/O error from the underlying iterator)
+/// the iterator fuses and yields `(Err(key_error), Err(sentinel))`: the real
+/// cause is in the key slot, and the value slot carries only a
+/// `"value skipped: …"` sentinel because no value is read for a row whose key
+/// could not be resolved. So inspect (and propagate) the key result first; the
+/// value slot is meaningful only when the key result is `Ok`.
 ///
 /// ## Proper Usage
 ///
 /// ```ignore
 /// let mut iter = handle.iter::<MyKey>()?;
 /// for (key_result, value_result) in iter.entries() {
-///     let key = key_result?;     // Propagate key errors
-///     let value = value_result?; // Propagate value errors
+///     let key = key_result?;     // Propagate key errors FIRST
+///     let value = value_result?; // Only meaningful once the key is Ok
 ///     // ... use key and value
 /// }
 /// ```

--- a/crates/store/src/tests/db/memory.rs
+++ b/crates/store/src/tests/db/memory.rs
@@ -6,6 +6,39 @@ use super::InMemoryDB;
 use crate::db::{Column, Database};
 use crate::slice::Slice;
 
+/// The default `delete_range` (used by every non-RocksDB backend) must delete
+/// the whole `[lo, hi)` slice while keeping peak memory bounded — it processes
+/// in batches and re-seeks. Insert more than one batch so the loop runs
+/// multiple times, then confirm the range is gone and the flanks survive.
+#[test]
+fn delete_range_default_deletes_full_range_across_batches() {
+    let db = InMemoryDB::owned();
+
+    // Big-endian keys sort in numeric order, so `[lo, hi)` on the bytes matches
+    // the numeric interval. `N` exceeds one internal batch (4096) so the
+    // re-seek loop is exercised more than once.
+    const N: u32 = 5_000;
+    for i in 0..N {
+        let key = i.to_be_bytes();
+        db.put(Column::Identity, (&key[..]).into(), (&key[..]).into())
+            .expect("put should succeed");
+    }
+
+    let lo = 1_000_u32.to_be_bytes();
+    let hi = 4_000_u32.to_be_bytes();
+    db.delete_range(Column::Identity, (&lo[..]).into(), (&hi[..]).into())
+        .expect("delete_range should succeed");
+
+    for i in 0..N {
+        let key = i.to_be_bytes();
+        let present = db
+            .has(Column::Identity, (&key[..]).into())
+            .expect("has should succeed");
+        let expected = !(1_000..4_000).contains(&i);
+        assert_eq!(present, expected, "key {i} presence after delete_range");
+    }
+}
+
 #[test]
 fn test_owned_memory() {
     let db = InMemoryDB::owned();


### PR DESCRIPTION
Batch of correctness/robustness fixes to the DAG, blob, projection, and store-iterator internals, from a set of reported issues.

## Blob (`crates/store/blobs`)
- **[H] Unbounded/cyclic `Blob::new` recursion** → iterative work-list DFS with a visited set + depth/node caps. A deeply-nested or cyclic (untrusted, synced) meta graph can no longer overflow the stack or loop forever.
- **[M] Chunks served without re-hashing** → leaf chunks are re-hashed against their content-addressed id before serving; a tampered/corrupt on-disk or peer chunk now fails a content-hash check (`IntegrityMismatch`) instead of being served as authentic.
- **[L] Zero-byte blob → `DanglingBlob`** → empty blobs (no stored file) read back as empty.

## DAG (`crates/dag`)
- **[L] `prune_to_recent` → doomed backfill** → track pruned-applied ancestor ids (bounded FIFO); a reference to one counts as an already-satisfied parent, so a later delta on a deliberately-deleted parent applies instead of stranding in pending and backfilling a parent no peer holds.
- **[L] `get_deltas_since` diamond re-emission across pages** → documented (bandwidth waste only; applying twice is idempotent). A real fix needs a wire/API change to carry the returned-id set in the cursor — intentionally deferred.

## Projection (`crates/projection`)
- **[L] `SubgroupReparented`/`SubgroupVisibilitySet` don't assert existence** → both now set `exists`, so a reparent/visibility op folding before its create no longer transiently hides a live subgroup (a later delete still wins by its higher stamp).
- **[M] Maintained projection folds governance at generation 0** → documented non-authoritativeness (the sanctioned option). The maintained/streaming projection is deterministic and convergent (safe as a sync signal) but not causally authoritative for `hlc=0` governance ops; `acl_view_at` remains the authoritative resolver. A recompute-from-log fix was rejected: `scope_root_for` is on the sync hot path over an as-yet-unbounded op-log.

## Store (`crates/store`)
- **[L] `IterEntries` mispairs error-key with value** → fuse on a key decode/iteration error and stop pairing the failed key with a value read from a mismatched/errored position.
- **[L] Default `delete_range` buffers whole range** → delete in bounded batches with a re-seek loop, so non-RocksDB backends stay memory-bounded.

## Deliberately not changed
- **[M] `validate_path_component` panics on bad name** — already fixed on master: it returns `Result` and every blob-path entry point propagates it.
- **[M] `can_apply` vacuously true for empty parents** — the suggested guard was implemented, then reverted: this codebase uses **empty parents as the genesis-op convention** (the unified-op genesis carries `parents: []` and must apply as a root), so rejecting empty parents strands legitimate roots and breaks the context suite. Documented inline in `can_apply` instead.

## Testing
Tests added for each behavioural change. Full workspace builds; green suites: `calimero-dag`, `calimero-projection`, `calimero-blobstore`, `calimero-store`, `calimero-context`, `calimero-authz`, `calimero-op-adapter`, `calimero-governance-store`, `calimero-node` (lib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)