### PR TITLE
fix(server): return 403 (not 500) when a node isn't a member of a group

### DIFF
--- a/apps/scaffolding-e2e/workflows/group-join-mesh-not-ready.yml
+++ b/apps/scaffolding-e2e/workflows/group-join-mesh-not-ready.yml
@@ -142,9 +142,31 @@ steps:
     peers:
       - notready-node-2
 
-  - name: Wait for libp2p to redial + namespace mesh to re-form
+  # Healing the libp2p cut does not instantly restore the connection, and the
+  # earlier fixed 15s sleep was racy: in CI node-2 was still unable to reach
+  # node-1 more than 60s after heal, so the re-join's direct request found no
+  # reachable mesh peer and fell through to the short (5s) gossip KeyDelivery
+  # fallback, which timed out ("KeyDelivery timed out for group ..."). Drive
+  # recovery actively instead of guessing a sleep: give libp2p a moment to
+  # notice the heal, then trigger a namespace governance sync between the two
+  # nodes and block until they converge. That forces the redial + gossipsub
+  # mesh re-GRAFT, so by the time we re-join, node-2 can reach node-1 and fetch
+  # the group key directly — the same wait -> wait_for_sync(trigger_sync)
+  # recovery shape the sync-resilience partition scenarios use. This hardens
+  # the TEST only; it does not touch the 5s key_delivery_fallback_wait product
+  # default.
+  - name: Wait for libp2p to notice the heal before driving sync
     type: wait
-    seconds: 15
+    seconds: 20
+
+  - name: Re-establish the namespace mesh (force redial + governance convergence)
+    type: wait_for_sync
+    group_id: '{{namespace_id}}'
+    nodes:
+      - notready-node-1
+      - notready-node-2
+    timeout: 120
+    trigger_sync: true
 
   - name: Node-2 re-joins the group (should now succeed)
     type: join_namespace

--- a/crates/context/src/error.rs
+++ b/crates/context/src/error.rs
@@ -37,4 +37,15 @@ pub enum ContextError {
         /// A description of the storage error.
         message: String,
     },
+
+    /// This node is not a member of the group the operation targets.
+    ///
+    /// A legitimate client-side precondition (the node hasn't joined the
+    /// group, or isn't in it), not a server fault — callers map this to a
+    /// `403`, never a generic `500`.
+    #[error("node is not a member of group '{group_id}'")]
+    NotAGroupMember {
+        /// Debug rendering of the target group id (for the message only).
+        group_id: String,
+    },
 }

--- a/crates/context/src/handlers/list_group_contexts.rs
+++ b/crates/context/src/handlers/list_group_contexts.rs
@@ -26,7 +26,12 @@ impl Handler<ListGroupContextsRequest> for ContextManager {
                 &group_id,
                 &node_identity,
             )? {
-                bail!("node is not a member of group '{group_id:?}'");
+                // Typed so the admin API surfaces this precondition as a 403,
+                // not a generic 500 (see `parse_api_error`).
+                return Err(crate::error::ContextError::NotAGroupMember {
+                    group_id: format!("{group_id:?}"),
+                }
+                .into());
             }
             MetadataRepository::new(&self.datastore)
                 .enumerate_contexts_with_names(&group_id, offset, limit)

--- a/crates/context/src/handlers/list_group_members.rs
+++ b/crates/context/src/handlers/list_group_members.rs
@@ -40,7 +40,12 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
                     .is_member(&group_id, &node_identity)?,
             };
             if !is_member {
-                bail!("node is not a member of group '{group_id:?}'");
+                // Typed so the admin API surfaces this precondition as a 403,
+                // not a generic 500 (see `parse_api_error`).
+                return Err(crate::error::ContextError::NotAGroupMember {
+                    group_id: format!("{group_id:?}"),
+                }
+                .into());
             }
 
             // Effective membership = stored explicit rows ∪ inherited

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -616,6 +616,19 @@ impl IntoResponse for ApiError {
 
 #[must_use]
 pub fn parse_api_error(err: Report) -> ApiError {
+    // A membership-gate rejection ("node is not a member of group X") is a
+    // legitimate client-side precondition, not a server fault. Surface it as a
+    // typed 403 with its (safe, intended) message instead of letting it fall
+    // through to the generic 500 below. This is what a caller sees when it
+    // lists a group the node hasn't joined / isn't in.
+    if let Some(calimero_context::error::ContextError::NotAGroupMember { .. }) =
+        err.downcast_ref::<calimero_context::error::ContextError>()
+    {
+        return ApiError {
+            status_code: StatusCode::FORBIDDEN,
+            message: err.to_string(),
+        };
+    }
     match err.downcast::<ApiError>() {
         Ok(api_error) => api_error,
         // An untyped error is an unexpected internal failure. Don't echo its
@@ -790,5 +803,47 @@ mod static_asset_tests {
         assert!(is_rewritable_text("text/css"));
         assert!(!is_rewritable_text("image/png"));
         assert!(!is_rewritable_text("application/wasm"));
+    }
+}
+
+#[cfg(test)]
+mod parse_api_error_tests {
+    use axum::http::StatusCode;
+
+    use super::{parse_api_error, ApiError};
+
+    #[test]
+    fn not_a_group_member_maps_to_403_with_message() {
+        let err = calimero_context::error::ContextError::NotAGroupMember {
+            group_id: "test-group".to_owned(),
+        };
+        let api = parse_api_error(err.into());
+        assert_eq!(api.status_code, StatusCode::FORBIDDEN);
+        assert!(
+            api.message.contains("not a member"),
+            "expected the typed reason to reach the client, got: {}",
+            api.message
+        );
+    }
+
+    #[test]
+    fn untyped_error_stays_a_generic_500() {
+        let api = parse_api_error(eyre::eyre!("some internal detail with /store/path"));
+        assert_eq!(api.status_code, StatusCode::INTERNAL_SERVER_ERROR);
+        // The internal detail must not leak to the client.
+        assert_eq!(api.message, "Internal server error");
+    }
+
+    #[test]
+    fn typed_api_error_is_preserved() {
+        let api = parse_api_error(
+            ApiError {
+                status_code: StatusCode::BAD_REQUEST,
+                message: "bad group id".to_owned(),
+            }
+            .into(),
+        );
+        assert_eq!(api.status_code, StatusCode::BAD_REQUEST);
+        assert_eq!(api.message, "bad group id");
     }
 }


### PR DESCRIPTION
## What & why

The membership gate on `list_group_members` / `list_group_contexts` bailed with an untyped `eyre` string:

```
node is not a member of group 'ContextGroupId(...)'
```

`parse_api_error` treats any untyped error as an unexpected internal failure and rewrites it to a generic **HTTP 500 "Internal server error"**. So a legitimate client-side precondition — the node hasn't joined the group, or isn't in it — surfaced as a **server fault**.

That's the exact papercut behind the original Slack report: the joiner's list calls returned `500 Internal server error`, which read as "seems like a core issue" instead of the truth ("you're not a member yet"). The join-side cause is already fixed (#3292, merged); this fixes the *diagnosability* so this class of condition is self-explaining.

## Change

- New typed `ContextError::NotAGroupMember { group_id }`.
- Both handlers `return Err(NotAGroupMember { .. }.into())` instead of `bail!(<string>)`.
- `parse_api_error` downcasts it and returns a **403** with its (safe, intended) message — before the generic-500 fallthrough. Untyped errors still become a generic 500 with **no message leak** (unchanged).

Centralizing the mapping in `parse_api_error` means every admin endpoint that can surface this condition gets the typed 403 consistently.

## Tests

`parse_api_error_tests` (in-process, deterministic):
- `not_a_group_member_maps_to_403_with_message` — the fix.
- `untyped_error_stays_a_generic_500` — internal detail still doesn't leak.
- `typed_api_error_is_preserved` — existing typed `ApiError`s pass through unchanged.

All green locally (`cargo test -p calimero-server parse_api_error`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
