### PR TITLE
fix(node): don't trust peer's claimed snapshot root on local hash error

### DIFF
--- a/crates/node/src/sync/snapshot.rs
+++ b/crates/node/src/sync/snapshot.rs
@@ -357,12 +357,13 @@ impl SyncManager {
             .await?;
 
         // Verify snapshot integrity by computing the actual root hash from storage (I7).
-        // On success we always trust the locally-computed hash because it reflects what
-        // is actually persisted -- storing the peer's claimed hash when it disagrees
-        // with local storage would create a silent divergence.
-        // On failure (deserialization error) we fall back to the peer's claimed hash so
-        // that sync can still proceed; compute_root_hash may fail if the minimal structs
-        // drift from the real storage layout.
+        // We always persist the locally-computed hash because it reflects what is
+        // actually persisted; storing the peer's claimed hash would risk a silent
+        // divergence. If the local compute fails we must NOT fall back to the peer's
+        // claimed root — that would persist an unverified, peer-supplied value on a
+        // purely local error. Instead we fail the sync here; the sync-in-progress
+        // marker is left set (we return before clearing it), so crash-recovery
+        // re-syncs and retries rather than accepting an untrusted root.
         let root_to_store = match self.context_client.compute_root_hash(&context_id) {
             Ok(computed_root) => {
                 if computed_root != *boundary.boundary_root_hash {
@@ -386,9 +387,12 @@ impl SyncManager {
                     %context_id,
                     error = %e,
                     claimed_root = %hex::encode(*boundary.boundary_root_hash),
-                    "Could not compute root hash, trusting peer's claimed hash"
+                    "Could not compute local root hash; refusing to trust peer's claimed \
+                     root, failing sync for retry"
                 );
-                *boundary.boundary_root_hash
+                return Err(eyre::eyre!(
+                    "snapshot verify: could not compute local root hash for {context_id}: {e}"
+                ));
             }
         };
 


### PR DESCRIPTION
## Summary

Removes a fallback where a **local** error caused the node to persist a **peer-supplied** root hash.

## Before

`request_snapshot_sync` (`crates/node/src/sync/snapshot.rs`) verifies the applied snapshot by recomputing the root hash locally. If the local `compute_root_hash` returned `Err`, it fell back to the peer's claimed root:

```rust
Err(e) => {
    warn!(..., "Could not compute root hash, trusting peer's claimed hash");
    *boundary.boundary_root_hash        // <-- unverified, peer-supplied
}
// ... force_root_hash(root_to_store)
```

So a local read/parse error → the node persists whatever root the peer claimed.

## After

The `Err` arm now **fails the sync** instead of trusting the peer:

```rust
Err(e) => {
    warn!(..., "Could not compute local root hash; refusing to trust peer's claimed root, failing sync for retry");
    return Err(eyre::eyre!("snapshot verify: could not compute local root hash for {context_id}: {e}"));
}
```

The early return happens **before** `clear_sync_in_progress_marker`, so the in-progress marker is left set and crash-recovery re-syncs/retries — rather than dead-ending or accepting an untrusted root.

## Scope

Low severity: not attacker-triggerable (`compute_root_hash` errors only on local store/layout issues, not on peer input), and snapshot entities are independently signature-verified on apply — so this only ever corrupted the persisted root-hash *metadata* used for divergence detection. Still, a local error should never make the node trust the peer.

## Verification

- `cargo check -p calimero-node` passes.

Finding #11 from the node/network security review (LOW).

🤖 Generated with [Claude Code](https://claude.com/claude-code)