### PR TITLE
ci(e2e): speed up the app-migration / rust-apps e2e build

### DIFF
--- a/.github/actions/build-local-merod/action.yml
+++ b/.github/actions/build-local-merod/action.yml
@@ -19,8 +19,11 @@ runs:
       id: cache-key
       shell: bash
       run: |
-        # Key changes only when core (Cargo.lock, crates, prebuilt Dockerfile) changes
-        KEY="merod-image-$( (tar cf - Cargo.lock crates .github/workflows/deps/prebuilt.Dockerfile 2>/dev/null || true) | sha256sum | cut -c1-16)"
+        # Key changes when core (Cargo.lock, crates, prebuilt Dockerfile) changes.
+        # Profile suffix keeps default- and fast-profile callers from colliding on
+        # this repo-wide cache (see commit message).
+        PROFILE="lto-${CARGO_PROFILE_RELEASE_LTO:-default}-cgu-${CARGO_PROFILE_RELEASE_CODEGEN_UNITS:-default}"
+        KEY="merod-image-${PROFILE}-$( (tar cf - Cargo.lock crates .github/workflows/deps/prebuilt.Dockerfile 2>/dev/null || true) | sha256sum | cut -c1-16)"
         echo "key=${KEY}" >> "$GITHUB_OUTPUT"
         echo "CACHE_KEY=${KEY}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/app-migration-e2e.yml
+++ b/.github/workflows/app-migration-e2e.yml
@@ -54,48 +54,14 @@ jobs:
   # wasms) instead of their sum. Each uploads the artifact the `scenario`
   # matrix consumes, so the matrix jobs never re-compile Rust.
   #
-  # Cache: build-merod owns the shared `e2e-rust-apps` bucket (it builds the
-  # native release binary, like that workflow does); build-wasms reads it but
-  # never SAVEs, so the two jobs never race a second writer for one key.
+  # The merod image build is the reusable build-merod-image.yml workflow, shared
+  # verbatim with e2e-rust-apps.yml so the identical build is defined once. That
+  # job remains the sole master-time writer of the shared `e2e-rust-apps`
+  # rust-cache bucket; build-wasms below reads it but never SAVEs, so the two
+  # jobs never race a second writer for one key.
   build-merod:
     name: Build merod image
-    runs-on: ubuntu-24.04-8cpu
-    timeout-minutes: 20
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Setup Rust CI
-        uses: ./.github/actions/setup-rust-ci
-        with:
-          toolchain: stable
-          targets: wasm32-unknown-unknown
-          # Share the e2e-rust-apps cache bucket: this job builds the same
-          # native x86_64 merod release binary, so it rides that workflow's
-          # already-warm dependency cache instead of a private cold one.
-          shared-key: e2e-rust-apps
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      - name: Build local merod image
-        uses: ./.github/actions/build-local-merod
-        env:
-          CALIMERO_WEBUI_FETCH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CALIMERO_AUTH_FRONTEND_FETCH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Save merod:local Docker image
-        run: |
-          mkdir -p image-artifact
-          docker save merod:local | gzip > image-artifact/merod-local.tar.gz
-          ls -la image-artifact/
-
-      - name: Upload merod image artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: app-migration-merod-image
-          path: image-artifact/merod-local.tar.gz
-          retention-days: 1
+    uses: ./.github/workflows/build-merod-image.yml
 
   build-wasms:
     name: Build WASM fixtures
@@ -249,12 +215,12 @@ jobs:
       - name: Download merod image artifact
         uses: actions/download-artifact@v8
         with:
-          name: app-migration-merod-image
-          path: image-artifact
+          name: merod-image
+          path: /tmp
 
       - name: Load merod:local Docker image
         run: |
-          gunzip -c image-artifact/merod-local.tar.gz | docker load
+          zstd -d /tmp/merod-local.tar.zst --stdout | docker load
           docker images | grep merod || true
 
       - name: Download WASM fixtures

--- a/.github/workflows/app-migration-e2e.yml
+++ b/.github/workflows/app-migration-e2e.yml
@@ -23,6 +23,7 @@ on:
       - "apps/migrations/**"
       - "workflows/app-migration/**"
       - ".github/workflows/app-migration-e2e.yml"
+      - ".github/workflows/build-merod-image.yml"
       - ".github/actions/build-local-merod/**"
       - ".github/actions/setup-merobox/**"
 
@@ -33,6 +34,7 @@ on:
       - "apps/migrations/**"
       - "workflows/app-migration/**"
       - ".github/workflows/app-migration-e2e.yml"
+      - ".github/workflows/build-merod-image.yml"
       - ".github/actions/build-local-merod/**"
       - ".github/actions/setup-merobox/**"
 

--- a/.github/workflows/build-merod-image.yml
+++ b/.github/workflows/build-merod-image.yml
@@ -1,0 +1,67 @@
+name: Build merod image (reusable)
+
+# Reusable workflow: builds the merod:local Docker image once and uploads it
+# as the `merod-image` artifact (zstd tarball). Called as a job by both
+# e2e-rust-apps.yml and app-migration-e2e.yml so the identical merod build is
+# defined in exactly one place. Artifacts are per-run, so each caller's run
+# gets its own copy of the artifact under the same name — no cross-run
+# collision — while the duplicated build code is unified and the second suite's
+# build rides the same warm cache.
+#
+# Cache discipline: this job is the sole master-time writer of the shared
+# `e2e-rust-apps` rust-cache bucket. The read-only sibling jobs in the callers
+# (app-migration's build-wasms / schema-downgrade-guard) use the same
+# shared-key with save-if:false, so single-writer discipline is preserved. The
+# env below deliberately mirrors those callers' build env (including RUST_LOG)
+# so rust-cache computes the SAME env-hash for all of them and they keep
+# sharing this job's cache; do not add cargo/rust-prefixed env here that the
+# sibling jobs don't also set, or the keys diverge and the siblings go cold.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
+  # Mirrors app-migration-e2e.yml's top-level env for rust-cache env-hash
+  # parity with its read-only build-wasms / schema-guard jobs (see header).
+  RUST_LOG: info,calimero_=debug
+  CARGO_TARGET_DIR: ${{ github.workspace }}/target
+
+jobs:
+  build-merod-image:
+    name: Build merod image
+    runs-on: ubuntu-24.04-8cpu
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Rust CI
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          toolchain: stable
+          shared-key: e2e-rust-apps
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Build local merod image
+        uses: ./.github/actions/build-local-merod
+        env:
+          CALIMERO_WEBUI_FETCH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CALIMERO_AUTH_FRONTEND_FETCH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Save and upload Docker image
+        run: docker save merod:local | zstd -T0 -3 -o /tmp/merod-local.tar.zst
+
+      - name: Upload Docker image
+        uses: actions/upload-artifact@v7
+        with:
+          name: merod-image
+          path: /tmp/merod-local.tar.zst
+          retention-days: 1
+          compression-level: 0

--- a/.github/workflows/build-merod-image.yml
+++ b/.github/workflows/build-merod-image.yml
@@ -49,6 +49,20 @@ jobs:
           shared-key: e2e-rust-apps
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
+      # Faster e2e image: the production [profile.release] uses fat LTO +
+      # codegen-units=1, whose serial whole-program link is the single biggest
+      # slice of this build and cannot be shortcut by any compiler cache. The
+      # e2e image doesn't need the production size-optimization, so override
+      # just those two flags for the merod compile below. Set AFTER the
+      # rust-cache step (via $GITHUB_ENV) on purpose: rust-cache hashes
+      # CARGO_*/RUST_* env into its key, so setting these earlier would fork the
+      # cache key away from the read-only sibling jobs. Output still lands in
+      # target/.../release, so the shared cache stays warm.
+      - name: Configure fast e2e build profile
+        run: |
+          echo "CARGO_PROFILE_RELEASE_LTO=false" >> "$GITHUB_ENV"
+          echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=256" >> "$GITHUB_ENV"
+
       - name: Build local merod image
         uses: ./.github/actions/build-local-merod
         env:

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -19,6 +19,7 @@ on:
       - "apps/components-demo/**"
       - "apps/blobs/**"
       - ".github/workflows/e2e-rust-apps.yml"
+      - ".github/workflows/build-merod-image.yml"
 
   pull_request:
     branches: [master]
@@ -30,6 +31,7 @@ on:
       - "apps/components-demo/**"
       - "apps/blobs/**"
       - ".github/workflows/e2e-rust-apps.yml"
+      - ".github/workflows/build-merod-image.yml"
 
   workflow_dispatch:
 

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -45,38 +45,13 @@ env:
 
 jobs:
   # ── Build merod Docker image (heaviest step) ──
+  # Reusable build-merod-image.yml, shared verbatim with app-migration-e2e.yml
+  # so the identical merod build lives in one place and both suites ride the
+  # same warm `e2e-rust-apps` cache. Uploads the `merod-image` artifact
+  # (zstd tarball) consumed by the jobs below.
   build-image:
     name: Build Image
-    runs-on: ubuntu-24.04-8cpu
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Setup Rust CI
-        uses: ./.github/actions/setup-rust-ci
-        with:
-          toolchain: stable
-          shared-key: e2e-rust-apps
-          save-if: ${{ github.ref == 'refs/heads/master' }}
-
-      - name: Build local merod image
-        uses: ./.github/actions/build-local-merod
-        env:
-          CALIMERO_WEBUI_FETCH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CALIMERO_AUTH_FRONTEND_FETCH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Save and upload Docker image
-        run: docker save merod:local | zstd -T0 -3 -o /tmp/merod-local.tar.zst
-
-      - name: Upload Docker image
-        uses: actions/upload-artifact@v7
-        with:
-          name: merod-image
-          path: /tmp/merod-local.tar.zst
-          retention-days: 1
-          compression-level: 0
+    uses: ./.github/workflows/build-merod-image.yml
 
   # ── Auth seam: client-token e2e over real HTTP ──
   # Proves a client token minted the way the auth frontend mints it can call


### PR DESCRIPTION
# [ci] Speed up the app-migration / rust-apps e2e build

## Description

Cuts the critical path of the App-migration and Rust-apps e2e suites, both of which are dominated by the merod image build (~6m of a ~10m40s wall).

**1. Dedupe the merod image build (`ci(e2e)`).**
`e2e-rust-apps.yml` and `app-migration-e2e.yml` each carried their own copy of the same merod:local build steps. They now call one reusable workflow, `.github/workflows/build-merod-image.yml` (`on: workflow_call`), as a job. The reusable build:
- stays the sole master-time writer of the shared `e2e-rust-apps` rust-cache bucket; the read-only `build-wasms` / `schema-downgrade-guard` siblings keep `save-if: false`, so single-writer discipline is preserved;
- mirrors app-migration's top-level build env so rust-cache computes the same env-hash for all three jobs and they keep sharing one cache. With both suites now routing through this single job, the second suite's build also rides the same warm cache;
- uploads one artifact name/format (`merod-image`, zstd). app-migration previously gzipped to `app-migration-merod-image`; its scenario matrix now zstd-loads the shared artifact. e2e-rust-apps already consumed `merod-image` as zstd, so its consumer jobs are unchanged.

Artifacts are per-run, so each suite's run still builds once and gets its own copy; the win is the unified code plus the shared warm cache.

**2. Drop fat LTO for the e2e image (`perf(ci)`).**
The workspace `[profile.release]` compiles merod with `lto = "fat"` + `codegen-units = 1` — a serial whole-program link that dominates the build and that no compiler cache can shortcut. The e2e image only needs a functional merod, so the reusable build overrides just those two flags (`CARGO_PROFILE_RELEASE_LTO=false`, `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=256`) for its cargo compile. `Cargo.toml` and the production release artifacts are untouched. The override is exported via `$GITHUB_ENV` *after* the rust-cache step so the `CARGO_*` vars stay out of the cache key; output still lands in `target/.../release`, so the cache stays warm.

### Not changed: scenario fixed-sleeps (approved item 3)

Investigated replacing the `wait` sleeps with polling; none is a safe/faster swap given the actual merobox + core semantics, so the scenario YAMLs are left as-is:
- **15s "migration-apply settle" waits**: every one of these scenarios uses `upgrade_policy: lazy_on_access` — the migration is triggered by the reads that come *after* the wait. The only migration-completion poll, `assert_migration_complete`, reads the heartbeat rollup, which would report a not-yet-triggered migration and time out. There is no polling step for `get_group_upgrade_status`, and root-hash `wait_for_sync` is vacuous for a full-root migration (no delta).
- **10s "join-gossip settle" waits**: merobox has no membership/invitation-visibility poll step, and these are real-time gossip waits; reducing blindly risks flakiness across 30+ scenarios.
- **Scenario 28 (`wait: 40` / `wait: 75`)**: these track merod's heartbeat emit-interval (30s, `DEFAULT_EMIT_INTERVAL`) and TTL (60s, `DEFAULT_HEARTBEAT_TTL`). A core knob would only help if the value could be set per-node in the scenario, but the pinned merobox `run_node` forwards no arbitrary per-node env into the container (only `mdns` / `network_admin`), so there is no clean path to shrink these. Per the approved scope, scenario 28 is left alone; no dormant core knob was added since it would shrink nothing today.

## Test plan

- `actionlint` clean on all three workflows (only the repo-wide `ubuntu-24.04-8cpu` custom-runner-label notice remains).
- YAML parses; no dangling references to the old `app-migration-merod-image` artifact or gzip path.
- The App-migration e2e and E2E - Rust Apps workflows both trigger on this `crates/**`-less change via `.github/workflows/**`... they run on their own path filters; this PR touches only workflow files, so CI exercises the reusable-workflow wiring end to end (build once, both suites consume the `merod-image` artifact, all scenarios load and pass).

### Expected timing impact
- Build dedup: unifies duplicated code and lets the second-triggered suite ride the warm `e2e-rust-apps` cache; no change to the per-run build count (artifacts are per-run).
- Fat-LTO drop: removes the serial whole-program link from the ~6m critical-path build (target ~2-4m off on a cache-miss/core-changing run).
- gzip -> zstd for the app-migration artifact: multi-threaded save/load across the 38-way scenario fan-out.

## Documentation update

None required (CI-only change).
