### PR TITLE
fix(context): apply MemberJoinedAt locally regardless of transport readiness

### DIFF
--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -22,16 +22,6 @@ use calimero_governance_store::op_events::OpEvent;
 
 const NAMESPACE_MESH_GRACE: Duration = Duration::from_secs(2);
 
-/// Upper bound on how long the background re-publisher keeps trying to announce
-/// membership when the joiner's namespace mesh is too thin at join time (e.g. it
-/// joined while another member was down). Generous enough to span a downed
-/// peer restarting and the mesh reforming; bounded so a genuinely partitioned
-/// joiner's task still exits.
-const MEMBER_JOINED_REPUBLISH_WINDOW: Duration = Duration::from_secs(120);
-
-/// Poll cadence while waiting for namespace mesh readiness.
-const MEMBER_JOINED_POLL_INTERVAL: Duration = Duration::from_millis(500);
-
 // Maximum time `join_group` waits on the gossip-fallback path for a
 // `KeyDelivery` op addressed to the joiner now lives on
 // [`ContextManagerConfig::key_delivery_fallback_wait`] so operators can
@@ -324,126 +314,30 @@ impl Handler<JoinGroupRequest> for ContextManager {
                     None
                 };
 
-                // Announce membership so other namespace members learn about
-                // us. The joiner can't ack its own op (it isn't a recognised
-                // member from the receiver's view until the op applies), so
-                // `required_signers = None` — any ack from any current member
-                // is fine.
-                //
-                // `sign_and_publish_namespace_op` hard-fails its transport gate
-                // (`assert_transport_ready`) when the mesh is too thin. That
-                // happens when we join while another member is down: our mesh
-                // only reaches the one peer that is up, yet the down member
-                // still counts as a known subscriber and inflates the required
-                // quorum. The announce is otherwise fire-and-forget, so a
-                // gated-out publish silently strands us — current members never
-                // learn we joined, and when we later sync the authoritative
-                // group state (which excludes us) we reconcile our own
-                // locally-added membership away and are stuck "not a member".
-                //
-                // If the transport is ready now, publish inline (one shot — the
-                // op is written to our local log and reaches peers via sync even
-                // if the immediate acks are thin). If it is NOT ready, hand off
-                // to a bounded background task that waits for the mesh to reform
-                // (e.g. once the down member restarts) and then publishes, so
-                // membership propagates without blocking the join.
+                // Announce membership on the namespace DAG. Apply + store it
+                // locally regardless of transport readiness, then publish
+                // best-effort: a thin mesh at join time must not stop the local
+                // DAG head from advancing, or a later `MemberJoinedOpen` for an
+                // Open subgroup won't causally parent onto this op and peers
+                // will apply the child before its prerequisite (the ~23%
+                // migration-e2e sync flake). The stored op reaches peers via
+                // sync even when the immediate publish acks are thin.
+                let member_joined_op = NamespaceOp::Root(RootOp::MemberJoinedAt {
+                    member: joiner_identity,
+                    signed_invitation: invitation.clone(),
+                    joined_at: now_secs,
+                });
+                if let Err(e) = calimero_governance_store::sign_apply_and_publish_namespace_op(
+                    &datastore,
+                    &node_client,
+                    &ack_router,
+                    namespace_id.into(),
+                    &sk,
+                    member_joined_op,
+                )
+                .await
                 {
-                    use calimero_governance_store::governance_broadcast::{
-                        assert_transport_ready, ns_topic,
-                    };
-                    let topic = ns_topic(namespace_id.into());
-                    let n_low = node_client.gossipsub_mesh_n_low();
-                    let mesh = node_client
-                        .mesh_peer_count_for_namespace(namespace_id)
-                        .await;
-                    let known = node_client.known_subscribers(&topic);
-
-                    if assert_transport_ready(mesh, known, n_low).is_ok() {
-                        let member_joined_op = NamespaceOp::Root(RootOp::MemberJoinedAt {
-                            member: joiner_identity,
-                            signed_invitation: invitation.clone(),
-                            joined_at: now_secs,
-                        });
-                        if let Err(e) = calimero_governance_store::sign_and_publish_namespace_op(
-                            &datastore,
-                            &node_client,
-                            &ack_router,
-                            namespace_id.into(),
-                            &sk,
-                            member_joined_op,
-                            None,
-                        )
-                        .await
-                        {
-                            warn!(?e, "failed to publish MemberJoined (non-fatal)");
-                        }
-                    } else {
-                        warn!(
-                            mesh,
-                            known,
-                            n_low,
-                            "MemberJoined transport not ready (likely joined with a peer down); \
-                             scheduling durable background re-publish"
-                        );
-                        // Owned captures for the detached re-publisher. `sk_bytes`
-                        // is a copy of the signing key so we can re-sign off-task;
-                        // it is rebuilt into a `ZeroizeOnDrop` `PrivateKey` inside
-                        // the task and dropped when the task ends.
-                        let datastore = datastore.clone();
-                        let node_client = node_client.clone();
-                        let ack_router = Arc::clone(&ack_router);
-                        let invitation = invitation.clone();
-                        actix::spawn(async move {
-                            let topic = ns_topic(namespace_id.into());
-                            let n_low = node_client.gossipsub_mesh_n_low();
-                            let deadline = Instant::now() + MEMBER_JOINED_REPUBLISH_WINDOW;
-                            loop {
-                                if Instant::now() >= deadline {
-                                    warn!(
-                                        "MemberJoined durable re-publish window elapsed; \
-                                         membership may not have propagated"
-                                    );
-                                    break;
-                                }
-                                let mesh = node_client
-                                    .mesh_peer_count_for_namespace(namespace_id)
-                                    .await;
-                                let known = node_client.known_subscribers(&topic);
-                                if assert_transport_ready(mesh, known, n_low).is_ok() {
-                                    let sk = PrivateKey::from(sk_bytes);
-                                    let member_joined_op =
-                                        NamespaceOp::Root(RootOp::MemberJoinedAt {
-                                            member: joiner_identity,
-                                            signed_invitation: invitation.clone(),
-                                            joined_at: now_secs,
-                                        });
-                                    match calimero_governance_store::sign_and_publish_namespace_op(
-                                        &datastore,
-                                        &node_client,
-                                        &ack_router,
-                                        namespace_id.into(),
-                                        &sk,
-                                        member_joined_op,
-                                        None,
-                                    )
-                                    .await
-                                    {
-                                        Ok(_) => info!("MemberJoined durable re-publish succeeded"),
-                                        // The op is written to our local log and
-                                        // reaches peers via sync even if acks were
-                                        // thin; stop either way so we don't sign a
-                                        // duplicate at the next nonce.
-                                        Err(e) => warn!(
-                                            ?e,
-                                            "MemberJoined re-publish produced no acks; relying on sync"
-                                        ),
-                                    }
-                                    break;
-                                }
-                                tokio::time::sleep(MEMBER_JOINED_POLL_INTERVAL).await;
-                            }
-                        });
-                    }
+                    warn!(?e, "failed to apply/publish MemberJoined locally (non-fatal)");
                 }
 
                 if let Some(rx) = op_event_rx.as_mut() {


### PR DESCRIPTION
## Summary

Fixes the ~23% flake in `app-migration-e2e` (and the same race in production) where a freshly-joined node stays at the empty root and never syncs.

**Root cause.** When a node joins a namespace while the gossip mesh is thin (the normal case in the first seconds of a CI run), `join_group` published `MemberJoinedAt` through the transport-gated `sign_and_publish_namespace_op`. That path calls `assert_transport_ready` and returns *before* `publish_post_gate` - the only place the op advances the head and is written to the local op-log. So on a thin mesh the joiner never stores its own `MemberJoinedAt` locally. Its subsequent `MemberJoinedOpen` (open-subgroup self-join) is signed with `parent_op_hashes = current heads`, which then don't include `MemberJoinedAt`. The causal dependency is real but absent from the DAG, so a receiver treats `MemberJoinedOpen` as causally ready, applies it before the membership prerequisite exists, hits "no membership path", and drops it. The joiner is never recognized as a context member, its sync streams are refused, and it stays at the empty root for the whole `wait_for_sync` window.

**Fix.** Author `MemberJoinedAt` once and apply+store it locally **unconditionally** via best-effort `sign_apply_and_publish_namespace_op`, then publish best-effort. The local DAG head always advances, so `MemberJoinedOpen` causally parents onto `MemberJoinedAt`. A receiver now holds the child as a normal missing-parent `Pending` - the DAG's existing bounded (`MAX_PENDING_DELTAS`, self-evicting) mechanism - until `MemberJoinedAt` arrives via sync, then applies both in causal order. Ordering rides the DAG's native causal mechanism instead of a semantic re-check.

This also removes the transport-gated inline/background-republish split: the op is durably stored at join time (stronger durability than before, where a thin-mesh join stored nothing until the mesh reformed) and propagates via sync, so the bounded background re-publisher is redundant. Net -106 lines.

## Test plan

- `cargo build` / `cargo clippy` / `cargo test` green for `calimero-context`, `calimero-governance-store`, `calimero-dag`.
- **Regression (the reproduction layer):** `app-migration-e2e` triggers on `crates/**` and reproduced this flake (node 2 stuck at the empty root `111...1` after join, ~23% of runs). This PR must show that suite green across repeated runs.
- `group-governance-peer-down` e2e (join while a member is down) still converges via sync - its assertion is unchanged.

## Proof

_The before/after evidence (repeated green `app-migration-e2e` runs vs. the historical ~23% failure) will be captured from this PR's CI runs._
