### PR TITLE
feat(server): configurable CORS origin allowlist + private-network toggle

### DIFF
--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -66,6 +66,23 @@ impl Default for CorsConfig {
     }
 }
 
+impl CorsConfig {
+    /// Fail fast on a misconfigured allowlist: every entry in `allowed_origins`
+    /// must parse as a valid origin header value. Called at startup so a typo in
+    /// a security-sensitive origin list is an immediate, actionable error rather
+    /// than a silently-narrowed (or empty) allowlist discovered at runtime.
+    pub fn validate(&self) -> Result<(), String> {
+        if let Some(origins) = &self.allowed_origins {
+            for origin in origins {
+                if axum::http::HeaderValue::from_str(origin).is_err() {
+                    return Err(format!("invalid entry in cors.allowed_origins: {origin:?}"));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ServerConfig {

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -25,6 +25,47 @@ pub enum AuthMode {
     Embedded,
 }
 
+const fn default_allow_private_network() -> bool {
+    // Preserve historical behavior when unset (see `CorsConfig`). Deployments
+    // that don't need public-page → private-node access should set this to
+    // `false` and configure `allowed_origins`.
+    true
+}
+
+/// Cross-origin policy for the HTTP layer.
+///
+/// Defaults preserve the historical permissive behavior (any origin, private
+/// network allowed) so existing browser apps / Tauri webviews keep working.
+/// Production deployments should set an explicit `allowed_origins` list and set
+/// `allow_private_network = false` — a wildcard origin combined with private
+/// network access lets any visited website drive authenticated requests against
+/// a local/private node once a token leaks into a URL (`?token=`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CorsConfig {
+    /// Exact origins permitted to make cross-origin requests. `None` (the
+    /// default) allows **any** origin. `Some(list)` restricts to that list.
+    #[serde(default)]
+    pub allowed_origins: Option<Vec<String>>,
+
+    /// Whether to advertise `Access-Control-Allow-Private-Network`, which lets a
+    /// more-public page reach this (private) node. Defaults to `true` to
+    /// preserve the historical behavior; set to `false` (together with an
+    /// `allowed_origins` list) to remove the wildcard-origin + private-network
+    /// combination that lets any website drive authenticated requests.
+    #[serde(default = "default_allow_private_network")]
+    pub allow_private_network: bool,
+}
+
+impl Default for CorsConfig {
+    fn default() -> Self {
+        Self {
+            allowed_origins: None,
+            allow_private_network: default_allow_private_network(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ServerConfig {
@@ -43,6 +84,8 @@ pub struct ServerConfig {
     pub auth_mode: AuthMode,
 
     pub embedded_auth: Option<AuthConfig>,
+
+    pub cors: CorsConfig,
 }
 
 impl ServerConfig {
@@ -64,6 +107,10 @@ impl ServerConfig {
             sse,
             auth_mode: AuthMode::Proxy,
             embedded_auth: None,
+            cors: CorsConfig {
+                allowed_origins: None,
+                allow_private_network: true,
+            },
         }
     }
 
@@ -90,6 +137,10 @@ impl ServerConfig {
             sse,
             auth_mode,
             embedded_auth,
+            cors: CorsConfig {
+                allowed_origins: None,
+                allow_private_network: true,
+            },
         }
     }
 

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -68,19 +68,47 @@ impl Default for CorsConfig {
 
 impl CorsConfig {
     /// Fail fast on a misconfigured allowlist: every entry in `allowed_origins`
-    /// must parse as a valid origin header value. Called at startup so a typo in
-    /// a security-sensitive origin list is an immediate, actionable error rather
-    /// than a silently-narrowed (or empty) allowlist discovered at runtime.
+    /// must be a concrete origin (`scheme://host[:port]`). Called at startup so a
+    /// typo in a security-sensitive origin list is an immediate, actionable error
+    /// rather than a silently-narrowed (or empty) allowlist discovered at runtime.
     pub fn validate(&self) -> Result<(), String> {
         if let Some(origins) = &self.allowed_origins {
             for origin in origins {
                 if axum::http::HeaderValue::from_str(origin).is_err() {
-                    return Err(format!("invalid entry in cors.allowed_origins: {origin:?}"));
+                    return Err(format!(
+                        "invalid entry in cors.allowed_origins (not a valid header value): \
+                         {origin:?}"
+                    ));
+                }
+                // tower-http compares allowlist entries against the browser's
+                // `Origin` header by exact string, so entries must be concrete
+                // origins. Reject `*`, `null`, path-bearing, or scheme-less
+                // values — these are almost always operator mistakes and would
+                // silently match nothing.
+                if !is_valid_origin(origin) {
+                    return Err(format!(
+                        "invalid entry in cors.allowed_origins (expected scheme://host[:port]): \
+                         {origin:?}"
+                    ));
                 }
             }
         }
         Ok(())
     }
+}
+
+/// Whether `s` is a concrete CORS origin: `http`/`https` scheme, a non-empty
+/// host[:port], and no path/query/fragment (browsers send `Origin` without a
+/// trailing slash). Rejects `*`, `null`, and malformed values.
+fn is_valid_origin(s: &str) -> bool {
+    let Some((scheme, rest)) = s.split_once("://") else {
+        return false;
+    };
+    matches!(scheme, "http" | "https")
+        && !rest.is_empty()
+        && !rest.contains('/')
+        && !rest.contains('?')
+        && !rest.contains('#')
 }
 
 #[derive(Debug, Clone)]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -229,11 +229,22 @@ fn build_cors_layer(cors: &crate::config::CorsConfig) -> CorsLayer {
                 .filter_map(|o| match axum::http::HeaderValue::from_str(o) {
                     Ok(v) => Some(v),
                     Err(err) => {
-                        tracing::warn!(origin = %o, %err, "ignoring invalid CORS origin");
+                        // A dropped origin silently weakens a security-sensitive
+                        // allowlist, so surface it loudly (error, not warn).
+                        tracing::error!(origin = %o, %err, "invalid CORS origin dropped from allowlist");
                         None
                     }
                 })
                 .collect();
+            // A configured-but-all-invalid allowlist refuses every origin —
+            // safe, but almost certainly a misconfiguration. Flag it clearly.
+            if list.is_empty() && !origins.is_empty() {
+                tracing::error!(
+                    configured = origins.len(),
+                    "CORS allowed_origins is set but no entry parsed as a valid origin; \
+                     all cross-origin requests will be refused"
+                );
+            }
             layer.allow_origin(AllowOrigin::list(list))
         }
         None => layer.allow_origin(Any),

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -69,6 +69,12 @@ pub async fn start(
 ) -> EyreResult<()> {
     let mut config = config;
 
+    // Fail fast on a misconfigured CORS allowlist rather than silently serving a
+    // narrower-than-intended (or empty) origin set at runtime.
+    if let Err(e) = config.cors.validate() {
+        bail!("invalid CORS configuration: {e}");
+    }
+
     // Register HTTP request metrics on the same registry before the
     // metrics service consumes ownership of it via `mount_runtime_services`
     // → `metrics::service`. The middleware below will resolve the handle

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -161,7 +161,7 @@ pub async fn start(
         .layer(axum::middleware::from_fn(crate::metrics::track_request))
         .layer(Extension(http_metrics));
 
-    app = app.layer(build_cors_layer());
+    app = app.layer(build_cors_layer(&config.cors));
 
     let mut set = JoinSet::new();
 
@@ -190,12 +190,19 @@ pub async fn start(
 ///
 /// **`allow_credentials` is intentionally not set.** It is incompatible with
 /// `allow_origin(Any)` per the CORS spec, so adding it here would be a no-op
-/// for browsers in the current configuration. If credentialed requests
-/// (cookies, TLS client certs) ever become required, `allow_origin(Any)`
-/// must first be replaced with an explicit allow-list of trusted origins.
-fn build_cors_layer() -> CorsLayer {
-    CorsLayer::new()
-        .allow_origin(Any)
+/// for browsers in the current configuration.
+///
+/// Origins and private-network access are driven by [`crate::config::CorsConfig`].
+/// The default (`allowed_origins: None`) preserves the historical permissive
+/// `Any` + private-network behavior so existing browser apps / Tauri webviews /
+/// deployed apps that reach a user's local node keep working. Production
+/// deployments should set an explicit `allowed_origins` list (and
+/// `allow_private_network = false`) to remove the wildcard-origin +
+/// private-network combination.
+fn build_cors_layer(cors: &crate::config::CorsConfig) -> CorsLayer {
+    use tower_http::cors::AllowOrigin;
+
+    let layer = CorsLayer::new()
         .allow_headers(Any)
         .allow_methods([
             Method::POST,
@@ -213,7 +220,24 @@ fn build_cors_layer() -> CorsLayer {
             axum::http::HeaderName::from_static("x-auth-user"),
             axum::http::HeaderName::from_static("x-auth-permissions"),
         ])
-        .allow_private_network(true)
+        .allow_private_network(cors.allow_private_network);
+
+    match &cors.allowed_origins {
+        Some(origins) => {
+            let list: Vec<axum::http::HeaderValue> = origins
+                .iter()
+                .filter_map(|o| match axum::http::HeaderValue::from_str(o) {
+                    Ok(v) => Some(v),
+                    Err(err) => {
+                        tracing::warn!(origin = %o, %err, "ignoring invalid CORS origin");
+                        None
+                    }
+                })
+                .collect();
+            layer.allow_origin(AllowOrigin::list(list))
+        }
+        None => layer.allow_origin(Any),
+    }
 }
 
 #[cfg(test)]
@@ -266,7 +290,7 @@ mod cors_tests {
     {
         Router::new()
             .route("/x", get(handler))
-            .layer(build_cors_layer())
+            .layer(build_cors_layer(&crate::config::CorsConfig::default()))
     }
 
     /// Browser preflight for the PATCH-backed admin routes (e.g.
@@ -391,6 +415,59 @@ mod cors_tests {
         assert!(
             exposed.contains("x-auth-error"),
             "X-Auth-Error must be exposed to JS even on error responses; got: {exposed}"
+        );
+    }
+
+    /// With a configured allowlist, only listed origins get an
+    /// `Access-Control-Allow-Origin` echo; others are refused.
+    #[tokio::test]
+    async fn cors_allowlist_admits_only_listed_origins() {
+        let cors = crate::config::CorsConfig {
+            allowed_origins: Some(vec!["http://localhost:5173".to_owned()]),
+            allow_private_network: false,
+        };
+        let app = Router::new()
+            .route("/x", get(ok_handler))
+            .layer(build_cors_layer(&cors));
+
+        // Allowlisted origin → echoed back.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/x")
+                    .header(header::ORIGIN, "http://localhost:5173")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.headers()
+                .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .and_then(|v| v.to_str().ok()),
+            Some("http://localhost:5173"),
+            "allowlisted origin must be admitted"
+        );
+
+        // Non-allowlisted origin → no allow-origin header.
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/x")
+                    .header(header::ORIGIN, "https://evil.example")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.headers()
+                .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .is_none(),
+            "a non-allowlisted origin must not receive Access-Control-Allow-Origin"
         );
     }
 }


### PR DESCRIPTION
## Summary

Turns the hard-coded permissive CORS policy into a configurable one, so deployments can lock it down.

## Before

`build_cors_layer()` hard-coded:
```rust
.allow_origin(Any)
.allow_headers(Any)
.allow_private_network(true)
```

Combined with the by-design `?token=` query-param auth path, this lets **any website** the user visits drive authenticated cross-origin requests against a local/private node once a token ends up in a URL (history/referrer/logs). (`allow_credentials` is already off, which blocks the ambient-cookie variant.)

## After

New `CorsConfig { allowed_origins, allow_private_network }` on `ServerConfig` drives the layer:
- `allowed_origins: Some(list)` → `AllowOrigin::list(...)` (only those exact origins); `None` → `Any`.
- `allow_private_network` is configurable.
- `expose_headers` (the `x-auth-error` regression guard) is unchanged.

## Compatibility (why the default is still permissive)

A hard default flip would break real flows — notably **deployed web apps reaching a user's local node** (a public page → private node, which *requires* private-network + a permissive origin), plus studio / mero-js / Tauri origins that vary per deployment. So the default preserves today's behavior (`Any` + private-network) and the fix is **opt-in tightening**: operators set an `allowed_origins` list and `allow_private_network = false` in production.

## Verification

- `cargo test -p calimero-server --lib cors` → 4 passed (existing 3 + new `cors_allowlist_admits_only_listed_origins`).
- `cargo check -p merod` passes.

## Follow-up

Surfacing `cors` in merod's node-config TOML (so it's settable without code) is a small follow-up; this PR lands the server-side mechanism with behavior preserved.

Finding #10 from the node/network security review (MED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)