### PR TITLE
fix(server): stop leaking raw errors in 500s + 404 on missing application

### DIFF
--- a/crates/server/src/admin/handlers/applications/get_application.rs
+++ b/crates/server/src/admin/handlers/applications/get_application.rs
@@ -1,13 +1,14 @@
 use std::sync::Arc;
 
 use axum::extract::Path;
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Extension;
 use calimero_primitives::application::ApplicationId;
 use calimero_server_primitives::admin::GetApplicationResponse;
 use tracing::{error, info};
 
-use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::admin::service::{parse_api_error, ApiError, ApiResponse};
 use crate::AdminState;
 
 pub async fn handler(
@@ -17,10 +18,19 @@ pub async fn handler(
     info!(application_id=%application_id, "Getting application");
 
     match state.node_client.get_application(&application_id) {
-        Ok(application) => {
+        Ok(Some(application)) => {
             info!(application_id=%application_id, "Application retrieved successfully");
             ApiResponse {
-                payload: GetApplicationResponse::new(application),
+                payload: GetApplicationResponse::new(Some(application)),
+            }
+            .into_response()
+        }
+        // A missing application is 404, not a 200 with a null payload.
+        Ok(None) => {
+            info!(application_id=%application_id, "Application not found");
+            ApiError {
+                status_code: StatusCode::NOT_FOUND,
+                message: "Application not found".to_owned(),
             }
             .into_response()
         }

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -567,10 +567,17 @@ impl IntoResponse for ApiError {
 pub fn parse_api_error(err: Report) -> ApiError {
     match err.downcast::<ApiError>() {
         Ok(api_error) => api_error,
-        Err(original_error) => ApiError {
-            status_code: StatusCode::INTERNAL_SERVER_ERROR,
-            message: original_error.to_string(),
-        },
+        // An untyped error is an unexpected internal failure. Don't echo its
+        // message back to the caller — it can carry store paths, key material,
+        // or other internals. Log the detail server-side and return a generic
+        // 500. (Typed `ApiError`s above keep their intended message/code.)
+        Err(original_error) => {
+            tracing::error!(error = ?original_error, "unhandled admin-api error");
+            ApiError {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                message: "Internal server error".to_owned(),
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Closes the remaining parts of the **"Raw-error 500s + wrong status codes; get_context_storage returns 0; alias validation"** finding that weren't covered by the alias PR (#3169). Together, #3169 + this PR + already-merged work fully resolve that finding.

## What this PR fixes

1. **Raw internal errors leaked in 500 bodies.** `parse_api_error` echoed an untyped error's `to_string()` straight into the JSON response (`{"error": "<raw internal message>"}`) — which can carry store paths, key material, or other internals. It now **logs the detail server-side** and returns a generic `"Internal server error"`. Typed `ApiError`s (deliberate 4xx with intended messages/codes) are unaffected, since they short-circuit the downcast.
2. **`GET /applications/{id}` returned 200-with-null for a missing app.** Now returns **404 NOT_FOUND**.

## Finding sub-items — full status

| Sub-item | Status |
|----------|--------|
| Raw `err.to_string()` in 500s | ✅ this PR (`parse_api_error` scrub) |
| Wrong codes: `get_application` not-found → 500/200 | ✅ this PR (404) |
| Wrong codes: alias conflict/not-found → 500 | ✅ PR #3169 (409/404) |
| `get_context_storage` returns 0 (quota bypass) | ✅ already on master (`context_storage_bytes`) |
| `create_alias` length/charset/dup guard | ✅ length/charset/empty enforced by `Alias` deserializer (master); dup → 409 in #3169 |

## Verification

`cargo check` / `clippy` / `fmt` clean on `calimero-server`. No server test asserts on 500 response bodies, so scrubbing the fallback message is behavior-safe for typed errors. Server-only; no wire/schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
