### PR TITLE
refactor(storage): remove the now-inert Action::Compare variant

### DIFF
--- a/crates/context/src/handlers/execute/signing.rs
+++ b/crates/context/src/handlers/execute/signing.rs
@@ -45,7 +45,6 @@ pub(crate) fn sign_authorized_actions(
                 let nonce = *deleted_at;
                 (metadata, nonce)
             }
-            Action::Compare { .. } => continue,
         };
 
         // STAMP THE NONCE BEFORE COMPUTING THE PAYLOAD.
@@ -105,7 +104,6 @@ pub(crate) fn sign_authorized_actions(
         let metadata = match action {
             Action::Add { metadata, .. } | Action::Update { metadata, .. } => metadata,
             Action::DeleteRef { metadata, .. } => metadata,
-            Action::Compare { .. } => continue,
         };
         let sig_data = match &mut metadata.storage_type {
             StorageType::User {
@@ -201,7 +199,6 @@ pub(crate) fn persist_signed_signatures(
                 Action::DeleteRef { id, metadata, .. } => {
                     (*id, metadata.storage_type.clone(), true)
                 }
-                Action::Compare { .. } => continue,
             };
             // Only Shared/User with a REAL signature need the
             // re-persist. Public/Frozen don't carry signatures.

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -374,7 +374,6 @@ impl DeltaApplier<Vec<Action>> for ContextStorageApplier {
                 .payload
                 .iter()
                 .map(|a| match a {
-                    Action::Compare { .. } => "Compare",
                     Action::Add { .. } => "Add",
                     Action::Update { .. } => "Update",
                     Action::DeleteRef { .. } => "DeleteRef",
@@ -857,7 +856,6 @@ impl ContextStorageApplier {
                 Action::Add { metadata, .. }
                 | Action::Update { metadata, .. }
                 | Action::DeleteRef { metadata, .. } => metadata,
-                Action::Compare { .. } => continue,
             };
             match metadata.storage_type {
                 StorageType::Shared { .. } => {
@@ -2156,7 +2154,6 @@ impl DeltaStore {
                     StorageType::SharedMember { anchor, .. } => anchor,
                     _ => continue,
                 },
-                Action::Compare { .. } => continue,
             };
             if shared_here.contains(&anchor) {
                 continue;

--- a/crates/node/tests/dag_causal_shared_e2e.rs
+++ b/crates/node/tests/dag_causal_shared_e2e.rs
@@ -167,7 +167,6 @@ impl SharedRotationApplier {
                 Action::Add { metadata, .. }
                 | Action::Update { metadata, .. }
                 | Action::DeleteRef { metadata, .. } => metadata,
-                Action::Compare { .. } => continue,
             };
             if matches!(metadata.storage_type, StorageType::Shared { .. }) {
                 let _inserted = shared_entities.insert(action.id());

--- a/crates/op-adapter/src/lib.rs
+++ b/crates/op-adapter/src/lib.rs
@@ -26,8 +26,9 @@ use calimero_storage::rotation_log::RotationLogEntry;
 
 /// Encode a storage data [`Action`] as an [`OpPayload`].
 ///
-/// Returns `None` for [`Action::Compare`] — a sync reconciliation *hint*, not
-/// a state change, so it has no op-model representation.
+/// Every state-changing [`Action`] maps to an op, so this currently always
+/// returns `Some`; the `Option` is retained so a future non-state-changing
+/// action can encode as `None` without a signature change.
 #[must_use]
 pub fn payload_from_action(action: &Action) -> Option<OpPayload> {
     match action {
@@ -36,7 +37,6 @@ pub fn payload_from_action(action: &Action) -> Option<OpPayload> {
             value: data.clone(),
         }),
         Action::DeleteRef { id, .. } => Some(OpPayload::Delete { entity: *id }),
-        Action::Compare { .. } => None,
     }
 }
 
@@ -270,7 +270,6 @@ mod tests {
             deleted_at: 0,
             metadata: Metadata::default(),
         };
-        let cmp = Action::Compare { id };
 
         assert_eq!(
             payload_from_action(&add),
@@ -290,8 +289,6 @@ mod tests {
             payload_from_action(&del),
             Some(OpPayload::Delete { entity: id })
         );
-        // Compare is a sync hint, not a state change.
-        assert_eq!(payload_from_action(&cmp), None);
     }
 
     /// Build a `SetWriters` op chain from a rotation log and assert the unified

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -1273,8 +1273,7 @@ impl VMHostFunctions<'_> {
                         .map(|action| match action {
                             Action::Add { id, .. }
                             | Action::Update { id, .. }
-                            | Action::DeleteRef { id, .. }
-                            | Action::Compare { id } => format!("{id:?}"),
+                            | Action::DeleteRef { id, .. } => format!("{id:?}"),
                         })
                         .collect();
 

--- a/crates/storage/src/action.rs
+++ b/crates/storage/src/action.rs
@@ -1,5 +1,7 @@
 //! Synchronization action types for CRDT operations.
 
+use std::io;
+
 use borsh::{BorshDeserialize, BorshSerialize};
 use sha2::{Digest, Sha256};
 
@@ -8,23 +10,11 @@ use crate::entities::{ChildInfo, Metadata, StorageType};
 
 /// Actions to be taken during synchronisation.
 ///
-/// The following variants represent the possible actions arising from either a
-/// direct change or a comparison between two nodes.
-///
-///   - **Direct change**: When a direct change is made, in other words, when
-///     there is local activity that results in data modification to propagate
-///     to other nodes, the possible resulting actions are [`Add`](Action::Add),
-///     [`DeleteRef`](Action::DeleteRef), and [`Update`](Action::Update). A comparison
-///     is not needed in this case, as the deltas are known, and assuming all of
-///     the actions are carried out, the nodes will be in sync.
-///
-///   - **Comparison**: When a comparison is made between two nodes, the
-///     possible resulting actions are [`Add`](Action::Add), [`DeleteRef`](Action::DeleteRef),
-///     [`Update`](Action::Update), and [`Compare`](Action::Compare). The extra
-///     comparison action arises in the case of tree traversal, where a child
-///     entity is found to differ between the two nodes. In this case, the child
-///     entity is compared, and the resulting actions are added to the list of
-///     actions to be taken. This process is recursive.
+/// The variants represent the actions arising from a direct change: local
+/// activity that modifies data to propagate to other nodes produces
+/// [`Add`](Action::Add), [`DeleteRef`](Action::DeleteRef), and
+/// [`Update`](Action::Update). The deltas are known, so assuming every action
+/// is carried out the nodes end up in sync.
 ///
 /// Note: Some actions contain the full entity, and not just the entity ID, as
 /// the actions will often be in context of data that is not available locally
@@ -35,7 +25,11 @@ use crate::entities::{ChildInfo, Metadata, StorageType};
 /// Note: This enum contains the entity type, for passing to the guest for
 /// processing along with the ID and data.
 ///
-#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+/// Borsh wire tags are assigned by hand (see the impls below) so they stay
+/// stable across the removal of the old `Compare` variant: `Add` = 0,
+/// `DeleteRef` = 2, `Update` = 3. Tag 1 (the removed `Compare`) is rejected, so
+/// every persisted and in-flight delta stays decodable.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 #[expect(clippy::exhaustive_enums, reason = "Exhaustive")]
 pub enum Action {
     /// Add an entity with the given ID, type, and data.
@@ -51,16 +45,6 @@ pub enum Action {
 
         /// The metadata of the entity.
         metadata: Metadata,
-    },
-
-    /// Compare the entity with the given ID and type. Note that this results in
-    /// a direct comparison of the specific entity in question, including data
-    /// that is immediately available to it, such as the hashes of its children.
-    /// This may well result in further actions being generated if children
-    /// differ, leading to a recursive comparison.
-    Compare {
-        /// Unique identifier of the entity.
-        id: Id,
     },
 
     /// Delete reference (tombstone-based deletion).
@@ -104,7 +88,6 @@ impl Action {
             Action::Add { id, .. } => *id,
             Action::Update { id, .. } => *id,
             Action::DeleteRef { id, .. } => *id,
-            Action::Compare { id, .. } => *id,
         }
     }
 
@@ -155,13 +138,84 @@ impl Action {
                 hasher.update(deleted_at.to_le_bytes());
                 hash_authorization_for_payload(&mut hasher, metadata);
             }
-            Action::Compare { id } => {
-                // Compare actions are not signed.
-                hasher.update(b"v2_compare");
-                hasher.update(id.as_bytes());
-            }
         }
         hasher.finalize().into()
+    }
+}
+
+impl BorshSerialize for Action {
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        // Hand-rolled to keep wire tags stable across the removal of the old
+        // `Compare` variant (tag 1): `Add` = 0, `DeleteRef` = 2, `Update` = 3.
+        // Field order matches what the derive produced, so the encoding of every
+        // surviving variant is byte-identical to pre-removal deltas.
+        match self {
+            Action::Add {
+                id,
+                data,
+                ancestors,
+                metadata,
+            } => {
+                0u8.serialize(writer)?;
+                id.serialize(writer)?;
+                data.serialize(writer)?;
+                ancestors.serialize(writer)?;
+                metadata.serialize(writer)?;
+            }
+            Action::DeleteRef {
+                id,
+                deleted_at,
+                metadata,
+            } => {
+                2u8.serialize(writer)?;
+                id.serialize(writer)?;
+                deleted_at.serialize(writer)?;
+                metadata.serialize(writer)?;
+            }
+            Action::Update {
+                id,
+                data,
+                ancestors,
+                metadata,
+            } => {
+                3u8.serialize(writer)?;
+                id.serialize(writer)?;
+                data.serialize(writer)?;
+                ancestors.serialize(writer)?;
+                metadata.serialize(writer)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl BorshDeserialize for Action {
+    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        let tag = u8::deserialize_reader(reader)?;
+        match tag {
+            0 => Ok(Action::Add {
+                id: Id::deserialize_reader(reader)?,
+                data: Vec::deserialize_reader(reader)?,
+                ancestors: Vec::deserialize_reader(reader)?,
+                metadata: Metadata::deserialize_reader(reader)?,
+            }),
+            // Tag 1 was the removed `Compare` variant; reject it.
+            2 => Ok(Action::DeleteRef {
+                id: Id::deserialize_reader(reader)?,
+                deleted_at: u64::deserialize_reader(reader)?,
+                metadata: Metadata::deserialize_reader(reader)?,
+            }),
+            3 => Ok(Action::Update {
+                id: Id::deserialize_reader(reader)?,
+                data: Vec::deserialize_reader(reader)?,
+                ancestors: Vec::deserialize_reader(reader)?,
+                metadata: Metadata::deserialize_reader(reader)?,
+            }),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid Action tag",
+            )),
+        }
     }
 }
 
@@ -632,5 +686,41 @@ mod tests {
             b.payload_for_signing(),
             "unsigned and signed-with-nonce-zero must produce distinct payloads"
         );
+    }
+
+    #[test]
+    fn borsh_wire_tags_are_stable_and_removed_compare_tag_is_rejected() {
+        let id = Id::from([7_u8; 32]);
+        let add = Action::Add {
+            id,
+            data: vec![1, 2, 3],
+            ancestors: vec![],
+            metadata: meta_public(),
+        };
+        let del = Action::DeleteRef {
+            id,
+            deleted_at: 42,
+            metadata: meta_public(),
+        };
+        let upd = Action::Update {
+            id,
+            data: vec![4, 5],
+            ancestors: vec![],
+            metadata: meta_public(),
+        };
+
+        // Tags must stay Add=0, DeleteRef=2, Update=3 (tag 1 was the removed
+        // `Compare`) so pre-removal persisted/in-flight deltas stay decodable.
+        for (action, tag) in [(&add, 0_u8), (&del, 2), (&upd, 3)] {
+            let bytes = borsh::to_vec(action).unwrap();
+            assert_eq!(bytes[0], tag, "unexpected wire tag for {action:?}");
+            let decoded: Action = borsh::from_slice(&bytes).unwrap();
+            assert_eq!(&decoded, action, "roundtrip mismatch for {action:?}");
+        }
+
+        // Tag 1 (the removed `Compare` variant) is rejected, not misinterpreted.
+        assert!(borsh::from_slice::<Action>(&[1_u8]).is_err());
+        // An unknown tag errors too.
+        assert!(borsh::from_slice::<Action>(&[9_u8]).is_err());
     }
 }

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -421,12 +421,6 @@ where
             let action_ctx = ctx_for_action(&action);
 
             match action {
-                // Legacy state-based-comparison sync trigger. That protocol has
-                // been removed (HashComparison/level-wise sync handles Merkle
-                // convergence), and no path emits `Compare` onto the wire, so a
-                // received `Compare` is an inert no-op rather than a reconcile
-                // request.
-                Action::Compare { .. } => {}
                 Action::Add {
                     id,
                     data,

--- a/crates/storage/src/delta.rs
+++ b/crates/storage/src/delta.rs
@@ -100,10 +100,6 @@ impl CausalDelta {
                     // deleted_at excluded - it's a timestamp
                     hash_metadata_storage_type_for_id(&mut hasher, metadata);
                 }
-                Action::Compare { id } => {
-                    let id_bytes: [u8; 32] = (*id).into();
-                    hasher.update(id_bytes);
-                }
             }
         }
 

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -344,7 +344,7 @@ impl<S: StorageAdaptor> Interface<S> {
                 Action::Add { id, metadata, .. } | Action::Update { id, metadata, .. } => {
                     (*id, metadata)
                 }
-                Action::DeleteRef { .. } | Action::Compare { .. } => continue,
+                Action::DeleteRef { .. } => continue,
             };
             let StorageType::Shared {
                 writers,
@@ -507,7 +507,6 @@ impl<S: StorageAdaptor> Interface<S> {
         match action {
             Action::Add { .. } | Action::Update { .. } => OpMask::WRITE,
             Action::DeleteRef { .. } => OpMask::DELETE,
-            Action::Compare { .. } => OpMask::NONE,
         }
     }
 
@@ -1883,7 +1882,6 @@ impl<S: StorageAdaptor> Interface<S> {
                     StorageType::Public => { /* No special checks */ }
                 }
             }
-            Action::Compare { .. } => { /* No checks needed */ }
         }
 
         match action {
@@ -2150,9 +2148,6 @@ impl<S: StorageAdaptor> Interface<S> {
                         ChildInfo::new(id, own_hash, metadata.clone()),
                     )?;
                 }
-            }
-            Action::Compare { .. } => {
-                return Err(StorageError::ActionNotAllowed("Compare".to_owned()))
             }
             Action::DeleteRef { id, deleted_at, .. } => {
                 Self::apply_delete_ref_action(id, deleted_at)?;
@@ -3714,7 +3709,6 @@ fn verify_action_timestamp(action: &Action) -> Result<(), StorageError> {
     let timestamp = match action {
         Action::Add { metadata, .. } | Action::Update { metadata, .. } => metadata.updated_at(),
         Action::DeleteRef { deleted_at, .. } => *deleted_at,
-        Action::Compare { .. } => return Ok(()),
     };
 
     let now = time_now();

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -1104,8 +1104,7 @@ impl<S: StorageAdaptor> Interface<S> {
 
     /// Applies a synchronization action from a remote node.
     ///
-    /// Handles Add/Update/Delete actions, creating missing ancestors if needed.
-    /// Generates Compare action for hash verification after applying changes.
+    /// Handles Add/Update/DeleteRef actions, creating missing ancestors if needed.
     ///
     /// `ctx` carries apply-time metadata. For `Shared`-storage actions
     /// (#2266), if `ctx.effective_writers` is `Some`, the signature is
@@ -1119,7 +1118,8 @@ impl<S: StorageAdaptor> Interface<S> {
     ///
     /// # Errors
     /// - `DeserializationError` if action data is invalid
-    /// - `ActionNotAllowed` if Compare action is passed directly
+    /// - `ActionNotAllowed` if the action violates storage-type access rules
+    ///   (e.g. deleting `Frozen` data, or an unauthorized `Shared`/`User` write)
     ///
     pub fn apply_action(action: Action, ctx: &ApplyContext) -> Result<(), StorageError> {
         // Verify that the action timestamp is not too far in the future

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -86,11 +86,10 @@ pub trait StorageAdaptor: 'static {
     /// Whether writes through this adaptor participate in the synced
     /// state delta stream.
     ///
-    /// `Interface::save_raw` (and the `Action::Compare` push at the end of
-    /// `Interface::apply_action`, and the `Action::DeleteRef` push at the
-    /// end of the delete path) records every storage mutation as an
-    /// `Action` in the global delta stream. Those actions get bundled into
-    /// the next outgoing `StateDelta` and replayed on every peer.
+    /// `Interface::save_raw` (and the `Action::DeleteRef` push at the end of
+    /// the delete path) records every storage mutation as an `Action` in the
+    /// global delta stream. Those actions get bundled into the next outgoing
+    /// `StateDelta` and replayed on every peer.
     ///
     /// That's correct for `MainStorage`, where the whole point is that
     /// writes propagate. It's a bug for `PrivateStorage`: a write that

--- a/crates/storage/src/tests/concurrency.rs
+++ b/crates/storage/src/tests/concurrency.rs
@@ -64,8 +64,8 @@ impl StorageAdaptor for SharedStore {
     }
 
     // These tests drive `Index::add_child_to` directly and assert on the index
-    // children list; they don't exercise the delta stream. Opt out of it so a
-    // stray `Action::Compare` push can't touch thread-local delta state.
+    // children list; they don't exercise the delta stream. Opt out of it so no
+    // stray action push can touch thread-local delta state.
     fn participates_in_sync() -> bool {
         false
     }

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -393,15 +393,6 @@ mod interface__apply_actions {
     }
 
     #[test]
-    fn apply_action__compare() {
-        let page = Page::new_from_element("Test Page", Element::root());
-        let action = Action::Compare { id: page.id() };
-
-        // Compare should fail
-        assert!(MainInterface::apply_action(action, &ApplyContext::empty()).is_err());
-    }
-
-    #[test]
     fn apply_action__non_existent_update() {
         let page = Page::new_from_element("Test Page", Element::root());
         let serialized = to_vec(&page).unwrap();
@@ -423,9 +414,8 @@ mod interface__apply_actions {
 
     // A stale-by-HLC apply (incoming.updated_at < stored.updated_at) hits the
     // `save_internal -> None` short-circuit and contributes nothing to the
-    // causal delta: the apply path no longer enqueues an `Action::Compare` for
-    // the stale entity. Merkle-root convergence for concurrently-merged entities
-    // is owned by the HashComparison / level-wise sync protocols instead. This
+    // causal delta. Merkle-root convergence for concurrently-merged entities is
+    // owned by the HashComparison / level-wise sync protocols instead. This
     // asserts that contract — the stale apply succeeds but emits no delta.
     #[test]
     fn apply_action__stale_update_emits_no_delta() {
@@ -459,8 +449,8 @@ mod interface__apply_actions {
         let delta = commit_causal_delta(&[0; 32]).unwrap();
         assert!(
             delta.is_none(),
-            "stale apply must not emit a delta now that the apply path no longer \
-             pushes Action::Compare, got: {delta:?}"
+            "stale apply must not emit a delta (the apply path enqueues no action \
+             for an entity that lost the LWW tiebreak), got: {delta:?}"
         );
     }
 }

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -1631,9 +1631,6 @@ fn test_e2e_sync_flow_with_isolated_storage() {
                 Action::DeleteRef { id, .. } => {
                     println!("  Action {i}: DeleteRef id={id}");
                 }
-                Action::Compare { id } => {
-                    println!("  Action {i}: Compare id={id}");
-                }
             }
         }
 

--- a/tools/merodb/src/dag.rs
+++ b/tools/merodb/src/dag.rs
@@ -120,10 +120,6 @@ pub fn get_delta_details(
                                 "storage_type": "UNIMPLEMENTED",
                             }
                         }),
-                        Action::Compare { id } => json!({
-                            "type": "Compare",
-                            "id": hex::encode(id.as_bytes()),
-                        }),
                     }
                 })
                 .collect();


### PR DESCRIPTION
## What

Follow-up to #3216. After the state-based Comparisons sync was removed, **nothing constructs `Action::Compare`** — its only producers (`compare_trees` and the `apply_action` pushes) are gone. This removes the dead variant and the ~20 defensive match arms that only existed to handle it, across `storage`, `context`, `node`, `op-adapter`, `runtime`, and `tools/merodb`.

## Wire compatibility (the one subtle part)

`Action` previously **derived** borsh, giving positional tags `Add=0, Compare=1, DeleteRef=2, Update=3`. Naively deleting `Compare` would renumber `DeleteRef` 2→1 and `Update` 3→2 — silently corrupting **every** persisted and in-flight delta (the live variants), not just the dead one.

So `Action` now has a **hand-rolled `BorshSerialize`/`BorshDeserialize`** that keeps `Add=0, DeleteRef=2, Update=3` and rejects tag 1 — byte-identical encoding for every surviving variant. Same approach #3216 used for `StorageDelta`. A new `action.rs` test pins the tag bytes, roundtrips each variant, and asserts tag 1 is rejected.

## Also

- Fixes now-stale comments that referenced the removed `Action::Compare` push (`store.rs`, `tests/concurrency.rs`, the stale-update test).
- Drops the op-adapter `payload_from_action` `None` arm (kept the `Option` return to avoid a signature change rippling to callers).

## Verification

- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` — clean
- `cargo test -p calimero-storage --features testing` — **668 passed, 0 failed** (incl. the new wire-tag test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)