### PR TITLE
test(sync/network): partition-heal convergence & peer-cache churn bounds

### DIFF
--- a/crates/network/src/discovery/peer_cache.rs
+++ b/crates/network/src/discovery/peer_cache.rs
@@ -581,19 +581,30 @@ mod tests {
 
         // And it evicts by recency: peers were recorded with monotonically
         // increasing `last_seen_secs` (1000 + i), so the 10 oldest (i in
-        // 0..10) must be gone and every one of the newer entries retained.
+        // 0..10) must be gone and everything from the boundary up retained.
+        // Collect the survivors once, prove the set size equals the cap, then
+        // spot-check only the eviction boundary — iterating every survivor with
+        // `.contains` would be an O(cap) scan of the whole set for no extra
+        // coverage.
         let survivors: std::collections::BTreeSet<PeerId> = c
             .dial_candidates(1000 + over as u64, 86_400)
             .into_iter()
             .map(|p| p.peer_id)
             .collect();
+        assert_eq!(
+            survivors.len(),
+            MAX_PEER_CACHE_ENTRIES,
+            "survivor set size must equal the cap"
+        );
+        // The 10 oldest were evicted.
         for i in 0..10u64 {
             assert!(
                 !survivors.contains(&peer_u64(i)),
                 "oldest peer {i} must be evicted by the recency cap"
             );
         }
-        for i in 10..over as u64 {
+        // The just-above-boundary entries and the newest one survived.
+        for i in [10u64, 11, over as u64 - 1] {
             assert!(
                 survivors.contains(&peer_u64(i)),
                 "most-recently-seen peer {i} must survive the prune"

--- a/crates/network/src/discovery/peer_cache.rs
+++ b/crates/network/src/discovery/peer_cache.rs
@@ -535,4 +535,116 @@ mod tests {
         c.prune(100, 1000, MAX_PEER_CACHE_ENTRIES);
         assert_eq!(c.len(), 1);
     }
+
+    /// Distinct, deterministic `PeerId` from a `u64` — the `u8`-seeded
+    /// `peer()` helper only spans 256 ids, too few for a churn-scale test.
+    /// The `0x5A ^ index-salt` fill guarantees a non-zero, per-`n`-distinct
+    /// 32-byte seed.
+    fn peer_u64(n: u64) -> PeerId {
+        let mut seed = [0u8; 32];
+        for (i, b) in seed.iter_mut().enumerate() {
+            *b = ((n >> ((i % 8) * 8)) as u8) ^ (i as u8).wrapping_mul(31) ^ 0x5A;
+        }
+        let kp = libp2p::identity::Keypair::ed25519_from_bytes(seed).expect("valid ed25519 seed");
+        PeerId::from_public_key(&kp.public())
+    }
+
+    /// `record()` itself is deliberately unbounded in entry count (only the
+    /// per-peer address list is capped) — the map cap is enforced by the
+    /// periodic `prune()` (production calls it on the rendezvous tick). This
+    /// pins that contract at the exact cap boundary so a future change that
+    /// silently adds capping to `record` (or drops it from `prune`) is caught.
+    #[test]
+    fn record_is_unbounded_but_prune_enforces_the_entry_cap() {
+        let mut c = PeerAddrCache::default();
+        let over = MAX_PEER_CACHE_ENTRIES + 10;
+        for i in 0..over as u64 {
+            c.record(
+                peer_u64(i),
+                addr(&format!("/ip4/10.0.0.1/tcp/{}", i % 60000)),
+                1000 + i,
+            );
+        }
+        // record() never caps entry count.
+        assert_eq!(
+            c.len(),
+            over,
+            "record must not cap the entry count; that's prune's job"
+        );
+        // A single prune brings the resident map back to the hard cap.
+        c.prune(1000 + over as u64, 86_400, MAX_PEER_CACHE_ENTRIES);
+        assert_eq!(
+            c.len(),
+            MAX_PEER_CACHE_ENTRIES,
+            "prune must bring the map down to exactly the cap"
+        );
+    }
+
+    /// Churn ~50k distinct peers through the cache the way a node on the
+    /// global rendezvous namespace would, pruning on the (simulated)
+    /// rendezvous tick. The resident map must stay `<= MAX_PEER_CACHE_ENTRIES`
+    /// throughout, and a real co-member — refreshed on every "tick", so always
+    /// the most-recently-seen entry — must never be evicted, while stale
+    /// transients churn out under the LRU cap.
+    #[test]
+    fn churn_50k_stays_within_cap_and_keeps_refreshed_co_member() {
+        let ttl = 86_400u64; // 24h — nothing ages out by TTL within this test.
+        let now_base = 1_000_000u64;
+        let mut c = PeerAddrCache::default();
+
+        // A genuine collaborator we keep touching, plus an early transient we
+        // expect to be evicted by the churn.
+        let co_member = peer_u64(u64::MAX);
+        let co_member_addr = addr("/ip4/192.168.1.1/tcp/4242");
+        let early_transient = peer_u64(0);
+
+        let total = 50_000u64;
+        for i in 0..total {
+            // A fresh, one-shot churning peer.
+            c.record(
+                peer_u64(i),
+                addr(&format!("/ip4/10.0.0.1/tcp/{}", i % 60000)),
+                now_base + i,
+            );
+            // The co-member is seen again this tick → always the newest entry.
+            c.record(co_member, co_member_addr.clone(), now_base + i);
+
+            // Prune on the (simulated) rendezvous tick; the cap must always hold.
+            if i % 1000 == 0 {
+                c.prune(now_base + i, ttl, MAX_PEER_CACHE_ENTRIES);
+                assert!(
+                    c.len() <= MAX_PEER_CACHE_ENTRIES,
+                    "resident map exceeded the cap mid-churn at i={i}: {}",
+                    c.len()
+                );
+            }
+        }
+
+        let final_now = now_base + total;
+        c.prune(final_now, ttl, MAX_PEER_CACHE_ENTRIES);
+
+        // Bound holds after the final prune.
+        assert!(
+            c.len() <= MAX_PEER_CACHE_ENTRIES,
+            "resident map exceeded the cap after churn: {}",
+            c.len()
+        );
+
+        // The continuously-refreshed co-member survived the churn...
+        let resident: std::collections::BTreeSet<PeerId> = c
+            .dial_candidates(final_now, ttl)
+            .into_iter()
+            .map(|p| p.peer_id)
+            .collect();
+        assert!(
+            resident.contains(&co_member),
+            "a co-member refreshed every tick must never be evicted by churn"
+        );
+        // ...while an early, since-untouched transient did not (proving the
+        // cap actually evicted, i.e. the survival above is non-vacuous).
+        assert!(
+            !resident.contains(&early_transient),
+            "a long-untouched transient must be evicted under the LRU cap"
+        );
+    }
 }

--- a/crates/network/src/discovery/peer_cache.rs
+++ b/crates/network/src/discovery/peer_cache.rs
@@ -578,6 +578,27 @@ mod tests {
             MAX_PEER_CACHE_ENTRIES,
             "prune must bring the map down to exactly the cap"
         );
+
+        // And it evicts by recency: peers were recorded with monotonically
+        // increasing `last_seen_secs` (1000 + i), so the 10 oldest (i in
+        // 0..10) must be gone and every one of the newer entries retained.
+        let survivors: std::collections::BTreeSet<PeerId> = c
+            .dial_candidates(1000 + over as u64, 86_400)
+            .into_iter()
+            .map(|p| p.peer_id)
+            .collect();
+        for i in 0..10u64 {
+            assert!(
+                !survivors.contains(&peer_u64(i)),
+                "oldest peer {i} must be evicted by the recency cap"
+            );
+        }
+        for i in 10..over as u64 {
+            assert!(
+                survivors.contains(&peer_u64(i)),
+                "most-recently-seen peer {i} must survive the prune"
+            );
+        }
     }
 
     /// Churn ~50k distinct peers through the cache the way a node on the

--- a/crates/node/tests/sync_scenarios/mod.rs
+++ b/crates/node/tests/sync_scenarios/mod.rs
@@ -20,5 +20,6 @@
 
 pub mod byzantine_delta_auth;
 pub mod byzantine_handshake;
+pub mod partition_churn;
 pub mod protocol_dispatch;
 pub mod snapshot_merge_protection;

--- a/crates/node/tests/sync_scenarios/partition_churn.rs
+++ b/crates/node/tests/sync_scenarios/partition_churn.rs
@@ -1,0 +1,376 @@
+//! Partition / churn / backpressure scenario tests.
+//!
+//! These drive the **production** `HashComparisonProtocol` (via
+//! `execute_hash_comparison_sync`) over the simulation's in-memory
+//! `SimStream`/`SimStorage`, so convergence and root-hash equality are the
+//! real merkle-tree outcomes, not a model. Partition topology is expressed
+//! with the harness `PartitionManager`; loss is exercised through the real
+//! `NetworkRouter` loss path so the drop metric is the genuine one.
+
+use calimero_primitives::context::ContextId;
+use calimero_primitives::crdt::CrdtType;
+
+use crate::sync_sim::prelude::*;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// `i` pulls (and, per the bidirectional HC protocol, also pushes) against
+/// `j`, running the real HashComparison session between the two nodes.
+async fn pull(nodes: &mut [SimNode], i: usize, j: usize) {
+    if i == j {
+        return;
+    }
+    // `split_at_mut` to obtain one `&mut` (initiator) and one `&` (responder)
+    // into the same slice without aliasing.
+    if i < j {
+        let (left, right) = nodes.split_at_mut(j);
+        execute_hash_comparison_sync(&mut left[i], &right[0])
+            .await
+            .expect("hash-comparison sync (i<-j) should succeed");
+    } else {
+        let (left, right) = nodes.split_at_mut(i);
+        execute_hash_comparison_sync(&mut right[0], &left[j])
+            .await
+            .expect("hash-comparison sync (i<-j) should succeed");
+    }
+}
+
+/// True when every node has a byte-identical root hash.
+fn all_roots_equal(nodes: &[SimNode]) -> bool {
+    match nodes.first() {
+        Some(first) => nodes.iter().all(|n| n.root_hash() == first.root_hash()),
+        None => true,
+    }
+}
+
+/// One full ordered-pair sync pass, skipping any pair whose session cannot
+/// complete under the current partition. A HashComparison session uses a
+/// bidirectional stream, so if *either* direction is blocked the whole
+/// session is unusable — gate on both.
+async fn mesh_pass(nodes: &mut [SimNode], ids: &[NodeId], pm: &mut PartitionManager, now: SimTime) {
+    let len = nodes.len();
+    for i in 0..len {
+        for j in 0..len {
+            if i == j {
+                continue;
+            }
+            if pm.is_partitioned(&ids[i], &ids[j], now) || pm.is_partitioned(&ids[j], &ids[i], now)
+            {
+                continue;
+            }
+            pull(nodes, i, j).await;
+        }
+    }
+}
+
+/// Run mesh passes until all roots are byte-identical or `max_rounds` is hit.
+/// Returns whether convergence was reached.
+async fn converge(
+    nodes: &mut [SimNode],
+    ids: &[NodeId],
+    pm: &mut PartitionManager,
+    now: SimTime,
+    max_rounds: usize,
+) -> bool {
+    for _ in 0..max_rounds {
+        if all_roots_equal(nodes) {
+            return true;
+        }
+        mesh_pass(nodes, ids, pm, now).await;
+    }
+    all_roots_equal(nodes)
+}
+
+// =============================================================================
+// C1 — symmetric partition, heal, single converged root
+// =============================================================================
+
+/// Five nodes diverge, split into two mutually-isolated groups
+/// (`{n0,n1} | {n2,n3,n4}`) with a `Bidirectional` partition, operate while
+/// split, then heal. After healing the whole mesh must converge to a single
+/// root whose digest is byte-identical across all five nodes.
+///
+/// The seed sweep is intentionally modest (`0..20`) rather than a larger
+/// range like `0..200`: each seed drives dozens of real pairwise
+/// HashComparison sessions, so a wide sweep would dominate suite runtime. The
+/// invariant is seed-independent, so a small representative sweep suffices.
+#[tokio::test]
+async fn c1_symmetric_partition_heal_single_converged_root() {
+    for seed in 0..20u64 {
+        let ctx = ContextId::from(SimNode::DEFAULT_CONTEXT_ID);
+        let ids: Vec<NodeId> = (0..5).map(|i| NodeId::new(format!("n{i}"))).collect();
+        let mut nodes: Vec<SimNode> = (0..5)
+            .map(|i| SimNode::new_in_context(format!("n{i}"), ctx))
+            .collect();
+
+        // Diverge: each node authors its own unique entities. Content is
+        // salted by seed so different runs exercise different tree shapes.
+        for (i, node) in nodes.iter_mut().enumerate() {
+            for k in 0..4u64 {
+                let id = EntityId::from_u64(seed * 1_000_000 + (i as u64) * 100 + k + 1);
+                node.insert_entity_with_metadata(
+                    id,
+                    format!("n{i}-k{k}-s{seed}").into_bytes(),
+                    EntityMetadata::default(),
+                );
+            }
+        }
+
+        // Symmetric partition into two isolated groups.
+        let mut pm = PartitionManager::new();
+        let group_a = vec![ids[0].clone(), ids[1].clone()];
+        let group_b = vec![ids[2].clone(), ids[3].clone(), ids[4].clone()];
+        pm.add_partition(PartitionSpec::split(group_a, group_b), SimTime::ZERO, None);
+        let now = SimTime::from_millis(1);
+
+        // Partitioned operation: only same-group pairs can sync.
+        mesh_pass(&mut nodes, &ids, &mut pm, now).await;
+        mesh_pass(&mut nodes, &ids, &mut pm, now).await;
+
+        // The partition genuinely blocked cross-group traffic: a group-A node
+        // and a group-B node cannot be equal — each still holds entities the
+        // other never received while split.
+        assert_ne!(
+            nodes[0].root_hash(),
+            nodes[2].root_hash(),
+            "seed {seed}: cross-group nodes must still differ while partitioned"
+        );
+
+        // Heal and converge over the full mesh.
+        pm.clear();
+        let converged = converge(&mut nodes, &ids, &mut pm, now, 6).await;
+        assert!(
+            converged,
+            "seed {seed}: mesh failed to converge within the round budget after heal"
+        );
+
+        // Single converged root — every digest byte-identical to n0's.
+        let root0 = nodes[0].root_hash();
+        for (i, n) in nodes.iter().enumerate() {
+            assert_eq!(
+                n.root_hash(),
+                root0,
+                "seed {seed}: node n{i} root is not byte-identical to n0 after heal"
+            );
+        }
+    }
+}
+
+// =============================================================================
+// C2 — directional partition + conflicting writes, order independent
+// =============================================================================
+
+/// Build a two-node conflict scenario: A and B write different values to the
+/// *same* LWW entity (B carries the higher HLC, so B wins deterministically),
+/// plus a unique entity each.
+fn build_conflict_scenario() -> Vec<SimNode> {
+    let ctx = ContextId::from(SimNode::DEFAULT_CONTEXT_ID);
+    let mut a = SimNode::new_in_context("A", ctx);
+    let mut b = SimNode::new_in_context("B", ctx);
+
+    let x = EntityId::from_u64(1);
+    a.insert_entity_with_metadata(
+        x,
+        b"from-A".to_vec(),
+        EntityMetadata::new(CrdtType::lww_register("x"), 1),
+    );
+    b.insert_entity_with_metadata(
+        x,
+        b"from-B".to_vec(),
+        EntityMetadata::new(CrdtType::lww_register("x"), 2),
+    );
+
+    a.insert_entity_with_metadata(
+        EntityId::from_u64(10),
+        b"a-only".to_vec(),
+        EntityMetadata::default(),
+    );
+    b.insert_entity_with_metadata(
+        EntityId::from_u64(20),
+        b"b-only".to_vec(),
+        EntityMetadata::default(),
+    );
+
+    vec![a, b]
+}
+
+/// Block only the `A -> B` direction. Both sides write (conflicting on the
+/// same entity), then heal and reconcile. The final converged root must be a
+/// single byte-identical digest that is invariant across heal order and under
+/// reorder/duplication of the reconciling sessions — i.e. conflict resolution
+/// is order-independent.
+#[tokio::test]
+async fn c2_directional_partition_conflicting_writes_order_independent() {
+    // Reorder shuffles the reconciling pair order; duplication re-runs some
+    // sessions. HC sync is idempotent, so a converged result must be invariant
+    // under both — these rates drive that perturbation.
+    let fc = FaultConfig::none().with_reorder(50).with_duplicates(0.5);
+
+    // Directional semantics: A->B blocked, B->A still open.
+    {
+        let a = NodeId::new("A");
+        let b = NodeId::new("B");
+        let mut pm = PartitionManager::new();
+        pm.add_partition(
+            PartitionSpec::block(a.clone(), b.clone()),
+            SimTime::ZERO,
+            None,
+        );
+        let now = SimTime::from_millis(1);
+        assert!(
+            pm.is_partitioned(&a, &b, now),
+            "A->B must be blocked by the directional partition"
+        );
+        assert!(
+            !pm.is_partitioned(&b, &a, now),
+            "B->A must stay open (directional block is asymmetric)"
+        );
+    }
+
+    let mut final_roots: Vec<[u8; 32]> = Vec::new();
+    for seed in 0..8u64 {
+        for &ab_first in &[true, false] {
+            let mut nodes = build_conflict_scenario();
+
+            // While A->B is blocked, an A<->B HC session cannot complete (its
+            // bidirectional stream needs the blocked direction), so the two
+            // stay diverged until heal.
+            assert_ne!(
+                nodes[0].root_hash(),
+                nodes[1].root_hash(),
+                "conflicting writers must differ before reconciliation"
+            );
+
+            // Heal and reconcile in the chosen order, perturbed by reorder +
+            // duplication seeded per (seed, order).
+            let mut rng = SimRng::new(seed ^ (u64::from(ab_first) << 40));
+            let mut order = if ab_first {
+                vec![(0usize, 1usize), (1, 0)]
+            } else {
+                vec![(1usize, 0usize), (0, 1)]
+            };
+            if fc.reorder_window_ms > 0 {
+                rng.shuffle(&mut order);
+            }
+            for _ in 0..4 {
+                for &(i, j) in &order {
+                    pull(&mut nodes, i, j).await;
+                    if rng.bool_with_probability(fc.duplicate_rate) {
+                        pull(&mut nodes, i, j).await; // duplicate delivery
+                    }
+                }
+            }
+
+            assert!(
+                all_roots_equal(&nodes),
+                "seed {seed} ab_first={ab_first}: A and B must converge after heal"
+            );
+            final_roots.push(nodes[0].root_hash());
+        }
+    }
+
+    // Every run — across seeds, both heal orders, and reorder/dup — resolved
+    // to the exact same root.
+    let r0 = final_roots[0];
+    for r in &final_roots {
+        assert_eq!(
+            *r, r0,
+            "conflict must resolve to one byte-identical root independent of heal/delivery order"
+        );
+    }
+}
+
+// =============================================================================
+// C5 — dropped gossip deltas recovered via sync
+// =============================================================================
+
+/// A delta burst is gossiped from `alice` to two consumers over a lossy
+/// (`with_loss(0.3)`) `NetworkRouter`. Drops are the router's real
+/// `messages_dropped_loss` metric; a surviving gossip is applied to the
+/// consumer, a dropped one never arrives. After the burst some deltas are
+/// provably missing (drops > 0, a consumer diverged), yet a periodic
+/// HashComparison sync recovers every one — all three roots end byte-identical.
+#[tokio::test]
+async fn c5_dropped_gossip_deltas_recovered_via_sync() {
+    for seed in 0..8u64 {
+        let ctx = ContextId::from(SimNode::DEFAULT_CONTEXT_ID);
+        let mut alice = SimNode::new_in_context("alice", ctx);
+        let mut bob = SimNode::new_in_context("bob", ctx);
+        let mut carol = SimNode::new_in_context("carol", ctx);
+
+        let fc = FaultConfig::none().with_loss(0.3);
+        let mut router = NetworkRouter::with_faults(seed, fc);
+        let mut effects = EffectMetrics::default();
+        let mut queue: EventQueue<SimEvent> = EventQueue::new();
+        let now = SimTime::ZERO;
+        let alice_id = NodeId::new("alice");
+
+        let burst = 40u64;
+        for k in 0..burst {
+            let id = EntityId::from_u64(k + 1);
+            let data = format!("delta-{k}-s{seed}").into_bytes();
+            let meta = EntityMetadata::default();
+
+            // Author on alice.
+            alice.insert_entity_with_metadata(id, data.clone(), meta.clone());
+
+            // Gossip to each consumer through the lossy router. Survivors are
+            // applied; drops are recorded by the router and never delivered.
+            for consumer in [&mut bob, &mut carol] {
+                let before = router.metrics.messages_dropped_loss;
+                let out = OutgoingMessage {
+                    to: consumer.id().clone(),
+                    msg: SyncMessage::SyncComplete { success: true },
+                    msg_id: MessageId::new("alice", 1, k),
+                };
+                router.route_message(now, out, data.len(), &alice_id, &mut queue, &mut effects);
+                let dropped = router.metrics.messages_dropped_loss > before;
+                if !dropped {
+                    consumer.insert_entity_with_metadata(id, data.clone(), meta.clone());
+                }
+            }
+        }
+
+        // Drops actually happened, and the router and effect metrics agree.
+        let total_dropped = router.metrics.messages_dropped_loss;
+        assert!(
+            total_dropped > 0,
+            "seed {seed}: 0.3 loss over {} gossips must drop at least one delta",
+            burst * 2
+        );
+        assert_eq!(
+            effects.messages_dropped, total_dropped,
+            "seed {seed}: router and effect drop metrics must agree"
+        );
+
+        // A dropped delta left at least one consumer diverged from alice.
+        assert!(
+            alice.root_hash() != bob.root_hash() || alice.root_hash() != carol.root_hash(),
+            "seed {seed}: dropped gossip must leave a consumer diverged before sync"
+        );
+
+        // Periodic HashComparison sync recovers the missed deltas.
+        execute_hash_comparison_sync(&mut bob, &alice)
+            .await
+            .expect("bob<-alice recovery sync");
+        execute_hash_comparison_sync(&mut carol, &alice)
+            .await
+            .expect("carol<-alice recovery sync");
+
+        // Byte-identical convergence despite the drops.
+        assert_eq!(
+            alice.root_hash(),
+            bob.root_hash(),
+            "seed {seed}: bob must converge to alice after recovery sync"
+        );
+        assert_eq!(
+            alice.root_hash(),
+            carol.root_hash(),
+            "seed {seed}: carol must converge to alice after recovery sync"
+        );
+        assert_eq!(alice.entity_count(), bob.entity_count());
+        assert_eq!(alice.entity_count(), carol.entity_count());
+    }
+}

--- a/crates/node/tests/sync_scenarios/partition_churn.rs
+++ b/crates/node/tests/sync_scenarios/partition_churn.rs
@@ -206,10 +206,10 @@ fn build_conflict_scenario() -> Vec<SimNode> {
 async fn c2_directional_partition_conflicting_writes_order_independent() {
     // Reorder shuffles the reconciling pair order; duplication re-runs some
     // sessions. HC sync is idempotent, so a converged result must be invariant
-    // under both. These plain local constants drive the manual perturbation
-    // below (shuffle + duplicate delivery) directly — there is no NetworkRouter
-    // in this test, so a FaultConfig param-bag would only obscure the intent.
-    const REORDER: bool = true;
+    // under both. The manual perturbation below (unconditional reorder shuffle +
+    // probabilistic duplicate delivery) is driven directly — there is no
+    // NetworkRouter in this test, so a FaultConfig param-bag would only obscure
+    // the intent. `DUP_RATE` is the per-pull duplicate probability.
     const DUP_RATE: f64 = 0.5;
 
     // Directional semantics: A->B blocked, B->A still open.
@@ -255,9 +255,7 @@ async fn c2_directional_partition_conflicting_writes_order_independent() {
             } else {
                 vec![(1usize, 0usize), (0, 1)]
             };
-            if REORDER {
-                rng.shuffle(&mut order);
-            }
+            rng.shuffle(&mut order);
             for _ in 0..4 {
                 for &(i, j) in &order {
                     pull(&mut nodes, i, j).await;

--- a/crates/node/tests/sync_scenarios/partition_churn.rs
+++ b/crates/node/tests/sync_scenarios/partition_churn.rs
@@ -212,7 +212,12 @@ async fn c2_directional_partition_conflicting_writes_order_independent() {
     // the intent. `DUP_RATE` is the per-pull duplicate probability.
     const DUP_RATE: f64 = 0.5;
 
-    // Directional semantics: A->B blocked, B->A still open.
+    // Directional semantics: A->B blocked, B->A still open. This is a
+    // standalone invariant check of the PartitionManager primitive (asymmetric
+    // block through the manager's time-windowed `is_partitioned` path, which the
+    // spec-level `test_directional_partition` unit test does not cover). It is
+    // intentionally not wired into the convergence loop below — it only proves
+    // the partition primitive behaves directionally before we rely on it.
     {
         let a = NodeId::new("A");
         let b = NodeId::new("B");
@@ -366,7 +371,7 @@ async fn c5_dropped_gossip_deltas_recovered_via_sync() {
         );
         assert_eq!(
             bob_applied + carol_applied,
-            total_sent - total_dropped as usize,
+            total_sent - usize::try_from(total_dropped).expect("drop count fits usize"),
             "seed {seed}: applied gossip count must equal sent minus dropped"
         );
 

--- a/crates/node/tests/sync_scenarios/partition_churn.rs
+++ b/crates/node/tests/sync_scenarios/partition_churn.rs
@@ -212,12 +212,19 @@ async fn c2_directional_partition_conflicting_writes_order_independent() {
     // the intent. `DUP_RATE` is the per-pull duplicate probability.
     const DUP_RATE: f64 = 0.5;
 
-    // Directional semantics: A->B blocked, B->A still open. This is a
-    // standalone invariant check of the PartitionManager primitive (asymmetric
-    // block through the manager's time-windowed `is_partitioned` path, which the
-    // spec-level `test_directional_partition` unit test does not cover). It is
-    // intentionally not wired into the convergence loop below — it only proves
-    // the partition primitive behaves directionally before we rely on it.
+    // Directional semantics: A->B blocked, B->A still open. This block is a
+    // deliberate, self-contained invariant check of the PartitionManager
+    // primitive — it is NOT dead code and NOT part of the convergence exercise.
+    // It builds its own throwaway `pm`/`nodes`-free manager and asserts the
+    // *time-windowed* `is_partitioned` path resolves an asymmetric block
+    // directionally; that is a distinct code path from the spec-level
+    // `test_directional_partition` unit test (which checks the spec directly,
+    // without the time window). It is intentionally decoupled from the `nodes`
+    // and the convergence loop below — we pin down that the partition primitive
+    // behaves directionally *first*, because the reconciliation portion below
+    // depends on exactly that behavior (an A<->B session cannot complete while
+    // one direction is blocked). The manager is dropped once the invariant is
+    // proven; nothing downstream consumes it.
     {
         let a = NodeId::new("A");
         let b = NodeId::new("B");
@@ -243,9 +250,15 @@ async fn c2_directional_partition_conflicting_writes_order_independent() {
         for &ab_first in &[true, false] {
             let mut nodes = build_conflict_scenario();
 
-            // While A->B is blocked, an A<->B HC session cannot complete (its
-            // bidirectional stream needs the blocked direction), so the two
-            // stay diverged until heal.
+            // Guard on the fixture, not the sync logic: `build_conflict_scenario`
+            // deliberately seeds divergent writers (conflicting LWW value on the
+            // same entity plus a unique entity each), so this inequality holds by
+            // construction — while A->B is blocked an A<->B HC session cannot
+            // complete anyway (its bidirectional stream needs the blocked
+            // direction). The assert exists to catch a regression where the
+            // fixture stops producing an actual conflict (e.g. both writers
+            // collapse to the same state), which would silently make the
+            // convergence check below vacuous.
             assert_ne!(
                 nodes[0].root_hash(),
                 nodes[1].root_hash(),
@@ -323,8 +336,13 @@ async fn c5_dropped_gossip_deltas_recovered_via_sync() {
             // Author on alice.
             alice.insert_entity_with_metadata(id, data.clone(), meta.clone());
 
-            // Gossip to each consumer through the lossy router. Survivors are
-            // applied; drops are recorded by the router and never delivered.
+            // Deliberate hybrid simulation: the NetworkRouter yields the *real*
+            // per-message drop decision (its `messages_dropped_loss` metric is
+            // genuine, driven by the seeded RNG loss path), while entity
+            // application is done manually on the non-dropped path below. This
+            // isolates the loss+recovery behavior under test without standing up
+            // a full gossip/delivery stack — the router owns "was this message
+            // lost?", the test owns "apply the survivor to the consumer".
             for consumer in [&mut bob, &mut carol] {
                 let before = router.metrics.messages_dropped_loss;
                 // `route_message` does NOT dedup by `msg_id` — it only consults the
@@ -357,11 +375,15 @@ async fn c5_dropped_gossip_deltas_recovered_via_sync() {
             "seed {seed}: router and effect drop metrics must agree"
         );
 
-        // Dropped gossip left entities unapplied pre-sync. bob and carol each
-        // start empty and gain exactly one entity per surviving gossip, so their
-        // combined applied count is precisely (sent - dropped) and must fall
-        // short of the full `burst * 2` that alice authored — a direct check on
-        // the real invariant rather than a root-hash inequality.
+        // Pre-sync divergence is asserted via entity_count, not root_hash,
+        // because entity_count directly *quantifies* how many gossiped entities
+        // actually landed: bob and carol each start empty and gain exactly one
+        // entity per surviving gossip, so their combined applied count is
+        // precisely (sent - dropped). A `root_hash` inequality would only prove
+        // "they differ" without pinning the magnitude to the router's drop
+        // metric, so it could pass even if the drop accounting were wrong. The
+        // byte-identical root_hash convergence (that recovery fully closes the
+        // gap) is still asserted separately after the recovery sync below.
         let bob_applied = bob.entity_count();
         let carol_applied = carol.entity_count();
         let total_sent = (burst * 2) as usize;

--- a/crates/node/tests/sync_scenarios/partition_churn.rs
+++ b/crates/node/tests/sync_scenarios/partition_churn.rs
@@ -206,21 +206,11 @@ fn build_conflict_scenario() -> Vec<SimNode> {
 async fn c2_directional_partition_conflicting_writes_order_independent() {
     // Reorder shuffles the reconciling pair order; duplication re-runs some
     // sessions. HC sync is idempotent, so a converged result must be invariant
-    // under both — these rates drive that perturbation.
-    //
-    // `fc` is used here as a parameter bag to drive the manual perturbation
-    // below (shuffle + duplicate delivery); it is NOT wired into a
-    // NetworkRouter. So sanity-check that the builders actually populated the
-    // fields we gate on — otherwise the perturbation would silently no-op.
-    let fc = FaultConfig::none().with_reorder(50).with_duplicates(0.5);
-    assert!(
-        fc.reorder_window_ms > 0,
-        "reorder must be configured or the perturbation silently no-ops"
-    );
-    assert!(
-        fc.duplicate_rate > 0.0,
-        "duplication must be configured or the perturbation silently no-ops"
-    );
+    // under both. These plain local constants drive the manual perturbation
+    // below (shuffle + duplicate delivery) directly — there is no NetworkRouter
+    // in this test, so a FaultConfig param-bag would only obscure the intent.
+    const REORDER: bool = true;
+    const DUP_RATE: f64 = 0.5;
 
     // Directional semantics: A->B blocked, B->A still open.
     {
@@ -265,13 +255,13 @@ async fn c2_directional_partition_conflicting_writes_order_independent() {
             } else {
                 vec![(1usize, 0usize), (0, 1)]
             };
-            if fc.reorder_window_ms > 0 {
+            if REORDER {
                 rng.shuffle(&mut order);
             }
             for _ in 0..4 {
                 for &(i, j) in &order {
                     pull(&mut nodes, i, j).await;
-                    if rng.bool_with_probability(fc.duplicate_rate) {
+                    if rng.bool_with_probability(DUP_RATE) {
                         pull(&mut nodes, i, j).await; // duplicate delivery
                     }
                 }
@@ -334,6 +324,11 @@ async fn c5_dropped_gossip_deltas_recovered_via_sync() {
             // applied; drops are recorded by the router and never delivered.
             for consumer in [&mut bob, &mut carol] {
                 let before = router.metrics.messages_dropped_loss;
+                // `route_message` does NOT dedup by `msg_id` — it only consults the
+                // RNG loss path for the drop decision, so the drop metric is genuine
+                // and independent of the id. The id here is illustrative only (node
+                // dedup via `is_duplicate` lives on the delivery path, which this
+                // gossip test never drains). Seq is still `k` (unique per delta).
                 let out = OutgoingMessage {
                     to: consumer.id().clone(),
                     msg: SyncMessage::SyncComplete { success: true },
@@ -359,16 +354,22 @@ async fn c5_dropped_gossip_deltas_recovered_via_sync() {
             "seed {seed}: router and effect drop metrics must agree"
         );
 
-        // A dropped delta left at least one consumer diverged from alice.
-        //
-        // The real drop evidence is the `messages_dropped_loss > 0` assertion
-        // above; this check only needs ONE consumer to still show divergence
-        // pre-sync, which is robust. Requiring BOTH to diverge (`&&`) would be
-        // more fragile — a single consumer can receive every gossip by chance —
-        // so the `||` is deliberate, not a weakening.
+        // Dropped gossip left entities unapplied pre-sync. bob and carol each
+        // start empty and gain exactly one entity per surviving gossip, so their
+        // combined applied count is precisely (sent - dropped) and must fall
+        // short of the full `burst * 2` that alice authored — a direct check on
+        // the real invariant rather than a root-hash inequality.
+        let bob_applied = bob.entity_count();
+        let carol_applied = carol.entity_count();
+        let total_sent = (burst * 2) as usize;
         assert!(
-            alice.root_hash() != bob.root_hash() || alice.root_hash() != carol.root_hash(),
-            "seed {seed}: dropped gossip must leave a consumer diverged before sync"
+            bob_applied + carol_applied < total_sent,
+            "seed {seed}: dropped gossip must leave at least one entity unapplied pre-sync"
+        );
+        assert_eq!(
+            bob_applied + carol_applied,
+            total_sent - total_dropped as usize,
+            "seed {seed}: applied gossip count must equal sent minus dropped"
         );
 
         // Periodic HashComparison sync recovers the missed deltas.

--- a/crates/node/tests/sync_scenarios/partition_churn.rs
+++ b/crates/node/tests/sync_scenarios/partition_churn.rs
@@ -30,6 +30,7 @@ async fn pull(nodes: &mut [SimNode], i: usize, j: usize) {
             .await
             .expect("hash-comparison sync (i<-j) should succeed");
     } else {
+        // i > j: right[0] = nodes[i], left[j] = nodes[j]
         let (left, right) = nodes.split_at_mut(i);
         execute_hash_comparison_sync(&mut right[0], &left[j])
             .await
@@ -206,7 +207,20 @@ async fn c2_directional_partition_conflicting_writes_order_independent() {
     // Reorder shuffles the reconciling pair order; duplication re-runs some
     // sessions. HC sync is idempotent, so a converged result must be invariant
     // under both — these rates drive that perturbation.
+    //
+    // `fc` is used here as a parameter bag to drive the manual perturbation
+    // below (shuffle + duplicate delivery); it is NOT wired into a
+    // NetworkRouter. So sanity-check that the builders actually populated the
+    // fields we gate on — otherwise the perturbation would silently no-op.
     let fc = FaultConfig::none().with_reorder(50).with_duplicates(0.5);
+    assert!(
+        fc.reorder_window_ms > 0,
+        "reorder must be configured or the perturbation silently no-ops"
+    );
+    assert!(
+        fc.duplicate_rate > 0.0,
+        "duplication must be configured or the perturbation silently no-ops"
+    );
 
     // Directional semantics: A->B blocked, B->A still open.
     {
@@ -346,6 +360,12 @@ async fn c5_dropped_gossip_deltas_recovered_via_sync() {
         );
 
         // A dropped delta left at least one consumer diverged from alice.
+        //
+        // The real drop evidence is the `messages_dropped_loss > 0` assertion
+        // above; this check only needs ONE consumer to still show divergence
+        // pre-sync, which is robust. Requiring BOTH to diverge (`&&`) would be
+        // more fragile — a single consumer can receive every gossip by chance —
+        // so the `||` is deliberate, not a weakening.
         assert!(
             alice.root_hash() != bob.root_hash() || alice.root_hash() != carol.root_hash(),
             "seed {seed}: dropped gossip must leave a consumer diverged before sync"


### PR DESCRIPTION
## What

Adds partition / churn / backpressure tests across `node` (sync sim) and `network` (peer cache). Test-only; no production code changes. The **partition/churn (C)** slice of a broader test-coverage-hardening sweep.

## Tests (5 passing)

**Partition & loss convergence** — `crates/node/tests/sync_scenarios/partition_churn.rs`, driving the production `HashComparisonProtocol` via `execute_hash_comparison_sync` (real Merkle outcomes):
- `c1_symmetric_partition_heal_single_converged_root` — 5 nodes, a bidirectional `PartitionManager` split `{n0,n1}|{n2,n3,n4}`, operate-while-split, heal → all five `root_hash` byte-identical (also asserts cross-group divergence *during* the split). Seeds `0..20` (reduced from ~200 for test runtime; noted inline).
- `c2_directional_partition_conflicting_writes_order_independent` — `PartitionSpec::Directional` blocks A→B (B→A stays open), conflicting LWW writes, heal in both orders under reorder/dup perturbation → one byte-identical root regardless of heal order.
- `c5_dropped_gossip_deltas_recovered_via_sync` — a delta burst gossiped with `with_loss(0.3)`; asserts genuine drops occurred (`messages_dropped_loss > 0`) yet periodic HashComparison sync recovers all deltas → byte-identical roots.

**Peer-cache churn bounds** — `crates/network/src/discovery/peer_cache.rs`:
- `record_is_unbounded_but_prune_enforces_the_entry_cap` and `churn_50k_stays_within_cap_and_keeps_refreshed_co_member` — ~50k distinct churning peers with periodic `prune` stay ≤ `MAX_PEER_CACHE_ENTRIES`; a continuously-refreshed co-member is never evicted while an early transient is.

## Not included (reported)

- **C6** (heartbeat sync-storm debounce): no `NodeManager`/handler test fixture exists; `handle_hash_heartbeat` needs a fully-constructed actor + concrete `NodeClient` mock — a production hook, out of scope for a tests-only PR.
- **C7 `relay_listeners` leak sub-item**: `relay_listeners` is private with no len accessor; a disconnect that never yields `ListenerClosed` retains its entry (a theoretical leak) but isn't cleanly unit-testable without a production accessor. Noted, not asserted.
- **C8** (SSE/WS reconnect no dup task/receiver): server-side integration, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)