### PR TITLE
fix(ci): create the release at trigger time, before master can move on

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
   prepare:
     name: Prepare
     runs-on: big-machine
+    permissions:
+      # Needed by "Create release at trigger time" below.
+      contents: write
     outputs:
       version: ${{ steps.version_info.outputs.version }}
       binary_release: ${{ steps.version_info.outputs.binary_release }}
@@ -92,6 +95,11 @@ jobs:
               binary_release=true
               crate_release=true
               docker_release=true
+            elif [ "$(gh release view "$version" --repo ${{ github.repository }} --json assets --jq '.assets | length')" = "0" ]; then
+              # The release shell exists (created at trigger time by a
+              # previous attempt, or manually after a race) but no binaries
+              # were ever attached — a re-run must still upload them.
+              binary_release=true
             fi
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
             docker_release=true
@@ -102,6 +110,38 @@ jobs:
           echo "binary_release=$binary_release" >> $GITHUB_OUTPUT
           echo "crate_release=$crate_release" >> $GITHUB_OUTPUT
           echo "docker_release=$docker_release" >> $GITHUB_OUTPUT
+
+      # Create the tag + release NOW, while ${{ github.sha }} is still the
+      # head of master. A workflow's GITHUB_TOKEN is an integration token,
+      # and GitHub rejects integration-token release/tag creation whose
+      # target is anything but the current branch head with
+      # `403 Resource not accessible by integration`
+      # (https://github.com/cli/cli/issues/9514). Release Binaries runs
+      # hours later (build + big-machine queue); if any PR merges to master
+      # in that window, the release-cut commit is no longer head and the
+      # upload step can no longer create the release. Creating it here
+      # shrinks the race window from hours to seconds. The upload step then
+      # finds the existing release and only attaches assets, which is
+      # always permitted.
+      - name: Create release at trigger time
+        if: github.event_name == 'push' && steps.version_info.outputs.binary_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version_info.outputs.version }}
+          PRERELEASE: ${{ steps.version_info.outputs.prerelease }}
+        run: |
+          if gh release view "$VERSION" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists — nothing to create."
+            exit 0
+          fi
+          args=(--repo "${{ github.repository }}" --target "${{ github.sha }}" --title "$VERSION" --notes "")
+          if [ "$PRERELEASE" = "true" ]; then
+            args+=(--prerelease)
+          fi
+          if ! gh release create "$VERSION" "${args[@]}"; then
+            echo "::error::Could not create release $VERSION. If master moved past ${{ github.sha }} already, create the tag+release manually and re-run failed jobs: gh api -X POST repos/${{ github.repository }}/git/refs -f ref=refs/tags/$VERSION -f sha=${{ github.sha }} && gh api -X POST repos/${{ github.repository }}/releases -f tag_name=$VERSION -f name=$VERSION -F prerelease=$PRERELEASE"
+            exit 1
+          fi
 
       # Match the file set that defines the profiling image's content:
       # the entrypoint + helper scripts baked into the image, the


### PR DESCRIPTION
cc @chefsale

## What was broken

The `0.11.0-rc.10` release failed today with `Failed to create release for tag 0.11.0-rc.10: Not Found` in **Release Binaries**, despite `permissions: contents: write` and no settings changes. Two things stacked:

1. **GitHub platform restriction** (cli/cli#9514, undocumented): a workflow's `GITHUB_TOKEN` is an *integration* token, and GitHub rejects release/tag creation whose target commit is anything but the **current head of the branch** with `403 Resource not accessible by integration`. User PATs are exempt.
2. **upload-release-action bug** masks the real error: its create-failure path logs the *earlier* `GET /releases/tags/{tag}` 404 (expected — the release doesn't exist yet) instead of the actual create error, so the log blames `#get-a-release-by-tag-name` and looks like nonsense.

## Example of what fails

1. `chore: cut release 0.11.0-rc.10` (#3194, `42096e9`) merges to master at **11:24** → Release workflow starts, `target_commit=42096e9`.
2. Binaries build/queue on `big-machine` for ~5 hours.
3. **Any other PR merges to master in that window** (today it was #3195 at ~13:00) → `42096e9` is no longer head.
4. Release Binaries finally runs at **16:16** → `POST /releases` targeting `42096e9` → `403 Resource not accessible by integration` → reported as the bogus 404.

rc.9 only survived because nothing merged during its build window. Verified empirically with token probes: draft release (no tag) → 201, tag at head → 201, tag/release at `42096e9` after master moved → 403. Rulesets, tag protection, and workflow-permission settings were all ruled out. Note: pre-creating just the *tag* is not enough — the action still passes `target_commitish`, which also 403s.

## Fix

- **Prepare** now creates the (pre)release immediately at trigger time, while `github.sha` is still master's head — shrinking the race window from hours to seconds. Release Binaries then finds the existing release and only attaches assets, which integration tokens may always do.
- `binary_release` also triggers when the release exists **with zero assets**, so a failed upload can be re-run (previously a pre-existing release shell would make re-runs skip Release Binaries entirely).
- If creation ever still races, Prepare fails fast with the exact manual fix-forward commands in the error annotation (that recipe is how rc.10 was shipped today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)