### PR TITLE
fix(server): refuse to delete blobs referenced by installed applications (blob-delete IDOR)

### DIFF
--- a/crates/node/primitives/src/client/application/query.rs
+++ b/crates/node/primitives/src/client/application/query.rs
@@ -39,6 +39,29 @@ impl NodeClient {
         Ok(applications)
     }
 
+    /// Returns `true` if `blob_id` is referenced as the bytecode or compiled
+    /// artifact of any installed application (including its named services).
+    ///
+    /// Application artifacts are shared, content-addressed blobs that installed
+    /// apps depend on to execute. Because blob deletion is a global,
+    /// reference-counted operation with no per-caller ownership, an unrelated
+    /// admin-api caller could otherwise release the last reference to an app's
+    /// bytecode and brick every context running it. The blob-delete endpoint
+    /// consults this guard and refuses such deletes.
+    pub fn is_blob_application_artifact(&self, blob_id: &BlobId) -> eyre::Result<bool> {
+        for app in self.list_applications()? {
+            if app.blob.bytecode == *blob_id || app.blob.compiled == *blob_id {
+                return Ok(true);
+            }
+            for svc in app.services.values() {
+                if svc.bytecode == *blob_id || svc.compiled == *blob_id {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    }
+
     /// Update the compiled blob for an application (or a named service within it).
     pub fn update_compiled_app(
         &self,

--- a/crates/server/src/admin/handlers/blob.rs
+++ b/crates/server/src/admin/handlers/blob.rs
@@ -336,6 +336,34 @@ pub async fn delete_handler(
 
     tracing::info!("Attempting to delete blob {}", blob_id);
 
+    // Blob deletion is a global, reference-counted operation with no per-caller
+    // ownership: any authenticated caller can release a reference to any blob by
+    // its global id. That is acceptable for ordinary content, but application
+    // bytecode/compiled artifacts are shared blobs that installed apps depend on
+    // to execute. Releasing the last reference to one would brick every context
+    // running that app. Refuse to delete blobs that are referenced as an
+    // application artifact.
+    match state.node_client.is_blob_application_artifact(&blob_id) {
+        Ok(true) => {
+            tracing::warn!(%blob_id, "refusing to delete blob referenced by an installed application");
+            return ApiError {
+                status_code: StatusCode::FORBIDDEN,
+                message: "Blob is referenced by an installed application and cannot be deleted"
+                    .to_owned(),
+            }
+            .into_response();
+        }
+        Ok(false) => {}
+        Err(err) => {
+            tracing::error!(%blob_id, ?err, "failed to check application references before delete");
+            return ApiError {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                message: "Failed to verify blob is safe to delete".to_owned(),
+            }
+            .into_response();
+        }
+    }
+
     match state.node_client.delete_blob(blob_id).await {
         Ok(true) => {
             tracing::info!("Successfully deleted blob {}", blob_id);


### PR DESCRIPTION
## Summary

Closes the highest-severity blob-handler finding: `DELETE /admin-api/blobs/:id` was an unscoped operation that could brick installed applications.

## Before

`delete_handler` parsed the blob id and called straight through to `NodeClient::delete_blob` → the reference-counted blob store, with **no authorization or safety check**:

- Blob deletion is a **global, reference-counted** operation. The blob store tracks only a *count* of references (`meta.refs`), not *which* caller/context owns them.
- Any authenticated admin-api caller could therefore call `DELETE /blobs/:id` on **any** blob by its global id — including an application's `bytecode`/`compiled` artifact — and, by repeating the call, drive its refcount to zero and physically remove it.
- For a single-referenced artifact (common on a single-context node), **one call** bricks every context running that app. This is irreversible.

## After

- New `NodeClient::is_blob_application_artifact(&blob_id)` enumerates installed applications and reports whether the blob is referenced as any app's `bytecode`/`compiled` artifact, including named services.
- `delete_handler` consults it first and returns **403 Forbidden** ("Blob is referenced by an installed application and cannot be deleted") instead of releasing the reference.
- Ordinary content blobs delete as before.

## Scope & rationale

The catastrophic, irreversible case in the finding is deletion of app bytecode. This PR neutralizes exactly that with a bounded, correct guard and no store-schema change.

**What this does _not_ do:** it does not add per-caller ownership for ordinary (non-artifact) content blobs — an authed caller can still release references to arbitrary data blobs. Doing that properly requires tracking *reference ownership* in the reference-counted blob store (which today stores only a count), a larger change best done as a dedicated follow-up. Alternatively/additionally, blob-delete could be gated on a management token scope once admin-api scope enforcement lands (tracked separately).

## Verification

- `cargo check -p calimero-node-primitives -p calimero-server` passes.
- Behavior: deleting an app's bytecode/compiled blob → 403; deleting an unreferenced data blob → unchanged (200 / 404).

Finding #3 from the blob-handler security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)