### PR TITLE
fix(governance): bound decoded governance-op fields (amplification DoS)

### DIFF
--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -1335,6 +1335,10 @@ pub fn apply_local_signed_group_op_at_cut(
             MAX_PARENT_OP_HASHES
         );
     }
+    // Anti-amplification: bound the op's variable-length fields (ciphertext,
+    // key-rotation envelopes, cascade/TEE lists, …) before doing crypto or
+    // touching state. Rejects an untrusted peer's egregiously oversized op.
+    op.validate()?;
     op.verify_signature()
         .map_err(|e| eyre::eyre!("signed group op: {e}"))?;
     let group_id = op.group_id;

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -180,6 +180,10 @@ impl<'a> NamespaceGovernance<'a> {
             ));
         }
 
+        // Anti-amplification: bound the op's variable-length fields (encrypted
+        // ciphertext, key-rotation envelopes, policy/cascade lists, …) before
+        // crypto or side effects. Rejects an untrusted peer's oversized op.
+        op.validate()?;
         op.verify_signature()
             .map_err(|e| eyre::eyre!("signed namespace op: {e}"))?;
 

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -1034,15 +1034,37 @@ pub mod bounds {
     pub const MAX_KEY_ENVELOPES: usize = 65_536;
     /// Max ids in a cascade (group-delete descendants) or per-context hash list.
     pub const MAX_ID_LIST: usize = 65_536;
-    /// Max entries in a TEE allow-list field, and max length of each entry.
+    /// Max entries in a TEE allow-list field.
     pub const MAX_TEE_ALLOWED_ENTRIES: usize = 1_024;
+    /// Max byte length of each string entry in a TEE allow-list.
     pub const MAX_TEE_ALLOWED_STRING_LEN: usize = 1_024;
+    /// Max entries in a metadata map (`GroupOp::*MetadataSet.data`).
+    pub const MAX_METADATA_ENTRIES: usize = 1_024;
+    /// Max byte length of a metadata name / key / value string.
+    pub const MAX_METADATA_STRING_LEN: usize = 8_192;
 }
 
 /// Fail with [`GovernanceError::Bounds`] if `len > max`.
 fn check_bound(field: &str, len: usize, max: usize) -> Result<(), GovernanceError> {
     if len > max {
         return Err(GovernanceError::Bounds(format!("{field}: {len} > {max}")));
+    }
+    Ok(())
+}
+
+/// Bound a metadata record's optional name plus its key/value map.
+fn check_metadata(
+    field: &str,
+    name: Option<&String>,
+    data: &std::collections::BTreeMap<String, String>,
+) -> Result<(), GovernanceError> {
+    if let Some(name) = name {
+        check_bound(field, name.len(), bounds::MAX_METADATA_STRING_LEN)?;
+    }
+    check_bound(field, data.len(), bounds::MAX_METADATA_ENTRIES)?;
+    for (k, v) in data {
+        check_bound(field, k.len(), bounds::MAX_METADATA_STRING_LEN)?;
+        check_bound(field, v.len(), bounds::MAX_METADATA_STRING_LEN)?;
     }
     Ok(())
 }
@@ -1102,7 +1124,19 @@ impl GroupOp {
             }
             | Self::CascadeGroupMigrationSet {
                 migration: Some(m), ..
+            }
+            | Self::CascadeUpgrade {
+                migration: Some(m), ..
             } => check_bound("group_op.migration", m.len(), bounds::MAX_BLOB_BYTES),
+            Self::GroupMetadataSet { name, data } => {
+                check_metadata("group_op.group_metadata", name.as_ref(), data)
+            }
+            Self::MemberMetadataSet { name, data, .. } => {
+                check_metadata("group_op.member_metadata", name.as_ref(), data)
+            }
+            Self::ContextMetadataSet { name, data, .. } => {
+                check_metadata("group_op.context_metadata", name.as_ref(), data)
+            }
             Self::TeeAdmissionPolicySet {
                 allowed_mrtd,
                 allowed_rtmr0,

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -1012,6 +1012,199 @@ pub enum GovernanceError {
     Signature(#[from] SignatureError),
     #[error("borsh serialization failed: {0}")]
     BorshSerialize(#[from] std::io::Error),
+    /// A decoded op's variable-length field exceeded its anti-amplification
+    /// bound (see [`bounds`]). Rejected before it can be applied/stored.
+    #[error("governance op exceeds size bounds: {0}")]
+    Bounds(String),
+}
+
+/// Anti-amplification bounds for variable-length fields in decoded governance
+/// ops. Legit ops are already capped at `MAX_SIGNED_GROUP_OP_PAYLOAD_BYTES`
+/// (64 KiB) on the send path, so every bound here sits far above any real op —
+/// they exist only to reject an untrusted peer's egregiously oversized op
+/// (borsh decodes gossip/backfill bytes with no inherent element cap).
+pub mod bounds {
+    /// Max DAG parents referenced by one op.
+    pub const MAX_PARENT_OP_HASHES: usize = 4096;
+    /// Max bytes in an encrypted-op / key-envelope ciphertext.
+    pub const MAX_CIPHERTEXT_BYTES: usize = 1 << 20;
+    /// Max bytes in a policy blob / migration blob.
+    pub const MAX_BLOB_BYTES: usize = 1 << 20;
+    /// Max ECDH envelopes in one key rotation (one per remaining member).
+    pub const MAX_KEY_ENVELOPES: usize = 65_536;
+    /// Max ids in a cascade (group-delete descendants) or per-context hash list.
+    pub const MAX_ID_LIST: usize = 65_536;
+    /// Max entries in a TEE allow-list field, and max length of each entry.
+    pub const MAX_TEE_ALLOWED_ENTRIES: usize = 1_024;
+    pub const MAX_TEE_ALLOWED_STRING_LEN: usize = 1_024;
+}
+
+/// Fail with [`GovernanceError::Bounds`] if `len > max`.
+fn check_bound(field: &str, len: usize, max: usize) -> Result<(), GovernanceError> {
+    if len > max {
+        return Err(GovernanceError::Bounds(format!("{field}: {len} > {max}")));
+    }
+    Ok(())
+}
+
+impl KeyEnvelope {
+    fn validate(&self) -> Result<(), GovernanceError> {
+        check_bound(
+            "key_envelope.ciphertext",
+            self.ciphertext.len(),
+            bounds::MAX_CIPHERTEXT_BYTES,
+        )
+    }
+}
+
+impl KeyRotation {
+    fn validate(&self) -> Result<(), GovernanceError> {
+        check_bound(
+            "key_rotation.envelopes",
+            self.envelopes.len(),
+            bounds::MAX_KEY_ENVELOPES,
+        )?;
+        for env in &self.envelopes {
+            env.validate()?;
+        }
+        Ok(())
+    }
+}
+
+impl EncryptedGroupOp {
+    /// Bound the ciphertext of an encrypted group op.
+    pub fn validate(&self) -> Result<(), GovernanceError> {
+        check_bound(
+            "encrypted_group_op.ciphertext",
+            self.ciphertext.len(),
+            bounds::MAX_CIPHERTEXT_BYTES,
+        )
+    }
+}
+
+impl GroupOp {
+    fn validate(&self) -> Result<(), GovernanceError> {
+        match self {
+            Self::MemberRemoved {
+                expected_context_state_hashes,
+                ..
+            }
+            | Self::MemberLeft {
+                expected_context_state_hashes,
+                ..
+            } => check_bound(
+                "group_op.expected_context_state_hashes",
+                expected_context_state_hashes.len(),
+                bounds::MAX_ID_LIST,
+            ),
+            Self::GroupMigrationSet {
+                migration: Some(m), ..
+            }
+            | Self::CascadeGroupMigrationSet {
+                migration: Some(m), ..
+            } => check_bound("group_op.migration", m.len(), bounds::MAX_BLOB_BYTES),
+            Self::TeeAdmissionPolicySet {
+                allowed_mrtd,
+                allowed_rtmr0,
+                allowed_rtmr1,
+                allowed_rtmr2,
+                allowed_rtmr3,
+                allowed_tcb_statuses,
+                ..
+            } => {
+                for (name, list) in [
+                    ("allowed_mrtd", allowed_mrtd),
+                    ("allowed_rtmr0", allowed_rtmr0),
+                    ("allowed_rtmr1", allowed_rtmr1),
+                    ("allowed_rtmr2", allowed_rtmr2),
+                    ("allowed_rtmr3", allowed_rtmr3),
+                    ("allowed_tcb_statuses", allowed_tcb_statuses),
+                ] {
+                    check_bound(name, list.len(), bounds::MAX_TEE_ALLOWED_ENTRIES)?;
+                    for s in list {
+                        check_bound(name, s.len(), bounds::MAX_TEE_ALLOWED_STRING_LEN)?;
+                    }
+                }
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+impl RootOp {
+    fn validate(&self) -> Result<(), GovernanceError> {
+        match self {
+            Self::GroupDeleted {
+                cascade_group_ids,
+                cascade_context_ids,
+                ..
+            } => {
+                check_bound(
+                    "root_op.cascade_group_ids",
+                    cascade_group_ids.len(),
+                    bounds::MAX_ID_LIST,
+                )?;
+                check_bound(
+                    "root_op.cascade_context_ids",
+                    cascade_context_ids.len(),
+                    bounds::MAX_ID_LIST,
+                )
+            }
+            Self::PolicyUpdated { policy_bytes } => check_bound(
+                "root_op.policy_bytes",
+                policy_bytes.len(),
+                bounds::MAX_BLOB_BYTES,
+            ),
+            Self::KeyDelivery { envelope, .. } => envelope.validate(),
+            _ => Ok(()),
+        }
+    }
+}
+
+impl NamespaceOp {
+    fn validate(&self) -> Result<(), GovernanceError> {
+        match self {
+            Self::Root(root) => root.validate(),
+            Self::Group {
+                encrypted,
+                key_rotation,
+                ..
+            } => {
+                encrypted.validate()?;
+                if let Some(rotation) = key_rotation {
+                    rotation.validate()?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl SignedGroupOp {
+    /// Reject an oversized/over-populated op before it is applied or stored.
+    /// See [`bounds`].
+    pub fn validate(&self) -> Result<(), GovernanceError> {
+        check_bound(
+            "signed_group_op.parent_op_hashes",
+            self.parent_op_hashes.len(),
+            bounds::MAX_PARENT_OP_HASHES,
+        )?;
+        self.op.validate()
+    }
+}
+
+impl SignedNamespaceOp {
+    /// Reject an oversized/over-populated op before it is applied or stored.
+    /// See [`bounds`].
+    pub fn validate(&self) -> Result<(), GovernanceError> {
+        check_bound(
+            "signed_namespace_op.parent_op_hashes",
+            self.parent_op_hashes.len(),
+            bounds::MAX_PARENT_OP_HASHES,
+        )?;
+        self.op.validate()
+    }
 }
 
 /// Bytes that are hashed/signed: `GROUP_GOVERNANCE_SIGN_DOMAIN` || `borsh(SignableGroupOp)`.

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -1487,4 +1487,44 @@ mod governance_op_storage_roundtrip {
             "expected a borsh length error, got: {err}"
         );
     }
+
+    #[test]
+    fn validate_bounds_encrypted_ciphertext() {
+        let oversized = EncryptedGroupOp {
+            nonce: [0u8; 12],
+            ciphertext: vec![0u8; bounds::MAX_CIPHERTEXT_BYTES + 1],
+        };
+        assert!(
+            oversized.validate().is_err(),
+            "ciphertext over the bound must be rejected"
+        );
+
+        let ok = EncryptedGroupOp {
+            nonce: [0u8; 12],
+            ciphertext: vec![0u8; 64],
+        };
+        assert!(ok.validate().is_ok(), "a normal ciphertext must pass");
+    }
+
+    #[test]
+    fn validate_bounds_parent_op_hashes() {
+        let mut op = SignedNamespaceOp {
+            version: 1,
+            namespace_id: NamespaceId::from([0u8; 32]),
+            parent_op_hashes: vec![[0u8; 32]; bounds::MAX_PARENT_OP_HASHES + 1],
+            signer: PublicKey::from([0u8; 32]),
+            nonce: 1,
+            op: NamespaceOp::Root(RootOp::AdminChanged {
+                new_admin: PublicKey::from([1u8; 32]),
+            }),
+            signature: [0u8; 64],
+        };
+        assert!(
+            op.validate().is_err(),
+            "too many parent_op_hashes must be rejected"
+        );
+
+        op.parent_op_hashes = vec![[0u8; 32]; 2];
+        assert!(op.validate().is_ok(), "a small parent set must pass");
+    }
 }

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -1509,7 +1509,7 @@ mod governance_op_storage_roundtrip {
     #[test]
     fn validate_bounds_parent_op_hashes() {
         let mut op = SignedNamespaceOp {
-            version: 1,
+            version: SIGNED_NAMESPACE_OP_SCHEMA_VERSION,
             namespace_id: NamespaceId::from([0u8; 32]),
             parent_op_hashes: vec![[0u8; 32]; bounds::MAX_PARENT_OP_HASHES + 1],
             signer: PublicKey::from([0u8; 32]),


### PR DESCRIPTION
Governance ops decoded from gossip/backfill had **no element/byte cap** on their variable-length fields — `ciphertext`, key-rotation `envelopes`, policy/migration blobs, cascade id lists, TEE allow-lists, `parent_op_hashes` — so an untrusted peer's op could carry huge nested Vecs (amplification DoS).

Adds `validate()` (bounds in the `bounds` module) on `SignedGroupOp` / `SignedNamespaceOp` / `EncryptedGroupOp` and calls it at **both `apply_signed_op` choke points** (group + namespace), before signature verification or any side effect. Bounds are generous — legit ops are already `<= MAX_SIGNED_GROUP_OP_PAYLOAD_BYTES` (64 KiB) on the send path — so only egregiously oversized ops are rejected. borsh 1.x already guards the length-prefix pre-allocation; this bounds the element counts at the consensus boundary as the finding recommends (post-decode validate()).

Tests: added ciphertext + parent_op_hashes bound tests; governance-types (44) and governance-store (405) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)