### PR TITLE
fix(server): return 409 on duplicate alias create (was 500)

### DIFF
--- a/crates/node/primitives/src/client.rs
+++ b/crates/node/primitives/src/client.rs
@@ -35,6 +35,7 @@ use crate::TopicManager;
 pub use crate::join_bundle::JoinBundle;
 
 mod alias;
+pub use alias::AliasExists;
 mod application;
 mod blob;
 

--- a/crates/node/primitives/src/client/alias.rs
+++ b/crates/node/primitives/src/client/alias.rs
@@ -2,12 +2,28 @@ use core::str::FromStr;
 
 use calimero_primitives::alias::Alias;
 use calimero_store::key::{self as key, Aliasable, StoreScopeCompat};
-use eyre::{bail, OptionExt};
+use eyre::OptionExt;
 
 use super::NodeClient;
 
 /// A resolved alias entry: the alias, its target value, and optional scope.
 type AliasEntry<T, S> = (Alias<T>, T, Option<S>);
+
+/// Returned by [`NodeClient::create_alias`] when the alias already exists.
+///
+/// A distinct error type (rather than a string `bail!`) so the caller can map
+/// it to `409 Conflict` by downcasting, without a separate pre-check that would
+/// race the write.
+#[derive(Debug)]
+pub struct AliasExists;
+
+impl core::fmt::Display for AliasExists {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("alias already exists")
+    }
+}
+
+impl core::error::Error for AliasExists {}
 
 impl NodeClient {
     pub fn create_alias<T>(
@@ -23,8 +39,11 @@ impl NodeClient {
 
         let key = key::Alias::new(scope, alias).ok_or_eyre("alias requires scope to be present")?;
 
+        // Existence check + write on the same handle (no separate caller-side
+        // pre-check that would race the write). Returns a typed `AliasExists` so
+        // the server can map it to 409 without inspecting the message.
         if handle.has(&key)? {
-            bail!("alias already exists");
+            return Err(AliasExists.into());
         }
 
         let value = (*value.as_ref()).into();

--- a/crates/node/primitives/src/client/alias.rs
+++ b/crates/node/primitives/src/client/alias.rs
@@ -34,6 +34,20 @@ impl NodeClient {
         Ok(())
     }
 
+    /// Whether an alias currently resolves in the given scope.
+    ///
+    /// Lets callers distinguish "already exists" / "not found" so they can
+    /// return the right status code, without needing the target value type
+    /// (unlike [`Self::lookup_alias`]).
+    pub fn alias_exists<T>(&self, alias: Alias<T>, scope: Option<T::Scope>) -> eyre::Result<bool>
+    where
+        T: Aliasable<Scope: StoreScopeCompat>,
+    {
+        let handle = self.datastore.handle();
+        let key = key::Alias::new(scope, alias).ok_or_eyre("alias requires scope to be present")?;
+        Ok(handle.has(&key)?)
+    }
+
     pub fn delete_alias<T>(&self, alias: Alias<T>, scope: Option<T::Scope>) -> eyre::Result<()>
     where
         T: Aliasable<Scope: StoreScopeCompat>,

--- a/crates/node/primitives/src/client/alias.rs
+++ b/crates/node/primitives/src/client/alias.rs
@@ -53,20 +53,6 @@ impl NodeClient {
         Ok(())
     }
 
-    /// Whether an alias currently resolves in the given scope.
-    ///
-    /// Lets callers distinguish "already exists" / "not found" so they can
-    /// return the right status code, without needing the target value type
-    /// (unlike [`Self::lookup_alias`]).
-    pub fn alias_exists<T>(&self, alias: Alias<T>, scope: Option<T::Scope>) -> eyre::Result<bool>
-    where
-        T: Aliasable<Scope: StoreScopeCompat>,
-    {
-        let handle = self.datastore.handle();
-        let key = key::Alias::new(scope, alias).ok_or_eyre("alias requires scope to be present")?;
-        Ok(handle.has(&key)?)
-    }
-
     pub fn delete_alias<T>(&self, alias: Alias<T>, scope: Option<T::Scope>) -> eyre::Result<()>
     where
         T: Aliasable<Scope: StoreScopeCompat>,

--- a/crates/server/src/admin/handlers/alias/create_alias.rs
+++ b/crates/server/src/admin/handlers/alias/create_alias.rs
@@ -4,6 +4,7 @@ use axum::extract::Path;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::{Extension, Json};
+use calimero_node_primitives::client::AliasExists;
 use calimero_server_primitives::admin::{AliasKind, CreateAliasRequest, CreateAliasResponse};
 use calimero_store::key::{Aliasable, StoreScopeCompat};
 use tracing::{error, info};
@@ -17,35 +18,27 @@ pub async fn handler<T>(
     Json(CreateAliasRequest { alias, value }): Json<CreateAliasRequest<T>>,
 ) -> impl IntoResponse
 where
-    T: Aliasable<Scope: StoreScopeCompat + Copy> + AliasKind + AsRef<[u8; 32]>,
+    T: Aliasable<Scope: StoreScopeCompat> + AliasKind + AsRef<[u8; 32]>,
 {
     let scope = scope.map(|Path(scope)| scope);
 
     info!(alias=%alias, "Creating alias");
 
-    // Reject a duplicate with 409 instead of letting the store's generic
-    // "alias already exists" error fall through to a 500. (Alias length/charset
-    // are already enforced by `Alias`'s deserializer, so a malformed alias 400s
-    // before reaching here.)
-    match state.node_client.alias_exists(alias, scope) {
-        Ok(true) => {
+    // `create_alias` does the existence check + write on one store handle and
+    // returns a typed `AliasExists` on conflict, which we map to 409 — no racy
+    // caller-side pre-check. (Alias length/charset are already enforced by
+    // `Alias`'s deserializer, so a malformed alias 400s before reaching here.)
+    if let Err(err) = state
+        .node_client
+        .create_alias(alias, scope, T::from_value(value))
+    {
+        if err.downcast_ref::<AliasExists>().is_some() {
             return ApiError {
                 status_code: StatusCode::CONFLICT,
                 message: "alias already exists".to_owned(),
             }
             .into_response();
         }
-        Ok(false) => {}
-        Err(err) => {
-            error!(alias=%alias, error=?err, "Failed to check alias existence");
-            return parse_api_error(err).into_response();
-        }
-    }
-
-    if let Err(err) = state
-        .node_client
-        .create_alias(alias, scope, T::from_value(value))
-    {
         error!(alias=%alias, error=?err, "Failed to create alias");
         return parse_api_error(err).into_response();
     }

--- a/crates/server/src/admin/handlers/alias/create_alias.rs
+++ b/crates/server/src/admin/handlers/alias/create_alias.rs
@@ -1,13 +1,14 @@
 use std::sync::Arc;
 
 use axum::extract::Path;
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::{Extension, Json};
 use calimero_server_primitives::admin::{AliasKind, CreateAliasRequest, CreateAliasResponse};
 use calimero_store::key::{Aliasable, StoreScopeCompat};
 use tracing::{error, info};
 
-use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::admin::service::{parse_api_error, ApiError, ApiResponse};
 use crate::AdminState;
 
 pub async fn handler<T>(
@@ -16,11 +17,30 @@ pub async fn handler<T>(
     Json(CreateAliasRequest { alias, value }): Json<CreateAliasRequest<T>>,
 ) -> impl IntoResponse
 where
-    T: Aliasable<Scope: StoreScopeCompat> + AliasKind + AsRef<[u8; 32]>,
+    T: Aliasable<Scope: StoreScopeCompat + Copy> + AliasKind + AsRef<[u8; 32]>,
 {
     let scope = scope.map(|Path(scope)| scope);
 
     info!(alias=%alias, "Creating alias");
+
+    // Reject a duplicate with 409 instead of letting the store's generic
+    // "alias already exists" error fall through to a 500. (Alias length/charset
+    // are already enforced by `Alias`'s deserializer, so a malformed alias 400s
+    // before reaching here.)
+    match state.node_client.alias_exists(alias, scope) {
+        Ok(true) => {
+            return ApiError {
+                status_code: StatusCode::CONFLICT,
+                message: "alias already exists".to_owned(),
+            }
+            .into_response();
+        }
+        Ok(false) => {}
+        Err(err) => {
+            error!(alias=%alias, error=?err, "Failed to check alias existence");
+            return parse_api_error(err).into_response();
+        }
+    }
 
     if let Err(err) = state
         .node_client

--- a/crates/server/src/admin/handlers/alias/delete_alias.rs
+++ b/crates/server/src/admin/handlers/alias/delete_alias.rs
@@ -18,7 +18,7 @@ pub async fn handler<T>(
     scoped_alias: Option<Path<(T::Scope, Alias<T>)>>,
 ) -> impl IntoResponse
 where
-    T: Aliasable<Scope: StoreScopeCompat>,
+    T: Aliasable<Scope: StoreScopeCompat + Copy>,
 {
     let Some((alias, scope)) = plain_alias
         .map(|Path(alias)| (alias, None))
@@ -29,6 +29,20 @@ where
     };
 
     info!(alias=%alias, "Deleting alias");
+
+    // Deleting an alias that doesn't exist is a 404 rather than a silent 200
+    // (the underlying store delete is idempotent and wouldn't surface it).
+    match state.node_client.alias_exists(alias, scope) {
+        Ok(true) => {}
+        Ok(false) => {
+            info!(alias=%alias, "Alias not found");
+            return (StatusCode::NOT_FOUND, "alias not found").into_response();
+        }
+        Err(err) => {
+            error!(alias=%alias, error=?err, "Failed to check alias existence");
+            return parse_api_error(err).into_response();
+        }
+    }
 
     if let Err(err) = state.node_client.delete_alias(alias, scope) {
         error!(alias=%alias, error=?err, "Failed to delete alias");

--- a/crates/server/src/admin/handlers/alias/delete_alias.rs
+++ b/crates/server/src/admin/handlers/alias/delete_alias.rs
@@ -18,7 +18,7 @@ pub async fn handler<T>(
     scoped_alias: Option<Path<(T::Scope, Alias<T>)>>,
 ) -> impl IntoResponse
 where
-    T: Aliasable<Scope: StoreScopeCompat + Copy>,
+    T: Aliasable<Scope: StoreScopeCompat>,
 {
     let Some((alias, scope)) = plain_alias
         .map(|Path(alias)| (alias, None))
@@ -30,20 +30,8 @@ where
 
     info!(alias=%alias, "Deleting alias");
 
-    // Deleting an alias that doesn't exist is a 404 rather than a silent 200
-    // (the underlying store delete is idempotent and wouldn't surface it).
-    match state.node_client.alias_exists(alias, scope) {
-        Ok(true) => {}
-        Ok(false) => {
-            info!(alias=%alias, "Alias not found");
-            return (StatusCode::NOT_FOUND, "alias not found").into_response();
-        }
-        Err(err) => {
-            error!(alias=%alias, error=?err, "Failed to check alias existence");
-            return parse_api_error(err).into_response();
-        }
-    }
-
+    // Delete is idempotent: removing an absent alias succeeds (the store delete
+    // doesn't distinguish), matching the SDK's expectation.
     if let Err(err) = state.node_client.delete_alias(alias, scope) {
         error!(alias=%alias, error=?err, "Failed to delete alias");
         return parse_api_error(err).into_response();

--- a/crates/server/src/admin/handlers/alias/lookup_alias.rs
+++ b/crates/server/src/admin/handlers/alias/lookup_alias.rs
@@ -32,14 +32,19 @@ where
     info!(alias=%alias, "Looking up alias");
 
     match state.node_client.lookup_alias(alias, scope) {
-        Ok(value) => {
+        Ok(Some(value)) => {
             info!(alias=%alias, "Alias looked up successfully");
             ApiResponse {
                 payload: LookupAliasResponse {
-                    data: LookupAliasResponseData::new(value),
+                    data: LookupAliasResponseData::new(Some(value)),
                 },
             }
             .into_response()
+        }
+        // A missing alias is 404, not a 200 with a null payload.
+        Ok(None) => {
+            info!(alias=%alias, "Alias not found");
+            (StatusCode::NOT_FOUND, "alias not found").into_response()
         }
         Err(err) => {
             error!(alias=%alias, error=?err, "Failed to lookup alias");

--- a/crates/server/src/admin/handlers/alias/lookup_alias.rs
+++ b/crates/server/src/admin/handlers/alias/lookup_alias.rs
@@ -31,20 +31,17 @@ where
 
     info!(alias=%alias, "Looking up alias");
 
+    // Lookup is a nullable getter: a missing alias returns 200 with a null
+    // `value` (the SDK contract), not 404 — callers use it to check existence.
     match state.node_client.lookup_alias(alias, scope) {
-        Ok(Some(value)) => {
-            info!(alias=%alias, "Alias looked up successfully");
+        Ok(value) => {
+            info!(alias=%alias, found=%value.is_some(), "Alias lookup complete");
             ApiResponse {
                 payload: LookupAliasResponse {
-                    data: LookupAliasResponseData::new(Some(value)),
+                    data: LookupAliasResponseData::new(value),
                 },
             }
             .into_response()
-        }
-        // A missing alias is 404, not a 200 with a null payload.
-        Ok(None) => {
-            info!(alias=%alias, "Alias not found");
-            (StatusCode::NOT_FOUND, "alias not found").into_response()
         }
         Err(err) => {
             error!(alias=%alias, error=?err, "Failed to lookup alias");


### PR DESCRIPTION
## Summary

Fixes the alias admin endpoints' status codes. This is the remaining actionable part of the "raw-error 500s + wrong status codes" finding.

## Behaviour

- **create** of a duplicate alias → **409 Conflict** (previously the store's generic "alias already exists" fell through to a **500** with the raw error string). The existence check + write happen on a single store handle in `create_alias`, which returns a typed `AliasExists` the handler maps to 409 — no caller-side check-then-write race.
- **lookup** of a missing alias → **200** with a null `value` (unchanged). Lookup is a nullable getter; callers (and the SDK e2e) use it to test existence, so it must not throw a 404.
- **delete** of an alias → **200**, idempotent (unchanged). The store delete doesn't distinguish present/absent; callers expect idempotent delete.

## Not changed (already correct)

- Input validation (length ≤ 50, non-empty, charset `[A-Za-z0-9._-]`) is enforced by `Alias`'s `Deserialize`/`FromStr`, so a malformed alias 400s before the handler.
- `get_context_storage` (same finding line) is already implemented on master.

_Earlier revisions of this PR also turned lookup/delete of a missing alias into 404s; that was reverted — those were never 500s and the 404 broke the SDK's nullable-lookup / idempotent-delete contract (SDK e2e). Only the genuine dup→409 fix remains._

## Verification

`cargo check` / `clippy` / `fmt` clean on `calimero-server` + `calimero-node-primitives`. SDK E2E green after the revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
