### PR TITLE
fix(server): only announce uploaded blobs to contexts the node belongs to

### DIFF
--- a/crates/server/src/admin/handlers/blob.rs
+++ b/crates/server/src/admin/handlers/blob.rs
@@ -124,18 +124,33 @@ pub async fn upload_handler(
                 "Blob upload details"
             );
 
-            // Announce blob to network if context_id is provided
+            // Announce blob to network if context_id is provided.
+            //
+            // Announcing writes a discovery record advertising that this node
+            // holds the blob for the given context. Only announce for a context
+            // this node actually participates in: without this check a caller
+            // could inject blob-availability records into arbitrary contexts'
+            // discovery. Membership is proven by the node owning an identity in
+            // the context (the same signal the signed serving path relies on).
             if let Some(ctx_id) = context_id {
-                match state
-                    .node_client
-                    .announce_blob_to_network(&blob_id, &ctx_id, size)
-                    .await
-                {
-                    Ok(_) => {
-                        info!(blob_id=%blob_id, context_id=%ctx_id, "Blob announced to network");
+                match state.node_client.find_owned_identity(&ctx_id) {
+                    Ok(Some(_)) => match state
+                        .node_client
+                        .announce_blob_to_network(&blob_id, &ctx_id, size)
+                        .await
+                    {
+                        Ok(_) => {
+                            info!(blob_id=%blob_id, context_id=%ctx_id, "Blob announced to network");
+                        }
+                        Err(err) => {
+                            error!(blob_id=%blob_id, context_id=%ctx_id, error=?err, "Failed to announce blob to network");
+                        }
+                    },
+                    Ok(None) => {
+                        error!(blob_id=%blob_id, context_id=%ctx_id, "Skipping announce: node is not a member of the requested context");
                     }
                     Err(err) => {
-                        error!(blob_id=%blob_id, context_id=%ctx_id, error=?err, "Failed to announce blob to network");
+                        error!(blob_id=%blob_id, context_id=%ctx_id, error=?err, "Skipping announce: failed to verify context membership");
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Defense-in-depth fix for the blob upload announce path.

## Before

`upload_handler` accepted an optional `?context_id=` and, after storing the blob, called `announce_blob_to_network(&blob_id, &ctx_id, size)` with **no membership check**. That writes a Kademlia discovery record keyed by `context_id || blob_id` advertising that this node holds the blob for that context. A caller could therefore inject blob-availability records into the discovery of arbitrary contexts the node doesn't participate in.

## After

Before announcing, the handler verifies the node owns an identity in the target context via `find_owned_identity` — the same membership signal the signed blob-serving path relies on. If the node isn't a member, the announce is skipped and logged; the upload itself still succeeds (announce has always been best-effort discovery — prior code only logged announce failures).

## Scope

Low practical severity: announcing only advertises possession in the DHT and grants **no** content access — the serving side is independently gated by a signed context-member check (`node/src/handlers/blob_protocol.rs`). This closes DHT/discovery pollution, not a data-disclosure hole.

## Verification

- `cargo check -p calimero-server` passes.
- Behavior: upload with a `context_id` the node belongs to → announced as before; with a foreign `context_id` → stored, announce skipped with a warning.

Finding #4 from the blob-handler security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)