### PR TITLE
chore: cut release 0.11.0-rc.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.17"
+version = "0.11.0-rc.18"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Bump the shared workspace release version **rc.17 → rc.18** (`[workspace.metadata.workspaces] version` in the root `Cargo.toml`), following the same one-line pattern as #3277 ("cut release 0.11.0-rc.17").

Cut on top of latest master, after the #3295 (pending-key reconciler) and #3296 (cold-context dial targets) fixes merged.

No code or `Cargo.lock` changes — public crate versions are `0.0.0`; this field is the release-tooling's shared version only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)