### PR TITLE
fix(node): self-seed readiness state in ApplyBeaconLocal

### DIFF
--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -909,9 +909,19 @@ impl Handler<ApplyBeaconLocal> for ReadinessManager {
         // A peer beacon has just been inserted into the cache. Re-evaluate
         // the FSM with the (possibly) updated `peer_summary` and edge-emit
         // if our tier transitions into *Ready.
-        let Some(mut state) = self.state_per_namespace.get(&msg.namespace_id).cloned() else {
-            return;
-        };
+        //
+        // Self-seed if the entry is missing: a beacon can reach this handler
+        // (one hop, sent straight to the readiness addr) before the
+        // subscribe-time `NamespaceSubscribed` seed, which takes an extra hop
+        // via `NodeManager`. `NamespaceOpApplied` only seeds once we apply
+        // locally. Seeding here keeps all three FSM eval entry points
+        // self-sufficient and symmetric; `or_insert_with` is idempotent, so an
+        // earlier `subscribed_at` from a subscribe/op signal is preserved.
+        let mut state = self
+            .state_per_namespace
+            .entry(msg.namespace_id)
+            .or_insert_with(|| ReadinessState::seed(Instant::now()))
+            .clone();
         // Refresh from the store before evaluating — see
         // `Handler<NamespaceOpApplied>` for rationale. Retain the current
         // value on a transient store error rather than regressing to 0.

--- a/crates/node/src/readiness/tests.rs
+++ b/crates/node/src/readiness/tests.rs
@@ -333,6 +333,60 @@ fn namespace_subscribed_seeds_entry_and_op_applied_preserves_subscribed_at() {
     );
 }
 
+#[test]
+fn apply_beacon_local_seeds_entry_when_absent_and_preserves_existing() {
+    // Mirrors the `.entry(ns).or_insert_with(ReadinessState::seed)` that
+    // `Handler<ApplyBeaconLocal>` runs on first contact. Before this seed the
+    // handler did `get(...).else { return }`, so a beacon arriving before the
+    // subscribe-time `NamespaceSubscribed` seed (which takes an extra hop via
+    // NodeManager) was silently dropped and the FSM never entered. Seeding
+    // here makes the entry exist so the subsequent evaluation runs.
+    let mut states: HashMap<[u8; 32], ReadinessState> = HashMap::new();
+    let ns = [11u8; 32];
+
+    assert!(!states.contains_key(&ns));
+    let beacon_at = Instant::now() - Duration::from_secs(5);
+    states
+        .entry(ns)
+        .or_insert_with(|| ReadinessState::seed(beacon_at));
+    assert!(
+        states.contains_key(&ns),
+        "a beacon arriving before any subscribe/op signal must seed the entry"
+    );
+    assert_eq!(states[&ns].tier, ReadinessTier::Bootstrapping);
+    assert_eq!(states[&ns].local_applied_through, 0);
+
+    // A later subscribe/op signal reuses the entry (idempotent), so the
+    // earlier `subscribed_at` survives.
+    let seeded_at = states[&ns].subscribed_at;
+    let entry = states
+        .entry(ns)
+        .or_insert_with(|| ReadinessState::seed(Instant::now()));
+    assert_eq!(
+        entry.subscribed_at, seeded_at,
+        "a beacon-seeded entry must not be overwritten by a later signal"
+    );
+}
+
+#[test]
+fn beacon_seeded_empty_dag_entry_evaluates_to_catching_up() {
+    // The point of seeding in ApplyBeaconLocal: once the entry exists, an
+    // empty-DAG node evaluated against a fresh peer beacon enters CatchingUp
+    // (a real target to sync toward) instead of having its beacon dropped.
+    let state = ReadinessState::seed(Instant::now());
+    let peers = PeerSummary {
+        max_applied_through: Some(42),
+        heard_recent_beacon: true,
+    };
+    let tier = evaluate_readiness(&state, &peers, &ReadinessConfig::default(), Instant::now());
+    assert!(matches!(
+        tier,
+        ReadinessTier::CatchingUp {
+            target_applied_through: 42
+        }
+    ));
+}
+
 fn make_beacon(pk: PublicKey, applied_through: u64, strong: bool) -> SignedReadinessBeacon {
     SignedReadinessBeacon {
         namespace_id: [42u8; 32].into(),


### PR DESCRIPTION
## Summary
- `Handler<ApplyBeaconLocal>` returned early (`get(...).else { return }`) when no per-namespace readiness entry existed, unlike `Handler<NamespaceSubscribed>` and `Handler<NamespaceOpApplied>`, which both `.entry(ns).or_insert_with(ReadinessState::seed(...))`.
- A peer beacon reaches `ApplyBeaconLocal` in one hop (sent straight to the readiness addr from the network-event handler), while the subscribe-time `NamespaceSubscribed` seed takes an extra hop via `NodeManager`. A beacon arriving right after subscribe can therefore beat the seed and hit the early return, dropping that beacon's re-evaluation and leaving the FSM un-entered for the namespace until a later signal (next beacon, periodic tick for an already-seeded entry, or first applied op).
- Self-seed on first contact so all three FSM evaluation entry points are self-sufficient and symmetric. `or_insert_with` is idempotent, so an earlier `subscribed_at` set by a subscribe/op signal is preserved (the `boot_grace` anchor is unaffected).

## Test plan
- `cargo fmt` (enforced by pre-commit hook).
- `cargo clippy -p calimero-node --all-targets`.
- `cargo test -p calimero-node`.
- New unit tests in `readiness::tests`:
  - `apply_beacon_local_seeds_entry_when_absent_and_preserves_existing` - a beacon arriving before any subscribe/op signal seeds a `Bootstrapping` entry, and a later signal reuses it (idempotent), preserving `subscribed_at`.
  - `beacon_seeded_empty_dag_entry_evaluates_to_catching_up` - once seeded, an empty-DAG node evaluated against a fresh peer beacon enters `CatchingUp` instead of having its beacon dropped.