### PR TITLE
fix: wasm guest validation, blob refcounting, and hardening batch

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -94,12 +94,17 @@ impl TeeConfig {
     /// must be mutually exclusive on a single node.
     ///
     /// Returns `false` when no KMS provider is configured (e.g. `kms.phala`
-    /// absent), which permits `--mock-tee`. If a second KMS provider is added,
-    /// extend this predicate to cover it.
+    /// absent), which permits `--mock-tee`.
+    ///
+    /// The `KmsConfig` is destructured field-by-field with no `..` rest pattern
+    /// on purpose: adding a new provider field to `KmsConfig` will fail to
+    /// compile here until it is folded into this predicate. That keeps the
+    /// `--mock-tee` deny-guard exhaustive across every provider rather than
+    /// silently ignoring a newly-added one.
     #[must_use]
     pub fn has_real_attestation(&self) -> bool {
-        self.kms
-            .phala
+        let KmsConfig { phala } = &self.kms;
+        phala
             .as_ref()
             .is_some_and(|phala| phala.attestation.enabled && !phala.attestation.accept_mock)
     }

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -854,44 +854,6 @@ impl ContextRegistry {
         Ok(())
     }
 
-    /// Verifies that the stored root hash matches the actual state.
-    ///
-    /// Computes the root hash from storage and compares with the claimed hash.
-    /// Returns Ok(()) if they match, or an error describing the mismatch.
-    ///
-    /// # Arguments
-    ///
-    /// * `context_id` - The ID of the context to verify.
-    /// * `claimed_hash` - The hash to verify against.
-    ///
-    /// # Returns
-    ///
-    /// A `Result` indicating success if hashes match, or an error if they don't.
-    pub fn verify_root_hash(
-        &self,
-        context_id: &ContextId,
-        claimed_hash: [u8; 32],
-    ) -> eyre::Result<()> {
-        let computed = self.compute_root_hash(context_id)?;
-
-        if computed != claimed_hash {
-            eyre::bail!(
-                "Root hash verification failed for context {}: computed {} != claimed {}",
-                context_id,
-                hex::encode(computed),
-                hex::encode(claimed_hash)
-            );
-        }
-
-        tracing::debug!(
-            %context_id,
-            hash = ?Hash::from(computed),
-            "Root hash verified successfully"
-        );
-
-        Ok(())
-    }
-
     /// Reads ROOT's index entry + `Key::Entry(ROOT)` bytes in a single
     /// pass and returns both the self-dump (own_hash/full_hash/entry
     /// summary) and the children list — diagnostic for #2319.
@@ -1433,15 +1395,6 @@ impl ContextClient {
     /// Forces the root hash for a context to a specific value.
     pub fn force_root_hash(&self, context_id: &ContextId, root_hash: Hash) -> eyre::Result<()> {
         self.registry.force_root_hash(context_id, root_hash)
-    }
-
-    /// Verifies that the stored root hash matches the actual state.
-    pub fn verify_root_hash(
-        &self,
-        context_id: &ContextId,
-        claimed_hash: [u8; 32],
-    ) -> eyre::Result<()> {
-        self.registry.verify_root_hash(context_id, claimed_hash)
     }
 
     /// Diagnostic — dump ROOT's self summary + children list in one read.

--- a/crates/merod/src/cli/run.rs
+++ b/crates/merod/src/cli/run.rs
@@ -54,10 +54,10 @@ impl RunCommand {
         // startup warning below. Do not flip this to an allow-list; this is the
         // agreed dev-only flag behavior.
         //
-        // FIXME: `has_real_attestation` only covers the Phala KMS provider. If a
-        // second KMS provider is ever added, extend that predicate (see its doc
-        // in `calimero_config::TeeConfig`) so this guard keeps refusing `--mock-tee`
-        // on real-attestation nodes.
+        // `has_real_attestation` destructures `KmsConfig` exhaustively (no `..`),
+        // so adding a second KMS provider fails to compile there until the new
+        // provider is folded into the predicate — this guard cannot silently
+        // stop covering a provider.
         if self.mock_tee {
             if config
                 .tee

--- a/crates/node/primitives/src/client/blob.rs
+++ b/crates/node/primitives/src/client/blob.rs
@@ -97,7 +97,12 @@ impl BlobManager {
         self.blobstore.get(blob_id)
     }
 
-    pub async fn delete_blob_file(&self, blob_id: BlobId) -> eyre::Result<bool> {
+    /// Release one reference to `blob_id`, deleting its files and metadata (and
+    /// those of its chunks) only once the last reference is gone. Content is
+    /// deduplicated by hash, so several owners can share the same blob; the
+    /// refcount-aware, tree-aware deletion lives in
+    /// [`calimero_blobstore::BlobManager::delete`].
+    pub async fn delete_blob(&self, blob_id: BlobId) -> eyre::Result<bool> {
         self.blobstore.delete(blob_id).await
     }
 }
@@ -503,82 +508,28 @@ impl NodeClient {
         Ok(root_blobs)
     }
 
-    /// Delete a blob by its ID
+    /// Release this owner's reference to a blob by its ID.
     ///
-    /// Removes blob metadata from database and deletes the actual blob files.
-    /// This includes all associated chunk files for large blobs.
+    /// Blobs are content-addressed and deduplicated: the same bytes can be
+    /// referenced by several contexts, and a chunk can be shared by several root
+    /// blobs. So this does not delete eagerly — it decrements the blob's (and,
+    /// for a root blob, each chunk's) reference count and removes the files and
+    /// metadata only once nothing references them. Deleting eagerly here would
+    /// corrupt other owners' blobs that share the same content.
+    ///
+    /// Returns `Ok(true)` when the blob existed and its reference was released;
+    /// errors with "Blob not found" when it was already absent.
     pub async fn delete_blob(&self, blob_id: BlobId) -> eyre::Result<bool> {
-        let mut handle = self.datastore.clone().handle();
-        let blob_key = key::BlobMeta::new(blob_id);
-
-        let blob_meta = match handle.get(&blob_key) {
-            Ok(Some(meta)) => meta,
-            Ok(None) => {
-                bail!("Blob not found");
+        match self.blob_manager.delete_blob(blob_id).await {
+            Ok(true) => {
+                tracing::info!(%blob_id, "released blob reference");
+                Ok(true)
             }
+            Ok(false) => bail!("Blob not found"),
             Err(err) => {
-                tracing::error!("Failed to get blob metadata {}: {:?}", blob_id, err);
-                bail!("Failed to access blob metadata: {}", err);
+                tracing::error!("Failed to delete blob {}: {:?}", blob_id, err);
+                bail!("Failed to delete blob: {}", err);
             }
-        };
-
-        tracing::info!(
-            "Starting deletion for blob {} with {} linked chunks",
-            blob_id,
-            blob_meta.links.len()
-        );
-
-        let mut blobs_to_delete = vec![blob_id];
-        let mut deleted_metadata_count = 0;
-        let mut deleted_files_count = 0;
-
-        blobs_to_delete.extend(blob_meta.links.iter().map(key::BlobMeta::blob_id));
-
-        // Delete blob files first
-        for current_blob_id in &blobs_to_delete {
-            match self.blob_manager.delete_blob_file(*current_blob_id).await {
-                Ok(true) => {
-                    deleted_files_count += 1;
-                    tracing::debug!("Successfully deleted blob file {}", current_blob_id);
-                }
-                Ok(false) => {
-                    tracing::debug!("Blob file {} was already missing", current_blob_id);
-                }
-                Err(err) => {
-                    tracing::warn!("Failed to delete blob file {}: {}", current_blob_id, err);
-                    // Continue with metadata deletion even if file deletion fails
-                }
-            }
-        }
-
-        // Delete metadata
-        for current_blob_id in blobs_to_delete {
-            let current_key = key::BlobMeta::new(current_blob_id);
-
-            match handle.delete(&current_key) {
-                Ok(()) => {
-                    deleted_metadata_count += 1;
-                    tracing::debug!("Successfully deleted metadata for blob {}", current_blob_id);
-                }
-                Err(err) => {
-                    tracing::warn!(
-                        "Failed to delete metadata for blob {}: {}",
-                        current_blob_id,
-                        err
-                    );
-                }
-            }
-        }
-
-        if deleted_metadata_count > 0 {
-            tracing::info!(
-                "Successfully deleted {} blob metadata entries and {} blob files",
-                deleted_metadata_count,
-                deleted_files_count
-            );
-            Ok(true)
-        } else {
-            bail!("Failed to delete any blob metadata");
         }
     }
 

--- a/crates/runtime/src/errors.rs
+++ b/crates/runtime/src/errors.rs
@@ -49,6 +49,8 @@ pub enum FunctionCallError {
     ExecutionError(Vec<u8>),
     #[error("module size limit (max_module_size) exceeded: {size} bytes > {max} bytes limit")]
     ModuleSizeLimitExceeded { size: u64, max: u64 },
+    #[error("module rejected by validation: {reason}")]
+    ModuleValidationError { reason: String },
 }
 
 /// Error returned by

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -107,12 +107,14 @@ impl Engine {
     pub fn new(mut engine: wasmer::Engine, limits: VMLimits) -> Self {
         // A self-contradictory limits config (e.g. a total register budget
         // smaller than a single register's cap) is a construction-time
-        // programming error, not a runtime condition, and is never reachable
-        // from guest input. Fail loudly here, at engine construction — once, at
-        // startup — instead of letting it misbehave on every execution.
-        limits
-            .validate_invariants()
-            .expect("invalid VMLimits passed to Engine::new");
+        // programming error: it is never reachable from guest input nor from
+        // operator config (which does not expose these fields), only from a code
+        // change. A debug assertion catches it in dev/CI/tests without a
+        // process-fatal panic in release library code.
+        debug_assert!(
+            limits.validate_invariants().is_ok(),
+            "invalid VMLimits passed to Engine::new: max_registers_capacity must be >= max_register_size"
+        );
 
         // Set tunables if this is a sys engine (native engine)
         if engine.is_sys() {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -105,6 +105,15 @@ impl Default for Engine {
 impl Engine {
     #[must_use]
     pub fn new(mut engine: wasmer::Engine, limits: VMLimits) -> Self {
+        // A self-contradictory limits config (e.g. a total register budget
+        // smaller than a single register's cap) is a construction-time
+        // programming error, not a runtime condition, and is never reachable
+        // from guest input. Fail loudly here, at engine construction — once, at
+        // startup — instead of letting it misbehave on every execution.
+        limits
+            .validate_invariants()
+            .expect("invalid VMLimits passed to Engine::new");
+
         // Set tunables if this is a sys engine (native engine)
         if engine.is_sys() {
             use wasmer::sys::NativeEngineExt;
@@ -193,23 +202,68 @@ impl Engine {
             });
         }
 
-        // todo! apply a prepare step
-        // todo! - parse the wasm blob, validate and apply transformations
-        // todo!   - validations:
-        // todo!     - there is no memory import
-        // todo!     - there is no _start function
-        // todo!   - transformations:
-        // todo!     - remove memory export
-        // todo!     - remove memory section
-        // todo! cache the compiled module in storage for later
-
         let module = wasmer::Module::new(&self.engine, bytes)?;
+
+        Self::validate_guest_module(&module)?;
 
         Ok(Module {
             limits: self.limits,
             engine: self.engine.clone(),
             module,
         })
+    }
+
+    /// Reject untrusted guest modules whose shape would let them escape the
+    /// sandbox contract the runtime relies on. Runs once per compile, after
+    /// wasmer has validated the bytes are well-formed WASM.
+    ///
+    /// Two checks:
+    ///
+    /// * **No imported memory.** Every guest must define and *export* its own
+    ///   linear memory named `memory` — the host reads guest state through
+    ///   `instance.exports.get_memory("memory")`. A module that instead
+    ///   *imports* its memory expects the host to hand it one, which the runtime
+    ///   never provides; such a module could only be attempting to alias
+    ///   host-supplied memory, so it is rejected outright rather than failing
+    ///   deeper in instantiation.
+    /// * **No `_start` export.** `_start` is the entry point a WASI *command*
+    ///   build emits (`wasm32-wasip1`/`wasm32-wasi` toolchains) — the WASI ABI's
+    ///   equivalent of `main`, meant to run once on start. It is a property of
+    ///   how the guest was *compiled*, independent of wasmer (the engine we run
+    ///   it with). Calimero guests are libraries built for
+    ///   `wasm32-unknown-unknown` and invoked by explicit method name, so a
+    ///   `_start` export means the module was built against the wrong target
+    ///   (and likely expects WASI syscall imports the host does not provide). It
+    ///   is refused up front rather than instantiated in a half-supported shape.
+    #[allow(
+        clippy::result_large_err,
+        reason = "pervasive #[from] error enum; boxing breaks the derive"
+    )]
+    fn validate_guest_module(module: &wasmer::Module) -> Result<(), FunctionCallError> {
+        use wasmer::ExternType;
+
+        for import in module.imports() {
+            if matches!(import.ty(), ExternType::Memory(_)) {
+                return Err(FunctionCallError::ModuleValidationError {
+                    reason: format!(
+                        "guest imports memory `{}::{}`; guests must define and export \
+                         their own memory, not import it from the host",
+                        import.module(),
+                        import.name()
+                    ),
+                });
+            }
+        }
+
+        if module.exports().any(|export| export.name() == "_start") {
+            return Err(FunctionCallError::ModuleValidationError {
+                reason: "guest exports a `_start` function; WASI command entry points are \
+                         not supported (guests are invoked by explicit method name)"
+                    .to_owned(),
+            });
+        }
+
+        Ok(())
     }
 
     /// Deserialize a precompiled (serialized) module produced by
@@ -1218,6 +1272,92 @@ mod wasm_integration_tests {
             result.is_ok(),
             "Expected successful compilation, got: {result:?}"
         );
+    }
+
+    /// A guest that imports its linear memory from the host is rejected: guests
+    /// must define and export their own memory, never alias a host-supplied one.
+    #[test]
+    fn guest_importing_memory_is_rejected() {
+        let wat = r#"
+            (module
+                (import "env" "memory" (memory 1))
+                (func (export "test_func"))
+            )
+        "#;
+        let wasm = wat::parse_str(wat).expect("Failed to parse WAT");
+
+        let engine = Engine::new(wasmer::Engine::default(), VMLimits::default());
+
+        match engine.compile(&wasm) {
+            Err(FunctionCallError::ModuleValidationError { reason }) => {
+                assert!(reason.contains("memory"), "unexpected reason: {reason}");
+            }
+            other => panic!("expected ModuleValidationError for imported memory, got: {other:?}"),
+        }
+    }
+
+    /// A guest exporting a WASI-style `_start` entry point is rejected: Calimero
+    /// guests are libraries invoked by explicit method name, not WASI commands.
+    #[test]
+    fn guest_exporting_start_is_rejected() {
+        let wat = r#"
+            (module
+                (memory (export "memory") 1)
+                (func (export "_start"))
+            )
+        "#;
+        let wasm = wat::parse_str(wat).expect("Failed to parse WAT");
+
+        let engine = Engine::new(wasmer::Engine::default(), VMLimits::default());
+
+        match engine.compile(&wasm) {
+            Err(FunctionCallError::ModuleValidationError { reason }) => {
+                assert!(reason.contains("_start"), "unexpected reason: {reason}");
+            }
+            other => panic!("expected ModuleValidationError for `_start`, got: {other:?}"),
+        }
+    }
+
+    /// A conforming guest — exports its own memory, no `_start`, no imported
+    /// memory — passes validation and compiles.
+    #[test]
+    fn conforming_guest_passes_validation() {
+        let wat = r#"
+            (module
+                (import "env" "some_host_fn" (func))
+                (memory (export "memory") 1)
+                (func (export "app_method"))
+            )
+        "#;
+        let wasm = wat::parse_str(wat).expect("Failed to parse WAT");
+
+        let engine = Engine::new(wasmer::Engine::default(), VMLimits::default());
+
+        assert!(
+            engine.compile(&wasm).is_ok(),
+            "a conforming guest module must pass validation"
+        );
+    }
+
+    /// The default limits satisfy the registers invariant, and violating it is
+    /// caught loudly at engine construction rather than at execution time.
+    #[test]
+    fn vmlimits_default_satisfies_registers_invariant() {
+        VMLimits::default()
+            .validate_invariants()
+            .expect("default limits must be valid");
+    }
+
+    #[test]
+    #[should_panic(expected = "max_registers_capacity")]
+    fn engine_rejects_registers_capacity_below_register_size() {
+        // A total register budget smaller than a single register's cap is
+        // self-contradictory; Engine::new must refuse it up front.
+        let limits = VMLimits {
+            max_registers_capacity: 1,
+            ..Default::default()
+        };
+        let _ = Engine::new(wasmer::Engine::default(), limits);
     }
 
     /// Test that modules exactly at the size limit compile successfully (boundary condition)

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -217,15 +217,17 @@ impl Engine {
     /// sandbox contract the runtime relies on. Runs once per compile, after
     /// wasmer has validated the bytes are well-formed WASM.
     ///
-    /// Two checks:
+    /// Three checks:
     ///
-    /// * **No imported memory.** Every guest must define and *export* its own
-    ///   linear memory named `memory` — the host reads guest state through
-    ///   `instance.exports.get_memory("memory")`. A module that instead
-    ///   *imports* its memory expects the host to hand it one, which the runtime
-    ///   never provides; such a module could only be attempting to alias
-    ///   host-supplied memory, so it is rejected outright rather than failing
-    ///   deeper in instantiation.
+    /// * **No imported memory.** A module that *imports* its linear memory
+    ///   expects the host to hand it one, which the runtime never provides; such
+    ///   a module could only be attempting to alias host-supplied memory, so it
+    ///   is rejected outright rather than failing deeper in instantiation.
+    /// * **Exports a memory named `memory`.** The host reads guest state through
+    ///   `instance.exports.get_memory("memory")`, so a guest that exports no such
+    ///   memory cannot be run. Requiring it here turns what would otherwise be a
+    ///   confusing export-not-found failure at instantiation into a clear
+    ///   validation error at compile time.
     /// * **No `_start` export.** `_start` is the entry point a WASI *command*
     ///   build emits (`wasm32-wasip1`/`wasm32-wasi` toolchains) — the WASI ABI's
     ///   equivalent of `main`, meant to run once on start. It is a property of
@@ -259,6 +261,17 @@ impl Engine {
             return Err(FunctionCallError::ModuleValidationError {
                 reason: "guest exports a `_start` function; WASI command entry points are \
                          not supported (guests are invoked by explicit method name)"
+                    .to_owned(),
+            });
+        }
+
+        let exports_memory = module.exports().any(|export| {
+            export.name() == "memory" && matches!(export.ty(), ExternType::Memory(_))
+        });
+        if !exports_memory {
+            return Err(FunctionCallError::ModuleValidationError {
+                reason: "guest does not export a linear memory named `memory`; the host \
+                         reads guest state through that export"
                     .to_owned(),
             });
         }
@@ -1315,6 +1328,27 @@ mod wasm_integration_tests {
                 assert!(reason.contains("_start"), "unexpected reason: {reason}");
             }
             other => panic!("expected ModuleValidationError for `_start`, got: {other:?}"),
+        }
+    }
+
+    /// A guest that exports no linear memory named `memory` is rejected with a
+    /// clear validation error rather than failing later at instantiation.
+    #[test]
+    fn guest_without_memory_export_is_rejected() {
+        let wat = r#"
+            (module
+                (func (export "app_method"))
+            )
+        "#;
+        let wasm = wat::parse_str(wat).expect("Failed to parse WAT");
+
+        let engine = Engine::new(wasmer::Engine::default(), VMLimits::default());
+
+        match engine.compile(&wasm) {
+            Err(FunctionCallError::ModuleValidationError { reason }) => {
+                assert!(reason.contains("memory"), "unexpected reason: {reason}");
+            }
+            other => panic!("expected ModuleValidationError for missing memory, got: {other:?}"),
         }
     }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -257,7 +257,9 @@ impl Engine {
             }
         }
 
-        if module.exports().any(|export| export.name() == "_start") {
+        if module.exports().any(|export| {
+            export.name() == "_start" && matches!(export.ty(), ExternType::Function(_))
+        }) {
             return Err(FunctionCallError::ModuleValidationError {
                 reason: "guest exports a `_start` function; WASI command entry points are \
                          not supported (guests are invoked by explicit method name)"

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -190,8 +190,10 @@ pub struct VMLimits {
     /// constrained to be less than u64::MAX
     /// because register_len returns u64::MAX if the register is not found
     pub max_register_size: Constrained<u64, MaxU64<{ u64::MAX - 1 }>>,
-    /// The total capacity across all registers in bytes.
-    pub max_registers_capacity: u64, // todo! must not be less than max_register_size
+    /// The total capacity across all registers in bytes. Must be `>=`
+    /// [`max_register_size`](Self::max_register_size) — enforced by
+    /// [`VMLimits::validate`], which every engine runs at construction.
+    pub max_registers_capacity: u64,
     /// The maximum number of log entries that can be created.
     pub max_logs: u64,
     /// The maximum size of a single log message in bytes.
@@ -247,6 +249,32 @@ pub struct VMLimits {
     /// deserialization error instead, matching the behavior of
     /// [`max_module_size`](Self::max_module_size).
     pub max_precompiled_module_size: u64,
+}
+
+impl VMLimits {
+    /// Check cross-field invariants that the individual field types can't
+    /// express on their own. Returns a message describing the first violation.
+    /// (Named `validate_invariants`, not `validate`, so it does not collide with
+    /// the blanket [`Constraint::validate`](crate::Constraint) method that every
+    /// type gets.)
+    ///
+    /// Enforces `max_registers_capacity >= max_register_size`: the total budget
+    /// shared across all registers cannot be smaller than the cap on a single
+    /// register. If it were, a lone maximum-size register write would already
+    /// blow the aggregate budget — the per-register check in `Registers::set`
+    /// would admit a write that the capacity check in the same function then
+    /// rejects, leaving the limit self-contradictory. Every engine runs this at
+    /// construction ([`Engine::new`](crate::Engine::new)) so such a config fails
+    /// loudly at startup rather than misbehaving per execution.
+    pub fn validate_invariants(&self) -> Result<(), &'static str> {
+        if self.max_registers_capacity < *self.max_register_size {
+            return Err(
+                "max_registers_capacity must be >= max_register_size (the total register \
+                 budget cannot be smaller than a single register's cap)",
+            );
+        }
+        Ok(())
+    }
 }
 
 impl Default for VMLimits {

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -253,7 +253,8 @@ pub struct VMLimits {
 
 impl VMLimits {
     /// Check cross-field invariants that the individual field types can't
-    /// express on their own. Returns a message describing the first violation.
+    /// express on their own. Returns `Ok(())` if all invariants hold, or `Err`
+    /// with a message describing the first violation.
     /// (Named `validate_invariants`, not `validate`, so it does not collide with
     /// the blanket [`Constraint::validate`](crate::Constraint) method that every
     /// type gets.)

--- a/crates/runtime/src/logic/errors.rs
+++ b/crates/runtime/src/logic/errors.rs
@@ -24,13 +24,15 @@ impl TryFrom<VMLogicError> for FunctionCallError {
     fn try_from(err: VMLogicError) -> Result<Self, Self::Error> {
         match err {
             VMLogicError::StorageError(err) => Err(VMRuntimeError::StorageError(err)),
-            // todo! is it fine to panic the node on host errors
-            // todo! because that is a bug in the node, or do we
-            // todo! include it in the result? and record it on chain
-            // VMLogicError::HostError(HostError::Panic {
-            //     context: PanicContext::Host,
-            //     message,
-            // }) => Err(VMRuntimeError::HostError(err)),
+            // Host errors surface as an ordinary failed call
+            // (`FunctionCallError::HostError`); they never panic or halt the
+            // node. Host-error paths are reachable while running guest code, so
+            // turning them into a node panic would let a crafted app that can
+            // provoke one take the node down — a denial-of-service. Keeping them
+            // as call failures also matches the `catch_unwind` boundary in
+            // `Module::run_with_origin`, whose whole purpose is that nothing in
+            // execution can crash the node. Surfacing host-side bugs through a
+            // durable/on-chain record is a separate concern, not handled here.
             VMLogicError::HostError(err) => Ok(Self::HostError(err)),
         }
     }

--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -155,9 +155,13 @@ impl BlobManager {
     /// ([`calimero_store::Store::apply`]).
     pub async fn delete(&self, id: BlobId) -> EyreResult<bool> {
         let Some(meta) = self.data_store.handle().get(&BlobMetaKey::new(id))? else {
-            // No metadata references this id. Best-effort remove any orphan file
-            // so `has` (metadata-only) and `get` (file-backed) stay consistent.
-            return self.blob_store.delete(id).await;
+            // No metadata row references this id, so as a *referenced blob* it was
+            // already absent — return `false` regardless of whether an orphan file
+            // happened to linger. Still sweep any such file best-effort (ignoring
+            // its outcome) so `has` (metadata-only) and `get` (file-backed) stay
+            // consistent.
+            let _ = self.blob_store.delete(id).await;
+            return Ok(false);
         };
 
         // Release the root's own reference. A root blob keeps its content in its
@@ -165,7 +169,7 @@ impl BlobManager {
         // the root id is a harmless no-op; it is kept for blobs that ever carry
         // their own file.
         if self.release_ref(id, &meta)? {
-            let _ = self.blob_store.delete(id).await?;
+            self.blob_store.delete(id).await?;
         }
 
         // Release one reference from every chunk, mirroring the per-chunk
@@ -178,7 +182,7 @@ impl BlobManager {
                 continue;
             };
             if self.release_ref(chunk_id, &chunk_meta)? {
-                let _ = self.blob_store.delete(chunk_id).await?;
+                self.blob_store.delete(chunk_id).await?;
             }
         }
 
@@ -235,11 +239,16 @@ impl BlobManager {
         links: Box<[BlobMetaKey]>,
     ) -> EyreResult<()> {
         let key = BlobMetaKey::new(id);
-        let refs = self
-            .data_store
-            .handle()
-            .get(&key)?
-            .map_or(1, |existing| existing.refs.saturating_add(1));
+        let refs = match self.data_store.handle().get(&key)? {
+            // Overflow is not physically reachable (it needs u32::MAX live
+            // references to one content id) but is surfaced rather than saturated:
+            // a saturated count could never decrement back to zero, permanently
+            // leaking the blob.
+            Some(existing) => existing.refs.checked_add(1).ok_or_else(|| {
+                eyre::eyre!("blob refcount overflow for {id}: already at u32::MAX references")
+            })?,
+            None => 1,
+        };
         self.data_store
             .handle()
             .put(&key, &BlobMetaValue::new(size, hash, links, refs))?;

--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -167,22 +167,40 @@ impl BlobManager {
         // Release the root's own reference. A root blob keeps its content in its
         // chunks and has no backing file of its own, so `blob_store.delete` on
         // the root id is a harmless no-op; it is kept for blobs that ever carry
-        // their own file.
+        // their own file. A failed file delete is logged, not propagated, so we
+        // still go on to release the chunk references below.
         if self.release_ref(id, &meta)? {
-            self.blob_store.delete(id).await?;
+            if let Err(err) = self.blob_store.delete(id).await {
+                tracing::warn!(%id, %err, "failed to delete root blob file during delete");
+            }
         }
 
         // Release one reference from every chunk, mirroring the per-chunk
         // increment on add. A chunk shared by another still-live root keeps a
-        // positive count and survives.
+        // positive count and survives. This loop is best-effort: a failure on one
+        // chunk is logged and skipped rather than propagated, so it cannot leave
+        // the *remaining* chunks with their reference counts un-decremented
+        // (which would leak them permanently).
         for link in &meta.links {
             let chunk_id = link.blob_id();
-            let Some(chunk_meta) = self.data_store.handle().get(&BlobMetaKey::new(chunk_id))?
-            else {
-                continue;
+            let chunk_meta = match self.data_store.handle().get(&BlobMetaKey::new(chunk_id)) {
+                Ok(Some(chunk_meta)) => chunk_meta,
+                Ok(None) => continue,
+                Err(err) => {
+                    tracing::warn!(%chunk_id, %err, "failed to read chunk metadata during delete; skipping");
+                    continue;
+                }
             };
-            if self.release_ref(chunk_id, &chunk_meta)? {
-                self.blob_store.delete(chunk_id).await?;
+            match self.release_ref(chunk_id, &chunk_meta) {
+                Ok(true) => {
+                    if let Err(err) = self.blob_store.delete(chunk_id).await {
+                        tracing::warn!(%chunk_id, %err, "failed to delete chunk file during delete");
+                    }
+                }
+                Ok(false) => {}
+                Err(err) => {
+                    tracing::warn!(%chunk_id, %err, "failed to release chunk reference during delete");
+                }
             }
         }
 

--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -132,18 +132,98 @@ impl BlobManager {
         Blob::new(id, self.clone())
     }
 
+    /// Release one reference to `id` and physically remove it once the last
+    /// reference is gone.
+    ///
+    /// Blobs are content-addressed and deduplicated, so the same bytes may be
+    /// shared by several owners (added more than once) or, as a chunk, by
+    /// several root blobs. Deleting eagerly would let one owner destroy content
+    /// another still references, so a blob's file and metadata are dropped only
+    /// once its reference count falls to zero. For a root blob this releases one
+    /// reference to each of its chunks too — symmetric with [`Self::put_sized`],
+    /// which increments the root and every chunk on add.
+    ///
+    /// Returns `true` if `id` existed (its reference was released), `false` if
+    /// it was already absent.
+    ///
+    /// The read-decrement-write is not atomic against a concurrent add/delete of
+    /// the *same* content id; callers today drive blob lifecycle serially per
+    /// id. Making it fully atomic would move the refcount update onto the
+    /// store's transaction path ([`calimero_store::Store::apply`]).
     pub async fn delete(&self, id: BlobId) -> EyreResult<bool> {
+        let Some(meta) = self.data_store.handle().get(&BlobMetaKey::new(id))? else {
+            // No metadata references this id. Best-effort remove any orphan file
+            // so `has` (metadata-only) and `get` (file-backed) stay consistent.
+            return self.blob_store.delete(id).await;
+        };
+
+        // Release the root's own reference. A root blob keeps its content in its
+        // chunks and has no backing file of its own, so `blob_store.delete` on
+        // the root id is a harmless no-op; it is kept for blobs that ever carry
+        // their own file.
+        if self.release_ref(id, &meta)? {
+            let _ = self.blob_store.delete(id).await?;
+        }
+
+        // Release one reference from every chunk, mirroring the per-chunk
+        // increment on add. A chunk shared by another still-live root keeps a
+        // positive count and survives.
+        for link in &meta.links {
+            let chunk_id = link.blob_id();
+            let Some(chunk_meta) = self.data_store.handle().get(&BlobMetaKey::new(chunk_id))?
+            else {
+                continue;
+            };
+            if self.release_ref(chunk_id, &chunk_meta)? {
+                let _ = self.blob_store.delete(chunk_id).await?;
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Decrement `id`'s reference count by one. Returns `true` when the count
+    /// reaches zero — the metadata row is deleted and the caller must remove the
+    /// backing file — or `false` when references remain, in which case the
+    /// decremented count is persisted and the blob is kept.
+    fn release_ref(&self, id: BlobId, meta: &BlobMetaValue) -> EyreResult<bool> {
         let key = BlobMetaKey::new(id);
+        match meta.refs.saturating_sub(1) {
+            0 => {
+                self.data_store.handle().delete(&key)?;
+                Ok(true)
+            }
+            remaining => {
+                self.data_store.handle().put(
+                    &key,
+                    &BlobMetaValue::new(meta.size, meta.hash, meta.links.clone(), remaining),
+                )?;
+                Ok(false)
+            }
+        }
+    }
 
-        // Remove the metadata row alongside the chunk file. Without this, `has`
-        // keeps reporting the blob as present (it only checks metadata) while
-        // `get` fails because the underlying file is gone.
-        let had_meta = self.data_store.handle().has(&key)?;
-        self.data_store.handle().delete(&key)?;
-
-        let had_file = self.blob_store.delete(id).await?;
-
-        Ok(had_meta || had_file)
+    /// Persist `id`'s metadata on add, incrementing its reference count when an
+    /// entry already exists. Deduplicated content re-added by another owner (or
+    /// a chunk shared by another root) bumps the count instead of silently
+    /// aliasing a single reference that the first delete would tear down.
+    fn persist_ref(
+        &self,
+        id: BlobId,
+        size: u64,
+        hash: [u8; 32],
+        links: Box<[BlobMetaKey]>,
+    ) -> EyreResult<()> {
+        let key = BlobMetaKey::new(id);
+        let refs = self
+            .data_store
+            .handle()
+            .get(&key)?
+            .map_or(1, |existing| existing.refs.saturating_add(1));
+        self.data_store
+            .handle()
+            .put(&key, &BlobMetaValue::new(size, hash, links, refs))?;
+        Ok(())
     }
 
     pub async fn put<T>(&self, stream: T) -> EyreResult<(BlobId, Hash, u64)>
@@ -218,10 +298,7 @@ impl BlobManager {
 
                 let id = BlobId::from(*AsRef::<[u8; 32]>::as_ref(&blob.digest.finalize()));
 
-                self.data_store.handle().put(
-                    &BlobMetaKey::new(id),
-                    &BlobMetaValue::new(blob.size as u64, *id, Box::default()),
-                )?;
+                self.persist_ref(id, blob.size as u64, *id, Box::default())?;
 
                 self.blob_store.put(id, &buf[..blob.size]).await?;
 
@@ -297,10 +374,7 @@ impl BlobManager {
 
         let id = BlobId::from(*(AsRef::<[u8; 32]>::as_ref(&digest.finalize())));
 
-        self.data_store.handle().put(
-            &BlobMetaKey::new(id),
-            &BlobMetaValue::new(size, *hash, links.into_boxed_slice()),
-        )?;
+        self.persist_ref(id, size, *hash, links.into_boxed_slice())?;
 
         debug!(
             ?id,
@@ -570,5 +644,129 @@ mod delete_tests {
 
         // A second delete has nothing left to remove.
         assert!(!mgr.delete(id).await.unwrap());
+    }
+
+    fn refs_of(mgr: &BlobManager, id: BlobId) -> Option<u32> {
+        mgr.data_store
+            .handle()
+            .get(&BlobMetaKey::new(id))
+            .unwrap()
+            .map(|meta| meta.refs)
+    }
+
+    async fn read_all(mgr: &BlobManager, id: BlobId) -> Vec<u8> {
+        let mut stream = mgr.get(id).unwrap().expect("blob present");
+        let mut out = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            out.extend_from_slice(&chunk.unwrap());
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn duplicate_content_is_refcounted_not_aliased() {
+        let dir = tempdir().unwrap();
+        let mgr = manager(dir.path()).await;
+
+        // Two owners add byte-identical content. Content addressing makes them
+        // one stored blob; without refcounting the first delete would destroy
+        // the bytes the second owner still relies on.
+        let data = b"identical bytes shared by two owners";
+        let (id, _, _) = mgr.put(&data[..]).await.unwrap();
+        let (id2, _, _) = mgr.put(&data[..]).await.unwrap();
+        assert_eq!(id, id2, "identical content must dedup to the same id");
+        assert_eq!(
+            refs_of(&mgr, id),
+            Some(2),
+            "second add must bump the refcount"
+        );
+
+        // First owner releases their reference: the blob survives for the second.
+        assert!(mgr.delete(id).await.unwrap());
+        assert_eq!(refs_of(&mgr, id), Some(1));
+        assert!(mgr.has(id).unwrap());
+        assert_eq!(
+            read_all(&mgr, id).await,
+            data,
+            "surviving owner keeps its data"
+        );
+
+        // Second owner releases the last reference: now it is really gone.
+        assert!(mgr.delete(id).await.unwrap());
+        assert_eq!(refs_of(&mgr, id), None);
+        assert!(!mgr.has(id).unwrap());
+    }
+
+    #[tokio::test]
+    async fn chunk_shared_across_roots_survives_sibling_delete() {
+        let dir = tempdir().unwrap();
+        let mgr = manager(dir.path()).await;
+
+        // Two different files that share an identical leading chunk. Their root
+        // blobs differ, but the shared chunk is stored once (same content id).
+        let prefix = vec![7_u8; CHUNK_SIZE];
+        let mut a = prefix.clone();
+        a.extend_from_slice(b"divergent tail A");
+        let mut b = prefix.clone();
+        b.extend_from_slice(b"divergent tail B");
+
+        let (root_a, _, _) = mgr.put(&a[..]).await.unwrap();
+        let (root_b, _, _) = mgr.put(&b[..]).await.unwrap();
+        assert_ne!(
+            root_a, root_b,
+            "different content must yield different roots"
+        );
+
+        // The shared leading chunk is the first link of both roots.
+        let links_a = mgr
+            .data_store
+            .handle()
+            .get(&BlobMetaKey::new(root_a))
+            .unwrap()
+            .unwrap()
+            .links;
+        let links_b = mgr
+            .data_store
+            .handle()
+            .get(&BlobMetaKey::new(root_b))
+            .unwrap()
+            .unwrap()
+            .links;
+        let shared_chunk = links_a[0].blob_id();
+        assert_eq!(
+            shared_chunk,
+            links_b[0].blob_id(),
+            "roots must share a chunk"
+        );
+        assert_eq!(
+            refs_of(&mgr, shared_chunk),
+            Some(2),
+            "shared chunk carries two refs"
+        );
+
+        let tail_a = links_a[1].blob_id();
+
+        // Delete the first root. Its unique tail chunk goes; the shared chunk is
+        // decremented but kept, and the sibling blob reads back intact.
+        assert!(mgr.delete(root_a).await.unwrap());
+        assert!(!mgr.has(root_a).unwrap());
+        assert!(
+            !mgr.has(tail_a).unwrap(),
+            "unique chunk of deleted root is freed"
+        );
+        assert_eq!(
+            refs_of(&mgr, shared_chunk),
+            Some(1),
+            "shared chunk survives"
+        );
+        assert_eq!(
+            read_all(&mgr, root_b).await,
+            b,
+            "sibling blob is not corrupted"
+        );
+
+        // Deleting the sibling now frees the shared chunk for good.
+        assert!(mgr.delete(root_b).await.unwrap());
+        assert_eq!(refs_of(&mgr, shared_chunk), None);
     }
 }

--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -144,12 +144,15 @@ impl BlobManager {
     /// which increments the root and every chunk on add.
     ///
     /// Returns `true` if `id` existed (its reference was released), `false` if
-    /// it was already absent.
+    /// it was already absent. Note that `true` does *not* imply the bytes were
+    /// physically removed — if other owners still reference the content, only
+    /// the count was decremented and the blob remains readable for them.
     ///
     /// The read-decrement-write is not atomic against a concurrent add/delete of
     /// the *same* content id; callers today drive blob lifecycle serially per
-    /// id. Making it fully atomic would move the refcount update onto the
-    /// store's transaction path ([`calimero_store::Store::apply`]).
+    /// id (see the INVARIANT on [`Self::release_ref`]). Making it fully atomic
+    /// would move the refcount update onto the store's transaction path
+    /// ([`calimero_store::Store::apply`]).
     pub async fn delete(&self, id: BlobId) -> EyreResult<bool> {
         let Some(meta) = self.data_store.handle().get(&BlobMetaKey::new(id))? else {
             // No metadata references this id. Best-effort remove any orphan file
@@ -186,8 +189,22 @@ impl BlobManager {
     /// reaches zero — the metadata row is deleted and the caller must remove the
     /// backing file — or `false` when references remain, in which case the
     /// decremented count is persisted and the blob is kept.
+    ///
+    /// INVARIANT: this and [`Self::persist_ref`] read-modify-write a single
+    /// metadata row across separate store operations and are NOT atomic. Callers
+    /// must serialize add/delete for the same blob id (the node drives blob
+    /// lifecycle serially per id today). A concurrent add interleaved with a
+    /// delete could lose an increment and free content that still has a live
+    /// owner; making it atomic means moving the update onto the store's
+    /// transaction path ([`calimero_store::Store::apply`]).
     fn release_ref(&self, id: BlobId, meta: &BlobMetaValue) -> EyreResult<bool> {
         let key = BlobMetaKey::new(id);
+        // refs should never be 0 for a stored entry; if it is (store corruption
+        // or a bug that wrote a zero-ref row), surface it rather than silently
+        // "fixing" it, then proceed to reclaim the row via the zero arm below.
+        if meta.refs == 0 {
+            tracing::warn!(%id, "release_ref on a blob with refs == 0; reclaiming as last reference");
+        }
         match meta.refs.saturating_sub(1) {
             0 => {
                 self.data_store.handle().delete(&key)?;
@@ -207,6 +224,9 @@ impl BlobManager {
     /// entry already exists. Deduplicated content re-added by another owner (or
     /// a chunk shared by another root) bumps the count instead of silently
     /// aliasing a single reference that the first delete would tear down.
+    ///
+    /// INVARIANT: like [`Self::release_ref`], the read-modify-write here is not
+    /// atomic; callers must serialize add/delete for the same blob id.
     fn persist_ref(
         &self,
         id: BlobId,

--- a/crates/store/src/types/blobs.rs
+++ b/crates/store/src/types/blobs.rs
@@ -7,17 +7,29 @@ use crate::types::PredefinedEntry;
 #[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct BlobMeta {
-    // todo! impl proper entry reference count
-    // pub refs: usize,
     pub size: u64,
     pub hash: [u8; 32],
     pub links: Box<[key::BlobMeta]>,
+    /// Number of live references to this content-addressed blob.
+    ///
+    /// Blobs are deduplicated by content hash: a given byte sequence is stored
+    /// once but may be referenced by many owners — the same bytes added by
+    /// several contexts, or a chunk shared by several root blobs. Each add
+    /// increments this count and each delete decrements it; the backing file
+    /// and this row are removed only when it reaches zero. Without it, one
+    /// owner deleting a blob would destroy content another still references.
+    pub refs: u32,
 }
 
 impl BlobMeta {
     #[must_use]
-    pub const fn new(size: u64, hash: [u8; 32], links: Box<[key::BlobMeta]>) -> Self {
-        Self { size, hash, links }
+    pub const fn new(size: u64, hash: [u8; 32], links: Box<[key::BlobMeta]>, refs: u32) -> Self {
+        Self {
+            size,
+            hash,
+            links,
+            refs,
+        }
     }
 }
 


### PR DESCRIPTION
Resolves five outstanding review findings. Each was verified still-present on latest `master` before fixing.

## [H] Wasm prepare/validate pass before compile
`Engine::compile` had a `todo!` block instead of validation. Untrusted guests could import host memory or define a `_start` entry point. Now `validate_guest_module` runs after compile and rejects:
- modules that **import** linear memory (guests must define and export their own — the host reads state via `exports.get_memory("memory")`);
- modules that export `_start` (a WASI *command* entry point emitted by `wasm32-wasi` toolchains; Calimero guests are `wasm32-unknown-unknown` libraries invoked by explicit method name).

Uses wasmer's existing `Module::imports()`/`exports()` introspection — **no new dependency**. New `FunctionCallError::ModuleValidationError`.

## [H] Blob delete had no refcount → cross-context data loss
Blobs are content-addressed and deduplicated, so identical content across contexts, or a chunk shared by two root blobs, resolves to one stored entry. The old delete path removed files + metadata unconditionally, destroying content other owners still referenced.

Added `refs` to `BlobMeta`. **Add** increments the root and every chunk; **delete** decrements them and removes files/metadata only at zero. The node-side `delete_blob` now delegates to one refcount-aware, tree-aware call instead of manually expanding root→chunks and deleting eagerly.

> ⚠️ Changes `BlobMeta`'s borsh layout — existing on-disk blobs won't deserialize. Acceptable pre-1.0 (dev data rebuilds).

## [M] `--mock-tee` guard only covered the Phala provider
`has_real_attestation` now destructures `KmsConfig` with no rest pattern, so adding a second KMS provider **fails to compile** until it's folded into the predicate — the mock-deny guard can't silently stop covering a provider.

## [L] `verify_root_hash` never called
Removed the dead public wrapper (+ registry impl). Sync integrity is unaffected: `reconciler.rs` already gates on the peer's **signed** expected root hash. `compute_root_hash` (the actually-used machinery) is retained.

## [L] Host-error policy + unenforced registers invariant
- Replaced the host-error `todo!` with a documented, deliberate policy: host errors surface as ordinary call failures and never panic the node (panicking would be guest-triggerable → DoS; it also fights the `catch_unwind` boundary). On-chain recording is a separate concern.
- Added `VMLimits::validate_invariants()` enforcing `max_registers_capacity >= max_register_size`, called in `Engine::new` so a self-contradictory config fails loud at startup instead of misbehaving per execution.

## Tests
- runtime: reject imported-memory, reject `_start`, accept a conforming guest; registers-invariant valid-by-default + `should_panic` on violation.
- blobstore: duplicate content survives one owner's delete (read back byte-for-byte); a chunk shared across two roots survives a sibling root's deletion.

All touched crates build, pass `cargo clippy` clean, and the new + existing tests pass.