### PR TITLE
chore: cut release 0.11.0-rc.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.15"
+version = "0.11.0-rc.16"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Bumps the shared workspace version 0.11.0-rc.15 → 0.11.0-rc.16.

**Why this cut exists:** the auth-frontend login UI ships **inside the merod binary** (embedded from the latest auth-frontend release at build time), so browsers only receive [auth-frontend#40](https://github.com/calimero-network/auth-frontend/pull/40) — the first-login setup-code field + the registry-trusted callback allowlist that un-breaks hosted-app → local-node login — once a new merod is built after that release exists.

## ⚠️ Merge order (matters!)
1. Merge **auth-frontend#40**
2. Cut an **auth-frontend release** (> v1.3.1)
3. Merge **this PR** — the release build then embeds the new UI
4. After binaries publish: tauri-app 0.0.69 bump PR (open separately) pins rc.16

Also picked up since rc.15: #3272 (governance leave→re-add test).

Merging this PR is the release trigger — Fran's call, as always.

🤖 Generated with [Claude Code](https://claude.com/claude-code)