### PR TITLE
test(xcall): e2e coverage for the local xcall depth cap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
  "tracing",
  "zeroize",
 ]
@@ -1779,6 +1780,7 @@ dependencies = [
  "strum 0.26.3",
  "thiserror 1.0.69",
  "thunderdome",
+ "zeroize",
 ]
 
 [[package]]
@@ -6077,6 +6079,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "x509-cert",
+ "zeroize",
 ]
 
 [[package]]

--- a/apps/xcall-example/src/lib.rs
+++ b/apps/xcall-example/src/lib.rs
@@ -131,6 +131,10 @@ impl XCallExample {
     /// directly, which is how the cascade is kicked off at depth 0.
     #[app::xcall(from_same_app)]
     pub fn relay(&mut self) -> app::Result<()> {
+        // No `env::xcall_origin()` check here (unlike `pong`): `relay` is
+        // intentionally callable both directly — to kick the cascade off at
+        // depth 0 — and via xcall. Adding an origin check would break the
+        // depth-cap test's direct kick-off.
         self.relay_counter.increment()?;
         let counter = self.relay_counter.value()?;
 

--- a/apps/xcall-example/src/lib.rs
+++ b/apps/xcall-example/src/lib.rs
@@ -11,6 +11,10 @@ pub struct XCallExample {
     /// targeting it is denied by the node, so it stays at zero unless reached
     /// by a direct call.
     secret_counter: Counter,
+    /// Bumped once per hop of the self-recursive `relay` cascade. The node's
+    /// xcall depth cap stops the cascade, so a single direct `relay` call
+    /// settles this at `MAX_XCALL_DEPTH + 1`.
+    relay_counter: Counter,
 }
 
 #[app::event]
@@ -32,6 +36,7 @@ impl XCallExample {
         XCallExample {
             counter: Counter::new(),
             secret_counter: Counter::new(),
+            relay_counter: Counter::new(),
         }
     }
 
@@ -112,6 +117,36 @@ impl XCallExample {
     /// reached via a denied `xcall`).
     pub fn get_secret_counter(&self) -> app::Result<u64> {
         Ok(self.secret_counter.value()?)
+    }
+
+    /// Exercises the node's xcall **depth cap**. Each hop bumps `relay_counter`
+    /// and queues one more `xcall` to `relay` on *this same context*, so a
+    /// single direct call would recurse forever if the node let it. It doesn't:
+    /// the node denies the onward xcall once the cascade reaches its depth cap,
+    /// so the counter settles at `MAX_XCALL_DEPTH + 1` (executions at depths
+    /// `0..=MAX_XCALL_DEPTH` all run; the deepest one's xcall is denied).
+    ///
+    /// Marked `#[app::xcall(from_same_app)]` so it is reachable via xcall (a
+    /// self-xcall is same-context, hence same app); it is also callable
+    /// directly, which is how the cascade is kicked off at depth 0.
+    #[app::xcall(from_same_app)]
+    pub fn relay(&mut self) -> app::Result<()> {
+        self.relay_counter.increment()?;
+        let counter = self.relay_counter.value()?;
+
+        let me = ContextId::from(calimero_sdk::env::context_id());
+        app::log!("relay hop {} on {}; queueing xcall to self", counter, me);
+
+        // Empty params: `relay` takes no arguments.
+        calimero_sdk::env::xcall(me.as_ref(), "relay", &[]);
+
+        Ok(())
+    }
+
+    /// Current `relay` cascade counter — how many hops ran before the depth cap
+    /// stopped the cascade.
+    pub fn get_relay_counter(&self) -> app::Result<u64> {
+        Ok(self.relay_counter.value()?)
     }
 
     /// Queue an `xcall` to `method` on `target_context`, passing this context's

--- a/apps/xcall-example/src/lib.rs
+++ b/apps/xcall-example/src/lib.rs
@@ -137,7 +137,10 @@ impl XCallExample {
         let me = ContextId::from(calimero_sdk::env::context_id());
         app::log!("relay hop {} on {}; queueing xcall to self", counter, me);
 
-        // Empty params: `relay` takes no arguments.
+        // Fire-and-forget: `env::xcall` returns `()` and only *queues* the call
+        // (empty params — `relay` takes no arguments). Whether the node then
+        // dispatches or denies it is invisible here; the depth cap denies it at
+        // its limit, which surfaces in the node log and the settled counter.
         calimero_sdk::env::xcall(me.as_ref(), "relay", &[]);
 
         Ok(())

--- a/apps/xcall-example/workflows/xcall.yml
+++ b/apps/xcall-example/workflows/xcall.yml
@@ -428,8 +428,8 @@ steps:
 
   # The cascade is (MAX_XCALL_DEPTH + 1) = 4 sequential hops, each dispatched
   # out-of-band and re-entering the actor. Single-hop waits above use 8s, so
-  # budget ~8s/hop → 40s to keep real headroom under CI load. Scale this with
-  # the depth cap if it is ever raised.
+  # budget 4 hops × 8s/hop + 8s buffer = 40s to keep real headroom under CI
+  # load. Scale this with the depth cap if it is ever raised.
   - name: Wait for the depth-capped cascade to fully drain
     type: wait
     seconds: 40
@@ -448,6 +448,8 @@ steps:
   - name: Assert the cascade ran exactly depth+1 hops then stopped
     type: json_assert
     statements:
+      # 4 = MAX_XCALL_DEPTH (3) + 1 — keep in sync with the cap in
+      # crates/context/src/handlers/execute/mod.rs.
       - "equal({{c1_relay_after}}, 4)"
 
   # Secondary confirmation that the stop was the depth cap specifically — the

--- a/apps/xcall-example/workflows/xcall.yml
+++ b/apps/xcall-example/workflows/xcall.yml
@@ -426,11 +426,13 @@ steps:
     context_id: "{{c1}}"
     method: relay
 
-  # Generous margin for a 3-hop sequential cascade — each hop is dispatched
-  # out-of-band and re-enters the actor. Single-hop waits above use 8s.
+  # The cascade is (MAX_XCALL_DEPTH + 1) = 4 sequential hops, each dispatched
+  # out-of-band and re-entering the actor. Single-hop waits above use 8s, so
+  # budget ~8s/hop → 40s to keep real headroom under CI load. Scale this with
+  # the depth cap if it is ever raised.
   - name: Wait for the depth-capped cascade to fully drain
     type: wait
-    seconds: 25
+    seconds: 40
 
   - name: C1 relay counter after the cascade
     type: call
@@ -439,9 +441,10 @@ steps:
     method: get_relay_counter
     outputs:
       c1_relay_after: result.output
-  # Exactly MAX_XCALL_DEPTH + 1 = 4. `== 4` (not `>= 1`) catches BOTH failure
-  # modes: the cap not firing (the counter would keep climbing / never settle)
-  # and the cascade dying early (counter < 4).
+  # Exactly MAX_XCALL_DEPTH + 1 = 4. The `4` tracks MAX_XCALL_DEPTH (defined in
+  # crates/context/src/handlers/execute/mod.rs) — change both together. `== 4`
+  # (not `>= 1`) catches BOTH failure modes: the cap not firing (the counter
+  # would keep climbing / never settle) and the cascade dying early (< 4).
   - name: Assert the cascade ran exactly depth+1 hops then stopped
     type: json_assert
     statements:

--- a/apps/xcall-example/workflows/xcall.yml
+++ b/apps/xcall-example/workflows/xcall.yml
@@ -17,7 +17,7 @@ description: >
   Denials are observable: the target counter never moves, and the node logs the
   same "xcall denied: ..." line that drives the `XCall` Denied event.
 
-  Two regression scenarios also run at the end:
+  Three regression scenarios also run at the end:
     * Self-xcall (C1 -> C1) must COMPLETE, not hang. xcalls are dispatched
       out-of-band; awaiting them inline re-entered the actor and deadlocked on
       the source context's execution lock. A reintroduced inline dispatch hangs
@@ -26,6 +26,10 @@ description: >
       DENIED. This is the owning-group boundary in its own right: same
       namespace, different owning group — the old namespace-root gate allowed
       it, the owning-group gate denies it.
+    * Depth cap: `relay` xcalls itself on the same context every hop, so an
+      uncapped node would recurse forever. The node bounds the local cascade at
+      MAX_XCALL_DEPTH, so the counter settles at MAX_XCALL_DEPTH + 1 and a
+      depth-limit denial is logged instead of the run spinning to wait_timeout.
 
   Single node: all contexts are created by node-1, which owns a member of each,
   so every xcall dispatches locally — the gates are node-local, so one node
@@ -393,6 +397,65 @@ steps:
       - xcall-authz-1
     patterns:
       - "xcall denied: owning group boundary"
+    min_matches: 1
+
+  # ============================================================================
+  # DEPTH CAP — `relay` xcalls `relay` on its OWN context every hop, so a single
+  # direct call would recurse without bound if the node let it. It doesn't: the
+  # node caps the local xcall cascade at MAX_XCALL_DEPTH (3). The direct call
+  # runs at depth 0, its xcall at depth 1, … and the depth-3 execution's onward
+  # xcall is denied — so executions run at depths 0..=3 (four hops) and the
+  # counter settles at MAX_XCALL_DEPTH + 1 = 4, with one depth-limit denial
+  # logged. Without the cap this step would spin until wait_timeout.
+  # ============================================================================
+  - name: C1 relay counter starts at 0
+    type: call
+    node: xcall-authz-1
+    context_id: "{{c1}}"
+    method: get_relay_counter
+    outputs:
+      c1_relay_before: result.output
+  - name: Assert C1 relay counter is 0
+    type: json_assert
+    statements:
+      - "equal({{c1_relay_before}}, 0)"
+
+  - name: Kick off the self-recursive relay cascade on C1 (direct call, depth 0)
+    type: call
+    node: xcall-authz-1
+    context_id: "{{c1}}"
+    method: relay
+
+  # Generous margin for a 3-hop sequential cascade — each hop is dispatched
+  # out-of-band and re-enters the actor. Single-hop waits above use 8s.
+  - name: Wait for the depth-capped cascade to fully drain
+    type: wait
+    seconds: 25
+
+  - name: C1 relay counter after the cascade
+    type: call
+    node: xcall-authz-1
+    context_id: "{{c1}}"
+    method: get_relay_counter
+    outputs:
+      c1_relay_after: result.output
+  # Exactly MAX_XCALL_DEPTH + 1 = 4. `== 4` (not `>= 1`) catches BOTH failure
+  # modes: the cap not firing (the counter would keep climbing / never settle)
+  # and the cascade dying early (counter < 4).
+  - name: Assert the cascade ran exactly depth+1 hops then stopped
+    type: json_assert
+    statements:
+      - "equal({{c1_relay_after}}, 4)"
+
+  # Secondary confirmation that the stop was the depth cap specifically — the
+  # deepest hop's onward xcall is denied with this reason. min_matches: 1: the
+  # log is cumulative and other denials (group/namespace) also appear above.
+  - name: Assert a depth-limit denial was logged
+    type: assert_log_present
+    nodes:
+      - xcall-authz-1
+    patterns:
+      - "xcall denied: depth limit reached"
     min_matches: 1
 
 stop_all_nodes: true

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -71,6 +71,10 @@ mod upgrade_gate;
 /// root call could recurse forever (a cycle A→B→A) or fan out `B^depth`. This
 /// cap bounds the executions one root call spawns to `B + B² + … + B^DEPTH`
 /// (children at depths 1..=`DEPTH`) — 584 at `B = 8`, `DEPTH = 3`.
+///
+/// Changing this value also changes the settled hop count asserted by the
+/// depth-cap scenario in `apps/xcall-example/workflows/xcall.yml` (it expects
+/// `MAX_XCALL_DEPTH + 1`); update that assertion alongside this constant.
 const MAX_XCALL_DEPTH: u32 = 3;
 
 use governance_position::compute_governance_position_for_context;


### PR DESCRIPTION
## Summary

Closes the coverage gap flagged when #3156 (local xcall cascade cap) landed: the xcall dispatch loop is a detached fire-and-forget task with no test exercising it end-to-end. This adds that coverage via the existing `xcall-example` merobox e2e (which CI runs in `e2e-rust-apps.yml`).

## What it does

- **App** (`apps/xcall-example/src/lib.rs`): adds a `relay` method — an `#[app::xcall(from_same_app)]` entry point that bumps a `relay_counter` and queues one more `xcall` to `relay` on **its own context** every hop. Uncapped, this recurses forever; also callable directly to kick the cascade off at depth 0.
- **Workflow** (`workflows/xcall.yml`): a new scenario kicks off `relay` on C1 with a direct call, waits for the cascade to drain, and asserts:
  - `relay_counter == 4` — executions run at depths `0..=MAX_XCALL_DEPTH` (=3), so exactly `MAX_XCALL_DEPTH + 1` hops run before the deepest one's onward xcall is denied. `== 4` (not `>= 1`) catches both the cap failing to fire (counter would keep climbing / the run would spin to `wait_timeout`) and the cascade dying early.
  - a `"xcall denied: depth limit reached"` denial is logged — confirming the stop was the depth cap specifically.

This drives the **real** detached dispatch loop, the depth threading on `ExecuteRequest`, and the entry-depth clamp — the exact machinery #3156 added.

## Testing

- `cargo build --target wasm32-unknown-unknown --profile app-release` on the app — clean (verified locally).
- `xcall.yml` parses; the new scenario is 3 asserts appended before `stop_all_nodes`.
- The full merobox e2e runs in CI (`e2e-rust-apps.yml` → matrix `xcall-example / workflows/xcall.yml`); it needs Docker, so it validates in CI rather than locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)