### PR TITLE
chore: cut release 0.11.0-rc.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.12"
+version = "0.11.0-rc.13"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Bumps the shared crate version to 0.11.0-rc.13.

Picks up since rc.12:
- #3211 — eager per-overlay rendezvous re-registration for topics subscribed after the last registration round
- #3210 — NetworkManager discovery loop e2e coverage in CI
- #3184 — stop re-transforming static assets on every request (+ deadlock fix from review)
- crossbeam-epoch 0.9.20 bump (RUSTSEC-2026-0204)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata version field change with no runtime or security logic in the diff.
> 
> **Overview**
> Cuts **0.11.0-rc.13** by updating the shared `workspace.metadata.workspaces` version in `Cargo.toml` from **0.11.0-rc.12** to **0.11.0-rc.13**, so public crates align on the new release tag per the cargo-workspaces flow.
> 
> This PR does not change application logic; it only publishes the version bump. The release notes in the PR description reference fixes and tests merged since rc.12 (overlay rendezvous re-registration, NetworkManager discovery e2e, static asset serving, and a `crossbeam-epoch` security bump), but those land in other commits—not in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 311be1e148aabec2752e325c355d34b585c3acfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->