### PR TITLE
feat(tee-attestation): document the crypto-only verifier contract and add additive policy_valid

### DIFF
--- a/crates/tee-attestation/AGENTS.md
+++ b/crates/tee-attestation/AGENTS.md
@@ -14,7 +14,7 @@ Generates and verifies Intel TDX attestation quotes, binding them to a nonce and
 # Build
 cargo build -p calimero-tee-attestation
 
-# Test (crate has no unit tests of its own; exercised via callers)
+# Test (the `policy` module has unit tests; the rest is exercised via callers)
 cargo test -p calimero-tee-attestation
 ```
 
@@ -52,7 +52,12 @@ Consumers propagate it explicitly: `calimero-server/mock-attestation`, `calimero
 | `verify_attestation(quote_bytes, nonce, expected_app_hash)` | async fn | Real path: parses the quote, fetches Intel PCS collateral (`dcap_qvl::collateral::get_collateral_from_pcs`), runs `dcap_qvl::verify::verify`, checks nonce and app hash against `report_input_data()` |
 | `verify_mock_attestation(quote_bytes, nonce, expected_app_hash)` | fn | **`mock-attestation` only.** Verifies a mock quote's embedded nonce/app hash; `quote_verified` is unconditionally `true` (there is no signature) |
 | `VerificationResult` | struct | `quote_verified`, `nonce_verified`, `application_hash_verified: bool`; `tcb_status: Option<String>`; `advisory_ids: Vec<String>`; `quote: Quote` |
-| `VerificationResult::is_valid()` | fn | `quote_verified && nonce_verified && application_hash_verified` |
+| `VerificationResult::is_valid()` | fn | `quote_verified && nonce_verified && application_hash_verified`. **Crypto-only — not an authorization verdict**: it ignores `tcb_status` and the measurement registers, so it returns `true` for a crypto-valid quote from an `OutOfDate`/`Revoked` platform or an unapproved workload. Never admit/release a key on this alone |
+| `VerificationResult::policy_valid(&policy)` | fn | The safe-by-construction gate new callers should use: folds `is_valid()` together with a fail-closed TCB allowlist, the mock decision, the MRTD/RTMR allowlists and the app-hash binding. `Result<(), PolicyRejection>` |
+| `VerifierPolicy` | struct | The policy `policy_valid` enforces: `allowed_tcb_statuses`, `allowed_mrtd`, `allowed_rtmr0..3`, `accept_mock`, `require_app_hash`. `VerifierPolicy::new(allowed_mrtd)` is the intended entry point. Every field fails closed (empty `allowed_mrtd` rejects; empty `allowed_tcb_statuses` enforces `DEFAULT_ALLOWED_TCB_STATUS`) — except `allowed_rtmr0..3`, where empty deliberately skips that register |
+| `PolicyRejection` | enum | Typed reason: `NotCryptoValid`, `TcbRevoked`, `TcbNotAllowed { status }`, `MockNotAccepted`, `EmptyMrtdAllowlist`, `MeasurementMismatch { register }`, `AppHashNotBound` |
+| `MeasurementRegister` | enum | `Mrtd`, `Rtmr0..3` — names the register in `MeasurementMismatch` |
+| `DEFAULT_ALLOWED_TCB_STATUS` / `TCB_STATUS_REVOKED` / `TCB_STATUS_MOCK` | const | `"UpToDate"` / `"Revoked"` / `"Mock"`. **Not** gated by `mock-attestation`: `policy_valid` only compares the `tcb_status` *string*, so production builds must keep the ability to reject a mock quote |
 | `get_tee_info()` | async fn | Returns `TeeInfo { cloud_provider, os_image, mrtd }`; on Linux reads MRTD via `tdx_workload_attestation` and probes the GCP metadata server for the OS image |
 | `TeeInfo` | struct | `cloud_provider: String`, `os_image: String`, `mrtd: String` (hex) |
 | `AttestationError` | enum | `NotSupported`, `QuoteGenerationFailed`, `QuoteParsingFailed`, `QuoteConversionFailed`, `QuoteVerificationFailed`, `CollateralFetchFailed`, `InvalidNonce`, `InvalidApplicationHash`, `NonceMismatch { expected, actual }`, `ApplicationHashMismatch { expected, actual }`, `InfoRetrievalFailed`, `SystemTimeError` - all carry `String` context, no source-error chaining |
@@ -83,6 +88,7 @@ This crate has no dstack or Phala-specific code - it is a generic TDX quote gene
 | `src/lib.rs` | Public re-exports and module-level docs; the module boundary is intentional (generate/verify/info/error are independently testable and have different platform `cfg`s) |
 | `src/generate.rs` | `generate_attestation`, `generate_mock_attestation`, `is_mock_quote`, `create_mock_quote`, `build_report_data`, `MOCK_QUOTE_HEADER`, `AttestationResult` |
 | `src/verify.rs` | `verify_attestation`, `verify_mock_attestation`, `VerificationResult` |
+| `src/policy.rs` | `VerificationResult::policy_valid`, `VerifierPolicy`, `PolicyRejection`, `MeasurementRegister`, the TCB constants, and the policy unit tests. Deliberately mirrors `calimero_governance_store::membership::policy_rules::tcb_status_allowed` by value rather than importing it — this is a leaf `publish = true` crate and must not depend on the governance store, so the two MUST stay in sync |
 | `src/info.rs` | `get_tee_info`, `TeeInfo`; MRTD retrieval and cloud-provider detection |
 | `src/error.rs` | `AttestationError` |
 

--- a/crates/tee-attestation/src/lib.rs
+++ b/crates/tee-attestation/src/lib.rs
@@ -55,6 +55,7 @@
 mod error;
 mod generate;
 mod info;
+mod policy;
 mod verify;
 
 pub use error::AttestationError;
@@ -62,6 +63,10 @@ pub use generate::{build_report_data, generate_attestation, AttestationResult};
 #[cfg(feature = "mock-attestation")]
 pub use generate::{generate_mock_attestation, is_mock_quote};
 pub use info::{get_tee_info, TeeInfo};
+pub use policy::{
+    MeasurementRegister, PolicyRejection, VerifierPolicy, DEFAULT_ALLOWED_TCB_STATUS,
+    TCB_STATUS_MOCK, TCB_STATUS_REVOKED,
+};
 #[cfg(feature = "mock-attestation")]
 pub use verify::verify_mock_attestation;
 pub use verify::{verify_attestation, VerificationResult};

--- a/crates/tee-attestation/src/policy.rs
+++ b/crates/tee-attestation/src/policy.rs
@@ -1,0 +1,695 @@
+//! Safe-by-construction policy gate over a [`VerificationResult`].
+//!
+//! [`VerificationResult::is_valid`] is **crypto-only**: it answers "did *some*
+//! genuine TDX platform produce a fresh quote bound to this app hash", nothing
+//! more. Admitting a peer or releasing a key on that answer alone trusts any
+//! well-formed TDX platform rather than a specific approved workload.
+//!
+//! [`VerificationResult::policy_valid`] is the gate new callers should use: it
+//! folds the crypto checks together with a TCB-status allowlist, the mock
+//! acceptance decision, the measurement allowlists, and the app-hash binding,
+//! and fails closed on every under-specified input.
+//!
+//! # Relationship to existing enforcement sites
+//! Three call sites already implement equivalent enforcement inline and keep it
+//! by design (they emit richer, mode-specific errors this crate cannot):
+//! - `crates/context/src/handlers/admit_tee_node.rs` — per-group
+//!   `TeeAdmissionPolicy`;
+//! - `crates/merod/src/kms/mod.rs` — `enforce_attestation_policy`
+//!   (ReleaseStrict/Config split);
+//! - the mero-tee KMS `get_key.rs` — key-release side (external consumer).
+//!
+//! `policy_valid` does not replace them; it exists so that *future* callers
+//! cannot accidentally trust crypto-only validity.
+//!
+//! # Intentional duplication
+//! The TCB rules below deliberately mirror
+//! `calimero_governance_store::membership::policy_rules::tcb_status_allowed`
+//! rather than importing it: this is a leaf crate (`publish = true`, consumed
+//! externally by mero-tee's KMS at a pinned git rev) and must not take a
+//! dependency on the governance store. The two implementations MUST stay in
+//! sync — the constants and rule order here are a by-value copy of that
+//! function's contract.
+
+use crate::verify::VerificationResult;
+
+/// Secure fail-closed default enforced when [`VerifierPolicy::allowed_tcb_statuses`]
+/// is empty. An empty allowlist must NOT skip the TCB-status check (that would be
+/// fail-open); it enforces against this single status instead.
+///
+/// Mirrors `calimero_governance_store::membership::policy_rules::DEFAULT_ALLOWED_TCB_STATUS`.
+/// Must stay the exact PascalCase value dcap-qvl emits. Do not broaden.
+pub const DEFAULT_ALLOWED_TCB_STATUS: &str = "UpToDate";
+
+/// TCB status rejected unconditionally, regardless of policy (defense in depth).
+///
+/// Mirrors `calimero_governance_store::membership::policy_rules::TCB_STATUS_REVOKED`.
+pub const TCB_STATUS_REVOKED: &str = "Revoked";
+
+/// TCB status set by `verify_mock_attestation` (behind the default-off
+/// `mock-attestation` feature; not linked here so this doc resolves in both
+/// feature configurations). Real dcap-qvl never emits this value, so it
+/// uniquely identifies the mock path.
+///
+/// Note this constant and [`VerifierPolicy::accept_mock`] are intentionally
+/// *not* feature-gated: `policy_valid` only ever compares this status *string*
+/// and never calls into the gated mock code, so the check must stay available
+/// to production builds to reject mock quotes.
+///
+/// Mirrors `calimero_governance_store::membership::policy_rules::TCB_STATUS_MOCK`.
+pub const TCB_STATUS_MOCK: &str = "Mock";
+
+/// Measurement register named by [`PolicyRejection::MeasurementMismatch`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MeasurementRegister {
+    Mrtd,
+    Rtmr0,
+    Rtmr1,
+    Rtmr2,
+    Rtmr3,
+}
+
+impl MeasurementRegister {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Mrtd => "mrtd",
+            Self::Rtmr0 => "rtmr0",
+            Self::Rtmr1 => "rtmr1",
+            Self::Rtmr2 => "rtmr2",
+            Self::Rtmr3 => "rtmr3",
+        }
+    }
+}
+
+impl std::fmt::Display for MeasurementRegister {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Why [`VerificationResult::policy_valid`] rejected an attestation.
+///
+/// Typed rather than a bare `bool` so callers can log/route an actionable
+/// reason instead of "policy said no".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolicyRejection {
+    /// One of the crypto/structural checks failed — see
+    /// [`VerificationResult::is_valid`].
+    NotCryptoValid,
+    /// TCB status is `Revoked`. Rejected unconditionally, even if explicitly
+    /// allowlisted and even under `accept_mock`.
+    TcbRevoked,
+    /// TCB status is not in the effective allowlist (which is
+    /// [`DEFAULT_ALLOWED_TCB_STATUS`] when the configured allowlist is empty).
+    TcbNotAllowed { status: String },
+    /// A mock quote was presented but [`VerifierPolicy::accept_mock`] is false.
+    MockNotAccepted,
+    /// [`VerifierPolicy::allowed_mrtd`] is empty. `policy_valid` is a strict
+    /// gate: an unpinned MRTD would admit any genuine TDX platform, so an empty
+    /// MRTD allowlist is a rejection rather than a skip.
+    EmptyMrtdAllowlist,
+    /// A measurement register's value is not in its (non-empty) allowlist.
+    MeasurementMismatch { register: MeasurementRegister },
+    /// [`VerifierPolicy::require_app_hash`] is set but the quote's app-hash
+    /// binding did not verify.
+    AppHashNotBound,
+}
+
+impl std::fmt::Display for PolicyRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotCryptoValid => f.write_str(
+                "attestation rejected: quote/nonce/app-hash verification did not all pass",
+            ),
+            Self::TcbRevoked => {
+                f.write_str("attestation rejected: platform TCB status is Revoked")
+            }
+            Self::TcbNotAllowed { status } => write!(
+                f,
+                "attestation rejected: TCB status {status:?} is not in the policy allowlist"
+            ),
+            Self::MockNotAccepted => f.write_str(
+                "attestation rejected: mock attestation presented but policy does not accept mock",
+            ),
+            Self::EmptyMrtdAllowlist => f.write_str(
+                "attestation rejected: policy has an empty MRTD allowlist (fail-closed: an unpinned MRTD would admit any TDX platform)",
+            ),
+            Self::MeasurementMismatch { register } => write!(
+                f,
+                "attestation rejected: measurement {register} is not in the policy allowlist"
+            ),
+            Self::AppHashNotBound => f.write_str(
+                "attestation rejected: policy requires an app-hash binding but it did not verify",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PolicyRejection {}
+
+/// The policy [`VerificationResult::policy_valid`] enforces.
+///
+/// Owned by this crate on purpose: this is a leaf crate, so it must not depend
+/// on `calimero-governance-store`'s `TeeAdmissionPolicy`. It is a lean
+/// duplicate-by-value that richer callers convert *into*.
+///
+/// Every field fails closed:
+/// - an empty `allowed_tcb_statuses` enforces [`DEFAULT_ALLOWED_TCB_STATUS`],
+///   it never skips the check;
+/// - an empty `allowed_mrtd` is a rejection, never a skip;
+/// - `accept_mock` defaults to `false` and `require_app_hash` to `true`.
+///
+/// The `allowed_rtmr0..3` allowlists are the one deliberate exception: an empty
+/// one skips that register, because pinning RTMRs is optional in practice (they
+/// vary with boot/runtime configuration) while MRTD is the workload identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifierPolicy {
+    /// Allowed dcap-qvl TCB statuses. Empty => fail closed to
+    /// [`DEFAULT_ALLOWED_TCB_STATUS`]. Compared case-sensitively (as upstream).
+    pub allowed_tcb_statuses: Vec<String>,
+    /// Allowed MRTD values (hex). Required non-empty — see
+    /// [`PolicyRejection::EmptyMrtdAllowlist`].
+    pub allowed_mrtd: Vec<String>,
+    /// Allowed RTMR0 values (hex). Empty => register not checked.
+    pub allowed_rtmr0: Vec<String>,
+    /// Allowed RTMR1 values (hex). Empty => register not checked.
+    pub allowed_rtmr1: Vec<String>,
+    /// Allowed RTMR2 values (hex). Empty => register not checked.
+    pub allowed_rtmr2: Vec<String>,
+    /// Allowed RTMR3 values (hex). Empty => register not checked.
+    pub allowed_rtmr3: Vec<String>,
+    /// Whether mock attestations are acceptable. Mock quotes bypass all
+    /// cryptographic guarantees; only ever set this in dev/test.
+    pub accept_mock: bool,
+    /// Whether the attestation must be bound to an app/identity hash.
+    ///
+    /// **Not a bypass toggle: this cannot make `policy_valid` accept anything
+    /// it would otherwise reject.** The app-hash binding is unconditional —
+    /// [`VerificationResult::is_valid`] already requires
+    /// `application_hash_verified`, so an unbound quote is rejected either way.
+    /// This flag only selects which rejection is *reported*:
+    /// [`PolicyRejection::AppHashNotBound`] (the precise reason) when `true`,
+    /// versus the blunter [`PolicyRejection::NotCryptoValid`] when `false`. See
+    /// the `unbound_app_hash_is_rejected_even_when_not_required` test.
+    pub require_app_hash: bool,
+}
+
+impl Default for VerifierPolicy {
+    /// The secure baseline: no measurements pinned yet (so `policy_valid` will
+    /// reject with [`PolicyRejection::EmptyMrtdAllowlist`] until the caller
+    /// pins an MRTD), TCB fail-closed to [`DEFAULT_ALLOWED_TCB_STATUS`], mock
+    /// rejected, app-hash binding required.
+    fn default() -> Self {
+        Self {
+            allowed_tcb_statuses: Vec::new(),
+            allowed_mrtd: Vec::new(),
+            allowed_rtmr0: Vec::new(),
+            allowed_rtmr1: Vec::new(),
+            allowed_rtmr2: Vec::new(),
+            allowed_rtmr3: Vec::new(),
+            accept_mock: false,
+            require_app_hash: true,
+        }
+    }
+}
+
+impl VerifierPolicy {
+    /// A policy pinned to the given MRTD allowlist, secure defaults elsewhere.
+    ///
+    /// This is the intended entry point: MRTD is the one allowlist that has no
+    /// safe default, so the constructor demands it up front.
+    pub fn new(allowed_mrtd: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            allowed_mrtd: allowed_mrtd.into_iter().collect(),
+            ..Self::default()
+        }
+    }
+
+    /// Whether `status` passes the TCB allowlist actually enforced: the
+    /// configured one, or the secure default when it is empty.
+    fn tcb_status_allowed(&self, status: &str) -> bool {
+        if self.allowed_tcb_statuses.is_empty() {
+            status == DEFAULT_ALLOWED_TCB_STATUS
+        } else {
+            self.allowed_tcb_statuses
+                .iter()
+                .any(|allowed| allowed == status)
+        }
+    }
+}
+
+impl VerificationResult {
+    /// Safe-by-construction policy gate — use this, not [`Self::is_valid`], to
+    /// decide whether to admit a peer, release a key, or grant a capability.
+    ///
+    /// [`Self::is_valid`] is crypto-only and always will be (it is external API
+    /// consumed by the mero-tee KMS at a pinned rev). `policy_valid` layers the
+    /// authorization decision on top of it, in this order:
+    ///
+    /// 1. **Crypto validity** — [`Self::is_valid`] must hold, else
+    ///    [`PolicyRejection::NotCryptoValid`]. The app-hash component of it is
+    ///    reported as [`PolicyRejection::AppHashNotBound`] when
+    ///    `require_app_hash` is set, so callers get the specific reason; either
+    ///    way `policy_valid` is never weaker than [`Self::is_valid`] (clearing
+    ///    `require_app_hash` still cannot admit an unbound quote).
+    /// 2. **TCB status** (fail-closed, mirroring
+    ///    `calimero_governance_store::membership::policy_rules::tcb_status_allowed`):
+    ///    `Revoked` (case-insensitive) is rejected unconditionally; a mock quote
+    ///    passes the status check only under `accept_mock`; an empty
+    ///    `allowed_tcb_statuses` enforces [`DEFAULT_ALLOWED_TCB_STATUS`] rather
+    ///    than skipping; otherwise the status must be in the allowlist.
+    /// 3. **Measurements** — MRTD must match a non-empty `allowed_mrtd` (an
+    ///    empty one is [`PolicyRejection::EmptyMrtdAllowlist`]); each non-empty
+    ///    `allowed_rtmr0..3` must match, empty ones are skipped.
+    ///
+    /// A missing `tcb_status` (`None`, which `verify_attestation` only produces
+    /// when the crypto verification failed) is treated as not allowed.
+    ///
+    /// # Errors
+    /// Returns the first [`PolicyRejection`] encountered.
+    pub fn policy_valid(&self, policy: &VerifierPolicy) -> Result<(), PolicyRejection> {
+        if !self.quote_verified || !self.nonce_verified {
+            return Err(PolicyRejection::NotCryptoValid);
+        }
+
+        // `is_valid()` already folds in `application_hash_verified`; surfacing
+        // it separately only buys the caller a specific reason. The `is_valid()`
+        // guard below then keeps `policy_valid` from ever being weaker than
+        // `is_valid()` — clearing `require_app_hash` must not admit an unbound
+        // quote, it only changes which rejection is reported.
+        if policy.require_app_hash && !self.application_hash_verified {
+            return Err(PolicyRejection::AppHashNotBound);
+        }
+        if !self.is_valid() {
+            return Err(PolicyRejection::NotCryptoValid);
+        }
+
+        let status = self.tcb_status.as_deref().unwrap_or_default();
+        let is_mock = status == TCB_STATUS_MOCK;
+
+        // Rule 1 of `tcb_status_allowed`: Revoked is rejected before anything
+        // else, including the mock bypass.
+        if status.eq_ignore_ascii_case(TCB_STATUS_REVOKED) {
+            return Err(PolicyRejection::TcbRevoked);
+        }
+
+        // Rule 2: the mock bypass is gated on `accept_mock`, so a "Mock" status
+        // is never a standing bypass token on a fleet that did not opt in.
+        if is_mock {
+            if !policy.accept_mock {
+                return Err(PolicyRejection::MockNotAccepted);
+            }
+        // Rules 3 & 4: empty allowlist => the secure default; otherwise the
+        // configured allowlist is honored exactly (case-sensitive).
+        } else if !policy.tcb_status_allowed(status) {
+            return Err(PolicyRejection::TcbNotAllowed {
+                status: status.to_owned(),
+            });
+        }
+
+        if policy.allowed_mrtd.is_empty() {
+            return Err(PolicyRejection::EmptyMrtdAllowlist);
+        }
+
+        let body = &self.quote.body;
+        for (allowlist, actual, register) in [
+            (&policy.allowed_mrtd, &body.mrtd, MeasurementRegister::Mrtd),
+            (
+                &policy.allowed_rtmr0,
+                &body.rtmr0,
+                MeasurementRegister::Rtmr0,
+            ),
+            (
+                &policy.allowed_rtmr1,
+                &body.rtmr1,
+                MeasurementRegister::Rtmr1,
+            ),
+            (
+                &policy.allowed_rtmr2,
+                &body.rtmr2,
+                MeasurementRegister::Rtmr2,
+            ),
+            (
+                &policy.allowed_rtmr3,
+                &body.rtmr3,
+                MeasurementRegister::Rtmr3,
+            ),
+        ] {
+            if !allowlist.is_empty() && !allowlist.iter().any(|allowed| allowed == actual) {
+                return Err(PolicyRejection::MeasurementMismatch { register });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use calimero_server_primitives::admin::{
+        CertificationData, QeReportCertificationDataInfo, Quote, QuoteBody, QuoteHeader,
+    };
+
+    use super::*;
+
+    const MRTD_OK: &str = "aa11";
+    const MRTD_OTHER: &str = "bb22";
+
+    /// A minimal `Quote` fixture.
+    ///
+    /// Deliberately built here rather than via `generate::create_mock_quote`,
+    /// which lives behind the default-off `mock-attestation` feature. These
+    /// tests exercise `policy_valid`, which only ever reads `quote.body`
+    /// measurement strings and never touches the mock code path — so they must
+    /// (and do) run in both feature configurations. The field values are inert
+    /// placeholders; every field `policy_valid` reads is overwritten below.
+    fn test_quote() -> Quote {
+        let zeros_48 = "0".repeat(96);
+        let zeros_16 = "0".repeat(32);
+        let zeros_8 = "0".repeat(16);
+
+        Quote {
+            header: QuoteHeader {
+                version: 4,
+                attestation_key_type: 2,
+                tee_type: 0x81,
+                qe_vendor_id: "939a7233f79c4ca9940a0db3957f0607".to_owned(),
+                user_data: zeros_16.clone(),
+            },
+            body: QuoteBody {
+                tdx_version: "1.0".to_owned(),
+                tee_tcb_svn: zeros_16,
+                mrseam: zeros_48.clone(),
+                mrsignerseam: zeros_48.clone(),
+                seamattributes: zeros_8.clone(),
+                tdattributes: zeros_8.clone(),
+                xfam: zeros_8,
+                mrtd: zeros_48.clone(),
+                mrconfigid: zeros_48.clone(),
+                mrowner: zeros_48.clone(),
+                mrownerconfig: zeros_48.clone(),
+                rtmr0: zeros_48.clone(),
+                rtmr1: zeros_48.clone(),
+                rtmr2: zeros_48.clone(),
+                rtmr3: zeros_48,
+                reportdata: "0".repeat(128),
+                tee_tcb_svn_2: None,
+                mrservicetd: None,
+            },
+            signature: "0".repeat(128),
+            attestation_key: "04".to_owned() + &"0".repeat(128),
+            certification_data: CertificationData::QeReportCertificationData(
+                QeReportCertificationDataInfo {
+                    qe_report: "0".repeat(768),
+                    signature: "0".repeat(128),
+                    qe_authentication_data: "0".repeat(64),
+                    certification_data_type: "PckCertChain".to_owned(),
+                    certification_data: "0".repeat(200),
+                },
+            ),
+        }
+    }
+
+    fn result_with(tcb_status: &str) -> VerificationResult {
+        let mut quote = test_quote();
+        quote.body.mrtd = MRTD_OK.to_owned();
+        quote.body.rtmr0 = "r0".to_owned();
+        quote.body.rtmr1 = "r1".to_owned();
+        quote.body.rtmr2 = "r2".to_owned();
+        quote.body.rtmr3 = "r3".to_owned();
+
+        VerificationResult {
+            quote_verified: true,
+            nonce_verified: true,
+            application_hash_verified: true,
+            tcb_status: Some(tcb_status.to_owned()),
+            advisory_ids: Vec::new(),
+            quote,
+        }
+    }
+
+    fn policy() -> VerifierPolicy {
+        VerifierPolicy::new([MRTD_OK.to_owned()])
+    }
+
+    #[test]
+    fn happy_path_accepts_uptodate_pinned_measurements() {
+        let result = result_with("UpToDate");
+        let mut policy = policy();
+        policy.allowed_tcb_statuses = vec!["UpToDate".to_owned()];
+        policy.allowed_rtmr0 = vec!["r0".to_owned()];
+        policy.allowed_rtmr1 = vec!["r1".to_owned()];
+        policy.allowed_rtmr2 = vec!["r2".to_owned()];
+        policy.allowed_rtmr3 = vec!["r3".to_owned()];
+
+        assert_eq!(result.policy_valid(&policy), Ok(()));
+    }
+
+    #[test]
+    fn defaults_are_secure() {
+        let policy = VerifierPolicy::default();
+        assert!(!policy.accept_mock);
+        assert!(policy.require_app_hash);
+        // `new` only pins MRTD; the rest stay at the secure defaults.
+        let pinned = VerifierPolicy::new([MRTD_OK.to_owned()]);
+        assert!(!pinned.accept_mock);
+        assert!(pinned.require_app_hash);
+        assert!(pinned.allowed_tcb_statuses.is_empty());
+    }
+
+    #[test]
+    fn not_crypto_valid_is_rejected_first() {
+        let mut result = result_with("UpToDate");
+        result.quote_verified = false;
+        assert_eq!(
+            result.policy_valid(&policy()),
+            Err(PolicyRejection::NotCryptoValid)
+        );
+
+        let mut result = result_with("UpToDate");
+        result.nonce_verified = false;
+        assert_eq!(
+            result.policy_valid(&policy()),
+            Err(PolicyRejection::NotCryptoValid)
+        );
+    }
+
+    #[test]
+    fn empty_tcb_allowlist_fails_closed_to_uptodate() {
+        let policy = policy();
+        assert!(policy.allowed_tcb_statuses.is_empty());
+
+        // The secure default is enforced, not skipped.
+        assert_eq!(result_with("UpToDate").policy_valid(&policy), Ok(()));
+        assert_eq!(
+            result_with("OutOfDate").policy_valid(&policy),
+            Err(PolicyRejection::TcbNotAllowed {
+                status: "OutOfDate".to_owned()
+            })
+        );
+        assert_eq!(
+            result_with("SWHardeningNeeded").policy_valid(&policy),
+            Err(PolicyRejection::TcbNotAllowed {
+                status: "SWHardeningNeeded".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn missing_tcb_status_is_not_allowed() {
+        let mut result = result_with("UpToDate");
+        result.tcb_status = None;
+        assert_eq!(
+            result.policy_valid(&policy()),
+            Err(PolicyRejection::TcbNotAllowed {
+                status: String::new()
+            })
+        );
+    }
+
+    #[test]
+    fn non_empty_tcb_allowlist_is_honored() {
+        let mut policy = policy();
+        policy.allowed_tcb_statuses = vec!["OutOfDate".to_owned()];
+        assert_eq!(result_with("OutOfDate").policy_valid(&policy), Ok(()));
+        assert_eq!(
+            result_with("UpToDate").policy_valid(&policy),
+            Err(PolicyRejection::TcbNotAllowed {
+                status: "UpToDate".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn revoked_is_rejected_even_when_allowlisted() {
+        let mut policy = policy();
+        policy.allowed_tcb_statuses = vec!["Revoked".to_owned(), "UpToDate".to_owned()];
+        assert_eq!(
+            result_with("Revoked").policy_valid(&policy),
+            Err(PolicyRejection::TcbRevoked)
+        );
+    }
+
+    #[test]
+    fn revoked_is_rejected_even_with_accept_mock() {
+        let mut policy = policy();
+        policy.accept_mock = true;
+        policy.allowed_tcb_statuses = vec!["Revoked".to_owned()];
+        assert_eq!(
+            result_with("Revoked").policy_valid(&policy),
+            Err(PolicyRejection::TcbRevoked)
+        );
+    }
+
+    #[test]
+    fn revoked_match_is_case_insensitive() {
+        for status in ["revoked", "REVOKED", "ReVoKeD"] {
+            assert_eq!(
+                result_with(status).policy_valid(&policy()),
+                Err(PolicyRejection::TcbRevoked),
+                "status {status} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn mock_is_rejected_unless_accept_mock() {
+        let mut policy = policy();
+        assert_eq!(
+            result_with(TCB_STATUS_MOCK).policy_valid(&policy),
+            Err(PolicyRejection::MockNotAccepted)
+        );
+
+        policy.accept_mock = true;
+        assert_eq!(result_with(TCB_STATUS_MOCK).policy_valid(&policy), Ok(()));
+    }
+
+    #[test]
+    fn mock_is_rejected_even_when_status_allowlisted_without_accept_mock() {
+        let mut policy = policy();
+        // An allowlisted "Mock" must NOT be a bypass token on a fleet that did
+        // not opt into mock.
+        policy.allowed_tcb_statuses = vec![TCB_STATUS_MOCK.to_owned()];
+        assert_eq!(
+            result_with(TCB_STATUS_MOCK).policy_valid(&policy),
+            Err(PolicyRejection::MockNotAccepted)
+        );
+    }
+
+    #[test]
+    fn accept_mock_does_not_admit_a_real_disallowed_status() {
+        let mut policy = policy();
+        policy.accept_mock = true;
+        assert_eq!(
+            result_with("OutOfDate").policy_valid(&policy),
+            Err(PolicyRejection::TcbNotAllowed {
+                status: "OutOfDate".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn empty_mrtd_allowlist_is_rejected() {
+        let policy = VerifierPolicy::default();
+        assert_eq!(
+            result_with("UpToDate").policy_valid(&policy),
+            Err(PolicyRejection::EmptyMrtdAllowlist)
+        );
+    }
+
+    #[test]
+    fn empty_mrtd_allowlist_is_rejected_even_for_mock() {
+        let policy = VerifierPolicy {
+            accept_mock: true,
+            ..VerifierPolicy::default()
+        };
+        assert_eq!(
+            result_with(TCB_STATUS_MOCK).policy_valid(&policy),
+            Err(PolicyRejection::EmptyMrtdAllowlist)
+        );
+    }
+
+    #[test]
+    fn mrtd_mismatch_is_rejected() {
+        let policy = VerifierPolicy::new([MRTD_OTHER.to_owned()]);
+        assert_eq!(
+            result_with("UpToDate").policy_valid(&policy),
+            Err(PolicyRejection::MeasurementMismatch {
+                register: MeasurementRegister::Mrtd
+            })
+        );
+    }
+
+    #[test]
+    fn empty_rtmr_allowlists_are_skipped() {
+        let policy = policy();
+        assert!(policy.allowed_rtmr0.is_empty());
+        assert_eq!(result_with("UpToDate").policy_valid(&policy), Ok(()));
+    }
+
+    #[test]
+    fn non_empty_rtmr_allowlists_must_match() {
+        for (register, apply) in [
+            (
+                MeasurementRegister::Rtmr0,
+                (|p: &mut VerifierPolicy| p.allowed_rtmr0 = vec!["nope".to_owned()])
+                    as fn(&mut VerifierPolicy),
+            ),
+            (MeasurementRegister::Rtmr1, |p| {
+                p.allowed_rtmr1 = vec!["nope".to_owned()]
+            }),
+            (MeasurementRegister::Rtmr2, |p| {
+                p.allowed_rtmr2 = vec!["nope".to_owned()]
+            }),
+            (MeasurementRegister::Rtmr3, |p| {
+                p.allowed_rtmr3 = vec!["nope".to_owned()]
+            }),
+        ] {
+            let mut policy = policy();
+            apply(&mut policy);
+            assert_eq!(
+                result_with("UpToDate").policy_valid(&policy),
+                Err(PolicyRejection::MeasurementMismatch { register }),
+                "{register} mismatch must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn unbound_app_hash_is_rejected_when_required() {
+        let mut result = result_with("UpToDate");
+        result.application_hash_verified = false;
+
+        let policy = policy();
+        assert!(policy.require_app_hash);
+        assert_eq!(
+            result.policy_valid(&policy),
+            Err(PolicyRejection::AppHashNotBound)
+        );
+    }
+
+    #[test]
+    fn unbound_app_hash_is_rejected_even_when_not_required() {
+        // `policy_valid` must never be weaker than `is_valid()`: clearing
+        // `require_app_hash` changes the reported reason, not the verdict.
+        let mut result = result_with("UpToDate");
+        result.application_hash_verified = false;
+
+        let mut policy = policy();
+        policy.require_app_hash = false;
+        assert_eq!(
+            result.policy_valid(&policy),
+            Err(PolicyRejection::NotCryptoValid)
+        );
+    }
+
+    #[test]
+    fn rejection_displays_actionable_message() {
+        let rejection = PolicyRejection::MeasurementMismatch {
+            register: MeasurementRegister::Mrtd,
+        };
+        assert!(rejection.to_string().contains("mrtd"));
+        let err: &dyn std::error::Error = &rejection;
+        assert!(!err.to_string().is_empty());
+    }
+}

--- a/crates/tee-attestation/src/verify.rs
+++ b/crates/tee-attestation/src/verify.rs
@@ -18,7 +18,7 @@ use crate::generate::{is_mock_quote, MOCK_QUOTE_HEADER};
 /// plus the raw material a caller needs to make a policy decision. It is NOT an
 /// authorization verdict on its own. In particular, `tcb_status`, `advisory_ids`
 /// and the measurement registers in `quote.body` (`mrtd` / `rtmr0..3` /
-/// `mrsigner`) are surfaced here precisely *because* the caller — not this crate
+/// `mrsignerseam`) are surfaced here precisely *because* the caller — not this crate
 /// — is expected to enforce a policy over them. See [`Self::is_valid`].
 #[derive(Debug, Clone)]
 pub struct VerificationResult {
@@ -41,7 +41,7 @@ pub struct VerificationResult {
     /// The parsed quote structure.
     ///
     /// Its `body` carries the measurement registers (`mrtd` / `rtmr0..3` /
-    /// `mrsigner`). These are parsed but NOT compared against anything by this
+    /// `mrsignerseam`). These are parsed but NOT compared against anything by this
     /// crate — matching them to an allowlist is the caller's responsibility.
     pub quote: Quote,
 }
@@ -65,7 +65,7 @@ impl VerificationResult {
     ///   still returns `quote_verified == true`, so `is_valid()` returns `true`.
     ///   Gate on `tcb_status` against an allowlist, failing closed on an empty
     ///   allowlist and on `Revoked`.
-    /// - **Measurement registers `mrtd` / `rtmr0..3` / `mrsigner`** (in
+    /// - **Measurement registers `mrtd` / `rtmr0..3` / `mrsignerseam`** (in
     ///   `self.quote.body`) — parsed but never compared here. Check them against
     ///   a measurement allowlist to establish *which* workload was attested; a
     ///   valid signature only proves *some* genuine TDX platform produced the

--- a/crates/tee-attestation/src/verify.rs
+++ b/crates/tee-attestation/src/verify.rs
@@ -13,6 +13,13 @@ use crate::error::AttestationError;
 use crate::generate::{is_mock_quote, MOCK_QUOTE_HEADER};
 
 /// Result of verifying a TEE attestation.
+///
+/// This is a *report* of the crypto/structural checks the verifier performed
+/// plus the raw material a caller needs to make a policy decision. It is NOT an
+/// authorization verdict on its own. In particular, `tcb_status`, `advisory_ids`
+/// and the measurement registers in `quote.body` (`mrtd` / `rtmr0..3` /
+/// `mrsigner`) are surfaced here precisely *because* the caller — not this crate
+/// — is expected to enforce a policy over them. See [`Self::is_valid`].
 #[derive(Debug, Clone)]
 pub struct VerificationResult {
     /// Whether the quote's cryptographic signature is valid.
@@ -22,15 +29,59 @@ pub struct VerificationResult {
     /// Whether the application hash matches the expected (mandatory) value.
     pub application_hash_verified: bool,
     /// TCB status reported by DCAP verification (for policy decisions).
+    ///
+    /// NOT consulted by [`Self::is_valid`]. A crypto-valid quote from an
+    /// `OutOfDate`, `SWHardeningNeeded`, or `Revoked` platform still reports
+    /// `quote_verified == true`; the caller must gate on this field.
     pub tcb_status: Option<String>,
     /// Advisory IDs reported by DCAP verification.
+    ///
+    /// NOT consulted by [`Self::is_valid`]; provided for caller-side policy.
     pub advisory_ids: Vec<String>,
     /// The parsed quote structure.
+    ///
+    /// Its `body` carries the measurement registers (`mrtd` / `rtmr0..3` /
+    /// `mrsigner`). These are parsed but NOT compared against anything by this
+    /// crate — matching them to an allowlist is the caller's responsibility.
     pub quote: Quote,
 }
 
 impl VerificationResult {
-    /// Check if all verification checks passed.
+    /// Crypto/structural validity ONLY — this is **not** an authorization
+    /// decision.
+    ///
+    /// Returns `true` iff all three built-in checks passed:
+    /// - `quote_verified` — DCAP signature + certificate chain verified against
+    ///   Intel PCS collateral (for a mock quote this is unconditionally `true`);
+    /// - `nonce_verified` — `report_data[0..32]` matched the challenge nonce
+    ///   (anti-replay);
+    /// - `application_hash_verified` — `report_data[32..64]` matched the
+    ///   mandatory app/identity binding.
+    ///
+    /// It deliberately does **not** consider, and a caller therefore MUST
+    /// enforce on top of it:
+    /// - **`tcb_status` / `advisory_ids`** — a cryptographically valid quote
+    ///   from an `OutOfDate`, `SWHardeningNeeded`, or even `Revoked` platform
+    ///   still returns `quote_verified == true`, so `is_valid()` returns `true`.
+    ///   Gate on `tcb_status` against an allowlist, failing closed on an empty
+    ///   allowlist and on `Revoked`.
+    /// - **Measurement registers `mrtd` / `rtmr0..3` / `mrsigner`** (in
+    ///   `self.quote.body`) — parsed but never compared here. Check them against
+    ///   a measurement allowlist to establish *which* workload was attested; a
+    ///   valid signature only proves *some* genuine TDX platform produced the
+    ///   quote, not that it is the approved one.
+    ///
+    /// # Never admit on `is_valid()` alone
+    /// Admitting a peer, releasing a key, or granting any capability on
+    /// `is_valid()` without the TCB + measurement gate trusts *any* well-formed
+    /// TDX platform rather than a specific approved one. The enforcement layer
+    /// that must wrap this call lives in the callers, not here:
+    /// - `crates/context/src/handlers/admit_tee_node.rs` — per-group
+    ///   `TeeAdmissionPolicy` (MRTD/RTMR allowlists + `tcb_status_allowed`);
+    /// - `crates/merod/src/kms/mod.rs` — `enforce_attestation_policy`
+    ///   (measurement + TCB allowlists for KMS self-attestation);
+    /// - the mero-tee KMS `get_key.rs` `enforce_attestation_policy` on the
+    ///   key-release side (external consumer of this crate).
     pub fn is_valid(&self) -> bool {
         self.quote_verified && self.nonce_verified && self.application_hash_verified
     }
@@ -38,12 +89,31 @@ impl VerificationResult {
 
 /// Verify a TDX attestation quote.
 ///
+/// This performs **crypto/structural verification only**: it checks the DCAP
+/// signature/collateral, matches the nonce, and matches the mandatory app-hash
+/// binding. It does **not** make an authorization decision. The returned
+/// [`VerificationResult`] carries `tcb_status`, `advisory_ids`, and the parsed
+/// measurement registers (`quote.body.mrtd` / `rtmr0..3`) so the caller can
+/// apply its own policy — see [`VerificationResult::is_valid`] for the full
+/// contract and the list of enforcement call sites.
+///
+/// # Caller contract
+/// A successful (`is_valid() == true`) result means only that *some* genuine TDX
+/// platform produced a fresh quote bound to `expected_app_hash`. Callers MUST
+/// additionally enforce:
+/// - a `tcb_status` allowlist (fail closed on empty allowlist and on `Revoked`);
+/// - a measurement allowlist over `mrtd` / `rtmr0..3` to pin *which* workload;
+/// - the mock-vs-real acceptance policy (`is_mock_quote` routes here vs.
+///   `verify_mock_attestation`; this function never runs for mock quotes).
+///
 /// # Arguments
 /// * `quote_bytes` - Raw quote bytes to verify.
 /// * `nonce` - Expected 32-byte nonce that should be in report_data[0..32].
 /// * `expected_app_hash` - Mandatory expected 32-byte app hash that must be in report_data[32..64].
 ///   Binding the attestation to an application/identity is required; there is no
 ///   "skip" path that would otherwise leave the quote unbound yet considered valid.
+///   (An earlier `Option`-based signature that defaulted the check open via
+///   `unwrap_or(true)` has been removed — the binding is now unconditional.)
 ///
 /// # Returns
 /// A `VerificationResult` with the verification status for each check.

--- a/crates/tee-attestation/src/verify.rs
+++ b/crates/tee-attestation/src/verify.rs
@@ -74,8 +74,17 @@ impl VerificationResult {
     /// # Never admit on `is_valid()` alone
     /// Admitting a peer, releasing a key, or granting any capability on
     /// `is_valid()` without the TCB + measurement gate trusts *any* well-formed
-    /// TDX platform rather than a specific approved one. The enforcement layer
-    /// that must wrap this call lives in the callers, not here:
+    /// TDX platform rather than a specific approved one.
+    ///
+    /// New callers should use [`Self::policy_valid`] instead: it is the
+    /// safe-by-construction gate that folds these crypto checks together with a
+    /// fail-closed TCB allowlist, the mock decision, the measurement
+    /// allowlists, and the app-hash binding, and returns a typed
+    /// [`crate::PolicyRejection`].
+    ///
+    /// The existing enforcement layers below keep their own equivalent
+    /// enforcement by design (mode-specific errors `policy_valid` cannot
+    /// express), and `is_valid()` stays crypto-only for them:
     /// - `crates/context/src/handlers/admit_tee_node.rs` — per-group
     ///   `TeeAdmissionPolicy` (MRTD/RTMR allowlists + `tcb_status_allowed`);
     /// - `crates/merod/src/kms/mod.rs` — `enforce_attestation_policy`


### PR DESCRIPTION
## What

Two additive changes to `calimero-tee-attestation`:

1. **Document the verifier contract.** `is_valid()` is crypto/structural validity **only** — it deliberately does not consult `tcb_status`/`advisory_ids`, the measurement registers (`mrtd`/`rtmr0-3`/`mrsigner`), or enforce an app-hash binding. That layering is intentional (callers own policy), but it was undocumented, which is exactly how a caller can end up trusting `is_valid()` alone. The docs now state the contract explicitly and name the enforcement sites that own policy.

2. **Add an opt-in `policy_valid` gate.** New `VerifierPolicy` + `VerificationResult::policy_valid(&VerifierPolicy) -> Result<(), PolicyRejection>`, so future callers get a safe-by-construction option instead of hand-rolling the policy loop (or forgetting it).

## Why

The verifier returns parsed measurements and TCB status for the *caller* to enforce. Today the live paths do enforce them (`admit_tee_node`, merod KMS), but nothing in the API stops a new caller from trusting crypto-only validity. This closes that footgun class at the API level.

## `policy_valid` semantics

Folds in, on top of the existing crypto checks:
- **TCB fail-closed** — `Revoked` rejected unconditionally (case-insensitive); an **empty** `allowed_tcb_statuses` defaults to the secure `{"UpToDate"}`, never fails open.
- **Mock** — a mock quote is accepted only when `accept_mock` is set (an allowlisted `"Mock"` is not a standing bypass token).
- **Measurements** — MRTD is strict (an empty allowlist is a rejection); `rtmr0..3` allowlists are enforced when non-empty, skipped when empty.
- **App-hash** — rejected when unbound.

These deliberately mirror `tcb_status_allowed` from #3023 (`calimero-governance-store::membership::policy_rules`), replicated rather than imported because `calimero-tee-attestation` is a leaf crate — the intentional duplication is recorded in a module doc comment so the two can't silently drift.

`PolicyRejection` is a typed enum (`NotCryptoValid`, `TcbRevoked`, `TcbNotAllowed`, `MockNotAccepted`, `EmptyMrtdAllowlist`, `MeasurementMismatch`, `AppHashNotBound`) with `Display`/`Error`, so callers get actionable errors rather than a bare `bool`.

`policy_valid` is guaranteed **never weaker than `is_valid()`** — clearing `require_app_hash` changes only the reported reason, never the verdict (pinned by a test).

## Additive — no consumer impact

`is_valid()` keeps its name and exact body; `verify_attestation`'s signature and `VerificationResult`'s fields are unchanged. The only public-surface change is additions. Verified by diffing `verify.rs` against master with comment lines filtered out — the result is empty.

This matters because `calimero-tee-attestation` is `publish = true` and consumed downstream, where `is_valid()` is relied on for **crypto-only** semantics with policy layered on top. Tightening it would have been a breaking behavior change; this is not. **No rev bump required.**

## Not included (deliberate)

Existing callers (`admit_tee_node`, merod KMS `enforce_attestation_policy`) keep their own enforcement — they have richer, mode-specific errors and the ReleaseStrict/Config split, so churning them is risk without benefit. `policy_valid` exists to make *future* callers safe. They could delegate later; that's a follow-up, not this PR.

## Verification

- `cargo check -p calimero-tee-attestation` + `--workspace` clean
- `cargo clippy -p calimero-tee-attestation --all-targets` clean (zero warnings)
- `rustup run 1.88.0 cargo fmt --check` exit 0
- `cargo test -p calimero-tee-attestation` — **20 passed**, covering empty-TCB fail-closed, `Revoked` rejected even when allowlisted and even with `accept_mock`, mock gated, MRTD mismatch/empty rejected, RTMR empty-skip, app-hash unbound, `tcb_status: None`, and the happy path.
