### PR TITLE
chore: cut release 0.11.0-rc.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.11"
+version = "0.11.0-rc.12"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Cuts **0.11.0-rc.12**.

**Do not merge yet** — held open until #3204 (rendezvous cookie poisoning fix for namespace-invite joins) lands so rc.12 ships with it. Merging this tags the release per docs/RELEASE.md.

Depends on: #3204

🤖 Generated with [Claude Code](https://claude.com/claude-code)