### PR TITLE
fix(node): re-drive persisted-but-unapplied deltas on restart (B1)

### DIFF
--- a/crates/node/src/crash_recovery_test.rs
+++ b/crates/node/src/crash_recovery_test.rs
@@ -117,10 +117,28 @@ async fn phase0_applied_false_row_not_promoted_on_restart() {
     // Restart: fresh DeltaStore over the same store, then reload from disk.
     // Keep a clone so we can read the persisted row's flag after reload.
     let (delta_store, _tmp, _rx) = delta_store_over(store.clone()).await;
-    let _ = delta_store
+    let result = delta_store
         .load_persisted_deltas()
         .await
         .expect("reload from persisted rows");
+
+    // An applied:false row is re-driven through the apply path, NOT restored as
+    // applied, so it must never surface `pending_handler_events` — those are
+    // harvested only for committed (applied:true) rows. Replaying an uncommitted
+    // row's handlers would fire effects for state that never landed.
+    assert!(
+        result.pending_handler_events.is_empty(),
+        "an applied:false row must not surface phantom handler events on restart"
+    );
+    // The re-drive was ATTEMPTED (the row went to the unapplied re-drive path,
+    // not the applied-topology restore). Its parent is genesis, so `add_delta`
+    // tries to apply immediately; with no WASM runtime that apply fails, leaving
+    // the delta neither applied nor pending — never silently promoted.
+    assert_eq!(
+        delta_store.pending_stats().await.count,
+        0,
+        "a re-driven delta whose apply cannot complete is not left dangling in pending"
+    );
 
     let dag_applied = delta_store.dag_has_delta_applied(&delta_id).await;
     let db_applied = store

--- a/crates/node/src/crash_recovery_test.rs
+++ b/crates/node/src/crash_recovery_test.rs
@@ -96,10 +96,6 @@ fn persist_row(
 /// `applied: false` row is promoted to applied (and made a head) on restart
 /// without re-executing its actions.
 #[tokio::test]
-#[ignore = "reveals possible bug: load_persisted_deltas ignores the persisted \
-            `applied` flag and promotes a Phase-0 applied:false row (killed \
-            before the heads commit) to applied on restart via \
-            restore_applied_delta, without re-executing its actions"]
 async fn phase0_applied_false_row_not_promoted_on_restart() {
     let store = Store::new(Arc::new(InMemoryDB::owned()));
     let delta_id = [0x01; 32];

--- a/crates/node/src/crash_recovery_test.rs
+++ b/crates/node/src/crash_recovery_test.rs
@@ -132,12 +132,18 @@ async fn phase0_applied_false_row_not_promoted_on_restart() {
     );
     // The re-drive was ATTEMPTED (the row went to the unapplied re-drive path,
     // not the applied-topology restore). Its parent is genesis, so `add_delta`
-    // tries to apply immediately; with no WASM runtime that apply fails, leaving
-    // the delta neither applied nor pending — never silently promoted.
+    // treats it as ready and tries to apply immediately (rather than enqueuing it
+    // as pending). With no WASM runtime that apply returns `Err`, which
+    // propagates out of `add_delta`/`add_delta_internal` BEFORE the delta is
+    // registered anywhere — so it is neither applied nor added to the pending
+    // queue, and the DB row stays `applied: false` for the next restart. Hence
+    // `pending_stats().count == 0`: this specifically asserts the apply erred (the
+    // "ready" path) rather than the delta silently going pending. (A missing
+    // parent would instead enqueue it as pending — a different, deliberate path.)
     assert_eq!(
         delta_store.pending_stats().await.count,
         0,
-        "a re-driven delta whose apply cannot complete is not left dangling in pending"
+        "a genesis-parented re-driven delta whose apply errors is not left dangling in pending"
     );
 
     let dag_applied = delta_store.dag_has_delta_applied(&delta_id).await;

--- a/crates/node/src/crash_recovery_test.rs
+++ b/crates/node/src/crash_recovery_test.rs
@@ -86,15 +86,18 @@ fn persist_row(
 ///
 /// Correct restart behavior: such a row — whose state effects were never
 /// committed (root hash unchanged, heads never advanced) — must NOT be treated
-/// as applied on reload. It must be re-driven through apply or left pending;
-/// otherwise the DAG believes a delta is applied whose actions never reached
-/// committed state, an unconvergeable divergence.
+/// as applied on reload. `load_persisted_deltas` now routes `applied: false`
+/// rows through the full `add_delta_internal` path, which re-executes the
+/// actions and, only on success, atomically flips the row to `applied: true`
+/// and advances the heads. The DAG's applied-state and the persisted `applied`
+/// flag therefore always agree — the buggy state (DAG marks it applied while the
+/// DB row is still `applied: false`, so the delta re-drives on every restart and
+/// advertises never-written state) can no longer occur.
 ///
-/// This test is `#[ignore]`d because it currently fails: `load_persisted_deltas`
-/// restores rows purely by parent-reachability (`restore_applied_delta`) and
-/// never consults the persisted `applied` flag, so a genesis-parented
-/// `applied: false` row is promoted to applied (and made a head) on restart
-/// without re-executing its actions.
+/// This harness has no WASM runtime, so the re-driven apply cannot complete;
+/// the delta stays unapplied in BOTH the DAG and the DB (consistent), rather
+/// than being promoted to applied-without-execution as the pre-fix
+/// `restore_applied_delta` path did.
 #[tokio::test]
 async fn phase0_applied_false_row_not_promoted_on_restart() {
     let store = Store::new(Arc::new(InMemoryDB::owned()));
@@ -112,16 +115,34 @@ async fn phase0_applied_false_row_not_promoted_on_restart() {
     );
 
     // Restart: fresh DeltaStore over the same store, then reload from disk.
-    let (delta_store, _tmp, _rx) = delta_store_over(store).await;
+    // Keep a clone so we can read the persisted row's flag after reload.
+    let (delta_store, _tmp, _rx) = delta_store_over(store.clone()).await;
     let _ = delta_store
         .load_persisted_deltas()
         .await
         .expect("reload from persisted rows");
 
+    let dag_applied = delta_store.dag_has_delta_applied(&delta_id).await;
+    let db_applied = store
+        .handle()
+        .get(&calimero_store::key::ContextDagDelta::new(
+            context(),
+            delta_id,
+        ))
+        .expect("read persisted row")
+        .is_some_and(|row| row.applied);
+
+    // The core regression guard: the pre-fix bug left the DAG marking the delta
+    // applied while the DB row stayed `applied: false`. Those two must agree.
+    assert_eq!(
+        dag_applied, db_applied,
+        "DAG applied-state and the persisted `applied` flag must agree; a mismatch \
+         is exactly the pre-fix bug (promoted-to-applied without a committed apply)"
+    );
     assert!(
-        !delta_store.dag_has_delta_applied(&delta_id).await,
-        "an applied:false row that never reached the heads commit must not be \
-         promoted to applied on restart"
+        !dag_applied,
+        "with no WASM runtime the re-drive cannot complete, so the uncommitted \
+         row must not be promoted to applied on restart"
     );
     assert!(
         !delta_store.get_heads().await.contains(&delta_id),

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1303,6 +1303,15 @@ impl DeltaStore {
         let first_key = iter.seek(start_key)?;
 
         let mut all_deltas: HashMap<[u8; 32], CausalDelta<Vec<Action>>> = HashMap::new();
+        // Persisted rows written in Phase 0 (`applied: false`) whose atomic heads
+        // commit never landed — either interrupted by a crash, or a gossip delta
+        // buffered before its parents arrived. Their actions were NEVER committed,
+        // so they must be re-driven through the normal apply-or-pend path
+        // (`add_delta_with_outcome`, which executes actions) rather than restored
+        // as already-applied via `restore_applied_delta` (topology only). Loading
+        // them as applied would insert them as DAG heads without ever running
+        // their effects — advertising committed state that was never written.
+        let mut unapplied_deltas: Vec<CausalDelta<Vec<Action>>> = Vec::new();
         let mut pending_handler_events: Vec<([u8; 32], Vec<u8>)> = Vec::new();
 
         // Process the seek result's (key, value) manually — entries()
@@ -1396,17 +1405,27 @@ impl DeltaStore {
             // as the computed hash (they should be the same for non-merge deltas).
             // For merge deltas, the actual computed hash may have differed, but we don't
             // persist that - this is a minor approximation that works for most cases.
-            {
-                let mut head_hashes = self.head_root_hashes.write().await;
-                let _ = head_hashes.insert(stored_delta.delta_id, stored_delta.expected_root_hash);
-            }
-            {
-                let mut parent_hashes = self.applier.parent_hashes.write().await;
-                let _ =
-                    parent_hashes.insert(stored_delta.delta_id, stored_delta.expected_root_hash);
-            }
+            // Only rows that were actually committed (`applied: true`) seed the
+            // root-hash maps and the topology restore. An `applied: false` row's
+            // `expected_root_hash` is a prediction that never committed, so it
+            // must not pre-seed these maps; it is re-driven below, where the
+            // apply path records the real post-apply hash.
+            if stored_delta.applied {
+                {
+                    let mut head_hashes = self.head_root_hashes.write().await;
+                    let _ =
+                        head_hashes.insert(stored_delta.delta_id, stored_delta.expected_root_hash);
+                }
+                {
+                    let mut parent_hashes = self.applier.parent_hashes.write().await;
+                    let _ = parent_hashes
+                        .insert(stored_delta.delta_id, stored_delta.expected_root_hash);
+                }
 
-            drop(all_deltas.insert(stored_delta.delta_id, dag_delta));
+                drop(all_deltas.insert(stored_delta.delta_id, dag_delta));
+            } else {
+                unapplied_deltas.push(dag_delta);
+            }
         }
 
         // Historically this function bailed early when `all_deltas`
@@ -1507,6 +1526,35 @@ impl DeltaStore {
                 context_id = %self.applier.context_id,
                 loaded_count,
                 "Loaded persisted deltas into DAG from database"
+            );
+        }
+
+        // Re-drive rows that were persisted but never committed (`applied: false`)
+        // through the real apply path AFTER the applied topology is restored, so
+        // their parents are present. `add_delta` executes their actions (or pends
+        // them if a parent is still missing, in which case `try_process_pending`
+        // below / a later parent's arrival drives them). This is the same path a
+        // gossip-received delta takes, so effects are actually applied — never
+        // silently promoted to a DAG head with uncommitted state.
+        if !unapplied_deltas.is_empty() {
+            let mut redriven = 0;
+            let mut dag = self.dag.write().await;
+            for delta in unapplied_deltas {
+                let delta_id = delta.id;
+                match dag.add_delta(delta, &*self.applier).await {
+                    Ok(_) => redriven += 1,
+                    Err(e) => warn!(
+                        ?e,
+                        context_id = %self.applier.context_id,
+                        delta_id = %Hash::from(delta_id).to_base58(),
+                        "Failed to re-drive a persisted-but-unapplied delta on load"
+                    ),
+                }
+            }
+            debug!(
+                context_id = %self.applier.context_id,
+                redriven,
+                "Re-drove persisted-but-unapplied deltas through the apply path"
             );
         }
 

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1306,12 +1306,15 @@ impl DeltaStore {
         // Persisted rows written in Phase 0 (`applied: false`) whose atomic heads
         // commit never landed — either interrupted by a crash, or a gossip delta
         // buffered before its parents arrived. Their actions were NEVER committed,
-        // so they must be re-driven through the normal apply-or-pend path
-        // (`add_delta_with_outcome`, which executes actions) rather than restored
-        // as already-applied via `restore_applied_delta` (topology only). Loading
-        // them as applied would insert them as DAG heads without ever running
-        // their effects — advertising committed state that was never written.
-        let mut unapplied_deltas: Vec<CausalDelta<Vec<Action>>> = Vec::new();
+        // so they must be re-driven through the full `add_delta_internal` path
+        // (which executes actions, persists `applied: true`, and commits the new
+        // heads) rather than restored as already-applied via `restore_applied_delta`
+        // (topology only). Loading them as applied would insert them as DAG heads
+        // without ever running their effects — advertising committed state that was
+        // never written. Re-driving carries the stored author / governance edge /
+        // signature so the receive-time verification the row already passed is
+        // reproduced (never re-applied unverified on a governance-gated context).
+        let mut unapplied_deltas: Vec<BatchDeltaInput> = Vec::new();
         let mut pending_handler_events: Vec<([u8; 32], Vec<u8>)> = Vec::new();
 
         // Process the seek result's (key, value) manually — entries()
@@ -1424,7 +1427,13 @@ impl DeltaStore {
 
                 drop(all_deltas.insert(stored_delta.delta_id, dag_delta));
             } else {
-                unapplied_deltas.push(dag_delta);
+                unapplied_deltas.push(BatchDeltaInput {
+                    delta: dag_delta,
+                    events: stored_delta.events.clone(),
+                    author_id: stored_delta.author_id,
+                    governance_position_blob: stored_delta.governance_position_blob.clone(),
+                    delta_signature: stored_delta.delta_signature,
+                });
             }
         }
 
@@ -1530,18 +1539,36 @@ impl DeltaStore {
         }
 
         // Re-drive rows that were persisted but never committed (`applied: false`)
-        // through the real apply path AFTER the applied topology is restored, so
-        // their parents are present. `add_delta` executes their actions (or pends
-        // them if a parent is still missing, in which case `try_process_pending`
-        // below / a later parent's arrival drives them). This is the same path a
-        // gossip-received delta takes, so effects are actually applied — never
-        // silently promoted to a DAG head with uncommitted state.
+        // AFTER the applied topology is restored, so their parents are present.
+        // Each goes through the FULL single-delta path (`add_delta_internal`), the
+        // same one a gossip-received delta takes: it executes the actions (or pends
+        // the delta if a parent is still missing), re-verifies with the stored
+        // author/governance/signature, seeds `head_root_hashes`, buffers orphan
+        // `SharedMember` deltas whose anchor hasn't synced, retains the per-context
+        // apply lock across the heads commit, and — on success — atomically flips
+        // the row to `applied: true` and advances `dag_heads`. That last step is
+        // why a re-driven delta is not re-driven again on the next restart, and why
+        // its head/root-hash is visible to concurrent readers.
+        //
+        // Crucially we do NOT hold the `dag` write lock across this loop: each WASM
+        // apply can run for up to the apply timeout, and `add_delta_internal` takes
+        // (and releases) its own locks per delta, so concurrent gossip application
+        // and head lookups are not starved.
         if !unapplied_deltas.is_empty() {
+            let total = unapplied_deltas.len();
             let mut redriven = 0;
-            let mut dag = self.dag.write().await;
-            for delta in unapplied_deltas {
-                let delta_id = delta.id;
-                match dag.add_delta(delta, &*self.applier).await {
+            for input in unapplied_deltas {
+                let delta_id = input.delta.id;
+                match self
+                    .add_delta_internal(
+                        input.delta,
+                        input.events,
+                        input.author_id,
+                        input.governance_position_blob,
+                        input.delta_signature,
+                    )
+                    .await
+                {
                     Ok(_) => redriven += 1,
                     Err(e) => warn!(
                         ?e,
@@ -1554,6 +1581,7 @@ impl DeltaStore {
             debug!(
                 context_id = %self.applier.context_id,
                 redriven,
+                total,
                 "Re-drove persisted-but-unapplied deltas through the apply path"
             );
         }


### PR DESCRIPTION
## Bug

`load_persisted_deltas` treated every persisted row as already-applied and restored each via `restore_applied_delta` (topology only, no execution), consulting the persisted `applied` flag nowhere. A Phase-0 `applied: false` row — written before the atomic heads commit and then orphaned by a crash (or a gossip delta buffered before its parents arrived) — was therefore promoted to *applied* and inserted as a DAG head on restart **without ever running its actions**, advertising committed state that was never written.

Surfaced by the `#[ignore]`d regression test added in #3120 (`phase0_applied_false_row_not_promoted_on_restart`).

## Fix

Partition persisted rows by the `applied` flag:
- **committed rows** (`applied: true`) keep the topology-only `restore_applied_delta` path;
- **`applied: false` rows** are re-driven through `add_delta` after the applied topology is restored (so their parents are present). `add_delta` is the same path a gossip delta takes — it executes the actions (or pends the delta if a parent is still missing) and only marks the delta applied once the apply succeeds. Applied-status once again implies the effects actually ran.

CRDT actions are idempotent by HLC/LWW, so re-driving a delta whose effects partially landed converges rather than double-counting.

Un-ignores the B1 regression test.

## Verification

- `crash_recovery_test`: both tests pass (`phase0_...` now green; `merge_topology_...` unaffected).
- `calimero-node` lib: **425 passed, 0 failed**.
- `dag_persistence` (7) and `concurrent_branches_root_hash` (2) integration tests: green.

Stacked on #3120 (the test PR); retargets to `master` when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)