### PR TITLE
fix(context): don't strand a joiner when the namespace mesh isn't ready

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -210,6 +210,9 @@ jobs:
           - workflow: group-join-then-list-from-joiner
             file: workflows/group-join-then-list-from-joiner.yml
             app: scaffolding-e2e
+          - workflow: group-join-mesh-not-ready
+            file: workflows/group-join-mesh-not-ready.yml
+            app: scaffolding-e2e
           - workflow: group-3node
             file: workflows/group-3node.yml
             app: scaffolding-e2e

--- a/apps/scaffolding-e2e/workflows/group-join-mesh-not-ready.yml
+++ b/apps/scaffolding-e2e/workflows/group-join-mesh-not-ready.yml
@@ -1,36 +1,37 @@
-name: E2E KV Store - Join With No Reachable Mesh Peer (not-ready repro)
+name: E2E KV Store - Join With No Reachable Mesh Peer (not-stranded regression)
 description: >
-  Reproduces the Slack report (2026-07-23): a node tries to join a group via
-  invitation but its gossip mesh to the inviter hasn't formed / isn't
-  reachable, so the join can't complete — and the node is left "not a member",
-  making every subsequent admin list endpoint return HTTP 500
-  ("node is not a member of group ..."). Fran joined fine; Sandi didn't.
+  Regression guard for the Slack report (2026-07-23): a node joins a group via
+  invitation while its gossip mesh to the inviter hasn't formed / isn't
+  reachable. Before the fix this left the node "not a member", so every admin
+  list endpoint returned HTTP 500 ("node is not a member of group ..."). Fran
+  joined fine; Sandi didn't.
 
-  Root cause (crates/context/src/handlers/join_group.rs): after writing the
-  group meta + adding the INVITER as a member, the handler does a single
-  `request_namespace_join(...).await?` (a direct stream to a mesh peer, with a
-  ~45s discovery budget). The joiner's OWN membership row is written only
-  AFTER that call returns (join_group.rs:303). So if no namespace-mesh peer is
-  reachable within the budget, the `?` aborts the join BEFORE the joiner is
-  recorded locally — leaving the node not-a-member, whose only user-visible
-  symptom is a 500 from list_group_members / list_group_contexts.
+  Root cause (crates/context/src/handlers/join_group.rs): the handler did a
+  single `request_namespace_join(...).await?` (a direct stream to a mesh peer,
+  ~45s discovery budget), and wrote the joiner's OWN membership row only AFTER
+  that call. So if no namespace-mesh peer was reachable within the budget, the
+  `?` aborted the join BEFORE recording membership — the node was stranded
+  not-a-member, and its only symptom was a 500 from list_group_members /
+  list_group_contexts.
 
-  This scenario forces that condition deterministically with merobox's
+  The fix: on a failed direct request, fall back to an empty join bundle and
+  proceed. The invitation signature is already verified, so the joiner still
+  records local membership and publishes `MemberJoinedAt`; the group key,
+  contexts, and governance ops catch up via the gossip `KeyDelivery` fallback
+  and namespace sync once a peer is reachable. The node is "joined, pending
+  key" — never stranded, and list endpoints no longer 500.
+
+  This scenario forces the condition deterministically with merobox's
   `partition_peers` (merobox#278): a libp2p-only cut between node-1 and node-2
   that leaves BOTH nodes RPC-reachable, so we can drive node-2's join while it
   cannot reach node-1's mesh.
 
-  Two things are asserted:
-    1. FAILURE: under the partition, node-2's join fails and node-2 is left
-       "not a member" — list_group_members returns an error (the reported 500).
-    2. RECOVERY: after `heal_peers`, a re-join succeeds and node-2 then lists
-       members including itself.
-
-  NOTE: (1) codifies the CURRENT (fragile) behavior — a not-ready mesh is a
-  hard, membership-losing failure. When join_group is hardened (readiness-gated
-  retry so a not-yet-ready mesh is waited on rather than fatal), the step marked
-  `expected_failure` below must be revisited: the join should no longer fail
-  outright. This file is the reproduction for that fix.
+  RED→GREEN: the discriminating assertion is that `list_group_members` on the
+  joining node SUCCEEDS while partitioned. On pre-fix code the join aborts and
+  that list 500s (workflow red); with the fix the node is a member pending key
+  and the list returns 200 (workflow green). (The earlier characterization
+  commit on this branch asserted the 500 via `expected_failure` — its green run
+  is the proof that the 500 reproduces on pre-fix code.)
 
 force_pull_image: false
 near_devnet: false
@@ -99,26 +100,39 @@ steps:
     peers:
       - notready-node-2
 
-  # ── (1) FAILURE: join can't reach a mesh peer → aborts pre-membership ─
-  # request_namespace_join exhausts its ~45s discovery budget with no
-  # reachable peer, so join_group returns Err before writing node-2's
-  # membership row. expected_failure asserts the join RPC fails.
+  # ── Join under partition ─────────────────────────────────────────────
+  # request_namespace_join exhausts its ~45s discovery budget with no reachable
+  # peer. The join RPC still returns an error because no group key can be
+  # delivered while partitioned (the KeyDelivery fallback times out) — that
+  # typed "joined but not yet usable" error is intentional (PR #3288), so we
+  # keep expecting it here. The FIX is not that this call succeeds; it is that
+  # it no longer aborts BEFORE recording membership.
 
-  - name: Node-2 attempts to join while partitioned (expected to fail)
+  - name: Node-2 joins while partitioned (RPC still errors — no key yet)
     type: join_namespace
     node: notready-node-2
     namespace_id: '{{namespace_id}}'
     invitation: '{{invitation}}'
     expected_failure: true
 
-  # The reported symptom: because the join aborted before recording node-2
-  # as a member, listing the group from node-2 errors ("node is not a
-  # member" -> HTTP 500). expected_failure asserts that error.
-  - name: Node-2 lists group members while not-a-member (expected 500)
+  # THE regression signal (RED→GREEN). Pre-fix: the join aborted before
+  # recording node-2, so this returned HTTP 500 ("node is not a member") and
+  # the workflow went red. Post-fix: node-2 recorded local membership from the
+  # verified invitation before the key-wait, so this now SUCCEEDS (200) — the
+  # node is "joined, pending key", not stranded. A failed list step (500) here
+  # fails the workflow, which is exactly the pre-fix behavior we are guarding
+  # against.
+  - name: Node-2 lists group members while join is pending (was HTTP 500 pre-fix)
     type: list_group_members
     node: notready-node-2
     group_id: '{{namespace_id}}'
-    expected_failure: true
+    outputs:
+      pending_members: members
+
+  - name: Assert the joining node is listable, not stranded (no "not a member" 500)
+    type: assert
+    statements:
+      - "is_set({{pending_members}})"
 
   # ── Recovery: heal the partition, then a re-join must succeed ─────────
 

--- a/apps/scaffolding-e2e/workflows/group-join-mesh-not-ready.yml
+++ b/apps/scaffolding-e2e/workflows/group-join-mesh-not-ready.yml
@@ -1,0 +1,161 @@
+name: E2E KV Store - Join With No Reachable Mesh Peer (not-ready repro)
+description: >
+  Reproduces the Slack report (2026-07-23): a node tries to join a group via
+  invitation but its gossip mesh to the inviter hasn't formed / isn't
+  reachable, so the join can't complete — and the node is left "not a member",
+  making every subsequent admin list endpoint return HTTP 500
+  ("node is not a member of group ..."). Fran joined fine; Sandi didn't.
+
+  Root cause (crates/context/src/handlers/join_group.rs): after writing the
+  group meta + adding the INVITER as a member, the handler does a single
+  `request_namespace_join(...).await?` (a direct stream to a mesh peer, with a
+  ~45s discovery budget). The joiner's OWN membership row is written only
+  AFTER that call returns (join_group.rs:303). So if no namespace-mesh peer is
+  reachable within the budget, the `?` aborts the join BEFORE the joiner is
+  recorded locally — leaving the node not-a-member, whose only user-visible
+  symptom is a 500 from list_group_members / list_group_contexts.
+
+  This scenario forces that condition deterministically with merobox's
+  `partition_peers` (merobox#278): a libp2p-only cut between node-1 and node-2
+  that leaves BOTH nodes RPC-reachable, so we can drive node-2's join while it
+  cannot reach node-1's mesh.
+
+  Two things are asserted:
+    1. FAILURE: under the partition, node-2's join fails and node-2 is left
+       "not a member" — list_group_members returns an error (the reported 500).
+    2. RECOVERY: after `heal_peers`, a re-join succeeds and node-2 then lists
+       members including itself.
+
+  NOTE: (1) codifies the CURRENT (fragile) behavior — a not-ready mesh is a
+  hard, membership-losing failure. When join_group is hardened (readiness-gated
+  retry so a not-yet-ready mesh is waited on rather than fatal), the step marked
+  `expected_failure` below must be revisited: the join should no longer fail
+  outright. This file is the reproduction for that fix.
+
+force_pull_image: false
+near_devnet: false
+
+auth_mode: embedded
+
+nodes:
+  count: 2
+  image: merod:local
+  prefix: notready-node
+
+steps:
+  - name: Login on notready-node-1
+    type: login
+    node: notready-node-1
+    username: dev
+    password: dev-password
+
+  - name: Login on notready-node-2
+    type: login
+    node: notready-node-2
+    username: dev
+    password: dev-password
+
+  # ── Bootstrap on node-1: app, namespace, a context, an invitation ─────
+
+  - name: Install application on node-1
+    type: install_application
+    node: notready-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Node-1 creates namespace (root group)
+    type: create_namespace
+    node: notready-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Node-1 creates a context in the group
+    type: create_context
+    node: notready-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    outputs:
+      ctx_id: contextId
+
+  - name: Node-1 creates a group open invitation
+    type: create_namespace_invitation
+    node: notready-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invitation: invitation
+
+  - name: Let the two nodes connect + namespace governance gossip
+    type: wait
+    seconds: 8
+
+  # ── Fault: libp2p-only cut between node-1 and node-2 (RPC stays up) ───
+
+  - name: Partition node-2 from node-1 (libp2p only; RPC reachable)
+    type: partition_peers
+    node: notready-node-1
+    peers:
+      - notready-node-2
+
+  # ── (1) FAILURE: join can't reach a mesh peer → aborts pre-membership ─
+  # request_namespace_join exhausts its ~45s discovery budget with no
+  # reachable peer, so join_group returns Err before writing node-2's
+  # membership row. expected_failure asserts the join RPC fails.
+
+  - name: Node-2 attempts to join while partitioned (expected to fail)
+    type: join_namespace
+    node: notready-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invitation}}'
+    expected_failure: true
+
+  # The reported symptom: because the join aborted before recording node-2
+  # as a member, listing the group from node-2 errors ("node is not a
+  # member" -> HTTP 500). expected_failure asserts that error.
+  - name: Node-2 lists group members while not-a-member (expected 500)
+    type: list_group_members
+    node: notready-node-2
+    group_id: '{{namespace_id}}'
+    expected_failure: true
+
+  # ── Recovery: heal the partition, then a re-join must succeed ─────────
+
+  - name: Heal the partition
+    type: heal_peers
+    node: notready-node-1
+    peers:
+      - notready-node-2
+
+  - name: Wait for libp2p to redial + namespace mesh to re-form
+    type: wait
+    seconds: 15
+
+  - name: Node-2 re-joins the group (should now succeed)
+    type: join_namespace
+    node: notready-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invitation}}'
+    outputs:
+      member_identity_node2: memberIdentity
+
+  - name: Assert re-join returned a member identity
+    type: assert
+    statements:
+      - "is_set({{member_identity_node2}})"
+
+  - name: Node-2 lists group members after recovery
+    type: list_group_members
+    node: notready-node-2
+    group_id: '{{namespace_id}}'
+    outputs:
+      joiner_members: members
+
+  - name: Assert joiner now sees the group members, including itself
+    type: assert
+    statements:
+      - "is_set({{joiner_members}})"
+      - "contains({{joiner_members}}, {{member_identity_node2}})"
+
+stop_all_nodes: true

--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -10,6 +10,7 @@ use actix::{ActorResponse, Handler, Message, WrapFuture};
 use calimero_context_client::group::{JoinGroupRequest, JoinGroupResponse};
 use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
 use calimero_context_client::messages::NamespaceApplyOutcome;
+use calimero_node_primitives::join_bundle::JoinBundle;
 use calimero_primitives::context::{ContextConfigParams, GroupMemberRole};
 use calimero_primitives::identity::PrivateKey;
 use calimero_store::key;
@@ -161,9 +162,36 @@ impl Handler<JoinGroupRequest> for ContextManager {
                 let invitation_bytes = borsh::to_vec(&invitation)
                     .map_err(|e| eyre::eyre!("failed to serialize invitation: {e}"))?;
 
-                let join_result = node_client
+                // A thin / still-forming namespace mesh at join time must not
+                // strand the joiner. If no mesh peer can serve the direct join
+                // bundle within the discovery budget, fall back to an empty
+                // bundle and proceed: the invitation signature is already
+                // verified above, so the joiner still records local membership
+                // (below) and publishes `MemberJoinedAt`. That keeps
+                // `list_group_*` from 500ing with "node is not a member", and
+                // the group key, contexts, and governance ops catch up via the
+                // gossip `KeyDelivery` fallback and namespace sync once a peer
+                // becomes reachable — no manual re-join. This follows the same
+                // "advance locally regardless of transport readiness" invariant
+                // the `MemberJoinedAt` publish further below already relies on.
+                // Previously this was a hard `?`, so a join attempted before the
+                // mesh formed aborted before writing the joiner's membership row
+                // and left the node not-a-member (the reported symptom).
+                let join_result = match node_client
                     .request_namespace_join(namespace_id, invitation_bytes, joiner_identity)
-                    .await?;
+                    .await
+                {
+                    Ok(bundle) => bundle,
+                    Err(e) => {
+                        warn!(
+                            ?e,
+                            ?group_id,
+                            "direct namespace-join request found no reachable mesh peer; \
+                             recording local membership and relying on gossip/sync catch-up"
+                        );
+                        JoinBundle::empty()
+                    }
+                };
 
                 // Unwrap and store the group key.
                 if !join_result.has_key() {

--- a/crates/node/primitives/src/join_bundle.rs
+++ b/crates/node/primitives/src/join_bundle.rs
@@ -27,4 +27,21 @@ impl JoinBundle {
     pub fn has_key(&self) -> bool {
         !self.key_envelope_bytes.is_empty()
     }
+
+    /// An empty bundle: no key, no contexts, no governance ops, zero
+    /// application id, default capabilities `0`. Used as the graceful
+    /// fallback when the direct namespace-join request cannot reach a mesh
+    /// peer, so the joiner can still record local membership from its
+    /// (already signature-verified) invitation and catch the rest up via the
+    /// gossip `KeyDelivery` fallback and namespace sync, rather than aborting
+    /// the join and leaving the node not-a-member.
+    pub fn empty() -> Self {
+        Self {
+            key_envelope_bytes: Vec::new(),
+            context_ids: Vec::new(),
+            application_id: ApplicationId::from([0u8; 32]),
+            governance_ops: Vec::new(),
+            default_capabilities: 0,
+        }
+    }
 }


### PR DESCRIPTION
## What & why

Fixes the reported join failure: a node joining a group via invitation **before its gossip mesh to the inviter has formed** got stuck "not a member", and every admin list endpoint returned HTTP 500 (`node is not a member of group ...`). Fran joined fine (mesh ready); Sandi didn't (mesh not ready).

### Root cause (`crates/context/src/handlers/join_group.rs`)

The handler did a single `request_namespace_join(...).await?` (a direct stream to a mesh peer, ~45s discovery budget) and wrote the joiner's **own** membership row only *after* that call. So if no namespace-mesh peer was reachable within the budget, the `?` **aborted the join before recording membership** — the node was stranded not-a-member, and the only symptom was the 500 from `list_group_members` / `list_group_contexts`.

### The fix

On a failed direct request, fall back to `JoinBundle::empty()` and **proceed** instead of aborting. The invitation signature is already verified, so the joiner still records local membership and publishes `MemberJoinedAt`; the group key, contexts, and governance ops catch up via the existing gossip `KeyDelivery` fallback + namespace sync once a peer is reachable. The node becomes **"joined, pending key"** — never stranded, `list_group_*` no longer 500s, and it recovers without a manual re-join. This follows the same "advance locally regardless of transport readiness" invariant the `MemberJoinedAt` publish already relies on.

Small addition: `JoinBundle::empty()` in `crates/node/primitives/src/join_bundle.rs`.

## Reproduce-first → red→green regression test

`apps/scaffolding-e2e/workflows/group-join-mesh-not-ready.yml` uses merobox `partition_peers` (a libp2p-only cut that keeps RPC reachable) to force "join while the mesh is unreachable".

The discriminating assertion: **`list_group_members` on the joining node SUCCEEDS while partitioned.**
- **Pre-fix:** the join aborts before recording membership → that list 500s → workflow **red**.
- **Post-fix:** node-2 recorded membership before the key-wait → list returns 200 → workflow **green**.

The branch history shows the red→green honestly: the first commit was a *characterization* test asserting the 500 via `expected_failure` (its green run proved the 500 reproduces on pre-fix code); this commit adds the fix and flips that step to assert success.

The scenario also covers recovery: after `heal_peers`, a re-join completes and the joiner lists members including itself.

## Notes

- The join RPC still returns a typed error while partitioned (no group key can be delivered yet) — that "joined but not yet usable" contract is intentional (PR #3288). The fix is that it no longer aborts *before* recording membership.
- Companion follow-up worth doing separately: map the membership-gate `bail!`s in `list_group_members.rs` / `list_group_contexts.rs` to a typed 4xx instead of the generic 500, so this class of "not a member (yet)" is self-explaining rather than looking like a server fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
