### PR TITLE
feat(runtime): JS host functions for PNCounter, RGA, SortedMap, SortedSet

### DIFF
--- a/crates/runtime/HOST_FUNCTIONS.md
+++ b/crates/runtime/HOST_FUNCTIONS.md
@@ -239,6 +239,59 @@ These functions support JavaScript SDK CRDT collections. All return `i32` status
 | `js_crdt_counter_value` | `(counter_id_ptr: u64, register_id: u64) -> i32` | Gets current counter value. |
 | `js_crdt_counter_get_executor_count` | `(counter_id_ptr: u64, executor_ptr: u64, has_executor: u32, register_id: u64) -> i32` | Gets per-executor count. `has_executor` indicates if executor provided. |
 
+The counter operations above wrap a G-Counter (grow-only, unsigned). The PN-Counter operations below add decrement and report a signed (`i64`) value.
+
+#### PN-Counter Operations
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `js_crdt_pncounter_new` | `(register_id: u64) -> i32` | Creates new PN-counter (increment/decrement). |
+| `js_crdt_pncounter_new_with_id` | `(id_ptr: u64, register_id: u64) -> i32` | Creates PN-counter at a caller-supplied deterministic 32-byte ID. |
+| `js_crdt_pncounter_increment` | `(counter_id_ptr: u64) -> i32` | Increments counter for the current executor. |
+| `js_crdt_pncounter_decrement` | `(counter_id_ptr: u64) -> i32` | Decrements counter for the current executor. |
+| `js_crdt_pncounter_value` | `(counter_id_ptr: u64, register_id: u64) -> i32` | Gets current signed value (`i64`, little-endian). |
+| `js_crdt_pncounter_get_executor_count` | `(counter_id_ptr: u64, executor_ptr: u64, has_executor: u32, register_id: u64) -> i32` | Gets a single executor's net contribution (`positive - negative`, `i64`). `has_executor` indicates if executor provided. |
+
+#### RGA Operations (Collaborative Text)
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `js_crdt_rga_new` | `(register_id: u64) -> i32` | Creates a new Replicated Growable Array. |
+| `js_crdt_rga_new_with_id` | `(id_ptr: u64, register_id: u64) -> i32` | Creates an RGA at a caller-supplied deterministic 32-byte ID. |
+| `js_crdt_rga_insert` | `(rga_id_ptr: u64, index: u64, value_ptr: u64) -> i32` | Inserts UTF-8 `value` at character `index`. |
+| `js_crdt_rga_delete` | `(rga_id_ptr: u64, index: u64) -> i32` | Deletes the character at `index`. |
+| `js_crdt_rga_get_text` | `(rga_id_ptr: u64, register_id: u64) -> i32` | Gets the full document as UTF-8 bytes. |
+| `js_crdt_rga_len` | `(rga_id_ptr: u64, register_id: u64) -> i32` | Gets the visible character count (`u64`, little-endian). |
+
+#### Sorted Map Operations
+
+Same byte API and CRDT semantics as the Map operations above, but `iter` yields entries in ascending key (byte) order.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `js_crdt_sortedmap_new` | `(register_id: u64) -> i32` | Creates a new ordered CRDT map. |
+| `js_crdt_sortedmap_new_with_id` | `(id_ptr: u64, register_id: u64) -> i32` | Creates an ordered map at a caller-supplied deterministic 32-byte ID. |
+| `js_crdt_sortedmap_get` | `(map_id_ptr: u64, key_ptr: u64, register_id: u64) -> i32` | Retrieves a value by key. |
+| `js_crdt_sortedmap_insert` | `(map_id_ptr: u64, key_ptr: u64, value_ptr: u64, register_id: u64) -> i32` | Inserts/replaces a value, returning any previous value. |
+| `js_crdt_sortedmap_remove` | `(map_id_ptr: u64, key_ptr: u64, register_id: u64) -> i32` | Removes a value, returning the previous value. |
+| `js_crdt_sortedmap_contains` | `(map_id_ptr: u64, key_ptr: u64) -> i32` | Checks whether a key exists. |
+| `js_crdt_sortedmap_iter` | `(map_id_ptr: u64, register_id: u64) -> i32` | Iterates all entries in ascending key order. |
+
+#### Sorted Set Operations
+
+Same byte API and CRDT semantics as the Set operations above, but `iter` yields values in ascending (byte) order.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `js_crdt_sortedset_new` | `(register_id: u64) -> i32` | Creates a new ordered CRDT set. |
+| `js_crdt_sortedset_new_with_id` | `(id_ptr: u64, register_id: u64) -> i32` | Creates an ordered set at a caller-supplied deterministic 32-byte ID. |
+| `js_crdt_sortedset_insert` | `(set_id_ptr: u64, value_ptr: u64) -> i32` | Inserts a value (returns 1 if newly added, 0 if already present). |
+| `js_crdt_sortedset_contains` | `(set_id_ptr: u64, value_ptr: u64) -> i32` | Checks membership. |
+| `js_crdt_sortedset_remove` | `(set_id_ptr: u64, value_ptr: u64) -> i32` | Removes a value (returns 1 if present, 0 otherwise). |
+| `js_crdt_sortedset_len` | `(set_id_ptr: u64, register_id: u64) -> i32` | Gets the element count (`u64`, little-endian). |
+| `js_crdt_sortedset_iter` | `(set_id_ptr: u64, register_id: u64) -> i32` | Iterates all values in ascending order. |
+| `js_crdt_sortedset_clear` | `(set_id_ptr: u64) -> i32` | Clears all values from the set. |
+
 ### User & Frozen Storage (JS)
 
 #### User Storage

--- a/crates/runtime/HOST_FUNCTIONS.md
+++ b/crates/runtime/HOST_FUNCTIONS.md
@@ -258,10 +258,16 @@ The counter operations above wrap a G-Counter (grow-only, unsigned). The PN-Coun
 |----------|-----------|-------------|
 | `js_crdt_rga_new` | `(register_id: u64) -> i32` | Creates a new Replicated Growable Array. |
 | `js_crdt_rga_new_with_id` | `(id_ptr: u64, register_id: u64) -> i32` | Creates an RGA at a caller-supplied deterministic 32-byte ID. |
-| `js_crdt_rga_insert` | `(rga_id_ptr: u64, index: u64, value_ptr: u64) -> i32` | Inserts UTF-8 `value` at character `index`. |
-| `js_crdt_rga_delete` | `(rga_id_ptr: u64, index: u64) -> i32` | Deletes the character at `index`. |
+| `js_crdt_rga_insert` | `(rga_id_ptr: u64, index: u64, value_ptr: u64) -> i32` | Inserts the UTF-8 `value` (a run of one or more codepoints) at codepoint offset `index`. |
+| `js_crdt_rga_delete` | `(rga_id_ptr: u64, index: u64) -> i32` | Deletes the codepoint at offset `index`. |
 | `js_crdt_rga_get_text` | `(rga_id_ptr: u64, register_id: u64) -> i32` | Gets the full document as UTF-8 bytes. |
-| `js_crdt_rga_len` | `(rga_id_ptr: u64, register_id: u64) -> i32` | Gets the visible character count (`u64`, little-endian). |
+| `js_crdt_rga_len` | `(rga_id_ptr: u64, register_id: u64) -> i32` | Gets the codepoint count (`u64`, little-endian). |
+
+`index`/`len` count **Unicode scalar values (codepoints)** — not bytes, and not UTF-16
+code units. RGA elements are `char`s, so a multi-byte UTF-8 sequence (e.g. `é`, or an
+emoji) is one position. JS SDK wrappers that receive a JS `string` index (which counts
+UTF-16 code units) must convert to a codepoint offset before calling these; for
+astral-plane characters the two differ.
 
 #### Sorted Map Operations
 

--- a/crates/runtime/src/logic/host_functions/js_collections.rs
+++ b/crates/runtime/src/logic/host_functions/js_collections.rs
@@ -3499,6 +3499,68 @@ mod tests {
         assert_eq!(host.borrow_logic().registers.get(reg3).unwrap(), b"ello!");
     }
 
+    /// RGA `index`/`len` count Unicode scalar values (codepoints), NOT bytes.
+    /// Exercises multi-byte characters (`é` = 2 bytes, `🎉` = 4 bytes) so a
+    /// byte-indexed implementation would either land mid-codepoint (error) or
+    /// miscount — this locks the documented codepoint semantics that the JS
+    /// SDK wrapper depends on.
+    #[test]
+    fn test_js_crdt_rga_multibyte_codepoint_indexing() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        let id: [u8; 32] = [22u8; 32];
+        put_buffer(&host, ID_DESC_PTR, ID_DATA_PTR, &id);
+        assert_eq!(host.js_crdt_rga_new_with_id(ID_DESC_PTR, 1).unwrap(), 0);
+
+        // "café" — 4 codepoints but 5 UTF-8 bytes (é is 2 bytes).
+        put_buffer(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, "café".as_bytes());
+        assert_eq!(
+            host.js_crdt_rga_insert(ID_DESC_PTR, 0, VALUE_DESC_PTR)
+                .unwrap(),
+            1
+        );
+
+        // len must be 4 (codepoints), not 5 (bytes).
+        let reg = 5u64;
+        assert_eq!(host.js_crdt_rga_len(ID_DESC_PTR, reg).unwrap(), 1);
+        let bytes = host.borrow_logic().registers.get(reg).unwrap();
+        assert_eq!(
+            u64::from_le_bytes(bytes.try_into().unwrap()),
+            4,
+            "len counts codepoints, not bytes"
+        );
+
+        // Insert an astral-plane emoji (4 bytes, 1 codepoint) at codepoint
+        // offset 4 (the end). Byte-index 4 would be mid-`é` and fail.
+        put_buffer(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, "🎉".as_bytes());
+        assert_eq!(
+            host.js_crdt_rga_insert(ID_DESC_PTR, 4, VALUE_DESC_PTR)
+                .unwrap(),
+            1
+        );
+
+        let reg2 = 6u64;
+        assert_eq!(host.js_crdt_rga_get_text(ID_DESC_PTR, reg2).unwrap(), 1);
+        assert_eq!(
+            host.borrow_logic().registers.get(reg2).unwrap(),
+            "café🎉".as_bytes(),
+            "insert at codepoint offset 4 lands after é, before nothing"
+        );
+
+        // Delete codepoint 3 (`é`) → "caf🎉".
+        assert_eq!(host.js_crdt_rga_delete(ID_DESC_PTR, 3).unwrap(), 1);
+        let reg3 = 7u64;
+        assert_eq!(host.js_crdt_rga_get_text(ID_DESC_PTR, reg3).unwrap(), 1);
+        assert_eq!(
+            host.borrow_logic().registers.get(reg3).unwrap(),
+            "caf🎉".as_bytes(),
+            "delete removes one codepoint by codepoint offset"
+        );
+    }
+
     /// SortedMap insert/get, and iteration must be in ascending key order
     /// regardless of insertion order.
     #[test]

--- a/crates/runtime/src/logic/host_functions/js_collections.rs
+++ b/crates/runtime/src/logic/host_functions/js_collections.rs
@@ -10,8 +10,8 @@ use calimero_storage::{
     index::Index,
     interface::{Interface, StorageError},
     js::{
-        JsCounter, JsFrozenStorage, JsLwwRegister, JsUnorderedMap, JsUnorderedSet, JsUserStorage,
-        JsVector,
+        JsCounter, JsFrozenStorage, JsLwwRegister, JsPnCounter, JsRga, JsSortedMap, JsSortedSet,
+        JsUnorderedMap, JsUnorderedSet, JsUserStorage, JsVector,
     },
     store::MainStorage,
 };
@@ -410,6 +410,226 @@ impl VMHostFunctions<'_> {
         hash_ptr: u64,
     ) -> VMLogicResult<i32> {
         self.invoke_with_storage_env(|host| host.frozen_storage_contains(storage_id_ptr, hash_ptr))
+    }
+
+    /// Creates a new PN-counter and returns its identifier.
+    pub fn js_crdt_pncounter_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_pncounter_new(dest_register_id))
+    }
+
+    /// Creates a new PN-counter at a caller-supplied deterministic id.
+    pub fn js_crdt_pncounter_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_pncounter_new_with_id(id_ptr, dest_register_id)
+        })
+    }
+
+    pub fn js_crdt_pncounter_increment(&mut self, counter_id_ptr: u64) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_pncounter_increment(counter_id_ptr))
+    }
+
+    pub fn js_crdt_pncounter_decrement(&mut self, counter_id_ptr: u64) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_pncounter_decrement(counter_id_ptr))
+    }
+
+    pub fn js_crdt_pncounter_value(
+        &mut self,
+        counter_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_pncounter_value(counter_id_ptr, dest_register_id)
+        })
+    }
+
+    pub fn js_crdt_pncounter_get_executor_count(
+        &mut self,
+        counter_id_ptr: u64,
+        executor_ptr: u64,
+        has_executor: u32,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_pncounter_get_executor_count(
+                counter_id_ptr,
+                executor_ptr,
+                has_executor,
+                dest_register_id,
+            )
+        })
+    }
+
+    /// Creates a new RGA (collaborative text sequence) and returns its identifier.
+    pub fn js_crdt_rga_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_rga_new(dest_register_id))
+    }
+
+    /// Creates a new RGA at a caller-supplied deterministic id.
+    pub fn js_crdt_rga_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_rga_new_with_id(id_ptr, dest_register_id))
+    }
+
+    pub fn js_crdt_rga_insert(
+        &mut self,
+        rga_id_ptr: u64,
+        index: u64,
+        value_ptr: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_rga_insert(rga_id_ptr, index, value_ptr))
+    }
+
+    pub fn js_crdt_rga_delete(&mut self, rga_id_ptr: u64, index: u64) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_rga_delete(rga_id_ptr, index))
+    }
+
+    pub fn js_crdt_rga_get_text(
+        &mut self,
+        rga_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_rga_get_text(rga_id_ptr, dest_register_id))
+    }
+
+    pub fn js_crdt_rga_len(
+        &mut self,
+        rga_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_rga_len(rga_id_ptr, dest_register_id))
+    }
+
+    /// Creates a new ordered CRDT map and returns its identifier.
+    pub fn js_crdt_sortedmap_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_sortedmap_new(dest_register_id))
+    }
+
+    /// Creates a new ordered CRDT map at a caller-supplied deterministic id.
+    pub fn js_crdt_sortedmap_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_sortedmap_new_with_id(id_ptr, dest_register_id)
+        })
+    }
+
+    pub fn js_crdt_sortedmap_get(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_sortedmap_get(map_id_ptr, key_ptr, dest_register_id)
+        })
+    }
+
+    pub fn js_crdt_sortedmap_insert(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+        value_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_sortedmap_insert(map_id_ptr, key_ptr, value_ptr, dest_register_id)
+        })
+    }
+
+    pub fn js_crdt_sortedmap_remove(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_sortedmap_remove(map_id_ptr, key_ptr, dest_register_id)
+        })
+    }
+
+    pub fn js_crdt_sortedmap_contains(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_sortedmap_contains(map_id_ptr, key_ptr))
+    }
+
+    pub fn js_crdt_sortedmap_iter(
+        &mut self,
+        map_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_sortedmap_iter(map_id_ptr, dest_register_id))
+    }
+
+    /// Creates a new ordered CRDT set and returns its identifier.
+    pub fn js_crdt_sortedset_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_sortedset_new(dest_register_id))
+    }
+
+    /// Creates a new ordered CRDT set at a caller-supplied deterministic id.
+    pub fn js_crdt_sortedset_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_sortedset_new_with_id(id_ptr, dest_register_id)
+        })
+    }
+
+    pub fn js_crdt_sortedset_insert(
+        &mut self,
+        set_id_ptr: u64,
+        value_ptr: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_sortedset_insert(set_id_ptr, value_ptr))
+    }
+
+    pub fn js_crdt_sortedset_contains(
+        &mut self,
+        set_id_ptr: u64,
+        value_ptr: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_sortedset_contains(set_id_ptr, value_ptr))
+    }
+
+    pub fn js_crdt_sortedset_remove(
+        &mut self,
+        set_id_ptr: u64,
+        value_ptr: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_sortedset_remove(set_id_ptr, value_ptr))
+    }
+
+    pub fn js_crdt_sortedset_len(
+        &mut self,
+        set_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_sortedset_len(set_id_ptr, dest_register_id))
+    }
+
+    pub fn js_crdt_sortedset_iter(
+        &mut self,
+        set_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_sortedset_iter(set_id_ptr, dest_register_id))
+    }
+
+    pub fn js_crdt_sortedset_clear(&mut self, set_id_ptr: u64) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_sortedset_clear(set_id_ptr))
     }
 
     fn crdt_map_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
@@ -1633,6 +1853,748 @@ impl VMHostFunctions<'_> {
         }
     }
 
+    fn crdt_pncounter_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsPnCounter, String> {
+            let mut counter = JsPnCounter::new();
+            save_js_pncounter_instance(&mut counter)?;
+            Ok(counter)
+        }));
+
+        match outcome {
+            Ok(Ok(counter)) => {
+                self.write_register_bytes(dest_register_id, counter.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn crdt_pncounter_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let id = match self.read_map_id(id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsPnCounter, String> {
+            let mut counter = JsPnCounter::new_with_id(id);
+            save_js_pncounter_instance(&mut counter)?;
+            Ok(counter)
+        }));
+
+        match outcome {
+            Ok(Ok(counter)) => {
+                self.write_register_bytes(dest_register_id, counter.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn crdt_pncounter_increment(&mut self, counter_id_ptr: u64) -> VMLogicResult<i32> {
+        let counter_id = match self.read_map_id(counter_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let mut counter = match load_js_pncounter_instance(counter_id) {
+            Ok(counter) => counter,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        match counter.increment() {
+            Ok(()) => match save_js_pncounter_instance(&mut counter) {
+                Ok(()) => Ok(1),
+                Err(message) => self.write_error_message(0, message),
+            },
+            Err(err) => self.write_error_message(0, err),
+        }
+    }
+
+    fn crdt_pncounter_decrement(&mut self, counter_id_ptr: u64) -> VMLogicResult<i32> {
+        let counter_id = match self.read_map_id(counter_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let mut counter = match load_js_pncounter_instance(counter_id) {
+            Ok(counter) => counter,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        match counter.decrement() {
+            Ok(()) => match save_js_pncounter_instance(&mut counter) {
+                Ok(()) => Ok(1),
+                Err(message) => self.write_error_message(0, message),
+            },
+            Err(err) => self.write_error_message(0, err),
+        }
+    }
+
+    fn crdt_pncounter_value(
+        &mut self,
+        counter_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let counter_id = match self.read_map_id(counter_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let counter = match load_js_pncounter_instance(counter_id) {
+            Ok(counter) => counter,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match counter.value() {
+            Ok(value) => {
+                self.write_register_bytes(dest_register_id, &value.to_le_bytes())?;
+                Ok(1)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_pncounter_get_executor_count(
+        &mut self,
+        counter_id_ptr: u64,
+        executor_ptr: u64,
+        has_executor: u32,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let counter_id = match self.read_map_id(counter_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let executor_bytes: [u8; 32] = if has_executor != 0 {
+            let bytes = self.read_buffer(executor_ptr)?;
+            match <[u8; 32]>::try_from(bytes.as_slice()) {
+                Ok(array) => array,
+                Err(_) => {
+                    return self.write_error_message(
+                        dest_register_id,
+                        "executor id must be exactly 32 bytes",
+                    )
+                }
+            }
+        } else {
+            self.borrow_logic().context.executor_public_key
+        };
+
+        let counter = match load_js_pncounter_instance(counter_id) {
+            Ok(counter) => counter,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match counter.get_executor_count(&executor_bytes) {
+            Ok(value) => {
+                self.write_register_bytes(dest_register_id, &value.to_le_bytes())?;
+                Ok(1)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_rga_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsRga, String> {
+            let mut rga = JsRga::new();
+            save_js_rga_instance(&mut rga)?;
+            Ok(rga)
+        }));
+
+        match outcome {
+            Ok(Ok(rga)) => {
+                self.write_register_bytes(dest_register_id, rga.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn crdt_rga_new_with_id(&mut self, id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
+        let id = match self.read_map_id(id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsRga, String> {
+            let mut rga = JsRga::new_with_id(id);
+            save_js_rga_instance(&mut rga)?;
+            Ok(rga)
+        }));
+
+        match outcome {
+            Ok(Ok(rga)) => {
+                self.write_register_bytes(dest_register_id, rga.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn crdt_rga_insert(
+        &mut self,
+        rga_id_ptr: u64,
+        index: u64,
+        value_ptr: u64,
+    ) -> VMLogicResult<i32> {
+        let rga_id = match self.read_map_id(rga_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let idx = match usize::try_from(index) {
+            Ok(value) => value,
+            Err(_) => {
+                return self
+                    .write_error_message(0, format!("index {index} does not fit into usize"))
+            }
+        };
+
+        let value = self.read_buffer(value_ptr)?;
+
+        let mut rga = match load_js_rga_instance(rga_id) {
+            Ok(rga) => rga,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        match rga.insert(idx, &value) {
+            Ok(()) => match save_js_rga_instance(&mut rga) {
+                Ok(()) => Ok(1),
+                Err(message) => self.write_error_message(0, message),
+            },
+            Err(err) => self.write_error_message(0, err.to_string()),
+        }
+    }
+
+    fn crdt_rga_delete(&mut self, rga_id_ptr: u64, index: u64) -> VMLogicResult<i32> {
+        let rga_id = match self.read_map_id(rga_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let idx = match usize::try_from(index) {
+            Ok(value) => value,
+            Err(_) => {
+                return self
+                    .write_error_message(0, format!("index {index} does not fit into usize"))
+            }
+        };
+
+        let mut rga = match load_js_rga_instance(rga_id) {
+            Ok(rga) => rga,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        match rga.delete(idx) {
+            Ok(()) => match save_js_rga_instance(&mut rga) {
+                Ok(()) => Ok(1),
+                Err(message) => self.write_error_message(0, message),
+            },
+            Err(err) => self.write_error_message(0, err.to_string()),
+        }
+    }
+
+    fn crdt_rga_get_text(&mut self, rga_id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
+        let rga_id = match self.read_map_id(rga_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let rga = match load_js_rga_instance(rga_id) {
+            Ok(rga) => rga,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match rga.get_text() {
+            Ok(text) => {
+                self.write_register_bytes(dest_register_id, &text)?;
+                Ok(1)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err.to_string()),
+        }
+    }
+
+    fn crdt_rga_len(&mut self, rga_id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
+        let rga_id = match self.read_map_id(rga_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let rga = match load_js_rga_instance(rga_id) {
+            Ok(rga) => rga,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match rga.len() {
+            Ok(len) => {
+                let len_u64 = u64::try_from(len).map_err(|_| HostError::IntegerOverflow)?;
+                self.write_register_bytes(dest_register_id, &len_u64.to_le_bytes())?;
+                Ok(1)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err.to_string()),
+        }
+    }
+
+    fn crdt_sortedmap_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsSortedMap, String> {
+            let mut map = JsSortedMap::new();
+            save_js_sortedmap_instance(&mut map)?;
+            Ok(map)
+        }));
+
+        match outcome {
+            Ok(Ok(map)) => {
+                self.write_register_bytes(dest_register_id, map.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn crdt_sortedmap_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let id = match self.read_map_id(id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsSortedMap, String> {
+            let mut map = JsSortedMap::new_with_id(id);
+            save_js_sortedmap_instance(&mut map)?;
+            Ok(map)
+        }));
+
+        match outcome {
+            Ok(Ok(map)) => {
+                self.write_register_bytes(dest_register_id, map.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn crdt_sortedmap_get(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let map_id = match self.read_map_id(map_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let key = self.read_buffer(key_ptr)?;
+
+        let map = match load_js_sortedmap_instance(map_id) {
+            Ok(map) => map,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match map.get(&key) {
+            Ok(Some(value)) => {
+                self.write_register_bytes(dest_register_id, &value)?;
+                Ok(1)
+            }
+            Ok(None) => {
+                self.clear_register(dest_register_id)?;
+                Ok(0)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_sortedmap_insert(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+        value_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let map_id = match self.read_map_id(map_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let key = self.read_buffer(key_ptr)?;
+        let value = self.read_buffer(value_ptr)?;
+
+        let mut map = match load_js_sortedmap_instance(map_id) {
+            Ok(map) => map,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match map.insert(&key, &value) {
+            Ok(previous) => {
+                if let Err(message) = save_js_sortedmap_instance(&mut map) {
+                    return self.write_error_message(dest_register_id, message);
+                }
+
+                if let Some(prev) = previous {
+                    self.write_register_bytes(dest_register_id, &prev)?;
+                    Ok(1)
+                } else {
+                    self.clear_register(dest_register_id)?;
+                    Ok(0)
+                }
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_sortedmap_remove(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let map_id = match self.read_map_id(map_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let key = self.read_buffer(key_ptr)?;
+
+        let mut map = match load_js_sortedmap_instance(map_id) {
+            Ok(map) => map,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match map.remove(&key) {
+            Ok(Some(previous)) => {
+                if let Err(message) = save_js_sortedmap_instance(&mut map) {
+                    return self.write_error_message(dest_register_id, message);
+                }
+                self.write_register_bytes(dest_register_id, &previous)?;
+                Ok(1)
+            }
+            Ok(None) => {
+                self.clear_register(dest_register_id)?;
+                Ok(0)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_sortedmap_contains(&mut self, map_id_ptr: u64, key_ptr: u64) -> VMLogicResult<i32> {
+        let map_id = match self.read_map_id(map_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let key = self.read_buffer(key_ptr)?;
+
+        let map = match load_js_sortedmap_instance(map_id) {
+            Ok(map) => map,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        match map.contains(&key) {
+            Ok(result) => Ok(i32::from(result)),
+            Err(err) => self.write_error_message(0, err),
+        }
+    }
+
+    fn crdt_sortedmap_iter(
+        &mut self,
+        map_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let map_id = match self.read_map_id(map_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let map = match load_js_sortedmap_instance(map_id) {
+            Ok(map) => map,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let entries = match map.entries() {
+            Ok(entries) => entries,
+            Err(err) => return self.write_error_message(dest_register_id, err),
+        };
+
+        let count = u32::try_from(entries.len()).map_err(|_| HostError::IntegerOverflow)?;
+
+        let mut total_len: usize = 4;
+        for (key, value) in &entries {
+            let key_len = key.len();
+            let value_len = value.len();
+            u32::try_from(key_len).map_err(|_| HostError::IntegerOverflow)?;
+            u32::try_from(value_len).map_err(|_| HostError::IntegerOverflow)?;
+            total_len = total_len
+                .checked_add(4)
+                .and_then(|acc| acc.checked_add(key_len))
+                .and_then(|acc| acc.checked_add(4))
+                .and_then(|acc| acc.checked_add(value_len))
+                .ok_or(HostError::IntegerOverflow)?;
+        }
+
+        let mut buffer = Vec::with_capacity(total_len);
+        buffer.extend_from_slice(&count.to_le_bytes());
+        for (key, value) in entries {
+            let key_len = u32::try_from(key.len()).map_err(|_| HostError::IntegerOverflow)?;
+            let value_len = u32::try_from(value.len()).map_err(|_| HostError::IntegerOverflow)?;
+            buffer.extend_from_slice(&key_len.to_le_bytes());
+            buffer.extend_from_slice(&key);
+            buffer.extend_from_slice(&value_len.to_le_bytes());
+            buffer.extend_from_slice(&value);
+        }
+
+        self.write_register_bytes(dest_register_id, &buffer)?;
+        Ok(1)
+    }
+
+    fn crdt_sortedset_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsSortedSet, String> {
+            let mut set = JsSortedSet::new();
+            save_js_sortedset_instance(&mut set)?;
+            Ok(set)
+        }));
+
+        match outcome {
+            Ok(Ok(set)) => {
+                self.write_register_bytes(dest_register_id, set.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn crdt_sortedset_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let id = match self.read_map_id(id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsSortedSet, String> {
+            let mut set = JsSortedSet::new_with_id(id);
+            save_js_sortedset_instance(&mut set)?;
+            Ok(set)
+        }));
+
+        match outcome {
+            Ok(Ok(set)) => {
+                self.write_register_bytes(dest_register_id, set.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn crdt_sortedset_insert(&mut self, set_id_ptr: u64, value_ptr: u64) -> VMLogicResult<i32> {
+        let set_id = match self.read_map_id(set_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let value = self.read_buffer(value_ptr)?;
+
+        let mut set = match load_js_sortedset_instance(set_id) {
+            Ok(set) => set,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        match set.insert(&value) {
+            Ok(inserted) => {
+                if !inserted {
+                    return Ok(0);
+                }
+                if let Err(message) = save_js_sortedset_instance(&mut set) {
+                    return self.write_error_message(0, message);
+                }
+                Ok(1)
+            }
+            Err(err) => self.write_error_message(0, err),
+        }
+    }
+
+    fn crdt_sortedset_contains(&mut self, set_id_ptr: u64, value_ptr: u64) -> VMLogicResult<i32> {
+        let set_id = match self.read_map_id(set_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let value = self.read_buffer(value_ptr)?;
+
+        let set = match load_js_sortedset_instance(set_id) {
+            Ok(set) => set,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        match set.contains(&value) {
+            Ok(result) => Ok(i32::from(result)),
+            Err(err) => self.write_error_message(0, err),
+        }
+    }
+
+    fn crdt_sortedset_remove(&mut self, set_id_ptr: u64, value_ptr: u64) -> VMLogicResult<i32> {
+        let set_id = match self.read_map_id(set_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let value = self.read_buffer(value_ptr)?;
+
+        let mut set = match load_js_sortedset_instance(set_id) {
+            Ok(set) => set,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        match set.remove(&value) {
+            Ok(removed) => {
+                if !removed {
+                    return Ok(0);
+                }
+                if let Err(message) = save_js_sortedset_instance(&mut set) {
+                    return self.write_error_message(0, message);
+                }
+                Ok(1)
+            }
+            Err(err) => self.write_error_message(0, err),
+        }
+    }
+
+    fn crdt_sortedset_len(&mut self, set_id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
+        let set_id = match self.read_map_id(set_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let set = match load_js_sortedset_instance(set_id) {
+            Ok(set) => set,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match set.len() {
+            Ok(len) => {
+                let len_u64 = u64::try_from(len).map_err(|_| HostError::IntegerOverflow)?;
+                self.write_register_bytes(dest_register_id, &len_u64.to_le_bytes())?;
+                Ok(1)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_sortedset_iter(
+        &mut self,
+        set_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let set_id = match self.read_map_id(set_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let set = match load_js_sortedset_instance(set_id) {
+            Ok(set) => set,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let values = match set.values() {
+            Ok(values) => values,
+            Err(err) => return self.write_error_message(dest_register_id, err),
+        };
+
+        let count = u32::try_from(values.len()).map_err(|_| HostError::IntegerOverflow)?;
+
+        let mut total_len: usize = 4;
+        for value in &values {
+            let value_len = value.len();
+            u32::try_from(value_len).map_err(|_| HostError::IntegerOverflow)?;
+            total_len = total_len
+                .checked_add(4)
+                .and_then(|acc| acc.checked_add(value_len))
+                .ok_or(HostError::IntegerOverflow)?;
+        }
+
+        let mut buffer = Vec::with_capacity(total_len);
+        buffer.extend_from_slice(&count.to_le_bytes());
+        for value in values {
+            let value_len = u32::try_from(value.len()).map_err(|_| HostError::IntegerOverflow)?;
+            buffer.extend_from_slice(&value_len.to_le_bytes());
+            buffer.extend_from_slice(&value);
+        }
+
+        self.write_register_bytes(dest_register_id, &buffer)?;
+        Ok(1)
+    }
+
+    fn crdt_sortedset_clear(&mut self, set_id_ptr: u64) -> VMLogicResult<i32> {
+        let set_id = match self.read_map_id(set_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let mut set = match load_js_sortedset_instance(set_id) {
+            Ok(set) => set,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let len_before = match set.len() {
+            Ok(len) => len,
+            Err(err) => return self.write_error_message(0, err),
+        };
+
+        match set.clear() {
+            Ok(()) => {
+                if len_before == 0 {
+                    return Ok(0);
+                }
+                if let Err(message) = save_js_sortedset_instance(&mut set) {
+                    return self.write_error_message(0, message);
+                }
+                Ok(1)
+            }
+            Err(err) => self.write_error_message(0, err),
+        }
+    }
+
     fn read_map_id(&mut self, map_id_ptr: u64) -> VMLogicResult<Result<Id, String>> {
         // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
         //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
@@ -2069,6 +3031,174 @@ fn save_js_frozen_storage_instance(storage: &mut JsFrozenStorage) -> Result<(), 
     }
 }
 
+fn load_js_pncounter_instance(id: Id) -> Result<JsPnCounter, String> {
+    match JsPnCounter::load(id) {
+        Ok(Some(counter)) => {
+            debug!(
+                target: "runtime::pncounter",
+                counter_id = %id.to_string(),
+                "loaded JsPnCounter from storage"
+            );
+            Ok(counter)
+        }
+        Ok(None) => {
+            let missing_id = id.to_string();
+            warn!(
+                target: "runtime::pncounter",
+                counter_id = %missing_id,
+                "JsPnCounter not found in storage"
+            );
+            let mut counter = JsPnCounter::new_with_id(id);
+            match save_js_pncounter_instance(&mut counter) {
+                Ok(()) => Ok(counter),
+                Err(err) => Err(err),
+            }
+        }
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+fn save_js_pncounter_instance(counter: &mut JsPnCounter) -> Result<(), String> {
+    match counter.save() {
+        Ok(_) => Ok(()),
+        Err(StorageError::CannotCreateOrphan(_)) => {
+            ensure_root_index_internal().map_err(|err| err.to_string())?;
+            match Interface::<MainStorage>::add_child_to(Id::root(), counter) {
+                Ok(_) => Ok(()),
+                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
+                Err(err) => Err(err.to_string()),
+            }
+        }
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+fn load_js_rga_instance(id: Id) -> Result<JsRga, String> {
+    match JsRga::load(id) {
+        Ok(Some(rga)) => {
+            debug!(
+                target: "runtime::rga",
+                rga_id = %id.to_string(),
+                "loaded JsRga from storage"
+            );
+            Ok(rga)
+        }
+        Ok(None) => {
+            let missing_id = id.to_string();
+            warn!(
+                target: "runtime::rga",
+                rga_id = %missing_id,
+                "JsRga not found in storage"
+            );
+            let mut rga = JsRga::new_with_id(id);
+            match save_js_rga_instance(&mut rga) {
+                Ok(()) => Ok(rga),
+                Err(err) => Err(err),
+            }
+        }
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+fn save_js_rga_instance(rga: &mut JsRga) -> Result<(), String> {
+    match rga.save() {
+        Ok(_) => Ok(()),
+        Err(StorageError::CannotCreateOrphan(_)) => {
+            ensure_root_index_internal().map_err(|err| err.to_string())?;
+            match Interface::<MainStorage>::add_child_to(Id::root(), rga) {
+                Ok(_) => Ok(()),
+                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
+                Err(err) => Err(err.to_string()),
+            }
+        }
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+fn load_js_sortedmap_instance(id: Id) -> Result<JsSortedMap, String> {
+    match JsSortedMap::load(id) {
+        Ok(Some(map)) => {
+            debug!(
+                target: "runtime::sortedmap",
+                map_id = %id.to_string(),
+                "loaded JsSortedMap from storage"
+            );
+            Ok(map)
+        }
+        Ok(None) => {
+            let missing_id = id.to_string();
+            warn!(
+                target: "runtime::sortedmap",
+                map_id = %missing_id,
+                "JsSortedMap not found in storage"
+            );
+            let mut map = JsSortedMap::new_with_id(id);
+            match save_js_sortedmap_instance(&mut map) {
+                Ok(()) => Ok(map),
+                Err(err) => Err(err),
+            }
+        }
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+fn save_js_sortedmap_instance(map: &mut JsSortedMap) -> Result<(), String> {
+    match map.save() {
+        Ok(_) => Ok(()),
+        Err(StorageError::CannotCreateOrphan(_)) => {
+            ensure_root_index_internal().map_err(|err| err.to_string())?;
+            match Interface::<MainStorage>::add_child_to(Id::root(), map) {
+                Ok(_) => Ok(()),
+                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
+                Err(err) => Err(err.to_string()),
+            }
+        }
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+fn load_js_sortedset_instance(id: Id) -> Result<JsSortedSet, String> {
+    match JsSortedSet::load(id) {
+        Ok(Some(set)) => {
+            debug!(
+                target: "runtime::sortedset",
+                set_id = %id.to_string(),
+                "loaded JsSortedSet from storage"
+            );
+            Ok(set)
+        }
+        Ok(None) => {
+            let missing_id = id.to_string();
+            warn!(
+                target: "runtime::sortedset",
+                set_id = %missing_id,
+                "JsSortedSet not found in storage"
+            );
+            let mut set = JsSortedSet::new_with_id(id);
+            match save_js_sortedset_instance(&mut set) {
+                Ok(()) => Ok(set),
+                Err(err) => Err(err),
+            }
+        }
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+fn save_js_sortedset_instance(set: &mut JsSortedSet) -> Result<(), String> {
+    match set.save() {
+        Ok(_) => Ok(()),
+        Err(StorageError::CannotCreateOrphan(_)) => {
+            ensure_root_index_internal().map_err(|err| err.to_string())?;
+            match Interface::<MainStorage>::add_child_to(Id::root(), set) {
+                Ok(_) => Ok(()),
+                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
+                Err(err) => Err(err.to_string()),
+            }
+        }
+        Err(err) => Err(err.to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::logic::{
@@ -2195,5 +3325,286 @@ mod tests {
             .js_crdt_set_contains(ID_DESC_PTR, VALUE_DESC_PTR)
             .unwrap();
         assert_eq!(res, 1, "value must be visible via the shared id");
+    }
+
+    /// Writes `bytes` at `data_ptr` and a `{ptr,len}` descriptor at `desc_ptr`.
+    fn put_buffer(
+        host: &crate::logic::VMHostFunctions<'_>,
+        desc_ptr: u64,
+        data_ptr: u64,
+        bytes: &[u8],
+    ) {
+        host.borrow_memory()
+            .write(data_ptr, bytes)
+            .expect("write bytes");
+        prepare_guest_buf_descriptor(host, desc_ptr, data_ptr, bytes.len() as u64);
+    }
+
+    /// Reads one `[len, bytes]` length-prefixed field starting at `*offset`,
+    /// advancing `*offset` past it.
+    fn read_field(buffer: &[u8], offset: &mut usize) -> Vec<u8> {
+        let len = u32::from_le_bytes(buffer[*offset..*offset + 4].try_into().unwrap()) as usize;
+        *offset += 4;
+        let field = buffer[*offset..*offset + len].to_vec();
+        *offset += len;
+        field
+    }
+
+    /// Decodes the `[count][len,value]...` payload the set `*_iter` host fns emit.
+    fn decode_set_items(buffer: &[u8]) -> Vec<Vec<u8>> {
+        let count = u32::from_le_bytes(buffer[0..4].try_into().unwrap());
+        let mut offset = 4usize;
+        (0..count)
+            .map(|_| read_field(buffer, &mut offset))
+            .collect()
+    }
+
+    /// Decodes the `[count][klen,key,vlen,value]...` payload the map `*_iter` host
+    /// fns emit (`count` is the number of entries, two fields each).
+    fn decode_map_items(buffer: &[u8]) -> Vec<(Vec<u8>, Vec<u8>)> {
+        let count = u32::from_le_bytes(buffer[0..4].try_into().unwrap());
+        let mut offset = 4usize;
+        (0..count)
+            .map(|_| {
+                let key = read_field(buffer, &mut offset);
+                let value = read_field(buffer, &mut offset);
+                (key, value)
+            })
+            .collect()
+    }
+
+    /// PN-counter must support increment AND decrement, and report a signed net.
+    #[test]
+    fn test_js_crdt_pncounter_increment_decrement_value() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        let id: [u8; 32] = [11u8; 32];
+        put_buffer(&host, ID_DESC_PTR, ID_DATA_PTR, &id);
+
+        assert_eq!(
+            host.js_crdt_pncounter_new_with_id(ID_DESC_PTR, 1).unwrap(),
+            0
+        );
+
+        // +3, then -1 → net +2 for this (single) executor.
+        for _ in 0..3 {
+            assert_eq!(host.js_crdt_pncounter_increment(ID_DESC_PTR).unwrap(), 1);
+        }
+        assert_eq!(host.js_crdt_pncounter_decrement(ID_DESC_PTR).unwrap(), 1);
+
+        let reg = 5u64;
+        assert_eq!(host.js_crdt_pncounter_value(ID_DESC_PTR, reg).unwrap(), 1);
+        let bytes = host.borrow_logic().registers.get(reg).unwrap();
+        let value = i64::from_le_bytes(bytes.try_into().unwrap());
+        assert_eq!(value, 2, "signed PN-counter value must be 3 - 1 = 2");
+
+        // The per-executor net should match the total for a single writer.
+        let reg2 = 6u64;
+        assert_eq!(
+            host.js_crdt_pncounter_get_executor_count(ID_DESC_PTR, 0, 0, reg2)
+                .unwrap(),
+            1
+        );
+        let bytes = host.borrow_logic().registers.get(reg2).unwrap();
+        assert_eq!(i64::from_le_bytes(bytes.try_into().unwrap()), 2);
+    }
+
+    /// A second handle built at the same deterministic id must observe a mutation
+    /// made through the first handle (the `*_new_with_id` determinism contract).
+    #[test]
+    fn test_js_crdt_pncounter_new_with_id_is_deterministic_and_shared() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        let id: [u8; 32] = [13u8; 32];
+        put_buffer(&host, ID_DESC_PTR, ID_DATA_PTR, &id);
+
+        assert_eq!(
+            host.js_crdt_pncounter_new_with_id(ID_DESC_PTR, 1).unwrap(),
+            0
+        );
+        assert_eq!(host.borrow_logic().registers.get(1).unwrap(), &id);
+
+        // Second handle at the SAME id.
+        assert_eq!(
+            host.js_crdt_pncounter_new_with_id(ID_DESC_PTR, 2).unwrap(),
+            0
+        );
+        assert_eq!(host.borrow_logic().registers.get(2).unwrap(), &id);
+
+        // Increment through the id, then read the value back via the shared id.
+        assert_eq!(host.js_crdt_pncounter_increment(ID_DESC_PTR).unwrap(), 1);
+
+        let reg = 5u64;
+        assert_eq!(host.js_crdt_pncounter_value(ID_DESC_PTR, reg).unwrap(), 1);
+        let bytes = host.borrow_logic().registers.get(reg).unwrap();
+        assert_eq!(
+            i64::from_le_bytes(bytes.try_into().unwrap()),
+            1,
+            "value must be visible via the shared id"
+        );
+    }
+
+    /// RGA insert then read-back the whole text as UTF-8 bytes; length reflects
+    /// the visible character count.
+    #[test]
+    fn test_js_crdt_rga_insert_get_text() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        let id: [u8; 32] = [21u8; 32];
+        put_buffer(&host, ID_DESC_PTR, ID_DATA_PTR, &id);
+        assert_eq!(host.js_crdt_rga_new_with_id(ID_DESC_PTR, 1).unwrap(), 0);
+
+        // Insert "Hello" at position 0.
+        put_buffer(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"Hello");
+        assert_eq!(
+            host.js_crdt_rga_insert(ID_DESC_PTR, 0, VALUE_DESC_PTR)
+                .unwrap(),
+            1
+        );
+
+        // Append "!" at position 5 → "Hello!".
+        put_buffer(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"!");
+        assert_eq!(
+            host.js_crdt_rga_insert(ID_DESC_PTR, 5, VALUE_DESC_PTR)
+                .unwrap(),
+            1
+        );
+
+        let reg = 5u64;
+        assert_eq!(host.js_crdt_rga_get_text(ID_DESC_PTR, reg).unwrap(), 1);
+        assert_eq!(
+            host.borrow_logic().registers.get(reg).unwrap(),
+            b"Hello!",
+            "RGA text round-trip must match inserts"
+        );
+
+        let reg2 = 6u64;
+        assert_eq!(host.js_crdt_rga_len(ID_DESC_PTR, reg2).unwrap(), 1);
+        let bytes = host.borrow_logic().registers.get(reg2).unwrap();
+        assert_eq!(u64::from_le_bytes(bytes.try_into().unwrap()), 6);
+
+        // Delete the first char → "ello!".
+        assert_eq!(host.js_crdt_rga_delete(ID_DESC_PTR, 0).unwrap(), 1);
+        let reg3 = 7u64;
+        assert_eq!(host.js_crdt_rga_get_text(ID_DESC_PTR, reg3).unwrap(), 1);
+        assert_eq!(host.borrow_logic().registers.get(reg3).unwrap(), b"ello!");
+    }
+
+    /// SortedMap insert/get, and iteration must be in ascending key order
+    /// regardless of insertion order.
+    #[test]
+    fn test_js_crdt_sortedmap_insert_get_and_ordered_iter() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        let id: [u8; 32] = [31u8; 32];
+        put_buffer(&host, ID_DESC_PTR, ID_DATA_PTR, &id);
+        assert_eq!(
+            host.js_crdt_sortedmap_new_with_id(ID_DESC_PTR, 1).unwrap(),
+            0
+        );
+
+        // Insert keys out of order: banana, apple, cherry.
+        for (key, value) in [
+            (b"banana".as_slice(), b"2".as_slice()),
+            (b"apple".as_slice(), b"1".as_slice()),
+            (b"cherry".as_slice(), b"3".as_slice()),
+        ] {
+            put_buffer(&host, KEY_DESC_PTR, KEY_DATA_PTR, key);
+            put_buffer(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, value);
+            assert_eq!(
+                host.js_crdt_sortedmap_insert(ID_DESC_PTR, KEY_DESC_PTR, VALUE_DESC_PTR, 9)
+                    .unwrap(),
+                0,
+                "inserting a new key returns 0"
+            );
+        }
+
+        // Point lookup.
+        put_buffer(&host, KEY_DESC_PTR, KEY_DATA_PTR, b"apple");
+        let reg = 5u64;
+        assert_eq!(
+            host.js_crdt_sortedmap_get(ID_DESC_PTR, KEY_DESC_PTR, reg)
+                .unwrap(),
+            1
+        );
+        assert_eq!(host.borrow_logic().registers.get(reg).unwrap(), b"1");
+
+        // Ordered iteration: keys come back apple < banana < cherry.
+        let reg2 = 6u64;
+        assert_eq!(host.js_crdt_sortedmap_iter(ID_DESC_PTR, reg2).unwrap(), 1);
+        let buffer = host.borrow_logic().registers.get(reg2).unwrap().to_vec();
+        let entries = decode_map_items(&buffer);
+        assert_eq!(
+            entries,
+            vec![
+                (b"apple".to_vec(), b"1".to_vec()),
+                (b"banana".to_vec(), b"2".to_vec()),
+                (b"cherry".to_vec(), b"3".to_vec()),
+            ],
+            "SortedMap iteration must be in ascending key order"
+        );
+    }
+
+    /// SortedSet insert then membership check via the shared id.
+    #[test]
+    fn test_js_crdt_sortedset_insert_contains() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        let id: [u8; 32] = [41u8; 32];
+        put_buffer(&host, ID_DESC_PTR, ID_DATA_PTR, &id);
+        assert_eq!(
+            host.js_crdt_sortedset_new_with_id(ID_DESC_PTR, 1).unwrap(),
+            0
+        );
+
+        // Insert out of order: gamma, alpha, beta.
+        for value in [b"gamma".as_slice(), b"alpha".as_slice(), b"beta".as_slice()] {
+            put_buffer(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, value);
+            assert_eq!(
+                host.js_crdt_sortedset_insert(ID_DESC_PTR, VALUE_DESC_PTR)
+                    .unwrap(),
+                1,
+                "first insert of a value returns 1"
+            );
+        }
+
+        // Membership.
+        put_buffer(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"alpha");
+        assert_eq!(
+            host.js_crdt_sortedset_contains(ID_DESC_PTR, VALUE_DESC_PTR)
+                .unwrap(),
+            1
+        );
+        put_buffer(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"missing");
+        assert_eq!(
+            host.js_crdt_sortedset_contains(ID_DESC_PTR, VALUE_DESC_PTR)
+                .unwrap(),
+            0
+        );
+
+        // Ordered iteration: alpha < beta < gamma.
+        let reg = 6u64;
+        assert_eq!(host.js_crdt_sortedset_iter(ID_DESC_PTR, reg).unwrap(), 1);
+        let buffer = host.borrow_logic().registers.get(reg).unwrap().to_vec();
+        assert_eq!(
+            decode_set_items(&buffer),
+            vec![b"alpha".to_vec(), b"beta".to_vec(), b"gamma".to_vec()],
+            "SortedSet iteration must be in ascending order"
+        );
     }
 }

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -102,6 +102,47 @@ impl VMLogic<'_> {
                 register_id: u64,
             ) -> i32;
 
+            fn js_crdt_pncounter_new(register_id: u64) -> i32;
+            fn js_crdt_pncounter_new_with_id(id_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_pncounter_increment(counter_id_ptr: u64) -> i32;
+            fn js_crdt_pncounter_decrement(counter_id_ptr: u64) -> i32;
+            fn js_crdt_pncounter_value(counter_id_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_pncounter_get_executor_count(
+                counter_id_ptr: u64,
+                executor_ptr: u64,
+                has_executor: u32,
+                register_id: u64,
+            ) -> i32;
+
+            fn js_crdt_rga_new(register_id: u64) -> i32;
+            fn js_crdt_rga_new_with_id(id_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_rga_insert(rga_id_ptr: u64, index: u64, value_ptr: u64) -> i32;
+            fn js_crdt_rga_delete(rga_id_ptr: u64, index: u64) -> i32;
+            fn js_crdt_rga_get_text(rga_id_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_rga_len(rga_id_ptr: u64, register_id: u64) -> i32;
+
+            fn js_crdt_sortedmap_new(register_id: u64) -> i32;
+            fn js_crdt_sortedmap_new_with_id(id_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_sortedmap_get(map_id_ptr: u64, key_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_sortedmap_insert(
+                map_id_ptr: u64,
+                key_ptr: u64,
+                value_ptr: u64,
+                register_id: u64,
+            ) -> i32;
+            fn js_crdt_sortedmap_remove(map_id_ptr: u64, key_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_sortedmap_contains(map_id_ptr: u64, key_ptr: u64) -> i32;
+            fn js_crdt_sortedmap_iter(map_id_ptr: u64, register_id: u64) -> i32;
+
+            fn js_crdt_sortedset_new(register_id: u64) -> i32;
+            fn js_crdt_sortedset_new_with_id(id_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_sortedset_insert(set_id_ptr: u64, value_ptr: u64) -> i32;
+            fn js_crdt_sortedset_contains(set_id_ptr: u64, value_ptr: u64) -> i32;
+            fn js_crdt_sortedset_remove(set_id_ptr: u64, value_ptr: u64) -> i32;
+            fn js_crdt_sortedset_len(set_id_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_sortedset_iter(set_id_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_sortedset_clear(set_id_ptr: u64) -> i32;
+
             fn js_user_storage_new(register_id: u64) -> i32;
             fn js_user_storage_new_with_id(id_ptr: u64, register_id: u64) -> i32;
             fn js_user_storage_insert(

--- a/crates/storage/src/js.rs
+++ b/crates/storage/src/js.rs
@@ -1015,13 +1015,29 @@ impl JsRga {
         self.storage.id()
     }
 
-    /// Inserts the UTF-8 `value` at character position `index`.
+    /// Inserts the UTF-8 `value` at codepoint position `index`.
     ///
     /// # Errors
     ///
     /// Returns [`StoreError`] if `value` is not valid UTF-8, if `index` is out of
     /// bounds, or if the underlying storage operation fails.
+    ///
+    /// Also returns [`StorageError::InvalidData`] if called during a state
+    /// migration / merge (`env::in_merge_mode()`): the underlying
+    /// [`ReplicatedGrowableArray::insert_str`] stamps a node-local HLC
+    /// timestamp that would diverge across replicas, so it must not run in
+    /// merge mode. Surfacing this as a typed error (rather than the `panic!`
+    /// the inner method raises) gives the JS host boundary a clean failure
+    /// instead of a caught `HostError::Panic`.
     pub fn insert(&mut self, index: usize, value: &[u8]) -> Result<(), StoreError> {
+        if crate::env::in_merge_mode() {
+            return Err(StorageError::InvalidData(
+                "RGA insert is not allowed during a state migration/merge: it stamps a \
+                 node-local HLC timestamp that would diverge across replicas"
+                    .to_owned(),
+            )
+            .into());
+        }
         let text = core::str::from_utf8(value).map_err(|_| {
             StorageError::InvalidData("RGA insert value must be valid UTF-8".to_owned())
         })?;

--- a/crates/storage/src/js.rs
+++ b/crates/storage/src/js.rs
@@ -9,6 +9,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use crate as calimero_storage;
 use crate::collections::{
     error::StoreError, Counter as StorageCounter, FrozenStorage, LwwRegister as StorageLwwRegister,
+    ReplicatedGrowableArray, SortedMap as StorageSortedMap, SortedSet as StorageSortedSet,
     UnorderedMap, UnorderedSet, UserStorage, Vector,
 };
 use crate::entities::{Element, Metadata};
@@ -865,6 +866,475 @@ impl JsFrozenStorage {
 }
 
 impl Default for JsFrozenStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Positive-negative counter wrapper exposed to JavaScript.
+///
+/// Unlike [`JsCounter`] (a grow-only G-Counter), this wraps a PN-Counter and so
+/// supports [`decrement`](Self::decrement); its [`value`](Self::value) is signed
+/// (`i64`) because the count can go negative.
+#[derive(Debug, AtomicUnit, BorshSerialize, BorshDeserialize)]
+pub struct JsPnCounter {
+    counter: StorageCounter<true>,
+
+    #[storage]
+    storage: Element,
+}
+
+impl JsPnCounter {
+    /// Creates a new positive-negative counter wrapper.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            counter: StorageCounter::new(),
+            storage: Element::new(None),
+        }
+    }
+
+    /// Rehydrates a counter using a known identifier.
+    #[must_use]
+    pub fn new_with_id(id: Id) -> Self {
+        Self {
+            counter: StorageCounter::new(),
+            storage: Element::new(Some(id)),
+        }
+    }
+
+    /// Returns the unique identifier of this counter collection.
+    #[must_use]
+    pub fn id(&self) -> Id {
+        self.storage.id()
+    }
+
+    /// Increments the counter for the current executor.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] if the increment operation fails.
+    pub fn increment(&mut self) -> Result<(), StoreError> {
+        self.counter.increment()
+    }
+
+    /// Decrements the counter for the current executor.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] if the decrement operation fails.
+    pub fn decrement(&mut self) -> Result<(), StoreError> {
+        self.counter.decrement()
+    }
+
+    /// Returns the total signed counter value (`positive - negative`).
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] from the underlying counter.
+    pub fn value(&self) -> Result<i64, StoreError> {
+        self.counter.value_signed()
+    }
+
+    /// Returns the net contribution for a specific executor
+    /// (`positive - negative`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] if the read operation fails, or if either
+    /// per-executor count exceeds `i64::MAX`.
+    pub fn get_executor_count(&self, executor_id: &[u8; 32]) -> Result<i64, StoreError> {
+        let positive = i64::try_from(self.counter.get_positive_count(executor_id)?)
+            .map_err(|_| StorageError::InvalidData("positive count exceeds i64::MAX".to_owned()))?;
+        let negative = i64::try_from(self.counter.get_negative_count(executor_id)?)
+            .map_err(|_| StorageError::InvalidData("negative count exceeds i64::MAX".to_owned()))?;
+        Ok(positive.saturating_sub(negative))
+    }
+
+    /// Persists the counter to storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] when persistence fails.
+    pub fn save(&mut self) -> Result<bool, StorageError> {
+        Interface::<MainStorage>::save(self)
+    }
+
+    /// Loads a counter instance by identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] if the counter cannot be retrieved.
+    pub fn load(id: Id) -> Result<Option<Self>, StorageError> {
+        Interface::<MainStorage>::find_by_id::<Self>(id)
+    }
+}
+
+impl Default for JsPnCounter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Replicated Growable Array (collaborative text sequence) wrapper exposed to
+/// JavaScript.
+///
+/// Text is exchanged as UTF-8 bytes: [`insert`](Self::insert) takes the bytes of
+/// a UTF-8 string to splice in at a character index, and
+/// [`get_text`](Self::get_text) returns the current document as UTF-8 bytes.
+#[derive(Debug, AtomicUnit, BorshSerialize, BorshDeserialize)]
+pub struct JsRga {
+    rga: ReplicatedGrowableArray,
+
+    #[storage]
+    storage: Element,
+}
+
+impl JsRga {
+    /// Creates a new RGA wrapper.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            rga: ReplicatedGrowableArray::new(),
+            storage: Element::new(None),
+        }
+    }
+
+    /// Rehydrates an RGA using a known identifier.
+    #[must_use]
+    pub fn new_with_id(id: Id) -> Self {
+        Self {
+            rga: ReplicatedGrowableArray::new(),
+            storage: Element::new(Some(id)),
+        }
+    }
+
+    /// Returns the unique identifier of this collection.
+    #[must_use]
+    pub fn id(&self) -> Id {
+        self.storage.id()
+    }
+
+    /// Inserts the UTF-8 `value` at character position `index`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] if `value` is not valid UTF-8, if `index` is out of
+    /// bounds, or if the underlying storage operation fails.
+    pub fn insert(&mut self, index: usize, value: &[u8]) -> Result<(), StoreError> {
+        let text = core::str::from_utf8(value).map_err(|_| {
+            StorageError::InvalidData("RGA insert value must be valid UTF-8".to_owned())
+        })?;
+        self.rga.insert_str(index, text)
+    }
+
+    /// Deletes the character at position `index`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] if `index` is out of bounds or the storage
+    /// operation fails.
+    pub fn delete(&mut self, index: usize) -> Result<(), StoreError> {
+        self.rga.delete(index)
+    }
+
+    /// Returns the current visible text as UTF-8 bytes.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] if reading from storage fails.
+    pub fn get_text(&self) -> Result<Vec<u8>, StoreError> {
+        Ok(self.rga.get_text()?.into_bytes())
+    }
+
+    /// Returns the number of visible characters.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] if reading from storage fails.
+    pub fn len(&self) -> Result<usize, StoreError> {
+        self.rga.len()
+    }
+
+    /// Returns `true` if the document is empty.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] through [`len`](Self::len).
+    pub fn is_empty(&self) -> Result<bool, StoreError> {
+        Ok(self.len()? == 0)
+    }
+
+    /// Persists the RGA to storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] when persistence fails.
+    pub fn save(&mut self) -> Result<bool, StorageError> {
+        Interface::<MainStorage>::save(self)
+    }
+
+    /// Loads an RGA instance by identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] if the RGA cannot be retrieved.
+    pub fn load(id: Id) -> Result<Option<Self>, StorageError> {
+        Interface::<MainStorage>::find_by_id::<Self>(id)
+    }
+}
+
+impl Default for JsRga {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A byte-oriented ordered map that integrates with Calimero storage.
+///
+/// Same byte API and CRDT semantics as [`JsUnorderedMap`], but
+/// [`entries`](Self::entries) yields pairs in ascending key (byte) order.
+#[derive(Debug, AtomicUnit, BorshSerialize, BorshDeserialize)]
+pub struct JsSortedMap {
+    map: StorageSortedMap<Vec<u8>, Vec<u8>>,
+
+    #[storage]
+    storage: Element,
+}
+
+impl JsSortedMap {
+    /// Creates a new JS sorted map backed by the main storage backend.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            map: StorageSortedMap::new(),
+            storage: Element::new(None),
+        }
+    }
+
+    /// Rehydrates a sorted map using a known identifier.
+    #[must_use]
+    pub fn new_with_id(id: Id) -> Self {
+        Self {
+            map: StorageSortedMap::new(),
+            storage: Element::new(Some(id)),
+        }
+    }
+
+    /// Returns the unique identifier of this collection.
+    #[must_use]
+    pub fn id(&self) -> Id {
+        self.storage.id()
+    }
+
+    /// Inserts a key/value pair into the map.
+    ///
+    /// # Errors
+    ///
+    /// Returns any [`StoreError`] surfaced by the underlying map insertion.
+    pub fn insert(&mut self, key: &[u8], value: &[u8]) -> Result<Option<Vec<u8>>, StoreError> {
+        self.map.insert(key.to_vec(), value.to_vec())
+    }
+
+    /// Retrieves the value for `key`, if present.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] when the underlying map read fails.
+    pub fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StoreError> {
+        Ok(self.map.get(key)?.map(|value| (*value).clone()))
+    }
+
+    /// Removes the value for `key`, returning the previous value if it existed.
+    ///
+    /// # Errors
+    ///
+    /// Returns any [`StoreError`] emitted by the storage layer.
+    pub fn remove(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>, StoreError> {
+        self.map.remove(key)
+    }
+
+    /// Checks whether `key` exists within the map.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] if the existence check fails.
+    pub fn contains(&self, key: &[u8]) -> Result<bool, StoreError> {
+        self.map.contains(key)
+    }
+
+    /// Returns all key/value pairs in ascending key (byte) order.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] if reading from storage fails.
+    pub fn entries(&self) -> Result<JsByteEntries, StoreError> {
+        Ok(self.map.entries()?.collect())
+    }
+
+    /// Returns the number of entries in the map.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] if the length query cannot be satisfied.
+    pub fn len(&self) -> Result<usize, StoreError> {
+        self.map.len()
+    }
+
+    /// Returns `true` if the map is empty.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] through the underlying [`len`](Self::len) call.
+    pub fn is_empty(&self) -> Result<bool, StoreError> {
+        Ok(self.len()? == 0)
+    }
+
+    /// Persists the map using the provided interface.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] produced by the storage interface.
+    pub fn save(&mut self) -> Result<bool, StorageError> {
+        Interface::<MainStorage>::save(self)
+    }
+
+    /// Loads a map by identifier using the provided interface.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] if the map cannot be fetched from storage.
+    pub fn load(id: Id) -> Result<Option<Self>, StorageError> {
+        Interface::<MainStorage>::find_by_id::<Self>(id)
+    }
+}
+
+impl Default for JsSortedMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A byte-oriented ordered set that integrates with Calimero storage.
+///
+/// Same byte API and CRDT semantics as [`JsUnorderedSet`], but
+/// [`values`](Self::values) yields elements in ascending (byte) order.
+#[derive(Debug, AtomicUnit, BorshSerialize, BorshDeserialize)]
+pub struct JsSortedSet {
+    set: StorageSortedSet<Vec<u8>>,
+
+    #[storage]
+    storage: Element,
+}
+
+impl JsSortedSet {
+    /// Creates a new JS sorted set backed by the main storage backend.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            set: StorageSortedSet::new(),
+            storage: Element::new(None),
+        }
+    }
+
+    /// Rehydrates a sorted set using a known identifier.
+    #[must_use]
+    pub fn new_with_id(id: Id) -> Self {
+        Self {
+            set: StorageSortedSet::new(),
+            storage: Element::new(Some(id)),
+        }
+    }
+
+    /// Returns the unique identifier of this collection.
+    #[must_use]
+    pub fn id(&self) -> Id {
+        self.storage.id()
+    }
+
+    /// Inserts `value` into the set, returning whether it was newly added.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] if insertion fails.
+    pub fn insert(&mut self, value: &[u8]) -> Result<bool, StoreError> {
+        self.set.insert(value.to_vec())
+    }
+
+    /// Checks whether `value` exists in the set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] if the membership check fails.
+    pub fn contains(&self, value: &[u8]) -> Result<bool, StoreError> {
+        self.set.contains(value)
+    }
+
+    /// Removes `value` from the set, returning `true` if it was present.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] emitted by the removal.
+    pub fn remove(&mut self, value: &[u8]) -> Result<bool, StoreError> {
+        self.set.remove(value)
+    }
+
+    /// Clears all values from the set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] when the clear operation fails.
+    pub fn clear(&mut self) -> Result<(), StoreError> {
+        self.set.clear()
+    }
+
+    /// Returns the number of elements stored in the set.
+    ///
+    /// # Errors
+    ///
+    /// Returns any [`StoreError`] produced by the set implementation.
+    pub fn len(&self) -> Result<usize, StoreError> {
+        self.set.len()
+    }
+
+    /// Returns `true` if there are no entries.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system.
+    pub fn is_empty(&self) -> Result<bool, StoreError> {
+        Ok(self.len()? == 0)
+    }
+
+    /// Returns all values in ascending (byte) order.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] if reading the underlying storage fails.
+    pub fn values(&self) -> Result<Vec<Vec<u8>>, StoreError> {
+        Ok(self.set.iter()?.collect())
+    }
+
+    /// Persists the set to storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] raised while saving.
+    pub fn save(&mut self) -> Result<bool, StorageError> {
+        Interface::<MainStorage>::save(self)
+    }
+
+    /// Loads a set instance by identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] if the set cannot be fetched from storage.
+    pub fn load(id: Id) -> Result<Option<Self>, StorageError> {
+        Interface::<MainStorage>::find_by_id::<Self>(id)
+    }
+}
+
+impl Default for JsSortedSet {
     fn default() -> Self {
         Self::new()
     }


### PR DESCRIPTION
## What

Adds the `js_crdt_*` host-function layer that bridges QuickJS-in-WASM to four **existing** storage CRDT types, so the JS Service SDK can wrap them. This is **Phase 1** of the JS CRDT-type expansion — the JS-side wrappers land in a follow-up `sdk-js` PR.

The Rust storage types already existed (`PNCounter`/`Counter<true>`, `ReplicatedGrowableArray`, `SortedMap`, `SortedSet`); this PR only adds the host bridge, exactly mirroring the existing `map`/`set`/`vector`/`counter`/`lww`/`user_storage`/`frozen_storage` host fns.

## Host functions added

**PNCounter** (signed, supports decrement — unlike the existing G-Counter path):
`js_crdt_pncounter_new`, `_new_with_id`, `_increment`, `_decrement`, `_value` (signed `i64`), `_get_executor_count` (signed net `positive - negative`).

**RGA (ReplicatedGrowableArray)** — collaborative text, UTF-8 byte round-trip:
`js_crdt_rga_new`, `_new_with_id`, `_insert(index, value)`, `_delete(index)`, `_get_text`, `_len`.

**SortedMap** — same byte API/CRDT semantics as the unordered map, ordered iteration:
`js_crdt_sortedmap_new`, `_new_with_id`, `_get`, `_insert`, `_remove`, `_contains`, `_iter`.

**SortedSet** — same byte API/CRDT semantics as the unordered set, ordered iteration:
`js_crdt_sortedset_new`, `_new_with_id`, `_insert`, `_contains`, `_remove`, `_len`, `_iter`, `_clear`.

New byte-oriented wrapper structs in `calimero-storage` (`crates/storage/src/js.rs`) — `JsPnCounter`, `JsRga`, `JsSortedMap`, `JsSortedSet` — mirror the existing `Js*` wrappers (`AtomicUnit`, save-as-child-of-root fallback, `new_with_id` determinism).

## Design notes

- Op sets were derived from each storage type's actual `pub fn`s. RGA exposes no distinct `serialize`/`deserialize` methods — its byte round-trip is `insert` (in) + `get_text` (out); the collection is persisted by id like the other wrappers, so no separate blob serialize/deserialize host fn was added.
- PNCounter `value` is signed `i64` (little-endian); `get_executor_count` returns that executor's net contribution.
- SortedMap/SortedSet `iter` return entries in ascending key/value (byte) order.

## Tests

Added `#[cfg(test)]` unit tests in `js_collections.rs` (using the existing `setup_vm!` / `SimpleMockStorage` / `prepare_guest_buf_descriptor` harness): PNCounter increment+decrement→value, RGA insert→get_text round-trip (+ delete), SortedMap insert→get + ordered iter, SortedSet insert→contains + ordered iter, plus a PNCounter `new_with_id` determinism/shared-entity check.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy -p calimero-runtime -- -D warnings` ✅ (and `-p calimero-storage`)
- `cargo test -p calimero-runtime` ✅ (137 lib + 21 conformance + 2 tracing)
- `cargo check -p calimero-node` ✅

Refs calimero-network/calimero-sdk-js#83

🤖 Generated with [Claude Code](https://claude.com/claude-code)
