### PR TITLE
fix(context,runtime): bound local xcall cascade (breadth 8, depth 3)

### DIFF
--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -1460,13 +1460,16 @@ impl ContextClient {
         aliases: Vec<Alias<PublicKey>>,
         atomic: Option<ContextAtomic>,
     ) -> Result<ExecuteResponse, ExecuteError> {
-        self.execute_with_origin(context_id, executor, method, payload, aliases, atomic, None)
-            .await
+        self.execute_with_origin(
+            context_id, executor, method, payload, aliases, atomic, None, 0,
+        )
+        .await
     }
 
     /// Like [`execute`](Self::execute), but tags the run with the source
     /// context that dispatched it via `xcall`, surfaced to the guest as
-    /// `env::xcall_origin()`. Pass `None` for a direct/RPC call.
+    /// `env::xcall_origin()`. Pass `None`/`0` for a direct/RPC call; the xcall
+    /// dispatch loop passes `Some(source)` and `parent_depth + 1`.
     #[allow(clippy::too_many_arguments, reason = "execution context is wide")]
     pub async fn execute_with_origin(
         &self,
@@ -1477,6 +1480,7 @@ impl ContextClient {
         aliases: Vec<Alias<PublicKey>>,
         atomic: Option<ContextAtomic>,
         xcall_origin: Option<ContextId>,
+        xcall_depth: u32,
     ) -> Result<ExecuteResponse, ExecuteError> {
         let (sender, receiver) = oneshot::channel();
 
@@ -1490,6 +1494,7 @@ impl ContextClient {
                     aliases,
                     atomic,
                     xcall_origin,
+                    xcall_depth,
                 },
                 outcome: sender,
             })

--- a/crates/context/primitives/src/messages.rs
+++ b/crates/context/primitives/src/messages.rs
@@ -82,6 +82,12 @@ pub struct ExecuteRequest {
     /// Source context when this execution is dispatched via `xcall`; `None`
     /// for direct/RPC calls. Surfaced to the guest via `env::xcall_origin()`.
     pub xcall_origin: Option<ContextId>,
+    /// Depth of this execution in a local xcall cascade: `0` for a direct/RPC
+    /// call, `parent + 1` for an execution dispatched via `xcall`. The handler
+    /// denies further xcalls once this would exceed the depth cap, bounding the
+    /// otherwise-unbounded local recursion (a cycle A→B→A would never
+    /// terminate) and the `B^depth` fan-out.
+    pub xcall_depth: u32,
 }
 
 #[derive(Debug)]

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -60,16 +60,17 @@ mod signing;
 pub mod storage;
 mod upgrade_gate;
 
-/// Maximum depth of a local xcall cascade: a direct/RPC call runs at depth 0,
-/// and each `xcall` it (transitively) triggers runs one level deeper. Once an
-/// execution reaches this depth its own xcalls are denied, so a chain can be at
-/// most this many hops long.
+/// Maximum depth of a local xcall cascade. A direct/RPC call runs at depth 0,
+/// and each `xcall` it (transitively) triggers runs one level deeper. An
+/// execution *at* this depth still runs, but its own xcalls are denied — so
+/// executions span depths `0..=MAX_XCALL_DEPTH` and a cascade makes at most
+/// `MAX_XCALL_DEPTH` xcall hops beyond the root.
 ///
 /// xcalls dispatch locally and each spawned execution can queue up to
 /// `max_xcalls` more (breadth `B`, default 8), so without a depth bound one
 /// root call could recurse forever (a cycle A→B→A) or fan out `B^depth`. This
-/// cap bounds one root call to at most `B + B² + … + B^DEPTH` local executions
-/// — 584 at `B = 8`, `DEPTH = 3`.
+/// cap bounds the executions one root call spawns to `B + B² + … + B^DEPTH`
+/// (children at depths 1..=`DEPTH`) — 584 at `B = 8`, `DEPTH = 3`.
 const MAX_XCALL_DEPTH: u32 = 3;
 
 use governance_position::compute_governance_position_for_context;
@@ -97,6 +98,18 @@ impl Handler<ExecuteRequest> for ContextManager {
         }: ExecuteRequest,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
+        // A direct/RPC call always starts a fresh cascade at depth 0; only an
+        // execution dispatched via `xcall` (`xcall_origin` = `Some`) carries a
+        // depth, and that depth was set by our own dispatch loop below. Ignore
+        // any depth supplied on a non-xcall request so the cap can't be
+        // sidestepped by handing the actor an `ExecuteRequest` with a high
+        // `xcall_depth`. Invariant: `xcall_origin.is_none()` ⟺ depth 0.
+        let xcall_depth = if xcall_origin.is_some() {
+            xcall_depth
+        } else {
+            0
+        };
+
         info!(
             %context_id,
             method,
@@ -1233,10 +1246,11 @@ impl Handler<ExecuteRequest> for ContextManager {
                                         vec![],
                                         None,
                                         Some(context_id),
-                                        // Child runs one level deeper; the depth
-                                        // check above guarantees this stays within
-                                        // `MAX_XCALL_DEPTH`.
-                                        xcall_depth + 1,
+                                        // Child runs one level deeper. The depth
+                                        // check above already caps this within
+                                        // `MAX_XCALL_DEPTH`; `saturating_add`
+                                        // keeps the arithmetic sound regardless.
+                                        xcall_depth.saturating_add(1),
                                     )
                                     .await;
 

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -60,6 +60,18 @@ mod signing;
 pub mod storage;
 mod upgrade_gate;
 
+/// Maximum depth of a local xcall cascade: a direct/RPC call runs at depth 0,
+/// and each `xcall` it (transitively) triggers runs one level deeper. Once an
+/// execution reaches this depth its own xcalls are denied, so a chain can be at
+/// most this many hops long.
+///
+/// xcalls dispatch locally and each spawned execution can queue up to
+/// `max_xcalls` more (breadth `B`, default 8), so without a depth bound one
+/// root call could recurse forever (a cycle A→B→A) or fan out `B^depth`. This
+/// cap bounds one root call to at most `B + B² + … + B^DEPTH` local executions
+/// — 584 at `B = 8`, `DEPTH = 3`.
+const MAX_XCALL_DEPTH: u32 = 3;
+
 use governance_position::compute_governance_position_for_context;
 pub(crate) use signing::{persist_signed_signatures, sign_authorized_actions};
 use storage::{ContextPrivateStorage, ContextStorage, ReadOnlyContextStorage};
@@ -81,6 +93,7 @@ impl Handler<ExecuteRequest> for ContextManager {
             aliases,
             atomic,
             xcall_origin,
+            xcall_depth,
         }: ExecuteRequest,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
@@ -1127,6 +1140,28 @@ impl Handler<ExecuteRequest> for ContextManager {
                                     ));
                                 };
 
+                                // Depth cap: an execution already at the maximum
+                                // cascade depth may not spawn further xcalls. This
+                                // is what bounds the otherwise-unbounded local
+                                // recursion — a cycle A→B→A would never terminate,
+                                // and each level multiplies the fan-out by up to
+                                // `max_xcalls`. `xcall_depth` is this execution's
+                                // depth; a child would run one deeper.
+                                if xcall_depth >= MAX_XCALL_DEPTH {
+                                    warn!(
+                                        %context_id,
+                                        target_context = ?target_context_id,
+                                        function = %function,
+                                        xcall_depth,
+                                        max = MAX_XCALL_DEPTH,
+                                        "xcall denied: depth limit reached"
+                                    );
+                                    emit(XCallOutcome::Denied {
+                                        reason: "xcall depth limit".to_owned(),
+                                    });
+                                    continue;
+                                }
+
                                 // A context may only xcall a target in its OWN
                                 // owning group. Gating on the shared namespace
                                 // root instead let any sibling context anywhere
@@ -1198,6 +1233,10 @@ impl Handler<ExecuteRequest> for ContextManager {
                                         vec![],
                                         None,
                                         Some(context_id),
+                                        // Child runs one level deeper; the depth
+                                        // check above guarantees this stays within
+                                        // `MAX_XCALL_DEPTH`.
+                                        xcall_depth + 1,
                                     )
                                     .await;
 

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -136,8 +136,15 @@ const DEFAULT_MAX_EVENTS: u64 = 100;
 const DEFAULT_MAX_EVENT_KIND_SIZE: u64 = 100;
 /// Default maximum event data size in KiB (16 KiB).
 const DEFAULT_MAX_EVENT_DATA_SIZE_KIB: u64 = 16;
-/// Default maximum number of cross-context calls.
-const DEFAULT_MAX_XCALLS: u64 = 100;
+/// Default maximum number of cross-context calls a single execution may queue.
+///
+/// This is the per-execution *breadth* of the xcall fan-out. Kept small because
+/// xcalls are dispatched locally and each spawned execution can itself queue up
+/// to this many more: with a node-side depth cap of `D`, one root call can
+/// trigger at most `B + B² + … + B^D` local executions (`B` = this value). At
+/// `B = 8`, `D = 3` that worst case is 584 — bounded and reasoned — whereas the
+/// former `B = 100` made every extra level of depth a 100× amplifier.
+const DEFAULT_MAX_XCALLS: u64 = 8;
 /// Default maximum cross-context call function name size in bytes.
 const DEFAULT_MAX_XCALL_FUNCTION_SIZE: u64 = 100;
 /// Default maximum cross-context call parameters size in KiB (16 KiB).
@@ -1198,7 +1205,7 @@ mod tests {
         assert_eq!(limits.max_events, 100);
         assert_eq!(limits.max_event_kind_size, 100);
         assert_eq!(limits.max_event_data_size, 16 << 10); // 16 KiB
-        assert_eq!(limits.max_xcalls, 100);
+        assert_eq!(limits.max_xcalls, 8);
         assert_eq!(limits.max_xcall_function_size, 100);
         assert_eq!(limits.max_xcall_params_size, 16 << 10); // 16 KiB
         assert_eq!(limits.max_storage_key_size.get(), 1 << 20); // 1 MiB


### PR DESCRIPTION
## Summary

Follow-up to #3143 (the deferred xcall item). xcalls dispatch **locally** — each one sends a fresh `ExecuteRequest` back to the same `ContextManager` actor — and every spawned execution can itself queue more. So a single root call could:

- **recurse without bound** — a cycle `A→B→A→B…` never terminates, or
- **fan out `max_xcalls^depth`** — each level multiplies the number of local executions.

Each of those executions is a full WASM run + storage + delta commit, so this is a real local CPU/IO amplification (and liveness) hazard, not just latency.

## Fix — two composing bounds

1. **Breadth** (runtime): lower the per-execution `max_xcalls` default from **100 → 8**. This cuts the per-level multiplier that drives the exponent (`8³ = 512` vs `100³ = 1,000,000`).
2. **Depth** (context): carry an `xcall_depth` on `ExecuteRequest` — `0` for a direct/RPC call, `parent + 1` for an xcall target — and deny any further xcalls once an execution reaches `MAX_XCALL_DEPTH` (**3**). Denials use the existing `XCallOutcome::Denied` path, so they're observable. Depth is what actually stops cycles (an `A↔B` ping-pong dies at hop 3) and caps chain length.

Worst-case local executions triggered by one root call: `8 + 8² + 8³ = 584` — bounded and reasoned, down from unbounded.

Both are simple knobs: `max_xcalls` is an existing `VMLimits` field; `MAX_XCALL_DEPTH` is a documented const in the dispatch handler (can be promoted to config later if needed).

## Testing

- `cargo build -p calimero-runtime -p calimero-context -p calimero-context-client -p calimero-node` — clean, no warnings
- `cargo clippy` on the touched crates — clean
- `cargo test -p calimero-runtime --lib` — 117 pass (incl. the updated `max_xcalls == 8` default-limits assertion)

**Follow-up:** the xcall dispatch loop is a detached fire-and-forget task with no existing integration-test coverage; a node-level test that wires two contexts into an `A↔B` cycle and asserts `XCallOutcome::Denied` at depth 3 would be a good addition but is a standalone effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)