### PR TITLE
fix(storage): lift tombstone when a strictly-newer write outlives it (D1)

### DIFF
--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -750,6 +750,31 @@ impl<S: StorageAdaptor> Index<S> {
         Ok(())
     }
 
+    /// Lifts a tombstone when a strictly-newer write outlives it.
+    ///
+    /// This is the counterpart to [`mark_deleted`](Self::mark_deleted). Once an
+    /// entity is tombstoned, [`find_by_id`](crate::Interface::find_by_id) hides
+    /// it regardless of any later value write. A concurrent update that
+    /// causally follows the delete (`at > deleted_at`) must win under LWW, so
+    /// the value write has to clear the tombstone or the freshly-written bytes
+    /// stay invisible — an over-suppression that diverges replicas (the replica
+    /// that saw `delete` before the newer `update` keeps hiding the value while
+    /// the replica that only saw the newer `update` shows it).
+    ///
+    /// The `at > deleted_at` guard is strict and monotonic, mirroring
+    /// `mark_deleted`: an equal-HLC write does NOT resurrect (delete wins ties),
+    /// and an older write never lifts a newer tombstone.
+    pub(crate) fn clear_deleted(id: Id, at: u64) -> Result<(), StorageError> {
+        let _mutation_guard = index_mutation_guard();
+        if let Some(mut index) = Self::get_index(id)? {
+            if index.deleted_at.is_some_and(|deleted_at| at > deleted_at) {
+                index.deleted_at = None;
+                Self::save_index(&index)?;
+            }
+        }
+        Ok(())
+    }
+
     /// Returns children from a specific collection.
     ///
     /// Collection param is ignored - entity only has one collection.

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -764,11 +764,25 @@ impl<S: StorageAdaptor> Index<S> {
     /// The `at > deleted_at` guard is strict and monotonic, mirroring
     /// `mark_deleted`: an equal-HLC write does NOT resurrect (delete wins ties),
     /// and an older write never lifts a newer tombstone.
+    ///
+    /// When it clears the tombstone it also advances the `updated_at` replay
+    /// nonce to at least `at` (monotonically, mirroring `mark_deleted`). This
+    /// keeps `clear_deleted` self-defensive regardless of call ordering: after
+    /// a resurrection the nonce is at least `at`, so a replayed older
+    /// `DeleteRef` carrying the original `deleted_at` still loses the
+    /// `apply_delete_ref_action` comparison even if this ever runs before the
+    /// caller's `update_hash_for` has persisted the new `updated_at`.
     pub(crate) fn clear_deleted(id: Id, at: u64) -> Result<(), StorageError> {
         let _mutation_guard = index_mutation_guard();
         if let Some(mut index) = Self::get_index(id)? {
             if index.deleted_at.is_some_and(|deleted_at| at > deleted_at) {
                 index.deleted_at = None;
+                // Advance the `updated_at` replay nonce alongside the
+                // resurrection, mirroring `mark_deleted`. Monotonic: an older
+                // write never lowers it. Without this, a `clear_deleted` that
+                // ran before `update_hash_for` would leave the nonce below
+                // `at`, reopening a replay window for the original delete.
+                *index.metadata.updated_at = (*index.metadata.updated_at).max(at);
                 Self::save_index(&index)?;
             }
         }

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -3178,6 +3178,11 @@ impl<S: StorageAdaptor> Interface<S> {
         // the delete path (deletes go through `apply_delete_ref_action`), and the
         // `> deleted_at` guard inside `clear_deleted` keeps ties and older writes
         // from resurrecting.
+        //
+        // Ordering: `update_hash_for` above already persisted the new
+        // `updated_at`, and both calls run inside the same reentrant
+        // `index_mutation_guard`, so no concurrent writer interleaves between
+        // them (`clear_deleted` also re-advances the nonce defensively).
         <Index<S>>::clear_deleted(id, *metadata.updated_at)?;
 
         if id.is_root() {

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -3169,6 +3169,17 @@ impl<S: StorageAdaptor> Interface<S> {
         // inconsistency surfaces immediately as a wrong-content read.
         let full_hash = <Index<S>>::update_hash_for(id, own_hash, Some(metadata.updated_at))?;
 
+        // A value write that causally follows an existing tombstone must lift it,
+        // or `find_by_id` would keep hiding the bytes we just wrote (the entity's
+        // `updated_at` already outran the tombstone in the LWW guard above, so
+        // the write won — but the stale `deleted_at` would silently suppress it,
+        // diverging replicas on delete-then-update vs update-only delivery). This
+        // is a no-op unless the entity is tombstoned; `save_internal` is never on
+        // the delete path (deletes go through `apply_delete_ref_action`), and the
+        // `> deleted_at` guard inside `clear_deleted` keeps ties and older writes
+        // from resurrecting.
+        <Index<S>>::clear_deleted(id, *metadata.updated_at)?;
+
         if id.is_root() {
             info!(
                 target: "storage::root_merge",

--- a/crates/storage/src/tests/crdt.rs
+++ b/crates/storage/src/tests/crdt.rs
@@ -846,9 +846,6 @@ fn d1_delete(id: Id, deleted_at: u64) -> Action {
 /// updates should win over older deletes (LWW-including-deletes / add-wins).
 #[test]
 #[serial]
-#[ignore = "reveals possible bug: a strictly-newer Update does not clear an older \
-            deleted_at tombstone, so the newer write is stored but stays invisible \
-            (over-suppressed) and replicas diverge on delete-then-update vs update-only"]
 fn d1_map_update_newer_than_delete_is_not_over_suppressed() {
     super::common::register_test_merge_functions();
     crate::env::reset_for_testing();


### PR DESCRIPTION
## Bug

A value write whose HLC causally follows an existing tombstone passed the LWW guard in `save_internal` and stored the newer bytes, but never cleared the entity's `deleted_at`. Since `find_by_id` filters on `deleted_at`, the freshly-written value stayed invisible ("over-suppressed"), and **replicas diverged**: the replica that saw `delete` before the newer `update` hid the value, while the replica that only saw the newer `update` (its older `delete` correctly loses in `apply_delete_ref_action`) showed it.

Surfaced by the regression test `d1_map_update_newer_than_delete_is_not_over_suppressed` (added `#[ignore]`d in #3119, now merged). The existing `tombstone_allows_newer_update` test had already hedged on exactly this ("may or may not resurrect").

## Fix

- Add `Index::clear_deleted(id, at)` — the counterpart to `mark_deleted` — which lifts a tombstone only when `at > deleted_at` (strict, monotonic: equal-HLC does not resurrect, older writes never lift a newer tombstone).
- Call it from `save_internal` after the index update. `save_internal` is only ever the value-write path (deletes go through `apply_delete_ref_action`), and it's a no-op unless the entity is tombstoned.
- Un-ignores the D1 regression test.

## Semantics note (for review)

This makes convergence follow **LWW-including-deletes / add-wins**: a causally-later update wins over an older delete. Flagging for maintainer confirmation this is intended (vs. permanent tombstones).

## Verification

- Full `calimero-storage` lib suite: **654 passed, 0 failed** (incl. all `tombstone_*` tests).
- `crdt_conformance` (runtime): **21 passed, 0 failed**.
- `tombstone_prevents_old_resurrection` still holds (older writes hit the early LWW return and never reach `clear_deleted`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)