### PR TITLE
fix(storage): fall back to LWW for opaque root local writes

### DIFF
--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -58,6 +58,30 @@ pub use crate::error::StorageError;
 /// Convenient type alias for the main storage system.
 pub type MainInterface = Interface<MainStorage>;
 
+/// Whether a root entity's stored `crdt_type` marks it as *opaque* — a root
+/// with no application-defined `Mergeable` merge dispatch.
+///
+/// An opaque root is one whose metadata carries no `crdt_type` (`None`). This
+/// is how the app-state container is stored for a JS app (written locally via
+/// the host `persist_root_state` → `save_raw` with `Metadata::new`, which
+/// leaves `crdt_type: None`) and for any app that does not use `#[app::state]`.
+/// A `#[app::state]` root registers a field-by-field `Mergeable` via the WASM
+/// module, and its root merge succeeds through the registry rather than being
+/// treated as opaque — so this predicate must never turn such a root into an
+/// LWW fallback. It is consulted only after the merge registry reports no
+/// registered function, so a registered merger always wins first.
+///
+/// The synthetic `LwwRegister { inner_type: "Opaque" }` marker the node sync
+/// layer attaches to opaque leaves *on the wire* is deliberately NOT matched
+/// here: that marker is a HashComparison wire-format concern owned by the node
+/// crate and never reaches a local `save_raw`/`save_internal` write (the sync
+/// apply path persists opaque roots with `crdt_type: None`, not the marker).
+/// The local write path this predicate guards only ever observes `None`.
+#[inline]
+fn is_opaque_root_crdt_type(crdt_type: &Option<crate::collections::crdt_meta::CrdtType>) -> bool {
+    crdt_type.is_none()
+}
+
 /// Apply-time context passed to [`Interface::apply_action`].
 ///
 /// Centralizes apply-time metadata so the call signature doesn't accumulate
@@ -2793,6 +2817,15 @@ impl<S: StorageAdaptor> Interface<S> {
                         incoming_updated_at,
                         "ROOT MERGE: Starting CRDT merge for root entity"
                     );
+                    // An opaque root (no `crdt_type`) has no app-defined
+                    // `Mergeable` to dispatch to. When no merger is registered,
+                    // `try_merge_data` resolves it by LWW instead of erroring;
+                    // a non-opaque root (real `crdt_type`) still errors loudly
+                    // (I5). Read the opaqueness off the STORED entity — its
+                    // metadata is the authoritative record of what kind of root
+                    // this is; a local `persist_root_state` write always carries
+                    // `crdt_type: None` (`Metadata::new`).
+                    let is_opaque_root = is_opaque_root_crdt_type(&last_metadata.crdt_type);
                     let merged = Self::try_merge_data(
                         id,
                         &existing_data,
@@ -2800,6 +2833,7 @@ impl<S: StorageAdaptor> Interface<S> {
                         last_metadata.created_at,
                         *last_metadata.updated_at,
                         *metadata.updated_at,
+                        is_opaque_root,
                     )?;
                     let merged_hash: [u8; 32] = Sha256::digest(&merged).into();
                     info!(
@@ -3100,11 +3134,21 @@ impl<S: StorageAdaptor> Interface<S> {
     /// Returns the merged data, or an error if merge fails.
     /// Merge mode is enabled to prevent timestamp generation during merge operations.
     ///
+    /// `is_opaque_root` is `true` when the stored root entity carries no
+    /// `crdt_type` (an *opaque* root — see [`is_opaque_root_crdt_type`]). Such a
+    /// root has no application-defined `Mergeable` to dispatch to, so when the
+    /// merge registry reports no registered function it falls back to a direct
+    /// last-writer-wins accept instead of failing (see the `# Errors` note).
+    ///
     /// # Errors
     ///
-    /// Returns `StorageError::MergeFailure` if no merge function is registered
-    /// for the root entity type. This enforces I5 (No Silent Data Loss) by failing
-    /// loudly rather than silently falling back to LWW.
+    /// Returns `StorageError::MergeFailure` when the merge registry has no
+    /// function for the root entity type **and** the root is not opaque
+    /// (`is_opaque_root == false`). This enforces I5 (No Silent Data Loss) for a
+    /// real `#[app::state]` root — a type that *should* merge field-by-field
+    /// must fail loudly rather than be silently overwritten by LWW. An opaque
+    /// root (`is_opaque_root == true`) never reaches this error: it resolves by
+    /// LWW, mirroring what the sync path does for opaque root leaves.
     fn try_merge_data(
         _id: Id,
         existing: &[u8],
@@ -3112,7 +3156,9 @@ impl<S: StorageAdaptor> Interface<S> {
         existing_created_at: u64,
         existing_timestamp: u64,
         incoming_timestamp: u64,
+        is_opaque_root: bool,
     ) -> Result<Vec<u8>, StorageError> {
+        use crate::collections::crdt_meta::MergeError;
         use crate::merge::merge_root_state;
 
         // Attempt CRDT merge with merge mode enabled
@@ -3135,11 +3181,45 @@ impl<S: StorageAdaptor> Interface<S> {
             )
         });
 
-        // I5 Enforcement: Propagate merge errors instead of falling back to LWW.
-        // If no merge function is registered and the entity isn't in the
-        // bootstrap-default state, this prevents silent data loss.
-        // The MergeError is preserved for programmatic error handling.
-        result.map_err(StorageError::from)
+        match result {
+            Ok(merged) => Ok(merged),
+            // Opaque root (no `crdt_type`) with no registered merger. Two ways
+            // to reach here for such a root, both benign:
+            //   * Host production builds delete the merge registry entirely, so
+            //     `merge_root_state` always reports `NoMergeFunctionRegistered`.
+            //     This is the local-write path a JS app (or any app that does
+            //     not use `#[app::state]`) takes via `persist_root_state`.
+            //   * A registry exists (WASM/test) but nothing was registered.
+            // Either way there is no `Mergeable` to dispatch to — WASM has no
+            // `__calimero_merge_root_state` for a type without a `Mergeable`
+            // impl — so the only convergent resolution is a direct LWW write.
+            // The enclosing `save_internal` branch is only entered when
+            // `incoming_timestamp >= existing_timestamp`, so incoming is the LWW
+            // winner; the explicit `>=` tie-break keeps this correct if the
+            // function is ever called from elsewhere and matches the opaque-root
+            // direct-LWW the sync path applies. Crucially the merge registry is
+            // consulted FIRST, so a real `#[app::state]` root whose merger IS
+            // registered takes the `Ok` arm above and is never LWW-collapsed.
+            Err(MergeError::NoMergeFunctionRegistered) if is_opaque_root => {
+                tracing::debug!(
+                    target: "storage::root_merge",
+                    existing_ts = existing_timestamp,
+                    incoming_ts = incoming_timestamp,
+                    "opaque root entity with no registered merge function; \
+                     resolving by LWW (incoming wins by updated_at)"
+                );
+                if incoming_timestamp >= existing_timestamp {
+                    Ok(incoming.to_vec())
+                } else {
+                    Ok(existing.to_vec())
+                }
+            }
+            // I5 Enforcement: for a NON-opaque root (a real `crdt_type`) with no
+            // registered merger — and for every other merge failure — propagate
+            // the error instead of falling back to LWW, preventing silent data
+            // loss. The MergeError is preserved for programmatic error handling.
+            Err(e) => Err(StorageError::from(e)),
+        }
     }
 
     /// Attempt to merge two versions of non-root entity data using CRDT semantics.

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -3848,3 +3848,122 @@ fn test_kv_map_same_key_concurrent_writes_converge() {
         hex::encode(b_root),
     );
 }
+
+/// An opaque root entity (`crdt_type: None`) — how a JS app's root is stored
+/// (written locally via the host `persist_root_state` → `save_raw` path, which
+/// uses `Metadata::new` and leaves `crdt_type: None`) — has no app-defined
+/// `Mergeable`.
+///
+/// On host production builds the merge registry is deleted entirely, so a local
+/// re-write of the root reaches `merge_root_state`'s `NoMergeFunctionRegistered`
+/// arm. Before the fix that surfaced as `StorageError::MergeFailure` and the
+/// host turned it into a `persist_root_state failed: Merge failed: No merge
+/// function registered for root entity` panic. The fix resolves an opaque root
+/// by direct LWW instead: the write succeeds and the later `updated_at` wins —
+/// mirroring the opaque-root direct-LWW the sync path already applies.
+///
+/// `clear_merge_registry()` reproduces the empty-registry condition of a host
+/// production build within the test binary (where the registry otherwise
+/// exists).
+#[test]
+#[serial]
+fn opaque_root_local_write_falls_back_to_lww_when_unregistered() {
+    use crate::address::Id;
+    use crate::entities::Metadata;
+    use crate::interface::Interface;
+    use crate::store::MockedStorage;
+
+    type NodeStorage = MockedStorage<990>;
+
+    env::reset_for_testing();
+    clear_merge_registry();
+    env::set_executor_id([7; 32]);
+
+    let root = Id::root();
+
+    // Creation (`created_at == updated_at`): no existing entity, stored verbatim.
+    Interface::<NodeStorage>::save_raw(root, b"v1".to_vec(), Metadata::new(100, 100))
+        .expect("initial opaque root write must succeed");
+
+    // First update: the stored root is still in the bootstrap state
+    // (`created_at == updated_at`), so `merge_root_state` accepts incoming via
+    // its bootstrap fast-path. This advances the stored `updated_at` to 200 but
+    // does not yet exercise the fix.
+    Interface::<NodeStorage>::save_raw(root, b"v2".to_vec(), Metadata::new(100, 200))
+        .expect("bootstrap-accepted opaque root update must succeed");
+
+    // Second update: the stored root now has `created_at (100) != updated_at
+    // (200)`, so the bootstrap fast-path no longer applies and
+    // `merge_root_state` reports `NoMergeFunctionRegistered`. This is the write
+    // that panicked pre-fix. With the fix it resolves by LWW, and the newer
+    // payload wins.
+    Interface::<NodeStorage>::save_raw(root, b"v3".to_vec(), Metadata::new(100, 300))
+        .expect("opaque root LWW fallback must succeed, not NoMergeFunctionRegistered");
+
+    let stored = Interface::<NodeStorage>::find_by_id_raw(root)
+        .expect("root entity must be present after LWW writes");
+    assert_eq!(
+        stored, b"v3",
+        "later updated_at must win under opaque-root LWW"
+    );
+}
+
+/// I5 (No Silent Data Loss) preserved for a NON-opaque root: a root whose
+/// stored metadata carries a real `crdt_type` is an app-state root expected to
+/// merge field-by-field via a registered `Mergeable`. Silently overwriting it
+/// by LWW would lose data, so with no merger registered the write must STILL
+/// fail loudly with `NoMergeFunctionRegistered` — exactly as before the
+/// opaque-root fix. Only the opaque (`crdt_type: None`) path changed to LWW.
+#[test]
+#[serial]
+fn non_opaque_root_local_write_still_errors_when_unregistered() {
+    use crate::address::Id;
+    use crate::collections::crdt_meta::{CrdtType, MergeError};
+    use crate::entities::Metadata;
+    use crate::error::StorageError;
+    use crate::interface::Interface;
+    use crate::store::MockedStorage;
+
+    type NodeStorage = MockedStorage<991>;
+
+    env::reset_for_testing();
+    clear_merge_registry();
+    env::set_executor_id([8; 32]);
+
+    let root = Id::root();
+    // A real (non-opaque) crdt_type marks this as an app-state root that is
+    // supposed to merge via a registered `Mergeable`.
+    let crdt = CrdtType::Custom("AppState".to_string());
+
+    Interface::<NodeStorage>::save_raw(
+        root,
+        b"v1".to_vec(),
+        Metadata::with_crdt_type(100, 100, crdt.clone()),
+    )
+    .expect("initial non-opaque root write must succeed");
+
+    // Bootstrap-accepted update (`created_at == updated_at`); no error yet.
+    Interface::<NodeStorage>::save_raw(
+        root,
+        b"v2".to_vec(),
+        Metadata::with_crdt_type(100, 200, crdt.clone()),
+    )
+    .expect("bootstrap-accepted non-opaque root update must succeed");
+
+    // Non-bootstrap update: no merger registered + a non-opaque root => this
+    // must fail loudly, preserving I5. This is the pre-fix behavior, and it is
+    // deliberately unchanged for non-opaque roots.
+    let err = Interface::<NodeStorage>::save_raw(
+        root,
+        b"v3".to_vec(),
+        Metadata::with_crdt_type(100, 300, crdt),
+    )
+    .expect_err("non-opaque root with no registered merger must fail loudly (I5)");
+    assert!(
+        matches!(
+            err,
+            StorageError::MergeFailure(MergeError::NoMergeFunctionRegistered)
+        ),
+        "expected NoMergeFunctionRegistered, got: {err:?}"
+    );
+}


### PR DESCRIPTION
## Problem

A local write from an app with an **opaque root** (root entity stored with `crdt_type: None`) panics:

```
persist_root_state failed: Merge failed:
No merge function registered for root entity.
```

Flow: `persist_root_state` (runtime host fn) → `Interface::save_raw(Id::root(), …)` → root-entity conflict merge → `merge_root_state` → on host builds the registry is gone → `NoFunctionsRegistered` → `Err(NoMergeFunctionRegistered)` → host panic.

`#[app::state]` (Rust) apps avoid this because their root merge dispatches to the WASM module's `__calimero_merge_root_state`. The **sync path already treats opaque roots as direct-LWW** (`node/src/sync/helpers.rs`), and the runtime itself calls root-merge registration "optional… especially for JS apps." But the **local `save_raw` merge path didn't honor that** — it hard-failed. This blocks every JS app's writes (JS roots are always `crdt_type: None`).

## Fix

Resolve an **opaque root** (root id **and** `crdt_type: None`) by **LWW** when the merge registry reports no registered function — incoming wins by `updated_at` (`>=` tie-break), mirroring the sync path's opaque-root direct-LWW.

Scoped tightly to preserve **I5 (No Silent Data Loss)**:
- The merge registry is consulted **first**, so a real `#[app::state]` root whose merger is registered still merges field-by-field.
- A **non-opaque** root (real `crdt_type`) with no registered merger **still fails loudly** with `NoMergeFunctionRegistered`.
- Opaqueness is read off the **stored** entity metadata (authoritative). The synthetic on-the-wire opaque marker (a node-crate HashComparison concern) is deliberately not matched — it never reaches a local `save_raw`.

## Tests (`crates/storage/src/tests/merge_integration.rs`)

- `opaque_root_local_write_falls_back_to_lww_when_unregistered`
- `non_opaque_root_local_write_still_errors_when_unregistered`

`cargo fmt --check`, `clippy`, the two new tests, and the merge/interface suite (101 passed) are green.

## Why (context)

Unblocks the JavaScript Service SDK (`calimero-sdk-js`): its apps store an opaque root and can't register a Rust-typed root merger, so every write panicked. With this, JS collection-based apps converge (the real CRDT data lives in separate entities that already merge host-side; the root doc is LWW). See calimero-sdk-js#77. Note: the JS SDK's E2E only turns green once this ships in `merod:edge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)