### PR TITLE
fix(wasm-abi): resolve GCounter/PNCounter alias identifiers in ABI normalization

### DIFF
--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -26,8 +26,8 @@ use calimero_sdk::serde::Serialize;
 use calimero_sdk::{app, env, PublicKey};
 use calimero_storage::collections::{
     AuthoredMap, AuthoredVector, Counter, FrozenStorage, GCounter, LwwRegister, Mergeable,
-    ReplicatedGrowableArray, SharedStorage, SortedMap, SortedSet, UnorderedMap, UnorderedSet,
-    UserStorage, Vector,
+    PNCounter, ReplicatedGrowableArray, SharedStorage, SortedMap, SortedSet, UnorderedMap,
+    UnorderedSet, UserStorage, Vector,
 };
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -121,7 +121,7 @@ pub struct E2eKvStore {
     crdt_counters: UnorderedMap<String, Counter>,
     /// Map of PN-Counters (supports decrement, concurrent inc/dec should merge correctly)
     /// Counter<true> = PNCounter (allows decrement)
-    crdt_pn_counters: UnorderedMap<String, Counter<true>>,
+    crdt_pn_counters: UnorderedMap<String, PNCounter>,
     /// Map of LWW registers (latest timestamp wins)
     crdt_registers: UnorderedMap<String, LwwRegister<String>>,
     /// Nested maps (field-level merge)
@@ -144,7 +144,7 @@ pub struct E2eKvStore {
     /// Collaborative text document
     rga_document: ReplicatedGrowableArray,
     /// Edit count for document (G-Counter)
-    rga_edit_count: Counter,
+    rga_edit_count: GCounter,
     /// Document metadata (title, owner)
     rga_metadata: UnorderedMap<String, LwwRegister<String>>,
 

--- a/crates/wasm-abi/src/normalize.rs
+++ b/crates/wasm-abi/src/normalize.rs
@@ -294,6 +294,8 @@ fn normalize_generic_type(
         // CRDT types - unwrap to inner type for ABI but preserve CRDT type metadata
         "LwwRegister"
         | "Counter"
+        | "GCounter"
+        | "PNCounter"
         | "ReplicatedGrowableArray"
         | "Vector"
         | "AuthoredVector"
@@ -303,16 +305,20 @@ fn normalize_generic_type(
             // These CRDT wrappers unwrap to their inner type for ABI purposes
             // but we preserve the CRDT type so deserializers know the format
 
-            if ident_str == "Counter" || ident_str == "ReplicatedGrowableArray" {
-                // Counter and RGA don't have generic args (or are opaque)
-                // Counter -> bytes (but preserve Counter type), RGA -> string (but preserve RGA type)
-                if ident_str == "Counter" {
+            // Counter/RGA are opaque (no ABI-visible generic args). GCounter and
+            // PNCounter are `pub type` aliases of Counter; syn does not expand
+            // aliases, so each spelling must be matched by name and collapse to
+            // the single `counter` tag.
+            match ident_str.as_str() {
+                "Counter" | "GCounter" | "PNCounter" => {
                     return Ok(opaque_crdt_placeholder(CrdtCollectionType::Counter));
-                } else {
+                }
+                "ReplicatedGrowableArray" => {
                     return Ok(opaque_crdt_placeholder(
                         CrdtCollectionType::ReplicatedGrowableArray,
                     ));
                 }
+                _ => {}
             }
 
             // LwwRegister<T>, Vector<T>, UnorderedSet<T> -> unwrap T but preserve CRDT type
@@ -527,7 +533,11 @@ fn normalize_scalar_type(
         // with the same fixed-size-bytes shape as `PublicKey`.
         "BlobId" | "ContextId" | "ApplicationId" => Ok(TypeRef::bytes_with_size(32, None)),
         // Storage CRDT wrappers – treat as opaque blobs until ABI definitions exist.
-        "Counter" => Ok(opaque_crdt_placeholder(CrdtCollectionType::Counter)),
+        // GCounter/PNCounter are `pub type` aliases of Counter; syn does not expand
+        // aliases, so each spelling is matched here (bare form is legal - generics default).
+        "Counter" | "GCounter" | "PNCounter" => {
+            Ok(opaque_crdt_placeholder(CrdtCollectionType::Counter))
+        }
         "ReplicatedGrowableArray" => Ok(opaque_crdt_placeholder(
             CrdtCollectionType::ReplicatedGrowableArray,
         )),

--- a/crates/wasm-abi/tests/normalize.rs
+++ b/crates/wasm-abi/tests/normalize.rs
@@ -530,3 +530,88 @@ fn test_unregistered_external_type_still_errors() {
     let result = normalize_type(&parse_type("TotallyUnknownExternalType"), true, &resolver);
     assert!(matches!(result, Err(NormalizeError::TypePathError(_))));
 }
+
+#[test]
+fn test_counter_and_aliases_normalize_to_counter_placeholder() {
+    use calimero_wasm_abi::schema::{CollectionType, CrdtCollectionType};
+
+    let resolver = MockResolver::new();
+
+    // `Counter` and its `GCounter` / `PNCounter` aliases all collapse to the
+    // single opaque `counter` ABI tag - the ALLOW_DECREMENT const generic is an
+    // internal serialization detail invisible to the ABI. syn does not expand
+    // `pub type` aliases, so each spelling is matched by name in normalize.rs.
+    // Bare forms are legal Rust (every generic is defaulted); generic spellings
+    // must resolve identically.
+    let spellings = [
+        "Counter",
+        "Counter<true>",
+        "GCounter",
+        "PNCounter",
+        "GCounter<MainStorage>",
+        "PNCounter<MainStorage>",
+    ];
+    for spelling in spellings {
+        let normalized = normalize_type(&parse_type(spelling), true, &resolver)
+            .unwrap_or_else(|e| panic!("{spelling} failed to normalize: {e:?}"));
+        match normalized {
+            TypeRef::Collection {
+                collection,
+                crdt_type,
+                inner_type,
+            } => {
+                assert_eq!(
+                    crdt_type,
+                    Some(CrdtCollectionType::Counter),
+                    "{spelling} must carry crdt_type = Counter"
+                );
+                assert!(
+                    matches!(collection, CollectionType::Record { .. }),
+                    "{spelling} must surface as the opaque placeholder Record"
+                );
+                assert!(
+                    inner_type.is_none(),
+                    "{spelling} opaque placeholder has no inner type"
+                );
+            }
+            other => panic!("{spelling}: expected Collection variant, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn test_all_public_storage_spellings_normalize() {
+    // RULE: every public storage-collection spelling an app can legally write in
+    // a type position must normalize without error. syn does not expand `pub type`
+    // aliases, so every alias over a storage wrapper must be listed BOTH here and
+    // in normalize.rs - a missed alias fails the WASM build with
+    // "unknown type: <Alias>". Bare spellings appear only where all generics are
+    // defaulted.
+    let resolver = MockResolver::new();
+    let spellings = [
+        "LwwRegister<String>",
+        "Counter",
+        "Counter<true>",
+        "GCounter",
+        "PNCounter",
+        "ReplicatedGrowableArray",
+        "Vector<String>",
+        "AuthoredVector<String>",
+        "UnorderedSet<String>",
+        "SortedSet<String>",
+        "UnorderedMap<String, String>",
+        "SortedMap<String, String>",
+        "AuthoredMap<String, String>",
+        "SharedStorage<String>",
+        "PermissionedStorage<String>",
+        "Ownable<String>",
+        "UserStorage<String>",
+        "FrozenStorage<String>",
+        "FrozenValue<String>",
+        "AccessControl",
+    ];
+    for spelling in spellings {
+        normalize_type(&parse_type(spelling), true, &resolver)
+            .unwrap_or_else(|e| panic!("{spelling} must normalize without error: {e:?}"));
+    }
+}


### PR DESCRIPTION
## Summary

- `normalize.rs` resolves Rust type identifiers from the `syn` AST by literal name, and `syn` never expands `pub type` aliases. The public storage aliases `GCounter`/`PNCounter` (over `Counter`) were matched nowhere, so any app with a field of those types failed its WASM build with `unknown type: PNCounter`. The sibling alias family (`Ownable`/`SharedStorage` over `PermissionedStorage`) was already special-cased; the counter aliases were missed.
- Match `GCounter`/`PNCounter` in both the generic and scalar normalization paths, collapsing to the same `counter` ABI tag as `Counter` (the `ALLOW_DECREMENT` const-generic is an internal serialization detail with no ABI surface).
- Add regression tests for all counter spellings (bare/generic, canonical/alias) - canonical `Counter` itself previously had no normalize test.
- Add an enumeration test asserting every public storage-collection spelling an app can legally write normalizes without error, with the rule documented: every future `pub type` storage alias must be added there and in `normalize.rs`.
- Switch one `Counter<true>` field to `PNCounter` and one `Counter` to `GCounter` in `apps/scaffolding-e2e` so the real emitter round-trip covers the alias spellings; the emitted `res/abi.json` is byte-identical.

## Test plan

- `cargo test -p calimero-wasm-abi` - 93 tests pass
- `cargo check -p scaffolding-e2e` - passes; build script re-emits the ABI manifest with alias-typed fields, and the output hash is unchanged
- `cargo fmt --check` clean on touched crates