### PR TITLE
feat(runtime): JS host functions for AuthoredMap and AuthoredVector

### DIFF
--- a/crates/runtime/HOST_FUNCTIONS.md
+++ b/crates/runtime/HOST_FUNCTIONS.md
@@ -298,6 +298,49 @@ Same byte API and CRDT semantics as the Set operations above, but `iter` yields 
 | `js_crdt_sortedset_iter` | `(set_id_ptr: u64, register_id: u64) -> i32` | Iterates all values in ascending order. |
 | `js_crdt_sortedset_clear` | `(set_id_ptr: u64) -> i32` | Clears all values from the set. |
 
+#### Authored Map Operations
+
+An attributed shared-keyspace map with per-entry ownership. Any context member may `insert` a
+new key, which **stamps the caller (executor) as the entry's owner**; only that owner may later
+`update` or `remove` the entry. Reads are unrestricted. Ownership is derived from the executor
+identity the runtime installs per-execution — no identity argument is passed. A non-owner
+`update`/`remove` returns `-1` with an ownership error message written to the register.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `js_crdt_authored_map_new` | `(register_id: u64) -> i32` | Creates a new attributed map. |
+| `js_crdt_authored_map_new_with_id` | `(id_ptr: u64, register_id: u64) -> i32` | Creates an attributed map at a caller-supplied deterministic 32-byte ID. |
+| `js_crdt_authored_map_insert` | `(map_id_ptr: u64, key_ptr: u64, value_ptr: u64, register_id: u64) -> i32` | Inserts a new key, stamping the caller as owner. Returns `0` on success; `-1` (error in register) if the key already exists. |
+| `js_crdt_authored_map_update` | `(map_id_ptr: u64, key_ptr: u64, value_ptr: u64, register_id: u64) -> i32` | Owner-only. Replaces the value at a key. Returns `1` on success; `-1` (error in register) for a non-owner or missing key. |
+| `js_crdt_authored_map_remove` | `(map_id_ptr: u64, key_ptr: u64, register_id: u64) -> i32` | Owner-only. Removes a key, returning the previous value (`1`) or `0` if absent; `-1` (error in register) for a non-owner. |
+| `js_crdt_authored_map_get` | `(map_id_ptr: u64, key_ptr: u64, register_id: u64) -> i32` | Retrieves a value by key (`1` found, `0` absent). |
+| `js_crdt_authored_map_contains` | `(map_id_ptr: u64, key_ptr: u64) -> i32` | Checks whether a key exists (`1`/`0`). |
+| `js_crdt_authored_map_owner_of` | `(map_id_ptr: u64, key_ptr: u64, register_id: u64) -> i32` | Writes the entry owner's 32-byte public key to the register (`1`); `0` with a cleared register if the key is absent. |
+| `js_crdt_authored_map_owned_by_me` | `(map_id_ptr: u64, key_ptr: u64) -> i32` | Whether the current executor owns the key (`1`/`0`; `0` for absent keys). |
+| `js_crdt_authored_map_iter` | `(map_id_ptr: u64, register_id: u64) -> i32` | Iterates all entries (`[count][klen,key,vlen,value]...`). |
+| `js_crdt_authored_map_len` | `(map_id_ptr: u64, register_id: u64) -> i32` | Gets the entry count (`u64`, little-endian). |
+
+#### Authored Vector Operations
+
+An attributed ordered shared-keyspace vector with per-slot ownership. Any context member may
+`push` a new entry at the tail, which **stamps the caller (executor) as the slot's owner**; only
+that owner may later `update` or `tombstone` the slot. There is intentionally no physical remove —
+`tombstone` overwrites the slot with an empty value while preserving its position and owner. A
+non-owner `update`/`tombstone` returns `-1` with an ownership error message written to the register.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `js_crdt_authored_vector_new` | `(register_id: u64) -> i32` | Creates a new attributed vector. |
+| `js_crdt_authored_vector_new_with_id` | `(id_ptr: u64, register_id: u64) -> i32` | Creates an attributed vector at a caller-supplied deterministic 32-byte ID. |
+| `js_crdt_authored_vector_push` | `(vector_id_ptr: u64, value_ptr: u64, register_id: u64) -> i32` | Pushes a value at the tail, stamping the caller as owner. Writes the new index (`u64`, little-endian) to the register; returns `1`. |
+| `js_crdt_authored_vector_update` | `(vector_id_ptr: u64, index: u64, value_ptr: u64, register_id: u64) -> i32` | Owner-only. Replaces the value at a slot. Returns `1` on success; `-1` (error in register) for a non-owner or out-of-bounds index. |
+| `js_crdt_authored_vector_tombstone` | `(vector_id_ptr: u64, index: u64, register_id: u64) -> i32` | Owner-only. Retracts a slot (overwrites with an empty value). Returns `1` on success; `-1` (error in register) for a non-owner or out-of-bounds index. |
+| `js_crdt_authored_vector_get` | `(vector_id_ptr: u64, index: u64, register_id: u64) -> i32` | Retrieves a value by index (`1` found, `0` absent). |
+| `js_crdt_authored_vector_owner_of` | `(vector_id_ptr: u64, index: u64, register_id: u64) -> i32` | Writes the slot owner's 32-byte public key to the register (`1`); `0` with a cleared register if the slot is out of bounds. |
+| `js_crdt_authored_vector_owned_by_me` | `(vector_id_ptr: u64, index: u64) -> i32` | Whether the current executor owns the slot (`1`/`0`; `0` for out-of-bounds slots). |
+| `js_crdt_authored_vector_iter` | `(vector_id_ptr: u64, register_id: u64) -> i32` | Iterates all values in insertion order (`[count][len,value]...`). |
+| `js_crdt_authored_vector_len` | `(vector_id_ptr: u64, register_id: u64) -> i32` | Gets the entry count including tombstoned slots (`u64`, little-endian). |
+
 ### User & Frozen Storage (JS)
 
 #### User Storage

--- a/crates/runtime/src/logic/host_functions/js_collections.rs
+++ b/crates/runtime/src/logic/host_functions/js_collections.rs
@@ -10,8 +10,8 @@ use calimero_storage::{
     index::Index,
     interface::{Interface, StorageError},
     js::{
-        JsCounter, JsFrozenStorage, JsLwwRegister, JsPnCounter, JsRga, JsSortedMap, JsSortedSet,
-        JsUnorderedMap, JsUnorderedSet, JsUserStorage, JsVector,
+        JsAuthoredMap, JsAuthoredVector, JsCounter, JsFrozenStorage, JsLwwRegister, JsPnCounter,
+        JsRga, JsSortedMap, JsSortedSet, JsUnorderedMap, JsUnorderedSet, JsUserStorage, JsVector,
     },
     store::MainStorage,
 };
@@ -630,6 +630,235 @@ impl VMHostFunctions<'_> {
 
     pub fn js_crdt_sortedset_clear(&mut self, set_id_ptr: u64) -> VMLogicResult<i32> {
         self.invoke_with_storage_env(|host| host.crdt_sortedset_clear(set_id_ptr))
+    }
+
+    /// Creates a new attributed CRDT map and returns its identifier.
+    pub fn js_crdt_authored_map_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_authored_map_new(dest_register_id))
+    }
+
+    /// Creates a new attributed CRDT map at a caller-supplied deterministic id.
+    pub fn js_crdt_authored_map_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_map_new_with_id(id_ptr, dest_register_id)
+        })
+    }
+
+    /// Inserts a new key/value pair, stamping the caller as the entry owner.
+    pub fn js_crdt_authored_map_insert(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+        value_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_map_insert(map_id_ptr, key_ptr, value_ptr, dest_register_id)
+        })
+    }
+
+    /// Updates the value at a key. Only the entry owner may call this.
+    pub fn js_crdt_authored_map_update(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+        value_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_map_update(map_id_ptr, key_ptr, value_ptr, dest_register_id)
+        })
+    }
+
+    /// Removes a key. Only the entry owner may call this.
+    pub fn js_crdt_authored_map_remove(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_map_remove(map_id_ptr, key_ptr, dest_register_id)
+        })
+    }
+
+    /// Retrieves the value at a key.
+    pub fn js_crdt_authored_map_get(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_map_get(map_id_ptr, key_ptr, dest_register_id)
+        })
+    }
+
+    /// Checks whether a key exists in the attributed map.
+    pub fn js_crdt_authored_map_contains(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_authored_map_contains(map_id_ptr, key_ptr))
+    }
+
+    /// Writes the 32-byte owner public key of a key to the register.
+    pub fn js_crdt_authored_map_owner_of(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_map_owner_of(map_id_ptr, key_ptr, dest_register_id)
+        })
+    }
+
+    /// Returns whether the current executor owns a key.
+    pub fn js_crdt_authored_map_owned_by_me(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_authored_map_owned_by_me(map_id_ptr, key_ptr))
+    }
+
+    /// Iterates all entries in the attributed map.
+    pub fn js_crdt_authored_map_iter(
+        &mut self,
+        map_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_map_iter(map_id_ptr, dest_register_id)
+        })
+    }
+
+    /// Returns the number of entries in the attributed map.
+    pub fn js_crdt_authored_map_len(
+        &mut self,
+        map_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_map_len(map_id_ptr, dest_register_id)
+        })
+    }
+
+    /// Creates a new attributed CRDT vector and returns its identifier.
+    pub fn js_crdt_authored_vector_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_authored_vector_new(dest_register_id))
+    }
+
+    /// Creates a new attributed CRDT vector at a caller-supplied deterministic id.
+    pub fn js_crdt_authored_vector_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_vector_new_with_id(id_ptr, dest_register_id)
+        })
+    }
+
+    /// Pushes a new value at the tail, stamping the caller as the slot owner.
+    /// Writes the new index (u64 LE) to the register.
+    pub fn js_crdt_authored_vector_push(
+        &mut self,
+        vector_id_ptr: u64,
+        value_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_vector_push(vector_id_ptr, value_ptr, dest_register_id)
+        })
+    }
+
+    /// Updates the value at a slot. Only the slot owner may call this.
+    pub fn js_crdt_authored_vector_update(
+        &mut self,
+        vector_id_ptr: u64,
+        index: u64,
+        value_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_vector_update(vector_id_ptr, index, value_ptr, dest_register_id)
+        })
+    }
+
+    /// Tombstones a slot. Only the slot owner may call this.
+    pub fn js_crdt_authored_vector_tombstone(
+        &mut self,
+        vector_id_ptr: u64,
+        index: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_vector_tombstone(vector_id_ptr, index, dest_register_id)
+        })
+    }
+
+    /// Retrieves the value at a slot.
+    pub fn js_crdt_authored_vector_get(
+        &mut self,
+        vector_id_ptr: u64,
+        index: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_vector_get(vector_id_ptr, index, dest_register_id)
+        })
+    }
+
+    /// Writes the 32-byte owner public key of a slot to the register.
+    pub fn js_crdt_authored_vector_owner_of(
+        &mut self,
+        vector_id_ptr: u64,
+        index: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_vector_owner_of(vector_id_ptr, index, dest_register_id)
+        })
+    }
+
+    /// Returns whether the current executor owns a slot.
+    pub fn js_crdt_authored_vector_owned_by_me(
+        &mut self,
+        vector_id_ptr: u64,
+        index: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_vector_owned_by_me(vector_id_ptr, index)
+        })
+    }
+
+    /// Iterates all values in the attributed vector (insertion order).
+    pub fn js_crdt_authored_vector_iter(
+        &mut self,
+        vector_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_vector_iter(vector_id_ptr, dest_register_id)
+        })
+    }
+
+    /// Returns the number of entries in the attributed vector.
+    pub fn js_crdt_authored_vector_len(
+        &mut self,
+        vector_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_vector_len(vector_id_ptr, dest_register_id)
+        })
     }
 
     fn crdt_map_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
@@ -2595,6 +2824,674 @@ impl VMHostFunctions<'_> {
         }
     }
 
+    fn crdt_authored_map_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsAuthoredMap, String> {
+            let mut map = JsAuthoredMap::new();
+            save_js_authored_map_instance(&mut map)?;
+            Ok(map)
+        }));
+
+        match outcome {
+            Ok(Ok(map)) => {
+                self.write_register_bytes(dest_register_id, map.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn crdt_authored_map_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let id = match self.read_map_id(id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsAuthoredMap, String> {
+            let mut map = JsAuthoredMap::new_with_id(id);
+            save_js_authored_map_instance(&mut map)?;
+            Ok(map)
+        }));
+
+        match outcome {
+            Ok(Ok(map)) => {
+                self.write_register_bytes(dest_register_id, map.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn crdt_authored_map_insert(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+        value_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let map_id = match self.read_map_id(map_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let key = self.read_buffer(key_ptr)?;
+        let value = self.read_buffer(value_ptr)?;
+
+        let mut map = match load_js_authored_map_instance(map_id) {
+            Ok(map) => map,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        // `insert` stamps the current executor (installed in the runtime env) as
+        // the entry owner and rejects an already-present key.
+        match map.insert(&key, &value) {
+            Ok(()) => {
+                if let Err(message) = save_js_authored_map_instance(&mut map) {
+                    return self.write_error_message(dest_register_id, message);
+                }
+                self.clear_register(dest_register_id)?;
+                Ok(0)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_authored_map_update(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+        value_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let map_id = match self.read_map_id(map_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let key = self.read_buffer(key_ptr)?;
+        let value = self.read_buffer(value_ptr)?;
+
+        let mut map = match load_js_authored_map_instance(map_id) {
+            Ok(map) => map,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        // Owner-only: the collection returns `ActionNotAllowed` when the current
+        // executor is not the stored owner; surface it verbatim.
+        match map.update(&key, &value) {
+            Ok(()) => match save_js_authored_map_instance(&mut map) {
+                Ok(()) => Ok(1),
+                Err(message) => self.write_error_message(dest_register_id, message),
+            },
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_authored_map_remove(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let map_id = match self.read_map_id(map_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let key = self.read_buffer(key_ptr)?;
+
+        let mut map = match load_js_authored_map_instance(map_id) {
+            Ok(map) => map,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        // Owner-only: a non-owner remove yields `ActionNotAllowed`; an absent key
+        // yields `Ok(None)`.
+        match map.remove(&key) {
+            Ok(Some(previous)) => {
+                if let Err(message) = save_js_authored_map_instance(&mut map) {
+                    return self.write_error_message(dest_register_id, message);
+                }
+                self.write_register_bytes(dest_register_id, &previous)?;
+                Ok(1)
+            }
+            Ok(None) => {
+                self.clear_register(dest_register_id)?;
+                Ok(0)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_authored_map_get(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let map_id = match self.read_map_id(map_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let key = self.read_buffer(key_ptr)?;
+
+        let map = match load_js_authored_map_instance(map_id) {
+            Ok(map) => map,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match map.get(&key) {
+            Ok(Some(value)) => {
+                self.write_register_bytes(dest_register_id, &value)?;
+                Ok(1)
+            }
+            Ok(None) => {
+                self.clear_register(dest_register_id)?;
+                Ok(0)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_authored_map_contains(&mut self, map_id_ptr: u64, key_ptr: u64) -> VMLogicResult<i32> {
+        let map_id = match self.read_map_id(map_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let key = self.read_buffer(key_ptr)?;
+
+        let map = match load_js_authored_map_instance(map_id) {
+            Ok(map) => map,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        match map.contains(&key) {
+            Ok(result) => Ok(i32::from(result)),
+            Err(err) => self.write_error_message(0, err),
+        }
+    }
+
+    fn crdt_authored_map_owner_of(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let map_id = match self.read_map_id(map_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let key = self.read_buffer(key_ptr)?;
+
+        let map = match load_js_authored_map_instance(map_id) {
+            Ok(map) => map,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        // Present key → 32-byte owner public key in the register (status 1);
+        // absent key → cleared register (status 0), matching `get`'s convention.
+        match map.owner_of(&key) {
+            Ok(Some(owner)) => {
+                self.write_register_bytes(dest_register_id, &owner)?;
+                Ok(1)
+            }
+            Ok(None) => {
+                self.clear_register(dest_register_id)?;
+                Ok(0)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_authored_map_owned_by_me(
+        &mut self,
+        map_id_ptr: u64,
+        key_ptr: u64,
+    ) -> VMLogicResult<i32> {
+        let map_id = match self.read_map_id(map_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let key = self.read_buffer(key_ptr)?;
+
+        let map = match load_js_authored_map_instance(map_id) {
+            Ok(map) => map,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        match map.owned_by_me(&key) {
+            Ok(result) => Ok(i32::from(result)),
+            Err(err) => self.write_error_message(0, err),
+        }
+    }
+
+    fn crdt_authored_map_iter(
+        &mut self,
+        map_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let map_id = match self.read_map_id(map_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let map = match load_js_authored_map_instance(map_id) {
+            Ok(map) => map,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let entries = match map.entries() {
+            Ok(entries) => entries,
+            Err(err) => return self.write_error_message(dest_register_id, err),
+        };
+
+        let count = u32::try_from(entries.len()).map_err(|_| HostError::IntegerOverflow)?;
+
+        let mut total_len: usize = 4;
+        for (key, value) in &entries {
+            let key_len = key.len();
+            let value_len = value.len();
+            u32::try_from(key_len).map_err(|_| HostError::IntegerOverflow)?;
+            u32::try_from(value_len).map_err(|_| HostError::IntegerOverflow)?;
+            total_len = total_len
+                .checked_add(4)
+                .and_then(|acc| acc.checked_add(key_len))
+                .and_then(|acc| acc.checked_add(4))
+                .and_then(|acc| acc.checked_add(value_len))
+                .ok_or(HostError::IntegerOverflow)?;
+        }
+
+        let mut buffer = Vec::with_capacity(total_len);
+        buffer.extend_from_slice(&count.to_le_bytes());
+        for (key, value) in entries {
+            let key_len = u32::try_from(key.len()).map_err(|_| HostError::IntegerOverflow)?;
+            let value_len = u32::try_from(value.len()).map_err(|_| HostError::IntegerOverflow)?;
+            buffer.extend_from_slice(&key_len.to_le_bytes());
+            buffer.extend_from_slice(&key);
+            buffer.extend_from_slice(&value_len.to_le_bytes());
+            buffer.extend_from_slice(&value);
+        }
+
+        self.write_register_bytes(dest_register_id, &buffer)?;
+        Ok(1)
+    }
+
+    fn crdt_authored_map_len(
+        &mut self,
+        map_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let map_id = match self.read_map_id(map_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let map = match load_js_authored_map_instance(map_id) {
+            Ok(map) => map,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match map.len() {
+            Ok(len) => {
+                let len_u64 = u64::try_from(len).map_err(|_| HostError::IntegerOverflow)?;
+                self.write_register_bytes(dest_register_id, &len_u64.to_le_bytes())?;
+                Ok(1)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_authored_vector_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
+        let outcome =
+            panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsAuthoredVector, String> {
+                let mut vector = JsAuthoredVector::new();
+                save_js_authored_vector_instance(&mut vector)?;
+                Ok(vector)
+            }));
+
+        match outcome {
+            Ok(Ok(vector)) => {
+                self.write_register_bytes(dest_register_id, vector.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn crdt_authored_vector_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let id = match self.read_map_id(id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let outcome =
+            panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsAuthoredVector, String> {
+                let mut vector = JsAuthoredVector::new_with_id(id);
+                save_js_authored_vector_instance(&mut vector)?;
+                Ok(vector)
+            }));
+
+        match outcome {
+            Ok(Ok(vector)) => {
+                self.write_register_bytes(dest_register_id, vector.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn crdt_authored_vector_push(
+        &mut self,
+        vector_id_ptr: u64,
+        value_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let vector_id = match self.read_map_id(vector_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let value = self.read_buffer(value_ptr)?;
+
+        let mut vector = match load_js_authored_vector_instance(vector_id) {
+            Ok(vector) => vector,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        // `push` stamps the current executor as owner and returns the new index.
+        match vector.push(&value) {
+            Ok(index) => {
+                if let Err(message) = save_js_authored_vector_instance(&mut vector) {
+                    return self.write_error_message(dest_register_id, message);
+                }
+                let index_u64 = u64::try_from(index).map_err(|_| HostError::IntegerOverflow)?;
+                self.write_register_bytes(dest_register_id, &index_u64.to_le_bytes())?;
+                Ok(1)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_authored_vector_update(
+        &mut self,
+        vector_id_ptr: u64,
+        index: u64,
+        value_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let vector_id = match self.read_map_id(vector_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let idx = match usize::try_from(index) {
+            Ok(value) => value,
+            Err(_) => {
+                return self.write_error_message(
+                    dest_register_id,
+                    format!("index {index} does not fit into usize"),
+                )
+            }
+        };
+
+        let value = self.read_buffer(value_ptr)?;
+
+        let mut vector = match load_js_authored_vector_instance(vector_id) {
+            Ok(vector) => vector,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        // Owner-only: a non-owner update yields `ActionNotAllowed`.
+        match vector.update(idx, &value) {
+            Ok(()) => match save_js_authored_vector_instance(&mut vector) {
+                Ok(()) => Ok(1),
+                Err(message) => self.write_error_message(dest_register_id, message),
+            },
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_authored_vector_tombstone(
+        &mut self,
+        vector_id_ptr: u64,
+        index: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let vector_id = match self.read_map_id(vector_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let idx = match usize::try_from(index) {
+            Ok(value) => value,
+            Err(_) => {
+                return self.write_error_message(
+                    dest_register_id,
+                    format!("index {index} does not fit into usize"),
+                )
+            }
+        };
+
+        let mut vector = match load_js_authored_vector_instance(vector_id) {
+            Ok(vector) => vector,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        // Owner-only: a non-owner tombstone yields `ActionNotAllowed`.
+        match vector.tombstone(idx) {
+            Ok(()) => match save_js_authored_vector_instance(&mut vector) {
+                Ok(()) => Ok(1),
+                Err(message) => self.write_error_message(dest_register_id, message),
+            },
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_authored_vector_get(
+        &mut self,
+        vector_id_ptr: u64,
+        index: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let vector_id = match self.read_map_id(vector_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let idx = match usize::try_from(index) {
+            Ok(value) => value,
+            Err(_) => {
+                return self.write_error_message(
+                    dest_register_id,
+                    format!("index {index} does not fit into usize"),
+                )
+            }
+        };
+
+        let vector = match load_js_authored_vector_instance(vector_id) {
+            Ok(vector) => vector,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match vector.get(idx) {
+            Ok(Some(value)) => {
+                self.write_register_bytes(dest_register_id, &value)?;
+                Ok(1)
+            }
+            Ok(None) => {
+                self.clear_register(dest_register_id)?;
+                Ok(0)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_authored_vector_owner_of(
+        &mut self,
+        vector_id_ptr: u64,
+        index: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let vector_id = match self.read_map_id(vector_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let idx = match usize::try_from(index) {
+            Ok(value) => value,
+            Err(_) => {
+                return self.write_error_message(
+                    dest_register_id,
+                    format!("index {index} does not fit into usize"),
+                )
+            }
+        };
+
+        let vector = match load_js_authored_vector_instance(vector_id) {
+            Ok(vector) => vector,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        // Present slot → 32-byte owner public key (status 1); out-of-bounds slot
+        // → cleared register (status 0), matching `get`'s convention.
+        match vector.owner_of(idx) {
+            Ok(Some(owner)) => {
+                self.write_register_bytes(dest_register_id, &owner)?;
+                Ok(1)
+            }
+            Ok(None) => {
+                self.clear_register(dest_register_id)?;
+                Ok(0)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_authored_vector_owned_by_me(
+        &mut self,
+        vector_id_ptr: u64,
+        index: u64,
+    ) -> VMLogicResult<i32> {
+        let vector_id = match self.read_map_id(vector_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let idx = match usize::try_from(index) {
+            Ok(value) => value,
+            Err(_) => {
+                return self
+                    .write_error_message(0, format!("index {index} does not fit into usize"))
+            }
+        };
+
+        let vector = match load_js_authored_vector_instance(vector_id) {
+            Ok(vector) => vector,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        match vector.owned_by_me(idx) {
+            Ok(result) => Ok(i32::from(result)),
+            Err(err) => self.write_error_message(0, err),
+        }
+    }
+
+    fn crdt_authored_vector_iter(
+        &mut self,
+        vector_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let vector_id = match self.read_map_id(vector_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let vector = match load_js_authored_vector_instance(vector_id) {
+            Ok(vector) => vector,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let values = match vector.iter() {
+            Ok(values) => values,
+            Err(err) => return self.write_error_message(dest_register_id, err),
+        };
+
+        let count = u32::try_from(values.len()).map_err(|_| HostError::IntegerOverflow)?;
+
+        let mut total_len: usize = 4;
+        for value in &values {
+            let value_len = value.len();
+            u32::try_from(value_len).map_err(|_| HostError::IntegerOverflow)?;
+            total_len = total_len
+                .checked_add(4)
+                .and_then(|acc| acc.checked_add(value_len))
+                .ok_or(HostError::IntegerOverflow)?;
+        }
+
+        let mut buffer = Vec::with_capacity(total_len);
+        buffer.extend_from_slice(&count.to_le_bytes());
+        for value in values {
+            let value_len = u32::try_from(value.len()).map_err(|_| HostError::IntegerOverflow)?;
+            buffer.extend_from_slice(&value_len.to_le_bytes());
+            buffer.extend_from_slice(&value);
+        }
+
+        self.write_register_bytes(dest_register_id, &buffer)?;
+        Ok(1)
+    }
+
+    fn crdt_authored_vector_len(
+        &mut self,
+        vector_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let vector_id = match self.read_map_id(vector_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let vector = match load_js_authored_vector_instance(vector_id) {
+            Ok(vector) => vector,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match vector.len() {
+            Ok(len) => {
+                let len_u64 = u64::try_from(len).map_err(|_| HostError::IntegerOverflow)?;
+                self.write_register_bytes(dest_register_id, &len_u64.to_le_bytes())?;
+                Ok(1)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
     fn read_map_id(&mut self, map_id_ptr: u64) -> VMLogicResult<Result<Id, String>> {
         // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
         //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
@@ -3199,6 +4096,90 @@ fn save_js_sortedset_instance(set: &mut JsSortedSet) -> Result<(), String> {
     }
 }
 
+fn load_js_authored_map_instance(id: Id) -> Result<JsAuthoredMap, String> {
+    match JsAuthoredMap::load(id) {
+        Ok(Some(map)) => {
+            debug!(
+                target: "runtime::authored_map",
+                map_id = %id.to_string(),
+                "loaded JsAuthoredMap from storage"
+            );
+            Ok(map)
+        }
+        Ok(None) => {
+            let missing_id = id.to_string();
+            warn!(
+                target: "runtime::authored_map",
+                map_id = %missing_id,
+                "JsAuthoredMap not found in storage"
+            );
+            let mut map = JsAuthoredMap::new_with_id(id);
+            match save_js_authored_map_instance(&mut map) {
+                Ok(()) => Ok(map),
+                Err(err) => Err(err),
+            }
+        }
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+fn save_js_authored_map_instance(map: &mut JsAuthoredMap) -> Result<(), String> {
+    match map.save() {
+        Ok(_) => Ok(()),
+        Err(StorageError::CannotCreateOrphan(_)) => {
+            ensure_root_index_internal().map_err(|err| err.to_string())?;
+            match Interface::<MainStorage>::add_child_to(Id::root(), map) {
+                Ok(_) => Ok(()),
+                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
+                Err(err) => Err(err.to_string()),
+            }
+        }
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+fn load_js_authored_vector_instance(id: Id) -> Result<JsAuthoredVector, String> {
+    match JsAuthoredVector::load(id) {
+        Ok(Some(vector)) => {
+            debug!(
+                target: "runtime::authored_vector",
+                vector_id = %id.to_string(),
+                "loaded JsAuthoredVector from storage"
+            );
+            Ok(vector)
+        }
+        Ok(None) => {
+            let missing_id = id.to_string();
+            warn!(
+                target: "runtime::authored_vector",
+                vector_id = %missing_id,
+                "JsAuthoredVector not found in storage"
+            );
+            let mut vector = JsAuthoredVector::new_with_id(id);
+            match save_js_authored_vector_instance(&mut vector) {
+                Ok(()) => Ok(vector),
+                Err(err) => Err(err),
+            }
+        }
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+fn save_js_authored_vector_instance(vector: &mut JsAuthoredVector) -> Result<(), String> {
+    match vector.save() {
+        Ok(_) => Ok(()),
+        Err(StorageError::CannotCreateOrphan(_)) => {
+            ensure_root_index_internal().map_err(|err| err.to_string())?;
+            match Interface::<MainStorage>::add_child_to(Id::root(), vector) {
+                Ok(_) => Ok(()),
+                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
+                Err(err) => Err(err.to_string()),
+            }
+        }
+        Err(err) => Err(err.to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::logic::{
@@ -3667,6 +4648,273 @@ mod tests {
             decode_set_items(&buffer),
             vec![b"alpha".to_vec(), b"beta".to_vec(), b"gamma".to_vec()],
             "SortedSet iteration must be in ascending order"
+        );
+    }
+
+    /// AuthoredMap: an insert stamps the caller as owner (`owner_of` returns the
+    /// executor identity, `owned_by_me` is true), and an `update` from a
+    /// DIFFERENT executor is rejected with an ownership error. The non-owner
+    /// path is exercised by building a second VM (with a different
+    /// `executor_public_key`) over the SAME backing storage.
+    #[test]
+    fn test_js_crdt_authored_map_owner_stamp_and_non_owner_update_rejected() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let id: [u8; 32] = [61u8; 32];
+        let alice: [u8; 32] = [0xA1; 32];
+        let bob: [u8; 32] = [0xB0; 32];
+
+        // --- Alice: create, insert, confirm ownership. ---
+        {
+            let context = VMContext::new(Cow::Owned(vec![]), [0u8; DIGEST_SIZE], alice);
+            let mut store = Store::default();
+            let memory =
+                wasmer::Memory::new(&mut store, wasmer::MemoryType::new(1, None, false)).unwrap();
+            let mut logic = VMLogic::new(&mut storage, None, context, &limits, None);
+            let _ = logic.with_memory(memory);
+            let mut host = logic.host_functions(store.as_store_mut());
+
+            put_buffer(&host, ID_DESC_PTR, ID_DATA_PTR, &id);
+            assert_eq!(
+                host.js_crdt_authored_map_new_with_id(ID_DESC_PTR, 1)
+                    .unwrap(),
+                0
+            );
+
+            put_buffer(&host, KEY_DESC_PTR, KEY_DATA_PTR, b"apple");
+            put_buffer(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"1");
+            assert_eq!(
+                host.js_crdt_authored_map_insert(ID_DESC_PTR, KEY_DESC_PTR, VALUE_DESC_PTR, 2)
+                    .unwrap(),
+                0,
+                "insert of a new key returns 0"
+            );
+
+            // Round-trip get.
+            let reg = 3u64;
+            assert_eq!(
+                host.js_crdt_authored_map_get(ID_DESC_PTR, KEY_DESC_PTR, reg)
+                    .unwrap(),
+                1
+            );
+            assert_eq!(host.borrow_logic().registers.get(reg).unwrap(), b"1");
+
+            // owner_of returns Alice's 32-byte identity.
+            let reg2 = 4u64;
+            assert_eq!(
+                host.js_crdt_authored_map_owner_of(ID_DESC_PTR, KEY_DESC_PTR, reg2)
+                    .unwrap(),
+                1
+            );
+            assert_eq!(host.borrow_logic().registers.get(reg2).unwrap(), &alice);
+
+            // owned_by_me is true for the inserter.
+            assert_eq!(
+                host.js_crdt_authored_map_owned_by_me(ID_DESC_PTR, KEY_DESC_PTR)
+                    .unwrap(),
+                1
+            );
+        }
+
+        // --- Bob: a different executor cannot update Alice's entry. ---
+        {
+            let context = VMContext::new(Cow::Owned(vec![]), [0u8; DIGEST_SIZE], bob);
+            let mut store = Store::default();
+            let memory =
+                wasmer::Memory::new(&mut store, wasmer::MemoryType::new(1, None, false)).unwrap();
+            let mut logic = VMLogic::new(&mut storage, None, context, &limits, None);
+            let _ = logic.with_memory(memory);
+            let mut host = logic.host_functions(store.as_store_mut());
+
+            put_buffer(&host, ID_DESC_PTR, ID_DATA_PTR, &id);
+            put_buffer(&host, KEY_DESC_PTR, KEY_DATA_PTR, b"apple");
+            put_buffer(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"99");
+
+            let reg = 1u64;
+            let res = host
+                .js_crdt_authored_map_update(ID_DESC_PTR, KEY_DESC_PTR, VALUE_DESC_PTR, reg)
+                .unwrap();
+            assert_eq!(res, -1, "non-owner update must be rejected");
+            let msg = String::from_utf8(host.borrow_logic().registers.get(reg).unwrap().to_vec())
+                .unwrap();
+            assert!(
+                msg.to_lowercase().contains("owner"),
+                "error should mention ownership, got: {msg}"
+            );
+
+            // owned_by_me is false for Bob.
+            assert_eq!(
+                host.js_crdt_authored_map_owned_by_me(ID_DESC_PTR, KEY_DESC_PTR)
+                    .unwrap(),
+                0
+            );
+
+            // The original value is unchanged.
+            let reg2 = 2u64;
+            assert_eq!(
+                host.js_crdt_authored_map_get(ID_DESC_PTR, KEY_DESC_PTR, reg2)
+                    .unwrap(),
+                1
+            );
+            assert_eq!(host.borrow_logic().registers.get(reg2).unwrap(), b"1");
+        }
+    }
+
+    /// AuthoredVector: `push` returns the new index (u64 LE) and stamps the
+    /// pusher as owner; `get`/`owner_of`/`owned_by_me` reflect that; a
+    /// `tombstone` by the owner succeeds and preserves the slot's position.
+    #[test]
+    fn test_js_crdt_authored_vector_push_get_owner_and_tombstone() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        let id: [u8; 32] = [71u8; 32];
+        put_buffer(&host, ID_DESC_PTR, ID_DATA_PTR, &id);
+        assert_eq!(
+            host.js_crdt_authored_vector_new_with_id(ID_DESC_PTR, 1)
+                .unwrap(),
+            0
+        );
+
+        // push returns the new index (u64 LE) in the register.
+        put_buffer(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"first");
+        let reg = 2u64;
+        assert_eq!(
+            host.js_crdt_authored_vector_push(ID_DESC_PTR, VALUE_DESC_PTR, reg)
+                .unwrap(),
+            1
+        );
+        let bytes = host.borrow_logic().registers.get(reg).unwrap();
+        assert_eq!(
+            u64::from_le_bytes(bytes.try_into().unwrap()),
+            0,
+            "first push lands at index 0"
+        );
+
+        put_buffer(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"second");
+        let reg_b = 3u64;
+        assert_eq!(
+            host.js_crdt_authored_vector_push(ID_DESC_PTR, VALUE_DESC_PTR, reg_b)
+                .unwrap(),
+            1
+        );
+        let bytes = host.borrow_logic().registers.get(reg_b).unwrap();
+        assert_eq!(
+            u64::from_le_bytes(bytes.try_into().unwrap()),
+            1,
+            "second push lands at index 1"
+        );
+
+        // get index 0.
+        let reg_c = 4u64;
+        assert_eq!(
+            host.js_crdt_authored_vector_get(ID_DESC_PTR, 0, reg_c)
+                .unwrap(),
+            1
+        );
+        assert_eq!(host.borrow_logic().registers.get(reg_c).unwrap(), b"first");
+
+        // owner_of(0) is the (default) executor identity.
+        let reg_d = 5u64;
+        assert_eq!(
+            host.js_crdt_authored_vector_owner_of(ID_DESC_PTR, 0, reg_d)
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            host.borrow_logic().registers.get(reg_d).unwrap(),
+            &[0u8; 32]
+        );
+
+        // owned_by_me(0) is true for the pusher.
+        assert_eq!(
+            host.js_crdt_authored_vector_owned_by_me(ID_DESC_PTR, 0)
+                .unwrap(),
+            1
+        );
+
+        // tombstone by owner succeeds; the slot becomes empty but is retained.
+        let reg_e = 6u64;
+        assert_eq!(
+            host.js_crdt_authored_vector_tombstone(ID_DESC_PTR, 0, reg_e)
+                .unwrap(),
+            1
+        );
+        let reg_f = 7u64;
+        assert_eq!(
+            host.js_crdt_authored_vector_get(ID_DESC_PTR, 0, reg_f)
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            host.borrow_logic().registers.get(reg_f).unwrap(),
+            b"",
+            "tombstone overwrites the slot with an empty value"
+        );
+
+        // len is still 2 — tombstone preserves the slot's position.
+        let reg_g = 8u64;
+        assert_eq!(
+            host.js_crdt_authored_vector_len(ID_DESC_PTR, reg_g)
+                .unwrap(),
+            1
+        );
+        let bytes = host.borrow_logic().registers.get(reg_g).unwrap();
+        assert_eq!(u64::from_le_bytes(bytes.try_into().unwrap()), 2);
+    }
+
+    /// A `*_new_with_id` constructor must place the authored vector at exactly
+    /// the caller-supplied id, and two handles at the same id must address the
+    /// same storage entity (push via one, read via another).
+    #[test]
+    fn test_js_crdt_authored_vector_new_with_id_is_deterministic_and_shared() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        let id: [u8; 32] = [81u8; 32];
+        put_buffer(&host, ID_DESC_PTR, ID_DATA_PTR, &id);
+
+        // First handle at the deterministic id.
+        let reg_a = 1u64;
+        assert_eq!(
+            host.js_crdt_authored_vector_new_with_id(ID_DESC_PTR, reg_a)
+                .unwrap(),
+            0
+        );
+        assert_eq!(host.borrow_logic().registers.get(reg_a).unwrap(), &id);
+
+        // Second handle at the SAME id.
+        let reg_b = 2u64;
+        assert_eq!(
+            host.js_crdt_authored_vector_new_with_id(ID_DESC_PTR, reg_b)
+                .unwrap(),
+            0
+        );
+        assert_eq!(host.borrow_logic().registers.get(reg_b).unwrap(), &id);
+
+        // Push through the id, then read back via the shared id.
+        put_buffer(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"payload");
+        let reg_c = 3u64;
+        assert_eq!(
+            host.js_crdt_authored_vector_push(ID_DESC_PTR, VALUE_DESC_PTR, reg_c)
+                .unwrap(),
+            1
+        );
+
+        let reg_d = 4u64;
+        assert_eq!(
+            host.js_crdt_authored_vector_get(ID_DESC_PTR, 0, reg_d)
+                .unwrap(),
+            1,
+            "value must be found via the shared id"
+        );
+        assert_eq!(
+            host.borrow_logic().registers.get(reg_d).unwrap(),
+            b"payload"
         );
     }
 }

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -143,6 +143,60 @@ impl VMLogic<'_> {
             fn js_crdt_sortedset_iter(set_id_ptr: u64, register_id: u64) -> i32;
             fn js_crdt_sortedset_clear(set_id_ptr: u64) -> i32;
 
+            fn js_crdt_authored_map_new(register_id: u64) -> i32;
+            fn js_crdt_authored_map_new_with_id(id_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_authored_map_insert(
+                map_id_ptr: u64,
+                key_ptr: u64,
+                value_ptr: u64,
+                register_id: u64,
+            ) -> i32;
+            fn js_crdt_authored_map_update(
+                map_id_ptr: u64,
+                key_ptr: u64,
+                value_ptr: u64,
+                register_id: u64,
+            ) -> i32;
+            fn js_crdt_authored_map_remove(map_id_ptr: u64, key_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_authored_map_get(map_id_ptr: u64, key_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_authored_map_contains(map_id_ptr: u64, key_ptr: u64) -> i32;
+            fn js_crdt_authored_map_owner_of(map_id_ptr: u64, key_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_authored_map_owned_by_me(map_id_ptr: u64, key_ptr: u64) -> i32;
+            fn js_crdt_authored_map_iter(map_id_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_authored_map_len(map_id_ptr: u64, register_id: u64) -> i32;
+
+            fn js_crdt_authored_vector_new(register_id: u64) -> i32;
+            fn js_crdt_authored_vector_new_with_id(id_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_authored_vector_push(
+                vector_id_ptr: u64,
+                value_ptr: u64,
+                register_id: u64,
+            ) -> i32;
+            fn js_crdt_authored_vector_update(
+                vector_id_ptr: u64,
+                index: u64,
+                value_ptr: u64,
+                register_id: u64,
+            ) -> i32;
+            fn js_crdt_authored_vector_tombstone(
+                vector_id_ptr: u64,
+                index: u64,
+                register_id: u64,
+            ) -> i32;
+            fn js_crdt_authored_vector_get(
+                vector_id_ptr: u64,
+                index: u64,
+                register_id: u64,
+            ) -> i32;
+            fn js_crdt_authored_vector_owner_of(
+                vector_id_ptr: u64,
+                index: u64,
+                register_id: u64,
+            ) -> i32;
+            fn js_crdt_authored_vector_owned_by_me(vector_id_ptr: u64, index: u64) -> i32;
+            fn js_crdt_authored_vector_iter(vector_id_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_authored_vector_len(vector_id_ptr: u64, register_id: u64) -> i32;
+
             fn js_user_storage_new(register_id: u64) -> i32;
             fn js_user_storage_new_with_id(id_ptr: u64, register_id: u64) -> i32;
             fn js_user_storage_insert(

--- a/crates/storage/src/js.rs
+++ b/crates/storage/src/js.rs
@@ -8,9 +8,9 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate as calimero_storage;
 use crate::collections::{
-    error::StoreError, Counter as StorageCounter, FrozenStorage, LwwRegister as StorageLwwRegister,
-    ReplicatedGrowableArray, SortedMap as StorageSortedMap, SortedSet as StorageSortedSet,
-    UnorderedMap, UnorderedSet, UserStorage, Vector,
+    error::StoreError, AuthoredMap, AuthoredVector, Counter as StorageCounter, FrozenStorage,
+    LwwRegister as StorageLwwRegister, ReplicatedGrowableArray, SortedMap as StorageSortedMap,
+    SortedSet as StorageSortedSet, UnorderedMap, UnorderedSet, UserStorage, Vector,
 };
 use crate::entities::{Element, Metadata};
 use crate::store::MainStorage;
@@ -1351,6 +1351,325 @@ impl JsSortedSet {
 }
 
 impl Default for JsSortedSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A byte-oriented attributed map that integrates with Calimero storage.
+///
+/// Wraps [`AuthoredMap`], a shared-keyspace map with per-entry ownership. Any
+/// context member may [`insert`](Self::insert) a new key, which stamps the
+/// current executor as the entry's owner; only that owner may later
+/// [`update`](Self::update) or [`remove`](Self::remove) the entry. Reads are
+/// unrestricted. Ownership is resolved from `env::executor_id()`, which the
+/// runtime installs per-execution — no identity argument is threaded through
+/// the byte API.
+#[derive(Debug, AtomicUnit, BorshSerialize, BorshDeserialize)]
+pub struct JsAuthoredMap {
+    map: AuthoredMap<Vec<u8>, Vec<u8>>,
+
+    #[storage]
+    storage: Element,
+}
+
+impl JsAuthoredMap {
+    /// Creates a new JS authored map backed by the main storage backend.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            map: AuthoredMap::new(),
+            storage: Element::new(None),
+        }
+    }
+
+    /// Rehydrates an authored map using a known identifier.
+    #[must_use]
+    pub fn new_with_id(id: Id) -> Self {
+        Self {
+            map: AuthoredMap::new(),
+            storage: Element::new(Some(id)),
+        }
+    }
+
+    /// Returns the unique identifier of this collection.
+    #[must_use]
+    pub fn id(&self) -> Id {
+        self.storage.id()
+    }
+
+    /// Inserts a new key/value pair, stamping the current executor as owner.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] if `key` already exists (ownership transfer is not
+    /// supported) or if the underlying storage write fails.
+    pub fn insert(&mut self, key: &[u8], value: &[u8]) -> Result<(), StoreError> {
+        self.map.insert(key.to_vec(), value.to_vec())
+    }
+
+    /// Replaces the value at `key`. Only the entry's owner may call this.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] with `ActionNotAllowed` if the current executor is
+    /// not the stored owner, `NotFound` if `key` is absent, or any underlying
+    /// storage error.
+    pub fn update(&mut self, key: &[u8], value: &[u8]) -> Result<(), StoreError> {
+        self.map.update(&key.to_vec(), value.to_vec())
+    }
+
+    /// Removes `key`, returning the previous value if it existed. Only the
+    /// entry's owner may call this.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] with `ActionNotAllowed` if the current executor is
+    /// not the stored owner, or any underlying storage error. Returns `Ok(None)`
+    /// if `key` is absent.
+    pub fn remove(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>, StoreError> {
+        self.map.remove(&key.to_vec())
+    }
+
+    /// Retrieves the value for `key`, if present.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] when the underlying map read fails.
+    pub fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StoreError> {
+        self.map.get(&key.to_vec())
+    }
+
+    /// Checks whether `key` exists within the map.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] if the existence check fails.
+    pub fn contains(&self, key: &[u8]) -> Result<bool, StoreError> {
+        self.map.contains(&key.to_vec())
+    }
+
+    /// Returns the 32-byte public key of the owner of `key`, if present.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] if reading entry metadata fails.
+    pub fn owner_of(&self, key: &[u8]) -> Result<Option<[u8; 32]>, StoreError> {
+        Ok(self.map.owner_of(&key.to_vec())?.map(|pk| *pk.as_ref()))
+    }
+
+    /// Returns whether the current executor owns `key`. False for absent keys.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] if reading entry metadata fails.
+    pub fn owned_by_me(&self, key: &[u8]) -> Result<bool, StoreError> {
+        self.map.owned_by_me(&key.to_vec())
+    }
+
+    /// Returns all key/value pairs currently stored in the map.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] if reading from storage fails.
+    pub fn entries(&self) -> Result<JsByteEntries, StoreError> {
+        Ok(self.map.entries()?.collect())
+    }
+
+    /// Returns the number of entries in the map.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] if the length query cannot be satisfied.
+    pub fn len(&self) -> Result<usize, StoreError> {
+        self.map.len()
+    }
+
+    /// Returns `true` if the map is empty.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] through the underlying [`len`](Self::len) call.
+    pub fn is_empty(&self) -> Result<bool, StoreError> {
+        Ok(self.len()? == 0)
+    }
+
+    /// Persists the map using the provided interface.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] produced by the storage interface.
+    pub fn save(&mut self) -> Result<bool, StorageError> {
+        Interface::<MainStorage>::save(self)
+    }
+
+    /// Loads a map by identifier using the provided interface.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] if the map cannot be fetched from storage.
+    pub fn load(id: Id) -> Result<Option<Self>, StorageError> {
+        Interface::<MainStorage>::find_by_id::<Self>(id)
+    }
+}
+
+impl Default for JsAuthoredMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A byte-oriented attributed vector that integrates with Calimero storage.
+///
+/// Wraps [`AuthoredVector`], an ordered shared-keyspace vector with per-slot
+/// ownership. Any context member may [`push`](Self::push) a new entry at the
+/// tail, which stamps the current executor as the slot's owner; only that owner
+/// may later [`update`](Self::update) or [`tombstone`](Self::tombstone) the
+/// slot. There is intentionally no physical remove — `tombstone` overwrites the
+/// slot with an empty value while preserving its position and owner. Ownership
+/// is resolved from `env::executor_id()`, which the runtime installs
+/// per-execution — no identity argument is threaded through the byte API.
+#[derive(Debug, AtomicUnit, BorshSerialize, BorshDeserialize)]
+pub struct JsAuthoredVector {
+    vector: AuthoredVector<Vec<u8>>,
+
+    #[storage]
+    storage: Element,
+}
+
+impl JsAuthoredVector {
+    /// Creates a new JS authored vector backed by the main storage backend.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            vector: AuthoredVector::new(),
+            storage: Element::new(None),
+        }
+    }
+
+    /// Rehydrates an authored vector using a known identifier.
+    #[must_use]
+    pub fn new_with_id(id: Id) -> Self {
+        Self {
+            vector: AuthoredVector::new(),
+            storage: Element::new(Some(id)),
+        }
+    }
+
+    /// Returns the unique identifier of this collection.
+    #[must_use]
+    pub fn id(&self) -> Id {
+        self.storage.id()
+    }
+
+    /// Pushes a new value at the tail, stamping the current executor as owner.
+    ///
+    /// Returns the index of the newly appended slot.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] if the storage write fails.
+    pub fn push(&mut self, value: &[u8]) -> Result<usize, StoreError> {
+        self.vector.push(value.to_vec())
+    }
+
+    /// Replaces the value at `index`. Only the slot's owner may call this.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] with `ActionNotAllowed` if the current executor is
+    /// not the stored owner, `InvalidData` if `index` is out of bounds, or any
+    /// underlying storage error.
+    pub fn update(&mut self, index: usize, value: &[u8]) -> Result<(), StoreError> {
+        self.vector.update(index, value.to_vec())
+    }
+
+    /// Tombstones the slot at `index` (overwrites it with an empty value). Only
+    /// the slot's owner may call this; the slot's position and owner are kept.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`update`](Self::update).
+    pub fn tombstone(&mut self, index: usize) -> Result<(), StoreError> {
+        self.vector.tombstone(index)
+    }
+
+    /// Retrieves the value at `index`, if it exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] when the underlying vector read fails.
+    pub fn get(&self, index: usize) -> Result<Option<Vec<u8>>, StoreError> {
+        self.vector.get(index)
+    }
+
+    /// Returns the 32-byte public key of the owner at `index`, if the slot
+    /// exists.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] if reading slot metadata fails.
+    pub fn owner_of(&self, index: usize) -> Result<Option<[u8; 32]>, StoreError> {
+        Ok(self.vector.owner_of(index)?.map(|pk| *pk.as_ref()))
+    }
+
+    /// Returns whether the current executor owns the slot at `index`. False for
+    /// out-of-bounds slots.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] if reading slot metadata fails.
+    pub fn owned_by_me(&self, index: usize) -> Result<bool, StoreError> {
+        self.vector.owned_by_me(index)
+    }
+
+    /// Returns all values in insertion order (including tombstoned slots).
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] if reading from storage fails.
+    pub fn iter(&self) -> Result<Vec<Vec<u8>>, StoreError> {
+        Ok(self.vector.iter()?.collect())
+    }
+
+    /// Returns the number of entries (including tombstoned slots).
+    ///
+    /// # Errors
+    ///
+    /// Returns any [`StoreError`] emitted by the underlying vector.
+    pub fn len(&self) -> Result<usize, StoreError> {
+        self.vector.len()
+    }
+
+    /// Returns `true` if there are no entries.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system.
+    pub fn is_empty(&self) -> Result<bool, StoreError> {
+        Ok(self.len()? == 0)
+    }
+
+    /// Persists the vector to storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] raised by the persistence layer.
+    pub fn save(&mut self) -> Result<bool, StorageError> {
+        Interface::<MainStorage>::save(self)
+    }
+
+    /// Loads a vector instance by identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] if the vector cannot be located in storage.
+    pub fn load(id: Id) -> Result<Option<Self>, StorageError> {
+        Interface::<MainStorage>::find_by_id::<Self>(id)
+    }
+}
+
+impl Default for JsAuthoredVector {
     fn default() -> Self {
         Self::new()
     }


### PR DESCRIPTION
## What

Adds the `js_crdt_*` host-function bridge for the two attributed CRDT collection types — **AuthoredMap** and **AuthoredVector** — exposing them to the JS SDK. This is **Phase 2a** of the JS CRDT-type expansion, following the PNCounter/RGA/SortedMap/SortedSet work in #3318 and mirroring its pattern exactly. The Rust storage types already exist (`crates/storage/src/collections/authored_map.rs`, `authored_vector.rs`); this PR only adds the host-fn bridge.

## Ownership model

Both types are shared-keyspace collections with **per-entry/per-slot ownership**. Ownership is stamped from the executor identity, which the runtime already installs per-execution — **no identity argument is threaded through the byte API**:

- `insert` (map) / `push` (vector) stamp the **caller (executor)** as the entry/slot owner.
- `update` / `remove` (map) and `update` / `tombstone` (vector) are **owner-only**. A non-owner call surfaces the collection's `ActionNotAllowed` error verbatim (`-1` + error message in the register) — no auth logic is added at the host boundary.

## What's in it

- **`Js*` wrappers** (`crates/storage/src/js.rs`): `JsAuthoredMap` (wraps `AuthoredMap<Vec<u8>, Vec<u8>>`) and `JsAuthoredVector` (wraps `AuthoredVector<Vec<u8>>`), mirroring `JsUnorderedMap`/`JsVector` (`new`/`new_with_id`/`id`/`save`/`load`).
- **Host functions** (`js_collections.rs`), registered in `imports.rs`:
  - `js_crdt_authored_map_{new, new_with_id, insert, update, remove, get, contains, owner_of, owned_by_me, iter, len}`
  - `js_crdt_authored_vector_{new, new_with_id, push, update, tombstone, get, owner_of, owned_by_me, iter, len}`
- **ABI encodings**: `owner_of` writes the 32-byte owner public key to the destination register (cleared register + status `0` on absent key/index, like `get`); `owned_by_me` returns a `0`/`1` status like `contains`; `push` returns the new index as a `u64` LE in the register.
- **`HOST_FUNCTIONS.md`**: new "Authored Map" / "Authored Vector" subsections documenting owner-stamping and owner-only mutation.

## Merge-mode discipline

No merge-mode guard is added. Unlike `JsRga` (whose `insert_str` stamps a node-local HLC and `panic!`s under `env::in_merge_mode()`, hence its typed-error guard), AuthoredMap and AuthoredVector wrap the Structured-storage `UnorderedMap`/`Vector`, which allocate no node-local timestamp on insert/push/update. This matches `JsUnorderedMap`/`JsVector`, which likewise carry no guard.

## Tests

Added to the existing harness in `js_collections.rs`:
- **AuthoredMap**: insert→get round-trip; `owner_of` returns the inserting executor's identity; `owned_by_me` true for the inserter; an `update` from a **different executor** is rejected with an ownership error (exercised by building a second VM with a different `executor_public_key` over the same backing storage).
- **AuthoredVector**: push→get with returned index; `owner_of(index)`; owner tombstone succeeds and preserves the slot.
- `*_new_with_id` determinism check for the vector (two handles at the same id share one entity).

## Verification (all green)

- `cargo fmt --check`
- `cargo clippy -p calimero-runtime -p calimero-storage -- -D warnings`
- `cargo test -p calimero-runtime` (141 passed) and `cargo test -p calimero-storage` (all passed)
- `cargo check -p calimero-node`

JS SDK wrappers land in a follow-up. Refs calimero-network/calimero-sdk-js#83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)