### PR TITLE
fix: harden integer casts, clock arithmetic & Eq/Ord contract

### DIFF
--- a/crates/auth/src/secrets.rs
+++ b/crates/auth/src/secrets.rs
@@ -99,13 +99,20 @@ impl fmt::Debug for VersionedSecret {
     }
 }
 
+/// Seconds since the UNIX epoch. Degrades to `0` if the system clock is set
+/// before 1970 rather than panicking, so a misconfigured clock can't crash the
+/// auth service. Pairs with the saturating arithmetic on the values it feeds.
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
 impl VersionedSecret {
     /// Create a new versioned secret
     pub fn new(secret_type: SecretType, rotation_config: &SecretRotationConfig) -> Self {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let now = now_secs();
 
         // Generate a secure random secret
         let secret: [u8; 32] = rand::thread_rng().gen();
@@ -124,10 +131,7 @@ impl VersionedSecret {
 
     /// Check if this secret has expired
     pub fn is_expired(&self) -> bool {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        let now = now_secs();
         self.expires_at < now
     }
 }
@@ -279,10 +283,7 @@ impl SecretManager {
             .iter()
             .find(|s| s.secret_type == secret_type && s.is_primary)
         {
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_secs();
+            let now = now_secs();
             // Saturate so a backward wall-clock step (NTP correction) that puts
             // `now` before `created_at` can't underflow into a spurious early
             // rotation (or panic in debug builds).

--- a/crates/auth/src/secrets.rs
+++ b/crates/auth/src/secrets.rs
@@ -114,7 +114,9 @@ impl VersionedSecret {
             value: URL_SAFE_NO_PAD.encode(secret),
             version: format!("v{now}"),
             created_at: now,
-            expires_at: now + rotation_config.grace_period,
+            // Saturate so a far-future clock plus a large grace period can't
+            // overflow the u64 expiry.
+            expires_at: now.saturating_add(rotation_config.grace_period),
             is_primary: true,
             secret_type,
         }
@@ -281,7 +283,10 @@ impl SecretManager {
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
                 .as_secs();
-            if now - secret.created_at >= self.rotation_config.rotation_interval {
+            // Saturate so a backward wall-clock step (NTP correction) that puts
+            // `now` before `created_at` can't underflow into a spurious early
+            // rotation (or panic in debug builds).
+            if now.saturating_sub(secret.created_at) >= self.rotation_config.rotation_interval {
                 drop(secrets);
                 self.rotate_secret(secret_type).await?;
             }

--- a/crates/merod/src/kms_policy.rs
+++ b/crates/merod/src/kms_policy.rs
@@ -667,8 +667,9 @@ mod tests {
         // saturated backoff instead of panicking on the `1 << exponent`.
         let far = policy_fetch_backoff(1_000);
         assert_eq!(far.as_millis(), u128::from(u64::MAX));
-        // And it must not panic at the exact boundary either.
-        let _ = policy_fetch_backoff(65);
+        // exponent == 64 (attempt 65) is the exact shift-width boundary: it must
+        // saturate rather than panic.
+        assert_eq!(policy_fetch_backoff(65).as_millis(), u128::from(u64::MAX));
     }
 
     #[test]

--- a/crates/merod/src/kms_policy.rs
+++ b/crates/merod/src/kms_policy.rs
@@ -617,7 +617,10 @@ fn is_valid_release_version(version: &str) -> bool {
 
 fn policy_fetch_backoff(attempt: usize) -> std::time::Duration {
     let exponent = (attempt as u32).saturating_sub(1);
-    std::time::Duration::from_millis(250_u64.saturating_mul(1_u64 << exponent))
+    // `1 << exponent` panics once `exponent >= 64` (attempts past ~64); fall back
+    // to u64::MAX so the saturating_mul below just clamps to the max backoff.
+    let factor = 1_u64.checked_shl(exponent).unwrap_or(u64::MAX);
+    std::time::Duration::from_millis(250_u64.saturating_mul(factor))
 }
 
 /// Resolve policy: fetch from release when version is set, else None.
@@ -652,6 +655,21 @@ mod tests {
     use super::*;
     use base64::Engine;
     use sigstore::cosign::bundle::{Bundle as RekorBundle, Payload as RekorPayload};
+
+    #[test]
+    fn policy_fetch_backoff_saturates_past_shift_width() {
+        // The first attempts grow exponentially from the 250ms base.
+        assert_eq!(policy_fetch_backoff(1).as_millis(), 250);
+        assert_eq!(policy_fetch_backoff(2).as_millis(), 500);
+        assert_eq!(policy_fetch_backoff(4).as_millis(), 2000);
+
+        // Attempts past the u64 shift width (exponent >= 64) must clamp to the
+        // saturated backoff instead of panicking on the `1 << exponent`.
+        let far = policy_fetch_backoff(1_000);
+        assert_eq!(far.as_millis(), u128::from(u64::MAX));
+        // And it must not panic at the exact boundary either.
+        let _ = policy_fetch_backoff(65);
+    }
 
     #[test]
     fn release_version_from_env_uses_priority_order() {

--- a/crates/merod/src/kms_policy.rs
+++ b/crates/merod/src/kms_policy.rs
@@ -620,7 +620,7 @@ fn is_valid_release_version(version: &str) -> bool {
 }
 
 fn policy_fetch_backoff(attempt: usize) -> std::time::Duration {
-    let exponent = (attempt as u32).saturating_sub(1);
+    let exponent = u32::try_from(attempt).unwrap_or(u32::MAX).saturating_sub(1);
     // `1 << exponent` panics once `exponent >= 64` (attempts past ~64); fall back
     // to u64::MAX so the saturating_mul below just clamps to the max backoff.
     let factor = 1_u64.checked_shl(exponent).unwrap_or(u64::MAX);
@@ -670,12 +670,18 @@ mod tests {
         assert_eq!(policy_fetch_backoff(2).as_millis(), 500);
         assert_eq!(policy_fetch_backoff(4).as_millis(), 2000);
 
-        // Growth is bounded by the practical ceiling rather than running away.
+        // The `.min(cap)` engages well before any shift-width concern: attempt 8
+        // (250 * 128 = 32s) is the last value under the 60s ceiling, and attempt
+        // 9 (250 * 256 = 64s) is the first clamped to it.
         let cap = u128::from(POLICY_FETCH_MAX_BACKOFF_MS);
-        assert_eq!(policy_fetch_backoff(1_000).as_millis(), cap);
-        // exponent == 64 (attempt 65) is the exact u64 shift-width boundary: it
-        // must clamp to the ceiling rather than panicking on the `1 << exponent`.
+        assert_eq!(policy_fetch_backoff(8).as_millis(), 32_000);
+        assert_eq!(policy_fetch_backoff(9).as_millis(), cap);
+
+        // Extreme attempts stay clamped: attempt 65 (exponent 64) is the exact
+        // u64 shift-width boundary where `checked_shl` returns None, so the
+        // `checked_shl`/`try_from` guards must keep it at the ceiling, not panic.
         assert_eq!(policy_fetch_backoff(65).as_millis(), cap);
+        assert_eq!(policy_fetch_backoff(usize::MAX).as_millis(), cap);
     }
 
     #[test]

--- a/crates/merod/src/kms_policy.rs
+++ b/crates/merod/src/kms_policy.rs
@@ -25,6 +25,10 @@ use x509_cert::Certificate;
 
 const POLICY_RELEASE_BASE: &str = "https://github.com/calimero-network/mero-tee/releases/download";
 const POLICY_FETCH_RETRIES: usize = 3;
+/// Upper bound on the exponential fetch backoff. Without it a large `attempt`
+/// would saturate to `u64::MAX` milliseconds (~585 million years); this caps
+/// the wait at a practical ceiling.
+const POLICY_FETCH_MAX_BACKOFF_MS: u64 = 60_000;
 const DEFAULT_ALLOWED_TCB_STATUSES: &[&str] = &["uptodate"];
 const POLICY_JSON_ASSET: &str = "kms-phala-attestation-policy.json";
 const POLICY_SIG_ASSET: &str = "kms-phala-attestation-policy.json.sig";
@@ -620,7 +624,10 @@ fn policy_fetch_backoff(attempt: usize) -> std::time::Duration {
     // `1 << exponent` panics once `exponent >= 64` (attempts past ~64); fall back
     // to u64::MAX so the saturating_mul below just clamps to the max backoff.
     let factor = 1_u64.checked_shl(exponent).unwrap_or(u64::MAX);
-    std::time::Duration::from_millis(250_u64.saturating_mul(factor))
+    let millis = 250_u64
+        .saturating_mul(factor)
+        .min(POLICY_FETCH_MAX_BACKOFF_MS);
+    std::time::Duration::from_millis(millis)
 }
 
 /// Resolve policy: fetch from release when version is set, else None.
@@ -657,19 +664,18 @@ mod tests {
     use sigstore::cosign::bundle::{Bundle as RekorBundle, Payload as RekorPayload};
 
     #[test]
-    fn policy_fetch_backoff_saturates_past_shift_width() {
+    fn policy_fetch_backoff_grows_then_caps() {
         // The first attempts grow exponentially from the 250ms base.
         assert_eq!(policy_fetch_backoff(1).as_millis(), 250);
         assert_eq!(policy_fetch_backoff(2).as_millis(), 500);
         assert_eq!(policy_fetch_backoff(4).as_millis(), 2000);
 
-        // Attempts past the u64 shift width (exponent >= 64) must clamp to the
-        // saturated backoff instead of panicking on the `1 << exponent`.
-        let far = policy_fetch_backoff(1_000);
-        assert_eq!(far.as_millis(), u128::from(u64::MAX));
-        // exponent == 64 (attempt 65) is the exact shift-width boundary: it must
-        // saturate rather than panic.
-        assert_eq!(policy_fetch_backoff(65).as_millis(), u128::from(u64::MAX));
+        // Growth is bounded by the practical ceiling rather than running away.
+        let cap = u128::from(POLICY_FETCH_MAX_BACKOFF_MS);
+        assert_eq!(policy_fetch_backoff(1_000).as_millis(), cap);
+        // exponent == 64 (attempt 65) is the exact u64 shift-width boundary: it
+        // must clamp to the ceiling rather than panicking on the `1 << exponent`.
+        assert_eq!(policy_fetch_backoff(65).as_millis(), cap);
     }
 
     #[test]

--- a/crates/network/primitives/src/specialized_node_invite.rs
+++ b/crates/network/primitives/src/specialized_node_invite.rs
@@ -197,8 +197,9 @@ impl Codec for SpecializedNodeInviteCodec {
             ));
         }
 
-        // Write length prefix. The bound above (<= MAX <= u32::MAX, asserted at
-        // compile time) guarantees this cast is lossless.
+        // Write length prefix. The runtime check above bounds `buf.len()` to
+        // MAX_SPECIALIZED_NODE_INVITE_MESSAGE_SIZE, which the compile-time assert
+        // bounds to u32::MAX, so together they make this cast lossless.
         let len = buf.len() as u32;
         io.write_all(&len.to_be_bytes()).await?;
 
@@ -230,8 +231,9 @@ impl Codec for SpecializedNodeInviteCodec {
             ));
         }
 
-        // Write length prefix. The bound above (<= MAX <= u32::MAX, asserted at
-        // compile time) guarantees this cast is lossless.
+        // Write length prefix. The runtime check above bounds `buf.len()` to
+        // MAX_SPECIALIZED_NODE_INVITE_MESSAGE_SIZE, which the compile-time assert
+        // bounds to u32::MAX, so together they make this cast lossless.
         let len = buf.len() as u32;
         io.write_all(&len.to_be_bytes()).await?;
 

--- a/crates/network/primitives/src/specialized_node_invite.rs
+++ b/crates/network/primitives/src/specialized_node_invite.rs
@@ -20,6 +20,11 @@ pub const CALIMERO_SPECIALIZED_NODE_INVITE_PROTOCOL: StreamProtocol =
 /// Maximum size of a specialized node invite message (1MB should be sufficient for attestation + invitation)
 pub const MAX_SPECIALIZED_NODE_INVITE_MESSAGE_SIZE: u64 = 1024 * 1024;
 
+// The message size is framed with a u32 length prefix, so the cap must fit a
+// u32. Enforcing this at compile time lets the write path bound against the cap
+// and then cast to u32 without a fallible conversion.
+const _: () = assert!(MAX_SPECIALIZED_NODE_INVITE_MESSAGE_SIZE <= u32::MAX as u64);
+
 /// Type of specialized node being invited
 #[derive(Debug, Clone, Copy, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum SpecializedNodeType {
@@ -192,9 +197,9 @@ impl Codec for SpecializedNodeInviteCodec {
             ));
         }
 
-        // Write length prefix
-        let len =
-            u32::try_from(buf.len()).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        // Write length prefix. The bound above (<= MAX <= u32::MAX, asserted at
+        // compile time) guarantees this cast is lossless.
+        let len = buf.len() as u32;
         io.write_all(&len.to_be_bytes()).await?;
 
         // Write message
@@ -225,9 +230,9 @@ impl Codec for SpecializedNodeInviteCodec {
             ));
         }
 
-        // Write length prefix
-        let len =
-            u32::try_from(buf.len()).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        // Write length prefix. The bound above (<= MAX <= u32::MAX, asserted at
+        // compile time) guarantees this cast is lossless.
+        let len = buf.len() as u32;
         io.write_all(&len.to_be_bytes()).await?;
 
         // Write message

--- a/crates/network/primitives/src/specialized_node_invite.rs
+++ b/crates/network/primitives/src/specialized_node_invite.rs
@@ -128,7 +128,8 @@ impl Codec for SpecializedNodeInviteCodec {
     where
         T: AsyncRead + Unpin + Send,
     {
-        // Read length prefix (4 bytes, big endian)
+        // Read length prefix (4 bytes, big endian). A u32 always fits usize on
+        // 32-bit and wider targets, so this cast is lossless everywhere.
         let mut len_buf = [0u8; 4];
         io.read_exact(&mut len_buf).await?;
         let len = u32::from_be_bytes(len_buf) as usize;
@@ -156,7 +157,8 @@ impl Codec for SpecializedNodeInviteCodec {
     where
         T: AsyncRead + Unpin + Send,
     {
-        // Read length prefix (4 bytes, big endian)
+        // Read length prefix (4 bytes, big endian). A u32 always fits usize on
+        // 32-bit and wider targets, so this cast is lossless everywhere.
         let mut len_buf = [0u8; 4];
         io.read_exact(&mut len_buf).await?;
         let len = u32::from_be_bytes(len_buf) as usize;

--- a/crates/network/primitives/src/specialized_node_invite.rs
+++ b/crates/network/primitives/src/specialized_node_invite.rs
@@ -183,8 +183,18 @@ impl Codec for SpecializedNodeInviteCodec {
         // Serialize
         let buf = borsh::to_vec(&req).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
+        // Bound the message size so the u32 framing prefix cannot truncate or
+        // misrepresent the payload length (the read side rejects anything larger).
+        if buf.len() as u64 > MAX_SPECIALIZED_NODE_INVITE_MESSAGE_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "request too large",
+            ));
+        }
+
         // Write length prefix
-        let len = buf.len() as u32;
+        let len =
+            u32::try_from(buf.len()).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         io.write_all(&len.to_be_bytes()).await?;
 
         // Write message
@@ -206,8 +216,18 @@ impl Codec for SpecializedNodeInviteCodec {
         // Serialize
         let buf = borsh::to_vec(&res).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
+        // Bound the message size so the u32 framing prefix cannot truncate or
+        // misrepresent the payload length (the read side rejects anything larger).
+        if buf.len() as u64 > MAX_SPECIALIZED_NODE_INVITE_MESSAGE_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "response too large",
+            ));
+        }
+
         // Write length prefix
-        let len = buf.len() as u32;
+        let len =
+            u32::try_from(buf.len()).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         io.write_all(&len.to_be_bytes()).await?;
 
         // Write message

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -628,7 +628,10 @@ impl VMHostFunctions<'_> {
     /// memory region (ptr + len) exceeds the bounds of guest memory.
     fn read_guest_memory_slice(&self, slice: &sys::Buffer<'_>) -> VMLogicResult<&[u8]> {
         let ptr = slice.ptr().value().as_usize();
-        let len = slice.len() as usize;
+        // The buffer length is a u64; on a 32-bit (wasm32) host a plain cast
+        // would silently keep only the low bits, letting the bounds check below
+        // pass while the true length exceeds addressable memory.
+        let len = usize::try_from(slice.len()).map_err(|_| HostError::InvalidMemoryAccess)?;
 
         trace!(
             target: "runtime::memory",
@@ -668,7 +671,9 @@ impl VMHostFunctions<'_> {
     /// memory region (ptr + len) exceeds the bounds of guest memory.
     fn check_guest_memory_bounds(&self, slice: &sys::BufferMut<'_>) -> VMLogicResult<()> {
         let ptr = slice.ptr().value().as_usize();
-        let len = slice.len() as usize;
+        // See `read_guest_memory_slice`: reject u64 lengths that don't fit usize
+        // rather than truncating them on a 32-bit host.
+        let len = usize::try_from(slice.len()).map_err(|_| HostError::InvalidMemoryAccess)?;
 
         let memory = self.borrow_memory();
         let memory_size = memory.data_size() as usize;
@@ -708,7 +713,9 @@ impl VMHostFunctions<'_> {
         data: &[u8],
     ) -> VMLogicResult<()> {
         let ptr = slice.ptr().value().as_usize();
-        let len = slice.len() as usize;
+        // See `read_guest_memory_slice`: reject u64 lengths that don't fit usize
+        // rather than truncating them on a 32-bit host.
+        let len = usize::try_from(slice.len()).map_err(|_| HostError::InvalidMemoryAccess)?;
 
         trace!(
             target: "runtime::memory",

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -584,8 +584,10 @@ impl VMHostFunctions<'_> {
         let lo = self.read_guest_memory_slice(&lo)?.to_vec();
         let hi = self.read_guest_memory_slice(&hi)?.to_vec();
 
-        // `n + 1`-encoded: 0 = unbounded, else `limit - 1`.
-        let limit = (limit != 0).then(|| (limit - 1) as usize);
+        // `n + 1`-encoded: 0 = unbounded, else `limit - 1`. Saturate rather than
+        // silently truncate `u64 -> usize` (usize is 32-bit on a wasm32 host
+        // build); a clamp to usize::MAX just caps at the largest possible bound.
+        let limit = (limit != 0).then(|| usize::try_from(limit - 1).unwrap_or(usize::MAX));
         // Saturate rather than silently truncate `u64 -> usize` (usize is 32-bit
         // on a wasm32 host build); a clamp to usize::MAX just means "skip all".
         let offset = usize::try_from(offset).unwrap_or(usize::MAX);

--- a/crates/server/src/sse/handlers.rs
+++ b/crates/server/src/sse/handlers.rs
@@ -381,7 +381,8 @@ pub async fn sse_handler(
             match load_session(&state.store, existing_session_id) {
                 Ok(Some(persisted_data)) => {
                     // Check if session expired
-                    if now_secs() - persisted_data.last_activity > SESSION_EXPIRY_SECS {
+                    if now_secs().saturating_sub(persisted_data.last_activity) > SESSION_EXPIRY_SECS
+                    {
                         warn!(%existing_session_id, "Persisted session expired, creating new session");
                         // Clean up expired session
                         let mut store = state.store.clone();
@@ -623,7 +624,7 @@ pub async fn get_session_handler(
         Ok(Some(persisted_data)) => {
             // Check if expired
             use super::session::now_secs;
-            if now_secs() - persisted_data.last_activity > SESSION_EXPIRY_SECS {
+            if now_secs().saturating_sub(persisted_data.last_activity) > SESSION_EXPIRY_SECS {
                 (
                     StatusCode::GONE,
                     Json(SseResponse {

--- a/crates/server/src/sse/session.rs
+++ b/crates/server/src/sse/session.rs
@@ -196,11 +196,15 @@ impl SessionState {
     }
 }
 
-/// Get current timestamp in seconds since UNIX epoch
+/// Get current timestamp in seconds since UNIX epoch.
+///
+/// Degrades to `0` if the system clock is set before 1970 rather than panicking,
+/// so a misconfigured clock can't crash the SSE service. Callers subtract this
+/// saturatingly, so a `0` reading just makes a session look maximally stale.
 #[must_use]
 pub fn now_secs() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .expect("System time before UNIX epoch")
+        .unwrap_or_default()
         .as_secs()
 }

--- a/crates/server/src/sse/session.rs
+++ b/crates/server/src/sse/session.rs
@@ -102,7 +102,10 @@ impl SessionStateInner {
     #[must_use]
     pub fn is_expired(&self) -> bool {
         let last = self.last_activity.load(Ordering::SeqCst);
-        now_secs() - last > SESSION_EXPIRY_SECS
+        // `last` is persisted; a backward wall-clock step (NTP correction) can
+        // make it exceed `now`, so subtract saturatingly to avoid an underflow
+        // panic/wrap that would spuriously flag the session as fresh forever.
+        now_secs().saturating_sub(last) > SESSION_EXPIRY_SECS
     }
 }
 

--- a/crates/storage/src/address.rs
+++ b/crates/storage/src/address.rs
@@ -137,7 +137,11 @@ impl Path {
         Ok(Self { offsets, path: str })
     }
 
-    /// Returns the depth (number of segments).
+    /// Returns the depth of the path: the zero-based index of the deepest
+    /// segment, i.e. the number of segments minus one. A single-segment root
+    /// path (`::root`) has depth `0`; `::a::b::c` has depth `2`. The segment
+    /// count is `depth() + 1`, which is why the segment accessors iterate
+    /// `0..=depth()`.
     #[must_use]
     pub fn depth(&self) -> usize {
         self.offsets.len()

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -772,6 +772,12 @@ pub fn needs_owner_convert(metadata: &Metadata, target_version: u32) -> bool {
 /// with `a.cmp(b) == Equal`) and, because it is compared field-wise inside
 /// `Metadata`'s derived `PartialEq`, would make the equal-vs-newer timestamp
 /// distinction in `save_internal` collapse to a single always-taken branch.
+///
+/// Consequence for callers: two `Metadata` values that differ only in
+/// `updated_at` now compare unequal (they previously compared equal under the
+/// always-true `eq`). Metadata equality is not on any production hot path — only
+/// convergence assertions in tests compare it — so this is the intended, safer
+/// behaviour rather than a regression.
 #[derive(
     BorshDeserialize, BorshSerialize, Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd,
 )]

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -765,15 +765,17 @@ pub fn needs_owner_convert(metadata: &Metadata, target_version: u32) -> bool {
 // Breaking change: Old data without crdt_type/field_name fields will fail to deserialize.
 // This is intentional - we require fresh nodes with the new data format.
 
-/// Update timestamp (PartialEq always true for CRDT semantics).
-#[derive(BorshDeserialize, BorshSerialize, Copy, Clone, Debug, Default, Eq, Ord, PartialOrd)]
+/// Update timestamp.
+///
+/// `PartialEq` compares the inner value like `Ord`/`PartialOrd` do: an
+/// always-true `eq` would violate the `Eq`/`Ord` contract (`a == b` must agree
+/// with `a.cmp(b) == Equal`) and, because it is compared field-wise inside
+/// `Metadata`'s derived `PartialEq`, would make the equal-vs-newer timestamp
+/// distinction in `save_internal` collapse to a single always-taken branch.
+#[derive(
+    BorshDeserialize, BorshSerialize, Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd,
+)]
 pub struct UpdatedAt(u64);
-
-impl PartialEq for UpdatedAt {
-    fn eq(&self, _other: &Self) -> bool {
-        true
-    }
-}
 
 impl Deref for UpdatedAt {
     type Target = u64;

--- a/crates/storage/src/tests/crdt.rs
+++ b/crates/storage/src/tests/crdt.rs
@@ -980,3 +980,104 @@ fn d1_map_delete_vs_update_convergence_is_apply_order_independent() {
         "map-container root hash must be identical regardless of apply order"
     );
 }
+
+type BranchNode = MockedStorage<7103>;
+type BranchIface = Interface<BranchNode>;
+
+/// `save_internal` picks its LWW-by-HLC branch by comparing `updated_at` under
+/// both `>` (`Ord`) and `==` (`PartialEq`). While `UpdatedAt::eq` was hard-coded
+/// to always return `true`, every non-stale write took the equal-timestamp
+/// branch and the strictly-newer branch was unreachable. This drives all three
+/// branches explicitly and asserts each applies the write it should — a
+/// regression guard for the corrected value-based `PartialEq`.
+#[test]
+#[serial]
+fn save_internal_selects_branch_by_updated_at() {
+    super::common::register_test_merge_functions();
+    crate::env::reset_for_testing();
+
+    let id = Id::new([0x5b; 32]);
+    let ancestors = vec![crate::entities::ChildInfo::new(
+        Id::root(),
+        [0; 32],
+        Metadata::default(),
+    )];
+
+    let make = |value: &str, updated_at: u64, is_add: bool| -> Action {
+        let mut page = Page::new_from_element(value, Element::new(Some(id)));
+        page.element_mut().set_updated_at(updated_at);
+        let data = borsh::to_vec(&page).unwrap();
+        let metadata = page.element().metadata.clone();
+        if is_add {
+            Action::Add {
+                id,
+                data,
+                ancestors: ancestors.clone(),
+                metadata,
+            }
+        } else {
+            Action::Update {
+                id,
+                data,
+                ancestors: vec![],
+                metadata,
+            }
+        }
+    };
+
+    let stored_nonce = || {
+        *Index::<BranchNode>::get_index(id)
+            .unwrap()
+            .unwrap()
+            .metadata
+            .updated_at
+    };
+
+    let base = time_now();
+    let t = base - 10_000_000;
+
+    // Base write at `t`.
+    BranchIface::apply_action(make("v0", t, true), &ApplyContext::empty()).unwrap();
+    assert_eq!(
+        BranchIface::find_by_id::<Page>(id).unwrap().unwrap().title,
+        "v0"
+    );
+    assert_eq!(stored_nonce(), t);
+
+    // Older write (`updated_at < stored`): the `>` guard must stale-skip it, so
+    // the stored value is unchanged and the nonce does not regress.
+    BranchIface::apply_action(make("v_old", t - 1, false), &ApplyContext::empty()).unwrap();
+    assert_eq!(
+        BranchIface::find_by_id::<Page>(id).unwrap().unwrap().title,
+        "v0",
+        "older write must be stale-skipped"
+    );
+    assert_eq!(stored_nonce(), t, "older write must not regress the nonce");
+
+    // Equal-timestamp write: the equal branch must merge, not drop the entity.
+    BranchIface::apply_action(make("v_eq", t, false), &ApplyContext::empty()).unwrap();
+    assert!(
+        BranchIface::find_by_id::<Page>(id).unwrap().is_some(),
+        "equal-timestamp write must merge, not drop the entity"
+    );
+    assert_eq!(
+        stored_nonce(),
+        t,
+        "equal-timestamp write keeps the same nonce"
+    );
+
+    // Strictly-newer write: the branch that was unreachable under the always-true
+    // `eq`. It must apply and win by LWW, advancing the nonce.
+    let t_new = t + 10_000_000;
+    BranchIface::apply_action(make("v_new", t_new, false), &ApplyContext::empty()).unwrap();
+    assert_eq!(
+        BranchIface::find_by_id::<Page>(id).unwrap().unwrap().title,
+        "v_new",
+        "strictly-newer write must win by LWW"
+    );
+    assert_eq!(
+        stored_nonce(),
+        t_new,
+        "strictly-newer write advances the nonce"
+    );
+}

--- a/crates/storage/src/tests/entities.rs
+++ b/crates/storage/src/tests/entities.rs
@@ -545,3 +545,34 @@ mod op_mask__borsh {
         }
     }
 }
+
+#[cfg(test)]
+mod updated_at__eq_ord_contract {
+    use crate::entities::UpdatedAt;
+
+    #[test]
+    fn eq_agrees_with_ord() {
+        // `PartialEq` must agree with `Ord`: `a == b` iff `a.cmp(&b) == Equal`.
+        // An always-true `eq` (the previous behaviour) violated this and made
+        // the equal-vs-newer timestamp branch in `save_internal` unreachable.
+        let a = UpdatedAt::from(10);
+        let b = UpdatedAt::from(20);
+        let a2 = UpdatedAt::from(10);
+
+        assert_eq!(a, a2);
+        assert_ne!(a, b);
+        assert!(a < b);
+        assert!(b > a);
+        assert_eq!(a.cmp(&a2), core::cmp::Ordering::Equal);
+
+        for &(x, y) in &[(0u64, 0u64), (0, 1), (5, 5), (7, 3), (u64::MAX, 0)] {
+            let lhs = UpdatedAt::from(x);
+            let rhs = UpdatedAt::from(y);
+            assert_eq!(
+                lhs == rhs,
+                lhs.cmp(&rhs) == core::cmp::Ordering::Equal,
+                "eq must match cmp==Equal for ({x}, {y})"
+            );
+        }
+    }
+}

--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -70,14 +70,12 @@ pub enum Size {
 }
 
 impl Size {
-    const fn hint(&self) -> usize {
-        // TODO: Check this, as the incoming int is a u64
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "This is never expected to overflow"
-        )]
+    fn hint(&self) -> usize {
+        // The size is a u64; on a 32-bit host a plain cast would truncate and
+        // mis-size the links vector. Clamp to usize::MAX instead — it only ever
+        // feeds `Vec::with_capacity`, so a saturated hint is harmless.
         match self {
-            Self::Hint(size) | Self::Exact(size) => *size as usize,
+            Self::Hint(size) | Self::Exact(size) => usize::try_from(*size).unwrap_or(usize::MAX),
         }
     }
 


### PR DESCRIPTION
## Summary

Correctness fixes for a batch of reported cast/arithmetic/contract issues. Most guard against silent `u64 -> usize`/`u32` truncation on 32-bit (wasm32) targets; the rest fix wall-clock underflow, a shift-width panic, and an `Eq`/`Ord` contract violation.

Two of the originally reported items were already fixed on `master` and are **not** in this PR:
- governance-store pagination `limit == 0` (early-return already present).
- `decode_index_pairs` value-length path (already uses `checked_add`).

## Fixes

| Area | File | Change |
|---|---|---|
| network | `specialized_node_invite.rs` | Bound write-side length to the same `MAX_…MESSAGE_SIZE` the read side enforces + encode via `u32::try_from`, so an oversized payload can't truncate the framing prefix. |
| runtime | `logic.rs` | `usize::try_from` guest-supplied lengths in the read/check/write guest-memory helpers (report named read; check & write had the identical truncation). |
| runtime | `host_functions/storage.rs` | `storage_index_scan` limit uses `usize::try_from(...).unwrap_or(usize::MAX)`, matching the already-saturated offset. |
| blobs | `store/blobs/lib.rs` | `Size::hint()` saturates the u64→usize conversion (mis-sized the links vector on 32-bit); dropped the stale `const`/`cast_possible_truncation` allow. |
| server (SSE) | `sse/session.rs`, `sse/handlers.rs` | `saturating_sub` on persisted-timestamp expiry checks (backward NTP step no longer underflows). |
| auth | `auth/secrets.rs` | `saturating_sub` (rotation check) + `saturating_add` (expiry). |
| merod | `kms_policy.rs` | KMS backoff uses `checked_shl` so retries past the u64 shift width clamp instead of panicking. |
| storage | `entities.rs` | `UpdatedAt` derives `PartialEq` (delegates to inner `u64`) instead of an always-true `eq` that violated the `Eq`/`Ord` contract and made the equal-vs-newer branch in `save_internal` unreachable. |
| storage | `address.rs` | Corrected `Path::depth()` doc to its actual `segments - 1` semantics (code/tests/callers all rely on this; changing the value would break the model). |

### Note on `UpdatedAt`

`Metadata` derives `PartialEq`, so the always-true `eq` was silently making `Metadata` equality ignore the timestamp. Only test code compares `Metadata` by `==`. The full sync_sim convergence suite (314 tests) passes with the change — nodes converge including HLC timestamps.

## Tests

- Added regression tests: `policy_fetch_backoff` saturation past the shift width, and `UpdatedAt` eq/cmp agreement.
- `cargo check` + `cargo clippy` clean on all affected crates.
- Passing: storage (653), sync_sim (314), runtime, auth, blobstore, network-primitives, merod, server.
- `Cargo.lock` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)