### PR TITLE
fix(storage): overflow/truncation guards (F172, #258) + low-sev verify

### DIFF
--- a/crates/storage/src/collections/rga.rs
+++ b/crates/storage/src/collections/rga.rs
@@ -411,7 +411,15 @@ impl<S: StorageAdaptor> ReplicatedGrowableArray<S> {
 
         // Insert each character
         for (seq, content) in s.chars().enumerate() {
-            let char_id = CharId::new(timestamp, seq as u32);
+            // `CharId.seq` is u32; widening it would change the borsh wire
+            // format and break RGA sync. Reject a >4 Gi-char insert instead of
+            // wrapping `seq` and overwriting an earlier char.
+            let seq = u32::try_from(seq).map_err(|_| {
+                StoreError::StorageError(crate::interface::StorageError::InvalidData(
+                    "insert too large: character offset exceeds u32::MAX".into(),
+                ))
+            })?;
+            let char_id = CharId::new(timestamp, seq);
             let new_char = RgaChar::new(content, left);
 
             let _ = self.chars.insert(CharKey::new(char_id), new_char)?;

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -412,6 +412,25 @@ where
         }).fuse())
     }
 
+    /// Entries in a deterministic, replica-independent order: sorted by
+    /// borsh-serialized key.
+    ///
+    /// Raw [`entries`](Self::entries) follows the stored child list, ordered by
+    /// `(created_at, id)`, and `created_at` can differ across replicas for the
+    /// same logical entry (a CRDT merge re-materialises it at each node's own
+    /// HLC time — see `Index::add_child_to`). `Serialize`/`Eq`/`Ord` must be
+    /// replica-stable, or anything hashing a serialized map — or comparing two
+    /// maps — diverges between replicas. Sorting by the borsh key (not the
+    /// entity id) keeps cross-map comparison correct: the same key sorts the
+    /// same regardless of which collection id derived its entity id.
+    fn sorted_entries(&self) -> Result<Vec<(K, V)>, StoreError> {
+        let mut entries: Vec<(K, V)> = self.entries()?.collect();
+        // ponytail: borsh key encode is effectively infallible for in-memory
+        // keys; on the impossible error, `default()` keeps the sort total.
+        entries.sort_by_cached_key(|(k, _)| borsh::to_vec(k).unwrap_or_default());
+        Ok(entries)
+    }
+
     /// Get the number of entries in the map.
     ///
     /// # Errors
@@ -616,7 +635,10 @@ where
     S: StorageAdaptor,
 {
     fn eq(&self, other: &Self) -> bool {
-        super::fallible_iter_eq(self.entries(), other.entries())
+        super::fallible_iter_eq(
+            self.sorted_entries().map(IntoIterator::into_iter),
+            other.sorted_entries().map(IntoIterator::into_iter),
+        )
     }
 }
 
@@ -627,7 +649,10 @@ where
     S: StorageAdaptor,
 {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        super::fallible_iter_cmp(self.entries(), other.entries())
+        super::fallible_iter_cmp(
+            self.sorted_entries().map(IntoIterator::into_iter),
+            other.sorted_entries().map(IntoIterator::into_iter),
+        )
     }
 }
 
@@ -638,7 +663,10 @@ where
     S: StorageAdaptor,
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        super::fallible_iter_partial_cmp(self.entries(), other.entries())
+        super::fallible_iter_partial_cmp(
+            self.sorted_entries().map(IntoIterator::into_iter),
+            other.sorted_entries().map(IntoIterator::into_iter),
+        )
     }
 }
 
@@ -694,12 +722,14 @@ where
     where
         Ser: serde::Serializer,
     {
-        let len = self.len().map_err(serde::ser::Error::custom)?;
+        // Sorted so the serialized bytes are identical across replicas holding
+        // the same logical map (see `sorted_entries`).
+        let entries = self.sorted_entries().map_err(serde::ser::Error::custom)?;
 
-        let mut seq = serializer.serialize_map(Some(len))?;
+        let mut seq = serializer.serialize_map(Some(entries.len()))?;
 
-        for (k, v) in self.entries().map_err(serde::ser::Error::custom)? {
-            seq.serialize_entry(&k, &v)?;
+        for (k, v) in &entries {
+            seq.serialize_entry(k, v)?;
         }
 
         seq.end()

--- a/crates/storage/src/logical_clock.rs
+++ b/crates/storage/src/logical_clock.rs
@@ -347,8 +347,11 @@ impl LogicalClock {
         let now_nanos = time_now_fn();
 
         // Convert nanoseconds to NTP64 format
-        // NTP64: upper 32 bits = seconds, lower 32 bits = fraction of second
-        let secs = now_nanos / 1_000_000_000;
+        // NTP64: upper 32 bits = seconds, lower 32 bits = fraction of second.
+        // Saturate seconds at u32::MAX (~year 2106, the last value the 32-bit
+        // seconds field can hold) so `secs << 32` caps deterministically
+        // instead of silently wrapping the physical time back to a small value.
+        let secs = (now_nanos / 1_000_000_000).min(u64::from(u32::MAX));
         let nanos = now_nanos % 1_000_000_000;
         let frac = (nanos * (1_u64 << 32)) / 1_000_000_000;
         // Quantize physical time to the bits not reserved for the counter so
@@ -396,8 +399,10 @@ impl LogicalClock {
         // Get current physical time for drift check
         let now_nanos = time_now_fn();
 
-        // Convert nanoseconds to NTP64 format
-        let secs = now_nanos / 1_000_000_000;
+        // Convert nanoseconds to NTP64 format. Saturate seconds at u32::MAX
+        // (~year 2106) so `secs << 32` caps deterministically rather than
+        // silently wrapping the physical time.
+        let secs = (now_nanos / 1_000_000_000).min(u64::from(u32::MAX));
         let nanos = now_nanos % 1_000_000_000;
         let frac = (nanos * (1_u64 << 32)) / 1_000_000_000;
         let local_ntp = (secs << 32) | frac;
@@ -406,7 +411,9 @@ impl LogicalClock {
         // only — the remote counter bits are logical ordering, not clock
         // drift, and would otherwise inflate the comparison at the boundary.
         const DRIFT_TOLERANCE_SECS: u64 = 5;
-        let drift_ntp = local_ntp + (DRIFT_TOLERANCE_SECS << 32);
+        // Saturate: a `local_ntp` near the u32::MAX-seconds cap would overflow
+        // the add (a debug panic / release wrap) otherwise.
+        let drift_ntp = local_ntp.saturating_add(DRIFT_TOLERANCE_SECS << 32);
 
         if remote_phys > drift_ntp {
             return Err(ClockUpdateError::Drift {
@@ -516,6 +523,22 @@ mod tests {
         // And a third reading, still on the rewound clock, keeps advancing.
         let third = hlc.new_timestamp(|| time.load(Ordering::Relaxed));
         assert!(third.get_time().as_u64() > after.get_time().as_u64());
+    }
+
+    #[test]
+    fn test_far_future_clock_saturates_instead_of_wrapping() {
+        // Seconds beyond NTP64's 32-bit seconds field (~year 2106) must
+        // saturate at u32::MAX, not wrap `secs << 32` down to a small physical
+        // time (which would let the HLC regress and collide timestamps).
+        let secs_overflow: u64 = (1_u64 << 33) * 1_000_000_000; // secs = 2^33
+        let time = AtomicU64::new(secs_overflow);
+        let mut hlc = LogicalClock::new(|buf| rand::thread_rng().fill_bytes(buf));
+        let ts = hlc.new_timestamp(|| time.load(Ordering::Relaxed));
+        assert_eq!(
+            physical_time_secs(&ts),
+            u32::MAX,
+            "far-future physical time must saturate at u32::MAX, not wrap to a small value",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two localized storage overflow/truncation guards plus verification of three low-severity findings. All changes are confined to `crates/storage/src/`; no wire formats change.

## Fixed

- **F172 [L] — RGA `CharId::new` truncated `usize` offset to `u32`.** `insert_str_at_timestamp` cast the per-char offset (`seq`) `as u32`, so an insert of more than `u32::MAX` chars (>4 GiB) wrapped `CharId.seq` and could overwrite an earlier char. The call site now uses `u32::try_from` and returns an `InvalidData` error on overflow, rejecting the oversized insert. `CharId.seq` stays `u32`, so the borsh wire format — and RGA sync — is unchanged. (`collections/rga.rs`)

- **#258 [L] — HLC `secs << 32` year-2106 overflow.** `new_timestamp` and `update` packed physical seconds via `secs << 32`, which silently drops the high bits once seconds exceed NTP64's 32-bit seconds field (~year 2106), wrapping physical time down to a small value and letting the clock regress. Seconds are now saturated at `u32::MAX` before the shift in both sites, and the drift bound uses `saturating_add`, so a far-future clock caps deterministically across all nodes instead of wrapping. Added `test_far_future_clock_saturates_instead_of_wrapping`. (`logical_clock.rs`)

- **F168 [M] — `UnorderedMap` `Serialize`/`Eq`/`Ord`/`PartialOrd` were replica-nondeterministic.** They iterated `entries()` in the stored child-list order, which is `(created_at, id)`. The Merkle `full_hash` sorts children by `id` only, but `created_at` can legitimately differ across replicas for the same logical entry (a merge re-materialises it at each node's own HLC time — see `Index::add_child_to`'s dedup-by-id comment). So two replicas holding the same logical map could serialize to different bytes / compare unequal — divergence for anything hashing a serialized map. Added a `sorted_entries` helper that sorts by the borsh-serialized key (deterministic, and correct for cross-map comparison since a key sorts the same regardless of which collection id derived its entity id) and routed all four impls through it.

## Verified (status per finding)

- **F168 [M]** — was NOT deterministic; **fixed** for `UnorderedMap` as above. Note: `UnorderedSet` (`Serialize`/`Eq`/`Ord`/`PartialOrd` over `iter()`) has the identical latent non-determinism but was out of the F168 scope (unordered_map.rs) and shares the copy-paste flagged in F173 — **left as a follow-on** (happy to push the same 4-line treatment if wanted).

- **F170 [M]** — **largely addressed already; no change.** Both `unordered_map.rs` (`reassign_deterministic_id_keyed`) and `unordered_set.rs` (`reassign_deterministic_id` / `rekey_relative_to`) already have the **skip-when-correct** fast path (`if old_id == new_id { return }`), so a re-key that is already correct is a no-op instead of O(n). When the id genuinely changes it still snapshots all entries + clears + re-inserts (O(n)), but that is **inherent**: every child's entity id is derived from the parent id, so a parent re-key necessarily re-homes every child. Not a fixable inefficiency; not in-place-able.

- **F173 [L]** — DRY/refactor bundle; **left for human** (nothing was a safe one-liner):
  - `counter.rs:128-179` GCounter↔PNCounter compat matches a borsh error by string (`e.to_string().contains("Unexpected length")`) — fragile but wire/compat-adjacent; risky to touch.
  - `rga.rs:311-313` `len()`/`is_empty()` run the full O(n log n) DFS linearization just to count; `self.chars.len()`/`is_empty()` would be O(1), but they are not provably equal for a malformed `left`-cycle (a pure cycle emits 0 while the map holds N), so not a safe one-liner.
  - `unordered_map.rs:384-409` vs `unordered_set.rs:264-278` copy-pasted ITER_DROP + `Eq`/`Ord`/`Serialize`/`Debug` — genuine duplication, wants a shared trait/macro (this is also why the F168 fix for the set is a follow-on).
  - `store.rs:348-359` `prefix_upper_bound` all-`0xFF` fallback is correct and self-contained; a DRY win only if the pattern recurs elsewhere.

## Tests

- `cargo fmt -p calimero-storage --check` — clean (husky pre-commit passed).
- `cargo build -p calimero-storage --all-targets` — clean.
- `cargo test -p calimero-storage` — **667 lib + 12 crdt_contract + 5 derive_mergeable + doc-tests, all passing** (includes the new saturation test; the CRDT structural-equality contract tests still pass with the sorted Eq/Serialize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)