### PR TITLE
fix(runtime): per-execution resource budgets for storage, blobs, returns & events

### DIFF
--- a/crates/runtime/src/errors.rs
+++ b/crates/runtime/src/errors.rs
@@ -140,6 +140,14 @@ pub enum HostError {
     KeyLengthOverflow,
     #[error("value length overflow")]
     ValueLengthOverflow,
+    #[error("storage write count budget exceeded (max: {max})")]
+    StorageWriteCountExceeded { max: u64 },
+    #[error("storage write byte budget exceeded (attempted: {attempted}, max: {max})")]
+    StorageWriteBytesExceeded { attempted: u64, max: u64 },
+    #[error("return value too large (size: {size}, max: {max})")]
+    ReturnValueSizeOverflow { size: u64, max: u64 },
+    #[error("event handler name too large (size: {size}, max: {max})")]
+    EventHandlerSizeOverflow { size: u64, max: u64 },
     #[error("log size overflow")]
     LogLengthOverflow,
     #[error("logs overflow")]

--- a/crates/runtime/src/errors.rs
+++ b/crates/runtime/src/errors.rs
@@ -178,6 +178,8 @@ pub enum HostError {
     TotalBlobMemoryExceeded { current: u64, max: u64 },
     #[error("blob write too large (size: {size}, max: {max})")]
     BlobWriteTooLarge { size: u64, max: u64 },
+    #[error("blob write failed (writer task unavailable)")]
+    BlobWriteFailed,
     #[error("context does not have permission to access this blob handle")]
     BlobContextMismatch,
     #[error("too many blob handles open")]

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -170,6 +170,58 @@ const DEFAULT_MAX_ARTIFACT_SIZE_MIB: u64 = 16;
 /// the source WASM it was compiled from. This is a defense-in-depth ceiling on
 /// deserialization input, not a tight functional limit.
 const DEFAULT_MAX_PRECOMPILED_MODULE_SIZE_MIB: u64 = 256;
+/// Default maximum number of storage writes a single execution may perform.
+///
+/// Bounds the *count* of direct guest key-value writes — `storage_write`,
+/// `private_storage_write`, and `storage_index_set` all draw from this one
+/// budget — so a guest loop cannot issue an unbounded stream of writes into the
+/// host store (each write carries fixed per-entry overhead independent of its
+/// size). CRDT/root writes performed by the storage interface
+/// (`persist_root_state`, `apply_storage_delta`) go through a separate writer
+/// closure and are NOT charged here.
+const DEFAULT_MAX_STORAGE_WRITES: u64 = 100_000;
+/// Default maximum cumulative bytes a single execution may write to storage, in
+/// MiB (128 MiB).
+///
+/// The companion to [`DEFAULT_MAX_STORAGE_WRITES`]: bounds the total `key + value`
+/// bytes across all direct guest writes in one execution. Without it a guest
+/// loop writing max-size (10 MiB) values could grow the host store without
+/// bound. Comfortably above the single-value cap so a handful of large values
+/// still fit, while turning an unbounded write loop into a bounded, trappable
+/// one.
+const DEFAULT_MAX_STORAGE_WRITE_BYTES_MIB: u64 = 128;
+/// Default maximum total bytes a single execution may stream into blobs, in MiB
+/// (512 MiB).
+///
+/// Bounds the sum of all `blob_write` payloads in one execution across every
+/// open write handle. Live memory is already bounded by the blob write
+/// channel's fixed capacity (backpressure); this is the additional quota that
+/// stops a guest from streaming an unbounded total through that channel.
+const DEFAULT_MAX_BLOB_TOTAL_SIZE_MIB: u64 = 512;
+/// Default cap on the number of entries an *unbounded* ordered-index scan
+/// (`storage_index_scan` with `limit = 0`) may materialize.
+///
+/// An unbounded scan otherwise reads the whole range into an owned `Vec` and
+/// then re-encodes it — two transient host allocations sized by the range, both
+/// before the register-size cap applies. Substituting this ceiling for the
+/// "unbounded" sentinel bounds both allocations up front. A guest that needs
+/// more must paginate via `offset`.
+const DEFAULT_MAX_STORAGE_INDEX_SCAN_LIMIT: u64 = 100_000;
+/// Default maximum size, in MiB, of the value a guest may hand to
+/// `env::value_return` (16 MiB).
+///
+/// The return value is copied out of guest memory onto the `Outcome` (and
+/// broadcast in receipts), so without a cap the only bound is guest memory
+/// itself (~64 MiB). Matches [`DEFAULT_MAX_ARTIFACT_SIZE_MIB`]: both are
+/// copied onto the `Outcome` and share the same reasoning.
+const DEFAULT_MAX_RETURN_VALUE_SIZE_MIB: u64 = 16;
+/// Fixed capacity, in chunks, of the channel feeding each blob writer task.
+///
+/// A blob is streamed chunk-by-chunk to the writer task over this channel; a
+/// bounded (rather than unbounded) channel applies backpressure so at most
+/// `BLOB_WRITE_CHANNEL_CAPACITY * max_blob_chunk_size` bytes are ever buffered
+/// in memory per handle, regardless of how fast the guest produces data.
+pub(crate) const BLOB_WRITE_CHANNEL_CAPACITY: usize = 4;
 
 /// Defines the resource limits for a VM instance.
 ///
@@ -214,10 +266,33 @@ pub struct VMLimits {
     pub max_storage_key_size: NonZeroU64,
     /// The maximum size of a storage value in bytes.
     pub max_storage_value_size: NonZeroU64,
+    /// The maximum number of direct guest storage writes per execution.
+    ///
+    /// Shared budget across `storage_write`, `private_storage_write`, and
+    /// `storage_index_set`: a per-execution *count* ceiling that turns an
+    /// unbounded write loop into a trappable one. CRDT/root writes made through
+    /// the storage interface are not charged against it.
+    pub max_storage_writes: u64,
+    /// The maximum cumulative `key + value` bytes written to storage per
+    /// execution.
+    ///
+    /// The byte-sized companion to [`max_storage_writes`](Self::max_storage_writes),
+    /// sharing the same budget across the three write host functions.
+    pub max_storage_write_bytes: u64,
     /// The maximum number of blob handles that can exist.
     pub max_blob_handles: u64,
     /// The maximum size of a single chunk when writing to or reading from a blob.
     pub max_blob_chunk_size: u64,
+    /// The maximum total bytes a single execution may stream into blobs across
+    /// all open write handles.
+    pub max_blob_total_size: u64,
+    /// The maximum number of entries an unbounded `storage_index_scan`
+    /// (`limit = 0`) may materialize before the register-size cap applies.
+    pub max_storage_index_scan_limit: u64,
+    /// The maximum size, in bytes, of a value returned via `env::value_return`.
+    /// The value is copied onto the `Outcome`; without this cap the only bound
+    /// is guest memory itself.
+    pub max_return_value_size: u64,
     /// The maximum length of a method name in bytes.
     pub max_method_name_length: u64,
     /// The maximum size of a WASM module in bytes before compilation.
@@ -307,8 +382,13 @@ impl Default for VMLimits {
             max_storage_value_size: is_valid(
                 (DEFAULT_MAX_STORAGE_VALUE_SIZE_MIB * u64::from(ONE_MIB)).try_into(),
             ),
+            max_storage_writes: DEFAULT_MAX_STORAGE_WRITES,
+            max_storage_write_bytes: DEFAULT_MAX_STORAGE_WRITE_BYTES_MIB * u64::from(ONE_MIB),
             max_blob_handles: DEFAULT_MAX_BLOB_HANDLES,
             max_blob_chunk_size: DEFAULT_MAX_BLOB_CHUNK_SIZE_MIB * u64::from(ONE_MIB),
+            max_blob_total_size: DEFAULT_MAX_BLOB_TOTAL_SIZE_MIB * u64::from(ONE_MIB),
+            max_storage_index_scan_limit: DEFAULT_MAX_STORAGE_INDEX_SCAN_LIMIT,
+            max_return_value_size: DEFAULT_MAX_RETURN_VALUE_SIZE_MIB * u64::from(ONE_MIB),
             max_method_name_length: DEFAULT_MAX_METHOD_NAME_LENGTH,
             max_module_size: DEFAULT_MAX_MODULE_SIZE_MIB * u64::from(ONE_MIB),
             max_artifact_size: DEFAULT_MAX_ARTIFACT_SIZE_MIB * u64::from(ONE_MIB),
@@ -366,6 +446,17 @@ pub struct VMLogic<'a> {
     blob_handles: HashMap<u64, BlobHandle>,
     /// The next available file descriptor for a new blob handle.
     next_blob_fd: u64,
+
+    // Per-execution resource budgets. Counters start at zero in `new` and are
+    // therefore scoped to a single execution.
+    /// Number of direct guest storage writes performed so far (shared across
+    /// `storage_write`, `private_storage_write`, and `storage_index_set`).
+    storage_writes: u64,
+    /// Cumulative `key + value` bytes written to storage so far (same shared
+    /// budget as `storage_writes`).
+    storage_write_bytes: u64,
+    /// Cumulative bytes streamed into blobs so far across all write handles.
+    blob_bytes_written: u64,
 }
 
 impl<'a> VMLogic<'a> {
@@ -412,7 +503,76 @@ impl<'a> VMLogic<'a> {
             node_client,
             blob_handles: HashMap::new(),
             next_blob_fd: 1,
+
+            storage_writes: 0,
+            storage_write_bytes: 0,
+            blob_bytes_written: 0,
         }
+    }
+
+    /// Charges one storage write of `bytes` (`key.len() + value.len()`) against
+    /// the shared per-execution storage-write budget.
+    ///
+    /// Shared by `storage_write`, `private_storage_write`, and
+    /// `storage_index_set` so a guest cannot sidestep the ceiling by spreading
+    /// writes across the main store, the private store, and the ordered index.
+    /// Charged *before* the backend write so a rejected write never touches the
+    /// store.
+    ///
+    /// # Errors
+    ///
+    /// * [`HostError::StorageWriteCountExceeded`] once the write count would
+    ///   exceed [`VMLimits::max_storage_writes`].
+    /// * [`HostError::StorageWriteBytesExceeded`] once the cumulative byte total
+    ///   would exceed [`VMLimits::max_storage_write_bytes`].
+    fn charge_storage_write(&mut self, bytes: u64) -> VMLogicResult<()> {
+        let next_writes = self
+            .storage_writes
+            .checked_add(1)
+            .ok_or(HostError::IntegerOverflow)?;
+        if next_writes > self.limits.max_storage_writes {
+            return Err(HostError::StorageWriteCountExceeded {
+                max: self.limits.max_storage_writes,
+            }
+            .into());
+        }
+        let next_bytes = self
+            .storage_write_bytes
+            .checked_add(bytes)
+            .ok_or(HostError::IntegerOverflow)?;
+        if next_bytes > self.limits.max_storage_write_bytes {
+            return Err(HostError::StorageWriteBytesExceeded {
+                attempted: next_bytes,
+                max: self.limits.max_storage_write_bytes,
+            }
+            .into());
+        }
+        self.storage_writes = next_writes;
+        self.storage_write_bytes = next_bytes;
+        Ok(())
+    }
+
+    /// Charges `bytes` of blob write payload against the per-execution total
+    /// blob-write budget ([`VMLimits::max_blob_total_size`]).
+    ///
+    /// # Errors
+    ///
+    /// * [`HostError::TotalBlobMemoryExceeded`] once the cumulative total would
+    ///   exceed the limit.
+    fn charge_blob_write(&mut self, bytes: u64) -> VMLogicResult<()> {
+        let next = self
+            .blob_bytes_written
+            .checked_add(bytes)
+            .ok_or(HostError::IntegerOverflow)?;
+        if next > self.limits.max_blob_total_size {
+            return Err(HostError::TotalBlobMemoryExceeded {
+                current: next,
+                max: self.limits.max_blob_total_size,
+            }
+            .into());
+        }
+        self.blob_bytes_written = next;
+        Ok(())
     }
 
     /// Associates a Wasmer memory instance with this `VMLogic`.
@@ -553,6 +713,13 @@ impl VMLogic<'_> {
         if !self.blob_handles.is_empty() {
             let handle_count = self.blob_handles.len();
             let blob_handles = std::mem::take(&mut self.blob_handles);
+            // Abort any still-running writer task before dropping its handle.
+            // Dropping alone only closes the channel, which lets the task drain
+            // what was buffered and persist a partial, never-closed blob; abort
+            // discards that abandoned write instead.
+            for handle in blob_handles.values() {
+                handle.abort_pending_task();
+            }
             drop(blob_handles);
             trace!(
                 target: "runtime::logic",
@@ -998,8 +1165,13 @@ mod tests {
         assert_eq!(limits.max_xcall_params_size, 16 << 10); // 16 KiB
         assert_eq!(limits.max_storage_key_size.get(), 1 << 20); // 1 MiB
         assert_eq!(limits.max_storage_value_size.get(), 10 << 20); // 10 MiB
+        assert_eq!(limits.max_storage_writes, 100_000);
+        assert_eq!(limits.max_storage_write_bytes, 128 << 20); // 128 MiB
         assert_eq!(limits.max_blob_handles, 100);
         assert_eq!(limits.max_blob_chunk_size, 10 << 20); // 10 MiB
+        assert_eq!(limits.max_blob_total_size, 512 << 20); // 512 MiB
+        assert_eq!(limits.max_storage_index_scan_limit, 100_000);
+        assert_eq!(limits.max_return_value_size, 16 << 20); // 16 MiB
         assert_eq!(limits.max_method_name_length, 256);
         assert_eq!(limits.max_artifact_size, 16 << 20); // 16 MiB
     }

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -459,6 +459,47 @@ pub struct VMLogic<'a> {
     blob_bytes_written: u64,
 }
 
+/// Charges one storage write of `add` bytes against the shared per-execution
+/// write counters, committing both only if both the count and byte checks pass.
+///
+/// A free function (rather than a `&mut self` method) so callers holding a live
+/// `&mut` borrow of another `VMLogic` field — notably `private_storage` — can
+/// still charge the budget: the borrow checker splits the two disjoint counter
+/// borrows from that field borrow, which a whole-`self` method call could not.
+///
+/// # Errors
+///
+/// * [`HostError::StorageWriteCountExceeded`] if the write count would exceed
+///   `max_writes`.
+/// * [`HostError::StorageWriteBytesExceeded`] if the cumulative bytes would
+///   exceed `max_bytes`.
+fn charge_write_counters(
+    writes: &mut u64,
+    bytes_total: &mut u64,
+    max_writes: u64,
+    max_bytes: u64,
+    add: u64,
+) -> VMLogicResult<()> {
+    let next_writes = writes.checked_add(1).ok_or(HostError::IntegerOverflow)?;
+    if next_writes > max_writes {
+        return Err(HostError::StorageWriteCountExceeded { max: max_writes }.into());
+    }
+    let next_bytes = bytes_total
+        .checked_add(add)
+        .ok_or(HostError::IntegerOverflow)?;
+    if next_bytes > max_bytes {
+        return Err(HostError::StorageWriteBytesExceeded {
+            attempted: next_bytes,
+            max: max_bytes,
+        }
+        .into());
+    }
+    // Commit both counters only after both checks pass — no partial state.
+    *writes = next_writes;
+    *bytes_total = next_bytes;
+    Ok(())
+}
+
 impl<'a> VMLogic<'a> {
     /// Creates a new `VMLogic` instance.
     ///
@@ -526,30 +567,17 @@ impl<'a> VMLogic<'a> {
     /// * [`HostError::StorageWriteBytesExceeded`] once the cumulative byte total
     ///   would exceed [`VMLimits::max_storage_write_bytes`].
     fn charge_storage_write(&mut self, bytes: u64) -> VMLogicResult<()> {
-        let next_writes = self
-            .storage_writes
-            .checked_add(1)
-            .ok_or(HostError::IntegerOverflow)?;
-        if next_writes > self.limits.max_storage_writes {
-            return Err(HostError::StorageWriteCountExceeded {
-                max: self.limits.max_storage_writes,
-            }
-            .into());
-        }
-        let next_bytes = self
-            .storage_write_bytes
-            .checked_add(bytes)
-            .ok_or(HostError::IntegerOverflow)?;
-        if next_bytes > self.limits.max_storage_write_bytes {
-            return Err(HostError::StorageWriteBytesExceeded {
-                attempted: next_bytes,
-                max: self.limits.max_storage_write_bytes,
-            }
-            .into());
-        }
-        self.storage_writes = next_writes;
-        self.storage_write_bytes = next_bytes;
-        Ok(())
+        // Delegate to the free function so `private_storage_write` can charge on
+        // the same budget inline (see there): a method borrows all of `self`,
+        // which would conflict with a live `&mut self.private_storage`, whereas
+        // the free function takes only the two counters and the limits by value.
+        charge_write_counters(
+            &mut self.storage_writes,
+            &mut self.storage_write_bytes,
+            self.limits.max_storage_writes,
+            self.limits.max_storage_write_bytes,
+            bytes,
+        )
     }
 
     /// Charges `bytes` of blob write payload against the per-execution total
@@ -573,6 +601,16 @@ impl<'a> VMLogic<'a> {
         }
         self.blob_bytes_written = next;
         Ok(())
+    }
+
+    /// Refunds a previously-charged blob write of `bytes`.
+    ///
+    /// Used when a charged chunk fails to reach the writer task (`blob_write`'s
+    /// `send` fails), so the optimistic charge is not left on the counter. The
+    /// subtraction saturates: it can never underflow because every refund
+    /// pairs with a prior successful [`charge_blob_write`].
+    fn refund_blob_write(&mut self, bytes: u64) {
+        self.blob_bytes_written = self.blob_bytes_written.saturating_sub(bytes);
     }
 
     /// Associates a Wasmer memory instance with this `VMLogic`.

--- a/crates/runtime/src/logic/host_functions/blobs.rs
+++ b/crates/runtime/src/logic/host_functions/blobs.rs
@@ -206,12 +206,16 @@ impl VMHostFunctions<'_> {
         // is confirmed to be a write handle — so a guest can't drain the budget
         // by hammering an invalid fd or an unreadable descriptor.
         //
-        // The charge is optimistic and not refunded: it lands before the `send`
-        // below so the budget is enforced strictly (a chunk that would exceed it
-        // is rejected before being buffered). The only way a charged chunk isn't
-        // written is a `send` failure, which returns `Err` and traps the whole
-        // execution — the `VMLogic` and this counter are discarded, so the
-        // charge has no observable effect and there is nothing to refund.
+        // The charge is optimistic and not refunded, so the budget is a
+        // pessimistic upper bound rather than an exact byte count. It lands
+        // before the `send` below so the budget is enforced strictly (a chunk
+        // that would exceed it is rejected before being buffered). The only way
+        // a charged chunk isn't written is a `send` failure, which returns `Err`
+        // and traps the whole execution — the `VMLogic` and this counter are
+        // discarded, so the charge has no observable effect and there is nothing
+        // to refund. (This "discarded on trap" assumption is load-bearing: were
+        // this error ever caught without dropping the `VMLogic`, the budget
+        // would be over-charged by one chunk.)
         self.with_logic_mut(|logic| logic.charge_blob_write(data_len))?;
 
         // `block_in_place` hands the blocking wait off the async worker so the
@@ -219,10 +223,14 @@ impl VMHostFunctions<'_> {
         // `Handle::block_on` would panic on a runtime thread. This requires a
         // multi-threaded Tokio runtime (as do `blob_read`/`blob_close`); it
         // would panic on a `current_thread` runtime.
+        //
+        // A `send` failure means the writer task's receiver is gone (task
+        // panicked/aborted) — distinct from an invalid fd, so surface it as
+        // `BlobWriteFailed` rather than the misleading `InvalidBlobHandle`.
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(sender.send(data))
         })
-        .map_err(|_| VMLogicError::HostError(HostError::InvalidBlobHandle))?;
+        .map_err(|_| VMLogicError::HostError(HostError::BlobWriteFailed))?;
 
         Ok(data_len)
     }

--- a/crates/runtime/src/logic/host_functions/blobs.rs
+++ b/crates/runtime/src/logic/host_functions/blobs.rs
@@ -4,11 +4,11 @@ use calimero_primitives::{blobs::BlobId, context::ContextId};
 
 use futures_util::{StreamExt, TryStreamExt};
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::wrappers::ReceiverStream;
 
 use crate::{
     errors::HostError,
-    logic::{sys, VMHostFunctions, VMLogicError, VMLogicResult},
+    logic::{sys, VMHostFunctions, VMLogicError, VMLogicResult, BLOB_WRITE_CHANNEL_CAPACITY},
 };
 use calimero_primitives::common::DIGEST_SIZE;
 
@@ -24,11 +24,30 @@ pub enum BlobHandle {
 /// A handle for managing an asynchronous blob write operation.
 #[derive(Debug)]
 pub struct BlobWriteHandle {
-    /// The sender part of a channel to stream data chunks to the writer task.
-    sender: mpsc::UnboundedSender<Vec<u8>>,
+    /// The sender part of a *bounded* channel that streams data chunks to the
+    /// writer task. A bounded channel (see [`BLOB_WRITE_CHANNEL_CAPACITY`])
+    /// applies backpressure to `blob_write`, so at most a fixed number of
+    /// chunks are ever buffered in memory regardless of how fast the guest
+    /// produces data.
+    sender: mpsc::Sender<Vec<u8>>,
     /// A handle to the spawned task that performs the blob writing,
     /// which will eventually yield the `BlobId` and total size of the data written.
     completion_handle: tokio::task::JoinHandle<eyre::Result<(BlobId, u64)>>,
+}
+
+impl BlobHandle {
+    /// Abort the background writer task if this is a write handle.
+    ///
+    /// Called by [`VMLogic::finish`](crate::logic::VMLogic) when cleaning up
+    /// handles the guest never closed. Aborting (rather than just dropping the
+    /// handle) matters: dropping only closes the channel, which lets the writer
+    /// task drain what was buffered and *persist a partial, abandoned blob*.
+    /// Aborting discards that never-committed write instead.
+    pub(crate) fn abort_pending_task(&self) {
+        if let BlobHandle::Write(w) = self {
+            w.completion_handle.abort();
+        }
+    }
 }
 
 /// A handle for managing a blob read operation.
@@ -102,10 +121,10 @@ impl VMHostFunctions<'_> {
                 .checked_add(1)
                 .ok_or(VMLogicError::HostError(HostError::IntegerOverflow))?;
 
-            let (data_sender, data_receiver) = mpsc::unbounded_channel();
+            let (data_sender, data_receiver) = mpsc::channel(BLOB_WRITE_CHANNEL_CAPACITY);
 
             let completion_handle = tokio::spawn(async move {
-                let stream = UnboundedReceiverStream::new(data_receiver);
+                let stream = ReceiverStream::new(data_receiver);
 
                 let byte_stream =
                     stream.map(|data: Vec<u8>| Ok::<bytes::Bytes, Error>(data.into()));
@@ -165,37 +184,35 @@ impl VMHostFunctions<'_> {
             }));
         }
 
+        // Charge the per-execution total-blob-write budget before buffering the
+        // chunk, so an unbounded stream of writes is trapped rather than
+        // silently accumulated across handles.
+        self.with_logic_mut(|logic| logic.charge_blob_write(data_len))?;
+
         let data = self.read_guest_memory_slice(&data)?.to_vec();
 
-        self.with_logic_mut(|logic| {
+        // Clone the sender (validating the fd is a write handle) so the chunk
+        // can be streamed outside the logic borrow. The channel is bounded, so
+        // `send` awaits when the buffer is full — this backpressure keeps
+        // buffered memory bounded no matter how fast the guest writes.
+        let sender = self.with_logic_mut(|logic| {
             let handle = logic
                 .blob_handles
                 .get(&fd)
                 .ok_or(VMLogicError::HostError(HostError::InvalidBlobHandle))?;
-
             match handle {
-                BlobHandle::Write(_) => Ok(()),
+                BlobHandle::Write(w) => Ok(w.sender.clone()),
                 BlobHandle::Read(_) => Err(VMLogicError::HostError(HostError::InvalidBlobHandle)),
             }
         })?;
 
-        self.with_logic_mut(|logic| {
-            let handle = logic
-                .blob_handles
-                .get_mut(&fd)
-                .ok_or(VMLogicError::HostError(HostError::InvalidBlobHandle))?;
-            match handle {
-                BlobHandle::Write(w) => {
-                    w.sender
-                        .send(data.clone())
-                        .map_err(|_| VMLogicError::HostError(HostError::InvalidBlobHandle))?;
-                }
-                BlobHandle::Read(_) => {
-                    return Err(VMLogicError::HostError(HostError::InvalidBlobHandle))
-                }
-            }
-            Ok::<(), VMLogicError>(())
-        })?;
+        // `block_in_place` hands the blocking wait off the async worker so the
+        // writer task can drain the channel on another worker; a bare
+        // `Handle::block_on` would panic on a runtime thread.
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(sender.send(data))
+        })
+        .map_err(|_| VMLogicError::HostError(HostError::InvalidBlobHandle))?;
 
         Ok(data_len)
     }

--- a/crates/runtime/src/logic/host_functions/blobs.rs
+++ b/crates/runtime/src/logic/host_functions/blobs.rs
@@ -205,6 +205,13 @@ impl VMHostFunctions<'_> {
         // is about to proceed — the memory descriptor has been read and the fd
         // is confirmed to be a write handle — so a guest can't drain the budget
         // by hammering an invalid fd or an unreadable descriptor.
+        //
+        // The charge is optimistic and not refunded: it lands before the `send`
+        // below so the budget is enforced strictly (a chunk that would exceed it
+        // is rejected before being buffered). The only way a charged chunk isn't
+        // written is a `send` failure, which returns `Err` and traps the whole
+        // execution — the `VMLogic` and this counter are discarded, so the
+        // charge has no observable effect and there is nothing to refund.
         self.with_logic_mut(|logic| logic.charge_blob_write(data_len))?;
 
         // `block_in_place` hands the blocking wait off the async worker so the

--- a/crates/runtime/src/logic/host_functions/blobs.rs
+++ b/crates/runtime/src/logic/host_functions/blobs.rs
@@ -206,16 +206,11 @@ impl VMHostFunctions<'_> {
         // is confirmed to be a write handle — so a guest can't drain the budget
         // by hammering an invalid fd or an unreadable descriptor.
         //
-        // The charge is optimistic and not refunded, so the budget is a
-        // pessimistic upper bound rather than an exact byte count. It lands
-        // before the `send` below so the budget is enforced strictly (a chunk
-        // that would exceed it is rejected before being buffered). The only way
-        // a charged chunk isn't written is a `send` failure, which returns `Err`
-        // and traps the whole execution — the `VMLogic` and this counter are
-        // discarded, so the charge has no observable effect and there is nothing
-        // to refund. (This "discarded on trap" assumption is load-bearing: were
-        // this error ever caught without dropping the `VMLogic`, the budget
-        // would be over-charged by one chunk.)
+        // Charge the budget before `send` so it is enforced strictly: a chunk
+        // that would exceed it is rejected before being buffered. If the chunk
+        // then fails to reach the writer task, the charge is refunded below, so
+        // the counter reflects only bytes actually handed off — no reliance on
+        // the execution being discarded.
         self.with_logic_mut(|logic| logic.charge_blob_write(data_len))?;
 
         // `block_in_place` hands the blocking wait off the async worker so the
@@ -223,14 +218,17 @@ impl VMHostFunctions<'_> {
         // `Handle::block_on` would panic on a runtime thread. This requires a
         // multi-threaded Tokio runtime (as do `blob_read`/`blob_close`); it
         // would panic on a `current_thread` runtime.
-        //
-        // A `send` failure means the writer task's receiver is gone (task
-        // panicked/aborted) — distinct from an invalid fd, so surface it as
-        // `BlobWriteFailed` rather than the misleading `InvalidBlobHandle`.
-        tokio::task::block_in_place(|| {
+        let send_result = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(sender.send(data))
-        })
-        .map_err(|_| VMLogicError::HostError(HostError::BlobWriteFailed))?;
+        });
+        if send_result.is_err() {
+            // The writer task's receiver is gone (task panicked/aborted) — the
+            // chunk was never handed off, so refund the charge. This is distinct
+            // from an invalid fd, so surface it as `BlobWriteFailed` rather than
+            // the misleading `InvalidBlobHandle`.
+            self.with_logic_mut(|logic| logic.refund_blob_write(data_len));
+            return Err(VMLogicError::HostError(HostError::BlobWriteFailed));
+        }
 
         Ok(data_len)
     }

--- a/crates/runtime/src/logic/host_functions/blobs.rs
+++ b/crates/runtime/src/logic/host_functions/blobs.rs
@@ -184,11 +184,6 @@ impl VMHostFunctions<'_> {
             }));
         }
 
-        // Charge the per-execution total-blob-write budget before buffering the
-        // chunk, so an unbounded stream of writes is trapped rather than
-        // silently accumulated across handles.
-        self.with_logic_mut(|logic| logic.charge_blob_write(data_len))?;
-
         let data = self.read_guest_memory_slice(&data)?.to_vec();
 
         // Clone the sender (validating the fd is a write handle) so the chunk
@@ -206,9 +201,17 @@ impl VMHostFunctions<'_> {
             }
         })?;
 
+        // Charge the per-execution total-blob-write budget only once the write
+        // is about to proceed — the memory descriptor has been read and the fd
+        // is confirmed to be a write handle — so a guest can't drain the budget
+        // by hammering an invalid fd or an unreadable descriptor.
+        self.with_logic_mut(|logic| logic.charge_blob_write(data_len))?;
+
         // `block_in_place` hands the blocking wait off the async worker so the
         // writer task can drain the channel on another worker; a bare
-        // `Handle::block_on` would panic on a runtime thread.
+        // `Handle::block_on` would panic on a runtime thread. This requires a
+        // multi-threaded Tokio runtime (as do `blob_read`/`blob_close`); it
+        // would panic on a `current_thread` runtime.
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(sender.send(data))
         })

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -468,10 +468,17 @@ impl VMHostFunctions<'_> {
             if logic.private_storage.is_none() {
                 return Ok(false);
             }
+            // Charge before writing. `charge_storage_write` borrows all of
+            // `logic`, so it must run before re-borrowing `private_storage`; the
+            // `is_none` check above guarantees the re-borrow is `Some`. Surface
+            // a broken invariant as an error rather than silently consuming the
+            // budget without writing.
             logic.charge_storage_write(key_len as u64 + value_len as u64)?;
-            if let Some(private_storage) = logic.private_storage.as_mut() {
-                let _evicted = private_storage.set(key, value);
-            }
+            let private_storage = logic
+                .private_storage
+                .as_mut()
+                .ok_or(HostError::InvalidMemoryAccess)?;
+            let _evicted = private_storage.set(key, value);
             Ok(true)
         })?;
 

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -465,19 +465,26 @@ impl VMHostFunctions<'_> {
         // work across the two backends. Only charge when there is a backing
         // store to write to.
         let written = self.with_logic_mut(|logic| -> VMLogicResult<bool> {
-            if logic.private_storage.is_none() {
+            // No private store → nothing to write and nothing to charge.
+            // Charge and write in a single arm on the live borrow. The budget
+            // counters and limits are disjoint fields from `private_storage`, so
+            // `charge_write_counters` can update them while `private_storage` is
+            // borrowed — a `charge_storage_write` method call would borrow all of
+            // `logic` and conflict. Read the limits out first (a `Copy` of two
+            // `u64`s) so nothing borrows `logic.limits` across the write.
+            let write_bytes = key_len as u64 + value_len as u64;
+            let max_writes = logic.limits.max_storage_writes;
+            let max_bytes = logic.limits.max_storage_write_bytes;
+            let Some(private_storage) = logic.private_storage.as_mut() else {
                 return Ok(false);
-            }
-            // Charge before writing. `charge_storage_write` borrows all of
-            // `logic`, so it must run before re-borrowing `private_storage`; the
-            // `is_none` check above guarantees the re-borrow is `Some`. Surface
-            // a broken invariant as an error rather than silently consuming the
-            // budget without writing.
-            logic.charge_storage_write(key_len as u64 + value_len as u64)?;
-            let private_storage = logic
-                .private_storage
-                .as_mut()
-                .ok_or(HostError::InvalidMemoryAccess)?;
+            };
+            crate::logic::charge_write_counters(
+                &mut logic.storage_writes,
+                &mut logic.storage_write_bytes,
+                max_writes,
+                max_bytes,
+                write_bytes,
+            )?;
             let _evicted = private_storage.set(key, value);
             Ok(true)
         })?;

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -217,7 +217,12 @@ impl VMHostFunctions<'_> {
             "storage_write"
         );
 
-        let evicted = self.with_logic_mut(|logic| logic.storage.set(key, value));
+        // Charge the shared per-execution write budget before touching the
+        // backend so a rejected write never lands in the store.
+        let evicted = self.with_logic_mut(|logic| -> VMLogicResult<Option<Vec<u8>>> {
+            logic.charge_storage_write(key_len as u64 + value_len as u64)?;
+            Ok(logic.storage.set(key, value))
+        })?;
 
         if let Some(evicted) = evicted {
             let evicted_len = evicted.len();
@@ -455,13 +460,20 @@ impl VMHostFunctions<'_> {
             "private_storage_write"
         );
 
-        let written = self.with_logic_mut(|logic| {
-            let Some(ref mut private_storage) = logic.private_storage else {
-                return false;
-            };
-            let _evicted = private_storage.set(key, value);
-            true
-        });
+        // Private storage draws from the same per-execution write budget as the
+        // main store, so a guest can't double its write allowance by splitting
+        // work across the two backends. Only charge when there is a backing
+        // store to write to.
+        let written = self.with_logic_mut(|logic| -> VMLogicResult<bool> {
+            if logic.private_storage.is_none() {
+                return Ok(false);
+            }
+            logic.charge_storage_write(key_len as u64 + value_len as u64)?;
+            if let Some(private_storage) = logic.private_storage.as_mut() {
+                let _evicted = private_storage.set(key, value);
+            }
+            Ok(true)
+        })?;
 
         if written {
             debug!(
@@ -515,7 +527,12 @@ impl VMHostFunctions<'_> {
         let key = self.read_guest_memory_slice(&key)?.to_vec();
         let value = self.read_guest_memory_slice(&value)?.to_vec();
         trace!(target: "runtime::host::storage", op = "index_set", key_len = key.len(), "storage_index_set");
-        let ok = self.with_logic_mut(|logic| logic.storage.index_set(&key, &value));
+        // Ordered-index writes share the same per-execution budget as the
+        // key-value stores, charged before the backend write.
+        let ok = self.with_logic_mut(|logic| -> VMLogicResult<bool> {
+            logic.charge_storage_write(key.len() as u64 + value.len() as u64)?;
+            Ok(logic.storage.index_set(&key, &value))
+        })?;
         Ok(ok.into())
     }
 
@@ -584,10 +601,18 @@ impl VMHostFunctions<'_> {
         let lo = self.read_guest_memory_slice(&lo)?.to_vec();
         let hi = self.read_guest_memory_slice(&hi)?.to_vec();
 
-        // `n + 1`-encoded: 0 = unbounded, else `limit - 1`. Saturate rather than
-        // silently truncate `u64 -> usize` (usize is 32-bit on a wasm32 host
-        // build); a clamp to usize::MAX just caps at the largest possible bound.
-        let limit = (limit != 0).then(|| usize::try_from(limit - 1).unwrap_or(usize::MAX));
+        // `n + 1`-encoded: 0 = unbounded, else `limit - 1`. Both the unbounded
+        // sentinel and any explicit request are capped at
+        // `max_storage_index_scan_limit` so a scan never reads the whole range
+        // into an owned `Vec` and re-encodes it — two transient allocations
+        // sized by the range — before the register-size cap can apply. A guest
+        // needing more paginates via `offset`.
+        let scan_cap = self.borrow_logic().limits.max_storage_index_scan_limit;
+        let requested = (limit != 0).then(|| limit - 1);
+        let effective = requested.unwrap_or(scan_cap).min(scan_cap);
+        // Saturate rather than silently truncate `u64 -> usize` (usize is 32-bit
+        // on a wasm32 host build).
+        let limit = Some(usize::try_from(effective).unwrap_or(usize::MAX));
         // Saturate rather than silently truncate `u64 -> usize` (usize is 32-bit
         // on a wasm32 host build); a clamp to usize::MAX just means "skip all".
         let offset = usize::try_from(offset).unwrap_or(usize::MAX);
@@ -1192,5 +1217,79 @@ mod tests {
                 expected_value.as_bytes()
             );
         }
+    }
+
+    /// A write past `max_storage_writes` traps with `StorageWriteCountExceeded`,
+    /// bounding the *count* of direct guest writes per execution.
+    #[test]
+    fn test_storage_write_count_budget() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits {
+            max_storage_writes: 1,
+            ..Default::default()
+        };
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        let key = "k";
+        let key_ptr = 200u64;
+        write_str(&host, key_ptr, key);
+        let key_buf_ptr = 10u64;
+        prepare_guest_buf_descriptor(&host, key_buf_ptr, key_ptr, key.len() as u64);
+
+        let value = "v";
+        let value_ptr = 300u64;
+        write_str(&host, value_ptr, value);
+        let value_buf_ptr = 32u64;
+        prepare_guest_buf_descriptor(&host, value_buf_ptr, value_ptr, value.len() as u64);
+
+        // First write is within budget.
+        host.storage_write(key_buf_ptr, value_buf_ptr, 1).unwrap();
+        // Second write exceeds `max_storage_writes = 1`.
+        let err = host
+            .storage_write(key_buf_ptr, value_buf_ptr, 1)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::logic::VMLogicError::HostError(
+                crate::errors::HostError::StorageWriteCountExceeded { .. }
+            )
+        ));
+    }
+
+    /// A write whose `key + value` bytes exceed the remaining byte budget traps
+    /// with `StorageWriteBytesExceeded`.
+    #[test]
+    fn test_storage_write_bytes_budget() {
+        let mut storage = SimpleMockStorage::new();
+        // Budget of 2 bytes: a 1-byte key + 3-byte value (4 total) trips it.
+        let limits = VMLimits {
+            max_storage_write_bytes: 2,
+            ..Default::default()
+        };
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        let key = "k";
+        let key_ptr = 200u64;
+        write_str(&host, key_ptr, key);
+        let key_buf_ptr = 10u64;
+        prepare_guest_buf_descriptor(&host, key_buf_ptr, key_ptr, key.len() as u64);
+
+        let value = "vvv";
+        let value_ptr = 300u64;
+        write_str(&host, value_ptr, value);
+        let value_buf_ptr = 32u64;
+        prepare_guest_buf_descriptor(&host, value_buf_ptr, value_ptr, value.len() as u64);
+
+        let err = host
+            .storage_write(key_buf_ptr, value_buf_ptr, 1)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::logic::VMLogicError::HostError(
+                crate::errors::HostError::StorageWriteBytesExceeded { .. }
+            )
+        ));
     }
 }

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -564,6 +564,20 @@ impl VMHostFunctions<'_> {
         //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
         //         it is sound; the read is bounds-checked. See `read_guest_memory_typed`.
         let value = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(payload_ptr)? };
+
+        // Bound the return value before copying it out of guest memory: it lands
+        // on the host `Outcome` (and is broadcast in receipts), so without this
+        // cap the only limit is guest memory itself (~64 MiB).
+        let value_len = value.len();
+        let max_return_value_size = self.borrow_logic().limits.max_return_value_size;
+        if value_len > max_return_value_size {
+            return Err(HostError::ReturnValueSizeOverflow {
+                size: value_len,
+                max: max_return_value_size,
+            }
+            .into());
+        }
+
         let bytes = self.read_guest_memory_slice(&value)?.to_vec();
 
         // Discriminant layout matches `sys::ValueReturn`: 0 = Ok, 1 = Err.
@@ -847,6 +861,19 @@ impl VMHostFunctions<'_> {
             //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
             let handler_buffer =
                 unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(src_handler_ptr)? };
+            // A handler is a callback method name; bound it before copying it out
+            // of guest memory so a guest can't stash arbitrarily large strings on
+            // the `Outcome` (one per event, up to `max_events`). Reuse the
+            // method-name limit — that's exactly what a handler is.
+            let handler_len = handler_buffer.len();
+            let max_handler_size = self.borrow_logic().limits.max_method_name_length;
+            if handler_len > max_handler_size {
+                return Err(HostError::EventHandlerSizeOverflow {
+                    size: handler_len,
+                    max: max_handler_size,
+                }
+                .into());
+            }
             match self.read_guest_memory_str(&handler_buffer) {
                 Ok(handler_str) => Some(handler_str.to_owned()),
                 Err(_) => None, // If we can't read the handler, just set to None
@@ -2054,5 +2081,71 @@ mod tests {
         assert!(host.borrow_logic().artifact.is_empty());
         assert_eq!(host.borrow_logic().root_hash, None);
         assert!(!host.borrow_logic().commit_called);
+    }
+
+    /// A return value larger than `max_return_value_size` traps before being
+    /// copied onto the `Outcome`.
+    #[test]
+    fn test_value_return_size_cap() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits {
+            max_return_value_size: 4,
+            ..Default::default()
+        };
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        // Payload of 5 bytes, one over the cap.
+        let data = b"hello";
+        let data_ptr = 400u64;
+        host.borrow_memory().write(data_ptr, data).unwrap();
+
+        // `ValueReturn` is `{ discriminant: u64, payload: Buffer }`: write the
+        // `Ok` discriminant (0) then the payload `Buffer` descriptor 8 bytes on.
+        let vr_ptr = 100u64;
+        host.borrow_memory()
+            .write(vr_ptr, &0u64.to_le_bytes())
+            .unwrap();
+        prepare_guest_buf_descriptor(&host, vr_ptr + 8, data_ptr, data.len() as u64);
+
+        let err = host.value_return(vr_ptr).unwrap_err();
+        assert!(matches!(
+            err,
+            VMLogicError::HostError(HostError::ReturnValueSizeOverflow { size: 5, max: 4 })
+        ));
+        // Nothing captured onto the outcome.
+        assert!(host.borrow_logic().returns.is_none());
+    }
+
+    /// A handler name longer than `max_method_name_length` traps rather than
+    /// stashing an arbitrarily large string on the event.
+    #[test]
+    fn test_emit_with_handler_size_cap() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        // Minimal valid `Event { kind: Buffer, data: Buffer }` (each 16 bytes).
+        let kind = b"k";
+        let kind_ptr = 400u64;
+        host.borrow_memory().write(kind_ptr, kind).unwrap();
+        let event_ptr = 100u64;
+        prepare_guest_buf_descriptor(&host, event_ptr, kind_ptr, kind.len() as u64);
+        prepare_guest_buf_descriptor(&host, event_ptr + 16, 500u64, 0);
+
+        // Handler descriptor claiming a length past `max_method_name_length`.
+        // The length check trips before the (unread) payload slice is touched.
+        let handler_ptr = 200u64;
+        let oversized = limits.max_method_name_length + 1;
+        prepare_guest_buf_descriptor(&host, handler_ptr, 600u64, oversized);
+
+        let err = host.emit_with_handler(event_ptr, handler_ptr).unwrap_err();
+        assert!(matches!(
+            err,
+            VMLogicError::HostError(HostError::EventHandlerSizeOverflow { .. })
+        ));
+        // The event must not have been recorded.
+        assert!(host.borrow_logic().events.is_empty());
     }
 }

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -874,10 +874,11 @@ impl VMHostFunctions<'_> {
                 }
                 .into());
             }
-            match self.read_guest_memory_str(&handler_buffer) {
-                Ok(handler_str) => Some(handler_str.to_owned()),
-                Err(_) => None, // If we can't read the handler, just set to None
-            }
+            // Propagate a read/UTF-8 failure rather than silently dropping the
+            // handler — a malformed handler descriptor is a guest bug, and this
+            // matches how `emit` reads the event `kind`.
+            let handler_str = self.read_guest_memory_str(&handler_buffer)?;
+            Some(handler_str.to_owned())
         };
 
         self.with_logic_mut(|logic| {

--- a/crates/runtime/src/logic/host_functions/utility.rs
+++ b/crates/runtime/src/logic/host_functions/utility.rs
@@ -1,5 +1,6 @@
 use borsh::from_slice as from_borsh_slice;
 use rand::RngCore;
+use std::io::Read;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
@@ -114,10 +115,21 @@ impl VMHostFunctions<'_> {
             request.send_bytes(body)
         };
 
+        // Bound the response body before buffering it. It ultimately lands in a
+        // register (capped at `max_register_size`), but `read_to_end` runs first
+        // and would otherwise read an unbounded response into host memory;
+        // `Read::take` caps the read at that same ceiling. (`fetch` is disabled
+        // today — this keeps the read bounded for whenever it is re-enabled.)
+        let max_response_size = *self.borrow_logic().limits.max_register_size;
+
         let (status, data) = match response {
             Ok(response) => {
                 let mut buffer = vec![];
-                match response.into_reader().read_to_end(&mut buffer) {
+                match response
+                    .into_reader()
+                    .take(max_response_size)
+                    .read_to_end(&mut buffer)
+                {
                     Ok(_) => (0, buffer),
                     Err(_) => (1, "Failed to read the response body.".into()),
                 }


### PR DESCRIPTION
## Summary

Guest host functions bounded only **per-call** sizes, so a guest loop could drive unbounded host resource use with no per-execution ceiling (there is no gas metering). This adds shared per-execution budgets across the runtime, closing 8 of 9 reported resource-budget issues. All changes are contained in `crates/runtime`.

## Changes

| Issue | Fix |
|---|---|
| storage_write count/bytes | Shared per-exec budget (`charge_storage_write`), limits `max_storage_writes` + `max_storage_write_bytes` |
| private_storage_write | Charges the **same** budget (can't double allowance across backends) |
| storage_index_set | Charges the same shared write budget |
| blob unbounded channel | **Bounded** channel with backpressure (`BLOB_WRITE_CHANNEL_CAPACITY`) + per-exec `max_blob_total_size` |
| storage_index_scan `limit=0` 2× alloc | Caps `limit` (incl. the unbounded sentinel) at `max_storage_index_scan_limit` before materializing |
| value_return | Enforces `max_return_value_size` before copying onto `Outcome` |
| emit_with_handler | Validates handler length against `max_method_name_length` |
| blob task/handle leak | `abort_pending_task()` in `VMLogic::finish` aborts unclosed writer tasks (prevents persisting an abandoned partial blob) |
| dead `fetch` `read_to_end` | Bounded via `Read::take` |

Budgets live on `VMLogic` (counters reset in `new`, so they are naturally per-execution). CRDT/root writes performed via the storage-interface writer closure (`persist_root_state` / `apply_storage_delta`) are **not** charged, so normal state sync is unaffected. Defaults are strict/conservative with headroom, all tunable via `RuntimeLimitsConfig`.

## Deferred follow-up

The **xcall fan-out depth budget** (`max_xcalls` only caps *per execution*, so each xcall spawns a fresh execution that resets the counter → N^depth amplification) is intentionally left out: a correct fix carries a decrementing budget across executions through the node dispatch layer (`ExecuteRequest`/`VMContext` + the xcall loop in `crates/context`), which escapes the runtime crate.

## Testing

- `cargo build -p calimero-runtime` — clean, no warnings
- `cargo clippy -p calimero-runtime --all-targets` — clean
- `cargo test -p calimero-runtime` — 117 lib tests + integration/CRDT/tracing suites pass, incl. 4 new regression tests (storage write count budget, storage write byte budget, value_return cap, emit_with_handler cap)
- `cargo check -p calimero-context -p calimero-node` — compiles (additive `#[non_exhaustive]` variants + `..Default::default()`-backed fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)