### PR TITLE
test(crdt): pin CrdtType borsh discriminants (#402)

### DIFF
--- a/crates/primitives/src/crdt.rs
+++ b/crates/primitives/src/crdt.rs
@@ -370,6 +370,7 @@ mod tests {
             CrdtType::FrozenStorage,
             CrdtType::SharedStorage,
             CrdtType::Custom("my_type".to_string()),
+            CrdtType::RotationLog,
         ];
 
         for crdt_type in &types {
@@ -397,6 +398,7 @@ mod tests {
             CrdtType::FrozenStorage,
             CrdtType::SharedStorage,
             CrdtType::Custom("my_type".to_string()),
+            CrdtType::RotationLog,
         ];
 
         for crdt_type in &types {

--- a/crates/primitives/src/crdt.rs
+++ b/crates/primitives/src/crdt.rs
@@ -405,4 +405,26 @@ mod tests {
             assert_eq!(*crdt_type, decoded);
         }
     }
+
+    #[cfg(feature = "borsh")]
+    #[test]
+    fn test_borsh_discriminant_tags_are_stable() {
+        // #402: pin borsh tags — reordering variants breaks the wire format.
+        let tag = |t: &CrdtType| borsh::to_vec(t).unwrap()[0];
+
+        assert_eq!(tag(&CrdtType::lww_register("x")), 0);
+        assert_eq!(tag(&CrdtType::GCounter), 1);
+        assert_eq!(tag(&CrdtType::PnCounter), 2);
+        assert_eq!(tag(&CrdtType::Rga), 3);
+        assert_eq!(tag(&CrdtType::unordered_map("k", "v")), 4);
+        assert_eq!(tag(&CrdtType::sorted_map("k", "v")), 5);
+        assert_eq!(tag(&CrdtType::unordered_set("e")), 6);
+        assert_eq!(tag(&CrdtType::sorted_set("e")), 7);
+        assert_eq!(tag(&CrdtType::vector("e")), 8);
+        assert_eq!(tag(&CrdtType::UserStorage), 9);
+        assert_eq!(tag(&CrdtType::FrozenStorage), 10);
+        assert_eq!(tag(&CrdtType::SharedStorage), 11);
+        assert_eq!(tag(&CrdtType::Custom("c".into())), 12);
+        assert_eq!(tag(&CrdtType::RotationLog), 13);
+    }
 }


### PR DESCRIPTION
## What

Adds a golden discriminant test for `CrdtType` in `crates/primitives/src/crdt.rs`.

`CrdtType` is a Borsh enum whose variant tag is **positional** — declaration order equals the wire byte. Variants have been inserted mid-enum before, shifting discriminants. The only existing coverage was `test_borsh_roundtrip`, which round-trips a value and therefore does **not** catch reordering or mid-enum insertion (both sides move together).

`test_borsh_discriminant_tags_are_stable` asserts, for every variant, that the first serialized byte (the Borsh `u8` enum tag) equals its 0-based declaration index (0..=13). Any future reorder or mid-enum insertion now fails CI instead of silently corrupting the wire format.

## No migration needed

Per the maintainer there is no pre-existing persisted data, so this is purely a guard — no migration and no format-version bump. This is a test-only change; no runtime behavior is touched.

## Verification

`cargo test -p calimero-primitives --features borsh` — 11 passed, 0 failed, including the new `test_borsh_discriminant_tags_are_stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)