### PR TITLE
fix(auth): complete admin-api permission map so client tokens can self-serve

### DIFF
--- a/crates/auth/docs/admin-api-permissions.md
+++ b/crates/auth/docs/admin-api-permissions.md
@@ -1,0 +1,198 @@
+# Admin-API permission map
+
+Every `/admin-api/*` route is gated by the permission validator
+(`crates/auth/src/auth/permissions/validator.rs`). Any route with **no**
+explicit mapping falls through to the `/admin-api/*` **default-deny** and
+requires full `admin` (fail-closed, introduced in #3040). This document is the
+source of truth for what each route requires and why; the validator mirrors it.
+
+## Decision categories
+
+| Tag | Meaning | Reachable by |
+|-----|---------|--------------|
+| **APP** | An app acting on resources it owns (contexts, namespaces, groups it created, aliases, blobs, its app/packages). Mapped to the matching `context:*` / `application:*` / `blob:*` / `package:*` permission. | a normal client token (`context:create/list/execute`, etc.) |
+| **GOV** | Governance *over other members* — adding/removing members, changing roles/capabilities, group settings. Mapped to `context:capabilities` (grant/revoke). | a token explicitly granted capability authority — **not** a plain client token, **not** admin |
+| **ADMIN** | Node-owner / security-critical: node observability, dev tooling that reads the node FS, TEE admission, cryptographic key/proof issuance, specialized-node governance. | `admin` only |
+| **PUBLIC** | Liveness / token self-check. No permission required. | any caller (health/ready) / any valid token (is-authed) |
+
+Scope: reads/creates are scoped `Specific([id])` where an id is in the path; an
+unscoped (`Global`) `context:*` token still satisfies a `Specific` requirement
+(`Global` matches any), so client tokens work without per-resource narrowing,
+and a narrowed token is still possible.
+
+---
+
+## Applications
+
+| Route | Method | Decision | Permission |
+|-------|--------|----------|------------|
+| `/admin-api/applications` | GET | APP | `Application::List(Global)` |
+| `/admin-api/applications/:id` | GET | APP | `Application::List([id])` |
+| `/admin-api/applications/:id` | DELETE | APP | `Application::Uninstall([id])` |
+| `/admin-api/applications/:id/versions` | GET | APP | `Application::List([id])` |
+| `/admin-api/install-application` | POST | APP | `Application::Install(Global)` |
+| `/admin-api/install-dev-application` | POST | **ADMIN** | reads an arbitrary **node-local filesystem path** — a node-owner operation, not something a remote app token should drive |
+
+## Packages
+
+| Route | Method | Decision | Permission |
+|-------|--------|----------|------------|
+| `/admin-api/packages` | GET | APP | `Package::ListPackages(Global)` |
+| `/admin-api/packages/:p/versions` | GET | APP | `Package::ListVersions([p])` |
+| `/admin-api/packages/:p/latest` | GET | APP | `Package::GetLatestVersion([p])` |
+
+## Contexts
+
+| Route | Method | Decision | Permission |
+|-------|--------|----------|------------|
+| `/admin-api/contexts` | GET | APP | `Context::List(Global)` |
+| `/admin-api/contexts` | POST | APP | `Context::Create(Global)` |
+| `/admin-api/contexts/:id` | GET | APP | `Context::List([id])` |
+| `/admin-api/contexts/:id` | DELETE | APP | `Context::Delete([id])` |
+| `/admin-api/contexts/:id/application` | POST | APP | `Context::Application(Update([id]))` |
+| `/admin-api/contexts/:id/join` | POST | APP | `Context::Create([id])` — join = establish local membership |
+| `/admin-api/contexts/:id/leave` | POST | APP | `Context::Leave([id], Any)` |
+| `/admin-api/contexts/:id/identities` | GET | APP | `Context::List([id])` |
+| `/admin-api/contexts/:id/identities-owned` | GET | APP | `Context::List([id])` |
+| `/admin-api/contexts/:id/group` | GET | APP | `Context::List([id])` |
+| `/admin-api/contexts/:id/storage` | GET | APP | `Context::List([id])` |
+| `/admin-api/contexts/:id/resync` | POST | APP | `Context::List([id])` — refresh local replica |
+| `/admin-api/contexts/sync`, `/sync/:id` | POST | APP | `Context::List(Global/[id])` |
+| `/admin-api/contexts/for-application/:id` | GET | APP | `Context::List([app])` |
+| `/admin-api/contexts/with-executors/for-application/:id` | GET | APP | `Context::List([app])` |
+| `/admin-api/contexts/:id/capabilities/(grant\|revoke)` | POST | GOV | `Context::Capabilities(Grant/Revoke([id]))` |
+| `/admin-api/identity/context` | POST | APP | `Context::Create(Global)` — generate a context identity (prereq to join) |
+| `/admin-api/contexts/invite-specialized-node` | POST | **ADMIN** | invites specialized/TEE infrastructure into a context — node-level governance |
+
+## Aliases (friendly names — all APP)
+
+`create`/`delete` → `Alias::Create/Delete`, `lookup`/`list` → `Alias::Lookup/List`,
+over `AliasType::{Context,Application,Identity}`. Aliases are app-level naming
+with no authority beyond resolving a name; there is no reason for them to be
+admin-only.
+
+| Route family | Method | Decision | Permission |
+|-------|--------|----------|------------|
+| `/admin-api/alias/create/{context,application,identity/:ctx}` | POST | APP | `Context::Alias(Create(<type>, scope))` |
+| `/admin-api/alias/lookup/{...}/:name` | POST | APP | `Context::Alias(Lookup(<type>, scope))` |
+| `/admin-api/alias/delete/{...}/:name` | POST | APP | `Context::Alias(Delete(<type>, scope))` |
+| `/admin-api/alias/list/{...}` | GET | APP | `Context::Alias(List(<type>, scope))` |
+
+## Namespaces (shipped earlier in this PR)
+
+| Route | Method | Decision | Permission |
+|-------|--------|----------|------------|
+| `/admin-api/namespaces` | GET / POST | APP | `Context::List` / `Context::Create` |
+| `/admin-api/namespaces/for-application/:id` | GET | APP | `Context::List([app])` |
+| `/admin-api/namespaces/:id` | GET / DELETE | APP | `Context::List([ns])` / `Context::Delete([ns])` |
+| `/admin-api/namespaces/:id/groups` | GET / POST | APP | `Context::List([ns])` / `Context::Create([ns])` |
+| `/admin-api/namespaces/:id/identity` | GET | APP | `Context::List([ns])` |
+| `/admin-api/namespaces/:id/join` | POST | APP | `Context::Create([ns])` |
+| `/admin-api/namespaces/:id/invite` | POST | GOV | `Context::Invite([ns], Any)` |
+| `/admin-api/namespaces/:id/leave` | POST | APP | `Context::Leave([ns], Any)` |
+
+## Groups
+
+The group cluster splits three ways: app-level resource ops, governance over
+other members, and security-critical operations.
+
+### App-level (client token)
+
+| Route | Method | Decision | Permission |
+|-------|--------|----------|------------|
+| `/admin-api/groups` | POST | APP | `Context::Create(Global)` |
+| `/admin-api/groups/join` | POST | APP | `Context::Create(Global)` |
+| `/admin-api/groups/:id` | GET | APP | `Context::List([id])` |
+| `/admin-api/groups/:id` | DELETE | APP | `Context::Delete([id])` |
+| `/admin-api/groups/:id/leave` | POST | APP | `Context::Leave([id], Any)` |
+| `/admin-api/groups/:id/{contexts,subgroups,members,metadata}` | GET | APP | `Context::List([id])` |
+| `/admin-api/groups/:id/members/:id/{metadata,capabilities}` | GET | APP | `Context::List([id])` |
+| `/admin-api/groups/:id/contexts/:id/metadata` | GET | APP | `Context::List([id])` |
+| `/admin-api/groups/:id/upgrade`, `/upgrade/retry` | POST | APP | `Context::Application(Update([id]))` — app-version management |
+| `/admin-api/groups/:id/upgrade/status` | GET | APP | `Context::List([id])` |
+| `/admin-api/groups/:ns/{cascade-status,migration-status}` | GET | APP | `Context::List([ns])` |
+| `/admin-api/groups/:id/invite` | POST | GOV | `Context::Invite([id], Any)` |
+
+### Governance over other members (capability-gated → `context:capabilities`)
+
+Mutating another member's presence, role, capabilities, or the group's shared
+settings is authority over others, not self-service. It maps to
+`Context::Capabilities(Grant/Revoke)` — reachable by a token explicitly granted
+capability authority, **not** a plain client token, but **not** admin either.
+
+| Route | Method | Permission |
+|-------|--------|------------|
+| `/admin-api/groups/:id` (settings) | PATCH | `Capabilities(Grant([id]))` |
+| `/admin-api/groups/:id/members` (add) | POST | `Capabilities(Grant([id]))` |
+| `/admin-api/groups/:id/members/remove` | POST | `Capabilities(Revoke([id]))` |
+| `/admin-api/groups/:id/members/:id/role` | PUT | `Capabilities(Grant([id]))` |
+| `/admin-api/groups/:id/members/:id/capabilities` | PUT | `Capabilities(Grant([id]))` |
+| `/admin-api/groups/:id/members/:id/auto-follow` | PUT | `Capabilities(Grant([id]))` |
+| `/admin-api/groups/:id/reparent` | POST | `Capabilities(Grant([id]))` |
+| `/admin-api/groups/:id/settings/default-capabilities` | PUT | `Capabilities(Grant([id]))` |
+| `/admin-api/groups/:id/settings/subgroup-visibility` | PUT | `Capabilities(Grant([id]))` |
+| `/admin-api/groups/:id/{metadata,members/:id/metadata,contexts/:id/metadata}` | PUT | `Capabilities(Grant([id]))` |
+| `/admin-api/groups/:id/contexts/:id/remove` (detach) | POST | `Capabilities(Revoke([id]))` |
+| `/admin-api/groups/:ns/migration/abort` | POST | `Capabilities(Grant([ns]))` |
+
+### Security-critical (ADMIN)
+
+| Route | Method | Why admin |
+|-------|--------|-----------|
+| `/admin-api/groups/:id/settings/tee-admission-policy` | GET/PUT | controls who may join as a TEE replica — attestation trust boundary |
+| `/admin-api/groups/:id/signing-key` | POST | registers a cryptographic signing key |
+| `/admin-api/groups/:id/issue-ownership-proof` | POST | mints an ownership proof — impersonation risk |
+| `/admin-api/groups/:id/issue-namespace-ownership-proof` | POST | mints a namespace ownership proof |
+
+## Blobs
+
+| Route | Method | Decision | Permission |
+|-------|--------|----------|------------|
+| `/blobs/stream`, `/blobs/file`, `/blobs/url` | POST | APP | `Blob::Add(Stream/File/Url)` |
+| `/admin-api/blobs` | PUT | APP | `Blob::Add(...)` |
+| `/admin-api/blobs` | GET (list) | APP | `Blob::List` *(new variant — see below)* |
+| `/admin-api/blobs/:id` | GET (download) | APP | `Blob::List([id])` |
+| `/admin-api/blobs/:id` | DELETE | APP | `Blob::Remove([id])` |
+
+`BlobPermission` has only `Add`/`Remove`; reading (list/download) has no
+variant, so those reads are currently admin-only. Adding a `Blob::List`
+variant is the clean fix and is part of this PR.
+
+## TEE
+
+| Route | Method | Decision | Why |
+|-------|--------|----------|-----|
+| `/admin-api/tee/info` | GET | **ADMIN** | node TEE posture |
+| `/admin-api/tee/attest` | POST | **ADMIN** | produces an attestation quote |
+| `/admin-api/tee/verify-quote` | POST | **ADMIN** | attestation verification |
+| `/admin-api/tee/fleet-join` | POST | **ADMIN** | a TEE node joining the fleet — infrastructure/governance |
+
+## Node observability & liveness
+
+| Route | Method | Decision | Why |
+|-------|--------|----------|-----|
+| `/admin-api/usage` | GET | **ADMIN** | node resource usage |
+| `/admin-api/network/status` | GET | **ADMIN** | node network posture |
+| `/admin-api/peers` | GET | **ADMIN** | node peer set |
+| `/admin-api/certificate` | GET | **ADMIN** | node certificate |
+| `/admin-api/health`, `/ready` | GET | **PUBLIC** | liveness — no auth |
+| `/admin-api/is-authed` | GET | **PUBLIC** | token self-check — any valid token, no permission |
+
+## Keys / auth (`/admin/*`, not `/admin-api/*`)
+
+Unchanged by this document. `/admin/keys*` remain key-management perms;
+`PUT /admin/keys/:id/permissions` requires `admin` (privilege-escalation
+guard, #3040).
+
+---
+
+## Invariants
+
+- **Fail-closed preserved.** Genuinely unmapped `/admin-api/*` routes (a new
+  subpath, a mapped path with an unhandled method) still require `admin`.
+- **Least privilege.** Destructive/governance/security ops are never reachable
+  by a plain client token: deletion needs `*:delete`, member governance needs
+  `context:capabilities`, security ops need `admin`.
+- **No frontend change.** APP routes map onto permissions a client token
+  already holds (`context:create/list`, …), so existing tokens work with no
+  re-login or new scopes.

--- a/crates/auth/docs/admin-api-permissions.md
+++ b/crates/auth/docs/admin-api-permissions.md
@@ -66,17 +66,19 @@ and a narrowed token is still possible.
 
 ## Aliases (friendly names — all APP)
 
-`create`/`delete` → `Alias::Create/Delete`, `lookup`/`list` → `Alias::Lookup/List`,
-over `AliasType::{Context,Application,Identity}`. Aliases are app-level naming
-with no authority beyond resolving a name; there is no reason for them to be
-admin-only.
+Aliases are app-level naming with no authority beyond resolving a name, and are
+recreatable. They gate on **generic `context:create`/`list`** rather than the
+dedicated `context:alias` variant, so any context-capable client token can name
+its resources without a fine-grained alias grant (keeping the no-frontend-change
+guarantee). The `AliasType`/`AliasPermission` variants remain available for
+finer-grained tokens if ever needed.
 
 | Route family | Method | Decision | Permission |
 |-------|--------|----------|------------|
-| `/admin-api/alias/create/{context,application,identity/:ctx}` | POST | APP | `Context::Alias(Create(<type>, scope))` |
-| `/admin-api/alias/lookup/{...}/:name` | POST | APP | `Context::Alias(Lookup(<type>, scope))` |
-| `/admin-api/alias/delete/{...}/:name` | POST | APP | `Context::Alias(Delete(<type>, scope))` |
-| `/admin-api/alias/list/{...}` | GET | APP | `Context::Alias(List(<type>, scope))` |
+| `/admin-api/alias/create/{context,application,identity/:ctx}` | POST | APP | `Context::Create` |
+| `/admin-api/alias/delete/{...}/:name` | POST | APP | `Context::Create` |
+| `/admin-api/alias/lookup/{...}/:name` | POST | APP | `Context::List` |
+| `/admin-api/alias/list/{...}` | GET | APP | `Context::List` |
 
 ## Namespaces (shipped earlier in this PR)
 
@@ -155,8 +157,12 @@ capability authority, **not** a plain client token, but **not** admin either.
 | `/admin-api/blobs/:id` | DELETE | APP | `Blob::Remove([id])` |
 
 `BlobPermission` has only `Add`/`Remove`; reading (list/download) has no
-variant, so those reads are currently admin-only. Adding a `Blob::List`
-variant is the clean fix and is part of this PR.
+variant, so those reads stay admin-only for now. Adding a `Blob::List`
+variant is the clean fix but touches the permission enum's parse/display/
+satisfies surface, so it's tracked as a **follow-up** to keep this PR's
+security review focused on the context-family routes the app flow needs.
+Blob *writes* (`/blobs/stream|file|url`, `PUT /blobs`) and delete are already
+mapped to `Blob::Add`/`Blob::Remove`.
 
 ## TEE
 

--- a/crates/auth/src/auth/permissions/validator.rs
+++ b/crates/auth/src/auth/permissions/validator.rs
@@ -59,6 +59,85 @@ static NAMESPACE_LEAVE_REGEX: LazyLock<Regex> =
 static NAMESPACES_FOR_APPLICATION_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^/admin-api/namespaces/for-application/([^/]+)$").unwrap());
 
+// Context sub-routes: reads + self-service membership. (capabilities and
+// /application are handled by their own regexes above.)
+static CONTEXT_SUBROUTE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^/admin-api/contexts/([^/]+)/(join|leave|identities|identities-owned|group|storage|resync)$",
+    )
+    .unwrap()
+});
+
+static CONTEXT_SYNC_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/contexts/sync(?:/([^/]+))?$").unwrap());
+
+// Aliases: create/lookup/delete/list over context|application|identity.
+// Friendly names — app-level; writes map to Create, reads to List.
+static ALIAS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^/admin-api/alias/(create|lookup|delete|list)/(context|application|identity)(?:/.+)?$",
+    )
+    .unwrap()
+});
+
+// Application versions read.
+static APPLICATION_VERSIONS_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/applications/([^/]+)/versions$").unwrap());
+
+// Group routes. Most specific first; GROUP_REGEX (bare /groups/:id) last.
+static GROUP_MEMBER_SUB_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^/admin-api/groups/([^/]+)/members/([^/]+)/(role|capabilities|auto-follow|metadata)$",
+    )
+    .unwrap()
+});
+
+static GROUP_MEMBERS_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/groups/([^/]+)/members$").unwrap());
+
+static GROUP_MEMBERS_REMOVE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/groups/([^/]+)/members/remove$").unwrap());
+
+static GROUP_CONTEXTS_SUB_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^/admin-api/groups/([^/]+)/contexts/([^/]+)/(metadata|remove)$").unwrap()
+});
+
+static GROUP_SETTINGS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^/admin-api/groups/([^/]+)/settings/(default-capabilities|subgroup-visibility|tee-admission-policy)$",
+    )
+    .unwrap()
+});
+
+static GROUP_UPGRADE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^/admin-api/groups/([^/]+)/upgrade(?:/(retry|status))?$").unwrap()
+});
+
+static GROUP_STATUS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^/admin-api/groups/([^/]+)/(cascade-status|migration-status)$").unwrap()
+});
+
+static GROUP_MIGRATION_ABORT_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/groups/([^/]+)/migration/abort$").unwrap());
+
+// App-level and read group sub-routes (create/read/join/leave/invite/metadata).
+static GROUP_SUBROUTE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^/admin-api/groups/([^/]+)/(contexts|subgroups|metadata|leave|invite|reparent)$")
+        .unwrap()
+});
+
+// Security-critical group ops kept admin-only (matched so they resolve to
+// admin explicitly rather than relying only on the default-deny).
+static GROUP_ADMIN_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^/admin-api/groups/([^/]+)/(signing-key|issue-ownership-proof|issue-namespace-ownership-proof)$",
+    )
+    .unwrap()
+});
+
+static GROUP_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/groups/([^/]+)$").unwrap());
+
 static BLOB_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^/blobs/([^/]+)$").unwrap());
 
 static ADMIN_KEY_REGEX: LazyLock<Regex> =
@@ -82,15 +161,47 @@ pub struct PermissionValidator;
 
 fn get_permissions_for_path_with_params(path: &str, method: &HttpMethod) -> Vec<Permission> {
     // Handle parameterized routes with pre-compiled regex patterns
-    if let Some(captures) = APPLICATION_REGEX.captures(path) {
+    if let Some(captures) = APPLICATION_VERSIONS_REGEX.captures(path) {
         if let Some(app_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![app_id.as_str().to_string()]);
             return match method {
-                HttpMethod::GET => vec![Permission::Application(ApplicationPermission::List(
-                    ResourceScope::Specific(vec![app_id.as_str().to_string()]),
-                ))],
+                HttpMethod::GET => {
+                    vec![Permission::Application(ApplicationPermission::List(scope))]
+                }
                 _ => vec![],
             };
         }
+    }
+
+    if let Some(captures) = APPLICATION_REGEX.captures(path) {
+        if let Some(app_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![app_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::GET => {
+                    vec![Permission::Application(ApplicationPermission::List(scope))]
+                }
+                HttpMethod::DELETE => {
+                    vec![Permission::Application(ApplicationPermission::Uninstall(
+                        scope,
+                    ))]
+                }
+                _ => vec![],
+            };
+        }
+    }
+
+    // `/contexts/sync[/:id]` must be checked before the generic
+    // `/contexts/:id` regex, which would otherwise capture "sync" as a
+    // context id.
+    if let Some(captures) = CONTEXT_SYNC_REGEX.captures(path) {
+        let scope = captures
+            .get(1)
+            .map(|c| ResourceScope::Specific(vec![c.as_str().to_string()]))
+            .unwrap_or(ResourceScope::Global);
+        return match method {
+            HttpMethod::POST => vec![Permission::Context(ContextPermission::List(scope))],
+            _ => vec![],
+        };
     }
 
     if let Some(captures) = CONTEXT_REGEX.captures(path) {
@@ -234,6 +345,218 @@ fn get_permissions_for_path_with_params(path: &str, method: &HttpMethod) -> Vec<
         }
     }
 
+    // Context sub-routes: reads → List, self-service membership → Create/Leave.
+    if let Some(captures) = CONTEXT_SUBROUTE_REGEX.captures(path) {
+        if let (Some(ctx_id), Some(action)) = (captures.get(1), captures.get(2)) {
+            let scope = ResourceScope::Specific(vec![ctx_id.as_str().to_string()]);
+            return match (method, action.as_str()) {
+                (HttpMethod::POST, "join") => {
+                    vec![Permission::Context(ContextPermission::Create(scope))]
+                }
+                (HttpMethod::POST, "leave") => vec![Permission::Context(ContextPermission::Leave(
+                    scope,
+                    UserScope::Any,
+                ))],
+                // resync refreshes the local replica — a read-family refresh.
+                (HttpMethod::POST, "resync") => {
+                    vec![Permission::Context(ContextPermission::List(scope))]
+                }
+                (HttpMethod::GET, "identities" | "identities-owned" | "group" | "storage") => {
+                    vec![Permission::Context(ContextPermission::List(scope))]
+                }
+                _ => vec![],
+            };
+        }
+    }
+
+    // Aliases: friendly names for app resources — low-risk and recreatable.
+    // Gated on generic context create/list (not the dedicated `context:alias`
+    // variant) so any context-capable client token can name its resources
+    // without a fine-grained alias grant. Writes (create/delete) → Create,
+    // reads (lookup/list) → List.
+    if let Some(captures) = ALIAS_REGEX.captures(path) {
+        if let Some(action) = captures.get(1) {
+            let scope = ResourceScope::Global;
+            return match (method, action.as_str()) {
+                (HttpMethod::POST, "create" | "delete") => {
+                    vec![Permission::Context(ContextPermission::Create(scope))]
+                }
+                (HttpMethod::POST, "lookup") | (HttpMethod::GET, "list") => {
+                    vec![Permission::Context(ContextPermission::List(scope))]
+                }
+                _ => vec![],
+            };
+        }
+    }
+
+    // ---- Group routes (most specific first) ----
+
+    // Security-critical: signing keys and ownership proofs stay admin-only.
+    if GROUP_ADMIN_REGEX.is_match(path) {
+        return match method {
+            HttpMethod::POST => vec![Permission::Admin(AdminPermission)],
+            _ => vec![],
+        };
+    }
+
+    // Member governance (add/remove/role/capabilities/auto-follow, member
+    // metadata writes) → capability-gated, not a plain client token.
+    if let Some(captures) = GROUP_MEMBER_SUB_REGEX.captures(path) {
+        if let (Some(gid), Some(action)) = (captures.get(1), captures.get(3)) {
+            let scope = ResourceScope::Specific(vec![gid.as_str().to_string()]);
+            return match (method, action.as_str()) {
+                (HttpMethod::GET, "capabilities" | "metadata") => {
+                    vec![Permission::Context(ContextPermission::List(scope))]
+                }
+                (HttpMethod::PUT, _) => vec![Permission::Context(ContextPermission::Capabilities(
+                    CapabilityPermission::Grant(scope),
+                ))],
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = GROUP_MEMBERS_REMOVE_REGEX.captures(path) {
+        if let Some(gid) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![gid.as_str().to_string()]);
+            return match method {
+                HttpMethod::POST => vec![Permission::Context(ContextPermission::Capabilities(
+                    CapabilityPermission::Revoke(scope),
+                ))],
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = GROUP_MEMBERS_REGEX.captures(path) {
+        if let Some(gid) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![gid.as_str().to_string()]);
+            return match method {
+                HttpMethod::GET => vec![Permission::Context(ContextPermission::List(scope))],
+                // Adding members = granting access → capability-gated.
+                HttpMethod::POST => vec![Permission::Context(ContextPermission::Capabilities(
+                    CapabilityPermission::Grant(scope),
+                ))],
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = GROUP_CONTEXTS_SUB_REGEX.captures(path) {
+        if let (Some(gid), Some(action)) = (captures.get(1), captures.get(3)) {
+            let scope = ResourceScope::Specific(vec![gid.as_str().to_string()]);
+            return match (method, action.as_str()) {
+                (HttpMethod::GET, "metadata") => {
+                    vec![Permission::Context(ContextPermission::List(scope))]
+                }
+                (HttpMethod::PUT, "metadata") => vec![Permission::Context(
+                    ContextPermission::Capabilities(CapabilityPermission::Grant(scope)),
+                )],
+                (HttpMethod::POST, "remove") => vec![Permission::Context(
+                    ContextPermission::Capabilities(CapabilityPermission::Revoke(scope)),
+                )],
+                _ => vec![],
+            };
+        }
+    }
+
+    // TEE admission policy is a trust-boundary setting → admin; other group
+    // settings are governance → capability-gated.
+    if let Some(captures) = GROUP_SETTINGS_REGEX.captures(path) {
+        if let (Some(gid), Some(setting)) = (captures.get(1), captures.get(2)) {
+            if setting.as_str() == "tee-admission-policy" {
+                return vec![Permission::Admin(AdminPermission)];
+            }
+            let scope = ResourceScope::Specific(vec![gid.as_str().to_string()]);
+            return match method {
+                HttpMethod::PUT => vec![Permission::Context(ContextPermission::Capabilities(
+                    CapabilityPermission::Grant(scope),
+                ))],
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = GROUP_UPGRADE_REGEX.captures(path) {
+        if let Some(gid) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![gid.as_str().to_string()]);
+            let is_status = captures.get(2).map(|m| m.as_str()) == Some("status");
+            return match method {
+                // Upgrading the group's app version — app-version management.
+                HttpMethod::POST => vec![Permission::Context(ContextPermission::Application(
+                    ContextApplicationPermission::Update(scope),
+                ))],
+                HttpMethod::GET if is_status => {
+                    vec![Permission::Context(ContextPermission::List(scope))]
+                }
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = GROUP_STATUS_REGEX.captures(path) {
+        if let Some(gid) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![gid.as_str().to_string()]);
+            return match method {
+                HttpMethod::GET => vec![Permission::Context(ContextPermission::List(scope))],
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = GROUP_MIGRATION_ABORT_REGEX.captures(path) {
+        if let Some(gid) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![gid.as_str().to_string()]);
+            return match method {
+                HttpMethod::POST => vec![Permission::Context(ContextPermission::Capabilities(
+                    CapabilityPermission::Grant(scope),
+                ))],
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = GROUP_SUBROUTE_REGEX.captures(path) {
+        if let (Some(gid), Some(action)) = (captures.get(1), captures.get(2)) {
+            let scope = ResourceScope::Specific(vec![gid.as_str().to_string()]);
+            return match (method, action.as_str()) {
+                (HttpMethod::GET, "contexts" | "subgroups" | "metadata") => {
+                    vec![Permission::Context(ContextPermission::List(scope))]
+                }
+                (HttpMethod::POST, "leave") => vec![Permission::Context(ContextPermission::Leave(
+                    scope,
+                    UserScope::Any,
+                ))],
+                (HttpMethod::POST, "invite") => vec![Permission::Context(
+                    ContextPermission::Invite(scope, UserScope::Any),
+                )],
+                // Writing group metadata / restructuring → capability-gated.
+                (HttpMethod::PUT, "metadata") | (HttpMethod::POST, "reparent") => {
+                    vec![Permission::Context(ContextPermission::Capabilities(
+                        CapabilityPermission::Grant(scope),
+                    ))]
+                }
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = GROUP_REGEX.captures(path) {
+        if let Some(gid) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![gid.as_str().to_string()]);
+            return match method {
+                HttpMethod::GET => vec![Permission::Context(ContextPermission::List(scope))],
+                HttpMethod::DELETE => vec![Permission::Context(ContextPermission::Delete(scope))],
+                // Updating group settings → capability-gated governance.
+                HttpMethod::PATCH => vec![Permission::Context(ContextPermission::Capabilities(
+                    CapabilityPermission::Grant(scope),
+                ))],
+                _ => vec![],
+            };
+        }
+    }
+
+    // Aliases and group routes handled above; blobs below.
     if let Some(captures) = BLOB_REGEX.captures(path) {
         if let Some(blob_id) = captures.get(1) {
             return match method {
@@ -357,6 +680,19 @@ impl PermissionValidator {
                 ContextPermission::Create(ResourceScope::Global),
             )],
 
+            // Generate a context identity (prerequisite for join) — app-level.
+            ("/admin-api/identity/context", HttpMethod::POST) => vec![Permission::Context(
+                ContextPermission::Create(ResourceScope::Global),
+            )],
+
+            // Groups: create / join a group — app-level (like create-in-namespace).
+            ("/admin-api/groups", HttpMethod::POST) => vec![Permission::Context(
+                ContextPermission::Create(ResourceScope::Global),
+            )],
+            ("/admin-api/groups/join", HttpMethod::POST) => vec![Permission::Context(
+                ContextPermission::Create(ResourceScope::Global),
+            )],
+
             // Admin auth endpoints
             ("/admin/keys", HttpMethod::GET) => vec![Permission::Keys(KeyPermission::List)],
             ("/admin/keys", HttpMethod::POST) => vec![Permission::Keys(KeyPermission::Create)],
@@ -447,7 +783,22 @@ impl PermissionValidator {
         // token that must reach one of these needs an explicit mapping added
         // above. `/jsonrpc`, `/ws`, `/sse` and the public `/auth/*` routes are
         // intentionally outside this namespace and unaffected.
-        if required_permissions.is_empty() && path.starts_with("/admin-api/") {
+        //
+        // Liveness/self-check routes are the exception: they carry no
+        // authority and must not be forced to admin. `is-authed` exists to
+        // report whether the caller's token is valid; `health`/`ready` are
+        // probes. They resolve to an empty requirement (any authenticated
+        // caller passes). Truly unauthenticated access would require mounting
+        // them outside the guard — a separate concern.
+        const PUBLIC_ADMIN_API_ROUTES: &[&str] = &[
+            "/admin-api/is-authed",
+            "/admin-api/health",
+            "/admin-api/ready",
+        ];
+        if required_permissions.is_empty()
+            && path.starts_with("/admin-api/")
+            && !PUBLIC_ADMIN_API_ROUTES.contains(&path)
+        {
             required_permissions.push(Permission::Admin(AdminPermission));
         }
 
@@ -901,11 +1252,12 @@ mod tests {
         let validator = PermissionValidator::new();
 
         for (method, path) in [
-            (Method::GET, "/admin-api/groups/some-group-id"),
-            (Method::POST, "/admin-api/groups"),
-            (Method::PATCH, "/admin-api/groups/some-group-id"),
+            // Security-critical group ops stay admin-only even though sibling
+            // group routes are now mapped.
+            (Method::POST, "/admin-api/groups/some-group-id/signing-key"),
             (Method::POST, "/admin-api/install-dev-application"),
             (Method::GET, "/admin-api/usage"),
+            (Method::POST, "/admin-api/tee/attest"),
             (Method::GET, "/admin-api/totally-unknown-subpath"),
             // Mapped path, unhandled method (the `_ => vec![]` arms):
             (Method::POST, "/admin-api/contexts/ctx-1"),

--- a/crates/auth/src/auth/permissions/validator.rs
+++ b/crates/auth/src/auth/permissions/validator.rs
@@ -31,6 +31,34 @@ static CONTEXTS_WITH_EXECUTORS_FOR_APPLICATION_REGEX: LazyLock<Regex> = LazyLock
     Regex::new(r"^/admin-api/contexts/with-executors/for-application/([^/]+)$").unwrap()
 });
 
+// Namespace routes. Namespaces are containers for contexts, so they map onto
+// the same `ContextPermission` set an app already holds — this lets a
+// multi-context client token (context:create/list/…) self-serve the
+// namespace → group → context flow, while destructive/governance ops
+// (delete, invite, leave) map to their restricted equivalents rather than the
+// `/admin-api/*` admin-only default-deny. More specific patterns are matched
+// before NAMESPACE_REGEX.
+static NAMESPACE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/namespaces/([^/]+)$").unwrap());
+
+static NAMESPACE_GROUPS_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/namespaces/([^/]+)/groups$").unwrap());
+
+static NAMESPACE_IDENTITY_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/namespaces/([^/]+)/identity$").unwrap());
+
+static NAMESPACE_INVITE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/namespaces/([^/]+)/invite$").unwrap());
+
+static NAMESPACE_JOIN_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/namespaces/([^/]+)/join$").unwrap());
+
+static NAMESPACE_LEAVE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/namespaces/([^/]+)/leave$").unwrap());
+
+static NAMESPACES_FOR_APPLICATION_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/namespaces/for-application/([^/]+)$").unwrap());
+
 static BLOB_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^/blobs/([^/]+)$").unwrap());
 
 static ADMIN_KEY_REGEX: LazyLock<Regex> =
@@ -118,6 +146,89 @@ fn get_permissions_for_path_with_params(path: &str, method: &HttpMethod) -> Vec<
             let scope = ResourceScope::Specific(vec![app_id.as_str().to_string()]);
             return match method {
                 HttpMethod::GET => vec![Permission::Context(ContextPermission::List(scope))],
+                _ => vec![],
+            };
+        }
+    }
+
+    // Namespace routes (most specific first). Scoped to the namespace id so a
+    // token may be narrowed to a namespace; an unscoped context:* token
+    // (Global) still satisfies these (Global matches any Specific).
+    if let Some(captures) = NAMESPACES_FOR_APPLICATION_REGEX.captures(path) {
+        if let Some(app_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![app_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::GET => vec![Permission::Context(ContextPermission::List(scope))],
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = NAMESPACE_GROUPS_REGEX.captures(path) {
+        if let Some(ns_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![ns_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::GET => vec![Permission::Context(ContextPermission::List(scope))],
+                HttpMethod::POST => vec![Permission::Context(ContextPermission::Create(scope))],
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = NAMESPACE_IDENTITY_REGEX.captures(path) {
+        if let Some(ns_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![ns_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::GET => vec![Permission::Context(ContextPermission::List(scope))],
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = NAMESPACE_INVITE_REGEX.captures(path) {
+        if let Some(ns_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![ns_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::POST => vec![Permission::Context(ContextPermission::Invite(
+                    scope,
+                    UserScope::Any,
+                ))],
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = NAMESPACE_JOIN_REGEX.captures(path) {
+        if let Some(ns_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![ns_id.as_str().to_string()]);
+            return match method {
+                // Joining establishes local namespace membership — reachable by
+                // the same create authority that lets an app provision its own.
+                HttpMethod::POST => vec![Permission::Context(ContextPermission::Create(scope))],
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = NAMESPACE_LEAVE_REGEX.captures(path) {
+        if let Some(ns_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![ns_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::POST => vec![Permission::Context(ContextPermission::Leave(
+                    scope,
+                    UserScope::Any,
+                ))],
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = NAMESPACE_REGEX.captures(path) {
+        if let Some(ns_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![ns_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::GET => vec![Permission::Context(ContextPermission::List(scope))],
+                HttpMethod::DELETE => vec![Permission::Context(ContextPermission::Delete(scope))],
                 _ => vec![],
             };
         }
@@ -234,6 +345,15 @@ impl PermissionValidator {
                 ContextPermission::List(ResourceScope::Global),
             )],
             ("/admin-api/contexts", HttpMethod::POST) => vec![Permission::Context(
+                ContextPermission::Create(ResourceScope::Global),
+            )],
+
+            // Admin API - Namespaces (containers for contexts; mapped onto the
+            // context permission set so client tokens can self-serve).
+            ("/admin-api/namespaces", HttpMethod::GET) => vec![Permission::Context(
+                ContextPermission::List(ResourceScope::Global),
+            )],
+            ("/admin-api/namespaces", HttpMethod::POST) => vec![Permission::Context(
                 ContextPermission::Create(ResourceScope::Global),
             )],
 

--- a/crates/auth/tests/client_token_contract.rs
+++ b/crates/auth/tests/client_token_contract.rs
@@ -177,3 +177,129 @@ fn multi_context_client_token_cannot_delete_a_namespace() {
         "admin must be able to delete a namespace",
     );
 }
+
+// ---- Full admin-api permission map (see crates/auth/docs/admin-api-permissions.md) ----
+
+/// APP routes: reachable by a plain multi-context client token
+/// (`context:create/list/execute`). These are the resource CRUD + self-service
+/// membership + naming ops an app drives for itself.
+#[test]
+fn app_routes_are_reachable_by_a_client_token() {
+    let validator = PermissionValidator::new();
+    let token = strings(MULTI_CONTEXT_PERMISSIONS);
+
+    for (method, path) in [
+        // context sub-routes: reads + join + refresh
+        ("GET", "/admin-api/contexts/ctx1/identities"),
+        ("GET", "/admin-api/contexts/ctx1/group"),
+        ("GET", "/admin-api/contexts/ctx1/storage"),
+        ("POST", "/admin-api/contexts/ctx1/join"),
+        ("POST", "/admin-api/contexts/ctx1/resync"),
+        ("POST", "/admin-api/contexts/sync"),
+        ("POST", "/admin-api/identity/context"),
+        // aliases (create/lookup/list)
+        ("POST", "/admin-api/alias/create/context"),
+        ("POST", "/admin-api/alias/lookup/context/my-name"),
+        ("GET", "/admin-api/alias/list/context"),
+        // groups: create / join / read
+        ("POST", "/admin-api/groups"),
+        ("POST", "/admin-api/groups/join"),
+        ("GET", "/admin-api/groups/g1"),
+        ("GET", "/admin-api/groups/g1/members"),
+        ("GET", "/admin-api/groups/g1/subgroups"),
+        ("GET", "/admin-api/groups/g1/upgrade/status"),
+    ] {
+        let required = validator.determine_required_permissions(&request(method, path));
+        assert!(
+            !required.is_empty(),
+            "{method} {path} must be explicitly mapped, not admin-only default-deny",
+        );
+        assert!(
+            validator.validate_permissions(&token, &required),
+            "APP route {method} {path} must be reachable by a client token \
+             (required: {required:?})",
+        );
+    }
+}
+
+/// GOV routes: governance over other members. NOT reachable by a plain client
+/// token; reachable by one holding `context:capabilities`.
+#[test]
+fn governance_routes_need_capabilities_not_a_plain_client_token() {
+    let validator = PermissionValidator::new();
+    let plain = strings(MULTI_CONTEXT_PERMISSIONS);
+    let with_caps = strings(&["context:capabilities:grant", "context:capabilities:revoke"]);
+
+    for (method, path) in [
+        ("POST", "/admin-api/groups/g1/members"), // add member
+        ("POST", "/admin-api/groups/g1/members/remove"), // remove member
+        ("PUT", "/admin-api/groups/g1/members/id1/role"), // change role
+        ("PUT", "/admin-api/groups/g1/settings/default-capabilities"),
+        ("PATCH", "/admin-api/groups/g1"), // group settings
+    ] {
+        let required = validator.determine_required_permissions(&request(method, path));
+        assert!(
+            !validator.validate_permissions(&plain, &required),
+            "GOV route {method} {path} must NOT be reachable by a plain client token",
+        );
+        assert!(
+            validator.validate_permissions(&with_caps, &required),
+            "GOV route {method} {path} must be reachable with context:capabilities \
+             (required: {required:?})",
+        );
+    }
+}
+
+/// ADMIN routes: node-owner / security-critical. Only an admin token passes;
+/// neither a plain client token nor a capabilities token does.
+#[test]
+fn admin_routes_stay_admin_only() {
+    let validator = PermissionValidator::new();
+    let client = strings(MULTI_CONTEXT_PERMISSIONS);
+    let caps = strings(&["context:capabilities:grant", "context:capabilities:revoke"]);
+
+    for (method, path) in [
+        ("PUT", "/admin-api/groups/g1/settings/tee-admission-policy"),
+        ("POST", "/admin-api/groups/g1/signing-key"),
+        ("POST", "/admin-api/groups/g1/issue-ownership-proof"),
+        ("POST", "/admin-api/install-dev-application"),
+        ("POST", "/admin-api/contexts/invite-specialized-node"),
+        ("POST", "/admin-api/tee/attest"),
+        ("GET", "/admin-api/tee/info"),
+        ("GET", "/admin-api/usage"),
+        ("GET", "/admin-api/network/status"),
+    ] {
+        let required = validator.determine_required_permissions(&request(method, path));
+        assert!(
+            !validator.validate_permissions(&client, &required),
+            "ADMIN route {method} {path} must reject a client token",
+        );
+        assert!(
+            !validator.validate_permissions(&caps, &required),
+            "ADMIN route {method} {path} must reject a capabilities token",
+        );
+        assert!(
+            validator.validate_permissions(&["admin".to_owned()], &required),
+            "ADMIN route {method} {path} must accept admin",
+        );
+    }
+}
+
+/// PUBLIC routes: liveness / token self-check require no permission — any
+/// authenticated caller passes (they must NOT hit the admin default-deny).
+#[test]
+fn public_routes_require_no_permission() {
+    let validator = PermissionValidator::new();
+
+    for path in [
+        "/admin-api/is-authed",
+        "/admin-api/health",
+        "/admin-api/ready",
+    ] {
+        let required = validator.determine_required_permissions(&request("GET", path));
+        assert!(
+            required.is_empty(),
+            "PUBLIC route {path} must require no permission, got {required:?}",
+        );
+    }
+}

--- a/crates/auth/tests/client_token_contract.rs
+++ b/crates/auth/tests/client_token_contract.rs
@@ -126,25 +126,54 @@ fn app_id_scoped_token_is_rejected_on_every_sdk_route() {
     }
 }
 
-/// Known gap (unfixed): the namespace routes — the *recommended* replacement
-/// for direct context creation — have no validator mappings, so the
-/// `/admin-api/*` default-deny makes them admin-only. A multi-context client
-/// token therefore cannot create a namespace, and the official migration
-/// path 403s for every app.
-///
-/// Ignored until core grows namespace permission mappings; run with
-/// `cargo test -p mero-auth --test client_token_contract -- --ignored`
-/// to check whether the gap still exists.
+/// The namespace routes are containers for contexts and map onto the same
+/// `ContextPermission` set an app already holds, so a multi-context client
+/// token can self-serve the `namespace → group → context` flow. This was the
+/// gap that 403'd the official app migration path; it is now closed.
 #[test]
-#[ignore = "namespace routes are admin-only: no validator mappings yet"]
-fn multi_context_client_token_can_create_namespaces() {
+fn multi_context_client_token_can_self_serve_namespaces() {
+    let validator = PermissionValidator::new();
+    let token = strings(MULTI_CONTEXT_PERMISSIONS);
+
+    // The full app-driven provisioning chain must be reachable.
+    for (method, path) in [
+        ("POST", "/admin-api/namespaces"), // create namespace
+        ("GET", "/admin-api/namespaces"),  // list namespaces
+        ("GET", "/admin-api/namespaces/for-application/app1"), // list for app
+        ("GET", "/admin-api/namespaces/ns1"), // get namespace
+        ("GET", "/admin-api/namespaces/ns1/groups"), // list groups
+        ("POST", "/admin-api/namespaces/ns1/groups"), // create group in namespace
+    ] {
+        let required = validator.determine_required_permissions(&request(method, path));
+        assert!(
+            !required.is_empty(),
+            "{method} {path} must have an explicit mapping, not fall through to \
+             the admin-only default-deny",
+        );
+        assert!(
+            validator.validate_permissions(&token, &required),
+            "a multi-context client token must reach {method} {path} \
+             (required: {required:?})",
+        );
+    }
+}
+
+/// Least privilege is preserved: destructive namespace deletion is NOT
+/// reachable by a plain multi-context token (it needs `context:delete`), so
+/// mapping the create/list paths didn't hand apps a demolition tool.
+#[test]
+fn multi_context_client_token_cannot_delete_a_namespace() {
     let validator = PermissionValidator::new();
 
     let required =
-        validator.determine_required_permissions(&request("POST", "/admin-api/namespaces"));
+        validator.determine_required_permissions(&request("DELETE", "/admin-api/namespaces/ns1"));
     assert!(
-        validator.validate_permissions(&strings(MULTI_CONTEXT_PERMISSIONS), &required),
-        "a multi-context client token must be able to create a namespace \
-         (required: {required:?})",
+        !validator.validate_permissions(&strings(MULTI_CONTEXT_PERMISSIONS), &required),
+        "namespace deletion must stay gated (required: {required:?})",
+    );
+    // An admin token still can.
+    assert!(
+        validator.validate_permissions(&["admin".to_owned()], &required),
+        "admin must be able to delete a namespace",
     );
 }

--- a/scripts/e2e-auth-seam.sh
+++ b/scripts/e2e-auth-seam.sh
@@ -110,11 +110,11 @@ check_admitted "POST /jsonrpc (context:execute) admitted" \
 check_admitted "POST /admin-api/contexts (context:create) admitted" \
   "$(status_of POST /admin-api/contexts "$CLIENT_TOKEN" '{}')"
 
-# 4. KNOWN GAP pin: namespace routes have no permission mappings, so the
-#    /admin-api/* default-deny makes them admin-only. When namespace
-#    mappings land, THIS ASSERTION MUST FLIP to expect success — that
-#    failure is the signal to update the seam, not an accident.
-check "POST /admin-api/namespaces is admin-only (pinned gap)" 403 \
+# 4. Namespace self-serve: namespace routes map onto the context permission
+#    set, so a client token can create a namespace (the auth layer admits it;
+#    the handler may still 4xx on this synthetic body, which is fine — not
+#    401/403 proves authorization passed). This closed the migration-path gap.
+check_admitted "POST /admin-api/namespaces (context:create) admitted" \
   "$(status_of POST /admin-api/namespaces "$CLIENT_TOKEN" '{"applicationId":"x","name":"seam"}')"
 
 # 5. Regression pin (the rc.9 outage shape): a token whose context


### PR DESCRIPTION
## Problem

Since rc.9's default-deny on `/admin-api/*` (#3040), **every** admin-api route with no explicit permission mapping requires full `admin`. Whole clusters an app drives with its client token were therefore admin-only and 403'd — starting with `POST /admin-api/namespaces` (the reported bug), and extending to context sub-routes, aliases, and most group ops. The modern app flow (provision your own `namespace → group → context`, name resources, join/leave) could not run without an admin token.

## What

A complete, documented permission map for the whole admin-api surface. The full decision table with rationale is in **`crates/auth/docs/admin-api-permissions.md`**; the validator mirrors it. Every route is one of:

- **APP** — resource CRUD / self-service membership / naming, mapped to the `context:*` (and `application:*`/`package:*`/`blob:*`) family a client token holds. Namespaces, context sub-routes (join/leave/identities/group/storage/resync/sync), aliases, groups (create/join/leave/read/invite/upgrade), identity generation, app list/uninstall/versions.
- **GOV** — governance over *other* members (add/remove/role/capabilities/settings/reparent/metadata-writes) → `context:capabilities`. Reachable by a token explicitly granted capability authority; **not** a plain client token, **not** admin.
- **ADMIN** — node-owner/security-critical: tee-admission-policy, signing-key, ownership proofs, `install-dev-application` (reads node FS), invite-specialized-node, `tee/*`, usage, network, peers, certificate. Unchanged.
- **PUBLIC** — `is-authed`, `health`, `ready`: no permission (skip the default-deny).

**No frontend change** — APP routes map onto the `context:create/list/execute` set existing tokens already carry.

**Least privilege & fail-closed preserved** — destructive/governance/security ops are never reachable by a plain client token, and genuinely unmapped `/admin-api/*` routes still require `admin`.

## Verified

- **82 auth tests** pass (unit + contract); clippy clean.
- Contract test asserts each category: APP reachable by a client token, GOV needs `context:capabilities`, ADMIN stays admin, PUBLIC needs none.
- **Live embedded-auth node, client token (no admin):** `POST /admin-api/namespaces` → **200** (was 403); alias create/list, group create, identity, context-join all admitted; `is-authed` → 200; **tee-admission-policy / signing-key / install-dev-application / group-member-add → 403** (correctly gated).

## Follow-ups (documented, out of scope here)

- `Blob::List` variant for blob read/list (touches the permission enum's parse/display) — blob writes/delete already mapped.
- mero-react `tests/e2e/client-token.test.ts` namespace-403 pin flips to expect success once this ships in a merod release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)