### PR TITLE
ci: baseline probe — run app-migration-e2e on unmodified master (do not merge)

### DIFF
--- a/crates/governance-store/src/ops/group.rs
+++ b/crates/governance-store/src/ops/group.rs
@@ -193,3 +193,6 @@ pub(crate) fn dispatch(ctx: &mut GroupApplyCtx<'_>, op: &GroupOp) -> EyreResult<
     }
     Ok(true)
 }
+
+// CI baseline probe: no-op comment to trip the app-migration-e2e path filter so the
+// suite runs on unmodified master. See the PR body.


### PR DESCRIPTION
**Diagnostic only — do not merge. I'll close this once it reports.**

The `app-migration-e2e` suite is path-filtered. Its last run on master was `1a64fa961` (Jul 13). Three commits have landed since:

- `db8a1211b` fix(crypto): internal AES-GCM nonces + ed25519 verify_strict hardening (#3226)
- `f54192cd0` fix: atomic config writes and stray no_mdns override (#3227)
- `62c01a1b3` fix(crypto): derive AEAD key via HKDF-SHA256 and reject small-order points (#3228)

None of them touch a trigger path, so **the suite has never run against them**.

#3240 is the first PR to trip the filter on top of them, and 25 of its migration scenarios fail — with node 2 reporting `lazy upgrade: target blob fetch failed`, `ladder hop blocked; proceeding with current application`, and repeated `Failed to query DHT for blob` / `Kademlia: No known peers`. That is a blob/DHT path, not the governance code #3240 changes.

This branch is a **comment-only** change to `crates/governance-store/src/ops/group.rs` — enough to trip the path filter, with zero behavioral change — so the suite runs against otherwise-unmodified master. If it fails the same way, the regression is already on master and #3240 is not the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)