### PR TITLE
fix(ai-review): raise thinking-agent max_tokens to 32000

### DIFF
--- a/.ai-reviewer.yaml
+++ b/.ai-reviewer.yaml
@@ -24,12 +24,12 @@ agents:
   - name: security-reviewer      # security, auth, crypto, untrusted input
     model: claude-sonnet-5
     thinking_enabled: true
-    max_tokens: 16000
+    max_tokens: 32000
     max_tool_calls: 20
   - name: logic-reviewer         # correctness, edge cases, concurrency, CRDT/DAG invariants
     model: claude-sonnet-5
     thinking_enabled: true
-    max_tokens: 16000
+    max_tokens: 32000
     max_tool_calls: 20
   - name: patterns-reviewer      # architecture, consistency, maintainability
     model: claude-sonnet-5


### PR DESCRIPTION
## Summary

Sonnet 5 extended thinking is adaptive-only and its thinking tokens share the same `max_tokens` ceiling as the response. On large PRs, deep thinking could consume most of the 16000-token budget and truncate the findings JSON - surfacing as "Review Incomplete" (observed on #3240, where logic-reviewer failed to finish).

Raises `max_tokens` 16000 -> 32000 for the two thinking-enabled agents (security-reviewer, logic-reviewer). Non-thinking agents are unchanged. Pairs with the reviewer-side change that caps adaptive thinking `effort` at `medium`.

## Test plan
- Config-only change; validated by the reviewer's config loader.
- Next PR review run should complete without truncation on large diffs.