### PR TITLE
docs(node): correct rotation-log resolver docs; warn on unauthenticated variants

### DIFF
--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -829,8 +829,11 @@ impl ContextStorageApplier {
     ///
     /// Iterates the action payload, picks out Shared `Add`/`Update`/
     /// `DeleteRef`s, dedups by entity, and resolves each via
-    /// [`rotation_log_reader::writers_at`] against this applier's
-    /// `topology` view of the DAG.
+    /// [`rotation_log_reader::writers_at_authenticated`] against this applier's
+    /// `topology` view of the DAG. The authenticated resolver is mandatory here
+    /// because the rotation log rides ordinary (untrusted) sync — it verifies
+    /// each rotation entry's signature + prior-set ADMIN authority before
+    /// admitting it to the resolved writer set.
     ///
     /// Returns a map keyed by entity id; non-Shared entities are absent.
     /// An empty result is normal — a delta with only User/Frozen/Public

--- a/crates/node/src/sync/mod.rs
+++ b/crates/node/src/sync/mod.rs
@@ -60,7 +60,8 @@ mod tracking;
 // Cross-node integration tests for the four motivating partition scenarios
 // of #2197 / ADR 0001. Migrated from `calimero_storage::tests` per #2266
 // step 5 — they exercise the production sync-layer flow: load rotation log,
-// resolve `effective_writers` via `rotation_log_reader::writers_at`, apply.
+// resolve `effective_writers` via `rotation_log_reader::writers_at_authenticated`,
+// apply.
 #[cfg(test)]
 mod p3_dag_causal_tests;
 #[cfg(test)]

--- a/crates/node/src/sync/rotation_log_reader.rs
+++ b/crates/node/src/sync/rotation_log_reader.rs
@@ -27,6 +27,14 @@ use calimero_storage::rotation_log::{RotationLog, RotationLogEntry};
 /// causal context is available (snapshot leaf push, local apply).
 ///
 /// Returns `None` if the log has no entries and no snapshot.
+///
+/// # Warning: unauthenticated
+///
+/// This does NOT verify rotation-entry signatures or ADMIN authority. It must
+/// never be used on a path fed by (untrusted) sync — a forged rotation entry
+/// would silently shift the resolved writer set. Sync-fed apply paths must use
+/// [`writers_at_authenticated`]. This variant is for contexts where the log is
+/// already trusted (tests, local apply of self-authored state).
 #[must_use]
 pub fn latest_writers(log: &RotationLog) -> Option<BTreeMap<PublicKey, OpMask>> {
     if let Some(entry) = log.entries.last() {
@@ -36,6 +44,13 @@ pub fn latest_writers(log: &RotationLog) -> Option<BTreeMap<PublicKey, OpMask>> 
 }
 
 /// Returns the writer set as-of a causal point in the DAG.
+///
+/// # Warning: unauthenticated
+///
+/// This resolves the writer set WITHOUT verifying rotation-entry signatures or
+/// ADMIN authority. It must never be used on a path fed by (untrusted) sync;
+/// those paths must use [`writers_at_authenticated`], which verifies each entry
+/// before admitting it. Kept for trusted-log contexts (tests, local apply).
 ///
 /// Implements ADR 0001's merge rule end-to-end:
 /// 1. Filter entries to those reachable from `causal_parents`.


### PR DESCRIPTION
## Summary

Documentation/hardening for the rotation-log writer resolution. **The security concern in the finding is already fixed** — this makes that explicit and guards against regressions.

## Context

The finding claimed `writers_at` / `latest_writers` resolve the writer set with no signature check on a sync-fed path. On current master the production sync-fed apply path already uses `writers_at_authenticated` (`delta_store.rs:899,929`), which verifies each rotation entry's ed25519 signature + prior-set ADMIN authority before admitting it. The unauthenticated `writers_at` / `latest_writers` have **zero production callers** (test-only).

## Changes (no behavior change)

- Fix stale doc comments in `sync/mod.rs` and `delta_store.rs` that still referenced the unauthenticated `writers_at` — they now name `writers_at_authenticated` and explain why it's mandatory on sync-fed paths.
- Add a `# Warning: unauthenticated` doc block to `writers_at` and `latest_writers` so a future caller can't accidentally wire them onto untrusted (sync) input.

## Verification

- `cargo check -p calimero-node` passes. The existing authenticated-fold tests (`authenticated_fold_rejects_unauthorized_rotation`, `..._rejects_bad_signature`) already cover the real security boundary.

Finding #8 from the node/network security review (verified ALREADY FIXED; this closes it with accurate docs + guardrails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)