### PR TITLE
test(context): migration heartbeat clock-zero & mixed-version HLC-fence tests

### DIFF
--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -1617,4 +1617,50 @@ mod migration_status_tests {
         assert!(!empty.rollup.all_migrated);
         assert_eq!(empty.rollup.total, 0);
     }
+
+    /// A heartbeat whose member-signed wall-clock stamp is `reported_at == 0`
+    /// — the value a `SystemTime::now()` failure would collapse to (`now_ms == 0`)
+    /// — must NOT be blanket-rejected by the rollup. The rollup keys on the
+    /// member's schema/residue/sync facts, never on `reported_at`, so a zero
+    /// stamp is counted exactly like any other in-cohort report: the cohort can
+    /// still go green, and there is no panic or overflow while clamping/comparing
+    /// a zero timestamp.
+    ///
+    /// (Far-future/clamp freshness filtering lives in the node's heartbeat cache
+    /// selection, upstream of this pure rollup; by the time a report reaches the
+    /// rollup it has already been chosen as the freshest in-TTL heartbeat. This
+    /// asserts the rollup itself does not second-guess a zero stamp and silently
+    /// drop the member.)
+    #[test]
+    fn zero_reported_at_is_counted_not_rejected() {
+        let (a, b) = (pk(0xA), pk(0xB));
+        // Both members fully migrated (v2, no residue) but with a zero wall-clock
+        // stamp — the exact shape a `now_ms == 0` clock failure produces.
+        let zero_stamp = MemberMigrationReport {
+            schema_version: 2,
+            residue_auto: 0,
+            residue_identity: 0,
+            synced_up_to_hlc: u64::MAX,
+            reported_at: 0,
+            authored_remaining: 0,
+            migration_failed: None,
+        };
+        assert_eq!(zero_stamp.reported_at, 0, "modeling a now_ms == 0 clock");
+
+        let st = compute_migration_status_rollup(2, None, None, &[a, b], |_| Some(zero_stamp));
+
+        // The zero-stamp reports are counted as migrated, not discarded.
+        assert_eq!(st.rollup.total, 2);
+        assert_eq!(st.rollup.migrated, 2);
+        assert_eq!(st.rollup.unknown, 0);
+        assert!(
+            st.rollup.all_migrated,
+            "a reported_at == 0 heartbeat must still count toward a green cohort"
+        );
+        // The report is surfaced verbatim (its zero stamp preserved), so the
+        // member is not silently dropped.
+        let a_row = st.members.iter().find(|m| m.peer == a).expect("A present");
+        assert_eq!(a_row.state, MemberMigrationState::Migrated);
+        assert_eq!(a_row.report.expect("report kept").reported_at, 0);
+    }
 }

--- a/crates/context/src/hlc_fence.rs
+++ b/crates/context/src/hlc_fence.rs
@@ -234,6 +234,13 @@ mod tests {
         HybridTimestamp::zero()
     }
 
+    /// An `HybridTimestamp` at NTP64 time `t` (id fixed at 1), for building
+    /// ordered before/at/after-boundary deltas in the version-skew narrative.
+    fn hlc_at(t: u64) -> HybridTimestamp {
+        let id = ID::from(NonZeroU128::new(1).expect("1 is non-zero"));
+        HybridTimestamp::new(Timestamp::new(NTP64(t), id))
+    }
+
     /// Sanity-check that our test helper actually produces a value > zero().
     #[test]
     fn hlc_after_zero_is_after_zero() {
@@ -332,5 +339,70 @@ mod tests {
     #[test]
     fn does_not_fence_without_boundary() {
         assert!(!should_fence([1; 32], [2; 32], hlc_after_zero(), None));
+    }
+
+    // -- Mixed-version fleet converges via the HLC fence ---------------------
+
+    /// End-to-end version-skew narrative at the fence-decision level, proving a
+    /// mixed v1/v2 fleet converges without ever dropping a delta.
+    ///
+    /// A group is cascading v1 → v2 with a sticky boundary at `hlc_at(10)`.
+    /// Under LazyOnAccess two nodes sit at different loaded readers:
+    ///   * a "fast" node whose binary already swapped to v2, and
+    ///   * a "slow" node still executing its v1 binary.
+    ///
+    /// The narrative walks three deltas and asserts the fence keeps every one
+    /// recoverable (only `Apply`/`Buffer`, never `Drop`):
+    ///   1. The v2 node receives a *pre-cascade* v1-schema delta (produced at
+    ///      `hlc_at(5)`, at-or-before the boundary): legitimate history the v2
+    ///      reader must still `Apply`.
+    ///   2. The v1 node receives a *post-cascade* v2-schema delta (`hlc_at(20)`):
+    ///      it cannot read the new schema yet, so it `Buffer`s (absorbs) it —
+    ///      never `Drop`.
+    ///   3. Buffer-then-replay: once the slow node's binary catches up (loaded
+    ///      reader advances to v2), replaying that SAME buffered v2 delta now
+    ///      matches its reader → `Apply`. Convergence achieved.
+    #[test]
+    fn mixed_version_fleet_converges_via_fence() {
+        const V1: [u8; 32] = [1; 32];
+        const V2: [u8; 32] = [2; 32];
+
+        let boundary = hlc_at(10);
+        let pre_cascade = hlc_at(5); // legitimate history, <= boundary
+        let post_cascade = hlc_at(20); // produced after the migration cut
+
+        // Sanity on the ordering the narrative depends on.
+        assert!(pre_cascade <= boundary);
+        assert!(post_cascade > boundary);
+
+        // 1. v2-reader node, pre-cascade v1 delta: readable history → Apply.
+        let d1 = fence_decision(V1, V2, V2, pre_cascade, Some(boundary));
+        assert_eq!(
+            d1,
+            FenceDecision::Apply,
+            "pre-cascade v1 history must apply on a v2 reader"
+        );
+
+        // 2. v1-reader node, post-cascade v2 delta: cannot read yet → Buffer.
+        let d2 = fence_decision(V2, V1, V2, post_cascade, Some(boundary));
+        assert_eq!(
+            d2,
+            FenceDecision::Buffer,
+            "a future-schema delta must be absorbed for replay, never dropped"
+        );
+
+        // 3. Slow node's binary catches up (loaded reader v1 → v2); replaying the
+        //    SAME buffered post-cascade v2 delta now matches its reader → Apply.
+        let d3 = fence_decision(V2, V2, V2, post_cascade, Some(boundary));
+        assert_eq!(
+            d3,
+            FenceDecision::Apply,
+            "buffered delta replays and applies once the reader catches up"
+        );
+
+        // Absorb-don't-drop invariant across the whole narrative.
+        for d in [d1, d2, d3] {
+            assert_ne!(d, FenceDecision::Drop, "the migration fence never drops");
+        }
     }
 }


### PR DESCRIPTION
## What

Adds two **version-skew / migration** tests to `crates/context`. Test-only; no production code changes. The **migration (E)** slice of a broader test-coverage-hardening sweep.

## Tests

- **`zero_reported_at_is_counted_not_rejected`** (`context/primitives/src/group.rs`) — a member migration report whose wall-clock stamp is `reported_at == 0` (the value a `SystemTime::now()` failure collapses to) is **not** blanket-rejected by `compute_migration_status_rollup`: it counts toward a green cohort and is surfaced verbatim. Verified against the real rollup, which keys on schema/residue/sync facts and never on `reported_at` (far-future/clamp freshness filtering lives upstream in the node's heartbeat-cache selection).
- **`mixed_version_fleet_converges_via_fence`** (`context/src/hlc_fence.rs`) — exercises the version-skew narrative at the `fence_decision` level: a v2 reader **Applies** a pre-cascade v1 delta; a v1 (loaded) reader **Buffers** a post-cascade v2 delta (never **Drop**); after the reader catches up, the same v2 delta **Applies** (buffer-then-replay). Pins the absorb-don't-drop invariant across the sequence.

## Related findings (reported separately)

While triaging this category, **E3** was confirmed as a likely production bug: `update_application` performs no caller-authorization check (`_public_key` is unused) — only signer-continuity is verified. A dedicated fix PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)