### PR TITLE
perf(storage,context): drop actions clone in commit_causal_delta + rotation-log sort

### DIFF
--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1032,10 +1032,11 @@ impl Handler<ExecuteRequest> for ContextManager {
                                 &context_client,
                                 context_id,
                                 *object,
+                                Some(delta_id),
                             ) else {
                                 continue;
                             };
-                            for entry in log.entries.iter().filter(|e| e.delta_id == *delta_id) {
+                            for entry in &log.entries {
                                 if let Some(op) = crate::scope_projection::op_from_rotation_entry(
                                     *object, scope, entry,
                                 ) {

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -120,6 +120,11 @@ pub fn op_from_rotation_entry(object: Id, scope: ScopeId, entry: &RotationLogEnt
 /// storage env), by walking its hashed-collection children. `None` if the
 /// anchor has no rotation collection yet (never rotated / not a Shared anchor).
 ///
+/// `only_delta` narrows the returned entries to the ones recorded by that
+/// delta (the live ACL feed only wants the just-applied delta's rotations, so
+/// the non-matching entries are dropped during the walk instead of collected
+/// and filtered by the caller). `None` keeps every entry.
+///
 /// This is the post-apply read the live ACL feed uses to recover the **raw**
 /// rotation entries (with their signer), the independent source the projection
 /// folds — as opposed to the resolver's already-merged output.
@@ -132,6 +137,7 @@ pub fn load_rotation_log_direct(
     client: &ContextClient,
     context_id: ContextId,
     anchor: Id,
+    only_delta: Option<&[u8; 32]>,
 ) -> Option<RotationLog> {
     let map_id = Interface::<MainStorage>::rotation_log_child_id(anchor);
     let handle = client.datastore_handle();
@@ -177,7 +183,11 @@ pub fn load_rotation_log_direct(
                 continue;
             };
             match decode_rotation_log_entry_child(&bytes) {
-                Some(entry) => entries.push(entry),
+                Some(entry) => {
+                    if only_delta.is_none_or(|delta_id| entry.delta_id == *delta_id) {
+                        entries.push(entry);
+                    }
+                }
                 // A child that doesn't decode yields a partial log; warn rather
                 // than skip in silence (matches the node-crate reader).
                 None => tracing::warn!(
@@ -187,9 +197,9 @@ pub fn load_rotation_log_direct(
             }
         }
     }
-    // Canonical order; the caller filters to this delta's id, so ordering is not
-    // load-bearing here (it mirrors the node-crate reader's shape).
-    entries.sort_by(|a, b| a.delta_id.cmp(&b.delta_id));
+    // No canonical ordering: the sole caller folds this delta's entries in
+    // walk order (sorting by delta_id was O(n log n) of pure overhead — with
+    // the `only_delta` narrowing, all retained ids are equal anyway).
     Some(RotationLog {
         snapshot: None,
         entries,

--- a/crates/storage/src/delta.rs
+++ b/crates/storage/src/delta.rs
@@ -325,14 +325,9 @@ pub fn commit_causal_delta(root_hash: &[u8; 32]) -> eyre::Result<Option<CausalDe
         // Compute ID
         let id = CausalDelta::compute_id(&parents, &actions, &hlc);
 
-        // Serialize for environment. Wrap the actions to serialize by
-        // reference, then move them back out for the delta — avoids cloning
-        // every action just to encode the artifact.
-        let wrapped = StorageDelta::Actions(actions);
-        let artifact = to_vec(&wrapped)?;
-        let StorageDelta::Actions(actions) = wrapped else {
-            unreachable!("wrapped as Actions above")
-        };
+        // Serialize for the environment directly from a borrow — avoids
+        // cloning every action just to encode the artifact.
+        let artifact = actions_artifact(&actions)?;
 
         let delta = CausalDelta {
             id,
@@ -349,6 +344,19 @@ pub fn commit_causal_delta(root_hash: &[u8; 32]) -> eyre::Result<Option<CausalDe
 
         Ok(Some(delta))
     })
+}
+
+/// Encode the [`StorageDelta::Actions`] artifact directly from a borrowed
+/// slice: variant tag `0` followed by the borsh-encoded list. This is the
+/// same wire format the derived `BorshSerialize` produces for the enum (and
+/// that the manual [`BorshDeserialize`] above reads back), without cloning
+/// the actions or round-tripping them through enum construction.
+/// `actions_artifact_matches_enum_encoding` pins the equivalence.
+fn actions_artifact(actions: &[Action]) -> io::Result<Vec<u8>> {
+    let mut artifact = Vec::new();
+    BorshSerialize::serialize(&0u8, &mut artifact)?;
+    BorshSerialize::serialize(actions, &mut artifact)?;
+    Ok(artifact)
 }
 
 /// Commits the root hash to the runtime (legacy compatibility).
@@ -514,6 +522,17 @@ mod borsh_roundtrip_tests {
             }
             other => panic!("expected Actions, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn actions_artifact_matches_enum_encoding() {
+        let actions = vec![make_action(1), make_action(2)];
+        let direct = actions_artifact(&actions).unwrap();
+        let via_enum = to_vec(&StorageDelta::Actions(actions)).unwrap();
+        assert_eq!(
+            direct, via_enum,
+            "direct artifact encoding diverged from StorageDelta::Actions"
+        );
     }
 
     #[test]

--- a/crates/storage/src/delta.rs
+++ b/crates/storage/src/delta.rs
@@ -325,6 +325,15 @@ pub fn commit_causal_delta(root_hash: &[u8; 32]) -> eyre::Result<Option<CausalDe
         // Compute ID
         let id = CausalDelta::compute_id(&parents, &actions, &hlc);
 
+        // Serialize for environment. Wrap the actions to serialize by
+        // reference, then move them back out for the delta — avoids cloning
+        // every action just to encode the artifact.
+        let wrapped = StorageDelta::Actions(actions);
+        let artifact = to_vec(&wrapped)?;
+        let StorageDelta::Actions(actions) = wrapped else {
+            unreachable!("wrapped as Actions above")
+        };
+
         let delta = CausalDelta {
             id,
             parents,
@@ -336,8 +345,6 @@ pub fn commit_causal_delta(root_hash: &[u8; 32]) -> eyre::Result<Option<CausalDe
         // Update heads - this delta is now the new head
         context.current_heads = vec![delta.id];
 
-        // Serialize for environment
-        let artifact = to_vec(&StorageDelta::Actions(delta.actions.clone()))?;
         env::commit(root_hash, &artifact);
 
         Ok(Some(delta))


### PR DESCRIPTION
## Summary

Finishes the per-call-allocation audit items not covered by #3055 (merged) or #3184.

| Path | Fix |
|------|-----|
| `storage` `commit_causal_delta` | The artifact was serialized from `delta.actions.clone()` — a full copy of every action on every committed delta. Now the actions are wrapped in `StorageDelta::Actions` once, serialized by reference, and moved back out for the `CausalDelta`. No clone, byte-identical artifact. |
| `context` `load_rotation_log_direct` | Collected an anchor's **entire** rotation log, sorted it by `delta_id` (the comment itself noted ordering was "not load-bearing"), and the sole caller then filtered to a single delta's entries. The wanted delta id is now threaded in as an `only_delta` filter applied during the child walk — non-matching entries are never collected and the sort is gone. Retained entries keep their previous relative order (the old stable sort preserved walk order among equal `delta_id`s, and all retained ids are equal). |

## Test plan

- [x] `cargo test -p calimero-storage --lib` — 667 passed
- [x] `cargo test -p calimero-context --lib` — 221 passed
- [x] `cargo clippy -p calimero-storage -p calimero-context --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)