### PR TITLE
ci: point Doc Auto-Update at GH_APP token (MeroReviewer App removed)

### DIFF
--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -66,16 +66,18 @@ jobs:
       - name: Install ai-code-reviewer
         run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@master
 
-      # Mint a short-lived MeroReviewer App installation token. Unlike the
-      # default GITHUB_TOKEN, an App token is not subject to the org/repo
-      # "Allow GitHub Actions to create and approve pull requests" setting,
-      # so `ai-reviewer update-docs` can actually open the doc PR.
+      # Mint a short-lived App installation token. Unlike the default
+      # GITHUB_TOKEN, an App token is not subject to the org/repo "Allow GitHub
+      # Actions to create and approve pull requests" setting AND the PRs it
+      # opens trigger CI, so `ai-reviewer update-docs` can open the doc PR.
+      # Uses GH_APP (also used by release.yml) - the MeroReviewer App was
+      # uninstalled from this repo, so its token would 404.
       - name: Create GitHub App token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.MERO_REVIEWER_APP_ID }}
-          private-key: ${{ secrets.MERO_REVIEWER_PRIVATE_KEY }}
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |
             core


### PR DESCRIPTION
## Summary

The Doc Auto-Update workflow minted its token from the MeroReviewer App's installation on this repo. The App was uninstalled (it double-reviewed PRs, per #3254), so the `Create GitHub App token` step now 404s and every doc-update run fails (e.g. run 29419617015).

Switch that step to `GH_APP` (the App `release.yml` already uses on core). Still a real App token, so the doc PRs it opens trigger CI, unlike plain `GITHUB_TOKEN`. Triggers and all other workflow behavior are unchanged - this is auth-only.

## Test plan
- YAML parses; `push` + `workflow_dispatch` triggers intact; single-file diff (token step only).
- Next merge to master runs the workflow through the token step without a 404.