### PR TITLE
fix(governance): make cascade authority deterministic to prevent cross-replica divergence

### DIFF
--- a/crates/governance-store/src/group_settings.rs
+++ b/crates/governance-store/src/group_settings.rs
@@ -72,6 +72,10 @@ impl<'a> GroupSettingsService<'a> {
     /// the whole op ONCE against the root admin: re-deriving live per-descendant
     /// authority here would make the apply/bail outcome depend on each replica's
     /// fold progress and diverge (see the cascade apply arms).
+    ///
+    /// Caller contract: invoke ONLY after a single deterministic root-authority
+    /// check (`ctx.permissions().require_manage_application`). Never from a
+    /// single-group op arm — use the checked [`Self::set_target_application`].
     pub(crate) fn set_target_application_unchecked(
         &self,
         app_key: &[u8; 32],

--- a/crates/governance-store/src/group_settings.rs
+++ b/crates/governance-store/src/group_settings.rs
@@ -64,6 +64,19 @@ impl<'a> GroupSettingsService<'a> {
     ) -> EyreResult<()> {
         let permissions = self.permissions();
         permissions.require_manage_application(signer, "set target application")?;
+        self.set_target_application_unchecked(app_key, target_application_id)
+    }
+
+    /// Write the target-application mutation WITHOUT the per-group
+    /// `MANAGE_APPLICATION` check. Used by the cascade arms, which authorize
+    /// the whole op ONCE against the root admin: re-deriving live per-descendant
+    /// authority here would make the apply/bail outcome depend on each replica's
+    /// fold progress and diverge (see the cascade apply arms).
+    pub(crate) fn set_target_application_unchecked(
+        &self,
+        app_key: &[u8; 32],
+        target_application_id: &ApplicationId,
+    ) -> EyreResult<()> {
         let mut meta = self.load_required_meta()?;
         meta.app_key = *app_key;
         meta.target_application_id = *target_application_id;
@@ -101,6 +114,16 @@ impl<'a> GroupSettingsService<'a> {
     ) -> EyreResult<()> {
         let permissions = self.permissions();
         permissions.require_manage_application(signer, "set group migration")?;
+        self.set_group_migration_unchecked(migration)
+    }
+
+    /// Migration analogue of [`set_target_application_unchecked`]: writes the
+    /// mutation without the per-group `MANAGE_APPLICATION` check, for the
+    /// cascade arms that authorize once against the root admin.
+    pub(crate) fn set_group_migration_unchecked(
+        &self,
+        migration: &Option<Vec<u8>>,
+    ) -> EyreResult<()> {
         let mut meta = self.load_required_meta()?;
         meta.migration = migration.clone();
         MetaRepository::new(self.store).save(&self.group_id, &meta)

--- a/crates/governance-store/src/ops/group/cascade_group_migration_set.rs
+++ b/crates/governance-store/src/ops/group/cascade_group_migration_set.rs
@@ -2,8 +2,8 @@
 //! `apply_group_op_mutations` in #2304.
 
 use super::context::GroupApplyCtx;
-use crate::{GroupSettingsService, PermissionChecker};
-use eyre::{bail, Result as EyreResult};
+use crate::GroupSettingsService;
+use eyre::Result as EyreResult;
 
 pub(crate) fn apply(
     ctx: &mut GroupApplyCtx<'_>,
@@ -13,6 +13,12 @@ pub(crate) fn apply(
     let signer = ctx.signer();
     let group_id = ctx.group_id();
     let store = ctx.store();
+
+    // Authorize the cascade ONCE against the root admin (at-cut resolver), not
+    // per-descendant. See `cascade_target_application_set` for the full
+    // divergence rationale.
+    ctx.permissions()
+        .require_manage_application(signer, "cascade group migration")?;
 
     // Mirror of `CascadeTargetApplicationSet` but for migration
     // bytes only. ASYMMETRY: this variant does NOT mark contexts
@@ -24,23 +30,6 @@ pub(crate) fn apply(
     // status + propagator effects fire exactly once per cascade
     // round (driven by the target-application op, not this one).
     let entries = crate::cascade::walk_for_predicate(store, *group_id, *from_app_key)?;
-
-    // Pre-scan: same atomicity guard as the target-application
-    // arm — see the longer rationale comment there.
-    for entry in &entries {
-        if !entry.matched {
-            continue;
-        }
-        let entry_permissions = PermissionChecker::new(store, entry.group_id);
-        if !entry_permissions.can_manage_application(signer)? {
-            bail!(
-                "cascade group-migration set: signer {} lacks MANAGE_APPLICATION on \
-                 descendant {}; aborting before any writes to keep cascade atomic",
-                signer,
-                hex::encode(entry.group_id.to_bytes())
-            );
-        }
-    }
 
     let mut any_applied = false;
     for entry in entries {
@@ -55,7 +44,7 @@ pub(crate) fn apply(
             continue;
         }
         let entry_settings = GroupSettingsService::new(store, entry.group_id);
-        entry_settings.set_group_migration(signer, migration)?;
+        entry_settings.set_group_migration_unchecked(migration)?;
         // Match-success log — symmetric with the
         // `CascadeTargetApplicationSet` apply log. Migration bytes
         // size is recorded instead of the bytes themselves to keep

--- a/crates/governance-store/src/ops/group/cascade_group_migration_set.rs
+++ b/crates/governance-store/src/ops/group/cascade_group_migration_set.rs
@@ -14,9 +14,11 @@ pub(crate) fn apply(
     let group_id = ctx.group_id();
     let store = ctx.store();
 
-    // Authorize the cascade ONCE against the root admin (at-cut resolver), not
-    // per-descendant. See `cascade_target_application_set` for the full
-    // divergence rationale.
+    // Authorize the cascade ONCE, against the ROOT signed group (this cascade's
+    // root, not necessarily the namespace root), using the at-cut apply-auth
+    // resolver (`ctx.permissions()`) — the deterministic decision already
+    // enforced at emit, NOT per-descendant caps. See `cascade_target_application_set`
+    // for the full divergence rationale.
     ctx.permissions()
         .require_manage_application(signer, "cascade group migration")?;
 

--- a/crates/governance-store/src/ops/group/cascade_target_application_set.rs
+++ b/crates/governance-store/src/ops/group/cascade_target_application_set.rs
@@ -2,9 +2,9 @@
 //! `apply_group_op_mutations` in #2304.
 
 use super::context::GroupApplyCtx;
-use crate::{GroupSettingsService, PermissionChecker};
+use crate::GroupSettingsService;
 use calimero_primitives::application::ApplicationId;
-use eyre::{bail, Result as EyreResult};
+use eyre::Result as EyreResult;
 
 pub(crate) fn apply(
     ctx: &mut GroupApplyCtx<'_>,
@@ -16,6 +16,23 @@ pub(crate) fn apply(
     let group_id = ctx.group_id();
     let store = ctx.store();
 
+    // Authorize the cascade ONCE, against the ROOT signed group, using the
+    // at-cut apply-auth resolver (`ctx.permissions()`) — the same deterministic,
+    // replicated decision the rest of governance folds. The cascade's authority
+    // is the root admin decision (already enforced at emit via
+    // `MembershipRepository::require_admin`), NOT per-descendant caps.
+    //
+    // The old code instead re-derived `can_manage_application(signer)` per matched
+    // descendant from LIVE store reads. Descendant caps come from `MemberCapabilitySet`
+    // / `DefaultCapabilitiesSet` / `MemberRoleSet` ops concurrent to the cascade,
+    // folded at different times per peer, so a peer that had folded a concurrent
+    // cap-revoke on a matched descendant BAILED the whole op while a peer that
+    // hadn't APPLIED it everywhere — a permanent, non-self-healing divergence on
+    // `target_application_id` / `app_key`. Gating once at the root removes that
+    // per-descendant divergence on BOTH the namespace-envelope and standalone paths.
+    ctx.permissions()
+        .require_manage_application(signer, "cascade target application")?;
+
     // Walk the descendant tree (incl. signed group) and apply the
     // settings mutation to every descendant whose current `app_key`
     // matches `from_app_key`. Heterogeneous descendants (`app_key !=
@@ -26,31 +43,6 @@ pub(crate) fn apply(
     // The walk is read-only and cycle/depth-bounded; see the
     // `crate::cascade::walk_for_predicate` doc-comment.
     let entries = crate::cascade::walk_for_predicate(store, *group_id, *from_app_key)?;
-
-    // Pre-scan: verify the signer would pass the per-descendant
-    // `require_manage_application` check on EVERY matched
-    // descendant before issuing any writes. Without this, a
-    // descendant deep in the cascade with a stricter capability
-    // configuration (e.g. Restricted subgroup where the
-    // namespace-level admin signer is not a direct admin) would
-    // cause the `set_target_application` `?` mid-loop to abort
-    // the whole apply AFTER prior descendants have already been
-    // mutated, leaving the store in a partial-cascade state on
-    // both emitter and receiver paths.
-    for entry in &entries {
-        if !entry.matched {
-            continue;
-        }
-        let entry_permissions = PermissionChecker::new(store, entry.group_id);
-        if !entry_permissions.can_manage_application(signer)? {
-            bail!(
-                "cascade target-application set: signer {} lacks MANAGE_APPLICATION on \
-                 descendant {}; aborting before any writes to keep cascade atomic",
-                signer,
-                hex::encode(entry.group_id.to_bytes())
-            );
-        }
-    }
 
     let mut any_applied = false;
     for entry in entries {
@@ -65,16 +57,13 @@ pub(crate) fn apply(
             continue;
         }
 
-        // Reuse the existing single-group settings mutation, scoped
-        // to each matched descendant. The pre-scan above already
-        // verified `signer` holds `MANAGE_APPLICATION` on every
-        // matched descendant, so the `?` here is unreachable in
-        // production — kept as a defensive backstop in case the
-        // store mutates between the scan and the apply (which
-        // can't happen on the single-threaded namespace actor
-        // path, but is cheap to leave in place).
+        // Reuse the single-group settings mutation, scoped to each matched
+        // descendant, via the UNCHECKED write: the cascade was already
+        // authorized once against the root admin above. Re-deriving live
+        // per-descendant authority here is exactly the cross-replica
+        // divergence this fix removes.
         let entry_settings = GroupSettingsService::new(store, entry.group_id);
-        entry_settings.set_target_application(signer, app_key, target_application_id)?;
+        entry_settings.set_target_application_unchecked(app_key, target_application_id)?;
         // Match-success log. Mirrors the skip-log fields so the
         // emitter (which both applies locally AND publishes the op)
         // and the receivers (which apply on gossip-receive) both

--- a/crates/governance-store/src/ops/group/cascade_upgrade.rs
+++ b/crates/governance-store/src/ops/group/cascade_upgrade.rs
@@ -20,11 +20,11 @@
 //! legitimately advances it to its own newer `cascade_hlc`.
 
 use super::context::GroupApplyCtx;
-use crate::{GroupSettingsService, NamespaceRepository, PermissionChecker, UpgradesRepository};
+use crate::{GroupSettingsService, NamespaceRepository, UpgradesRepository};
 use calimero_primitives::application::ApplicationId;
 use calimero_storage::logical_clock::HybridTimestamp;
 use calimero_store::key::{GroupUpgradeStatus, GroupUpgradeValue, NamespaceGovHead};
-use eyre::{bail, Result as EyreResult};
+use eyre::Result as EyreResult;
 
 pub(crate) fn apply(
     ctx: &mut GroupApplyCtx<'_>,
@@ -37,6 +37,25 @@ pub(crate) fn apply(
     let signer = ctx.signer();
     let group_id = ctx.group_id();
     let store = ctx.store();
+
+    // Authorize the cascade ONCE, against the ROOT signed group, using the
+    // at-cut apply-auth resolver (`ctx.permissions()`) — the deterministic,
+    // replicated decision the rest of governance folds. The cascade's authority
+    // is the root admin decision (already enforced at emit via
+    // `MembershipRepository::require_admin`), NOT per-descendant caps.
+    //
+    // The old code re-derived `can_manage_application(signer)` per matched
+    // descendant from LIVE store reads. Descendant caps come from concurrent
+    // `MemberCapabilitySet` / `DefaultCapabilitiesSet` / `MemberRoleSet` ops,
+    // folded at different times per peer, so a peer that had folded a concurrent
+    // cap-revoke on a matched descendant BAILED the whole op (Err before the
+    // nonce was recorded — no partial apply, not self-healing) while a peer that
+    // hadn't APPLIED to root + all descendants: a permanent divergence on
+    // `target_application_id` / `app_key` / migration. Gating once at the root
+    // removes that per-descendant divergence on BOTH the namespace-envelope and
+    // standalone paths.
+    ctx.permissions()
+        .require_manage_application(signer, "cascade upgrade")?;
 
     // Walk the descendant tree (incl. signed group) and apply the atomic
     // mutation to every descendant whose current `app_key` matches
@@ -64,27 +83,6 @@ pub(crate) fn apply(
         .get(&NamespaceGovHead::new(ns.to_bytes()))?
         .map(|head| head.sequence);
 
-    // Pre-scan: verify the signer would pass the per-descendant
-    // `require_manage_application` check on EVERY matched descendant
-    // before issuing any writes, so a stricter descendant deep in the
-    // cascade can't abort the apply mid-loop after earlier descendants
-    // were already mutated (partial-cascade state on both emitter and
-    // receiver paths).
-    for entry in &entries {
-        if !entry.matched {
-            continue;
-        }
-        let entry_permissions = PermissionChecker::new(store, entry.group_id);
-        if !entry_permissions.can_manage_application(signer)? {
-            bail!(
-                "cascade upgrade: signer {} lacks MANAGE_APPLICATION on \
-                 descendant {}; aborting before any writes to keep cascade atomic",
-                signer,
-                hex::encode(entry.group_id.to_bytes())
-            );
-        }
-    }
-
     let mut any_applied = false;
     for entry in entries {
         if !entry.matched {
@@ -102,12 +100,13 @@ pub(crate) fn apply(
 
         // Atomic per-descendant mutation: target_application_id + app_key
         // AND migration in one go, eliminating the legacy two-op ordering
-        // hazard. The pre-scan above already verified `signer` holds
-        // `MANAGE_APPLICATION` on every matched descendant, so these `?`s
-        // are unreachable in production — kept as defensive backstops.
+        // hazard. UNCHECKED writes: the cascade was authorized once against
+        // the root admin above, so per-descendant authority is not re-derived
+        // here (doing so from live caps is the cross-replica divergence this
+        // fix removes).
         let entry_settings = GroupSettingsService::new(store, gid);
-        entry_settings.set_target_application(signer, app_key, target_application_id)?;
-        entry_settings.set_group_migration(signer, migration)?;
+        entry_settings.set_target_application_unchecked(app_key, target_application_id)?;
+        entry_settings.set_group_migration_unchecked(migration)?;
 
         // Stamp the sticky cascade fence onto the per-group upgrade
         // record. Load-or-default: a descendant with no prior upgrade

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -7526,3 +7526,136 @@ fn placeholder_admin_identity_never_equals_a_real_key() {
          it is not a legitimate signing identity"
     );
 }
+
+// -----------------------------------------------------------------------
+// Cascade authority determinism / cross-replica convergence
+// -----------------------------------------------------------------------
+
+/// CONVERGENCE PIN: two logical replicas with DIFFERENT fold progress on a
+/// matched descendant's capabilities MUST reach the SAME apply/bail outcome
+/// for the same signed cascade op.
+///
+/// The only difference between the two stores is descendant `D`'s
+/// `MANAGE_APPLICATION` capability for the signer — modelling a concurrent
+/// `MemberCapabilitySet` cap-revoke on `D` that one replica has folded and the
+/// other has not. Under the old per-descendant LIVE pre-scan, the replica that
+/// folded the revoke BAILED the whole op while the other APPLIED it, permanently
+/// diverging `target_application_id`/`app_key`. The fix authorizes the cascade
+/// once against the root admin, so the descendant's live caps no longer flip the
+/// outcome. Runs on the STANDALONE group-DAG path (`apply_local_signed_group_op`,
+/// LIVE fallback), so it proves convergence without relying on the at-cut
+/// authorizer.
+#[test]
+fn cascade_authority_is_root_only_and_converges_despite_descendant_cap_skew() {
+    use calimero_context_client::local_governance::{GroupOp, SignedGroupOp};
+    use calimero_primitives::identity::PrivateKey;
+    use calimero_storage::logical_clock::HybridTimestamp;
+    use rand::rngs::OsRng;
+
+    let mut rng = OsRng;
+    let admin_sk = PrivateKey::random(&mut rng);
+    let admin_pk = admin_sk.public_key();
+
+    let root = ContextGroupId::from([0x70; 32]);
+    let descendant = ContextGroupId::from([0xD1; 32]);
+    let from_app_key = [0x11; 32];
+    let to_app_key = [0x22; 32];
+    let app_v1 = ApplicationId::from([0xC1; 32]);
+    let app_v2 = ApplicationId::from([0xC2; 32]);
+    // A different admin for `D`, so the signer is NOT admin-of-D via meta.
+    let other_admin = PublicKey::from([0x09; 32]);
+
+    // Build a store where `signer_has_cap_on_descendant` is the ONLY knob:
+    // whether the signer holds MANAGE_APPLICATION on the (Restricted) descendant.
+    let build = |signer_has_cap_on_descendant: bool| {
+        let store = test_store();
+
+        // Root: signer is a direct admin, on `from_app_key`.
+        let mut root_meta = sample_meta_with_admin(admin_pk);
+        root_meta.app_key = from_app_key;
+        root_meta.target_application_id = app_v1;
+        MetaRepository::new(&store).save(&root, &root_meta).unwrap();
+        MembershipRepository::new(&store)
+            .add_member(&root, &admin_pk, GroupMemberRole::Admin)
+            .unwrap();
+
+        // Descendant: matched (same `from_app_key`) but admin'd by someone else.
+        // Left at the DEFAULT Restricted visibility, so the signer does NOT
+        // inherit admin authority across the boundary.
+        let mut d_meta = sample_meta_with_admin(other_admin);
+        d_meta.app_key = from_app_key;
+        d_meta.target_application_id = app_v1;
+        MetaRepository::new(&store)
+            .save(&descendant, &d_meta)
+            .unwrap();
+        nest_for_test(&store, &root, &descendant);
+
+        if signer_has_cap_on_descendant {
+            // Replica that has NOT folded the cap-revoke: signer still holds
+            // MANAGE_APPLICATION on the descendant (old pre-scan passes).
+            CapabilitiesRepository::new(&store)
+                .set_member_capability(
+                    &descendant,
+                    &admin_pk,
+                    calimero_context_config::MemberCapabilities::MANAGE_APPLICATION.bits(),
+                )
+                .unwrap();
+        }
+        // else: replica that HAS folded the cap-revoke — no cap on the
+        // descendant (old pre-scan bails the whole op).
+
+        store
+    };
+
+    let sign_cascade = || {
+        SignedGroupOp::sign(
+            &admin_sk,
+            root.to_bytes().into(),
+            vec![],
+            1,
+            GroupOp::CascadeUpgrade {
+                from_app_key: from_app_key.into(),
+                app_key: to_app_key.into(),
+                target_application_id: app_v2,
+                migration: None,
+                cascade_hlc: HybridTimestamp::zero(),
+            },
+        )
+        .expect("sign CascadeUpgrade")
+    };
+
+    let store_behind = build(true); // cap-revoke NOT yet folded
+    let store_synced = build(false); // cap-revoke folded
+
+    let res_behind = apply_local_signed_group_op(&store_behind, &sign_cascade());
+    let res_synced = apply_local_signed_group_op(&store_synced, &sign_cascade());
+
+    // Convergence: both replicas MUST reach the same apply/bail outcome. On the
+    // old code, `res_behind` is Ok and `res_synced` is Err -> divergence.
+    assert_eq!(
+        res_behind.is_ok(),
+        res_synced.is_ok(),
+        "cascade apply/bail outcome diverged across replicas with different \
+         descendant-cap fold progress: behind={:?} synced={:?}",
+        res_behind.as_ref().map(|_| ()),
+        res_synced.as_ref().map(|_| ()),
+    );
+    res_behind.expect("cascade authorized by root admin must apply (behind replica)");
+    res_synced.expect("cascade authorized by root admin must apply (synced replica)");
+
+    // And both must have actually mutated the matched descendant identically.
+    for (label, store) in [("behind", &store_behind), ("synced", &store_synced)] {
+        let d = MetaRepository::new(store)
+            .load(&descendant)
+            .unwrap()
+            .expect("descendant meta");
+        assert_eq!(
+            d.app_key, to_app_key,
+            "descendant must be cascaded to the new app_key on the {label} replica"
+        );
+        assert_eq!(
+            d.target_application_id, app_v2,
+            "descendant must point at the new target on the {label} replica"
+        );
+    }
+}

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -7701,5 +7701,18 @@ fn cascade_authority_is_root_only_and_converges_despite_descendant_cap_skew() {
             d.target_application_id, app_v2,
             "descendant must point at the new target on the {label} replica"
         );
+        // The sticky cascade fence must be stamped identically on both
+        // replicas — it is the boundary the state-delta HLC fence reads, and a
+        // dropped `repo.save` would silently regress it while the meta asserts
+        // above still pass.
+        let up = UpgradesRepository::new(store)
+            .load(&descendant)
+            .unwrap()
+            .expect("descendant upgrade record");
+        assert_eq!(
+            up.cascade_hlc,
+            Some(HybridTimestamp::zero()),
+            "descendant must carry the signed cascade_hlc fence on the {label} replica"
+        );
     }
 }


### PR DESCRIPTION
## The bug (governance convergence violation)

The cascade apply arms (`CascadeUpgrade`, and the deprecated
`CascadeTargetApplicationSet` / `CascadeGroupMigrationSet`) authorized each
matched descendant with a **LIVE per-descendant** `can_manage_application(signer)`
read: an explicit pre-scan, plus the same check baked into
`GroupSettingsService::set_target_application` / `set_group_migration`.

Descendant capabilities come from `MemberCapabilitySet` / `DefaultCapabilitiesSet`
/ `MemberRoleSet` ops that run **concurrently** with the cascade and fold at
**different times per peer**. So the whole-op apply/bail decision depended on each
replica's fold progress, not on the signed op:

- **Peer A** — folded a concurrent cap-revoke on a matched descendant → **BAILS**
  the whole op with `Err`.
- **Peer B** — hasn't folded it → **APPLIES** to the root and every descendant.

A bail returns `Err` before the nonce is recorded, maps to
`ApplyError::Application`, applies **nothing**, and is **not self-healing**, so
replicas permanently diverge on `target_application_id` / `app_key` / migration.
The single cascade op is already gated deterministically on **root** authority at
emit (`MembershipRepository::require_admin`); only the per-descendant apply-time
gate was live and divergent.

## The fix (Option a: root-only authority)

Authorize the cascade **once**, against the **root signed group**, via the at-cut
apply-auth resolver `ctx.permissions().require_manage_application(signer, …)` —
the same deterministic, replicated decision the rest of governance folds, and the
same authority the emitter enforces at sign time. The per-matched-descendant
mutations now use new `set_target_application_unchecked` /
`set_group_migration_unchecked` writes on `GroupSettingsService`, so descendant
caps no longer flip the outcome.

- The **single-group** `TargetApplicationSet` / `GroupMigrationSet` arms keep
  their existing **checked** mutations, unchanged.
- The `_unchecked` variants are `pub(crate)` and only reachable from the cascade
  arms.

**Why not thread the at-cut authorizer through the per-descendant checks?** On the
standalone group-DAG path the at-cut resolver is inert (a group op's
`parent_op_hashes` are in the group op-log id-space, not the namespace projection
the resolver is keyed by), so that would only converge the namespace-envelope path
and leave the standalone path divergent. Root-only authorization converges on
**both** paths.

## Standalone vs namespace path

The at-cut resolver is authoritative on the namespace-envelope path and falls back
to live on the standalone path — as it always has for *every* group op. The
property that matters: the cascade no longer introduces a **per-descendant**
divergence beyond what a single-group op already carries. The root gate resolves
identically to any other group op on each path, so convergence holds on both. The
convergence test runs on the **standalone** path specifically, proving the fix
does not rely on the at-cut resolver.

## Atomicity preserved

The old pre-scan existed to avoid a mid-loop partial apply. With per-descendant
auth removed, the only authorization bail is the single up-front root check
(before any write), so atomicity is preserved and simplified. No existing test
asserted the per-descendant bail behavior (grepped `lacks MANAGE_APPLICATION` /
`aborting before any writes` — only the three arms themselves).

## Test evidence

`cascade_authority_is_root_only_and_converges_despite_descendant_cap_skew`
(`crates/governance-store/src/tests.rs`): two stores identical **except** for a
matched descendant's `MANAGE_APPLICATION` cap for the signer — modelling a
concurrent cap-revoke folded on one replica but not the other — must reach the
**same** apply outcome for the same signed `CascadeUpgrade` op.

- **Old code:** `assert_eq` fails — `behind=Ok`, `synced=Err(… lacks
  MANAGE_APPLICATION … aborting before any writes …)`.
- **Fixed code:** both `Ok`, both descendants cascaded to the new `app_key` /
  target → passes.

Verified discriminating by reverting `cascade_upgrade.rs` to `origin/master`
(test fails) and restoring the fix (test passes).

- `cargo test -p calimero-governance-store` — **406 passed, 0 failed**
- `crates/context` cascade suites (`cascade_atomic_apply`, `cascade_apply_walk`,
  `cascade_concurrent_safety`) — pass
- `cargo clippy -p calimero-governance-store --all-targets` — clean
- `cargo fmt --check` — clean
