### PR TITLE
fix(storage): Collection soundness — aliasing UB, corruption-masking, read-only writeback, error propagation

### DIFF
--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -1,10 +1,10 @@
 //! High-level data structures for storage.
 
-use core::cell::RefCell;
+use core::cell::{RefCell, RefMut};
 use core::cmp::Ordering;
+use core::fmt;
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
-use core::{fmt, ptr};
 use std::collections::BTreeMap;
 use std::sync::LazyLock;
 
@@ -713,7 +713,11 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
     fn entries(
         &self,
     ) -> StoreResult<impl ExactSizeIterator<Item = StoreResult<T>> + DoubleEndedIterator + '_> {
-        let iter = self.children_cache()?.iter().copied().map(|child| {
+        // Snapshot the child ids so the returned iterator does not borrow the
+        // `RefMut` guard (which is dropped at the end of this statement); each
+        // entry is still read lazily on iteration.
+        let ids: Vec<Id> = self.children_cache()?.iter().copied().collect();
+        let iter = ids.into_iter().map(|child| {
             let entry = <Interface<S>>::find_by_id::<Entry<_>>(child)?
                 .ok_or(StoreError::StorageError(StorageError::NotFound(child)))?;
 
@@ -769,37 +773,37 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         Ok(())
     }
 
+    /// Lazily loads the child-id set from the index and hands back a `RefMut`
+    /// guard over it. The guard ties the borrow to the returned value, so
+    /// callers hold the `RefCell` borrow for exactly as long as they use the
+    /// set — no aliasing `&mut` outlives it (F166).
     #[expect(
         clippy::unwrap_in_result,
         clippy::expect_used,
-        clippy::mut_from_ref,
-        reason = "fatal error if it happens"
+        reason = "cache is populated immediately above"
     )]
-    fn children_cache(&self) -> StoreResult<&mut IndexSet<Id>> {
+    fn children_cache(&self) -> StoreResult<RefMut<'_, IndexSet<Id>>> {
         let mut cache = self.children_ids.borrow_mut();
 
         if cache.is_none() {
-            // Try to load children from index
-            // After CRDT sync, newly created collections might not have index entries yet
-            // In that case, start with an empty set
+            // `IndexNotFound` here means the parent has NO index record yet — a
+            // just-created or freshly-synced collection with no children, which
+            // is legitimately empty. Genuine read corruption surfaces as
+            // `DeserializationError` (from the index borsh decode) and is
+            // propagated by the `Err(e)` arm below, NOT collapsed to empty
+            // (F169). The one case indistinguishable from "never created" is a
+            // *lost* index record whose child entries survive — inherent to the
+            // storage model, where the index is the sole record of children.
             let children: IndexSet<Id> = match <Interface<S>>::child_info_for(self.id()) {
                 Ok(info) => info.into_iter().map(|c| c.id()).collect(),
-                Err(StorageError::IndexNotFound(_)) => {
-                    // Collection was just created/synced, no children yet
-                    IndexSet::new()
-                }
+                Err(StorageError::IndexNotFound(_)) => IndexSet::new(),
                 Err(e) => return Err(StoreError::StorageError(e)),
             };
 
             *cache = Some(children);
         }
 
-        let children = cache.as_mut().expect("children");
-
-        #[expect(unsafe_code, reason = "necessary for caching")]
-        let children = unsafe { &mut *ptr::from_mut(children) };
-
-        Ok(children)
+        Ok(RefMut::map(cache, |c| c.as_mut().expect("children")))
     }
 }
 
@@ -908,7 +912,7 @@ where
     }
 
     fn clear(&mut self) -> StoreResult<()> {
-        let children = self.collection.children_cache()?;
+        let mut children = self.collection.children_cache()?;
 
         for child in children.drain(..) {
             let _ = <Interface<S>>::remove_child_from(self.collection.id(), child)?;
@@ -921,7 +925,7 @@ where
     /// children via [`Interface::relocate_child_from`] so `Frozen` entries are
     /// relocated rather than rejected. See [`Collection::clear_for_rekey`].
     fn clear_for_rekey(&mut self) -> StoreResult<()> {
-        let children = self.collection.children_cache()?;
+        let mut children = self.collection.children_cache()?;
 
         for child in children.drain(..) {
             let _ = <Interface<S>>::relocate_child_from(self.collection.id(), child)?;

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -703,6 +703,7 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
             collection: CollectionMut::new(self),
             entry,
             removed: false,
+            dirty: false,
         }))
     }
 
@@ -815,6 +816,9 @@ struct EntryMut<'a, T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> {
     /// When `remove()` is called, this is set to true to prevent the Drop impl
     /// from generating an Update action for the deleted entity.
     removed: bool,
+    /// Set by `deref_mut`. A `get_mut` used only for reading never writes back,
+    /// so its Drop must not emit a spurious Update (F167).
+    dirty: bool,
 }
 
 impl<T, S> EntryMut<'_, T, S>
@@ -869,6 +873,9 @@ where
     T: BorshSerialize + BorshDeserialize,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
+        // Any real mutation goes through here, so this is the one place that can
+        // authoritatively mark the entry as needing a write-back (F167).
+        self.dirty = true;
         &mut self.entry.item
     }
 }
@@ -880,8 +887,11 @@ where
 {
     fn drop(&mut self) {
         // Don't save if the entry was removed - the DeleteRef action has
-        // already been created, and saving would create a conflicting Update action
-        if self.removed {
+        // already been created, and saving would create a conflicting Update action.
+        // Don't save a read-only `get_mut` either: with no mutation there is
+        // nothing to persist, and a spurious Update bumps `updated_at`,
+        // recomputes hashes, and can win an LWW race it should have lost (F167).
+        if self.removed || !self.dirty {
             return;
         }
         self.entry.element_mut().update();


### PR DESCRIPTION
Fixes four storage-collection soundness findings, all confined to
`crates/storage/src/collections.rs`. Correctness-sensitive — please review the
judgment calls flagged below.

## Commit → finding map

| Commit | Findings |
|--------|----------|
| `children_cache hands back a RefMut guard…` | **F166** (fix) + **F169** (documented) |
| `EntryMut writes back only when actually mutated` | **F167** (fix) |

## F166 [HIGH] — aliasing `&mut` from `&self` (UB) — FIXED
`children_cache` populated a `RefCell` then returned
`unsafe { &mut *ptr::from_mut(children) }`, an `&mut` that outlived the `RefMut`
guard (UB), and yielded two live `&mut` to the same set whenever a caller held
an iterator while calling `len()`/`get_mut()`.

Now returns `RefMut<'_, IndexSet<Id>>` via `RefMut::map`: the borrow is tied to
the returned guard, so every caller holds the `RefCell` borrow for exactly as
long as it touches the set. Removed the `unsafe` block, the `ptr` import, and
the `clippy::mut_from_ref` escape hatch.

Call-site changes (all other callers are unchanged — `RefMut` derefs to
`&`/`&mut IndexSet`):
- `entries()` snapshots the child ids into a `Vec` before building its lazy
  iterator (that iterator must not borrow the guard, which drops at end of
  statement); each entry is still read lazily on iteration.
- `clear` / `clear_for_rekey` bind the guard `mut` so they can `drain` it.

Note: the guard now keeps the `RefCell` borrowed across the `clear`/`clear_for_rekey`
loops (the old code cleared the borrow flag by leaking a raw pointer). This is
safe — `remove_child_from`/`relocate_child_from` operate on the index/storage
layer by id and never re-enter this handle's `children_ids`, so there is no
re-entrant `borrow_mut` panic. Verified by the full storage test suite.

## F169 [MED] — `IndexNotFound → empty` corruption masking — DOCUMENTED (no behaviour change)
Investigated distinguishability. `child_info_for` → `get_children_of` →
`get_index()?.ok_or(IndexNotFound)`. `get_index` returns `Ok(None)` only when
**no index record exists**, and a corrupt/undecodable index returns
`DeserializationError` (a different variant). So:
- "never created / freshly synced" (no index record) → `IndexNotFound` → empty. **Correct.**
- genuine read corruption → `DeserializationError` → **already propagated** by the
  `Err(e)` arm, NOT collapsed to empty.

These two ARE cleanly distinguished today. The **only** case that cannot be told
apart from "never created" is a *lost* index record whose child entries survive
— but that is inherent to the storage model (the index is the sole record of a
parent's children; no index literally means no children), and resolving it would
need a separate existence/tombstone signal — out of scope for this pass. I left
behaviour as-is and added a precise comment at the site explaining exactly this.

## F167 [MED] — `EntryMut::drop` writes back on read-only `get_mut` — FIXED
`EntryMut` had only a `removed` flag, so `Drop` unconditionally ran
`element_mut().update()` + `Interface::save()`. A `get_mut()` used purely for
reading still emitted an Update (bumped `updated_at`, recomputed hashes, could
win an LWW race it should have lost).

Added `dirty: bool` (default false), set to true in `DerefMut::deref_mut` (the
single path every genuine mutation takes), and `Drop` now writes back only when
`dirty` (the `removed` early-return is unchanged). Real writes still persist;
read-only `get_mut` is a no-op on drop.

## F171 [MED] — nested-collection constructors `.expect()` on storage error — DEFERRED (judgment call)
**Not changed.** Propagating `StoreError`/`StoreResult` out of `new` /
`new_shared` / `new_with_field_name_and_crdt_type` /
`reassign_deterministic_id_*` cannot be localized to `crates/storage`: the
entire construction surface is deliberately infallible and feeds
`Result`-incompatible boundaries.

- `Collection::new` backs `impl Default` and `impl FromIterator` — std traits
  that **cannot** return `Result`.
- Every public wrapper constructor (`UnorderedMap::new`, `UnorderedSet::new`,
  `SortedSet::new`, `Vector::new`, `Root::new`, `WriterSetCell::new`, …) returns
  `-> Self` and itself carries `#[expect(clippy::expect_used, reason = "fatal
  error if it happens")]`.
- `reassign_deterministic_id_*` is driven by the SDK `#[app::state]` codegen
  `pub fn __assign_deterministic_ids(&mut self)` (in `crates/sdk/macros/src/state.rs`),
  which is infallible and called by the init wrapper.

Threading `Result` through would change public constructor signatures on every
collection type **and** the SDK codegen/init path — i.e. blow up the public API
surface well beyond storage, which the task scoped out. Adding a parallel
`try_*` API would serve zero current callers (dead code), so I did not.
Recommend tracking F171 as its own cross-crate change if graceful handling of
transient construction errors is wanted.

## Verification
- `cargo fmt -p calimero-storage --check` → OK
- `cargo build -p calimero-storage --all-targets` → OK
- `cargo test -p calimero-storage` → 666 + 1 + 12 + 5 + 3 (doc) passed, 0 failed
- `cargo clippy -p calimero-storage --all-targets` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
