### PR TITLE
fix(network): per-overlay rendezvous cookies poisoned global discovery, breaking namespace-invite joins

### DIFF
--- a/crates/network/src/discovery/state.rs
+++ b/crates/network/src/discovery/state.rs
@@ -530,6 +530,16 @@ impl DiscoveryState {
             .and_modify(|info| info.update_rendezvous_cookie(cookie.clone()));
     }
 
+    /// Forget the discovery cookie stored for `rendezvous_peer`. Called when
+    /// the server rejects the cookie (`InvalidCookie`) so the next discover
+    /// starts from scratch instead of re-sending the rejected cookie forever.
+    pub(crate) fn clear_rendezvous_cookie(&mut self, rendezvous_peer: &PeerId) {
+        let _ = self
+            .peers
+            .entry(*rendezvous_peer)
+            .and_modify(|info| info.clear_rendezvous_cookie());
+    }
+
     /// Remember that `listener_id` was opened against `relay_peer` as a
     /// relayed listener. The ListenerClosed handler uses this to route
     /// recovery for the quota-denied case where libp2p tears the listener
@@ -947,6 +957,12 @@ impl PeerInfo {
         }
     }
 
+    fn clear_rendezvous_cookie(&mut self) {
+        if let Some(ref mut info) = self.rendezvous {
+            info.clear_cookie();
+        }
+    }
+
     fn update_relay_reservation_status(&mut self, status: RelayReservationStatus) {
         if let Some(ref mut info) = self.relay {
             info.update_reservation_status(status);
@@ -1064,6 +1080,10 @@ impl PeerRendezvousInfo {
     fn update_cookie(&mut self, cookie: Cookie) {
         self.cookie = Some(cookie);
         self.last_discovery_at = Some(Instant::now());
+    }
+
+    fn clear_cookie(&mut self) {
+        self.cookie = None;
     }
 
     pub(crate) const fn registration_status(&self) -> RendezvousRegistrationStatus {

--- a/crates/network/src/discovery/state_tests.rs
+++ b/crates/network/src/discovery/state_tests.rs
@@ -1627,3 +1627,31 @@ fn reachability_reachable_to_unreachable_when_last_address_removed() {
     assert!(gone.disable_autonat_server);
     assert!(gone.has_actions());
 }
+
+#[test]
+fn test_clear_rendezvous_cookie_forgets_rejected_cookie() {
+    let mut state = DiscoveryState::default();
+    let peer_id = PeerId::random();
+    let cookie = Cookie::for_namespace(Namespace::from_static("test"));
+
+    state.update_peer_protocols(&peer_id, &[RENDEZVOUS_PROTOCOL_NAME]);
+    state.update_rendezvous_cookie(&peer_id, &cookie);
+    assert_eq!(
+        state.peers[&peer_id].rendezvous.as_ref().unwrap().cookie(),
+        Some(&cookie)
+    );
+
+    // Server rejected the cookie (InvalidCookie) → the handler clears it so
+    // the next discover starts cookie-less instead of re-sending the
+    // rejected cookie forever.
+    state.clear_rendezvous_cookie(&peer_id);
+    assert_eq!(
+        state.peers[&peer_id].rendezvous.as_ref().unwrap().cookie(),
+        None
+    );
+
+    // Clearing for an unknown peer is a no-op, not a panic or an insertion.
+    let unknown = PeerId::random();
+    state.clear_rendezvous_cookie(&unknown);
+    assert!(!state.peers.contains_key(&unknown));
+}

--- a/crates/network/src/handlers/stream/swarm/rendezvous.rs
+++ b/crates/network/src/handlers/stream/swarm/rendezvous.rs
@@ -1,11 +1,28 @@
 use libp2p::rendezvous::client::Event;
-use libp2p::rendezvous::ErrorCode;
+use libp2p::rendezvous::{Cookie, ErrorCode, Namespace};
 use libp2p::swarm::dial_opts::{DialOpts, PeerCondition};
 use owo_colors::OwoColorize;
 use tracing::{debug, error, warn};
 
 use super::{EventHandler, NetworkManager};
 use crate::discovery::state::{PeerDiscoveryMechanism, RendezvousRegistrationStatus};
+
+/// May `cookie` occupy the per-peer cookie slot that the next *global*
+/// discover sends for incremental results?
+///
+/// `rendezvous_discover` sends one global discover (WITH the stored
+/// cookie) plus per-overlay discovers (deliberately cookie-less). Cookies
+/// are bound to the namespace they were issued for, and the server
+/// rejects a discover whose cookie was issued for a different namespace
+/// (`CookieNamespaceMismatch` → `InvalidCookie`). So only a cookie issued
+/// for the global namespace may be stored: storing whichever cookie
+/// arrived last let a per-overlay response poison the slot, after which
+/// every global discover — the only discovery path a namespace-join has,
+/// since the joiner is not a member of any shared overlay yet — failed
+/// with `InvalidCookie` until the node restarted.
+fn is_global_discovery_cookie(cookie: &Cookie, global_namespace: &Namespace) -> bool {
+    cookie.namespace() == Some(global_namespace)
+}
 
 impl EventHandler<Event> for NetworkManager {
     fn handle(&mut self, event: Event) {
@@ -17,20 +34,10 @@ impl EventHandler<Event> for NetworkManager {
                 registrations,
                 cookie,
             } => {
-                // Only remember cookies issued for the global discovery
-                // namespace. `rendezvous_discover` sends one global discover
-                // (WITH this stored cookie, for incremental results) plus
-                // per-overlay discovers (deliberately cookie-less). Cookies
-                // are bound to the namespace they were issued for, and the
-                // server rejects a discover whose cookie was issued for a
-                // different namespace (`CookieNamespaceMismatch` →
-                // `InvalidCookie`). Unconditionally storing whichever cookie
-                // arrived last let a per-overlay response poison the slot,
-                // after which every global discover — the only discovery
-                // path a namespace-join has, since the joiner is not a
-                // member of any shared overlay yet — failed with
-                // `InvalidCookie` until the node restarted.
-                if cookie.namespace() == Some(&self.discovery.rendezvous_config.namespace) {
+                // See `is_global_discovery_cookie`: only a global-namespace
+                // cookie may occupy the slot the next global discover sends.
+                if is_global_discovery_cookie(&cookie, &self.discovery.rendezvous_config.namespace)
+                {
                     self.discovery
                         .state
                         .update_rendezvous_cookie(&rendezvous_node, &cookie);
@@ -187,5 +194,45 @@ impl EventHandler<Event> for NetworkManager {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn global() -> Namespace {
+        Namespace::from_static("/calimero/devnet/global")
+    }
+
+    #[test]
+    fn global_namespace_cookie_is_stored() {
+        let cookie = Cookie::for_namespace(global());
+        assert!(is_global_discovery_cookie(&cookie, &global()));
+    }
+
+    #[test]
+    fn per_overlay_cookie_must_not_poison_the_global_slot() {
+        // The production failure: a per-overlay discover response
+        // (`/calimero/ns/<hex>` etc.) returned a cookie, it was stored,
+        // and the next global discover sent it — which the server
+        // rejects with InvalidCookie, forever, because nothing cleared
+        // it. Namespace-invite joins (which can only find members via
+        // the global discover) failed with an opaque 500/HTTP 0 until
+        // the node was restarted.
+        let overlay = Namespace::new(format!("/calimero/ns/{}", hex::encode([0x11; 32]))).unwrap();
+        let cookie = Cookie::for_namespace(overlay);
+        assert!(!is_global_discovery_cookie(&cookie, &global()));
+    }
+
+    #[test]
+    fn namespace_less_cookie_is_not_stored_either() {
+        // We never issue discover-all requests, so a namespace-less
+        // cookie can't pair with our global discover — keep it out of
+        // the slot (the server rejects (Some(ns), None-namespace-cookie)
+        // combinations only in the inverse case, but a cookie we never
+        // produced has no business being replayed).
+        let cookie = Cookie::for_all_namespaces();
+        assert!(!is_global_discovery_cookie(&cookie, &global()));
     }
 }

--- a/crates/network/src/handlers/stream/swarm/rendezvous.rs
+++ b/crates/network/src/handlers/stream/swarm/rendezvous.rs
@@ -1,4 +1,5 @@
 use libp2p::rendezvous::client::Event;
+use libp2p::rendezvous::ErrorCode;
 use libp2p::swarm::dial_opts::{DialOpts, PeerCondition};
 use owo_colors::OwoColorize;
 use tracing::{debug, error, warn};
@@ -16,9 +17,24 @@ impl EventHandler<Event> for NetworkManager {
                 registrations,
                 cookie,
             } => {
-                self.discovery
-                    .state
-                    .update_rendezvous_cookie(&rendezvous_node, &cookie);
+                // Only remember cookies issued for the global discovery
+                // namespace. `rendezvous_discover` sends one global discover
+                // (WITH this stored cookie, for incremental results) plus
+                // per-overlay discovers (deliberately cookie-less). Cookies
+                // are bound to the namespace they were issued for, and the
+                // server rejects a discover whose cookie was issued for a
+                // different namespace (`CookieNamespaceMismatch` →
+                // `InvalidCookie`). Unconditionally storing whichever cookie
+                // arrived last let a per-overlay response poison the slot,
+                // after which every global discover — the only discovery
+                // path a namespace-join has, since the joiner is not a
+                // member of any shared overlay yet — failed with
+                // `InvalidCookie` until the node restarted.
+                if cookie.namespace() == Some(&self.discovery.rendezvous_config.namespace) {
+                    self.discovery
+                        .state
+                        .update_rendezvous_cookie(&rendezvous_node, &cookie);
+                }
 
                 for registration in registrations {
                     let peer_id = registration.record.peer_id();
@@ -123,6 +139,24 @@ impl EventHandler<Event> for NetworkManager {
                 error,
             } => {
                 warn!(?rendezvous_node, ?namespace, error_code=?error, "Rendezvous discovery failed");
+
+                // A rejected cookie never heals on its own: the server
+                // rejects the same stale/mismatched cookie on every retry
+                // (server restarts invalidate cookies too). Drop it and
+                // immediately re-discover from scratch. A cookie-less
+                // discover cannot be rejected for cookie reasons, so this
+                // cannot loop.
+                if error == ErrorCode::InvalidCookie {
+                    self.discovery
+                        .state
+                        .clear_rendezvous_cookie(&rendezvous_node);
+                    if let Err(err) = self.rendezvous_discover(&rendezvous_node, true) {
+                        error!(
+                            %err,
+                            "Failed to re-run rendezvous discovery after clearing rejected cookie"
+                        );
+                    }
+                }
             }
             Event::RegisterFailed {
                 rendezvous_node,

--- a/crates/network/tests/rendezvous_namespace.rs
+++ b/crates/network/tests/rendezvous_namespace.rs
@@ -371,3 +371,193 @@ async fn client_discovered_under_global_and_per_namespace_keys_additive() {
         "A must be discoverable under per-namespace key"
     );
 }
+
+/// Regression pin for the cookie-poisoning failure behind broken
+/// namespace-invite joins: replaying a cookie issued for a *per-overlay*
+/// discover on the *global* discover is rejected by the server with
+/// `InvalidCookie` — and a cookie-less global discover afterwards
+/// succeeds.
+///
+/// The production client stored whichever cookie arrived last into the
+/// single per-peer slot, so a per-overlay response poisoned the next
+/// global discover; nothing cleared the rejected cookie, so global
+/// discovery (the only path a namespace-join has to find members of a
+/// namespace the joiner isn't in yet) stayed dead until restart. The
+/// handler-side rules are unit-tested next to the handler
+/// (`is_global_discovery_cookie`, clear-on-`InvalidCookie`); this test
+/// pins the server-side contract those rules exist for, so a future
+/// "simplification" that reintroduces cross-namespace cookie reuse fails
+/// CI instead of shipping.
+#[tokio::test]
+async fn cross_namespace_cookie_is_rejected_and_cookieless_discover_recovers() {
+    use libp2p::rendezvous::ErrorCode;
+
+    let port_a = {
+        let l = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let p = l.local_addr().unwrap().port();
+        drop(l);
+        p
+    };
+    let port_b = {
+        let l = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let p = l.local_addr().unwrap().port();
+        drop(l);
+        p
+    };
+
+    let (mut server, server_peer, server_addr) = build_server().await;
+    let mut a = build_client(format!("/ip4/127.0.0.1/tcp/{port_a}").parse().unwrap()).await;
+    let mut b = build_client(format!("/ip4/127.0.0.1/tcp/{port_b}").parse().unwrap()).await;
+    let peer_a = *a.local_peer_id();
+
+    let global_ns = Namespace::from_static("/calimero/devnet/global");
+    let per_ns = ns(0x44); // the overlay key whose cookie poisons the slot
+
+    a.dial(server_addr.clone()).expect("A dial server");
+    b.dial(server_addr.clone()).expect("B dial server");
+
+    // Phase machine mirroring the production sequence:
+    // RegisterGlobal/RegisterPerNs: A registers under both keys.
+    // DiscoverPerNs: B discovers the overlay key → captures its cookie.
+    // PoisonedGlobal: B replays that cookie on a GLOBAL discover →
+    //   must fail with InvalidCookie (the bug's mechanism).
+    // RecoveryGlobal: B re-discovers global cookie-less → must find A
+    //   (what the clear-on-InvalidCookie handler now guarantees).
+    #[derive(Debug, PartialEq)]
+    enum Phase {
+        RegisterGlobal,
+        RegisterPerNs,
+        DiscoverPerNs,
+        PoisonedGlobal,
+        RecoveryGlobal,
+    }
+    let mut phase = Phase::RegisterGlobal;
+    let mut a_connected = false;
+    let mut b_connected = false;
+    let mut a_global_sent = false;
+    let mut a_per_ns_sent = false;
+    let mut saw_invalid_cookie = false;
+
+    let outcome = timeout(Duration::from_secs(45), async {
+        loop {
+            tokio::select! {
+                ev = server.next() => { let _ = ev; }
+                ev = a.next() => {
+                    if let Some(SwarmEvent::ConnectionEstablished { peer_id, .. }) = ev {
+                        if peer_id == server_peer { a_connected = true; }
+                    }
+                    if let Some(SwarmEvent::Behaviour(BehaviourEvent::Rendezvous(
+                        RzClientEvent::Registered { .. },
+                    ))) = ev
+                    {
+                        match phase {
+                            Phase::RegisterGlobal => phase = Phase::RegisterPerNs,
+                            Phase::RegisterPerNs => {
+                                if b_connected {
+                                    b.behaviour_mut().rendezvous.discover(
+                                        Some(per_ns.clone()),
+                                        None,
+                                        None,
+                                        server_peer,
+                                    );
+                                    phase = Phase::DiscoverPerNs;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                ev = b.next() => {
+                    if let Some(SwarmEvent::ConnectionEstablished { peer_id, .. }) = ev {
+                        if peer_id == server_peer { b_connected = true; }
+                    }
+                    match ev {
+                        Some(SwarmEvent::Behaviour(BehaviourEvent::Rendezvous(
+                            RzClientEvent::Discovered { registrations, cookie, .. },
+                        ))) => {
+                            let found_a = registrations
+                                .iter()
+                                .any(|r| r.record.peer_id() == peer_a);
+                            match phase {
+                                Phase::DiscoverPerNs => {
+                                    assert!(
+                                        found_a,
+                                        "sanity: A must be discoverable under its overlay key"
+                                    );
+                                    // THE BUG'S MECHANISM: replay the
+                                    // per-overlay cookie on a global discover.
+                                    b.behaviour_mut().rendezvous.discover(
+                                        Some(global_ns.clone()),
+                                        Some(cookie),
+                                        None,
+                                        server_peer,
+                                    );
+                                    phase = Phase::PoisonedGlobal;
+                                }
+                                Phase::PoisonedGlobal => {
+                                    panic!(
+                                        "server accepted a per-overlay cookie on a global \
+                                         discover — the cookie-namespace contract changed; \
+                                         re-evaluate is_global_discovery_cookie"
+                                    );
+                                }
+                                Phase::RecoveryGlobal => {
+                                    if found_a {
+                                        return; // recovered: global discovery works again
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                        Some(SwarmEvent::Behaviour(BehaviourEvent::Rendezvous(
+                            RzClientEvent::DiscoverFailed { error, .. },
+                        ))) => {
+                            assert_eq!(
+                                phase, Phase::PoisonedGlobal,
+                                "only the poisoned global discover may fail"
+                            );
+                            assert_eq!(error, ErrorCode::InvalidCookie);
+                            saw_invalid_cookie = true;
+                            // What clear-on-InvalidCookie now does: retry
+                            // the global discover WITHOUT a cookie.
+                            b.behaviour_mut().rendezvous.discover(
+                                Some(global_ns.clone()),
+                                None,
+                                None,
+                                server_peer,
+                            );
+                            phase = Phase::RecoveryGlobal;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            if a_connected {
+                if !a_global_sent {
+                    a.behaviour_mut()
+                        .rendezvous
+                        .register(global_ns.clone(), server_peer, None)
+                        .expect("A register under global");
+                    a_global_sent = true;
+                } else if !a_per_ns_sent && phase == Phase::RegisterPerNs {
+                    a.behaviour_mut()
+                        .rendezvous
+                        .register(per_ns.clone(), server_peer, None)
+                        .expect("A register under per-namespace");
+                    a_per_ns_sent = true;
+                }
+            }
+        }
+    })
+    .await;
+
+    outcome.expect(
+        "sequence did not complete: per-overlay cookie replayed on global discover must be \
+         rejected with InvalidCookie, and a cookie-less global discover must then find A",
+    );
+    assert!(
+        saw_invalid_cookie,
+        "the poisoned global discover must have failed"
+    );
+}

--- a/crates/server/src/admin/handlers/namespaces/join_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/join_namespace.rs
@@ -43,7 +43,27 @@ pub async fn handler(
             group_name: req.group_name,
         })
         .await
-        .map_err(parse_api_error);
+        .map_err(|err| {
+            // The failure users actually hit here is peer discovery: the
+            // joiner holds a valid invitation but cannot open a stream to
+            // any current member within the discovery deadline (see
+            // node/src/sync/manager/namespace_join.rs). parse_api_error
+            // deliberately masks untyped reports as a bare 500, which the
+            // client then can't distinguish from a real internal fault —
+            // so type this one as a retryable 504 with an actionable
+            // message before falling through.
+            if format!("{err:?}").contains("namespace-join stream") {
+                ApiError {
+                    status_code: StatusCode::GATEWAY_TIMEOUT,
+                    message: "could not reach any member of this namespace to \
+                              complete the join; make sure the inviting node is \
+                              online and retry"
+                        .into(),
+                }
+            } else {
+                parse_api_error(err)
+            }
+        });
 
     match result {
         Ok(resp) => {


### PR DESCRIPTION
## Why this PR exists

Namespace invitations were failing in production between two internet-separated nodes (laptops in Spain and Croatia, testing mero-meet). The desktop app showed only **HTTP 0** — no status, no body. Accepting the same invite eventually worked after several retries, which made it look flaky rather than broken.

## What the logs showed

On the joining node, every `POST /admin-api/namespaces/:id/join` spun for the full discovery deadline and died at `namespace_join.rs:224`:

```
could not open a namespace-join stream to any mesh peer for namespace fb19e206… (deadline 45000ms, elapsed 44095ms, excluded 0)
```

Meanwhile, from ~100 seconds after node startup until shutdown (2h45m, 137 occurrences, every ~15s, zero recoveries):

```
WARN Rendezvous discovery failed rendezvous_node=… namespace=Some(Namespace("/calimero/devnet/global")) error_code=InvalidCookie
```

## Root cause — cookie poisoning

`rendezvous_discover()` sends **two kinds** of discover requests per tick:

1. a **global** discover (`/calimero/devnet/global`) that carries the stored per-peer cookie for incremental results, and
2. **per-overlay** discovers (one per under-connected namespace/group key) that deliberately pass `cookie=None`.

The `Discovered` event handler stored **whichever cookie arrived** into the single per-peer cookie slot. But rendezvous cookies are **bound to the namespace they were issued for**: `libp2p-rendezvous` server rejects a discover whose cookie namespace doesn't match the discover namespace (`CookieNamespaceMismatch` → `ErrorCode::InvalidCookie`, see `libp2p-rendezvous-0.17.1/src/server.rs:492-498`).

So the failure loop was:

1. A per-overlay response lands → its overlay-namespace cookie overwrites the global cookie.
2. The next global discover sends that cookie → server replies `InvalidCookie`.
3. The `DiscoverFailed` handler only logged a warning — the poisoned cookie was **never cleared**, and per-overlay responses kept re-poisoning it.
4. Global discovery stays dead for the lifetime of the process.

Namespace-join is the one flow with **no fallback**: the joiner isn't a member of the namespace yet, so per-overlay discovery, gossipsub topics and the context mesh can't find the inviter — the global discover is the only door (the comment in `rendezvous_discover` says exactly this). With it dead, `join_namespace` burns its whole deadline and 500s.

### Why it looked like it "worked before" (rc.9 / rc.10)

This code is unchanged since #2514 — it is a race, not a version regression. Poisoning only starts once the node has under-connected overlay keys firing per-overlay discovers; fresh test nodes with few namespaces rarely hit it, while long-lived production nodes carrying many namespaces/groups hit it within the first ~2 minutes, every boot. Retries eventually "worked" only when the two nodes got connected through an unrelated door (shared-context sync via the persistent peer cache) — at that point the join stream opened over the existing connection.

### Why the client saw HTTP 0

The admin handler holds the HTTP request for the full 45s discovery deadline, then returns a **bare 500** — `parse_api_error` deliberately masks untyped reports ("Internal server error"), and the desktop client times out before that anyway → HTTP 0 with nothing to debug from.

## The fix

1. **Stop the poisoning** (`handlers/stream/swarm/rendezvous.rs`): only store a cookie when it was issued for the global namespace (`cookie.namespace() == rendezvous_config.namespace`). Per-overlay discovers never use the stored cookie, so dropping their cookies loses nothing — overlay result sets are small and fully re-polled by design.
2. **Self-heal if a cookie is ever rejected anyway** (server restarts also invalidate cookies): on `DiscoverFailed(InvalidCookie)`, clear the stored cookie (`clear_rendezvous_cookie`, new in `discovery/state.rs`) and force an immediate cookie-less re-discover. This cannot loop: a cookie-less discover has no cookie to reject.
3. **Surface the real failure** (`admin/handlers/namespaces/join_namespace.rs`): map the "could not open a namespace-join stream to any mesh peer" report to a typed **504** with an actionable message ("could not reach any member of this namespace… make sure the inviting node is online and retry") instead of the masked generic 500.

## What was tried / considered and rejected

- **Clearing the cookie on failure alone** (fix 2 without fix 1) — insufficient: the very next per-overlay response re-poisons the slot, so global discovery would still fail on most ticks.
- **Storing cookies per-namespace** — unnecessary complexity: only the global discover uses incremental cookies; per-overlay discovers intentionally do a full poll each time.
- **Typed error across the node→server boundary for fix 3** — the report crosses actor/client layers where a downcast isn't reliable; matching the fixed message string from our own repo is the pragmatic option and is scoped to one handler.

## Verification

- New regression test `test_clear_rendezvous_cookie_forgets_rejected_cookie` (store → clear → gone; clearing for an unknown peer is a no-op).
- `cargo test -p calimero-network`: 103 + 9 integration tests pass; `cargo test -p calimero-server`: 49 pass; clippy clean on both crates.
- Field evidence in the production log matches every link of the chain above (timestamps and counts in the PR discussion if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
