### PR TITLE
fix: encode group-membership ids as hex so group subscriptions match

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -13,6 +13,7 @@ bs58.workspace = true
 borsh = { workspace = true, features = ["derive"], optional = true }
 ed25519-dalek.workspace = true
 eyre.workspace = true
+hex.workspace = true
 multiaddr.workspace = true
 rand = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/primitives/src/events.rs
+++ b/crates/primitives/src/events.rs
@@ -18,7 +18,10 @@ pub enum NodeEvent {
 #[serde(rename_all = "camelCase")]
 pub struct GroupMembershipEvent {
     /// The group whose membership changed (the JOINED subgroup for a join,
-    /// never the namespace root). Serialized base58, like every 32-byte id.
+    /// never the namespace root). Hex-encoded, matching the group/namespace
+    /// admin API's id representation, so a client can correlate it with the
+    /// `groupId`/`namespaceId` it subscribed with.
+    #[serde(with = "crate::hash::hex_repr")]
     pub group_id: Hash,
     #[serde(flatten)]
     pub payload: MembershipChangePayload,
@@ -235,7 +238,9 @@ mod tests {
         });
         let v = serde_json::to_value(&event).expect("serialize");
         assert_eq!(v["type"], "MemberJoined");
-        assert!(v.get("groupId").is_some(), "groupId on the wrapper");
+        // groupId must be hex (matches the group/namespace admin API), so a client
+        // can correlate the event to the id it subscribed with.
+        assert_eq!(v["groupId"], hex::encode([0x07; 32]), "groupId is hex");
         assert!(v.get("contextId").is_none(), "no contextId leaks in");
         assert_eq!(v["data"]["role"], "Member");
         assert!(v["data"].get("member").is_some());

--- a/crates/primitives/src/events.rs
+++ b/crates/primitives/src/events.rs
@@ -17,10 +17,8 @@ pub enum NodeEvent {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupMembershipEvent {
-    /// The group whose membership changed (the JOINED subgroup for a join,
-    /// never the namespace root). Hex-encoded, matching the group/namespace
-    /// admin API's id representation, so a client can correlate it with the
-    /// `groupId`/`namespaceId` it subscribed with.
+    /// The group whose membership changed (the joined subgroup, never the
+    /// namespace root). Hex-encoded to match the group/namespace admin API.
     #[serde(with = "crate::hash::hex_repr")]
     pub group_id: Hash,
     #[serde(flatten)]

--- a/crates/primitives/src/hash.rs
+++ b/crates/primitives/src/hash.rs
@@ -238,6 +238,58 @@ impl Serialize for Hash {
     }
 }
 
+/// Serde helpers that (de)serialize a [`Hash`] as a **hex** string instead of
+/// base58. The group/namespace admin API represents 32-byte ids as hex (see the
+/// server's `parse_group_id`), so the group-membership surface - the SSE
+/// subscription `groupIds` and the emitted event `groupId` - must use hex too,
+/// or a client that obtained its ids from that API can neither subscribe with
+/// them nor correlate a received event back to a known group.
+pub mod hex_repr {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    use super::{Hash, BYTES_LEN};
+
+    fn decode<E: serde::de::Error>(s: &str) -> Result<Hash, E> {
+        let bytes = hex::decode(s).map_err(E::custom)?;
+        let arr: [u8; BYTES_LEN] = bytes
+            .try_into()
+            .map_err(|v: Vec<u8>| E::invalid_length(v.len(), &"32 hex-encoded bytes"))?;
+        Ok(Hash::from(arr))
+    }
+
+    pub fn serialize<S: Serializer>(hash: &Hash, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&hex::encode(hash.as_bytes()))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Hash, D::Error> {
+        let s = String::deserialize(d)?;
+        decode(&s)
+    }
+
+    /// Same hex representation, for a `Vec<Hash>` field.
+    pub mod vec {
+        use serde::ser::SerializeSeq;
+        use serde::{Deserialize, Deserializer, Serializer};
+
+        use super::{decode, Hash};
+
+        pub fn serialize<S: Serializer>(hashes: &[Hash], s: S) -> Result<S::Ok, S::Error> {
+            let mut seq = s.serialize_seq(Some(hashes.len()))?;
+            for h in hashes {
+                seq.serialize_element(&hex::encode(h.as_bytes()))?;
+            }
+            seq.end()
+        }
+
+        pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<Hash>, D::Error> {
+            Vec::<String>::deserialize(d)?
+                .iter()
+                .map(|s| decode(s))
+                .collect()
+        }
+    }
+}
+
 impl<'de> Deserialize<'de> for Hash {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         struct HashVisitor;

--- a/crates/primitives/src/hash.rs
+++ b/crates/primitives/src/hash.rs
@@ -238,12 +238,8 @@ impl Serialize for Hash {
     }
 }
 
-/// Serde helpers that (de)serialize a [`Hash`] as a **hex** string instead of
-/// base58. The group/namespace admin API represents 32-byte ids as hex (see the
-/// server's `parse_group_id`), so the group-membership surface - the SSE
-/// subscription `groupIds` and the emitted event `groupId` - must use hex too,
-/// or a client that obtained its ids from that API can neither subscribe with
-/// them nor correlate a received event back to a known group.
+/// (De)serialize a [`Hash`] as hex instead of base58, matching the group/namespace
+/// admin API's id representation so a client can subscribe with the ids it got there.
 pub mod hex_repr {
     use serde::{Deserialize, Deserializer, Serializer};
 

--- a/crates/server/primitives/src/sse.rs
+++ b/crates/server/primitives/src/sse.rs
@@ -129,6 +129,49 @@ mod tests {
         }
     }
 
+    // The invariant the hex/base58 bug broke: the id representation the
+    // group/namespace admin API EMITS must be exactly the one the subscribe
+    // payload ACCEPTS and the one the emitted event CARRIES. If any leg drifts
+    // (e.g. subscribe back to base58), a client can't correlate what it holds,
+    // subscribes with, and receives. All three are pinned to one hex string.
+    #[test]
+    fn admin_emit_subscribe_and_event_share_one_hex_representation() {
+        use calimero_primitives::events::{
+            GroupMembershipEvent, MembershipChange, MembershipChangePayload,
+        };
+        use calimero_primitives::identity::PublicKey;
+
+        let id = Hash::from([0x2bu8; 32]);
+        // Leg 1: what the admin API emits for this id.
+        let emitted = hex::encode(id.as_bytes());
+
+        // Leg 2: the subscribe payload must deserialize that exact string back
+        // into the same id.
+        let parsed = match parse_payload(&format!(
+            r#"{{"id":"1","method":"subscribe","params":{{"groupIds":["{emitted}"]}}}}"#
+        )) {
+            RequestPayload::Subscribe(ids) => ids,
+            other => panic!("expected Subscribe, got {other:?}"),
+        };
+        assert_eq!(
+            parsed.group_ids,
+            vec![id],
+            "subscribe must accept the emitted hex"
+        );
+
+        // Leg 3: the event carrying that id must serialize `groupId` to the
+        // same string.
+        let event = GroupMembershipEvent {
+            group_id: id,
+            payload: MembershipChangePayload::MemberJoined(MembershipChange {
+                member: PublicKey::from([9u8; 32]),
+                role: None,
+            }),
+        };
+        let v = serde_json::to_value(&event).expect("event serializes");
+        assert_eq!(v["groupId"], emitted, "the event must carry the same hex");
+    }
+
     // A context-only subscribe (legacy clients) still parses with `groupIds`
     // absent.
     #[test]

--- a/crates/server/primitives/src/sse.rs
+++ b/crates/server/primitives/src/sse.rs
@@ -31,10 +31,19 @@ pub enum RequestPayload {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ContextIds {
+    /// Default so a group-only subscribe (`groupIds` present, `contextIds`
+    /// omitted) parses; without it such a payload fails with "missing field
+    /// `contextIds`" and no subscription is registered.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub context_ids: Vec<ContextId>,
     /// Group ids to observe for `GroupMembership` events. Optional, so
-    /// existing `contextIds`-only clients are unaffected.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    /// existing `contextIds`-only clients are unaffected. Hex-encoded, matching
+    /// the group/namespace admin API's id representation (not base58).
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        with = "calimero_primitives::hash::hex_repr::vec"
+    )]
     pub group_ids: Vec<Hash>,
 }
 
@@ -88,6 +97,50 @@ impl SseEvent {
             SseEvent::Close => "close",
             SseEvent::Error => "error",
             SseEvent::Connect => "connect",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_payload(raw: &str) -> RequestPayload {
+        let req: Request<serde_json::Value> = serde_json::from_str(raw).expect("envelope parses");
+        serde_json::from_value(req.payload).expect("subscribe payload parses")
+    }
+
+    // A group-only subscribe carrying the exact payload the mero-js SSE client
+    // sends: `contextIds` omitted, and `groupIds` a HEX-encoded 32-byte id (the
+    // representation the group/namespace admin API returns). Both must parse, or
+    // no subscription is registered and the events are dropped.
+    #[test]
+    fn group_only_hex_subscribe_parses() {
+        let hex = "0d477ad6039aec8f2e7fc72a7f23aec1b98a08ba7c2faac7ba5271954813509a";
+        match parse_payload(&format!(
+            r#"{{"id":"1","method":"subscribe","params":{{"groupIds":["{hex}"]}}}}"#
+        )) {
+            RequestPayload::Subscribe(ids) => {
+                assert!(ids.context_ids.is_empty());
+                assert_eq!(ids.group_ids.len(), 1);
+                assert_eq!(hex::encode(ids.group_ids[0].as_bytes()), hex);
+            }
+            other => panic!("expected Subscribe, got {other:?}"),
+        }
+    }
+
+    // A context-only subscribe (legacy clients) still parses with `groupIds`
+    // absent.
+    #[test]
+    fn context_only_subscribe_parses() {
+        match parse_payload(
+            r#"{"id":"1","method":"subscribe","params":{"contextIds":["11111111111111111111111111111111"]}}"#,
+        ) {
+            RequestPayload::Subscribe(ids) => {
+                assert_eq!(ids.context_ids.len(), 1);
+                assert!(ids.group_ids.is_empty());
+            }
+            other => panic!("expected Subscribe, got {other:?}"),
         }
     }
 }

--- a/crates/server/primitives/src/sse.rs
+++ b/crates/server/primitives/src/sse.rs
@@ -31,14 +31,11 @@ pub enum RequestPayload {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ContextIds {
-    /// Default so a group-only subscribe (`groupIds` present, `contextIds`
-    /// omitted) parses; without it such a payload fails with "missing field
-    /// `contextIds`" and no subscription is registered.
+    /// Default so a group-only subscribe (no `contextIds`) still parses.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub context_ids: Vec<ContextId>,
-    /// Group ids to observe for `GroupMembership` events. Optional, so
-    /// existing `contextIds`-only clients are unaffected. Hex-encoded, matching
-    /// the group/namespace admin API's id representation (not base58).
+    /// Groups to observe for `GroupMembership` events. Hex-encoded, matching the
+    /// group/namespace admin API's id representation.
     #[serde(
         default,
         skip_serializing_if = "Vec::is_empty",
@@ -110,10 +107,7 @@ mod tests {
         serde_json::from_value(req.payload).expect("subscribe payload parses")
     }
 
-    // A group-only subscribe carrying the exact payload the mero-js SSE client
-    // sends: `contextIds` omitted, and `groupIds` a HEX-encoded 32-byte id (the
-    // representation the group/namespace admin API returns). Both must parse, or
-    // no subscription is registered and the events are dropped.
+    // A group-only subscribe (no `contextIds`) with a hex group id must parse.
     #[test]
     fn group_only_hex_subscribe_parses() {
         let hex = "0d477ad6039aec8f2e7fc72a7f23aec1b98a08ba7c2faac7ba5271954813509a";
@@ -129,11 +123,8 @@ mod tests {
         }
     }
 
-    // The invariant the hex/base58 bug broke: the id representation the
-    // group/namespace admin API EMITS must be exactly the one the subscribe
-    // payload ACCEPTS and the one the emitted event CARRIES. If any leg drifts
-    // (e.g. subscribe back to base58), a client can't correlate what it holds,
-    // subscribes with, and receives. All three are pinned to one hex string.
+    // The invariant the hex/base58 bug broke: what the admin API emits, what
+    // subscribe accepts, and what the event carries are all one hex string.
     #[test]
     fn admin_emit_subscribe_and_event_share_one_hex_representation() {
         use calimero_primitives::events::{
@@ -142,11 +133,10 @@ mod tests {
         use calimero_primitives::identity::PublicKey;
 
         let id = Hash::from([0x2bu8; 32]);
-        // Leg 1: what the admin API emits for this id.
+        // What the admin API emits for this id.
         let emitted = hex::encode(id.as_bytes());
 
-        // Leg 2: the subscribe payload must deserialize that exact string back
-        // into the same id.
+        // Subscribe must deserialize that exact string back into the same id.
         let parsed = match parse_payload(&format!(
             r#"{{"id":"1","method":"subscribe","params":{{"groupIds":["{emitted}"]}}}}"#
         )) {
@@ -159,8 +149,7 @@ mod tests {
             "subscribe must accept the emitted hex"
         );
 
-        // Leg 3: the event carrying that id must serialize `groupId` to the
-        // same string.
+        // The event carrying that id must serialize `groupId` to the same string.
         let event = GroupMembershipEvent {
             group_id: id,
             payload: MembershipChangePayload::MemberJoined(MembershipChange {
@@ -172,8 +161,7 @@ mod tests {
         assert_eq!(v["groupId"], emitted, "the event must carry the same hex");
     }
 
-    // A context-only subscribe (legacy clients) still parses with `groupIds`
-    // absent.
+    // A context-only subscribe (no `groupIds`) still parses.
     #[test]
     fn context_only_subscribe_parses() {
         match parse_payload(

--- a/crates/server/primitives/src/ws.rs
+++ b/crates/server/primitives/src/ws.rs
@@ -74,10 +74,16 @@ pub enum ServerResponseError {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscribeRequest {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub context_ids: Vec<ContextId>,
     /// Group ids to observe for `GroupMembership` events. Optional and defaulted
     /// so pre-existing clients (which send only `contextIds`) are unaffected.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    /// Hex-encoded, matching the group/namespace admin API's id representation.
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        with = "calimero_primitives::hash::hex_repr::vec"
+    )]
     pub group_ids: Vec<Hash>,
 }
 
@@ -86,7 +92,11 @@ pub struct SubscribeRequest {
 pub struct SubscribeResponse {
     pub context_ids: Vec<ContextId>,
     /// The group ids actually subscribed (unauthorized ones are dropped).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        with = "calimero_primitives::hash::hex_repr::vec"
+    )]
     pub group_ids: Vec<Hash>,
 }
 // *************************************************************************
@@ -95,8 +105,13 @@ pub struct SubscribeResponse {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UnsubscribeRequest {
-    pub context_ids: Vec<ContextId>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub context_ids: Vec<ContextId>,
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        with = "calimero_primitives::hash::hex_repr::vec"
+    )]
     pub group_ids: Vec<Hash>,
 }
 
@@ -104,7 +119,11 @@ pub struct UnsubscribeRequest {
 #[serde(rename_all = "camelCase")]
 pub struct UnsubscribeResponse {
     pub context_ids: Vec<ContextId>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        with = "calimero_primitives::hash::hex_repr::vec"
+    )]
     pub group_ids: Vec<Hash>,
 }
 // *************************************************************************

--- a/crates/server/primitives/src/ws.rs
+++ b/crates/server/primitives/src/ws.rs
@@ -76,9 +76,8 @@ pub enum ServerResponseError {
 pub struct SubscribeRequest {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub context_ids: Vec<ContextId>,
-    /// Group ids to observe for `GroupMembership` events. Optional and defaulted
-    /// so pre-existing clients (which send only `contextIds`) are unaffected.
-    /// Hex-encoded, matching the group/namespace admin API's id representation.
+    /// Groups to observe for `GroupMembership` events. Hex-encoded, matching the
+    /// group/namespace admin API's id representation.
     #[serde(
         default,
         skip_serializing_if = "Vec::is_empty",

--- a/crates/server/src/sse/handlers.rs
+++ b/crates/server/src/sse/handlers.rs
@@ -285,7 +285,12 @@ pub async fn handle_subscription(
                         body: ResponseBody::Result(serde_json::json!({
                             "status": "subscribed",
                             "contexts": subscribed,
-                            "groups": subscribed_groups,
+                            // Hex-encoded to match the id representation the
+                            // client subscribed with (and the group admin API).
+                            "groups": subscribed_groups
+                                .iter()
+                                .map(|g| hex::encode(g.as_bytes()))
+                                .collect::<Vec<_>>(),
                         })),
                     }),
                 )

--- a/crates/server/src/sse/handlers.rs
+++ b/crates/server/src/sse/handlers.rs
@@ -206,13 +206,9 @@ pub async fn handle_subscription(
                     }
                 }
 
-                // Only subscribe to contexts this caller may observe. Context
-                // events carry state roots and application execution-event
-                // payloads, so a session must not receive events for a context
-                // its caller isn't a member of. The node owner (and a no-auth dev
-                // server) may observe everything; any other caller must prove
-                // membership via its authenticated key. Unauthorized ids are
-                // dropped and the response reflects only what was subscribed.
+                // Only subscribe to contexts this caller may observe; context events
+                // carry state, so a non-member must not receive them. Unauthorized
+                // ids are dropped and the response reflects only what was subscribed.
                 let node_owner = auth_node_owner.is_some();
                 let subscribed: Vec<_> = ctxs
                     .context_ids

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -999,8 +999,8 @@ mod tests {
         assert_eq!(sub_resp["id"], json!(1));
         assert_eq!(
             sub_resp["result"]["groupIds"],
-            serde_json::to_value(vec![group]).unwrap(),
-            "the group id should be echoed as subscribed"
+            json!([hex::encode(group.as_bytes())]),
+            "the group id should be echoed as subscribed, hex-encoded like the admin API"
         );
 
         let listening = tokio::time::timeout(Duration::from_secs(5), async {
@@ -1033,6 +1033,66 @@ mod tests {
         assert!(
             leaked.is_none(),
             "a non-group-subscriber must not receive the event: {leaked:?}"
+        );
+    }
+
+    // Regression for the hex/base58 id-representation bug: a real client
+    // subscribes with the RAW group-only wire frame it actually sends - no
+    // `contextIds`, and `groupIds` a HEX-encoded id in the exact form the
+    // group/namespace admin API returns (`hex::encode(id)`), not base58. Both
+    // the hex parse and the group-only payload must survive the socket + route
+    // path, and the delivered event's `groupId` must echo that same hex, or a
+    // client can neither subscribe with the id it holds nor correlate the event
+    // it receives.
+    #[tokio::test]
+    async fn group_only_hex_subscribe_receives_event() {
+        let server = spawn_test_ws().await;
+        let group = Hash::from([0x2bu8; 32]);
+        // Exactly what the admin API emits for this id.
+        let group_hex = hex::encode(group.as_bytes());
+
+        let (mut write, mut read) = connect_async(&server.url).await.unwrap().0.split();
+
+        // The raw frame a real client puts on the wire, not a typed
+        // SubscribeRequest built from a Hash on both ends.
+        let raw =
+            format!(r#"{{"id":1,"method":"subscribe","params":{{"groupIds":["{group_hex}"]}}}}"#);
+        write.send(Message::Text(raw)).await.unwrap();
+
+        let sub_resp = next_json(&mut read, Duration::from_secs(5))
+            .await
+            .expect("subscribe response");
+        assert_eq!(sub_resp["id"], json!(1));
+        assert_eq!(
+            sub_resp["result"]["groupIds"],
+            json!([group_hex]),
+            "the subscribed group must be echoed as the same hex the client sent: {sub_resp}"
+        );
+
+        let listening = tokio::time::timeout(Duration::from_secs(5), async {
+            while server.event_sender.receiver_count() < 1 {
+                sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .is_ok();
+        assert!(listening, "the event fan-out task should be listening");
+
+        server
+            .event_sender
+            .send(group_membership_event(group))
+            .unwrap();
+
+        let pushed = next_json(&mut read, Duration::from_secs(5))
+            .await
+            .expect("the hex-subscribed client should receive the event");
+        assert_eq!(
+            pushed["result"]["type"], "MemberJoined",
+            "the frame should carry the membership-change discriminant: {pushed}"
+        );
+        assert_eq!(
+            pushed["result"]["groupId"], group_hex,
+            "the delivered groupId must equal the hex the client subscribed with: {pushed}"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes the group-membership event surface (added in #3291) so a client can actually subscribe to it. Two defects, both on the SSE/WS subscribe path, each of which caused the node to reject a group subscription so `group_subscriptions` stayed empty and every `NodeEvent::GroupMembership` was dropped:

1. **id encoding mismatch (the real bug).** The group/namespace admin API represents 32-byte ids as **hex** (`create_namespace` returns `hex::encode(...)`, group handlers decode hex). But the group-membership types serialized ids as `Hash`, whose serde is **base58**. A client subscribing with the hex `namespaceId` it got from `create_namespace` sent a `groupIds` array that `Vec<Hash>` (base58) could never parse (a hex id contains characters outside base58 and decodes to the wrong length), so the whole subscribe payload failed to deserialize. The emitted event's `groupId` was likewise base58, so a client could not correlate it either.
2. **`context_ids` required.** The subscribe payload left `context_ids` mandatory, so a group-only subscribe (`{"groupIds":[...]}` with no `contextIds`) failed with `missing field contextIds`.

## What changed

- `crates/primitives/src/hash.rs`: add a `hex_repr` serde helper (and `hex_repr::vec`) that (de)serializes a `Hash` as lowercase hex, with real serde errors on malformed/wrong-length input (no panics). `crates/primitives/Cargo.toml`: promote `hex` to a dependency.
- `crates/primitives/src/events.rs`: `GroupMembershipEvent.group_id` now uses `#[serde(with = "hex_repr")]`, so the emitted `groupId` is hex and matches what a client subscribed with.
- `crates/server/primitives/src/sse.rs` and `.../ws.rs`: subscribe/unsubscribe `group_ids` use `hex_repr::vec`; `context_ids` is now `#[serde(default)]` so a group-only subscribe parses. WS is included because it shares the now-hex `GroupMembershipEvent` and leaving it base58 would be incoherent.
- `crates/server/src/sse/handlers.rs`: the subscribe-response group echo is hex-encoded.

Context-event subscriptions are unaffected: `ContextId` encoding is unchanged, and a context-only payload still parses exactly as before.

## Test plan

- `cargo test -p calimero-primitives` / `-p calimero-server-primitives`: new tests assert a group-only hex subscribe parses, a context-only subscribe still parses, and the emitted `groupId` is hex.
- Verified live: built merod from this branch, ran one embedded-auth node with debug logging, created a namespace + subgroup, subscribed over SSE with `groupIds: [hexId]`, then `add_group_members`. The event was delivered over SSE with a hex `groupId` matching the subscription:
  `{"groupId":"7a4e8db8…","type":"MemberAdded","data":{"member":"CTy1…","role":"Member"}}`. Before the fix the subscribe was rejected and nothing was delivered.
- `cargo fmt --check` and `cargo clippy -- -A warnings` clean on the touched crates.
