### PR TITLE
fix(auth): treat HEAD as GET in permission mapping (blob-info 403 for client tokens)

### DIFF
--- a/crates/auth/src/auth/permissions/validator.rs
+++ b/crates/auth/src/auth/permissions/validator.rs
@@ -528,7 +528,11 @@ impl PermissionValidator {
     pub fn determine_required_permissions(&self, request: &Request<Body>) -> Vec<Permission> {
         let path = request.uri().path();
         let method = match request.method().as_str() {
-            "GET" => HttpMethod::GET,
+            // HEAD is GET-without-body (RFC 9110 §9.3.2): same resource read,
+            // same permission. Without this, HEAD probes on mapped GET routes
+            // (e.g. mero-js getBlobInfo → HEAD /admin-api/blobs/:id) fall into
+            // the /admin-api/* default-deny and 403 for scoped client tokens.
+            "GET" | "HEAD" => HttpMethod::GET,
             "POST" => HttpMethod::POST,
             "PUT" => HttpMethod::PUT,
             "DELETE" => HttpMethod::DELETE,
@@ -882,6 +886,21 @@ mod tests {
     #[test]
     fn test_blob_permissions() {
         let validator = PermissionValidator::new();
+
+        // HEAD is a body-less GET: blob info probes (mero-js getBlobInfo)
+        // must require blob:get, not fall into the admin default-deny.
+        let req = Request::builder()
+            .method(Method::HEAD)
+            .uri("/admin-api/blobs/blob-1")
+            .body(Body::empty())
+            .unwrap();
+        let perms = validator.determine_required_permissions(&req);
+        assert_eq!(perms.len(), 1);
+        assert!(matches!(
+            &perms[0],
+            Permission::Blob(BlobPermission::Get(ResourceScope::Specific(ids)))
+                if ids == &vec!["blob-1".to_string()]
+        ));
 
         // Test stream upload permission
         let req = Request::builder()


### PR DESCRIPTION
Found by mero-react's new live client-token e2e battery (calimero-network/mero-react#42) running against released **rc.11**: `getBlobInfo` (HEAD `/admin-api/blobs/:id`) 403s for client tokens because the validator parses HEAD as `HttpMethod::Any`, which matches no mapping and falls into the `/admin-api/*` default-deny.

Fix: parse `HEAD` as `HttpMethod::GET` — HEAD is a body-less GET (RFC 9110 §9.3.2), same resource read, same permission. Covers this route and any future HEAD probe on mapped GET routes. Test pins `HEAD /admin-api/blobs/:id` → `blob:get[id]`.

mero-react pins the current behavior as a KNOWN GAP e2e test; when this ships in a release, that test flips to `resolves`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)