### PR TITLE
fix(storage): persist root crdt_type on hash updates (JS concurrent-writer convergence)

### DIFF
--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -1183,6 +1183,7 @@ impl<S: StorageAdaptor> Index<S> {
         id: Id,
         merkle_hash: [u8; 32],
         updated_at: Option<UpdatedAt>,
+        crdt_type: Option<crate::collections::crdt_meta::CrdtType>,
     ) -> Result<[u8; 32], StorageError> {
         // RMW on this entity's index entry — serialize against a concurrent
         // `add_child_to` on the same entry so neither clobbers the other
@@ -1195,6 +1196,19 @@ impl<S: StorageAdaptor> Index<S> {
         index.full_hash = Self::calculate_full_hash_for_children(index.own_hash, &index.children)?;
         if let Some(updated_at) = updated_at {
             index.metadata.updated_at = updated_at;
+        }
+        // `crdt_type` is set only at `add_root`/`add_child_to` creation; a plain
+        // hash update never carried it, so a root's merge-dispatch tag was frozen
+        // at whatever it was first stored as. A JS app that opts into the WASM
+        // root merge stamps the `JsRoot` marker on every `persist_root_state`
+        // write, but if the root was first created opaque (`None`) — e.g. a joiner
+        // materialises it via sync before ever writing locally — that stamp was
+        // silently dropped here, so the root stayed opaque and never routed to the
+        // guest merge. Threading the update through lets a local write (re)assert
+        // the marker. `None` means "leave unchanged" (every non-root caller);
+        // callers only ever pass `Some` to SET a tag, never to clear one.
+        if let Some(crdt_type) = crdt_type {
+            index.metadata.crdt_type = Some(crdt_type);
         }
 
         // Log detailed info for root entity hash updates

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2977,7 +2977,18 @@ impl<S: StorageAdaptor> Interface<S> {
         // *does* propagate index-advertised entries through every
         // production caller, so a "hash exists, bytes don't"
         // inconsistency surfaces immediately as a wrong-content read.
-        let full_hash = <Index<S>>::update_hash_for(id, own_hash, Some(metadata.updated_at))?;
+        // (Re)assert the root's merge-dispatch tag on every local write. Unlike
+        // creation (`add_root`), a plain hash update never persisted `crdt_type`,
+        // so a root first stored opaque could never be upgraded to `JsRoot` by a
+        // later `persist_root_state` — the write stamped the marker on `metadata`
+        // but it was dropped here. Non-root entities pass `None` (leave unchanged).
+        let root_crdt_type = if crate::collections::is_app_root_entry(id) {
+            metadata.crdt_type.clone()
+        } else {
+            None
+        };
+        let full_hash =
+            <Index<S>>::update_hash_for(id, own_hash, Some(metadata.updated_at), root_crdt_type)?;
 
         // A value write that causally follows an existing tombstone must lift it,
         // or `find_by_id` would keep hiding the bytes we just wrote (the entity's
@@ -3138,7 +3149,17 @@ impl<S: StorageAdaptor> Interface<S> {
         // doesn't serialize concurrent writes anyway — re-checking
         // would just narrow the race window without closing it.
         let _ignored = S::storage_write(Key::Entry(id), merged);
-        let full_hash = <Index<S>>::update_hash_for(id, own_hash, Some(metadata.updated_at))?;
+        // Preserve the root's merge-dispatch tag across a sync-applied write so a
+        // `JsRoot` root materialised via sync keeps routing to the guest merge
+        // (see the note in `Index::update_hash_for`). Only the app root carries a
+        // meaningful tag on this path; non-root entities pass `None`.
+        let root_crdt_type = if crate::collections::is_app_root_entry(id) {
+            metadata.crdt_type.clone()
+        } else {
+            None
+        };
+        let full_hash =
+            <Index<S>>::update_hash_for(id, own_hash, Some(metadata.updated_at), root_crdt_type)?;
         Ok(full_hash)
     }
 

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -1111,7 +1111,7 @@ mod hashing {
         // Change greatgrandchild's own_hash. `update_hash_for` rewrites
         // the stored own/full hashes and walks ancestors itself, so no
         // separate `recalculate_ancestor_hashes_for` call is needed.
-        <Index<MainStorage>>::update_hash_for(greatgrandchild_id, [9_u8; 32], None).unwrap();
+        <Index<MainStorage>>::update_hash_for(greatgrandchild_id, [9_u8; 32], None, None).unwrap();
 
         let updated_root_index_with_greatgrandchild =
             <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
@@ -1142,7 +1142,7 @@ mod hashing {
         );
 
         // Same pattern — update_hash_for handles the ancestor walk itself.
-        <Index<MainStorage>>::update_hash_for(greatgrandchild_id, [99_u8; 32], None).unwrap();
+        <Index<MainStorage>>::update_hash_for(greatgrandchild_id, [99_u8; 32], None, None).unwrap();
 
         let updated_root_index_with_greatgrandchild =
             <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
@@ -1203,7 +1203,7 @@ mod hashing {
         assert_eq!(root_index.id, root_id);
         assert_eq!(root_index.full_hash, initial_full_hash);
 
-        assert!(<Index<MainStorage>>::update_hash_for(root_id, root_hash2, None).is_ok());
+        assert!(<Index<MainStorage>>::update_hash_for(root_id, root_hash2, None, None).is_ok());
         let updated_root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(updated_root_index.id, root_id);
         assert_eq!(updated_root_index.full_hash, root_full_hash);
@@ -1226,7 +1226,7 @@ mod hashing {
         assert_eq!(root_index.id, root_id);
         assert_eq!(root_index.own_hash, root_hash1);
 
-        assert!(<Index<MainStorage>>::update_hash_for(root_id, root_hash2, None).is_ok());
+        assert!(<Index<MainStorage>>::update_hash_for(root_id, root_hash2, None, None).is_ok());
         let updated_root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         assert_eq!(updated_root_index.id, root_id);
         assert_eq!(updated_root_index.own_hash, root_hash2);

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -4034,3 +4034,59 @@ fn js_root_local_write_falls_back_to_lww_when_unregistered() {
         "later updated_at must win under JsRoot local LWW"
     );
 }
+
+/// The `JsRoot` marker must survive a plain hash update, not just creation. A
+/// root first stored opaque (`crdt_type: None`) — exactly what a joiner gets
+/// when it materialises the root via sync before ever writing locally — must be
+/// upgraded to `JsRoot` by a later local write that stamps the marker. Before
+/// the fix, `update_hash_for` dropped the incoming `crdt_type`, so the root
+/// stayed opaque forever, was sent to peers with the `Opaque` wire tag, never
+/// deferred to the guest `__calimero_merge_root_state`, and concurrent writers
+/// never converged.
+#[test]
+#[serial]
+fn js_root_update_reasserts_crdt_type_marker() {
+    use crate::address::Id;
+    use crate::collections::crdt_meta::CrdtType;
+    use crate::entities::Metadata;
+    use crate::index::Index;
+    use crate::interface::Interface;
+    use crate::store::MockedStorage;
+
+    type NodeStorage = MockedStorage<993>;
+
+    env::reset_for_testing();
+    clear_merge_registry();
+    env::set_executor_id([11; 32]);
+
+    let root = Id::root();
+
+    // Root first created OPAQUE (crdt_type: None).
+    Interface::<NodeStorage>::save_raw(root, b"v1".to_vec(), Metadata::new(100, 100))
+        .expect("initial opaque root write must succeed");
+    assert_eq!(
+        <Index<NodeStorage>>::get_metadata(root)
+            .expect("metadata read")
+            .and_then(|m| m.crdt_type),
+        None,
+        "root must start opaque"
+    );
+
+    // A later local write stamps the JsRoot marker (as `persist_root_state`
+    // does once the guest called `register_js_sdk_root_merge`).
+    Interface::<NodeStorage>::save_raw(
+        root,
+        b"v2".to_vec(),
+        Metadata::with_crdt_type(100, 200, CrdtType::js_root()),
+    )
+    .expect("JsRoot root update must succeed");
+
+    let stored = <Index<NodeStorage>>::get_metadata(root)
+        .expect("metadata read")
+        .expect("root metadata present");
+    assert!(
+        stored.crdt_type.as_ref().is_some_and(CrdtType::is_js_root),
+        "a local write must re-assert the JsRoot marker on the stored root, got {:?}",
+        stored.crdt_type
+    );
+}


### PR DESCRIPTION
## What

Follow-up to #3309. Fixes a bug that prevented JS-app concurrent-writer convergence from actually working end-to-end, found during real-node validation.

## The bug

`Index::update_hash_for` updated `own_hash`/`full_hash`/`updated_at` but **never `crdt_type`**. So a root entity's merge-dispatch tag was frozen at whatever it was first stored as (`add_root`).

#3309 stamps the `JsRoot` marker in `persist_root_state` on every JS-app write, so a JS root should route to the guest `__calimero_merge_root_state` on sync. But if the root was **first created opaque** (`crdt_type: None`) — which is exactly what happens on a **joiner** that materialises the root via sync before ever writing locally — that stamp was silently dropped on every subsequent local write. The root stayed opaque, was pushed to peers with the `Opaque` wire tag, was never deferred to the guest merge (`deferred_root_merges=0`), and the two nodes' roots **never converged** (persistent root-hash divergence).

Reproduced on real 2-node networks (merod built from #3309 + JS SDK J1): `user_storage` wrote on both nodes, all entities merged (`entities_merged=37`), but `deferred_root_merges=0` and roots stayed split.

## The fix

Thread `crdt_type` through `update_hash_for` (`None` = leave unchanged; callers only ever pass `Some` to SET a tag, never clear one). Both write paths re-assert the app root's tag:
- `save_internal` (local write) → a local write upgrades an opaque root to `JsRoot`.
- `write_pre_merged_root_state` (sync apply) → a sync-materialised root keeps its wire tag.

Non-root entities pass `None` (unchanged behavior). Non-opted-in JS apps never stamp a tag, so their roots stay opaque exactly as before.

## Tests

- New regression: `js_root_update_reasserts_crdt_type_marker` — a root created opaque, then given a `JsRoot` write, ends up **stored** as `JsRoot` (fails before the fix).
- `cargo fmt --check`, `clippy -p calimero-storage`, full `cargo test -p calimero-storage` (**673 passed**) all green.

## Rollout

Merge → `merod:edge` rebuild → the JS SDK side (calimero-sdk-js J1, PR incoming) can then re-enable the concurrent-writer example workflows. Tracks calimero-network/calimero-sdk-js#83.
