### PR TITLE
fix(server): clamp page size on group/context list endpoints

### DIFF
--- a/crates/server/src/admin/handlers/groups.rs
+++ b/crates/server/src/admin/handlers/groups.rs
@@ -45,6 +45,14 @@ use reqwest::StatusCode;
 
 use crate::admin::service::ApiError;
 
+/// Hard cap on the page size accepted by the group/context list endpoints,
+/// regardless of the caller-supplied `limit`. Keeps a single request's work
+/// (and response size) bounded.
+pub(crate) const MAX_LIST_LIMIT: usize = 1000;
+
+/// Default page size when the caller omits `limit`.
+pub(crate) const DEFAULT_LIST_LIMIT: usize = 100;
+
 fn upgrade_info_to_api_data(info: &GroupUpgradeInfo) -> GroupUpgradeStatusApiData {
     let (status, total, completed, failed, completed_at) = match &info.status {
         GroupUpgradeStatus::InProgress {

--- a/crates/server/src/admin/handlers/groups/list_all_groups.rs
+++ b/crates/server/src/admin/handlers/groups/list_all_groups.rs
@@ -9,6 +9,7 @@ use calimero_server_primitives::admin::{
 };
 use tracing::{error, info};
 
+use super::{DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT};
 use crate::admin::service::{parse_api_error, ApiResponse};
 use crate::AdminState;
 
@@ -17,7 +18,10 @@ pub async fn handler(
     Extension(state): Extension<Arc<AdminState>>,
 ) -> impl IntoResponse {
     let offset = query.offset.unwrap_or(0);
-    let limit = query.limit.unwrap_or(100);
+    let limit = query
+        .limit
+        .unwrap_or(DEFAULT_LIST_LIMIT)
+        .min(MAX_LIST_LIMIT);
 
     info!(%offset, %limit, "Listing all groups");
 

--- a/crates/server/src/admin/handlers/groups/list_group_contexts.rs
+++ b/crates/server/src/admin/handlers/groups/list_group_contexts.rs
@@ -9,7 +9,7 @@ use calimero_server_primitives::admin::{
 };
 use tracing::{error, info};
 
-use super::parse_group_id;
+use super::{parse_group_id, DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT};
 use crate::admin::service::{parse_api_error, ApiResponse};
 use crate::AdminState;
 
@@ -24,7 +24,10 @@ pub async fn handler(
     };
 
     let offset = query.offset.unwrap_or(0);
-    let limit = query.limit.unwrap_or(100);
+    let limit = query
+        .limit
+        .unwrap_or(DEFAULT_LIST_LIMIT)
+        .min(MAX_LIST_LIMIT);
 
     info!(group_id=%group_id_str, %offset, %limit, "Listing group contexts");
 

--- a/crates/server/src/admin/handlers/groups/list_group_members.rs
+++ b/crates/server/src/admin/handlers/groups/list_group_members.rs
@@ -9,7 +9,7 @@ use calimero_server_primitives::admin::{
 };
 use tracing::{error, info};
 
-use super::parse_group_id;
+use super::{parse_group_id, DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT};
 use crate::admin::service::{parse_api_error, ApiResponse};
 use crate::AdminState;
 
@@ -24,7 +24,10 @@ pub async fn handler(
     };
 
     let offset = query.offset.unwrap_or(0);
-    let limit = query.limit.unwrap_or(100);
+    let limit = query
+        .limit
+        .unwrap_or(DEFAULT_LIST_LIMIT)
+        .min(MAX_LIST_LIMIT);
 
     info!(group_id=%group_id_str, %offset, %limit, "Listing group members");
 


### PR DESCRIPTION
## Summary

Hardening/hygiene: bound the page size of the group and context list endpoints.

## Before

`list_group_members`, `list_all_groups`, and `list_group_contexts` used the caller-supplied `limit` with no upper bound (`query.limit.unwrap_or(100)`). A caller could request `limit=u64::MAX`.

## After

`limit` is clamped to a shared `MAX_LIST_LIMIT = 1000` (default stays 100).

## Note

The original review flagged this as a potential unbounded allocation. In practice the downstream walk is bounded by rows that **actually exist** (there is no `Vec::with_capacity(limit)` anywhere), so a huge `limit` cannot pre-allocate — this is **not** a memory-DoS. The clamp is pure hygiene: it keeps a single request's work and response size bounded regardless of input.

## Verification

- `cargo check -p calimero-server` passes.

Finding #5 from the security review (verified as a low-severity hygiene item, not a DoS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)