### PR TITLE
fix(network): re-dial a peer's known direct address on disconnect, not just rendezvous

### DIFF
--- a/crates/network/src/discovery.rs
+++ b/crates/network/src/discovery.rs
@@ -166,6 +166,38 @@ impl NetworkManager {
         self.peer_cache.record(peer_id, addr, now);
     }
 
+    /// Fire-and-forget re-dial of `peer_id` at its last known **direct**
+    /// addresses, used by the `ConnectionClosed` recovery cascade so a peer we
+    /// hold a working direct address for is reconnected immediately rather than
+    /// via a rendezvous round-trip. No-op when `addrs` is empty (a relay-only /
+    /// NAT'd peer), so those keep relying on the rendezvous path.
+    ///
+    /// `PeerCondition::DisconnectedAndNotDialing` makes the dial idempotent —
+    /// if we've already reconnected or a dial is in flight, this is a no-op, so
+    /// the immediate attempt and the 5/15/30/60s re-fires can't stack up
+    /// redundant dials. Errors are debug-logged; a genuine failure resurfaces
+    /// as `OutgoingConnectionError`, which records the dial failure and leaves
+    /// the parallel rendezvous recovery to carry the peer.
+    pub(crate) fn redial_direct(&mut self, peer_id: PeerId, addrs: Vec<Multiaddr>) {
+        if addrs.is_empty() {
+            return;
+        }
+        for addr in &addrs {
+            let _ignored = self
+                .swarm
+                .behaviour_mut()
+                .kad
+                .add_address(&peer_id, addr.clone());
+        }
+        let opts = DialOpts::peer_id(peer_id)
+            .condition(PeerCondition::DisconnectedAndNotDialing)
+            .addresses(addrs)
+            .build();
+        if let Err(err) = self.swarm.dial(opts) {
+            debug!(%peer_id, %err, "direct re-dial on disconnect failed to initiate");
+        }
+    }
+
     /// Connected peers subscribed to at least one of our own
     /// (non-reserved) overlay topics — the relevant set to persist/dial.
     fn current_overlay_subscribers(&self) -> std::collections::BTreeSet<PeerId> {

--- a/crates/network/src/discovery/state.rs
+++ b/crates/network/src/discovery/state.rs
@@ -470,6 +470,23 @@ impl DiscoveryState {
         let _ = self.autonat_index.remove(peer_id);
     }
 
+    /// The peer's known **direct** (non-relayed) addresses, insertion-ordered
+    /// (freshest last, per [`add_peer_addr`](Self::add_peer_addr)). Empty for a
+    /// peer we only ever reached via relay — relayed multiaddrs are never stored
+    /// in the book (see `swarm.rs` `ConnectionEstablished`) — so a NAT'd peer
+    /// yields nothing here and disconnect recovery falls through to rendezvous.
+    ///
+    /// Used by the `ConnectionClosed` cascade to re-dial a peer we hold a
+    /// working direct address for, instead of waiting on a rendezvous
+    /// round-trip. Must be read BEFORE [`remove_peer`](Self::remove_peer), which
+    /// drops the entry.
+    pub(crate) fn peer_direct_addrs(&self, peer_id: &PeerId) -> Vec<Multiaddr> {
+        self.peers
+            .get(peer_id)
+            .map(|info| info.addrs().cloned().collect())
+            .unwrap_or_default()
+    }
+
     pub(crate) fn update_peer_protocols(&mut self, peer_id: &PeerId, protocols: &[StreamProtocol]) {
         for protocol in protocols {
             if protocol == &HOP_PROTOCOL_NAME {

--- a/crates/network/src/discovery/state_tests.rs
+++ b/crates/network/src/discovery/state_tests.rs
@@ -3,6 +3,28 @@ use libp2p::rendezvous::Namespace;
 use super::*;
 
 #[test]
+fn peer_direct_addrs_returns_book_then_clears_on_remove() {
+    let mut state = DiscoveryState::default();
+    let peer = PeerId::random();
+    let a1: Multiaddr = "/ip4/127.0.0.1/tcp/4001".parse().unwrap();
+    let a2: Multiaddr = "/ip4/127.0.0.1/udp/4002/quic-v1".parse().unwrap();
+
+    // Unknown peer → nothing to re-dial.
+    assert!(state.peer_direct_addrs(&peer).is_empty());
+
+    state.add_peer_addr(peer, &a1);
+    state.add_peer_addr(peer, &a2);
+    let addrs = state.peer_direct_addrs(&peer);
+    assert!(addrs.contains(&a1) && addrs.contains(&a2));
+    assert_eq!(addrs.len(), 2);
+
+    // After remove_peer the entry is gone — which is exactly why the
+    // ConnectionClosed cascade must read the addrs BEFORE removing the peer.
+    state.remove_peer(&peer);
+    assert!(state.peer_direct_addrs(&peer).is_empty());
+}
+
+#[test]
 fn test_get_preferred_addr() {
     let mut peer_info = PeerInfo::default();
     let tcp_addr_1: Multiaddr = "/ip4/127.0.0.1/tcp/4001".parse().unwrap();

--- a/crates/network/src/handlers/stream/swarm.rs
+++ b/crates/network/src/handlers/stream/swarm.rs
@@ -199,7 +199,28 @@ impl StreamHandler<FromSwarm> for NetworkManager {
                             .state
                             .is_peer_discovered_via(&peer_id, PeerDiscoveryMechanism::Mdns)
                     {
+                        // Capture the peer's known DIRECT addresses BEFORE
+                        // `remove_peer` drops them. A peer we hold a confirmed
+                        // direct address for (same-LAN, or any previously
+                        // directly-connected member) should be re-dialed
+                        // straight away rather than rediscovered via a
+                        // rendezvous round-trip — the rendezvous-only recovery
+                        // below strands such a peer whenever rendezvous is slow
+                        // or unreachable (e.g. mDNS dead on a CI runner), which
+                        // is exactly the `group-join-mesh-not-ready` post-heal
+                        // flake. Empty for a purely relayed/NAT'd peer (their
+                        // relayed address is never stored in the book), so those
+                        // correctly fall through to the rendezvous path alone.
+                        let direct_addrs = self.discovery.state.peer_direct_addrs(&peer_id);
+
                         self.discovery.state.remove_peer(&peer_id);
+
+                        // Direct re-dial now (and on the re-fire schedule
+                        // below). Safe for NAT'd peers: a stale direct address
+                        // just fails the dial (recorded by the
+                        // `OutgoingConnectionError` handler) and the rendezvous
+                        // path still recovers them.
+                        self.redial_direct(peer_id, direct_addrs.clone());
 
                         // Our address book held nothing dialable for
                         // them — relayed addresses are intentionally
@@ -278,6 +299,7 @@ impl StreamHandler<FromSwarm> for NetworkManager {
                         // specifically).
                         let disconnected_peer = peer_id;
                         for delay_secs in [5_u64, 15, 30, 60] {
+                            let refire_addrs = direct_addrs.clone();
                             ctx.run_later(
                                 core::time::Duration::from_secs(delay_secs),
                                 move |actor, _ctx| {
@@ -287,6 +309,13 @@ impl StreamHandler<FromSwarm> for NetworkManager {
                                     let actions =
                                         actor.discovery.state.on_regular_peer_disconnected();
                                     actor.execute_reachability_actions(actions);
+                                    // Retry the direct dial too: the immediate
+                                    // attempt above lands during the outage
+                                    // (partition not yet healed / peer still
+                                    // restarting); a later re-fire lands after
+                                    // connectivity returns and reconnects
+                                    // without waiting on rendezvous.
+                                    actor.redial_direct(disconnected_peer, refire_addrs.clone());
                                 },
                             );
                         }


### PR DESCRIPTION
## Summary

Fixes the root cause behind the flaky `group-join-mesh-not-ready` failures (the recurring post-heal red on master), rather than patching the test.

When a connection to a regular peer closes, the `ConnectionClosed` recovery cascade (`handlers/stream/swarm.rs`) calls `remove_peer` — discarding the direct address we were **just connected on** — and then relies **solely on a rendezvous re-query** to rediscover the peer (its own comment: *"the only way to pick up the post-restart registration is to re-query rendezvous"*). For a peer we hold a working *direct* address for (same-LAN containers, or any previously directly-connected member), that's the wrong recovery: when rendezvous is slow or unavailable — e.g. **mDNS is dead on the CI runner** (netlink unavailable) and the rendezvous re-register races — the peer is **never re-dialed**, the gossipsub mesh never reforms, and `wait_for_sync` times out.

I traced two distinct symptoms across failing runs, both this root cause:
1. After `heal_peers`, node-2 never redials node-1 (kad had no route; rendezvous didn't resurface it in time).
2. node-2 reconnects, then the ping watchdog force-closes after 3 consecutive failures (`MAX_PING_FAILURES`), and node-2 never redials again.

## Fix

In the regular-peer `ConnectionClosed` branch, capture the peer's known **direct** addresses *before* `remove_peer`, and issue a direct re-dial — immediately and on the existing **5/15/30/60s** re-fire schedule (gated on `!is_connected`) — **alongside** the unchanged rendezvous path.

- Idempotent: the dial uses `PeerCondition::DisconnectedAndNotDialing`, so the immediate attempt and the re-fires can't stack redundant dials, and it no-ops once reconnected.
- Safe for NAT'd / relay-only peers: their relayed address is never stored in the direct book (existing `P2pCircuit` filter), so `peer_direct_addrs` is empty and recovery falls through to rendezvous **exactly as before**. A stale direct address just fails the dial (recorded by `OutgoingConnectionError`); rendezvous still carries the peer.
- Covers the post-heal case precisely: a disconnect during the outage schedules re-fires that land *after* connectivity returns, reconnecting without waiting on rendezvous.

## Changes

- `discovery/state.rs` — `peer_direct_addrs(peer)` accessor (read the direct book; must be read before `remove_peer`, which clears it) + unit test.
- `discovery.rs` — `redial_direct(peer, addrs)`: idempotent fire-and-forget dial of a peer's direct addresses.
- `handlers/stream/swarm.rs` — wire both into the regular-peer `ConnectionClosed` branch and its re-fire closures.

## Validation

`cargo fmt` / `cargo clippy -p calimero-network --all-targets` / `cargo test -p calimero-network` (111) all green. The behavioral proof is the `group-join-mesh-not-ready` merobox scenario, which exercises exactly this partition→heal→reconnect path; since that scenario is flaky at the reconnection layer, I'll want a few consecutive green runs on this PR (not a single pass) before trusting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)