### PR TITLE
fix(context): harden xcall, join, upgrade, storage & handler race conditions

### DIFF
--- a/apps/xcall-example/workflows/xcall.yml
+++ b/apps/xcall-example/workflows/xcall.yml
@@ -1,10 +1,13 @@
-name: XCall Authorization (L1 namespace · L3 entry-point · L2a provenance)
+name: XCall Authorization (L1 owning-group · L3 entry-point · L2a provenance)
 description: >
   End-to-end validation of cross-context-call authorization (closes #2130 / #2137).
 
   A node-local xcall is gated by three independent layers, all exercised here:
-    * L1 — namespace boundary: a context may only xcall a target in its OWN
-      namespace. Cross-namespace calls are denied (fail-closed).
+    * L1 — owning-group boundary: a context may only xcall a target in its OWN
+      owning group. Calls to a target in a different group — a different
+      namespace, or a different subgroup of the same namespace — are denied
+      (fail-closed). Gating on the shared namespace root instead would let any
+      sibling context anywhere in the namespace reach into another subgroup.
     * L3 — entry points: only methods declared `#[app::xcall]` are reachable
       via xcall. The non-entry-point `secret` method is denied.
     * L2a — provenance: `env::xcall_origin()` is set by the node from the
@@ -81,9 +84,11 @@ steps:
       c3_key: memberPublicKey
 
   # ============================================================================
-  # POSITIVE — same-namespace xcall to a declared entry point is ALLOWED.
-  # Exercises L1 (C1 and C2 share namespace N), L3 (pong is `#[app::xcall]`),
-  # and L2a (the node-set origin equals C1, which pong verifies before running).
+  # POSITIVE — same-group xcall to a declared entry point is ALLOWED.
+  # C1 and C2 are both created directly in namespace N's root group, so they
+  # share an owning group. Exercises L1 (same owning group), L3 (pong is
+  # `#[app::xcall]`), and L2a (the node-set origin equals C1, which pong
+  # verifies before running).
   # ============================================================================
   - name: C2 pong counter starts at 0
     type: call
@@ -129,9 +134,10 @@ steps:
       - "xcall denied"
 
   # ============================================================================
-  # NEGATIVE L1 — cross-namespace xcall is DENIED (fail-closed).
-  # C1 (namespace N) -> C3 (namespace M): pong must NOT run; the node logs the
-  # namespace-boundary denial.
+  # NEGATIVE L1 — an xcall to a target in a different owning group is DENIED
+  # (fail-closed). C1 (namespace N's root group) -> C3 (namespace M's root
+  # group) do not share an owning group: pong must NOT run and the node logs
+  # the owning-group-boundary denial.
   # ============================================================================
   - name: C3 pong counter starts at 0
     type: call
@@ -164,20 +170,20 @@ steps:
     method: get_counter
     outputs:
       c3_after: result.output
-  - name: Assert pong did NOT run across namespaces (L1 denied)
+  - name: Assert pong did NOT run across owning groups (L1 denied)
     type: json_assert
     statements:
       - "equal({{c3_after}}, 0)"
-  - name: Assert L1 namespace-boundary denial was logged
+  - name: Assert L1 owning-group-boundary denial was logged
     type: assert_log_present
     nodes:
       - xcall-authz-1
     patterns:
-      - "xcall denied: namespace boundary"
+      - "xcall denied: owning group boundary"
     min_matches: 1
 
   # ============================================================================
-  # NEGATIVE L3 — same-namespace xcall to a NON-entry-point method is DENIED.
+  # NEGATIVE L3 — same-group xcall to a NON-entry-point method is DENIED.
   # C1 -> C2 targeting `secret` (not `#[app::xcall]`): secret must NOT run.
   # ============================================================================
   - name: C2 secret counter starts at 0

--- a/crates/context/src/handlers/create_group.rs
+++ b/crates/context/src/handlers/create_group.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use actix::{ActorResponse, Handler, Message, WrapFuture};
+use actix::{ActorFutureExt, ActorResponse, Handler, Message, WrapFuture};
 use calimero_context_client::group::{CreateGroupRequest, CreateGroupResponse};
 use calimero_context_client::local_governance::{NamespaceOp, RootOp};
 use calimero_context_config::types::AppKey;
@@ -131,6 +131,38 @@ impl Handler<CreateGroupRequest> for ContextManager {
                 &admin_identity,
                 sk,
             );
+        }
+
+        // Reserve the group id SYNCHRONOUSLY, before spawning the async body.
+        // The existence guard at the top of `handle` and this save both run in
+        // the synchronous portion of the handler, which the actor runs to
+        // completion before dequeuing the next message. Without a synchronous
+        // reservation, two same-id CreateGroupRequests could both pass the
+        // guard (the meta was only written later, inside the async body) and
+        // each run the full create, emitting duplicate governance ops. The
+        // async body overwrites this reservation with the final meta once the
+        // app_key is resolved/verified; the cleanup map on the returned future
+        // deletes it if that async work fails, so a failed create frees the id
+        // for a clean retry rather than wedging it behind the guard forever.
+        let reservation_now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let reservation_meta = GroupMetaValue {
+            app_key: requested_app_key
+                .as_ref()
+                .map(AppKey::to_bytes)
+                .unwrap_or(row_blob),
+            target_application_id: effective_application_id,
+            upgrade_policy: upgrade_policy.clone(),
+            created_at: reservation_now,
+            admin_identity,
+            owner_identity: admin_identity,
+            migration: None,
+            auto_join: true,
+        };
+        if let Err(err) = MetaRepository::new(&self.datastore).save(&group_id, &reservation_meta) {
+            return ActorResponse::reply(Err(err));
         }
 
         ActorResponse::r#async(
@@ -473,7 +505,25 @@ impl Handler<CreateGroupRequest> for ContextManager {
 
                 Ok(CreateGroupResponse { group_id })
             }
-            .into_actor(self),
+            .into_actor(self)
+            .map(move |res, act, _ctx| {
+                // Free the synchronously-reserved id on any failure that the
+                // inner rollback didn't already unwind, so the existence guard
+                // doesn't wedge the id against a clean retry. Delete is
+                // idempotent, so double-deleting after the genesis rollback is
+                // harmless; success has replaced the reservation with the final
+                // meta, so we leave it in place.
+                if res.is_err() {
+                    if let Err(err) = MetaRepository::new(&act.datastore).delete(&group_id) {
+                        warn!(
+                            ?group_id,
+                            ?err,
+                            "failed to free reserved group id after create error"
+                        );
+                    }
+                }
+                res
+            }),
         )
     }
 }

--- a/crates/context/src/handlers/create_group.rs
+++ b/crates/context/src/handlers/create_group.rs
@@ -149,10 +149,12 @@ impl Handler<CreateGroupRequest> for ContextManager {
             .map(|d| d.as_secs())
             .unwrap_or(0);
         let reservation_meta = GroupMetaValue {
-            app_key: requested_app_key
-                .as_ref()
-                .map(AppKey::to_bytes)
-                .unwrap_or(row_blob),
+            // The reservation only holds the id slot; use the verified
+            // application-row blob (never the caller's still-unverified
+            // `requested_app_key`) so a concurrent reader can't observe an
+            // unverified `app_key`. The async body overwrites this with the
+            // final, verified `app_key` on success.
+            app_key: row_blob,
             target_application_id: effective_application_id,
             upgrade_policy: upgrade_policy.clone(),
             created_at: reservation_now,

--- a/crates/context/src/handlers/create_group.rs
+++ b/crates/context/src/handlers/create_group.rs
@@ -144,10 +144,19 @@ impl Handler<CreateGroupRequest> for ContextManager {
         // app_key is resolved/verified; the cleanup map on the returned future
         // deletes it if that async work fails, so a failed create frees the id
         // for a clean retry rather than wedging it behind the guard forever.
-        let reservation_now = std::time::SystemTime::now()
+        let reservation_now = match std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+        {
+            Ok(d) => d.as_secs(),
+            Err(err) => {
+                warn!(
+                    %err,
+                    ?group_id,
+                    "system clock is before UNIX_EPOCH; stamping created_at=0 on the group reservation"
+                );
+                0
+            }
+        };
         let reservation_meta = GroupMetaValue {
             // The reservation only holds the id slot; use the verified
             // application-row blob (never the caller's still-unverified

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1066,156 +1066,196 @@ impl Handler<ExecuteRequest> for ContextManager {
                     // The handler field is preserved in the broadcast so receivers can
                     // pick it up via execute_event_handlers_parsed().
 
-                    // Process cross-context calls
-                    // NOTE: XCalls are executed locally on the current node after the main execution completes.
-                    // This allows contexts to communicate by calling functions on other contexts.
-                    for xcall in &outcome.xcalls {
-                        let target_context_id = ContextId::from(xcall.context_id);
+                    // Process cross-context calls.
+                    //
+                    // Each xcall runs the target's method by sending a fresh
+                    // ExecuteRequest back to THIS ContextManager actor via
+                    // `execute_with_origin`. Awaiting that inline — while this
+                    // future is still the actor's in-flight response — is the
+                    // same self-mailbox re-entrancy the lazy-upgrade path
+                    // deliberately avoids: it hangs the actor, and for a
+                    // self-targeted xcall it also deadlocks on the source
+                    // context's execution lock (still held here via `guard`).
+                    // So we snapshot each call's fields and dispatch the whole
+                    // batch out-of-band on a detached task. The source execute
+                    // returns and drops its guard without waiting; the detached
+                    // task then re-enters the actor cleanly. xcalls are already
+                    // best-effort (their only product is an observability event),
+                    // so fire-and-forget matches their contract.
+                    if !outcome.xcalls.is_empty() {
+                        // `XCall` is neither `Clone` nor constructible outside
+                        // its crate (`#[non_exhaustive]`), so lift the owned
+                        // fields into a plain tuple the task can take by value.
+                        let xcall_jobs: Vec<(ContextId, String, Vec<u8>)> = outcome
+                            .xcalls
+                            .iter()
+                            .map(|xcall| {
+                                (
+                                    ContextId::from(xcall.context_id),
+                                    xcall.function.clone(),
+                                    xcall.params.clone(),
+                                )
+                            })
+                            .collect();
+                        let xcall_node_client = node_client.clone();
+                        let xcall_context_client = context_client.clone();
+                        let xcall_store = xcall_datastore.clone();
+                        drop(global_runtime().spawn(async move {
+                            use futures_util::TryStreamExt;
+                            for (target_context_id, function, params) in xcall_jobs {
+                                info!(
+                                    %context_id,
+                                    target_context = ?target_context_id,
+                                    function = %function,
+                                    params_len = params.len(),
+                                    "Processing cross-context call"
+                                );
 
-                        info!(
-                            %context_id,
-                            target_context = ?target_context_id,
-                            function = %xcall.function,
-                            params_len = xcall.params.len(),
-                            "Processing cross-context call"
-                        );
+                                // Best-effort observability event for this xcall.
+                                // Source rides on the wrapper `context_id`;
+                                // emission failure must never abort the batch.
+                                let emit = |outcome: XCallOutcome| {
+                                    let _ = xcall_node_client.send_event(NodeEvent::Context(
+                                        ContextEvent {
+                                            context_id,
+                                            payload: ContextEventPayload::XCall(XCallPayload {
+                                                target_context_id,
+                                                function: function.clone(),
+                                                outcome,
+                                            }),
+                                        },
+                                    ));
+                                };
 
-                        // Best-effort observability event for this xcall (#2137).
-                        // Source rides on the wrapper `context_id`; emission
-                        // failure must never abort the loop or the source exec.
-                        let emit = |outcome: XCallOutcome| {
-                            let _ = node_client.send_event(NodeEvent::Context(ContextEvent {
-                                context_id,
-                                payload: ContextEventPayload::XCall(XCallPayload {
-                                    target_context_id,
-                                    function: xcall.function.clone(),
-                                    outcome,
-                                }),
-                            }));
-                        };
-
-                        // A context may only xcall a target in its own namespace.
-                        // A resolution error or unresolved namespace denies.
-                        let same_namespace = (|| -> eyre::Result<bool> {
-                            let src = resolve_namespace_for_context(&xcall_datastore, &context_id)?;
-                            let tgt =
-                                resolve_namespace_for_context(&xcall_datastore, &target_context_id)?;
-                            Ok(matches!((src, tgt), (Some(a), Some(b)) if a == b))
-                        })();
-                        if !matches!(same_namespace, Ok(true)) {
-                            warn!(
-                                %context_id,
-                                target_context = ?target_context_id,
-                                function = %xcall.function,
-                                resolved = ?same_namespace,
-                                "xcall denied: namespace boundary"
-                            );
-                            emit(XCallOutcome::Denied {
-                                reason: "namespace boundary".to_owned(),
-                            });
-                            continue;
-                        }
-
-                        // Find an owned member of the target context to execute as
-                        // We need to use a member that has permissions on the target context
-                        use futures_util::TryStreamExt;
-                        let members: Vec<_> = context_client
-                            .get_context_members(&target_context_id, Some(true))
-                            .try_collect()
-                            .await
-                            .unwrap_or_default();
-
-                        let Some((target_executor, _is_owned)) = members.first() else {
-                            warn!(
-                                %context_id,
-                                target_context = ?target_context_id,
-                                function = %xcall.function,
-                                "xcall denied: no owned member of target context"
-                            );
-                            emit(XCallOutcome::Denied {
-                                reason: "no owned member".to_owned(),
-                            });
-                            continue;
-                        };
-
-                        let target_executor = *target_executor;
-
-                        info!(
-                            %context_id,
-                            target_context = ?target_context_id,
-                            target_executor = ?target_executor,
-                            "Found owned member for target context"
-                        );
-
-                        // Execute as the target's member, tagging the call with
-                        // the source context so the target can read it via
-                        // `env::xcall_origin()`. The node sets the origin here —
-                        // never from guest memory. The target's handler rejects
-                        // non-`#[app::xcall]` methods with XCallNotPermitted.
-                        let xcall_result = context_client
-                            .execute_with_origin(
-                                &target_context_id,
-                                &target_executor,
-                                xcall.function.clone(),
-                                xcall.params.clone(),
-                                vec![],
-                                None,
-                                Some(context_id),
-                            )
-                            .await;
-
-                        match xcall_result {
-                            // A normally-finished run returns `Ok(ExecuteResponse)`
-                            // even when the target *method* errored — that failure
-                            // lives in `returns`, so inspect it before reporting Ok.
-                            Ok(response) => match &response.returns {
-                                Ok(_) => {
-                                    info!(
-                                        %context_id,
-                                        target_context = ?target_context_id,
-                                        function = %xcall.function,
-                                        "Cross-context call executed successfully"
-                                    );
-                                    emit(XCallOutcome::Ok);
-                                }
-                                Err(err) => {
+                                // A context may only xcall a target in its OWN
+                                // owning group. Gating on the shared namespace
+                                // root instead let any sibling context anywhere
+                                // in the namespace — including a different, even
+                                // Restricted, subgroup — call in and execute as a
+                                // member of the target. A resolution error or an
+                                // unregistered context denies.
+                                let same_group = xcall_same_owning_group(
+                                    &xcall_store,
+                                    &context_id,
+                                    &target_context_id,
+                                );
+                                if !matches!(same_group, Ok(true)) {
                                     warn!(
                                         %context_id,
                                         target_context = ?target_context_id,
-                                        function = %xcall.function,
-                                        %err,
-                                        "Cross-context call target method returned an error"
+                                        function = %function,
+                                        resolved = ?same_group,
+                                        "xcall denied: owning group boundary"
                                     );
-                                    emit(XCallOutcome::ExecError {
-                                        message: err.to_string(),
+                                    emit(XCallOutcome::Denied {
+                                        reason: "owning group boundary".to_owned(),
                                     });
+                                    continue;
                                 }
-                            },
-                            // A rejected entry point is a denial, not an exec error.
-                            Err(ExecuteError::XCallNotPermitted { .. }) => {
-                                warn!(
+
+                                // Find an owned member of the target context to
+                                // execute as — one that has permissions there.
+                                let members: Vec<_> = xcall_context_client
+                                    .get_context_members(&target_context_id, Some(true))
+                                    .try_collect()
+                                    .await
+                                    .unwrap_or_default();
+
+                                let Some((target_executor, _is_owned)) = members.first() else {
+                                    warn!(
+                                        %context_id,
+                                        target_context = ?target_context_id,
+                                        function = %function,
+                                        "xcall denied: no owned member of target context"
+                                    );
+                                    emit(XCallOutcome::Denied {
+                                        reason: "no owned member".to_owned(),
+                                    });
+                                    continue;
+                                };
+
+                                let target_executor = *target_executor;
+
+                                info!(
                                     %context_id,
                                     target_context = ?target_context_id,
-                                    function = %xcall.function,
-                                    "xcall denied: not an #[app::xcall] entry point"
+                                    target_executor = ?target_executor,
+                                    "Found owned member for target context"
                                 );
-                                emit(XCallOutcome::Denied {
-                                    reason: "not an xcall entry point".to_owned(),
-                                });
+
+                                // Execute as the target's member, tagging the
+                                // call with the source context so the target can
+                                // read it via `env::xcall_origin()`. The node sets
+                                // the origin here — never from guest memory. The
+                                // target's handler rejects non-`#[app::xcall]`
+                                // methods with XCallNotPermitted.
+                                let xcall_result = xcall_context_client
+                                    .execute_with_origin(
+                                        &target_context_id,
+                                        &target_executor,
+                                        function.clone(),
+                                        params.clone(),
+                                        vec![],
+                                        None,
+                                        Some(context_id),
+                                    )
+                                    .await;
+
+                                match xcall_result {
+                                    // A normally-finished run returns `Ok` even
+                                    // when the target *method* errored — that
+                                    // failure lives in `returns`, so inspect it
+                                    // before reporting Ok.
+                                    Ok(response) => match &response.returns {
+                                        Ok(_) => {
+                                            info!(
+                                                %context_id,
+                                                target_context = ?target_context_id,
+                                                function = %function,
+                                                "Cross-context call executed successfully"
+                                            );
+                                            emit(XCallOutcome::Ok);
+                                        }
+                                        Err(err) => {
+                                            warn!(
+                                                %context_id,
+                                                target_context = ?target_context_id,
+                                                function = %function,
+                                                %err,
+                                                "Cross-context call target method returned an error"
+                                            );
+                                            emit(XCallOutcome::ExecError {
+                                                message: err.to_string(),
+                                            });
+                                        }
+                                    },
+                                    // A rejected entry point is a denial, not an exec error.
+                                    Err(ExecuteError::XCallNotPermitted { .. }) => {
+                                        warn!(
+                                            %context_id,
+                                            target_context = ?target_context_id,
+                                            function = %function,
+                                            "xcall denied: not an #[app::xcall] entry point"
+                                        );
+                                        emit(XCallOutcome::Denied {
+                                            reason: "not an xcall entry point".to_owned(),
+                                        });
+                                    }
+                                    Err(err) => {
+                                        error!(
+                                            %context_id,
+                                            target_context = ?target_context_id,
+                                            function = %function,
+                                            ?err,
+                                            "Cross-context call failed"
+                                        );
+                                        emit(XCallOutcome::ExecError {
+                                            message: err.to_string(),
+                                        });
+                                    }
+                                }
                             }
-                            Err(err) => {
-                                error!(
-                                    %context_id,
-                                    target_context = ?target_context_id,
-                                    function = %xcall.function,
-                                    ?err,
-                                    "Cross-context call failed"
-                                );
-                                emit(XCallOutcome::ExecError {
-                                    message: err.to_string(),
-                                });
-                            }
-                        }
+                        }));
                     }
 
                     // Broadcast state deltas to other nodes when:
@@ -2437,20 +2477,26 @@ fn extract_xcall_policies(bytecode: &[u8]) -> Option<Arc<crate::XCallPolicyMap>>
     }
 }
 
-/// Resolve a context to its namespace root group, or `None` if it is not
-/// registered in any group. An xcall is allowed only when source and target
-/// resolve to the same namespace; callers treat `Err`/`None` as deny.
-fn resolve_namespace_for_context(
+/// Whether `source` and `target` share the SAME directly-owning group, and are
+/// therefore permitted to cross-call each other. Callers treat `Err` or an
+/// unregistered (`None`) resolution as a denial.
+///
+/// The xcall boundary used to be the shared *namespace root*, but that let any
+/// sibling context anywhere in the namespace — including a different, even
+/// `Restricted`, subgroup — call in and execute as a member of the target
+/// (possibly its admin). Requiring the same owning group keeps a cross-call
+/// inside the one group whose membership both contexts already belong to, so it
+/// can never punch through a subgroup boundary. There is no cross-subgroup
+/// xcall grant mechanism; contexts that must call across subgroups have to
+/// share an owning group.
+fn xcall_same_owning_group(
     store: &calimero_store::Store,
-    context_id: &ContextId,
-) -> eyre::Result<Option<ContextGroupId>> {
-    let Some(group_id) = calimero_governance_store::get_group_for_context(store, context_id)?
-    else {
-        return Ok(None);
-    };
-    let namespace =
-        calimero_governance_store::NamespaceRepository::new(store).resolve(&group_id)?;
-    Ok(Some(namespace))
+    source: &ContextId,
+    target: &ContextId,
+) -> eyre::Result<bool> {
+    let src = calimero_governance_store::get_group_for_context(store, source)?;
+    let tgt = calimero_governance_store::get_group_for_context(store, target)?;
+    Ok(matches!((src, tgt), (Some(a), Some(b)) if a == b))
 }
 
 fn substitute_aliases_in_payload(
@@ -2521,8 +2567,8 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{
-        extract_xcall_policies, resolve_namespace_for_context, resolve_producing_app_key,
-        should_block, upgrade_blocks_write, upgrade_rejects_committed_write, xcall_caller_denied,
+        extract_xcall_policies, resolve_producing_app_key, should_block, upgrade_blocks_write,
+        upgrade_rejects_committed_write, xcall_caller_denied, xcall_same_owning_group,
         XCallCallers,
     };
     use calimero_store::key::GroupUpgradeStatus;
@@ -2547,29 +2593,50 @@ mod tests {
     }
 
     #[test]
-    fn resolve_namespace_for_context_returns_root_namespace() {
+    fn xcall_same_owning_group_allows_same_group() {
         let store = fresh_store();
-        // namespace N (root) ⊃ subgroup ⊃ context
-        let ns = ContextGroupId::from([0xAA; 32]);
-        let sub = ContextGroupId::from([0xBB; 32]);
-        let ctx = ContextId::from([0xCC; 32]);
+        let group = ContextGroupId::from([0xAA; 32]);
+        let a = ContextId::from([0x01; 32]);
+        let b = ContextId::from([0x02; 32]);
 
-        NamespaceRepository::new(&store)
-            .nest(&ns, &sub)
-            .expect("nest subgroup under namespace");
-        register_context_in_group(&store, &sub, &ctx).expect("register context in subgroup");
+        register_context_in_group(&store, &group, &a).expect("register a");
+        register_context_in_group(&store, &group, &b).expect("register b");
 
-        // resolve walks sub → ns (the root group is the namespace)
-        let got = resolve_namespace_for_context(&store, &ctx).expect("resolve ok");
-        assert_eq!(got, Some(ns));
+        assert!(xcall_same_owning_group(&store, &a, &b).expect("resolve ok"));
     }
 
     #[test]
-    fn resolve_namespace_for_context_unregistered_is_none() {
+    fn xcall_same_owning_group_denies_across_subgroups_of_one_namespace() {
         let store = fresh_store();
-        let ctx = ContextId::from([0xDD; 32]);
-        let got = resolve_namespace_for_context(&store, &ctx).expect("resolve ok");
-        assert_eq!(got, None);
+        // namespace N (root) ⊃ { sub_a ⊃ ctx_a, sub_b ⊃ ctx_b }.
+        // Both contexts share the namespace root but live in DIFFERENT
+        // owning subgroups, so the cross-call must be denied even though the
+        // old namespace-root check would have allowed it.
+        let ns = ContextGroupId::from([0xAA; 32]);
+        let sub_a = ContextGroupId::from([0xB1; 32]);
+        let sub_b = ContextGroupId::from([0xB2; 32]);
+        let ctx_a = ContextId::from([0x0A; 32]);
+        let ctx_b = ContextId::from([0x0B; 32]);
+
+        let ns_repo = NamespaceRepository::new(&store);
+        ns_repo.nest(&ns, &sub_a).expect("nest sub_a");
+        ns_repo.nest(&ns, &sub_b).expect("nest sub_b");
+        register_context_in_group(&store, &sub_a, &ctx_a).expect("register ctx_a");
+        register_context_in_group(&store, &sub_b, &ctx_b).expect("register ctx_b");
+
+        assert!(!xcall_same_owning_group(&store, &ctx_a, &ctx_b).expect("resolve ok"));
+    }
+
+    #[test]
+    fn xcall_same_owning_group_denies_unregistered() {
+        let store = fresh_store();
+        let group = ContextGroupId::from([0xAA; 32]);
+        let a = ContextId::from([0x01; 32]);
+        let b = ContextId::from([0x02; 32]);
+        register_context_in_group(&store, &group, &a).expect("register a");
+
+        // `b` is registered in no group at all → deny.
+        assert!(!xcall_same_owning_group(&store, &a, &b).expect("resolve ok"));
     }
 
     #[test]

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1100,7 +1100,7 @@ impl Handler<ExecuteRequest> for ContextManager {
                         let xcall_node_client = node_client.clone();
                         let xcall_context_client = context_client.clone();
                         let xcall_store = xcall_datastore.clone();
-                        drop(global_runtime().spawn(async move {
+                        let xcall_task = global_runtime().spawn(async move {
                             use futures_util::TryStreamExt;
                             for (target_context_id, function, params) in xcall_jobs {
                                 info!(
@@ -1254,6 +1254,20 @@ impl Handler<ExecuteRequest> for ContextManager {
                                         });
                                     }
                                 }
+                            }
+                        });
+                        // Supervise the detached batch so a panic inside it is
+                        // logged rather than silently swallowed (a dropped
+                        // JoinHandle discards the panic). The source execute
+                        // still does not wait on the xcalls — this supervisor
+                        // task is what keeps it fire-and-forget yet observable.
+                        drop(global_runtime().spawn(async move {
+                            if let Err(err) = xcall_task.await {
+                                error!(
+                                    %context_id,
+                                    %err,
+                                    "cross-context call dispatch task terminated abnormally (panic or cancellation)"
+                                );
                             }
                         }));
                     }

--- a/crates/context/src/handlers/execute/storage.rs
+++ b/crates/context/src/handlers/execute/storage.rs
@@ -505,12 +505,11 @@ mod tests {
         let mut s = storage();
         for len in [0usize, 1, 31, 33, 64] {
             let key = vec![0x42u8; len];
-            // The write is a no-op (the key is refused, not truncated/padded)...
-            assert!(
-                s.set(key.clone(), b"value".to_vec()).is_none(),
-                "set must no-op for a {len}-byte key"
-            );
-            // ...and the key reads back as absent rather than colliding.
+            // Attempt the write. Its `None` return is NOT proof of rejection —
+            // `set` also returns `None` on an accepted insert with no prior
+            // value — so the reads below are what prove the key was refused
+            // (not truncated/padded and stored).
+            s.set(key.clone(), b"value".to_vec());
             assert_eq!(s.get(&key), None, "get must miss for a {len}-byte key");
             assert!(!s.has(&key), "has must be false for a {len}-byte key");
         }

--- a/crates/context/src/handlers/execute/storage.rs
+++ b/crates/context/src/handlers/execute/storage.rs
@@ -114,9 +114,16 @@ impl ContextStorage {
     fn state_key(&self, key: &[u8]) -> Option<&'static key::ContextState> {
         let mut state_key = [0; 32];
 
-        (key.len() <= state_key.len()).then_some(())?;
+        // Context-state keys are exactly 32 bytes (the runtime hands us
+        // fixed-width `calimero_storage::store::Key::to_bytes()` values).
+        // Anything else is rejected outright: zero-padding a shorter key
+        // collided distinct keys onto the same slot (e.g. `b"a"` and
+        // `b"a\0"`), and silently truncating/dropping a longer one turned
+        // get/set/remove/has into no-ops — both are data loss. Refusing the
+        // key surfaces the mismatch as a clean miss instead.
+        (key.len() == state_key.len()).then_some(())?;
 
-        state_key[..key.len()].copy_from_slice(key);
+        state_key.copy_from_slice(key);
 
         let mut keys = self.borrow_keys().borrow_mut();
 
@@ -309,9 +316,12 @@ impl ContextPrivateStorage {
     fn state_key(&self, key: &[u8]) -> Option<&'static key::ContextPrivateState> {
         let mut state_key = [0; 32];
 
-        (key.len() <= state_key.len()).then_some(())?;
+        // Exactly 32 bytes required — see `ContextStorage::state_key` for why
+        // zero-padding short keys (collision) and dropping long keys (silent
+        // no-op) are both unacceptable.
+        (key.len() == state_key.len()).then_some(())?;
 
-        state_key[..key.len()].copy_from_slice(key);
+        state_key.copy_from_slice(key);
 
         let mut keys = self.borrow_keys().borrow_mut();
 
@@ -462,5 +472,66 @@ impl<S: Storage> Storage for ReadOnlyContextStorage<'_, S> {
     fn index_del_prefix(&mut self, _prefix: &[u8]) -> bool {
         tracing::debug!("ReadOnlyContextStorage: write suppressed (index_del_prefix)");
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use calimero_primitives::context::ContextId;
+    use calimero_runtime::store::Storage;
+    use calimero_store::db::InMemoryDB;
+    use calimero_store::Store;
+
+    use super::ContextStorage;
+
+    fn storage() -> ContextStorage {
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        ContextStorage::from(store, ContextId::from([0x11; 32]))
+    }
+
+    #[test]
+    fn exact_32_byte_key_roundtrips() {
+        let mut s = storage();
+        let key = vec![0x42u8; 32];
+        assert!(s.set(key.clone(), b"value".to_vec()).is_none());
+        assert_eq!(s.get(&key), Some(b"value".to_vec()));
+        assert!(s.has(&key));
+    }
+
+    #[test]
+    fn keys_not_exactly_32_bytes_are_rejected() {
+        let mut s = storage();
+        for len in [0usize, 1, 31, 33, 64] {
+            let key = vec![0x42u8; len];
+            // The write is a no-op (the key is refused, not truncated/padded)...
+            assert!(
+                s.set(key.clone(), b"value".to_vec()).is_none(),
+                "set must no-op for a {len}-byte key"
+            );
+            // ...and the key reads back as absent rather than colliding.
+            assert_eq!(s.get(&key), None, "get must miss for a {len}-byte key");
+            assert!(!s.has(&key), "has must be false for a {len}-byte key");
+        }
+    }
+
+    #[test]
+    fn short_key_does_not_collide_with_zero_padded_32_byte_key() {
+        // Before the fix a 31-byte key was zero-padded to 32 bytes, colliding
+        // with the genuine 32-byte key that ends in a zero. Now the short key
+        // is refused outright, so the padded key is the only real entry.
+        let mut s = storage();
+        let mut padded = vec![0x42u8; 31];
+        padded.push(0x00); // 32 bytes — the OLD zero-padding of `short`
+        let short = vec![0x42u8; 31];
+
+        s.set(padded.clone(), b"real".to_vec());
+        assert_eq!(
+            s.get(&short),
+            None,
+            "short key must not alias the padded key"
+        );
+        assert_eq!(s.get(&padded), Some(b"real".to_vec()));
     }
 }

--- a/crates/context/src/handlers/issue_ownership_proof.rs
+++ b/crates/context/src/handlers/issue_ownership_proof.rs
@@ -26,6 +26,69 @@ pub const OWNERSHIP_PROOF_DOMAIN: &[u8] = b"calimero.ownership-claim.v1\x00";
 /// `min(expires_at_ms, issued_at_ms + MAX_PROOF_LIFETIME_MS)`.
 pub const MAX_PROOF_LIFETIME_MS: u64 = 5 * 60 * 1000;
 
+/// Maximum byte length accepted for each free-form proof field (`audience`,
+/// `subject`, `nonce`). These strings are signed verbatim and embedded in the
+/// canonical JSON payload, so an unbounded value would let a caller inflate
+/// the signed blob without limit. 256 bytes comfortably fits a URL, DID, or
+/// public-key string while keeping the signed payload small.
+pub const MAX_PROOF_FIELD_LEN: usize = 256;
+
+/// Minimum byte length required of the `nonce`. A one-byte nonce offers no
+/// meaningful uniqueness; requiring some width makes accidental collisions far
+/// less likely. This is a defence-in-depth floor only — single-use enforcement
+/// remains the verifier's responsibility (see the verifier-obligations note
+/// below).
+pub const MIN_NONCE_LEN: usize = 8;
+
+/// Validate a free-form proof field. Rejects empty, over-long, and values
+/// carrying ASCII control characters (which have no legitimate place in an
+/// audience/subject/nonce and would render ambiguously across verifiers).
+fn validate_proof_field(name: &str, value: &str) -> eyre::Result<()> {
+    if value.is_empty() {
+        bail!("ownership-proof `{name}` must not be empty");
+    }
+    if value.len() > MAX_PROOF_FIELD_LEN {
+        bail!(
+            "ownership-proof `{name}` is {} bytes; maximum is {MAX_PROOF_FIELD_LEN}",
+            value.len()
+        );
+    }
+    if value.chars().any(|c| c.is_control()) {
+        bail!("ownership-proof `{name}` must not contain control characters");
+    }
+    Ok(())
+}
+
+/// Validate the `audience`/`subject`/`nonce` triple shared by both proof
+/// variants.
+///
+/// # Verifier obligations (MANDATORY — enforced by the relying party, NOT here)
+///
+/// An issued proof is only an admin's *signed assertion*. Issuance bounds the
+/// fields and clamps the lifetime, but it does NOT and CANNOT establish
+/// freshness or that the `subject` is entitled to anything. A verifier MUST:
+///
+///   * reconstruct the signed bytes as `OWNERSHIP_PROOF_DOMAIN || signed_payload`
+///     and check the signature against `signer_public_key`;
+///   * confirm `payload.issuer_identity == signer_public_key` and that the
+///     signer is a current admin of `group_id`;
+///   * reject the proof unless `now` is within `[issued_at_ms, expires_at_ms)`;
+///   * match `audience` against its own identifier (reject proofs minted for a
+///     different relying party);
+///   * enforce `nonce` single-use within the proof's validity window (the node
+///     keeps no issued-nonce record — replay defence lives entirely here);
+///   * treat `subject` as an admin-vouched claim and independently authorize
+///     what that subject is allowed to do (an admin can assert any subject).
+fn validate_proof_fields(audience: &str, subject: &str, nonce: &str) -> eyre::Result<()> {
+    validate_proof_field("audience", audience)?;
+    validate_proof_field("subject", subject)?;
+    validate_proof_field("nonce", nonce)?;
+    if nonce.len() < MIN_NONCE_LEN {
+        bail!("ownership-proof `nonce` must be at least {MIN_NONCE_LEN} bytes");
+    }
+    Ok(())
+}
+
 /// Canonical ownership-claim payload.
 ///
 /// Field order is locked by the struct definition order (serde_json preserves
@@ -70,6 +133,8 @@ pub(crate) fn build_ownership_proof(
     requested_expires_at_ms: u64,
     now_ms: u64,
 ) -> eyre::Result<OwnershipProofBuildOutput> {
+    validate_proof_fields(audience, subject, nonce)?;
+
     if !MembershipRepository::new(store).is_direct_admin(&group_id, &node_identity)? {
         bail!("node is not a direct admin of this group");
     }
@@ -166,6 +231,8 @@ pub(crate) fn build_namespace_ownership_proof(
     requested_expires_at_ms: u64,
     now_ms: u64,
 ) -> eyre::Result<OwnershipProofBuildOutput> {
+    validate_proof_fields(audience, subject, nonce)?;
+
     if !MembershipRepository::new(store).is_direct_admin(&group_id, &node_identity)? {
         bail!("node is not a direct admin of this group");
     }
@@ -746,5 +813,86 @@ mod tests {
             err.to_string().contains("root"),
             "error must mention namespace root, got: {err}"
         );
+    }
+
+    #[test]
+    fn rejects_empty_and_oversized_and_control_and_short_nonce_fields() {
+        let (store, group_id, context_id, signing_pub, _sk) = setup_admin_with_signing_key();
+        let valid_nonce = "deadbeefcafebabe1122334455667788";
+        let over = "x".repeat(super::MAX_PROOF_FIELD_LEN + 1);
+
+        let call = |audience: &str, subject: &str, nonce: &str| {
+            build_ownership_proof(
+                &store,
+                signing_pub,
+                group_id,
+                context_id,
+                audience,
+                subject,
+                nonce,
+                NOW_MS + 1_000,
+                NOW_MS,
+            )
+        };
+
+        // Empty fields.
+        assert!(call("", "sub", valid_nonce)
+            .expect_err("empty audience")
+            .to_string()
+            .contains("audience"));
+        assert!(call("aud", "", valid_nonce)
+            .expect_err("empty subject")
+            .to_string()
+            .contains("subject"));
+        assert!(call("aud", "sub", "")
+            .expect_err("empty nonce")
+            .to_string()
+            .contains("nonce"));
+
+        // Oversized field.
+        assert!(call(&over, "sub", valid_nonce)
+            .expect_err("oversized audience")
+            .to_string()
+            .contains("maximum"));
+
+        // Control characters.
+        assert!(call("aud\n", "sub", valid_nonce)
+            .expect_err("control char in audience")
+            .to_string()
+            .contains("control"));
+
+        // Nonce below the minimum width.
+        assert!(call("aud", "sub", "short")
+            .expect_err("short nonce")
+            .to_string()
+            .contains("nonce"));
+
+        // The exact-max boundary and a valid nonce are accepted (fields are
+        // validated before the admin/signing-key checks, so this reaches the
+        // happy path).
+        let at_max = "x".repeat(super::MAX_PROOF_FIELD_LEN);
+        call(&at_max, "sub", valid_nonce).expect("field at max length is accepted");
+    }
+
+    #[test]
+    fn namespace_proof_validates_fields_too() {
+        let store = test_store();
+        let group_id = ContextGroupId::from([0xAA; 32]);
+        let identity = PublicKey::from([0x44; 32]);
+
+        // A bad field is rejected before the admin check, so we don't need a
+        // fully-set-up admin to observe the field validation firing.
+        let err = build_namespace_ownership_proof(
+            &store,
+            identity,
+            group_id,
+            "aud",
+            "sub",
+            "short",
+            NOW_MS + 1_000,
+            NOW_MS,
+        )
+        .expect_err("short nonce must be rejected");
+        assert!(err.to_string().contains("nonce"));
     }
 }

--- a/crates/context/src/handlers/join_context.rs
+++ b/crates/context/src/handlers/join_context.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 
 use actix::{ActorResponse, Handler, Message, WrapFuture};
 use calimero_context_client::group::{JoinContextRequest, JoinContextResponse};
-use calimero_context_config::types::ContextGroupId;
 use calimero_primitives::context::ContextConfigParams;
 use eyre::bail;
 use tokio::sync::broadcast::error::RecvError;
@@ -24,6 +23,13 @@ const GROUP_LOOKUP_TIMEOUT: Duration = Duration::from_secs(30);
 /// re-reading the datastore; this bounds how long a lagged receiver
 /// waits before that recheck.
 const FALLBACK_POLL: Duration = Duration::from_millis(200);
+
+/// Ceiling for the exponential backoff on fallback namespace re-syncs. The
+/// datastore is still rechecked every [`FALLBACK_POLL`] (cheap, local), but the
+/// network re-sync kicked from a poll tick backs off from [`FALLBACK_POLL`] up
+/// to this cap so a single unresolved join doesn't fire a full namespace sync
+/// every 200ms for its whole 30s budget.
+const MAX_RESYNC_BACKOFF: Duration = Duration::from_secs(5);
 
 impl Handler<JoinContextRequest> for ContextManager {
     type Result = ActorResponse<Self, <JoinContextRequest as Message>::Result>;
@@ -59,6 +65,10 @@ impl Handler<JoinContextRequest> for ContextManager {
                     if group_id.is_none() {
                         let deadline = tokio::time::Instant::now() + GROUP_LOOKUP_TIMEOUT;
                         let started = tokio::time::Instant::now();
+                        // Exponential backoff for the fallback re-sync. Seeded
+                        // from the initial `sync_known_namespaces` above.
+                        let mut resync_backoff = FALLBACK_POLL;
+                        let mut last_resync = tokio::time::Instant::now();
                         loop {
                             // Race the notifier against a short poll interval: if
                             // the channel lagged (bursty traffic), we still catch
@@ -102,15 +112,24 @@ impl Handler<JoinContextRequest> for ContextManager {
                                     break;
                                 }
                                 Err(_elapsed) => {
-                                    // Poll tick — recheck the datastore and kick another
-                                    // namespace sync to cover the "peer arrived late" case.
+                                    // Poll tick — recheck the datastore (cheap,
+                                    // local) every interval, but throttle the
+                                    // network namespace re-sync with exponential
+                                    // backoff so an unresolved join doesn't
+                                    // re-sync every 200ms for its whole budget.
                                     group_id = calimero_governance_store::get_group_for_context(
                                         &datastore, &context_id,
                                     )?;
                                     if group_id.is_some() {
                                         break;
                                     }
-                                    sync_known_namespaces(&datastore, &node_client).await;
+                                    let now = tokio::time::Instant::now();
+                                    if now.duration_since(last_resync) >= resync_backoff {
+                                        sync_known_namespaces(&datastore, &node_client).await;
+                                        last_resync = tokio::time::Instant::now();
+                                        resync_backoff =
+                                            (resync_backoff * 2).min(MAX_RESYNC_BACKOFF);
+                                    }
                                 }
                             }
                             if tokio::time::Instant::now() >= deadline {
@@ -293,30 +312,29 @@ async fn sync_known_namespaces(
     datastore: &calimero_store::Store,
     node_client: &calimero_node_primitives::client::NodeClient,
 ) {
-    let groups = match MetaRepository::new(datastore).enumerate_all(0, usize::MAX) {
-        Ok(groups) => groups,
+    // Sync only namespaces the node actually holds an identity in — those are
+    // the only ones where this join can ultimately succeed (the join later
+    // requires `NamespaceRepository::resolve_identity` for the context's owning
+    // group). `iter_identities` returns distinct namespace roots, so this both
+    // narrows the fan-out to plausibly-owning namespaces AND removes the old
+    // duplication where a namespace with N subgroups was enumerated and synced
+    // N times (`enumerate_all` over every group, resolving each back to its
+    // root) on every single pass.
+    let namespaces = match NamespaceRepository::new(datastore).iter_identities() {
+        Ok(namespaces) => namespaces,
         Err(err) => {
-            warn!(error = ?err, "failed to enumerate groups for namespace sync");
+            warn!(error = ?err, "failed to enumerate namespace identities for sync");
             return;
         }
     };
 
-    for (group_id_bytes, _) in groups {
-        let group_id = ContextGroupId::from(group_id_bytes);
-        let namespace = match NamespaceRepository::new(datastore).resolve(&group_id) {
-            Ok(namespace) => namespace,
-            Err(err) => {
-                warn!(?group_id, error = ?err, "failed to resolve namespace while syncing");
-                continue;
-            }
-        };
-
+    for namespace in namespaces {
         let namespace_id = namespace.to_bytes();
         if let Err(err) = node_client.subscribe_namespace(namespace_id).await {
-            warn!(?group_id, error = ?err, "failed to subscribe namespace during join_context");
+            warn!(?namespace, error = ?err, "failed to subscribe namespace during join_context");
         }
         if let Err(err) = node_client.sync_namespace(namespace_id).await {
-            warn!(?group_id, error = ?err, "failed to sync namespace during join_context");
+            warn!(?namespace, error = ?err, "failed to sync namespace during join_context");
         }
     }
 }

--- a/crates/context/src/handlers/leave_context.rs
+++ b/crates/context/src/handlers/leave_context.rs
@@ -145,8 +145,14 @@ impl Handler<LeaveContextRequest> for ContextManager {
                 }
 
                 // The response reports the primary (first) identity; every
-                // identity above has been tombstoned regardless.
-                let member_public_key = member_public_keys[0];
+                // identity above has been tombstoned regardless. The vec is
+                // non-empty here by construction (the scan found keys, or the
+                // fallback pushed one, or we already bailed) — make that
+                // invariant explicit rather than indexing blindly.
+                let member_public_key = member_public_keys
+                    .first()
+                    .copied()
+                    .expect("member_public_keys is non-empty: scan found keys or fallback pushed one");
 
                 // Stop receiving gossipsub traffic for this context. The
                 // inverse of `node_client.subscribe(context_id)` that

--- a/crates/context/src/handlers/leave_context.rs
+++ b/crates/context/src/handlers/leave_context.rs
@@ -3,15 +3,17 @@
 //! See `architecture/membership-and-leave.html` § 4 for the design.
 //!
 //! Mechanism:
-//!   1. Look up the context's local signing identity by scanning
-//!      `ContextIdentity` rows for `(context_id, *)` and finding the one
-//!      where this node holds the private key. This handles cases where
-//!      a context was created with a per-context identity that differs
-//!      from the namespace-level identity (e.g. via
-//!      `CreateContextRequest.identity_secret`).
-//!   2. In a single batched store handle, write the `ContextLeftMarker`
+//!   1. Look up ALL of the context's local signing identities by scanning
+//!      `ContextIdentity` rows for `(context_id, *)` and collecting every
+//!      one where this node holds the private key. A node can hold more
+//!      than one identity per context (e.g. one minted at create time via
+//!      `CreateContextRequest.identity_secret` plus an inherited
+//!      namespace-level identity); tombstoning only the first would leave
+//!      the rest syncing and re-armable by auto-follow.
+//!   2. In a single batched store handle, write a `ContextLeftMarker`
 //!      tombstone in `Column::ContextLocal` AND delete the
-//!      `ContextIdentity` row. The auto-follow handler
+//!      `ContextIdentity` row for every one of those identities. The
+//!      auto-follow handler
 //!      (`crate::auto_follow::has_left_context`) checks the marker
 //!      before re-joining; the deleted identity row stops sync.
 //!   3. Unsubscribe from the context's gossipsub topic so the node
@@ -53,65 +55,62 @@ impl Handler<LeaveContextRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                // Find this node's actual context-specific identity by scanning
-                // the `ContextIdentity` column for a row keyed by this context
-                // where we hold the private key. Falls back to the namespace
-                // identity only when no such row exists (e.g. inherited
-                // membership we've never explicitly joined).
+                // Find EVERY local identity for this context by scanning the
+                // `ContextIdentity` column for rows keyed by this context where
+                // we hold the private key. Falls back to the namespace identity
+                // only when no such row exists (e.g. inherited membership we've
+                // never explicitly joined).
                 //
-                // This is the right resolution because `ContextIdentity` rows
-                // can be keyed by an identity that differs from the
-                // namespace-level pk (`CreateContextRequest.identity_secret`
-                // can mint a per-context identity on creation). Resolving
-                // through `find_local_signing_identity` deletes the row that
-                // actually exists on disk.
-                let member_public_key = match calimero_governance_store::find_local_signing_identity(
-                    &datastore,
-                    &context_id,
-                )? {
-                    Some(pk) => pk,
-                    None => {
-                        // No ContextIdentity row exists locally — the node
-                        // never joined or was already cleaned up. Fall back
-                        // to the namespace identity for the marker so a
-                        // future auto-follow event still finds an opt-out
-                        // record under our identity. If even that fails,
-                        // there's nothing for us to leave.
-                        let group_id =
-                            calimero_governance_store::get_group_for_context(&datastore, &context_id)?
-                                .ok_or_else(|| {
-                                    eyre!(
-                                        "context {} is not mapped to any local group; \
-                                         nothing to leave on this node",
-                                        context_id
-                                    )
-                                })?;
-                        match NamespaceRepository::new(&datastore).resolve_identity(&group_id)? {
-                            Some((pk, _, _)) => pk,
-                            None => bail!(
-                                "no local identity for context {}; nothing to leave",
-                                context_id
-                            ),
-                        }
+                // Enumerating all of them (not just the first) matters:
+                // `ContextIdentity` rows can be keyed by identities that differ
+                // from the namespace-level pk (`CreateContextRequest.identity_secret`
+                // can mint a per-context identity on creation), and a node may
+                // legitimately hold several. Tombstoning only one would leave
+                // the others syncing, and a later auto-follow event could
+                // re-arm them.
+                let mut member_public_keys =
+                    calimero_governance_store::find_local_signing_identities(
+                        &datastore,
+                        &context_id,
+                    )?;
+
+                if member_public_keys.is_empty() {
+                    // No ContextIdentity row exists locally — the node
+                    // never joined or was already cleaned up. Fall back
+                    // to the namespace identity for the marker so a
+                    // future auto-follow event still finds an opt-out
+                    // record under our identity. If even that fails,
+                    // there's nothing for us to leave.
+                    let group_id =
+                        calimero_governance_store::get_group_for_context(&datastore, &context_id)?
+                            .ok_or_else(|| {
+                                eyre!(
+                                    "context {} is not mapped to any local group; \
+                                     nothing to leave on this node",
+                                    context_id
+                                )
+                            })?;
+                    match NamespaceRepository::new(&datastore).resolve_identity(&group_id)? {
+                        Some((pk, _, _)) => member_public_keys.push(pk),
+                        None => bail!(
+                            "no local identity for context {}; nothing to leave",
+                            context_id
+                        ),
                     }
-                };
+                }
 
                 let now_ms = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .wrap_err("system clock is before UNIX_EPOCH")?
                     .as_millis() as u64;
 
-                let marker_key = key::ContextLeftMarker::new(context_id, member_public_key);
-                let marker_value = types::ContextLeftMarker { left_at_ms: now_ms };
-                let identity_key = key::ContextIdentity::new(context_id, member_public_key);
-
-                // The two writes are sequential, not atomic — `Handle`
-                // forwards each `put`/`delete` directly to the underlying
-                // DB layer, which commits per-call. The store does have a
-                // batched `WriteLayer::apply(&Transaction)` primitive
-                // (crates/store/src/layer.rs:44) we could thread through,
-                // but ordering + idempotency get us the same correctness
-                // guarantee here:
+                // The marker/delete pair per identity is written sequentially,
+                // not atomically — `Handle` forwards each `put`/`delete`
+                // directly to the underlying DB layer, which commits per-call.
+                // The store does have a batched `WriteLayer::apply(&Transaction)`
+                // primitive (crates/store/src/layer.rs:44) we could thread
+                // through, but ordering + idempotency get us the same
+                // correctness guarantee here:
                 //
                 //   * Marker first → if the delete then fails, the marker
                 //     still gates auto-follow (it returns `false` for any
@@ -130,13 +129,24 @@ impl Handler<LeaveContextRequest> for ContextManager {
                 // auto-follow won't re-add. Calling leave again succeeds.
                 {
                     let mut handle = datastore.handle();
-                    handle
-                        .put(&marker_key, &marker_value)
-                        .wrap_err("failed to write context-leave marker")?;
-                    handle
-                        .delete(&identity_key)
-                        .wrap_err("failed to delete context identity row")?;
+                    for member_public_key in &member_public_keys {
+                        let marker_key =
+                            key::ContextLeftMarker::new(context_id, *member_public_key);
+                        let marker_value = types::ContextLeftMarker { left_at_ms: now_ms };
+                        let identity_key =
+                            key::ContextIdentity::new(context_id, *member_public_key);
+                        handle
+                            .put(&marker_key, &marker_value)
+                            .wrap_err("failed to write context-leave marker")?;
+                        handle
+                            .delete(&identity_key)
+                            .wrap_err("failed to delete context identity row")?;
+                    }
                 }
+
+                // The response reports the primary (first) identity; every
+                // identity above has been tombstoned regardless.
+                let member_public_key = member_public_keys[0];
 
                 // Stop receiving gossipsub traffic for this context. The
                 // inverse of `node_client.subscribe(context_id)` that

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -137,15 +137,40 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
         // Launching a propagator would race with the lazy mechanism and could
         // invoke migration functions twice on the same context.
         //
-        // Save the upgrade record as Completed immediately — InProgress serves
-        // no purpose for lazy upgrades (no propagator runs) and would
-        // permanently block future upgrades since nothing transitions it out.
+        // Persist a short-lived InProgress record SYNCHRONOUSLY before the async
+        // work, exactly as the canary path below does. Without it two concurrent
+        // LazyOnAccess requests both clear `validate_upgrade` (which rejects only
+        // when an InProgress record already exists) and each emit its own racing
+        // TargetApplicationSet/GroupMigrationSet op pair. The async block below
+        // overwrites it with a Completed record on success, and the cleanup map
+        // on the future deletes it on failure so a failed attempt never leaves
+        // the group permanently blocked.
         if matches!(upgrade_policy, UpgradePolicy::LazyOnAccess) {
             let datastore = self.datastore.clone();
             let ack_router_for_lazy = Arc::clone(&ack_router);
             let target_blob_bytes: Option<[u8; 32]> = app_meta_for_contract
                 .as_ref()
                 .map(|m| *m.bytecode.blob_id().as_ref());
+
+            let inprogress = GroupUpgradeValue {
+                from_version: from_version.clone(),
+                to_version: to_version.clone(),
+                migration: None,
+                initiated_at: now,
+                initiated_by: requester,
+                status: GroupUpgradeStatus::InProgress {
+                    total: total_contexts as u32,
+                    completed: 0,
+                    failed: 0,
+                },
+                cascade_hlc: None,
+                cascade_seq: None,
+            };
+            if let Err(err) = UpgradesRepository::new(&self.datastore).save(&group_id, &inprogress)
+            {
+                return ActorResponse::reply(Err(err));
+            }
+
             return ActorResponse::r#async(
                 async move {
                     // Resolve the emission ladder from the apps' embedded
@@ -297,7 +322,24 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                         status: completed_status,
                     })
                 }
-                .into_actor(self),
+                .into_actor(self)
+                .map(move |res, act, _ctx| {
+                    // On failure, drop the synchronously-persisted InProgress
+                    // record so the group isn't permanently wedged (nothing
+                    // else transitions it out on the lazy path). Success has
+                    // already overwritten it with a Completed record.
+                    if res.is_err() {
+                        if let Err(err) = UpgradesRepository::new(&act.datastore).delete(&group_id)
+                        {
+                            warn!(
+                                ?group_id,
+                                ?err,
+                                "failed to clear InProgress upgrade record after lazy upgrade error"
+                            );
+                        }
+                    }
+                    res
+                }),
             );
         }
 
@@ -2074,5 +2116,79 @@ mod tests {
         ];
         let rungs = select_intermediate_rungs(1, 3, &candidates).unwrap();
         assert_eq!(rungs, vec![([0x02; 32], 2)]);
+    }
+
+    #[test]
+    fn validate_upgrade_rejects_when_an_inprogress_record_exists() {
+        // The LazyOnAccess handler persists a short-lived InProgress record
+        // synchronously before its async work so a second concurrent request
+        // is refused rather than emitting a second racing op pair. This pins
+        // the guard that makes that work: with an InProgress record present,
+        // `validate_upgrade` bails.
+        use std::sync::Arc;
+
+        use calimero_primitives::application::ApplicationId;
+        use calimero_primitives::context::GroupMemberRole;
+        use calimero_primitives::identity::PublicKey;
+        use calimero_store::db::InMemoryDB;
+        use calimero_store::key::{GroupMetaValue, GroupUpgradeStatus, GroupUpgradeValue};
+        use calimero_store::Store;
+
+        use calimero_governance_store::{MembershipRepository, MetaRepository, UpgradesRepository};
+
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let group_id = gid(0xA0);
+        let requester = PublicKey::from([0x33; 32]);
+        let current_app = ApplicationId::from([0x01; 32]);
+        let target_app = ApplicationId::from([0x02; 32]);
+
+        MetaRepository::new(&store)
+            .save(
+                &group_id,
+                &GroupMetaValue {
+                    app_key: [0x11; 32],
+                    target_application_id: current_app,
+                    upgrade_policy: UpgradePolicy::LazyOnAccess,
+                    created_at: 1_700_000_000,
+                    admin_identity: requester,
+                    owner_identity: requester,
+                    migration: None,
+                    auto_join: true,
+                },
+            )
+            .expect("save meta");
+        MembershipRepository::new(&store)
+            .add_member(&group_id, &requester, GroupMemberRole::Admin)
+            .expect("add admin");
+        UpgradesRepository::new(&store)
+            .save(
+                &group_id,
+                &GroupUpgradeValue {
+                    from_version: "0.1.0".to_owned(),
+                    to_version: "0.2.0".to_owned(),
+                    migration: None,
+                    initiated_at: 1_700_000_000,
+                    initiated_by: requester,
+                    status: GroupUpgradeStatus::InProgress {
+                        total: 1,
+                        completed: 0,
+                        failed: 0,
+                    },
+                    cascade_hlc: None,
+                    cascade_seq: None,
+                },
+            )
+            .expect("save in-progress record");
+
+        // `has_raw_signing_key = true` skips the signing-key requirement; the
+        // InProgress guard fires before the target-differs / has-contexts checks.
+        // (`UpgradePreamble` is not `Debug`, so match rather than `expect_err`.)
+        match super::validate_upgrade(&store, &group_id, &target_app, &requester, true) {
+            Ok(_) => panic!("a pending upgrade must block a second one"),
+            Err(err) => assert!(
+                err.to_string().contains("already in progress"),
+                "unexpected error: {err}"
+            ),
+        }
     }
 }

--- a/crates/governance-store/src/context_tree.rs
+++ b/crates/governance-store/src/context_tree.rs
@@ -128,4 +128,37 @@ impl<'a> ContextTreeService<'a> {
 
         Ok(None)
     }
+
+    /// Scans ContextIdentity rows for this context and returns EVERY identity
+    /// for which the node holds a local private key. Unlike
+    /// [`find_local_signing_identity`](Self::find_local_signing_identity),
+    /// which stops at the first match, this returns them all — a node can hold
+    /// several per-context identities (e.g. one minted at create time via
+    /// `CreateContextRequest.identity_secret` plus an inherited namespace
+    /// identity), and callers such as `leave_context` must act on all of them.
+    pub fn find_local_signing_identities(
+        &self,
+        context_id: &ContextId,
+    ) -> EyreResult<Vec<PublicKey>> {
+        let handle = self.store.handle();
+        let start_key = ContextIdentity::new(*context_id, [0u8; 32].into());
+        let mut iter = handle.iter::<ContextIdentity>()?;
+        let first = iter.seek(start_key).transpose();
+
+        let mut identities = Vec::new();
+        for key_result in first.into_iter().chain(iter.keys()) {
+            let key = key_result?;
+            if key.context_id() != *context_id {
+                break;
+            }
+            let Some(value) = handle.get(&key)? else {
+                continue;
+            };
+            if value.private_key.is_some() {
+                identities.push(key.public_key());
+            }
+        }
+
+        Ok(identities)
+    }
 }

--- a/crates/governance-store/src/contexts.rs
+++ b/crates/governance-store/src/contexts.rs
@@ -275,3 +275,79 @@ pub fn find_local_signing_identity(
     ContextTreeService::new(store, ContextGroupId::from([0u8; 32]))
         .find_local_signing_identity(context_id)
 }
+
+/// Scans the ContextIdentity column for the given context and returns EVERY
+/// `PublicKey` for which the node holds a local private key. Used by
+/// `leave_context`, which must tombstone all of the node's identities in a
+/// context, not just the first one.
+pub fn find_local_signing_identities(
+    store: &Store,
+    context_id: &ContextId,
+) -> EyreResult<Vec<PublicKey>> {
+    ContextTreeService::new(store, ContextGroupId::from([0u8; 32]))
+        .find_local_signing_identities(context_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use calimero_primitives::context::ContextId;
+    use calimero_primitives::identity::PublicKey;
+    use calimero_store::db::InMemoryDB;
+    use calimero_store::{key, types, Store};
+
+    use super::{find_local_signing_identities, find_local_signing_identity};
+
+    fn store() -> Store {
+        Store::new(Arc::new(InMemoryDB::owned()))
+    }
+
+    fn put_identity(store: &Store, context: &ContextId, member: &PublicKey, has_private: bool) {
+        let mut handle = store.handle();
+        handle
+            .put(
+                &key::ContextIdentity::new(*context, *member),
+                &types::ContextIdentity {
+                    private_key: has_private.then_some([0x77; 32]),
+                    sender_key: None,
+                },
+            )
+            .expect("put identity");
+    }
+
+    #[test]
+    fn returns_all_identities_holding_a_private_key() {
+        let store = store();
+        let context = ContextId::from([0x11; 32]);
+        let a = PublicKey::from([0x01; 32]);
+        let b = PublicKey::from([0x02; 32]);
+        let keyless = PublicKey::from([0x03; 32]);
+        // Row belonging to a DIFFERENT context — must be excluded.
+        let other_ctx = ContextId::from([0x22; 32]);
+        let other_member = PublicKey::from([0x04; 32]);
+
+        put_identity(&store, &context, &a, true);
+        put_identity(&store, &context, &b, true);
+        put_identity(&store, &context, &keyless, false);
+        put_identity(&store, &other_ctx, &other_member, true);
+
+        let mut got = find_local_signing_identities(&store, &context).expect("enumerate");
+        got.sort();
+        assert_eq!(got, vec![a, b]);
+
+        // The singular helper still returns just one of them (the first).
+        let one = find_local_signing_identity(&store, &context).expect("single");
+        assert!(one == Some(a) || one == Some(b));
+    }
+
+    #[test]
+    fn returns_empty_when_no_local_key() {
+        let store = store();
+        let context = ContextId::from([0x11; 32]);
+        put_identity(&store, &context, &PublicKey::from([0x01; 32]), false);
+        assert!(find_local_signing_identities(&store, &context)
+            .expect("enumerate")
+            .is_empty());
+    }
+}

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -77,9 +77,9 @@ pub use self::capabilities::CapabilitiesRepository;
 pub use self::context_registration::ContextRegistrationService;
 pub use self::context_tree::ContextTreeService;
 pub use self::contexts::{
-    cascade_remove_member_from_group_tree, enumerate_group_contexts, find_local_signing_identity,
-    get_group_for_context, is_currently_authorized_for_context, register_context_in_group,
-    restore_member_context_identities, unregister_context_from_group,
+    cascade_remove_member_from_group_tree, enumerate_group_contexts, find_local_signing_identities,
+    find_local_signing_identity, get_group_for_context, is_currently_authorized_for_context,
+    register_context_in_group, restore_member_context_identities, unregister_context_from_group,
 };
 pub use self::deny_list::DenyListRepository;
 

--- a/crates/primitives/src/events.rs
+++ b/crates/primitives/src/events.rs
@@ -155,7 +155,7 @@ mod tests {
                 target_context_id: ContextId::from([0x03; 32]),
                 function: "on_match_finished".to_owned(),
                 outcome: XCallOutcome::Denied {
-                    reason: "namespace boundary".to_owned(),
+                    reason: "owning group boundary".to_owned(),
                 },
             }),
         };
@@ -165,7 +165,7 @@ mod tests {
         assert_eq!(v["data"]["outcome"]["status"], "denied");
         assert_eq!(
             v["data"]["outcome"]["detail"]["reason"],
-            "namespace boundary"
+            "owning group boundary"
         );
         assert!(
             v.get("contextId").is_some(),


### PR DESCRIPTION
## Summary

A batch of correctness/security fixes across the `ContextManager` handlers. Each item is independent; grouped here because they share the same subsystem and review surface.

| Sev | Finding | Fix |
|-----|---------|-----|
| **H** | xcall re-enters the same actor and can deadlock/hang (self-mailbox `execute_with_origin().await` while the source future is in flight; self-xcall also deadlocks on the source execution lock) | Dispatch the whole xcall batch **out-of-band** on a detached `global_runtime().spawn` task. The source execute returns and drops its guard first, so the re-entrant execute runs cleanly. xcalls are already best-effort (their only product is an observability event), so fire-and-forget matches their contract. |
| **M** | xcall authorized on the namespace root → crosses subgroup boundary (any sibling context anywhere in the namespace can call a Restricted-subgroup context and execute as a member) | Gate xcall on the **same owning group** (`get_group_for_context` equality) instead of the shared namespace root. Denial reason renamed `owning group boundary`. No cross-subgroup grant mechanism exists; contexts that must call across subgroups have to share an owning group. |
| **M** | `join_context` fallback re-enumerates all groups every 200ms (full namespace re-enumeration + network sync per unresolved join) | Sync only namespaces the node holds an identity in (`iter_identities`, deduped roots — the only ones the join can succeed in), and back the fallback re-sync off exponentially (200ms → 5s). |
| **M** | `state_key` silently drops keys >32 bytes and zero-pads <32 (data loss for long keys; short keys collide) | Require `key.len() == 32` in both `ContextStorage` and `ContextPrivateStorage`. |
| **M** | Concurrent lazy upgrades both pass validation and emit racing op pairs | Persist a short-lived `InProgress` record **synchronously** before the async work (mirrors the canary path), so a concurrent request fails `validate_upgrade`; a cleanup map deletes it on failure so nothing wedges. |
| **L** | `create_group` existence guard races the async write | Reserve the group id **synchronously** in the handler body; cleanup map frees it on failure. |
| **L** | Ownership-proof fields unbounded / no field validation | Bound & validate `audience`/`subject`/`nonce` (non-empty, ≤256B, no control chars, nonce ≥8B) and document the **mandatory verifier obligations** (nonce single-use, audience match, subject authorization). |
| **L** | `leave_context` tombstones only one local identity | Enumerate and tombstone **all** local `ContextIdentity` rows (new `find_local_signing_identities`), so extra identities can't keep syncing / re-arm auto-follow. |

### Not changed
The reported auto_follow backfill stall (`handle_auto_follow_enabled` awaited inline) is **already fixed on current master** — `run()` dispatches each event onto a `JoinSet` task with an explicit rationale comment. Verified directly; no change needed.

## Tests
- **storage**: exact-32 roundtrip, non-32 rejection, short-key no-longer-collides-with-padded
- **xcall boundary**: same-group allow, cross-subgroup deny, unregistered deny
- **ownership proof**: empty/oversized/control/short-nonce rejection + at-max acceptance; namespace-variant validation
- **leave_context helper**: returns all key-holding identities, excludes keyless / other-context rows
- **upgrade_group**: `validate_upgrade` rejects when an `InProgress` record exists (pins the guard the lazy fix relies on)
- **e2e**: `apps/xcall-example/workflows/xcall.yml` updated to the same-owning-group semantics and the renamed `owning group boundary` denial

`cargo check -p calimero-node` (full downstream), `calimero-context` (216) and `calimero-governance-store` (400) lib tests pass; clippy `-D warnings` clean on touched crates. `Cargo.lock` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
