### PR TITLE
chore: cut release 0.11.0-rc.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.14"
+version = "0.11.0-rc.15"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Bumps the shared workspace version 0.11.0-rc.14 → 0.11.0-rc.15.

Headline change since rc.14: **#3270 — auto-generated first-login setup code**, which un-breaks the fresh-node first login that rc.14's bootstrap-secret gate (#3221) introduced (merod init/run now provisions the secret into config.toml and prints it at startup; clients present it transparently — auth-frontend#40, tauri-app#148).

Also since rc.14: MemberJoinedAt local-apply fix (#3266), Open-subgroup buffered-op re-drive on key delivery (#3264), TEE admission fail-closed on empty TCB allowlist (#3023) + `merod tee probe` self-check (#3262), e2e build speedup (#3255), serde_with bump (#3261), CI/review plumbing (#3260, #3263, #3265).

Merging this PR is the release trigger — Fran's call, as always.

🤖 Generated with [Claude Code](https://claude.com/claude-code)