### PR TITLE
fix(auth): validate node binding against trusted config host (security finding #7)

### DIFF
--- a/crates/auth/config/config.toml
+++ b/crates/auth/config/config.toml
@@ -8,6 +8,15 @@ listen_addr = "0.0.0.0:3001"
 issuer = "calimero-auth"
 access_token_expiry = 1800          # 30 minutes
 refresh_token_expiry = 2592000    # 30 days
+# Trusted authoritative host for node-binding validation (security finding #7).
+# When set, node-bound tokens are validated against THIS host instead of the
+# client-controllable Host/X-Forwarded-Host request headers, preventing a caller
+# that reaches the auth service directly from spoofing X-Forwarded-Host to replay
+# a token bound to another node. Set it to the public host clients reach this
+# node at (e.g. "node.example.com" or "localhost:2428"); host-only comparison.
+# Leave it unset (default) to keep legacy header-based behavior — a backend
+# cannot auto-discover its public host, so this hardening is opt-in.
+# node_host = "node.example.com"
 
 # Storage configuration
 [storage]

--- a/crates/auth/src/auth/middleware.rs
+++ b/crates/auth/src/auth/middleware.rs
@@ -204,6 +204,7 @@ mod tests {
             issuer: "test_issuer".to_string(),
             access_token_expiry: 3600,
             refresh_token_expiry: 86400,
+            node_host: None,
         };
 
         let token_manager = TokenManager::new(

--- a/crates/auth/src/auth/token/jwt.rs
+++ b/crates/auth/src/auth/token/jwt.rs
@@ -135,11 +135,21 @@ impl TokenManager {
         }
     }
 
-    /// Validate that a token's node_url matches the request host
+    /// Validate that a token's node_url matches the host this node is reachable
+    /// at.
     ///
-    /// This function compares the host from the token's node_url with the original
-    /// host from the request headers. It skips validation for internal auth service
-    /// requests.
+    /// The host to compare against is chosen as follows (security finding #7):
+    ///
+    /// * If a trusted authoritative host is configured (`jwt.node_host`), it is
+    ///   used and the request headers are **ignored entirely**. `Host` and
+    ///   `X-Forwarded-Host` are both client-controllable, so a caller that
+    ///   reaches the auth service directly (outside the intended reverse-proxy
+    ///   path) could otherwise spoof `X-Forwarded-Host` to replay a token bound
+    ///   to node A against node B. A configured host closes that hole.
+    /// * Otherwise the host is derived from `X-Forwarded-Host` (else `Host`), as
+    ///   before. This preserves the legacy behavior for deployments that have
+    ///   not opted in — a backend cannot reliably auto-discover its own public
+    ///   host, so the trusted-host hardening is opt-in rather than mandatory.
     ///
     /// # Arguments
     ///
@@ -154,10 +164,14 @@ impl TokenManager {
         token_node_url: &str,
         headers: &HeaderMap,
     ) -> Result<(), String> {
-        let request_host = headers
-            .get("X-Forwarded-Host")
-            .or_else(|| headers.get("host"))
-            .and_then(|h| h.to_str().ok());
+        let request_host = if let Some(node_host) = self.config.node_host.as_deref() {
+            Some(node_host)
+        } else {
+            headers
+                .get("X-Forwarded-Host")
+                .or_else(|| headers.get("host"))
+                .and_then(|h| h.to_str().ok())
+        };
 
         Self::validate_node_host_match(token_node_url, request_host)
     }
@@ -1013,6 +1027,7 @@ mod tests {
             issuer: "calimero-test".to_string(),
             access_token_expiry: 3600,
             refresh_token_expiry: 30 * 24 * 3600,
+            node_host: None,
         }
     }
 
@@ -1561,6 +1576,7 @@ mod tests {
                 issuer: "test".to_string(),
                 access_token_expiry: 3600,
                 refresh_token_expiry: 86400,
+                node_host: None,
             },
             storage,
             secret_manager,
@@ -1573,6 +1589,77 @@ mod tests {
         // there is no error to handle here.
         drop(h.insert(name, value.parse().unwrap()));
         h
+    }
+
+    async fn test_token_manager_with_node_host(node_host: &str) -> TokenManager {
+        use crate::storage::providers::memory::MemoryStorage;
+        use crate::storage::Storage;
+
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new());
+        let secret_manager = Arc::new(SecretManager::new(Arc::clone(&storage)));
+        secret_manager.initialize().await.unwrap();
+        TokenManager::new(
+            JwtConfig {
+                issuer: "test".to_string(),
+                access_token_expiry: 3600,
+                refresh_token_expiry: 86400,
+                node_host: Some(node_host.to_string()),
+            },
+            storage,
+            secret_manager,
+        )
+    }
+
+    /// With a trusted `node_host` configured (finding #7), node-binding is
+    /// validated against that value and the request headers are ignored — so a
+    /// spoofed `X-Forwarded-Host` can no longer replay a node-A token against a
+    /// node-B service, even though the attacker fully controls the header.
+    #[tokio::test]
+    async fn configured_node_host_ignores_spoofed_header() {
+        // This service is authoritatively node-b.
+        let tm = test_token_manager_with_node_host("node-b.example").await;
+
+        // A token bound to node-b: accepted regardless of what the header says
+        // (attacker sets X-Forwarded-Host to node-a to try to look like node-a).
+        assert!(tm
+            .validate_node_host(
+                "http://node-b.example:2428",
+                &headers_with("X-Forwarded-Host", "node-a.example")
+            )
+            .is_ok());
+
+        // A token bound to node-a replayed against this node-b service: the
+        // spoofed matching header is IGNORED, so it is rejected on the trusted
+        // config host. This is the exact cross-node replay finding #7 describes.
+        assert!(tm
+            .validate_node_host(
+                "http://node-a.example:2428",
+                &headers_with("X-Forwarded-Host", "node-a.example")
+            )
+            .is_err());
+
+        // Missing headers entirely: still validated against the trusted host,
+        // so a node-b token passes even with no Host header (the config, not the
+        // request, is authoritative).
+        assert!(tm
+            .validate_node_host("http://node-b.example:2428", &HeaderMap::new())
+            .is_ok());
+    }
+
+    /// Local-dev topology: node + embedded auth on localhost:2428, app on :5173.
+    /// A token minted with the node's own URL validates against the configured
+    /// localhost host; the app's :5173 origin is a CORS concern and never enters
+    /// node-host binding.
+    #[tokio::test]
+    async fn configured_node_host_accepts_localhost() {
+        let tm = test_token_manager_with_node_host("localhost:2428").await;
+        assert!(tm
+            .validate_node_host("http://localhost:2428", &HeaderMap::new())
+            .is_ok());
+        // A token for a different host is rejected against the configured one.
+        assert!(tm
+            .validate_node_host("http://evil.example:2428", &HeaderMap::new())
+            .is_err());
     }
 
     /// A spoofed `X-Forwarded-Host` for a different node must NOT validate a

--- a/crates/auth/src/config.rs
+++ b/crates/auth/src/config.rs
@@ -55,6 +55,22 @@ pub struct JwtConfig {
     /// Refresh token expiry time in seconds (default: 30 days)
     #[serde(default = "default_refresh_token_expiry")]
     pub refresh_token_expiry: u64,
+
+    /// Trusted authoritative host for node-binding validation (security finding
+    /// #7). When set, a node-bound token is validated against THIS value instead
+    /// of the request's `Host`/`X-Forwarded-Host` header — both of which are
+    /// client-controllable, so an attacker reaching the auth service directly
+    /// (outside the reverse-proxy path) could otherwise spoof `X-Forwarded-Host`
+    /// to replay a node-A token against node-B.
+    ///
+    /// Set it to the node's public host that clients actually reach (e.g.
+    /// `node.example.com` or `localhost:2428`); the scheme/port are compared
+    /// host-only. Leave it unset to preserve the legacy header-based behavior —
+    /// a backend cannot reliably auto-discover its own public host, so this
+    /// hardening is opt-in and non-breaking for local/dev and existing
+    /// deployments.
+    #[serde(default)]
+    pub node_host: Option<String>,
 }
 
 fn default_access_token_expiry() -> u64 {

--- a/crates/auth/src/embedded.rs
+++ b/crates/auth/src/embedded.rs
@@ -110,6 +110,10 @@ pub fn default_config() -> AuthConfig {
             issuer: "calimero-auth".to_string(),
             access_token_expiry: 3600,
             refresh_token_expiry: 2592000,
+            // Opt-in (finding #7): unset keeps legacy header-derived node-host
+            // validation. Operators set the node's public host to enforce
+            // node-binding against trusted config instead of request headers.
+            node_host: None,
         },
         storage: StorageConfig::RocksDB {
             path: "auth".into(),

--- a/crates/auth/src/providers/impls/user_password.rs
+++ b/crates/auth/src/providers/impls/user_password.rs
@@ -722,6 +722,7 @@ mod tests {
                 issuer: "calimero-test".to_string(),
                 access_token_expiry: 3600,
                 refresh_token_expiry: 30 * 24 * 3600,
+                node_host: None,
             },
             Arc::clone(&storage),
             secret_manager,


### PR DESCRIPTION
## Security finding

**[M] Node-binding bypass via X-Forwarded-Host** (security-review item **7**) — `crates/auth/src/auth/token/jwt.rs`.

`validate_node_host` derived the host it checks a node-bound token against **entirely from request headers** (`X-Forwarded-Host`, else `Host`) — both client-controllable. In the normal deployment that's safe only *because a reverse proxy overwrites `X-Forwarded-Host`*. A caller that reaches the auth service **directly** (outside the proxy path) can send `X-Forwarded-Host: node-a` and replay a token bound to node A against node B. #3081 hardened the *comparison* (exact host, fail-closed) but left the *source* client-controlled — this closes that residual.

## Before → after

| | Before | After |
|---|---|---|
| Host source | `X-Forwarded-Host` / `Host` request header (client-controllable) | If `jwt.node_host` is configured → **that trusted value**, headers ignored. Else → legacy header behavior (unchanged). |
| Cross-node replay | node-A token + spoofed `X-Forwarded-Host: node-a` passes on a node-B service | Rejected: validated against node-B's configured host, the spoofed header is not consulted |

## Design: opt-in, non-breaking

New `jwt.node_host: Option<String>` (host the node is publicly reached at). **Unset by default** — a backend cannot reliably auto-discover its own public host (that's *why* the old code trusted the proxy header), so mandatory enforcement would break legitimate deployments. Operators who want the hardening set it; everyone else keeps working.

- **Local dev** (node `localhost:2428`, embedded auth, app `localhost:5173`): set `node_host = "localhost:2428"` (or leave unset — single node, no replay surface). The app's `:5173` origin is **CORS**, never node-host binding, so it is unaffected either way.
- **Deployed** (app on Vercel, node in cloud): set `node_host` to the node's public host (e.g. `node.example.com`). Left unset → legacy behavior, non-breaking.

Embedded mode reads it from the server's auth config; standalone from `[jwt] node_host` in `config.toml`. **Core-only change — no client/SDK/app impact.**

## How to test

\`\`\`
cargo test -p mero-auth
\`\`\`
- \`configured_node_host_ignores_spoofed_header\` — a node-A token with a spoofed matching `X-Forwarded-Host` is **rejected** on a node-B-configured service; a node-B token passes regardless of the header (incl. no header at all).
- \`configured_node_host_accepts_localhost\` — local-dev topology: node-B token accepted, foreign host rejected.
- Existing \`forwarded_host_spoof_is_rejected_cross_node\` (unset path) unchanged.

Manual: configure `jwt.node_host = "node-b"`, present a token minted for `node-a` with `X-Forwarded-Host: node-a` → 401.

Resolves the residual flagged on #3081. Full suite: 159 lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)