### PR TITLE
feat: upgrade AI reviewer default model to claude-sonnet-5

### DIFF
--- a/.ai-reviewer.yaml
+++ b/.ai-reviewer.yaml
@@ -11,7 +11,7 @@ version: 1
 # to emit valid find/replace patches and most files were silently skipped.
 # Do not switch to Opus without an explicit cost discussion.
 anthropic:
-  default_model: claude-sonnet-4-6
+  default_model: claude-sonnet-5
   enable_prompt_caching: true
 
 # Doc auto-update — opens a draft PR on merges to master with proposed
@@ -23,7 +23,7 @@ anthropic:
 # new site (see the docs-generation plan), not free-form HTML.
 doc_generation:
   enabled: false
-  model: claude-sonnet-4-6  # Sonnet: Haiku failed the HTML find/replace patch task
+  model: claude-sonnet-5  # Sonnet: Haiku failed the HTML find/replace patch task
   max_files: 15
   static_docs_dirs:
     - architecture/   # GitHub Pages source for the architecture site


### PR DESCRIPTION
## Summary
- Bumps `default_model` and `doc_generation.model` in `.ai-reviewer.yaml` from `claude-sonnet-4-6` to `claude-sonnet-5`, matching the same upgrade in calimero-network/ai-code-reviewer#89.
- `doc_generation` stays disabled — this only affects PR review agents (all of which use `default_model` since no per-agent overrides are set here).

## Test plan
- [x] YAML diff reviewed by hand — no other keys touched