### PR TITLE
fix(server): bind inviter_id to an owned identity

### DIFF
--- a/crates/server/src/admin/handlers/context/invite_specialized_node.rs
+++ b/crates/server/src/admin/handlers/context/invite_specialized_node.rs
@@ -4,19 +4,35 @@
 //! allowing specialized nodes (e.g., read-only TEE nodes) to respond with verification
 //! and receive invitations.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Extension;
+use calimero_primitives::context::ContextId;
 use calimero_server_primitives::admin::{
     InviteSpecializedNodeRequest, InviteSpecializedNodeResponse,
 };
 use futures_util::TryStreamExt;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::admin::handlers::validation::ValidatedJson;
 use crate::admin::service::{parse_api_error, ApiError, ApiResponse};
 use crate::AdminState;
+
+/// Minimum interval between specialized-node invite broadcasts for the same
+/// context. Each broadcast publishes to the *global* invite topic, so without a
+/// throttle an authenticated caller could flood the network. Rate-limiting is
+/// keyed by context (only real contexts with owned identities reach this point,
+/// so the map cannot be grown with arbitrary ids).
+const INVITE_MIN_INTERVAL: Duration = Duration::from_secs(5);
+
+fn last_broadcasts() -> &'static Mutex<HashMap<ContextId, Instant>> {
+    static LAST: OnceLock<Mutex<HashMap<ContextId, Instant>>> = OnceLock::new();
+    LAST.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
 pub async fn handler(
     Extension(state): Extension<Arc<AdminState>>,
@@ -24,35 +40,67 @@ pub async fn handler(
 ) -> impl IntoResponse {
     info!(context_id=%req.context_id, "Initiating specialized node invitation");
 
-    // Resolve inviter_id - use provided or get default identity for context
-    let inviter_id = match req.inviter_id {
-        Some(id) => id,
-        None => {
-            // Get the first owned identity for this context
-            let stream = state
-                .ctx_client
-                .get_context_members(&req.context_id, Some(true)); // true = owned only
-
-            match stream.map_ok(|(id, _)| id).try_collect::<Vec<_>>().await {
-                Ok(identities) => {
-                    if let Some(first_identity) = identities.into_iter().next() {
-                        first_identity
-                    } else {
-                        error!(context_id=%req.context_id, "No owned identities found for context");
-                        return ApiError {
-                            status_code: axum::http::StatusCode::BAD_REQUEST,
-                            message: "No owned identities found for context".to_owned(),
-                        }
-                        .into_response();
-                    }
-                }
-                Err(err) => {
-                    error!(error=?err, "Failed to get context identities");
-                    return parse_api_error(err).into_response();
-                }
-            }
+    // The invite is stamped with an `inviter_id`. Resolve the set of identities
+    // this node owns in the context and require the inviter to be one of them:
+    // a caller must not be able to broadcast an invite spoofed as an arbitrary
+    // identity it does not control. When no `inviter_id` is supplied, default to
+    // the node's first owned identity for the context.
+    let owned: Vec<_> = match state
+        .ctx_client
+        .get_context_members(&req.context_id, Some(true)) // true = owned only
+        .map_ok(|(id, _)| id)
+        .try_collect()
+        .await
+    {
+        Ok(identities) => identities,
+        Err(err) => {
+            error!(error=?err, "Failed to get context identities");
+            return parse_api_error(err).into_response();
         }
     };
+
+    let inviter_id = match req.inviter_id {
+        Some(id) => {
+            if !owned.contains(&id) {
+                warn!(context_id=%req.context_id, %id, "rejecting specialized invite: inviter_id is not an owned identity of the context");
+                return ApiError {
+                    status_code: StatusCode::FORBIDDEN,
+                    message: "inviter_id is not an owned identity of this context".to_owned(),
+                }
+                .into_response();
+            }
+            id
+        }
+        None => match owned.into_iter().next() {
+            Some(first_identity) => first_identity,
+            None => {
+                error!(context_id=%req.context_id, "No owned identities found for context");
+                return ApiError {
+                    status_code: StatusCode::BAD_REQUEST,
+                    message: "No owned identities found for context".to_owned(),
+                }
+                .into_response();
+            }
+        },
+    };
+
+    // Throttle broadcasts per context to bound global-topic traffic.
+    {
+        let now = Instant::now();
+        let mut last = last_broadcasts().lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(prev) = last.get(&req.context_id) {
+            if now.duration_since(*prev) < INVITE_MIN_INTERVAL {
+                warn!(context_id=%req.context_id, "throttling specialized invite broadcast");
+                return ApiError {
+                    status_code: StatusCode::TOO_MANY_REQUESTS,
+                    message: "Specialized node invites for this context are rate limited"
+                        .to_owned(),
+                }
+                .into_response();
+            }
+        }
+        let _ = last.insert(req.context_id, now);
+    }
 
     // Broadcast specialized node invite and register pending invite
     let result = state

--- a/crates/server/src/admin/handlers/context/invite_specialized_node.rs
+++ b/crates/server/src/admin/handlers/context/invite_specialized_node.rs
@@ -86,10 +86,9 @@ pub async fn handler(
 
     // Throttle broadcasts per context to bound global-topic traffic.
     {
-        let now = Instant::now();
-        let mut last = last_broadcasts().lock().unwrap_or_else(|e| e.into_inner());
+        let last = last_broadcasts().lock().unwrap_or_else(|e| e.into_inner());
         if let Some(prev) = last.get(&req.context_id) {
-            if now.duration_since(*prev) < INVITE_MIN_INTERVAL {
+            if prev.elapsed() < INVITE_MIN_INTERVAL {
                 warn!(context_id=%req.context_id, "throttling specialized invite broadcast");
                 return ApiError {
                     status_code: StatusCode::TOO_MANY_REQUESTS,
@@ -99,7 +98,6 @@ pub async fn handler(
                 .into_response();
             }
         }
-        let _ = last.insert(req.context_id, now);
     }
 
     // Broadcast specialized node invite and register pending invite
@@ -110,6 +108,16 @@ pub async fn handler(
 
     match result {
         Ok(nonce) => {
+            // Commit the throttle timestamp only now that the broadcast
+            // succeeded, and prune entries older than the interval so the map
+            // can't grow without bound over the process lifetime.
+            {
+                let now = Instant::now();
+                let mut last = last_broadcasts().lock().unwrap_or_else(|e| e.into_inner());
+                last.retain(|_, t| now.duration_since(*t) < INVITE_MIN_INTERVAL);
+                last.insert(req.context_id, now);
+            }
+
             let nonce_hex = hex::encode(nonce);
             info!(
                 context_id=%req.context_id,

--- a/crates/server/src/admin/handlers/context/invite_specialized_node.rs
+++ b/crates/server/src/admin/handlers/context/invite_specialized_node.rs
@@ -4,14 +4,11 @@
 //! allowing specialized nodes (e.g., read-only TEE nodes) to respond with verification
 //! and receive invitations.
 
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex, OnceLock};
-use std::time::{Duration, Instant};
+use std::sync::Arc;
 
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Extension;
-use calimero_primitives::context::ContextId;
 use calimero_server_primitives::admin::{
     InviteSpecializedNodeRequest, InviteSpecializedNodeResponse,
 };
@@ -21,18 +18,6 @@ use tracing::{error, info, warn};
 use crate::admin::handlers::validation::ValidatedJson;
 use crate::admin::service::{parse_api_error, ApiError, ApiResponse};
 use crate::AdminState;
-
-/// Minimum interval between specialized-node invite broadcasts for the same
-/// context. Each broadcast publishes to the *global* invite topic, so without a
-/// throttle an authenticated caller could flood the network. Rate-limiting is
-/// keyed by context (only real contexts with owned identities reach this point,
-/// so the map cannot be grown with arbitrary ids).
-const INVITE_MIN_INTERVAL: Duration = Duration::from_secs(5);
-
-fn last_broadcasts() -> &'static Mutex<HashMap<ContextId, Instant>> {
-    static LAST: OnceLock<Mutex<HashMap<ContextId, Instant>>> = OnceLock::new();
-    LAST.get_or_init(|| Mutex::new(HashMap::new()))
-}
 
 pub async fn handler(
     Extension(state): Extension<Arc<AdminState>>,
@@ -84,22 +69,6 @@ pub async fn handler(
         },
     };
 
-    // Throttle broadcasts per context to bound global-topic traffic.
-    {
-        let last = last_broadcasts().lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(prev) = last.get(&req.context_id) {
-            if prev.elapsed() < INVITE_MIN_INTERVAL {
-                warn!(context_id=%req.context_id, "throttling specialized invite broadcast");
-                return ApiError {
-                    status_code: StatusCode::TOO_MANY_REQUESTS,
-                    message: "Specialized node invites for this context are rate limited"
-                        .to_owned(),
-                }
-                .into_response();
-            }
-        }
-    }
-
     // Broadcast specialized node invite and register pending invite
     let result = state
         .node_client
@@ -108,16 +77,6 @@ pub async fn handler(
 
     match result {
         Ok(nonce) => {
-            // Commit the throttle timestamp only now that the broadcast
-            // succeeded, and prune entries older than the interval so the map
-            // can't grow without bound over the process lifetime.
-            {
-                let now = Instant::now();
-                let mut last = last_broadcasts().lock().unwrap_or_else(|e| e.into_inner());
-                last.retain(|_, t| now.duration_since(*t) < INVITE_MIN_INTERVAL);
-                last.insert(req.context_id, now);
-            }
-
             let nonce_hex = hex::encode(nonce);
             info!(
                 context_id=%req.context_id,


### PR DESCRIPTION
## Summary

Fixes identity spoofing in the context invite endpoint: a caller could stamp an invite with an arbitrary `inviter_id` it does not control.

## Before

The handler took `req.inviter_id` and, when present, used it **verbatim** — no check that the identity is owned by this node or is even a member of the context. The `inviter_id` is carried in the pending-invite record and the broadcast payload, so a caller could issue an invite spoofed as an **arbitrary identity it does not control**.

## After

The handler always resolves the node's **owned** identities for the context (`get_context_members(.., Some(true))`) and requires any supplied `inviter_id` to be one of them, returning **403** otherwise. The no-`inviter_id` path still defaults to the first owned identity (unchanged behavior).

## Verification

- `cargo check -p calimero-server` passes.
- Behavior: `inviter_id` not owned by the node → 403; valid owned `inviter_id` → invite proceeds; omitted `inviter_id` → first owned identity, as before.

Finding #8 from the security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
