### PR TITLE
fix(client): preserve reverse-proxy base path for token refresh & auth probe

### DIFF
--- a/crates/client/src/connection.rs
+++ b/crates/client/src/connection.rs
@@ -612,9 +612,13 @@ where
                     Ok(AuthMode::Required)
                 }
             }
-            Err(_) => {
-                // If we can't reach the endpoint, assume no authentication required
-                // This is common for local nodes that don't have the admin API enabled
+            Err(e) => {
+                // If we can't reach the endpoint, assume no authentication
+                // required — common for local nodes without the admin API. This
+                // also fires when a reverse-proxy base path is misconfigured or
+                // the proxy is down, so log the cause at debug to make that
+                // diagnosable rather than silently skipping auth.
+                tracing::debug!("detect_auth_mode: probe request failed, assuming no auth: {e}");
                 Ok(AuthMode::None)
             }
         }

--- a/crates/client/src/connection.rs
+++ b/crates/client/src/connection.rs
@@ -506,7 +506,11 @@ where
     }
 
     async fn try_refresh_token(&self, access_token: &str, refresh_token: &str) -> Result<JwtToken> {
-        let refresh_url = self.api_url.join("/auth/refresh")?;
+        // Resolve via `resolve_path` (not a raw `join`) so a reverse-proxy base
+        // path on `api_url` is preserved — an absolute `join("/auth/refresh")`
+        // would drop it and send the refresh to the wrong origin, the same class
+        // of bug the request/ws_url paths already guard against.
+        let refresh_url = resolve_path(&self.api_url, "auth/refresh")?;
 
         #[derive(serde::Serialize)]
         struct RefreshRequest {
@@ -588,7 +592,10 @@ where
     pub async fn detect_auth_mode(&self) -> Result<AuthMode> {
         // Probe a protected endpoint — if it returns 401, auth is required.
         // admin-api/health is intentionally public, so we probe a protected endpoint instead.
-        let probe_url = self.api_url.join("admin-api/contexts")?;
+        // Use `resolve_path` so a reverse-proxy base path is preserved and the
+        // probe doesn't depend on `api_url` having a trailing slash (a raw
+        // relative `join` drops the last base segment when it doesn't).
+        let probe_url = resolve_path(&self.api_url, "admin-api/contexts")?;
 
         match self.client.get(probe_url).send().await {
             Ok(response) => {

--- a/crates/client/src/connection.rs
+++ b/crates/client/src/connection.rs
@@ -34,6 +34,11 @@ pub(crate) const MAX_JSON_BODY_BYTES: usize = 16 * 1024 * 1024;
 /// message. Error bodies should be tiny; cap them hard.
 const MAX_ERROR_BODY_BYTES: usize = 64 * 1024;
 
+/// Maximum size of a token endpoint response body. A refresh response is just a
+/// pair of JWT strings, so cap it far below the general JSON limit — the auth
+/// path shouldn't let a hostile/misconfigured proxy buffer megabytes.
+const MAX_TOKEN_BODY_BYTES: usize = 64 * 1024;
+
 /// Maximum size of a binary (blob) response body. Larger than the JSON cap
 /// because blobs are the data plane, but still bounded so a lying
 /// `Content-Length` or an endless stream can't exhaust memory.
@@ -556,7 +561,7 @@ where
             ));
         }
 
-        let body = read_body_capped(response, MAX_JSON_BODY_BYTES).await?;
+        let body = read_body_capped(response, MAX_TOKEN_BODY_BYTES).await?;
         let wrapped_response: WrappedResponse = serde_json::from_slice(&body)?;
 
         Ok(JwtToken::with_refresh(

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -1179,3 +1179,86 @@ async fn traversal_path_is_rejected_before_send() {
         client.connection().get("admin-api/groups/../evil").await;
     assert!(result.is_err());
 }
+
+// ---- Reverse-proxy base-path preservation ----
+//
+// When `api_url` carries a mount path (a node behind a reverse proxy), every
+// endpoint the connection reaches — requests, token refresh, and the auth-mode
+// probe — must stay under that base path rather than resetting to the host root.
+
+#[tokio::test]
+async fn detect_auth_mode_preserves_base_path() {
+    let server = MockServer::start().await;
+    // Only the base-path-prefixed probe is mocked → 200 = AuthMode::None. If the
+    // base path were dropped the probe would hit `/admin-api/contexts` (unmocked
+    // → 404 → AuthMode::Required), so asserting `None` proves it was preserved.
+    Mock::given(method("GET"))
+        .and(path("/proxy/base/admin-api/contexts"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"data": []})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let base = Url::parse(&format!("{}/proxy/base/", server.uri())).unwrap();
+    let client = make_client(&base);
+    let mode = client.connection().detect_auth_mode().await.unwrap();
+    assert!(matches!(mode, crate::connection::AuthMode::None));
+}
+
+#[tokio::test]
+async fn token_refresh_preserves_base_path() {
+    let server = MockServer::start().await;
+
+    // Protected endpoint under the base path: 401 once, then 200.
+    Mock::given(method("GET"))
+        .and(path("/proxy/base/admin-api/contexts"))
+        .respond_with(ResponseTemplate::new(401))
+        .up_to_n_times(1)
+        .with_priority(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/proxy/base/admin-api/contexts"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+        .with_priority(2)
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // The refresh endpoint is mocked ONLY at the base-path-prefixed URL. If the
+    // refresh used an absolute `/auth/refresh` it would miss this mock, the
+    // refresh would fail, and the flow would fall back to interactive auth —
+    // so `expect(1)` here (plus `authenticate` never being called) proves the
+    // base path was preserved for the refresh POST.
+    Mock::given(method("POST"))
+        .and(path("/proxy/base/auth/refresh"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": { "access_token": "new-access", "refresh_token": "new-refresh" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Seed a token that carries a refresh token so the 401 drives the refresh
+    // path (not the interactive-auth fallback).
+    let storage = MemStorage {
+        token: Arc::new(StdMutex::new(Some(JwtToken::with_refresh(
+            "initial-access".to_owned(),
+            "refresh-tok".to_owned(),
+        )))),
+    };
+    let auth_calls = Arc::new(StdMutex::new(0));
+    let auth = MemAuth {
+        calls: Arc::clone(&auth_calls),
+    };
+    let base = Url::parse(&format!("{}/proxy/base/", server.uri())).unwrap();
+    let conn = Conn::new(base, Some("node".to_owned()), auth, storage);
+    let client = Client::new(conn).unwrap();
+
+    let resp: serde_json::Value = client.connection().get("admin-api/contexts").await.unwrap();
+
+    assert_eq!(resp["ok"], serde_json::Value::Bool(true));
+    // Refresh succeeded via the base-path URL, so interactive auth was not used.
+    assert_eq!(*auth_calls.lock().unwrap(), 0);
+}

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -1190,8 +1190,10 @@ async fn traversal_path_is_rejected_before_send() {
 async fn detect_auth_mode_preserves_base_path() {
     let server = MockServer::start().await;
     // Only the base-path-prefixed probe is mocked → 200 = AuthMode::None. If the
-    // base path were dropped the probe would hit `/admin-api/contexts` (unmocked
-    // → 404 → AuthMode::Required), so asserting `None` proves it was preserved.
+    // base path were dropped the probe would hit `/admin-api/contexts`, which is
+    // unmocked — wiremock answers unmatched routes with 404, and `detect_auth_mode`
+    // maps a non-401 non-2xx status to AuthMode::Required. So asserting `None`
+    // (not `Required`) proves the prefixed path was hit and returned 200.
     Mock::given(method("GET"))
         .and(path("/proxy/base/admin-api/contexts"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"data": []})))


### PR DESCRIPTION
## Summary

Follow-up to #3142. That PR made request and WebSocket URLs preserve a reverse-proxy base path on `api_url`, but left two sibling calls using raw `Url::join` that discard it — so a node behind a proxy mount path (e.g. `https://host/calimero/node1/`) had working admin-api + WS but broken token refresh and auth-mode detection.

| Site | Before | Problem |
|---|---|---|
| `try_refresh_token` (`connection.rs`) | `api_url.join("/auth/refresh")` | Absolute join → refresh POST goes to `https://host/auth/refresh`, dropping the base path (bearer-bearing request to the wrong origin). |
| `detect_auth_mode` (`connection.rs`) | `api_url.join("admin-api/contexts")` | Relative join → drops the last base segment when `api_url` has no trailing slash (`.../node1` → `.../admin-api/contexts`). |

Both now go through the existing base-path-preserving `resolve_path` helper (the same one requests already use), so refresh and probe stay under the mount path. `resolve_path` also uses `path_segments_mut` append, so the result is correct with or without a trailing slash.

## Testing
- New wiremock tests: `token_refresh_preserves_base_path` (asserts the refresh POST hits `<base>/auth/refresh` and interactive auth is never reached) and `detect_auth_mode_preserves_base_path` (probe hits `<base>/admin-api/contexts`).
- `cargo test -p calimero-client` → 62 passed.
- `cargo clippy -p calimero-client -p meroctl --all-targets -- -D warnings` → clean.
- No `Cargo.toml`/`Cargo.lock` change (no new deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)