### PR TITLE
fix(sync): bind inbound handshake identity to the transport with a proof of possession

### DIFF
--- a/crates/node/primitives/src/sync.rs
+++ b/crates/node/primitives/src/sync.rs
@@ -81,7 +81,7 @@ pub use bloom_filter::{
 };
 
 // Wire protocol types (used by all sync protocols)
-pub use wire::{InitPayload, MessagePayload, StreamMessage, MAX_TREE_REQUEST_DEPTH};
+pub use wire::{InitPayload, InitProof, MessagePayload, StreamMessage, MAX_TREE_REQUEST_DEPTH};
 
 // Snapshot types
 pub use snapshot::{

--- a/crates/node/primitives/src/sync/wire.rs
+++ b/crates/node/primitives/src/sync/wire.rs
@@ -160,16 +160,33 @@ pub enum StreamMessage<'a> {
 /// - the claimed `party_id`,
 /// - the **initiator's own** libp2p `PeerId` bytes.
 ///
-/// # Why it resists replay
+/// # Why it resists replay (and why there is deliberately no freshness nonce)
 ///
 /// The bound `PeerId` is the dialer's. The responder recomputes the message
 /// with the `PeerId` it observes on the transport — which libp2p's noise
 /// handshake authenticates — so a proof captured from one member cannot be
 /// presented by a different peer (the observed `PeerId` would differ), and a
-/// caller cannot forge a proof for an identity whose key it lacks. The proof is
-/// independent of the payload and nonce, so one signature is reusable for every
-/// request a node issues for a given (context, identity) — it is a capability
-/// to *speak as* that identity from that peer, not a per-message token.
+/// caller cannot forge a proof for an identity whose key it lacks.
+///
+/// The proof is intentionally payload/nonce/time-independent — one signature is
+/// reusable for every request a node issues for a given (context, identity). It
+/// is a capability to *speak as* that identity **from that peer**, not a
+/// per-message token, and it needs no responder-issued challenge (which would
+/// add a round-trip to every sync) because a captured proof is not usable on its
+/// own:
+///
+/// - The stream is carried over libp2p's noise-encrypted transport, so the proof
+///   is not observable by a passive on-path attacker — only by the responder it
+///   is sent to (which already gets served) or a party that has compromised the
+///   host.
+/// - Even given the proof bytes, replaying them requires speaking as the bound
+///   `PeerId`, which the transport only lets the holder of that peer's network
+///   private key do. An attacker with that key already *is* the node.
+/// - Key rotation changes the network key and therefore the `PeerId`, so proofs
+///   bound to the old `PeerId` do not carry over to a rotated identity.
+///
+/// Bump [`InitProof::DOMAIN`] if a future change needs to invalidate all
+/// outstanding proofs.
 #[derive(Clone, Copy, Debug, BorshSerialize, BorshDeserialize)]
 pub struct InitProof {
     /// Ed25519 signature over [`InitProof::message`] by `party_id`'s key.
@@ -189,7 +206,11 @@ impl InitProof {
     /// the initiator side, the transport-observed peer on the responder side.
     #[must_use]
     pub fn message(context_id: &ContextId, party_id: &PublicKey, dialer_peer_id: &[u8]) -> Vec<u8> {
-        let mut msg = Vec::with_capacity(Self::DOMAIN.len() + 32 + 32 + dialer_peer_id.len());
+        use calimero_primitives::common::DIGEST_SIZE;
+        // context_id.digest() + party_id.digest() are each DIGEST_SIZE bytes.
+        let mut msg = Vec::with_capacity(
+            Self::DOMAIN.len() + DIGEST_SIZE + DIGEST_SIZE + dialer_peer_id.len(),
+        );
         msg.extend_from_slice(Self::DOMAIN);
         msg.extend_from_slice(context_id.digest());
         msg.extend_from_slice(party_id.digest());

--- a/crates/node/primitives/src/sync/wire.rs
+++ b/crates/node/primitives/src/sync/wire.rs
@@ -68,6 +68,23 @@ pub enum StreamMessage<'a> {
         payload: InitPayload,
         /// Nonce for the next message.
         next_nonce: Nonce,
+        /// Proof that the sender controls `party_id`, bound to the dialer's
+        /// transport `PeerId` (see [`InitProof`]). `None` on handshake acks,
+        /// sentinel/keyless party ids, and pre-upgrade peers. The responder
+        /// **requires** a valid proof before serving state-read requests
+        /// (deltas, DAG heads, snapshots, tree/level nodes) or acting on a
+        /// namespace/subgroup join, and ignores it on paths whose payload is
+        /// already bound to the claimed identity by other means (e.g. blob and
+        /// group-key shares are ECDH-wrapped to `party_id`).
+        ///
+        /// # Wire Format Change
+        ///
+        /// New trailing field on the `Init` variant. Borsh is positional, so
+        /// pre-upgrade peers cannot deserialize an `Init` carrying it and vice
+        /// versa — a coordinated network upgrade is required, the same
+        /// constraint documented on `Message::sequence_id` and the
+        /// `NotMaterialized` variant.
+        pop: Option<InitProof>,
     },
     /// Follow-up message in an ongoing sync operation.
     Message {
@@ -114,6 +131,86 @@ pub enum StreamMessage<'a> {
     /// to the previous behaviour (no benign signal) and continue working
     /// for all other variants.
     NotMaterialized,
+}
+
+// =============================================================================
+// Init Proof (transport-bound proof of possession)
+// =============================================================================
+
+/// Proof that the sender of an [`StreamMessage::Init`] controls the private
+/// key of the identity it names in `party_id`, bound to the dialer's transport
+/// `PeerId`.
+///
+/// # Why
+///
+/// The responder serves context state — DAG heads, snapshots, deltas, tree and
+/// level nodes — and performs namespace/subgroup pre-registration keyed off the
+/// `party_id` (or `joiner_public_key`) carried in the `Init`. Those values are
+/// attacker-chosen: without a proof, any peer that learns a member's public key
+/// can name it and be served as that member, or register an identity it does
+/// not control. Membership checks alone don't help — they only confirm the
+/// *named* identity is a member, not that the *caller* holds it.
+///
+/// # Construction
+///
+/// An Ed25519 signature by `party_id`'s key over [`InitProof::message`], which
+/// binds:
+/// - the domain separator (protocol/version),
+/// - the `context_id`,
+/// - the claimed `party_id`,
+/// - the **initiator's own** libp2p `PeerId` bytes.
+///
+/// # Why it resists replay
+///
+/// The bound `PeerId` is the dialer's. The responder recomputes the message
+/// with the `PeerId` it observes on the transport — which libp2p's noise
+/// handshake authenticates — so a proof captured from one member cannot be
+/// presented by a different peer (the observed `PeerId` would differ), and a
+/// caller cannot forge a proof for an identity whose key it lacks. The proof is
+/// independent of the payload and nonce, so one signature is reusable for every
+/// request a node issues for a given (context, identity) — it is a capability
+/// to *speak as* that identity from that peer, not a per-message token.
+#[derive(Clone, Copy, Debug, BorshSerialize, BorshDeserialize)]
+pub struct InitProof {
+    /// Ed25519 signature over [`InitProof::message`] by `party_id`'s key.
+    pub signature: [u8; 64],
+}
+
+impl InitProof {
+    /// Domain separator for the signed message. Bump the version suffix on any
+    /// change to the signed layout so proofs never cross protocol versions.
+    pub const DOMAIN: &'static [u8] = b"calimero:sync:init-pop:v1";
+
+    /// Canonical bytes the [`signature`](InitProof::signature) covers:
+    /// `DOMAIN ‖ context_id ‖ party_id ‖ dialer_peer_id`.
+    ///
+    /// `dialer_peer_id` must be the raw `libp2p::PeerId` bytes
+    /// (`PeerId::to_bytes()`) of the node that opens the stream — the signer on
+    /// the initiator side, the transport-observed peer on the responder side.
+    #[must_use]
+    pub fn message(context_id: &ContextId, party_id: &PublicKey, dialer_peer_id: &[u8]) -> Vec<u8> {
+        let mut msg = Vec::with_capacity(Self::DOMAIN.len() + 32 + 32 + dialer_peer_id.len());
+        msg.extend_from_slice(Self::DOMAIN);
+        msg.extend_from_slice(context_id.digest());
+        msg.extend_from_slice(party_id.digest());
+        msg.extend_from_slice(dialer_peer_id);
+        msg
+    }
+
+    /// Verify this proof authorizes `party_id` to speak for `context_id` from
+    /// the peer identified by `dialer_peer_id` (raw `PeerId` bytes).
+    #[must_use]
+    pub fn verify(
+        &self,
+        context_id: &ContextId,
+        party_id: &PublicKey,
+        dialer_peer_id: &[u8],
+    ) -> bool {
+        let message = Self::message(context_id, party_id, dialer_peer_id);
+        party_id
+            .verify_raw_signature(&message, &self.signature)
+            .is_ok()
+    }
 }
 
 // =============================================================================
@@ -834,6 +931,109 @@ mod tests {
                 assert_eq!(applied_count, 42);
             }
             _ => panic!("wrong variant"),
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // InitProof (transport-bound proof of possession)
+    // ---------------------------------------------------------------------
+
+    use calimero_primitives::identity::PrivateKey;
+
+    /// A deterministic keypair from a seed byte (no `rand` feature needed).
+    fn test_keypair(seed: u8) -> (PrivateKey, PublicKey) {
+        let sk = PrivateKey::from([seed; 32]);
+        let pk = sk.public_key();
+        (sk, pk)
+    }
+
+    fn sign_pop(sk: &PrivateKey, ctx: &ContextId, party: &PublicKey, peer: &[u8]) -> InitProof {
+        let message = InitProof::message(ctx, party, peer);
+        InitProof {
+            signature: sk.sign(&message).expect("sign").to_bytes(),
+        }
+    }
+
+    #[test]
+    fn init_proof_verifies_for_matching_context_party_and_peer() {
+        let ctx = ContextId::from([7u8; 32]);
+        let (sk, pk) = test_keypair(1);
+        let peer = b"peer-id-bytes-A";
+
+        let proof = sign_pop(&sk, &ctx, &pk, peer);
+        assert!(proof.verify(&ctx, &pk, peer));
+    }
+
+    #[test]
+    fn init_proof_rejects_wrong_peer_id() {
+        // A proof captured for one dialer must not verify when replayed from a
+        // different transport peer — this is what stops identity spoofing.
+        let ctx = ContextId::from([7u8; 32]);
+        let (sk, pk) = test_keypair(1);
+
+        let proof = sign_pop(&sk, &ctx, &pk, b"peer-id-bytes-A");
+        assert!(!proof.verify(&ctx, &pk, b"peer-id-bytes-B"));
+    }
+
+    #[test]
+    fn init_proof_rejects_wrong_party_id() {
+        // Signing with one key but claiming another identity must fail: a caller
+        // cannot prove possession of a key it does not hold.
+        let ctx = ContextId::from([7u8; 32]);
+        let (attacker_sk, _attacker_pk) = test_keypair(1);
+        let (_victim_sk, victim_pk) = test_keypair(2);
+        let peer = b"peer-id-bytes-A";
+
+        // Attacker signs with its own key but stamps the victim's public key.
+        let forged = sign_pop(&attacker_sk, &ctx, &victim_pk, peer);
+        assert!(!forged.verify(&ctx, &victim_pk, peer));
+    }
+
+    #[test]
+    fn init_proof_rejects_wrong_context() {
+        let (sk, pk) = test_keypair(1);
+        let peer = b"peer-id-bytes-A";
+
+        let proof = sign_pop(&sk, &ContextId::from([7u8; 32]), &pk, peer);
+        assert!(!proof.verify(&ContextId::from([8u8; 32]), &pk, peer));
+    }
+
+    #[test]
+    fn init_proof_rejects_tampered_signature() {
+        let ctx = ContextId::from([7u8; 32]);
+        let (sk, pk) = test_keypair(1);
+        let peer = b"peer-id-bytes-A";
+
+        let mut proof = sign_pop(&sk, &ctx, &pk, peer);
+        proof.signature[0] ^= 0xff;
+        assert!(!proof.verify(&ctx, &pk, peer));
+    }
+
+    #[test]
+    fn init_message_roundtrips_with_and_without_pop() {
+        let ctx = ContextId::from([7u8; 32]);
+        let (sk, pk) = test_keypair(3);
+        let peer = b"peer-id-bytes-A";
+        let proof = sign_pop(&sk, &ctx, &pk, peer);
+
+        for pop in [Some(proof), None] {
+            let msg = StreamMessage::Init {
+                context_id: ctx,
+                party_id: pk,
+                payload: InitPayload::DagHeadsRequest { context_id: ctx },
+                next_nonce: [0u8; 12],
+                pop,
+            };
+            let encoded = borsh::to_vec(&msg).expect("serialize");
+            let decoded: StreamMessage<'_> = borsh::from_slice(&encoded).expect("deserialize");
+            match decoded {
+                StreamMessage::Init {
+                    pop: decoded_pop, ..
+                } => {
+                    assert_eq!(decoded_pop.map(|p| p.signature), pop.map(|p| p.signature));
+                }
+                _ => panic!("wrong variant"),
+            }
         }
     }
 }

--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -571,6 +571,9 @@ async fn fetch_and_apply_namespace_backfill(
             use rand::Rng;
             rand::thread_rng().gen()
         },
+        // Sentinel party id; backfill serves only already-signed deltas, which
+        // the requester re-verifies on receipt — no proof of possession.
+        pop: None,
     };
 
     if let Err(err) = crate::sync::stream::send(&mut stream, &msg, None).await {

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -1202,7 +1202,33 @@ async fn request_missing_deltas(
     // inline so the borrow outlives every projection read.
     node_state: &crate::NodeState,
 ) -> Result<Vec<([u8; 32], Vec<u8>)>> {
-    use calimero_node_primitives::sync::{InitPayload, MessagePayload, StreamMessage};
+    use calimero_node_primitives::sync::{InitPayload, InitProof, MessagePayload, StreamMessage};
+
+    // Transport-binding proof of possession for `our_identity`, attached to
+    // every DeltaRequest below so the responder can reject a caller that
+    // doesn't control the claimed identity (see `InitProof`). Signed once —
+    // it's independent of the per-delta payload/nonce — from the identity's
+    // private key in the local store and this node's own PeerId. `None` (no
+    // owned key / lookup failure) leaves the requests unproven, which a
+    // proof-requiring responder rejects.
+    let delta_pop: Option<InitProof> = {
+        let key = calimero_store::key::ContextIdentity::new(context_id, our_identity);
+        match datastore.handle().get(&key) {
+            Ok(Some(identity)) => match identity.private_key {
+                Some(sk_bytes) => {
+                    let private_key = calimero_primitives::identity::PrivateKey::from(sk_bytes);
+                    let peer_id = network_client.network_status().await.local_peer_id;
+                    let message =
+                        InitProof::message(&context_id, &our_identity, &peer_id.to_bytes());
+                    private_key.sign(&message).ok().map(|signature| InitProof {
+                        signature: signature.to_bytes(),
+                    })
+                }
+                None => None,
+            },
+            _ => None,
+        }
+    };
 
     // Metric: number of missing-parent IDs the caller is about to fetch.
     // Recorded *before* the stream open so a peer-stream failure doesn't
@@ -1266,6 +1292,7 @@ async fn request_missing_deltas(
                     use rand::Rng;
                     rand::thread_rng().gen()
                 },
+                pop: delta_pop,
             };
 
             crate::sync::stream::send(&mut stream, &request_msg, None).await?;

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -1215,8 +1215,14 @@ async fn request_missing_deltas(
         let key = calimero_store::key::ContextIdentity::new(context_id, our_identity);
         match datastore.handle().get(&key) {
             Ok(Some(identity)) => match identity.private_key {
-                Some(sk_bytes) => {
+                Some(mut sk_bytes) => {
+                    use zeroize::Zeroize;
                     let private_key = calimero_primitives::identity::PrivateKey::from(sk_bytes);
+                    // `PrivateKey::from` copies into its own zeroizing wrapper,
+                    // but the bare `[u8; 32]` read out of the store value is a
+                    // `Copy` that lingers on the stack — wipe it now (mirrors the
+                    // discipline in `join_namespace` / `emit_namespace_ack`).
+                    sk_bytes.zeroize();
                     let peer_id = network_client.network_status().await.local_peer_id;
                     let message =
                         InitProof::message(&context_id, &our_identity, &peer_id.to_bytes());

--- a/crates/node/src/sync/blobs.rs
+++ b/crates/node/src/sync/blobs.rs
@@ -40,6 +40,9 @@ impl SyncManager {
                 party_id: our_identity,
                 payload: InitPayload::BlobShare { blob_id },
                 next_nonce: our_nonce,
+                // Blob bytes are ECDH-encrypted to `our_identity` on the wire,
+                // so an impersonator can't read them; no read-gating proof here.
+                pop: None,
             },
             None,
         )
@@ -214,6 +217,9 @@ impl SyncManager {
                 party_id: our_identity,
                 payload: InitPayload::BlobShare { blob_id },
                 next_nonce: our_nonce,
+                // Blob bytes are ECDH-encrypted to `our_identity` on the wire,
+                // so an impersonator can't read them; no read-gating proof here.
+                pop: None,
             },
             None,
         )

--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -496,6 +496,7 @@ impl SyncManager {
                 delta_id,
             },
             next_nonce: super::helpers::generate_nonce(),
+            pop: self.build_init_pop(*context_id, our_identity).await,
         };
 
         super::stream::send(stream, &msg, None).await?;

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -46,7 +46,7 @@ use crate::sync::helpers::{
 use async_trait::async_trait;
 use calimero_context_client::client::ContextClient;
 use calimero_node_primitives::sync::{
-    compare_tree_nodes, create_runtime_env, EntityDeletion, InitPayload, LeafMetadata,
+    compare_tree_nodes, create_runtime_env, EntityDeletion, InitPayload, InitProof, LeafMetadata,
     MessagePayload, StreamMessage, SyncProtocolExecutor, SyncTransport, TreeCompareResult,
     TreeLeafData, TreeNode, TreeNodeResponse, MAX_LEAF_VALUE_SIZE, MAX_NODES_PER_RESPONSE,
 };
@@ -108,6 +108,11 @@ pub struct HashComparisonConfig {
     /// (Public) leaves on the peer's current membership. `None` when
     /// unattributable (e.g. sync-sim harness) → historical allow.
     pub session_peer: Option<PublicKey>,
+    /// Transport-binding proof of possession for `identity`, attached to every
+    /// state-read `Init` this initiator sends so the responder can reject a
+    /// caller that doesn't control the claimed identity. `None` in harnesses
+    /// with no real transport identity. See [`InitProof`].
+    pub init_pop: Option<InitProof>,
 }
 
 /// Data from the first `TreeNodeRequest` for responder dispatch.
@@ -184,6 +189,7 @@ impl SyncProtocolExecutor for HashComparisonProtocol {
             config.remote_root_hash,
             config.context_client.as_ref(),
             config.session_peer,
+            config.init_pop,
         )
         .await
     }
@@ -211,6 +217,7 @@ impl SyncProtocolExecutor for HashComparisonProtocol {
 // Initiator Implementation
 // =============================================================================
 
+#[allow(clippy::too_many_arguments)]
 async fn run_initiator_impl<T: SyncTransport>(
     transport: &mut T,
     store: &Store,
@@ -219,6 +226,7 @@ async fn run_initiator_impl<T: SyncTransport>(
     remote_root_hash: [u8; 32],
     context_client: Option<&ContextClient>,
     session_peer: Option<PublicKey>,
+    init_pop: Option<InitProof>,
 ) -> Result<HashComparisonStats> {
     info!(%context_id, "Starting HashComparison sync (initiator)");
 
@@ -267,6 +275,7 @@ async fn run_initiator_impl<T: SyncTransport>(
         let request_msg = StreamMessage::Init {
             context_id,
             party_id: identity,
+            pop: init_pop,
             payload: InitPayload::TreeNodeRequest {
                 context_id,
                 node_id,
@@ -688,7 +697,7 @@ async fn run_initiator_impl<T: SyncTransport>(
     // converges through HC's ordinary tree traversal like any other entity; no
     // separate writer-set reconcile is needed.)
     let (peer_current_root, peer_scope_root) =
-        match query_peer_current_root(transport, context_id, identity).await {
+        match query_peer_current_root(transport, context_id, identity, init_pop).await {
             Ok(Some((root, scope_root))) => (root, scope_root),
             Ok(None) | Err(_) => (remote_root_hash, None),
         };
@@ -807,12 +816,14 @@ pub(crate) async fn query_peer_current_root<T: SyncTransport>(
     transport: &mut T,
     context_id: ContextId,
     identity: PublicKey,
+    init_pop: Option<InitProof>,
 ) -> Result<Option<([u8; 32], Option<[u8; 32]>)>> {
     let request = StreamMessage::Init {
         context_id,
         party_id: identity,
         payload: InitPayload::DagHeadsRequest { context_id },
         next_nonce: generate_nonce(),
+        pop: init_pop,
     };
     transport.send(&request).await?;
 
@@ -1373,6 +1384,10 @@ async fn push_entities<T: SyncTransport>(
                 entities: chunk.to_vec(),
             },
             next_nonce: generate_nonce(),
+            // Pushes are writes: each entity is authorized by its own action
+            // path on apply, not by the sender's `party_id`, so no read-gating
+            // proof is attached (or required by the responder) here.
+            pop: None,
         };
 
         transport.send(&push_msg).await?;
@@ -1427,6 +1442,9 @@ async fn push_deletions<T: SyncTransport>(
                 deletions: chunk.to_vec(),
             },
             next_nonce: generate_nonce(),
+            // Writes (tombstones) — authorized per-action on apply. See the
+            // EntityPush site above.
+            pop: None,
         };
 
         transport.send(&push_msg).await?;
@@ -1677,6 +1695,7 @@ mod tests {
             remote_root_hash: [1u8; 32],
             context_client: None,
             session_peer: None,
+            init_pop: None,
         };
         assert_eq!(config.remote_root_hash, [1u8; 32]);
     }

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -60,7 +60,7 @@ use std::collections::{HashMap, HashSet};
 use async_trait::async_trait;
 use calimero_context_client::client::ContextClient;
 use calimero_node_primitives::sync::{
-    compare_level_nodes, create_runtime_env, EntityDeletion, InitPayload, LevelNode,
+    compare_level_nodes, create_runtime_env, EntityDeletion, InitPayload, InitProof, LevelNode,
     MessagePayload, StreamMessage, SyncProtocolExecutor, SyncTransport, TreeLeafData,
     MAX_LEVELWISE_DEPTH, MAX_NODES_PER_LEVEL, MAX_PARENTS_PER_REQUEST, MAX_REQUESTS_PER_SESSION,
 };
@@ -99,6 +99,10 @@ pub struct LevelWiseConfig {
     /// Remote peer's attributable member identity — gates authorless leaves on
     /// the peer's current membership. See `HashComparisonConfig::session_peer`.
     pub session_peer: Option<PublicKey>,
+    /// Transport-binding proof of possession for `identity`, attached to every
+    /// state-read `Init` this initiator sends. See `HashComparisonConfig::init_pop`
+    /// and [`InitProof`].
+    pub init_pop: Option<InitProof>,
 }
 
 /// Data from the first `LevelWiseRequest` for responder dispatch.
@@ -189,6 +193,7 @@ impl SyncProtocolExecutor for LevelWiseProtocol {
             config.max_depth,
             config.context_client.as_ref(),
             config.session_peer,
+            config.init_pop,
         )
         .await
     }
@@ -227,6 +232,7 @@ async fn run_initiator_impl<T: SyncTransport>(
     max_depth: u32,
     context_client: Option<&ContextClient>,
     session_peer: Option<PublicKey>,
+    init_pop: Option<InitProof>,
 ) -> Result<LevelWiseStats> {
     info!(
         %context_id,
@@ -257,6 +263,7 @@ async fn run_initiator_impl<T: SyncTransport>(
         let request_msg = StreamMessage::Init {
             context_id,
             party_id: identity,
+            pop: init_pop,
             payload: InitPayload::LevelWiseRequest {
                 context_id,
                 level,
@@ -548,6 +555,9 @@ async fn run_initiator_impl<T: SyncTransport>(
                     deletions: chunk.to_vec(),
                 },
                 next_nonce: generate_nonce(),
+                // Write (tombstone) — authorized per-action on apply, not by the
+                // sender's `party_id`; no read-gating proof needed.
+                pop: None,
             };
             transport.send(&msg).await?;
 
@@ -574,7 +584,7 @@ async fn run_initiator_impl<T: SyncTransport>(
     // peer).
     let (peer_current_root, peer_scope_root) =
         match super::hash_comparison_protocol::query_peer_current_root(
-            transport, context_id, identity,
+            transport, context_id, identity, init_pop,
         )
         .await
         {
@@ -1182,6 +1192,7 @@ mod tests {
             max_depth: 2,
             context_client: None,
             session_peer: None,
+            init_pop: None,
         };
         assert_eq!(config.remote_root_hash, [1u8; 32]);
         assert_eq!(config.max_depth, 2);

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -3403,8 +3403,19 @@ impl SyncManager {
         // that accidentally moves a variant in or out fails a unit test rather
         // than silently changing behaviour.
         if payload_requires_init_pop(&payload) {
+            // Join `Init`s carry a sentinel `context_id` ([0; 32]); bind their
+            // proof to the target `namespace_id` instead so a join proof can't
+            // be lifted from one namespace to another. Other payloads bind their
+            // real `context_id`.
+            let pop_context = match &payload {
+                InitPayload::NamespaceJoinRequest { namespace_id, .. }
+                | InitPayload::OpenSubgroupJoinRequest { namespace_id, .. } => {
+                    ContextId::from(*namespace_id)
+                }
+                _ => context_id,
+            };
             let pop_ok = pop.is_some_and(|proof| {
-                proof.verify(&context_id, &their_identity, &peer_id.to_bytes())
+                proof.verify(&pop_context, &their_identity, &peer_id.to_bytes())
             });
             // For joins, the identity that gets pre-registered is
             // `joiner_public_key`; require it to equal the proven `party_id` so
@@ -3429,7 +3440,10 @@ impl SyncManager {
                 if let Err(err) = self.send(stream, &StreamMessage::OpaqueError, None).await {
                     debug!(%err, "failed to send OpaqueError after rejecting unproven sync init");
                 }
-                return Ok(Some(()));
+                // Close the stream (Ok(None)) rather than looping for another
+                // Init: an unproven dialer must not get to keep issuing requests
+                // on the same stream after a rejection.
+                return Ok(None);
             }
         }
 

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -12,7 +12,7 @@ use calimero_network_primitives::client::NetworkClient;
 use calimero_network_primitives::stream::Stream;
 use calimero_node_primitives::client::{NamespaceJoinParams, NodeClient, OpenSubgroupJoinParams};
 use calimero_node_primitives::join_bundle::JoinBundle;
-use calimero_node_primitives::sync::{InitPayload, MessagePayload, StreamMessage};
+use calimero_node_primitives::sync::{InitPayload, InitProof, MessagePayload, StreamMessage};
 use calimero_primitives::common::DIGEST_SIZE;
 use calimero_primitives::context::{ContextId, GroupMemberRole};
 use calimero_primitives::identity::PublicKey;
@@ -216,6 +216,14 @@ pub struct SyncManager {
     /// Called from `handle_dag_sync` after `select_protocol` has
     /// chosen the protocol to run. See `sync::protocol_selector`.
     pub(super) protocol_selector: super::protocol_selector::ProtocolSelector,
+
+    /// This node's own libp2p `PeerId`, memoized on first use. Read via
+    /// [`SyncManager::local_peer_id`] to sign the transport-binding
+    /// [`InitProof`] on outbound `Init`s. Constant for the process lifetime,
+    /// so one `network_status` round-trip fills it forever; shared across
+    /// clones. `OnceCell` (async) rather than `OnceLock` because the fill
+    /// awaits the network actor.
+    pub(super) local_peer_id: Arc<tokio::sync::OnceCell<PeerId>>,
 }
 
 impl std::fmt::Debug for SyncManager {
@@ -260,6 +268,9 @@ impl Clone for SyncManager {
             // `ContextClient`; cloning is cheap and shares the same
             // surfaces as the parent.
             protocol_selector: self.protocol_selector.clone(),
+            // Shared across clones: the local PeerId is a process constant, so
+            // whichever handle fills the cell first serves the rest.
+            local_peer_id: Arc::clone(&self.local_peer_id),
         }
     }
 }
@@ -268,6 +279,37 @@ impl Clone for SyncManager {
 // as Phase 3 of #2313. The free-fn predicates that used to live here
 // (`dispatch_recently_attempted`, `session_dispatch_wedged`) and the
 // nested `apply_session_result` helper now live alongside that struct.
+
+/// Whether an inbound `Init` of this payload must carry a valid
+/// [`InitProof`] before the responder acts on it.
+///
+/// `true` for payloads that serve context state to the caller (deltas, DAG
+/// heads, snapshots, HashComparison tree nodes, LevelWise level nodes) or that
+/// pre-register the caller's identity (namespace / open-subgroup joins) — these
+/// are exactly the paths where an unauthenticated `party_id` would let a peer
+/// be served as, or registered as, an identity it does not control.
+///
+/// `false` for:
+/// - `BlobShare` / `GroupKeyRequest`: the response is ECDH-encrypted/wrapped to
+///   the named identity, so only its key-holder can use it — possession is
+///   proven implicitly.
+/// - `NamespaceBackfillRequest`: serves only already-signed deltas the
+///   requester re-verifies; its `party_id` is a sentinel with no key to prove.
+/// - `EntityPush` / `EntityDeletePush`: writes authorized per-action on apply,
+///   not by the sender's `party_id`.
+const fn payload_requires_init_pop(payload: &InitPayload) -> bool {
+    matches!(
+        payload,
+        InitPayload::DeltaRequest { .. }
+            | InitPayload::DagHeadsRequest { .. }
+            | InitPayload::SnapshotBoundaryRequest { .. }
+            | InitPayload::SnapshotStreamRequest { .. }
+            | InitPayload::TreeNodeRequest { .. }
+            | InitPayload::LevelWiseRequest { .. }
+            | InitPayload::NamespaceJoinRequest { .. }
+            | InitPayload::OpenSubgroupJoinRequest { .. }
+    )
+}
 
 /// One probe of the inbound materialisation poll loop.
 ///
@@ -403,6 +445,7 @@ impl SyncManager {
             stale_blob_attempts: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             reconciler,
             protocol_selector,
+            local_peer_id: Arc::new(tokio::sync::OnceCell::new()),
         }
     }
 
@@ -1023,6 +1066,7 @@ impl SyncManager {
                         party_id: our_identity,
                         payload: InitPayload::DagHeadsRequest { context_id },
                         next_nonce: rand::thread_rng().gen(),
+                        pop: self.build_init_pop(context_id, our_identity).await,
                     };
 
                     self.send(&mut stream, &request_msg, None).await?;
@@ -1153,6 +1197,68 @@ impl SyncManager {
         );
 
         Ok((peer_id, protocol))
+    }
+
+    /// This node's own libp2p `PeerId`, fetched once and memoized.
+    ///
+    /// Used to sign the transport-binding [`InitProof`] on outbound `Init`s.
+    /// The value is a process constant, so the first call pays a single
+    /// `network_status` round-trip and every later call (and every clone)
+    /// reads the cached value.
+    pub(super) async fn local_peer_id(&self) -> PeerId {
+        *self
+            .local_peer_id
+            .get_or_init(|| async { self.network_client.network_status().await.local_peer_id })
+            .await
+    }
+
+    /// Sign a transport-bound [`InitProof`] for `party_id` in `context_id`
+    /// using an explicitly supplied private key.
+    ///
+    /// Use this when the signing key lives outside the per-context identity
+    /// store — e.g. the namespace-scoped joiner key held by
+    /// `NamespaceRepository` on the join paths. The signed message binds the
+    /// claimed identity to this node's own transport `PeerId`; see [`InitProof`].
+    pub(super) async fn sign_init_pop(
+        &self,
+        context_id: ContextId,
+        party_id: PublicKey,
+        private_key: &calimero_primitives::identity::PrivateKey,
+    ) -> Option<InitProof> {
+        let peer_id = self.local_peer_id().await;
+        let message = InitProof::message(&context_id, &party_id, &peer_id.to_bytes());
+        match private_key.sign(&message) {
+            Ok(signature) => Some(InitProof {
+                signature: signature.to_bytes(),
+            }),
+            Err(err) => {
+                warn!(%context_id, %party_id, %err, "failed to sign sync init proof of possession");
+                None
+            }
+        }
+    }
+
+    /// Build a transport-bound proof of possession for `party_id` in
+    /// `context_id`, to attach to an outbound state-read `Init`.
+    ///
+    /// Returns `None` when this node holds no private key for `party_id` in the
+    /// context (e.g. sentinel/genesis party ids or identities owned by another
+    /// node) — such `Init`s are only accepted by responders on paths that don't
+    /// require a proof. See [`InitProof`] for what the signature binds and why
+    /// it can't be replayed from another peer.
+    pub(super) async fn build_init_pop(
+        &self,
+        context_id: ContextId,
+        party_id: PublicKey,
+    ) -> Option<InitProof> {
+        let private_key = self
+            .context_client
+            .get_identity(&context_id, &party_id)
+            .ok()
+            .flatten()
+            .and_then(|identity| identity.private_key)?;
+
+        self.sign_init_pop(context_id, party_id, &private_key).await
     }
 
     /// Sends a message over the stream (delegates to stream module).
@@ -1653,6 +1759,7 @@ impl SyncManager {
             party_id: our_identity,
             payload: InitPayload::DagHeadsRequest { context_id },
             next_nonce: rand::thread_rng().gen(),
+            pop: self.build_init_pop(context_id, our_identity).await,
         };
 
         self.send(stream, &request_msg, None).await?;
@@ -1979,6 +2086,7 @@ impl SyncManager {
                 use rand::Rng;
                 rand::thread_rng().gen()
             },
+            pop: self.build_init_pop(context_id, our_identity).await,
         };
 
         self.send(stream, &request_msg, None).await?;
@@ -2085,6 +2193,10 @@ impl SyncManager {
                 // borrowed read-only by the membership check and the
                 // group-id parity check; both can share.
                 let datastore_for_heads = self.context_client.datastore_handle().into_inner();
+                // Sign the transport-binding proof once — it's independent of
+                // the per-head payload/nonce (see `InitProof`), so every head
+                // in this loop reuses the same signature.
+                let delta_pop = self.build_init_pop(context_id, our_identity).await;
                 for head_id in &dag_heads {
                     info!(
                         %context_id,
@@ -2099,6 +2211,7 @@ impl SyncManager {
                             context_id,
                             delta_id: *head_id,
                         },
+                        pop: delta_pop,
                         next_nonce: {
                             use rand::Rng;
                             rand::thread_rng().gen()
@@ -2917,6 +3030,7 @@ impl SyncManager {
             party_id: our_identity,
             payload: InitPayload::DagHeadsRequest { context_id },
             next_nonce: rand::random(),
+            pop: self.build_init_pop(context_id, our_identity).await,
         };
         self.send(stream, &request_msg, None).await?;
 
@@ -3253,20 +3367,63 @@ impl SyncManager {
             return Ok(None);
         };
 
-        let (context_id, their_identity, payload, nonce) = match message {
+        let (context_id, their_identity, payload, nonce, pop) = match message {
             StreamMessage::Init {
                 context_id,
                 party_id,
                 payload,
                 next_nonce,
-                ..
-            } => (context_id, party_id, payload, next_nonce),
+                pop,
+            } => (context_id, party_id, payload, next_nonce, pop),
             unexpected @ (StreamMessage::Message { .. }
             | StreamMessage::OpaqueError
             | StreamMessage::NotMaterialized) => {
                 bail!("expected initialization handshake, got {:?}", unexpected)
             }
         };
+
+        // Transport-binding proof-of-possession gate.
+        //
+        // For payloads that serve context state (deltas, DAG heads, snapshots,
+        // tree/level nodes) or pre-register an identity (namespace/subgroup
+        // joins), require a valid `pop` binding `party_id` to *this* dialer's
+        // transport PeerId. Without it, a caller that merely learns a member's
+        // public key could be served as — or registered as — an identity it
+        // does not control (the inbound handshake was never bound to the
+        // transport). Paths whose payload is already bound to the named
+        // identity by other means (blob / group-key ECDH shares) or that serve
+        // only self-verifying data (already-signed backfill deltas) are exempt.
+        // See [`InitProof`].
+        if payload_requires_init_pop(&payload) {
+            let pop_ok = pop.is_some_and(|proof| {
+                proof.verify(&context_id, &their_identity, &peer_id.to_bytes())
+            });
+            // For joins, the identity that gets pre-registered is
+            // `joiner_public_key`; require it to equal the proven `party_id` so
+            // a caller can't prove possession of one key and register another.
+            let join_binding_ok = match &payload {
+                InitPayload::NamespaceJoinRequest {
+                    joiner_public_key, ..
+                }
+                | InitPayload::OpenSubgroupJoinRequest {
+                    joiner_public_key, ..
+                } => *joiner_public_key == their_identity,
+                _ => true,
+            };
+            if !pop_ok || !join_binding_ok {
+                warn!(
+                    %context_id,
+                    %their_identity,
+                    %peer_id,
+                    pop_present = pop.is_some(),
+                    "rejecting sync init: missing or invalid transport-bound proof of possession"
+                );
+                if let Err(err) = self.send(stream, &StreamMessage::OpaqueError, None).await {
+                    debug!(%err, "failed to send OpaqueError after rejecting unproven sync init");
+                }
+                return Ok(Some(()));
+            }
+        }
 
         if let InitPayload::NamespaceBackfillRequest {
             namespace_id,
@@ -3606,6 +3763,14 @@ impl super::protocol_selector::ProtocolDispatch for SyncManager {
     ) -> eyre::Result<SyncProtocol> {
         SyncManager::fallback_to_snapshot_sync(self, context_id, our_identity, chosen_peer).await
     }
+
+    async fn build_init_pop(
+        &self,
+        context_id: ContextId,
+        party_id: PublicKey,
+    ) -> Option<InitProof> {
+        SyncManager::build_init_pop(self, context_id, party_id).await
+    }
 }
 
 // Driver-dispatch back into `SyncManager` for the cross-actor message
@@ -3839,6 +4004,98 @@ pub(crate) fn pending_upgrade_info(
     let applied =
         calimero_context::activation::activated_blob(store, context_id) == Some(meta.app_key);
     (!applied).then(|| (target, stage_blob_for(store, &meta)))
+}
+
+#[cfg(test)]
+mod init_pop_gate_tests {
+    use calimero_node_primitives::sync::InitPayload;
+    use calimero_primitives::blobs::BlobId;
+    use calimero_primitives::context::ContextId;
+
+    use super::payload_requires_init_pop;
+
+    #[test]
+    fn state_read_and_join_payloads_require_a_proof() {
+        let ctx = ContextId::from([1u8; 32]);
+        let requires = [
+            InitPayload::DeltaRequest {
+                context_id: ctx,
+                delta_id: [0; 32],
+            },
+            InitPayload::DagHeadsRequest { context_id: ctx },
+            InitPayload::SnapshotBoundaryRequest {
+                context_id: ctx,
+                requested_cutoff_timestamp: None,
+            },
+            InitPayload::SnapshotStreamRequest {
+                context_id: ctx,
+                boundary_root_hash: [0; 32].into(),
+                page_limit: 1,
+                byte_limit: 1,
+                resume_cursor: None,
+            },
+            InitPayload::TreeNodeRequest {
+                context_id: ctx,
+                node_id: [0; 32],
+                max_depth: None,
+            },
+            InitPayload::LevelWiseRequest {
+                context_id: ctx,
+                level: 0,
+                parent_ids: None,
+            },
+            InitPayload::NamespaceJoinRequest {
+                namespace_id: [0; 32],
+                invitation_bytes: vec![],
+                joiner_public_key: [0; 32].into(),
+            },
+            InitPayload::OpenSubgroupJoinRequest {
+                namespace_id: [0; 32],
+                subgroup_id: [0; 32],
+                joiner_public_key: [0; 32].into(),
+            },
+        ];
+        for p in &requires {
+            assert!(
+                payload_requires_init_pop(p),
+                "expected {p:?} to require a proof of possession"
+            );
+        }
+    }
+
+    #[test]
+    fn implicitly_bound_or_self_verifying_payloads_are_exempt() {
+        let ctx = ContextId::from([1u8; 32]);
+        let exempt = [
+            InitPayload::BlobShare {
+                blob_id: BlobId::from([0; 32]),
+            },
+            InitPayload::GroupKeyRequest {
+                namespace_id: [0; 32],
+                group_id: [0; 32],
+                requester_public_key: [0; 32].into(),
+                key_id: None,
+            },
+            InitPayload::NamespaceBackfillRequest {
+                namespace_id: [0; 32],
+                delta_ids: vec![],
+            },
+            InitPayload::EntityPush {
+                context_id: ctx,
+                entities: vec![],
+            },
+            InitPayload::EntityDeletePush {
+                context_id: ctx,
+                deletions: vec![],
+            },
+        ];
+        for p in &exempt {
+            assert!(
+                !payload_requires_init_pop(p),
+                "expected {p:?} to be exempt from the proof gate"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -3394,6 +3394,14 @@ impl SyncManager {
         // identity by other means (blob / group-key ECDH shares) or that serve
         // only self-verifying data (already-signed backfill deltas) are exempt.
         // See [`InitProof`].
+        //
+        // This gate runs before the per-payload dispatch below, so the exempt
+        // set in `payload_requires_init_pop` is the single source of truth for
+        // what bypasses it — e.g. `NamespaceBackfillRequest` must stay exempt or
+        // its own early-return handler further down would never be reached. The
+        // `init_pop_gate_tests` module pins that classification so a future edit
+        // that accidentally moves a variant in or out fails a unit test rather
+        // than silently changing behaviour.
         if payload_requires_init_pop(&payload) {
             let pop_ok = pop.is_some_and(|proof| {
                 proof.verify(&context_id, &their_identity, &peer_id.to_bytes())

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -755,8 +755,15 @@ impl SyncManager {
         // plain `[u8; 32]` copy left in the record struct on the stack (mirrors
         // the discipline in join_namespace / request_missing_deltas).
         record.private_key.zeroize();
-        self.sign_init_pop(ContextId::from([0u8; 32]), joiner_public_key, &private_key)
-            .await
+        // Bind the proof to the target namespace (the join `Init` itself carries
+        // a sentinel context_id) so it can't be replayed against a different
+        // namespace; the responder verifies against the same namespace id.
+        self.sign_init_pop(
+            ContextId::from(namespace_id),
+            joiner_public_key,
+            &private_key,
+        )
+        .await
     }
 
     pub(super) async fn initiate_open_subgroup_join(

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -12,7 +12,7 @@ use calimero_crypto::Nonce;
 use calimero_network_primitives::stream::Stream;
 use calimero_node_primitives::client::{NamespaceJoinParams, OpenSubgroupJoinParams};
 use calimero_node_primitives::join_bundle::JoinBundle;
-use calimero_node_primitives::sync::{InitPayload, MessagePayload, StreamMessage};
+use calimero_node_primitives::sync::{InitPayload, InitProof, MessagePayload, StreamMessage};
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
 use libp2p::PeerId;
@@ -102,6 +102,9 @@ impl SyncManager {
                 delta_ids: Vec::new(),
             },
             next_nonce: rand::thread_rng().gen(),
+            // Sentinel party id (no owned key to prove); backfill serves only
+            // already-signed deltas, which the requester re-verifies on receipt.
+            pop: None,
         };
 
         if let Err(err) = crate::sync::stream::send(&mut stream, &msg, None).await {
@@ -726,10 +729,38 @@ impl SyncManager {
     /// on the namespace topic, opens a stream, sends the request, and
     /// returns the wrapped key envelope. Same peer-discovery retry loop
     /// as `initiate_namespace_join`.
+    /// Sign the transport-binding proof for a namespace/subgroup join `Init`.
+    ///
+    /// The joiner's key lives in the namespace identity store (keyed by the
+    /// namespace group id), not the per-context identity store, so this loads
+    /// it directly rather than via [`SyncManager::build_init_pop`]. The proof
+    /// binds the zero context id — matching the sentinel the join `Init`
+    /// carries — plus `joiner_public_key` and this node's transport `PeerId`,
+    /// so the responder can confirm the caller controls the identity it is
+    /// about to pre-register. See [`InitProof`].
+    async fn build_join_init_pop(
+        &self,
+        namespace_id: [u8; 32],
+        joiner_public_key: PublicKey,
+    ) -> Option<InitProof> {
+        let store = self.context_client.datastore_handle().into_inner();
+        let group_id = calimero_context_config::types::ContextGroupId::from(namespace_id);
+        let record = NamespaceRepository::new(&store)
+            .resolve_identity_record(&group_id)
+            .ok()
+            .flatten()?;
+        let private_key = calimero_primitives::identity::PrivateKey::from(record.private_key);
+        self.sign_init_pop(ContextId::from([0u8; 32]), joiner_public_key, &private_key)
+            .await
+    }
+
     pub(super) async fn initiate_open_subgroup_join(
         &self,
         params: OpenSubgroupJoinParams,
     ) -> eyre::Result<Vec<u8>> {
+        let join_pop = self
+            .build_join_init_pop(params.namespace_id, params.joiner_public_key)
+            .await;
         let topic = libp2p::gossipsub::TopicHash::from_raw(format!(
             "ns/{}",
             hex::encode(params.namespace_id)
@@ -802,6 +833,7 @@ impl SyncManager {
                     joiner_public_key: params.joiner_public_key,
                 },
                 next_nonce: rand::thread_rng().gen(),
+                pop: join_pop,
             };
 
             if let Err(e) = crate::sync::stream::send(&mut stream, &msg, None).await {
@@ -929,6 +961,9 @@ impl SyncManager {
         &self,
         params: NamespaceJoinParams,
     ) -> eyre::Result<JoinBundle> {
+        let join_pop = self
+            .build_join_init_pop(params.namespace_id, params.joiner_public_key)
+            .await;
         // Connect-loop logic (shuffled-peer retry, per-peer timeout,
         // outer deadline) lives in `super::namespace_join::open_namespace_join_stream`
         // so it can be unit-tested against `MockSyncNetwork` without
@@ -1008,6 +1043,7 @@ impl SyncManager {
             let msg = StreamMessage::Init {
                 context_id: calimero_primitives::context::ContextId::from([0u8; 32]),
                 party_id: params.joiner_public_key,
+                pop: join_pop,
                 payload: InitPayload::NamespaceJoinRequest {
                     namespace_id: params.namespace_id,
                     invitation_bytes: params.invitation_bytes.clone(),
@@ -1165,6 +1201,8 @@ impl SyncManager {
                 use rand::Rng;
                 rand::thread_rng().gen()
             },
+            // Sentinel party id; see the catch-up backfill site above.
+            pop: None,
         };
 
         if let Err(err) = crate::sync::stream::send(&mut stream, &msg, None).await {
@@ -1510,6 +1548,11 @@ impl SyncManager {
                 use rand::Rng;
                 rand::thread_rng().gen()
             },
+            // The response is an ECDH key envelope wrapped to
+            // `requester_public_key`; only the holder of its private key can
+            // unwrap it, so possession is proven implicitly and no signed proof
+            // is required on this path.
+            pop: None,
         };
 
         if let Err(err) = crate::sync::stream::send(&mut stream, &msg, None).await {

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -743,13 +743,18 @@ impl SyncManager {
         namespace_id: [u8; 32],
         joiner_public_key: PublicKey,
     ) -> Option<InitProof> {
+        use zeroize::Zeroize;
         let store = self.context_client.datastore_handle().into_inner();
         let group_id = calimero_context_config::types::ContextGroupId::from(namespace_id);
-        let record = NamespaceRepository::new(&store)
+        let mut record = NamespaceRepository::new(&store)
             .resolve_identity_record(&group_id)
             .ok()
             .flatten()?;
         let private_key = calimero_primitives::identity::PrivateKey::from(record.private_key);
+        // `PrivateKey::from` copies into its own zeroizing wrapper; wipe the
+        // plain `[u8; 32]` copy left in the record struct on the stack (mirrors
+        // the discipline in join_namespace / request_missing_deltas).
+        record.private_key.zeroize();
         self.sign_init_pop(ContextId::from([0u8; 32]), joiner_public_key, &private_key)
             .await
     }

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -29,7 +29,9 @@
 use async_trait::async_trait;
 use calimero_context_client::client::ContextClient;
 use calimero_network_primitives::stream::Stream;
-use calimero_node_primitives::sync::{ProtocolSelection, SyncProtocol, SyncProtocolExecutor};
+use calimero_node_primitives::sync::{
+    InitProof, ProtocolSelection, SyncProtocol, SyncProtocolExecutor,
+};
 use calimero_primitives::context::ContextId;
 use calimero_primitives::hash::Hash;
 use calimero_primitives::identity::PublicKey;
@@ -71,6 +73,13 @@ pub(crate) trait ProtocolDispatch {
         our_identity: PublicKey,
         chosen_peer: PeerId,
     ) -> Result<SyncProtocol>;
+
+    /// Build the transport-binding proof of possession for `party_id` in
+    /// `context_id`, to attach to the state-read `Init`s the HashComparison /
+    /// LevelWise initiators send. `None` when this node can't sign for
+    /// `party_id`. See [`InitProof`].
+    async fn build_init_pop(&self, context_id: ContextId, party_id: PublicKey)
+        -> Option<InitProof>;
 }
 
 /// Protocol-dispatch component.
@@ -226,6 +235,7 @@ impl ProtocolSelector {
                     remote_root_hash: root_hash,
                     context_client: Some(self.context_client.clone()),
                     session_peer,
+                    init_pop: dispatch.build_init_pop(context_id, our_identity).await,
                 };
 
                 match HashComparisonProtocol::run_initiator(
@@ -372,6 +382,7 @@ impl ProtocolSelector {
                     max_depth,
                     context_client: Some(self.context_client.clone()),
                     session_peer,
+                    init_pop: dispatch.build_init_pop(context_id, our_identity).await,
                 };
 
                 match LevelWiseProtocol::run_initiator(

--- a/crates/node/src/sync/snapshot.rs
+++ b/crates/node/src/sync/snapshot.rs
@@ -437,6 +437,7 @@ impl SyncManager {
                 requested_cutoff_timestamp: None,
             },
             next_nonce: super::helpers::generate_nonce(),
+            pop: self.build_init_pop(context_id, our_identity).await,
         };
         super::stream::send(stream, &msg, None).await?;
 
@@ -591,6 +592,11 @@ impl SyncManager {
         // target instead of the schema the synced entities actually carry).
         let mut deferred_members: DeferredMembers = Vec::new();
 
+        // Sign the transport-binding proof once — it's independent of the
+        // per-page cursor/nonce (see `InitProof`), so every page request in the
+        // burst loop reuses the same signature.
+        let pop = self.build_init_pop(context_id, our_identity).await;
+
         loop {
             let msg = StreamMessage::Init {
                 context_id,
@@ -603,6 +609,7 @@ impl SyncManager {
                     resume_cursor: resume_cursor.clone(),
                 },
                 next_nonce: super::helpers::generate_nonce(),
+                pop,
             };
             super::stream::send(stream, &msg, None).await?;
 

--- a/crates/node/tests/sync_sim/protocol.rs
+++ b/crates/node/tests/sync_sim/protocol.rs
@@ -130,6 +130,7 @@ pub async fn execute_hash_comparison_sync(
         remote_root_hash: resp_root,
         context_client: None,
         session_peer: None,
+        init_pop: None,
     };
 
     // Run both sides concurrently using the PRODUCTION protocol
@@ -207,6 +208,7 @@ pub async fn execute_level_wise_sync(initiator: &mut SimNode, responder: &SimNod
         max_depth: 8,
         context_client: None,
         session_peer: None,
+        init_pop: None,
     };
 
     let initiator_fut = async {
@@ -1708,6 +1710,7 @@ mod tests {
                     remote_root_hash: stale_root,
                     context_client: None,
                     session_peer: None,
+                    init_pop: None,
                 },
             )
             .await
@@ -1785,6 +1788,7 @@ mod tests {
             remote_root_hash,
             context_client: None,
             session_peer: None,
+            init_pop: None,
         };
 
         let initiator_fut = async {

--- a/crates/node/tests/sync_sim/transport.rs
+++ b/crates/node/tests/sync_sim/transport.rs
@@ -325,6 +325,7 @@ mod tests {
                 context_id: test_context_id(),
             },
             next_nonce: [0; NONCE_LEN],
+            pop: None,
         };
 
         // Alice sends
@@ -351,6 +352,7 @@ mod tests {
                 context_id: test_context_id(),
             },
             next_nonce: [1; NONCE_LEN],
+            pop: None,
         };
 
         let msg_from_bob = StreamMessage::Message {
@@ -407,6 +409,7 @@ mod tests {
                 context_id: test_context_id(),
             },
             next_nonce: [0; NONCE_LEN],
+            pop: None,
         };
         let result = alice.send(&msg).await;
         assert!(result.is_err());

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,62 @@
+# Security review — status & plan
+
+_Last updated 2026-07-02. Verified against `master` @ `fec752e3` + open PRs._
+
+Legend: ✅ fixed (merged) · 🟦 fixed (open PR) · ⛔ won't-fix (decision) · ⬜ left
+
+---
+
+## A. Sync / handshake / DHT findings
+
+| # | Sev | Finding | Status | Where |
+|---|-----|---------|--------|-------|
+| 1 | H | Inbound handshake identity not bound to transport (`sync/manager/mod.rs`) — `their_identity` taken from attacker `party_id`; no PoP before serving DAG heads/snapshot/deltas | 🟦 open PR | **#3167** |
+| 2 | M | Namespace pre-registers identity via direct write (`namespace_sync.rs`) — `add_member` from replayable invitation + unverified `party_id` | 🟦 open PR | **#3167** (join `Init` PoP) |
+| 3 | M | TEE admission nonce self-chosen / replayable (`tee_attestation_admission.rs`) | ⬜ left | — (owned by teammate) |
+| 4 | M | DHT blob providers trusted without validation (`kad.rs`) — provider peer ids dispatched unvalidated (eclipse) | 🟦 open PR | **#3168** |
+
+### #3167 — `fix/sync-init-pop-transport-binding`
+- Adds `InitProof` on `StreamMessage::Init`: Ed25519 PoP over `(context_id, party_id, initiator PeerId)`, verified by the responder against the transport-authenticated PeerId before state-read + join paths. Join path also requires `party_id == joiner_public_key`.
+- Exempt (by design): blob/group-key shares (ECDH-wrapped), namespace backfill (self-verifying signed deltas), entity pushes (per-action auth).
+- Tests: InitProof verify/replay/forge/tamper + Init borsh round-trip; responder-gate classification. Full sync-sim (322) + `sync::` (243) green.
+- Review: 3 MeroReviewer comments addressed (DIGEST_SIZE constant; freshness rationale in docs; gate-ordering note) — commit `264a3381`.
+- **Left before merge:** live 2-node merobox smoke (state-read + namespace join) — sim harness bypasses `internal_handle_opened_stream`. Coordinated-upgrade wire change (Borsh-positional field on `Init`).
+
+### #3168 — `fix/dht-signed-blob-provider-records`
+- Adds signed `BlobProviderRecord` (public key + Ed25519 sig; verify requires sig valid **and** embedded key hashes to claimed peer). `announce_blob` signs with the node network keypair; read path + inbound-replication validator authenticate before dispatch/store.
+- Tests: record roundtrip/wrong-key/tamper/peer≠key/garbage + kad validator paths. Network suite (110) green. LGTM from MeroReviewer, no inline comments.
+- **Left before merge:** soft wire change (records TTL'd + re-announced, converges); blob discovery only interoperates between same-format peers.
+
+---
+
+## B. Server / blob / admin-API batch
+
+Re-verified against `master` — **most were already fixed** by earlier hardening PRs (#3040, #3138, …). Kept here for the record.
+
+| # | Sev | Finding | Status | Evidence on `master` |
+|---|-----|---------|--------|----------------------|
+| 5 | M | Blob responses cached public `max-age=3600` (`blob.rs:198`) | ✅ fixed | `Cache-Control: private, no-cache` (blob.rs ~219) |
+| 6 | M | Fabricated zero metadata corrupts blob HTTP framing (`blob.rs:195,264`) | ✅ fixed | missing metadata now returns **500**, never fabricates `Content-Length: 0`/zero ETag (blob.rs ~283) |
+| 7 | M | Blob delete unscoped IDOR (`blob.rs:322`) | ✅ fixed | `delete_handler` refuses blobs referenced as application artifacts (`is_blob_application_artifact`) |
+| 8 | M | Blob upload announces to caller-supplied context w/o membership check (`blob.rs:128`) | ✅ fixed | upload announces only when node is a member; else "Skipping announce: not a member" |
+| 9 | M | List endpoints don't clamp `limit` (`list_group_members`, `list_all_groups`, subgroups/contexts) | ✅ fixed | `.min(MAX_LIST_LIMIT)` on all list handlers (#3138) |
+| 10 | M | `GET /contexts` no pagination + N+1 (`get_context_ids.rs`) | ✅ fixed | `offset.min(MAX_OFFSET)` + `limit.min(MAX_PAGE=1000)` |
+| 11 | L | WS subscribe no membership check — IDOR (`ws/subscribe.rs`) | ✅ fixed | per-context `has_member` gate; unauthorized ids dropped |
+| 12 | L | `invite_specialized_node` arbitrary `inviter_id`, no rate limit | ⛔ won't-fix | still verbatim `inviter_id` on master; the fix (PR **#3136**) was **closed** — specialized-node feature being dropped |
+| 13 | L | Raw-error 500s / wrong codes; `get_context_storage` returns 0; alias validation | 🟨 mostly fixed | `get_application`/alias handlers use `parse_api_error`; `get_context_storage` implemented (`context_storage_bytes`). **Residual:** `create_alias` does no explicit handler-level length/charset/dup guard — it delegates to the typed `Alias` + `node_client.create_alias`; needs a check of whether the `Alias` newtype enforces charset/length on construction |
+
+---
+
+## C. Plan for what's left
+
+1. **#3167 & #3168 → merge.** Both are open with green local tests. Before merge:
+   - Run a live merobox 2-node smoke: cold namespace join, a state-read sync (DAG-heads/delta/snapshot), and a blob fetch — confirms the PoP gate and signed-provider path over a real transport (the sim harness does not exercise `internal_handle_opened_stream`).
+   - Both are network-upgrade-sensitive; land behind the usual coordinated-rollout messaging (see PR bodies). #3167 is a hard flag-day for state-read/join sync; #3168 converges softly.
+
+2. **Finding 3 (TEE nonce) — teammate.** Not started. Fix = verifier-issued challenge nonce, consumed once, bound to the announcer. Adjacent open work: #2996 (rate-limit/dedup on the verify entrypoints) mitigates spam but does **not** change the self-chosen-nonce model. Coordinate so the two don't collide in `tee_attestation_admission.rs`.
+
+3. **Finding 12 (invite_specialized_node) — confirm won't-fix.** Left vulnerable on `master` because the specialized-node invite feature is being removed (PR #3136 closed on that basis). If the feature is NOT actually being deleted, this reverts to an open [L] and #3136 should be reopened/rebased. **Decision needed:** delete the endpoint, or reopen the fix.
+
+4. **Finding 13 residual (alias validation) — small follow-up.** Verify whether `create_alias` enforces length/charset and rejects duplicates; if not, add validation returning `400` (one-file change, no wire impact). Low priority.
+
+5. **Docs (both PRs).** AutoDocs bot flagged `architecture/crates/{node,sync,network}.html` + `wire-protocol.html` as stale. Handled by the AutoDocs pipeline on merge, not by hand — no action unless the bot's follow-up doc PR fails.


### PR DESCRIPTION
## Summary

Binds the inbound sync handshake identity to the transport with a proof of possession, closing two findings from the security review:

- **[H] Inbound handshake identity not bound to transport** — `internal_handle_opened_stream` took `their_identity` from the attacker-controlled `party_id` and served DAG heads / snapshots / deltas / tree+level state with no proof the caller controlled that identity.
- **[M] Namespace pre-registers identity via unverified `party_id`** — the join handlers `add_member(joiner_public_key)` off an attacker-chosen key.

## Before

`Init` carried `context_id`, `party_id`, `payload`, `next_nonce`. The responder resolved `their_identity = party_id` verbatim and, after a membership check on that *named* identity, served state-read requests and ran namespace/subgroup pre-registration. Nothing tied `party_id` (or `joiner_public_key`) to the caller's transport identity, so any peer that learned a member's public key could be served as — or registered as — an identity it does not control.

## After

New `InitProof` on `Init` (`pop: Option<InitProof>`): an Ed25519 signature by `party_id`'s key over a domain-separated message binding **(context_id, party_id, the initiator's own libp2p `PeerId`)**.

- **Initiator** signs once per session (the proof is payload/nonce-independent) from the identity's private key and this node's PeerId, and attaches it to every state-read / join `Init`.
- **Responder** recomputes the message with the PeerId it observes on the transport — which libp2p's noise handshake authenticates — and verifies before acting. A proof can't be replayed from a different peer (the observed PeerId wouldn't match) and can't be forged for a key the caller doesn't hold.

Enforced (proof required) on: `DeltaRequest`, `DagHeadsRequest`, `SnapshotBoundaryRequest`, `SnapshotStreamRequest`, `TreeNodeRequest`, `LevelWiseRequest`, `NamespaceJoinRequest`, `OpenSubgroupJoinRequest`. For joins, `party_id == joiner_public_key` is also required, so a caller can't prove one key and register another.

Exempt (no proof required, by design):
- `BlobShare` / `GroupKeyRequest` — response is ECDH-wrapped to the named identity; only its key-holder can use it (possession is implicit).
- `NamespaceBackfillRequest` — serves only already-signed deltas the requester re-verifies; its `party_id` is a keyless sentinel.
- `EntityPush` / `EntityDeletePush` — writes authorized per-action on apply, not by `party_id`.

## Wire compatibility

⚠️ **Coordinated network upgrade required.** `Init` gains a trailing `pop` field; Borsh is positional, so pre-upgrade peers can't deserialize a post-upgrade `Init` and vice-versa. This is the same constraint already documented on `Message::sequence_id` (usize→u64) and the `NotMaterialized` variant. During rollout, state-read and join sync between old and new nodes on the affected paths will not interoperate until both sides are upgraded.

## Verification

- `cargo check` / `clippy` / `fmt` clean on `calimero-node` + `calimero-node-primitives`.
- New unit tests: `InitProof` verify / wrong-peer / wrong-party / wrong-context / tampered-sig, `Init` borsh round-trip with & without pop (node-primitives); responder-gate payload classification (node).
- Regression: full `sync_sim` suite (322 tests) and node `sync::` unit suite (243 tests) green.
- Not covered by automated tests here: a live two-node namespace-join / state-read e2e exercising the real transport PeerId path — the sim harness drives the protocols directly and doesn't go through `internal_handle_opened_stream`. Worth a merobox smoke check before/after merge.

## Notes

- The signing key on the join paths lives in the namespace identity store (`NamespaceRepository`), not the per-context identity store, so those paths load it directly (`build_join_init_pop`) rather than via `build_init_pop`.
- Local PeerId is fetched once via `network_status` and memoized on `SyncManager`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
