### PR TITLE
feat(auth): auto-generate the first-login setup code on fresh embedded-auth nodes

### DIFF
--- a/crates/auth/src/config.rs
+++ b/crates/auth/src/config.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 /// Authentication service configuration
@@ -120,6 +121,36 @@ pub struct UserPasswordConfig {
     /// a blank value from env interpolation can never open the gate.
     #[serde(default)]
     pub bootstrap_secret: Option<String>,
+}
+
+impl UserPasswordConfig {
+    /// Generate a fresh first-login bootstrap secret (setup code).
+    ///
+    /// 128 bits from the process CSPRNG, hex-encoded (32 chars) — unguessable,
+    /// yet short enough to paste from the merod console into a login form.
+    #[must_use]
+    pub fn generate_bootstrap_secret() -> String {
+        let bytes: [u8; 16] = rand::thread_rng().gen();
+        hex::encode(bytes)
+    }
+
+    /// Resolve the effective bootstrap secret.
+    ///
+    /// The `MERO_AUTH_BOOTSTRAP_SECRET` environment variable takes precedence
+    /// (the recommended out-of-band channel); the configured value is used as
+    /// a fallback. Returns `None` when neither is set, which disables
+    /// first-login bootstrap entirely. An empty string in either source is
+    /// treated as unset — otherwise a blank env interpolation or
+    /// `bootstrap_secret = ""` in config would let `""` match a caller that
+    /// omitted the field, silently re-enabling the unauthenticated TOFU
+    /// bootstrap this gate exists to close.
+    #[must_use]
+    pub fn effective_bootstrap_secret(&self) -> Option<String> {
+        std::env::var("MERO_AUTH_BOOTSTRAP_SECRET")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .or_else(|| self.bootstrap_secret.clone().filter(|s| !s.is_empty()))
+    }
 }
 
 impl Default for UserPasswordConfig {
@@ -384,4 +415,39 @@ pub fn load_config(path: &str) -> eyre::Result<AuthConfig> {
         .try_deserialize()?;
 
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UserPasswordConfig;
+
+    #[test]
+    fn generated_bootstrap_secret_is_32_hex_chars_and_unique() {
+        let a = UserPasswordConfig::generate_bootstrap_secret();
+        let b = UserPasswordConfig::generate_bootstrap_secret();
+        assert_eq!(a.len(), 32);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a, b, "two generated setup codes must not collide");
+    }
+
+    // Relies on MERO_AUTH_BOOTSTRAP_SECRET being unset in the test
+    // environment, same as the bootstrap-gate tests in user_password.rs.
+    #[test]
+    fn effective_bootstrap_secret_uses_config_and_treats_empty_as_unset() {
+        let mut cfg = UserPasswordConfig::default();
+        assert_eq!(cfg.effective_bootstrap_secret(), None);
+
+        cfg.bootstrap_secret = Some(String::new());
+        assert_eq!(
+            cfg.effective_bootstrap_secret(),
+            None,
+            "empty string must not open the bootstrap gate"
+        );
+
+        cfg.bootstrap_secret = Some("s3cret-code".to_owned());
+        assert_eq!(
+            cfg.effective_bootstrap_secret().as_deref(),
+            Some("s3cret-code")
+        );
+    }
 }

--- a/crates/auth/src/embedded.rs
+++ b/crates/auth/src/embedded.rs
@@ -83,6 +83,47 @@ pub async fn build_app(config: AuthConfig) -> Result<EmbeddedAuthApp> {
     let metrics = AuthMetrics::new();
     let key_manager = KeyManager::new(Arc::clone(&storage));
 
+    // Surface the first-login setup code while the node is still
+    // un-bootstrapped (no root keys yet), then never again. The code is
+    // already at rest in the 0600 config.toml next to the node's private
+    // key, so logging it here exposes nothing the node's owner can't read —
+    // and without this, a fresh node's first login fails with an opaque 401
+    // (core#3221 deliberately makes the rejection indistinguishable from a
+    // wrong password).
+    if config
+        .providers
+        .get("user_password")
+        .copied()
+        .unwrap_or(false)
+    {
+        match key_manager
+            .list_keys(crate::storage::models::KeyType::Root)
+            .await
+        {
+            Ok(keys) if keys.is_empty() => {
+                if let Some(secret) = config.user_password.effective_bootstrap_secret() {
+                    info!("==============================================================");
+                    info!("No account exists on this node yet.");
+                    info!("First-login setup code: {secret}");
+                    info!("Log in with your chosen username/password plus this code to");
+                    info!("create the admin account. (Also stored in config.toml.)");
+                    info!("==============================================================");
+                } else {
+                    info!(
+                        "No account exists on this node yet and no bootstrap secret is \
+                         configured — first login will be rejected. Set \
+                         MERO_AUTH_BOOTSTRAP_SECRET or [user_password] bootstrap_secret \
+                         to enable first-login setup."
+                    );
+                }
+            }
+            Ok(_) => {}
+            Err(err) => {
+                info!("Could not determine bootstrap state: {err}");
+            }
+        }
+    }
+
     let state = Arc::new(AppState {
         auth_service: auth_service.clone(),
         storage,

--- a/crates/auth/src/providers/impls/user_password.rs
+++ b/crates/auth/src/providers/impls/user_password.rs
@@ -309,26 +309,11 @@ impl UserPasswordProvider {
         Ok((key_id, root_key))
     }
 
-    /// Resolve the effective bootstrap secret.
-    ///
-    /// The `MERO_AUTH_BOOTSTRAP_SECRET` environment variable takes precedence
-    /// (the recommended out-of-band channel); the configured value is used as
-    /// a fallback. Returns `None` when neither is set, which disables
-    /// first-login bootstrap entirely. An empty string in either source is
-    /// treated as unset — otherwise a blank env interpolation or
-    /// `bootstrap_secret = ""` in config would let `""` match a caller that
-    /// omitted the field (`unwrap_or_default`), silently re-enabling the
-    /// unauthenticated TOFU bootstrap this gate exists to close.
+    /// Resolve the effective bootstrap secret (env over config; empty =
+    /// unset). Shared with the startup setup-code banner — see
+    /// [`UserPasswordConfig::effective_bootstrap_secret`].
     fn effective_bootstrap_secret(&self) -> Option<String> {
-        std::env::var("MERO_AUTH_BOOTSTRAP_SECRET")
-            .ok()
-            .filter(|s| !s.is_empty())
-            .or_else(|| {
-                self.config
-                    .bootstrap_secret
-                    .clone()
-                    .filter(|s| !s.is_empty())
-            })
+        self.config.effective_bootstrap_secret()
     }
 
     /// Constant-time comparison of a presented bootstrap secret against the

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -21,7 +21,9 @@ use core::net::IpAddr;
 use core::time::Duration;
 use eyre::{bail, Result as EyreResult, WrapErr};
 use libp2p::identity::Keypair;
-use mero_auth::config::{AuthConfig as EmbeddedAuthConfig, StorageConfig as AuthStorageConfig};
+use mero_auth::config::{
+    AuthConfig as EmbeddedAuthConfig, StorageConfig as AuthStorageConfig, UserPasswordConfig,
+};
 use multiaddr::{Multiaddr, Protocol};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -333,6 +335,17 @@ impl InitCommand {
         let auth_mode = self.auth_mode.map(Into::into).unwrap_or(AuthMode::Proxy);
         let embedded_auth = if matches!(auth_mode, AuthMode::Embedded) {
             let mut auth_cfg: EmbeddedAuthConfig = mero_auth::embedded::default_config();
+
+            // Fresh embedded-auth nodes get an auto-generated first-login
+            // setup code (bootstrap secret, core#3221) so the very first
+            // login can mint the root key without manual provisioning. It
+            // lives in config.toml (0600, alongside the node's private key),
+            // so only the node's owner can read it; deployments that
+            // provision out of band (MERO_AUTH_BOOTSTRAP_SECRET or their own
+            // config value) simply overwrite or ignore it.
+            auth_cfg.user_password.bootstrap_secret =
+                Some(UserPasswordConfig::generate_bootstrap_secret());
+
             let storage_choice = self.auth_storage.unwrap_or(AuthStorageArg::Persistent);
             let storage_path = self.auth_storage_path.clone();
 

--- a/crates/merod/src/cli/run.rs
+++ b/crates/merod/src/cli/run.rs
@@ -7,7 +7,7 @@ use calimero_server::config::{AuthMode, ServerConfig};
 use calimero_store::config::StoreConfig;
 use clap::Parser;
 use eyre::{bail, Result as EyreResult, WrapErr};
-use mero_auth::config::StorageConfig as AuthStorageConfig;
+use mero_auth::config::{StorageConfig as AuthStorageConfig, UserPasswordConfig};
 use mero_auth::embedded::default_config;
 use multiaddr::{Multiaddr, Protocol};
 use tracing::{info, warn};
@@ -40,7 +40,10 @@ impl RunCommand {
 
         let mut config = ConfigFile::load(&path).await?;
 
-        // Apply CLI auth_mode override before validation
+        // Apply CLI auth_mode override before validation. The configured mode
+        // is kept around so the setup-code backfill below can persist config
+        // changes without also freezing a per-run CLI override into the file.
+        let configured_auth_mode = config.network.server.auth_mode;
         if let Some(mode) = self.auth_mode {
             config.network.server.auth_mode = mode.into();
         }
@@ -145,6 +148,44 @@ impl RunCommand {
         if node_mode == NodeMode::ReadOnly {
             info!("Starting node in read-only mode - JSON-RPC execution disabled");
             config.network.server.jsonrpc = None;
+        }
+
+        // Nodes initialized before setup codes existed have embedded auth but
+        // no bootstrap secret, which makes the very first login fail with an
+        // opaque 401 (core#3221). Backfill a generated one on startup so an
+        // upgraded-but-fresh node keeps the "just log in" UX. Provisioned
+        // deployments are untouched: an env secret skips generation entirely
+        // (and is never persisted), a configured secret is kept, and a node
+        // that already has a root key never consults the value again.
+        // Only an existing embedded_auth section is backfilled — a missing
+        // section is rejected by validate_config above, same as before.
+        let needs_setup_code = matches!(config.network.server.auth_mode, AuthMode::Embedded)
+            && std::env::var("MERO_AUTH_BOOTSTRAP_SECRET").map_or(true, |s| s.is_empty())
+            && config
+                .network
+                .server
+                .embedded_auth
+                .as_ref()
+                .is_some_and(|auth_config| {
+                    auth_config
+                        .user_password
+                        .bootstrap_secret
+                        .as_deref()
+                        .is_none_or(str::is_empty)
+                });
+        if needs_setup_code {
+            if let Some(auth_config) = config.network.server.embedded_auth.as_mut() {
+                auth_config.user_password.bootstrap_secret =
+                    Some(UserPasswordConfig::generate_bootstrap_secret());
+            }
+            // Persist with the *configured* auth mode so a per-run
+            // `--auth-mode` override doesn't get frozen into config.toml
+            // as a side effect of saving the generated secret.
+            let effective_auth_mode = config.network.server.auth_mode;
+            config.network.server.auth_mode = configured_auth_mode;
+            config.save(&path).await?;
+            config.network.server.auth_mode = effective_auth_mode;
+            info!("Generated a first-login setup code and saved it to config.toml");
         }
 
         let network = config.network;

--- a/crates/merod/src/main.rs
+++ b/crates/merod/src/main.rs
@@ -44,7 +44,9 @@ async fn main() -> EyreResult<()> {
 fn setup() -> EyreResult<()> {
     let directives = match var("RUST_LOG") {
         Ok(value) if !value.trim().is_empty() => value,
-        _ => "merod=info,calimero_=info".to_owned(),
+        // mero_auth is included so embedded-auth startup messages (notably
+        // the first-login setup code on a fresh node) are visible by default.
+        _ => "merod=info,calimero_=info,mero_auth=info".to_owned(),
     };
 
     registry()


### PR DESCRIPTION
## Problem

#3221 (in rc.14) gates the first root key behind an out-of-band bootstrap secret. Right call for exposed nodes — but it silently broke the fresh-node UX: with no secret configured, the **very first login fails with the same opaque 401 as a wrong password** (deliberately indistinguishable), and nothing tells the user why or what to do. Every fresh local node and every desktop-app first-run on rc.14 hits this.

## Fix — keep the gate, remove the manual step

- **`merod init` (embedded auth)** generates a 128-bit hex setup code into `[server.embedded_auth.user_password] bootstrap_secret`. `config.toml` is already written 0600 next to the node's private key, so only the node's owner can read it — the TOFU hole #3221 closed stays closed (a remote first-comer still can't bootstrap).
- **`merod run`** backfills the same for nodes initialized ≤ rc.14 that have an `embedded_auth` section but no secret. `MERO_AUTH_BOOTSTRAP_SECRET` skips generation entirely and is never persisted; a per-run `--auth-mode` CLI override is not frozen into the file by the save; a missing `embedded_auth` section is still rejected by `validate_config` as before.
- **Startup banner**: the embedded auth service logs the setup code while the node has no root keys yet (and a pointer message when bootstrap is disabled), then never again — the code is discoverable exactly when it's needed. merod's default log filter now includes `mero_auth=info` so auth startup lines are actually visible (they were filtered out entirely before).
- `UserPasswordConfig` grows `generate_bootstrap_secret()` and `effective_bootstrap_secret()` (env over config, empty = unset); the provider's private resolver delegates to the shared impl.

Client-side follow-ups (auth-frontend setup-code field + URL param, desktop app auto-wiring) ship separately; with those, first login is back to plain "type username/password" on desktop, and one extra pasted code from the console for manual/browser setups.

## Proof

On a debug build:
1. `merod --node t1 init --auth-mode embedded` → `bootstrap_secret` present in config.toml.
2. Old-style config (no secret, `auth_mode = "proxy"`) + `merod run --auth-mode embedded` → `Generated a first-login setup code and saved it to config.toml`; file keeps `auth_mode = "proxy"`.
3. Startup log: `First-login setup code: 152f14cd…` banner while un-bootstrapped.
4. `POST /auth/token` with `provider_data.bootstrap_secret` → tokens; subsequent plain username/password login → tokens. Before the fix, step 4's first call returned 401 `Invalid username or password`.

`cargo test -p mero-auth -p merod` green (238 tests), fmt + clippy clean. New unit tests cover generation format/uniqueness and empty-string-stays-closed resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)