### PR TITLE
ci(ai-review): multi-agent review with domain context and targeted thinking

### DIFF
--- a/.ai-reviewer.yaml
+++ b/.ai-reviewer.yaml
@@ -14,6 +14,35 @@ anthropic:
   default_model: claude-sonnet-5
   enable_prompt_caching: true
 
+# Review agents. Only takes effect when the workflow passes --config; the App's
+# webhook uses its own config. Names must match the reviewer's registry exactly.
+# Order matters: --agents N runs the first N. Thinking is ON only for the two
+# highest-value reasoning agents (security, logic) - off elsewhere to bound cost
+# and latency. max_tokens is raised where thinking is on so it doesn't eat the
+# findings-JSON budget.
+agents:
+  - name: security-reviewer      # security, auth, crypto, untrusted input
+    model: claude-sonnet-5
+    thinking_enabled: true
+    max_tokens: 16000
+    max_tool_calls: 20
+  - name: logic-reviewer         # correctness, edge cases, concurrency, CRDT/DAG invariants
+    model: claude-sonnet-5
+    thinking_enabled: true
+    max_tokens: 16000
+    max_tool_calls: 20
+  - name: patterns-reviewer      # architecture, consistency, maintainability
+    model: claude-sonnet-5
+    thinking_enabled: false
+    max_tool_calls: 20
+
+# Skip agents on vendored / generated paths (read even without --config).
+ignore:
+  - "target/**"
+  - "Cargo.lock"
+  - "**/*.lock"
+  - "**/snapshots/**"
+
 # Doc auto-update — opens a draft PR on merges to master with proposed
 # changes to the architecture site (and any Markdown docs that go stale).
 # Disabled by default upstream; enabled here so doc-update.yaml has work to do.

--- a/.ai/rules/conventions.md
+++ b/.ai/rules/conventions.md
@@ -1,0 +1,17 @@
+# Review guidance for calimero-network/core
+
+This is a distributed p2p system: CRDT state, a causal DAG, consensus/governance,
+a WASM runtime, and node-to-node crypto. Weight these as high-severity when reviewing:
+
+- Determinism: consensus and state-transition paths must be deterministic across nodes.
+  Flag HashMap/HashSet iteration order, system time, RNG, or float math on any path that
+  feeds replicated state or the DAG.
+- CRDT correctness: merges must stay commutative, associative, and idempotent. Flag changes
+  that could break convergence or make merge order-dependent.
+- DAG invariants: causal ordering and cycle prevention; never assume a total order.
+- Untrusted input: bytes from peers are hostile. Deserialization must bound-check and never
+  panic on malformed input, since a panic on the network path is a denial of service.
+- Crypto: constant-time comparison for secrets and MACs, correct nonce/key lifecycle, and no
+  key material in logs or error messages.
+- Authorization: capability and governance checks must not be bypassable by message reordering
+  or a crafted payload.

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -81,8 +81,9 @@ jobs:
             echo "agents=${{ github.event.inputs.agents }}"    >> $GITHUB_OUTPUT
           else
             echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-            # Default to 1 agent for cost; bump via workflow_dispatch when needed.
-            echo "agents=1"                                        >> $GITHUB_OUTPUT
+            # 3 agents so the cross-review validation round runs (needs >=3);
+            # the agents block in .ai-reviewer.yaml selects security/logic/patterns.
+            echo "agents=3"                                        >> $GITHUB_OUTPUT
           fi
 
       - name: Run AI Code Review
@@ -93,6 +94,7 @@ jobs:
           ai-reviewer review-pr \
             ${{ github.repository }} \
             ${{ steps.pr.outputs.number }} \
+            --config .ai-reviewer.yaml \
             --agents ${{ steps.pr.outputs.agents }} \
             --reviewer-name "MeroReviewer" \
             --output github


### PR DESCRIPTION
## Why
Core's AI review has been completing but surfacing nothing on real PRs. Root causes (diagnosed from the reviewer's production logs):
- The workflow ran **1 agent** with no cross-review, and did not pass `--config`, so the `.ai-reviewer.yaml` review settings were never loaded.
- Agents ran **thinking-off**, which on Sonnet 5 is much more conservative than it was on Sonnet 4.6 - it investigates then declines to report. (The reviewer's own CI, which runs thinking-on, posts real findings on the same model.)
- Agents had **no domain context**, so on subtle CRDT/consensus/crypto PRs they don't know what to scrutinize.

## Changes
- **`agents` block**: security, logic, patterns. Thinking **ON** for security + logic (the highest-value reasoning agents) with `max_tokens: 16000` so thinking doesn't eat the findings-JSON budget; **OFF** for patterns to bound cost/latency.
- **`.ai/rules/conventions.md`**: the distributed-systems review charter (determinism, CRDT convergence, DAG causal order, untrusted-input panics = DoS, crypto, authz). Auto-loaded into every agent via `CONVENTION_PATHS`.
- **Workflow**: pass `--config .ai-reviewer.yaml` (without it the agents block is inert) and run **3 agents** so the cross-review validation round activates (needs >=3).
- **`ignore`**: skip `target/`, lockfiles, snapshots.

## Cost/latency
3 agents (2 thinking-on) vs the previous 1 agent is roughly 3-4x per review, and thinking-on lengthens generations. This is the deliberate quality-over-cost tradeoff for core's high-risk code. `--agents` is still overridable via `workflow_dispatch`.

## Depends on
The reviewer-side recall fixes (calimero-network/ai-code-reviewer#97: lower confidence floors + coverage-first; #95: streaming so thinking-on long generations don't drop the connection). Core installs `ai-code-reviewer@master`, so this takes full effect once those merge and the reviewer redeploys.

## Validation
- `.ai-reviewer.yaml` parses and validates clean: agents = security(thinking, 16k), logic(thinking, 16k), patterns(8k); no validation errors.