### PR TITLE
fix(server): stop caching private blobs publicly; refuse corrupt blob framing

### DIFF
--- a/crates/server/src/admin/handlers/blob.rs
+++ b/crates/server/src/admin/handlers/blob.rs
@@ -195,10 +195,11 @@ fn build_blob_response_headers(blob_metadata: &BlobMetadata, blob_id: BlobId) ->
         .header("Content-Length", blob_metadata.size.to_string())
         .header("Content-Type", &blob_metadata.mime_type)
         .header("ETag", &etag)
-        // Blobs may be private context data served through this admin API. Never
-        // allow shared proxies/CDNs to cache them. Content is hash-addressed and
-        // immutable per blob id, so private caching with revalidation is safe.
-        .header("Cache-Control", "private, no-cache")
+        // Blobs may be private context data served through this admin API, so
+        // never allow shared proxies/CDNs to cache them (`private`). Content is
+        // hash-addressed and immutable per blob id, so a client's own cache can
+        // keep it indefinitely without revalidation (`immutable`, long max-age).
+        .header("Cache-Control", "private, max-age=31536000, immutable")
         .header("X-Blob-ID", blob_id.to_string())
         .header("X-Blob-Hash", hex::encode(blob_metadata.hash))
         .header("X-Blob-MIME-Type", &blob_metadata.mime_type)

--- a/crates/server/src/admin/handlers/blob.rs
+++ b/crates/server/src/admin/handlers/blob.rs
@@ -195,7 +195,10 @@ fn build_blob_response_headers(blob_metadata: &BlobMetadata, blob_id: BlobId) ->
         .header("Content-Length", blob_metadata.size.to_string())
         .header("Content-Type", &blob_metadata.mime_type)
         .header("ETag", &etag)
-        .header("Cache-Control", "public, max-age=3600") // 1 hour cache
+        // Blobs may be private context data served through this admin API. Never
+        // allow shared proxies/CDNs to cache them. Content is hash-addressed and
+        // immutable per blob id, so private caching with revalidation is safe.
+        .header("Cache-Control", "private, no-cache")
         .header("X-Blob-ID", blob_id.to_string())
         .header("X-Blob-Hash", hex::encode(blob_metadata.hash))
         .header("X-Blob-MIME-Type", &blob_metadata.mime_type)
@@ -257,28 +260,32 @@ pub async fn download_handler(
 
     match blob_result {
         Ok(Some(blob)) => {
-            // Now get metadata for headers (blob should be local after discovery)
+            // Now get metadata for headers (blob should be local after discovery).
+            //
+            // The metadata drives the Content-Length and ETag response headers. If
+            // it is missing or unreadable we must NOT fabricate zero metadata: that
+            // would emit `Content-Length: 0` and an all-zero ETag while streaming a
+            // non-empty body, causing clients to truncate the response and caches to
+            // collide distinct blobs under the same `"00..00"` ETag. A blob whose
+            // bytes exist but whose metadata is gone is an inconsistent store state,
+            // so surface it as a 500 rather than serving a corrupt response.
             let blob_metadata = match state.node_client.get_blob_info(blob_id).await {
                 Ok(Some(metadata)) => metadata,
                 Ok(None) => {
-                    tracing::warn!("Blob found but metadata missing: {}", blob_id);
-                    // Create default metadata
-                    BlobMetadata {
-                        blob_id,
-                        size: 0,       // Will be updated by streaming response
-                        hash: [0; 32], // Default hash
-                        mime_type: "application/octet-stream".to_owned(),
+                    error!(%blob_id, "Blob bytes found but metadata missing; refusing to serve");
+                    return ApiError {
+                        status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                        message: "Blob metadata is unavailable".to_owned(),
                     }
+                    .into_response();
                 }
                 Err(err) => {
-                    tracing::warn!("Failed to get blob metadata {}: {:?}", blob_id, err);
-                    // Create default metadata
-                    BlobMetadata {
-                        blob_id,
-                        size: 0,
-                        hash: [0; 32], // Default hash
-                        mime_type: "application/octet-stream".to_owned(),
+                    error!(%blob_id, ?err, "Failed to read blob metadata; refusing to serve");
+                    return ApiError {
+                        status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                        message: "Failed to read blob metadata".to_owned(),
                     }
+                    .into_response();
                 }
             };
 

--- a/crates/server/src/admin/handlers/blob.rs
+++ b/crates/server/src/admin/handlers/blob.rs
@@ -196,10 +196,12 @@ fn build_blob_response_headers(blob_metadata: &BlobMetadata, blob_id: BlobId) ->
         .header("Content-Type", &blob_metadata.mime_type)
         .header("ETag", &etag)
         // Blobs may be private context data served through this admin API, so
-        // never allow shared proxies/CDNs to cache them (`private`). Content is
-        // hash-addressed and immutable per blob id, so a client's own cache can
-        // keep it indefinitely without revalidation (`immutable`, long max-age).
-        .header("Cache-Control", "private, max-age=31536000, immutable")
+        // never allow shared proxies/CDNs to cache them (`private`). We use
+        // `no-cache` (revalidate before reuse) rather than `immutable`: a blob
+        // id can be deleted via this same API, and `immutable` would let a
+        // client keep serving a since-deleted blob for the max-age window.
+        // Revalidation is cheap for an admin API, so correctness wins.
+        .header("Cache-Control", "private, no-cache")
         .header("X-Blob-ID", blob_id.to_string())
         .header("X-Blob-Hash", hex::encode(blob_metadata.hash))
         .header("X-Blob-MIME-Type", &blob_metadata.mime_type)


### PR DESCRIPTION
## Summary

Two correctness/privacy fixes in the admin-api blob handlers (`crates/server/src/admin/handlers/blob.rs`), surfaced by a security review of the blob endpoints.

## 1. Private blobs were cached with a public `Cache-Control`

**Before:** every blob download/HEAD response set `Cache-Control: public, max-age=3600`, regardless of whether the blob was a private context blob fetched via `?context_id=`. A shared proxy/CDN placed in front of the admin API would be permitted to cache and re-serve those private bytes to other clients.

**After:** the header is `Cache-Control: private, no-cache`. Blob content is hash-addressed and immutable per id, so there is never a reason to allow *shared* caching; `private, no-cache` lets a single client's browser revalidate but keeps intermediaries out.

## 2. Missing blob metadata produced a corrupt, truncating response

**Before:** in `download_handler`, if a blob's bytes were retrievable but its `BlobMetadata` was missing (`Ok(None)`) or unreadable (`Err`), the handler fabricated default metadata with `size: 0` and an all-zero hash. It then streamed the real, non-empty body under `Content-Length: 0` and `ETag: "0000…0000"`. Clients honoring `Content-Length` truncate to zero bytes, and every such blob collides in caches under the same all-zero ETag.

**After:** a blob whose bytes exist but whose metadata is gone is an inconsistent store state, so the handler returns `500 Internal Server Error` instead of serving a mis-framed body.

## Scope / risk

- Touches only `blob.rs`. No API signature changes.
- Practical severity is low–moderate (the admin API is normally loopback and not CDN-fronted; the metadata path only triggers on store inconsistency), but both are clear correctness bugs.

## Verification

- `cargo check -p calimero-server` passes.
- Handler-level HTTP behavior requires a full node-client harness (none exists for blob handlers today); the change is a localized header/branch edit. Manual check: a blob download response now carries `Cache-Control: private, no-cache`, and a blob with deleted metadata returns 500 rather than a zero-length body.

Findings #1 and #2 from the blob-handler security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)