### PR TITLE
feat: JS SDK root-state convergence (deterministic ids + WASM root-merge routing)

### DIFF
--- a/crates/primitives/src/crdt.rs
+++ b/crates/primitives/src/crdt.rs
@@ -179,6 +179,21 @@ impl Default for CrdtType {
     }
 }
 
+/// Wire/persistence marker for a JS SDK app root that carries a guest-provided
+/// `__calimero_merge_root_state` callback.
+///
+/// A JS app's root is not a `#[app::state]` type, so core has no registered
+/// `Mergeable` for it and would otherwise treat the root as opaque
+/// (`crdt_type: None`) and resolve conflicts by Last-Writer-Wins — which cannot
+/// converge concurrent writers. When the guest calls `register_js_sdk_root_merge`,
+/// the runtime stamps the root with `LwwRegister { inner_type: "JsRoot" }` instead
+/// of `None`. That is deliberately distinct from the sync layer's opaque-leaf
+/// marker (`"Opaque"`): a `"JsRoot"` leaf is NOT opaque, so the sync apply path
+/// defers it to the WASM `__calimero_merge_root_state` callback (the same path a
+/// Rust `#[app::state]` root uses) rather than LWW-collapsing it. Reusing the
+/// existing `LwwRegister` variant keeps the pinned borsh discriminants unchanged.
+pub const JS_ROOT_CRDT_TYPE_NAME: &str = "JsRoot";
+
 impl CrdtType {
     /// Create an LwwRegister with a known inner type.
     #[must_use]
@@ -186,6 +201,18 @@ impl CrdtType {
         Self::LwwRegister {
             inner_type: inner_type.into(),
         }
+    }
+
+    /// The JS-SDK root marker (see [`JS_ROOT_CRDT_TYPE_NAME`]).
+    #[must_use]
+    pub fn js_root() -> Self {
+        Self::lww_register(JS_ROOT_CRDT_TYPE_NAME)
+    }
+
+    /// Whether this is the JS-SDK root marker (see [`JS_ROOT_CRDT_TYPE_NAME`]).
+    #[must_use]
+    pub fn is_js_root(&self) -> bool {
+        matches!(self, Self::LwwRegister { inner_type } if inner_type == JS_ROOT_CRDT_TYPE_NAME)
     }
 
     /// Create an UnorderedMap with known key and value types.
@@ -290,6 +317,24 @@ mod tests {
                 inner_type: "String".to_string()
             }
         );
+    }
+
+    #[test]
+    fn test_js_root_marker() {
+        let js_root = CrdtType::js_root();
+        assert_eq!(
+            js_root,
+            CrdtType::LwwRegister {
+                inner_type: JS_ROOT_CRDT_TYPE_NAME.to_string()
+            }
+        );
+        assert!(js_root.is_js_root());
+        // A JsRoot root is NOT the opaque-leaf marker the sync layer uses, so it
+        // is routed to the WASM merge callback rather than opaque LWW; and an
+        // ordinary register is not a JsRoot.
+        assert!(!CrdtType::lww_register("Opaque").is_js_root());
+        assert!(!CrdtType::lww_register("String").is_js_root());
+        assert!(!CrdtType::GCounter.is_js_root());
     }
 
     #[test]

--- a/crates/runtime/HOST_FUNCTIONS.md
+++ b/crates/runtime/HOST_FUNCTIONS.md
@@ -187,6 +187,7 @@ These functions support JavaScript SDK CRDT collections. All return `i32` status
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `js_crdt_map_new` | `(register_id: u64) -> i32` | Creates new CRDT map, ID written to register. |
+| `js_crdt_map_new_with_id` | `(id_ptr: u64, register_id: u64) -> i32` | Creates CRDT map at a caller-supplied deterministic 32-byte ID. |
 | `js_crdt_map_get` | `(map_id_ptr: u64, key_ptr: u64, register_id: u64) -> i32` | Gets value for key. |
 | `js_crdt_map_insert` | `(map_id_ptr: u64, key_ptr: u64, value_ptr: u64, register_id: u64) -> i32` | Inserts key-value pair. |
 | `js_crdt_map_remove` | `(map_id_ptr: u64, key_ptr: u64, register_id: u64) -> i32` | Removes key from map. |
@@ -198,6 +199,7 @@ These functions support JavaScript SDK CRDT collections. All return `i32` status
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `js_crdt_vector_new` | `(register_id: u64) -> i32` | Creates new CRDT vector. |
+| `js_crdt_vector_new_with_id` | `(id_ptr: u64, register_id: u64) -> i32` | Creates CRDT vector at a caller-supplied deterministic 32-byte ID. |
 | `js_crdt_vector_len` | `(vector_id_ptr: u64, register_id: u64) -> i32` | Gets vector length. |
 | `js_crdt_vector_push` | `(vector_id_ptr: u64, value_ptr: u64) -> i32` | Appends value to vector. |
 | `js_crdt_vector_get` | `(vector_id_ptr: u64, index: u64, register_id: u64) -> i32` | Gets value at index. |
@@ -208,6 +210,7 @@ These functions support JavaScript SDK CRDT collections. All return `i32` status
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `js_crdt_set_new` | `(register_id: u64) -> i32` | Creates new CRDT set. |
+| `js_crdt_set_new_with_id` | `(id_ptr: u64, register_id: u64) -> i32` | Creates CRDT set at a caller-supplied deterministic 32-byte ID. |
 | `js_crdt_set_insert` | `(set_id_ptr: u64, value_ptr: u64) -> i32` | Inserts value into set. |
 | `js_crdt_set_contains` | `(set_id_ptr: u64, value_ptr: u64) -> i32` | Checks if value exists. |
 | `js_crdt_set_remove` | `(set_id_ptr: u64, value_ptr: u64) -> i32` | Removes value from set. |
@@ -220,6 +223,7 @@ These functions support JavaScript SDK CRDT collections. All return `i32` status
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `js_crdt_lww_new` | `(register_id: u64) -> i32` | Creates new Last-Writer-Wins register. |
+| `js_crdt_lww_new_with_id` | `(id_ptr: u64, register_id: u64) -> i32` | Creates LWW register at a caller-supplied deterministic 32-byte ID. |
 | `js_crdt_lww_set` | `(register_id_ptr: u64, value_ptr: u64, has_value: u32) -> i32` | Sets register value. |
 | `js_crdt_lww_get` | `(register_id_ptr: u64, register_id: u64) -> i32` | Gets current value. |
 | `js_crdt_lww_timestamp` | `(register_id_ptr: u64, register_id: u64) -> i32` | Gets last update timestamp. |
@@ -229,6 +233,7 @@ These functions support JavaScript SDK CRDT collections. All return `i32` status
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `js_crdt_counter_new` | `(register_id: u64) -> i32` | Creates new CRDT counter. |
+| `js_crdt_counter_new_with_id` | `(id_ptr: u64, register_id: u64) -> i32` | Creates CRDT counter at a caller-supplied deterministic 32-byte ID. |
 | `js_crdt_counter_increment` | `(counter_id_ptr: u64) -> i32` | Increments counter. |
 | `js_crdt_counter_value` | `(counter_id_ptr: u64, register_id: u64) -> i32` | Gets current counter value. |
 | `js_crdt_counter_get_executor_count` | `(counter_id_ptr: u64, executor_ptr: u64, has_executor: u32, register_id: u64) -> i32` | Gets per-executor count. `has_executor` indicates if executor provided. |
@@ -242,6 +247,7 @@ Per-user storage keyed by executor identity.
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `js_user_storage_new` | `(register_id: u64) -> i32` | Creates user storage instance. |
+| `js_user_storage_new_with_id` | `(id_ptr: u64, register_id: u64) -> i32` | Creates user storage instance at a caller-supplied deterministic 32-byte ID. |
 | `js_user_storage_insert` | `(storage_id_ptr: u64, value_ptr: u64, register_id: u64) -> i32` | Inserts value for current user. |
 | `js_user_storage_get` | `(storage_id_ptr: u64, register_id: u64) -> i32` | Gets current user's value. |
 | `js_user_storage_get_for_user` | `(storage_id_ptr: u64, user_key_ptr: u64, register_id: u64) -> i32` | Gets specific user's value. |
@@ -256,6 +262,7 @@ Content-addressable storage for immutable blobs.
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `js_frozen_storage_new` | `(register_id: u64) -> i32` | Creates frozen storage instance. |
+| `js_frozen_storage_new_with_id` | `(id_ptr: u64, register_id: u64) -> i32` | Creates frozen storage instance at a caller-supplied deterministic 32-byte ID. |
 | `js_frozen_storage_add` | `(storage_id_ptr: u64, value_ptr: u64, register_id: u64) -> i32` | Adds blob, returns hash. |
 | `js_frozen_storage_get` | `(storage_id_ptr: u64, hash_ptr: u64, register_id: u64) -> i32` | Gets blob by hash. |
 | `js_frozen_storage_contains` | `(storage_id_ptr: u64, hash_ptr: u64) -> i32` | Checks if hash exists. |

--- a/crates/runtime/HOST_FUNCTIONS.md
+++ b/crates/runtime/HOST_FUNCTIONS.md
@@ -177,6 +177,7 @@ Node-local storage that is **NOT synchronized** across the network.
 | `read_root_state` | `(register_id: u64) -> i32` | Reads persisted root state. Returns `1` if exists, `0` if not. |
 | `apply_storage_delta` | `(delta_ptr: u64)` | Applies Borsh-encoded `StorageDelta::Actions` from another executor. |
 | `flush_delta` | `() -> i32` | Flushes pending CRDT actions as causal delta. Returns `1` if delta emitted, `0` if nothing to commit. |
+| `register_js_sdk_root_merge` | `()` | Opts the JS app root into the WASM `__calimero_merge_root_state` sync path (concurrent-writer convergence). `persist_root_state` then stamps the root with the `JsRoot` marker instead of `None`. |
 
 ### CRDT Collections (JS)
 

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -472,6 +472,13 @@ pub struct VMLogic<'a> {
     migration_witness: Option<Vec<u8>>,
     /// Tracks whether the guest has explicitly called `env.commit`.
     commit_called: bool,
+    /// Tracks whether the guest called `register_js_sdk_root_merge`, opting its
+    /// opaque JS root into the WASM `__calimero_merge_root_state` sync path.
+    /// When set, `persist_root_state` stamps the root with the `JsRoot` marker
+    /// instead of `None`, so concurrent writers converge via the guest merge
+    /// callback rather than Last-Writer-Wins. Set during the runtime's
+    /// `__calimero_register_merge` call, which runs in this same execution.
+    js_root_merge: bool,
 
     /// An optional client for interacting with the node's blob storage and aliases.
     node_client: Option<NodeClient>,
@@ -579,6 +586,7 @@ impl<'a> VMLogic<'a> {
             artifact: vec![],
             migration_witness: None,
             commit_called: false,
+            js_root_merge: false,
 
             node_client,
             blob_handles: HashMap::new(),

--- a/crates/runtime/src/logic/host_functions/js_collections.rs
+++ b/crates/runtime/src/logic/host_functions/js_collections.rs
@@ -50,6 +50,15 @@ impl VMHostFunctions<'_> {
         self.invoke_with_storage_env(|host| host.crdt_map_new(dest_register_id))
     }
 
+    /// Creates a new CRDT map at a caller-supplied deterministic id.
+    pub fn js_crdt_map_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_map_new_with_id(id_ptr, dest_register_id))
+    }
+
     /// Retrieves a value from the CRDT map.
     pub fn js_crdt_map_get(
         &mut self,
@@ -105,6 +114,15 @@ impl VMHostFunctions<'_> {
         self.invoke_with_storage_env(|host| host.crdt_vector_new(dest_register_id))
     }
 
+    /// Creates a new vector collection at a caller-supplied deterministic id.
+    pub fn js_crdt_vector_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_vector_new_with_id(id_ptr, dest_register_id))
+    }
+
     pub fn js_crdt_vector_len(
         &mut self,
         vector_id_ptr: u64,
@@ -144,6 +162,15 @@ impl VMHostFunctions<'_> {
         self.invoke_with_storage_env(|host| host.crdt_set_new(dest_register_id))
     }
 
+    /// Creates a new set collection at a caller-supplied deterministic id.
+    pub fn js_crdt_set_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_set_new_with_id(id_ptr, dest_register_id))
+    }
+
     pub fn js_crdt_set_insert(&mut self, set_id_ptr: u64, value_ptr: u64) -> VMLogicResult<i32> {
         self.invoke_with_storage_env(|host| host.crdt_set_insert(set_id_ptr, value_ptr))
     }
@@ -180,6 +207,15 @@ impl VMHostFunctions<'_> {
         self.invoke_with_storage_env(|host| host.crdt_lww_new(dest_register_id))
     }
 
+    /// Creates a new LWW register at a caller-supplied deterministic id.
+    pub fn js_crdt_lww_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_lww_new_with_id(id_ptr, dest_register_id))
+    }
+
     pub fn js_crdt_lww_set(
         &mut self,
         register_id_ptr: u64,
@@ -211,6 +247,15 @@ impl VMHostFunctions<'_> {
 
     pub fn js_crdt_counter_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
         self.invoke_with_storage_env(|host| host.crdt_counter_new(dest_register_id))
+    }
+
+    /// Creates a new counter at a caller-supplied deterministic id.
+    pub fn js_crdt_counter_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_counter_new_with_id(id_ptr, dest_register_id))
     }
 
     pub fn js_crdt_counter_increment(&mut self, counter_id_ptr: u64) -> VMLogicResult<i32> {
@@ -247,6 +292,15 @@ impl VMHostFunctions<'_> {
     /// Creates a new UserStorage and returns its identifier.
     pub fn js_user_storage_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
         self.invoke_with_storage_env(|host| host.user_storage_new(dest_register_id))
+    }
+
+    /// Creates a new UserStorage at a caller-supplied deterministic id.
+    pub fn js_user_storage_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.user_storage_new_with_id(id_ptr, dest_register_id))
     }
 
     /// Inserts or replaces a value in UserStorage for the current executor.
@@ -314,6 +368,17 @@ impl VMHostFunctions<'_> {
         self.invoke_with_storage_env(|host| host.frozen_storage_new(dest_register_id))
     }
 
+    /// Creates a new FrozenStorage at a caller-supplied deterministic id.
+    pub fn js_frozen_storage_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.frozen_storage_new_with_id(id_ptr, dest_register_id)
+        })
+    }
+
     /// Inserts a value into FrozenStorage and returns its hash.
     pub fn js_frozen_storage_add(
         &mut self,
@@ -351,6 +416,32 @@ impl VMHostFunctions<'_> {
         let outcome =
             panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsUnorderedMap, String> {
                 let mut map = JsUnorderedMap::new();
+                save_js_map_instance(&mut map)?;
+                Ok(map)
+            }));
+
+        match outcome {
+            Ok(Ok(map)) => {
+                self.write_register_bytes(dest_register_id, map.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn crdt_map_new_with_id(&mut self, id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
+        let id = match self.read_map_id(id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let outcome =
+            panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsUnorderedMap, String> {
+                let mut map = JsUnorderedMap::new_with_id(id);
                 save_js_map_instance(&mut map)?;
                 Ok(map)
             }));
@@ -557,6 +648,35 @@ impl VMHostFunctions<'_> {
         }
     }
 
+    fn crdt_vector_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let id = match self.read_map_id(id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsVector, String> {
+            let mut vector = JsVector::new_with_id(id);
+            save_js_vector_instance(&mut vector)?;
+            Ok(vector)
+        }));
+
+        match outcome {
+            Ok(Ok(vector)) => {
+                self.write_register_bytes(dest_register_id, vector.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
     fn crdt_vector_len(&mut self, vector_id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
         let vector_id = match self.read_map_id(vector_id_ptr)? {
             Ok(id) => id,
@@ -670,6 +790,32 @@ impl VMHostFunctions<'_> {
         let outcome =
             panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsUnorderedSet, String> {
                 let mut set = JsUnorderedSet::new();
+                save_js_set_instance(&mut set)?;
+                Ok(set)
+            }));
+
+        match outcome {
+            Ok(Ok(set)) => {
+                self.write_register_bytes(dest_register_id, set.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn crdt_set_new_with_id(&mut self, id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
+        let id = match self.read_map_id(id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let outcome =
+            panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsUnorderedSet, String> {
+                let mut set = JsUnorderedSet::new_with_id(id);
                 save_js_set_instance(&mut set)?;
                 Ok(set)
             }));
@@ -871,6 +1017,31 @@ impl VMHostFunctions<'_> {
         }
     }
 
+    fn crdt_lww_new_with_id(&mut self, id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
+        let id = match self.read_map_id(id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsLwwRegister, String> {
+            let mut register = JsLwwRegister::new_with_id(id);
+            save_js_lww_instance(&mut register)?;
+            Ok(register)
+        }));
+
+        match outcome {
+            Ok(Ok(register)) => {
+                self.write_register_bytes(dest_register_id, register.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
     fn crdt_lww_set(
         &mut self,
         register_id_ptr: u64,
@@ -977,6 +1148,35 @@ impl VMHostFunctions<'_> {
         }
     }
 
+    fn crdt_counter_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let id = match self.read_map_id(id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsCounter, String> {
+            let mut counter = JsCounter::new_with_id(id);
+            save_js_counter_instance(&mut counter)?;
+            Ok(counter)
+        }));
+
+        match outcome {
+            Ok(Ok(counter)) => {
+                self.write_register_bytes(dest_register_id, counter.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
     fn crdt_counter_increment(&mut self, counter_id_ptr: u64) -> VMLogicResult<i32> {
         let counter_id = match self.read_map_id(counter_id_ptr)? {
             Ok(id) => id,
@@ -1065,6 +1265,35 @@ impl VMHostFunctions<'_> {
     fn user_storage_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
         let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsUserStorage, String> {
             let mut storage = JsUserStorage::new();
+            save_js_user_storage_instance(&mut storage)?;
+            Ok(storage)
+        }));
+
+        match outcome {
+            Ok(Ok(storage)) => {
+                self.write_register_bytes(dest_register_id, storage.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn user_storage_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let id = match self.read_map_id(id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsUserStorage, String> {
+            let mut storage = JsUserStorage::new_with_id(id);
             save_js_user_storage_instance(&mut storage)?;
             Ok(storage)
         }));
@@ -1263,6 +1492,36 @@ impl VMHostFunctions<'_> {
         let outcome =
             panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsFrozenStorage, String> {
                 let mut storage = JsFrozenStorage::new();
+                save_js_frozen_storage_instance(&mut storage)?;
+                Ok(storage)
+            }));
+
+        match outcome {
+            Ok(Ok(storage)) => {
+                self.write_register_bytes(dest_register_id, storage.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn frozen_storage_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let id = match self.read_map_id(id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let outcome =
+            panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsFrozenStorage, String> {
+                let mut storage = JsFrozenStorage::new_with_id(id);
                 save_js_frozen_storage_instance(&mut storage)?;
                 Ok(storage)
             }));
@@ -1807,5 +2066,134 @@ fn save_js_frozen_storage_instance(storage: &mut JsFrozenStorage) -> Result<(), 
             }
         }
         Err(err) => Err(err.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::logic::{
+        tests::{prepare_guest_buf_descriptor, setup_vm, SimpleMockStorage},
+        Cow, VMContext, VMLimits, VMLogic, DIGEST_SIZE,
+    };
+    use wasmer::{AsStoreMut, Store};
+
+    // Guest memory offsets used across the tests below. The `*_desc` offsets hold
+    // 16-byte `{ ptr, len }` buffer descriptors; the `*_data` offsets hold payloads.
+    const ID_DATA_PTR: u64 = 1000;
+    const ID_DESC_PTR: u64 = 100;
+    const KEY_DATA_PTR: u64 = 2000;
+    const KEY_DESC_PTR: u64 = 200;
+    const VALUE_DATA_PTR: u64 = 3000;
+    const VALUE_DESC_PTR: u64 = 300;
+
+    /// A `*_new_with_id` constructor must place the collection at exactly the
+    /// caller-supplied id, and two handles built at the same id must address the
+    /// same storage entity (insert via one, read via another).
+    #[test]
+    fn test_js_crdt_map_new_with_id_is_deterministic_and_shared() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        // A known, non-random 32-byte id both nodes would derive independently.
+        let id: [u8; 32] = [7u8; 32];
+        host.borrow_memory()
+            .write(ID_DATA_PTR, &id)
+            .expect("write id bytes");
+        prepare_guest_buf_descriptor(&host, ID_DESC_PTR, ID_DATA_PTR, id.len() as u64);
+
+        // First handle at the deterministic id.
+        let reg_a = 1u64;
+        let res = host.js_crdt_map_new_with_id(ID_DESC_PTR, reg_a).unwrap();
+        assert_eq!(res, 0, "constructor should succeed");
+        assert_eq!(
+            host.borrow_logic().registers.get(reg_a).unwrap(),
+            &id,
+            "returned id must equal the caller-supplied id"
+        );
+
+        // Second handle at the SAME id (as a different node/logical handle would).
+        let reg_b = 2u64;
+        let res = host.js_crdt_map_new_with_id(ID_DESC_PTR, reg_b).unwrap();
+        assert_eq!(res, 0);
+        assert_eq!(
+            host.borrow_logic().registers.get(reg_b).unwrap(),
+            &id,
+            "second handle must resolve to the same id"
+        );
+
+        // Insert through the id, then read it back: both handles share one entity.
+        let key = b"field";
+        let value = b"payload";
+        host.borrow_memory()
+            .write(KEY_DATA_PTR, key)
+            .expect("write key");
+        prepare_guest_buf_descriptor(&host, KEY_DESC_PTR, KEY_DATA_PTR, key.len() as u64);
+        host.borrow_memory()
+            .write(VALUE_DATA_PTR, value)
+            .expect("write value");
+        prepare_guest_buf_descriptor(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, value.len() as u64);
+
+        let reg_c = 3u64;
+        let res = host
+            .js_crdt_map_insert(ID_DESC_PTR, KEY_DESC_PTR, VALUE_DESC_PTR, reg_c)
+            .unwrap();
+        assert_eq!(res, 0, "inserting a new key returns 0 (no previous value)");
+
+        let reg_d = 4u64;
+        let res = host
+            .js_crdt_map_get(ID_DESC_PTR, KEY_DESC_PTR, reg_d)
+            .unwrap();
+        assert_eq!(res, 1, "value must be found via the shared id");
+        assert_eq!(
+            host.borrow_logic().registers.get(reg_d).unwrap(),
+            value,
+            "round-tripped value must match what was inserted"
+        );
+    }
+
+    /// Same guarantee for a second collection type (set), to cover a different
+    /// save/load helper path.
+    #[test]
+    fn test_js_crdt_set_new_with_id_is_deterministic_and_shared() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        let id: [u8; 32] = [42u8; 32];
+        host.borrow_memory()
+            .write(ID_DATA_PTR, &id)
+            .expect("write id bytes");
+        prepare_guest_buf_descriptor(&host, ID_DESC_PTR, ID_DATA_PTR, id.len() as u64);
+
+        let reg_a = 1u64;
+        let res = host.js_crdt_set_new_with_id(ID_DESC_PTR, reg_a).unwrap();
+        assert_eq!(res, 0);
+        assert_eq!(host.borrow_logic().registers.get(reg_a).unwrap(), &id);
+
+        // Second handle at the same id.
+        let reg_b = 2u64;
+        let res = host.js_crdt_set_new_with_id(ID_DESC_PTR, reg_b).unwrap();
+        assert_eq!(res, 0);
+        assert_eq!(host.borrow_logic().registers.get(reg_b).unwrap(), &id);
+
+        let value = b"member";
+        host.borrow_memory()
+            .write(VALUE_DATA_PTR, value)
+            .expect("write value");
+        prepare_guest_buf_descriptor(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, value.len() as u64);
+
+        let res = host
+            .js_crdt_set_insert(ID_DESC_PTR, VALUE_DESC_PTR)
+            .unwrap();
+        assert_eq!(res, 1, "first insert of a value returns 1");
+
+        // Reading membership via the shared id sees the insert.
+        let res = host
+            .js_crdt_set_contains(ID_DESC_PTR, VALUE_DESC_PTR)
+            .unwrap();
+        assert_eq!(res, 1, "value must be visible via the shared id");
     }
 }

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -1018,6 +1018,23 @@ impl VMHostFunctions<'_> {
         Ok(())
     }
 
+    /// Opts the JS app's opaque root into the WASM merge sync path.
+    ///
+    /// A JS root is not a `#[app::state]` type, so core has no registered
+    /// `Mergeable` and would treat it as opaque (`crdt_type: None`), resolving
+    /// conflicts by Last-Writer-Wins — which cannot converge concurrent writers.
+    /// The JS SDK calls this from its `__calimero_register_merge` hook (invoked by
+    /// the runtime in this same execution, before the method runs) to declare that
+    /// its module exports `__calimero_merge_root_state`. `persist_root_state` then
+    /// stamps the root with the `JsRoot` marker so the sync apply path defers it to
+    /// that guest merge callback instead of LWW. Idempotent and non-failing.
+    pub fn register_js_sdk_root_merge(&mut self) -> VMLogicResult<()> {
+        self.with_logic_mut(|logic| {
+            logic.js_root_merge = true;
+        });
+        Ok(())
+    }
+
     /// Persists the root state document provided by the guest runtime.
     ///
     /// Instead of writing directly to storage (which would bypass Merkle bookkeeping),
@@ -1078,12 +1095,18 @@ impl VMHostFunctions<'_> {
                 .take()
                 .expect("persist_root_state payload already consumed");
 
+            // A guest that called `register_js_sdk_root_merge` provides a
+            // `__calimero_merge_root_state` callback; stamp the root with the
+            // `JsRoot` marker so the sync apply path defers to that callback
+            // instead of LWW-collapsing concurrent writes. Without the opt-in
+            // the root stays opaque (`crdt_type: None`) exactly as before.
+            let mut metadata = Metadata::new(final_created_at, final_updated_at);
+            if logic.js_root_merge {
+                metadata.crdt_type = Some(calimero_primitives::crdt::CrdtType::js_root());
+            }
+
             with_runtime_env(env, move || {
-                Interface::<MainStorage>::save_raw(
-                    Id::root(),
-                    payload,
-                    Metadata::new(final_created_at, final_updated_at),
-                )
+                Interface::<MainStorage>::save_raw(Id::root(), payload, metadata)
             })
             .map_err(|err| {
                 VMLogicError::from(HostError::Panic {

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -133,6 +133,10 @@ impl VMLogic<'_> {
             ) -> i32;
             fn js_frozen_storage_contains(storage_id_ptr: u64, hash_ptr: u64) -> i32;
 
+            // Opts the JS root into the WASM `__calimero_merge_root_state` sync
+            // path (concurrent-writer convergence) instead of opaque LWW.
+            fn register_js_sdk_root_merge();
+
             fn fetch(
                 url_ptr: u64,
                 method_ptr: u64,

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -61,6 +61,7 @@ impl VMLogic<'_> {
             fn private_storage_remove(key_ptr: u64, register_id: u64) -> u32;
             fn private_storage_write(key_ptr: u64, value_ptr: u64) -> u32;
             fn js_crdt_map_new(register_id: u64) -> i32;
+            fn js_crdt_map_new_with_id(id_ptr: u64, register_id: u64) -> i32;
             fn js_crdt_map_get(map_id_ptr: u64, key_ptr: u64, register_id: u64) -> i32;
             fn js_crdt_map_insert(
                 map_id_ptr: u64,
@@ -72,11 +73,13 @@ impl VMLogic<'_> {
             fn js_crdt_map_contains(map_id_ptr: u64, key_ptr: u64) -> i32;
             fn js_crdt_map_iter(map_id_ptr: u64, register_id: u64) -> i32;
             fn js_crdt_vector_new(register_id: u64) -> i32;
+            fn js_crdt_vector_new_with_id(id_ptr: u64, register_id: u64) -> i32;
             fn js_crdt_vector_len(vector_id_ptr: u64, register_id: u64) -> i32;
             fn js_crdt_vector_push(vector_id_ptr: u64, value_ptr: u64) -> i32;
             fn js_crdt_vector_get(vector_id_ptr: u64, index: u64, register_id: u64) -> i32;
             fn js_crdt_vector_pop(vector_id_ptr: u64, register_id: u64) -> i32;
             fn js_crdt_set_new(register_id: u64) -> i32;
+            fn js_crdt_set_new_with_id(id_ptr: u64, register_id: u64) -> i32;
             fn js_crdt_set_insert(set_id_ptr: u64, value_ptr: u64) -> i32;
             fn js_crdt_set_contains(set_id_ptr: u64, value_ptr: u64) -> i32;
             fn js_crdt_set_remove(set_id_ptr: u64, value_ptr: u64) -> i32;
@@ -84,10 +87,12 @@ impl VMLogic<'_> {
             fn js_crdt_set_iter(set_id_ptr: u64, register_id: u64) -> i32;
             fn js_crdt_set_clear(set_id_ptr: u64) -> i32;
             fn js_crdt_lww_new(register_id: u64) -> i32;
+            fn js_crdt_lww_new_with_id(id_ptr: u64, register_id: u64) -> i32;
             fn js_crdt_lww_set(register_id_ptr: u64, value_ptr: u64, has_value: u32) -> i32;
             fn js_crdt_lww_get(register_id_ptr: u64, register_id: u64) -> i32;
             fn js_crdt_lww_timestamp(register_id_ptr: u64, register_id: u64) -> i32;
             fn js_crdt_counter_new(register_id: u64) -> i32;
+            fn js_crdt_counter_new_with_id(id_ptr: u64, register_id: u64) -> i32;
             fn js_crdt_counter_increment(counter_id_ptr: u64) -> i32;
             fn js_crdt_counter_value(counter_id_ptr: u64, register_id: u64) -> i32;
             fn js_crdt_counter_get_executor_count(
@@ -98,6 +103,7 @@ impl VMLogic<'_> {
             ) -> i32;
 
             fn js_user_storage_new(register_id: u64) -> i32;
+            fn js_user_storage_new_with_id(id_ptr: u64, register_id: u64) -> i32;
             fn js_user_storage_insert(
                 storage_id_ptr: u64,
                 value_ptr: u64,
@@ -114,6 +120,7 @@ impl VMLogic<'_> {
             fn js_user_storage_contains_user(storage_id_ptr: u64, user_key_ptr: u64) -> i32;
 
             fn js_frozen_storage_new(register_id: u64) -> i32;
+            fn js_frozen_storage_new_with_id(id_ptr: u64, register_id: u64) -> i32;
             fn js_frozen_storage_add(
                 storage_id_ptr: u64,
                 value_ptr: u64,

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2823,9 +2823,22 @@ impl<S: StorageAdaptor> Interface<S> {
                     // a non-opaque root (real `crdt_type`) still errors loudly
                     // (I5). Read the opaqueness off the STORED entity — its
                     // metadata is the authoritative record of what kind of root
-                    // this is; a local `persist_root_state` write always carries
-                    // `crdt_type: None` (`Metadata::new`).
-                    let is_opaque_root = is_opaque_root_crdt_type(&last_metadata.crdt_type);
+                    // this is.
+                    //
+                    // A JS-SDK root (the `JsRoot` marker, stamped when the guest
+                    // called `register_js_sdk_root_merge`) resolves LOCAL writes
+                    // by LWW too: a local write's incoming state always descends
+                    // from the existing state, so incoming-wins is correct here.
+                    // Its field-aware convergence for CONCURRENT writers runs only
+                    // on the sync path, where the marker routes the root to the
+                    // guest `__calimero_merge_root_state` callback. A real
+                    // `#[app::state]` root still merges through the registry
+                    // (checked first) and never reaches the LWW arm.
+                    let is_opaque_root = is_opaque_root_crdt_type(&last_metadata.crdt_type)
+                        || last_metadata
+                            .crdt_type
+                            .as_ref()
+                            .is_some_and(|t| t.is_js_root());
                     let merged = Self::try_merge_data(
                         id,
                         &existing_data,

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -3967,3 +3967,70 @@ fn non_opaque_root_local_write_still_errors_when_unregistered() {
         "expected NoMergeFunctionRegistered, got: {err:?}"
     );
 }
+
+/// A JS-SDK root carries the `JsRoot` marker (stamped by `persist_root_state`
+/// when the guest called `register_js_sdk_root_merge`) rather than `crdt_type:
+/// None`. That marker is what routes the root to the guest
+/// `__calimero_merge_root_state` callback on the SYNC path. On the LOCAL write
+/// path there is no concurrent peer — incoming descends from existing — so a
+/// `JsRoot` root must resolve by LWW just like an opaque root, NOT fail with
+/// `NoMergeFunctionRegistered` (which would break every JS-app local write once
+/// the marker is present). This guards the local-path predicate that treats the
+/// `JsRoot` marker as LWW-eligible.
+#[test]
+#[serial]
+fn js_root_local_write_falls_back_to_lww_when_unregistered() {
+    use crate::address::Id;
+    use crate::collections::crdt_meta::CrdtType;
+    use crate::entities::Metadata;
+    use crate::interface::Interface;
+    use crate::store::MockedStorage;
+
+    type NodeStorage = MockedStorage<992>;
+
+    env::reset_for_testing();
+    clear_merge_registry();
+    env::set_executor_id([9; 32]);
+
+    let root = Id::root();
+    let js_root = CrdtType::js_root();
+    assert!(
+        js_root.is_js_root(),
+        "sanity: js_root() must be the JsRoot marker"
+    );
+
+    // Creation (`created_at == updated_at`): stored verbatim with the marker.
+    Interface::<NodeStorage>::save_raw(
+        root,
+        b"v1".to_vec(),
+        Metadata::with_crdt_type(100, 100, js_root.clone()),
+    )
+    .expect("initial JsRoot root write must succeed");
+
+    // Bootstrap-accepted update (`created_at == updated_at`); accepted via the
+    // bootstrap fast-path, advances `updated_at` to 200.
+    Interface::<NodeStorage>::save_raw(
+        root,
+        b"v2".to_vec(),
+        Metadata::with_crdt_type(100, 200, js_root.clone()),
+    )
+    .expect("bootstrap-accepted JsRoot root update must succeed");
+
+    // Non-bootstrap update: stored root now has `created_at (100) != updated_at
+    // (200)`, so `merge_root_state` reports `NoMergeFunctionRegistered`. A NON-
+    // opaque non-JsRoot root would fail here (I5); a JsRoot root must instead
+    // resolve by LWW (newer wins) so local writes keep working.
+    Interface::<NodeStorage>::save_raw(
+        root,
+        b"v3".to_vec(),
+        Metadata::with_crdt_type(100, 300, js_root),
+    )
+    .expect("JsRoot root local write must LWW-fall-back, not NoMergeFunctionRegistered");
+
+    let stored = Interface::<NodeStorage>::find_by_id_raw(root)
+        .expect("root entity must be present after LWW writes");
+    assert_eq!(
+        stored, b"v3",
+        "later updated_at must win under JsRoot local LWW"
+    );
+}


### PR DESCRIPTION
## What

Core groundwork so JS SDK apps can **converge concurrent writers**. Today a JS app root is opaque to core (`crdt_type: None`) and resolves conflicts by Last-Writer-Wins on both the local-write and sync paths — which converges a single writer but not two, so two nodes writing the same JS app never reconcile their roots (persistent root-hash divergence, `root_hash_verified=false`).

This PR adds the two missing core primitives. Both are **dormant until a guest opts in**, so no existing app changes behavior.

### 1. Deterministic-id CRDT constructors (commit 1)
`js_crdt_{map,set,vector,lww,counter}_new_with_id` and `js_{user,frozen}_storage_new_with_id`. The JS SDK creates nested collections with host-allocated random ids, so two nodes get different ids for the same logical field and can never merge them. These let the guest construct a collection at a deterministic id (derived from its field path).

### 2. `JsRoot` root-merge routing (commit 2)
`register_js_sdk_root_merge`: a guest that exports `__calimero_merge_root_state` calls it (from its `__calimero_register_merge` hook, run in the same execution) to opt in. `persist_root_state` then stamps the root with a `JsRoot` marker (`LwwRegister { inner_type: "JsRoot" }`, reusing the pinned borsh variant — no discriminant change) instead of `None`.

**No sync-engine changes.** The sync sender already preserves any non-`None` crdt_type verbatim (`hash_comparison_protocol.rs` uses `crdt_type.clone().unwrap_or_else(|| Opaque)`), and the receiver defers anything that isn't the `"Opaque"` marker. So a `JsRoot` leaf automatically flows through the **existing** deferred-root-merge path (`ContextClient::merge_root_state` → WASM `__calimero_merge_root_state`) that Rust `#[app::state]` roots already use. The local-write path treats `JsRoot` as LWW-eligible (a local write's incoming always descends from existing), so opting in never breaks a local write; **I5 is untouched** for genuinely-unregistered non-opaque roots.

## Why now

Prereq for calimero-network/calimero-sdk-js#83. Pairs with the JS-side merge callback + deterministic-id adoption (J1, in the sdk-js repo). Design: `calimero-sdk-js/docs/design/js-root-merge.md`.

## Tests / verification

- `crdt::tests::test_js_root_marker` — marker identity, distinct from the sync `"Opaque"` marker.
- `merge_integration::js_root_local_write_falls_back_to_lww_when_unregistered` — a `JsRoot` local write LWWs instead of hitting `NoMergeFunctionRegistered` (I5), alongside the unchanged opaque + non-opaque sibling tests.
- `js_collections` deterministic-id tests — a collection built at a known id round-trips through a second handle at the same id.
- `cargo fmt --check`, `cargo clippy -p calimero-{primitives,storage,runtime} -- -A warnings`, `cargo test -p calimero-{primitives,storage,runtime}` all green; `calimero-node` compiles.

## Not in this PR

End-to-end convergence needs the JS side (J1: write `merge.ts`, use `*_new_with_id`, call `register_js_sdk_root_merge` + export `__calimero_merge_root_state`). Once this merges and `merod:edge` rebuilds, J1 re-enables the 4 gated example workflows in calimero-sdk-js#83.

Draft until J1 is ready to co-validate on real nodes.
