### PR TITLE
test(node/store/storage): crash-recovery & persistence-durability tests

### DIFF
--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -2343,6 +2343,82 @@ mod atomic_persist_tests {
         );
     }
 
+    // Compaction interrupt safety: `DeltaStore::compact` prunes in-memory first,
+    // then mirrors the prune to durable storage via `prune_delta_records`. That
+    // durable delete is one atomic transaction, so a crash mid-prune can only
+    // leave the delta column fully pruned or fully intact — never a partial
+    // state where an ancestor still reachable from a retained head has been
+    // deleted out from under it. Here DELTA_A stands in for a retained ancestor
+    // batched alongside the prunable DELTA_B: a failed (interrupted) prune must
+    // drop neither.
+    #[test]
+    fn interrupted_prune_deletes_nothing() {
+        let cid = ctx();
+
+        // Happy path: pruning only the prunable delta removes it while the
+        // retained ancestor stays put.
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let registry = ContextRegistry::new(store.clone());
+        registry
+            .persist_delta_records(&[delta_record(&cid, DELTA_A), delta_record(&cid, DELTA_B)])
+            .expect("seed records");
+        registry
+            .prune_delta_records(&[key::ContextDagDelta::new(cid, DELTA_B)])
+            .expect("prune succeeds");
+        assert!(
+            has_delta(&store, &cid, DELTA_A),
+            "retained ancestor must survive a normal prune"
+        );
+        assert!(
+            !has_delta(&store, &cid, DELTA_B),
+            "prunable delta must be deleted on a normal prune"
+        );
+
+        // Interrupt path: a backend whose `apply` fails at commit deletes
+        // nothing, so both the retained ancestor and the prune target remain —
+        // the atomic transaction is the interrupt guarantee.
+        let armed = Arc::new(AtomicBool::new(false));
+        let failing = Store::new(Arc::new(FailOnApply {
+            inner: InMemoryDB::owned(),
+            armed: Arc::clone(&armed),
+        }));
+        let failing_registry = ContextRegistry::new(failing.clone());
+
+        // Seed via direct `put` while disarmed (the failing backend rejects
+        // every `apply`, so records can't be seeded through the atomic path).
+        {
+            let (ka, ra) = delta_record(&cid, DELTA_A);
+            let (kb, rb) = delta_record(&cid, DELTA_B);
+            let mut handle = failing.handle();
+            handle.put(&ka, &ra).expect("seed A");
+            handle.put(&kb, &rb).expect("seed B");
+        }
+
+        // Arm the backend, then attempt to prune BOTH keys in one batch.
+        armed.store(true, Ordering::SeqCst);
+        let err = failing_registry
+            .prune_delta_records(&[
+                key::ContextDagDelta::new(cid, DELTA_A),
+                key::ContextDagDelta::new(cid, DELTA_B),
+            ])
+            .expect_err("interrupted prune must surface the backend failure");
+        assert!(
+            err.to_string().contains("injected apply failure"),
+            "unexpected error: {err}"
+        );
+
+        // Nothing was deleted — a retained head's ancestor is never dropped by
+        // an interrupted prune.
+        assert!(
+            has_delta(&failing, &cid, DELTA_A),
+            "retained ancestor must survive an interrupted prune"
+        );
+        assert!(
+            has_delta(&failing, &cid, DELTA_B),
+            "prune target must survive an interrupted prune (all-or-nothing)"
+        );
+    }
+
     #[test]
     fn store_batch_stages_until_commit_and_discards_on_drop() {
         use calimero_store::StoreBatch;

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -2254,6 +2254,10 @@ mod atomic_persist_tests {
         }
 
         fn delete(&self, col: Column, key: Slice<'_>) -> EyreResult<()> {
+            assert!(
+                !self.armed.load(Ordering::SeqCst),
+                "atomic persist must not write via direct `delete`; all writes go through `apply`"
+            );
             self.inner.delete(col, key)
         }
 
@@ -2393,6 +2397,18 @@ mod atomic_persist_tests {
             handle.put(&ka, &ra).expect("seed A");
             handle.put(&kb, &rb).expect("seed B");
         }
+
+        // Sanity: the seeded rows are readable before we arm the backend, so the
+        // survival assertions below test a real delete-nothing outcome rather
+        // than rows that were never present.
+        assert!(
+            has_delta(&failing, &cid, DELTA_A),
+            "seeded A must be readable"
+        );
+        assert!(
+            has_delta(&failing, &cid, DELTA_B),
+            "seeded B must be readable"
+        );
 
         // Arm the backend, then attempt to prune BOTH keys in one batch.
         armed.store(true, Ordering::SeqCst);

--- a/crates/node/src/crash_recovery_test.rs
+++ b/crates/node/src/crash_recovery_test.rs
@@ -38,6 +38,10 @@ fn persist_row(
     parents: Vec<[u8; 32]>,
     applied: bool,
     expected_root_hash: [u8; 32],
+    // Only Phase-0 pre-persisted (`applied: false`) rows carry an events blob;
+    // a committed row leaves it `None` so a restart harvests no phantom handler
+    // replays. Explicit per-call so the two concerns aren't conflated.
+    events: Option<Vec<u8>>,
 ) {
     let mut handle = store.handle();
     let actions = borsh::to_vec(&one_action(delta_id[0])).expect("serialize actions");
@@ -51,9 +55,7 @@ fn persist_row(
                 hlc: HybridTimestamp::default(),
                 applied,
                 expected_root_hash,
-                // Phase-0 only pre-persists event-carrying inputs; carry a
-                // non-None events blob so the row matches that shape.
-                events: Some(vec![1, 2, 3]),
+                events,
                 author_id: Some(PublicKey::from([0xBB; 32])),
                 governance_position_blob: None,
                 delta_signature: None,
@@ -91,10 +93,17 @@ async fn phase0_applied_false_row_not_promoted_on_restart() {
 
     // On-disk state at crash time: the standalone applied:false row, no heads
     // commit (nothing advanced the DAG heads past genesis).
-    persist_row(&store, delta_id, vec![GENESIS], false, [0x11; 32]);
+    persist_row(
+        &store,
+        delta_id,
+        vec![GENESIS],
+        false,
+        [0x11; 32],
+        Some(vec![1, 2, 3]),
+    );
 
     // Restart: fresh DeltaStore over the same store, then reload from disk.
-    let (delta_store, _tmp) = delta_store_over(store).await;
+    let (delta_store, _tmp, _rx) = delta_store_over(store).await;
     let _ = delta_store
         .load_persisted_deltas()
         .await
@@ -130,12 +139,12 @@ async fn merge_topology_and_root_hash_identical_across_restart() {
     let (root_a, root_b, root_m) = ([0xAA; 32], [0xBB; 32], [0xCC; 32]);
 
     // Concurrent branches off genesis, then a committed merge over both.
-    persist_row(&store, a, vec![GENESIS], true, root_a);
-    persist_row(&store, b, vec![GENESIS], true, root_b);
-    persist_row(&store, m, vec![a, b], true, root_m);
+    persist_row(&store, a, vec![GENESIS], true, root_a, None);
+    persist_row(&store, b, vec![GENESIS], true, root_b, None);
+    persist_row(&store, m, vec![a, b], true, root_m, None);
 
     // First restart.
-    let (ds1, _tmp1) = delta_store_over(store.clone()).await;
+    let (ds1, _tmp1, _rx1) = delta_store_over(store.clone()).await;
     let _ = ds1.load_persisted_deltas().await.expect("reload #1");
 
     assert!(ds1.dag_has_delta_applied(&a).await);
@@ -169,7 +178,7 @@ async fn merge_topology_and_root_hash_identical_across_restart() {
 
     // A second, independent restart reproduces the identical head and root hash
     // — the reconstruction is deterministic, not order-dependent.
-    let (ds2, _tmp2) = delta_store_over(store).await;
+    let (ds2, _tmp2, _rx2) = delta_store_over(store).await;
     let _ = ds2.load_persisted_deltas().await.expect("reload #2");
     let mut heads2 = ds2.get_heads().await;
     heads2.sort_unstable();

--- a/crates/node/src/crash_recovery_test.rs
+++ b/crates/node/src/crash_recovery_test.rs
@@ -1,0 +1,235 @@
+//! Crash-recovery / persistence tests for `DeltaStore` restart behavior.
+//!
+//! These exercise the real persistence + reload path (`load_persisted_deltas`)
+//! over an in-memory store: a `DeltaStore` is built, `ContextDagDelta` rows are
+//! written directly to simulate what was on disk at crash time, then a FRESH
+//! `DeltaStore` is built over the SAME store and `load_persisted_deltas` is run
+//! — exactly the sequence a node performs on restart.
+
+use std::sync::Arc;
+
+use calimero_blobstore::config::BlobStoreConfig;
+use calimero_blobstore::{BlobManager as BlobStore, FileSystem};
+use calimero_context_client::client::ContextClient;
+use calimero_network_primitives::client::NetworkClient;
+use calimero_node_primitives::client::{BlobManager, NodeClient, SyncClient};
+use calimero_primitives::context::ContextId;
+use calimero_primitives::identity::PublicKey;
+use calimero_storage::action::Action;
+use calimero_storage::address::Id;
+use calimero_storage::entities::Metadata;
+use calimero_storage::logical_clock::HybridTimestamp;
+use calimero_store::db::InMemoryDB;
+use calimero_store::Store;
+use calimero_utils_actix::LazyRecipient;
+use tokio::sync::{broadcast, mpsc};
+
+use crate::delta_store::DeltaStore;
+
+const GENESIS: [u8; 32] = [0u8; 32];
+
+fn context() -> ContextId {
+    ContextId::from([0xAA; 32])
+}
+
+/// Build a `DeltaStore` over the supplied `store` (so a caller can pre-seed the
+/// store, then "restart" by building a fresh `DeltaStore` over the same rows).
+/// Mirrors `delta_store_batch_test`'s helper. The returned `TempDir` must be
+/// kept alive for the blob filesystem.
+async fn delta_store_over(store: Store) -> (DeltaStore, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let blob_config =
+        BlobStoreConfig::new(tmp.path().to_path_buf().try_into().expect("utf8 blob path"));
+    let file_system = FileSystem::new(&blob_config).await.expect("blob fs");
+    let blob_store = BlobStore::new(store.clone(), file_system);
+    let blob_manager = BlobManager::new(blob_store);
+
+    let network_client = NetworkClient::new(LazyRecipient::new());
+    let (event_sender, _) = broadcast::channel(16);
+    let (ctx_sync_tx, _r0) = mpsc::channel(1);
+    let (ns_sync_tx, _r1) = mpsc::channel(1);
+    let (ns_join_tx, _r2) = mpsc::channel(1);
+    let (open_subgroup_join_tx, _r3) = mpsc::channel(1);
+    let sync_client = SyncClient::new(ctx_sync_tx, ns_sync_tx, ns_join_tx, open_subgroup_join_tx);
+
+    let node_client = NodeClient::new(
+        store.clone(),
+        blob_manager,
+        network_client,
+        LazyRecipient::new(),
+        event_sender,
+        sync_client,
+        String::new(),
+        None,
+    );
+
+    let context_client = ContextClient::new(store, node_client, LazyRecipient::new());
+    let our_identity = PublicKey::from([0xBB; 32]);
+
+    (
+        DeltaStore::new(GENESIS, context_client, context(), our_identity),
+        tmp,
+    )
+}
+
+/// A single non-empty action so the reconstructed delta is classified as a
+/// regular delta (a genesis-parented, empty-action delta would be inferred as a
+/// checkpoint by `load_persisted_deltas`).
+fn one_action(tag: u8) -> Vec<Action> {
+    vec![Action::Add {
+        id: Id::new([tag; 32]),
+        data: vec![tag, tag, tag],
+        ancestors: vec![],
+        metadata: Metadata::default(),
+    }]
+}
+
+/// Write a `ContextDagDelta` row into the store exactly as the persistence path
+/// would, with an explicit `applied` flag.
+fn persist_row(
+    store: &Store,
+    delta_id: [u8; 32],
+    parents: Vec<[u8; 32]>,
+    applied: bool,
+    expected_root_hash: [u8; 32],
+) {
+    let mut handle = store.handle();
+    let actions = borsh::to_vec(&one_action(delta_id[0])).expect("serialize actions");
+    handle
+        .put(
+            &calimero_store::key::ContextDagDelta::new(context(), delta_id),
+            &calimero_store::types::ContextDagDelta {
+                delta_id,
+                parents,
+                actions,
+                hlc: HybridTimestamp::default(),
+                applied,
+                expected_root_hash,
+                // Phase-0 only pre-persists event-carrying inputs; carry a
+                // non-None events blob so the row matches that shape.
+                events: Some(vec![1, 2, 3]),
+                author_id: Some(PublicKey::from([0xBB; 32])),
+                governance_position_blob: None,
+                delta_signature: None,
+            },
+        )
+        .expect("persist ContextDagDelta row");
+}
+
+/// B1 — Phase-0 kill before the atomic heads commit.
+///
+/// `add_deltas_batch` / `add_delta_internal` pre-persist an event-carrying input
+/// as a standalone `applied: false` row BEFORE the DAG apply and BEFORE the
+/// atomic `dag_heads` commit that would flip it to `applied: true`. If the node
+/// is killed in that window, the row is left `applied: false`.
+///
+/// Correct restart behavior: such a row — whose state effects were never
+/// committed (root hash unchanged, heads never advanced) — must NOT be treated
+/// as applied on reload. It must be re-driven through apply or left pending;
+/// otherwise the DAG believes a delta is applied whose actions never reached
+/// committed state, an unconvergeable divergence.
+///
+/// This test is `#[ignore]`d because it currently fails: `load_persisted_deltas`
+/// restores rows purely by parent-reachability (`restore_applied_delta`) and
+/// never consults the persisted `applied` flag, so a genesis-parented
+/// `applied: false` row is promoted to applied (and made a head) on restart
+/// without re-executing its actions.
+#[tokio::test]
+#[ignore = "reveals possible bug: load_persisted_deltas ignores the persisted \
+            `applied` flag and promotes a Phase-0 applied:false row (killed \
+            before the heads commit) to applied on restart via \
+            restore_applied_delta, without re-executing its actions"]
+async fn phase0_applied_false_row_not_promoted_on_restart() {
+    let store = Store::new(Arc::new(InMemoryDB::owned()));
+    let delta_id = [0x01; 32];
+
+    // On-disk state at crash time: the standalone applied:false row, no heads
+    // commit (nothing advanced the DAG heads past genesis).
+    persist_row(&store, delta_id, vec![GENESIS], false, [0x11; 32]);
+
+    // Restart: fresh DeltaStore over the same store, then reload from disk.
+    let (delta_store, _tmp) = delta_store_over(store).await;
+    let _ = delta_store
+        .load_persisted_deltas()
+        .await
+        .expect("reload from persisted rows");
+
+    assert!(
+        !delta_store.dag_has_delta_applied(&delta_id).await,
+        "an applied:false row that never reached the heads commit must not be \
+         promoted to applied on restart"
+    );
+    assert!(
+        !delta_store.get_heads().await.contains(&delta_id),
+        "an uncommitted delta must not become a DAG head on restart"
+    );
+}
+
+/// B2 — merge topology and persisted root hash are byte-identical across restart.
+///
+/// Two concurrent branches (A, B off genesis) plus a merge delta M (parents
+/// [A, B]) are persisted as applied, exactly as a committed merge would leave
+/// them on disk. A restart (`load_persisted_deltas` on a fresh `DeltaStore`)
+/// must reconstruct the identical DAG: M is the single head (the two branches
+/// collapse to one — the merge-vs-sequential shape is preserved) and M's stored
+/// `expected_root_hash` and parent set round-trip byte-for-byte.
+///
+/// Note: the WASM-side CRDT recompute of a merge root hash needs a full context
+/// + application and is covered by the e2e sync-catchup suites; this pins the
+/// persistence/topology determinism that a deterministic root relies on.
+#[tokio::test]
+async fn merge_topology_and_root_hash_identical_across_restart() {
+    let store = Store::new(Arc::new(InMemoryDB::owned()));
+    let (a, b, m) = ([0x0A; 32], [0x0B; 32], [0x0C; 32]);
+    let (root_a, root_b, root_m) = ([0xAA; 32], [0xBB; 32], [0xCC; 32]);
+
+    // Concurrent branches off genesis, then a committed merge over both.
+    persist_row(&store, a, vec![GENESIS], true, root_a);
+    persist_row(&store, b, vec![GENESIS], true, root_b);
+    persist_row(&store, m, vec![a, b], true, root_m);
+
+    // First restart.
+    let (ds1, _tmp1) = delta_store_over(store.clone()).await;
+    let _ = ds1.load_persisted_deltas().await.expect("reload #1");
+
+    assert!(ds1.dag_has_delta_applied(&a).await);
+    assert!(ds1.dag_has_delta_applied(&b).await);
+    assert!(ds1.dag_has_delta_applied(&m).await);
+
+    // The merge collapses both branches into a single head, M.
+    assert_eq!(
+        ds1.get_heads().await,
+        vec![m],
+        "merge must leave exactly one head after restart"
+    );
+
+    // The merge delta's persisted root hash and parents survive byte-identically.
+    let m_reloaded = ds1.get_delta(&m).await.expect("merge delta reloaded");
+    assert_eq!(
+        m_reloaded.expected_root_hash, root_m,
+        "merge root hash must round-trip byte-for-byte across restart"
+    );
+    let mut parents = m_reloaded.parents.clone();
+    parents.sort_unstable();
+    let mut expected_parents = vec![a, b];
+    expected_parents.sort_unstable();
+    assert_eq!(
+        parents, expected_parents,
+        "merge parent set must be preserved"
+    );
+
+    // A second, independent restart reproduces the identical head and root hash
+    // — the reconstruction is deterministic, not order-dependent.
+    let (ds2, _tmp2) = delta_store_over(store).await;
+    let _ = ds2.load_persisted_deltas().await.expect("reload #2");
+    assert_eq!(ds2.get_heads().await, vec![m]);
+    assert_eq!(
+        ds2.get_delta(&m)
+            .await
+            .expect("merge reloaded #2")
+            .expected_root_hash,
+        root_m,
+        "root hash must be identical across repeated restarts"
+    );
+}

--- a/crates/node/src/crash_recovery_test.rs
+++ b/crates/node/src/crash_recovery_test.rs
@@ -60,6 +60,11 @@ fn persist_row(
                 delta_id,
                 parents,
                 actions,
+                // A zero HLC is safe for these tests: `load_persisted_deltas`
+                // only infers a checkpoint from `parents == [genesis] && actions
+                // empty` — never from the HLC — and every row here carries a
+                // non-empty `one_action`, so none is misclassified. A future row
+                // with empty actions would need a real HLC to stay a regular delta.
                 hlc: HybridTimestamp::default(),
                 applied,
                 expected_root_hash,

--- a/crates/node/src/crash_recovery_test.rs
+++ b/crates/node/src/crash_recovery_test.rs
@@ -8,12 +8,6 @@
 
 use std::sync::Arc;
 
-use calimero_blobstore::config::BlobStoreConfig;
-use calimero_blobstore::{BlobManager as BlobStore, FileSystem};
-use calimero_context_client::client::ContextClient;
-use calimero_network_primitives::client::NetworkClient;
-use calimero_node_primitives::client::{BlobManager, NodeClient, SyncClient};
-use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
 use calimero_storage::action::Action;
 use calimero_storage::address::Id;
@@ -21,57 +15,8 @@ use calimero_storage::entities::Metadata;
 use calimero_storage::logical_clock::HybridTimestamp;
 use calimero_store::db::InMemoryDB;
 use calimero_store::Store;
-use calimero_utils_actix::LazyRecipient;
-use tokio::sync::{broadcast, mpsc};
 
-use crate::delta_store::DeltaStore;
-
-const GENESIS: [u8; 32] = [0u8; 32];
-
-fn context() -> ContextId {
-    ContextId::from([0xAA; 32])
-}
-
-/// Build a `DeltaStore` over the supplied `store` (so a caller can pre-seed the
-/// store, then "restart" by building a fresh `DeltaStore` over the same rows).
-/// Mirrors `delta_store_batch_test`'s helper. The returned `TempDir` must be
-/// kept alive for the blob filesystem.
-async fn delta_store_over(store: Store) -> (DeltaStore, tempfile::TempDir) {
-    let tmp = tempfile::tempdir().expect("tempdir");
-
-    let blob_config =
-        BlobStoreConfig::new(tmp.path().to_path_buf().try_into().expect("utf8 blob path"));
-    let file_system = FileSystem::new(&blob_config).await.expect("blob fs");
-    let blob_store = BlobStore::new(store.clone(), file_system);
-    let blob_manager = BlobManager::new(blob_store);
-
-    let network_client = NetworkClient::new(LazyRecipient::new());
-    let (event_sender, _) = broadcast::channel(16);
-    let (ctx_sync_tx, _r0) = mpsc::channel(1);
-    let (ns_sync_tx, _r1) = mpsc::channel(1);
-    let (ns_join_tx, _r2) = mpsc::channel(1);
-    let (open_subgroup_join_tx, _r3) = mpsc::channel(1);
-    let sync_client = SyncClient::new(ctx_sync_tx, ns_sync_tx, ns_join_tx, open_subgroup_join_tx);
-
-    let node_client = NodeClient::new(
-        store.clone(),
-        blob_manager,
-        network_client,
-        LazyRecipient::new(),
-        event_sender,
-        sync_client,
-        String::new(),
-        None,
-    );
-
-    let context_client = ContextClient::new(store, node_client, LazyRecipient::new());
-    let our_identity = PublicKey::from([0xBB; 32]);
-
-    (
-        DeltaStore::new(GENESIS, context_client, context(), our_identity),
-        tmp,
-    )
-}
+use crate::test_support::{context, delta_store_over, GENESIS};
 
 /// A single non-empty action so the reconstructed delta is classified as a
 /// regular delta (a genesis-parented, empty-action delta would be inferred as a
@@ -197,9 +142,12 @@ async fn merge_topology_and_root_hash_identical_across_restart() {
     assert!(ds1.dag_has_delta_applied(&b).await);
     assert!(ds1.dag_has_delta_applied(&m).await);
 
-    // The merge collapses both branches into a single head, M.
+    // The merge collapses both branches into a single head, M. `get_heads()`
+    // order is DAG-impl-dependent, so sort before the exact-equality compare.
+    let mut heads1 = ds1.get_heads().await;
+    heads1.sort_unstable();
     assert_eq!(
-        ds1.get_heads().await,
+        heads1,
         vec![m],
         "merge must leave exactly one head after restart"
     );
@@ -223,7 +171,9 @@ async fn merge_topology_and_root_hash_identical_across_restart() {
     // — the reconstruction is deterministic, not order-dependent.
     let (ds2, _tmp2) = delta_store_over(store).await;
     let _ = ds2.load_persisted_deltas().await.expect("reload #2");
-    assert_eq!(ds2.get_heads().await, vec![m]);
+    let mut heads2 = ds2.get_heads().await;
+    heads2.sort_unstable();
+    assert_eq!(heads2, vec![m]);
     assert_eq!(
         ds2.get_delta(&m)
             .await

--- a/crates/node/src/crash_recovery_test.rs
+++ b/crates/node/src/crash_recovery_test.rs
@@ -20,11 +20,14 @@ use crate::test_support::{context, delta_store_over, GENESIS};
 
 /// A single non-empty action so the reconstructed delta is classified as a
 /// regular delta (a genesis-parented, empty-action delta would be inferred as a
-/// checkpoint by `load_persisted_deltas`).
-fn one_action(tag: u8) -> Vec<Action> {
+/// checkpoint by `load_persisted_deltas`). The action's entity id is the full
+/// `delta_id`, so distinct deltas always target distinct entities — deriving it
+/// from a single tag byte would collide whenever two delta ids shared a first
+/// byte (and an all-zero tag would alias the root/genesis id).
+fn one_action(delta_id: [u8; 32]) -> Vec<Action> {
     vec![Action::Add {
-        id: Id::new([tag; 32]),
-        data: vec![tag, tag, tag],
+        id: Id::new(delta_id),
+        data: delta_id[..3].to_vec(),
         ancestors: vec![],
         metadata: Metadata::default(),
     }]
@@ -49,7 +52,7 @@ fn persist_row(
     events: Option<Vec<u8>>,
 ) {
     let mut handle = store.handle();
-    let actions = borsh::to_vec(&one_action(delta_id[0])).expect("serialize actions");
+    let actions = borsh::to_vec(&one_action(delta_id)).expect("serialize actions");
     handle
         .put(
             &calimero_store::key::ContextDagDelta::new(context(), delta_id),

--- a/crates/node/src/crash_recovery_test.rs
+++ b/crates/node/src/crash_recovery_test.rs
@@ -38,9 +38,14 @@ fn persist_row(
     parents: Vec<[u8; 32]>,
     applied: bool,
     expected_root_hash: [u8; 32],
-    // Only Phase-0 pre-persisted (`applied: false`) rows carry an events blob;
-    // a committed row leaves it `None` so a restart harvests no phantom handler
-    // replays. Explicit per-call so the two concerns aren't conflated.
+    // Passed through verbatim. This is a per-call test convention, NOT an
+    // enforced invariant: the B1 phase-0 row uses `Some(..)` (the event-carrying
+    // pre-persist shape) and the B2 committed rows use `None` (a clean restart
+    // harvests no phantom handler replays). An `applied: true` row with
+    // `events: Some(..)` is itself a legitimate production state — a committed
+    // row whose handler events were not yet cleared, replayed via
+    // `pending_handler_events` on reload — so there is no invariant to assert
+    // here; these tests simply don't exercise that combination.
     events: Option<Vec<u8>>,
 ) {
     let mut handle = store.handle();

--- a/crates/node/src/dag_compactor.rs
+++ b/crates/node/src/dag_compactor.rs
@@ -160,3 +160,29 @@ impl Actor for DagCompactor {
         info!("DAG compaction actor stopped");
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A compaction sweep that unwinds mid-run must still clear
+    /// `sweep_in_progress`, or the guard permanently wedges the compactor and no
+    /// later sweep ever starts. The flag is released by `SweepGuard::drop`, which
+    /// runs on panic, so catching a simulated panic must leave it cleared.
+    #[test]
+    fn panicking_sweep_clears_in_progress_flag() {
+        let flag = Arc::new(AtomicBool::new(false));
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = SweepGuard(Arc::clone(&flag));
+            flag.store(true, Ordering::Release);
+            panic!("simulated compaction sweep panic");
+        }));
+        assert!(result.is_err(), "the sweep must have unwound");
+
+        assert!(
+            !flag.load(Ordering::Acquire),
+            "SweepGuard must clear the in-progress flag even when the sweep panics"
+        );
+    }
+}

--- a/crates/node/src/dag_compactor.rs
+++ b/crates/node/src/dag_compactor.rs
@@ -174,8 +174,14 @@ mod tests {
         let flag = Arc::new(AtomicBool::new(false));
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _guard = SweepGuard(Arc::clone(&flag));
+            // Set the flag BEFORE constructing the guard, matching production
+            // (`spawn_sweep` sets it via `compare_exchange`, then builds the
+            // guard). If it were set after — or not at all — the flag would
+            // already be `false` and the final assertion would pass even with a
+            // no-op `Drop`; setting it first makes the assertion actually prove
+            // the guard cleared it.
             flag.store(true, Ordering::Release);
+            let _guard = SweepGuard(Arc::clone(&flag));
             panic!("simulated compaction sweep panic");
         }));
         assert!(result.is_err(), "the sweep must have unwound");

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -3829,3 +3829,117 @@ mod seed_topology_tests {
         assert_eq!(topology.len(), 100);
     }
 }
+
+#[cfg(test)]
+mod apply_lock_poison_recovery_tests {
+    //! Crash recovery for the per-context apply-lock relay slot.
+    //!
+    //! If an apply panics while holding `apply_lock_slot`, the mutex is poisoned.
+    //! `lock_apply_slot` recovers it via `PoisonError::into_inner` so a single
+    //! transient panic can't turn every later apply on the context into a crash.
+    //! This drives that path: poison the real slot from a panicking thread, then
+    //! assert the recovery accessor still acquires it (and observes an untorn
+    //! `Option`, since every access takes/replaces the value wholesale).
+
+    use std::sync::Arc;
+    use std::thread;
+
+    use calimero_blobstore::config::BlobStoreConfig;
+    use calimero_blobstore::{BlobManager as BlobStore, FileSystem};
+    use calimero_context_client::client::ContextClient;
+    use calimero_network_primitives::client::NetworkClient;
+    use calimero_node_primitives::client::{BlobManager, NodeClient, SyncClient};
+    use calimero_primitives::context::ContextId;
+    use calimero_primitives::identity::PublicKey;
+    use calimero_store::db::InMemoryDB;
+    use calimero_store::Store;
+    use calimero_utils_actix::LazyRecipient;
+    use tokio::sync::{broadcast, mpsc};
+
+    use super::DeltaStore;
+
+    /// Build a standalone `DeltaStore` (and its live `ContextStorageApplier`)
+    /// backed by an in-memory store. Mirrors `delta_store_batch_test`'s helper;
+    /// the returned `TempDir` guard must be kept alive for the blob fs.
+    async fn build_delta_store() -> (DeltaStore, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+
+        let blob_config =
+            BlobStoreConfig::new(tmp.path().to_path_buf().try_into().expect("utf8 blob path"));
+        let file_system = FileSystem::new(&blob_config).await.expect("blob fs");
+        let blob_store = BlobStore::new(store.clone(), file_system);
+        let blob_manager = BlobManager::new(blob_store);
+
+        let node_recipient = LazyRecipient::new();
+        let context_recipient = LazyRecipient::new();
+        let network_recipient = LazyRecipient::new();
+
+        let network_client = NetworkClient::new(network_recipient);
+        let (event_sender, _) = broadcast::channel(16);
+        let (ctx_sync_tx, _ctx_sync_rx) = mpsc::channel(1);
+        let (ns_sync_tx, _ns_sync_rx) = mpsc::channel(1);
+        let (ns_join_tx, _ns_join_rx) = mpsc::channel(1);
+        let (open_subgroup_join_tx, _open_subgroup_join_rx) = mpsc::channel(1);
+        let sync_client =
+            SyncClient::new(ctx_sync_tx, ns_sync_tx, ns_join_tx, open_subgroup_join_tx);
+
+        let node_client = NodeClient::new(
+            store.clone(),
+            blob_manager,
+            network_client,
+            node_recipient,
+            event_sender,
+            sync_client,
+            String::new(),
+            None,
+        );
+
+        let context_client = ContextClient::new(store, node_client, context_recipient);
+
+        let context_id = ContextId::from([0xAA; 32]);
+        let our_identity = PublicKey::from([0xBB; 32]);
+        let root = [0u8; 32];
+
+        (
+            DeltaStore::new(root, context_client, context_id, our_identity),
+            tmp,
+        )
+    }
+
+    #[tokio::test]
+    async fn lock_apply_slot_recovers_poisoned_relay_mutex() {
+        let (ds, _tmp) = build_delta_store().await;
+        let applier = Arc::clone(&ds.applier);
+
+        // A thread panics while holding the relay slot — exactly the shape of an
+        // apply unwinding mid-relay — which poisons the mutex.
+        let poisoner = Arc::clone(&applier);
+        let handle = thread::spawn(move || {
+            let _guard = poisoner
+                .apply_lock_slot
+                .lock()
+                .expect("first lock is clean");
+            panic!("simulated apply panic while holding the relay slot");
+        });
+        assert!(
+            handle.join().is_err(),
+            "poisoner thread must have unwound to poison the mutex"
+        );
+
+        // Sanity: a naive `.lock()` now fails — the mutex really is poisoned, so
+        // the recovery below is exercising the poisoned path, not a clean one.
+        assert!(
+            applier.apply_lock_slot.lock().is_err(),
+            "mutex must report poisoned after the holder panicked"
+        );
+
+        // The recovery accessor acquires the slot without panicking and observes
+        // a consistent value (no retained key was stashed before the panic).
+        let guard = applier.lock_apply_slot();
+        assert!(
+            guard.is_none(),
+            "recovered relay slot must hold no retained apply-lock key"
+        );
+    }
+}

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -3844,68 +3844,7 @@ mod apply_lock_poison_recovery_tests {
     use std::sync::Arc;
     use std::thread;
 
-    use calimero_blobstore::config::BlobStoreConfig;
-    use calimero_blobstore::{BlobManager as BlobStore, FileSystem};
-    use calimero_context_client::client::ContextClient;
-    use calimero_network_primitives::client::NetworkClient;
-    use calimero_node_primitives::client::{BlobManager, NodeClient, SyncClient};
-    use calimero_primitives::context::ContextId;
-    use calimero_primitives::identity::PublicKey;
-    use calimero_store::db::InMemoryDB;
-    use calimero_store::Store;
-    use calimero_utils_actix::LazyRecipient;
-    use tokio::sync::{broadcast, mpsc};
-
-    use super::DeltaStore;
-
-    /// Build a standalone `DeltaStore` (and its live `ContextStorageApplier`)
-    /// backed by an in-memory store. Mirrors `delta_store_batch_test`'s helper;
-    /// the returned `TempDir` guard must be kept alive for the blob fs.
-    async fn build_delta_store() -> (DeltaStore, tempfile::TempDir) {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let store = Store::new(Arc::new(InMemoryDB::owned()));
-
-        let blob_config =
-            BlobStoreConfig::new(tmp.path().to_path_buf().try_into().expect("utf8 blob path"));
-        let file_system = FileSystem::new(&blob_config).await.expect("blob fs");
-        let blob_store = BlobStore::new(store.clone(), file_system);
-        let blob_manager = BlobManager::new(blob_store);
-
-        let node_recipient = LazyRecipient::new();
-        let context_recipient = LazyRecipient::new();
-        let network_recipient = LazyRecipient::new();
-
-        let network_client = NetworkClient::new(network_recipient);
-        let (event_sender, _) = broadcast::channel(16);
-        let (ctx_sync_tx, _ctx_sync_rx) = mpsc::channel(1);
-        let (ns_sync_tx, _ns_sync_rx) = mpsc::channel(1);
-        let (ns_join_tx, _ns_join_rx) = mpsc::channel(1);
-        let (open_subgroup_join_tx, _open_subgroup_join_rx) = mpsc::channel(1);
-        let sync_client =
-            SyncClient::new(ctx_sync_tx, ns_sync_tx, ns_join_tx, open_subgroup_join_tx);
-
-        let node_client = NodeClient::new(
-            store.clone(),
-            blob_manager,
-            network_client,
-            node_recipient,
-            event_sender,
-            sync_client,
-            String::new(),
-            None,
-        );
-
-        let context_client = ContextClient::new(store, node_client, context_recipient);
-
-        let context_id = ContextId::from([0xAA; 32]);
-        let our_identity = PublicKey::from([0xBB; 32]);
-        let root = [0u8; 32];
-
-        (
-            DeltaStore::new(root, context_client, context_id, our_identity),
-            tmp,
-        )
-    }
+    use crate::test_support::build_delta_store;
 
     #[tokio::test]
     async fn lock_apply_slot_recovers_poisoned_relay_mutex() {

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -3848,7 +3848,7 @@ mod apply_lock_poison_recovery_tests {
 
     #[tokio::test]
     async fn lock_apply_slot_recovers_poisoned_relay_mutex() {
-        let (ds, _tmp) = build_delta_store().await;
+        let (ds, _tmp, _rx) = build_delta_store().await;
         let applier = Arc::clone(&ds.applier);
 
         // A thread panics while holding the relay slot — exactly the shape of an

--- a/crates/node/src/delta_store_batch_test.rs
+++ b/crates/node/src/delta_store_batch_test.rs
@@ -9,24 +9,13 @@
 //! pending classification, the no-apply persist gate, and behavioural
 //! equivalence to a loop of single `add_delta` calls.
 
-use std::sync::Arc;
-
-use calimero_blobstore::config::BlobStoreConfig;
-use calimero_blobstore::{BlobManager as BlobStore, FileSystem};
-use calimero_context_client::client::ContextClient;
 use calimero_dag::{CausalDelta, DeltaKind};
-use calimero_network_primitives::client::NetworkClient;
-use calimero_node_primitives::client::{BlobManager, NodeClient, SyncClient};
-use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
 use calimero_storage::action::Action;
 use calimero_storage::logical_clock::HybridTimestamp;
-use calimero_store::db::InMemoryDB;
-use calimero_store::Store;
-use calimero_utils_actix::LazyRecipient;
-use tokio::sync::{broadcast, mpsc};
 
-use crate::delta_store::{BatchDeltaInput, DeltaStore};
+use crate::delta_store::BatchDeltaInput;
+use crate::test_support::build_delta_store;
 
 /// A parent id that is never supplied, so every delta referencing it stays
 /// pending (and the applier — i.e. WASM — is never invoked).
@@ -55,54 +44,6 @@ fn pending_input(id: [u8; 32], hash: [u8; 32]) -> BatchDeltaInput {
         governance_position_blob: None,
         delta_signature: None,
     }
-}
-
-/// Build a standalone `DeltaStore` backed by an in-memory store. Returns the
-/// store plus the `TempDir` guard, which the caller must keep alive for the
-/// blob filesystem to stay valid.
-async fn build_delta_store() -> (DeltaStore, tempfile::TempDir) {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let store = Store::new(Arc::new(InMemoryDB::owned()));
-
-    let blob_config =
-        BlobStoreConfig::new(tmp.path().to_path_buf().try_into().expect("utf8 blob path"));
-    let file_system = FileSystem::new(&blob_config).await.expect("blob fs");
-    let blob_store = BlobStore::new(store.clone(), file_system);
-    let blob_manager = BlobManager::new(blob_store);
-
-    let node_recipient = LazyRecipient::new();
-    let context_recipient = LazyRecipient::new();
-    let network_recipient = LazyRecipient::new();
-
-    let network_client = NetworkClient::new(network_recipient);
-    let (event_sender, _) = broadcast::channel(16);
-    let (ctx_sync_tx, _ctx_sync_rx) = mpsc::channel(1);
-    let (ns_sync_tx, _ns_sync_rx) = mpsc::channel(1);
-    let (ns_join_tx, _ns_join_rx) = mpsc::channel(1);
-    let (open_subgroup_join_tx, _open_subgroup_join_rx) = mpsc::channel(1);
-    let sync_client = SyncClient::new(ctx_sync_tx, ns_sync_tx, ns_join_tx, open_subgroup_join_tx);
-
-    let node_client = NodeClient::new(
-        store.clone(),
-        blob_manager,
-        network_client,
-        node_recipient,
-        event_sender,
-        sync_client,
-        String::new(),
-        None,
-    );
-
-    let context_client = ContextClient::new(store, node_client, context_recipient);
-
-    let context_id = ContextId::from([0xAA; 32]);
-    let our_identity = PublicKey::from([0xBB; 32]);
-    let root = [0u8; 32];
-
-    (
-        DeltaStore::new(root, context_client, context_id, our_identity),
-        tmp,
-    )
 }
 
 #[tokio::test]

--- a/crates/node/src/delta_store_batch_test.rs
+++ b/crates/node/src/delta_store_batch_test.rs
@@ -48,7 +48,7 @@ fn pending_input(id: [u8; 32], hash: [u8; 32]) -> BatchDeltaInput {
 
 #[tokio::test]
 async fn add_deltas_batch_empty_is_noop() {
-    let (delta_store, _tmp) = build_delta_store().await;
+    let (delta_store, _tmp, _rx) = build_delta_store().await;
 
     let result = delta_store
         .add_deltas_batch(Vec::new())
@@ -66,7 +66,7 @@ async fn add_deltas_batch_empty_is_noop() {
 
 #[tokio::test]
 async fn add_deltas_batch_classifies_all_pending() {
-    let (delta_store, _tmp) = build_delta_store().await;
+    let (delta_store, _tmp, _rx) = build_delta_store().await;
 
     let ids = [[0x01u8; 32], [0x02u8; 32], [0x03u8; 32]];
     let inputs: Vec<BatchDeltaInput> = ids
@@ -106,7 +106,7 @@ async fn add_deltas_batch_matches_single_path_for_pending() {
     let hashes = [[0x10u8; 32], [0x20u8; 32], [0x30u8; 32], [0x40u8; 32]];
 
     // Store A: single-delta path, one call per delta.
-    let (store_a, _tmp_a) = build_delta_store().await;
+    let (store_a, _tmp_a, _rx_a) = build_delta_store().await;
     for (id, hash) in ids.iter().zip(hashes.iter()) {
         let applied = store_a
             .add_delta(
@@ -121,7 +121,7 @@ async fn add_deltas_batch_matches_single_path_for_pending() {
     }
 
     // Store B: batch path, one call for all deltas.
-    let (store_b, _tmp_b) = build_delta_store().await;
+    let (store_b, _tmp_b, _rx_b) = build_delta_store().await;
     let inputs: Vec<BatchDeltaInput> = ids
         .iter()
         .zip(hashes.iter())

--- a/crates/node/src/gc.rs
+++ b/crates/node/src/gc.rs
@@ -433,6 +433,31 @@ mod tests {
         store.get(key).unwrap().is_some()
     }
 
+    /// A sweep that panics mid-run must still clear `sweep_in_progress` so the
+    /// next tick is not permanently skipped. The flag lives in a `SweepGuard`
+    /// held inside the sweep task; its `Drop` runs on unwind, so catching a
+    /// simulated panic must leave the flag cleared.
+    #[test]
+    fn panicking_sweep_clears_in_progress_flag() {
+        let flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        // Enter a sweep: claim the flag exactly as `spawn_sweep` does.
+        assert!(!flag.load(std::sync::atomic::Ordering::Acquire));
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = SweepGuard(Arc::clone(&flag));
+            flag.store(true, std::sync::atomic::Ordering::Release);
+            // A sweep aborting mid-run (e.g. a store error surfacing as a panic).
+            panic!("simulated sweep panic");
+        }));
+        assert!(result.is_err(), "the sweep must have unwound");
+
+        // The guard's Drop ran during unwind, so a later tick can start.
+        assert!(
+            !flag.load(std::sync::atomic::Ordering::Acquire),
+            "SweepGuard must clear the in-progress flag even when the sweep panics"
+        );
+    }
+
     /// A delete stamps every descendant index row with the same `deleted_at`, so
     /// a single sweep reclaims the whole tombstoned subtree at once — while a
     /// still-live row (no `deleted_at`) and a within-retention tombstone survive.

--- a/crates/node/src/gc.rs
+++ b/crates/node/src/gc.rs
@@ -444,8 +444,13 @@ mod tests {
         // Enter a sweep: claim the flag exactly as `spawn_sweep` does.
         assert!(!flag.load(std::sync::atomic::Ordering::Acquire));
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _guard = SweepGuard(Arc::clone(&flag));
+            // Claim the flag BEFORE constructing the guard, matching production
+            // (`spawn_sweep` sets it, then builds the guard). Setting it after —
+            // or not at all — would leave it `false`, so the final assertion
+            // would pass even with a no-op `Drop`; setting it first makes the
+            // assertion actually prove the guard cleared it.
             flag.store(true, std::sync::atomic::Ordering::Release);
+            let _guard = SweepGuard(Arc::clone(&flag));
             // A sweep aborting mid-run (e.g. a store error surfacing as a panic).
             panic!("simulated sweep panic");
         }));

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -48,6 +48,8 @@ pub use sync::SyncManager;
 #[cfg(test)]
 mod cascade_dispatch_e2e;
 #[cfg(test)]
+mod crash_recovery_test;
+#[cfg(test)]
 mod delta_store_batch_test;
 #[cfg(test)]
 mod delta_store_head_hashes_test;

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -55,3 +55,5 @@ mod delta_store_batch_test;
 mod delta_store_head_hashes_test;
 #[cfg(test)]
 mod local_governance_node_e2e;
+#[cfg(test)]
+mod test_support;

--- a/crates/node/src/test_support.rs
+++ b/crates/node/src/test_support.rs
@@ -1,0 +1,85 @@
+//! Shared `#[cfg(test)]` scaffolding for the node crate's `DeltaStore` tests.
+//!
+//! `delta_store_over` / `build_delta_store` construct a real `DeltaStore` over an
+//! in-memory store with fully-wired (but inert) node/sync/context clients.
+//! Several test modules (`crash_recovery_test`, `delta_store_batch_test`, and the
+//! in-file `apply_lock_poison_recovery_tests`) previously each carried a
+//! near-identical ~35-line copy of this boilerplate; this is the single source of
+//! truth so those copies can't silently diverge.
+
+use std::sync::Arc;
+
+use calimero_blobstore::config::BlobStoreConfig;
+use calimero_blobstore::{BlobManager as BlobStore, FileSystem};
+use calimero_context_client::client::ContextClient;
+use calimero_network_primitives::client::NetworkClient;
+use calimero_node_primitives::client::{BlobManager, NodeClient, SyncClient};
+use calimero_primitives::context::ContextId;
+use calimero_primitives::identity::PublicKey;
+use calimero_store::db::InMemoryDB;
+use calimero_store::Store;
+use calimero_utils_actix::LazyRecipient;
+use tokio::sync::{broadcast, mpsc};
+
+use crate::delta_store::DeltaStore;
+
+/// Root / genesis hash every test `DeltaStore` is seeded with.
+pub(crate) const GENESIS: [u8; 32] = [0u8; 32];
+
+/// The single context id every `DeltaStore` test operates in.
+pub(crate) fn context() -> ContextId {
+    ContextId::from([0xAA; 32])
+}
+
+/// Build a `DeltaStore` over the supplied `store`, so a caller can pre-seed the
+/// store and then "restart" by building a fresh `DeltaStore` over the same rows.
+/// The returned `TempDir` guard must be kept alive for the blob filesystem.
+pub(crate) async fn delta_store_over(store: Store) -> (DeltaStore, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let blob_config =
+        BlobStoreConfig::new(tmp.path().to_path_buf().try_into().expect("utf8 blob path"));
+    let file_system = FileSystem::new(&blob_config).await.expect("blob fs");
+    let blob_store = BlobStore::new(store.clone(), file_system);
+    let blob_manager = BlobManager::new(blob_store);
+
+    let network_client = NetworkClient::new(LazyRecipient::new());
+
+    // Keep every channel receiver bound for the life of this helper. Binding to a
+    // discard pattern (`_`) would drop the receiver at the `let`, leaving the
+    // paired sender with no receivers — so an emit/send would observe a closed
+    // channel and the constructed clients would exercise a degraded path. These
+    // receivers can't be threaded back through the `(DeltaStore, TempDir)` return
+    // shape, so keeping them alive to the end of construction is the documented
+    // minimum.
+    let (event_sender, _event_rx) = broadcast::channel(16);
+    let (ctx_sync_tx, _ctx_sync_rx) = mpsc::channel(1);
+    let (ns_sync_tx, _ns_sync_rx) = mpsc::channel(1);
+    let (ns_join_tx, _ns_join_rx) = mpsc::channel(1);
+    let (open_subgroup_join_tx, _open_subgroup_join_rx) = mpsc::channel(1);
+    let sync_client = SyncClient::new(ctx_sync_tx, ns_sync_tx, ns_join_tx, open_subgroup_join_tx);
+
+    let node_client = NodeClient::new(
+        store.clone(),
+        blob_manager,
+        network_client,
+        LazyRecipient::new(),
+        event_sender,
+        sync_client,
+        String::new(),
+        None,
+    );
+
+    let context_client = ContextClient::new(store, node_client, LazyRecipient::new());
+    let our_identity = PublicKey::from([0xBB; 32]);
+
+    (
+        DeltaStore::new(GENESIS, context_client, context(), our_identity),
+        tmp,
+    )
+}
+
+/// Build a standalone `DeltaStore` over a fresh in-memory store.
+pub(crate) async fn build_delta_store() -> (DeltaStore, tempfile::TempDir) {
+    delta_store_over(Store::new(Arc::new(InMemoryDB::owned()))).await
+}

--- a/crates/node/src/test_support.rs
+++ b/crates/node/src/test_support.rs
@@ -31,10 +31,22 @@ pub(crate) fn context() -> ContextId {
     ContextId::from([0xAA; 32])
 }
 
+/// Keeps a test `DeltaStore`'s client channel receivers alive.
+///
+/// The node/sync clients hold the *senders*; if the paired receivers were
+/// dropped at the end of `delta_store_over` (which is what a `_`-binding does —
+/// the `_` prefix silences the lint but does NOT extend the binding's lifetime),
+/// every sender would see a closed channel and an emit/send would exercise a
+/// degraded path. Returning them to the caller keeps them alive for the whole
+/// test, not just for construction. Opaque so the (nameable-only-via-inference)
+/// receiver types don't leak into the return signature; bind it (e.g. `_rx`).
+pub(crate) struct KeepAlive(#[allow(dead_code)] Box<dyn std::any::Any>);
+
 /// Build a `DeltaStore` over the supplied `store`, so a caller can pre-seed the
 /// store and then "restart" by building a fresh `DeltaStore` over the same rows.
-/// The returned `TempDir` guard must be kept alive for the blob filesystem.
-pub(crate) async fn delta_store_over(store: Store) -> (DeltaStore, tempfile::TempDir) {
+/// The returned `TempDir` guard must be kept alive for the blob filesystem, and
+/// the [`KeepAlive`] for the client channel receivers.
+pub(crate) async fn delta_store_over(store: Store) -> (DeltaStore, tempfile::TempDir, KeepAlive) {
     let tmp = tempfile::tempdir().expect("tempdir");
 
     let blob_config =
@@ -45,19 +57,22 @@ pub(crate) async fn delta_store_over(store: Store) -> (DeltaStore, tempfile::Tem
 
     let network_client = NetworkClient::new(LazyRecipient::new());
 
-    // Keep every channel receiver bound for the life of this helper. Binding to a
-    // discard pattern (`_`) would drop the receiver at the `let`, leaving the
-    // paired sender with no receivers — so an emit/send would observe a closed
-    // channel and the constructed clients would exercise a degraded path. These
-    // receivers can't be threaded back through the `(DeltaStore, TempDir)` return
-    // shape, so keeping them alive to the end of construction is the documented
-    // minimum.
-    let (event_sender, _event_rx) = broadcast::channel(16);
-    let (ctx_sync_tx, _ctx_sync_rx) = mpsc::channel(1);
-    let (ns_sync_tx, _ns_sync_rx) = mpsc::channel(1);
-    let (ns_join_tx, _ns_join_rx) = mpsc::channel(1);
-    let (open_subgroup_join_tx, _open_subgroup_join_rx) = mpsc::channel(1);
+    let (event_sender, event_rx) = broadcast::channel(16);
+    let (ctx_sync_tx, ctx_sync_rx) = mpsc::channel(1);
+    let (ns_sync_tx, ns_sync_rx) = mpsc::channel(1);
+    let (ns_join_tx, ns_join_rx) = mpsc::channel(1);
+    let (open_subgroup_join_tx, open_subgroup_join_rx) = mpsc::channel(1);
     let sync_client = SyncClient::new(ctx_sync_tx, ns_sync_tx, ns_join_tx, open_subgroup_join_tx);
+
+    // Handed back to the caller so the senders inside the clients keep live
+    // receivers for the duration of the test (see `KeepAlive`).
+    let keep_alive = KeepAlive(Box::new((
+        event_rx,
+        ctx_sync_rx,
+        ns_sync_rx,
+        ns_join_rx,
+        open_subgroup_join_rx,
+    )));
 
     let node_client = NodeClient::new(
         store.clone(),
@@ -76,10 +91,11 @@ pub(crate) async fn delta_store_over(store: Store) -> (DeltaStore, tempfile::Tem
     (
         DeltaStore::new(GENESIS, context_client, context(), our_identity),
         tmp,
+        keep_alive,
     )
 }
 
 /// Build a standalone `DeltaStore` over a fresh in-memory store.
-pub(crate) async fn build_delta_store() -> (DeltaStore, tempfile::TempDir) {
+pub(crate) async fn build_delta_store() -> (DeltaStore, tempfile::TempDir, KeepAlive) {
     delta_store_over(Store::new(Arc::new(InMemoryDB::owned()))).await
 }

--- a/crates/storage/src/logical_clock.rs
+++ b/crates/storage/src/logical_clock.rs
@@ -469,6 +469,56 @@ mod tests {
     }
 
     #[test]
+    fn test_hlc_monotonic_across_backward_wall_clock_jump() {
+        // Crash-recovery / NTP-correction scenario: after a reading is taken the
+        // wall clock jumps BACKWARD (e.g. the machine's clock is corrected on
+        // restart). The HLC must never emit a timestamp that sorts at or before
+        // one it already emitted — even a delta_id derived from a later reading
+        // must be strictly greater — or two distinct events collide and one is
+        // silently lost. Monotonicity is preserved by holding physical time at
+        // the last observed value and advancing the logical counter instead.
+        let time = AtomicU64::new(2_000_000_000_000_000_000);
+        let mut hlc = LogicalClock::new(|buf| rand::thread_rng().fill_bytes(buf));
+
+        let before = hlc.new_timestamp(|| time.load(Ordering::Relaxed));
+
+        // Move the wall clock a full second into the past.
+        let jumped_back = time.load(Ordering::Relaxed) - 1_000_000_000;
+        time.store(jumped_back, Ordering::Relaxed);
+
+        let after = hlc.new_timestamp(|| time.load(Ordering::Relaxed));
+
+        // Strictly monotonic despite the backward jump: no collision, no
+        // regression. This is the invariant a delta_id derived from the HLC
+        // relies on for uniqueness across a clock correction.
+        assert!(
+            after.get_time().as_u64() > before.get_time().as_u64(),
+            "HLC regressed across a backward wall-clock jump: {after} !> {before}",
+        );
+        assert_ne!(
+            after.get_time().as_u64(),
+            before.get_time().as_u64(),
+            "backward jump produced a colliding timestamp",
+        );
+
+        // Physical time was pinned to the pre-jump value (the clock did not
+        // follow the wall clock backward); progress came from the counter.
+        assert_eq!(
+            physical_time_secs(&after),
+            physical_time_secs(&before),
+            "physical time must hold at the last observed value, not regress",
+        );
+        assert!(
+            logical_counter(&after) > logical_counter(&before),
+            "the logical counter must advance to preserve ordering",
+        );
+
+        // And a third reading, still on the rewound clock, keeps advancing.
+        let third = hlc.new_timestamp(|| time.load(Ordering::Relaxed));
+        assert!(third.get_time().as_u64() > after.get_time().as_u64());
+    }
+
+    #[test]
     fn test_hybrid_timestamp_borsh() {
         let time = AtomicU64::new(1_000_000_000_000_000_000);
         let mut hlc = LogicalClock::new(|buf| rand::thread_rng().fill_bytes(buf));

--- a/crates/store/src/batch.rs
+++ b/crates/store/src/batch.rs
@@ -232,6 +232,14 @@ mod tests {
         batch
             .put(&good, &GenericData::from(Slice::from(&b"good"[..])))
             .expect("good put stages");
+        // Confirm the good put actually staged (not a silent no-op) so the
+        // post-abort absence assertion below is meaningful — it proves a *staged*
+        // write is discarded, not merely that nothing was ever staged.
+        assert_eq!(
+            batch.len(),
+            1,
+            "good put must be staged before the failing put"
+        );
 
         // `put` returns `&mut Self` on success, which is not `Debug`, so match
         // rather than `expect_err`.

--- a/crates/store/src/batch.rs
+++ b/crates/store/src/batch.rs
@@ -101,15 +101,13 @@ mod tests {
         store.handle().get(key).expect("read").is_some()
     }
 
-    // Multi-key all-or-nothing: several staged puts either all land at commit or,
-    // if the batch is dropped before commit, none do. This pins the invariant the
-    // one atomic `Store::apply` (a single RocksDB `WriteBatch`) exists to provide.
+    // Dropping an uncommitted batch writes nothing, even with many staged ops:
+    // staging is invisible until `commit`, and abandoning the batch discards it.
     #[test]
-    fn commit_persists_all_keys_and_drop_persists_none() {
+    fn drop_persists_nothing() {
         let store = store();
-        let (a, b, c) = (gkey(1), gkey(2), gkey(3));
+        let (a, b) = (gkey(1), gkey(2));
 
-        // Dropping an uncommitted batch writes nothing, even with many staged ops.
         let mut dropped = StoreBatch::new(&store);
         dropped
             .put(&a, &GenericData::from(Slice::from(&b"a"[..])))
@@ -118,11 +116,31 @@ mod tests {
             .put(&b, &GenericData::from(Slice::from(&b"b"[..])))
             .expect("stage b");
         assert_eq!(dropped.len(), 2);
+
+        // Staged-but-uncommitted keys are not yet observable in the store.
+        assert!(
+            !present(&store, &a),
+            "staged a must be invisible before commit"
+        );
+        assert!(
+            !present(&store, &b),
+            "staged b must be invisible before commit"
+        );
+
         drop(dropped);
         assert!(!present(&store, &a), "dropped batch must not persist a");
         assert!(!present(&store, &b), "dropped batch must not persist b");
+    }
 
-        // Committing lands every staged key together.
+    // Multi-key all-or-nothing on the happy path: several staged puts stay
+    // invisible until `commit`, then all land together. This pins the invariant
+    // the one atomic `Store::apply` (a single RocksDB `WriteBatch`) exists to
+    // provide.
+    #[test]
+    fn commit_persists_all_keys() {
+        let store = store();
+        let (a, b, c) = (gkey(1), gkey(2), gkey(3));
+
         let mut batch = StoreBatch::new(&store);
         batch
             .put(&a, &GenericData::from(Slice::from(&b"a"[..])))
@@ -133,6 +151,21 @@ mod tests {
         batch
             .put(&c, &GenericData::from(Slice::from(&b"c"[..])))
             .expect("stage c");
+
+        // Nothing is visible while the batch is still staged.
+        assert!(
+            !present(&store, &a),
+            "staged a must be invisible before commit"
+        );
+        assert!(
+            !present(&store, &b),
+            "staged b must be invisible before commit"
+        );
+        assert!(
+            !present(&store, &c),
+            "staged c must be invisible before commit"
+        );
+
         batch.commit().expect("commit");
         assert!(present(&store, &a) && present(&store, &b) && present(&store, &c));
     }

--- a/crates/store/src/batch.rs
+++ b/crates/store/src/batch.rs
@@ -75,3 +75,147 @@ impl<'a> StoreBatch<'a> {
         self.store.apply(&self.tx)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::db::{Column, InMemoryDB};
+    use crate::entry::Codec;
+    use crate::key::{AsKeyParts, Generic, Key};
+    use crate::slice::Slice;
+    use crate::types::{GenericData, PredefinedEntry};
+    use crate::Store;
+
+    use super::StoreBatch;
+
+    fn store() -> Store {
+        Store::new(Arc::new(InMemoryDB::owned()))
+    }
+
+    fn gkey(fragment: u8) -> Generic {
+        Generic::new([0u8; 16], [fragment; 32])
+    }
+
+    fn present(store: &Store, key: &Generic) -> bool {
+        store.handle().get(key).expect("read").is_some()
+    }
+
+    // Multi-key all-or-nothing: several staged puts either all land at commit or,
+    // if the batch is dropped before commit, none do. This pins the invariant the
+    // one atomic `Store::apply` (a single RocksDB `WriteBatch`) exists to provide.
+    #[test]
+    fn commit_persists_all_keys_and_drop_persists_none() {
+        let store = store();
+        let (a, b, c) = (gkey(1), gkey(2), gkey(3));
+
+        // Dropping an uncommitted batch writes nothing, even with many staged ops.
+        let mut dropped = StoreBatch::new(&store);
+        dropped
+            .put(&a, &GenericData::from(Slice::from(&b"a"[..])))
+            .expect("stage a");
+        dropped
+            .put(&b, &GenericData::from(Slice::from(&b"b"[..])))
+            .expect("stage b");
+        assert_eq!(dropped.len(), 2);
+        drop(dropped);
+        assert!(!present(&store, &a), "dropped batch must not persist a");
+        assert!(!present(&store, &b), "dropped batch must not persist b");
+
+        // Committing lands every staged key together.
+        let mut batch = StoreBatch::new(&store);
+        batch
+            .put(&a, &GenericData::from(Slice::from(&b"a"[..])))
+            .expect("stage a");
+        batch
+            .put(&b, &GenericData::from(Slice::from(&b"b"[..])))
+            .expect("stage b");
+        batch
+            .put(&c, &GenericData::from(Slice::from(&b"c"[..])))
+            .expect("stage c");
+        batch.commit().expect("commit");
+        assert!(present(&store, &a) && present(&store, &b) && present(&store, &c));
+    }
+
+    // A value that fails to encode surfaces the error from `put` itself — before
+    // anything reaches the backend. Because the caller aborts the batch (never
+    // reaching `commit`), an earlier good put staged in the same batch is also
+    // never written: a mid-batch serialization failure is all-or-nothing too.
+    #[test]
+    fn encode_failure_surfaces_at_put_before_any_write() {
+        // A key whose codec always fails to encode, so `put` must return `Err`.
+        // It shares `Generic`'s column and key shape, so a leaked write (if the
+        // error did not short-circuit) would be observable via `Handle::get`.
+        #[derive(Clone, Copy)]
+        struct FailKey(Generic);
+
+        impl AsKeyParts for FailKey {
+            type Components = <Generic as AsKeyParts>::Components;
+
+            fn column() -> Column {
+                Column::Generic
+            }
+
+            fn as_key(&self) -> &Key<Self::Components> {
+                self.0.as_key()
+            }
+        }
+
+        #[derive(Debug)]
+        struct EncodeAlwaysFails;
+
+        impl core::fmt::Display for EncodeAlwaysFails {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.write_str("intentional encode failure")
+            }
+        }
+
+        impl std::error::Error for EncodeAlwaysFails {}
+
+        enum FailCodec {}
+
+        impl<'a> Codec<'a, ()> for FailCodec {
+            type Error = EncodeAlwaysFails;
+
+            fn encode(_: &()) -> Result<Slice<'_>, Self::Error> {
+                Err(EncodeAlwaysFails)
+            }
+
+            fn decode(_: Slice<'a>) -> Result<(), Self::Error> {
+                Err(EncodeAlwaysFails)
+            }
+        }
+
+        impl PredefinedEntry for FailKey {
+            type Codec = FailCodec;
+            type DataType<'a> = ();
+        }
+
+        let store = store();
+        let good = gkey(1);
+        let bad = FailKey(gkey(2));
+
+        let mut batch = StoreBatch::new(&store);
+        batch
+            .put(&good, &GenericData::from(Slice::from(&b"good"[..])))
+            .expect("good put stages");
+
+        // `put` returns `&mut Self` on success, which is not `Debug`, so match
+        // rather than `expect_err`.
+        let err = match batch.put(&bad, &()) {
+            Ok(_) => panic!("encode failure must surface from put"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("intentional encode failure"),
+            "unexpected error: {err}"
+        );
+
+        // The batch was abandoned mid-way (commit never reached), so not even the
+        // earlier good put reached the backend.
+        assert!(
+            !present(&store, &good),
+            "no key may persist when the batch is aborted before commit"
+        );
+    }
+}


### PR DESCRIPTION
## What

Adds crash-recovery / persistence-durability tests across `store`, `node`, `storage`, and `context`. Test-only; no production code changes. The **crash-recovery (B)** slice of a broader test-coverage-hardening sweep.

## Tests (8 passing + 1 `#[ignore]` regression)

| Item | Location | Test |
|---|---|---|
| B3 | `store/src/batch.rs` | `commit_persists_all_keys_and_drop_persists_none`, `encode_failure_surfaces_at_put_before_any_write` |
| B5 | `node/src/gc.rs`, `node/src/dag_compactor.rs` | `panicking_sweep_clears_in_progress_flag` (×2) |
| B7 | `node/src/delta_store.rs` | `lock_apply_slot_recovers_poisoned_relay_mutex` |
| B8 | `storage/src/logical_clock.rs` | `test_hlc_monotonic_across_backward_wall_clock_jump` |
| B2 | `node/src/crash_recovery_test.rs` | `merge_topology_and_root_hash_identical_across_restart` |
| B4 | `context/primitives/src/client/mod.rs` | `interrupted_prune_deletes_nothing` |
| B1 | `node/src/crash_recovery_test.rs` | `phase0_applied_false_row_not_promoted_on_restart` — **`#[ignore]`, documents a bug** |

Notes:
- **B3** store-batch tests are feature-gated like the crate's other `datatypes` tests — run with `--all-features` (or `-F datatypes`).
- **B2** covers the reachable half of the restart determinism guarantee via the real `load_persisted_deltas` path (merge collapses to a single head; persisted merge root hash + parent set round-trip byte-identically across two independent restarts). The full WASM CRDT root recompute needs an installed application/context, out of reach for a unit test.
- **B4** is asserted at the durable layer where the interrupt guarantee lives: `prune_delta_records` is one atomic transaction, so an injected backend `apply` failure deletes nothing.

## ⚠️ Bug documented by the ignored test (B1)

`load_persisted_deltas` restores rows purely by parent-reachability (`restore_applied_delta`) and **never consults the persisted `applied` flag**. A Phase-0 `applied:false` row (written before the atomic heads commit, then orphaned by a crash) is promoted to *applied* — and inserted as a DAG head — on restart, **without re-executing its actions**, even though its state effects were never committed. The test asserts the correct invariant and fails today. A dedicated fix PR follows that un-ignores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)