### PR TITLE
test(storage): CRDT hash order-independence & map delete-vs-update convergence

### DIFF
--- a/crates/storage/src/tests/crdt.rs
+++ b/crates/storage/src/tests/crdt.rs
@@ -752,3 +752,234 @@ fn test_delete_near_future_accepted() {
         "Should accept delete timestamp within tolerance"
     );
 }
+
+// ============================================================
+// D1 — map delete-vs-update converges, no resurrection
+// ============================================================
+//
+// These tests live at the DELTA / `apply_action` (Index) layer, NOT
+// `Mergeable::merge`. `UnorderedMap::merge` is an add-wins UNION that
+// iterates `other.entries()` (tombstoned keys are already skipped) and
+// never consults tombstones — a delete-vs-update run purely through it
+// would RESURRECT the deleted key. The real tombstone-vs-value HLC
+// resolution is in `apply_delete_ref_action` / `save_internal`, exercised
+// here.
+//
+// A map entry is modelled as a single content-addressed entity whose id is
+// stable across nodes (the key). Two nodes are two independent
+// `MockedStorage` instances; each op is an `Action` cross-applied in both
+// directions. Timestamps are explicit nanosecond HLC nonces in the recent
+// past (< now, so the future-drift guard accepts them) to make "strictly
+// later" deterministic without wall-clock sleeps.
+
+// Two independent replicas, each with its own store.
+type D1NodeA = MockedStorage<7101>;
+type D1NodeB = MockedStorage<7102>;
+type D1IfaceA = Interface<D1NodeA>;
+type D1IfaceB = Interface<D1NodeB>;
+
+// A fixed content-addressed id standing in for one map key "k". Modelled as
+// a child of the map-container root so it gets a real Index entry (a
+// parent-less non-root Add is an orphan with no index, which `DeleteRef`
+// can't resolve).
+fn d1_key_id() -> Id {
+    Id::new([0x7c; 32])
+}
+
+// The map container: the shared root parent that the key entity hangs under.
+fn d1_map_ancestors() -> Vec<crate::entities::ChildInfo> {
+    vec![crate::entities::ChildInfo::new(
+        Id::root(),
+        [0; 32],
+        Metadata::default(),
+    )]
+}
+
+// Build an upsert action (Add or Update) for the key entity carrying an
+// explicit `updated_at` HLC nonce. The base `Add` supplies the root ancestor
+// so the entity is linked under the container and indexed; later `Update`s
+// pass empty ancestors (the entity already exists).
+fn d1_upsert(id: Id, value: &str, updated_at: u64, is_add: bool) -> Action {
+    let mut page = Page::new_from_element(value, Element::new(Some(id)));
+    page.element_mut().set_updated_at(updated_at);
+    let data = borsh::to_vec(&page).unwrap();
+    let metadata = page.element().metadata.clone();
+    if is_add {
+        Action::Add {
+            id,
+            data,
+            ancestors: d1_map_ancestors(),
+            metadata,
+        }
+    } else {
+        Action::Update {
+            id,
+            data,
+            ancestors: vec![],
+            metadata,
+        }
+    }
+}
+
+fn d1_delete(id: Id, deleted_at: u64) -> Action {
+    Action::DeleteRef {
+        id,
+        deleted_at,
+        metadata: Metadata::default(),
+    }
+}
+
+/// (a) A newer `insert("k", v')` must NOT be over-suppressed by an older
+/// `remove("k")` tombstone: after both replicas exchange the two ops, both
+/// agree "k" is present with value `v'`.
+///
+/// REVEALS A BUG (kept asserting the correct CRDT invariant, `#[ignore]`d):
+/// `apply_action`'s upsert path does NOT clear an existing older `deleted_at`
+/// tombstone when a strictly-newer `Update` arrives. `save_internal` passes
+/// the LWW guard (`stored.updated_at == t_del < t_upd`) and writes the new
+/// bytes, but the stale tombstone is never lifted, so `find_by_id` keeps
+/// returning `None` — the newer write lands in storage yet stays invisible.
+/// This makes the two replicas DIVERGE on the exact scenario this test models:
+/// the replica that saw `remove` before the newer `insert` hides the value,
+/// while the replica that only ever saw the newer `insert` (its older
+/// `remove` correctly loses via `apply_delete_ref_action`) shows it. Newer
+/// updates should win over older deletes (LWW-including-deletes / add-wins).
+#[test]
+#[serial]
+#[ignore = "reveals possible bug: a strictly-newer Update does not clear an older \
+            deleted_at tombstone, so the newer write is stored but stays invisible \
+            (over-suppressed) and replicas diverge on delete-then-update vs update-only"]
+fn d1_map_update_newer_than_delete_is_not_over_suppressed() {
+    super::common::register_test_merge_functions();
+    crate::env::reset_for_testing();
+
+    let id = d1_key_id();
+    let base = time_now();
+    let t0 = base - 30_000_000; // shared base insert
+    let t_del = base - 20_000_000; // A's delete
+    let t_upd = base - 10_000_000; // B's update, strictly later than the delete
+
+    // Shared base: both replicas hold "k" = "v0".
+    let base_add = d1_upsert(id, "v0", t0, true);
+    D1IfaceA::apply_action(base_add.clone(), &ApplyContext::empty()).unwrap();
+    D1IfaceB::apply_action(base_add, &ApplyContext::empty()).unwrap();
+
+    // A removes "k" (tombstone at t_del). B updates "k" = "v1" (at t_upd > t_del).
+    let del = d1_delete(id, t_del);
+    let upd = d1_upsert(id, "v1", t_upd, false);
+    D1IfaceA::apply_action(del.clone(), &ApplyContext::empty()).unwrap();
+    D1IfaceB::apply_action(upd.clone(), &ApplyContext::empty()).unwrap();
+
+    // Cross-apply: A learns of B's newer update; B learns of A's older delete.
+    D1IfaceA::apply_action(upd, &ApplyContext::empty()).unwrap();
+    D1IfaceB::apply_action(del, &ApplyContext::empty()).unwrap();
+
+    // Both replicas must converge to "k" present = "v1" — the newer update
+    // wins over the older tombstone; it must not be suppressed.
+    let a = D1IfaceA::find_by_id::<Page>(id).unwrap();
+    let b = D1IfaceB::find_by_id::<Page>(id).unwrap();
+    assert!(
+        a.is_some(),
+        "node A: newer update must resurrect over the older tombstone"
+    );
+    assert!(
+        b.is_some(),
+        "node B: older delete must not suppress the newer local update"
+    );
+    assert_eq!(a.unwrap().title, "v1", "node A converged value");
+    assert_eq!(b.unwrap().title, "v1", "node B converged value");
+}
+
+/// (b) A `remove("k")` strictly-later than an `insert("k", v)` must win on
+/// BOTH replicas — no resurrection of the deleted key from the older insert.
+#[test]
+#[serial]
+fn d1_map_delete_newer_than_update_no_resurrection() {
+    super::common::register_test_merge_functions();
+    crate::env::reset_for_testing();
+
+    let id = d1_key_id();
+    let base = time_now();
+    let t0 = base - 30_000_000; // shared base insert
+    let t_upd = base - 20_000_000; // A's update
+    let t_del = base - 10_000_000; // B's delete, strictly later than the update
+
+    // Shared base.
+    let base_add = d1_upsert(id, "v0", t0, true);
+    D1IfaceA::apply_action(base_add.clone(), &ApplyContext::empty()).unwrap();
+    D1IfaceB::apply_action(base_add, &ApplyContext::empty()).unwrap();
+
+    // A updates "k" = "v1" (t_upd). B removes "k" (t_del > t_upd).
+    let upd = d1_upsert(id, "v1", t_upd, false);
+    let del = d1_delete(id, t_del);
+    D1IfaceA::apply_action(upd.clone(), &ApplyContext::empty()).unwrap();
+    D1IfaceB::apply_action(del.clone(), &ApplyContext::empty()).unwrap();
+
+    // Cross-apply: A learns of B's newer delete; B learns of A's older update.
+    D1IfaceA::apply_action(del, &ApplyContext::empty()).unwrap();
+    D1IfaceB::apply_action(upd, &ApplyContext::empty()).unwrap();
+
+    // Both replicas must converge to "k" ABSENT — the newer delete wins and
+    // the older update must not resurrect it.
+    assert!(
+        D1IfaceA::find_by_id::<Page>(id).unwrap().is_none(),
+        "node A: newer delete must win over the older update"
+    );
+    assert!(
+        D1IfaceB::find_by_id::<Page>(id).unwrap().is_none(),
+        "node B: older update must NOT resurrect the newer-deleted key"
+    );
+}
+
+/// (c) Convergence is symmetric: applying the same delete + update ops in
+/// opposite orders must yield the identical final storage state (same
+/// visibility AND same Merkle hash for the key id).
+#[test]
+#[serial]
+fn d1_map_delete_vs_update_convergence_is_apply_order_independent() {
+    super::common::register_test_merge_functions();
+    crate::env::reset_for_testing();
+
+    let id = d1_key_id();
+    let base = time_now();
+    let t0 = base - 30_000_000;
+    let t_upd = base - 20_000_000;
+    let t_del = base - 10_000_000; // delete strictly later than update
+
+    let base_add = d1_upsert(id, "v0", t0, true);
+    let upd = d1_upsert(id, "v1", t_upd, false);
+    let del = d1_delete(id, t_del);
+
+    // Node A applies update-then-delete; node B applies delete-then-update.
+    D1IfaceA::apply_action(base_add.clone(), &ApplyContext::empty()).unwrap();
+    D1IfaceA::apply_action(upd.clone(), &ApplyContext::empty()).unwrap();
+    D1IfaceA::apply_action(del.clone(), &ApplyContext::empty()).unwrap();
+
+    D1IfaceB::apply_action(base_add, &ApplyContext::empty()).unwrap();
+    D1IfaceB::apply_action(del, &ApplyContext::empty()).unwrap();
+    D1IfaceB::apply_action(upd, &ApplyContext::empty()).unwrap();
+
+    // Same visibility.
+    let a_visible = D1IfaceA::find_by_id::<Page>(id).unwrap().is_some();
+    let b_visible = D1IfaceB::find_by_id::<Page>(id).unwrap().is_some();
+    assert_eq!(
+        a_visible, b_visible,
+        "visibility must be independent of apply order"
+    );
+    assert!(
+        !a_visible,
+        "newer delete wins ⇒ key absent on both replicas"
+    );
+
+    // Convergence signal that actually drives sync: the map-container (root)
+    // Merkle hash. A tombstoned child is unlinked from its parent's children
+    // list, so the dead leaf's own bytes no longer feed the container hash —
+    // the two replicas must agree on the container root regardless of the
+    // order they applied the update vs the delete.
+    let a_root = Index::<D1NodeA>::get_hashes_for(Id::root()).unwrap();
+    let b_root = Index::<D1NodeB>::get_hashes_for(Id::root()).unwrap();
+    assert_eq!(
+        a_root, b_root,
+        "map-container root hash must be identical regardless of apply order"
+    );
+}

--- a/crates/storage/src/tests/nested_crdt_merge.rs
+++ b/crates/storage/src/tests/nested_crdt_merge.rs
@@ -332,3 +332,143 @@ fn test_map_union_merge_with_disjoint_keys() {
         2
     );
 }
+
+// ============================================================
+// D5 — iteration-order independence of serialized/hashed state
+// ============================================================
+//
+// A node's state is content-addressed: an entry's entity id is
+// `compute_id(parent_id, key)` and a collection's own id is
+// `compute_collection_id(parent, field_name)` — neither depends on when
+// the entry was inserted. The parent Merkle hash sorts children by id
+// (content-derived) before hashing, and an entry's own hash is
+// `Sha256(borsh(Entry))` over `(item, id)` only — the `#[storage] Element`
+// serializes just its id, NOT the local `created_at`/`updated_at` clocks.
+// Together these make the stored Merkle digest a pure function of the
+// logical key/value SET, independent of physical insertion order.
+//
+// This guards against a regression that would hash raw HashMap iteration
+// order (or fold a per-entry local timestamp into the leaf hash): either
+// would make two nodes that applied the same writes in different orders
+// diverge on root hash forever, blocking sync convergence.
+//
+// Each `build_*` closure resets storage first, so the two orderings are
+// built against a clean store under the SAME deterministic collection id
+// (same `field_name`) — the only thing that varies between h1/h2 is the
+// physical insert order. The digest is read from the storage Index (the
+// same Merkle root sync compares), mirroring `rga.rs`'s `root_hash`
+// helper.
+
+#[test]
+#[serial]
+fn test_unordered_map_digest_is_insert_order_independent() {
+    use crate::collections::compute_collection_id;
+    use crate::index::Index;
+    use crate::store::MainStorage;
+
+    // Build the same {key -> value} set in the given physical insert order,
+    // return (merkle_digest, sorted_entries). Same field name ⇒ same map id
+    // ⇒ same content-addressed child ids regardless of order.
+    let build = |order: &[&str]| -> ([u8; 32], Vec<(String, String)>) {
+        env::reset_for_testing();
+        let mut m: UnorderedMap<String, String> = UnorderedMap::new_with_field_name("items");
+        for k in order {
+            m.insert((*k).to_string(), format!("v-{k}")).unwrap();
+        }
+        let id = compute_collection_id(None, "items");
+        let digest = Index::<MainStorage>::get_hashes_for(id)
+            .unwrap()
+            .map(|(full, _)| full)
+            .unwrap_or([0; 32]);
+        let mut entries: Vec<(String, String)> = m.entries().unwrap().collect();
+        entries.sort();
+        (digest, entries)
+    };
+
+    let (h1, e1) = build(&["alpha", "beta", "gamma", "delta"]);
+    let (h2, e2) = build(&["delta", "gamma", "beta", "alpha"]);
+    let (h3, e3) = build(&["gamma", "alpha", "delta", "beta"]);
+
+    // The digest must be non-trivial (entries actually landed and were hashed).
+    assert_ne!(h1, [0u8; 32], "map merkle digest must be non-empty");
+
+    // Same keys, different insert order ⇒ IDENTICAL digest.
+    assert_eq!(
+        h1, h2,
+        "UnorderedMap merkle digest must not depend on insert order (reverse)"
+    );
+    assert_eq!(
+        h1, h3,
+        "UnorderedMap merkle digest must not depend on insert order (shuffled)"
+    );
+
+    // And `entries()` yields the same LOGICAL set regardless of order.
+    assert_eq!(
+        e1, e2,
+        "map entries set must be order-independent (reverse)"
+    );
+    assert_eq!(
+        e1, e3,
+        "map entries set must be order-independent (shuffled)"
+    );
+    assert_eq!(
+        e1,
+        vec![
+            ("alpha".to_string(), "v-alpha".to_string()),
+            ("beta".to_string(), "v-beta".to_string()),
+            ("delta".to_string(), "v-delta".to_string()),
+            ("gamma".to_string(), "v-gamma".to_string()),
+        ]
+    );
+}
+
+#[test]
+#[serial]
+fn test_unordered_set_digest_is_insert_order_independent() {
+    use crate::collections::{compute_collection_id, UnorderedSet};
+    use crate::index::Index;
+    use crate::store::MainStorage;
+
+    let build = |order: &[&str]| -> ([u8; 32], Vec<String>) {
+        env::reset_for_testing();
+        let mut s: UnorderedSet<String> = UnorderedSet::new_with_field_name("items");
+        for k in order {
+            s.insert((*k).to_string()).unwrap();
+        }
+        let id = compute_collection_id(None, "items");
+        let digest = Index::<MainStorage>::get_hashes_for(id)
+            .unwrap()
+            .map(|(full, _)| full)
+            .unwrap_or([0; 32]);
+        let mut members: Vec<String> = s.iter().unwrap().collect();
+        members.sort();
+        (digest, members)
+    };
+
+    let (h1, m1) = build(&["one", "two", "three", "four"]);
+    let (h2, m2) = build(&["four", "three", "two", "one"]);
+    let (h3, m3) = build(&["three", "one", "four", "two"]);
+
+    assert_ne!(h1, [0u8; 32], "set merkle digest must be non-empty");
+
+    assert_eq!(
+        h1, h2,
+        "UnorderedSet merkle digest must not depend on insert order (reverse)"
+    );
+    assert_eq!(
+        h1, h3,
+        "UnorderedSet merkle digest must not depend on insert order (shuffled)"
+    );
+
+    assert_eq!(m1, m2, "set members must be order-independent (reverse)");
+    assert_eq!(m1, m3, "set members must be order-independent (shuffled)");
+    assert_eq!(
+        m1,
+        vec![
+            "four".to_string(),
+            "one".to_string(),
+            "three".to_string(),
+            "two".to_string(),
+        ]
+    );
+}


### PR DESCRIPTION
## What

Adds CRDT-determinism tests to `crates/storage`. Test-only; no production code changes. The **CRDT-determinism (D)** slice of a broader test-coverage-hardening sweep.

## Tests (4 passing + 1 `#[ignore]` regression)

**Iteration-order independence (D5)** — `nested_crdt_merge.rs`:
- `test_unordered_map_digest_is_insert_order_independent` / `test_unordered_set_digest_is_insert_order_independent` — the same logical `{key→value}` set inserted in different physical orders yields an **identical** storage Merkle digest (`Index::get_hashes_for`) and identical `entries()`. Guards against a regression that would hash raw HashMap iteration order. Confirmed the digest is content-derived (content-addressed ids; parent sorts children by id before hashing; an entry's own hash omits local `created_at`/`updated_at`).

**Map delete-vs-update convergence (D1)** — `crdt.rs`, at the delta/`apply_action` layer across two independent `MockedStorage` replicas with explicit HLC nonces (the `Mergeable::merge` root path is add-wins union and is *not* the tombstone-resolving layer):
- `d1_map_delete_newer_than_update_no_resurrection` — a later remove wins on both replicas; no resurrection.
- `d1_map_delete_vs_update_convergence_is_apply_order_independent` — update-then-delete vs delete-then-update converge to identical visibility and identical container root hash.
- `d1_map_update_newer_than_delete_is_not_over_suppressed` — **`#[ignore]`d; documents a real bug** (assertion kept at the correct CRDT invariant).

## ⚠️ Bug documented by the ignored test

A strictly-newer `Update` does **not** clear an older `deleted_at` tombstone: `save_internal` passes the LWW guard and writes the newer bytes, but the stale tombstone is never lifted, so `find_by_id` keeps returning `None`. The newer write lands in storage yet stays invisible ("over-suppressed"), which **diverges replicas** on delete-then-update vs update-only delivery. Fix belongs in `interface.rs` `apply_action`/`save_internal` (clear `deleted_at` when a strictly-newer write wins). A dedicated fix PR follows that un-ignores this test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)