### PR TITLE
fix(server): enforce context membership on WS and SSE subscribe (subscription IDOR)

### DIFF
--- a/crates/server/src/service_mounts.rs
+++ b/crates/server/src/service_mounts.rs
@@ -44,16 +44,23 @@ pub(crate) fn mount_runtime_services(
         service_count += 1;
     }
 
-    if let Some((path, handler)) =
-        ws::service(config, node_client.clone(), ctx_client, auth_enabled)
-    {
+    if let Some((path, handler)) = ws::service(
+        config,
+        node_client.clone(),
+        ctx_client.clone(),
+        auth_enabled,
+    ) {
         app = app.route(&path, with_optional_auth(handler, auth_service.clone()));
         service_count += 1;
     }
 
-    if let Some((path, router)) =
-        sse::service(config, node_client.clone(), datastore.clone(), auth_enabled)
-    {
+    if let Some((path, router)) = sse::service(
+        config,
+        node_client.clone(),
+        ctx_client,
+        datastore.clone(),
+        auth_enabled,
+    ) {
         app = app.nest(path, with_optional_auth(router, auth_service.clone()));
         service_count += 1;
     }

--- a/crates/server/src/sse.rs
+++ b/crates/server/src/sse.rs
@@ -43,6 +43,7 @@ mod storage;
 use axum::routing::{get, post};
 use axum::Extension;
 use axum::Router;
+use calimero_context_client::client::ContextClient;
 use calimero_node_primitives::client::NodeClient;
 use calimero_store::Store;
 use std::sync::Arc;
@@ -66,6 +67,7 @@ use state::ServiceState;
 pub fn service(
     config: &ServerConfig,
     node_client: NodeClient,
+    ctx_client: ContextClient,
     store: Store,
     auth_enabled: bool,
 ) -> Option<(&'static str, Router)> {
@@ -83,7 +85,12 @@ pub fn service(
         info!("SSE server listening on {}/http{{{}}}", listen, path);
     }
 
-    let state = Arc::new(ServiceState::new(node_client, store, auth_enabled));
+    let state = Arc::new(ServiceState::new(
+        node_client,
+        ctx_client,
+        store,
+        auth_enabled,
+    ));
 
     let router = Router::new()
         .route("/", get(sse_handler))

--- a/crates/server/src/sse/handlers.rs
+++ b/crates/server/src/sse/handlers.rs
@@ -193,26 +193,44 @@ pub async fn handle_subscription(
                 // `inner`. Lock order is persist-guard → `inner`.
                 let _persist = session.persist_guard().await;
 
+                // Enforce session ownership FIRST, before any per-context work or
+                // logging. Otherwise a caller who guesses a session id they don't
+                // own could still trigger membership-probe lookups and log lines
+                // for arbitrary context ids. Ownership is immutable for a session,
+                // so a short read lock here is sufficient.
+                {
+                    let inner = session.inner.read().await;
+                    if !owner_allows_access(&inner.owner, &caller) {
+                        warn!(%session_id, "SSE subscribe denied: caller is not the session owner");
+                        return forbidden();
+                    }
+                }
+
                 // Only subscribe to contexts this caller may observe. Context
                 // events carry state roots and application execution-event
                 // payloads, so a session must not receive events for a context
-                // its caller isn't a member of — the session-owner check above
-                // guards the session, not the contexts. The node owner (and a
-                // no-auth dev server) may observe everything; any other caller
-                // must prove membership via its authenticated key. Unauthorized
-                // ids are dropped and the response reflects only what was
-                // actually subscribed.
+                // its caller isn't a member of. The node owner (and a no-auth dev
+                // server) may observe everything; any other caller must prove
+                // membership via its authenticated key. Unauthorized ids are
+                // dropped and the response reflects only what was subscribed.
                 let node_owner = auth_node_owner.is_some();
                 let subscribed: Vec<_> = ctxs
                     .context_ids
                     .iter()
                     .copied()
                     .filter(|ctx| {
-                        let caller_is_member = auth_key.as_ref().map(|Extension(AuthenticatedKey(pk))| {
-                            state.ctx_client.has_member(ctx, pk).unwrap_or(false)
-                        });
-                        let authorized =
-                            crate::ws::may_observe_context(state.auth_enabled, node_owner, caller_is_member);
+                        let caller_is_member =
+                            auth_key.as_ref().map(|Extension(AuthenticatedKey(pk))| {
+                                state.ctx_client.has_member(ctx, pk).unwrap_or_else(|err| {
+                                    warn!(%session_id, context_id=%ctx, %err, "has_member lookup failed; denying subscription");
+                                    false
+                                })
+                            });
+                        let authorized = crate::ws::may_observe_context(
+                            state.auth_enabled,
+                            node_owner,
+                            caller_is_member,
+                        );
                         if !authorized {
                             warn!(%session_id, context_id=%ctx, "SSE subscribe denied: caller is not a member of the context");
                         }
@@ -222,10 +240,6 @@ pub async fn handle_subscription(
 
                 let persisted = {
                     let mut inner = session.inner.write().await;
-                    if !owner_allows_access(&inner.owner, &caller) {
-                        warn!(%session_id, "SSE subscribe denied: caller is not the session owner");
-                        return forbidden();
-                    }
                     for ctx in &subscribed {
                         let _ = inner.subscriptions.insert(*ctx);
                     }

--- a/crates/server/src/sse/handlers.rs
+++ b/crates/server/src/sse/handlers.rs
@@ -193,13 +193,40 @@ pub async fn handle_subscription(
                 // `inner`. Lock order is persist-guard → `inner`.
                 let _persist = session.persist_guard().await;
 
+                // Only subscribe to contexts this caller may observe. Context
+                // events carry state roots and application execution-event
+                // payloads, so a session must not receive events for a context
+                // its caller isn't a member of — the session-owner check above
+                // guards the session, not the contexts. The node owner (and a
+                // no-auth dev server) may observe everything; any other caller
+                // must prove membership via its authenticated key. Unauthorized
+                // ids are dropped and the response reflects only what was
+                // actually subscribed.
+                let node_owner = auth_node_owner.is_some();
+                let subscribed: Vec<_> = ctxs
+                    .context_ids
+                    .iter()
+                    .copied()
+                    .filter(|ctx| {
+                        let caller_is_member = auth_key.as_ref().map(|Extension(AuthenticatedKey(pk))| {
+                            state.ctx_client.has_member(ctx, pk).unwrap_or(false)
+                        });
+                        let authorized =
+                            crate::ws::may_observe_context(state.auth_enabled, node_owner, caller_is_member);
+                        if !authorized {
+                            warn!(%session_id, context_id=%ctx, "SSE subscribe denied: caller is not a member of the context");
+                        }
+                        authorized
+                    })
+                    .collect();
+
                 let persisted = {
                     let mut inner = session.inner.write().await;
                     if !owner_allows_access(&inner.owner, &caller) {
                         warn!(%session_id, "SSE subscribe denied: caller is not the session owner");
                         return forbidden();
                     }
-                    for ctx in &ctxs.context_ids {
+                    for ctx in &subscribed {
                         let _ = inner.subscriptions.insert(*ctx);
                     }
                     inner.touch();
@@ -217,7 +244,7 @@ pub async fn handle_subscription(
                     Json(SseResponse {
                         body: ResponseBody::Result(serde_json::json!({
                             "status": "subscribed",
-                            "contexts": ctxs.context_ids,
+                            "contexts": subscribed,
                         })),
                     }),
                 )

--- a/crates/server/src/sse/state.rs
+++ b/crates/server/src/sse/state.rs
@@ -1,3 +1,4 @@
+use calimero_context_client::client::ContextClient;
 use calimero_node_primitives::client::NodeClient;
 use calimero_server_primitives::sse::ConnectionId;
 use calimero_store::Store;
@@ -9,6 +10,9 @@ use super::session::SessionState;
 /// Global SSE service state
 pub struct ServiceState {
     pub node_client: NodeClient,
+    /// Used to verify context membership before allowing a session to subscribe
+    /// to a context's event stream.
+    pub ctx_client: ContextClient,
     pub store: Store,
     /// Session state persists across reconnections (in-memory cache)
     pub sessions: RwLock<HashMap<ConnectionId, SessionState>>,
@@ -22,9 +26,15 @@ pub struct ServiceState {
 impl ServiceState {
     /// Create new service state
     #[must_use]
-    pub fn new(node_client: NodeClient, store: Store, auth_enabled: bool) -> Self {
+    pub fn new(
+        node_client: NodeClient,
+        ctx_client: ContextClient,
+        store: Store,
+        auth_enabled: bool,
+    ) -> Self {
         Self {
             node_client,
+            ctx_client,
             store,
             sessions: RwLock::default(),
             auth_enabled,

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -37,6 +37,8 @@ mod execute;
 mod subscribe;
 mod unsubscribe;
 
+pub(crate) use subscribe::may_observe_context;
+
 /// Globally unique identifier of a WebSocket client connection. Internal to the
 /// server (log correlation + connection-map key); never serialized to clients,
 /// so it lives here rather than in `calimero-server-primitives`.

--- a/crates/server/src/ws/subscribe.rs
+++ b/crates/server/src/ws/subscribe.rs
@@ -14,8 +14,14 @@ async fn handle(
     state: Arc<ServiceState>,
     connection_state: ConnectionState,
 ) -> EyreResult<SubscribeResponse> {
-    let mut inner = connection_state.inner.write().await;
-    let (caller, node_owner) = (inner.caller, inner.node_owner);
+    // Snapshot the connection's identity under a short read lock. The membership
+    // lookups below can touch the store, so we must not hold a lock across them:
+    // holding the write lock across `has_member` would stall the node-event task
+    // that reads `subscriptions` on every broadcast.
+    let (caller, node_owner) = {
+        let inner = connection_state.inner.read().await;
+        (inner.caller, inner.node_owner)
+    };
 
     // Only subscribe to contexts this connection is authorized to observe.
     // Context events carry state roots and application execution-event payloads,
@@ -23,17 +29,30 @@ async fn handle(
     // owner (and a no-auth dev server) may observe everything; any other
     // connection must prove membership via its authenticated caller identity.
     // Unauthorized ids are dropped rather than subscribed, and the response
-    // reflects only the contexts that were actually subscribed.
+    // reflects only the contexts that were actually subscribed. This runs
+    // without holding any lock.
     let mut subscribed = Vec::with_capacity(request.context_ids.len());
     for id in request.context_ids {
         let caller_is_member =
-            caller.map(|key| state.ctx_client.has_member(&id, &key).unwrap_or(false));
+            caller.map(|key| {
+                state.ctx_client.has_member(&id, &key).unwrap_or_else(|err| {
+                warn!(context_id=%id, %err, "has_member lookup failed; denying subscription");
+                false
+            })
+            });
 
         if may_observe_context(state.auth_enabled, node_owner, caller_is_member) {
-            let _ = inner.subscriptions.insert(id);
             subscribed.push(id);
         } else {
             warn!(context_id=%id, "denying WS subscription: caller is not a member of the context");
+        }
+    }
+
+    // Acquire the write lock only to record the approved subscriptions.
+    {
+        let mut inner = connection_state.inner.write().await;
+        for id in &subscribed {
+            let _ = inner.subscriptions.insert(*id);
         }
     }
 

--- a/crates/server/src/ws/subscribe.rs
+++ b/crates/server/src/ws/subscribe.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use calimero_server_primitives::ws::{SubscribeRequest, SubscribeResponse};
 use calimero_server_primitives::Infallible;
 use eyre::Result as EyreResult;
+use tracing::warn;
 
 use crate::ws::{mount_method, ConnectionState, ServiceState};
 
@@ -10,15 +11,74 @@ mount_method!(SubscribeRequest-> Result<SubscribeResponse, Infallible>, handle);
 
 async fn handle(
     request: SubscribeRequest,
-    _state: Arc<ServiceState>,
+    state: Arc<ServiceState>,
     connection_state: ConnectionState,
 ) -> EyreResult<SubscribeResponse> {
     let mut inner = connection_state.inner.write().await;
-    request.context_ids.iter().for_each(|id| {
-        let _ = inner.subscriptions.insert(*id);
-    });
+    let (caller, node_owner) = (inner.caller, inner.node_owner);
+
+    // Only subscribe to contexts this connection is authorized to observe.
+    // Context events carry state roots and application execution-event payloads,
+    // so delivering them to a non-member is a cross-context data leak. The node
+    // owner (and a no-auth dev server) may observe everything; any other
+    // connection must prove membership via its authenticated caller identity.
+    // Unauthorized ids are dropped rather than subscribed, and the response
+    // reflects only the contexts that were actually subscribed.
+    let mut subscribed = Vec::with_capacity(request.context_ids.len());
+    for id in request.context_ids {
+        let caller_is_member =
+            caller.map(|key| state.ctx_client.has_member(&id, &key).unwrap_or(false));
+
+        if may_observe_context(state.auth_enabled, node_owner, caller_is_member) {
+            let _ = inner.subscriptions.insert(id);
+            subscribed.push(id);
+        } else {
+            warn!(context_id=%id, "denying WS subscription: caller is not a member of the context");
+        }
+    }
 
     Ok(SubscribeResponse {
-        context_ids: request.context_ids,
+        context_ids: subscribed,
     })
+}
+
+/// Whether a connection may subscribe to (observe) a context's event stream.
+///
+/// The node owner and a no-auth dev server may observe everything. Any other
+/// connection must present an authenticated caller that is a member of the
+/// context (`caller_is_member == Some(true)`); a connection with no caller
+/// identity (`None`) is denied when auth is enabled.
+pub(crate) fn may_observe_context(
+    auth_enabled: bool,
+    node_owner: bool,
+    caller_is_member: Option<bool>,
+) -> bool {
+    if node_owner || !auth_enabled {
+        true
+    } else {
+        caller_is_member.unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::may_observe_context;
+
+    #[test]
+    fn node_owner_observes_everything() {
+        assert!(may_observe_context(true, true, None));
+        assert!(may_observe_context(true, true, Some(false)));
+    }
+
+    #[test]
+    fn no_auth_server_observes_everything() {
+        assert!(may_observe_context(false, false, None));
+    }
+
+    #[test]
+    fn member_is_allowed_non_member_and_no_caller_denied() {
+        assert!(may_observe_context(true, false, Some(true)));
+        assert!(!may_observe_context(true, false, Some(false)));
+        assert!(!may_observe_context(true, false, None));
+    }
 }


### PR DESCRIPTION
## Summary

Closes a cross-context data-disclosure (IDOR) affecting **both** event-streaming transports.

## Before

- **WebSocket** `subscribe` (`ws/subscribe.rs`) inserted every caller-requested `context_id` into the connection's subscription set with **no membership/existence check**.
- **SSE** `/subscription` (`sse/handlers.rs`) verified only the *session owner* (`owner_allows_access`), never context membership.

The event fan-out delivers a `NodeEvent::Context` to any subscriber whose set contains the event's `context_id`. That payload includes state-root hashes and application `ExecutionEvent` contents. So any authenticated client (or, on SSE, any owner of its own session) could subscribe to **any** context id it could guess or enumerate and receive that context's live events without being a member. The in-repo test `events_only_reach_subscribers` confirms delivery is purely subscription-driven, with no per-event authorization.

## After

Both subscribe paths gate each requested context on membership:

- The **node owner** (and a **no-auth dev server**, `auth_enabled == false`) may observe everything — unchanged.
- Any other connection must present an **authenticated caller that is a member** of the context, verified via `ContextClient::has_member` (covers direct `ContextIdentity`, group membership, and the group-admin fallback).
- Unauthorized ids are **dropped** (not subscribed), and the subscribe response reflects only the contexts actually subscribed, so a client can tell what it got.

The decision is centralized in a small pure helper `ws::may_observe_context(auth_enabled, node_owner, caller_is_member)` (unit-tested) and reused by SSE to avoid drift. SSE's `ServiceState` now carries a `ContextClient` for the membership lookup (threaded through `sse::service` / `service_mounts`).

## Verification

- `cargo test -p calimero-server --lib` → **46 passed** (43 existing + 3 new unit tests for `may_observe_context`).
- Existing `events_only_reach_subscribers`, `subscribe_and_unsubscribe_round_trip`, and the SSE owner-binding tests still pass (they run with auth disabled → allow-all path).

**Test-harness note:** a full authenticated + membership integration test would require mounting the auth guard in the WS/SSE test harness (which today runs with `auth_enabled: false`). Rather than expand the harness in this PR, the authorization decision was extracted into `may_observe_context` and unit-tested for the node-owner, no-auth, member, non-member, and no-caller cases.

Finding #7 from the security review (upgraded to High; SSE shares the gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)