### PR TITLE
fix(network): authenticate blob-provider DHT records with a signature

### DIFF
--- a/crates/network/src/blob_provider_record.rs
+++ b/crates/network/src/blob_provider_record.rs
@@ -1,0 +1,179 @@
+//! Signed, self-authenticating blob-provider DHT records.
+//!
+//! A blob-provider record announces "peer P holds blob B in context C" on the
+//! Kademlia DHT. Peers that resolve the record then dial P to fetch the blob.
+//!
+//! The record value used to be a bare `peer_id_bytes ‖ size` concatenation with
+//! no authentication, so **any** peer could publish (or replicate) a record
+//! naming an **arbitrary** peer id as the provider. A malicious peer could plant
+//! records pointing queriers at peers of its choosing — a misdirection / eclipse
+//! vector on blob discovery. (Blob *content* can't be forged this way, since
+//! blobs are content-addressed and re-hashed on receipt; the risk is who you're
+//! pointed at, and the wasted/observable requests that follow.)
+//!
+//! [`BlobProviderRecord`] binds the announcement to the announcing peer: the
+//! value carries the provider's network public key and an Ed25519 signature
+//! over `DOMAIN ‖ record_key ‖ peer_id ‖ size`, and verification requires both
+//! that the signature is valid **and** that the embedded public key hashes to
+//! the claimed peer id. A record can therefore only name the peer that signed
+//! it — an attacker can announce *itself*, but cannot impersonate a victim or
+//! name a peer whose key it does not hold. Verification is self-contained: the
+//! public key travels in the record, so no external key distribution is needed.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use libp2p::identity::{Keypair, PublicKey};
+use libp2p::PeerId;
+
+/// Domain separator for the signed message. Bump the version suffix on any
+/// change to the signed layout so signatures never cross protocol versions.
+const DOMAIN: &[u8] = b"calimero:dht:blob-provider:v1";
+
+/// The authenticated value stored under a blob-provider DHT record key.
+///
+/// Borsh-encoded into `Record::value`. This is a wire-format change from the
+/// previous bare `peer_id ‖ size` layout — see the module docs.
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub struct BlobProviderRecord {
+    /// Provider `PeerId::to_bytes()`.
+    pub peer_id: Vec<u8>,
+    /// Blob size in bytes.
+    pub size: u64,
+    /// Provider's network public key, protobuf-encoded. Must hash to `peer_id`.
+    pub public_key: Vec<u8>,
+    /// Ed25519 signature by the provider's network key over [`Self::signed_message`].
+    pub signature: Vec<u8>,
+}
+
+impl BlobProviderRecord {
+    /// Canonical bytes the signature covers: `DOMAIN ‖ record_key ‖ peer_id ‖ size`.
+    ///
+    /// `record_key` is the full DHT key (`context_id ‖ blob_id`), so a record
+    /// signed for one (context, blob) can't be lifted onto another key.
+    fn signed_message(record_key: &[u8], peer_id: &[u8], size: u64) -> Vec<u8> {
+        let mut message = Vec::with_capacity(DOMAIN.len() + record_key.len() + peer_id.len() + 8);
+        message.extend_from_slice(DOMAIN);
+        message.extend_from_slice(record_key);
+        message.extend_from_slice(peer_id);
+        message.extend_from_slice(&size.to_le_bytes());
+        message
+    }
+
+    /// Build a signed record value for `record_key`, provided by the local node
+    /// (identified by `keypair`), advertising a blob of `size` bytes.
+    pub fn signed_value(record_key: &[u8], keypair: &Keypair, size: u64) -> eyre::Result<Vec<u8>> {
+        let peer_id = keypair.public().to_peer_id().to_bytes();
+        let message = Self::signed_message(record_key, &peer_id, size);
+        let signature = keypair.sign(&message)?;
+        let record = Self {
+            peer_id,
+            size,
+            public_key: keypair.public().encode_protobuf(),
+            signature,
+        };
+        Ok(borsh::to_vec(&record)?)
+    }
+
+    /// Parse and authenticate a record value against its DHT key.
+    ///
+    /// Returns the provider `PeerId` only when the record is well-formed, the
+    /// embedded public key hashes to the claimed peer id, and the signature
+    /// verifies. Any failure yields `None` — the record must be dropped, not
+    /// dispatched or stored.
+    #[must_use]
+    pub fn verify(record_key: &[u8], value: &[u8]) -> Option<PeerId> {
+        let record = Self::try_from_slice(value).ok()?;
+
+        let claimed_peer = PeerId::from_bytes(&record.peer_id).ok()?;
+        let public_key = PublicKey::try_decode_protobuf(&record.public_key).ok()?;
+
+        // Bind the record to its signer: the embedded key must hash to the
+        // claimed peer id, so a record can only ever name the peer that holds
+        // this key. Without this an attacker could pair a victim's peer id with
+        // its own key + signature.
+        if public_key.to_peer_id() != claimed_peer {
+            return None;
+        }
+
+        let message = Self::signed_message(record_key, &record.peer_id, record.size);
+        if !public_key.verify(&message, &record.signature) {
+            return None;
+        }
+
+        Some(claimed_peer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libp2p::identity::Keypair;
+
+    use super::*;
+
+    fn key() -> Vec<u8> {
+        // context_id (32) || blob_id (32)
+        [[7u8; 32], [9u8; 32]].concat()
+    }
+
+    #[test]
+    fn signed_value_verifies_and_returns_signer_peer() {
+        let kp = Keypair::generate_ed25519();
+        let value = BlobProviderRecord::signed_value(&key(), &kp, 4096).expect("sign");
+        assert_eq!(
+            BlobProviderRecord::verify(&key(), &value),
+            Some(kp.public().to_peer_id())
+        );
+    }
+
+    #[test]
+    fn rejects_value_on_a_different_key() {
+        let kp = Keypair::generate_ed25519();
+        let value = BlobProviderRecord::signed_value(&key(), &kp, 4096).expect("sign");
+        let other_key = [[1u8; 32], [2u8; 32]].concat();
+        assert_eq!(BlobProviderRecord::verify(&other_key, &value), None);
+    }
+
+    #[test]
+    fn rejects_tampered_size() {
+        let kp = Keypair::generate_ed25519();
+        let value = BlobProviderRecord::signed_value(&key(), &kp, 4096).expect("sign");
+        let mut record = BlobProviderRecord::try_from_slice(&value).unwrap();
+        record.size = 1; // signature was over size=4096
+        let tampered = borsh::to_vec(&record).unwrap();
+        assert_eq!(BlobProviderRecord::verify(&key(), &tampered), None);
+    }
+
+    #[test]
+    fn rejects_peer_id_not_matching_embedded_key() {
+        // Attacker pairs a victim's peer id with its own key + a signature it
+        // can legitimately produce for that key. The peer-id/key binding check
+        // must reject it.
+        let attacker = Keypair::generate_ed25519();
+        let victim = Keypair::generate_ed25519();
+
+        let peer_id = victim.public().to_peer_id().to_bytes();
+        let message = BlobProviderRecord::signed_message(&key(), &peer_id, 4096);
+        let forged = BlobProviderRecord {
+            peer_id,
+            size: 4096,
+            public_key: attacker.public().encode_protobuf(),
+            signature: attacker.sign(&message).unwrap(),
+        };
+        let value = borsh::to_vec(&forged).unwrap();
+        assert_eq!(BlobProviderRecord::verify(&key(), &value), None);
+    }
+
+    #[test]
+    fn rejects_tampered_signature() {
+        let kp = Keypair::generate_ed25519();
+        let value = BlobProviderRecord::signed_value(&key(), &kp, 4096).expect("sign");
+        let mut record = BlobProviderRecord::try_from_slice(&value).unwrap();
+        record.signature[0] ^= 0xff;
+        let tampered = borsh::to_vec(&record).unwrap();
+        assert_eq!(BlobProviderRecord::verify(&key(), &tampered), None);
+    }
+
+    #[test]
+    fn rejects_garbage_value() {
+        assert_eq!(BlobProviderRecord::verify(&key(), b"not a record"), None);
+    }
+}

--- a/crates/network/src/blob_provider_record.rs
+++ b/crates/network/src/blob_provider_record.rs
@@ -37,6 +37,12 @@ const DOMAIN: &[u8] = b"calimero:dht:blob-provider:v1";
 /// (which produces a correctly signed record) and borsh-deserializing a value
 /// through [`Self::verify`] (which authenticates it). This prevents callers
 /// elsewhere in the crate from hand-constructing an unauthenticated record.
+///
+/// Borsh serializes fields in declaration order, so this field order
+/// (`peer_id`, `size`, `public_key`, `signature`) is a wire-format commitment:
+/// reordering, inserting, or removing a field changes the on-DHT encoding and
+/// is only safe as a coordinated format change (bump [`DOMAIN`] alongside it so
+/// old and new records can't be confused).
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct BlobProviderRecord {
     /// Provider `PeerId::to_bytes()`.
@@ -55,16 +61,18 @@ impl BlobProviderRecord {
     ///
     /// `record_key` is the full DHT key (`context_id ‖ blob_id`), so a record
     /// signed for one (context, blob) can't be lifted onto another key. The
-    /// variable-length fields are length-prefixed (`u32` LE) so no crafted
+    /// variable-length fields are length-prefixed (`u64` LE) so no crafted
     /// `record_key` / `peer_id` pair can shift the field boundary and collide
     /// with a different `(record_key, peer_id)` under the same signed message.
+    /// Lengths use `u64` (not `u32`) so the prefix can't silently truncate on
+    /// any target.
     fn signed_message(record_key: &[u8], peer_id: &[u8], size: u64) -> Vec<u8> {
         let mut message =
-            Vec::with_capacity(DOMAIN.len() + 4 + record_key.len() + 4 + peer_id.len() + 8);
+            Vec::with_capacity(DOMAIN.len() + 8 + record_key.len() + 8 + peer_id.len() + 8);
         message.extend_from_slice(DOMAIN);
-        message.extend_from_slice(&(record_key.len() as u32).to_le_bytes());
+        message.extend_from_slice(&(record_key.len() as u64).to_le_bytes());
         message.extend_from_slice(record_key);
-        message.extend_from_slice(&(peer_id.len() as u32).to_le_bytes());
+        message.extend_from_slice(&(peer_id.len() as u64).to_le_bytes());
         message.extend_from_slice(peer_id);
         message.extend_from_slice(&size.to_le_bytes());
         message
@@ -187,5 +195,20 @@ mod tests {
     #[test]
     fn rejects_garbage_value() {
         assert_eq!(BlobProviderRecord::verify(&key(), b"not a record"), None);
+    }
+
+    #[test]
+    fn signed_value_fits_under_the_kad_value_ceiling() {
+        // The inbound-replication validator drops values over
+        // `KAD_MAX_VALUE_BYTES`; a legitimately signed record must stay well
+        // under it, or our own announcements would be rejected on replication.
+        let kp = Keypair::generate_ed25519();
+        let value = BlobProviderRecord::signed_value(&key(), &kp, u64::MAX).expect("sign");
+        assert!(
+            value.len() <= crate::behaviour::KAD_MAX_VALUE_BYTES,
+            "signed record ({} bytes) must fit under KAD_MAX_VALUE_BYTES ({})",
+            value.len(),
+            crate::behaviour::KAD_MAX_VALUE_BYTES,
+        );
     }
 }

--- a/crates/network/src/blob_provider_record.rs
+++ b/crates/network/src/blob_provider_record.rs
@@ -32,27 +32,39 @@ const DOMAIN: &[u8] = b"calimero:dht:blob-provider:v1";
 ///
 /// Borsh-encoded into `Record::value`. This is a wire-format change from the
 /// previous bare `peer_id ‖ size` layout — see the module docs.
+///
+/// Fields are private: the only ways to obtain one are [`Self::signed_value`]
+/// (which produces a correctly signed record) and borsh-deserializing a value
+/// through [`Self::verify`] (which authenticates it). This prevents callers
+/// elsewhere in the crate from hand-constructing an unauthenticated record.
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct BlobProviderRecord {
     /// Provider `PeerId::to_bytes()`.
-    pub peer_id: Vec<u8>,
+    peer_id: Vec<u8>,
     /// Blob size in bytes.
-    pub size: u64,
+    size: u64,
     /// Provider's network public key, protobuf-encoded. Must hash to `peer_id`.
-    pub public_key: Vec<u8>,
+    public_key: Vec<u8>,
     /// Ed25519 signature by the provider's network key over [`Self::signed_message`].
-    pub signature: Vec<u8>,
+    signature: Vec<u8>,
 }
 
 impl BlobProviderRecord {
-    /// Canonical bytes the signature covers: `DOMAIN ‖ record_key ‖ peer_id ‖ size`.
+    /// Canonical bytes the signature covers:
+    /// `DOMAIN ‖ len(record_key) ‖ record_key ‖ len(peer_id) ‖ peer_id ‖ size`.
     ///
     /// `record_key` is the full DHT key (`context_id ‖ blob_id`), so a record
-    /// signed for one (context, blob) can't be lifted onto another key.
+    /// signed for one (context, blob) can't be lifted onto another key. The
+    /// variable-length fields are length-prefixed (`u32` LE) so no crafted
+    /// `record_key` / `peer_id` pair can shift the field boundary and collide
+    /// with a different `(record_key, peer_id)` under the same signed message.
     fn signed_message(record_key: &[u8], peer_id: &[u8], size: u64) -> Vec<u8> {
-        let mut message = Vec::with_capacity(DOMAIN.len() + record_key.len() + peer_id.len() + 8);
+        let mut message =
+            Vec::with_capacity(DOMAIN.len() + 4 + record_key.len() + 4 + peer_id.len() + 8);
         message.extend_from_slice(DOMAIN);
+        message.extend_from_slice(&(record_key.len() as u32).to_le_bytes());
         message.extend_from_slice(record_key);
+        message.extend_from_slice(&(peer_id.len() as u32).to_le_bytes());
         message.extend_from_slice(peer_id);
         message.extend_from_slice(&size.to_le_bytes());
         message

--- a/crates/network/src/handlers/commands/announce_blob.rs
+++ b/crates/network/src/handlers/commands/announce_blob.rs
@@ -28,9 +28,21 @@ impl Handler<AnnounceBlob> for NetworkManager {
             key.as_ref().len(),
         );
 
-        // Create a record with blob metadata (size and peer ID)
-        let peer_id = *self.swarm.local_peer_id();
-        let value = [peer_id.to_bytes().as_slice(), &request.size.to_le_bytes()].concat();
+        // Create a signed record binding (this node, blob, size) to the
+        // record key, so peers resolving it can authenticate that the
+        // announcement was made by the peer it names. See
+        // `crate::blob_provider_record`.
+        let value = match crate::blob_provider_record::BlobProviderRecord::signed_value(
+            key.as_ref(),
+            &self.identity,
+            request.size,
+        ) {
+            Ok(value) => value,
+            Err(err) => {
+                warn!("Failed to sign blob provider record: {:?}", err);
+                return Response::reply(Err(eyre!("Failed to sign record: {:?}", err)));
+            }
+        };
 
         let record = Record::new(key, value);
 

--- a/crates/network/src/handlers/commands/announce_blob.rs
+++ b/crates/network/src/handlers/commands/announce_blob.rs
@@ -39,8 +39,11 @@ impl Handler<AnnounceBlob> for NetworkManager {
         ) {
             Ok(value) => value,
             Err(err) => {
+                // Log the underlying signing error server-side only; return a
+                // generic error so key/crypto detail can't leak into a caller
+                // response or downstream log.
                 warn!("Failed to sign blob provider record: {:?}", err);
-                return Response::reply(Err(eyre!("Failed to sign record: {:?}", err)));
+                return Response::reply(Err(eyre!("failed to sign blob provider record")));
             }
         };
 

--- a/crates/network/src/handlers/stream/swarm/kad.rs
+++ b/crates/network/src/handlers/stream/swarm/kad.rs
@@ -3,7 +3,6 @@ use calimero_primitives::blobs::BlobId;
 use calimero_primitives::context::ContextId;
 use libp2p::kad::store::RecordStore;
 use libp2p::kad::{Event, GetRecordError, GetRecordOk, InboundRequest, QueryResult, Record};
-use libp2p::PeerId;
 use libp2p_metrics::Recorder;
 use owo_colors::OwoColorize;
 use tracing::{debug, warn};
@@ -46,23 +45,25 @@ impl EventHandler<Event> for NetworkManager {
                                 record.record.value.len()
                             );
 
-                            // Extract peer IDs from record values
+                            // Authenticate the provider record before trusting
+                            // the peer id it names. An unsigned/forged record
+                            // could otherwise point us at an arbitrary peer
+                            // (misdirection / eclipse); `verify` binds the
+                            // record to the peer that signed it.
                             let mut peers = Vec::new();
-                            if record.record.value.len() >= 8 {
-                                // Need at least 8 bytes for size
-                                // The value format is: peer_id_bytes (variable length) + size (8 bytes)
-                                // Extract size from the last 8 bytes
-                                let size_start = record.record.value.len() - 8;
-                                if let Ok(peer_id) =
-                                    PeerId::from_bytes(&record.record.value[..size_start])
-                                {
+                            match crate::blob_provider_record::BlobProviderRecord::verify(
+                                record.record.key.as_ref(),
+                                &record.record.value,
+                            ) {
+                                Some(peer_id) => {
                                     peers.push(peer_id);
-                                    debug!("Extracted peer_id {} from DHT record", peer_id);
-                                } else {
-                                    debug!("Failed to parse peer_id from DHT record value");
+                                    debug!("Verified provider peer_id {} from DHT record", peer_id);
+                                }
+                                None => {
+                                    debug!("Dropping DHT record: provider signature invalid or malformed");
                                 }
                             }
-                            debug!("Found {} peers with blob", peers.len());
+                            debug!("Found {} verified peers with blob", peers.len());
 
                             // Extract blob_id and context_id from record key
                             if record.record.key.as_ref().len() >= 64 {
@@ -183,116 +184,93 @@ impl EventHandler<Event> for NetworkManager {
 fn is_valid_blob_provider_record(record: &Record) -> bool {
     /// context_id (32) + blob_id (32).
     const EXPECTED_KEY_LEN: usize = 64;
-    /// Trailing little-endian `u64` blob size.
-    const SIZE_LEN: usize = 8;
 
     if record.key.as_ref().len() != EXPECTED_KEY_LEN {
         return false;
     }
 
-    // Reject anything larger than the store would accept, up front — a valid
-    // blob-provider value is ~50 bytes, far below this ceiling.
+    // Reject anything larger than the store would accept, up front.
     if record.value.len() > crate::behaviour::KAD_MAX_VALUE_BYTES {
         return false;
     }
 
-    let Some(peer_id_bytes) = record
-        .value
-        .len()
-        .checked_sub(SIZE_LEN)
-        .map(|end| &record.value[..end])
-    else {
-        return false;
-    };
-
-    // A zero-length peer id can never be valid; `from_bytes` also rejects it,
-    // but bail explicitly so intent is clear.
-    !peer_id_bytes.is_empty() && PeerId::from_bytes(peer_id_bytes).is_ok()
+    // Authenticate the record: valid signature + the embedded key hashes to the
+    // named peer. This is applied to records another peer asks us to replicate,
+    // so we never store (and later re-serve) a forged provider announcement.
+    crate::blob_provider_record::BlobProviderRecord::verify(record.key.as_ref(), &record.value)
+        .is_some()
 }
 
 #[cfg(test)]
 mod tests {
+    use libp2p::identity::Keypair;
     use libp2p::kad::RecordKey;
 
     use super::*;
+    use crate::blob_provider_record::BlobProviderRecord;
 
     fn record(key: Vec<u8>, value: Vec<u8>) -> Record {
         Record::new(RecordKey::new(&key), value)
     }
 
-    fn valid_value() -> Vec<u8> {
-        let peer_id = PeerId::random();
-        let size: u64 = 4096;
-        [peer_id.to_bytes().as_slice(), &size.to_le_bytes()].concat()
+    /// A signed value for a 64-byte key of all `key_byte`s.
+    fn signed_value(key_byte: u8) -> (Vec<u8>, Vec<u8>) {
+        let key = vec![key_byte; 64];
+        let kp = Keypair::generate_ed25519();
+        let value = BlobProviderRecord::signed_value(&key, &kp, 4096).expect("sign");
+        (key, value)
     }
 
     #[test]
-    fn accepts_a_well_formed_blob_record() {
-        let rec = record(vec![7u8; 64], valid_value());
-        assert!(is_valid_blob_provider_record(&rec));
+    fn accepts_a_well_formed_signed_record() {
+        let (key, value) = signed_value(7);
+        assert!(is_valid_blob_provider_record(&record(key, value)));
     }
 
     #[test]
     fn rejects_wrong_key_length() {
-        // One byte short and one byte long — only exactly 64 is a blob key.
+        // Exactly 64 is the only accepted blob-key length; the validator bails
+        // on length before even attempting to verify.
+        let (_key, value) = signed_value(7);
         assert!(!is_valid_blob_provider_record(&record(
             vec![7u8; 63],
-            valid_value()
+            value.clone()
         )));
         assert!(!is_valid_blob_provider_record(&record(
             vec![7u8; 65],
-            valid_value()
-        )));
-    }
-
-    #[test]
-    fn rejects_value_too_short_for_a_size_suffix() {
-        // At most 8 bytes (<= SIZE_LEN) leaves no room for a peer id: below 8
-        // the `checked_sub` fails, and exactly 8 yields an empty prefix caught
-        // by the `is_empty` guard.
-        assert!(!is_valid_blob_provider_record(&record(
-            vec![7u8; 64],
-            vec![0u8; 4]
-        )));
-        assert!(!is_valid_blob_provider_record(&record(
-            vec![7u8; 64],
-            vec![0u8; 8]
-        )));
-        // One byte past the size suffix is a non-empty prefix, so it clears the
-        // `is_empty` guard and must instead be rejected by the peer-id parse.
-        assert!(!is_valid_blob_provider_record(&record(
-            vec![7u8; 64],
-            vec![0u8; 9]
-        )));
-    }
-
-    #[test]
-    fn rejects_unparseable_peer_id() {
-        // Right shape (>8 bytes) but the leading bytes aren't a valid peer id.
-        let value = [vec![0xffu8; 16], 1024u64.to_le_bytes().to_vec()].concat();
-        assert!(!is_valid_blob_provider_record(&record(
-            vec![7u8; 64],
             value
+        )));
+    }
+
+    #[test]
+    fn rejects_record_signed_for_a_different_key() {
+        // A record legitimately signed for key A must not validate under key B —
+        // `verify` binds the signature to the DHT key.
+        let (_key_a, value) = signed_value(7);
+        assert!(!is_valid_blob_provider_record(&record(
+            vec![9u8; 64],
+            value
+        )));
+    }
+
+    #[test]
+    fn rejects_unsigned_or_garbage_value() {
+        assert!(!is_valid_blob_provider_record(&record(
+            vec![7u8; 64],
+            b"legacy-unsigned-or-garbage".to_vec()
         )));
     }
 
     #[test]
     fn rejects_value_over_the_store_ceiling() {
-        // A parseable peer id + size suffix, but padded past the store's
-        // `max_value_bytes`: the validator drops it up front rather than
-        // leaving the store's `put` as the only guard.
-        let peer_id = PeerId::random();
-        let padding = vec![0u8; crate::behaviour::KAD_MAX_VALUE_BYTES];
-        let value = [
-            peer_id.to_bytes().as_slice(),
-            &padding,
-            &4096u64.to_le_bytes(),
-        ]
-        .concat();
+        // Padded past the store's `max_value_bytes`: dropped up front rather
+        // than leaving the store's `put` as the only guard.
+        let (key, mut value) = signed_value(7);
+        value.extend(std::iter::repeat_n(
+            0u8,
+            crate::behaviour::KAD_MAX_VALUE_BYTES,
+        ));
         assert!(value.len() > crate::behaviour::KAD_MAX_VALUE_BYTES);
-        assert!(!is_valid_blob_provider_record(&record(
-            vec![7u8; 64],
-            value
-        )));
+        assert!(!is_valid_blob_provider_record(&record(key, value)));
     }
 }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -19,6 +19,7 @@ use calimero_network_primitives::stream::{CALIMERO_BLOB_PROTOCOL, CALIMERO_STREA
 use calimero_utils_actix::actor;
 use eyre::Result as EyreResult;
 use futures_util::StreamExt;
+use libp2p::identity::Keypair;
 use libp2p::kad::QueryId;
 use libp2p::swarm::{ConnectionId, Swarm};
 use libp2p::PeerId;
@@ -34,6 +35,7 @@ use crate::handlers::stream::incoming::FromIncoming;
 
 pub use calimero_network_primitives::autonat_v2 as autonat;
 pub mod behaviour;
+mod blob_provider_record;
 mod discovery;
 mod handlers;
 
@@ -76,6 +78,10 @@ pub struct NetworkManager {
     // `ConnectionClosed` that the rest of the recovery machinery waits for.
     // Reset to absent on the next ping success or when the connection closes.
     ping_failures: HashMap<ConnectionId, u32>,
+    /// This node's network keypair, used to sign the blob-provider DHT records
+    /// it publishes so peers resolving them can authenticate the announcement
+    /// binds to this peer. See [`blob_provider_record`].
+    identity: Keypair,
     metrics: Metrics,
 }
 
@@ -138,6 +144,7 @@ impl NetworkManager {
             pending_bootstrap: HashMap::default(),
             pending_blob_queries: HashMap::new(),
             ping_failures: HashMap::default(),
+            identity: config.identity.clone(),
             metrics: Metrics::new(prom_registry),
         };
 

--- a/crates/network/tests/kad_record_filtering.rs
+++ b/crates/network/tests/kad_record_filtering.rs
@@ -17,7 +17,7 @@ use libp2p::identity::Keypair;
 use libp2p::kad::store::{MemoryStore, RecordStore};
 use libp2p::kad::{self, InboundRequest, Mode, Quorum, Record, RecordKey, StoreInserts};
 use libp2p::swarm::{NetworkBehaviour, SwarmEvent};
-use libp2p::{PeerId, Swarm};
+use libp2p::Swarm;
 use libp2p_swarm_test::SwarmExt;
 
 #[derive(NetworkBehaviour)]
@@ -37,15 +37,12 @@ impl KadOnly {
     }
 }
 
-/// A record shaped like the blob announcement `AnnounceBlob` produces: a
-/// 64-byte key (context id + blob id) and a value of a peer id + 8-byte size.
+/// A record with a blob-announcement-shaped 64-byte key (context id + blob id).
+/// This test exercises the store's `FilterBoth` behaviour and the handler's
+/// explicit `put` directly, so the value bytes are opaque here — provider-record
+/// signature validation is covered in the `blob_provider_record` unit tests.
 fn blob_record() -> Record {
-    let value = [
-        PeerId::random().to_bytes().as_slice(),
-        &4096_u64.to_le_bytes(),
-    ]
-    .concat();
-    Record::new(RecordKey::new(&vec![9_u8; 64]), value)
+    Record::new(RecordKey::new(&vec![9_u8; 64]), b"opaque-value".to_vec())
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Authenticates blob-provider DHT records so a peer resolving one can trust the provider it names. Closes the **[M] DHT blob providers trusted without validation** finding.

## Before

A blob-provider record (`context_id ‖ blob_id` key → `peer_id ‖ size` value) carried **no authentication**. Any peer could publish, or replicate to others, a record naming an **arbitrary** peer id as the provider. On the read path (`GetRecord` → `NetworkEvent::BlobProvidersFound`) those peer ids were extracted and dispatched with no validation, so a malicious peer could point queriers at peers of its choosing — a misdirection / eclipse vector on blob discovery.

(#3109 already added `StoreInserts::FilterBoth` + a *structural* `is_valid_blob_provider_record` on the inbound-replication path, which closed the blind-store / resource-exhaustion angle. It did **not** authenticate the provider, and the read/dispatch path had no check at all.)

Blob *content* was never forgeable here — blobs are content-addressed and re-hashed on receipt — so the risk is strictly *who you get pointed at*, plus the wasted and observable requests that follow.

## After

New `BlobProviderRecord` (`crates/network/src/blob_provider_record.rs`): a borsh value carrying the provider's **network public key** and an **Ed25519 signature** over `DOMAIN ‖ record_key ‖ peer_id ‖ size`.

`verify()` accepts a record only when **both**:
1. the signature is valid under the embedded public key, and
2. that public key hashes to the claimed `peer_id` (`PublicKey::to_peer_id()`).

So a record can only ever name the peer that signed it. An attacker can announce **itself** as a provider (harmless — content is verified on fetch), but **cannot** impersonate a victim or name a peer whose key it doesn't hold. It's self-contained: the public key rides in the record, binding to the peer id, so there's no external key-distribution requirement — the record key model is just the node's existing libp2p network keypair.

Wiring:
- `announce_blob` signs with the node's network keypair (now held on `NetworkManager`, sourced from `config.identity`).
- The `GetRecord` read path dispatches **only** the verified provider peer (drops the record otherwise).
- `is_valid_blob_provider_record` (the #3109 FilterBoth inbound-replication gate) now **authenticates** rather than shape-checks, so a forged record is never stored and later re-served.

## Wire compatibility

The record value changes from bare `peer_id ‖ size` to the signed borsh struct. DHT records are TTL'd and periodically re-announced, so this converges without a hard flag day — but a node only interoperates on **blob discovery** with peers already on the new format. No node-to-node RPC/gossip schema changes.

## Scope note

This authenticates the *provider announcement*. It intentionally does **not** try to prevent a peer from announcing a blob it doesn't actually serve — that's caught for free on fetch (content-addressed re-hash), and gating it would need a separate possession-proof scheme. The finding's vector (unvalidated/forged provider peer ids) is fully closed.

## Verification

- `cargo clippy` / `fmt` clean on `calimero-network`.
- New unit tests — record roundtrip, wrong-key, tampered-size, tampered-sig, peer-id≠embedded-key, garbage value; kad validator accept + reject-signed-for-other-key + reject-garbage + over-ceiling.
- Full `calimero-network` test suite (110 tests) green, incl. the existing `kad_record_filtering` integration test.

## Relationship to #3167

Independent. #3167 binds the *sync handshake* identity to the transport; this binds *DHT provider records* to their announcer. Different subsystems, no shared files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
