### PR TITLE
fix(node): verify invitation signature before seeding namespace admin

### DIFF
--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -72,6 +72,15 @@ impl Handler<JoinGroupRequest> for ContextManager {
                     _ => GroupMemberRole::Member,
                 };
 
+                // Verify the invitation's inviter signature before it seeds any
+                // local trust. `admin_identity` written in Phase 1 becomes the
+                // local root of trust for this namespace's beacon / ack /
+                // heartbeat verification and `is_admin`, so a forged invitation
+                // must not reach the seed below.
+                calimero_governance_store::NamespaceMembershipService::verify_open_invitation_signature(
+                    &invitation,
+                )?;
+
                 // -------------------------------------------------------
                 // Phase 1: Set up local state.
                 // -------------------------------------------------------

--- a/crates/governance-store/src/namespace/membership.rs
+++ b/crates/governance-store/src/namespace/membership.rs
@@ -147,6 +147,22 @@ impl<'a> NamespaceMembershipService<'a> {
         &self,
         signed_invitation: &SignedGroupOpenInvitation,
     ) -> EyreResult<()> {
+        Self::verify_open_invitation_signature(signed_invitation)
+    }
+
+    /// Store-free verification of an open invitation's inviter signature:
+    /// `sha256(borsh(invitation))` checked against `inviter_identity`.
+    ///
+    /// Exposed so trust-seeding paths that run before governance state is
+    /// available (e.g. a fresh joiner writing its local `admin_identity` in
+    /// `join_namespace` / the `join_group` handler) can reject a forged
+    /// invitation up front. This is only the cryptographic check — namespace
+    /// ownership, inviter permission, and expiry still require DAG state and are
+    /// enforced by [`Self::validate_open_invitation`] on the responder and by
+    /// the deterministic apply-time check.
+    pub fn verify_open_invitation_signature(
+        signed_invitation: &SignedGroupOpenInvitation,
+    ) -> EyreResult<()> {
         let inv = &signed_invitation.invitation;
         let inviter_pk = PublicKey::from(inv.inviter_identity.to_bytes());
         let invitation_bytes = borsh::to_vec(inv).map_err(|e| eyre::eyre!("borsh: {e}"))?;

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -151,6 +151,27 @@ fn validate_open_invitation_rejects_forged_inviter_signature() {
 }
 
 #[test]
+fn verify_open_invitation_signature_accepts_valid_rejects_forged() {
+    // Store-free crypto gate used by the join trust-seed paths.
+    let mut rng = rand::rngs::OsRng;
+    let admin_sk = PrivateKey::random(&mut rng);
+    let gid = test_group_id();
+
+    let signed = test_signed_invitation(&admin_sk, gid, 9_999_999_999);
+    assert!(
+        NamespaceMembershipService::verify_open_invitation_signature(&signed).is_ok(),
+        "a correctly-signed invitation must verify"
+    );
+
+    let mut forged = signed;
+    forged.inviter_signature = hex::encode([0u8; 64]);
+    assert!(
+        NamespaceMembershipService::verify_open_invitation_signature(&forged).is_err(),
+        "a forged inviter signature must be rejected (store-free path)"
+    );
+}
+
+#[test]
 fn validate_open_invitation_rejects_unauthorized_inviter() {
     let mut rng = rand::rngs::OsRng;
     let store = test_store();

--- a/crates/node/src/join_namespace.rs
+++ b/crates/node/src/join_namespace.rs
@@ -129,6 +129,16 @@ pub async fn join_namespace(
         return Err(JoinError::InvalidInvitation("invitation expired".into()));
     }
 
+    // step 1b: verify the invitation's inviter signature before it seeds any
+    // local trust. The `admin_identity` written in step 2b becomes the local
+    // root of trust for readiness-beacon / ack / heartbeat verification and
+    // `is_admin`, and genesis won't overwrite a seeded non-placeholder admin —
+    // so a forged invitation must never reach the seed.
+    calimero_context::group_store::NamespaceMembershipService::verify_open_invitation_signature(
+        &invitation,
+    )
+    .map_err(|e| JoinError::InvalidInvitation(format!("invalid invitation signature: {e}")))?;
+
     // step 2: provision identity (mark_membership_pending equivalent —
     // the namespace identity row IS the local pending marker until
     // MemberJoined ack arrives).

--- a/crates/node/src/join_namespace.rs
+++ b/crates/node/src/join_namespace.rs
@@ -164,8 +164,12 @@ pub async fn join_namespace(
     // — `await_first_fresh_beacon` then always times out, defeating the
     // J6 fast path (#2269 review issue #1).
     //
-    // The invitation is admin-signed, so `inviter_identity` is by
-    // definition an authorized namespace member. Writing a minimal
+    // The invitation's inviter signature is verified above (step 1b), which
+    // proves the sender controls `inviter_identity`'s key. Whether that identity
+    // is actually a namespace admin needs DAG state a fresh joiner doesn't have
+    // yet, so that check is deferred to `validate_open_invitation` on the
+    // responder and re-enforced at apply time; seeding it here is a bounded local
+    // trust bootstrap that genesis later reconciles. Writing a minimal
     // `GroupMeta { admin_identity: inviter, ... }` makes
     // `namespace_member_pubkeys` include the inviter (the meta-admin
     // is added by `namespace_member_pubkeys` even without a member row),
@@ -360,6 +364,15 @@ pub async fn await_namespace_ready(
     sender_key.zeroize();
     let signing_key = PrivateKey::from(my_sk_bytes);
     my_sk_bytes.zeroize();
+
+    // Defense-in-depth: verify the invitation signature here too, so this entry
+    // point is self-contained regardless of call order. The `join_namespace`
+    // fast path already verifies before seeding, but a direct/refactored caller
+    // of `await_namespace_ready` must not be able to bypass the check.
+    calimero_context::group_store::NamespaceMembershipService::verify_open_invitation_signature(
+        &invitation,
+    )
+    .map_err(|e| ReadyError::InvalidInvitation(format!("invalid invitation signature: {e}")))?;
 
     // step 3: publish MemberJoined via three-phase contract.
     // Local fast-fail on an already-expired invitation; the


### PR DESCRIPTION
## Summary

Closes a trust-seeding gap: a joiner wrote its local `admin_identity` from an **unverified** invitation.

## Before

Both joiner-local seed paths wrote `GroupMetaValue.admin_identity` from `invitation.invitation.inviter_identity` with **no signature check** (only expiry was validated locally):
- `crates/node/src/join_namespace.rs` (J6 fast path)
- `crates/context/src/handlers/join_group.rs` (the admin-API join path)

That `admin_identity` is the joiner's local **root of trust**: `MembershipRepository::namespace_pubkeys` unconditionally adds it, so it gates `verify_readiness_beacon`, `verify_ack`, `verify_migration_heartbeat`, and `is_admin`. Worse, the genesis handler treats a namespace as "established" once `admin_identity != placeholder`, so a seeded (possibly forged) real admin is **not** overwritten when the authoritative `NamespaceCreated` op later arrives. → a forged invitation could seed a malicious admin.

## After

The existing inviter-signature crypto is exposed as a store-free public helper and called **before** the seed in both paths:

```rust
NamespaceMembershipService::verify_open_invitation_signature(&invitation)?; // sha256(borsh(inv)) vs inviter_identity
```

- The private `verify_inviter_signature` now delegates to the new public fn (no logic duplication).
- On a bad/forged signature the join is rejected before any local trust is written.

Only the **cryptographic** check runs at seed time — namespace ownership, inviter permission, and expiry need DAG state the fresh joiner lacks, and remain enforced by `validate_open_invitation` on the responder plus the deterministic apply-time check (`verify_member_join_signature`).

## Verification

- `cargo check` on governance-store / context / node passes.
- New store-free unit test `verify_open_invitation_signature_accepts_valid_rejects_forged` (valid signature verifies; zeroed signature rejected). Existing `validate_open_invitation_rejects_forged_inviter_signature` still passes (now exercises the delegated path).

Finding #4 from the node/network security review (HIGH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)