### PR TITLE
fix(sync): restore chained nonce on encrypted blob-share stream

### DIFF
--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -95,7 +95,15 @@ impl SharedKey {
     #[must_use]
     pub fn encrypt(&self, payload: Vec<u8>) -> Option<(Nonce, Vec<u8>)> {
         let nonce: Nonce = rand::random();
+        let cipher_text = self.encrypt_with_nonce(payload, nonce)?;
+        Some((nonce, cipher_text))
+    }
 
+    /// Encrypts with a caller-supplied nonce. The caller MUST guarantee the nonce
+    /// is single-use per key; the sync stream protocol satisfies this via its
+    /// per-message `next_nonce` ratchet (see `node/src/sync/blobs.rs`).
+    #[must_use]
+    pub fn encrypt_with_nonce(&self, payload: Vec<u8>, nonce: Nonce) -> Option<Vec<u8>> {
         let encryption_key =
             aead::LessSafeKey::new(aead::UnboundKey::new(&aead::AES_256_GCM, &*self.key).ok()?);
 
@@ -108,7 +116,7 @@ impl SharedKey {
             )
             .ok()?;
 
-        Some((nonce, cipher_text))
+        Some(cipher_text)
     }
 
     #[must_use]
@@ -272,6 +280,42 @@ mod tests {
                 .ok_or_eyre("decrypt with correct nonce failed")?,
             payload
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_encrypt_with_nonce_roundtrip() -> eyre::Result<()> {
+        // The sync stream ratchet seals with a caller-chosen nonce and the
+        // receiver decrypts with that same nonce; a different nonce must fail.
+        let mut csprng = thread_rng();
+        let signer = PrivateKey::random(&mut csprng);
+        let verifier = PrivateKey::random(&mut csprng);
+        let signer_shared_key = SharedKey::new(&signer, &verifier.public_key())?;
+        let verifier_shared_key = SharedKey::new(&verifier, &signer.public_key())?;
+
+        let payload = b"privacy is important";
+        let nonce: Nonce = rand::random();
+
+        let encrypted = signer_shared_key
+            .encrypt_with_nonce(payload.to_vec(), nonce)
+            .ok_or_eyre("encryption failed")?;
+
+        assert_eq!(
+            verifier_shared_key
+                .decrypt(encrypted.clone(), nonce)
+                .ok_or_eyre("decryption failed")?,
+            payload
+        );
+
+        let mut wrong_nonce = nonce;
+        wrong_nonce[0] ^= 0x01;
+        assert!(
+            verifier_shared_key
+                .decrypt(encrypted, wrong_nonce)
+                .is_none(),
+            "decrypt must fail under a nonce other than the one used to seal"
+        );
+
         Ok(())
     }
 

--- a/crates/node/src/sync/stream.rs
+++ b/crates/node/src/sync/stream.rs
@@ -41,11 +41,10 @@ pub async fn send(
     let encoded = borsh::to_vec(message)?;
 
     let message = match shared_key {
-        // Dead path: `send` is only ever called with `None`. If enabled, carry
-        // the per-call nonce to the receiver instead of dropping it here.
-        Some((key, _nonce)) => key
-            .encrypt(encoded)
-            .map(|(_nonce, ciphertext)| ciphertext)
+        // `nonce` is the chained per-message nonce from the sync ratchet
+        // (see blobs.rs); the receiver decrypts with this same nonce.
+        Some((key, nonce)) => key
+            .encrypt_with_nonce(encoded, nonce)
             .ok_or_eyre("encryption failed")?,
         None => encoded,
     };


### PR DESCRIPTION
## Summary

#3226 changed `SharedKey::encrypt` to generate its own random nonce and rewrote `sync/stream.rs` `send()` on the assumption that the `Some((key, nonce))` arm was dead, dropping the caller-supplied nonce (`.map(|(_nonce, ciphertext)| ciphertext)`).

That arm is live. The blob-share protocol (`sync/blobs.rs`, via the `SyncManager` wrappers) sends each `StreamMessage` with a per-message chained nonce and the receiver decrypts with that same nonce - a nonce-chaining ratchet where every message announces the next single-use nonce. Since #3226 the sender sealed with a random internal nonce it then threw away while the receiver decrypted with the chained nonce, so every cross-node blob share failed with "decryption failed", blocking app migration on receiving nodes (the 25 red app-migration-e2e scenarios).

This restores the send path to seal with the caller's chained nonce by adding `SharedKey::encrypt_with_nonce`, keeping `encrypt` (random nonce) for other call sites. The ratchet guarantees each nonce is single-use per key, so there is no AES-GCM nonce reuse.

## Test plan

- Added a focused unit test (`test_encrypt_with_nonce_roundtrip`): seal with a chosen nonce, decrypt with the same nonce roundtrips, decrypt with a different nonce fails.
- `cargo test -p calimero-crypto`: 9 passed.
- `cargo build -p calimero-node`: clean.
- `cargo test -p calimero-node`: full suite green (0 failed).
- `cargo clippy -p calimero-crypto -p calimero-node -- -D warnings`: clean.
- app-migration-e2e validation via `workflow_dispatch` on this branch.