### PR TITLE
fix(node): bind the bundle signature to the artifact bytes it describes

### DIFF
--- a/apps/migrations/bundle-wasm.sh
+++ b/apps/migrations/bundle-wasm.sh
@@ -17,6 +17,7 @@ APP_VERSION="$4"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PATH="$("$REPO_ROOT/scripts/setup-cargo-mero.sh"):$PATH"
 
 cd "$SUITE_DIR"
 
@@ -34,8 +35,24 @@ if [ -f res/abi.json ]; then
 fi
 
 size() { stat -f%z "$1" 2>/dev/null || stat -c%s "$1"; }
+sha256() { shasum -a 256 "$1" | cut -d' ' -f1; }
+
 WASM_SIZE=$(size res/bundle-temp/app.wasm)
-ABI_SIZE=$( [ -f res/bundle-temp/abi.json ] && size res/bundle-temp/abi.json || echo 0)
+WASM_HASH=$(sha256 res/bundle-temp/app.wasm)
+
+# Declared only when the file was actually staged: a required hash cannot
+# describe an artifact that is not in the archive.
+ABI_BLOCK=""
+if [ -f res/bundle-temp/abi.json ]; then
+    ABI_BLOCK=$(cat <<ABI
+  "abi": {
+    "path": "abi.json",
+    "size": $(size res/bundle-temp/abi.json),
+    "hash": "$(sha256 res/bundle-temp/abi.json)"
+  },
+ABI
+)
+fi
 
 cat > res/bundle-temp/manifest.json <<EOF
 {
@@ -46,20 +63,14 @@ cat > res/bundle-temp/manifest.json <<EOF
   "wasm": {
     "path": "app.wasm",
     "size": ${WASM_SIZE},
-    "hash": null
+    "hash": "${WASM_HASH}"
   },
-  "abi": {
-    "path": "abi.json",
-    "size": ${ABI_SIZE},
-    "hash": null
-  },
+${ABI_BLOCK}
   "migrations": []
 }
 EOF
 
-cargo run --manifest-path "$REPO_ROOT/Cargo.toml" -p mero-sign --quiet -- \
-    sign res/bundle-temp/manifest.json \
-    --dev
+cargo mero sign res/bundle-temp/manifest.json --dev
 
 LEAF="${PACKAGE##*.}"
 OUT="${LEAF}-${APP_VERSION}.mpk"

--- a/apps/scaffolding-e2e/build-multi-service-bundle.sh
+++ b/apps/scaffolding-e2e/build-multi-service-bundle.sh
@@ -10,7 +10,7 @@ cargo mero build --manifest-path Cargo.toml
 
 mkdir -p res/multi-bundle-temp
 
-# Both services use the same WASM — this is what we want to test:
+# Both services use the same WASM - this is what we want to test:
 # the multi-service bundle install + service_name selection path in merod.
 cp res/scaffolding_e2e.wasm res/multi-bundle-temp/store-a.wasm
 cp res/scaffolding_e2e.wasm res/multi-bundle-temp/store-b.wasm
@@ -22,11 +22,36 @@ if [ -f res/abi.json ]; then
     ABI_ARGS="store-a-abi.json store-b-abi.json"
 fi
 
-WASM_SIZE=$(stat -f%z res/scaffolding_e2e.wasm 2>/dev/null || stat -c%s res/scaffolding_e2e.wasm 2>/dev/null || echo 0)
-ABI_SIZE=0
-if [ -f res/abi.json ]; then
-    ABI_SIZE=$(stat -f%z res/abi.json 2>/dev/null || stat -c%s res/abi.json 2>/dev/null || echo 0)
-fi
+sha256() { shasum -a 256 "$1" | cut -d' ' -f1; }
+
+WASM_SIZE=$(stat -f%z res/scaffolding_e2e.wasm 2>/dev/null || stat -c%s res/scaffolding_e2e.wasm)
+WASM_HASH=$(sha256 res/scaffolding_e2e.wasm)
+# Declared only when the file was actually staged: a required hash cannot
+# describe an artifact that is not in the archive.
+abi_block() {
+    [ -f res/abi.json ] || return 0
+    cat <<ABI
+,
+      "abi": {
+        "path": "$1-abi.json",
+        "size": $(stat -f%z res/abi.json 2>/dev/null || stat -c%s res/abi.json),
+        "hash": "$(sha256 res/abi.json)"
+      }
+ABI
+}
+
+service_block() {
+    cat <<SVC
+    {
+      "name": "$1",
+      "wasm": {
+        "path": "$1.wasm",
+        "size": ${WASM_SIZE},
+        "hash": "${WASM_HASH}"
+      }$(abi_block "$1")
+    }
+SVC
+}
 
 cat > res/multi-bundle-temp/manifest.json <<EOF
 {
@@ -35,36 +60,14 @@ cat > res/multi-bundle-temp/manifest.json <<EOF
   "appVersion": "0.1.0",
   "minRuntimeVersion": "0.0.0",
   "services": [
-    {
-      "name": "store-a",
-      "wasm": {
-        "path": "store-a.wasm",
-        "size": ${WASM_SIZE},
-        "hash": null
-      },
-      "abi": {
-        "path": "store-a-abi.json",
-        "size": ${ABI_SIZE},
-        "hash": null
-      }
-    },
-    {
-      "name": "store-b",
-      "wasm": {
-        "path": "store-b.wasm",
-        "size": ${WASM_SIZE},
-        "hash": null
-      },
-      "abi": {
-        "path": "store-b-abi.json",
-        "size": ${ABI_SIZE},
-        "hash": null
-      }
-    }
+$(service_block store-a),
+$(service_block store-b)
   ],
   "migrations": []
 }
 EOF
+
+cargo mero sign res/multi-bundle-temp/manifest.json --dev
 
 cd res/multi-bundle-temp
 tar -czf ../scaffolding-e2e-multi-0.1.0.mpk manifest.json store-a.wasm store-b.wasm ${ABI_ARGS} 2>/dev/null || \

--- a/crates/context/primitives/src/client/sync.rs
+++ b/crates/context/primitives/src/client/sync.rs
@@ -202,7 +202,6 @@ impl ContextClient {
             );
             // Blob doesn't exist yet - create ApplicationMeta entry anyway
             // The blob will be shared later in initiate_sync_inner
-            // When blob arrives, get_application_bytes will handle extraction on-demand
             self.install_regular_application(blob_id, size, source, metadata)
                 .await
         }

--- a/crates/node/AGENTS.md
+++ b/crates/node/AGENTS.md
@@ -239,3 +239,13 @@ cargo test -p calimero-node --test network_simulation
   `BroadcastMessage::NamespaceGovernanceDelta { namespace_id, delta_id,
   parent_ids, payload: borsh(NamespaceTopicMsg) }` - sender-side
   envelope skips break receive-side decoding silently
+- `VerifiedBundle` is the only way to read artifact bytes out of a
+  `.mpk`; `extract_bundle_files` is module-private so the compiler
+  enforces it. Construction requires a valid manifest signature, and
+  every wasm artifact is digest-checked against the signed manifest
+  before its bytes are returned. Nothing is unpacked to disk: the
+  `.mpk` stays a content-addressed blob, and a multi-service install
+  copies each service's wasm into a blob of its own
+- `BundleManifest::artifacts` destructures the manifest without `..`,
+  so adding an artifact field is a compile error until it is
+  classified; keep it that way rather than reaching for a wildcard

--- a/crates/node/AGENTS.md
+++ b/crates/node/AGENTS.md
@@ -246,6 +246,11 @@ cargo test -p calimero-node --test network_simulation
   before its bytes are returned. Nothing is unpacked to disk: the
   `.mpk` stays a content-addressed blob, and a multi-service install
   copies each service's wasm into a blob of its own
+- A bundle's manifest is the entry at exactly `manifest.json`, never a
+  nested one: an `old/manifest.json` would be an authentically signed
+  older release, so basename matching is a signed rollback. A second
+  entry at that path is refused, after the signature rather than during
+  the pre-auth scan, since the check has to reach the archive's end
 - `BundleManifest::artifacts` destructures the manifest without `..`,
   so adding an artifact field is a compile error until it is
   classified; keep it that way rather than reaching for a wildcard

--- a/crates/node/AGENTS.md
+++ b/crates/node/AGENTS.md
@@ -248,9 +248,12 @@ cargo test -p calimero-node --test network_simulation
   copies each service's wasm into a blob of its own
 - A bundle's manifest is the entry at exactly `manifest.json`, never a
   nested one: an `old/manifest.json` would be an authentically signed
-  older release, so basename matching is a signed rollback. A second
-  entry at that path is refused, after the signature rather than during
-  the pre-auth scan, since the check has to reach the archive's end
+  older release, so basename matching is a signed rollback. Only a
+  leading `./` is normalised away, since that is how ordinary tar
+  spells a top-level entry; every other component is significant, on
+  the manifest's declared paths as much as on the archive's entries. A
+  second entry at that path is refused, after the signature rather than
+  during the pre-auth scan, since the check has to reach the archive's end
 - `BundleManifest::artifacts` destructures the manifest without `..`,
   so adding an artifact field is a compile error until it is
   classified; keep it that way rather than reaching for a wildcard

--- a/crates/node/primitives/src/bundle/mod.rs
+++ b/crates/node/primitives/src/bundle/mod.rs
@@ -9,11 +9,14 @@ pub use signature::{
 use serde::{Deserialize, Serialize};
 
 /// Represents an artifact within a bundle (WASM, ABI, migration)
+///
+/// `hash` is what binds the artifact bytes to the manifest signature, so a
+/// manifest that omits it is malformed rather than merely unhashed.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BundleArtifact {
     pub path: String,
-    pub hash: Option<String>,
+    pub hash: String,
     pub size: u64,
 }
 
@@ -126,7 +129,6 @@ pub struct WasmArtifact<'a> {
     /// Service name. `None` for single-service bundles.
     pub name: Option<&'a str>,
     pub wasm: &'a BundleArtifact,
-    pub abi: Option<&'a BundleArtifact>,
 }
 
 impl BundleManifest {
@@ -148,7 +150,7 @@ impl BundleManifest {
     ///
     /// - Multi-service (`services` non-empty): yields one `WasmArtifact` per service.
     /// - Single-service: yields one `WasmArtifact` with `name: None` from the
-    ///   top-level `wasm`/`abi` fields.
+    ///   top-level `wasm` field.
     pub fn wasm_artifacts(&self) -> Vec<WasmArtifact<'_>> {
         match &self.services {
             Some(svcs) if !svcs.is_empty() => svcs
@@ -156,7 +158,6 @@ impl BundleManifest {
                 .map(|s| WasmArtifact {
                     name: Some(&s.name),
                     wasm: &s.wasm,
-                    abi: s.abi.as_ref(),
                 })
                 .collect(),
             _ => self
@@ -166,11 +167,48 @@ impl BundleManifest {
                     vec![WasmArtifact {
                         name: None,
                         wasm: w,
-                        abi: self.abi.as_ref(),
                     }]
                 })
                 .unwrap_or_default(),
         }
+    }
+
+    /// Every artifact the manifest declares, paired with its manifest field. The
+    /// `..`-free destructure stops compiling until a new field is classified.
+    pub fn artifacts(&self) -> Vec<(String, &BundleArtifact)> {
+        let Self {
+            wasm,
+            abi,
+            services,
+            migrations,
+            version: _,
+            package: _,
+            app_version: _,
+            signer_id: _,
+            min_runtime_version: _,
+            metadata: _,
+            interfaces: _,
+            links: _,
+            signature: _,
+        } = self;
+
+        let mut artifacts = Vec::new();
+        if let Some(wasm) = wasm {
+            artifacts.push(("wasm".to_owned(), wasm));
+        }
+        if let Some(abi) = abi {
+            artifacts.push(("abi".to_owned(), abi));
+        }
+        for (i, service) in services.iter().flatten().enumerate() {
+            artifacts.push((format!("services[{i}].wasm"), &service.wasm));
+            if let Some(abi) = &service.abi {
+                artifacts.push((format!("services[{i}].abi"), abi));
+            }
+        }
+        for (i, migration) in migrations.iter().enumerate() {
+            artifacts.push((format!("migrations[{i}]"), migration));
+        }
+        artifacts
     }
 
     /// Serialize the manifest's display metadata to JSON bytes for storage.

--- a/crates/node/primitives/src/client/application.rs
+++ b/crates/node/primitives/src/client/application.rs
@@ -10,7 +10,7 @@ use calimero_primitives::blobs::BlobId;
 use calimero_store::key;
 use calimero_store::key::AsKeyParts;
 use eyre::bail;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use super::NodeClient;
 
@@ -67,182 +67,11 @@ impl NodeClient {
         service_name: Option<&str>,
     ) -> eyre::Result<Option<Arc<[u8]>>> {
         let handle = self.datastore.handle();
-
-        let key = key::ApplicationMeta::new(*application_id);
-
-        let Some(application) = handle.get(&key)? else {
+        let Some(application) = handle.get(&key::ApplicationMeta::new(*application_id))? else {
             return Ok(None);
         };
-
-        // Determine if this is a bundle by checking package/version
-        // Bundles have real package/version values, non-bundles use "unknown"/"0.0.0"
-        // This avoids repeated decompression on every get_application_bytes call
-        let is_bundle =
-            application.package.as_ref() != "unknown" && application.version.as_ref() != "0.0.0";
-
-        // Get blob bytes
-        let Some(blob_bytes) = self
-            .get_blob_bytes(&application.bytecode.blob_id(), None)
-            .await?
-        else {
-            bail!("fatal: application points to dangling blob");
-        };
-
-        if is_bundle {
-            // This is a bundle, extract WASM from extracted directory or bundle.
-            // The bundle was already admitted (possibly unsigned in dev mode),
-            // so use the unsigned-tolerant extractor here.
-            let blob_bytes_clone = Arc::clone(&blob_bytes);
-            let (_, manifest) = tokio::task::spawn_blocking(move || {
-                bundle::extract_manifest_allow_unsigned(&blob_bytes_clone)
-            })
-            .await??;
-            let package = &manifest.package;
-            let version = &manifest.app_version;
-
-            // Resolve relative path against node root (must be done before spawn_blocking)
-            let blobstore_root = self.blob_manager.root_path();
-            let node_root = blobstore_root
-                .parent()
-                .ok_or_else(|| eyre::eyre!("blobstore root has no parent"))?
-                .to_path_buf();
-            let extract_dir = node_root
-                .join("applications")
-                .join(package)
-                .join(version)
-                .join("extracted");
-
-            // Resolve WASM path from manifest, supporting both single and multi-service bundles
-            let wasm_relative_path = match service_name {
-                Some(name) => {
-                    // Multi-service: find the named service in the services array
-                    manifest
-                        .services
-                        .as_ref()
-                        .and_then(|svcs| svcs.iter().find(|s| s.name == name))
-                        .map(|s| s.wasm.path.as_str())
-                        .ok_or_else(|| {
-                            eyre::eyre!("service '{}' not found in bundle manifest", name)
-                        })?
-                }
-                None => {
-                    // Single-service: use top-level wasm field (fallback to "app.wasm")
-                    manifest
-                        .wasm
-                        .as_ref()
-                        .map(|w| w.path.as_str())
-                        .unwrap_or("app.wasm")
-                }
-            };
-
-            // Validate WASM path to prevent path traversal attacks
-            // Check that the relative path doesn't contain ".." components that would escape
-            if wasm_relative_path.contains("..") {
-                bail!(
-                    "WASM path traversal detected: {} contains '..' component",
-                    wasm_relative_path
-                );
-            }
-
-            let wasm_path = extract_dir.join(wasm_relative_path);
-
-            // Additional validation: ensure the resolved path stays within extract_dir
-            // Use canonicalize if path exists, otherwise validate components
-            if wasm_path.exists() {
-                let canonical_wasm = wasm_path.canonicalize_utf8()?;
-
-                // extract_dir might not exist if wasm_relative_path contains subdirectories
-                // Reconstruct canonical extract_dir from wasm_path by removing relative path components
-                let canonical_extract = if extract_dir.exists() {
-                    extract_dir.canonicalize_utf8()?
-                } else {
-                    // Reconstruct extract_dir from wasm_path by removing wasm_relative_path components
-                    // Since we validated wasm_relative_path doesn't contain "..", this is safe
-                    let wasm_parent = wasm_path
-                        .parent()
-                        .ok_or_else(|| eyre::eyre!("WASM path has no parent directory"))?;
-                    let wasm_parent_canonical = wasm_parent.canonicalize_utf8()?;
-
-                    // Count depth of wasm_relative_path (number of path components)
-                    let relative_depth = wasm_relative_path
-                        .split('/')
-                        .filter(|s| !s.is_empty())
-                        .count()
-                        .saturating_sub(1); // Subtract 1 for the filename itself
-
-                    // Go up relative_depth levels from wasm_parent to get extract_dir
-                    let mut canonical_extract_candidate = wasm_parent_canonical.clone();
-                    for _ in 0..relative_depth {
-                        if let Some(parent) = canonical_extract_candidate.parent() {
-                            canonical_extract_candidate = parent.to_path_buf();
-                        } else {
-                            bail!("Cannot reconstruct extract_dir from WASM path");
-                        }
-                    }
-
-                    canonical_extract_candidate
-                };
-
-                // Ensure canonical_wasm is within canonical_extract
-                if !canonical_wasm.starts_with(&canonical_extract) {
-                    bail!(
-                        "WASM path traversal detected: {} escapes extraction directory {}",
-                        wasm_relative_path,
-                        extract_dir
-                    );
-                }
-            }
-
-            if wasm_path.exists() {
-                let wasm_bytes = tokio::fs::read(&wasm_path).await?;
-                return Ok(Some(wasm_bytes.into()));
-            } else {
-                // Fallback: re-extract from bundle blob if extracted files missing
-                warn!(
-                    wasm_path = %wasm_path,
-                    "extracted WASM not found, attempting to re-extract from bundle and persist to disk"
-                );
-
-                // Remove marker file if it exists (files were deleted, marker is stale)
-                let marker_file_path = extract_dir.join(".extracted");
-                if marker_file_path.exists() {
-                    let _ = tokio::fs::remove_file(&marker_file_path).await;
-                }
-
-                // Re-extract entire bundle to disk (not just WASM) so future calls don't need to re-extract
-                // This handles the case where sync_context_config installed the app before blob arrived
-                // Wrap blocking I/O in spawn_blocking to avoid blocking async runtime
-                let blob_bytes_clone = Arc::clone(&blob_bytes);
-                let manifest_clone = manifest.clone();
-                let extract_dir_clone = extract_dir.to_path_buf();
-                let node_root_clone = node_root.to_path_buf();
-                let package_clone = package.to_string();
-                let version_clone = version.to_string();
-                tokio::task::spawn_blocking(move || {
-                    Self::extract_bundle_artifacts(
-                        &blob_bytes_clone,
-                        &manifest_clone,
-                        &extract_dir_clone,
-                        &node_root_clone,
-                        &package_clone,
-                        &version_clone,
-                    )
-                })
-                .await??;
-
-                // Now read the WASM file that was just extracted
-                if wasm_path.exists() {
-                    let wasm_bytes = tokio::fs::read(&wasm_path).await?;
-                    return Ok(Some(wasm_bytes.into()));
-                }
-
-                bail!("WASM file not found in bundle after extraction");
-            }
-        }
-
-        // Single WASM installation (existing behavior)
-        // Reuse blob_bytes that were already fetched for bundle detection
-        Ok(Some(blob_bytes))
+        self.application_bytes_from_blob(&application.bytecode.blob_id(), service_name)
+            .await
     }
 
     pub fn has_application(&self, application_id: &ApplicationId) -> eyre::Result<bool> {
@@ -257,7 +86,7 @@ impl NodeClient {
         Ok(false)
     }
 
-    // Installation, uninstallation, and bundle extraction are in `install` submodule.
+    // Installation and uninstallation are in `install` submodule.
     // Query and management functions are in `query` submodule.
 }
 
@@ -279,11 +108,6 @@ pub struct ApplicationVersionInfo {
 }
 
 impl NodeClient {
-    /// Application wasm bytes straight from a bytecode BLOB — used for a
-    /// context pinned to a blob the application row no longer references
-    /// (version-stable bundle id overwritten in place). Fully in-memory: the
-    /// pinned version's extracted dir may be gone, but the blob is still in
-    /// the blobstore. `None` when the blob itself is absent locally.
     /// Service names inside the bundle at `blob_id`: one `Some(name)` per
     /// declared service, or a single `None` for single-service bundles. For a
     /// raw (non-bundle) wasm blob the result is also `[None]` — exactly the
@@ -300,8 +124,9 @@ impl NodeClient {
             return Ok(Some(vec![None]));
         }
         let names = tokio::task::spawn_blocking(move || -> eyre::Result<Vec<Option<String>>> {
-            let (_, manifest) = bundle::extract_manifest_allow_unsigned(&blob_bytes)?;
-            Ok(manifest
+            let verified = bundle::VerifiedBundle::open(blob_bytes)?;
+            Ok(verified
+                .manifest()
                 .wasm_artifacts()
                 .iter()
                 .map(|a| a.name.map(str::to_owned))
@@ -312,9 +137,8 @@ impl NodeClient {
         Ok(Some(names))
     }
 
-    /// Bundle manifest of the blob at `blob_id`, parsed leniently (unsigned
-    /// allowed — admission verification happened at install/upgrade time).
-    /// `None` when the blob is absent locally or is not a bundle.
+    /// Bundle manifest of the blob at `blob_id`. `None` when the blob is
+    /// absent locally or is not a bundle.
     pub async fn bundle_manifest_for_blob(
         &self,
         blob_id: &BlobId,
@@ -326,11 +150,10 @@ impl NodeClient {
             return Ok(None);
         }
         let manifest = tokio::task::spawn_blocking(move || {
-            bundle::extract_manifest_allow_unsigned(&blob_bytes)
+            bundle::VerifiedBundle::open(blob_bytes).map(|v| v.manifest().clone())
         })
         .await
-        .map_err(|e| eyre::eyre!("bundle manifest read task failed: {e}"))??
-        .1;
+        .map_err(|e| eyre::eyre!("bundle manifest read task failed: {e}"))??;
         Ok(Some(manifest))
     }
 
@@ -419,11 +242,11 @@ impl NodeClient {
             let size = blob_bytes.len() as u64;
             if Self::is_bundle_blob(&blob_bytes) {
                 let manifest = match tokio::task::spawn_blocking(move || {
-                    bundle::extract_manifest_allow_unsigned(&blob_bytes)
+                    bundle::VerifiedBundle::open(blob_bytes).map(|v| v.manifest().clone())
                 })
                 .await
                 {
-                    Ok(Ok((_, manifest))) => manifest,
+                    Ok(Ok(manifest)) => manifest,
                     // Unparseable manifests are skipped, not fatal: foreign
                     // or corrupt blobs must not break the inventory.
                     Ok(Err(err)) => {
@@ -475,6 +298,9 @@ impl NodeClient {
         Ok(versions)
     }
 
+    /// Application wasm bytes straight from a bytecode blob - the blobstore is
+    /// the only copy, so a context pinned to a blob the application row no
+    /// longer references still resolves. `None` when the blob is absent locally.
     pub async fn application_bytes_from_blob(
         &self,
         blob_id: &BlobId,
@@ -483,36 +309,16 @@ impl NodeClient {
         let Some(blob_bytes) = self.get_blob_bytes(blob_id, None).await? else {
             return Ok(None);
         };
-        if !Self::is_bundle_blob(&blob_bytes) {
-            return Ok(Some(blob_bytes));
-        }
-        let service_owned = service_name.map(str::to_owned);
-        let wasm = tokio::task::spawn_blocking(move || -> eyre::Result<Option<Vec<u8>>> {
-            let (_, manifest) = bundle::extract_manifest_allow_unsigned(&blob_bytes)?;
-            let wasm_relative_path = match service_owned.as_deref() {
-                Some(name) => manifest
-                    .services
-                    .as_ref()
-                    .and_then(|svcs| svcs.iter().find(|s| s.name == name))
-                    .map(|s| s.wasm.path.clone())
-                    .ok_or_else(|| {
-                        eyre::eyre!("service '{}' not found in bundle manifest", name)
-                    })?,
-                None => manifest
-                    .wasm
-                    .as_ref()
-                    .map(|w| w.path.clone())
-                    .unwrap_or_else(|| "app.wasm".to_owned()),
-            };
-            if wasm_relative_path.contains("..") {
-                bail!(
-                    "WASM path traversal detected: {} contains '..' component",
-                    wasm_relative_path
-                );
+        let service = service_name.map(str::to_owned);
+        // Detection gunzips too, so it belongs on the blocking pool with the
+        // read it gates rather than on the reactor thread.
+        let wasm = tokio::task::spawn_blocking(move || -> eyre::Result<_> {
+            if !Self::is_bundle_blob(&blob_bytes) {
+                return Ok(blob_bytes);
             }
-            bundle::extract_bundle_file(&blob_bytes, &wasm_relative_path)
+            bundle::VerifiedBundle::open(blob_bytes)?.wasm(service.as_deref())
         })
         .await??;
-        Ok(wasm.map(Into::into))
+        Ok(Some(wasm))
     }
 }

--- a/crates/node/primitives/src/client/application/bundle.rs
+++ b/crates/node/primitives/src/client/application/bundle.rs
@@ -68,9 +68,28 @@ fn bounded_archive(data: &[u8], limit: u64) -> Archive<Capped<GzDecoder<&[u8]>>>
     })
 }
 
-/// One rule for both archive scans, so they cannot be edited apart.
+/// One rule for both archive scans, so they cannot be edited apart. Exact and
+/// top-level: a nested `old/manifest.json` can carry an authentic older release.
 fn is_manifest_entry(path: &Path) -> bool {
-    path.file_name().and_then(|n| n.to_str()) == Some("manifest.json")
+    path == Path::new("manifest.json")
+}
+
+/// A second `manifest.json` leaves an unpacker holding one the signature never
+/// covered, so the archive is refused rather than resolved by entry order.
+fn ensure_single_manifest(bundle_data: &[u8]) -> eyre::Result<()> {
+    let mut archive = bounded_archive(bundle_data, MAX_ARCHIVE_BYTES);
+    let mut seen = false;
+    for entry in archive.entries()? {
+        let entry = entry?;
+        if !is_manifest_entry(&entry.path()?) {
+            continue;
+        }
+        if seen {
+            bail!("bundle archive has more than one entry at 'manifest.json'");
+        }
+        seen = true;
+    }
+    Ok(())
 }
 
 /// Validates that a string is safe for use as a filesystem path component.
@@ -185,11 +204,13 @@ pub fn extract_bundle_manifest(
     bail!("manifest.json not found in bundle")
 }
 
-/// Whether a blob is a bundle archive: any tar entry named `manifest.json`.
+/// Whether a blob is a bundle archive: a tar entry at `manifest.json`.
 ///
 /// Same walk, same bound and same predicate as [`extract_bundle_manifest`], since
 /// this is the only signature gate on the execution-time read: where the two
 /// disagree, one path installs a verified bundle the other serves as raw bytes.
+/// [`VerifiedBundle::open`] is stricter still, refusing a duplicated manifest;
+/// stricter here would instead mean serving the archive as raw bytes.
 pub fn is_bundle_blob(blob_bytes: &[u8]) -> bool {
     let mut archive = bounded_archive(blob_bytes, MAX_MANIFEST_SCAN_BYTES);
 
@@ -282,6 +303,9 @@ impl VerifiedBundle {
     pub fn open(data: Arc<[u8]>) -> eyre::Result<Self> {
         let (manifest_json, manifest) = extract_bundle_manifest(&data)?;
         let ManifestVerification { signer_id, .. } = verify_manifest_signature(&manifest_json)?;
+        // After the signature, not during the scan: reaching the end of a large
+        // archive needs the archive cap, which the pre-auth scan must not spend.
+        ensure_single_manifest(&data)?;
         debug!(%signer_id, package = %manifest.package, "bundle manifest signature verified");
         Ok(Self {
             data,

--- a/crates/node/primitives/src/client/application/bundle.rs
+++ b/crates/node/primitives/src/client/application/bundle.rs
@@ -1,16 +1,77 @@
 //! Bundle verification, manifest extraction, and path validation.
 //!
-//! Pure functions for working with `.mpk` bundle archives — no
+//! Pure functions for working with `.mpk` bundle archives - no
 //! `NodeClient` or blob manager state needed.
 
-use std::io::Read;
+use std::collections::{BTreeSet, HashMap};
+use std::io::{self, Read};
+use std::path::Path;
+use std::sync::Arc;
 
-use crate::bundle::{verify_manifest_signature, BundleManifest, ManifestVerification};
+use crate::bundle::{
+    verify_manifest_signature, BundleArtifact, BundleManifest, ManifestVerification,
+};
 use eyre::bail;
 use flate2::read::GzDecoder;
 use semver::Version;
+use sha2::{Digest, Sha256};
 use tar::Archive;
 use tracing::{debug, warn};
+
+/// How far the manifest scan may decompress. It runs before any signature is
+/// checked, and the manifest must appear within it or the archive is refused.
+const MAX_MANIFEST_SCAN_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Bounds the JSON parse that follows, which the stream cap does not: a `Value`
+/// tree costs several times the bytes it was built from.
+const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
+
+/// How far any one archive walk may decompress. Every read walks the whole
+/// archive, so this bounds a bundle's total decompressed size.
+const MAX_ARCHIVE_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Bounds total decompressed bytes. `tar` buffers GNU long-name, long-link and
+/// pax members with an unbounded read inside `entries()`, before any `Entry` is
+/// handed out, so a per-entry limit is unreachable and this has to sit lower.
+struct Capped<R> {
+    inner: R,
+    limit: u64,
+    used: u64,
+}
+
+impl<R: Read> Read for Capped<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // One byte of slack, so a stream of exactly `limit` bytes still reaches
+        // EOF instead of tripping the cap on its final empty read.
+        let allowed = self.limit.saturating_add(1).saturating_sub(self.used);
+        if allowed == 0 {
+            return Err(io::Error::other(format!(
+                "bundle archive exceeds the {} byte decompressed cap",
+                self.limit
+            )));
+        }
+        let len = buf
+            .len()
+            .min(usize::try_from(allowed).unwrap_or(usize::MAX));
+        let read = self.inner.read(&mut buf[..len])?;
+        self.used += read as u64;
+        Ok(read)
+    }
+}
+
+/// A `.mpk`'s tar stream, bounded to `limit` decompressed bytes.
+fn bounded_archive(data: &[u8], limit: u64) -> Archive<Capped<GzDecoder<&[u8]>>> {
+    Archive::new(Capped {
+        inner: GzDecoder::new(data),
+        limit,
+        used: 0,
+    })
+}
+
+/// One rule for both archive scans, so they cannot be edited apart.
+fn is_manifest_entry(path: &Path) -> bool {
+    path.file_name().and_then(|n| n.to_str()) == Some("manifest.json")
+}
 
 /// Validates that a string is safe for use as a filesystem path component.
 ///
@@ -58,68 +119,27 @@ pub fn validate_artifact_path(value: &str, field_name: &str) -> eyre::Result<()>
     Ok(())
 }
 
-/// Extracts bundle manifest, verifies signature, and returns both verification
-/// result and typed manifest. Signature is mandatory.
-pub fn verify_and_extract_manifest(
-    bundle_data: &[u8],
-) -> eyre::Result<(ManifestVerification, BundleManifest)> {
-    let (manifest_json, manifest) = extract_bundle_manifest(bundle_data)?;
-    let verification = verify_manifest_signature(&manifest_json)?;
-    debug!(
-        signer_id = %verification.signer_id,
-        bundle_hash = %hex::encode(verification.bundle_hash),
-        "bundle manifest signature verified"
-    );
-    Ok((verification, manifest))
-}
-
-/// Extracts bundle manifest, verifying signature only if present.
-///
-/// Used for dev installs and WASM loading of already-installed bundles,
-/// where the bundle may have been admitted unsigned. If a signature IS
-/// present it is still verified — invalid signatures are always rejected.
-///
-/// Production installs MUST use `verify_and_extract_manifest` instead,
-/// which requires a valid signature.
-pub fn extract_manifest_allow_unsigned(
-    bundle_data: &[u8],
-) -> eyre::Result<(ManifestVerification, BundleManifest)> {
-    let (manifest_json, manifest) = extract_bundle_manifest(bundle_data)?;
-    let verification = if manifest_json.get("signature").is_some() {
-        let v = verify_manifest_signature(&manifest_json)?;
-        debug!(
-            signer_id = %v.signer_id,
-            bundle_hash = %hex::encode(v.bundle_hash),
-            "bundle manifest signature verified"
-        );
-        v
-    } else {
-        debug!("bundle has no signature field, treating as unsigned dev bundle");
-        ManifestVerification {
-            signer_id: "dev:unsigned".to_owned(),
-            bundle_hash: [0u8; 32],
-        }
-    };
-    Ok((verification, manifest))
-}
-
 /// Extract and parse bundle manifest from bundle archive data.
 /// Returns both the raw JSON value (for signature verification) and the typed manifest.
 pub fn extract_bundle_manifest(
     bundle_data: &[u8],
 ) -> eyre::Result<(serde_json::Value, BundleManifest)> {
-    let tar = GzDecoder::new(bundle_data);
-    let mut archive = Archive::new(tar);
+    let mut archive = bounded_archive(bundle_data, MAX_MANIFEST_SCAN_BYTES);
 
     for entry in archive.entries()? {
-        let mut entry = entry?;
+        let entry = entry?;
         let path = entry.path()?;
 
-        if path.file_name().and_then(|n| n.to_str()) == Some("manifest.json") {
-            let mut manifest_str = String::new();
-            entry.read_to_string(&mut manifest_str)?;
+        if is_manifest_entry(&path) {
+            let mut manifest_bytes = Vec::new();
+            let _ = entry
+                .take(MAX_MANIFEST_BYTES + 1)
+                .read_to_end(&mut manifest_bytes)?;
+            if manifest_bytes.len() as u64 > MAX_MANIFEST_BYTES {
+                bail!("bundle manifest.json exceeds the {MAX_MANIFEST_BYTES} byte cap");
+            }
 
-            let manifest_json: serde_json::Value = serde_json::from_str(&manifest_str)
+            let manifest_json: serde_json::Value = serde_json::from_slice(&manifest_bytes)
                 .map_err(|e| eyre::eyre!("failed to parse manifest.json as JSON: {}", e))?;
 
             let manifest: BundleManifest = serde_json::from_value(manifest_json.clone())
@@ -135,14 +155,8 @@ pub fn extract_bundle_manifest(
             validate_path_component(&manifest.package, "package")?;
             validate_path_component(&manifest.app_version, "appVersion")?;
 
-            if let Some(ref wasm) = manifest.wasm {
-                validate_artifact_path(&wasm.path, "wasm.path")?;
-            }
-            if let Some(ref abi) = manifest.abi {
-                validate_artifact_path(&abi.path, "abi.path")?;
-            }
-            for (i, migration) in manifest.migrations.iter().enumerate() {
-                validate_artifact_path(&migration.path, &format!("migrations[{i}].path"))?;
+            for (field, artifact) in manifest.artifacts() {
+                validate_artifact_path(&artifact.path, &format!("{field}.path"))?;
             }
 
             let current_runtime_version = Version::parse(env!("CALIMERO_RELEASE_VERSION"))
@@ -171,12 +185,13 @@ pub fn extract_bundle_manifest(
     bail!("manifest.json not found in bundle")
 }
 
-/// Check if a blob contains a bundle archive by peeking at the first few entries.
+/// Whether a blob is a bundle archive: any tar entry named `manifest.json`.
 ///
-/// Returns true if manifest.json is found, false otherwise.
+/// Same walk, same bound and same predicate as [`extract_bundle_manifest`], since
+/// this is the only signature gate on the execution-time read: where the two
+/// disagree, one path installs a verified bundle the other serves as raw bytes.
 pub fn is_bundle_blob(blob_bytes: &[u8]) -> bool {
-    let tar = GzDecoder::new(blob_bytes);
-    let mut archive = Archive::new(tar);
+    let mut archive = bounded_archive(blob_bytes, MAX_MANIFEST_SCAN_BYTES);
 
     let entries = match archive.entries() {
         Ok(entries) => entries,
@@ -190,17 +205,16 @@ pub fn is_bundle_blob(blob_bytes: &[u8]) -> bool {
     };
 
     for (i, entry) in entries.enumerate() {
-        if i >= 10 {
-            break;
-        }
         match entry {
             Ok(entry) => {
-                if let Ok(path) = entry.path() {
-                    if path.file_name().and_then(|n| n.to_str()) == Some("manifest.json") {
-                        return true;
-                    }
+                // Existential: one hit is decisive, so stopping here cannot
+                // change the answer the way the old entry-count cap could.
+                if entry.path().is_ok_and(|p| is_manifest_entry(&p)) {
+                    return true;
                 }
             }
+            // A corrupt entry stops this walk and `extract_bundle_manifest`
+            // alike, so neither path reaches a manifest hidden behind it.
             Err(e) => {
                 warn!("Failed to read tar entry {}: {}", i, e);
                 break;
@@ -216,23 +230,136 @@ pub fn is_bundle_archive(path: &camino::Utf8Path) -> bool {
     path.extension().map(|ext| ext == "mpk").unwrap_or(false)
 }
 
-/// Read one file's bytes out of a bundle archive in memory (no extraction to
-/// disk). `file_path` is the manifest-relative artifact path (already
-/// validated against traversal by the manifest parser). Returns `None` when
-/// the archive has no such entry.
-pub fn extract_bundle_file(bundle_data: &[u8], file_path: &str) -> eyre::Result<Option<Vec<u8>>> {
-    let tar = GzDecoder::new(bundle_data);
-    let mut archive = Archive::new(tar);
+/// Read the `wanted` paths out of a bundle archive in memory (no extraction to
+/// disk), in one walk. Paths are manifest-relative and matched exactly against
+/// the whole archive: a basename or first-hit match would let a decoy entry pass
+/// the digest check for the entry an unpacker later writes. Paths the archive
+/// does not hold are simply absent from the result.
+///
+/// One walk for every path, not one per path: skipping an entry still
+/// decompresses it, so a walk per artifact would multiply the archive's whole
+/// decompressed size by the number of artifacts.
+fn extract_bundle_files<'a>(
+    bundle_data: &[u8],
+    wanted: &BTreeSet<&'a str>,
+) -> eyre::Result<HashMap<&'a str, Arc<[u8]>>> {
+    let mut archive = bounded_archive(bundle_data, MAX_ARCHIVE_BYTES);
+    let mut found = HashMap::new();
     for entry in archive.entries()? {
         let mut entry = entry?;
-        let path = entry.path()?;
-        if path.to_str() == Some(file_path)
-            || path.file_name().and_then(|n| n.to_str()) == Some(file_path)
-        {
-            let mut bytes = Vec::new();
-            let _ = entry.read_to_end(&mut bytes)?;
-            return Ok(Some(bytes));
+        let Some(&path) = entry.path()?.to_str().and_then(|p| wanted.get(p)) else {
+            continue;
+        };
+        if found.contains_key(path) {
+            bail!("bundle archive has more than one entry at '{path}'");
+        }
+        let mut bytes = Vec::new();
+        let _ = entry.read_to_end(&mut bytes)?;
+        let _ = found.insert(path, Arc::from(bytes));
+    }
+    Ok(found)
+}
+
+/// One artifact out of a completed walk. Several services may name one path, so
+/// the bytes are shared rather than copied per service.
+fn take_artifact(found: &HashMap<&str, Arc<[u8]>>, path: &str) -> eyre::Result<Arc<[u8]>> {
+    found.get(path).map(Arc::clone).ok_or_else(|| {
+        eyre::eyre!("bundle artifact '{path}' named in the manifest is missing from the archive")
+    })
+}
+
+/// A bundle whose manifest signature has been verified. The only way to obtain
+/// artifact bytes: every accessor checks the artifact digest against the signed
+/// manifest first, so unverified bytes have no representation.
+pub struct VerifiedBundle {
+    data: Arc<[u8]>,
+    manifest: BundleManifest,
+    signer_id: String,
+}
+
+impl VerifiedBundle {
+    /// Signature is mandatory. There is no unsigned constructor.
+    pub fn open(data: Arc<[u8]>) -> eyre::Result<Self> {
+        let (manifest_json, manifest) = extract_bundle_manifest(&data)?;
+        let ManifestVerification { signer_id, .. } = verify_manifest_signature(&manifest_json)?;
+        debug!(%signer_id, package = %manifest.package, "bundle manifest signature verified");
+        Ok(Self {
+            data,
+            manifest,
+            signer_id,
+        })
+    }
+
+    pub fn manifest(&self) -> &BundleManifest {
+        &self.manifest
+    }
+
+    pub fn signer_id(&self) -> &str {
+        &self.signer_id
+    }
+
+    /// Wasm bytes for a service (`None` selects a single-service bundle's
+    /// top-level `wasm`), checked against the manifest digest.
+    pub fn wasm(&self, service: Option<&str>) -> eyre::Result<Arc<[u8]>> {
+        let artifact = self.wasm_artifact(service)?;
+        let path = artifact.path.as_str();
+        let found = extract_bundle_files(&self.data, &BTreeSet::from([path]))?;
+        let bytes = take_artifact(&found, path)?;
+        verify_artifact_digest(artifact, &bytes)?;
+        Ok(bytes)
+    }
+
+    /// Every declared wasm artifact, digest-checked, paired with its service
+    /// name. One walk covers every path, and a path named by several services
+    /// is read once and shared.
+    pub fn all_wasm(&self) -> eyre::Result<Vec<(Option<String>, Arc<[u8]>)>> {
+        let artifacts = self.manifest.wasm_artifacts();
+        let wanted = artifacts
+            .iter()
+            .map(|a| a.wasm.path.as_str())
+            .collect::<BTreeSet<_>>();
+        let found = extract_bundle_files(&self.data, &wanted)?;
+
+        let mut all = Vec::new();
+        for artifact in &artifacts {
+            let bytes = take_artifact(&found, &artifact.wasm.path)?;
+            // Per artifact, never per read: two services may declare different
+            // digests for one path, and sharing the bytes must not share the check.
+            verify_artifact_digest(artifact.wasm, &bytes)?;
+            all.push((artifact.name.map(str::to_owned), bytes));
+        }
+        Ok(all)
+    }
+
+    fn wasm_artifact(&self, service: Option<&str>) -> eyre::Result<&BundleArtifact> {
+        match service {
+            Some(name) => self
+                .manifest
+                .wasm_artifacts()
+                .into_iter()
+                .find(|a| a.name == Some(name))
+                .map(|a| a.wasm)
+                .ok_or_else(|| eyre::eyre!("service '{}' not found in bundle manifest", name)),
+            None => self
+                .manifest
+                .wasm
+                .as_ref()
+                .ok_or_else(|| eyre::eyre!("bundle manifest declares no top-level wasm")),
         }
     }
-    Ok(None)
+}
+
+/// Compare an artifact's bytes against the digest the publisher signed. Hex case
+/// carries no information, so a case-differing manifest is still a match.
+fn verify_artifact_digest(artifact: &BundleArtifact, bytes: &[u8]) -> eyre::Result<()> {
+    let actual = hex::encode(Sha256::digest(bytes));
+    if !actual.eq_ignore_ascii_case(&artifact.hash) {
+        bail!(
+            "bundle artifact '{}' failed its integrity check: manifest hash {}, actual {}",
+            artifact.path,
+            artifact.hash,
+            actual
+        );
+    }
+    Ok(())
 }

--- a/crates/node/primitives/src/client/application/bundle.rs
+++ b/crates/node/primitives/src/client/application/bundle.rs
@@ -289,6 +289,14 @@ fn take_artifact(found: &HashMap<&str, Arc<[u8]>>, path: &str) -> eyre::Result<A
     })
 }
 
+/// One digest-checked wasm artifact out of a [`VerifiedBundle`], the owned
+/// counterpart to the manifest's [`crate::bundle::WasmArtifact`].
+pub struct VerifiedWasm {
+    /// Service name. `None` for single-service bundles.
+    pub name: Option<String>,
+    pub bytes: Arc<[u8]>,
+}
+
 /// A bundle whose manifest signature has been verified. The only way to obtain
 /// artifact bytes: every accessor checks the artifact digest against the signed
 /// manifest first, so unverified bytes have no representation.
@@ -336,7 +344,7 @@ impl VerifiedBundle {
     /// Every declared wasm artifact, digest-checked, paired with its service
     /// name. One walk covers every path, and a path named by several services
     /// is read once and shared.
-    pub fn all_wasm(&self) -> eyre::Result<Vec<(Option<String>, Arc<[u8]>)>> {
+    pub fn all_wasm(&self) -> eyre::Result<Vec<VerifiedWasm>> {
         let artifacts = self.manifest.wasm_artifacts();
         let wanted = artifacts
             .iter()
@@ -350,7 +358,10 @@ impl VerifiedBundle {
             // Per artifact, never per read: two services may declare different
             // digests for one path, and sharing the bytes must not share the check.
             verify_artifact_digest(artifact.wasm, &bytes)?;
-            all.push((artifact.name.map(str::to_owned), bytes));
+            all.push(VerifiedWasm {
+                name: artifact.name.map(str::to_owned),
+                bytes,
+            });
         }
         Ok(all)
     }

--- a/crates/node/primitives/src/client/application/bundle.rs
+++ b/crates/node/primitives/src/client/application/bundle.rs
@@ -15,7 +15,7 @@ use eyre::bail;
 use flate2::read::GzDecoder;
 use semver::Version;
 use sha2::{Digest, Sha256};
-use tar::Archive;
+use tar::{Archive, Entry};
 use tracing::{debug, warn};
 
 /// How far the manifest scan may decompress. It runs before any signature is
@@ -68,10 +68,15 @@ fn bounded_archive(data: &[u8], limit: u64) -> Archive<Capped<GzDecoder<&[u8]>>>
     })
 }
 
-/// One rule for both archive scans, so they cannot be edited apart. Exact and
+/// One rule for every archive scan, so they cannot be edited apart. Exact and
 /// top-level: a nested `old/manifest.json` can carry an authentic older release.
-fn is_manifest_entry(path: &Path) -> bool {
-    path == Path::new("manifest.json")
+/// It takes the entry, not a path, so that resolving the path is part of the
+/// shared rule: an unresolvable one is a non-match here and must never abort a
+/// scan, since [`is_bundle_blob`] can only fail by falling back to raw bytes.
+fn is_manifest_entry<R: Read>(entry: &Entry<'_, R>) -> bool {
+    entry
+        .path()
+        .is_ok_and(|path| path == Path::new("manifest.json"))
 }
 
 /// A second `manifest.json` leaves an unpacker holding one the signature never
@@ -81,7 +86,7 @@ fn ensure_single_manifest(bundle_data: &[u8]) -> eyre::Result<()> {
     let mut seen = false;
     for entry in archive.entries()? {
         let entry = entry?;
-        if !is_manifest_entry(&entry.path()?) {
+        if !is_manifest_entry(&entry) {
             continue;
         }
         if seen {
@@ -147,9 +152,8 @@ pub fn extract_bundle_manifest(
 
     for entry in archive.entries()? {
         let entry = entry?;
-        let path = entry.path()?;
 
-        if is_manifest_entry(&path) {
+        if is_manifest_entry(&entry) {
             let mut manifest_bytes = Vec::new();
             let _ = entry
                 .take(MAX_MANIFEST_BYTES + 1)
@@ -206,9 +210,12 @@ pub fn extract_bundle_manifest(
 
 /// Whether a blob is a bundle archive: a tar entry at `manifest.json`.
 ///
-/// Same walk, same bound and same predicate as [`extract_bundle_manifest`], since
-/// this is the only signature gate on the execution-time read: where the two
-/// disagree, one path installs a verified bundle the other serves as raw bytes.
+/// Same walk, same bound and the same [`is_manifest_entry`] predicate as
+/// [`extract_bundle_manifest`], since this is the only signature gate on the
+/// execution-time read: where the two disagree, one path installs a verified
+/// bundle the other serves as raw bytes. The one asymmetry left is an entry that
+/// will not decode at all, which ends this walk as `false` where the verified
+/// read raises it; neither reaches a manifest sitting behind it.
 /// [`VerifiedBundle::open`] is stricter still, refusing a duplicated manifest;
 /// stricter here would instead mean serving the archive as raw bytes.
 pub fn is_bundle_blob(blob_bytes: &[u8]) -> bool {
@@ -230,7 +237,7 @@ pub fn is_bundle_blob(blob_bytes: &[u8]) -> bool {
             Ok(entry) => {
                 // Existential: one hit is decisive, so stopping here cannot
                 // change the answer the way the old entry-count cap could.
-                if entry.path().is_ok_and(|p| is_manifest_entry(&p)) {
+                if is_manifest_entry(&entry) {
                     return true;
                 }
             }
@@ -255,7 +262,9 @@ pub fn is_bundle_archive(path: &camino::Utf8Path) -> bool {
 /// disk), in one walk. Paths are manifest-relative and matched exactly against
 /// the whole archive: a basename or first-hit match would let a decoy entry pass
 /// the digest check for the entry an unpacker later writes. Paths the archive
-/// does not hold are simply absent from the result.
+/// does not hold are simply absent from the result. A path that will not decode
+/// is a non-match rather than an abort, as everywhere else: a manifest declares
+/// its paths as JSON strings, so one that is not valid UTF-8 is never sought.
 ///
 /// One walk for every path, not one per path: skipping an entry still
 /// decompresses it, so a walk per artifact would multiply the archive's whole
@@ -268,7 +277,11 @@ fn extract_bundle_files<'a>(
     let mut found = HashMap::new();
     for entry in archive.entries()? {
         let mut entry = entry?;
-        let Some(&path) = entry.path()?.to_str().and_then(|p| wanted.get(p)) else {
+        let Some(&path) = entry
+            .path()
+            .ok()
+            .and_then(|p| p.to_str().and_then(|p| wanted.get(p)))
+        else {
             continue;
         };
         if found.contains_key(path) {

--- a/crates/node/primitives/src/client/application/bundle.rs
+++ b/crates/node/primitives/src/client/application/bundle.rs
@@ -5,7 +5,7 @@
 
 use std::collections::{BTreeSet, HashMap};
 use std::io::{self, Read};
-use std::path::Path;
+use std::path::{Component, Path};
 use std::sync::Arc;
 
 use crate::bundle::{
@@ -68,6 +68,17 @@ fn bounded_archive(data: &[u8], limit: u64) -> Archive<Capped<GzDecoder<&[u8]>>>
     })
 }
 
+/// Whether two archive-relative paths name the same entry. A leading `./` is the
+/// spelling ordinary tar producers emit and means nothing, but `old/` is a real
+/// component, so this is not basename matching: a nested manifest stays distinct.
+fn same_archive_path(a: &Path, b: &Path) -> bool {
+    fn parts(path: &Path) -> impl Iterator<Item = Component<'_>> {
+        path.components()
+            .skip_while(|c| matches!(c, Component::CurDir))
+    }
+    parts(a).eq(parts(b))
+}
+
 /// One rule for every archive scan, so they cannot be edited apart. Exact and
 /// top-level: a nested `old/manifest.json` can carry an authentic older release.
 /// It takes the entry, not a path, so that resolving the path is part of the
@@ -76,7 +87,7 @@ fn bounded_archive(data: &[u8], limit: u64) -> Archive<Capped<GzDecoder<&[u8]>>>
 fn is_manifest_entry<R: Read>(entry: &Entry<'_, R>) -> bool {
     entry
         .path()
-        .is_ok_and(|path| path == Path::new("manifest.json"))
+        .is_ok_and(|path| same_archive_path(&path, Path::new("manifest.json")))
 }
 
 /// A second `manifest.json` leaves an unpacker holding one the signature never
@@ -259,12 +270,12 @@ pub fn is_bundle_archive(path: &camino::Utf8Path) -> bool {
 }
 
 /// Read the `wanted` paths out of a bundle archive in memory (no extraction to
-/// disk), in one walk. Paths are manifest-relative and matched exactly against
-/// the whole archive: a basename or first-hit match would let a decoy entry pass
-/// the digest check for the entry an unpacker later writes. Paths the archive
-/// does not hold are simply absent from the result. A path that will not decode
-/// is a non-match rather than an abort, as everywhere else: a manifest declares
-/// its paths as JSON strings, so one that is not valid UTF-8 is never sought.
+/// disk), in one walk. Paths are manifest-relative and matched whole against the
+/// archive under the same [`same_archive_path`] rule the manifest scan uses: a
+/// basename or first-hit match would let a decoy entry pass the digest check for
+/// the entry an unpacker later writes. Paths the archive does not hold are simply
+/// absent from the result. A path that will not decode is a non-match rather than
+/// an abort, as everywhere else.
 ///
 /// One walk for every path, not one per path: skipping an entry still
 /// decompresses it, so a walk per artifact would multiply the archive's whole
@@ -277,19 +288,27 @@ fn extract_bundle_files<'a>(
     let mut found = HashMap::new();
     for entry in archive.entries()? {
         let mut entry = entry?;
-        let Some(&path) = entry
-            .path()
-            .ok()
-            .and_then(|p| p.to_str().and_then(|p| wanted.get(p)))
-        else {
+        let Ok(entry_path) = entry.path() else {
             continue;
         };
-        if found.contains_key(path) {
-            bail!("bundle archive has more than one entry at '{path}'");
+        // Every match, not the first: a manifest may spell one path two ways,
+        // and each declaration carries its own digest.
+        let matched = wanted
+            .iter()
+            .copied()
+            .filter(|w| same_archive_path(Path::new(w), &entry_path))
+            .collect::<Vec<_>>();
+        if matched.is_empty() {
+            continue;
         }
         let mut bytes = Vec::new();
         let _ = entry.read_to_end(&mut bytes)?;
-        let _ = found.insert(path, Arc::from(bytes));
+        let bytes: Arc<[u8]> = Arc::from(bytes);
+        for path in matched {
+            if found.insert(path, Arc::clone(&bytes)).is_some() {
+                bail!("bundle archive has more than one entry at '{path}'");
+            }
+        }
     }
     Ok(found)
 }

--- a/crates/node/primitives/src/client/application/install.rs
+++ b/crates/node/primitives/src/client/application/install.rs
@@ -220,6 +220,12 @@ impl NodeClient {
         })
         .await??;
 
+        // Otherwise the application row is written with no bytecode and the
+        // bundle only reads as malformed at its first execution.
+        if wasm_bytes.is_empty() {
+            bail!("bundle manifest declares no wasm artifact: expected a top-level 'wasm' or a non-empty 'services' list");
+        }
+
         let manifest = verified.manifest();
         let package = &manifest.package;
         let version = &manifest.app_version;

--- a/crates/node/primitives/src/client/application/install.rs
+++ b/crates/node/primitives/src/client/application/install.rs
@@ -213,16 +213,16 @@ impl NodeClient {
     ) -> eyre::Result<ApplicationId> {
         // Every artifact, including the unnamed single-service one that gets no
         // blob of its own, so substituted bytes are refused before first execution.
-        let (verified, wasm_bytes) = tokio::task::spawn_blocking(move || -> eyre::Result<_> {
+        let (verified, wasm) = tokio::task::spawn_blocking(move || -> eyre::Result<_> {
             let verified = bundle::VerifiedBundle::open(bundle_data)?;
-            let wasm_bytes = verified.all_wasm()?;
-            Ok((verified, wasm_bytes))
+            let wasm = verified.all_wasm()?;
+            Ok((verified, wasm))
         })
         .await??;
 
         // Otherwise the application row is written with no bytecode and the
         // bundle only reads as malformed at its first execution.
-        if wasm_bytes.is_empty() {
+        if wasm.is_empty() {
             bail!("bundle manifest declares no wasm artifact: expected a top-level 'wasm' or a non-empty 'services' list");
         }
 
@@ -231,10 +231,14 @@ impl NodeClient {
         let version = &manifest.app_version;
 
         let mut services = Vec::new();
-        for (name, wasm) in &wasm_bytes {
-            let Some(name) = name else { continue };
+        for artifact in &wasm {
+            let Some(name) = &artifact.name else { continue };
             let (svc_blob_id, _svc_size) = self
-                .add_blob(Cursor::new(&wasm[..]), Some(wasm.len() as u64), None)
+                .add_blob(
+                    Cursor::new(&artifact.bytes[..]),
+                    Some(artifact.bytes.len() as u64),
+                    None,
+                )
                 .await?;
             services.push(types::ServiceMeta {
                 name: name.as_str().into(),

--- a/crates/node/primitives/src/client/application/install.rs
+++ b/crates/node/primitives/src/client/application/install.rs
@@ -1,25 +1,20 @@
-//! Application installation, uninstallation, and bundle extraction.
+//! Application installation and uninstallation.
 
 use std::io::{self, ErrorKind};
 use std::sync::Arc;
 
 use super::bundle;
-use crate::bundle::{BundleManifest, ManifestVerification};
 use calimero_primitives::application::{ApplicationId, ApplicationSource};
 use calimero_primitives::blobs::BlobId;
 use calimero_primitives::hash::Hash;
 use calimero_store::{key, types};
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8PathBuf;
 use eyre::bail;
-use flate2::read::GzDecoder;
 use futures_util::{io::Cursor, TryStreamExt};
 use reqwest::Url;
-use sha2::{Digest, Sha256};
-use std::fs;
-use tar::Archive;
 use tokio::fs::File;
 use tokio_util::compat::TokioAsyncReadCompatExt;
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace};
 
 use crate::client::NodeClient;
 
@@ -207,134 +202,53 @@ impl NodeClient {
         Ok(application_id)
     }
 
-    /// Install a bundle given an already-resolved manifest and verification.
-    async fn install_bundle_with_manifest(
+    /// Install a `.mpk`. The signature is mandatory and every wasm artifact is
+    /// digest-checked before any bytes are stored.
+    async fn install_bundle(
         &self,
-        bundle_data: Arc<Vec<u8>>,
+        bundle_data: Arc<[u8]>,
         blob_id: &BlobId,
         stored_size: u64,
         source: &ApplicationSource,
-        verification: ManifestVerification,
-        manifest: BundleManifest,
     ) -> eyre::Result<ApplicationId> {
-        let signer_id = verification.signer_id;
-        let package = &manifest.package;
-        let version = &manifest.app_version;
-
-        let blobstore_root = self.blob_manager.root_path();
-        let node_root = blobstore_root
-            .parent()
-            .ok_or_else(|| eyre::eyre!("blobstore root has no parent"))?
-            .to_path_buf();
-        let extract_dir = node_root
-            .join("applications")
-            .join(package)
-            .join(version)
-            .join("extracted");
-
-        let bundle_data_clone = Arc::clone(&bundle_data);
-        let manifest_clone = manifest.clone();
-        let extract_dir_clone = extract_dir.clone();
-        let node_root_clone = node_root.clone();
-        let package_clone = package.to_string();
-        let version_clone = version.to_string();
-        tokio::task::spawn_blocking(move || {
-            Self::extract_bundle_artifacts(
-                &bundle_data_clone,
-                &manifest_clone,
-                &extract_dir_clone,
-                &node_root_clone,
-                &package_clone,
-                &version_clone,
-            )
+        // Every artifact, including the unnamed single-service one that gets no
+        // blob of its own, so substituted bytes are refused before first execution.
+        let (verified, wasm_bytes) = tokio::task::spawn_blocking(move || -> eyre::Result<_> {
+            let verified = bundle::VerifiedBundle::open(bundle_data)?;
+            let wasm_bytes = verified.all_wasm()?;
+            Ok((verified, wasm_bytes))
         })
         .await??;
 
-        let mut services = Vec::new();
-        for artifact in manifest.wasm_artifacts() {
-            if let Some(name) = artifact.name {
-                let wasm_path = extract_dir.join(&artifact.wasm.path);
-                let wasm_bytes = tokio::fs::read(&wasm_path).await?;
-                let cursor = Cursor::new(wasm_bytes.as_slice());
-                let (svc_blob_id, _svc_size) = self
-                    .add_blob(cursor, Some(wasm_bytes.len() as u64), None)
-                    .await?;
-                services.push(types::ServiceMeta {
-                    name: name.to_owned().into_boxed_str(),
-                    bytecode: key::BlobMeta::new(svc_blob_id),
-                    compiled: key::BlobMeta::new(BlobId::from([0; 32])),
-                });
-            }
-        }
+        let manifest = verified.manifest();
+        let package = &manifest.package;
+        let version = &manifest.app_version;
 
-        let bundle_metadata = manifest.to_metadata_json()?;
+        let mut services = Vec::new();
+        for (name, wasm) in &wasm_bytes {
+            let Some(name) = name else { continue };
+            let (svc_blob_id, _svc_size) = self
+                .add_blob(Cursor::new(&wasm[..]), Some(wasm.len() as u64), None)
+                .await?;
+            services.push(types::ServiceMeta {
+                name: name.as_str().into(),
+                bytecode: key::BlobMeta::new(svc_blob_id),
+                compiled: key::BlobMeta::new(BlobId::from([0; 32])),
+            });
+        }
 
         self.install_bundle_application(
             blob_id,
             stored_size,
             source,
-            bundle_metadata,
+            manifest.to_metadata_json()?,
             types::PackageInfo {
                 package: package.as_str().into(),
                 version: version.as_str().into(),
-                signer_id: signer_id.into(),
+                signer_id: verified.signer_id().into(),
             },
             services,
         )
-    }
-
-    /// Install a bundle from a registry. Signature is mandatory.
-    async fn install_verified_bundle(
-        &self,
-        bundle_data: Arc<Vec<u8>>,
-        blob_id: &BlobId,
-        stored_size: u64,
-        source: &ApplicationSource,
-    ) -> eyre::Result<ApplicationId> {
-        let bundle_data_clone = Arc::clone(&bundle_data);
-        let (verification, manifest) = tokio::task::spawn_blocking(move || {
-            bundle::verify_and_extract_manifest(&bundle_data_clone)
-        })
-        .await??;
-
-        self.install_bundle_with_manifest(
-            bundle_data,
-            blob_id,
-            stored_size,
-            source,
-            verification,
-            manifest,
-        )
-        .await
-    }
-
-    /// Install a bundle from a local dev path.
-    ///
-    /// Signature is optional: verified if present, unsigned allowed otherwise.
-    /// Production installs from registries go through `install_verified_bundle`
-    /// which always requires a valid signature.
-    async fn install_dev_bundle(
-        &self,
-        bundle_data: Arc<Vec<u8>>,
-        blob_id: &BlobId,
-        stored_size: u64,
-        source: &ApplicationSource,
-    ) -> eyre::Result<ApplicationId> {
-        let bundle_data_clone = Arc::clone(&bundle_data);
-        let (verification, manifest) = tokio::task::spawn_blocking(move || {
-            bundle::extract_manifest_allow_unsigned(&bundle_data_clone)
-        })
-        .await??;
-
-        self.install_bundle_with_manifest(
-            bundle_data,
-            blob_id,
-            stored_size,
-            source,
-            verification,
-            manifest,
-        )
-        .await
     }
 
     pub async fn install_application_from_path(
@@ -465,9 +379,10 @@ impl NodeClient {
         if is_bundle {
             // Read with a hard cap so a missing/lying Content-Length can't grow
             // the buffer without bound.
-            let bundle_data = Arc::new(read_body_capped(response, MAX_INSTALL_BYTES).await?);
+            let bundle_data: Arc<[u8]> =
+                read_body_capped(response, MAX_INSTALL_BYTES).await?.into();
 
-            let cursor = Cursor::new(bundle_data.as_slice());
+            let cursor = Cursor::new(&bundle_data[..]);
             let (bundle_blob_id, stored_size) = self
                 .add_blob(cursor, Some(bundle_data.len() as u64), expected_hash)
                 .await?;
@@ -480,7 +395,7 @@ impl NodeClient {
             );
 
             return self
-                .install_verified_bundle(bundle_data, &bundle_blob_id, stored_size, &uri)
+                .install_bundle(bundle_data, &bundle_blob_id, stored_size, &uri)
                 .await;
         }
 
@@ -512,9 +427,9 @@ impl NodeClient {
     ) -> eyre::Result<ApplicationId> {
         debug!(path = %path, "install_bundle_from_path started");
 
-        let bundle_data = Arc::new(tokio::fs::read(&path).await?);
+        let bundle_data: Arc<[u8]> = tokio::fs::read(&path).await?.into();
 
-        let cursor = Cursor::new(bundle_data.as_slice());
+        let cursor = Cursor::new(&bundle_data[..]);
         let (bundle_blob_id, stored_size) = self
             .add_blob(cursor, Some(bundle_data.len() as u64), None)
             .await?;
@@ -530,9 +445,7 @@ impl NodeClient {
             bail!("non-absolute path")
         };
 
-        // Dev installs from local path skip signature verification — the
-        // bundle may be unsigned during development/testing.
-        self.install_dev_bundle(
+        self.install_bundle(
             bundle_data,
             &bundle_blob_id,
             stored_size,
@@ -565,474 +478,14 @@ impl NodeClient {
         };
 
         let stored_size = bundle_bytes.len() as u64;
-        let bundle_data = Arc::new(bundle_bytes.to_vec());
 
-        self.install_verified_bundle(bundle_data, blob_id, stored_size, source)
+        self.install_bundle(bundle_bytes, blob_id, stored_size, source)
             .await
-    }
-
-    /// Find duplicate artifact in other versions by hash and relative path
-    /// Only matches files with the same relative path within the bundle to avoid
-    /// collisions between files with the same name in different directories
-    fn find_duplicate_artifact(
-        node_root: &Utf8Path,
-        package: &str,
-        current_version: &str,
-        hash: &[u8; 32],
-        relative_path: &str,
-    ) -> Option<Utf8PathBuf> {
-        // Check other versions for the same hash at the same relative path
-        let package_dir = node_root.join("applications").join(package);
-
-        if let Ok(entries) = fs::read_dir(package_dir.as_std_path()) {
-            for entry in entries.flatten() {
-                if let Ok(version_name) = entry.file_name().into_string() {
-                    if version_name == current_version {
-                        continue; // Skip current version
-                    }
-
-                    // Check extracted directory in this version at the same relative path
-                    let extracted_dir = package_dir.join(&version_name).join("extracted");
-                    let candidate_path = extracted_dir.join(relative_path);
-
-                    if candidate_path.exists() {
-                        // Compute hash of candidate file
-                        if let Ok(candidate_content) = fs::read(candidate_path.as_std_path()) {
-                            let candidate_hash = Sha256::digest(&candidate_content);
-                            let candidate_array: [u8; 32] = candidate_hash.into();
-                            if candidate_array == *hash {
-                                return Some(candidate_path);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        None
-    }
-
-    /// Extract bundle artifacts with deduplication
-    ///
-    /// This function is synchronized per package-version to prevent race conditions
-    /// when multiple concurrent calls try to extract the same bundle.
-    pub(crate) fn extract_bundle_artifacts(
-        bundle_data: &[u8],
-        _manifest: &BundleManifest,
-        extract_dir: &Utf8Path,
-        node_root: &Utf8Path,
-        package: &str,
-        current_version: &str,
-    ) -> eyre::Result<()> {
-        // Create extraction directory
-        fs::create_dir_all(extract_dir)?;
-
-        // Use a lock file to prevent concurrent extraction of the same bundle version
-        // Lock file path: extract_dir/.extracting.lock
-        let lock_file_path = extract_dir.join(".extracting.lock");
-        let marker_file_path = extract_dir.join(".extracted");
-
-        // Check if extraction is already complete
-        // Only skip if marker exists AND the expected WASM file exists
-        // This handles the case where files were deleted but marker remains
-        if marker_file_path.exists() {
-            // Check if WASM file exists (using manifest to determine path)
-            // If marker exists but WASM doesn't, marker is stale - remove it and re-extract
-            let wasm_relative_path = _manifest
-                .wasm
-                .as_ref()
-                .map(|w| w.path.as_str())
-                .unwrap_or("app.wasm");
-
-            // Validate WASM path to prevent path traversal attacks before checking existence
-            if wasm_relative_path.contains("..") {
-                bail!(
-                    "WASM path traversal detected in manifest: {} contains '..' component",
-                    wasm_relative_path
-                );
-            }
-
-            let wasm_path = extract_dir.join(wasm_relative_path);
-
-            // Additional validation: ensure the resolved path stays within extract_dir
-            if wasm_path.exists() {
-                // Validate path traversal even if file exists
-                let canonical_wasm = wasm_path.canonicalize_utf8()?;
-
-                // extract_dir might not exist if wasm_relative_path contains subdirectories
-                // Reconstruct canonical extract_dir from wasm_path by removing relative path components
-                let canonical_extract = if extract_dir.exists() {
-                    extract_dir.canonicalize_utf8()?
-                } else {
-                    // Reconstruct extract_dir from wasm_path by removing wasm_relative_path components
-                    // Since we validated wasm_relative_path doesn't contain "..", this is safe
-                    let wasm_parent = wasm_path
-                        .parent()
-                        .ok_or_else(|| eyre::eyre!("WASM path has no parent directory"))?;
-                    let wasm_parent_canonical = wasm_parent.canonicalize_utf8()?;
-
-                    // Count depth of wasm_relative_path (number of path components)
-                    let relative_depth = wasm_relative_path
-                        .split('/')
-                        .filter(|s| !s.is_empty())
-                        .count()
-                        .saturating_sub(1); // Subtract 1 for the filename itself
-
-                    // Go up relative_depth levels from wasm_parent to get extract_dir
-                    let mut canonical_extract_candidate = wasm_parent_canonical.clone();
-                    for _ in 0..relative_depth {
-                        if let Some(parent) = canonical_extract_candidate.parent() {
-                            canonical_extract_candidate = parent.to_path_buf();
-                        } else {
-                            bail!("Cannot reconstruct extract_dir from WASM path");
-                        }
-                    }
-
-                    canonical_extract_candidate
-                };
-
-                if !canonical_wasm.starts_with(&canonical_extract) {
-                    bail!(
-                        "WASM path traversal detected: {} escapes extraction directory {}",
-                        wasm_relative_path,
-                        extract_dir
-                    );
-                }
-
-                debug!(
-                    package,
-                    version = current_version,
-                    "Bundle already extracted (marker file and WASM exist), skipping"
-                );
-                return Ok(());
-            } else {
-                // Marker exists but WASM doesn't - remove stale marker and re-extract
-                debug!(
-                    package,
-                    version = current_version,
-                    "Marker file exists but WASM not found, removing stale marker"
-                );
-                let _ = fs::remove_file(&marker_file_path);
-            }
-        }
-
-        // Try to acquire exclusive lock by creating lock file atomically
-        // create_new() is atomic - fails if file exists (works on Unix and Windows)
-        let lock_acquired = match std::fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(lock_file_path.as_std_path())
-        {
-            Ok(_) => {
-                // Lock file created - we're the first to extract
-                true
-            }
-            Err(_) => {
-                // Lock file already exists - another extraction is in progress
-                // Wait and check if extraction completes
-                for _ in 0..20 {
-                    std::thread::sleep(std::time::Duration::from_millis(100));
-                    if marker_file_path.exists() {
-                        debug!(
-                            package,
-                            version = current_version,
-                            "Bundle extraction completed by another process"
-                        );
-                        return Ok(());
-                    }
-                }
-                // If marker still doesn't exist after waiting, proceed anyway
-                // (lock file might be stale from crashed process)
-                warn!(
-                    package,
-                    version = current_version,
-                    "Lock file exists but extraction not complete, proceeding anyway"
-                );
-                false
-            }
-        };
-
-        // Track if we created a lock file that needs cleanup
-        let mut lock_created_by_us = lock_acquired;
-
-        // Only proceed with extraction if we acquired the lock
-        // (or if lock is stale and we're proceeding anyway)
-        if !lock_acquired {
-            // Try to remove stale lock and retry
-            let _ = fs::remove_file(&lock_file_path);
-            // Check marker one more time
-            if marker_file_path.exists() {
-                return Ok(());
-            }
-            // Create lock file again - handle race condition where another thread
-            // might have created it between removal and this creation
-            match std::fs::OpenOptions::new()
-                .create_new(true)
-                .write(true)
-                .open(lock_file_path.as_std_path())
-            {
-                Ok(_) => {
-                    // Successfully acquired lock, proceed with extraction
-                    lock_created_by_us = true;
-                }
-                Err(_) => {
-                    // Another thread created the lock between removal and creation
-                    // Wait briefly and check if extraction completed
-                    std::thread::sleep(std::time::Duration::from_millis(100));
-                    if marker_file_path.exists() {
-                        debug!(
-                            package,
-                            version = current_version,
-                            "Bundle extraction completed by another process after lock retry"
-                        );
-                        return Ok(());
-                    }
-                    // If marker still doesn't exist, the other thread is still extracting
-                    // Return error to avoid concurrent extraction
-                    bail!(
-                        "Failed to acquire extraction lock after retry - another process is extracting"
-                    );
-                }
-            }
-        }
-
-        // Ensure lock file is cleaned up even if extraction fails
-        // Use a guard to clean up on early return or error
-        struct LockGuard {
-            path: Utf8PathBuf,
-            should_remove: std::cell::Cell<bool>,
-        }
-
-        impl Drop for LockGuard {
-            fn drop(&mut self) {
-                if self.should_remove.get() {
-                    let _ = fs::remove_file(&self.path);
-                }
-            }
-        }
-
-        let lock_guard = LockGuard {
-            path: lock_file_path.clone(),
-            should_remove: std::cell::Cell::new(lock_created_by_us),
-        };
-
-        let tar = GzDecoder::new(bundle_data);
-        let mut archive = Archive::new(tar);
-
-        // Extract all files from bundle
-        for entry_result in archive.entries()? {
-            let mut entry = entry_result?;
-
-            // Extract path_bytes first, converting to owned to drop borrow
-            let path_bytes_owned = {
-                let header = entry.header();
-                header.path_bytes().into_owned()
-            };
-
-            let relative_path = {
-                let path_str = std::str::from_utf8(&path_bytes_owned)
-                    .map_err(|_| eyre::eyre!("invalid UTF-8 in file path"))?;
-                path_str.to_string()
-            };
-
-            // Skip directory entries and macOS resource fork files
-            if entry.header().entry_type().is_dir() {
-                continue;
-            }
-            if let Some(file_name) = std::path::Path::new(&relative_path)
-                .file_name()
-                .and_then(|n| n.to_str())
-            {
-                if file_name.starts_with("._") {
-                    continue;
-                }
-            }
-
-            // Read content (header borrow is dropped)
-            let mut content = Vec::new();
-            std::io::copy(&mut entry, &mut content)?;
-
-            // Preserve directory structure from bundle
-            let dest_path = extract_dir.join(&relative_path);
-
-            // Validate path to prevent path traversal attacks
-            // Check that the relative path doesn't contain ".." components that would escape
-            if relative_path.contains("..") {
-                bail!(
-                    "Path traversal detected: {} contains '..' component",
-                    relative_path
-                );
-            }
-
-            // Additional validation: ensure the resolved path stays within extract_dir
-            // Always validate by constructing expected path, regardless of whether it exists
-            // This prevents path traversal even when parent directories don't exist yet
-            let canonical_extract = extract_dir.canonicalize_utf8()?;
-
-            // Construct what the canonical dest_path should be
-            // Since we already checked relative_path doesn't contain "..",
-            // joining extract_dir with relative_path is safe
-            let expected_dest = canonical_extract.join(&relative_path);
-
-            // Verify the expected path stays within extract_dir
-            // This works even if the path doesn't exist yet because we're constructing
-            // it from the canonical extract_dir and a validated relative_path
-            if !expected_dest.starts_with(&canonical_extract) {
-                bail!(
-                    "Path traversal detected: {} would escape extraction directory {}",
-                    relative_path,
-                    extract_dir
-                );
-            }
-
-            // If dest_path exists, also verify the actual canonicalized path matches expected
-            if dest_path.exists() {
-                let canonical_dest = dest_path.canonicalize_utf8()?;
-                if !canonical_dest.starts_with(&canonical_extract) {
-                    bail!(
-                        "Path traversal detected: {} escapes extraction directory {}",
-                        relative_path,
-                        extract_dir
-                    );
-                }
-            }
-
-            // Create parent directories if needed
-            if let Some(parent) = dest_path.parent() {
-                fs::create_dir_all(parent)?;
-            }
-
-            // Compute hash
-            let hash = Sha256::digest(&content);
-            let hash_array: [u8; 32] = hash.into();
-
-            // Check for duplicates in other versions at the same relative path
-            if let Some(duplicate_path) = Self::find_duplicate_artifact(
-                node_root,
-                package,
-                current_version,
-                &hash_array,
-                &relative_path,
-            ) {
-                // Create hardlink to duplicate file
-                if let Err(e) = fs::hard_link(duplicate_path.as_std_path(), dest_path.as_std_path())
-                {
-                    // If hardlink fails (e.g., cross-filesystem), fall back to copying
-                    warn!(
-                        file = %relative_path,
-                        duplicate = %duplicate_path,
-                        error = %e,
-                        "hardlink failed, copying instead"
-                    );
-                    fs::write(&dest_path, &content)?;
-                } else {
-                    debug!(
-                        file = %relative_path,
-                        hash = hex::encode(hash),
-                        duplicate = %duplicate_path,
-                        "deduplicated artifact via hardlink"
-                    );
-                }
-            } else {
-                // No duplicate found, write new file
-                fs::write(&dest_path, &content)?;
-                debug!(
-                    file = %relative_path,
-                    hash = hex::encode(hash),
-                    "extracted artifact"
-                );
-            }
-        }
-
-        // Write marker file to indicate extraction is complete
-        fs::write(&marker_file_path, b"extracted")?;
-
-        // Remove lock file explicitly on success (guard will skip removal if we already did it)
-        if lock_guard.should_remove.get() {
-            let _ = fs::remove_file(&lock_file_path);
-            lock_guard.should_remove.set(false); // Prevent guard from removing it again
-        }
-
-        Ok(())
     }
 
     pub fn uninstall_application(&self, application_id: &ApplicationId) -> eyre::Result<()> {
         let mut handle = self.datastore.handle();
-
-        let key = key::ApplicationMeta::new(*application_id);
-
-        // Get application metadata before deleting to check if it's a bundle
-        let application_meta = handle.get(&key)?;
-
-        // Delete the ApplicationMeta entry
-        handle.delete(&key)?;
-
-        // Clean up extracted bundle files if this is a bundle
-        if let Some(application) = application_meta {
-            // Check if this is a bundle by checking package/version
-            // Bundles have meaningful package/version (not "unknown"/"0.0.0")
-            let is_bundle = application.package.as_ref() != "unknown"
-                && application.version.as_ref() != "0.0.0";
-
-            if is_bundle {
-                // Construct path to extracted bundle directory
-                let blobstore_root = self.blob_manager.root_path();
-                let node_root = blobstore_root
-                    .parent()
-                    .ok_or_else(|| eyre::eyre!("blobstore root has no parent"))?;
-                let bundle_dir = node_root
-                    .join("applications")
-                    .join(application.package.as_ref())
-                    .join(application.version.as_ref());
-
-                // Delete the entire version directory (includes extracted/ subdirectory)
-                if bundle_dir.exists() {
-                    debug!(
-                        package = %application.package,
-                        version = %application.version,
-                        path = %bundle_dir,
-                        "Removing extracted bundle directory"
-                    );
-                    if let Err(e) = fs::remove_dir_all(bundle_dir.as_std_path()) {
-                        warn!(
-                            package = %application.package,
-                            version = %application.version,
-                            path = %bundle_dir,
-                            error = %e,
-                            "Failed to remove extracted bundle directory"
-                        );
-                        // Don't fail uninstallation if cleanup fails - metadata is already deleted
-                    } else {
-                        debug!(
-                            package = %application.package,
-                            version = %application.version,
-                            "Successfully removed extracted bundle directory"
-                        );
-                    }
-
-                    // Also try to remove parent package directory if it's empty
-                    let package_dir = node_root
-                        .join("applications")
-                        .join(application.package.as_ref());
-                    if package_dir.exists() {
-                        // Check if package directory is empty
-                        if let Ok(mut entries) = fs::read_dir(package_dir.as_std_path()) {
-                            if entries.next().is_none() {
-                                // Directory is empty, remove it
-                                if let Err(e) = fs::remove_dir(package_dir.as_std_path()) {
-                                    debug!(
-                                        package = %application.package,
-                                        error = %e,
-                                        "Failed to remove empty package directory (non-fatal)"
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
+        handle.delete(&key::ApplicationMeta::new(*application_id))?;
         Ok(())
     }
 

--- a/crates/node/primitives/src/client/application/tests.rs
+++ b/crates/node/primitives/src/client/application/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for the application module (bundle validation, path safety).
 
+use std::sync::Arc;
+
 use super::bundle;
 
 #[test]
@@ -174,7 +176,7 @@ fn test_is_bundle_archive_non_mpk() {
 }
 
 // -----------------------------------------------------------------------
-// is_bundle_blob — non-bundle data
+// is_bundle_blob - non-bundle data
 // -----------------------------------------------------------------------
 
 #[test]
@@ -185,7 +187,7 @@ fn test_is_bundle_blob_random_bytes() {
 }
 
 // -----------------------------------------------------------------------
-// extract_bundle_manifest — edge cases
+// extract_bundle_manifest - edge cases
 // -----------------------------------------------------------------------
 
 #[test]
@@ -214,17 +216,11 @@ fn test_extract_manifest_empty_tar() {
 }
 
 // -----------------------------------------------------------------------
-// extract_manifest_allow_unsigned — verify branching
+// VerifiedBundle - construction rejects non-archives
 // -----------------------------------------------------------------------
 
 #[test]
-fn test_extract_unsigned_rejects_non_tar() {
-    let result = bundle::extract_manifest_allow_unsigned(b"garbage");
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_verify_and_extract_rejects_non_tar() {
-    let result = bundle::verify_and_extract_manifest(b"garbage");
+fn test_verified_bundle_rejects_non_tar() {
+    let result = bundle::VerifiedBundle::open(Arc::from(b"garbage".as_slice()));
     assert!(result.is_err());
 }

--- a/crates/node/primitives/src/client/blob.rs
+++ b/crates/node/primitives/src/client/blob.rs
@@ -13,7 +13,6 @@ use calimero_primitives::{
 use calimero_store::key;
 use calimero_store::layer::LayerExt;
 use calimero_store::namespace_signer::resolve_owned_namespace_signer;
-use camino::Utf8PathBuf;
 use eyre::bail;
 use futures_util::{AsyncRead, StreamExt};
 use libp2p::PeerId;
@@ -36,10 +35,6 @@ impl BlobManager {
     #[must_use]
     pub fn new(blobstore: BlobStore) -> Self {
         Self { blobstore }
-    }
-
-    pub fn root_path(&self) -> Utf8PathBuf {
-        self.blobstore.root_path()
     }
 
     pub async fn add_blob<S: AsyncRead>(

--- a/crates/node/primitives/tests/bundle_allocation_bounds.rs
+++ b/crates/node/primitives/tests/bundle_allocation_bounds.rs
@@ -1,0 +1,306 @@
+//! Bundle reads whose bound is a resource bound, provable only by measuring:
+//! a bomb `tar` would buffer inside `entries()` before any `Entry` reaches
+//! caller code, and an archive walked once per artifact instead of once.
+//!
+//! Both the counting allocator and the clock are process-wide, so every
+//! measurement here takes `PROBE`.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::io::Write;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use calimero_node_primitives::bundle::{derive_signer_id_did_key, sign_manifest_json};
+use calimero_node_primitives::client::NodeClient;
+use ed25519_dalek::SigningKey;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use futures_util::io::Cursor;
+use rand::rngs::OsRng;
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+
+mod common;
+
+use common::{hex_lower, node_client, pack_entries};
+
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+fn record(live: usize) {
+    let _ = PEAK.fetch_max(live, Ordering::Relaxed);
+}
+
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            record(LIVE.fetch_add(layout.size(), Ordering::Relaxed) + layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc_zeroed(layout) };
+        if !ptr.is_null() {
+            record(LIVE.fetch_add(layout.size(), Ordering::Relaxed) + layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) };
+        let _ = LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new = unsafe { System.realloc(ptr, layout, new_size) };
+        if !new.is_null() {
+            if new_size >= layout.size() {
+                let grew = new_size - layout.size();
+                record(LIVE.fetch_add(grew, Ordering::Relaxed) + grew);
+            } else {
+                let _ = LIVE.fetch_sub(layout.size() - new_size, Ordering::Relaxed);
+            }
+        }
+        new
+    }
+}
+
+#[global_allocator]
+static ALLOC: Counting = Counting;
+
+/// Serializes measurement, since the counter is process-wide and the harness
+/// runs tests in parallel threads.
+static PROBE: Mutex<()> = Mutex::new(());
+
+/// Peak bytes allocated while `body` runs, excluding whatever was already live.
+fn peak_while<T>(body: impl FnOnce() -> T) -> (T, usize) {
+    let before = LIVE.load(Ordering::Relaxed);
+    PEAK.store(before, Ordering::Relaxed);
+    let out = body();
+    (out, PEAK.load(Ordering::Relaxed).saturating_sub(before))
+}
+
+/// Bytes the bomb expands to. Comfortably over the manifest scan cap, and small
+/// enough that the archive builds in well under a second.
+const BOMB_BYTES: usize = 64 * 1024 * 1024;
+
+/// A `.mpk` whose first member is a GNU long-name header declaring, and
+/// carrying, `BOMB_BYTES` of zeros. Roughly 64 KiB on the wire.
+fn long_name_bomb() -> Vec<u8> {
+    let mut header = tar::Header::new_gnu();
+    header.set_entry_type(tar::EntryType::GNULongName);
+    header.set_size(BOMB_BYTES as u64);
+    header.set_cksum();
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
+    encoder.write_all(header.as_bytes()).unwrap();
+    let chunk = vec![0u8; 64 * 1024];
+    for _ in 0..(BOMB_BYTES / chunk.len()) {
+        encoder.write_all(&chunk).unwrap();
+    }
+    encoder.finish().unwrap()
+}
+
+#[test]
+fn long_name_bomb_is_refused_without_buffering_it() {
+    let _probe = PROBE.lock().unwrap_or_else(|e| e.into_inner());
+    // Built before the baseline is taken, so the fixture's own bytes are excluded.
+    let archive = long_name_bomb();
+
+    let (verdict, peak) = peak_while(|| NodeClient::is_bundle_blob(&archive));
+
+    assert!(
+        !verdict,
+        "a bomb carrying no manifest.json must not read as a bundle"
+    );
+    // Unbounded, `tar` buffers the declared size and Vec doubling lands near 3x
+    // it. Anything at or above the payload itself means the bound did not hold.
+    assert!(
+        peak < BOMB_BYTES / 2,
+        "peak allocation {peak} bytes for a {} byte archive declaring {BOMB_BYTES} bytes: \
+         the bomb was buffered",
+        archive.len()
+    );
+}
+
+/// Bytes of the one artifact every service names. Big enough to dwarf harness
+/// noise, small enough to stay quick.
+const SHARED_ARTIFACT_BYTES: usize = 4 * 1024 * 1024;
+const SERVICES: usize = 8;
+
+/// A signed `.mpk` whose `SERVICES` services all name one `app.wasm`.
+fn many_services_one_artifact(dir: &TempDir, wasm: &[u8]) -> Vec<u8> {
+    let key = SigningKey::generate(&mut OsRng);
+    let services: Vec<_> = (0..SERVICES)
+        .map(|i| {
+            serde_json::json!({
+                "name": format!("svc{i}"),
+                "wasm": {
+                    "path": "app.wasm",
+                    "size": wasm.len(),
+                    "hash": hex_lower(&Sha256::digest(wasm)),
+                },
+            })
+        })
+        .collect();
+    let mut manifest = serde_json::json!({
+        "version": "1.0",
+        "package": "com.example.manyservices",
+        "appVersion": "1.0.0",
+        "signerId": derive_signer_id_did_key(key.verifying_key().as_bytes()),
+        "minRuntimeVersion": "0.1.0",
+        "services": services,
+        "migrations": []
+    });
+    sign_manifest_json(&mut manifest, &key).unwrap();
+    pack_entries(
+        dir,
+        "manyservices.mpk",
+        &[
+            ("manifest.json", &serde_json::to_vec(&manifest).unwrap()),
+            ("app.wasm", wasm),
+        ],
+    )
+}
+
+/// Install holds every service's bytes at once, so reading one path once is the
+/// only thing between a manifest naming it N times and N copies in memory.
+#[test]
+fn services_sharing_one_artifact_cost_one_copy() {
+    let _probe = PROBE.lock().unwrap_or_else(|e| e.into_inner());
+
+    let dir = TempDir::new().unwrap();
+    let wasm = vec![0xABu8; SHARED_ARTIFACT_BYTES];
+    let bundle = many_services_one_artifact(&dir, &wasm);
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let (node, _data, _blobs) = runtime.block_on(node_client());
+    let (blob_id, _) = runtime
+        .block_on(node.add_blob(
+            Cursor::new(bundle.as_slice()),
+            Some(bundle.len() as u64),
+            None,
+        ))
+        .unwrap();
+    let source = "https://registry.example.com/app.mpk".parse().unwrap();
+
+    let (installed, peak) = peak_while(|| {
+        runtime.block_on(node.install_application_from_bundle_blob(&blob_id, &source))
+    });
+    installed.expect("multi-service install");
+
+    // One copy costs ~3x the artifact, not 1x: the read buffer and the `Arc` it
+    // is copied into are both live. N copies cost ~10x, so half of N separates them.
+    assert!(
+        peak < SHARED_ARTIFACT_BYTES * SERVICES / 2,
+        "peak allocation {peak} bytes installing {SERVICES} services that name one \
+         {SHARED_ARTIFACT_BYTES} byte artifact: the shared read is not shared"
+    );
+}
+
+/// Zero-filled padding entry: ~64 MiB to inflate, ~64 KiB on the wire. Skipping
+/// an entry still decompresses it, so this is what a redundant walk pays for.
+const PADDING_BYTES: usize = 64 * 1024 * 1024;
+
+/// A signed `.mpk` with `services` distinct tiny wasm artifacts, each named by
+/// one service, optionally behind a `padding` byte entry the walk must cross.
+fn padded_bundle(dir: &TempDir, name: &str, services: usize, padding: usize) -> Vec<u8> {
+    let key = SigningKey::generate(&mut OsRng);
+    let wasms: Vec<Vec<u8>> = (0..services)
+        .map(|i| format!("wasm for service {i}").into_bytes())
+        .collect();
+    let declared: Vec<_> = wasms
+        .iter()
+        .enumerate()
+        .map(|(i, wasm)| {
+            serde_json::json!({
+                "name": format!("svc{i}"),
+                "wasm": {
+                    "path": format!("svc{i}.wasm"),
+                    "size": wasm.len(),
+                    "hash": hex_lower(&Sha256::digest(wasm)),
+                },
+            })
+        })
+        .collect();
+    let mut manifest = serde_json::json!({
+        "version": "1.0",
+        "package": format!("com.example.padded{services}"),
+        "appVersion": "1.0.0",
+        "signerId": derive_signer_id_did_key(key.verifying_key().as_bytes()),
+        "minRuntimeVersion": "0.1.0",
+        "services": declared,
+        "migrations": []
+    });
+    sign_manifest_json(&mut manifest, &key).unwrap();
+
+    let manifest_bytes = serde_json::to_vec(&manifest).unwrap();
+    let padding = vec![0u8; padding];
+    let paths: Vec<String> = (0..services).map(|i| format!("svc{i}.wasm")).collect();
+    let mut entries: Vec<(&str, &[u8])> = vec![("manifest.json", &manifest_bytes)];
+    if !padding.is_empty() {
+        // Ahead of the artifacts, so every read has to walk through it.
+        entries.push(("padding.bin", &padding));
+    }
+    entries.extend(
+        paths
+            .iter()
+            .map(|p| p.as_str())
+            .zip(wasms.iter().map(Vec::as_slice)),
+    );
+    pack_entries(dir, name, &entries)
+}
+
+fn install_elapsed(bundle: Vec<u8>) -> Duration {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let (node, _data, _blobs) = runtime.block_on(node_client());
+    let (blob_id, _) = runtime
+        .block_on(node.add_blob(
+            Cursor::new(bundle.as_slice()),
+            Some(bundle.len() as u64),
+            None,
+        ))
+        .unwrap();
+    let source = "https://registry.example.com/app.mpk".parse().unwrap();
+
+    let started = Instant::now();
+    runtime
+        .block_on(node.install_application_from_bundle_blob(&blob_id, &source))
+        .expect("install");
+    started.elapsed()
+}
+
+/// What crossing the padding costs during one install. Everything else about
+/// the two installs is identical, so the difference isolates the walk from a
+/// fixed cost that would otherwise swamp it.
+fn walk_cost(dir: &TempDir, services: usize) -> Duration {
+    let padded = padded_bundle(dir, &format!("pad{services}.mpk"), services, PADDING_BYTES);
+    let bare = padded_bundle(dir, &format!("bare{services}.mpk"), services, 0);
+    install_elapsed(padded).saturating_sub(install_elapsed(bare))
+}
+
+/// Reading D distinct artifacts must cost one walk, not D. Nothing caps
+/// `services[]`, so a walk per artifact multiplies the archive's whole
+/// decompressed size by D, and D can reach thousands in a small `.mpk`.
+#[test]
+fn distinct_artifacts_cost_one_walk() {
+    let _probe = PROBE.lock().unwrap_or_else(|e| e.into_inner());
+
+    const DISTINCT: usize = 8;
+    let dir = TempDir::new().unwrap();
+    let one = walk_cost(&dir, 1);
+    let many = walk_cost(&dir, DISTINCT);
+
+    // One walk either way, so the padding is crossed once in both. A walk per
+    // artifact would make it ~{DISTINCT}x, since each read re-inflates it.
+    assert!(
+        many < one * 3,
+        "crossing {PADDING_BYTES} bytes of padding cost {many:?} for {DISTINCT} distinct \
+         artifacts against {one:?} for one: the archive is being walked per artifact"
+    );
+}

--- a/crates/node/primitives/tests/bundle_artifact_integrity.rs
+++ b/crates/node/primitives/tests/bundle_artifact_integrity.rs
@@ -1,0 +1,509 @@
+//! Swapping `app.wasm` after signing leaves the manifest byte-identical, so the
+//! per-artifact digest is the only thing that can catch a tampered bundle.
+
+use std::fs;
+
+use calimero_node_primitives::bundle::{derive_signer_id_did_key, sign_manifest_json};
+use calimero_node_primitives::client::NodeClient;
+use ed25519_dalek::SigningKey;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use futures_util::io::Cursor;
+use rand::rngs::OsRng;
+use sha2::{Digest, Sha256};
+use tar::Builder;
+use tempfile::TempDir;
+
+mod common;
+
+use common::{hex_lower, node_client, pack_entries};
+
+/// Sign a manifest exactly the way `cargo mero bundle` does: real lowercase-hex
+/// SHA-256 per artifact, then an Ed25519 signature over the canonical manifest.
+fn signed_manifest(package: &str, version: &str, wasm: &[u8], key: &SigningKey) -> Vec<u8> {
+    let signer_id = derive_signer_id_did_key(key.verifying_key().as_bytes());
+    let mut manifest = serde_json::json!({
+        "version": "1.0",
+        "package": package,
+        "appVersion": version,
+        "signerId": signer_id,
+        "minRuntimeVersion": "0.1.0",
+        "wasm": {
+            "path": "app.wasm",
+            "size": wasm.len(),
+            "hash": hex_lower(&Sha256::digest(wasm)),
+        },
+        "migrations": []
+    });
+    sign_manifest_json(&mut manifest, key).unwrap();
+    serde_json::to_vec(&manifest).unwrap()
+}
+
+/// Pack a `.mpk` from an exact manifest byte string plus wasm bytes. Keeping the
+/// manifest as raw bytes is the point: the attacker's copy is byte-identical.
+fn pack(dir: &TempDir, name: &str, manifest_bytes: &[u8], wasm: &[u8]) -> Vec<u8> {
+    let path = dir.path().join(name);
+    let encoder = GzEncoder::new(fs::File::create(&path).unwrap(), Compression::default());
+    let mut tar = Builder::new(encoder);
+
+    for (entry_path, content) in [("manifest.json", manifest_bytes), ("app.wasm", wasm)] {
+        let mut header = tar::Header::new_gnu();
+        header.set_path(entry_path).unwrap();
+        header.set_size(content.len() as u64);
+        header.set_cksum();
+        tar.append(&header, content).unwrap();
+    }
+    tar.finish().unwrap();
+    drop(tar);
+    fs::read(&path).unwrap()
+}
+
+/// Install through the production path (mandatory signature) and return the
+/// ApplicationId plus the bytes the node would hand to the WASM runtime.
+async fn install(
+    client: &NodeClient,
+    bundle: Vec<u8>,
+) -> eyre::Result<(calimero_primitives::application::ApplicationId, Vec<u8>)> {
+    let (blob_id, _) = client
+        .add_blob(
+            Cursor::new(bundle.as_slice()),
+            Some(bundle.len() as u64),
+            None,
+        )
+        .await?;
+    let source = "https://registry.example.com/app.mpk".parse().unwrap();
+    let app_id = client
+        .install_application_from_bundle_blob(&blob_id, &source)
+        .await?;
+    let bytes = client
+        .get_application_bytes(&app_id, None)
+        .await?
+        .expect("application bytes");
+    Ok((app_id, bytes.to_vec()))
+}
+
+#[tokio::test]
+async fn tampered_wasm_is_rejected_even_though_manifest_signature_verifies() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+
+    let honest_wasm = b"HONEST wasm bytecode from the publisher".as_slice();
+    let evil_wasm = b"EVIL!! wasm bytecode from the registry ".as_slice();
+    assert_eq!(
+        honest_wasm.len(),
+        evil_wasm.len(),
+        "same length, so even manifest `size` still matches"
+    );
+
+    // One manifest, signed once. Both bundles carry these exact bytes.
+    let manifest_bytes = signed_manifest("com.example.tamper", "1.0.0", honest_wasm, &key);
+    let honest = pack(&dir, "honest.mpk", &manifest_bytes, honest_wasm);
+    let evil = pack(&dir, "evil.mpk", &manifest_bytes, evil_wasm);
+
+    // Separate nodes so neither install observes the other's state: both bundles
+    // carry the same package and signer, hence the same application row.
+    let (honest_node, _d1, _b1) = node_client().await;
+    let (victim_node, _d2, _b2) = node_client().await;
+
+    let (honest_id, honest_bytes) = install(&honest_node, honest).await.expect("honest install");
+    assert_eq!(honest_bytes, honest_wasm);
+
+    match install(&victim_node, evil).await {
+        Err(err) => {
+            let msg = err.to_string();
+            assert!(
+                msg.contains("app.wasm") && msg.contains("failed its integrity check"),
+                "the digest must be what rejects it, not a missing or malformed artifact, got: {msg}"
+            );
+        }
+        Ok((evil_id, bytes)) => panic!(
+            "regression: a signed manifest admitted substituted bytecode.\n  \
+             manifest.wasm.hash  = {}\n  \
+             sha256(served wasm) = {}\n  \
+             bytes served to the runtime = {:?}\n  \
+             ApplicationId honest = {honest_id}\n  \
+             ApplicationId evil   = {evil_id}  (same = {})",
+            hex_lower(&Sha256::digest(honest_wasm)),
+            hex_lower(&Sha256::digest(&bytes)),
+            String::from_utf8_lossy(&bytes),
+            honest_id == evil_id,
+        ),
+    }
+}
+
+/// A manifest with no per-artifact hash must not parse: the field is what binds
+/// bytes to the signature, so its absence is a malformed bundle, not a default.
+#[tokio::test]
+async fn manifest_without_artifact_hash_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+    let wasm = b"some wasm".as_slice();
+
+    let signer_id = derive_signer_id_did_key(key.verifying_key().as_bytes());
+    let mut manifest = serde_json::json!({
+        "version": "1.0",
+        "package": "com.example.nohash",
+        "appVersion": "1.0.0",
+        "signerId": signer_id,
+        "minRuntimeVersion": "0.1.0",
+        "wasm": { "path": "app.wasm", "size": wasm.len() },
+        "migrations": []
+    });
+    sign_manifest_json(&mut manifest, &key).unwrap();
+    let bundle = pack(
+        &dir,
+        "nohash.mpk",
+        &serde_json::to_vec(&manifest).unwrap(),
+        wasm,
+    );
+
+    let (node, _d, _b) = node_client().await;
+    let err = install(&node, bundle)
+        .await
+        .expect_err("a hashless manifest must not install");
+    // Must be refused while parsing: a defaulted hash would fail the digest check
+    // too, so "it errored" alone would not catch the field turning optional again.
+    let msg = err.to_string();
+    assert!(
+        msg.contains("hash") && !msg.contains("failed its integrity check"),
+        "a hashless manifest must be rejected as malformed, got: {msg}"
+    );
+}
+
+/// The manifest is read before its signature can be checked, so an unbounded
+/// read is a pre-auth decompression bomb. This manifest is otherwise valid and
+/// correctly signed: without the cap it installs, so only the cap can reject it.
+#[tokio::test]
+async fn oversized_manifest_is_refused_before_any_signature_check() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+    let wasm = b"wasm behind an oversized manifest".as_slice();
+
+    let signer_id = derive_signer_id_did_key(key.verifying_key().as_bytes());
+    let mut manifest = serde_json::json!({
+        "version": "1.0",
+        "package": "com.example.bigmanifest",
+        "appVersion": "1.0.0",
+        "signerId": signer_id,
+        "minRuntimeVersion": "0.1.0",
+        "metadata": { "name": "big", "description": "p".repeat(1024 * 1024) },
+        "wasm": {
+            "path": "app.wasm",
+            "size": wasm.len(),
+            "hash": hex_lower(&Sha256::digest(wasm)),
+        },
+        "migrations": []
+    });
+    sign_manifest_json(&mut manifest, &key).unwrap();
+    let manifest_bytes = serde_json::to_vec(&manifest).unwrap();
+    assert!(
+        manifest_bytes.len() > 1024 * 1024,
+        "the fixture must exceed the cap, got {} bytes",
+        manifest_bytes.len()
+    );
+    let bundle = pack(&dir, "bigmanifest.mpk", &manifest_bytes, wasm);
+
+    let (node, _d, _b) = node_client().await;
+    let err = install(&node, bundle)
+        .await
+        .expect_err("an oversized manifest must not install");
+    // Pinned to the cap's own wording: a signature or parse rejection, which a
+    // truncated read would also produce, must not satisfy this assertion.
+    let msg = err.to_string();
+    assert!(
+        msg.contains("manifest.json exceeds the 1048576 byte cap"),
+        "must be refused by the manifest size cap, got: {msg}"
+    );
+}
+
+/// The cap must not touch manifests of any realistic size.
+#[tokio::test]
+async fn normal_manifest_still_installs() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+    let wasm = b"wasm behind a normal manifest".as_slice();
+    let manifest = signed_manifest("com.example.normal", "1.0.0", wasm, &key);
+    let bundle = pack(&dir, "normal.mpk", &manifest, wasm);
+
+    let (node, _d, _b) = node_client().await;
+    let (_app_id, served) = install(&node, bundle).await.expect("install");
+    assert_eq!(served, wasm);
+}
+
+/// Reading each artifact path once is what stops N services naming one large
+/// artifact from costing N copies, so the shared read must still hand every
+/// service its own artifact's bytes.
+#[tokio::test]
+async fn services_sharing_an_artifact_path_each_get_the_right_bytes() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+    let a = b"wasm for service a".as_slice();
+    let b = b"wasm for service b, distinct".as_slice();
+
+    let signer_id = derive_signer_id_did_key(key.verifying_key().as_bytes());
+    let artifact = |path: &str, bytes: &[u8]| {
+        serde_json::json!({
+            "path": path,
+            "size": bytes.len(),
+            "hash": hex_lower(&Sha256::digest(bytes)),
+        })
+    };
+    let mut manifest = serde_json::json!({
+        "version": "1.0",
+        "package": "com.example.shared",
+        "appVersion": "1.0.0",
+        "signerId": signer_id,
+        "minRuntimeVersion": "0.1.0",
+        // `c` deliberately names `a`'s path: one read, two services.
+        "services": [
+            { "name": "a", "wasm": artifact("a.wasm", a) },
+            { "name": "b", "wasm": artifact("b.wasm", b) },
+            { "name": "c", "wasm": artifact("a.wasm", a) },
+        ],
+        "migrations": []
+    });
+    sign_manifest_json(&mut manifest, &key).unwrap();
+    let bundle = pack_entries(
+        &dir,
+        "shared.mpk",
+        &[
+            ("manifest.json", &serde_json::to_vec(&manifest).unwrap()),
+            ("a.wasm", a),
+            ("b.wasm", b),
+        ],
+    );
+
+    let (node, _d, _b) = node_client().await;
+    let (blob_id, _) = node
+        .add_blob(
+            Cursor::new(bundle.as_slice()),
+            Some(bundle.len() as u64),
+            None,
+        )
+        .await
+        .unwrap();
+    let source = "https://registry.example.com/app.mpk".parse().unwrap();
+    let app_id = node
+        .install_application_from_bundle_blob(&blob_id, &source)
+        .await
+        .expect("multi-service install");
+
+    // The per-service bytecode blob is what the shared read decides, so it is
+    // what pins the keying; the served bytes are re-read and digest-checked and
+    // would look right even if a service had been registered against the wrong blob.
+    let app = node.get_application(&app_id).unwrap().expect("application");
+    for (service, expected) in [("a", a), ("b", b), ("c", a)] {
+        let blob = app
+            .services
+            .get(service)
+            .unwrap_or_else(|| panic!("service '{service}' missing"))
+            .bytecode;
+        let stored = node
+            .get_blob_bytes(&blob, None)
+            .await
+            .unwrap()
+            .expect("service blob bytes");
+        assert_eq!(
+            stored.as_ref(),
+            expected,
+            "service '{service}' was registered against another artifact's blob"
+        );
+
+        let served = node
+            .get_application_bytes(&app_id, Some(service))
+            .await
+            .unwrap()
+            .expect("service bytes");
+        assert_eq!(
+            served.as_ref(),
+            expected,
+            "service '{service}' was served another artifact's bytes"
+        );
+    }
+}
+
+/// Sharing one read between services must not share one digest check: the
+/// second service declares a different hash for the same path, and its own
+/// check is the only thing that can catch it.
+#[tokio::test]
+async fn a_shared_path_is_checked_against_every_service_digest() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+    let wasm = b"the one artifact both services name".as_slice();
+    let other = b"bytes no entry in this archive holds".as_slice();
+
+    let signer_id = derive_signer_id_did_key(key.verifying_key().as_bytes());
+    let mut manifest = serde_json::json!({
+        "version": "1.0",
+        "package": "com.example.mixedhash",
+        "appVersion": "1.0.0",
+        "signerId": signer_id,
+        "minRuntimeVersion": "0.1.0",
+        // Same path, two digests. `a` matches the archive, `b` does not.
+        "services": [
+            { "name": "a", "wasm": {
+                "path": "app.wasm",
+                "size": wasm.len(),
+                "hash": hex_lower(&Sha256::digest(wasm)),
+            } },
+            { "name": "b", "wasm": {
+                "path": "app.wasm",
+                "size": wasm.len(),
+                "hash": hex_lower(&Sha256::digest(other)),
+            } },
+        ],
+        "migrations": []
+    });
+    sign_manifest_json(&mut manifest, &key).unwrap();
+    let bundle = pack_entries(
+        &dir,
+        "mixedhash.mpk",
+        &[
+            ("manifest.json", &serde_json::to_vec(&manifest).unwrap()),
+            ("app.wasm", wasm),
+        ],
+    );
+
+    let (node, _d, _b) = node_client().await;
+    let err = install(&node, bundle)
+        .await
+        .expect_err("a service whose declared digest does not match must not install");
+    // Pinned to the digest check: a missing-artifact or parse rejection would
+    // mean the second service's hash was never compared at all.
+    let msg = err.to_string();
+    assert!(
+        msg.contains("app.wasm") && msg.contains("failed its integrity check"),
+        "the second service's digest must be the thing that fails, got: {msg}"
+    );
+}
+
+/// `is_bundle_blob` is the only signature gate on the execution-time read, so it
+/// must answer for the same archive the verified read parses. A manifest sitting
+/// past a peeked prefix installed verified, then served the raw archive instead.
+#[tokio::test]
+async fn manifest_past_the_tenth_entry_is_a_bundle_on_both_paths() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+    let wasm = b"wasm behind eleven leading entries".as_slice();
+    let manifest = signed_manifest("com.example.latemanifest", "1.0.0", wasm, &key);
+
+    let padding: Vec<String> = (0..10).map(|i| format!("pad/{i}.txt")).collect();
+    let mut entries: Vec<(&str, &[u8])> = padding
+        .iter()
+        .map(|p| (p.as_str(), b"pad".as_slice()))
+        .collect();
+    entries.push(("manifest.json", &manifest));
+    entries.push(("app.wasm", wasm));
+    let bundle = pack_entries(&dir, "late.mpk", &entries);
+
+    assert!(
+        NodeClient::is_bundle_blob(&bundle),
+        "detection must find the same manifest the verified read finds"
+    );
+
+    let (node, _d, _b) = node_client().await;
+    let (_app_id, served) = install(&node, bundle).await.expect("install");
+    assert_eq!(
+        served, wasm,
+        "the served bytes must be the digest-checked artifact, not the raw archive"
+    );
+}
+
+/// The bytes whose digest was checked must be the bytes the node later serves: a
+/// decoy sharing the manifest path's basename must not satisfy the check for it.
+#[tokio::test]
+async fn decoy_entry_cannot_satisfy_the_digest_check_for_another_entry() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+
+    let honest = b"HONEST wasm bytecode from the publisher".as_slice();
+    let evil = b"EVIL!! wasm bytecode from the registry ".as_slice();
+
+    // Signed manifest commits to the honest bytes at path "app.wasm".
+    let manifest = signed_manifest("com.example.decoy", "1.0.0", honest, &key);
+
+    // The decoy sits BEFORE the real path so a first-match-by-basename lookup
+    // hashes it, while an unpack-everything writer lets the later entry win.
+    let bundle = pack_entries(
+        &dir,
+        "decoy.mpk",
+        &[
+            ("manifest.json", &manifest),
+            ("decoy/app.wasm", honest),
+            ("app.wasm", evil),
+        ],
+    );
+
+    let (node, _d, _b) = node_client().await;
+    match install(&node, bundle).await {
+        // The decoy must be skipped outright, leaving the real `app.wasm` hashed
+        // and refused; any other rejection means the decoy was still reached.
+        Err(err) => {
+            let msg = err.to_string();
+            assert!(
+                msg.contains("app.wasm") && msg.contains("failed its integrity check"),
+                "the decoy must be ignored and the real entry must fail its digest, got: {msg}"
+            );
+        }
+        Ok((_app_id, served)) => assert_eq!(
+            served,
+            honest,
+            "BYPASS: digest checked the decoy entry but the node served {:?}",
+            String::from_utf8_lossy(&served),
+        ),
+    }
+}
+
+/// The content-addressed blob is the only copy of a bundle's bytes. Nothing is
+/// unpacked to disk, so there is no second copy to go stale or be tampered with.
+#[tokio::test]
+async fn install_writes_no_extracted_directory() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+    let wasm = b"wasm for the no-extract check".as_slice();
+    let manifest = signed_manifest("com.example.noextract", "1.0.0", wasm, &key);
+    let bundle = pack(&dir, "noextract.mpk", &manifest, wasm);
+
+    let (node, _data, blob_dir) = node_client().await;
+    let (_app_id, served) = install(&node, bundle).await.expect("install");
+    assert_eq!(served, wasm, "the blob must still serve the right bytes");
+
+    let applications = blob_dir.path().join("applications");
+    assert!(
+        !applications.exists(),
+        "no artifacts should be unpacked to disk, found {}",
+        applications.display()
+    );
+}
+
+/// Two entries at the manifest's path: whichever one an unpacker keeps, the
+/// digest check saw the other. The archive is refused outright.
+#[tokio::test]
+async fn duplicate_entries_at_the_manifest_path_are_refused() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+
+    let honest = b"HONEST wasm bytecode from the publisher".as_slice();
+    let evil = b"EVIL!! wasm bytecode from the registry ".as_slice();
+    let manifest = signed_manifest("com.example.dup", "1.0.0", honest, &key);
+
+    let bundle = pack_entries(
+        &dir,
+        "dup.mpk",
+        &[
+            ("manifest.json", &manifest),
+            ("app.wasm", honest),
+            ("app.wasm", evil),
+        ],
+    );
+
+    let (node, _d, _b) = node_client().await;
+    let err = install(&node, bundle)
+        .await
+        .expect_err("a duplicated artifact entry must not install");
+    assert!(
+        err.to_string()
+            .contains("more than one entry at 'app.wasm'"),
+        "the duplicate must be refused as such, not left to hash ordering, got: {err}"
+    );
+}

--- a/crates/node/primitives/tests/bundle_artifact_integrity.rs
+++ b/crates/node/primitives/tests/bundle_artifact_integrity.rs
@@ -21,6 +21,16 @@ use common::{hex_lower, node_client, pack_entries};
 /// Sign a manifest exactly the way `cargo mero bundle` does: real lowercase-hex
 /// SHA-256 per artifact, then an Ed25519 signature over the canonical manifest.
 fn signed_manifest(package: &str, version: &str, wasm: &[u8], key: &SigningKey) -> Vec<u8> {
+    signed_manifest_at(package, version, "app.wasm", wasm, key)
+}
+
+fn signed_manifest_at(
+    package: &str,
+    version: &str,
+    wasm_path: &str,
+    wasm: &[u8],
+    key: &SigningKey,
+) -> Vec<u8> {
     let signer_id = derive_signer_id_did_key(key.verifying_key().as_bytes());
     let mut manifest = serde_json::json!({
         "version": "1.0",
@@ -29,7 +39,7 @@ fn signed_manifest(package: &str, version: &str, wasm: &[u8], key: &SigningKey) 
         "signerId": signer_id,
         "minRuntimeVersion": "0.1.0",
         "wasm": {
-            "path": "app.wasm",
+            "path": wasm_path,
             "size": wasm.len(),
             "hash": hex_lower(&Sha256::digest(wasm)),
         },
@@ -473,6 +483,142 @@ async fn install_writes_no_extracted_directory() {
         !applications.exists(),
         "no artifacts should be unpacked to disk, found {}",
         applications.display()
+    );
+}
+
+/// The rollback in its bare form: the archive's only manifest is nested, and it
+/// is authentically signed, so nothing but the exact path can refuse it.
+#[tokio::test]
+async fn a_nested_manifest_is_never_the_bundle_manifest() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+    let old_wasm = b"wasm bytecode of the superseded release".as_slice();
+    let old = signed_manifest_at(
+        "com.example.nested",
+        "1.0.0",
+        "old/app.wasm",
+        old_wasm,
+        &key,
+    );
+
+    let bundle = pack_entries(
+        &dir,
+        "nested.mpk",
+        &[("old/manifest.json", &old), ("old/app.wasm", old_wasm)],
+    );
+
+    let (node, _d, _b) = node_client().await;
+    let err = install(&node, bundle)
+        .await
+        .expect_err("a bundle whose only manifest is nested must not install");
+    assert!(
+        err.to_string()
+            .contains("manifest.json not found in bundle"),
+        "the nested manifest must not be selected at all, got: {err}"
+    );
+}
+
+/// A nested `old/manifest.json` holds a genuinely signed older release, so no
+/// signature check can catch it: only selecting the exact top-level path can.
+/// Both manifests here install cleanly, so which one wins is the whole test.
+#[tokio::test]
+async fn a_nested_manifest_cannot_roll_the_install_back_to_an_older_release() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+
+    let old_wasm = b"wasm bytecode of the superseded release".as_slice();
+    let new_wasm = b"wasm bytecode of the current release !!".as_slice();
+
+    // Same publisher key, each manifest committing to its own artifact.
+    let old = signed_manifest_at(
+        "com.example.rollback",
+        "1.0.0",
+        "old/app.wasm",
+        old_wasm,
+        &key,
+    );
+    let new = signed_manifest_at("com.example.rollback", "2.0.0", "app.wasm", new_wasm, &key);
+
+    // The old pair leads, so a basename-and-first-match selection installs 1.0.0.
+    let bundle = pack_entries(
+        &dir,
+        "rollback.mpk",
+        &[
+            ("old/manifest.json", &old),
+            ("old/app.wasm", old_wasm),
+            ("manifest.json", &new),
+            ("app.wasm", new_wasm),
+        ],
+    );
+
+    let (node, _d, _b) = node_client().await;
+    let (app_id, served) = install(&node, bundle).await.expect("install");
+    assert_eq!(
+        served, new_wasm,
+        "ROLLBACK: the nested manifest was selected and the superseded release installed"
+    );
+    let app = node.get_application(&app_id).unwrap().expect("application");
+    assert_eq!(
+        app.version.map(|v| v.to_string()).as_deref(),
+        Some("2.0.0"),
+        "the installed version must come from the top-level manifest"
+    );
+}
+
+/// Two entries at the manifest's own path: whichever one an unpacker keeps, the
+/// signature was checked against the other. Both are authentic, so nothing but
+/// the duplicate rule can separate them.
+#[tokio::test]
+async fn duplicate_top_level_manifest_entries_are_refused() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+    let wasm = b"wasm behind two manifests".as_slice();
+
+    let first = signed_manifest("com.example.twomanifests", "1.0.0", wasm, &key);
+    let second = signed_manifest("com.example.twomanifests", "2.0.0", wasm, &key);
+
+    let bundle = pack_entries(
+        &dir,
+        "twomanifests.mpk",
+        &[
+            ("manifest.json", &first),
+            ("app.wasm", wasm),
+            ("manifest.json", &second),
+        ],
+    );
+
+    let (node, _d, _b) = node_client().await;
+    let err = install(&node, bundle)
+        .await
+        .expect_err("a duplicated manifest entry must not install");
+    assert!(
+        err.to_string()
+            .contains("more than one entry at 'manifest.json'"),
+        "the duplicate must be refused as such, not left to entry order, got: {err}"
+    );
+}
+
+/// Finding the duplicate means walking to the end of the archive, so the cap
+/// that bounds the pre-signature manifest scan must not bound the whole bundle.
+#[tokio::test]
+async fn a_bundle_larger_than_the_manifest_scan_cap_still_installs() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+
+    // Past the 8 MiB scan cap, and compressible enough to stay quick.
+    let wasm = vec![0xABu8; 12 * 1024 * 1024];
+    let manifest = signed_manifest("com.example.large", "1.0.0", &wasm, &key);
+    let bundle = pack_entries(
+        &dir,
+        "large.mpk",
+        &[("manifest.json", &manifest), ("app.wasm", &wasm)],
+    );
+
+    let (node, _d, _b) = node_client().await;
+    let (_app_id, served) = install(&node, bundle).await.expect("install");
+    assert!(
+        served == wasm,
+        "a bundle whose artifacts outweigh the manifest scan cap must still install"
     );
 }
 

--- a/crates/node/primitives/tests/bundle_artifact_integrity.rs
+++ b/crates/node/primitives/tests/bundle_artifact_integrity.rs
@@ -622,6 +622,50 @@ async fn a_bundle_larger_than_the_manifest_scan_cap_still_installs() {
     );
 }
 
+/// A manifest declaring no wasm is malformed at install, not at first
+/// execution: without the check the row is written with no bytecode at all.
+#[tokio::test]
+async fn a_manifest_declaring_no_wasm_is_refused_at_install() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+    let migration = b"migration bytes and nothing to run them against".as_slice();
+
+    let signer_id = derive_signer_id_did_key(key.verifying_key().as_bytes());
+    let mut manifest = serde_json::json!({
+        "version": "1.0",
+        "package": "com.example.nowasm",
+        "appVersion": "1.0.0",
+        "signerId": signer_id,
+        "minRuntimeVersion": "0.1.0",
+        "migrations": [{
+            "path": "migrations/1.wasm",
+            "size": migration.len(),
+            "hash": hex_lower(&Sha256::digest(migration)),
+        }]
+    });
+    sign_manifest_json(&mut manifest, &key).unwrap();
+    let bundle = pack_entries(
+        &dir,
+        "nowasm.mpk",
+        &[
+            ("manifest.json", &serde_json::to_vec(&manifest).unwrap()),
+            ("migrations/1.wasm", migration),
+        ],
+    );
+
+    let (node, _d, _b) = node_client().await;
+    let err = install(&node, bundle)
+        .await
+        .expect_err("a bundle with no wasm artifact must not install");
+    // Pinned to the install-time wording: the deferred failure said "declares no
+    // top-level wasm" and only ever surfaced once something tried to run it.
+    let msg = err.to_string();
+    assert!(
+        msg.contains("declares no wasm artifact"),
+        "the missing wasm must be named at install, got: {msg}"
+    );
+}
+
 /// Two entries at the manifest's path: whichever one an unpacker keeps, the
 /// digest check saw the other. The archive is refused outright.
 #[tokio::test]

--- a/crates/node/primitives/tests/bundle_artifact_integrity.rs
+++ b/crates/node/primitives/tests/bundle_artifact_integrity.rs
@@ -419,6 +419,43 @@ async fn manifest_past_the_tenth_entry_is_a_bundle_on_both_paths() {
     );
 }
 
+/// An entry no walk can match says nothing about the manifest's authenticity, so
+/// every walk must step over it rather than end there. It leads the archive, so a
+/// walk that stopped would leave the manifest and the artifact behind it unread.
+#[cfg(unix)]
+#[tokio::test]
+async fn an_unmatchable_entry_ahead_of_the_manifest_installs_on_both_paths() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+    use std::path::Path;
+
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+    let wasm = b"wasm behind an entry no path can name".as_slice();
+    let manifest = signed_manifest("com.example.oddentry", "1.0.0", wasm, &key);
+
+    // Not valid UTF-8: no manifest-declared path can name it here, and on a
+    // platform whose paths must be Unicode it will not resolve at all.
+    let entries: [(&Path, &[u8]); 3] = [
+        (Path::new(OsStr::from_bytes(b"\xff\xfe.bin")), b"opaque"),
+        (Path::new("manifest.json"), &manifest),
+        (Path::new("app.wasm"), wasm),
+    ];
+    let bundle = pack_entries(&dir, "oddentry.mpk", &entries);
+
+    assert!(
+        NodeClient::is_bundle_blob(&bundle),
+        "detection must step over an entry it cannot match, not answer `false`"
+    );
+
+    let (node, _d, _b) = node_client().await;
+    let (_app_id, served) = install(&node, bundle).await.expect("install");
+    assert_eq!(
+        served, wasm,
+        "the verified read must agree with detection and serve the digest-checked artifact"
+    );
+}
+
 /// The bytes whose digest was checked must be the bytes the node later serves: a
 /// decoy sharing the manifest path's basename must not satisfy the check for it.
 #[tokio::test]

--- a/crates/node/primitives/tests/bundle_artifact_integrity.rs
+++ b/crates/node/primitives/tests/bundle_artifact_integrity.rs
@@ -6,12 +6,13 @@ use std::fs;
 use calimero_node_primitives::bundle::{derive_signer_id_did_key, sign_manifest_json};
 use calimero_node_primitives::client::NodeClient;
 use ed25519_dalek::SigningKey;
+use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use futures_util::io::Cursor;
 use rand::rngs::OsRng;
 use sha2::{Digest, Sha256};
-use tar::Builder;
+use tar::{Archive, Builder};
 use tempfile::TempDir;
 
 mod common;
@@ -66,6 +67,34 @@ fn pack(dir: &TempDir, name: &str, manifest_bytes: &[u8], wasm: &[u8]) -> Vec<u8
     tar.finish().unwrap();
     drop(tar);
     fs::read(&path).unwrap()
+}
+
+/// Pack with entry names written into the header verbatim: `Header::set_path`
+/// drops a leading `./`, which is the very spelling these fixtures need.
+fn pack_verbatim(dir: &TempDir, name: &str, entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let path = dir.path().join(name);
+    let encoder = GzEncoder::new(fs::File::create(&path).unwrap(), Compression::default());
+    let mut tar = Builder::new(encoder);
+    for (entry_path, content) in entries {
+        let mut header = tar::Header::new_gnu();
+        header.as_old_mut().name[..entry_path.len()].copy_from_slice(entry_path.as_bytes());
+        header.set_size(content.len() as u64);
+        header.set_cksum();
+        tar.append(&header, *content).unwrap();
+    }
+    tar.finish().unwrap();
+    drop(tar);
+
+    let bundle = fs::read(&path).unwrap();
+    let mut written = Archive::new(GzDecoder::new(bundle.as_slice()));
+    for (entry, (expected, _)) in written.entries().unwrap().zip(entries) {
+        assert_eq!(
+            entry.unwrap().path_bytes().as_ref(),
+            expected.as_bytes(),
+            "the fixture proves nothing unless the archive holds this exact spelling"
+        );
+    }
+    bundle
 }
 
 /// Install through the production path (mandatory signature) and return the
@@ -732,5 +761,177 @@ async fn duplicate_entries_at_the_manifest_path_are_refused() {
         err.to_string()
             .contains("more than one entry at 'app.wasm'"),
         "the duplicate must be refused as such, not left to hash ordering, got: {err}"
+    );
+}
+
+/// `tar -czf out.mpk .` writes every member as `./name`, which is the same path
+/// spelled differently. Such a bundle went unrecognised entirely: detection
+/// answered `false` and the archive was served to the runtime as raw bytes.
+#[tokio::test]
+async fn a_bundle_written_with_leading_dot_slash_installs_on_both_paths() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+    let wasm = b"wasm from a bundle built by ordinary tar".as_slice();
+
+    // The manifest declares the plain path; only the entries carry the `./`.
+    let manifest = signed_manifest("com.example.dotslash", "1.0.0", wasm, &key);
+    let bundle = pack_verbatim(
+        &dir,
+        "dotslash.mpk",
+        &[("./manifest.json", &manifest), ("./app.wasm", wasm)],
+    );
+
+    assert!(
+        NodeClient::is_bundle_blob(&bundle),
+        "a `./`-spelled archive is a bundle, not raw bytes"
+    );
+
+    let (node, _d, _b) = node_client().await;
+    let (_app_id, served) = install(&node, bundle).await.expect("install");
+    assert_eq!(
+        served, wasm,
+        "the served bytes must be the digest-checked artifact, not the raw archive"
+    );
+}
+
+/// The other direction: normalising only the entry side would leave a manifest
+/// that declares `./app.wasm` unable to find the artifact it signed.
+#[tokio::test]
+async fn a_manifest_declaring_a_dot_slash_path_matches_a_plain_entry() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+    let wasm = b"wasm named with a leading dot-slash".as_slice();
+
+    let manifest = signed_manifest_at(
+        "com.example.dotslashmanifest",
+        "1.0.0",
+        "./app.wasm",
+        wasm,
+        &key,
+    );
+    let bundle = pack_entries(
+        &dir,
+        "dotslashmanifest.mpk",
+        &[("manifest.json", &manifest), ("app.wasm", wasm)],
+    );
+
+    let (node, _d, _b) = node_client().await;
+    let (_app_id, served) = install(&node, bundle).await.expect("install");
+    assert_eq!(served, wasm, "the declared `./app.wasm` must resolve");
+}
+
+/// `./` is a no-op, `old/` is a component. Normalising the first must not have
+/// restored basename matching, so the nested release must still lose.
+#[tokio::test]
+async fn a_dot_slash_archive_still_refuses_a_nested_manifest_rollback() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+
+    let old_wasm = b"wasm bytecode of the superseded release".as_slice();
+    let new_wasm = b"wasm bytecode of the current release !!".as_slice();
+
+    let old = signed_manifest_at(
+        "com.example.dotslashrollback",
+        "1.0.0",
+        "old/app.wasm",
+        old_wasm,
+        &key,
+    );
+    let new = signed_manifest_at(
+        "com.example.dotslashrollback",
+        "2.0.0",
+        "app.wasm",
+        new_wasm,
+        &key,
+    );
+
+    // Every entry `./`-spelled, the nested pair first: both manifests would
+    // install on their own, so which one is selected is the whole test.
+    let bundle = pack_verbatim(
+        &dir,
+        "dotslashrollback.mpk",
+        &[
+            ("./old/manifest.json", &old),
+            ("./old/app.wasm", old_wasm),
+            ("./manifest.json", &new),
+            ("./app.wasm", new_wasm),
+        ],
+    );
+
+    let (node, _d, _b) = node_client().await;
+    let (app_id, served) = install(&node, bundle).await.expect("install");
+    assert_eq!(
+        served, new_wasm,
+        "ROLLBACK: the nested manifest was selected and the superseded release installed"
+    );
+    let app = node.get_application(&app_id).unwrap().expect("application");
+    assert_eq!(
+        app.version.map(|v| v.to_string()).as_deref(),
+        Some("2.0.0"),
+        "the installed version must come from the top-level manifest"
+    );
+}
+
+/// Two spellings of one path are two entries at that path. Preferring either
+/// leaves an unpacker holding the manifest the signature never covered.
+#[tokio::test]
+async fn a_dot_slash_duplicate_of_the_manifest_is_refused() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+    let wasm = b"wasm behind two spellings of one manifest".as_slice();
+
+    let first = signed_manifest("com.example.dotslashdupmanifest", "1.0.0", wasm, &key);
+    let second = signed_manifest("com.example.dotslashdupmanifest", "2.0.0", wasm, &key);
+
+    let bundle = pack_verbatim(
+        &dir,
+        "dotslashdupmanifest.mpk",
+        &[
+            ("manifest.json", &first),
+            ("app.wasm", wasm),
+            ("./manifest.json", &second),
+        ],
+    );
+
+    let (node, _d, _b) = node_client().await;
+    let err = install(&node, bundle)
+        .await
+        .expect_err("a manifest duplicated under another spelling must not install");
+    assert!(
+        err.to_string()
+            .contains("more than one entry at 'manifest.json'"),
+        "the duplicate must be refused as such, not resolved by entry order, got: {err}"
+    );
+}
+
+/// Same on the artifact side: the digest check saw one of the two, and nothing
+/// says an unpacker keeps that one.
+#[tokio::test]
+async fn a_dot_slash_duplicate_of_an_artifact_is_refused() {
+    let dir = TempDir::new().unwrap();
+    let key = SigningKey::generate(&mut OsRng);
+
+    let honest = b"HONEST wasm bytecode from the publisher".as_slice();
+    let evil = b"EVIL!! wasm bytecode from the registry ".as_slice();
+    let manifest = signed_manifest("com.example.dotslashdup", "1.0.0", honest, &key);
+
+    let bundle = pack_verbatim(
+        &dir,
+        "dotslashdup.mpk",
+        &[
+            ("manifest.json", &manifest),
+            ("app.wasm", honest),
+            ("./app.wasm", evil),
+        ],
+    );
+
+    let (node, _d, _b) = node_client().await;
+    let err = install(&node, bundle)
+        .await
+        .expect_err("an artifact duplicated under another spelling must not install");
+    assert!(
+        err.to_string()
+            .contains("more than one entry at 'app.wasm'"),
+        "the duplicate must be refused as such, not left to entry order, got: {err}"
     );
 }

--- a/crates/node/primitives/tests/bundle_installation.rs
+++ b/crates/node/primitives/tests/bundle_installation.rs
@@ -1,4 +1,4 @@
-//! Tests for bundle installation and extraction
+//! Tests for bundle installation
 
 use std::fs;
 
@@ -20,6 +20,7 @@ use flate2::write::GzEncoder;
 use flate2::Compression;
 use futures_util::io::Cursor;
 use rand::rngs::OsRng;
+use sha2::{Digest, Sha256};
 use tar::Builder;
 use tempfile::TempDir;
 use tokio::sync::{broadcast, mpsc};
@@ -28,6 +29,14 @@ use tokio::sync::{broadcast, mpsc};
 /// This is a convenience wrapper around the shared sign_manifest_json function.
 fn sign_manifest(manifest_json: &mut serde_json::Value, signing_key: &SigningKey) {
     sign_manifest_json(manifest_json, signing_key).unwrap();
+}
+
+/// Lowercase-hex SHA-256, the way `cargo mero bundle` records an artifact hash.
+fn artifact_hash(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
 }
 
 /// Create a test bundle archive with manifest.json, app.wasm, abi.json, and migrations
@@ -59,12 +68,12 @@ fn create_test_bundle(
         interfaces: None,
         wasm: Some(calimero_node_primitives::bundle::BundleArtifact {
             path: "app.wasm".to_string(),
-            hash: None,
+            hash: artifact_hash(wasm_content),
             size: wasm_content.len() as u64,
         }),
         abi: abi_content.map(|content| calimero_node_primitives::bundle::BundleArtifact {
             path: "abi.json".to_string(),
-            hash: None,
+            hash: artifact_hash(content),
             size: content.len() as u64,
         }),
         migrations: migrations
@@ -72,7 +81,7 @@ fn create_test_bundle(
             .map(
                 |(path, content)| calimero_node_primitives::bundle::BundleArtifact {
                     path: path.to_string(),
-                    hash: None,
+                    hash: artifact_hash(content),
                     size: content.len() as u64,
                 },
             )
@@ -138,13 +147,15 @@ async fn create_test_node_client(datastore: Option<Store>) -> (NodeClient, TempD
     // Default to InMemoryDB if no store is provided (avoids dependency on calimero-store-rocksdb)
     let datastore = datastore.unwrap_or_else(|| Store::new(Arc::new(InMemoryDB::owned())));
 
+    // Nest the blobstore one level down: the node derives its root as the blob
+    // root's parent, so a bare TempDir would make every node share the OS temp
+    // dir as its root.
+    let blob_root = blob_dir.path().join("blobs");
     let blob_store = BlobStore::new(
         datastore.clone(),
-        FileSystem::new(&BlobStoreConfig::new(
-            blob_dir.path().to_path_buf().try_into().unwrap(),
-        ))
-        .await
-        .unwrap(),
+        FileSystem::new(&BlobStoreConfig::new(blob_root.try_into().unwrap()))
+            .await
+            .unwrap(),
     );
     let blob_manager = BlobManager::new(blob_store);
 
@@ -202,7 +213,7 @@ async fn test_bundle_detection() {
 #[tokio::test]
 async fn test_bundle_installation() {
     let temp_dir = TempDir::new().unwrap();
-    let (node_client, _data_dir, blob_dir) = create_test_node_client(None).await;
+    let (node_client, _data_dir, _blob_dir) = create_test_node_client(None).await;
 
     // Create a test bundle
     let wasm_content = b"fake wasm bytecode";
@@ -220,7 +231,7 @@ async fn test_bundle_installation() {
         "1.0.0",
         wasm_content,
         Some(abi_content),
-        migrations.clone(),
+        migrations,
     );
 
     // Install the bundle
@@ -242,39 +253,14 @@ async fn test_bundle_installation() {
         .expect("Should check blob existence");
     assert!(blob_exists, "Bundle blob should exist");
 
-    // Verify extracted files exist
-    // Applications are now extracted to node root (parent of blobstore), not blobstore root
-    let node_root = blob_dir.path().parent().unwrap();
-    let extract_dir = node_root
-        .join("applications")
-        .join("com.example.test")
-        .join("1.0.0")
-        .join("extracted");
-
-    let wasm_path = extract_dir.join("app.wasm");
-    assert!(wasm_path.exists(), "Extracted WASM should exist");
-
-    let abi_path = extract_dir.join("abi.json");
-    assert!(abi_path.exists(), "Extracted ABI should exist");
-
-    let migration1_path = extract_dir.join("migrations/001_init.sql");
-    assert!(migration1_path.exists(), "First migration should exist");
-
-    let migration2_path = extract_dir.join("migrations/002_add_users.sql");
-    assert!(migration2_path.exists(), "Second migration should exist");
-
-    // Verify file contents
-    let extracted_wasm = fs::read(&wasm_path).unwrap();
-    assert_eq!(extracted_wasm, wasm_content, "WASM content should match");
-
-    let extracted_abi = fs::read(&abi_path).unwrap();
-    assert_eq!(extracted_abi, abi_content, "ABI content should match");
-
-    let extracted_migration1 = fs::read(&migration1_path).unwrap();
-    assert_eq!(
-        extracted_migration1, migrations[0].1,
-        "Migration 1 content should match"
-    );
+    // The wasm entry must still be picked out of an archive that also carries an
+    // ABI and migrations.
+    let bytes = node_client
+        .get_application_bytes(&application_id, None)
+        .await
+        .expect("Should get application bytes")
+        .expect("Application bytes should exist");
+    assert_eq!(bytes.as_ref(), wasm_content, "WASM content should match");
 }
 
 #[tokio::test]
@@ -299,7 +285,7 @@ async fn test_bundle_get_application_bytes() {
         .await
         .expect("Bundle installation should succeed");
 
-    // Get application bytes (should read from extracted directory)
+    // Get application bytes (should read the wasm out of the bundle blob)
     let bytes = node_client
         .get_application_bytes(&application_id, None)
         .await
@@ -311,77 +297,6 @@ async fn test_bundle_get_application_bytes() {
         wasm_content,
         "Application bytes should match WASM content"
     );
-}
-
-#[tokio::test]
-async fn test_bundle_deduplication() {
-    let temp_dir = TempDir::new().unwrap();
-    let (node_client, _data_dir, blob_dir) = create_test_node_client(None).await;
-
-    // Create first bundle with specific WASM content
-    let wasm_content_v1 = b"shared wasm bytecode";
-    let bundle_path_v1 = create_test_bundle(
-        &temp_dir,
-        "com.example.shared",
-        "1.0.0",
-        wasm_content_v1,
-        None,
-        vec![],
-    );
-
-    // Install first version
-    let _app_id_v1 = node_client
-        .install_application_from_path(bundle_path_v1, vec![], None, None)
-        .await
-        .expect("First bundle installation should succeed");
-
-    // Create second bundle with same WASM content (should be deduplicated)
-    let wasm_content_v2 = wasm_content_v1; // Same content
-    let bundle_path_v2 = create_test_bundle(
-        &temp_dir,
-        "com.example.shared",
-        "2.0.0",
-        wasm_content_v2,
-        None,
-        vec![],
-    );
-
-    // Install second version
-    let _app_id_v2 = node_client
-        .install_application_from_path(bundle_path_v2, vec![], None, None)
-        .await
-        .expect("Second bundle installation should succeed");
-
-    // Check that both versions have the WASM file
-    // Applications are now extracted to node root (parent of blobstore), not blobstore root
-    let node_root = blob_dir.path().parent().unwrap();
-    let extract_dir_v1 = node_root
-        .join("applications")
-        .join("com.example.shared")
-        .join("1.0.0")
-        .join("extracted");
-
-    let extract_dir_v2 = node_root
-        .join("applications")
-        .join("com.example.shared")
-        .join("2.0.0")
-        .join("extracted");
-
-    let wasm_path_v1 = extract_dir_v1.join("app.wasm");
-    let wasm_path_v2 = extract_dir_v2.join("app.wasm");
-
-    assert!(wasm_path_v1.exists(), "V1 WASM should exist");
-    assert!(wasm_path_v2.exists(), "V2 WASM should exist");
-
-    // Verify both files exist and have the same content
-    // (Deduplication may use hardlinks or copies depending on filesystem)
-    let content_v1 = fs::read(&wasm_path_v1).unwrap();
-    let content_v2 = fs::read(&wasm_path_v2).unwrap();
-    assert_eq!(
-        content_v1, content_v2,
-        "Both versions should have same WASM content"
-    );
-    assert_eq!(content_v1, wasm_content_v1, "Content should match original");
 }
 
 #[tokio::test]
@@ -423,19 +338,21 @@ async fn test_bundle_validation_missing_fields() {
     let encoder = GzEncoder::new(bundle_file, Compression::default());
     let mut tar = Builder::new(encoder);
 
-    // Create manifest.json with missing package field
-    // Use a raw JSON string to ensure package field is truly missing
-    let invalid_manifest_json = r#"{
+    // The package key is simply absent. The artifact hash is real, so the only
+    // thing this manifest is malformed about is the field the test names.
+    let invalid_manifest_json = serde_json::json!({
         "version": "1.0",
         "appVersion": "1.0.0",
         "minRuntimeVersion": "0.1.0",
         "wasm": {
             "path": "app.wasm",
-            "size": 10
+            "size": 10,
+            "hash": artifact_hash(b"fake wasm")
         },
         "migrations": []
-    }"#;
-    let manifest_json = invalid_manifest_json.as_bytes();
+    });
+    let manifest_bytes = serde_json::to_vec(&invalid_manifest_json).unwrap();
+    let manifest_json = manifest_bytes.as_slice();
     let mut manifest_header = tar::Header::new_gnu();
     manifest_header.set_path("manifest.json").unwrap();
     manifest_header.set_size(manifest_json.len() as u64);
@@ -463,16 +380,11 @@ async fn test_bundle_validation_missing_fields() {
         "Bundle installation should fail for invalid manifest"
     );
     let error_msg = result.unwrap_err().to_string();
-    // BundleManifest deserialization will fail if package field is missing
-    // The error could be "missing field 'package'" from serde or "package field is empty" from validation
-    // Or it could be a tar parsing error if the archive is malformed
+    // Named after the absent field, so nothing looser will do: an empty-package
+    // or malformed-archive rejection would mean the manifest never got that far.
     assert!(
-        error_msg.contains("package")
-            || error_msg.contains("missing field")
-            || error_msg.contains("empty")
-            || error_msg.contains("manifest")
-            || error_msg.contains("parse"),
-        "Error should mention missing package field, manifest issue, or parse error, got: {error_msg}"
+        error_msg.contains("missing field `package`"),
+        "the absent package field must be what refuses the bundle, got: {error_msg}"
     );
 }
 
@@ -538,7 +450,7 @@ fn create_test_bundle_custom_wasm_path(
         interfaces: None,
         wasm: Some(calimero_node_primitives::bundle::BundleArtifact {
             path: wasm_path.to_string(),
-            hash: None,
+            hash: artifact_hash(wasm_content),
             size: wasm_content.len() as u64,
         }),
         abi: None,
@@ -574,7 +486,7 @@ fn create_test_bundle_custom_wasm_path(
 #[tokio::test]
 async fn test_bundle_custom_wasm_path() {
     let temp_dir = TempDir::new().unwrap();
-    let (node_client, _data_dir, blob_dir) = create_test_node_client(None).await;
+    let (node_client, _data_dir, _blob_dir) = create_test_node_client(None).await;
 
     // Create bundle with WASM at custom path
     let wasm_content = b"custom path wasm bytecode";
@@ -592,20 +504,7 @@ async fn test_bundle_custom_wasm_path() {
         .await
         .expect("Bundle installation should succeed");
 
-    // Verify WASM was extracted at custom path
-    let node_root = blob_dir.path().parent().unwrap();
-    let extract_dir = node_root
-        .join("applications")
-        .join("com.example.custom")
-        .join("1.0.0")
-        .join("extracted");
-    let wasm_path = extract_dir.join("src/main.wasm");
-    assert!(
-        wasm_path.exists(),
-        "WASM should be extracted at custom path"
-    );
-
-    // Verify get_application_bytes reads from custom path
+    // A custom `wasm.path` must resolve to the entry at that path in the archive
     let bytes = node_client
         .get_application_bytes(&application_id, None)
         .await
@@ -676,18 +575,20 @@ async fn test_bundle_validation_empty_package() {
     let encoder = GzEncoder::new(bundle_file, Compression::default());
     let mut tar = Builder::new(encoder);
 
-    let invalid_manifest_json = r#"{
+    let invalid_manifest_json = serde_json::json!({
         "version": "1.0",
         "package": "",
         "appVersion": "1.0.0",
         "minRuntimeVersion": "0.1.0",
         "wasm": {
             "path": "app.wasm",
-            "size": 10
+            "size": 10,
+            "hash": artifact_hash(b"fake wasm")
         },
         "migrations": []
-    }"#;
-    let manifest_json = invalid_manifest_json.as_bytes();
+    });
+    let manifest_bytes = serde_json::to_vec(&invalid_manifest_json).unwrap();
+    let manifest_json = manifest_bytes.as_slice();
     let mut manifest_header = tar::Header::new_gnu();
     manifest_header.set_path("manifest.json").unwrap();
     manifest_header.set_size(manifest_json.len() as u64);
@@ -730,18 +631,20 @@ async fn test_bundle_validation_empty_app_version() {
     let encoder = GzEncoder::new(bundle_file, Compression::default());
     let mut tar = Builder::new(encoder);
 
-    let invalid_manifest_json = r#"{
+    let invalid_manifest_json = serde_json::json!({
         "version": "1.0",
         "package": "com.example.test",
         "appVersion": "",
         "minRuntimeVersion": "0.1.0",
         "wasm": {
             "path": "app.wasm",
-            "size": 10
+            "size": 10,
+            "hash": artifact_hash(b"fake wasm")
         },
         "migrations": []
-    }"#;
-    let manifest_json = invalid_manifest_json.as_bytes();
+    });
+    let manifest_bytes = serde_json::to_vec(&invalid_manifest_json).unwrap();
+    let manifest_json = manifest_bytes.as_slice();
     let mut manifest_header = tar::Header::new_gnu();
     manifest_header.set_path("manifest.json").unwrap();
     manifest_header.set_size(manifest_json.len() as u64);
@@ -784,17 +687,19 @@ async fn test_bundle_validation_missing_app_version() {
     let encoder = GzEncoder::new(bundle_file, Compression::default());
     let mut tar = Builder::new(encoder);
 
-    let invalid_manifest_json = r#"{
+    let invalid_manifest_json = serde_json::json!({
         "version": "1.0",
         "package": "com.example.test",
         "minRuntimeVersion": "0.1.0",
         "wasm": {
             "path": "app.wasm",
-            "size": 10
+            "size": 10,
+            "hash": artifact_hash(b"fake wasm")
         },
         "migrations": []
-    }"#;
-    let manifest_json = invalid_manifest_json.as_bytes();
+    });
+    let manifest_bytes = serde_json::to_vec(&invalid_manifest_json).unwrap();
+    let manifest_json = manifest_bytes.as_slice();
     let mut manifest_header = tar::Header::new_gnu();
     manifest_header.set_path("manifest.json").unwrap();
     manifest_header.set_size(manifest_json.len() as u64);
@@ -826,129 +731,6 @@ async fn test_bundle_validation_missing_app_version() {
             || error_msg.contains("version")
             || error_msg.contains("parse"),
         "Error should mention missing appVersion field, got: {error_msg}"
-    );
-}
-
-#[tokio::test]
-async fn test_bundle_deduplication_different_paths() {
-    let temp_dir = TempDir::new().unwrap();
-    let (node_client, _data_dir, blob_dir) = create_test_node_client(None).await;
-
-    // Create first bundle with WASM at one path
-    let wasm_content = b"shared wasm";
-    let bundle_path_v1 = create_test_bundle_custom_wasm_path(
-        &temp_dir,
-        "com.example.paths",
-        "1.0.0",
-        "src/app.wasm",
-        wasm_content,
-    );
-
-    let _app_id_v1 = node_client
-        .install_application_from_path(bundle_path_v1, vec![], None, None)
-        .await
-        .expect("First bundle installation should succeed");
-
-    // Create second bundle with WASM at different path but same content
-    let bundle_path_v2 = create_test_bundle_custom_wasm_path(
-        &temp_dir,
-        "com.example.paths",
-        "2.0.0",
-        "lib/app.wasm", // Different path
-        wasm_content,   // Same content
-    );
-
-    let _app_id_v2 = node_client
-        .install_application_from_path(bundle_path_v2, vec![], None, None)
-        .await
-        .expect("Second bundle installation should succeed");
-
-    // Verify both paths exist (should NOT be deduplicated because paths differ)
-    let node_root = blob_dir.path().parent().unwrap();
-    let extract_dir_v1 = node_root
-        .join("applications")
-        .join("com.example.paths")
-        .join("1.0.0")
-        .join("extracted");
-    let extract_dir_v2 = node_root
-        .join("applications")
-        .join("com.example.paths")
-        .join("2.0.0")
-        .join("extracted");
-
-    let wasm_path_v1 = extract_dir_v1.join("src/app.wasm");
-    let wasm_path_v2 = extract_dir_v2.join("lib/app.wasm");
-
-    assert!(
-        wasm_path_v1.exists(),
-        "V1 WASM should exist at src/app.wasm"
-    );
-    assert!(
-        wasm_path_v2.exists(),
-        "V2 WASM should exist at lib/app.wasm"
-    );
-
-    // Both should have same content but be separate files (not deduplicated due to different paths)
-    let content_v1 = fs::read(&wasm_path_v1).unwrap();
-    let content_v2 = fs::read(&wasm_path_v2).unwrap();
-    assert_eq!(content_v1, content_v2, "Both should have same content");
-    assert_eq!(content_v1, wasm_content, "Content should match original");
-}
-
-#[tokio::test]
-async fn test_bundle_extract_dir_derived_from_manifest() {
-    let temp_dir = TempDir::new().unwrap();
-    let (node_client, _data_dir, blob_dir) = create_test_node_client(None).await;
-
-    // Install bundle
-    let bundle_path = create_test_bundle(
-        &temp_dir,
-        "com.example.derived",
-        "2.5.0",
-        b"wasm content",
-        None,
-        vec![],
-    );
-
-    let application_id = node_client
-        .install_application_from_path(bundle_path, vec![], None, None)
-        .await
-        .expect("Bundle installation should succeed");
-
-    // Verify metadata contains package and version extracted from manifest
-    let application = node_client
-        .get_application(&application_id)
-        .expect("Application should exist")
-        .expect("Application should be found");
-
-    // Metadata should contain at least package and version
-    assert!(
-        !application.metadata.is_empty(),
-        "Bundle metadata should contain package and version extracted from manifest"
-    );
-
-    // Verify package and version are present
-    let metadata_json: serde_json::Value =
-        serde_json::from_slice(&application.metadata).expect("Metadata should be valid JSON");
-    assert_eq!(
-        metadata_json["package"], "com.example.derived",
-        "Package should match manifest"
-    );
-    assert_eq!(
-        metadata_json["version"], "2.5.0",
-        "Version should match manifest"
-    );
-
-    // Verify files were extracted to correct location derived from manifest
-    let node_root = blob_dir.path().parent().unwrap();
-    let extract_dir = node_root
-        .join("applications")
-        .join("com.example.derived")
-        .join("2.5.0")
-        .join("extracted");
-    assert!(
-        extract_dir.exists(),
-        "Extract dir should exist at derived path"
     );
 }
 
@@ -1038,7 +820,7 @@ async fn test_is_bundle_blob() {
 #[tokio::test]
 async fn test_install_application_from_bundle_blob() {
     let temp_dir = TempDir::new().unwrap();
-    let (node_client, _data_dir, blob_dir) = create_test_node_client(None).await;
+    let (node_client, _data_dir, _blob_dir) = create_test_node_client(None).await;
 
     // Create a bundle
     let wasm_content = b"bundle wasm bytecode";
@@ -1072,24 +854,6 @@ async fn test_install_application_from_bundle_blob() {
         .get_application(&application_id)
         .expect("Application should exist");
     assert!(application.is_some(), "Application should be found");
-
-    // Verify bundle was extracted
-    let node_root = blob_dir.path().parent().unwrap();
-    let extract_dir = node_root
-        .join("applications")
-        .join("com.example.blob")
-        .join("1.0.0")
-        .join("extracted");
-
-    let wasm_path = extract_dir.join("app.wasm");
-    assert!(wasm_path.exists(), "Extracted WASM should exist");
-
-    let abi_path = extract_dir.join("abi.json");
-    assert!(abi_path.exists(), "Extracted ABI should exist");
-
-    // Verify file contents
-    let extracted_wasm = fs::read(&wasm_path).unwrap();
-    assert_eq!(extracted_wasm, wasm_content, "WASM content should match");
 
     // Verify we can get application bytes
     let bytes = node_client
@@ -1408,31 +1172,19 @@ async fn test_bundle_blob_sharing_integration() {
         "User 2 should be able to read WASM from bundle"
     );
 
-    // Step 7: Verify bundle was extracted on User 2's node
-    let node_root_2 = blob_dir_2.path().parent().unwrap();
-    let extract_dir_2 = node_root_2
-        .join("applications")
-        .join("com.example.integration")
-        .join("1.0.0")
-        .join("extracted");
-
-    let wasm_path_2 = extract_dir_2.join("app.wasm");
+    // Step 7: The received bundle stays a blob on User 2's node
+    let applications_2 = blob_dir_2.path().join("applications");
     assert!(
-        wasm_path_2.exists(),
-        "User 2 should have extracted WASM file"
-    );
-
-    let extracted_wasm_2 = fs::read(&wasm_path_2).unwrap();
-    assert_eq!(
-        extracted_wasm_2, wasm_content,
-        "Extracted WASM content should match"
+        !applications_2.exists(),
+        "no artifacts should be unpacked to disk, found {}",
+        applications_2.display()
     );
 }
 
 // Note: install_application_from_url tests require HTTP/HTTPS URLs and would need
 // a mock HTTP server or real server. The URL installation logic is covered by
 // integration tests. Path-based installation (which covers the same code paths
-// for bundle detection and extraction) is tested below.
+// for bundle detection) is tested below.
 
 // Signature Verification Integration Tests
 
@@ -1459,7 +1211,8 @@ fn create_unsigned_bundle(
         "minRuntimeVersion": "0.1.0",
         "wasm": {
             "path": "app.wasm",
-            "size": wasm_content.len()
+            "size": wasm_content.len(),
+            "hash": artifact_hash(wasm_content)
         },
         "migrations": []
         // Note: no "signature" field
@@ -1512,7 +1265,8 @@ fn create_tampered_bundle(
         "minRuntimeVersion": "0.1.0",
         "wasm": {
             "path": "app.wasm",
-            "size": wasm_content.len()
+            "size": wasm_content.len(),
+            "hash": artifact_hash(wasm_content)
         },
         "migrations": []
     });
@@ -1532,7 +1286,8 @@ fn create_tampered_bundle(
         "minRuntimeVersion": "0.1.0",
         "wasm": {
             "path": "app.wasm",
-            "size": wasm_content.len()
+            "size": wasm_content.len(),
+            "hash": artifact_hash(wasm_content)
         },
         "migrations": [],
         "signature": signature  // Original signature (won't match tampered content)
@@ -1597,7 +1352,8 @@ fn create_signer_id_mismatch_bundle(
         "minRuntimeVersion": "0.1.0",
         "wasm": {
             "path": "app.wasm",
-            "size": wasm_content.len()
+            "size": wasm_content.len(),
+            "hash": artifact_hash(wasm_content)
         },
         "migrations": []
     });
@@ -1666,7 +1422,7 @@ fn create_test_bundle_with_key(
         interfaces: None,
         wasm: Some(calimero_node_primitives::bundle::BundleArtifact {
             path: "app.wasm".to_string(),
-            hash: None,
+            hash: artifact_hash(wasm_content),
             size: wasm_content.len() as u64,
         }),
         abi: None,
@@ -1699,29 +1455,23 @@ fn create_test_bundle_with_key(
     bundle_path.try_into().unwrap()
 }
 
-/// Test: Dev installation of an unsigned bundle should succeed.
-///
-/// Bundles installed from local paths (dev mode) are allowed to omit the
-/// signature field. Signature verification is only mandatory for production
-/// installs from registries.
+/// An unsigned bundle is not installable by any path. `create_unsigned_bundle`
+/// is kept because this is the only test that needs one.
 #[tokio::test]
-async fn test_dev_bundle_installation_succeeds_without_signature() {
+async fn test_unsigned_bundle_installation_is_rejected() {
     let temp_dir = TempDir::new().unwrap();
     let (node_client, _data_dir, _blob_dir) = create_test_node_client(None).await;
 
-    // Create an unsigned bundle
     let bundle_path =
         create_unsigned_bundle(&temp_dir, "com.example.unsigned", "1.0.0", b"wasm content");
 
-    // Dev installs allow unsigned bundles
-    let result = node_client
+    let err = node_client
         .install_application_from_path(bundle_path, vec![], None, None)
-        .await;
-
+        .await
+        .expect_err("an unsigned bundle must not install");
     assert!(
-        result.is_ok(),
-        "Dev bundle installation should succeed without signature, got: {}",
-        result.unwrap_err()
+        err.to_string().contains("signature"),
+        "error should name the missing signature, got: {err}"
     );
 }
 
@@ -1923,16 +1673,18 @@ async fn test_bundle_application_id_derived_from_package_and_signer_id() {
     // is verified by the assertions above (different signerIds produce different ApplicationIds).
 }
 
+/// The blob is the only copy of a bundle's bytes: nothing is unpacked to disk,
+/// and the wasm is still served.
 #[tokio::test]
-async fn test_bundle_get_application_bytes_fallback() {
+async fn test_bundle_get_application_bytes_needs_no_disk_copy() {
     let temp_dir = TempDir::new().unwrap();
     let (node_client, _data_dir, blob_dir) = create_test_node_client(None).await;
 
     // Create a test bundle
-    let wasm_content = b"fallback test wasm bytecode";
+    let wasm_content = b"blob-only test wasm bytecode";
     let bundle_path = create_test_bundle(
         &temp_dir,
-        "com.example.fallback",
+        "com.example.blobonly",
         "1.0.0",
         wasm_content,
         None,
@@ -1945,38 +1697,23 @@ async fn test_bundle_get_application_bytes_fallback() {
         .await
         .expect("Bundle installation should succeed");
 
-    // Verify extracted WASM exists initially
-    let node_root = blob_dir.path().parent().unwrap();
-    let extract_dir = node_root
-        .join("applications")
-        .join("com.example.fallback")
-        .join("1.0.0")
-        .join("extracted");
-    let wasm_path = extract_dir.join("app.wasm");
-    assert!(wasm_path.exists(), "Extracted WASM should exist initially");
-
-    // Delete extracted WASM to trigger fallback
-    fs::remove_file(&wasm_path).expect("Should delete extracted WASM");
-    assert!(!wasm_path.exists(), "WASM should be deleted");
-
-    // Get application bytes - should fallback to re-extract from bundle blob
-    // Note: fallback now extracts entire bundle to disk for persistence
     let bytes = node_client
         .get_application_bytes(&application_id, None)
         .await
-        .expect("Should get application bytes via fallback")
+        .expect("Should get application bytes")
         .expect("Application bytes should exist");
 
     assert_eq!(
         bytes.as_ref(),
         wasm_content,
-        "Application bytes should match WASM content (re-extracted from bundle blob)"
+        "Application bytes should match WASM content (served from the bundle blob)"
     );
 
-    // Verify WASM file now exists (fallback extracts bundle to disk for persistence)
+    let applications = blob_dir.path().join("applications");
     assert!(
-        wasm_path.exists(),
-        "WASM file should exist after fallback (fallback extracts bundle to disk)"
+        !applications.exists(),
+        "no artifacts should be unpacked to disk, found {}",
+        applications.display()
     );
 }
 
@@ -2106,7 +1843,8 @@ async fn test_bundle_validation_path_traversal_in_package() {
         "minRuntimeVersion": "0.1.0",
         "wasm": {
             "path": "app.wasm",
-            "size": 12
+            "size": 12,
+            "hash": artifact_hash(b"wasm content")
         },
         "migrations": []
     });
@@ -2152,7 +1890,8 @@ async fn test_bundle_validation_path_traversal_in_version() {
         "minRuntimeVersion": "0.1.0",
         "wasm": {
             "path": "app.wasm",
-            "size": 12
+            "size": 12,
+            "hash": artifact_hash(b"wasm content")
         },
         "migrations": []
     });
@@ -2179,6 +1918,52 @@ async fn test_bundle_validation_path_traversal_in_version() {
     );
 }
 
+/// Test: a service's wasm path is validated like every other artifact path.
+///
+/// The single- and multi-service shapes must not diverge here: a validator that
+/// covers `wasm.path` but skips `services[].wasm.path` is a trap for whoever
+/// next resolves a manifest path against a path on disk.
+#[tokio::test]
+async fn test_bundle_validation_path_traversal_in_service_wasm_path() {
+    let temp_dir = TempDir::new().unwrap();
+    let (node_client, _data_dir, _blob_dir) = create_test_node_client(None).await;
+
+    let signing_key = SigningKey::generate(&mut OsRng);
+    let signer_id = derive_signer_id_did_key(signing_key.verifying_key().as_bytes());
+
+    let mut manifest = serde_json::json!({
+        "version": "1.0",
+        "package": "com.example.test",
+        "appVersion": "1.0.0",
+        "signerId": signer_id,
+        "minRuntimeVersion": "0.1.0",
+        "services": [{
+            "name": "svc",
+            "wasm": {
+                "path": "../../../etc/malicious.wasm",  // Path traversal!
+                "size": 12,
+                "hash": artifact_hash(b"wasm content")
+            }
+        }],
+        "migrations": []
+    });
+
+    sign_manifest(&mut manifest, &signing_key);
+
+    let bundle_path = create_bundle_with_custom_manifest(&temp_dir, manifest, b"wasm content");
+
+    let err = node_client
+        .install_application_from_path(bundle_path, vec![], None, None)
+        .await
+        .expect_err("a service wasm path with '..' must not install");
+
+    let error_msg = err.to_string();
+    assert!(
+        error_msg.contains("services[0].wasm.path") && error_msg.contains("'..'"),
+        "Error should name the offending service field, got: {error_msg}"
+    );
+}
+
 /// Test: Installation should fail when package contains forward slash
 #[tokio::test]
 async fn test_bundle_validation_forward_slash_in_package() {
@@ -2198,7 +1983,8 @@ async fn test_bundle_validation_forward_slash_in_package() {
         "minRuntimeVersion": "0.1.0",
         "wasm": {
             "path": "app.wasm",
-            "size": 12
+            "size": 12,
+            "hash": artifact_hash(b"wasm content")
         },
         "migrations": []
     });
@@ -2244,7 +2030,8 @@ async fn test_bundle_validation_backslash_in_package() {
         "minRuntimeVersion": "0.1.0",
         "wasm": {
             "path": "app.wasm",
-            "size": 12
+            "size": 12,
+            "hash": artifact_hash(b"wasm content")
         },
         "migrations": []
     });
@@ -2290,7 +2077,8 @@ async fn test_bundle_validation_windows_absolute_path_in_package() {
         "minRuntimeVersion": "0.1.0",
         "wasm": {
             "path": "app.wasm",
-            "size": 12
+            "size": 12,
+            "hash": artifact_hash(b"wasm content")
         },
         "migrations": []
     });

--- a/crates/node/primitives/tests/common/mod.rs
+++ b/crates/node/primitives/tests/common/mod.rs
@@ -1,6 +1,7 @@
 //! Fixtures shared by the bundle integration tests.
 
 use std::fs;
+use std::path::Path;
 use std::sync::Arc;
 
 use calimero_blobstore::config::BlobStoreConfig;
@@ -56,8 +57,9 @@ pub async fn node_client() -> (NodeClient, TempDir, TempDir) {
 }
 
 /// Pack a `.mpk` from an explicit list of tar entries, so a test can ship a
-/// decoy or duplicate entry the way a hostile mirror would.
-pub fn pack_entries(dir: &TempDir, name: &str, entries: &[(&str, &[u8])]) -> Vec<u8> {
+/// decoy or duplicate entry the way a hostile mirror would. Generic over the
+/// path so a test can also ship one no `str` can hold.
+pub fn pack_entries<P: AsRef<Path>>(dir: &TempDir, name: &str, entries: &[(P, &[u8])]) -> Vec<u8> {
     let path = dir.path().join(name);
     let encoder = GzEncoder::new(fs::File::create(&path).unwrap(), Compression::default());
     let mut tar = Builder::new(encoder);

--- a/crates/node/primitives/tests/common/mod.rs
+++ b/crates/node/primitives/tests/common/mod.rs
@@ -1,0 +1,74 @@
+//! Fixtures shared by the bundle integration tests.
+
+use std::fs;
+use std::sync::Arc;
+
+use calimero_blobstore::config::BlobStoreConfig;
+use calimero_blobstore::{BlobManager as BlobStore, FileSystem};
+use calimero_network_primitives::client::NetworkClient;
+use calimero_node_primitives::client::{BlobManager, NodeClient, SyncClient};
+use calimero_store::db::InMemoryDB;
+use calimero_store::Store;
+use calimero_utils_actix::LazyRecipient;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use tar::Builder;
+use tempfile::TempDir;
+use tokio::sync::{broadcast, mpsc};
+
+pub fn hex_lower(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+pub async fn node_client() -> (NodeClient, TempDir, TempDir) {
+    let data_dir = TempDir::new().unwrap();
+    let blob_dir = TempDir::new().unwrap();
+    let datastore = Store::new(Arc::new(InMemoryDB::owned()));
+
+    // Nested one level down: the node derives its root as the blob root's
+    // parent, so a bare TempDir would make every node share the OS temp dir.
+    let blob_root = blob_dir.path().join("blobs");
+    let blob_store = BlobStore::new(
+        datastore.clone(),
+        FileSystem::new(&BlobStoreConfig::new(blob_root.try_into().unwrap()))
+            .await
+            .unwrap(),
+    );
+    let blob_manager = BlobManager::new(blob_store);
+
+    let (event_sender, _) = broadcast::channel(256);
+    let (ctx_sync_tx, _) = mpsc::channel(64);
+    let (ns_sync_tx, _) = mpsc::channel(64);
+    let (ns_join_tx, _) = mpsc::channel(16);
+    let (open_subgroup_join_tx, _) = mpsc::channel(16);
+    let sync_client = SyncClient::new(ctx_sync_tx, ns_sync_tx, ns_join_tx, open_subgroup_join_tx);
+
+    let node_client = NodeClient::new(
+        datastore,
+        blob_manager,
+        NetworkClient::new(LazyRecipient::new()),
+        LazyRecipient::new(),
+        event_sender,
+        sync_client,
+        None,
+    );
+    (node_client, data_dir, blob_dir)
+}
+
+/// Pack a `.mpk` from an explicit list of tar entries, so a test can ship a
+/// decoy or duplicate entry the way a hostile mirror would.
+pub fn pack_entries(dir: &TempDir, name: &str, entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let path = dir.path().join(name);
+    let encoder = GzEncoder::new(fs::File::create(&path).unwrap(), Compression::default());
+    let mut tar = Builder::new(encoder);
+    for (entry_path, content) in entries {
+        let mut header = tar::Header::new_gnu();
+        header.set_path(entry_path).unwrap();
+        header.set_size(content.len() as u64);
+        header.set_cksum();
+        tar.append(&header, *content).unwrap();
+    }
+    tar.finish().unwrap();
+    drop(tar);
+    fs::read(&path).unwrap()
+}

--- a/crates/node/src/cascade_dispatch_e2e.rs
+++ b/crates/node/src/cascade_dispatch_e2e.rs
@@ -697,22 +697,32 @@ async fn cascade_dispatch_e2e_migration_under_automatic_descendant_rejected() {
     }
 }
 
-/// Minimal in-memory bundle: gz tar with an UNSIGNED manifest.json (every
-/// node-side read path goes through `extract_manifest_allow_unsigned`) and
-/// one `app.wasm` carrying an embedded ABI. Same shape the bundle
-/// installation tests build on disk.
+/// Minimal in-memory bundle: gz tar with a signed manifest.json and one
+/// `app.wasm` carrying an embedded ABI. The signature and the artifact digest
+/// are both mandatory on the node-side read path, so a fixture without them
+/// reads back as an absent ABI rather than an error.
 fn build_bundle_blob(package: &str, app_version: &str, wasm: &[u8]) -> Vec<u8> {
+    use calimero_node_primitives::bundle::sign_manifest_json;
     use flate2::write::GzEncoder;
     use flate2::Compression;
+    use sha2::{Digest, Sha256};
 
-    let manifest = serde_json::json!({
+    // Fixed key: the fixture's blob ids stay stable across runs.
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&[7; 32]);
+
+    let mut manifest = serde_json::json!({
         "version": "1.0",
         "package": package,
         "appVersion": app_version,
         "minRuntimeVersion": "0.1.0",
-        "wasm": { "path": "app.wasm", "size": wasm.len() },
+        "wasm": {
+            "path": "app.wasm",
+            "size": wasm.len(),
+            "hash": hex::encode(Sha256::digest(wasm)),
+        },
         "migrations": [],
     });
+    sign_manifest_json(&mut manifest, &signing_key).expect("sign manifest");
     let manifest_bytes = serde_json::to_vec(&manifest).expect("manifest json");
 
     let mut tar = tar::Builder::new(GzEncoder::new(Vec::new(), Compression::default()));

--- a/crates/store/blobs/src/lib.rs
+++ b/crates/store/blobs/src/lib.rs
@@ -116,11 +116,6 @@ impl BlobManager {
         self.blob_store.version_path(package, version)
     }
 
-    /// Get the root/base path of the blobstore
-    pub fn root_path(&self) -> Utf8PathBuf {
-        self.blob_store.root_path()
-    }
-
     /// Get the path for a blob stored in a package/version directory
     ///
     /// # Errors
@@ -715,11 +710,6 @@ impl FileSystem {
         utils::validate_path_component(version, Some("version"))?;
 
         Ok(self.root.join("applications").join(package).join(version))
-    }
-
-    /// Get the root/base path of the blobstore
-    pub fn root_path(&self) -> Utf8PathBuf {
-        self.root.clone()
     }
 }
 

--- a/docs/CODE-DOC-GAPS.md
+++ b/docs/CODE-DOC-GAPS.md
@@ -17,7 +17,7 @@ against `src/content/docs/`. Ordered by priority. `file:line` anchors included.
 
 ## 1. Big undocumented subsystems (P1)
 
-- **App signing + `.mpk` bundle format.** JCS-canonical manifest, `ed25519`, `did:key` signerId, signed vs dev-unsigned install split, multi-service `services[]` + `--service`. Entirely undocumented. → `protocol/upgrades.mdx` + `build/advanced-sdk.mdx` (+ a bundle-format page).
+- **App signing + `.mpk` bundle format.** JCS-canonical manifest, `ed25519`, `did:key` signerId, multi-service `services[]` + `--service`. Entirely undocumented. → `protocol/upgrades.mdx` + `build/advanced-sdk.mdx` (+ a bundle-format page).
 - **Auto-follow machinery.** Dangling cross-refs ("see Governance") point at content that doesn't exist. The two flags, event-driven auto-join, backfill (1000 cap), 20 joins/min token bucket, inherited Open-anchor rule, `leave_context` opt-out. This is how membership becomes data replication ("joined but nothing synced"). `crates/context/src/auto_follow.rs`. → new section in `protocol/governance.mdx`.
 - **Authored-data migration is per-owner.** Whole-root `#[app::migrate]` does NOT convert `Authored*` entries; an auto-generated signed `migrate_my_entries` RPC must be called by each owner. Silent-correctness footgun. `crates/sdk/macros/src/state.rs:962`. → `build/migrations.mdx`.
 - **A "hot" peer can never serve a snapshot.** Any write during transfer aborts it (`InvalidBoundary`) → a node bootstrapping against a busy peer retries forever. `crates/node/src/sync/snapshot.rs:152,214`. → `operate/troubleshooting.mdx`.

--- a/docs/src/content/docs/build/cargo-mero.mdx
+++ b/docs/src/content/docs/build/cargo-mero.mdx
@@ -111,7 +111,7 @@ meroctl app install --path dist/<package>.mpk ...   # 5. install on a node (mero
 
 4. **Bundle.**
    Builds every service, stages the wasm/abi files, writes `manifest.json`, signs it, and packages everything into a tar.gz `.mpk` at `dist/<package>.mpk`.
-   Pass a signing method: `--dev` (local), `--key <file>` (production), or `--unsigned`.
+   Pass a signing method: `--dev` (local) or `--key <file>` (production).
 
    ```
    $ cargo mero bundle --dev
@@ -201,7 +201,7 @@ There are two kinds of key:
   A private Ed25519 key that only you hold, for anything you publish or install against a registry.
   Generate one with `cargo mero key generate -o my-key.json`.
 
-In CI, inject the key rather than checking it in: when none of `--key` / `--dev` / `--unsigned` is passed, `bundle` reads `MERO_SIGN_KEY` as the path to a key file.
+In CI, inject the key rather than checking it in: when neither `--key` nor `--dev` is passed, `bundle` reads `MERO_SIGN_KEY` as the path to a key file.
 
 ```bash
 export MERO_SIGN_KEY="$RUNNER_TEMP/mero-key.json"

--- a/docs/src/content/docs/build/packaging-signing.mdx
+++ b/docs/src/content/docs/build/packaging-signing.mdx
@@ -118,12 +118,14 @@ different application id — it is a *different application*, not an upgrade, an
 existing contexts will not pick it up. Treat the signing key as the long-lived
 identity of your app and guard it accordingly.
 
-<Aside type="note" title="Signing vs. install trust">
-Signing a bundle and *requiring* a valid signature are separate concerns. A
-registry install demands a valid signature; a local dev install can admit an
-unsigned bundle as a synthetic dev identity. That install-time trust split, and
-the exact verification rules, are documented in
-[Upgrades & migration](/protocol/upgrades/).
+<Aside type="note" title="Every install path requires a signature">
+There is one rule, not a per-path split: a bundle must carry a valid Ed25519
+manifest signature to be installed, whether it comes from a registry, a URL, or
+a local file. Dev builds are not an exception - they sign with the well-known
+dev key (`cargo mero bundle --dev`) and are verified like any other bundle. The
+signature also binds the wasm bytes: each wasm artifact is checked against the
+SHA-256 the signed manifest records for it. The exact verification rules are
+documented in [Upgrades & migration](/protocol/upgrades/).
 </Aside>
 
 <CardGrid>
@@ -134,7 +136,7 @@ the exact verification rules, are documented in
   />
   <LinkCard
     title="Upgrades & migration"
-    description="The manifest/signing format, signature verification, and the install trust split."
+    description="The manifest/signing format, signature verification, and the artifact digest check on install."
     href="/protocol/upgrades/"
   />
   <LinkCard

--- a/docs/src/content/docs/protocol/applications.mdx
+++ b/docs/src/content/docs/protocol/applications.mdx
@@ -47,7 +47,7 @@ How the **application id** is derived depends on how the application entered the
 | Install kind | Application id is | Stability |
 | --- | --- | --- |
 | Raw `.wasm` | `hash_borsh(bytecode, size, source, metadata)` | tied to the exact bytes — any change is a new id |
-| Signed/dev bundle | `hash_borsh(package, signer_id)` | **version-stable** — same `package` + signer keeps one id across releases |
+| Signed bundle | `hash_borsh(package, signer_id)` | **version-stable** — same `package` + signer keeps one id across releases |
 
 Both are computed at install time in
 `crates/node/primitives/src/client/application/install.rs`. The raw-`.wasm` id folds
@@ -68,13 +68,13 @@ migration.
 
 An application is published as an **`.mpk` bundle** (Mero Package Kit): a
 gzip-compressed tar of a `manifest.json`, the WASM / ABI / migration artifacts it
-references, and an optional Ed25519 signature. Installing a bundle is what *produces*
+references, and a required Ed25519 signature. Installing a bundle is what *produces*
 an application — the manifest's `package` and `signerId` fix the application id, and
 the artifacts become the stored bytecode and service blobs.
 
 The manifest format, the signing payload (RFC 8785 canonicalization + SHA-256), and
-the install trust split (signature required from a registry, optional for a local dev
-path) are documented in full under
+the verification rules on install - a valid signature on every path, plus a SHA-256
+check of each wasm artifact against the signed manifest - are documented in full under
 [Application Upgrades & Migration → Bundles, signing & install](/protocol/upgrades/).
 This page does not repeat that detail; it picks up at what the bundle *contains*.
 

--- a/docs/src/content/docs/protocol/upgrades.mdx
+++ b/docs/src/content/docs/protocol/upgrades.mdx
@@ -78,16 +78,20 @@ content. A blob is treated as a bundle when it contains a `manifest.json` entry
 | `minRuntimeVersion` | floor on the node runtime (see the Aside above) |
 | `metadata` | display info — `name`, `description`, `icon`, `tags`, `license` |
 | `interfaces` | declared `exports` / `uses` intents |
-| `wasm` + `abi` | single-service artifacts, each a `{path, hash, size}` record |
+| `wasm` + `abi` | single-service artifacts, each a `{path, hash, size}` record; `hash` is required |
 | `services` | named multi-service modules; overrides `wasm` / `abi` when present and non-empty |
 | `migrations` | migration artifacts |
 | `links` | `frontend` / `github` / `docs` URLs |
 | `signature` | the Ed25519 signature object (below) |
 
-`package` and `appVersion` double as on-disk path components (the bundle extracts to
-`applications/{package}/{appVersion}/extracted`), so both are validated against path
-traversal when the manifest is parsed — a `package`, `appVersion`, or artifact path
-that escapes its directory is rejected
+Nothing is written out of the archive: the content-addressed blob is the only copy of
+a bundle's bytes, and it re-verifies its own content hashes on every read. Manifest
+parsing still rejects `package` and `appVersion` values that are not safe path
+components, and rejects any artifact path that is absolute or carries a `..` segment.
+That path check runs over *every* artifact the manifest declares - `wasm`, `abi`, each
+`services[].wasm` and `services[].abi`, and each `migrations[]` - enumerated by a
+single exhaustive destructure of the manifest, so a new artifact field stops compiling
+until it is classified
 (`crates/node/primitives/src/client/application/bundle.rs`).
 
 ### Signing
@@ -130,21 +134,64 @@ workspace tool under `tools/mero-sign`), not by the node or `meroctl` — the no
 *verifies*. `mero-sign` sets `signerId` from the key, canonicalizes, signs the
 payload, and writes the `signature` object back into the manifest.
 
-### Install trust split
+### Install trust
 
-Where a bundle comes from decides whether a signature is mandatory:
+Every install path requires a valid signature, whatever the bundle's source:
 
 | Path | Source | Signature |
 | --- | --- | --- |
-| `install-application` | registry / URL / stored `.mpk` blob | **required** — install bails on a missing or invalid signature (`install_verified_bundle`) |
-| `install-dev-application` | a local filesystem path | **optional** — verified if present; admitted as an unsigned dev build if absent (`install_dev_bundle`) |
+| `install-application` | registry / URL / stored `.mpk` blob | **required** |
+| `install-dev-application` | a local filesystem path | **required** |
 
-An unsigned dev bundle is given the synthetic signer `"dev:unsigned"` and a zero
-bundle hash, so it never collides with a real `did:key` update authority
-(`extract_manifest_allow_unsigned`,
-`crates/node/primitives/src/client/application/bundle.rs`). A signature that **is**
-present is verified on either path — an invalid one is always rejected. Either way the
-`minRuntimeVersion` floor documented above is still enforced.
+There is no unsigned path and no synthetic dev signer. A local dev build signs with
+the well-known dev key (`cargo mero bundle --dev`), so it carries a real `signerId`
+without the publisher having to generate one; a dev-signed bundle is still a signed
+bundle and goes through exactly the same verification.
+
+The signature also binds the wasm bytes. `VerifiedBundle` verifies the manifest
+signature, then checks each wasm artifact's SHA-256 against the `hash` the publisher
+signed and fails the install on a mismatch, so a mirror that swaps `app.wasm` under an
+otherwise untouched signed manifest is rejected
+(`crates/node/primitives/src/client/application/bundle.rs`). The artifact path is
+matched exactly and must be unique in the archive, so a decoy or duplicate entry
+cannot pass the check on behalf of the entry the node actually runs. `VerifiedBundle`
+is the only way to obtain artifact bytes at all, so there is no route that reads a
+`.mpk` without first clearing the signature.
+
+The scope of that guarantee is exactly the wasm artifacts. Everything else in the
+archive - the ABI, migrations, and any entry the manifest does not name - is
+path-validated but read back without a digest check. The `minRuntimeVersion` floor
+documented above is still enforced.
+
+Two size bounds apply to attacker-supplied bytes read *before* the signature clears.
+They are measured on decompressed output, so a compression bomb cannot get past them:
+the scan for `manifest.json` stops after 8 MiB, and the whole-archive read that serves
+artifact bytes stops after 512 MiB.
+
+<Aside type="caution" title="Two operational edges the E2E suite cannot catch">
+Every merobox node is the same build against fresh state, so neither of these shows
+up there: one needs data an older node wrote, the other needs a hand-built archive.
+
+**A bundle an older node admitted unsigned is no longer readable.** Signatures are
+now mandatory on every path, and the check runs on read, not just at install, so a
+`.mpk` blob already persisted without a valid signature fails when it is next opened,
+with `"manifest is missing required 'signature' field"`. Two paths surface that as a
+hard error: creating a group against an explicit `app_key`, and resolving an upgrade's
+migration parameters from the target blob. Two others degrade quietly instead: the
+displayed app version (`blob_app_version`) goes empty, and the affected blob is
+skipped from `list_application_versions`. The fix in every case is to reinstall the
+application from a signed bundle.
+
+**A `manifest.json` past 8 MiB of decompressed data classifies as "not a bundle".**
+Installing such an archive from a `.mpk` path reports the cap directly. Reading it
+back as a blob does not: the classifier that decides bundle-or-raw-wasm answers "not
+a bundle" when the scan trips the cap, so the blob is handed to the runtime as raw
+wasm and rejected there - a `.mpk` starts with the gzip magic `1f 8b` and can never
+be valid wasm. It fails closed either way, but on that second path the error names an
+instantiation failure rather than the cap. `cargo mero bundle` writes `manifest.json`
+as the archive's first entry, so bundles it produces are never affected; a bundle
+built by hand should place the manifest first.
+</Aside>
 
 ## What a migration is
 

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -47,7 +47,7 @@ cargo mero bundle --dev      # -> dist/<package>.mpk (dev key; --key <file> for 
 
 # CI signing without a checked-in key
 export MERO_SIGN_KEY="$RUNNER_TEMP/mero-key.json"
-cargo mero bundle            # reads MERO_SIGN_KEY when no --key/--dev/--unsigned
+cargo mero bundle            # reads MERO_SIGN_KEY when no --key/--dev
 ```
 
 ### File Organization

--- a/tools/cargo-mero/README.md
+++ b/tools/cargo-mero/README.md
@@ -51,7 +51,7 @@ No node or network is needed.
 **4. `cargo mero bundle`**
 Builds every service, stages the wasm/abi files under `res/bundle-temp/`, writes `manifest.json`, signs it, and packages everything into a tar.gz `.mpk`.
 Artifact: `dist/<package>.mpk` (the `<package>` is the `[package.metadata.calimero] package` id; the app version lives inside the manifest, not the filename).
-Pass a signing method: `--dev` (local), `--key <file>` (production), or `--unsigned`.
+Pass a signing method: `--dev` (local) or `--key <file>` (production).
 See [SIGNING.md](SIGNING.md).
 
 **5. `meroctl app install --path dist/<package>.mpk`**

--- a/tools/cargo-mero/SIGNING.md
+++ b/tools/cargo-mero/SIGNING.md
@@ -26,9 +26,6 @@ A private Ed25519 key that only you hold.
 Use it for anything you publish or install against a registry.
 Generate one with `cargo mero key generate` (below).
 
-`cargo mero bundle` also accepts `--unsigned`, which skips signing entirely.
-An unsigned bundle cannot be published to or installed from a registry.
-
 ## Generating and storing a production key
 
 ```bash
@@ -49,7 +46,7 @@ Treat the key file the way you would treat any signing credential:
   Keep key files out of the repository (the scaffold's `.gitignore` already ignores them; if you store one elsewhere, add its path).
 - **In CI, inject it, do not check it in.**
   Point `cargo mero bundle` at a key file through the `MERO_SIGN_KEY` environment variable instead of `--key`.
-  When none of `--key` / `--dev` / `--unsigned` is passed, `bundle` reads `MERO_SIGN_KEY` as the path to a key file, so a CI job can materialize the key from a secret at build time and set the variable:
+  When none of `--key` / `--dev` is passed, `bundle` reads `MERO_SIGN_KEY` as the path to a key file, so a CI job can materialize the key from a secret at build time and set the variable:
 
   ```bash
   export MERO_SIGN_KEY="$RUNNER_TEMP/mero-key.json"

--- a/tools/cargo-mero/src/bundle.rs
+++ b/tools/cargo-mero/src/bundle.rs
@@ -19,14 +19,13 @@ use crate::workspace;
 use crate::{BuildArgs, BundleArgs};
 
 /// Environment variable naming a signing-key JSON file, used when none of
-/// `--key`/`--dev`/`--unsigned` is passed.
+/// `--key`/`--dev` is passed.
 const SIGN_KEY_ENV: &str = "MERO_SIGN_KEY";
 
 /// How the manifest will be signed, resolved from the flags + `MERO_SIGN_KEY`.
 enum SignMode {
     Key(SigningKey),
     Dev(SigningKey),
-    Unsigned,
 }
 
 pub fn run(args: &BundleArgs) -> Result<PathBuf> {
@@ -61,7 +60,7 @@ pub fn run(args: &BundleArgs) -> Result<PathBuf> {
     println!("\nbundle:     {output}");
     println!("package:    {}", bundle_meta.package);
     println!("appVersion: {}", bundle_meta.app_version);
-    println!("signerId:   {}", signer_id.as_deref().unwrap_or("UNSIGNED"));
+    println!("signerId:   {signer_id}");
 
     Ok(output.into_std_path_buf())
 }
@@ -123,9 +122,6 @@ fn resolve_sign_mode(args: &BundleArgs) -> Result<SignMode> {
     if args.dev {
         return Ok(SignMode::Dev(mero_sign::dev_signing_key()));
     }
-    if args.unsigned {
-        return Ok(SignMode::Unsigned);
-    }
     if let Some(path) = std::env::var_os(SIGN_KEY_ENV) {
         return Ok(SignMode::Key(mero_sign::load_signing_key(
             PathBuf::from(path).as_path(),
@@ -134,31 +130,24 @@ fn resolve_sign_mode(args: &BundleArgs) -> Result<SignMode> {
     bail!(
         "no signing method given. Pass one of:\n  \
          --key <FILE>   sign with a production key (cargo mero key generate)\n  \
-         --dev          sign with the well-known dev key (not publishable)\n  \
-         --unsigned     skip signing\n\
+         --dev          sign with the well-known dev key (not publishable)\n\
          or set {SIGN_KEY_ENV} to a key-file path."
     );
 }
 
-/// Sign `manifest.json` in place; returns the signerId, or `None` when unsigned.
-fn sign(manifest_path: &Utf8Path, mode: &SignMode) -> Result<Option<String>> {
+/// Sign `manifest.json` in place; returns the signerId.
+fn sign(manifest_path: &Utf8Path, mode: &SignMode) -> Result<String> {
     match mode {
         SignMode::Key(key) => {
             println!("• signing manifest.json");
             mero_sign::sign_manifest(manifest_path.as_std_path(), key)?;
-            Ok(Some(signer_id_of(key)))
+            Ok(signer_id_of(key))
         }
         SignMode::Dev(key) => {
             print_dev_warning();
             println!("• signing manifest.json with the DEV key");
             mero_sign::sign_manifest(manifest_path.as_std_path(), key)?;
-            Ok(Some(signer_id_of(key)))
-        }
-        SignMode::Unsigned => {
-            eprintln!(
-                "WARNING: --unsigned bundle. It cannot be published to or installed from a registry."
-            );
-            Ok(None)
+            Ok(signer_id_of(key))
         }
     }
 }
@@ -277,6 +266,8 @@ fn package(output: &Utf8Path, manifest_path: &Utf8Path, staged: &[StagedArtifact
         .parent()
         .ok_or_else(|| eyre!("manifest path has no parent"))?;
 
+    // First, and not merely by convention: the node's manifest scan runs before
+    // any signature check, so it is bounded and stops a few MiB in.
     tar.append_path_with_name(manifest_path, "manifest.json")
         .wrap_err("failed to add manifest.json to the bundle")?;
     for artifact in staged {

--- a/tools/cargo-mero/src/main.rs
+++ b/tools/cargo-mero/src/main.rs
@@ -106,10 +106,6 @@ struct BundleArgs {
     #[arg(long, group = "signing")]
     dev: bool,
 
-    /// Skip signing (bundle cannot be published or installed against a registry)
-    #[arg(long, group = "signing")]
-    unsigned: bool,
-
     /// Override the app version recorded in manifest.json
     #[arg(long)]
     app_version: Option<String>,
@@ -323,8 +319,7 @@ mod tests {
 
     #[test]
     fn bundle_signing_flags_are_exclusive_but_orthogonal_to_other_args() {
-        // The three signing flags are mutually exclusive.
-        assert!(Cargo::try_parse_from(["cargo", "mero", "bundle", "--dev", "--unsigned"]).is_err());
+        // The signing flags are mutually exclusive.
         assert!(
             Cargo::try_parse_from(["cargo", "mero", "bundle", "--dev", "--key", "k.json"]).is_err()
         );
@@ -340,6 +335,11 @@ mod tests {
             "Cargo.toml"
         ])
         .is_ok());
+    }
+
+    #[test]
+    fn bundle_rejects_the_removed_unsigned_flag() {
+        assert!(Cargo::try_parse_from(["cargo", "mero", "bundle", "--unsigned"]).is_err());
     }
 
     #[test]

--- a/tools/cargo-mero/src/manifest.rs
+++ b/tools/cargo-mero/src/manifest.rs
@@ -12,8 +12,8 @@ use crate::meta::BundleMeta;
 const MANIFEST_VERSION: &str = "1.0";
 
 /// One bundle file: bundle-relative path, byte size, and lowercase-hex SHA-256.
-/// The node does not verify this hash - integrity comes from the manifest
-/// signature - but a real value is recorded rather than a null.
+/// The node requires this hash and checks the artifact bytes against it, so a
+/// wrong value here makes the bundle uninstallable.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Artifact {

--- a/tools/mero-sign/src/lib.rs
+++ b/tools/mero-sign/src/lib.rs
@@ -505,7 +505,7 @@ mod tests {
             "wasm": {
                 "path": "app.wasm",
                 "size": 1024,
-                "hash": null
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
             }
         });
         std::fs::write(


### PR DESCRIPTION
## Summary

A bundle's Ed25519 signature covered the canonicalized `manifest.json` only. The manifest records a SHA-256 per artifact, but nothing ever compared it to the bytes being installed, so anyone able to modify a `.mpk` between signing and install - a compromised or malicious registry, a mirror, a CDN, an artifact store, MITM on an unauthenticated fetch - could replace `app.wasm`, leave `manifest.json` byte-identical, and the node would install and execute the substituted bytecode under the original publisher's `signerId` and the same `ApplicationId`.

Closes #3311.

`VerifiedBundle` is now the only way to obtain artifact bytes from a `.mpk`. Construction requires a valid signature, and every wasm artifact is checked against the digest the publisher signed before its bytes are returned. `extract_bundle_file` is private to that module, so the compiler enforces this rather than a convention.

Four further defects surfaced while closing that one, each of which independently defeated the fix:

- **The check and the read disagreed about which entry is `app.wasm`.** Lookup returned the first tar entry matching by exact path *or basename*; extraction unpacked every entry, last write wins. A bundle carrying `[manifest.json, decoy/app.wasm = honest, app.wasm = evil]` passed its digest check against the decoy and then served the evil bytes. Paths now match exactly, the whole archive is scanned, and two entries claiming one path are refused.
- **Two different "is this a bundle" rules.** `is_bundle_blob` stopped after ten tar entries while the verified read scanned all of them, so a `.mpk` with a late `manifest.json` installed verified and was then served as a raw archive with no verification at all. Both now share one bounded scan and one predicate.
- **A pre-authentication decompression bomb.** The manifest read was unbounded and necessarily runs before signature verification. `tar` buffers extension headers internally, so bounding the entry did nothing - measured, 1.04 MB of input allocated 3.07 GiB. The bound now sits under the decompressor.
- **An unauthenticated second copy of every artifact.** Bundles were unpacked to `applications/<pkg>/<ver>/extracted/` and the read path preferred that copy. It is deleted; the content-addressed blob is the only source, which also removes the lock file, the staleness marker, and the hardlink dedup around it.

`BundleArtifact.hash` is now a required `String`, and every artifact path is validated through one exhaustive destructure, so adding an artifact field to `BundleManifest` is a compile error until it is handled. Signatures are mandatory on every install path, including local dev, and `cargo mero bundle --unsigned` is removed - `--dev` signs with the well-known dev key and needs no setup.

## Behaviour changes when upgrading

- A bundle an older node admitted **unsigned** is no longer readable, on read as well as on install. `create_group` with an explicit `app_key` and the migration ABI resolution hard-error; version listings degrade quietly. E2E cannot catch this - every merobox node is the same build against fresh state.
- `manifest.json` must appear within 8 MiB of decompressed output. `cargo mero bundle` writes it first; a third-party bundler that orders `app.wasm` first is affected.
- `cargo mero bundle --unsigned` no longer exists. This is a breaking CLI change.

## Test plan

**Reproduction, before the fix.** A signed manifest, then the same bundle repacked with a different `app.wasm` and a byte-identical `manifest.json`:

```
manifest.wasm.hash  = 5e8b2408dd5e7c328a2192c10732363ae953d98343659054626c5b496c2fc97d
sha256(served wasm) = bf35fac0bcf164c98e31fcc97a85224463a7d7886b3e62390b46c54b82d41063
bytes served to the runtime = "EVIL!! wasm bytecode from the registry "
ApplicationId honest = ATz6bnpZVaEsWqgDPe8ZWeSrLpY8eZTFnrGdRmnrGsgP
ApplicationId evil   = ATz6bnpZVaEsWqgDPe8ZWeSrLpY8eZTFnrGdRmnrGsgP  (same = true)
```

The substituted bytecode installed, executed, and was indistinguishable from the publisher's. After the fix it is refused, naming the artifact.

The same attack against a real `cargo mero bundle` artifact (477 KB `app.wasm` swapped for 12 bytes) likewise installed with the signature verifying, and is now refused.

**Regression tests** in `crates/node/primitives/tests/`: tampered wasm, the decoy entry, duplicate entries at one path, a hashless manifest, an unsigned bundle, a manifest past the tenth entry, a `services[]` traversal path, no disk copy after install, and two allocation-bounds tests (the long-name bomb, and N services sharing one artifact costing one read).

Each guard was mutation-tested individually - the guard removed, every other guard asserted still present in the source - and confirmed to fail exactly the test that claims it.

**End to end**, against real nodes built from this branch:

```
merobox bootstrap run apps/kv-store/workflows/bundle-invitation-test.yml --image merod:local
Workflow 'Bundle Invitation Flow Test' completed successfully
```

with, on both nodes:

```
bundle manifest signature verified
  signer_id=did:key:z6MknF3p5L5FDHJQ7FREUapuX4Wmp4MtF6WrHYaXS2B3eZQd
  package=com.calimero.kv-store
```

Node 2 never installed from disk - it verified a blob pulled over BlobShare and again at execution, exercising the read-side gate over real P2P.

**Gates:** `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -A warnings`, `cargo test --workspace`, and the docs site build (78 pages) all pass.

## Notes for review

- Only wasm artifacts are digest-checked. ABI and migration artifacts are path-validated only, because nothing reads their bytes; whoever adds an accessor for them must route it through `verify_artifact_digest`.
- `verify_manifest_signature` validates against the manifest's own embedded key, so a valid signature proves the bytes match what that publisher published, not that the publisher is trusted. The `signerId` feeds the `ApplicationId`, which is where trust is anchored.
- Net -1403 lines against +1555, most of the deletion being the extracted-artifact directory and its concurrency machinery.
