### PR TITLE
fix(network): prune autonat peers_with_server_support on disconnect

### DIFF
--- a/crates/network/primitives/src/autonat_v2/behaviour.rs
+++ b/crates/network/primitives/src/autonat_v2/behaviour.rs
@@ -253,6 +253,11 @@ impl NetworkBehaviour for Behaviour {
                 if conn_closed.remaining_established == 0 {
                     _ = self.server_dialback_peers.remove(&conn_closed.peer_id);
                     _ = self.client_expecting_dialback.remove(&conn_closed.peer_id);
+                    // Also drop the server-support marker: without this the set
+                    // grows one entry per peer ever seen (never pruned), an
+                    // unbounded map under peer churn. It's re-learned on the next
+                    // successful dial-request exchange if the peer reconnects.
+                    _ = self.peers_with_server_support.remove(&conn_closed.peer_id);
 
                     tracing::debug!(
                         peer_id = %conn_closed.peer_id,


### PR DESCRIPTION
`peers_with_server_support` was insert-only — one entry per peer ever seen, never removed — an unbounded map under adversarial/normal peer churn. Now removed when a peer's last connection closes (alongside the existing `server_dialback_peers`/`client_expecting_dialback` cleanup); re-learned on the next dial-request exchange if the peer reconnects.

Verified: `cargo check`/`fmt` clean on calimero-network-primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)