### PR TITLE
ci: Actions owns core reviews per-push (synchronize); remove App double-review; tune reviewer config

### DIFF
--- a/.ai-reviewer.yaml
+++ b/.ai-reviewer.yaml
@@ -35,6 +35,10 @@ agents:
     model: claude-sonnet-5
     thinking_enabled: false
     max_tool_calls: 20
+  - name: performance-reviewer   # hot paths, allocations, sync/network throughput
+    model: claude-sonnet-5       # 4th slot: not run by default (--agents 3);
+    thinking_enabled: false      # included via workflow_dispatch agents>=4
+    max_tool_calls: 20
 
 # Skip agents on vendored / generated paths (read even without --config).
 ignore:
@@ -42,6 +46,10 @@ ignore:
   - "Cargo.lock"
   - "**/*.lock"
   - "**/snapshots/**"
+  - "**/*.wasm"
+  - "CHANGELOG.md"
+  - "graphify-out/**"
+  - "docs-site/**"
 
 # Doc auto-update — opens a draft PR on merges to master with proposed
 # changes to the architecture site (and any Markdown docs that go stale).

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -1,11 +1,20 @@
 name: AI Code Review
 
 on:
-  # Automatic reviews are owned by the MeroReviewer App (webhook): it reviews
-  # on PR open AND on every push, with delta tracking and convergence so
-  # repeat passes stay cheap. Running this workflow on pull_request too made
-  # every PR double-reviewed. Kept as manual-only: a deliberate full re-run
-  # lever when the App's verdict needs a second opinion.
+  # This workflow is core's ONLY automatic reviewer (the MeroReviewer App is
+  # removed from this repo - it double-reviewed every PR). `synchronize` is
+  # included: every push re-reviews, with delta tracking + convergence keeping
+  # repeat passes cheap and cancel-in-progress deduping rapid push trains.
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+    # Skipped only when ALL changed files are doc-site content - mixed PRs
+    # still trigger (standard paths-ignore semantics). Pure-doc PRs are owned
+    # by the Doc Auto-Update workflow.
+    paths-ignore:
+      - 'docs/**'
+      - 'architecture/**'
+      - 'docs-static/**'
+      - 'docs-site/**'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -20,12 +29,19 @@ on:
         options: ["1", "2", "3", "4", "5"]
 
 concurrency:
-  group: ai-review-${{ github.event.inputs.pr_number }}
+  group: ai-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   review:
     runs-on: ubuntu-latest
+    # Skip drafts and fork PRs (forks don't get repo secrets, so the run
+    # would call Claude with no key and fail noisily). Review fork PRs via
+    # workflow_dispatch after auditing the diff.
+    if: >-
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
       pull-requests: write
@@ -59,8 +75,15 @@ jobs:
       - name: Determine PR number and agent count
         id: pr
         run: |
-          echo "number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
-          echo "agents=${{ github.event.inputs.agents }}"    >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
+            echo "agents=${{ github.event.inputs.agents }}"    >> $GITHUB_OUTPUT
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            # 3 agents so the cross-review validation round runs (needs >=3);
+            # the agents block in .ai-reviewer.yaml selects security/logic/patterns.
+            echo "agents=3"                                        >> $GITHUB_OUTPUT
+          fi
 
       - name: Run AI Code Review
         env:

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -1,19 +1,11 @@
 name: AI Code Review
 
 on:
-  pull_request:
-    # `synchronize` (re-run on every push) deliberately omitted to control
-    # cost — a review fires on PR open / reopen / draft→ready, not on each
-    # push. Re-trigger a review by toggling draft or via workflow_dispatch.
-    types: [opened, reopened, ready_for_review]
-    # Skipped only when ALL changed files are under docs/architecture/docs-static —
-    # mixed PRs still trigger a review (standard GitHub Actions paths-ignore semantics).
-    # Pure-doc PRs are owned by the `Doc Auto-Update` workflow; this avoids paying
-    # twice for the same diff.
-    paths-ignore:
-      - 'docs/**'
-      - 'architecture/**'
-      - 'docs-static/**'
+  # Automatic reviews are owned by the MeroReviewer App (webhook): it reviews
+  # on PR open AND on every push, with delta tracking and convergence so
+  # repeat passes stay cheap. Running this workflow on pull_request too made
+  # every PR double-reviewed. Kept as manual-only: a deliberate full re-run
+  # lever when the App's verdict needs a second opinion.
   workflow_dispatch:
     inputs:
       pr_number:
@@ -28,21 +20,12 @@ on:
         options: ["1", "2", "3", "4", "5"]
 
 concurrency:
-  group: ai-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  group: ai-review-${{ github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   review:
     runs-on: ubuntu-latest
-    # Skip on draft PRs and on PRs from forks (forks don't get repo secrets,
-    # so the run would attempt to call Claude with no key and fail noisily).
-    # Maintainers can review fork PRs manually via workflow_dispatch after
-    # auditing the diff.
-    if: >-
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.pull_request.draft == false &&
-       github.event.pull_request.head.repo.full_name == github.repository)
-
     permissions:
       contents: read
       pull-requests: write
@@ -76,15 +59,8 @@ jobs:
       - name: Determine PR number and agent count
         id: pr
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
-            echo "agents=${{ github.event.inputs.agents }}"    >> $GITHUB_OUTPUT
-          else
-            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-            # 3 agents so the cross-review validation round runs (needs >=3);
-            # the agents block in .ai-reviewer.yaml selects security/logic/patterns.
-            echo "agents=3"                                        >> $GITHUB_OUTPUT
-          fi
+          echo "number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
+          echo "agents=${{ github.event.inputs.agents }}"    >> $GITHUB_OUTPUT
 
       - name: Run AI Code Review
         env:


### PR DESCRIPTION
## Summary

Every core PR is currently double-reviewed: this workflow AND the MeroReviewer App webhook (both post as meroreviewer[bot] so it looks like one reviewer - see #3251/#3244 headers and timestamps). Decision: **this workflow is core's only automatic reviewer**; the App will be removed from this repo's installation. The Actions path is the reliable one (during the 2026-07-15 App outage it reviewed the same PRs the App was failing on) and it runs core's own `.ai-reviewer.yaml`.

- **Per-push reviews**: `synchronize` added to the triggers - every push re-reviews. Delta tracking + convergence keep repeat passes cheap (incremental findings, LGTM fast-path, skip once stable), and `cancel-in-progress` dedupes rapid push trains so only the latest state is reviewed.
- `docs-site/**` added to paths-ignore (pure doc-site PRs are owned by the doc flows).
- `.ai-reviewer.yaml` tuned for core:
  - ignore generated/vendored content (`**/*.wasm`, `CHANGELOG.md`, `graphify-out/**`, `docs-site/**`) so agents don't burn tool budget on it
  - `performance-reviewer` defined as the 4th agent: automatic runs stay at 3 (security/logic/patterns + cross-review), and `workflow_dispatch` with agents >= 4 now includes a hot-path/allocations pass for deliberate deep reviews
- `workflow_dispatch` retained as the manual lever (choose 1-5 agents).

Companion action (org admin, after merge): remove `core` from the MeroReviewer App's repository access so the double-review stops.

## Test plan
- Workflow parses; PR-event path restores the draft/fork guard and 3-agent default.
- After merge: push to any open PR - exactly one review per push, none from the App once repo access is removed.