### PR TITLE
fix(client): single-flight token refresh and interactive auth

### DIFF
--- a/crates/client/src/connection.rs
+++ b/crates/client/src/connection.rs
@@ -4,10 +4,13 @@
 //! authenticated API requests to Calimero services.
 
 // External crates
+use std::sync::Arc;
+
 use eyre::{bail, eyre, Result};
 use reqwest::Client;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use tokio::sync::Mutex;
 use url::Url;
 
 // Local crate
@@ -52,6 +55,12 @@ where
     node_name: Option<String>,
     authenticator: A,
     client_storage: S,
+    // Single-flight guard shared across clones: serializes token
+    // refresh/re-authentication so N concurrent 401s (or N concurrent
+    // token-less requests) coalesce into one refresh / one interactive login
+    // instead of each firing its own — which would race the one-time refresh
+    // token and, for interactive auth, spawn N browser prompts.
+    refresh_lock: Arc<Mutex<()>>,
 }
 
 impl<A, S> ConnectionInfo<A, S>
@@ -71,6 +80,7 @@ where
             node_name,
             authenticator,
             client_storage,
+            refresh_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -272,7 +282,16 @@ where
             }
         }
 
-        // No tokens — authenticate proactively
+        // No tokens — authenticate proactively, single-flight so concurrent
+        // token-less requests don't each spawn an interactive login.
+        let _guard = self.refresh_lock.lock().await;
+
+        // Another task may have authenticated while we waited for the lock;
+        // reuse its result instead of authenticating again.
+        if let Ok(Some(tokens)) = self.client_storage.load_tokens(node_name).await {
+            return Ok(Some(format!("Bearer {}", tokens.access_token)));
+        }
+
         match self.authenticator.authenticate(&self.api_url).await {
             Ok(new_tokens) => {
                 self.client_storage
@@ -307,7 +326,7 @@ where
             // Load a fresh auth header on EVERY iteration so retries use up-to-date tokens.
             let auth_header = self.ensure_auth_header(requires_auth).await?;
 
-            let response = request_builder(auth_header).await?;
+            let response = request_builder(auth_header.clone()).await?;
 
             if response.status() == 401 && retry_count < MAX_RETRIES {
                 if self.node_name.is_none() {
@@ -318,31 +337,11 @@ where
 
                 retry_count += 1;
 
-                // Try to refresh first; fall back to full re-auth on any failure
-                // (including missing refresh token). Previously, missing refresh token
-                // caused an immediate bail; now any refresh failure triggers full
-                // re-authentication so the user gets a working session regardless.
-                match self.refresh_token().await {
-                    Ok(new_token) => {
-                        if let Some(ref node_name) = self.node_name {
-                            self.client_storage
-                                .update_tokens(node_name, &new_token)
-                                .await?;
-                        }
-                    }
-                    Err(_) => match self.authenticator.authenticate(&self.api_url).await {
-                        Ok(new_tokens) => {
-                            if let Some(ref node_name) = self.node_name {
-                                self.client_storage
-                                    .update_tokens(node_name, &new_tokens)
-                                    .await?;
-                            }
-                        }
-                        Err(auth_err) => {
-                            bail!("Authentication failed: {}", auth_err);
-                        }
-                    },
-                }
+                // Refresh (or fall back to full re-auth) under the single-flight
+                // lock so concurrent 401s don't each hit /auth/refresh with the
+                // same one-time refresh token.
+                self.refresh_or_reauth(auth_header.as_deref()).await?;
+
                 // Loop back — next iteration loads fresh tokens.
                 continue;
             }
@@ -367,6 +366,57 @@ where
             }
 
             return Ok(response);
+        }
+    }
+
+    /// Refresh the stored token, or fall back to full re-authentication, under
+    /// the single-flight lock.
+    ///
+    /// `used_auth_header` is the `Authorization` value the request that just got
+    /// a 401 was sent with. After acquiring the lock we compare it against the
+    /// currently-stored token: if another task already refreshed while we
+    /// waited, the stored token differs, so we skip and let the caller retry
+    /// with the now-current token instead of burning the (already-rotated)
+    /// refresh token a second time.
+    async fn refresh_or_reauth(&self, used_auth_header: Option<&str>) -> Result<()> {
+        let Some(node_name) = self.node_name.clone() else {
+            bail!(
+                "Authentication required but no node name is available to load or persist tokens"
+            );
+        };
+
+        let _guard = self.refresh_lock.lock().await;
+
+        // Did someone else already refresh while we waited for the lock?
+        if let Some(used) = used_auth_header {
+            if let Ok(Some(tokens)) = self.client_storage.load_tokens(&node_name).await {
+                if format!("Bearer {}", tokens.access_token) != used {
+                    return Ok(());
+                }
+            }
+        }
+
+        // Try to refresh first; fall back to full re-auth on any failure
+        // (including a missing refresh token) so the user gets a working session
+        // regardless.
+        match self.refresh_token().await {
+            Ok(new_token) => {
+                self.client_storage
+                    .update_tokens(&node_name, &new_token)
+                    .await?;
+                Ok(())
+            }
+            Err(_) => match self.authenticator.authenticate(&self.api_url).await {
+                Ok(new_tokens) => {
+                    self.client_storage
+                        .update_tokens(&node_name, &new_tokens)
+                        .await?;
+                    Ok(())
+                }
+                Err(auth_err) => {
+                    bail!("Authentication failed: {}", auth_err);
+                }
+            },
         }
     }
 


### PR DESCRIPTION
## Summary

Coalesces concurrent token refresh / re-authentication in the client library (`crates/client`, consumed by meroctl).

## Before

Refresh and re-auth had no coordination:
- **N concurrent 401s** each independently `POST /auth/refresh` with the **same one-time refresh token**. Once the token rotates (client-type keys), all but the first fail with "key not found" and cascade to full re-authentication.
- **N concurrent token-less requests** each call `authenticate()` in `ensure_auth_header`, which for meroctl opens a **browser window per request** → N popups.

## After

A single `Arc<tokio::sync::Mutex<()>>` is shared across all clones of `ConnectionInfo`, and both paths go through it:

- The 401 path now calls a new `refresh_or_reauth(used_auth_header)` that takes the lock and, **before** refreshing, compares the stored token to the token the failed request used. If another task already refreshed while this one waited, the stored token differs → it **skips** and lets the caller retry with the now-current token (so the one-time refresh token is spent exactly once).
- The proactive (no-token) branch of `ensure_auth_header` takes the same lock and **re-checks storage after acquiring it**, so concurrent first-time requests trigger **one** interactive login instead of N browser prompts.

## Scope

Practical severity is low–medium (meroctl is largely sequential, and root-key refresh isn't strictly one-time), but the coordination removes a real thundering-herd + popup-storm failure mode and is a prerequisite for the interactive/non-interactive `auth_header` split (finding 19).

## Verification

- `cargo test -p calimero-client` → 43 passed.
- `cargo check -p meroctl` passes.

Findings #11 and #19 (popup-storm half) from the security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)