### PR TITLE
ci(docker): pin prebuilt base images by digest, exec-form auth ENTRYPOINT (F108/F112)

### DIFF
--- a/.github/workflows/deps/prebuilt.Dockerfile
+++ b/.github/workflows/deps/prebuilt.Dockerfile
@@ -2,7 +2,7 @@
 
 # Dockerfile for prebuilt binaries
 
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/.github/workflows/deps/prebuilt.auth.Dockerfile
+++ b/.github/workflows/deps/prebuilt.auth.Dockerfile
@@ -2,7 +2,7 @@
 
 # Dockerfile for prebuilt binaries
 
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -32,4 +32,4 @@ WORKDIR /data
 VOLUME /data
 EXPOSE 3001
 
-ENTRYPOINT mero-auth --config /etc/calimero/auth.toml --verbose
+ENTRYPOINT ["/usr/local/bin/mero-auth", "--config", "/etc/calimero/auth.toml", "--verbose"]

--- a/.github/workflows/deps/prebuilt.profiling.Dockerfile
+++ b/.github/workflows/deps/prebuilt.profiling.Dockerfile
@@ -4,7 +4,7 @@
 # This image includes perf, flamegraph, jemalloc, and heaptrack for performance analysis
 # Binaries are pre-built with frame pointers enabled and debug symbols preserved (profiling profile)
 
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 
 LABEL org.opencontainers.image.description="Calimero Node with Profiling Tools" \
     org.opencontainers.image.licenses="MIT OR Apache-2.0" \

--- a/crates/auth/config/config.toml
+++ b/crates/auth/config/config.toml
@@ -16,7 +16,9 @@ path = "./data/auth_db_local"
 
 # CORS configuration
 [cors]
-allow_all_origins = true
+# Locked down by default (matches the code default). To allow cross-origin
+# browser clients, list them in `allowed_origins` (or set this true for any).
+allow_all_origins = false
 allowed_methods = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
 allowed_headers = ["Authorization", "Content-Type", "Accept", "X-CSRF-Token"]
 exposed_headers = ["X-Auth-Error"]

--- a/crates/auth/config/config.toml
+++ b/crates/auth/config/config.toml
@@ -16,9 +16,7 @@ path = "./data/auth_db_local"
 
 # CORS configuration
 [cors]
-# Locked down by default (matches the code default). To allow cross-origin
-# browser clients, list them in `allowed_origins` (or set this true for any).
-allow_all_origins = false
+allow_all_origins = true
 allowed_methods = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
 allowed_headers = ["Authorization", "Content-Type", "Accept", "X-CSRF-Token"]
 exposed_headers = ["X-Auth-Error"]


### PR DESCRIPTION
Container-hygiene items from audit §9 for the prebuilt images. (Main `Dockerfile`/`Dockerfile.auth` were already digest-pinned + exec-form on master.)

- **F108** — pin `FROM ubuntu:24.04` → `@sha256:4fbb8e6a…` in all three `deps/prebuilt*.Dockerfile` (node, auth, profiling). Reproducible base image; tag kept for readability.
- **F112** — `prebuilt.auth.Dockerfile`: shell-form `ENTRYPOINT mero-auth …` → exec form `["/usr/local/bin/mero-auth", …]` so SIGTERM reaches the process directly. Matches `Dockerfile.auth`.

## F111 (auth CORS) — reverted, intentionally NOT included
An earlier commit flipped the shipped `config.toml` `allow_all_origins` `true → false`; it's been **reverted**. Reasons:
- The `true` default is long-standing (since #1305 "Server initialization") with no documented rationale — flipping it risks breaking cross-origin browser clients of the standalone `mero-auth` service; that's a deployment/product decision, not a safe mechanical default.
- Note `config.toml` governs only the **standalone mero-auth service**. Embedded auth (`merod --auth-mode embedded`) uses `embedded.rs` (already `allow_all_origins = false`) and is unaffected by this file either way.

## F109 / F110 — already done on master
`download-contracts.sh` verifies each asset's GitHub sha256; `setup-vmagent.sh` pins `VMAGENT_SHA256` and reads the bearer token from env.