### PR TITLE
perf(storage,node): fix confirmed CRDT/DAG hot-path costs

### DIFF
--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1282,6 +1282,12 @@ impl DeltaStore {
     ///
     /// Deltas are loaded in topological order (parents before children) to properly
     /// reconstruct the DAG topology.
+    ///
+    /// Contract: call once per store at creation/restart, before it serves
+    /// concurrent appliers (all callers are `is_new`-gated). The topological
+    /// restore holds the DAG write lock across all passes, so a concurrent
+    /// `add_delta` would block for the whole restore — safe only under this
+    /// startup-only contract.
     pub async fn load_persisted_deltas(&self) -> Result<LoadPersistedResult> {
         use std::collections::HashMap;
 

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1475,32 +1475,37 @@ impl DeltaStore {
         // incorrectly return false for any cross-restart ancestry.
         let mut topology_seed: Vec<([u8; 32], Vec<[u8; 32]>)> = Vec::new();
 
-        while progress_made && !remaining.is_empty() {
-            progress_made = false;
-            let mut to_remove = Vec::new();
+        // Hold the DAG write lock once across all restore passes rather than
+        // re-acquiring it per delta (the loop's only await was this lock).
+        // Scoped so it drops before the `restore_topology` await below.
+        // Startup-only path with no concurrent appliers, so no contention cost.
+        {
+            let mut dag = self.dag.write().await;
+            while progress_made && !remaining.is_empty() {
+                progress_made = false;
+                let mut to_remove = Vec::new();
 
-            for (delta_id, dag_delta) in &remaining {
-                let mut dag = self.dag.write().await;
+                for (delta_id, dag_delta) in &remaining {
+                    // Check if all parents have been applied before restoring
+                    let can_restore = dag_delta
+                        .parents
+                        .iter()
+                        .all(|p| *p == [0u8; 32] || dag.is_applied(p));
 
-                // Check if all parents have been applied before restoring
-                let can_restore = dag_delta
-                    .parents
-                    .iter()
-                    .all(|p| *p == [0u8; 32] || dag.is_applied(p));
-
-                if can_restore {
-                    // Restore topology WITHOUT re-applying (delta was already applied)
-                    if dag.restore_applied_delta(dag_delta.clone()) {
-                        loaded_count += 1;
-                        to_remove.push(*delta_id);
-                        topology_seed.push((*delta_id, dag_delta.parents.clone()));
-                        progress_made = true;
+                    if can_restore {
+                        // Restore topology WITHOUT re-applying (delta was already applied)
+                        if dag.restore_applied_delta(dag_delta.clone()) {
+                            loaded_count += 1;
+                            to_remove.push(*delta_id);
+                            topology_seed.push((*delta_id, dag_delta.parents.clone()));
+                            progress_made = true;
+                        }
                     }
                 }
-            }
 
-            for delta_id in to_remove {
-                drop(remaining.remove(&delta_id));
+                for delta_id in to_remove {
+                    drop(remaining.remove(&delta_id));
+                }
             }
         }
 

--- a/crates/storage/src/collections/rga.rs
+++ b/crates/storage/src/collections/rga.rs
@@ -309,7 +309,11 @@ impl<S: StorageAdaptor> ReplicatedGrowableArray<S> {
     ///
     /// Returns error if storage operation fails
     pub fn len(&self) -> Result<usize, StoreError> {
-        self.get_ordered_chars().map(|chars| chars.len())
+        // Deleted chars are dropped from the live child list `chars.len()`
+        // counts (tombstoned for merge, but excluded from that list) — the same
+        // list `get_ordered_chars` walks via `entries()`. So the stored count
+        // already equals the visible length; no need to re-linearize.
+        self.chars.len()
     }
 
     /// Check if the text is empty
@@ -629,6 +633,22 @@ mod merge_mode_tests {
                 .unwrap();
         });
         assert_eq!(rga.len().unwrap(), 1);
+    }
+
+    #[test]
+    fn len_matches_visible_text_after_delete() {
+        env::reset_for_testing();
+        let mut rga = Root::new(ReplicatedGrowableArray::new);
+        env::with_merge_mode(|| {
+            rga.insert_str_at_timestamp(0, HybridTimestamp::zero(), "Hi")
+                .unwrap();
+        });
+        assert_eq!(rga.len().unwrap(), 2);
+        rga.delete(0).unwrap(); // drops 'H' from the live child list
+                                // len() now reads the stored count; it must stay equal to the
+                                // re-linearized visible length that get_text() reflects.
+        assert_eq!(rga.len().unwrap(), 1);
+        assert_eq!(rga.len().unwrap(), rga.get_text().unwrap().chars().count());
     }
 }
 

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -230,12 +230,12 @@ where
     ///
     pub fn get(&self, index: usize) -> Result<Option<ValueRef<V>>, StoreError> {
         validate_index_bounds(index)?;
-        Ok(self
-            .inner
-            .entries()?
-            .nth(index)
-            .transpose()?
-            .map(ValueRef::new))
+        // O(1) positional lookup (id by index, then value by id), mirroring
+        // `update`. Avoid `entries().nth(index)`, which loads index+1 entries.
+        let Some(id) = self.inner.nth(index)? else {
+            return Ok(None);
+        };
+        Ok(self.inner.get(id)?.map(ValueRef::new))
     }
 
     /// Update the value at a specific index in the vector.


### PR DESCRIPTION
Three independent, behavior-preserving performance fixes surfaced by a perf-claim audit. Each reuses helpers already in the codebase — no new abstractions or deps.

## Fixes

- **`Vector::get`: O(n) → O(1).** It used `entries().nth(i)`, which loads `i+1` entries to return one. Now `nth` (id-by-index, O(1)) + `get` (value-by-id, O(1)), mirroring the existing `update`. This alone collapses `Vector::merge` from **O(n²) → O(n)** (its docstring already claimed `O(min(N,M))`, which is now true).

- **`rga::len`/`is_empty`: skip the O(n log n) re-linearization.** They called `get_ordered_chars` (full DFS + sort over all live chars) just to count. Deleted chars are dropped from the live child list that both `len()` and `get_ordered_chars`' `entries()` read, so the stored `chars.len()` already equals the visible length. Guard test added for the post-delete path.

- **`delta_store::load_persisted_deltas`: hoist the DAG write lock.** The topological-restore loop re-acquired `self.dag.write().await` per delta per pass (worst case O(N²) acquisitions). The loop's only await *was* that lock, so it's now held once across all passes, scoped to drop before the later `restore_topology().await`. Startup-only path, uncontended.

## Verification

- `calimero-storage`: 668 tests pass (incl. new `len_matches_visible_text_after_delete`)
- `calimero-node`: 431 lib tests pass
- clippy clean, fmt clean

## Deliberately not included

- **`acl_view_at` refold** (confirmed O(L) fold per call, twice per delta on the apply path): it's an **authorization** path and `acl_view_at` is `&self` under a shared read lock, so a memo needs interior mutability + its own eviction (the log is unbounded) and a stale entry is a wrong membership verdict. The code's own `TODO(cutover)` calls for an indexed-ancestry redesign. Deserves a dedicated PR with at-cut auth tests, not a batch commit.
- **`buffer_governance_pending` linear dedup**: real but bounded at 256 under a per-*shard* `DashMap` lock — a `HashSet` to sync with FIFO eviction costs more than it saves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)