### PR TITLE
chore: cut release 0.11.0-rc.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.10"
+version = "0.11.0-rc.11"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Bumps the workspace version to **0.11.0-rc.11**.

⚠️ **Stacked on #3201** (client-token admin-api permission coverage) — this branch contains that commit, so merging this PR ships both. Merge #3201 first if you want separate history; either way rc.11 cannot release without the permission fix.

rc.11 is the version where app tokens regain namespaces/groups/blobs/aliases/context-sub-ops access (broken since the rc.9 scope enforcement). Companion client PR: calimero-network/mero-react#42.

Note: with #3199 merged, the release will be created at trigger time by the Prepare job, avoiding the rc.10 tag-creation 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)