### PR TITLE
ci(e2e): trigger app-migration e2e on any crates/** change

### DIFF
--- a/.github/workflows/app-migration-e2e.yml
+++ b/.github/workflows/app-migration-e2e.yml
@@ -7,6 +7,10 @@ name: App migration e2e
 # `scenario` matrix fans those artifacts out across one job per workflow
 # under workflows/app-migration/ so every scenario runs in parallel and
 # reports its own pass/fail.
+#
+# Triggers on any crates/** change (like e2e-rust-apps.yml) rather than a
+# narrow subset of paths: the narrow filter previously let master
+# regressions land without running this suite.
 
 permissions:
   contents: read
@@ -15,16 +19,7 @@ on:
   push:
     branches: [master]
     paths:
-      - "crates/context/src/handlers/update_application/**"
-      - "crates/context/src/handlers/upgrade_group.rs"
-      - "crates/context/src/handlers/apply_signed_group_op.rs"
-      - "crates/context/src/handlers/create_group.rs"
-      - "crates/context/src/handlers/get_migration_status.rs"
-      - "crates/node/src/migration_status.rs"
-      - "crates/context/primitives/src/local_governance/**"
-      - "crates/governance-store/src/ops/**"
-      - "crates/storage/src/interface.rs"
-      - "crates/sdk/macros/**"
+      - "crates/**"
       - "apps/migrations/**"
       - "workflows/app-migration/**"
       - ".github/workflows/app-migration-e2e.yml"
@@ -34,16 +29,7 @@ on:
   pull_request:
     branches: [master]
     paths:
-      - "crates/context/src/handlers/update_application/**"
-      - "crates/context/src/handlers/upgrade_group.rs"
-      - "crates/context/src/handlers/apply_signed_group_op.rs"
-      - "crates/context/src/handlers/create_group.rs"
-      - "crates/context/src/handlers/get_migration_status.rs"
-      - "crates/node/src/migration_status.rs"
-      - "crates/context/primitives/src/local_governance/**"
-      - "crates/governance-store/src/ops/**"
-      - "crates/storage/src/interface.rs"
-      - "crates/sdk/macros/**"
+      - "crates/**"
       - "apps/migrations/**"
       - "workflows/app-migration/**"
       - ".github/workflows/app-migration-e2e.yml"


### PR DESCRIPTION
## Summary

- Widen the `app-migration-e2e.yml` path filter from ~10 individual `crates/...` file entries to a single `crates/**` entry, in both `on.push.paths` and `on.pull_request.paths`.
- Non-crates entries (`apps/migrations/**`, `workflows/app-migration/**`, the workflow file itself, and the local-merod/setup-merobox actions) are unchanged.

The narrow filter previously masked a master regression: commits db8a1211b, f54192cd0, and 62c01a1b3 landed without triggering this suite, and cross-node migration is broken on master. This was only caught when PR #3240 happened to trip the filter. This change aligns the trigger with `e2e-rust-apps.yml`, which already runs on any `crates/**` change.

Note: this PR's migration-e2e run is expected to fail until the underlying master regression is fixed (tracked separately).

## Test plan

- [x] Validated the workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/app-migration-e2e.yml'))"`)
- [x] The widened filter is exercised by this PR's own CI run