### PR TITLE
chore: cut release 0.11.0-rc.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.18"
+version = "0.11.0-rc.19"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Bump the shared workspace release version **rc.18 → rc.19** (`[workspace.metadata.workspaces] version` in the root `Cargo.toml`), the same one-line pattern as #3300 (rc.18) and #3277 (rc.17).

No code and no `Cargo.lock` changes — public crate versions are `0.0.0`, so this field is the release tooling's shared version only.

Cut on top of `1042d19d`. **Do not merge yet.**

## What rc.19 picks up since rc.18 (`d5f5b79a`)

**JS SDK / runtime convergence** — the bulk of this release:
- `feat(runtime)`: JS host functions for PNCounter, RGA, SortedMap, SortedSet (#3318)
- `feat`: JS SDK root-state convergence — deterministic ids + WASM root-merge routing (#3309)
- `fix(storage)`: store the JS app root document as the `ROOT_ENTRY_ID` leaf, for concurrent-writer convergence (#3315)
- `fix(storage)`: persist root `crdt_type` on hash updates (#3314)
- `fix(storage)`: fall back to LWW for opaque root local writes (#3305)

**Governance / networking:**
- `fix(governance)`: converge a namespace join whose broadcast reached no peer (#3316)
- `fix`: encode group-membership ids as hex so group subscriptions match (#3304)

**Upgrades / ABI — note the behaviour change:**
- `fix`: cfg-aware ABI emission and **refuse-by-default for evidence-less upgrades** (#3286). An upgrade whose target build carries no embedded `calimero_abi_v1` section is now refused rather than swapped in blind; `forceCodeOnly=true` is the opt-out. Anything that upgrades an app built by `apps/*/build.sh` needs `mero-abi embed` run after `build.sh`, since wasm-opt strips custom sections. This already required a fix in merobox's fixture build (calimero-network/merobox#306) and is the most likely source of surprise for downstream consumers of this rc.
- `fix(wasm-abi)`: emit methods and events name-sorted (#3307)

**Tooling:**
- `feat`: import the cargo-mero toolchain into `tools/` (#3303)

## Not included

calimero-network/core#3317 (blob namespace-identity signing — cross-node blob transfer for namespace-backed contexts) is still open and is **not** in this cut.