### PR TITLE
fix(node): feed peer-identity cache from the governance path so cold contexts get dial targets

### DIFF
--- a/apps/scaffolding-e2e/workflows/group-governance-cold-context-push-converge.yml
+++ b/apps/scaffolding-e2e/workflows/group-governance-cold-context-push-converge.yml
@@ -1,0 +1,198 @@
+description: >
+  Cold-context regression (#3296): a node that joined a context purely via
+  governance — and has NEVER received a state delta on it — must still acquire
+  dial targets for that context's members and converge via gossip push, WITHOUT
+  a forced pull.
+
+  The bug
+  -------
+
+  Proactive dialing draws from the durable peer-identity cache, which used to be
+  populated ONLY on the state-delta receive path. A context joined through
+  governance but that never received a delta therefore had an EMPTY dial-target
+  cache, so the node never proactively dialed that context's members. Behind NAT
+  (no incidental inbound dials to compensate) the node's subscriber set for the
+  context topic stayed empty, `Mesh peer discovery exhausted all retries` fired,
+  and deltas reached nobody — the context went silently dark while every member
+  was online. The fix also feeds the durable cache from the governance/membership
+  path (see `NamespaceDeltaApply::resolve_signer_membership`), so a freshly-joined
+  cold context has dial targets immediately.
+
+  What this scenario does
+  -----------------------
+
+  1. node-1 creates a namespace + context and writes a SEED key BEFORE node-2
+     exists — node-2 never pulls this.
+  2. node-2 joins the namespace and the context via governance. Crucially there
+     is NO `wait_for_sync` / pull after the join, so node-2's ONLY population of
+     the peer-identity cache for this context is the governance join path — the
+     exact cold-context condition.
+  3. node-1 writes a NEW key.
+  4. node-2 must converge on BOTH keys via `trigger_sync: false` (no manual poke).
+     Seeing the NEW key proves push works; seeing the SEED (written before the
+     join, so it is only reachable by a pull node-2 must initiate itself) proves
+     node-2 had dial targets for node-1 on a cold cache.
+
+  Topology is `nat_mode: cone` (as in `sync-resilience-peer-restart-autoresync`):
+  both peers sit behind a NAT gateway, so there are no incidental inbound dials —
+  node-2 must proactively dial node-1 using the governance-populated cache.
+
+  Scope / honesty note
+  --------------------
+
+  A 2-node local merobox run cannot perfectly reproduce the field's cold peer
+  cache (rendezvous/DHT often still surface node-1 here), so this is a behavioral
+  guard, not a hermetic repro of the NAT isolation. The authoritative regression
+  guard for the cache-population path is the in-process integration test
+  `member_peers_for_context_unions_root_group_for_subgroup_context` (and its
+  sibling) in `crates/node/src/local_governance_node_e2e.rs`.
+
+name: "Group Governance — Cold-Context Push Converge (NAT cone, no pull, #3296)"
+
+force_pull_image: false
+
+topology:
+  type: nat
+  nat_mode: cone
+
+auth_mode: embedded
+
+nodes:
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: cold-ctx-node
+
+steps:
+  - name: Login on cold-ctx-node-1
+    type: login
+    node: cold-ctx-node-1
+    username: dev
+    password: dev-password
+
+  - name: Login on cold-ctx-node-2
+    type: login
+    node: cold-ctx-node-2
+    username: dev
+    password: dev-password
+
+  # ---------- Setup: node-1 alone creates namespace + context ----------
+
+  - name: Install application on node-1
+    type: install_application
+    node: cold-ctx-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: cold-ctx-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Create context in namespace on node-1
+    type: create_context
+    node: cold-ctx-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{namespace_id}}'
+    outputs:
+      ctx_id: contextId
+
+  # Seed written BEFORE node-2 joins. node-2 is only reachable to this via a
+  # pull it initiates itself — which needs a dial target it can only have if
+  # the governance join populated the cache.
+  - name: Node-1 seeds initial state (before node-2 exists)
+    type: call
+    node: cold-ctx-node-1
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: seed
+      value: from_node_1_pre_join
+
+  # ---------- Cold governance join: NO wait_for_sync / pull ----------
+
+  - name: Create namespace invitation for node-2
+    type: create_namespace_invitation
+    node: cold-ctx-node-1
+    namespace_id: '{{namespace_id}}'
+    outputs:
+      invitation_node2: invitation
+
+  - name: Wait for namespace gossip
+    type: wait
+    seconds: 5
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: cold-ctx-node-2
+    namespace_id: '{{namespace_id}}'
+    invitation: '{{invitation_node2}}'
+
+  - name: Node-2 joins context via group membership (governance only)
+    type: join_context
+    node: cold-ctx-node-2
+    context_id: '{{ctx_id}}'
+
+  # DELIBERATELY no wait_for_sync here — node-2 must NOT pull before the push.
+
+  # ---------- New write + push-only convergence (the regression gate) ----------
+
+  - name: Node-1 writes a new key after node-2's cold join
+    type: call
+    node: cold-ctx-node-1
+    context_id: '{{ctx_id}}'
+    method: set
+    args:
+      key: post_join
+      value: pushed_to_cold_node2
+
+  # trigger_sync: false — no manual poke. node-2 must proactively dial node-1
+  # using the governance-populated peer-identity cache, form a subscriber set,
+  # and converge. If the cache is empty (the bug), discovery exhausts its
+  # retries and this wait_for_sync times out.
+  - name: Wait for cold node-2 to auto-converge (NO trigger_sync)
+    type: wait_for_sync
+    context_id: '{{ctx_id}}'
+    nodes:
+      - cold-ctx-node-1
+      - cold-ctx-node-2
+    timeout: 90
+    trigger_sync: false
+
+  - name: Read the post-join key on node-2
+    type: call
+    node: cold-ctx-node-2
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: post_join
+    outputs:
+      post_join_n2: result
+
+  - name: Assert node-2 received the pushed write on a cold cache
+    type: assert
+    statements:
+      - "contains({{post_join_n2}}, 'pushed_to_cold_node2')"
+
+  # The stronger assertion: the SEED was written before node-2 existed, so it is
+  # reachable ONLY by a pull node-2 initiates against a dial target it learned
+  # from the governance join.
+  - name: Read the pre-join seed on node-2
+    type: call
+    node: cold-ctx-node-2
+    context_id: '{{ctx_id}}'
+    method: get
+    args:
+      key: seed
+    outputs:
+      seed_n2: result
+
+  - name: Assert node-2 pulled the pre-join seed (proves cold-cache dial targets)
+    type: assert
+    statements:
+      - "contains({{seed_n2}}, 'from_node_1_pre_join')"
+
+stop_all_nodes: true

--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use actix::{AsyncContext, WrapFuture};
 use calimero_context::governance_broadcast::sign_ack;
-use calimero_context::group_store::NamespaceRepository;
+use calimero_context::group_store::{MembershipRepository, NamespaceRepository};
 use calimero_context_client::local_governance::{
     hash_scoped_namespace, NamespaceTopicMsg, SignedNamespaceOp,
 };
@@ -268,6 +268,35 @@ impl NamespaceDeltaApply {
         // instead of the old single fire-and-forget shot.
     }
 
+    /// Resolve the group + role to attach to a governance-path peer-identity
+    /// observation so it persists to the durable cache rather than only the
+    /// in-memory reverse view.
+    ///
+    /// The signer just authored a namespace governance op, so they are a member
+    /// of the namespace root group — whose id IS the namespace id. We record the
+    /// observation under that root group; the cold-start peer resolver unions
+    /// the root group's bucket into every context in the namespace, so a root
+    /// member becomes a dial target for any of the namespace's contexts. Returns
+    /// `None` — an in-memory-only observation — when the signer has no resolvable
+    /// root-group role (e.g. a subgroup-only member) or the store read fails. The
+    /// cache is a routing hint, never a trust gate, so a miss costs at most the
+    /// durable write, never correctness.
+    fn resolve_signer_membership(
+        &self,
+        namespace_id: [u8; 32],
+        signer: &calimero_primitives::identity::PublicKey,
+    ) -> Option<crate::peer_identity_cache::ObservedMembership> {
+        let root_group = ContextGroupId::from(namespace_id);
+        let store = self.context_client.datastore_handle().into_inner();
+        let role = MembershipRepository::new(&store)
+            .role_of(&root_group, signer)
+            .ok()??;
+        Some(crate::peer_identity_cache::ObservedMembership {
+            group_id: root_group,
+            role,
+        })
+    }
+
     /// Side effects that run only when the op *newly* applied: nudge the
     /// readiness FSM, drive an on-change migration heartbeat, record the
     /// (peer, identity) pair, drain governance-pending / absorbed state deltas,
@@ -306,10 +335,16 @@ impl NamespaceDeltaApply {
 
         // Record the (peer, identity) pair now that the signature verified, the
         // nonce was monotonic, and the op applied. Consumed by anchor-preferred
-        // sync peer selection. `None`: this path doesn't carry the signer's
-        // group + role cheaply, so it updates only the in-memory reverse view;
-        // the durable cache is populated from the state-delta path that follows.
-        self.node_state.observe_peer_identity(source, signer, None);
+        // sync peer selection. Resolve the signer's root-group role so the
+        // observation also writes through to the DURABLE peer-identity cache:
+        // that is what gives a context joined purely via governance — one that
+        // has never received a state delta, so the state-delta observe path
+        // never ran for it — dial targets on a cold cache. Without this the
+        // node has no one to dial for that context and sync goes dark even
+        // though the members are online.
+        let membership = self.resolve_signer_membership(namespace_id, &signer);
+        self.node_state
+            .observe_peer_identity(source, signer, membership);
 
         // Governance-pending active drain: a governance op that just applied may
         // unblock state deltas previously buffered as `Unknown`. Without this

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -2909,6 +2909,61 @@ async fn member_peers_for_context_resolves_cached_members_end_to_end() {
     );
 }
 
+/// End-to-end (#3296): the governance path records a member under the namespace
+/// ROOT group (see `NamespaceDeltaApply::resolve_signer_membership`), and a
+/// context registered to a SUBGROUP must still resolve that member as a dial
+/// target via the ancestor-walk union in `member_peers_for_context`.
+///
+/// This is the cold-context case the issue is about: a context joined via
+/// governance that has never received a state delta only ever populates the
+/// cache through the governance path (which keys at the root), so a subgroup
+/// context whose own bucket is empty must walk up to the root bucket — otherwise
+/// it has no dial targets, topic discovery comes up empty, and sync goes dark
+/// despite the members being online.
+#[tokio::test]
+async fn member_peers_for_context_unions_root_group_for_subgroup_context() {
+    use calimero_context::group_store::{register_context_in_group, NamespaceRepository};
+
+    let (sync_manager, store, node_state, _tmp) = build_standalone_sync_manager().await;
+
+    let root_group = ContextGroupId::from([0x11; 32]);
+    let sub_group = ContextGroupId::from([0x22; 32]);
+    let context_id = calimero_primitives::context::ContextId::from([0x33; 32]);
+
+    // Topology: sub_group nested under root_group; the context is registered to
+    // the subgroup (so `get_group_for_context` returns the subgroup, whose own
+    // cache bucket stays empty in this test).
+    NamespaceRepository::new(&store)
+        .nest(&root_group, &sub_group)
+        .expect("nest subgroup under root");
+    register_context_in_group(&store, &sub_group, &context_id)
+        .expect("register context -> subgroup");
+
+    // A member recorded ONLY under the root group — exactly what the governance
+    // path produces for a cold context.
+    let admin_id = PrivateKey::random(&mut OsRng).public_key();
+    let admin_peer = libp2p::PeerId::random();
+    node_state.observe_peer_identity(
+        admin_peer,
+        admin_id,
+        Some(ObservedMembership {
+            group_id: root_group,
+            role: GroupMemberRole::Admin,
+        }),
+    );
+
+    let resolved: std::collections::BTreeMap<_, _> = sync_manager
+        .member_peers_for_context(&context_id)
+        .into_iter()
+        .collect();
+    assert_eq!(
+        resolved.get(&admin_peer),
+        Some(&GroupMemberRole::Admin),
+        "a member recorded under the namespace root must resolve as a dial \
+         target for a context registered to a subgroup (ancestor-walk union)"
+    );
+}
+
 /// End-to-end: a self-leave from a Restricted subgroup drives a REMAINING ADMIN's
 /// node all the way through a real key rotation.
 ///

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -947,9 +947,34 @@ impl SyncManager {
         else {
             return Vec::new();
         };
-        Self::dedup_peers_by_strongest_role(
-            self.state_access.cached_member_peers_for_group(&group_id),
-        )
+        // Union the cache buckets of the context's own group AND every
+        // ancestor up to the namespace root. The durable cache is keyed
+        // per group, but a member's dial target is recorded under whichever
+        // group the observation resolved: the state-delta path records under
+        // the context's own group, while the governance path records under the
+        // namespace root (see `resolve_signer_membership`). A member is a valid
+        // direct-stream sync partner for ANY context in the namespace, so a
+        // subgroup context must be able to reach root-recorded members — hence
+        // the walk. `dedup_peers_by_strongest_role` collapses a peer that
+        // appears at multiple levels to its strongest role.
+        let mut pairs = self.state_access.cached_member_peers_for_group(&group_id);
+        let ns_repo = NamespaceRepository::new(&store);
+        let mut current = group_id;
+        // `<=` because reaching the root at depth D takes D+1 parent hops to
+        // observe the root's `None` parent (mirrors `NamespaceRepository::resolve`).
+        for _ in 0..=calimero_context_config::MAX_NAMESPACE_DEPTH {
+            match ns_repo.parent(&current) {
+                Ok(Some(parent)) => {
+                    pairs.extend(self.state_access.cached_member_peers_for_group(&parent));
+                    current = parent;
+                }
+                // Root reached (`None`) or a store error: stop walking. A read
+                // error just means we union fewer levels — the cache is a hint,
+                // never load-bearing, so degrade rather than abort selection.
+                _ => break,
+            }
+        }
+        Self::dedup_peers_by_strongest_role(pairs)
     }
 
     /// Anchor-preference ordering of a cached role: higher binds the

--- a/crates/node/src/sync/network/mock.rs
+++ b/crates/node/src/sync/network/mock.rs
@@ -134,6 +134,10 @@ pub(crate) struct MockSyncNetwork {
     /// global counter can't tell whether a *specific* topic's queue
     /// was ever read.
     subscribed_peers_reads_by_topic: Mutex<HashMap<TopicHash, u32>>,
+    /// Number of connected peers reported by `connected_peer_count`.
+    /// Defaults to 0; a test sets it via `set_connected_peer_count` to
+    /// exercise the "connected but not subscribed" diagnostic branch.
+    connected_peer_count: Mutex<usize>,
 }
 
 impl MockSyncNetwork {
@@ -142,6 +146,12 @@ impl MockSyncNetwork {
     /// that don't distinguish topics.
     pub(crate) fn push_subscribed_peers(&self, peers: Vec<PeerId>) -> &Self {
         self.subscribed_peers_responses.lock().push_back(peers);
+        self
+    }
+
+    /// Set the connected-peer count returned by `connected_peer_count`.
+    pub(crate) fn set_connected_peer_count(&self, count: usize) -> &Self {
+        *self.connected_peer_count.lock() = count;
         self
     }
 
@@ -302,6 +312,10 @@ impl SyncNetwork for MockSyncNetwork {
         // the shared queue's "seeded but never read" guard.
         *self.shared_queue_reads.lock() += 1;
         sticky_last(&mut self.subscribed_peers_responses.lock())
+    }
+
+    async fn connected_peer_count(&self) -> usize {
+        *self.connected_peer_count.lock()
     }
 
     async fn open_stream(&self, _peer_id: PeerId) -> eyre::Result<Stream> {

--- a/crates/node/src/sync/network/mod.rs
+++ b/crates/node/src/sync/network/mod.rs
@@ -53,6 +53,14 @@ pub trait SyncNetwork: Send + Sync + 'static {
     /// occupying a mesh slot could starve sync discovery.
     async fn subscribed_peers(&self, topic: TopicHash) -> Vec<PeerId>;
 
+    /// Total number of peers this node is currently connected to, across
+    /// all topics. Used only for diagnostics: when topic discovery finds
+    /// zero subscribers, this distinguishes "connected to no one" (a
+    /// dial/discovery gap) from "connected but no one subscribes to this
+    /// topic" (a materialisation/relay gap) so the exhausted-retries warn
+    /// is actionable without a bespoke log capture.
+    async fn connected_peer_count(&self) -> usize;
+
     /// Open a new substream to `peer_id` over the calimero protocol.
     ///
     /// Used by every sync initiator path. Mock impls can return
@@ -75,6 +83,10 @@ impl SyncNetwork for NetworkClient {
     // compile instead — the failure mode we want.
     async fn subscribed_peers(&self, topic: TopicHash) -> Vec<PeerId> {
         NetworkClient::subscribed_peers(self, topic).await
+    }
+
+    async fn connected_peer_count(&self) -> usize {
+        NetworkClient::peer_count(self).await
     }
 
     async fn open_stream(&self, peer_id: PeerId) -> eyre::Result<Stream> {

--- a/crates/node/src/sync/peers.rs
+++ b/crates/node/src/sync/peers.rs
@@ -207,12 +207,32 @@ pub(crate) async fn discover_mesh_peers_with_namespace_fallback(
     }
 
     let elapsed = discovery_started.elapsed();
-    warn!(
-        %context_id,
-        attempts = max_retries,
-        ?elapsed,
-        "Mesh peer discovery exhausted all retries (context mesh + namespace fallback)"
-    );
+    // Split the diagnostic on connectivity so the next occurrence is
+    // actionable without a bespoke capture: zero connected peers means a
+    // dial/discovery gap (the node reached nobody — the cold-context case
+    // where sync goes dark despite members being online); connected peers
+    // present but none subscribed to the topic means a materialisation or
+    // relay gap (we reached peers, but none follow this context/namespace).
+    let connected_peers = sync_network.connected_peer_count().await;
+    if connected_peers == 0 {
+        warn!(
+            %context_id,
+            attempts = max_retries,
+            ?elapsed,
+            connected_peers,
+            "Mesh peer discovery exhausted all retries: not connected to any peer \
+             (dial/discovery gap — no dial targets for this context's members)"
+        );
+    } else {
+        warn!(
+            %context_id,
+            attempts = max_retries,
+            ?elapsed,
+            connected_peers,
+            "Mesh peer discovery exhausted all retries: connected to peers but none \
+             subscribe to the context or namespace topic (materialisation/relay gap)"
+        );
+    }
     // Typed error so `apply_session_result` can recognise "no peer right
     // now" as benign (no failure_count bump, no exponential-backoff warn)
     // rather than a sync failure. Display still contains "No peers to
@@ -446,6 +466,45 @@ mod tests {
         assert!(
             result.is_err(),
             "all namespace peers opted out → no candidates → Err"
+        );
+    }
+
+    /// The exhausted-retries bail is unchanged whether or not the node is
+    /// connected to peers — connectivity only selects which diagnostic warn
+    /// fires (dial/discovery gap vs materialisation/relay gap). Both branches
+    /// still return the benign `NoPeersAvailable` error so the caller retries
+    /// promptly rather than backing off.
+    #[tokio::test(start_paused = true)]
+    async fn discovery_errs_regardless_of_connectivity_diagnostic() {
+        // Connected to peers, but none subscribe to the topic.
+        let connected = MockSyncNetwork::default();
+        connected.set_connected_peer_count(3);
+        assert!(
+            discover_mesh_peers_with_namespace_fallback(
+                &connected,
+                ctx(0xAA),
+                2,
+                Duration::from_millis(10),
+                || None,
+            )
+            .await
+            .is_err(),
+            "connected-but-not-subscribed still bails"
+        );
+
+        // Connected to no one at all.
+        let isolated = MockSyncNetwork::default();
+        assert!(
+            discover_mesh_peers_with_namespace_fallback(
+                &isolated,
+                ctx(0xAA),
+                2,
+                Duration::from_millis(10),
+                || None,
+            )
+            .await
+            .is_err(),
+            "not-connected still bails"
         );
     }
 


### PR DESCRIPTION
Closes #3296.

## Summary

A context joined **via governance** that has **never received a state delta** went silently dark: it neither received nor pushed deltas even though its members were online, logging `Mesh peer discovery exhausted all retries` — the field symptom (Slack, 2026-07-23: a NAT'd node with 4 contexts, only the one with prior traffic had a dialable peer).

Root cause, confirmed against current code: proactive dialing draws from the durable per-group `peer_identity_cache`, and the cold-start dial fallback in the sync manager (`PeerSource::PersistentCache`) already dials cached members when topic discovery is empty. But the durable cache was written **only** from the state-delta receive path. The governance/namespace path recorded the `(peer, identity)` pair in memory only (`observe_peer_identity(.., None)`), so a governance-only context had an **empty** dial-target cache — nothing for the cold-start fallback to dial. Behind NAT (no incidental inbound dials) the subscriber set stayed empty and the context stopped converging.

The issue's cold-start dial fallback (its "solution #2") already exists; this PR lands the missing write-through ("solution #1") plus the diagnosability win ("solution #4").

## Changes

- **Core fix** (`handlers/network_event/namespace.rs`): resolve the signer's root-group role (`MembershipRepository::role_of`; the namespace id *is* the root `ContextGroupId`) and pass `Some(ObservedMembership)` so the governance path writes through to the durable cache. A miss (subgroup-only member / store error) degrades to the in-memory-only observation — the cache is a routing hint, never a trust gate.
- **Tree-walk union** (`sync/manager/mod.rs`): `member_peers_for_context` now walks the context's group → parents → namespace root and unions the cache buckets, so a subgroup context reaches root-recorded members (any namespace peer is a valid direct-stream sync partner).
- **Observability** (`sync/network/*`, `sync/peers.rs`): added `connected_peer_count()` to `SyncNetwork`; the exhausted-retries warn now distinguishes **"not connected to any peer (dial/discovery gap)"** from **"connected but none subscribe to the topic (materialisation/relay gap)"** so the next occurrence is diagnosable without a bespoke capture.

## Tests / proof

- **Integration test** `member_peers_for_context_unions_root_group_for_subgroup_context` (`crates/node/src/local_governance_node_e2e.rs`): a member recorded **only** under the namespace root resolves as a dial target for a context registered to a **subgroup**. This is the authoritative regression guard — it fails pre-fix, where only the (empty) subgroup bucket was read.
- **merobox scenario** `apps/scaffolding-e2e/workflows/group-governance-cold-context-push-converge.yml`: NAT-cone, node-2 joins the context via governance with **no pull**, then must converge on node-1's writes via **push only** (`trigger_sync: false`). Documented in-file as a behavioral guard (a 2-node local run can't perfectly reproduce the field's cold peer cache), with the integration test as the hermetic guard.

Local verification: `cargo fmt --check` ✅, `cargo clippy -p calimero-node --all-targets -- -A warnings` ✅, sync module tests (250) ✅, governance e2e (19, incl. new) ✅.

## Known residual (by design)

A **subgroup-only member that never sends a delta** is not recorded by the governance path (we key at the namespace root). The union walk covers the direction that matters — a subgroup context reaching root-recorded members — and the state-delta path still records such a member once they are active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)