### PR TITLE
feat(server): optional path confinement for install-dev-application

### DIFF
--- a/crates/server/src/admin/handlers/applications/install_dev_application.rs
+++ b/crates/server/src/admin/handlers/applications/install_dev_application.rs
@@ -22,20 +22,29 @@ const DEV_INSTALL_ROOT_ENV: &str = "MEROD_DEV_INSTALL_ROOT";
 
 /// When `MEROD_DEV_INSTALL_ROOT` is set, require `path` to resolve within it.
 /// Returns `Ok(())` when unset (historical behavior) or when confined.
+///
+/// The `Err` string is deliberately generic — detailed reasons (including the
+/// operator-configured root and OS errno) are logged server-side only, so the
+/// endpoint never discloses server filesystem layout to the caller.
 fn check_dev_install_confinement(path: &str) -> Result<(), String> {
     let Ok(root) = std::env::var(DEV_INSTALL_ROOT_ENV) else {
         return Ok(());
     };
-    let canon_root = std::fs::canonicalize(&root)
-        .map_err(|e| format!("invalid {DEV_INSTALL_ROOT_ENV} ('{root}'): {e}"))?;
-    let canon_path =
-        std::fs::canonicalize(path).map_err(|e| format!("cannot resolve install path: {e}"))?;
+    let canon_root = std::fs::canonicalize(&root).map_err(|e| {
+        error!(root = %root, error = %e, "invalid MEROD_DEV_INSTALL_ROOT");
+        "server misconfiguration: dev-install root is unavailable".to_owned()
+    })?;
+    let canon_path = std::fs::canonicalize(path).map_err(|e| {
+        warn!(path = %path, error = %e, "dev-install path could not be resolved");
+        "install path could not be resolved".to_owned()
+    })?;
+    // `Path::starts_with` is component-aware, so a root of "/srv/app" does NOT
+    // match "/srv/application/x" — no string-prefix false positives.
     if canon_path.starts_with(&canon_root) {
         Ok(())
     } else {
-        Err(format!(
-            "install path is outside the configured {DEV_INSTALL_ROOT_ENV}"
-        ))
+        warn!(path = %path, "dev-install path is outside the configured root");
+        Err("install path is not permitted".to_owned())
     }
 }
 
@@ -45,8 +54,9 @@ pub async fn handler(
 ) -> impl IntoResponse {
     info!(path=%req.path, "Installing dev application");
 
+    // Detailed reason is logged inside the check; `msg` is a generic,
+    // caller-safe string.
     if let Err(msg) = check_dev_install_confinement(req.path.as_str()) {
-        warn!(path=%req.path, "{msg}");
         return ApiError {
             status_code: StatusCode::FORBIDDEN,
             message: msg,

--- a/crates/server/src/admin/handlers/applications/install_dev_application.rs
+++ b/crates/server/src/admin/handlers/applications/install_dev_application.rs
@@ -4,17 +4,55 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Extension;
 use calimero_server_primitives::admin::{InstallApplicationResponse, InstallDevApplicationRequest};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::admin::handlers::validation::ValidatedJson;
-use crate::admin::service::ApiResponse;
+use crate::admin::service::{ApiError, ApiResponse};
 use crate::AdminState;
+
+/// Env var that, when set, confines `install-dev-application` to a directory.
+///
+/// This endpoint reads an arbitrary node-local filesystem path and exposes its
+/// bytes as a blob. It is admin-auth gated and rejects `..` traversal, and
+/// reading the node owner's own files is not a privilege boundary — so absolute
+/// paths are allowed by default. Operators who want to lock the endpoint down
+/// (e.g. a shared/managed node) can set `MEROD_DEV_INSTALL_ROOT` to a directory;
+/// dev installs then only succeed for paths that resolve within it.
+const DEV_INSTALL_ROOT_ENV: &str = "MEROD_DEV_INSTALL_ROOT";
+
+/// When `MEROD_DEV_INSTALL_ROOT` is set, require `path` to resolve within it.
+/// Returns `Ok(())` when unset (historical behavior) or when confined.
+fn check_dev_install_confinement(path: &str) -> Result<(), String> {
+    let Ok(root) = std::env::var(DEV_INSTALL_ROOT_ENV) else {
+        return Ok(());
+    };
+    let canon_root = std::fs::canonicalize(&root)
+        .map_err(|e| format!("invalid {DEV_INSTALL_ROOT_ENV} ('{root}'): {e}"))?;
+    let canon_path =
+        std::fs::canonicalize(path).map_err(|e| format!("cannot resolve install path: {e}"))?;
+    if canon_path.starts_with(&canon_root) {
+        Ok(())
+    } else {
+        Err(format!(
+            "install path is outside the configured {DEV_INSTALL_ROOT_ENV}"
+        ))
+    }
+}
 
 pub async fn handler(
     Extension(state): Extension<Arc<AdminState>>,
     ValidatedJson(req): ValidatedJson<InstallDevApplicationRequest>,
 ) -> impl IntoResponse {
     info!(path=%req.path, "Installing dev application");
+
+    if let Err(msg) = check_dev_install_confinement(req.path.as_str()) {
+        warn!(path=%req.path, "{msg}");
+        return ApiError {
+            status_code: StatusCode::FORBIDDEN,
+            message: msg,
+        }
+        .into_response();
+    }
     let metadata_len = req.metadata.len();
     debug!(
         path=%req.path,

--- a/crates/server/src/admin/handlers/applications/install_dev_application.rs
+++ b/crates/server/src/admin/handlers/applications/install_dev_application.rs
@@ -30,15 +30,17 @@ const DEV_INSTALL_ROOT_ENV: &str = "MEROD_DEV_INSTALL_ROOT";
 /// The `Err` string is deliberately generic — detailed reasons (including the
 /// operator-configured root and OS errno) are logged server-side only, so the
 /// endpoint never discloses server filesystem layout to the caller.
-fn check_dev_install_confinement(path: &str) -> Result<(), String> {
+async fn check_dev_install_confinement(path: &str) -> Result<(), String> {
     let Ok(root) = std::env::var(DEV_INSTALL_ROOT_ENV) else {
         return Ok(());
     };
-    let canon_root = std::fs::canonicalize(&root).map_err(|e| {
+    // Use the async filesystem API so the stat/readlink syscalls don't block the
+    // executor thread.
+    let canon_root = tokio::fs::canonicalize(&root).await.map_err(|e| {
         error!(root = %root, error = %e, "invalid MEROD_DEV_INSTALL_ROOT");
         "server misconfiguration: dev-install root is unavailable".to_owned()
     })?;
-    let canon_path = std::fs::canonicalize(path).map_err(|e| {
+    let canon_path = tokio::fs::canonicalize(path).await.map_err(|e| {
         warn!(path = %path, error = %e, "dev-install path could not be resolved");
         "install path could not be resolved".to_owned()
     })?;
@@ -60,7 +62,7 @@ pub async fn handler(
 
     // Detailed reason is logged inside the check; `msg` is a generic,
     // caller-safe string.
-    if let Err(msg) = check_dev_install_confinement(req.path.as_str()) {
+    if let Err(msg) = check_dev_install_confinement(req.path.as_str()).await {
         return ApiError {
             status_code: StatusCode::FORBIDDEN,
             message: msg,

--- a/crates/server/src/admin/handlers/applications/install_dev_application.rs
+++ b/crates/server/src/admin/handlers/applications/install_dev_application.rs
@@ -18,6 +18,10 @@ use crate::AdminState;
 /// paths are allowed by default. Operators who want to lock the endpoint down
 /// (e.g. a shared/managed node) can set `MEROD_DEV_INSTALL_ROOT` to a directory;
 /// dev installs then only succeed for paths that resolve within it.
+///
+/// Note: when confinement is enabled the target must exist at request time —
+/// confinement resolves the path with `canonicalize`, which fails (request
+/// refused) for a missing file or a dangling symlink.
 const DEV_INSTALL_ROOT_ENV: &str = "MEROD_DEV_INSTALL_ROOT";
 
 /// When `MEROD_DEV_INSTALL_ROOT` is set, require `path` to resolve within it.


### PR DESCRIPTION
## Summary

Adds an opt-in lockdown for the `install-dev-application` endpoint, which reads an arbitrary node-local path and exposes its bytes as a blob.

## Before

The endpoint accepts any absolute path (its `..`-traversal check and admin-auth gate are already in place). Reading the node owner's own filesystem is not a privilege boundary, and `meroctl app install --path /abs/build/app.wasm` depends on absolute paths — so there was no way to restrict it on a shared/managed node.

## After

When the `MEROD_DEV_INSTALL_ROOT` env var is set, a dev-install path must **canonicalize within** that directory or the request is refused with **403**. When it's unset, behavior is exactly as before.

- Self-contained in the handler (no config-struct plumbing); mirrors the existing `MEROD_*` env pattern (e.g. `--mock-tee`).
- Non-breaking: default (unset) preserves the current admin-gated, absolute-path-allowed behavior.

## Scope

Defense-in-depth for the by-design behavior — the endpoint remains admin-auth gated and traversal-checked regardless. Operators who want hard confinement now have a switch.

## Verification

- `cargo check -p calimero-server` passes.

Finding #2 from the node/network security review (traversal already fixed; this adds opt-in confinement for the by-design absolute-path read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)