### PR TITLE
test(e2e): flip the scenario matrix to embedded auth

### DIFF
--- a/apps/blobs/workflows/blobs-example.yml
+++ b/apps/blobs/workflows/blobs-example.yml
@@ -5,6 +5,8 @@ result_dir: results/download-blobs
 force_pull_image: true
 
 # Node configuration
+auth_mode: embedded
+
 nodes:
   chain_id: calimero-testnet
   count: 2
@@ -13,6 +15,20 @@ nodes:
 
 # Test workflow steps
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on node-blob-1
+    type: login
+    node: node-blob-1
+    username: dev
+    password: dev
+
+  - name: Login on node-blob-2
+    type: login
+    node: node-blob-2
+    username: dev
+    password: dev
+
   # ============================================================================
   # SETUP: Install Application & Create Context
   # ============================================================================

--- a/apps/blobs/workflows/blobs.yml
+++ b/apps/blobs/workflows/blobs.yml
@@ -3,6 +3,8 @@ description: Upload, announce, discover and delete blobs using the Rust SDK exam
 
 force_pull_image: true
 
+auth_mode: embedded
+
 nodes:
   chain_id: calimero-testnet
   count: 2
@@ -10,6 +12,20 @@ nodes:
   prefix: rust-blob
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on rust-blob-1
+    type: login
+    node: rust-blob-1
+    username: dev
+    password: dev
+
+  - name: Login on rust-blob-2
+    type: login
+    node: rust-blob-2
+    username: dev
+    password: dev
+
   - name: Install Rust blobs app on inviter
     type: install_application
     node: rust-blob-1

--- a/apps/components-demo/workflows/components-demo.yml
+++ b/apps/components-demo/workflows/components-demo.yml
@@ -10,6 +10,8 @@ stop_all_nodes: false
 restart: false
 wait_timeout: 120
 
+auth_mode: embedded
+
 nodes:
   chain_id: testnet-1
   count: 2
@@ -17,6 +19,20 @@ nodes:
   prefix: new-calimero-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on new-calimero-node-1
+    type: login
+    node: new-calimero-node-1
+    username: dev
+    password: dev
+
+  - name: Login on new-calimero-node-2
+    type: login
+    node: new-calimero-node-2
+    username: dev
+    password: dev
+
   # Node 1 installs; the installer is config owner, sole settings writer, admin.
   - name: Install Application on Node 1
     type: install_application

--- a/apps/kv-store-with-shared-storage/workflows/test_shared_storage.yml
+++ b/apps/kv-store-with-shared-storage/workflows/test_shared_storage.yml
@@ -6,6 +6,8 @@ stop_all_nodes: false
 restart: false
 wait_timeout: 120
 
+auth_mode: embedded
+
 nodes:
   chain_id: testnet-1
   count: 2
@@ -13,6 +15,20 @@ nodes:
   prefix: new-calimero-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on new-calimero-node-1
+    type: login
+    node: new-calimero-node-1
+    username: dev
+    password: dev
+
+  - name: Login on new-calimero-node-2
+    type: login
+    node: new-calimero-node-2
+    username: dev
+    password: dev
+
   # Step 1: Install on node 1. Installer becomes the sole initial writer.
   - name: Install Application on Node 1
     type: install_application

--- a/apps/scaffolding-e2e/workflows/auto-follow/asymmetric-context-membership.yml
+++ b/apps/scaffolding-e2e/workflows/auto-follow/asymmetric-context-membership.yml
@@ -61,12 +61,28 @@ no_docker: false
 nuke_on_start: true
 nuke_on_end: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: af-asym-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on af-asym-node-1
+    type: login
+    node: af-asym-node-1
+    username: dev
+    password: dev
+
+  - name: Login on af-asym-node-2
+    type: login
+    node: af-asym-node-2
+    username: dev
+    password: dev
+
   # ── Phase 1: Bootstrap namespace + both nodes joined ────────────────
   - name: Install application on node-1
     type: install_application

--- a/apps/scaffolding-e2e/workflows/auto-follow/auto-follow-backfill-on-join.yml
+++ b/apps/scaffolding-e2e/workflows/auto-follow/auto-follow-backfill-on-join.yml
@@ -40,12 +40,28 @@ no_docker: false
 nuke_on_start: true
 nuke_on_end: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: af-backfill-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on af-backfill-node-1
+    type: login
+    node: af-backfill-node-1
+    username: dev
+    password: dev
+
+  - name: Login on af-backfill-node-2
+    type: login
+    node: af-backfill-node-2
+    username: dev
+    password: dev
+
   # ── Phase 1: Bootstrap with pre-existing contexts BEFORE node-2 joins ─
   - name: Install application on node-1
     type: install_application

--- a/apps/scaffolding-e2e/workflows/auto-follow/auto-follow-flag-flipped-late.yml
+++ b/apps/scaffolding-e2e/workflows/auto-follow/auto-follow-flag-flipped-late.yml
@@ -39,12 +39,28 @@ no_docker: false
 nuke_on_start: true
 nuke_on_end: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: af-late-flip-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on af-late-flip-node-1
+    type: login
+    node: af-late-flip-node-1
+    username: dev
+    password: dev
+
+  - name: Login on af-late-flip-node-2
+    type: login
+    node: af-late-flip-node-2
+    username: dev
+    password: dev
+
   # ── Phase 1: Same starting shape as workflow 2 ──────────────────────
   - name: Install application on node-1
     type: install_application

--- a/apps/scaffolding-e2e/workflows/auto-follow/auto-follow-on-context-registered.yml
+++ b/apps/scaffolding-e2e/workflows/auto-follow/auto-follow-on-context-registered.yml
@@ -22,6 +22,8 @@ no_docker: false
 nuke_on_start: true
 nuke_on_end: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   # `merod:local` is built by the auto-follow-regression CI runner from
@@ -31,6 +33,20 @@ nodes:
   prefix: af-baseline-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on af-baseline-node-1
+    type: login
+    node: af-baseline-node-1
+    username: dev
+    password: dev
+
+  - name: Login on af-baseline-node-2
+    type: login
+    node: af-baseline-node-2
+    username: dev
+    password: dev
+
   # ── Phase 1: Bootstrap two-node namespace + subgroup ────────────────
   - name: Install kv-store-with-handlers on node-1
     type: install_application

--- a/apps/scaffolding-e2e/workflows/auto-follow/no-unknown-context-rejection-spam.yml
+++ b/apps/scaffolding-e2e/workflows/auto-follow/no-unknown-context-rejection-spam.yml
@@ -65,12 +65,28 @@ no_docker: false
 nuke_on_start: true
 nuke_on_end: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: af-no-spam-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on af-no-spam-node-1
+    type: login
+    node: af-no-spam-node-1
+    username: dev
+    password: dev
+
+  - name: Login on af-no-spam-node-2
+    type: login
+    node: af-no-spam-node-2
+    username: dev
+    password: dev
+
   - name: Install application on node-1
     type: install_application
     node: af-no-spam-node-1

--- a/apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml
+++ b/apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml
@@ -32,12 +32,34 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 3
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-3
+    type: login
+    node: e2e-node-3
+    username: dev
+    password: dev
+
   # --- Setup: app + namespace on node-1 (the namespace owner) ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/e2e.yml
+++ b/apps/scaffolding-e2e/workflows/e2e.yml
@@ -4,12 +4,34 @@ description: Consolidated E2E backend tests covering KV operations, handlers, us
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 3
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-3
+    type: login
+    node: e2e-node-3
+    username: dev
+    password: dev
+
   # SETUP: Install app and create mesh
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/frozen-rga-convergence.yml
+++ b/apps/scaffolding-e2e/workflows/frozen-rga-convergence.yml
@@ -12,12 +12,34 @@ description: >
 
 force_pull_image: false
 
+auth_mode: embedded
+
 nodes:
   count: 3
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-3
+    type: login
+    node: e2e-node-3
+    username: dev
+    password: dev
+
   # --- Setup: 3-node mesh ---
   - name: Install application on node-1
     type: install_application

--- a/apps/scaffolding-e2e/workflows/group-3node.yml
+++ b/apps/scaffolding-e2e/workflows/group-3node.yml
@@ -7,12 +7,34 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 3
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-3
+    type: login
+    node: e2e-node-3
+    username: dev
+    password: dev
+
   # --- Setup ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-capabilities.yml
+++ b/apps/scaffolding-e2e/workflows/group-capabilities.yml
@@ -12,12 +12,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   # --- Setup ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-context-isolation.yml
+++ b/apps/scaffolding-e2e/workflows/group-context-isolation.yml
@@ -8,12 +8,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   # --- Setup ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-default-capabilities-propagation.yml
+++ b/apps/scaffolding-e2e/workflows/group-default-capabilities-propagation.yml
@@ -41,12 +41,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   # --- Setup ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-governance-late-joiner.yml
+++ b/apps/scaffolding-e2e/workflows/group-governance-late-joiner.yml
@@ -8,12 +8,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   - name: Install application on node-1
     type: install_application
     node: e2e-node-1

--- a/apps/scaffolding-e2e/workflows/group-governance-peer-down.yml
+++ b/apps/scaffolding-e2e/workflows/group-governance-peer-down.yml
@@ -8,12 +8,34 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 3
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-3
+    type: login
+    node: e2e-node-3
+    username: dev
+    password: dev
+
   - name: Install application on node-1
     type: install_application
     node: e2e-node-1

--- a/apps/scaffolding-e2e/workflows/group-join-via-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-join-via-inheritance.yml
@@ -36,12 +36,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: merod:local
   prefix: join-inherit-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on join-inherit-node-1
+    type: login
+    node: join-inherit-node-1
+    username: dev
+    password: dev
+
+  - name: Login on join-inherit-node-2
+    type: login
+    node: join-inherit-node-2
+    username: dev
+    password: dev
+
   # ── Phase 1: Bootstrap mesh, namespace, Open subgroup, context ────
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-kick-and-readd-deny-list.yml
+++ b/apps/scaffolding-e2e/workflows/group-kick-and-readd-deny-list.yml
@@ -38,12 +38,34 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 3
   image: merod:local
   prefix: kick-readd-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on kick-readd-node-1
+    type: login
+    node: kick-readd-node-1
+    username: dev
+    password: dev
+
+  - name: Login on kick-readd-node-2
+    type: login
+    node: kick-readd-node-2
+    username: dev
+    password: dev
+
+  - name: Login on kick-readd-node-3
+    type: login
+    node: kick-readd-node-3
+    username: dev
+    password: dev
+
   # ── Phase 1: Bootstrap namespace + Restricted subgroup + context ──
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
+++ b/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
@@ -44,12 +44,34 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 3
   image: merod:local
   prefix: kick-rejoin-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on kick-rejoin-node-1
+    type: login
+    node: kick-rejoin-node-1
+    username: dev
+    password: dev
+
+  - name: Login on kick-rejoin-node-2
+    type: login
+    node: kick-rejoin-node-2
+    username: dev
+    password: dev
+
+  - name: Login on kick-rejoin-node-3
+    type: login
+    node: kick-rejoin-node-3
+    username: dev
+    password: dev
+
   # ── Phase 1: Bootstrap namespace + Open subgroup + context ────────
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-late-joiner.yml
+++ b/apps/scaffolding-e2e/workflows/group-late-joiner.yml
@@ -8,12 +8,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   # --- Setup: node-1 alone creates namespace and context ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-leave-context.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-context.yml
@@ -7,12 +7,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   - name: Install application on node-1
     type: install_application
     node: e2e-node-1

--- a/apps/scaffolding-e2e/workflows/group-leave-member.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-member.yml
@@ -7,12 +7,34 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 3
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-3
+    type: login
+    node: e2e-node-3
+    username: dev
+    password: dev
+
   - name: Install application on node-1
     type: install_application
     node: e2e-node-1

--- a/apps/scaffolding-e2e/workflows/group-leave-namespace.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-namespace.yml
@@ -8,12 +8,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   - name: Install application on node-1
     type: install_application
     node: e2e-node-1

--- a/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
@@ -41,12 +41,34 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 3
   image: merod:local
   prefix: leave-rejoin-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on leave-rejoin-node-1
+    type: login
+    node: leave-rejoin-node-1
+    username: dev
+    password: dev
+
+  - name: Login on leave-rejoin-node-2
+    type: login
+    node: leave-rejoin-node-2
+    username: dev
+    password: dev
+
+  - name: Login on leave-rejoin-node-3
+    type: login
+    node: leave-rejoin-node-3
+    username: dev
+    password: dev
+
   # ── Phase 1: Bootstrap namespace + Open subgroup + context ────────
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-list-subgroups-restricted-hidden.yml
+++ b/apps/scaffolding-e2e/workflows/group-list-subgroups-restricted-hidden.yml
@@ -34,12 +34,34 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 3
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-3
+    type: login
+    node: e2e-node-3
+    username: dev
+    password: dev
+
   # --- Setup: app + namespace on node-1 (the namespace owner) ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-member-channel-lifecycle.yml
+++ b/apps/scaffolding-e2e/workflows/group-member-channel-lifecycle.yml
@@ -26,12 +26,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   # --- Setup ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-membership.yml
+++ b/apps/scaffolding-e2e/workflows/group-membership.yml
@@ -8,12 +8,34 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 3
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-3
+    type: login
+    node: e2e-node-3
+    username: dev
+    password: dev
+
   # --- Setup: install app, create namespace, invite all nodes ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-metadata.yml
+++ b/apps/scaffolding-e2e/workflows/group-metadata.yml
@@ -27,12 +27,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   # --- Phase 1: Bootstrap namespace + subgroup + context on node-1 ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-multi-service.yml
+++ b/apps/scaffolding-e2e/workflows/group-multi-service.yml
@@ -12,12 +12,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   # --- Setup: install multi-service bundle ---
 
   - name: Install multi-service bundle on node-1

--- a/apps/scaffolding-e2e/workflows/group-open-self-join-key-delivery.yml
+++ b/apps/scaffolding-e2e/workflows/group-open-self-join-key-delivery.yml
@@ -38,12 +38,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: merod:local
   prefix: open-selfjoin-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on open-selfjoin-node-1
+    type: login
+    node: open-selfjoin-node-1
+    username: dev
+    password: dev
+
+  - name: Login on open-selfjoin-node-2
+    type: login
+    node: open-selfjoin-node-2
+    username: dev
+    password: dev
+
   # ── Phase 1: Bootstrap mesh, namespace, Open subgroup, context ────
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-private-add-then-write.yml
+++ b/apps/scaffolding-e2e/workflows/group-private-add-then-write.yml
@@ -36,12 +36,34 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 3
   image: merod:local
   prefix: private-add-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on private-add-node-1
+    type: login
+    node: private-add-node-1
+    username: dev
+    password: dev
+
+  - name: Login on private-add-node-2
+    type: login
+    node: private-add-node-2
+    username: dev
+    password: dev
+
+  - name: Login on private-add-node-3
+    type: login
+    node: private-add-node-3
+    username: dev
+    password: dev
+
   # ── Phase 1: Bootstrap namespace + Restricted subgroup ────────────
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-remove-from-root-revokes-inherited.yml
+++ b/apps/scaffolding-e2e/workflows/group-remove-from-root-revokes-inherited.yml
@@ -51,12 +51,34 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 3
   image: merod:local
   prefix: revoke-inherit-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on revoke-inherit-node-1
+    type: login
+    node: revoke-inherit-node-1
+    username: dev
+    password: dev
+
+  - name: Login on revoke-inherit-node-2
+    type: login
+    node: revoke-inherit-node-2
+    username: dev
+    password: dev
+
+  - name: Login on revoke-inherit-node-3
+    type: login
+    node: revoke-inherit-node-3
+    username: dev
+    password: dev
+
   # ── Phase 1: Bootstrap namespace + Open subgroup + context ────────
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-reparent-and-cascade-delete.yml
+++ b/apps/scaffolding-e2e/workflows/group-reparent-and-cascade-delete.yml
@@ -13,12 +13,22 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 1
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
   # --- Setup ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-reparent.yml
+++ b/apps/scaffolding-e2e/workflows/group-reparent.yml
@@ -16,12 +16,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   # --- Setup ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-subgroup-cold-sync.yml
+++ b/apps/scaffolding-e2e/workflows/group-subgroup-cold-sync.yml
@@ -30,12 +30,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   # ── Setup: install, namespace, invite node-2 ───────────────────────
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-subgroup-queued-deltas.yml
+++ b/apps/scaffolding-e2e/workflows/group-subgroup-queued-deltas.yml
@@ -44,12 +44,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   # ── Setup: install app on both nodes ──────────────────────────────
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-subgroup-visibility-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-subgroup-visibility-inheritance.yml
@@ -29,12 +29,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   # --- Setup ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/group-subgroup.yml
+++ b/apps/scaffolding-e2e/workflows/group-subgroup.yml
@@ -11,12 +11,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   # --- Setup ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/groups.yml
+++ b/apps/scaffolding-e2e/workflows/groups.yml
@@ -6,12 +6,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   # --- SCENARIO 1: Full namespace lifecycle ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/handler-test.yml
+++ b/apps/scaffolding-e2e/workflows/handler-test.yml
@@ -10,12 +10,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   - name: Install application on node-1
     type: install_application
     node: e2e-node-1

--- a/apps/scaffolding-e2e/workflows/hashcomparison-shared-user-reconcile.yml
+++ b/apps/scaffolding-e2e/workflows/hashcomparison-shared-user-reconcile.yml
@@ -72,12 +72,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: merod:local
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   # --- Phase 1: bootstrap; both nodes join the namespace + context
   #     and write a baseline value so both end up with
   #     `has_state = true`. This is the precondition for the

--- a/apps/scaffolding-e2e/workflows/kv-store-joiner-cold.yml
+++ b/apps/scaffolding-e2e/workflows/kv-store-joiner-cold.yml
@@ -13,12 +13,28 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   # --- Setup: node-1 alone creates namespace and context ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/member-removed-late-joiner-catchup.yml
+++ b/apps/scaffolding-e2e/workflows/member-removed-late-joiner-catchup.yml
@@ -29,12 +29,34 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 3
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-3
+    type: login
+    node: e2e-node-3
+    username: dev
+    password: dev
+
   - name: Install application on node-1
     type: install_application
     node: e2e-node-1

--- a/apps/scaffolding-e2e/workflows/member-removed-multi-context-convergence.yml
+++ b/apps/scaffolding-e2e/workflows/member-removed-multi-context-convergence.yml
@@ -27,12 +27,34 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 3
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-3
+    type: login
+    node: e2e-node-3
+    username: dev
+    password: dev
+
   # --- Setup: app + namespace owned by node-1 ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/mesh-soak-8node.yml
+++ b/apps/scaffolding-e2e/workflows/mesh-soak-8node.yml
@@ -11,12 +11,64 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 8
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-3
+    type: login
+    node: e2e-node-3
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-4
+    type: login
+    node: e2e-node-4
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-5
+    type: login
+    node: e2e-node-5
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-6
+    type: login
+    node: e2e-node-6
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-7
+    type: login
+    node: e2e-node-7
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-8
+    type: login
+    node: e2e-node-8
+    username: dev
+    password: dev
+
   # --- Setup on node-1 ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/root-bootstrap-converge.yml
+++ b/apps/scaffolding-e2e/workflows/root-bootstrap-converge.yml
@@ -56,12 +56,28 @@ near_devnet: false
 # flag on `merobox bootstrap run` overrides it so the matrix tests the
 # binary that this PR's `Build Image` job just built. `force_pull_image:
 # false` prevents merobox from pulling the remote tag on top of either.
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
   # --- Phase 1: node-1 alone seeds the context with several writes ---
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
+++ b/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
@@ -83,12 +83,34 @@ description: >
 
 force_pull_image: false
 
+auth_mode: embedded
+
 nodes:
   count: 3
   image: merod:local
   prefix: e2e-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev
+
+  - name: Login on e2e-node-3
+    type: login
+    node: e2e-node-3
+    username: dev
+    password: dev
+
   # ---------- Setup: context with writer set {A} ----------
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/sync-resilience-network-partition-symmetric.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-network-partition-symmetric.yml
@@ -44,12 +44,28 @@ topology:
   type: nat
   nat_mode: symmetric
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: sync-resil-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on sync-resil-node-1
+    type: login
+    node: sync-resil-node-1
+    username: dev
+    password: dev
+
+  - name: Login on sync-resil-node-2
+    type: login
+    node: sync-resil-node-2
+    username: dev
+    password: dev
+
   - name: Install application on node-1
     type: install_application
     node: sync-resil-node-1

--- a/apps/scaffolding-e2e/workflows/sync-resilience-network-partition.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-network-partition.yml
@@ -77,12 +77,28 @@ topology:
   type: nat
   nat_mode: cone
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: sync-resil-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on sync-resil-node-1
+    type: login
+    node: sync-resil-node-1
+    username: dev
+    password: dev
+
+  - name: Login on sync-resil-node-2
+    type: login
+    node: sync-resil-node-2
+    username: dev
+    password: dev
+
   # ---------- Setup ----------
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/sync-resilience-peer-pause-symmetric.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-peer-pause-symmetric.yml
@@ -39,12 +39,28 @@ topology:
   type: nat
   nat_mode: symmetric
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: sync-resil-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on sync-resil-node-1
+    type: login
+    node: sync-resil-node-1
+    username: dev
+    password: dev
+
+  - name: Login on sync-resil-node-2
+    type: login
+    node: sync-resil-node-2
+    username: dev
+    password: dev
+
   - name: Install application on node-1
     type: install_application
     node: sync-resil-node-1

--- a/apps/scaffolding-e2e/workflows/sync-resilience-peer-pause.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-peer-pause.yml
@@ -35,12 +35,28 @@ topology:
   type: nat
   nat_mode: cone
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: sync-resil-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on sync-resil-node-1
+    type: login
+    node: sync-resil-node-1
+    username: dev
+    password: dev
+
+  - name: Login on sync-resil-node-2
+    type: login
+    node: sync-resil-node-2
+    username: dev
+    password: dev
+
   # ---------- Setup ----------
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart-autoresync.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart-autoresync.yml
@@ -48,12 +48,28 @@ topology:
   type: nat
   nat_mode: cone
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: sync-autoresync-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on sync-autoresync-node-1
+    type: login
+    node: sync-autoresync-node-1
+    username: dev
+    password: dev
+
+  - name: Login on sync-autoresync-node-2
+    type: login
+    node: sync-autoresync-node-2
+    username: dev
+    password: dev
+
   # ---------- Setup: 2-node namespace + context ----------
 
   - name: Install application on node-1

--- a/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart-symmetric.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart-symmetric.yml
@@ -39,12 +39,28 @@ topology:
   type: nat
   nat_mode: symmetric
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: sync-resil-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on sync-resil-node-1
+    type: login
+    node: sync-resil-node-1
+    username: dev
+    password: dev
+
+  - name: Login on sync-resil-node-2
+    type: login
+    node: sync-resil-node-2
+    username: dev
+    password: dev
+
   # Steps mirror the cone variant exactly. Setup → baseline → fault
   # (restart node-1) → recovery → assert post-restart write
   # replicated. Timeouts bumped modestly because symmetric NAT

--- a/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart.yml
@@ -43,12 +43,28 @@ topology:
   type: nat
   nat_mode: cone
 
+auth_mode: embedded
+
 nodes:
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: sync-resil-node
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on sync-resil-node-1
+    type: login
+    node: sync-resil-node-1
+    username: dev
+    password: dev
+
+  - name: Login on sync-resil-node-2
+    type: login
+    node: sync-resil-node-2
+    username: dev
+    password: dev
+
   # ---------- Setup: 2-node namespace + context ----------
 
   - name: Install application on node-1

--- a/apps/xcall-example/workflows/xcall.yml
+++ b/apps/xcall-example/workflows/xcall.yml
@@ -41,12 +41,22 @@ description: >
 force_pull_image: false
 near_devnet: false
 
+auth_mode: embedded
+
 nodes:
   count: 1
   image: merod:local
   prefix: xcall-authz
 
 steps:
+  # First login on a fresh embedded-auth node bootstraps its root key
+  # and seeds merobox's token cache; every step below runs authenticated.
+  - name: Login on xcall-authz-1
+    type: login
+    node: xcall-authz-1
+    username: dev
+    password: dev
+
   # ---------------- setup: namespace N ⊃ {C1, C2}, namespace M ⊃ {C3} ----------------
   - name: Install app on Node 1
     type: install_application


### PR DESCRIPTION
## Why

All **57 scenarios** in the `e2e-rust-apps` matrix ran unauthenticated — a configuration no production node ships, and the blind spot that let the 0.11.0-rc.9 scope-enforcement outage pass every e2e green (context: #3191, auth-frontend#33). Closes #3193.

## What

Purely mechanical, per scenario:
- `auth_mode: embedded` in the workflow header
- one `login` step per node at the top of `steps` (first login on a fresh embedded-auth node bootstraps its root key and seeds merobox's token cache — every subsequent step runs authenticated automatically)

**No other step changes.** +1032 lines across 57 files, all additions.

## Coverage gained / not gained

Gained: the auth guard mounted on every route, JWT validation in the hot path, token handling across multi-node invite/join/sync flows, per-node auth stores — none of which any matrix scenario exercised before.

**Not gained (by design):** scope enforcement — the root login is `admin`, which short-circuits the permission validator. That layer is owned by the client-token auth-seam suite (#3191). Both layers together are the contract.

## Status: ✅ ready, CI green

Unblocked by merobox docker-mode embedded auth (calimero-network/merobox#288), shipped in **merobox 0.6.41** (now on the apt repo that CI installs from). Full `E2E - Rust Apps` run on this branch: **all 61 jobs green** — every scenario now boots nodes with "All API endpoints require a valid JWT token (embedded auth enabled)" and passes authenticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)