### PR TITLE
fix(governance): resolve() strands the deepest legal subgroup (off-by-one depth bound)

### DIFF
--- a/crates/governance-store/src/namespace/core.rs
+++ b/crates/governance-store/src/namespace/core.rs
@@ -368,7 +368,10 @@ impl<'a> NamespaceRepository<'a> {
     /// Walk the parent chain to find the root group (namespace).
     pub fn resolve(&self, group_id: &ContextGroupId) -> EyreResult<ContextGroupId> {
         let mut current = *group_id;
-        for _ in 0..MAX_NAMESPACE_DEPTH {
+        // Inclusive bound (mirrors `check_path`): reaching the root at depth D
+        // requires D+1 iterations to observe the root's `None` parent, so the
+        // deepest legal subgroup (depth MAX) needs MAX+1 walk steps.
+        for _ in 0..=MAX_NAMESPACE_DEPTH {
             match self.parent(&current)? {
                 Some(parent) => current = parent,
                 None => return Ok(current),

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -3565,6 +3565,50 @@ fn resolve_signing_key_none_when_exceeding_max_depth() {
     );
 }
 
+#[test]
+fn resolve_reaches_root_at_max_depth() {
+    use super::namespace::MAX_NAMESPACE_DEPTH;
+
+    let store = test_store();
+
+    // Chain of MAX_NAMESPACE_DEPTH + 2 groups so we can exercise both the
+    // deepest legal subgroup (depth MAX) and one level past it (depth MAX+1).
+    let groups: Vec<ContextGroupId> = (0..=MAX_NAMESPACE_DEPTH + 1)
+        .map(|i| {
+            let mut bytes = [0u8; 32];
+            bytes[0] = 0xD0;
+            bytes[1] = i as u8;
+            ContextGroupId::from(bytes)
+        })
+        .collect();
+    for i in 0..MAX_NAMESPACE_DEPTH + 1 {
+        NamespaceRepository::new(&store)
+            .nest(&groups[i], &groups[i + 1])
+            .unwrap();
+    }
+
+    // Depth MAX (MAX edges to root) must resolve to the root. This is the
+    // regression: the old exclusive `0..MAX` bound bailed `DepthExceeded`
+    // here because reaching the root needs MAX+1 walk steps to observe its
+    // `None` parent.
+    assert_eq!(
+        NamespaceRepository::new(&store)
+            .resolve(&groups[MAX_NAMESPACE_DEPTH])
+            .unwrap(),
+        groups[0],
+        "deepest legal subgroup (depth MAX) must resolve to the root",
+    );
+
+    // One level past MAX stays unresolvable — depth-(MAX+1) is unreachable in
+    // production anyway, and this matches `check_path`'s inclusive bound.
+    assert!(
+        NamespaceRepository::new(&store)
+            .resolve(&groups[MAX_NAMESPACE_DEPTH + 1])
+            .is_err(),
+        "depth MAX+1 must still bail DepthExceeded",
+    );
+}
+
 // -----------------------------------------------------------------------
 // governance_preflight logic — testing the store-level checks that
 // governance_preflight orchestrates (admin auth + signing key resolution)


### PR DESCRIPTION
## Bug (Medium)

`NamespaceRepository::resolve` (`crates/governance-store/src/namespace/core.rs`) walks the parent chain to find a namespace root:

```rust
for _ in 0..MAX_NAMESPACE_DEPTH {      // exclusive
    match self.parent(&current)? {
        Some(parent) => current = parent,
        None => return Ok(current),    // terminates by walking ONTO the root
    }
}
eyre::bail!(NamespaceError::DepthExceeded)
```

The loop terminates only by observing the root's `None` parent — it walks *onto* the root node. So resolving a node at depth `D` requires `D+1` iterations. With `MAX_NAMESPACE_DEPTH = 16`, an exclusive `0..16` bound gives only 16 iterations and there is **no post-loop check**, so `resolve` handles depth `<= 15` and bails `DepthExceeded` for a **depth-16** node.

### Off-by-one analysis (depth-16 node, chain `root=g0 - g1 - ... - g16`)

| iter | current before | parent |
|------|----------------|--------|
| 1    | g16            | g15    |
| ...  | ...            | ...    |
| 16   | g1             | g0 (root) |
| 17 (needed) | g0      | `None` → return g0 |

The 17th iteration that observes `parent(root) == None` never runs, so `current == root` but the loop exits and bails.

## Why inclusive is correct

- **`check_path`** (`crates/governance-store/src/membership/core.rs:233`) — the sibling walker with the *identical* None-parent termination — already uses the inclusive `for _ in 0..=MAX_NAMESPACE_DEPTH`.
- **`nest`** (same file, ~line 152) permits creating a subgroup at depth up to `MAX_NAMESPACE_DEPTH`.

So `resolve` was short exactly one iteration versus both what production can create and what `check_path` accepts. The depth-16 subgroup was legally creatable but unresolvable, hard-failing every `resolve(...)?` caller for it — publish (`group_governance_publisher.rs`), leave-detection (`ops/group/member_left.rs`), namespace-membership (`namespace/membership.rs`).

(Note: `SigningKeysRepository::resolve` in `signing_keys.rs` uses the exclusive bound but is *already correct* because it has a post-loop `get_key` check — a different structure. `is_descendant_of` uses the exclusive bound with different check-before-walk semantics and returns `Ok(false)` rather than bailing; left untouched as out of scope.)

## Fix

Change the bound to inclusive `0..=MAX_NAMESPACE_DEPTH`, mirroring `check_path`. Depth-`(MAX+1)` still bails `DepthExceeded` (matching `check_path`) and is unreachable in production anyway, since creating it requires first resolving a depth-`MAX` parent.

## Test evidence

Added `resolve_reaches_root_at_max_depth` (in `crates/governance-store/src/tests.rs`): builds a chain of depth `MAX+1`, asserts `resolve(depth-MAX)` returns the root, and asserts `resolve(depth-(MAX+1))` still errors.

Discriminating verification:
- **Old exclusive `0..MAX` bound:** test FAILS — `resolve(&groups[MAX_NAMESPACE_DEPTH])` bails `DepthExceeded` (panic at `resolve`'s `bail!`, `core.rs:380`).
- **New inclusive `0..=MAX` bound:** test PASSES.

CI (debug) results on `-p calimero-governance-store`:
- `cargo test`: **406 passed; 0 failed**
- `cargo clippy --all-targets`: clean
- `cargo fmt --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)