### PR TITLE
fix(auth): map client-facing admin-api routes to scoped permissions (post-rc.9 403s)

### DIFF
--- a/crates/auth/src/auth/permissions/mod.rs
+++ b/crates/auth/src/auth/permissions/mod.rs
@@ -4,6 +4,7 @@ mod validator;
 pub use types::{
     AddBlobPermission, AdminPermission, AliasPermission, AliasType, ApplicationPermission,
     BlobPermission, CapabilityPermission, ContextApplicationPermission, ContextPermission,
-    HttpMethod, KeyPermission, Permission, ResourceScope, UserScope,
+    GroupPermission, HttpMethod, KeyPermission, NamespacePermission, Permission, ResourceScope,
+    UserScope,
 };
 pub use validator::PermissionValidator;

--- a/crates/auth/src/auth/permissions/types.rs
+++ b/crates/auth/src/auth/permissions/types.rs
@@ -83,6 +83,26 @@ pub enum BlobPermission {
     All,
     Add(AddBlobPermission),
     Remove(ResourceScope),
+    List(ResourceScope),
+    Get(ResourceScope),
+}
+
+/// Namespace-related permissions
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NamespacePermission {
+    All(ResourceScope),
+    Create(ResourceScope),
+    List(ResourceScope),
+    Manage(ResourceScope),
+}
+
+/// Group (governance) permissions
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GroupPermission {
+    All(ResourceScope),
+    Create(ResourceScope),
+    List(ResourceScope),
+    Manage(ResourceScope),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -96,6 +116,7 @@ pub enum AddBlobPermission {
 /// Context alias permissions
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AliasPermission {
+    All(ResourceScope),
     Create(AliasType, ResourceScope),
     List(AliasType, ResourceScope),
     Lookup(AliasType, ResourceScope),
@@ -146,6 +167,8 @@ pub enum Permission {
     Package(PackagePermission),
     Blob(BlobPermission),
     Context(ContextPermission),
+    Namespace(NamespacePermission),
+    Group(GroupPermission),
     Keys(KeyPermission),
 }
 
@@ -358,8 +381,42 @@ impl FromStr for Permission {
                         let (scope, _, _) = parse_permission_params(params_part);
                         Ok(Permission::Blob(BlobPermission::Remove(scope)))
                     }
+                    "list" => {
+                        let (scope, _, _) = parse_permission_params(params_part);
+                        Ok(Permission::Blob(BlobPermission::List(scope)))
+                    }
+                    "get" => {
+                        let (scope, _, _) = parse_permission_params(params_part);
+                        Ok(Permission::Blob(BlobPermission::Get(scope)))
+                    }
                     "" => Ok(Permission::Blob(BlobPermission::All)),
                     _ => Err(format!("Unknown blob action: {action}")),
+                }
+            }
+
+            "namespace" => {
+                let action = parts.get(1).unwrap_or(&"");
+                let (scope, _, _) = parse_permission_params(params_part);
+
+                match *action {
+                    "create" => Ok(Permission::Namespace(NamespacePermission::Create(scope))),
+                    "list" => Ok(Permission::Namespace(NamespacePermission::List(scope))),
+                    "manage" => Ok(Permission::Namespace(NamespacePermission::Manage(scope))),
+                    "" => Ok(Permission::Namespace(NamespacePermission::All(scope))),
+                    _ => Err(format!("Unknown namespace action: {action}")),
+                }
+            }
+
+            "group" => {
+                let action = parts.get(1).unwrap_or(&"");
+                let (scope, _, _) = parse_permission_params(params_part);
+
+                match *action {
+                    "create" => Ok(Permission::Group(GroupPermission::Create(scope))),
+                    "list" => Ok(Permission::Group(GroupPermission::List(scope))),
+                    "manage" => Ok(Permission::Group(GroupPermission::Manage(scope))),
+                    "" => Ok(Permission::Group(GroupPermission::All(scope))),
+                    _ => Err(format!("Unknown group action: {action}")),
                 }
             }
 
@@ -442,6 +499,9 @@ impl FromStr for Permission {
                                 AliasPermission::Delete(alias_type, scope),
                             )))
                         }
+                        "" => Ok(Permission::Context(ContextPermission::Alias(
+                            AliasPermission::All(scope),
+                        ))),
                         _ => Err(format!("Unknown context alias action: {subaction}")),
                     },
                     "" => Ok(Permission::Context(ContextPermission::All(scope))),
@@ -526,6 +586,50 @@ impl fmt::Display for Permission {
                     let params = format_params(scope, &UserScope::Any, &None);
                     write!(f, "blob:remove{params}")
                 }
+                BlobPermission::List(scope) => {
+                    let params = format_params(scope, &UserScope::Any, &None);
+                    write!(f, "blob:list{params}")
+                }
+                BlobPermission::Get(scope) => {
+                    let params = format_params(scope, &UserScope::Any, &None);
+                    write!(f, "blob:get{params}")
+                }
+            },
+            Permission::Namespace(ns_perm) => match ns_perm {
+                NamespacePermission::All(scope) => {
+                    let params = format_params(scope, &UserScope::Any, &None);
+                    write!(f, "namespace{params}")
+                }
+                NamespacePermission::Create(scope) => {
+                    let params = format_params(scope, &UserScope::Any, &None);
+                    write!(f, "namespace:create{params}")
+                }
+                NamespacePermission::List(scope) => {
+                    let params = format_params(scope, &UserScope::Any, &None);
+                    write!(f, "namespace:list{params}")
+                }
+                NamespacePermission::Manage(scope) => {
+                    let params = format_params(scope, &UserScope::Any, &None);
+                    write!(f, "namespace:manage{params}")
+                }
+            },
+            Permission::Group(group_perm) => match group_perm {
+                GroupPermission::All(scope) => {
+                    let params = format_params(scope, &UserScope::Any, &None);
+                    write!(f, "group{params}")
+                }
+                GroupPermission::Create(scope) => {
+                    let params = format_params(scope, &UserScope::Any, &None);
+                    write!(f, "group:create{params}")
+                }
+                GroupPermission::List(scope) => {
+                    let params = format_params(scope, &UserScope::Any, &None);
+                    write!(f, "group:list{params}")
+                }
+                GroupPermission::Manage(scope) => {
+                    let params = format_params(scope, &UserScope::Any, &None);
+                    write!(f, "group:manage{params}")
+                }
             },
             Permission::Context(ctx_perm) => match ctx_perm {
                 ContextPermission::All(scope) => {
@@ -557,6 +661,10 @@ impl fmt::Display for Permission {
                     write!(f, "context:execute{params}")
                 }
                 ContextPermission::Alias(alias_perm) => match alias_perm {
+                    AliasPermission::All(scope) => {
+                        let params = format_simple_params(scope);
+                        write!(f, "context:alias{params}")
+                    }
                     AliasPermission::Create(alias_type, scope) => {
                         let type_str = match alias_type {
                             AliasType::Context => "context",
@@ -669,8 +777,22 @@ impl Permission {
                 (BlobPermission::Remove(h_scope), BlobPermission::Remove(r_scope)) => {
                     matches_scope(h_scope, r_scope)
                 }
+                (BlobPermission::List(h_scope), BlobPermission::List(r_scope)) => {
+                    matches_scope(h_scope, r_scope)
+                }
+                (BlobPermission::Get(h_scope), BlobPermission::Get(r_scope)) => {
+                    matches_scope(h_scope, r_scope)
+                }
                 _ => false,
             },
+
+            // Namespace permissions
+            (Permission::Namespace(held), Permission::Namespace(req)) => {
+                matches_namespace(held, req)
+            }
+
+            // Group permissions
+            (Permission::Group(held), Permission::Group(req)) => matches_group(held, req),
 
             // Context permissions
             (Permission::Context(ContextPermission::All(h_scope)), Permission::Context(req)) => {
@@ -762,9 +884,79 @@ fn matches_method(held: Option<&str>, required: Option<&str>) -> bool {
     }
 }
 
+/// Helper function to extract the resource scope of a namespace permission
+fn namespace_scope(perm: &NamespacePermission) -> &ResourceScope {
+    match perm {
+        NamespacePermission::All(scope)
+        | NamespacePermission::Create(scope)
+        | NamespacePermission::List(scope)
+        | NamespacePermission::Manage(scope) => scope,
+    }
+}
+
+/// Helper function to check if one namespace permission satisfies another
+fn matches_namespace(held: &NamespacePermission, required: &NamespacePermission) -> bool {
+    match (held, required) {
+        // `namespace` (All) is an umbrella over every namespace verb.
+        (NamespacePermission::All(h_scope), req) => matches_scope(h_scope, namespace_scope(req)),
+        (NamespacePermission::Create(h_scope), NamespacePermission::Create(r_scope)) => {
+            matches_scope(h_scope, r_scope)
+        }
+        (NamespacePermission::List(h_scope), NamespacePermission::List(r_scope)) => {
+            matches_scope(h_scope, r_scope)
+        }
+        (NamespacePermission::Manage(h_scope), NamespacePermission::Manage(r_scope)) => {
+            matches_scope(h_scope, r_scope)
+        }
+        _ => false,
+    }
+}
+
+/// Helper function to extract the resource scope of a group permission
+fn group_scope(perm: &GroupPermission) -> &ResourceScope {
+    match perm {
+        GroupPermission::All(scope)
+        | GroupPermission::Create(scope)
+        | GroupPermission::List(scope)
+        | GroupPermission::Manage(scope) => scope,
+    }
+}
+
+/// Helper function to check if one group permission satisfies another
+fn matches_group(held: &GroupPermission, required: &GroupPermission) -> bool {
+    match (held, required) {
+        // `group` (All) is an umbrella over every group verb.
+        (GroupPermission::All(h_scope), req) => matches_scope(h_scope, group_scope(req)),
+        (GroupPermission::Create(h_scope), GroupPermission::Create(r_scope)) => {
+            matches_scope(h_scope, r_scope)
+        }
+        (GroupPermission::List(h_scope), GroupPermission::List(r_scope)) => {
+            matches_scope(h_scope, r_scope)
+        }
+        (GroupPermission::Manage(h_scope), GroupPermission::Manage(r_scope)) => {
+            matches_scope(h_scope, r_scope)
+        }
+        _ => false,
+    }
+}
+
+/// Helper function to extract the resource scope of an alias permission
+fn alias_scope(perm: &AliasPermission) -> &ResourceScope {
+    match perm {
+        AliasPermission::All(scope) => scope,
+        AliasPermission::Create(_, scope)
+        | AliasPermission::List(_, scope)
+        | AliasPermission::Lookup(_, scope)
+        | AliasPermission::Delete(_, scope) => scope,
+    }
+}
+
 /// Helper function to check if one alias permission satisfies another
 fn matches_alias(held: &AliasPermission, required: &AliasPermission) -> bool {
     match (held, required) {
+        // `context:alias` (All) is an umbrella over every alias verb and type.
+        // A required All is only satisfied by a held All whose scope covers it.
+        (AliasPermission::All(h_scope), req) => matches_scope(h_scope, alias_scope(req)),
         (
             AliasPermission::Create(held_type, held_scope),
             AliasPermission::Create(req_type, req_scope),
@@ -1057,5 +1249,139 @@ mod tests {
             .parse::<Permission>()
             .unwrap();
         assert!(held.satisfies(&required));
+    }
+
+    #[test]
+    fn test_new_permission_round_trips() {
+        // Unscoped (global) forms must round-trip to the exact same string.
+        for s in [
+            "namespace",
+            "namespace:create",
+            "namespace:list",
+            "namespace:manage",
+            "group",
+            "group:create",
+            "group:list",
+            "group:manage",
+            "blob:list",
+            "blob:get",
+            "context:alias",
+            "context:alias[ctx-1]",
+        ] {
+            let parsed = s.parse::<Permission>().unwrap_or_else(|e| {
+                panic!("{s} must parse: {e}");
+            });
+            assert_eq!(parsed.to_string(), s, "Display must reproduce {s}");
+        }
+
+        // Scoped forms display with the shared `format_params` layout (which
+        // pads a trailing user slot, e.g. `namespace:list[ns-1,]`, exactly
+        // like the existing `context:list` verbs), so pin the semantic round
+        // trip: FromStr → Display → FromStr must be the identity.
+        for s in [
+            "namespace:list[ns-1]",
+            "namespace:manage[ns-1]",
+            "group:list[grp-1]",
+            "group:manage[grp-1]",
+            "blob:list[blob-1]",
+            "blob:get[blob-1]",
+        ] {
+            let parsed = s.parse::<Permission>().unwrap_or_else(|e| {
+                panic!("{s} must parse: {e}");
+            });
+            assert_eq!(
+                parsed.to_string().parse::<Permission>(),
+                Ok(parsed),
+                "{s} must survive a full round trip",
+            );
+        }
+
+        // Unknown verbs in the new families must be rejected.
+        for s in ["namespace:delete", "group:destroy", "blob:read"] {
+            assert!(s.parse::<Permission>().is_err(), "{s} must not parse");
+        }
+    }
+
+    #[test]
+    fn test_namespace_group_umbrella_satisfaction() {
+        // The bare umbrella covers every verb at any scope...
+        for (umbrella, verbs) in [
+            (
+                "namespace",
+                [
+                    "namespace:create",
+                    "namespace:list[ns-1]",
+                    "namespace:manage[ns-1]",
+                ],
+            ),
+            (
+                "group",
+                ["group:create", "group:list[grp-1]", "group:manage[grp-1]"],
+            ),
+        ] {
+            let held = umbrella.parse::<Permission>().unwrap();
+            for verb in verbs {
+                let required = verb.parse::<Permission>().unwrap();
+                assert!(held.satisfies(&required), "{umbrella} must satisfy {verb}");
+            }
+        }
+
+        // ...a verb satisfies the same verb when the scope covers...
+        let held = "namespace:manage".parse::<Permission>().unwrap();
+        let required = "namespace:manage[ns-1]".parse::<Permission>().unwrap();
+        assert!(held.satisfies(&required));
+
+        // ...but not a different verb, a wider scope, or the other family.
+        let held = "namespace:list".parse::<Permission>().unwrap();
+        let required = "namespace:manage[ns-1]".parse::<Permission>().unwrap();
+        assert!(!held.satisfies(&required));
+
+        let held = "group:manage[grp-1]".parse::<Permission>().unwrap();
+        let required = "group:manage".parse::<Permission>().unwrap();
+        assert!(!held.satisfies(&required));
+
+        let held = "namespace".parse::<Permission>().unwrap();
+        let required = "group:list".parse::<Permission>().unwrap();
+        assert!(!held.satisfies(&required));
+    }
+
+    #[test]
+    fn test_blob_list_get_satisfaction() {
+        let all = "blob".parse::<Permission>().unwrap();
+        let list = "blob:list".parse::<Permission>().unwrap();
+        let get_specific = "blob:get[blob-1]".parse::<Permission>().unwrap();
+
+        assert!(all.satisfies(&list));
+        assert!(all.satisfies(&get_specific));
+
+        let held = "blob:get".parse::<Permission>().unwrap();
+        assert!(held.satisfies(&get_specific));
+        assert!(!held.satisfies(&list));
+        assert!(!list.satisfies(&get_specific));
+    }
+
+    #[test]
+    fn test_alias_umbrella_satisfaction() {
+        let umbrella = "context:alias".parse::<Permission>().unwrap();
+        for verb in [
+            "context:alias:create:context",
+            "context:alias:lookup:identity[ctx-123]",
+            "context:alias:list:application",
+            "context:alias:delete:context[alias-name]",
+            "context:alias",
+        ] {
+            let required = verb.parse::<Permission>().unwrap();
+            assert!(
+                umbrella.satisfies(&required),
+                "context:alias must satisfy {verb}"
+            );
+        }
+
+        // A single verb does NOT satisfy a required umbrella.
+        let held = "context:alias:create:context"
+            .parse::<Permission>()
+            .unwrap();
+        let required = "context:alias".parse::<Permission>().unwrap();
+        assert!(!held.satisfies(&required));
     }
 }

--- a/crates/auth/src/auth/permissions/validator.rs
+++ b/crates/auth/src/auth/permissions/validator.rs
@@ -5,9 +5,10 @@ use axum::http::Request;
 use regex::Regex;
 
 use super::types::{
-    AddBlobPermission, AdminPermission, ApplicationPermission, BlobPermission,
-    CapabilityPermission, ContextApplicationPermission, ContextPermission, HttpMethod,
-    KeyPermission, PackagePermission, Permission, ResourceScope, UserScope,
+    AddBlobPermission, AdminPermission, AliasPermission, AliasType, ApplicationPermission,
+    BlobPermission, CapabilityPermission, ContextApplicationPermission, ContextPermission,
+    GroupPermission, HttpMethod, KeyPermission, NamespacePermission, PackagePermission, Permission,
+    ResourceScope, UserScope,
 };
 
 /// Pre-compiled regex patterns for performance
@@ -47,6 +48,57 @@ static PACKAGE_VERSIONS_REGEX: LazyLock<Regex> =
 
 static PACKAGE_LATEST_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^/admin-api/packages/([^/]+)/latest$").unwrap());
+
+static NAMESPACES_FOR_APPLICATION_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/namespaces/for-application/([^/]+)$").unwrap());
+
+static NAMESPACE_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/namespaces/([^/]+)$").unwrap());
+
+static NAMESPACE_READ_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/namespaces/([^/]+)/(identity|groups)$").unwrap());
+
+static NAMESPACE_MEMBERSHIP_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/namespaces/([^/]+)/(invite|join|leave)$").unwrap());
+
+static GROUP_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/groups/([^/]+)(?:/.*)?$").unwrap());
+
+static CONTEXT_READ_SUBRESOURCE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^/admin-api/contexts/([^/]+)/(identities|identities-owned|storage|group)$")
+        .unwrap()
+});
+
+static CONTEXT_MEMBERSHIP_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/contexts/([^/]+)/(join|leave|resync)$").unwrap());
+
+static CONTEXT_SYNC_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/contexts/sync/([^/]+)$").unwrap());
+
+static ADMIN_BLOB_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/blobs/([^/]+)$").unwrap());
+
+static ALIAS_MUTATION_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^/admin-api/alias/(create|lookup|delete)/(context|application|identity)(?:/.*)?$")
+        .unwrap()
+});
+
+static ALIAS_LIST_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^/admin-api/alias/list/(context|application|identity)(?:/.*)?$").unwrap()
+});
+
+static APPLICATION_VERSIONS_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/applications/([^/]+)/versions$").unwrap());
+
+/// Map an alias path segment to its [`AliasType`]. The regexes only capture
+/// `context|application|identity`, so every capture maps.
+fn alias_type_from_segment(segment: &str) -> AliasType {
+    match segment {
+        "context" => AliasType::Context,
+        "application" => AliasType::Application,
+        _ => AliasType::Identity,
+    }
+}
 
 /// Permission validator for checking request permissions
 #[derive(Debug, Default)]
@@ -195,6 +247,186 @@ fn get_permissions_for_path_with_params(path: &str, method: &HttpMethod) -> Vec<
         }
     }
 
+    // Namespace endpoints (checked before the single-segment namespace regex so
+    // `/namespaces/for-application/:app_id` scopes to the application id)
+    if let Some(captures) = NAMESPACES_FOR_APPLICATION_REGEX.captures(path) {
+        if let Some(app_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![app_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::GET => vec![Permission::Namespace(NamespacePermission::List(scope))],
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = NAMESPACE_REGEX.captures(path) {
+        if let Some(ns_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![ns_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::GET => vec![Permission::Namespace(NamespacePermission::List(scope))],
+                HttpMethod::DELETE => {
+                    vec![Permission::Namespace(NamespacePermission::Manage(scope))]
+                }
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = NAMESPACE_READ_REGEX.captures(path) {
+        if let (Some(ns_id), Some(resource)) = (captures.get(1), captures.get(2)) {
+            let scope = ResourceScope::Specific(vec![ns_id.as_str().to_string()]);
+            return match (method, resource.as_str()) {
+                (HttpMethod::GET, _) => {
+                    vec![Permission::Namespace(NamespacePermission::List(scope))]
+                }
+                // POST /namespaces/:id/groups creates a group in the namespace
+                (HttpMethod::POST, "groups") => {
+                    vec![Permission::Group(GroupPermission::Create(
+                        ResourceScope::Global,
+                    ))]
+                }
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = NAMESPACE_MEMBERSHIP_REGEX.captures(path) {
+        if let Some(ns_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![ns_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::POST => {
+                    vec![Permission::Namespace(NamespacePermission::Manage(scope))]
+                }
+                _ => vec![],
+            };
+        }
+    }
+
+    // Group governance endpoints: catch-all for `/admin-api/groups/:group_id`
+    // and everything nested below it (members, metadata, settings, upgrade,
+    // migration, signing keys, ownership proofs, sync, …). Reads require
+    // `group:list[<id>]`, mutations `group:manage[<id>]`.
+    if let Some(captures) = GROUP_REGEX.captures(path) {
+        if let Some(group_id) = captures.get(1) {
+            // `/admin-api/groups/join` is an exact route (join by invitation
+            // payload), already mapped in `get_permissions_for_exact_paths`;
+            // it must not be treated as a group id here.
+            if group_id.as_str() == "join" {
+                return vec![];
+            }
+            let scope = ResourceScope::Specific(vec![group_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::GET => vec![Permission::Group(GroupPermission::List(scope))],
+                HttpMethod::POST | HttpMethod::PUT | HttpMethod::PATCH | HttpMethod::DELETE => {
+                    vec![Permission::Group(GroupPermission::Manage(scope))]
+                }
+                HttpMethod::Any => vec![],
+            };
+        }
+    }
+
+    // Context sub-resources: read-only views of a context a member needs
+    if let Some(captures) = CONTEXT_READ_SUBRESOURCE_REGEX.captures(path) {
+        if let Some(ctx_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![ctx_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::GET => vec![Permission::Context(ContextPermission::List(scope))],
+                _ => vec![],
+            };
+        }
+    }
+
+    // Context membership operations (join/leave/resync): member-level actions
+    if let Some(captures) = CONTEXT_MEMBERSHIP_REGEX.captures(path) {
+        if let Some(ctx_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![ctx_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::POST => vec![Permission::Context(ContextPermission::Execute(
+                    scope,
+                    UserScope::Any,
+                    None,
+                ))],
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = CONTEXT_SYNC_REGEX.captures(path) {
+        if let Some(ctx_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![ctx_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::POST => vec![Permission::Context(ContextPermission::Execute(
+                    scope,
+                    UserScope::Any,
+                    None,
+                ))],
+                _ => vec![],
+            };
+        }
+    }
+
+    // Admin-api blob endpoints (nested under /admin-api, unlike the legacy
+    // top-level /blobs routes above)
+    if let Some(captures) = ADMIN_BLOB_REGEX.captures(path) {
+        if let Some(blob_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![blob_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::GET => vec![Permission::Blob(BlobPermission::Get(scope))],
+                HttpMethod::DELETE => vec![Permission::Blob(BlobPermission::Remove(scope))],
+                _ => vec![],
+            };
+        }
+    }
+
+    // Alias endpoints: /admin-api/alias/{create,lookup,delete}/{type}[/…]
+    if let Some(captures) = ALIAS_MUTATION_REGEX.captures(path) {
+        if let (Some(action), Some(kind)) = (captures.get(1), captures.get(2)) {
+            let alias_type = alias_type_from_segment(kind.as_str());
+            return match (method, action.as_str()) {
+                (HttpMethod::POST, "create") => {
+                    vec![Permission::Context(ContextPermission::Alias(
+                        AliasPermission::Create(alias_type, ResourceScope::Global),
+                    ))]
+                }
+                (HttpMethod::POST, "lookup") => {
+                    vec![Permission::Context(ContextPermission::Alias(
+                        AliasPermission::Lookup(alias_type, ResourceScope::Global),
+                    ))]
+                }
+                (HttpMethod::POST, "delete") => {
+                    vec![Permission::Context(ContextPermission::Alias(
+                        AliasPermission::Delete(alias_type, ResourceScope::Global),
+                    ))]
+                }
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = ALIAS_LIST_REGEX.captures(path) {
+        if let Some(kind) = captures.get(1) {
+            let alias_type = alias_type_from_segment(kind.as_str());
+            return match method {
+                HttpMethod::GET => vec![Permission::Context(ContextPermission::Alias(
+                    AliasPermission::List(alias_type, ResourceScope::Global),
+                ))],
+                _ => vec![],
+            };
+        }
+    }
+
+    if let Some(captures) = APPLICATION_VERSIONS_REGEX.captures(path) {
+        if let Some(app_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![app_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::GET => {
+                    vec![Permission::Application(ApplicationPermission::List(scope))]
+                }
+                _ => vec![],
+            };
+        }
+    }
+
     vec![]
 }
 
@@ -236,6 +468,38 @@ impl PermissionValidator {
             ("/admin-api/contexts", HttpMethod::POST) => vec![Permission::Context(
                 ContextPermission::Create(ResourceScope::Global),
             )],
+            ("/admin-api/contexts/sync", HttpMethod::POST) => vec![Permission::Context(
+                ContextPermission::Execute(ResourceScope::Global, UserScope::Any, None),
+            )],
+            // Generating a fresh context identity keypair is a member-level
+            // operation: it grants no access to any existing resource.
+            ("/admin-api/identity/context", HttpMethod::POST) => vec![Permission::Context(
+                ContextPermission::Execute(ResourceScope::Global, UserScope::Any, None),
+            )],
+
+            // Admin API - Namespaces
+            ("/admin-api/namespaces", HttpMethod::GET) => vec![Permission::Namespace(
+                NamespacePermission::List(ResourceScope::Global),
+            )],
+            ("/admin-api/namespaces", HttpMethod::POST) => vec![Permission::Namespace(
+                NamespacePermission::Create(ResourceScope::Global),
+            )],
+
+            // Admin API - Groups
+            ("/admin-api/groups", HttpMethod::POST) => vec![Permission::Group(
+                GroupPermission::Create(ResourceScope::Global),
+            )],
+            ("/admin-api/groups/join", HttpMethod::POST) => vec![Permission::Group(
+                GroupPermission::Manage(ResourceScope::Global),
+            )],
+
+            // Admin API - Blobs
+            ("/admin-api/blobs", HttpMethod::PUT) => vec![Permission::Blob(BlobPermission::Add(
+                AddBlobPermission::Stream,
+            ))],
+            ("/admin-api/blobs", HttpMethod::GET) => vec![Permission::Blob(BlobPermission::List(
+                ResourceScope::Global,
+            ))],
 
             // Admin auth endpoints
             ("/admin/keys", HttpMethod::GET) => vec![Permission::Keys(KeyPermission::List)],
@@ -321,12 +585,18 @@ impl PermissionValidator {
         // unmapped admin routes fail closed.
         //
         // This deliberately makes every unmapped `/admin-api/*` route
-        // admin/node-owner only (governance under `/admin-api/groups`,
-        // `/admin-api/alias`, `install-dev-application`, context sub-operations,
-        // `/admin-api/blobs`, usage/network/peers, …). A scoped (non-admin)
-        // token that must reach one of these needs an explicit mapping added
-        // above. `/jsonrpc`, `/ws`, `/sse` and the public `/auth/*` routes are
-        // intentionally outside this namespace and unaffected.
+        // admin/node-owner only. The client-facing route families —
+        // namespaces, group governance, context sub-operations
+        // (identities/join/leave/resync/storage/sync), `/admin-api/blobs`,
+        // `/admin-api/alias`, `/admin-api/identity/context` — are mapped to
+        // scoped permissions above; what remains admin-only is the node
+        // operator surface: `install-dev-application`, `usage`,
+        // `network/status`, `peers`, `/admin-api/tee/*`,
+        // `contexts/invite-specialized-node`, and any future unmapped route.
+        // A scoped (non-admin) token that must reach one of these needs an
+        // explicit mapping added above. `/jsonrpc`, `/ws`, `/sse` and the
+        // public `/auth/*` routes are intentionally outside this namespace
+        // and unaffected.
         if required_permissions.is_empty() && path.starts_with("/admin-api/") {
             required_permissions.push(Permission::Admin(AdminPermission));
         }
@@ -781,15 +1051,16 @@ mod tests {
         let validator = PermissionValidator::new();
 
         for (method, path) in [
-            (Method::GET, "/admin-api/groups/some-group-id"),
-            (Method::POST, "/admin-api/groups"),
-            (Method::PATCH, "/admin-api/groups/some-group-id"),
             (Method::POST, "/admin-api/install-dev-application"),
             (Method::GET, "/admin-api/usage"),
+            (Method::GET, "/admin-api/network/status"),
+            (Method::GET, "/admin-api/peers"),
+            (Method::POST, "/admin-api/contexts/invite-specialized-node"),
             (Method::GET, "/admin-api/totally-unknown-subpath"),
             // Mapped path, unhandled method (the `_ => vec![]` arms):
             (Method::POST, "/admin-api/contexts/ctx-1"),
             (Method::DELETE, "/admin-api/applications"),
+            (Method::POST, "/admin-api/blobs/blob-1"),
         ] {
             let req = Request::builder()
                 .method(method.clone())
@@ -886,5 +1157,113 @@ mod tests {
             validator.determine_required_permissions(&get).as_slice(),
             [Permission::Keys(KeyPermission::GetPermissions(_))]
         ));
+    }
+
+    /// The full grant set a client app token holds (the context trio plus the
+    /// namespace/group/blob/alias umbrellas) must reach every client-facing
+    /// route family, and must still be denied on the node-operator surface.
+    /// This is the post-rc.9 403 regression pin: every route below returned
+    /// 403 for app tokens on rc.9/rc.10 because it fell through to the
+    /// `/admin-api/*` default-deny.
+    #[test]
+    fn client_token_battery_covers_client_facing_routes() {
+        let validator = PermissionValidator::new();
+
+        let token = [
+            "context:create",
+            "context:list",
+            "context:execute",
+            "namespace",
+            "group",
+            "blob",
+            "context:alias",
+        ]
+        .map(str::to_owned)
+        .to_vec();
+
+        for (method, path) in [
+            // Namespaces
+            (Method::GET, "/admin-api/namespaces"),
+            (Method::POST, "/admin-api/namespaces"),
+            (Method::GET, "/admin-api/namespaces/ns-1"),
+            (Method::DELETE, "/admin-api/namespaces/ns-1"),
+            (Method::GET, "/admin-api/namespaces/ns-1/identity"),
+            (Method::GET, "/admin-api/namespaces/ns-1/groups"),
+            (Method::POST, "/admin-api/namespaces/ns-1/groups"),
+            (Method::POST, "/admin-api/namespaces/ns-1/invite"),
+            (Method::POST, "/admin-api/namespaces/ns-1/join"),
+            (Method::POST, "/admin-api/namespaces/ns-1/leave"),
+            (Method::GET, "/admin-api/namespaces/for-application/app-1"),
+            // Group governance
+            (Method::POST, "/admin-api/groups"),
+            (Method::POST, "/admin-api/groups/join"),
+            (Method::GET, "/admin-api/groups/grp-1"),
+            (Method::PATCH, "/admin-api/groups/grp-1"),
+            (Method::DELETE, "/admin-api/groups/grp-1"),
+            (Method::GET, "/admin-api/groups/grp-1/members"),
+            (Method::POST, "/admin-api/groups/grp-1/members"),
+            (Method::PUT, "/admin-api/groups/grp-1/members/id-1/role"),
+            (Method::POST, "/admin-api/groups/grp-1/invite"),
+            (Method::POST, "/admin-api/groups/grp-1/leave"),
+            (Method::GET, "/admin-api/groups/grp-1/contexts"),
+            (Method::PUT, "/admin-api/groups/grp-1/metadata"),
+            // Context sub-operations
+            (Method::GET, "/admin-api/contexts/ctx-1/identities"),
+            (Method::GET, "/admin-api/contexts/ctx-1/identities-owned"),
+            (Method::GET, "/admin-api/contexts/ctx-1/storage"),
+            (Method::GET, "/admin-api/contexts/ctx-1/group"),
+            (Method::POST, "/admin-api/contexts/ctx-1/join"),
+            (Method::POST, "/admin-api/contexts/ctx-1/leave"),
+            (Method::POST, "/admin-api/contexts/ctx-1/resync"),
+            (Method::POST, "/admin-api/contexts/sync"),
+            (Method::POST, "/admin-api/contexts/sync/ctx-1"),
+            // Blobs
+            (Method::PUT, "/admin-api/blobs"),
+            (Method::GET, "/admin-api/blobs"),
+            (Method::GET, "/admin-api/blobs/blob-1"),
+            (Method::DELETE, "/admin-api/blobs/blob-1"),
+            // Aliases
+            (Method::POST, "/admin-api/alias/create/context"),
+            (Method::POST, "/admin-api/alias/lookup/context/foo"),
+            (Method::POST, "/admin-api/alias/delete/identity/ctx-1/foo"),
+            (Method::GET, "/admin-api/alias/list/application"),
+            // Identity + RPC
+            (Method::POST, "/admin-api/identity/context"),
+            (Method::POST, "/jsonrpc"),
+        ] {
+            let req = Request::builder()
+                .method(method.clone())
+                .uri(path)
+                .body(Body::empty())
+                .unwrap();
+            let required = validator.determine_required_permissions(&req);
+            assert!(
+                !required.contains(&Permission::Admin(AdminPermission)),
+                "{method} {path} must not require admin, got {required:?}",
+            );
+            assert!(
+                validator.validate_permissions(&token, &required),
+                "client token must reach {method} {path} (required: {required:?})",
+            );
+        }
+
+        // The node-operator surface stays out of reach.
+        for (method, path) in [
+            (Method::GET, "/admin-api/usage"),
+            (Method::POST, "/admin-api/install-dev-application"),
+            (Method::GET, "/admin/keys"),
+            (Method::PUT, "/admin/keys/key-1/permissions"),
+        ] {
+            let req = Request::builder()
+                .method(method.clone())
+                .uri(path)
+                .body(Body::empty())
+                .unwrap();
+            let required = validator.determine_required_permissions(&req);
+            assert!(
+                !validator.validate_permissions(&token, &required),
+                "client token must NOT reach {method} {path}",
+            );
+        }
     }
 }

--- a/crates/auth/tests/client_token_contract.rs
+++ b/crates/auth/tests/client_token_contract.rs
@@ -30,6 +30,20 @@ use mero_auth::auth::permissions::PermissionValidator;
 /// non-deprecated app mode. auth-frontend forwards these unmodified.
 const MULTI_CONTEXT_PERMISSIONS: &[&str] = &["context:create", "context:list", "context:execute"];
 
+/// The grant set mero-react's companion PR requests once core maps the
+/// client-facing admin-api routes: the context trio plus the
+/// namespace/group/blob/alias umbrellas. Must be kept in lockstep with
+/// `getPermissionsForMode` when that PR lands.
+const MULTI_CONTEXT_PERMISSIONS_NEXT: &[&str] = &[
+    "context:create",
+    "context:list",
+    "context:execute",
+    "namespace",
+    "group",
+    "blob",
+    "context:alias",
+];
+
 /// The routes a multi-context app depends on after login: the mero-react
 /// auth gate used `GET /admin-api/contexts` up to v4.1.0, context
 /// self-service needs list + create, and every RPC goes through `/jsonrpc`.
@@ -126,25 +140,37 @@ fn app_id_scoped_token_is_rejected_on_every_sdk_route() {
     }
 }
 
-/// Known gap (unfixed): the namespace routes — the *recommended* replacement
-/// for direct context creation — have no validator mappings, so the
-/// `/admin-api/*` default-deny makes them admin-only. A multi-context client
-/// token therefore cannot create a namespace, and the official migration
-/// path 403s for every app.
-///
-/// Ignored until core grows namespace permission mappings; run with
-/// `cargo test -p mero-auth --test client_token_contract -- --ignored`
-/// to check whether the gap still exists.
+/// The namespace routes — the *recommended* replacement for direct context
+/// creation — are mapped to `namespace:*` permissions. A client token minted
+/// with the extended grant set (context trio + umbrellas) must be able to
+/// list and create namespaces; the legacy context-only grant set must NOT
+/// (the umbrella grants are opt-in, requested at login).
 #[test]
-#[ignore = "namespace routes are admin-only: no validator mappings yet"]
-fn multi_context_client_token_can_create_namespaces() {
+fn extended_client_token_can_create_namespaces() {
     let validator = PermissionValidator::new();
 
-    let required =
-        validator.determine_required_permissions(&request("POST", "/admin-api/namespaces"));
-    assert!(
-        validator.validate_permissions(&strings(MULTI_CONTEXT_PERMISSIONS), &required),
-        "a multi-context client token must be able to create a namespace \
-         (required: {required:?})",
-    );
+    for (method, path) in [
+        ("GET", "/admin-api/namespaces"),
+        ("POST", "/admin-api/namespaces"),
+    ] {
+        let required = validator.determine_required_permissions(&request(method, path));
+        assert!(
+            validator.validate_permissions(&strings(MULTI_CONTEXT_PERMISSIONS_NEXT), &required),
+            "an extended client token must be able to call {method} {path} \
+             (required: {required:?})",
+        );
+        assert!(
+            !validator.validate_permissions(&strings(MULTI_CONTEXT_PERMISSIONS), &required),
+            "the legacy context-only grant set must not reach {method} {path}",
+        );
+    }
+}
+
+/// The extended grant set must also reach every legacy SDK route — adding
+/// grants can only widen access, never narrow it.
+#[test]
+fn extended_client_token_reaches_every_sdk_route() {
+    let validator = PermissionValidator::new();
+
+    assert_token_reaches(&validator, &strings(MULTI_CONTEXT_PERMISSIONS_NEXT));
 }


### PR DESCRIPTION
cc @chefsale

## What broke

Since 0.11.0-rc.9 the auth guard enforces token permission scopes with default-deny on `/admin-api/*` (#3018 / #3040). The validator (`crates/auth/src/auth/permissions/validator.rs`) only mapped `contexts` (partially), `applications`, `packages`, `keys`, and the legacy blob routes. **Everything else fell through to `Permission::Admin`**, so client app tokens — which hold `context:*` grants — get 403 on route families that all worked on rc.7:

```
WARN permission denied: required=[Admin(AdminPermission)] granted=["context:list","context:create","context:execute"]
```
(example: `POST /admin-api/namespaces`)

## Restored route families (now mapped to scoped permissions)

| Route family | Required permission |
|---|---|
| `GET/POST /admin-api/namespaces`, `/namespaces/:id{,/identity,/groups}`, `/for-application/:app` | `namespace:list` / `namespace:create` |
| `POST /admin-api/namespaces/:id/{invite,join,leave}`, `DELETE /namespaces/:id` | `namespace:manage[<ns>]` |
| `POST /admin-api/namespaces/:id/groups`, `POST /admin-api/groups` | `group:create` |
| `/admin-api/groups/:id/**` (~40 governance routes) | GET → `group:list[<id>]`, mutations → `group:manage[<id>]` |
| `POST /admin-api/groups/join` | `group:manage` |
| `GET /admin-api/contexts/:id/{identities,identities-owned,storage,group}` | `context:list[<ctx>]` |
| `POST /admin-api/contexts/:id/{join,leave,resync}`, `/contexts/sync{,/:id}` | `context:execute` |
| `PUT/GET /admin-api/blobs`, `GET/DELETE /admin-api/blobs/:id` | `blob:add:stream` / `blob:list` / `blob:get` / `blob:remove` |
| `/admin-api/alias/{create,lookup,delete,list}/{context,application,identity}/**` | `context:alias:<verb>:<type>` |
| `POST /admin-api/identity/context` (keypair generation, no resource access) | `context:execute` |
| `GET /admin-api/applications/:id/versions` | `application:list[<app>]` |

## New permission vocabulary

| Grant string | Meaning |
|---|---|
| `namespace` / `namespace:{create,list,manage}[scope]` | new family; bare `namespace` is a true umbrella over all verbs |
| `group` / `group:{create,list,manage}[scope]` | new family; bare `group` is a true umbrella over all verbs |
| `blob:list[scope]`, `blob:get[scope]` | new verbs; existing bare `blob` already covers them |
| `context:alias[scope]` | new umbrella over every alias verb and alias type |

The `namespace`/`group` umbrellas behave like `application` (All covers every verb) — deliberately unlike `context`'s narrow `All`, whose semantics are unchanged.

## What stays admin-only

`install-dev-application`, `usage`, `network/status`, `peers`, `/admin-api/tee/*`, `contexts/invite-specialized-node`, `certificate`, and any future unmapped `/admin-api/*` route (the default-deny is untouched; its doc comment now reflects the new coverage).

## Compat check: do old nodes reject the new grant strings?

**Yes — requesting `"namespace"`/`"group"` breaks client-key minting on rc.10-and-older nodes.** `generate_client_key_handler` validates every requested permission via `root_key.has_permission(&perm)` (`crates/auth/src/api/handlers/client_keys.rs:190`), and `Key::has_permission` (`crates/auth/src/storage/models/keys.rs:112-143`) first parses the string with `Permission::from_str` — an unknown category fails to parse and returns `false` even for admin root keys, so the handler 400s (`"Root key does not have permission: namespace"`). The mero-react companion PR must therefore feature-detect (or retry without the new grants on 400) rather than send them unconditionally.

## Rollout

- mero-react must add the new grants to its request set (companion PR, with the old-node fallback above).
- Should ship in **0.11.0-rc.11**.

## Tests

- Client-token battery: the extended grant set (`context:*` trio + `namespace` + `group` + `blob` + `context:alias`) reaches all 40+ restored routes and is still denied on `usage`, `install-dev-application`, `/admin/keys`, `PUT /admin/keys/:id/permissions`.
- Umbrella/verb satisfaction + round-trip tests for every new permission string.
- Default-deny test rewritten around the still-unmapped operator routes.
- `crates/auth/tests/client_token_contract.rs` now pins the extended grant set (namespace test un-ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)