### PR TITLE
fix(merod): warn when Proxy auth is bound to a non-loopback address

### DIFF
--- a/crates/merod/src/cli/run.rs
+++ b/crates/merod/src/cli/run.rs
@@ -9,7 +9,8 @@ use clap::Parser;
 use eyre::{bail, Result as EyreResult, WrapErr};
 use mero_auth::config::StorageConfig as AuthStorageConfig;
 use mero_auth::embedded::default_config;
-use tracing::info;
+use multiaddr::{Multiaddr, Protocol};
+use tracing::{info, warn};
 
 use super::auth_mode::AuthModeArg;
 use super::validation::validate_config;
@@ -172,6 +173,12 @@ impl RunCommand {
                 }
             }
         }
+        if let Some(msg) =
+            unauthenticated_exposure_warning(server_source.auth_mode, &server_source.listen)
+        {
+            warn!("{msg}");
+        }
+
         let server_config = ServerConfig::with_auth(
             server_source.listen,
             config.identity.keypair.clone(),
@@ -229,5 +236,82 @@ impl RunCommand {
             mock_tee: self.mock_tee,
         })
         .await
+    }
+}
+
+/// Warn when the server is reachable off-box but the node authenticates nothing
+/// itself. In `Proxy` mode the node relies entirely on a front reverse proxy for
+/// auth, so a non-loopback bind without one exposes an unauthenticated admin/RPC
+/// API. Returns the warning message when it applies, else `None`.
+fn unauthenticated_exposure_warning(auth_mode: AuthMode, listen: &[Multiaddr]) -> Option<String> {
+    if !matches!(auth_mode, AuthMode::Proxy) {
+        return None;
+    }
+
+    let exposed: Vec<&Multiaddr> = listen
+        .iter()
+        .filter(|addr| multiaddr_ip(addr).is_some_and(|ip| !ip.is_loopback()))
+        .collect();
+
+    if exposed.is_empty() {
+        return None;
+    }
+
+    let addrs = exposed
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(format!(
+        "SECURITY: server is bound to non-loopback address(es) [{addrs}] while auth mode is \
+         Proxy - the node performs NO authentication of its own in Proxy mode. Ensure an \
+         authenticating reverse proxy is in front of it, or switch to Embedded auth. The \
+         admin/RPC API is otherwise reachable UNAUTHENTICATED from the network."
+    ))
+}
+
+fn multiaddr_ip(addr: &Multiaddr) -> Option<core::net::IpAddr> {
+    addr.iter().find_map(|proto| match proto {
+        Protocol::Ip4(ip) => Some(ip.into()),
+        Protocol::Ip6(ip) => Some(ip.into()),
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(s: &str) -> Multiaddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn proxy_non_loopback_warns() {
+        let listen = vec![addr("/ip4/0.0.0.0/tcp/2528")];
+        assert!(unauthenticated_exposure_warning(AuthMode::Proxy, &listen).is_some());
+    }
+
+    #[test]
+    fn proxy_loopback_only_is_silent() {
+        let listen = vec![addr("/ip4/127.0.0.1/tcp/2528"), addr("/ip6/::1/tcp/2528")];
+        assert!(unauthenticated_exposure_warning(AuthMode::Proxy, &listen).is_none());
+    }
+
+    #[test]
+    fn embedded_non_loopback_is_silent() {
+        let listen = vec![addr("/ip4/0.0.0.0/tcp/2528")];
+        assert!(unauthenticated_exposure_warning(AuthMode::Embedded, &listen).is_none());
+    }
+
+    #[test]
+    fn proxy_mixed_loopback_and_public_warns() {
+        let listen = vec![
+            addr("/ip4/127.0.0.1/tcp/2528"),
+            addr("/ip4/192.168.1.5/tcp/2528"),
+        ];
+        let msg = unauthenticated_exposure_warning(AuthMode::Proxy, &listen).unwrap();
+        assert!(msg.contains("192.168.1.5"));
+        assert!(!msg.contains("127.0.0.1"));
     }
 }


### PR DESCRIPTION
## Summary

In `Proxy` auth mode (the default) the node performs no authentication of its own - it delegates entirely to an external reverse proxy, and the admin/JSON-RPC/WS/SSE routers mount with no auth guard. The default bind is loopback (`127.0.0.1,::1`), so a default install is not network-exposed, but an operator who binds a non-loopback address (common in containers) while staying in Proxy mode and without a real proxy in front silently exposes an unauthenticated admin/RPC API.

- `crates/merod/src/cli/run.rs`: log a loud `warn!` at startup when the auth mode is `Proxy` and any server listen address is non-loopback, naming the offending addresses and pointing at the two remedies (put an authenticating proxy in front, or switch to Embedded auth).
- The check is factored into a pure helper, `unauthenticated_exposure_warning(auth_mode, listen) -> Option<String>`, so the decision is unit-testable.

This is a warning only. It is deliberately not a hard refusal and adds no flag: binding non-loopback with a real authenticating proxy in front is a legitimate production topology (bind wide inside a pod, let the ingress enforce auth), and refusing to start would break those deployments. No defaults change.

## Test plan

- [x] `cargo test -p merod` - 61 passed, including four new helper tests:
  - `proxy_non_loopback_warns` - Proxy + `0.0.0.0` warns
  - `proxy_loopback_only_is_silent` - Proxy + `127.0.0.1`/`::1` does not warn
  - `embedded_non_loopback_is_silent` - Embedded + `0.0.0.0` does not warn
  - `proxy_mixed_loopback_and_public_warns` - warns and names only the non-loopback address
- [x] `cargo fmt --all` - clean
- [x] `cargo clippy -p merod --all-targets` - clean
