### PR TITLE
fix(blobstore): repair BlobMetaValue::new test call sites broken by #3128 (master build red)

### DIFF
--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -1051,16 +1051,18 @@ mod traversal_tests {
         let b = BlobId::from([2u8; 32]);
         let mut handle = mgr.data_store.handle();
         // A -> B and B -> A: both are internal nodes (non-empty links).
+        // `refs = 1`: each is a single live reference (the value is incidental to
+        // this cycle-rejection test).
         handle
             .put(
                 &BlobMetaKey::new(a),
-                &BlobMetaValue::new(1, *a, vec![BlobMetaKey::new(b)].into_boxed_slice()),
+                &BlobMetaValue::new(1, *a, vec![BlobMetaKey::new(b)].into_boxed_slice(), 1),
             )
             .unwrap();
         handle
             .put(
                 &BlobMetaKey::new(b),
-                &BlobMetaValue::new(1, *b, vec![BlobMetaKey::new(a)].into_boxed_slice()),
+                &BlobMetaValue::new(1, *b, vec![BlobMetaKey::new(a)].into_boxed_slice(), 1),
             )
             .unwrap();
 


### PR DESCRIPTION
## Problem

`master` currently fails `cargo test` at compile time — the **Rust** CI job is red on every open PR.

#3128 ("wasm guest validation, blob refcounting, and hardening batch") added a `refs: u32` parameter to `BlobMetaValue::new` and updated the production call sites, but left **two test call sites** in `cycle_in_meta_graph_is_rejected` (`crates/store/blobs/src/lib.rs:1057,1063`) at the old 3-arg arity:

```
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
  --> crates/store/blobs/src/lib.rs:1057:18
error: could not compile `calimero-blobstore` (lib test) due to 2 previous errors
```

The production build is fine, so this slipped through — only the `#[cfg(test)]` target references the stale signature.

## Fix

Pass `refs = 1` at both call sites (a single live reference; the exact value is incidental to this cycle-rejection test). Confirmed the only stale call sites in the repo — the other two `BlobMetaValue::new` uses already pass 4 args.

## Verification

- `cargo test -p calimero-blobstore` → **22 passed, 0 failed** (was: does not compile).
- Grep confirms no remaining 3-arg `BlobMetaValue::new` call sites.

This unblocks the **Rust** job so the open test/fix PRs (#3120, #3122, #3124, #3127) can go green once rebased on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)