### PR TITLE
fix(governance): re-drive Open-subgroup buffered ops on namespace-key delivery (#3198)

### DIFF
--- a/crates/context/src/auto_follow.rs
+++ b/crates/context/src/auto_follow.rs
@@ -327,11 +327,61 @@ async fn run(
                     });
                 }
             }
+            OpEvent::SubgroupVisibilityChanged {
+                group_id,
+                open: true,
+            } => {
+                let store = store.clone();
+                let context_client = context_client.clone();
+                let limiter = Arc::clone(&limiter);
+                let _ = tasks.spawn(async move {
+                    handle_subgroup_opened(&store, &context_client, &limiter, group_id).await;
+                });
+            }
             // Subgroup auto-follow (SubgroupNested) and other variants
-            // are handled in a separate pass — see module docs.
+            // (including a Subgroup flip to `Restricted`) are handled in a
+            // separate pass — see module docs.
             _ => {}
         }
     }
+}
+
+/// A subgroup just flipped to `Open`. A root-admitted member (e.g. a
+/// `ReadOnlyTee`) inherits membership into `Open` subgroups, so contexts
+/// registered under it whose `ContextRegistered` auto-follow decision ran while
+/// the subgroup still read `Restricted` were never joined. Re-run the follow
+/// decision for every context in the now-`Open` subgroup.
+///
+/// This is the event-driven complement to the `SubgroupVisibilitySet` re-drive
+/// on the governance side: the re-drive makes the subgroup read `Open` locally,
+/// and this makes auto-follow act on it without waiting for a fresh
+/// `ContextRegistered` (which, for contexts registered before the flip applied,
+/// will never come again).
+async fn handle_subgroup_opened(
+    store: &Store,
+    context_client: &ContextClient,
+    limiter: &Arc<RateLimiter>,
+    group_id: [u8; 32],
+) {
+    let gid = ContextGroupId::from(group_id);
+    let Some(self_pk) = self_pk_for_group(store, &gid) else {
+        return;
+    };
+    // Respect the member's opt-in. `should_auto_follow_contexts` is
+    // inheritance-aware: for a member with no direct row (the root-admitted TEE)
+    // it resolves the Open-chain anchor row's `auto_follow.contexts` flag.
+    if !should_auto_follow_contexts(store, &gid, &self_pk) {
+        return;
+    }
+    info!(
+        group_id = %hex::encode(group_id),
+        "auto-follow: subgroup flipped to Open — re-evaluating its contexts for inherited join"
+    );
+    // Reuse the flag-enabled backfill path: enumerate the subgroup's contexts
+    // and (idempotently) join each. `join_context` is inheritance-aware, so a
+    // non-inherited member is refused there and an already-joined context is a
+    // no-op.
+    handle_auto_follow_enabled(store, context_client, limiter, group_id, self_pk).await;
 }
 
 /// Decision produced by inspecting store state for a

--- a/crates/context/src/auto_follow.rs
+++ b/crates/context/src/auto_follow.rs
@@ -327,6 +327,12 @@ async fn run(
                     });
                 }
             }
+            // TODO(#3198 follow-up): only the `open: true` transition is handled.
+            // An Open->Restricted flip-back (`open: false`) is ignored, which
+            // leaves an inherited-only ReadOnlyTee with neither inherited access
+            // (the wall now hides the subgroup) nor a direct admit row — it
+            // silently stops following with no re-admit path. Tracked separately;
+            // needs a re-admit-or-leave decision on flip-back.
             OpEvent::SubgroupVisibilityChanged {
                 group_id,
                 open: true,
@@ -363,16 +369,13 @@ async fn handle_subgroup_opened(
     limiter: &Arc<RateLimiter>,
     group_id: [u8; 32],
 ) {
-    let gid = ContextGroupId::from(group_id);
-    let Some(self_pk) = self_pk_for_group(store, &gid) else {
-        return;
-    };
-    // Respect the member's opt-in. `should_auto_follow_contexts` is
-    // inheritance-aware: for a member with no direct row (the root-admitted TEE)
-    // it resolves the Open-chain anchor row's `auto_follow.contexts` flag.
-    if !should_auto_follow_contexts(store, &gid, &self_pk) {
+    if !should_follow_on_subgroup_open(store, group_id) {
         return;
     }
+    // `should_follow_on_subgroup_open` already confirmed a namespace identity.
+    let Some(self_pk) = self_pk_for_group(store, &ContextGroupId::from(group_id)) else {
+        return;
+    };
     info!(
         group_id = %hex::encode(group_id),
         "auto-follow: subgroup flipped to Open — re-evaluating its contexts for inherited join"
@@ -382,6 +385,24 @@ async fn handle_subgroup_opened(
     // non-inherited member is refused there and an already-joined context is a
     // no-op.
     handle_auto_follow_enabled(store, context_client, limiter, group_id, self_pk).await;
+}
+
+/// Whether a `SubgroupVisibilityChanged { open: true }` on `group_id` should
+/// make this node re-evaluate the subgroup's contexts for an inherited join.
+///
+/// `true` iff this node holds a namespace identity for the subgroup AND
+/// auto-follows its contexts. `should_auto_follow_contexts` is inheritance-aware:
+/// for a member with NO direct row (the root-admitted `ReadOnlyTee`) it resolves
+/// the Open-chain anchor row's `auto_follow.contexts` flag — which only yields
+/// `true` once the subgroup actually reads `Open` (a `Restricted` subgroup walls
+/// off inheritance). Extracted from [`handle_subgroup_opened`] so this gate is
+/// unit-testable without a live `ContextClient`/rate-limiter/broadcast bus.
+pub(crate) fn should_follow_on_subgroup_open(store: &Store, group_id: [u8; 32]) -> bool {
+    let gid = ContextGroupId::from(group_id);
+    match self_pk_for_group(store, &gid) {
+        Some(self_pk) => should_auto_follow_contexts(store, &gid, &self_pk),
+        None => false,
+    }
 }
 
 /// Decision produced by inspecting store state for a
@@ -786,8 +807,9 @@ mod tests {
         use rand::rngs::OsRng;
 
         use super::super::{
-            decide_on_auto_follow_enabled, decide_on_context_registered, AutoFollowEnabledDecision,
-            ContextRegisteredDecision, BACKFILL_LIMIT,
+            decide_on_auto_follow_enabled, decide_on_context_registered,
+            should_follow_on_subgroup_open, AutoFollowEnabledDecision, ContextRegisteredDecision,
+            BACKFILL_LIMIT,
         };
         use calimero_governance_store::{
             register_context_in_group, CapabilitiesRepository, MembershipRepository,
@@ -1042,6 +1064,146 @@ mod tests {
             assert_eq!(
                 decide_on_context_registered(&store, sub_gid.to_bytes(), &context_id),
                 ContextRegisteredDecision::NotAutoFollowing,
+            );
+        }
+
+        // ----- should_follow_on_subgroup_open (#3198 secondary path) ------
+        //
+        // The `SubgroupVisibilitySet -> Open` re-trigger: a flip that applies
+        // AFTER a context was registered must itself re-evaluate the subgroup's
+        // contexts for an inherited join (the context's own `ContextRegistered`
+        // follow decision already ran while the subgroup read `Restricted`).
+        // These pin the gate `handle_subgroup_opened` applies before it
+        // enumerates+joins.
+
+        /// Seed a root-admitted inherited member (root row with
+        /// `CAN_JOIN_OPEN_SUBGROUPS` + `auto_follow.contexts = true`, no direct
+        /// subgroup row) whose subgroup starts `Restricted`. Returns the store,
+        /// the root gid, the subgroup gid, and self pk.
+        fn seed_inherited_member_with_restricted_subgroup(
+            rng: &mut OsRng,
+            root_gid: ContextGroupId,
+            sub_gid: ContextGroupId,
+        ) -> (Store, PublicKey) {
+            let (store, _sk, pk) = seed_self_member(rng, root_gid);
+            CapabilitiesRepository::new(&store)
+                .set_member_capability(
+                    &root_gid,
+                    &pk,
+                    MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS.bits(),
+                )
+                .expect("set_member_capability");
+            MembershipRepository::new(&store)
+                .set_auto_follow(
+                    &root_gid,
+                    &pk,
+                    AutoFollowFlags {
+                        contexts: true,
+                        subgroups: false,
+                    },
+                )
+                .expect("set_member_auto_follow");
+            // Subgroup nested under root, meta present, but visibility
+            // Restricted (the `GroupCreated` birth default — NOT flipped).
+            MetaRepository::new(&store)
+                .save(&sub_gid, &sample_meta(pk))
+                .expect("save_subgroup_meta");
+            NamespaceRepository::new(&store)
+                .nest(&root_gid, &sub_gid)
+                .expect("nest subgroup under root");
+            CapabilitiesRepository::new(&store)
+                .set_subgroup_visibility(&sub_gid, VisibilityMode::Restricted)
+                .expect("set subgroup Restricted");
+            (store, pk)
+        }
+
+        /// A `Restricted` subgroup walls off inheritance, so an inherited-only
+        /// member must NOT be triggered to follow — even though the root anchor
+        /// grants `CAN_JOIN_OPEN_SUBGROUPS` + `auto_follow.contexts`.
+        #[test]
+        fn subgroup_open_flip_no_follow_while_restricted() {
+            let mut rng = OsRng;
+            let root_gid = ContextGroupId::from([0xF1u8; 32]);
+            let sub_gid = ContextGroupId::from([0xF2u8; 32]);
+            let (store, _pk) =
+                seed_inherited_member_with_restricted_subgroup(&mut rng, root_gid, sub_gid);
+
+            assert!(
+                !should_follow_on_subgroup_open(&store, sub_gid.to_bytes()),
+                "a Restricted subgroup must not trigger inherited follow"
+            );
+        }
+
+        /// After the flip to `Open`, the SAME inherited-only member IS triggered,
+        /// and the subgroup's already-registered context is the join target
+        /// (`decide_on_auto_follow_enabled` enumerates it). This is the durable
+        /// signal `handle_subgroup_opened` acts on.
+        #[test]
+        fn subgroup_open_flip_triggers_follow_for_inherited_member() {
+            let mut rng = OsRng;
+            let root_gid = ContextGroupId::from([0xF3u8; 32]);
+            let sub_gid = ContextGroupId::from([0xF4u8; 32]);
+            let (store, self_pk) =
+                seed_inherited_member_with_restricted_subgroup(&mut rng, root_gid, sub_gid);
+
+            // A context is registered under the subgroup BEFORE the flip.
+            let context_id = ContextId::from([0xF5u8; 32]);
+            register_context_in_group(&store, &sub_gid, &context_id)
+                .expect("register context -> subgroup");
+
+            // Pre-flip: the gate is closed (Restricted walls off inheritance).
+            assert!(
+                !should_follow_on_subgroup_open(&store, sub_gid.to_bytes()),
+                "precondition: no follow while the subgroup is Restricted"
+            );
+
+            // Flip to Open — exactly what `SubgroupVisibilitySet` apply does.
+            CapabilitiesRepository::new(&store)
+                .set_subgroup_visibility(&sub_gid, VisibilityMode::Open)
+                .expect("flip subgroup Open");
+
+            assert!(
+                should_follow_on_subgroup_open(&store, sub_gid.to_bytes()),
+                "the flip to Open must open the inherited-follow gate"
+            );
+            // And the previously-registered context is the enumerated join target.
+            assert_eq!(
+                decide_on_auto_follow_enabled(&store, sub_gid.to_bytes(), self_pk),
+                AutoFollowEnabledDecision::Backfill {
+                    contexts: vec![context_id],
+                    truncated: false,
+                },
+                "the flip must surface the subgroup's existing context for an inherited join"
+            );
+        }
+
+        /// Even Open, an anchor with `auto_follow.contexts = false` must NOT be
+        /// triggered — the flip respects the member's opt-out.
+        #[test]
+        fn subgroup_open_flip_no_follow_when_anchor_flag_false() {
+            let mut rng = OsRng;
+            let root_gid = ContextGroupId::from([0xF6u8; 32]);
+            let sub_gid = ContextGroupId::from([0xF7u8; 32]);
+            let (store, pk) =
+                seed_inherited_member_with_restricted_subgroup(&mut rng, root_gid, sub_gid);
+            // Opt out on the anchor row.
+            MembershipRepository::new(&store)
+                .set_auto_follow(
+                    &root_gid,
+                    &pk,
+                    AutoFollowFlags {
+                        contexts: false,
+                        subgroups: false,
+                    },
+                )
+                .expect("set_member_auto_follow");
+            CapabilitiesRepository::new(&store)
+                .set_subgroup_visibility(&sub_gid, VisibilityMode::Open)
+                .expect("flip subgroup Open");
+
+            assert!(
+                !should_follow_on_subgroup_open(&store, sub_gid.to_bytes()),
+                "an anchor opt-out (auto_follow.contexts = false) must suppress the flip trigger"
             );
         }
 

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -1291,6 +1291,51 @@ impl<'a> NamespaceGovernance<'a> {
             record_namespace_retry_event("none");
         }
 
+        // #2256/#3198: an `Open` subgroup encrypts its governance ops with the
+        // *namespace* key (see `GroupGovernancePublisher`), not its own. A
+        // root-admitted member (e.g. a `ReadOnlyTee`) that receives an
+        // Open-subgroup op BEFORE the namespace key was delivered parks it
+        // undecryptable. The per-group retry above only re-drives the group
+        // whose key just arrived — here the namespace root — so nothing
+        // re-drives the *subgroup's* own buffered ops. A `SubgroupVisibilitySet
+        // -> Open` that arrived early then stays applied-at-DAG-but-effect-
+        // skipped forever: the subgroup keeps reading `Restricted`, and
+        // inherited auto-follow refuses to join contexts registered under it.
+        //
+        // When the delivered/rotated key IS the namespace key, also re-drive
+        // every OTHER group in this namespace that now holds a decryptable
+        // buffered op — exactly the held-key buffered-op set the #2848 Part C
+        // startup sweep re-drives, applied here at delivery time so recovery
+        // does not have to wait for a node restart. Each re-drive runs through
+        // the normal signature/nonce/authorizer apply path (no security bypass),
+        // is idempotent (nonce-window deduped), and the set is self-limiting to
+        // groups with pending decryptable ops.
+        if group_id == self.namespace_id.to_bytes() {
+            match retry_service.groups_with_held_key_buffered_ops() {
+                Ok(groups) => {
+                    for sub in groups {
+                        if sub == group_id {
+                            continue;
+                        }
+                        if let Err(e) = self.redrive_encrypted_ops_for_group_counted(sub) {
+                            tracing::warn!(
+                                group_id = %hex::encode(sub),
+                                error = %format!("{e:#}"),
+                                "failed to re-drive Open-subgroup buffered ops after \
+                                 namespace key delivery"
+                            );
+                        }
+                    }
+                }
+                Err(e) => tracing::warn!(
+                    namespace_id = %hex::encode(self.namespace_id.to_bytes()),
+                    error = %format!("{e:#}"),
+                    "failed to enumerate held-key buffered-op groups after namespace \
+                     key delivery"
+                ),
+            }
+        }
+
         Ok(retry_divergence)
     }
 

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -1310,6 +1310,12 @@ impl<'a> NamespaceGovernance<'a> {
         // the normal signature/nonce/authorizer apply path (no security bypass),
         // is idempotent (nonce-window deduped), and the set is self-limiting to
         // groups with pending decryptable ops.
+        //
+        // This runs on EVERY namespace-key delivery/rotation, but once a
+        // subgroup's buffered ops have applied their nonces are windowed, so
+        // subsequent passes are cheap no-ops (`redrive_..._counted` returns 0) —
+        // bounded and idempotent, so no extra "already re-driven" filtering is
+        // needed here.
         if group_id == self.namespace_id.to_bytes() {
             match retry_service.groups_with_held_key_buffered_ops() {
                 Ok(groups) => {
@@ -1317,6 +1323,13 @@ impl<'a> NamespaceGovernance<'a> {
                         if sub == group_id {
                             continue;
                         }
+                        // Intentional: unlike the namespace-root `retry` above
+                        // (which threads `retry_divergence` back to the caller),
+                        // this fan-out uses the counted re-drive and DROPS the
+                        // divergence signal. A re-driven Open-subgroup
+                        // MemberRemoved/MemberLeft divergence is instead surfaced
+                        // by that subgroup's own key-delivery path or the #2848
+                        // startup sweep — not reported from here.
                         if let Err(e) = self.redrive_encrypted_ops_for_group_counted(sub) {
                             tracing::warn!(
                                 group_id = %hex::encode(sub),

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -5789,6 +5789,124 @@ fn curative_sweep_redrives_stranded_context() {
     );
 }
 
+/// #3198 regression: delivering the NAMESPACE key must re-drive an `Open`
+/// subgroup's buffered ops, not only the namespace root's own ops.
+///
+/// An `Open` subgroup encrypts its governance ops with the *namespace* key (see
+/// `GroupGovernancePublisher`). A root-admitted member (e.g. a `ReadOnlyTee`)
+/// that receives a `SubgroupVisibilitySet -> Open` op BEFORE the namespace key
+/// arrived parks it undecryptable, and the subgroup keeps reading `Restricted`.
+/// Before the fix, the key-delivery retry (`retry_encrypted_ops_for_group`) only
+/// re-drove the group whose key just arrived — the namespace root — so the
+/// parked subgroup op stayed effect-skipped forever, and inherited auto-follow
+/// never joined contexts registered under the subgroup (`meroctl context ls`
+/// empty on the replica). The fix fans the namespace-key delivery out to every
+/// group that now holds a decryptable buffered op.
+#[test]
+fn namespace_key_delivery_redrives_open_subgroup_visibility_flip() {
+    use calimero_context_client::local_governance::{NamespaceOp, SignedNamespaceOp};
+    use calimero_context_config::VisibilityMode;
+    use rand::rngs::OsRng;
+    use rand::RngCore;
+
+    let store = test_store();
+    let mut rng = OsRng;
+
+    // ---- Namespace root + this (receiver) node's identity ------------------
+    let ns_gid = ContextGroupId::from([0xA7u8; 32]);
+    let namespace_id = ns_gid.to_bytes();
+
+    let owner_sk = PrivateKey::random(&mut rng);
+    let owner_pk = owner_sk.public_key();
+    let member_sk = PrivateKey::random(&mut rng);
+    let member_pk = member_sk.public_key();
+
+    MetaRepository::new(&store)
+        .save(&ns_gid, &sample_meta_with_admin(owner_pk))
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&ns_gid, &owner_pk, GroupMemberRole::Admin)
+        .unwrap();
+    NamespaceRepository::new(&store)
+        .store_identity(&ns_gid, &member_pk, member_sk.as_bytes(), &[0u8; 32])
+        .unwrap();
+
+    // ---- The Open subgroup: born Restricted, owner is its admin ------------
+    let sub_gid = ContextGroupId::from(*PrivateKey::random(&mut rng).public_key());
+    nest_for_test(&store, &ns_gid, &sub_gid);
+    MetaRepository::new(&store)
+        .save(&sub_gid, &sample_meta_with_admin(owner_pk))
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&sub_gid, &owner_pk, GroupMemberRole::Admin)
+        .unwrap();
+    assert_eq!(
+        CapabilitiesRepository::new(&store)
+            .subgroup_visibility(&sub_gid)
+            .unwrap(),
+        VisibilityMode::Restricted,
+        "precondition: the subgroup is born Restricted"
+    );
+
+    // ---- Mint the NAMESPACE key (Open subgroups encrypt under it) ----------
+    let ns_key: [u8; 32] = {
+        let mut k = [0u8; 32];
+        rng.fill_bytes(&mut k);
+        k
+    };
+    let ns_key_id = GroupKeyring::key_id_for(&ns_key);
+
+    // ---- Buffer the namespace-key-encrypted SubgroupVisibilitySet(Open) ----
+    let inner_op = GroupOp::SubgroupVisibilitySet {
+        mode: VisibilityMode::Open,
+    };
+    let encrypted = GroupKeyring::encrypt_op(&ns_key, &inner_op).unwrap();
+    let flip_op = SignedNamespaceOp::sign(
+        &owner_sk,
+        namespace_id.into(),
+        vec![],
+        1,
+        NamespaceOp::Group {
+            group_id: sub_gid.to_bytes().into(),
+            key_id: ns_key_id.into(),
+            encrypted,
+            key_rotation: None,
+        },
+    )
+    .unwrap();
+    // Applied WITHOUT the namespace key present → DAG-applied but effect-skipped.
+    apply_signed_namespace_op(&store, &flip_op)
+        .expect("apply buffered SubgroupVisibilitySet (effect-skipped: no namespace key)");
+    assert_eq!(
+        CapabilitiesRepository::new(&store)
+            .subgroup_visibility(&sub_gid)
+            .unwrap(),
+        VisibilityMode::Restricted,
+        "the flip must be effect-skipped while the namespace key is absent"
+    );
+
+    // ---- Namespace key arrives; drive the key-delivery retry entry point ---
+    let stored_id = GroupKeyring::new(&store, ns_gid)
+        .store_key(&ns_key)
+        .unwrap();
+    assert_eq!(stored_id, ns_key_id, "stored namespace key id must match");
+
+    // This is exactly what `apply_received_group_key` calls after storing a
+    // delivered key. Pre-fix it only re-drove the namespace root's own ops and
+    // left the subgroup Restricted; post-fix it fans out to the Open subgroup.
+    retry_encrypted_ops_for_group(&store, namespace_id.into(), namespace_id)
+        .expect("namespace-key delivery retry must not error");
+
+    assert_eq!(
+        CapabilitiesRepository::new(&store)
+            .subgroup_visibility(&sub_gid)
+            .unwrap(),
+        VisibilityMode::Open,
+        "#3198: delivering the namespace key must re-drive the Open subgroup's \
+         buffered SubgroupVisibilitySet so it reads Open (enabling inherited follow)"
+    );
+}
+
 // -----------------------------------------------------------------------
 // `GroupCreated` must authorize at the op's causal cut.
 //

--- a/crates/governance-store/src/op_events.rs
+++ b/crates/governance-store/src/op_events.rs
@@ -114,6 +114,16 @@ pub enum OpEvent {
         group_id: [u8; 32],
         recipient: PublicKey,
     },
+    /// `GroupOp::SubgroupVisibilitySet` applied and changed a subgroup's
+    /// visibility. `open` reflects the post-apply mode (`true` == `Open`).
+    ///
+    /// A root-admitted member (e.g. a `ReadOnlyTee`) inherits membership only
+    /// into `Open` subgroups, so an `Open` flip that applies AFTER a context
+    /// was registered — or after that context's `ContextRegistered` auto-follow
+    /// decision already ran while the subgroup still read `Restricted` — must
+    /// re-trigger the inherited-follow decision for that subgroup's contexts.
+    /// Auto-follow subscribes to this so a late-arriving flip is not a dead end.
+    SubgroupVisibilityChanged { group_id: [u8; 32], open: bool },
 }
 
 /// The process-wide broadcast channel. Tests share this channel, so

--- a/crates/governance-store/src/ops/group/subgroup_visibility_set.rs
+++ b/crates/governance-store/src/ops/group/subgroup_visibility_set.rs
@@ -15,6 +15,14 @@ pub(crate) fn apply(ctx: &mut GroupApplyCtx<'_>, mode: &VisibilityMode) -> EyreR
     // (e.g. a `SubgroupVisibilitySet -> Open` re-driven late, once the namespace
     // key arrived) would otherwise never re-run the follow decision. See
     // `OpEvent::SubgroupVisibilityChanged` and `calimero_context::auto_follow`.
+    //
+    // Apply-semantics coupling: a queued event is flushed only on a GENUINE
+    // apply — a nonce-deduped replay discards `pending_events` (see the apply
+    // pipeline in `lib.rs`). This is exactly why the late-key case works: the
+    // first (key-less) receipt of an Open-subgroup op is effect-skipped WITHOUT
+    // running this handler or burning its nonce, so the later re-drive is a real
+    // apply that both performs the mutation and flushes this event. The fix thus
+    // relies on effect-skipped ops NOT being nonce-windowed/op-logged.
     ctx.queue_event(crate::op_events::OpEvent::SubgroupVisibilityChanged {
         group_id: group_id.to_bytes(),
         open: matches!(mode, VisibilityMode::Open),

--- a/crates/governance-store/src/ops/group/subgroup_visibility_set.rs
+++ b/crates/governance-store/src/ops/group/subgroup_visibility_set.rs
@@ -7,6 +7,17 @@ use eyre::Result as EyreResult;
 
 pub(crate) fn apply(ctx: &mut GroupApplyCtx<'_>, mode: &VisibilityMode) -> EyreResult<()> {
     let signer = ctx.signer();
+    let group_id = ctx.group_id();
     ctx.settings().set_subgroup_visibility(signer, *mode)?;
+    // Re-trigger inherited auto-follow for this subgroup's contexts. A
+    // root-admitted member (e.g. a `ReadOnlyTee`) inherits membership only into
+    // `Open` subgroups; a flip that applies after the contexts were registered
+    // (e.g. a `SubgroupVisibilitySet -> Open` re-driven late, once the namespace
+    // key arrived) would otherwise never re-run the follow decision. See
+    // `OpEvent::SubgroupVisibilityChanged` and `calimero_context::auto_follow`.
+    ctx.queue_event(crate::op_events::OpEvent::SubgroupVisibilityChanged {
+        group_id: group_id.to_bytes(),
+        open: matches!(mode, VisibilityMode::Open),
+    });
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes #3198. A root-admitted member (e.g. a `ReadOnlyTee` HA replica) never follows contexts registered in an **Open** subgroup: the subgroup's `SubgroupVisibilitySet → Open` op never applies on the replica, so its inheritance check (`check_path`) keeps reading the subgroup as `Restricted`, refuses inherited membership, and never emits `JoinContext`. `meroctl context ls` on the replica stays empty.

**Root cause (verified by native repro, not inference):** an Open subgroup encrypts its governance ops with the **namespace** key, not its own per-subgroup key (`group_governance_publisher.rs`). A root member that receives the `SubgroupVisibilitySet → Open` op *before* the namespace key arrives parks it undecryptable. On namespace-key delivery, `retry_encrypted_ops_for_group` only re-drove the group whose key just arrived (the namespace root) — so the subgroup's own buffered op was never re-applied. The `#2848` curative sweep would recover it, but only at **startup**; a same-session late key delivery had no trigger.

This is **not** an rc.10 regression and **not** Docker-specific: both `0.11.0-rc.9` and current `master` fail identically in native/binary mode. It is a longstanding, never-completed half of the Open-subgroup inheritance feature (the authorization half landed in #2809; the delivery half did not). This corrects the original diagnosis in #3198 (#3167 / #3134 are ruled out).

## Fix

- **Primary** (`crates/governance-store/src/namespace/governance.rs`): when the delivered/rotated key is the **namespace** key, fan the retry out to every group that now holds a decryptable buffered op — reusing the same `groups_with_held_key_buffered_ops()` + counted re-drive primitives the startup sweep already uses, but at delivery time. Each re-drive runs the normal signature/nonce/authorizer apply path, is idempotent, and the set is self-limiting. No security bypass.
- **Secondary** (robustness): `SubgroupVisibilitySet` apply now emits `OpEvent::SubgroupVisibilityChanged`; `auto_follow` reacts to an Open flip by re-evaluating that subgroup's contexts, so a flip that lands *after* the contexts' `ContextRegistered` decisions already ran still triggers the inherited join (gated on `should_auto_follow_contexts`, respecting opt-in). This proved load-bearing in the repro.

No public API surface (`calimero-server-primitives` / `calimero-tee-attestation`) is touched — the new `OpEvent` variant is internal to `calimero-governance-store` — so no downstream rev bump is implied.

## Reproduction & evidence

Native (`--no-docker`) mock-TEE merobox scenario:
```
merobox bootstrap run workflow-examples/tee-g2-open-inheritance-replication.yml --no-docker \
  --binary-path <core>/target/release/merod
```
- **Before:** `{"data":{"contexts":[]}}` → `FAIL: context … NOT found on the TEE replica`
- **After:** `OK: context … is present on the TEE replica` → `Workflow completed successfully`

Verified against a freshly-built binary from this branch:

| Scenario | Before | After |
|---|---|---|
| tee-g2-open-inheritance-replication | ❌ | ✅ |
| tee-matrix-open-join-with-created | ❌ | ✅ |
| tee-matrix-open-late-join | ❌ | ✅ |
| tee-r2-open-no-direct-row (negative guard) | ✅ | ✅ |
| tee-g1-restricted-auto-admit (control) | ✅ | ✅ |
| tee-matrix-restricted-late-join (control) | ✅ | ✅ |

## Tests

- Regression test `namespace_key_delivery_redrives_open_subgroup_visibility_flip` in `calimero-governance-store` — asserts a namespace-key delivery re-drives a parked Open-subgroup `SubgroupVisibilitySet`; **fails without** the primary fix, **passes with** it.
- `cargo fmt --check` (1.88.0), `cargo clippy -p calimero-governance-store -p calimero-context -- -A warnings`, `cargo test` (governance-store 435 passed, context suites passed) — all green.

## Follow-up

Once merged, revert the CI exclusion in calimero-network/merobox#294 so these three scenarios re-enter the required matrix.