### PR TITLE
fix(server): consistent admin errors, real context storage, alias validation

### DIFF
--- a/crates/primitives/src/alias.rs
+++ b/crates/primitives/src/alias.rs
@@ -61,6 +61,10 @@ impl<T> Clone for Alias<T> {
 pub enum InvalidAlias {
     #[error("exceeds maximum length of {} characters", MAX_ALIAS_LEN)]
     TooLong,
+    #[error("must not be empty")]
+    Empty,
+    #[error("contains an invalid character; allowed characters are [A-Za-z0-9._-]")]
+    InvalidCharacter,
 }
 
 impl<T> Alias<T> {
@@ -102,6 +106,20 @@ impl<T> FromStr for Alias<T> {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.len() > MAX_ALIAS_LEN {
             return Err(InvalidAlias::TooLong);
+        }
+
+        if s.is_empty() {
+            return Err(InvalidAlias::Empty);
+        }
+
+        // Aliases are interpolated into store keys and URL paths, so restrict
+        // them to an unambiguous character set. This excludes path separators
+        // and whitespace that could otherwise change how an alias is routed.
+        if !s
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
+        {
+            return Err(InvalidAlias::InvalidCharacter);
         }
 
         let mut str = [0; MAX_ALIAS_LEN];

--- a/crates/primitives/src/tests/alias.rs
+++ b/crates/primitives/src/tests/alias.rs
@@ -20,26 +20,42 @@ fn test_alias_length_limit() {
 }
 
 #[test]
-fn test_empty_alias() {
-    // Empty string should be valid
-    let alias: Alias<()> = "".parse().unwrap();
-    assert_eq!(alias.as_str(), "");
+fn test_empty_alias_is_rejected() {
+    // Empty aliases are not allowed.
+    let err = "".parse::<Alias<()>>().expect_err("empty alias");
+    assert!(err.to_string().contains("must not be empty"));
 }
 
 #[test]
-fn test_special_characters() {
-    // Test with various special characters
-    let special = "test-123_@#$%^&*()";
-    let alias: Alias<()> = special.parse().unwrap();
-    assert_eq!(alias.as_str(), special);
+fn test_allowed_punctuation() {
+    // Dots, dashes, and underscores are permitted.
+    let allowed = "test-123_v1.2";
+    let alias: Alias<()> = allowed.parse().unwrap();
+    assert_eq!(alias.as_str(), allowed);
 }
 
 #[test]
-fn test_unicode_characters() {
-    // Test with Unicode characters
-    let unicode = "测试-алиас-🦀";
-    let alias: Alias<()> = unicode.parse().unwrap();
-    assert_eq!(alias.as_str(), unicode);
+fn test_special_characters_are_rejected() {
+    // Characters outside [A-Za-z0-9._-] are rejected, including path
+    // separators and shell metacharacters.
+    for bad in ["test@host", "a/b", "a b", "a\\b", "with#hash", "a$b"] {
+        let err = bad
+            .parse::<Alias<()>>()
+            .expect_err("special characters should be rejected");
+        assert!(
+            err.to_string().contains("invalid character"),
+            "unexpected error for {bad:?}: {err}"
+        );
+    }
+}
+
+#[test]
+fn test_unicode_characters_are_rejected() {
+    // Non-ASCII aliases are rejected.
+    let err = "测试-алиас-🦀"
+        .parse::<Alias<()>>()
+        .expect_err("unicode alias");
+    assert!(err.to_string().contains("invalid character"));
 }
 
 #[test]

--- a/crates/server/src/admin/handlers/alias/create_alias.rs
+++ b/crates/server/src/admin/handlers/alias/create_alias.rs
@@ -5,10 +5,9 @@ use axum::response::IntoResponse;
 use axum::{Extension, Json};
 use calimero_server_primitives::admin::{AliasKind, CreateAliasRequest, CreateAliasResponse};
 use calimero_store::key::{Aliasable, StoreScopeCompat};
-use reqwest::StatusCode;
 use tracing::{error, info};
 
-use crate::admin::service::ApiResponse;
+use crate::admin::service::{parse_api_error, ApiResponse};
 use crate::AdminState;
 
 pub async fn handler<T>(
@@ -28,7 +27,7 @@ where
         .create_alias(alias, scope, T::from_value(value))
     {
         error!(alias=%alias, error=?err, "Failed to create alias");
-        return (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response();
+        return parse_api_error(err).into_response();
     }
 
     info!(alias=%alias, "Alias created successfully");

--- a/crates/server/src/admin/handlers/alias/delete_alias.rs
+++ b/crates/server/src/admin/handlers/alias/delete_alias.rs
@@ -9,7 +9,7 @@ use calimero_store::key::{Aliasable, StoreScopeCompat};
 use reqwest::StatusCode;
 use tracing::{error, info};
 
-use crate::admin::service::ApiResponse;
+use crate::admin::service::{parse_api_error, ApiResponse};
 use crate::AdminState;
 
 pub async fn handler<T>(
@@ -32,7 +32,7 @@ where
 
     if let Err(err) = state.node_client.delete_alias(alias, scope) {
         error!(alias=%alias, error=?err, "Failed to delete alias");
-        return (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response();
+        return parse_api_error(err).into_response();
     }
 
     info!(alias=%alias, "Alias deleted successfully");

--- a/crates/server/src/admin/handlers/alias/lookup_alias.rs
+++ b/crates/server/src/admin/handlers/alias/lookup_alias.rs
@@ -10,7 +10,7 @@ use reqwest::StatusCode;
 use serde::Serialize;
 use tracing::{error, info};
 
-use crate::admin::service::ApiResponse;
+use crate::admin::service::{parse_api_error, ApiResponse};
 use crate::AdminState;
 
 pub async fn handler<T>(
@@ -43,7 +43,7 @@ where
         }
         Err(err) => {
             error!(alias=%alias, error=?err, "Failed to lookup alias");
-            (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
+            parse_api_error(err).into_response()
         }
     }
 }

--- a/crates/server/src/admin/handlers/applications/get_application.rs
+++ b/crates/server/src/admin/handlers/applications/get_application.rs
@@ -1,14 +1,13 @@
 use std::sync::Arc;
 
 use axum::extract::Path;
-use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Extension;
 use calimero_primitives::application::ApplicationId;
 use calimero_server_primitives::admin::GetApplicationResponse;
 use tracing::{error, info};
 
-use crate::admin::service::ApiResponse;
+use crate::admin::service::{parse_api_error, ApiResponse};
 use crate::AdminState;
 
 pub async fn handler(
@@ -27,7 +26,7 @@ pub async fn handler(
         }
         Err(err) => {
             error!(application_id=%application_id, error=?err, "Failed to get application");
-            (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
+            parse_api_error(err).into_response()
         }
     }
 }

--- a/crates/server/src/admin/handlers/context/get_context_storage.rs
+++ b/crates/server/src/admin/handlers/context/get_context_storage.rs
@@ -1,19 +1,37 @@
 use std::sync::Arc;
 
 use axum::extract::Path;
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Extension;
+use calimero_primitives::context::ContextId;
 use calimero_server_primitives::admin::GetContextStorageResponse;
+use tracing::info;
 
-use crate::admin::service::ApiResponse;
+use crate::admin::handlers::usage::context_storage_bytes;
+use crate::admin::service::{ApiError, ApiResponse};
 use crate::AdminState;
 
 pub async fn handler(
-    Path(_context_id): Path<String>,
-    Extension(_state): Extension<Arc<AdminState>>,
+    Path(context_id): Path<String>,
+    Extension(state): Extension<Arc<AdminState>>,
 ) -> impl IntoResponse {
+    let context_id: ContextId = match context_id.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            return ApiError {
+                status_code: StatusCode::BAD_REQUEST,
+                message: "Invalid context ID format".to_owned(),
+            }
+            .into_response();
+        }
+    };
+
+    let size_in_bytes = context_storage_bytes(&state.store, context_id.as_ref());
+    info!(context_id=%context_id, size_in_bytes, "Reporting context storage");
+
     ApiResponse {
-        payload: GetContextStorageResponse::new(0),
+        payload: GetContextStorageResponse::new(size_in_bytes),
     }
     .into_response()
 }

--- a/crates/server/src/admin/handlers/usage.rs
+++ b/crates/server/src/admin/handlers/usage.rs
@@ -142,6 +142,17 @@ fn increment_prefix(bytes: &mut [u8]) {
     }
 }
 
+/// Approximate on-disk bytes stored for a single context: the sum of its
+/// State, PrivateState, and Delta columns. Governance bytes are namespace-scoped
+/// (not per-context) and therefore excluded. Uses the same sampling probe as the
+/// per-namespace usage report.
+pub(crate) fn context_storage_bytes(store: &Store, context_id: &[u8; 32]) -> u64 {
+    let (start, end) = context_prefix_range(context_id);
+    probe(store, Column::State, &start, &end)
+        .saturating_add(probe(store, Column::PrivateState, &start, &end))
+        .saturating_add(probe(store, Column::Delta, &start, &end))
+}
+
 fn probe(store: &Store, col: Column, start: &[u8], end: &[u8]) -> u64 {
     match store.approximate_size(col, start, end) {
         Ok(n) => n,


### PR DESCRIPTION
## Summary

Three admin-API quality fixes from the security review's grab-bag finding.

### 1. Structured error responses (`get_application`, alias handlers)

**Before:** `get_application` and the create/delete/lookup alias handlers returned raw `(StatusCode::INTERNAL_SERVER_ERROR, err.to_string())` tuples — plain-text 500s that also dropped any structured status carried in the error chain.

**After:** all four route through the existing `parse_api_error`, producing consistent `{"error": ...}` JSON and preserving any `ApiError` status already in the chain (falling back to 500 only for genuinely unstructured errors).

### 2. `get_context_storage` returned a hardcoded 0

**Before:** the handler discarded both the context id and state and unconditionally returned `size_in_bytes: 0`. Any storage/quota consumer saw zero for every context.

**After:** it parses the context id and reports the real approximate on-disk size — State + PrivateState + Delta column bytes — via a `context_storage_bytes` helper factored out of the per-namespace usage report (same sampling probe). Invalid context id → 400.

### 3. Alias validation

**Before:** `Alias::from_str` accepted any UTF-8 up to 50 bytes — including empty strings, path separators (`/`, `\`), whitespace, and shell metacharacters — all of which flow into store keys and URL paths.

**After:** empty aliases are rejected and the character set is restricted to `[A-Za-z0-9._-]`. Existing tests that asserted the permissive behavior (empty/unicode/special chars "valid") were updated to assert the new validation.

## Scope / follow-up

Mapping **duplicate alias → 409** and **not-found → 404** requires typed errors in the node-client alias layer (currently `eyre::Result`, also consumed by meroctl via `?`). That's a broader change left as a follow-up; this PR makes the responses structured and correct in body, and hardens the input.

## Verification

- `cargo test -p calimero-primitives --lib alias` → **9 passed** (empty/special/unicode now asserted as rejected; dots/dashes/underscores allowed).
- `cargo check -p calimero-server` passes.

Finding #9 from the security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)