### PR TITLE
fix(network): register newly-subscribed overlays with rendezvous, unblocking namespace-invite joins

### DIFF
--- a/crates/network/src/discovery.rs
+++ b/crates/network/src/discovery.rs
@@ -568,6 +568,99 @@ impl NetworkManager {
         Ok(())
     }
 
+    /// Eagerly register a newly-subscribed overlay topic with every
+    /// rendezvous peer that already holds (or is awaiting) a registration.
+    ///
+    /// `rendezvous_register` snapshots the subscribed-topic set at call
+    /// time, so an overlay subscribed *after* the last registration round
+    /// is invisible on the rendezvous server until an unrelated trigger
+    /// re-registers — TTL expiry (hours), a reachability flip, or a
+    /// restart. During that window a peer joining the namespace discovers
+    /// zero registrations under `/calimero/ns/<hex>` and the join stalls
+    /// on "No namespace mesh peer discovered yet" until it gives up.
+    /// Registering the key at subscribe time closes the window.
+    ///
+    /// Deliberately bypasses `is_rendezvous_registration_required`: that
+    /// gate bounds fan-out across rendezvous *peers*; here we only add a
+    /// key to registrations that already occupy a slot.
+    pub(crate) fn register_new_overlay_topic(&mut self, topic: &str) {
+        if self.discovery.reserved_topics.contains(topic) {
+            return;
+        }
+        let Some(key) = rendezvous_key_for_topic(topic) else {
+            return;
+        };
+
+        for peer_id in self.discovery.state.slot_holding_rendezvous_peers() {
+            if !self.swarm.is_connected(&peer_id) {
+                continue;
+            }
+            match self
+                .swarm
+                .behaviour_mut()
+                .rendezvous
+                .register(key.clone(), peer_id, None)
+            {
+                Ok(()) => {
+                    debug!(
+                        %peer_id,
+                        rendezvous_namespace = %key,
+                        "Registered newly-subscribed overlay with rendezvous"
+                    );
+                }
+                Err(RegisterError::NoExternalAddresses) => {
+                    // Nothing to advertise yet. The next
+                    // ExternalAddrConfirmed triggers a full re-register,
+                    // which enumerates subscribed topics at send time and
+                    // will carry this key.
+                    trace!(
+                        %peer_id,
+                        rendezvous_namespace = %key,
+                        "No external addresses; overlay key rides the next full registration"
+                    );
+                }
+                Err(err @ RegisterError::FailedToMakeRecord(_)) => {
+                    error!(
+                        %err,
+                        %peer_id,
+                        rendezvous_namespace = %key,
+                        "Failed to register newly-subscribed overlay with rendezvous"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Mirror of [`Self::register_new_overlay_topic`] for unsubscribe:
+    /// drop the per-overlay key from every slot-holding rendezvous peer so
+    /// departed members stop being discovered under it. Without this the
+    /// stale record lingers until its TTL, steering joiners toward a node
+    /// that no longer follows the overlay. Unregistering a key we never
+    /// registered is a harmless server-side no-op.
+    pub(crate) fn unregister_dropped_overlay_topic(&mut self, topic: &str) {
+        if self.discovery.reserved_topics.contains(topic) {
+            return;
+        }
+        let Some(key) = rendezvous_key_for_topic(topic) else {
+            return;
+        };
+
+        for peer_id in self.discovery.state.slot_holding_rendezvous_peers() {
+            if !self.swarm.is_connected(&peer_id) {
+                continue;
+            }
+            self.swarm
+                .behaviour_mut()
+                .rendezvous
+                .unregister(key.clone(), peer_id);
+            debug!(
+                %peer_id,
+                rendezvous_namespace = %key,
+                "Unregistered dropped overlay from rendezvous"
+            );
+        }
+    }
+
     // Requests relay reservation on relay peer if one is required.
     // This function expectes that the relay peer is already connected.
     pub(crate) fn create_relay_reservation(&mut self, relay_peer: &PeerId) -> EyreResult<()> {

--- a/crates/network/src/discovery/state.rs
+++ b/crates/network/src/discovery/state.rs
@@ -690,6 +690,35 @@ impl DiscoveryState {
         self.rendezvous_index.iter().copied()
     }
 
+    /// Rendezvous peers currently holding (or awaiting confirmation of) a
+    /// server-side registration — status `Requested` or `Registered`.
+    ///
+    /// These are the peers whose registrations must be *extended* when the
+    /// node subscribes a new overlay topic: `rendezvous_register` snapshots
+    /// the subscribed-topic set at call time, and its fan-out gate
+    /// ([`Self::is_rendezvous_registration_required`]) skips peers in these
+    /// two states, so a key subscribed afterwards stays unknown to the
+    /// server until an unrelated trigger re-registers (TTL expiry — hours —
+    /// a reachability flip, or a restart). Idle peers (`Discovered`,
+    /// `Pending`, `Expired`) are deliberately excluded: their next full
+    /// registration re-enumerates the subscribed topics and picks the new
+    /// key up on its own.
+    pub(crate) fn slot_holding_rendezvous_peers(&self) -> Vec<PeerId> {
+        self.get_rendezvous_peer_ids()
+            .filter(|peer_id| {
+                self.get_peer_info(peer_id)
+                    .and_then(PeerInfo::rendezvous)
+                    .is_some_and(|info| {
+                        matches!(
+                            info.registration_status(),
+                            RendezvousRegistrationStatus::Requested
+                                | RendezvousRegistrationStatus::Registered
+                        )
+                    })
+            })
+            .collect()
+    }
+
     pub(crate) fn get_relay_peer_ids(&self) -> impl Iterator<Item = PeerId> + '_ {
         self.relay_index.iter().copied()
     }

--- a/crates/network/src/discovery/state_tests.rs
+++ b/crates/network/src/discovery/state_tests.rs
@@ -1655,3 +1655,74 @@ fn test_clear_rendezvous_cookie_forgets_rejected_cookie() {
     state.clear_rendezvous_cookie(&unknown);
     assert!(!state.peers.contains_key(&unknown));
 }
+
+// ---------------------------------------------------------------------------
+// slot_holding_rendezvous_peers — the eager-registration target set for
+// overlays subscribed after the last full registration round
+// ---------------------------------------------------------------------------
+
+#[test]
+fn slot_holding_peers_are_requested_and_registered_only() {
+    let mut state = DiscoveryState::default();
+
+    let registered = PeerId::random();
+    let requested = PeerId::random();
+    let discovered = PeerId::random();
+    let pending = PeerId::random();
+    let expired = PeerId::random();
+
+    for peer in [&registered, &requested, &discovered, &pending, &expired] {
+        state.update_peer_protocols(peer, &[RENDEZVOUS_PROTOCOL_NAME]);
+    }
+
+    state.update_rendezvous_registration_status(
+        &registered,
+        RendezvousRegistrationStatus::Registered,
+    );
+    state
+        .update_rendezvous_registration_status(&requested, RendezvousRegistrationStatus::Requested);
+    state.update_rendezvous_registration_status(
+        &discovered,
+        RendezvousRegistrationStatus::Discovered,
+    );
+    state.update_rendezvous_registration_status(&pending, RendezvousRegistrationStatus::Pending);
+    state.update_rendezvous_registration_status(&expired, RendezvousRegistrationStatus::Expired);
+
+    let slot_holding = state.slot_holding_rendezvous_peers();
+
+    assert!(
+        slot_holding.contains(&registered),
+        "a Registered peer holds a live server-side record that must be extended"
+    );
+    assert!(
+        slot_holding.contains(&requested),
+        "a Requested peer has a register in flight; the new key must follow it"
+    );
+    for (peer, status) in [
+        (&discovered, "Discovered"),
+        (&pending, "Pending"),
+        (&expired, "Expired"),
+    ] {
+        assert!(
+            !slot_holding.contains(peer),
+            "{status} peers re-enumerate topics on their next full registration; \
+             eagerly registering with them would duplicate that"
+        );
+    }
+}
+
+#[test]
+fn slot_holding_peers_excludes_non_rendezvous_peers() {
+    let mut state = DiscoveryState::default();
+
+    // A regular peer (no rendezvous protocol) never appears, even though
+    // the peer map knows it.
+    let regular = PeerId::random();
+    state.update_peer_protocols(&regular, &[]);
+
+    // A rendezvous peer we merely discovered doesn't either.
+    let idle_rendezvous = PeerId::random();
+    state.update_peer_protocols(&idle_rendezvous, &[RENDEZVOUS_PROTOCOL_NAME]);
+
+    assert!(state.slot_holding_rendezvous_peers().is_empty());
+}

--- a/crates/network/src/handlers/commands/subscribe.rs
+++ b/crates/network/src/handlers/commands/subscribe.rs
@@ -7,7 +7,17 @@ impl Handler<Subscribe> for NetworkManager {
     type Result = <Subscribe as Message>::Result;
 
     fn handle(&mut self, Subscribe(topic): Subscribe, _ctx: &mut Context<Self>) -> Self::Result {
-        let _ignored = self.swarm.behaviour_mut().gossipsub.subscribe(&topic)?;
+        let newly_subscribed = self.swarm.behaviour_mut().gossipsub.subscribe(&topic)?;
+
+        // A topic subscribed after the last rendezvous registration round
+        // is invisible on the server until something unrelated re-registers
+        // (TTL expiry, reachability flip, restart) — so peers joining this
+        // overlay would discover nobody under its key. Extend our existing
+        // registrations with the new key right away.
+        if newly_subscribed {
+            self.register_new_overlay_topic(topic.hash().as_str());
+        }
+
         Ok(topic)
     }
 }

--- a/crates/network/src/handlers/commands/unsubscribe.rs
+++ b/crates/network/src/handlers/commands/unsubscribe.rs
@@ -11,7 +11,15 @@ impl Handler<Unsubscribe> for NetworkManager {
         Unsubscribe(topic): Unsubscribe,
         _ctx: &mut Context<Self>,
     ) -> Self::Result {
-        let _ignored = self.swarm.behaviour_mut().gossipsub.unsubscribe(&topic);
+        let was_subscribed = self.swarm.behaviour_mut().gossipsub.unsubscribe(&topic);
+
+        // Mirror of the subscribe path: drop our per-overlay rendezvous key
+        // so joiners stop being steered toward a node that no longer
+        // follows this overlay (the record would otherwise linger until
+        // its TTL).
+        if was_subscribed {
+            self.unregister_dropped_overlay_topic(topic.hash().as_str());
+        }
 
         Ok(topic)
     }


### PR DESCRIPTION
## Problem

Namespace-invite joins still fail on rc.12 even with the cookie-poisoning fix (#3204) in place. Live repro today (desktop rc.12 inviter + rc.12 joiner over the devnet rendezvous):

1. **13:05:08Z** — inviter registers with the rendezvous server. `rendezvous_register` derives its key set from the gossipsub topics subscribed *at that moment*, so it registers the global key only.
2. **13:05:59Z** — namespace is created; the node subscribes `ns/001fa806…`. The `Subscribe` handler only calls `gossipsub.subscribe()` — nothing tells the rendezvous server.
3. **13:06–13:08Z** — joiner discovers `/calimero/ns/001fa806…` and the server answers `registrations: []`. The join loops on `No namespace mesh peer discovered yet` until it gives up.

Nothing re-registers until an unrelated trigger: registration TTL expiry (7200s), a reachability transition, or a restart. Calling `rendezvous_register` after subscribe wouldn't help either — its `is_rendezvous_registration_required` gate early-returns once the node already holds `registrations_limit` registrations. This is exactly why the field mitigation "restart the inviter, then accept the invite quickly" works: after a restart the persisted topics are subscribed *before* the first registration.

## Fix

Extend live registrations at subscribe time:

- `DiscoveryState::slot_holding_rendezvous_peers()` — rendezvous peers whose registration is `Requested`/`Registered` (the ones whose server-side record must be extended; idle peers re-enumerate topics on their own next full registration).
- `NetworkManager::register_new_overlay_topic()` — on a **newly** subscribed, non-reserved overlay topic, send the per-overlay key (`/calimero/ns/…`, `/calimero/grp/…`, `/calimero/ctx/…`) to every connected slot-holding peer. Deliberately bypasses the peer-count gate — that gate bounds fan-out across rendezvous *peers*, not keys. `NoExternalAddresses` is left to the pending `ExternalAddrConfirmed`-driven full register, which enumerates topics at send time and picks the key up.
- Unsubscribe mirrors it (`unregister_dropped_overlay_topic`), so departed members stop steering joiners toward a node that no longer follows the overlay instead of lingering until TTL.

The late `Registered` confirmation for an already-`Registered` peer is dropped by the existing status check in the rendezvous event handler — status tracking is unaffected; the server-side record is what matters.

## Testing

- New unit tests for `slot_holding_rendezvous_peers` (status filtering, non-rendezvous exclusion).
- `cargo test -p calimero-network` — 118 tests green, including the real-server integration suite (`tests/rendezvous_namespace.rs`), whose additive global+per-ns registration test pins the server-side contract this relies on.
- Clippy clean.

The NetworkManager-level end-to-end path (Subscribe command → key visible on a live server) can be pinned in CI once the manager-discovery e2e harness (`test/manager-discovery-e2e`) lands — happy to add that test on top of it.

## Impact

Fixes the remaining namespace-invite join failure: any namespace/group/context created after the node's last registration round was undiscoverable by joiners for up to 2 hours.

Note for reviewers: today's repro also surfaced an unrelated infra issue — the devnet relay (63.181.86.34) rejects circuits with "resource limit exceeded" and advertises its private LAN IP (10.0.8.121) in circuit addresses, which breaks the global-discovery fallback path independently of this fix. Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)