### PR TITLE
fix(governance): clear member capabilities on removal to prevent stale privilege restore on re-add

### DIFF
--- a/crates/governance-store/src/capabilities.rs
+++ b/crates/governance-store/src/capabilities.rs
@@ -184,6 +184,19 @@ impl<'a> CapabilitiesRepository<'a> {
         Ok(())
     }
 
+    /// Delete a single member's per-member capability row. Idempotent on a
+    /// member who has no row. Mirrors `set_member_capability`'s key.
+    pub fn delete_member_capability(
+        &self,
+        group_id: &ContextGroupId,
+        member: &PublicKey,
+    ) -> EyreResult<()> {
+        let mut handle = self.store.handle();
+        let key = GroupMemberCapability::new(group_id.to_bytes(), *member);
+        handle.delete(&key)?;
+        Ok(())
+    }
+
     pub fn delete_all_member_caps(&self, group_id: &ContextGroupId) -> EyreResult<()> {
         let gid = group_id.to_bytes();
         let keys = collect_keys_with_prefix(

--- a/crates/governance-store/src/membership/core.rs
+++ b/crates/governance-store/src/membership/core.rs
@@ -162,6 +162,11 @@ impl<'a> MembershipRepository<'a> {
             handle.delete(&GroupMember::new(group_id.to_bytes(), *identity))?;
         }
         MetadataRepository::new(self.store).delete_member(group_id, identity)?;
+        // Clear the per-member capability row so a stale (possibly elevated)
+        // grant can't survive removal and be read back on re-add. Mirrors the
+        // deny-list clear on `MemberAdded`. Hash-neutral: a separate column
+        // from `GroupMember`, so it doesn't feed `compute_state_hash`.
+        CapabilitiesRepository::new(self.store).delete_member_capability(group_id, identity)?;
         Ok(())
     }
 

--- a/crates/governance-store/src/membership/core.rs
+++ b/crates/governance-store/src/membership/core.rs
@@ -166,6 +166,8 @@ impl<'a> MembershipRepository<'a> {
         // grant can't survive removal and be read back on re-add. Mirrors the
         // deny-list clear on `MemberAdded`. Hash-neutral: a separate column
         // from `GroupMember`, so it doesn't feed `compute_state_hash`.
+        // The three deletes aren't atomic, but apply is replay-safe: a crash
+        // between them is healed when the idempotent op re-applies.
         CapabilitiesRepository::new(self.store).delete_member_capability(group_id, identity)?;
         Ok(())
     }

--- a/crates/governance-store/src/membership/tests.rs
+++ b/crates/governance-store/src/membership/tests.rs
@@ -104,6 +104,37 @@ fn remove_member_clears_stale_capabilities_so_readd_starts_fresh() {
     );
 }
 
+// Complementary path: when the group DOES have non-zero default caps, re-add
+// must seed exactly those defaults — never the stale elevated grant. Distinguishes
+// "cap row cleared on removal" from "cap row happened to be overwritten by defaults".
+#[test]
+fn readd_with_defaults_seeds_defaults_not_stale_caps() {
+    use calimero_context_config::MemberCapabilities;
+
+    let store = test_store();
+    let gid = test_group_id();
+    let pk = PublicKey::from([0x08; 32]);
+    let elevated = MemberCapabilities::CAN_INVITE_MEMBERS.bits();
+    let defaults = MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS.bits();
+    assert_ne!(elevated, defaults);
+
+    let membership = MembershipRepository::new(&store);
+    let caps = CapabilitiesRepository::new(&store);
+    caps.set_default_capabilities(&gid, defaults).unwrap();
+
+    membership
+        .add_member(&gid, &pk, GroupMemberRole::Member)
+        .unwrap();
+    caps.set_member_capability(&gid, &pk, elevated).unwrap();
+
+    membership.remove_member(&gid, &pk).unwrap();
+    membership
+        .add_member(&gid, &pk, GroupMemberRole::Member)
+        .unwrap();
+
+    assert_eq!(caps.member_capability(&gid, &pk).unwrap(), Some(defaults));
+}
+
 #[test]
 fn get_member_role() {
     let store = test_store();

--- a/crates/governance-store/src/membership/tests.rs
+++ b/crates/governance-store/src/membership/tests.rs
@@ -67,6 +67,43 @@ fn remove_member() {
         .unwrap());
 }
 
+// A removed member's per-member capability row must NOT survive removal and be
+// read back on re-add — otherwise an elevated grant is silently restored when
+// the member re-joins as a plain Member with no non-zero group defaults.
+#[test]
+fn remove_member_clears_stale_capabilities_so_readd_starts_fresh() {
+    use calimero_context_config::MemberCapabilities;
+
+    let store = test_store();
+    let gid = test_group_id();
+    let pk = PublicKey::from([0x07; 32]);
+    let elevated = MemberCapabilities::CAN_INVITE_MEMBERS.bits();
+
+    let membership = MembershipRepository::new(&store);
+    let caps = CapabilitiesRepository::new(&store);
+
+    // Add member and grant an elevated capability.
+    membership
+        .add_member(&gid, &pk, GroupMemberRole::Member)
+        .unwrap();
+    caps.set_member_capability(&gid, &pk, elevated).unwrap();
+    assert_eq!(caps.member_capability(&gid, &pk).unwrap(), Some(elevated));
+
+    // Remove, then re-add as a plain Member. The group has no default caps
+    // (never set → `default_capabilities` is None), so `add_member` seeds none.
+    membership.remove_member(&gid, &pk).unwrap();
+    membership
+        .add_member(&gid, &pk, GroupMemberRole::Member)
+        .unwrap();
+
+    // The stale elevated grant must be gone — fresh member, no capability row.
+    assert_eq!(caps.member_capability(&gid, &pk).unwrap(), None);
+    assert_eq!(
+        membership.effective_capabilities(&gid, &pk).unwrap(),
+        Some(0)
+    );
+}
+
 #[test]
 fn get_member_role() {
     let store = test_store();


### PR DESCRIPTION
## Bug

`MembershipRepository::remove_member` (`crates/governance-store/src/membership/core.rs`) deleted the member's `GroupMember` (role) row and the metadata row, but **never cleared the per-member `GroupMemberCapability` row**.

The re-add path `add_member_with_keys` only overwrites capabilities when the group has non-zero default caps — `default_capabilities` returns `Some(n)` with `n != 0`:

```rust
if !is_admin {
    let capabilities = CapabilitiesRepository::new(self.store);
    if let Some(defaults) = capabilities.default_capabilities(group_id)? {
        if defaults != 0 {
            capabilities.set_member_capability(group_id, identity, defaults)?;
        }
    }
}
```

When a group has no defaults (`None`) or `0` — the **common** default — a removed member's stale (possibly elevated) capability bits survive removal and are read back on re-add. `effective_capabilities` and `member_capability` then return the OLD grant for a member re-joined as a plain `Member`.

## Reachability chain

admin grants caps (`MemberCapabilitySet`) → member removed (`MemberRemoved` / `MemberLeft` → `remove_member`) → member re-added as plain `Member` with no non-zero group defaults → **stale elevated caps return**.

## The asymmetry-with-deny-list tell

The deny-list IS explicitly cleared on re-add (`ops/group/member_added.rs` → `DenyListRepository::clear`). The per-member capability row was not — evidence the cap-clear was an oversight, not intentional.

## The fix (root cause, shared path)

Clear the per-member capability row **inside `remove_member`**, the one place every remover routes through:
- `ops/group/member_removed.rs` (root + TEE-cascade descendants)
- `ops/group/member_left.rs` (root + descendants)
- `namespace/core.rs::recursive_remove_member`

Adds a single-key `CapabilitiesRepository::delete_member_capability(group_id, member)` (mirrors `set_member_capability`'s key construction; idempotent on a member with no row) and calls it from `remove_member`, right where it already deletes the metadata row.

## Hash-neutrality

`hash_group_state` (`crates/governance-store/src/meta.rs`) — the sole input to `compute_state_hash` / `verify_post_apply_state_hashes` — feeds only `group_id`, meta `admin_identity` / `owner_identity` / `target_application_id`, and the sorted `GroupMember` `(pk, role)` rows. It never reads `GroupMemberCapability`, which is a separate store column. Clearing the cap row therefore does **not** perturb the group state hash — the same reasoning the deny-list mark already relies on. Verified by reading the hash function; no apply-semantics change.

## Test evidence

New discriminating test `membership::tests::remove_member_clears_stale_capabilities_so_readd_starts_fresh`:
1. add member (`Member`), grant `CAN_INVITE_MEMBERS` via the caps repo
2. remove, then re-add as plain `Member` (group has no default caps)
3. assert `member_capability` is `None` and `effective_capabilities` is `Some(0)` — the fresh state, not the old elevated bits

- **Without the fix:** `member_capability` returns `Some(2)` (stale `CAN_INVITE_MEMBERS = 1<<1`) → test FAILS.
- **With the fix:** `None` / `Some(0)` → test PASSES.

Verified by temporarily reverting the `remove_member` change (fail) and restoring it (pass).

## Checks

- `cargo test -p calimero-governance-store` — 406 passed, 0 failed (debug build, `debug_assert!` active)
- `cargo clippy -p calimero-governance-store --all-targets` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)