### PR TITLE
test(e2e): wire the blobs app scenarios into the CI matrix

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -17,6 +17,7 @@ on:
       - "apps/xcall-example/**"
       - "apps/kv-store-with-shared-storage/**"
       - "apps/components-demo/**"
+      - "apps/blobs/**"
       - ".github/workflows/e2e-rust-apps.yml"
 
   pull_request:
@@ -27,6 +28,7 @@ on:
       - "apps/xcall-example/**"
       - "apps/kv-store-with-shared-storage/**"
       - "apps/components-demo/**"
+      - "apps/blobs/**"
       - ".github/workflows/e2e-rust-apps.yml"
 
   workflow_dispatch:
@@ -170,6 +172,11 @@ jobs:
           cd apps/components-demo
           ./build.sh
 
+      - name: Build blobs app
+        run: |
+          cd apps/blobs
+          ./build.sh
+
       - name: Upload app artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -187,6 +194,9 @@ jobs:
             apps/components-demo/res/*.wasm
             apps/components-demo/res/abi.json
             apps/components-demo/res/state-schema.json
+            apps/blobs/res/*.wasm
+            apps/blobs/res/abi.json
+            apps/blobs/res/state-schema.json
           retention-days: 1
 
   # ── Test phase: run each workflow in parallel ──
@@ -331,6 +341,17 @@ jobs:
           - workflow: components-demo
             file: workflows/components-demo.yml
             app: components-demo
+          # Blobs app lifecycle: upload/announce/register/read-back/delete.
+          # These scenarios sat unwired in apps/blobs/workflows while the
+          # blobs app's file-id scheme changed (#3047) — only merobox's CI
+          # (testing a stale example against moving edge) noticed. Wired so
+          # blobs-app/storage regressions fail HERE, pre-merge.
+          - workflow: blobs-lifecycle
+            file: workflows/blobs.yml
+            app: blobs
+          - workflow: blobs-api-example
+            file: workflows/blobs-example.yml
+            app: blobs
           - workflow: kv-store-joiner-cold
             file: workflows/kv-store-joiner-cold.yml
             app: scaffolding-e2e

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -341,11 +341,6 @@ jobs:
           - workflow: components-demo
             file: workflows/components-demo.yml
             app: components-demo
-          # Blobs app lifecycle: upload/announce/register/read-back/delete.
-          # These scenarios sat unwired in apps/blobs/workflows while the
-          # blobs app's file-id scheme changed (#3047) — only merobox's CI
-          # (testing a stale example against moving edge) noticed. Wired so
-          # blobs-app/storage regressions fail HERE, pre-merge.
           - workflow: blobs-lifecycle
             file: workflows/blobs.yml
             app: blobs


### PR DESCRIPTION
## Why

`apps/blobs/workflows/{blobs,blobs-example}.yml` existed but were wired into **no CI matrix** — blobs-app behavior ran nowhere in core CI. So when #3047 (Jun 29) deliberately changed the app's file-id scheme (`file_<n>` → `<uploader>_<n>`, fixing silent CRDT id collisions), nothing in this repo could notice. The change surfaced days later in **merobox's** CI — which tests its own (stale, `file_0`-hardcoding) copy of the example against moving `merod:edge` — where the resulting `FunctionCallError: File not found: file_0` initially read as a core storage regression. Diagnosis trail: calimero-network/merobox#288 (comments).

Same lesson as the rc.9 auth outage (#3191): behavior must be tested in the repo that owns it, against the PR's own build — not discovered downstream against a moving target.

## What

- wire both existing scenarios into `e2e-rust-apps.yml`: build `blobs.wasm` in **build-apps**, upload its `res/` artifacts, add two matrix entries (`blobs-lifecycle`, `blobs-api-example`), trigger on `apps/blobs/**`
- no changes to the scenarios themselves — they were already correctly parameterized (`{{png_file_id}}` captured from `result.output`), just never executed

## Verified

Both scenarios green locally against current master (`merod:edge`, merobox 0.6.39):
- `blobs.yml` — 2-node lifecycle: upload, announce, register, read-back, cross-node discovery, delete
- `blobs-example.yml` — blob API example flow

Companion fix on the merobox side (updating its stale example to use the captured file ids) is a separate PR there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)