### PR TITLE
ci(release): maintain a moving `latest` tag on every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,26 @@ jobs:
             exit 1
           fi
 
+      # Keep a moving `latest` tag on the released commit so downstream
+      # contract repos can depend on the newest release without editing
+      # their Cargo.toml every cut:
+      #   calimero-sdk = { git = ".../core", tag = "latest" }
+      # `cargo update` then re-resolves the tag to the current release.
+      # Force-move via the git-data API (update with force=true, create on
+      # first run); no workflow triggers on tag pushes, so this is inert.
+      - name: Move `latest` tag to this release
+        if: github.event_name == 'push' && steps.version_info.outputs.binary_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version_info.outputs.version }}
+        run: |
+          if ! gh api -X PATCH "repos/${{ github.repository }}/git/refs/tags/latest" \
+              -f sha="${{ github.sha }}" -F force=true >/dev/null 2>&1; then
+            gh api -X POST "repos/${{ github.repository }}/git/refs" \
+              -f ref="refs/tags/latest" -f sha="${{ github.sha }}"
+          fi
+          echo "latest -> ${{ github.sha }} ($VERSION)"
+
       # Match the file set that defines the profiling image's content:
       # the entrypoint + helper scripts baked into the image, the
       # Dockerfile itself, and the fuzzy workflow that exercises it.


### PR DESCRIPTION
## Why

Every contract repo (mero-blocks, merraria, mero-chat, calendar, design, pixart, meet, drive, tag, ar) pins the core SDK by git tag — four Cargo.toml lines × ten repos edited on every release cut. Fran asked for a "just use the latest release" mode.

Cargo has no "highest semver tag" selector, so the standard pattern is a **moving `latest` tag** (same idea as Docker's `latest`): the release workflow re-points it at the released commit, apps declare `tag = "latest"` once, and `cargo update` picks up each new release. Cargo.lock still records the exact resolved commit, so builds stay reproducible — nothing floats silently.

## Change

One step in `release.yml`, right after "Create release at trigger time", gated by the same `binary_release` condition: force-move `refs/tags/latest` to `${{ github.sha }}` via the git-data API (PATCH with `force=true`; POST on first run).

Safety: no workflow in this repo triggers on tag pushes (release flow triggers on master pushes touching Cargo.toml), so the moving tag is inert. Versioned tags remain the immutable source of truth.

I have NOT created the `latest` tag manually — the first run of this workflow (next release cut) creates it, or it can be seeded now with:
`gh api -X POST repos/calimero-network/core/git/refs -f ref=refs/tags/latest -f sha=<rc.15 commit>`

App-side PRs switching to `tag = "latest"` follow once the tag exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)