### PR TITLE
ci: use the built-in token for AI reviews (App installation removed)

### DIFF
--- a/.ai-reviewer.yaml
+++ b/.ai-reviewer.yaml
@@ -14,6 +14,12 @@ anthropic:
   default_model: claude-sonnet-5
   enable_prompt_caching: true
 
+# Reviews now post via the built-in github-actions token; keep recognizing the
+# reviews the removed MeroReviewer App posted so delta tracking stays continuous.
+github:
+  extra_reviewer_users:
+    - "meroreviewer[bot]"
+
 # Review agents. Only takes effect when the workflow passes --config; the App's
 # webhook uses its own config. Names must match the reviewer's registry exactly.
 # Order matters: --agents N runs the first N. Thinking is ON only for the two

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -59,19 +59,6 @@ jobs:
       - name: Install ai-code-reviewer
         run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@master
 
-      # Authenticate as the MeroReviewer App so review comments genuinely
-      # come from meroreviewer[bot] (not whatever GH_PAT/GITHUB_TOKEN
-      # resolves to), matching the --reviewer-name label below.
-      - name: Create GitHub App token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
-        with:
-          app-id: ${{ vars.MERO_REVIEWER_APP_ID }}
-          private-key: ${{ secrets.MERO_REVIEWER_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: |
-            core
-
       - name: Determine PR number and agent count
         id: pr
         run: |
@@ -88,7 +75,12 @@ jobs:
       - name: Run AI Code Review
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Built-in token: the MeroReviewer App was removed from this repo
+          # (it double-reviewed), so its installation token no longer exists.
+          # Reviews post as github-actions[bot]; the body header still says
+          # MeroReviewer via --reviewer-name, and past meroreviewer[bot]
+          # reviews stay recognized via extra_reviewer_users in .ai-reviewer.yaml.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ai-reviewer review-pr \
             ${{ github.repository }} \


### PR DESCRIPTION
## Summary

Removing the MeroReviewer App from this repo (the single-reviewer decision, #3254) broke both workflows that minted tokens from its installation:

1. **AI Code Review** - died at auth on every run (#3255). Fixed: drop the App-token step, use the built-in `GITHUB_TOKEN` (workflow already grants `pull-requests: write`). Reviews post as `github-actions[bot]`; the body header still reads MeroReviewer via `--reviewer-name`. Adds `github.extra_reviewer_users: ["meroreviewer[bot]"]` to `.ai-reviewer.yaml` so delta tracking still recognizes the App's historical reviews (wiring lands in ai-code-reviewer#111, picked up automatically via @master).
2. **Doc Auto-Update** - same 404 at token mint. Removed entirely: its generation half was already disabled at the docs-site cutover (`doc_generation.enabled: false`), and migrating it to `GITHUB_TOKEN` would leave its PRs unable to trigger CI. Revive from git history if the doc bot is repointed at the new docs site.

## Test plan
- After merge, the next PR push runs the review workflow end to end with the built-in token; no Doc Auto-Update runs fire.