### PR TITLE
fix(storage): invalidate SortedSet/SortedMap ordered-index marker on sync-apply

### DIFF
--- a/crates/context/src/handlers/execute/storage.rs
+++ b/crates/context/src/handlers/execute/storage.rs
@@ -317,6 +317,13 @@ impl Storage for ContextStorage {
             .raw_get(Column::SortedIndexMeta, &full)
             .ok()?
     }
+
+    fn index_meta_del(&mut self, key: &[u8]) -> bool {
+        let full = self.index_key(key);
+        self.borrow_index_store()
+            .raw_delete(Column::SortedIndexMeta, &full)
+            .is_ok()
+    }
 }
 
 // Same safety reasoning as ContextStorage
@@ -500,6 +507,11 @@ impl<S: Storage> Storage for ReadOnlyContextStorage<'_, S> {
 
     fn index_meta_set(&mut self, _key: &[u8], _value: &[u8]) -> bool {
         tracing::debug!("ReadOnlyContextStorage: write suppressed (index_meta_set)");
+        false
+    }
+
+    fn index_meta_del(&mut self, _key: &[u8]) -> bool {
+        tracing::debug!("ReadOnlyContextStorage: write suppressed (index_meta_del)");
         false
     }
 }

--- a/crates/context/src/handlers/execute/storage.rs
+++ b/crates/context/src/handlers/execute/storage.rs
@@ -162,6 +162,15 @@ impl ContextStorage {
 }
 
 impl Storage for ContextStorage {
+    // The real host store backs the ordered index (RocksDB `Column::SortedIndex`
+    // / `SortedIndexMeta` via the methods below), so the runtime installs the
+    // `RuntimeEnv` ordered-index bridge and native SortedSet/SortedMap ops reach
+    // these durable, context-scoped columns instead of the process-thread-local
+    // mock.
+    fn supports_index(&self) -> bool {
+        true
+    }
+
     fn get(&self, key: &Key) -> Option<Vec<u8>> {
         let key = self.state_key(key)?;
 
@@ -451,6 +460,13 @@ impl<'a, S: Storage> ReadOnlyContextStorage<'a, S> {
 }
 
 impl<S: Storage> Storage for ReadOnlyContextStorage<'_, S> {
+    // Delegate to the wrapped store: a read-only view over a `ContextStorage`
+    // still backs the ordered index (reads/`index_meta_get` pass through), so
+    // the bridge must install for read-only #[app::view] executions too.
+    fn supports_index(&self) -> bool {
+        self.0.supports_index()
+    }
+
     fn get(&self, key: &Key) -> Option<Value> {
         self.0.get(key)
     }

--- a/crates/node/primitives/src/sync/storage_bridge.rs
+++ b/crates/node/primitives/src/sync/storage_bridge.rs
@@ -32,8 +32,9 @@ use std::rc::Rc;
 
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
-use calimero_storage::env::RuntimeEnv;
+use calimero_storage::env::{IndexCallbacks, RuntimeEnv};
 use calimero_storage::store::Key;
+use calimero_store::db::Column;
 use calimero_store::{key, types, Store};
 use tracing::warn;
 
@@ -70,6 +71,145 @@ pub fn create_runtime_env(
         *context_id.as_ref(),
         *executor_id.as_ref(),
     )
+    .with_index(create_index_callbacks(store, context_id))
+}
+
+/// The exclusive upper bound for a byte prefix (smallest key not starting with
+/// `prefix`) — mirrors `ContextStorage`'s helper for range-clearing a prefix.
+fn index_prefix_upper_bound(prefix: &[u8]) -> Vec<u8> {
+    let mut end = prefix.to_vec();
+    while let Some(&last) = end.last() {
+        if last == 0xFF {
+            let _ = end.pop();
+        } else {
+            *end.last_mut().expect("non-empty") += 1;
+            return end;
+        }
+    }
+    vec![0xFF; prefix.len() + 1]
+}
+
+/// Build ordered-index host callbacks bridging `calimero-storage`'s node-local
+/// index + validity marker to this context's RocksDB `Column::SortedIndex` /
+/// `Column::SortedIndexMeta`.
+///
+/// This is the sync-side twin of the runtime's `build_runtime_env` bridge: it
+/// makes host-side `SortedSet`/`SortedMap` ops during native apply
+/// (`Interface::apply_action` on the HashComparison / delta-apply path) target
+/// the SAME durable, context-scoped columns the guest and JS read paths use —
+/// so an apply-time marker clear (invalidate-on-sync) is seen by the next
+/// ordered read instead of landing in a per-thread mock (sdk-js#87).
+///
+/// Keys mirror `ContextStorage::index_key`: the adaptor-level `collection ‖
+/// order_key` (marker: `collection_id`) is prefixed with the 32-byte context id
+/// to keep contexts disjoint in the shared columns.
+fn create_index_callbacks(store: &Store, context_id: ContextId) -> IndexCallbacks {
+    // `context ‖ key` — the column-scoped key for this context.
+    fn scoped(ctx: &[u8; 32], key: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(ctx.len() + key.len());
+        out.extend_from_slice(ctx);
+        out.extend_from_slice(key);
+        out
+    }
+
+    let ctx = *context_id.as_ref();
+
+    let set = {
+        let store = store.clone();
+        Rc::new(move |key: &[u8], value: &[u8]| {
+            store
+                .raw_put(Column::SortedIndex, &scoped(&ctx, key), value)
+                .is_ok()
+        }) as Rc<dyn Fn(&[u8], &[u8]) -> bool>
+    };
+    let remove = {
+        let store = store.clone();
+        Rc::new(move |key: &[u8]| {
+            store
+                .raw_delete(Column::SortedIndex, &scoped(&ctx, key))
+                .is_ok()
+        }) as Rc<dyn Fn(&[u8]) -> bool>
+    };
+    let remove_prefix = {
+        let store = store.clone();
+        Rc::new(move |prefix: &[u8]| {
+            let lo = scoped(&ctx, prefix);
+            let hi = index_prefix_upper_bound(&lo);
+            store
+                .raw_delete_range(Column::SortedIndex, &lo, &hi)
+                .is_ok()
+        }) as Rc<dyn Fn(&[u8]) -> bool>
+    };
+    let scan = {
+        let store = store.clone();
+        Rc::new(
+            move |lo: &[u8], hi: &[u8], offset: usize, limit: Option<usize>| {
+                let full_lo = scoped(&ctx, lo);
+                let full_hi = scoped(&ctx, hi);
+                // Walk O(offset + limit), matching ContextStorage.
+                let max = limit.map(|n| offset.saturating_add(n));
+                let pairs = store
+                    .raw_scan(Column::SortedIndex, &full_lo, &full_hi, max)
+                    .unwrap_or_default();
+                let stripped = pairs
+                    .into_iter()
+                    .filter_map(|(k, v)| k.get(ctx.len()..).map(|key| (key.to_vec(), v)))
+                    .skip(offset);
+                match limit {
+                    Some(n) => stripped.take(n).collect(),
+                    None => stripped.collect(),
+                }
+            },
+        ) as Rc<dyn Fn(&[u8], &[u8], usize, Option<usize>) -> Vec<(Vec<u8>, Vec<u8>)>>
+    };
+    let last = {
+        let store = store.clone();
+        Rc::new(move |lo: &[u8], hi: &[u8]| {
+            let full_lo = scoped(&ctx, lo);
+            let full_hi = scoped(&ctx, hi);
+            store
+                .raw_last(Column::SortedIndex, &full_lo, &full_hi)
+                .ok()
+                .flatten()
+                .and_then(|(k, v)| k.get(ctx.len()..).map(|key| (key.to_vec(), v)))
+        }) as Rc<dyn Fn(&[u8], &[u8]) -> Option<(Vec<u8>, Vec<u8>)>>
+    };
+    let meta_set = {
+        let store = store.clone();
+        Rc::new(move |key: &[u8], value: &[u8]| {
+            store
+                .raw_put(Column::SortedIndexMeta, &scoped(&ctx, key), value)
+                .is_ok()
+        }) as Rc<dyn Fn(&[u8], &[u8]) -> bool>
+    };
+    let meta_get = {
+        let store = store.clone();
+        Rc::new(move |key: &[u8]| {
+            store
+                .raw_get(Column::SortedIndexMeta, &scoped(&ctx, key))
+                .ok()
+                .flatten()
+        }) as Rc<dyn Fn(&[u8]) -> Option<Vec<u8>>>
+    };
+    let meta_clear = {
+        let store = store.clone();
+        Rc::new(move |key: &[u8]| {
+            store
+                .raw_delete(Column::SortedIndexMeta, &scoped(&ctx, key))
+                .is_ok()
+        }) as Rc<dyn Fn(&[u8]) -> bool>
+    };
+
+    IndexCallbacks {
+        set,
+        remove,
+        remove_prefix,
+        scan,
+        last,
+        meta_set,
+        meta_get,
+        meta_clear,
+    }
 }
 
 /// Storage callback closures that bridge `calimero-storage` Key API to the Store.

--- a/crates/node/primitives/src/sync/storage_bridge.rs
+++ b/crates/node/primitives/src/sync/storage_bridge.rs
@@ -479,7 +479,7 @@ mod tests {
             .raw_delete_range(Column::SortedIndex, &ctx, &index_prefix_upper_bound(&ctx))
             .unwrap();
         assert!(
-            store
+            !store
                 .raw_scan(
                     Column::SortedIndexMeta,
                     &ctx,
@@ -487,8 +487,7 @@ mod tests {
                     None
                 )
                 .unwrap()
-                .len()
-                > 0,
+                .is_empty(),
             "marker must survive the index wipe (this is the false-positive state)"
         );
 

--- a/crates/node/primitives/src/sync/storage_bridge.rs
+++ b/crates/node/primitives/src/sync/storage_bridge.rs
@@ -415,4 +415,128 @@ mod tests {
             "root entity should exist in snapshot-restored store"
         );
     }
+
+    /// Host-side (JS-path) regression for sdk-js#87: a native `SortedSet` whose
+    /// ordered index is stale but whose validity marker still matches the
+    /// converged `full_hash` must self-heal when a synced child is applied.
+    ///
+    /// This exercises the REAL host store the JS SDK uses: with the index bridge
+    /// installed by `create_runtime_env`, the ordered index + marker live in the
+    /// RocksDB `Column::SortedIndex` / `Column::SortedIndexMeta` (context-scoped),
+    /// NOT the storage crate's process-thread-local mock. The receiver applies a
+    /// child via the same native `Interface::apply_action` path HashComparison
+    /// uses; its `index_meta_clear` must invalidate the RocksDB marker so the
+    /// next ordered read rebuilds. Fails if the bridge or the apply-time clear is
+    /// removed (marker stays matched → stale subset served forever).
+    #[test]
+    fn sorted_set_apply_invalidates_host_index_marker() {
+        use calimero_storage::collections::{Root, SortedSet};
+        use calimero_storage::delta::StorageDelta;
+        use calimero_storage::env::take_last_artifact;
+        use calimero_storage::interface::{ApplyContext, Interface};
+
+        let db = InMemoryDB::owned();
+        let store = Store::new(Arc::new(db));
+        let context_id = ContextId::from([9u8; 32]);
+        let identity = PublicKey::from([2u8; 32]);
+        let ctx = *context_id.as_ref();
+
+        // Build the set host-side through the bridge → index + marker land in the
+        // RocksDB SortedIndex / SortedIndexMeta columns. Capture the delta a peer
+        // would apply.
+        let delta = with_runtime_env(create_runtime_env(&store, context_id, identity), || {
+            let mut set = Root::new(SortedSet::<String, MainStorage>::new);
+            assert!(set.insert("a".to_owned()).unwrap());
+            assert!(set.insert("b".to_owned()).unwrap());
+            // Warm the ordered index (rebuild + stamp marker) in RocksDB.
+            assert_eq!(
+                set.iter().unwrap().collect::<Vec<_>>(),
+                vec!["a".to_owned(), "b".to_owned()]
+            );
+            set.commit();
+            take_last_artifact().expect("commit emitted a delta")
+        });
+
+        // Sanity: the ordered index really is in RocksDB (bridge is wired), not
+        // the mock — there is at least one SortedIndex row for this context.
+        let index_rows = store
+            .raw_scan(
+                Column::SortedIndex,
+                &ctx,
+                &index_prefix_upper_bound(&ctx),
+                None,
+            )
+            .unwrap();
+        assert!(
+            !index_rows.is_empty(),
+            "ordered index must be backed by RocksDB SortedIndex (bridge wired)"
+        );
+
+        // Manufacture the false positive: wipe the SortedIndex rows for this
+        // context (index is now a strict subset — empty) but LEAVE the marker in
+        // SortedIndexMeta intact, so `index_marker_current()` still returns true.
+        store
+            .raw_delete_range(Column::SortedIndex, &ctx, &index_prefix_upper_bound(&ctx))
+            .unwrap();
+        assert!(
+            store
+                .raw_scan(
+                    Column::SortedIndexMeta,
+                    &ctx,
+                    &index_prefix_upper_bound(&ctx),
+                    None
+                )
+                .unwrap()
+                .len()
+                > 0,
+            "marker must survive the index wipe (this is the false-positive state)"
+        );
+
+        // CONTROL: the O(1) marker-only read trusts the matching marker and
+        // serves the stale (empty) index — the bug.
+        with_runtime_env(create_runtime_env(&store, context_id, identity), || {
+            let set = Root::<SortedSet<String, MainStorage>>::fetch().expect("state present");
+            assert!(
+                set.contains("a").unwrap(),
+                "child 'a' still present in state"
+            );
+            assert_eq!(set.len().unwrap(), 2, "both children enumerable");
+            assert_eq!(
+                set.iter().unwrap().collect::<Vec<String>>(),
+                Vec::<String>::new(),
+                "control: matching marker → stale (empty) ordered index served"
+            );
+        });
+
+        // Drive the REAL receiver apply path: replay the collection's own child
+        // links through native apply_action (idempotent → full_hash unchanged, so
+        // only the marker clear can heal the read).
+        let actions = match borsh::from_slice::<StorageDelta>(&delta).expect("decode delta") {
+            StorageDelta::Actions(a) => a,
+            StorageDelta::CausalActions { actions, .. } => actions,
+        };
+        with_runtime_env(create_runtime_env(&store, context_id, identity), || {
+            for action in actions {
+                if action.id().is_root() {
+                    continue;
+                }
+                Interface::<MainStorage>::apply_action(action, &ApplyContext::empty())
+                    .expect("apply_action");
+            }
+        });
+
+        // The apply cleared the RocksDB marker, so the next ordered read rebuilds
+        // and serves the full converged set.
+        with_runtime_env(create_runtime_env(&store, context_id, identity), || {
+            let set = Root::<SortedSet<String, MainStorage>>::fetch().expect("state present");
+            assert_eq!(
+                set.iter().unwrap().collect::<Vec<String>>(),
+                vec!["a".to_owned(), "b".to_owned()],
+                "host-side ordered iter() stayed stale — the native apply did not \
+                 invalidate the RocksDB SortedIndexMeta marker (sdk-js#87)"
+            );
+            assert_eq!(set.first().unwrap(), Some("a".to_owned()));
+            assert_eq!(set.last().unwrap(), Some("b".to_owned()));
+        });
+    }
 }

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -765,7 +765,14 @@ impl VMHostFunctions<'_> {
         }
         let key = self.read_guest_memory_slice(&key)?.to_vec();
         trace!(target: "runtime::host::storage", op = "index_meta_clear", key_len = key.len(), "storage_index_meta_clear");
-        let ok = self.with_logic_mut(|logic| logic.storage.index_meta_del(&key));
+        // Meter the delete against the per-execution write budget, like every
+        // other mutating storage host fn (e.g. index_meta_set above) — otherwise
+        // a guest could drive unbounded unmetered writes/rebuilds against
+        // Column::SortedIndexMeta.
+        let ok = self.with_logic_mut(|logic| -> VMLogicResult<bool> {
+            logic.charge_storage_write(key.len() as u64)?;
+            Ok(logic.storage.index_meta_del(&key))
+        })?;
         Ok(ok.into())
     }
 }

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -748,6 +748,26 @@ impl VMHostFunctions<'_> {
         }
         Ok(0)
     }
+
+    /// Clear the node-local ordered-index validity marker for `key`, forcing the
+    /// next ordered read to rebuild the index. The invalidate-on-sync primitive:
+    /// the storage apply/merge path calls this whenever it links or unlinks a
+    /// child of a collection. Returns `1` if the write was persisted, `0`
+    /// otherwise.
+    pub fn storage_index_meta_clear(&mut self, key_ptr: u64) -> VMLogicResult<u32> {
+        // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
+        //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
+        //         it is sound; the guest SDK wrote a well-formed instance at this
+        //         offset and the read is bounds-checked. See `read_guest_memory_typed`.
+        let key = unsafe { self.read_guest_memory_typed::<sys::Buffer<'_>>(key_ptr)? };
+        if key.len() > self.borrow_logic().limits.max_storage_key_size.get() {
+            return Err(HostError::KeyLengthOverflow.into());
+        }
+        let key = self.read_guest_memory_slice(&key)?.to_vec();
+        trace!(target: "runtime::host::storage", op = "index_meta_clear", key_len = key.len(), "storage_index_meta_clear");
+        let ok = self.with_logic_mut(|logic| logic.storage.index_meta_del(&key));
+        Ok(ok.into())
+    }
 }
 
 /// Encode ordered-index scan results into the length-prefixed wire format the

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -11,7 +11,7 @@ use crate::{
     logic::{sys, VMHostFunctions, VMLogicError, VMLogicResult},
 };
 use calimero_primitives::common::DIGEST_SIZE;
-use calimero_storage::env::{with_runtime_env, RuntimeEnv};
+use calimero_storage::env::{with_runtime_env, IndexCallbacks, RuntimeEnv};
 use calimero_storage::{
     address::Id, entities::Metadata, index::Index, interface::Interface, store::MainStorage,
 };
@@ -93,7 +93,62 @@ pub(super) fn build_runtime_env(
     //   the storage crate falls back to its default environment, so subsequent
     //   calls that do not install an override will continue to use the mock /
     //   WASM backends.
-    RuntimeEnv::new(reader, writer, remover, context_id, executor_id)
+
+    // Ordered-index bridge: route the node-local ordered index + validity marker
+    // to the SAME `ContextStorage` (its `Column::SortedIndex`/`SortedIndexMeta`).
+    // Without this, a host-side `SortedSet`/`SortedMap` (the JS SDK path, and
+    // native `apply_action`) would hit the storage crate's process-thread-local
+    // mock instead of the durable, context-scoped columns — so an ordered read
+    // and its sync-apply marker clear could target different stores and a
+    // converged set could stay stale on the ordered readers (sdk-js#87). Every
+    // closure dereferences the same exclusive `storage` pointer as the callbacks
+    // above; the same safety reasoning applies.
+    let index = {
+        macro_rules! idx_cell {
+            () => {{
+                Rc::clone(&storage_cell)
+            }};
+        }
+        let set_cell = idx_cell!();
+        let remove_cell = idx_cell!();
+        let remove_prefix_cell = idx_cell!();
+        let scan_cell = idx_cell!();
+        let last_cell = idx_cell!();
+        let meta_set_cell = idx_cell!();
+        let meta_get_cell = idx_cell!();
+        let meta_clear_cell = idx_cell!();
+        IndexCallbacks {
+            // SAFETY (every closure): the VM holds exclusive access to
+            // `logic.storage` for the duration of the host call, the only time
+            // these run — same invariant as the read/write/remove closures above.
+            set: Rc::new(move |key: &[u8], value: &[u8]| unsafe {
+                (&mut *set_cell.get()).index_set(key, value)
+            }),
+            remove: Rc::new(move |key: &[u8]| unsafe { (&mut *remove_cell.get()).index_del(key) }),
+            remove_prefix: Rc::new(move |prefix: &[u8]| unsafe {
+                (&mut *remove_prefix_cell.get()).index_del_prefix(prefix)
+            }),
+            scan: Rc::new(
+                move |lo: &[u8], hi: &[u8], offset: usize, limit: Option<usize>| unsafe {
+                    (&*scan_cell.get()).index_scan(lo, hi, offset, limit)
+                },
+            ),
+            last: Rc::new(move |lo: &[u8], hi: &[u8]| unsafe {
+                (&*last_cell.get()).index_last(lo, hi)
+            }),
+            meta_set: Rc::new(move |key: &[u8], value: &[u8]| unsafe {
+                (&mut *meta_set_cell.get()).index_meta_set(key, value)
+            }),
+            meta_get: Rc::new(move |key: &[u8]| unsafe {
+                (&*meta_get_cell.get()).index_meta_get(key)
+            }),
+            meta_clear: Rc::new(move |key: &[u8]| unsafe {
+                (&mut *meta_clear_cell.get()).index_meta_del(key)
+            }),
+        }
+    };
+
+    RuntimeEnv::new(reader, writer, remover, context_id, executor_id).with_index(index)
 }
 
 thread_local! {

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -48,6 +48,14 @@ pub(super) fn build_runtime_env(
     //         this `RuntimeEnv` is installed via `with_runtime_env`, which
     //         happens strictly within the host call that created it (see the
     //         per-closure safety notes below).
+    // Whether this backend actually persists the ordered index (only the real
+    // `ContextStorage` does). Captured via the `&mut` borrow before it is erased
+    // into the raw pointer below, so the bridge is installed only when it has a
+    // real target — test mocks (`SimpleMockStorage`, which implements just
+    // get/set/remove/has) return `false` and keep using `calimero-storage`'s
+    // process-thread-local index mock, exactly as before this bridge existed.
+    let wants_index = storage.supports_index();
+
     let raw_ptr: *mut dyn RuntimeStorage = storage;
     let raw_static: *mut (dyn RuntimeStorage + 'static) = unsafe { mem::transmute(raw_ptr) };
     let storage_cell = Rc::new(Cell::new(raw_static));
@@ -93,6 +101,17 @@ pub(super) fn build_runtime_env(
     //   the storage crate falls back to its default environment, so subsequent
     //   calls that do not install an override will continue to use the mock /
     //   WASM backends.
+
+    let base = RuntimeEnv::new(reader, writer, remover, context_id, executor_id);
+
+    // Only bridge the ordered index when the backend actually persists it (the
+    // real `ContextStorage`). A backend that doesn't (test mocks) leaves the
+    // bridge off, so native `SortedSet`/`SortedMap` index ops fall back to
+    // `calimero-storage`'s process-thread-local mock — the pre-bridge behaviour
+    // the runtime unit tests rely on.
+    if !wants_index {
+        return base;
+    }
 
     // Ordered-index bridge: route the node-local ordered index + validity marker
     // to the SAME `ContextStorage` (its `Column::SortedIndex`/`SortedIndexMeta`).
@@ -148,7 +167,7 @@ pub(super) fn build_runtime_env(
         }
     };
 
-    RuntimeEnv::new(reader, writer, remover, context_id, executor_id).with_index(index)
+    base.with_index(index)
 }
 
 thread_local! {

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -59,6 +59,7 @@ impl VMLogic<'_> {
             // keyed by `collection_id`, lives in its own non-synced column.
             fn storage_index_meta_set(key_ptr: u64, value_ptr: u64) -> u32;
             fn storage_index_meta_get(key_ptr: u64, register_id: u64) -> u32;
+            fn storage_index_meta_clear(key_ptr: u64) -> u32;
 
             // Private storage functions (node-local, NOT synchronized)
             fn private_storage_read(key_ptr: u64, register_id: u64) -> u32;

--- a/crates/runtime/src/store.rs
+++ b/crates/runtime/src/store.rs
@@ -89,6 +89,18 @@ pub trait Storage: Reflect {
         let _ = key;
         None
     }
+
+    /// Delete the ordered-index validity marker for `key` (a `collection_id`),
+    /// forcing the next ordered read to rebuild the index. The sync/apply path
+    /// calls this to invalidate a collection whose element set changed outside
+    /// `insert` (see `calimero_storage`'s `index_meta_clear`). Returns whether
+    /// the write was persisted. Default is inert (see [`index_set`]).
+    ///
+    /// [`index_set`]: Self::index_set
+    fn index_meta_del(&mut self, key: &[u8]) -> bool {
+        let _ = key;
+        false
+    }
 }
 
 #[derive(Debug, Default, Clone)]
@@ -180,6 +192,11 @@ impl Storage for InMemoryStorage {
 
     fn index_meta_get(&self, key: &[u8]) -> Option<Vec<u8>> {
         self.index_meta.get(key).cloned()
+    }
+
+    fn index_meta_del(&mut self, key: &[u8]) -> bool {
+        let _ = self.index_meta.remove(key);
+        true
     }
 }
 

--- a/crates/runtime/src/store.rs
+++ b/crates/runtime/src/store.rs
@@ -16,6 +16,18 @@ pub trait Storage: Reflect {
     fn remove(&mut self, key: &Key) -> Option<Vec<u8>>;
     fn has(&self, key: &Key) -> bool;
 
+    /// Whether this backend actually persists the ordered-index methods below
+    /// (as opposed to inheriting their inert defaults). Gates whether the
+    /// runtime installs the `RuntimeEnv` ordered-index bridge: only a backend
+    /// that returns `true` (the real `ContextStorage`) routes native
+    /// `SortedSet`/`SortedMap` index ops to this store; everything else (test
+    /// mocks that only implement `get`/`set`/`remove`/`has`) leaves the bridge
+    /// off so those ops fall back to `calimero-storage`'s process-thread-local
+    /// index mock. Default `false`.
+    fn supports_index(&self) -> bool {
+        false
+    }
+
     // === Ordered secondary index (SortedMap, core#2559) ===
     //
     // A separate, byte-ordered keyspace (the backend keeps keys in sorted

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -863,6 +863,28 @@ pub fn storage_index_meta_get(key: &[u8]) -> Option<Vec<u8>> {
     }
 }
 
+/// Clear the node-local ordered-index validity marker for `key`, forcing the
+/// next ordered read to rebuild the index (see [`storage_index_meta_set`]). The
+/// invalidate-on-sync primitive called by the storage apply/merge path when a
+/// collection's element set changes outside `insert`. Returns whether the host
+/// persisted the write.
+#[inline]
+pub fn storage_index_meta_clear(key: &[u8]) -> bool {
+    #[cfg(target_arch = "wasm32")]
+    {
+        unsafe { sys::storage_index_meta_clear(Ref::new(&Buffer::from(key))) }
+            .try_into()
+            .unwrap_or_else(expected_boolean)
+    }
+    // Off-wasm, `calimero_storage`'s native mock serves the marker directly, so
+    // this SDK-level host hook is never reached (see `storage_index_set`).
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let _ = key;
+        unsupported_native("storage_index_meta_clear")
+    }
+}
+
 /// Decode the length-prefixed scan reply produced by the host's
 /// `encode_index_pairs`. Malformed/truncated input yields what was parsed so
 /// far (the host controls this buffer, so it's well-formed in practice).

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -584,6 +584,14 @@ where
         S::index_meta_get(self.inner.id()).as_deref() == Some(&self.current_full_hash()[..])
     }
 
+    /// The number of entries currently persisted in the node-local ordered
+    /// index. Compared against [`len`](Self::len) (the authoritative live entry
+    /// count) as a staleness cross-check the `full_hash` marker cannot provide
+    /// reliably — see [`ensure_index`](Self::ensure_index).
+    fn index_len(&self) -> usize {
+        S::index_range(self.inner.id(), Bound::Unbounded, Bound::Unbounded, 0, None).len()
+    }
+
     /// Reconcile the ordered index with the authoritative entry set, then stamp
     /// the validity marker. Used when a remote sync (or an untracked local edit)
     /// left the index stale.
@@ -649,7 +657,22 @@ where
         if !S::index_supported() {
             return Ok(false);
         }
-        if !self.index_marker_current() {
+        // The `full_hash` validity marker alone is an unreliable staleness
+        // signal. A remote sync mutates the entry set host-side (never through
+        // `insert`), and a rebuild that ran while this node's child list was
+        // momentarily stale can stamp the marker to the *converged* full_hash
+        // while the index still holds only a subset of the entries. The marker
+        // then equals the current full_hash, `index_marker_current()` returns a
+        // false positive, and the stale index is served forever — the entry is
+        // present and enumerable (`contains`/`len` converge) yet the ordered
+        // readers return a subset (sdk-js#87). So also cross-check the index
+        // against the authoritative entry set: if the number of persisted index
+        // entries disagrees with the live entry count, the index is provably
+        // stale and must be rebuilt regardless of the marker. The count read
+        // only runs when the marker looks current (`||` short-circuits when it
+        // is already stale), so a stale marker still triggers a rebuild for one
+        // meta read, not an index scan.
+        if !self.index_marker_current() || self.index_len() != self.len()? {
             self.rebuild_index()?;
         }
         Ok(true)

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -584,14 +584,6 @@ where
         S::index_meta_get(self.inner.id()).as_deref() == Some(&self.current_full_hash()[..])
     }
 
-    /// The number of entries currently persisted in the node-local ordered
-    /// index. Compared against [`len`](Self::len) (the authoritative live entry
-    /// count) as a staleness cross-check the `full_hash` marker cannot provide
-    /// reliably — see [`ensure_index`](Self::ensure_index).
-    fn index_len(&self) -> usize {
-        S::index_range(self.inner.id(), Bound::Unbounded, Bound::Unbounded, 0, None).len()
-    }
-
     /// Reconcile the ordered index with the authoritative entry set, then stamp
     /// the validity marker. Used when a remote sync (or an untracked local edit)
     /// left the index stale.
@@ -657,22 +649,17 @@ where
         if !S::index_supported() {
             return Ok(false);
         }
-        // The `full_hash` validity marker alone is an unreliable staleness
-        // signal. A remote sync mutates the entry set host-side (never through
-        // `insert`), and a rebuild that ran while this node's child list was
-        // momentarily stale can stamp the marker to the *converged* full_hash
-        // while the index still holds only a subset of the entries. The marker
-        // then equals the current full_hash, `index_marker_current()` returns a
-        // false positive, and the stale index is served forever — the entry is
-        // present and enumerable (`contains`/`len` converge) yet the ordered
-        // readers return a subset (sdk-js#87). So also cross-check the index
-        // against the authoritative entry set: if the number of persisted index
-        // entries disagrees with the live entry count, the index is provably
-        // stale and must be rebuilt regardless of the marker. The count read
-        // only runs when the marker looks current (`||` short-circuits when it
-        // is already stale), so a stale marker still triggers a rebuild for one
-        // meta read, not an index scan.
-        if !self.index_marker_current() || self.index_len() != self.len()? {
+        // O(1) marker check: rebuild only when the node-local validity marker
+        // disagrees with the collection's current `full_hash`. This read pays a
+        // single meta read — no index scan, no child-list load. The marker is
+        // kept honest from the *write* side: the sync/apply path clears it
+        // whenever it links or unlinks a child of this collection (see
+        // `Interface::apply_action` / `apply_delete_ref_action`), so a converged-
+        // but-unindexed collection has its marker invalidated and rebuilds here
+        // on the next ordered read. The local `insert` path likewise leaves the
+        // marker stale, so both mutation paths funnel back through this one
+        // rebuild.
+        if !self.index_marker_current() {
             self.rebuild_index()?;
         }
         Ok(true)

--- a/crates/storage/src/collections/sorted_set.rs
+++ b/crates/storage/src/collections/sorted_set.rs
@@ -340,14 +340,6 @@ where
         S::index_meta_get(self.inner.id()).as_deref() == Some(&self.current_full_hash()[..])
     }
 
-    /// The number of entries currently persisted in the node-local ordered
-    /// index. Compared against [`len`](Self::len) (the authoritative live
-    /// element count) as a staleness cross-check the `full_hash` marker cannot
-    /// provide reliably — see [`ensure_index`](Self::ensure_index).
-    fn index_len(&self) -> usize {
-        S::index_range(self.inner.id(), Bound::Unbounded, Bound::Unbounded, 0, None).len()
-    }
-
     /// Reconcile the index with the authoritative element set, then stamp the
     /// marker — writes only the diff (`O(changed)` writes; the entry read is
     /// `O(n)`). Used when a remote sync left the index stale.
@@ -390,22 +382,17 @@ where
         if !S::index_supported() {
             return Ok(false);
         }
-        // The `full_hash` validity marker alone is an unreliable staleness
-        // signal. A remote sync mutates the element set host-side (never through
-        // `insert`), and a rebuild that ran while this node's child list was
-        // momentarily stale can stamp the marker to the *converged* full_hash
-        // while the index still holds only a subset of the elements. The marker
-        // then equals the current full_hash, `index_marker_current()` returns a
-        // false positive, and the stale index is served forever — the element is
-        // present and enumerable (`contains`/`len` converge) yet the ordered
-        // readers return a subset (sdk-js#87). So also cross-check the index
-        // against the authoritative element set: if the number of persisted
-        // index entries disagrees with the live element count, the index is
-        // provably stale and must be rebuilt regardless of the marker. The count
-        // read only runs when the marker looks current (`||` short-circuits when
-        // it is already stale), so a stale marker still triggers a rebuild for
-        // one meta read, not an index scan.
-        if !self.index_marker_current() || self.index_len() != self.len()? {
+        // O(1) marker check: rebuild only when the node-local validity marker
+        // disagrees with the collection's current `full_hash`. This read pays a
+        // single meta read — no index scan, no child-list load. The marker is
+        // kept honest from the *write* side: the sync/apply path clears it
+        // whenever it links or unlinks a child of this collection (see
+        // `Interface::apply_action` / `apply_delete_ref_action`), so a converged-
+        // but-unindexed collection has its marker invalidated and rebuilds here
+        // on the next ordered read. The local `insert` path likewise leaves the
+        // marker stale (see the comment near `stamp_index_marker`'s callers), so
+        // both mutation paths funnel back through this one rebuild.
+        if !self.index_marker_current() {
             self.rebuild_index()?;
         }
         Ok(true)

--- a/crates/storage/src/collections/sorted_set.rs
+++ b/crates/storage/src/collections/sorted_set.rs
@@ -340,6 +340,14 @@ where
         S::index_meta_get(self.inner.id()).as_deref() == Some(&self.current_full_hash()[..])
     }
 
+    /// The number of entries currently persisted in the node-local ordered
+    /// index. Compared against [`len`](Self::len) (the authoritative live
+    /// element count) as a staleness cross-check the `full_hash` marker cannot
+    /// provide reliably — see [`ensure_index`](Self::ensure_index).
+    fn index_len(&self) -> usize {
+        S::index_range(self.inner.id(), Bound::Unbounded, Bound::Unbounded, 0, None).len()
+    }
+
     /// Reconcile the index with the authoritative element set, then stamp the
     /// marker — writes only the diff (`O(changed)` writes; the entry read is
     /// `O(n)`). Used when a remote sync left the index stale.
@@ -382,7 +390,22 @@ where
         if !S::index_supported() {
             return Ok(false);
         }
-        if !self.index_marker_current() {
+        // The `full_hash` validity marker alone is an unreliable staleness
+        // signal. A remote sync mutates the element set host-side (never through
+        // `insert`), and a rebuild that ran while this node's child list was
+        // momentarily stale can stamp the marker to the *converged* full_hash
+        // while the index still holds only a subset of the elements. The marker
+        // then equals the current full_hash, `index_marker_current()` returns a
+        // false positive, and the stale index is served forever — the element is
+        // present and enumerable (`contains`/`len` converge) yet the ordered
+        // readers return a subset (sdk-js#87). So also cross-check the index
+        // against the authoritative element set: if the number of persisted
+        // index entries disagrees with the live element count, the index is
+        // provably stale and must be rebuilt regardless of the marker. The count
+        // read only runs when the marker looks current (`||` short-circuits when
+        // it is already stale), so a stale marker still triggers a rebuild for
+        // one meta read, not an index scan.
+        if !self.index_marker_current() || self.index_len() != self.len()? {
             self.rebuild_index()?;
         }
         Ok(true)

--- a/crates/storage/src/env.rs
+++ b/crates/storage/src/env.rs
@@ -404,6 +404,17 @@ pub fn clear_sorted_index_for_testing() {
     mocked::clear_sorted_index_for_testing();
 }
 
+/// Drops the single node-local ordered-index entry for `order_key`, leaving the
+/// index's validity marker and all synced state intact. Test-only seam for
+/// reproducing a node whose ordered index holds a stale subset of the converged
+/// element set while its marker still equals the converged `full_hash` — the
+/// false positive an ordered read must detect and rebuild past (sdk-js#87).
+/// Native-only.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn drop_sorted_index_entry_for_testing(order_key: &[u8]) {
+    mocked::drop_sorted_index_entry_for_testing(order_key);
+}
+
 /// Set executor ID. `pub(crate)` because the only sanctioned way to mutate
 /// executor identity from outside the crate is the scoped [`with_executor_id`]
 /// guard below — that guard guarantees restoration on panic, whereas a raw
@@ -793,6 +804,21 @@ mod mocked {
     pub(super) fn clear_sorted_index_for_testing() {
         INDEX.with(|index| index.borrow_mut().clear());
         INDEX_META.with(|meta| meta.borrow_mut().clear());
+    }
+
+    /// Drop the single node-local ordered-index entry for `order_key` (matched
+    /// as the suffix of the `collection_id ‖ order_key` composite), leaving the
+    /// validity marker and all state untouched. Models a node whose index holds
+    /// a stale subset of the converged element set while its marker still equals
+    /// the converged `full_hash` — the false positive the rebuild trigger must
+    /// catch (sdk-js#87).
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(super) fn drop_sorted_index_entry_for_testing(order_key: &[u8]) {
+        INDEX.with(|index| {
+            index
+                .borrow_mut()
+                .retain(|k, _| !(k.len() == 32 + order_key.len() && k.ends_with(order_key)));
+        });
     }
 
     // Why these don't consult `RUNTIME_ENV` like their main-storage

--- a/crates/storage/src/env.rs
+++ b/crates/storage/src/env.rs
@@ -72,6 +72,66 @@ type StorageWriteFn = std::rc::Rc<dyn Fn(Key, &[u8]) -> bool>;
 /// Reference-counted host callback for removing a key.
 type StorageRemoveFn = std::rc::Rc<dyn Fn(&Key) -> bool>;
 
+// === Ordered-index host callbacks (SortedMap/SortedSet, core#2559) ===
+//
+// The node-local ordered index and its validity marker live in dedicated,
+// non-synced columns (`Column::SortedIndex` / `Column::SortedIndexMeta`). On a
+// WASM guest those are reached through the `storage_index_*` host imports →
+// `ContextStorage`. But `SortedSet`/`SortedMap` also run **host-side, natively**
+// (the JS SDK drives `js_crdt_sortedset_*` → `SortedSet::<MainStorage>::iter`
+// inside `merod`, and delta/HashComparison apply runs `Interface::apply_action`
+// natively). On that native path `MainStorage`'s index ops go through
+// `calimero_storage::env`, which without these callbacks falls back to a
+// process-thread-local mock — NOT the durable, context-scoped RocksDB columns.
+// That split let a JS `SortedSet`'s ordered read and its sync-apply target
+// different stores, so a converged set stayed stale on the ordered readers
+// (sdk-js#87).
+//
+// These callbacks bridge the native index ops to the SAME host store the guest
+// path uses (`ContextStorage` under the runtime, the RocksDB `SortedIndex`/
+// `SortedIndexMeta` columns under the node's sync bridge), so every native
+// SortedSet/SortedMap read and every native apply-time marker clear share one
+// durable, cross-thread-coherent store. Keys are the adaptor-level
+// `collection ‖ order_key` (meta: `collection_id`); the bridge implementation
+// applies whatever context scoping the underlying store needs.
+#[cfg(not(target_arch = "wasm32"))]
+type IndexWriteFn = std::rc::Rc<dyn Fn(&[u8], &[u8]) -> bool>;
+#[cfg(not(target_arch = "wasm32"))]
+type IndexKeyFn = std::rc::Rc<dyn Fn(&[u8]) -> bool>;
+#[cfg(not(target_arch = "wasm32"))]
+type IndexScanFn =
+    std::rc::Rc<dyn Fn(&[u8], &[u8], usize, Option<usize>) -> Vec<(Vec<u8>, Vec<u8>)>>;
+#[cfg(not(target_arch = "wasm32"))]
+type IndexSeekFn = std::rc::Rc<dyn Fn(&[u8], &[u8]) -> Option<(Vec<u8>, Vec<u8>)>>;
+#[cfg(not(target_arch = "wasm32"))]
+type IndexReadFn = std::rc::Rc<dyn Fn(&[u8]) -> Option<Vec<u8>>>;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone)]
+/// Host callbacks routing the node-local ordered index + validity marker to the
+/// real host store (see the module comment above). Installed on a [`RuntimeEnv`]
+/// via [`RuntimeEnv::with_index`]; when absent, the native ordered-index ops use
+/// the process-thread-local mock (fine for pure `calimero-storage` unit tests,
+/// wrong for a real node running host-side SortedSet/SortedMap).
+pub struct IndexCallbacks {
+    /// `collection ‖ order_key -> entry_id` insert/overwrite.
+    pub set: IndexWriteFn,
+    /// Remove one `collection ‖ order_key`.
+    pub remove: IndexKeyFn,
+    /// Remove every key beginning with `prefix` (a `collection_id`).
+    pub remove_prefix: IndexKeyFn,
+    /// Ascending `[lo, hi)` scan after `offset`, capped at `limit`.
+    pub scan: IndexScanFn,
+    /// Largest `(key, value)` in `[lo, hi)` (reverse seek for `last`).
+    pub last: IndexSeekFn,
+    /// Write the validity marker for `collection_id`.
+    pub meta_set: IndexWriteFn,
+    /// Read the validity marker for `collection_id`.
+    pub meta_get: IndexReadFn,
+    /// Clear the validity marker for `collection_id` (invalidate-on-sync).
+    pub meta_clear: IndexKeyFn,
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone)]
 /// Runtime-provided storage environment used by host functions.
@@ -82,12 +142,17 @@ type StorageRemoveFn = std::rc::Rc<dyn Fn(&Key) -> bool>;
 /// that close over the current storage trait object.  While the host function is
 /// executing we install this environment thread-locally so every
 /// `Interface::<MainStorage>::*` call can reach the real context storage.
+///
+/// `index` optionally routes the node-local ordered index + marker to the same
+/// host store (see [`IndexCallbacks`]); when `None`, those ops use the
+/// process-thread-local mock.
 pub struct RuntimeEnv {
     storage_read: StorageReadFn,
     storage_write: StorageWriteFn,
     storage_remove: StorageRemoveFn,
     context_id: [u8; 32],
     executor_id: [u8; 32],
+    index: Option<IndexCallbacks>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -111,7 +176,25 @@ impl RuntimeEnv {
             storage_remove,
             context_id,
             executor_id,
+            index: None,
         }
+    }
+
+    #[must_use]
+    /// Attaches ordered-index host callbacks so native `SortedSet`/`SortedMap`
+    /// index + marker ops reach the real host store instead of the
+    /// process-thread-local mock (see [`IndexCallbacks`]). Consuming builder so
+    /// the common [`new`](Self::new) path stays unchanged for callers that don't
+    /// drive host-side ordered collections.
+    pub fn with_index(mut self, index: IndexCallbacks) -> Self {
+        self.index = Some(index);
+        self
+    }
+
+    #[must_use]
+    /// Returns the installed ordered-index callbacks, if any.
+    pub fn index(&self) -> Option<IndexCallbacks> {
+        self.index.clone()
     }
 
     #[must_use]
@@ -735,8 +818,10 @@ mod mocked {
     }
 
     // Native ordered-index backend. A process-local `BTreeMap` standing in for
-    // the node's RocksDB `SortedIndex` column — enough for native tests; the
-    // node provides the durable, cross-run backing once wired. Keys are the raw
+    // the node's RocksDB `SortedIndex` column — used for pure `calimero-storage`
+    // unit tests, where no `RuntimeEnv` index bridge is installed. On a real node
+    // an installed `RuntimeEnv::with_index` routes every op below to the durable,
+    // context-scoped host store instead (see `IndexCallbacks`). Keys are the raw
     // composite `collection ‖ order_key`, so `BTreeMap` order == key order.
     thread_local! {
         static INDEX: RefCell<std::collections::BTreeMap<Vec<u8>, Vec<u8>>> =
@@ -749,7 +834,17 @@ mod mocked {
             const { RefCell::new(std::collections::BTreeMap::new()) };
     }
 
+    /// The ordered-index callbacks installed by the current `RuntimeEnv`, if any.
+    /// When present, every native index op below routes to the host store rather
+    /// than the process-thread-local `INDEX`/`INDEX_META` mock.
+    fn index_bridge() -> Option<super::IndexCallbacks> {
+        RUNTIME_ENV.with(|env| env.borrow().as_ref().and_then(super::RuntimeEnv::index))
+    }
+
     pub(super) fn storage_index_set(key: &[u8], value: &[u8]) -> bool {
+        if let Some(bridge) = index_bridge() {
+            return (bridge.set)(key, value);
+        }
         INDEX.with(|index| {
             let _ = index.borrow_mut().insert(key.to_vec(), value.to_vec());
         });
@@ -757,6 +852,9 @@ mod mocked {
     }
 
     pub(super) fn storage_index_remove(key: &[u8]) -> bool {
+        if let Some(bridge) = index_bridge() {
+            return (bridge.remove)(key);
+        }
         INDEX.with(|index| {
             let _ = index.borrow_mut().remove(key);
         });
@@ -764,6 +862,9 @@ mod mocked {
     }
 
     pub(super) fn storage_index_remove_prefix(prefix: &[u8]) -> bool {
+        if let Some(bridge) = index_bridge() {
+            return (bridge.remove_prefix)(prefix);
+        }
         INDEX.with(|index| index.borrow_mut().retain(|k, _| !k.starts_with(prefix)));
         true
     }
@@ -774,6 +875,9 @@ mod mocked {
         offset: usize,
         limit: Option<usize>,
     ) -> Vec<(Vec<u8>, Vec<u8>)> {
+        if let Some(bridge) = index_bridge() {
+            return (bridge.scan)(lo, hi, offset, limit);
+        }
         INDEX.with(|index| {
             let matched: Vec<(Vec<u8>, Vec<u8>)> = index
                 .borrow()
@@ -789,6 +893,9 @@ mod mocked {
     }
 
     pub(super) fn storage_index_last(lo: &[u8], hi: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+        if let Some(bridge) = index_bridge() {
+            return (bridge.last)(lo, hi);
+        }
         INDEX.with(|index| {
             index
                 .borrow()
@@ -799,6 +906,9 @@ mod mocked {
     }
 
     pub(super) fn storage_index_meta_set(key: &[u8], value: &[u8]) -> bool {
+        if let Some(bridge) = index_bridge() {
+            return (bridge.meta_set)(key, value);
+        }
         INDEX_META.with(|meta| {
             let _ = meta.borrow_mut().insert(key.to_vec(), value.to_vec());
         });
@@ -806,10 +916,16 @@ mod mocked {
     }
 
     pub(super) fn storage_index_meta_get(key: &[u8]) -> Option<Vec<u8>> {
+        if let Some(bridge) = index_bridge() {
+            return (bridge.meta_get)(key);
+        }
         INDEX_META.with(|meta| meta.borrow().get(key).cloned())
     }
 
     pub(super) fn storage_index_meta_clear(key: &[u8]) -> bool {
+        if let Some(bridge) = index_bridge() {
+            return (bridge.meta_clear)(key);
+        }
         INDEX_META.with(|meta| {
             let _ = meta.borrow_mut().remove(key);
         });

--- a/crates/storage/src/env.rs
+++ b/crates/storage/src/env.rs
@@ -284,6 +284,15 @@ pub fn storage_index_meta_get(key: &[u8]) -> Option<Vec<u8>> {
     imp::storage_index_meta_get(key)
 }
 
+/// Clear the node-local ordered-index validity marker for `key` (a
+/// `collection_id`), so the next ordered read rebuilds the index. This is the
+/// invalidate-on-sync primitive routed to the same non-synced marker column as
+/// [`storage_index_meta_set`]. Returns whether the write was persisted.
+#[must_use]
+pub fn storage_index_meta_clear(key: &[u8]) -> bool {
+    imp::storage_index_meta_clear(key)
+}
+
 /// Reads data from node-local (private) persistent storage.
 ///
 /// Private storage is **NOT synchronised across nodes** — entries
@@ -569,6 +578,10 @@ mod calimero_vm {
         env::storage_index_meta_get(key)
     }
 
+    pub(super) fn storage_index_meta_clear(key: &[u8]) -> bool {
+        env::storage_index_meta_clear(key)
+    }
+
     /// Fills the buffer with random bytes.
     pub(super) fn random_bytes(buf: &mut [u8]) {
         env::random_bytes(buf)
@@ -794,6 +807,13 @@ mod mocked {
 
     pub(super) fn storage_index_meta_get(key: &[u8]) -> Option<Vec<u8>> {
         INDEX_META.with(|meta| meta.borrow().get(key).cloned())
+    }
+
+    pub(super) fn storage_index_meta_clear(key: &[u8]) -> bool {
+        INDEX_META.with(|meta| {
+            let _ = meta.borrow_mut().remove(key);
+        });
+        true
     }
 
     /// Clear ONLY the node-local ordered index and its validity markers, leaving

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2135,6 +2135,23 @@ impl<S: StorageAdaptor> Interface<S> {
                     }
                 }
 
+                // Invalidate-on-sync: this apply links `id` as a child of
+                // `parent` outside `Collection::insert`, so it mutates the
+                // parent's enumerable child set without touching the parent's
+                // node-local ordered index or its validity marker. If `parent`
+                // is a `SortedSet`/`SortedMap`, a marker left stamped to a
+                // `full_hash` that ran ahead of the child list would let the next
+                // ordered read serve a stale subset forever (sdk-js#87). Clear
+                // the parent's marker unconditionally so the next ordered read
+                // rebuilds the index once from the converged child set. This is
+                // done BEFORE `save_internal` so it also fires on the idempotent
+                // re-delivery path below (where `save_internal` returns `None`
+                // and this arm returns early). Clearing a non-sorted parent's
+                // marker is a no-op, so no "is this sorted?" check is needed.
+                if let Some(parent) = parent {
+                    let _ = S::index_meta_clear(parent.id());
+                }
+
                 // Save data (might merge, producing different hash)
                 let Some((_, _full_hash)) = Self::save_internal(id, &data, metadata.clone())?
                 else {
@@ -2432,6 +2449,14 @@ impl<S: StorageAdaptor> Interface<S> {
             // Remove child from parent's children list and recalculate hashes
             <Index<S>>::update_parent_after_child_removal(parent_id, id)?;
             <Index<S>>::recalculate_ancestor_hashes_for(parent_id)?;
+            // Invalidate-on-sync (mirror of the add path in `apply_action`): a
+            // synced delete unlinks a child from `parent_id` outside
+            // `Collection::insert`, changing the enumerable child set without
+            // touching the parent's node-local ordered index / marker. Clear the
+            // marker so a `SortedSet`/`SortedMap` rebuilds its ordered index on
+            // the next read rather than serving the removed element. No-op for a
+            // non-sorted parent.
+            let _ = S::index_meta_clear(parent_id);
         }
 
         Ok(())

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -193,6 +193,24 @@ pub trait StorageAdaptor: 'static {
         let _ = collection;
         None
     }
+
+    /// Clear `collection`'s ordered-index validity marker (see
+    /// [`index_meta_put`](Self::index_meta_put)), forcing the next ordered read
+    /// to rebuild the index. This is the *invalidate-on-sync* primitive: the
+    /// apply/merge path calls it whenever it links or unlinks a child of a
+    /// collection outside `Collection::insert` (which never touches the marker),
+    /// so a `SortedSet`/`SortedMap` whose element set changed under sync rebuilds
+    /// its ordered index on the next read instead of trusting a marker that ran
+    /// ahead of the enumerable child list. Clearing a collection that has no
+    /// marker (any non-sorted collection) is a harmless no-op, so the caller need
+    /// not — and must not — try to detect whether the collection is sorted.
+    /// Returns whether the write was persisted. The inert default is never
+    /// reached on the invalidation path (gated on
+    /// [`index_supported`](Self::index_supported)).
+    fn index_meta_clear(collection: Id) -> bool {
+        let _ = collection;
+        false
+    }
 }
 
 /// Storage iteration support for GC and snapshots.
@@ -348,6 +366,10 @@ impl StorageAdaptor for MainStorage {
 
     fn index_meta_get(collection: Id) -> Option<Vec<u8>> {
         crate::env::storage_index_meta_get(collection.as_bytes())
+    }
+
+    fn index_meta_clear(collection: Id) -> bool {
+        crate::env::storage_index_meta_clear(collection.as_bytes())
     }
 }
 
@@ -741,6 +763,13 @@ pub mod mocked {
 
         fn index_meta_get(collection: Id) -> Option<Vec<u8>> {
             INDEX_META.with(|meta| meta.borrow().get(&(SCOPE, collection)).cloned())
+        }
+
+        fn index_meta_clear(collection: Id) -> bool {
+            INDEX_META.with(|meta| {
+                let _ = meta.borrow_mut().remove(&(SCOPE, collection));
+            });
+            true
         }
     }
 

--- a/crates/storage/tests/sorted_index_convergence.rs
+++ b/crates/storage/tests/sorted_index_convergence.rs
@@ -43,10 +43,12 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use calimero_storage::collections::{Root, SortedMap, SortedSet};
+use calimero_storage::delta::StorageDelta;
 use calimero_storage::env::{
     clear_sorted_index_for_testing, drop_sorted_index_entry_for_testing, reset_environment,
-    with_runtime_env, RuntimeEnv,
+    take_last_artifact, with_runtime_env, RuntimeEnv,
 };
+use calimero_storage::interface::{ApplyContext, Interface};
 use calimero_storage::store::{Key, MainStorage};
 
 /// A shared, synced state store — models state that both nodes have converged on.
@@ -163,40 +165,74 @@ fn sorted_map_ordered_read_converges_on_second_node() {
     });
 }
 
-// === Stale-index-with-matching-marker (the deeper bug #3323 did not fix) ===
+// === Invalidate-on-sync: the apply path must clear the ordered-index marker ===
 //
 // #3323 made the validity marker node-local, so a peer no longer inherits
 // another node's marker. But that only fixes the case where the receiving node's
 // index is *fresh* (marker absent → rebuild fires). The real 2-node merobox run
 // (sdk-js#87, AFTER #3323 merged) showed a subtler state on the receiving node:
-// its index had been built for a *subset* of the element set (`{b}`) and its
+// its index had been built for a *subset* of the element set (`{b}`) while its
 // marker had been stamped to the *converged* `full_hash` (`H({a,b})`). So
-// `index_marker_current()` returned `true` even though the index content
-// (`{b}`) disagreed with the live, fully-synced element set (`{a,b}`):
+// `index_marker_current()` returned `true` even though the index content (`{b}`)
+// disagreed with the live, fully-synced element set (`{a,b}`):
 //   - `contains('a')` = true   (direct child lookup)
 //   - `len()`         = 2      (children linked & enumerable)
 //   - `iter()`        = ['b']  (stale ordered index served forever)
-// The `full_hash` marker is therefore an unreliable staleness signal: the index
-// can be stale while the marker matches. The fix cross-checks the persisted
-// index entry count against the live element count and rebuilds on disagreement.
 //
-// These tests construct that faithful state directly: build the full collection
-// + index + marker, then drop ONE index entry while leaving the marker and the
-// synced children intact (`drop_sorted_index_entry_for_testing`). That is the
-// exact "index = {b}, children = {a,b}, marker == current full_hash" condition;
-// it exercises the real `ensure_index` trigger rather than a cleared index.
+// The `full_hash` marker can therefore run ahead of the enumerable child list,
+// and a read-side check cannot both stay O(1) and catch this (`len()` is itself
+// O(n)). The fix keeps ordered reads O(1) (marker-only) and moves correctness to
+// the *write* side: `Interface::apply_action` / `apply_delete_ref_action` clear
+// the parent collection's node-local marker whenever a synced delta links or
+// unlinks a child (the non-`insert` path), so the next ordered read rebuilds the
+// index once from the converged child set.
+//
+// These tests reproduce the exact false-positive state
+// (`drop_sorted_index_entry_for_testing` leaves index = {b}, children = {a,b},
+// marker == current full_hash), assert the O(1) read serves the stale subset
+// while the marker matches (the CONTROL — this is what the read alone can never
+// fix), then drive the REAL apply choke point by replaying the collection's own
+// delta through `Interface::apply_action` (exactly what `Root::sync` does per
+// action on the receive path). The child-link apply clears the marker, so the
+// next ordered read heals to the full converged set. Remove the
+// `index_meta_clear` call from `apply_action` and these tests fail: the read
+// stays stale because the marker still matches.
+//
+// The replay is idempotent (same node, its own already-applied delta), so it
+// does NOT change `full_hash` — which is the point: if the apply changed the
+// child set the marker would mismatch and rebuild "for free", masking whether
+// the invalidation fired. Holding `full_hash` fixed isolates the marker clear as
+// the sole thing that heals the read. Root actions are skipped on replay so the
+// test exercises the child-link path without the root-state merge (which would
+// require a registered `Mergeable`).
 
-/// SortedSet: an index that holds a stale subset while its marker still equals
-/// the converged `full_hash` must still serve the full set in order — the
-/// ordered reader has to notice the index disagrees with the live element count
-/// and rebuild, not trust the matching marker.
+/// Replay the non-root (child-link) actions of a captured `StorageDelta` through
+/// the real `Interface::apply_action` receive path — the choke point that must
+/// clear the parent collection's ordered-index marker.
+fn replay_child_links<S: calimero_storage::store::StorageAdaptor>(delta: &[u8]) {
+    let actions = match borsh::from_slice::<StorageDelta>(delta).expect("decode delta") {
+        StorageDelta::Actions(actions) => actions,
+        StorageDelta::CausalActions { actions, .. } => actions,
+    };
+    for action in actions {
+        if action.id().is_root() {
+            continue;
+        }
+        Interface::<S>::apply_action(action, &ApplyContext::empty()).expect("apply_action");
+    }
+}
+
+/// SortedSet: a synced child-link apply must invalidate the ordered-index marker
+/// so a converged-but-stale index rebuilds on the next ordered read — even when
+/// the marker still equals the collection's current `full_hash`.
 #[test]
-fn sorted_set_ordered_read_rebuilds_stale_index_with_matching_marker() {
+fn sorted_set_apply_invalidates_stale_index_marker() {
     reset_environment();
     let state: SharedState = Rc::new(RefCell::new(HashMap::new()));
 
-    // Build the full set: index = {a,b}, marker = H({a,b}), state converged.
-    with_runtime_env(env_for(&state, [1u8; 32]), || {
+    // Build the full set + warm its index/marker, and capture the delta the
+    // collection emitted (the Add actions a peer would receive & apply).
+    let delta = with_runtime_env(env_for(&state, [1u8; 32]), || {
         let mut set = Root::new(SortedSet::<String, MainStorage>::new);
         assert!(set.insert("a".to_owned()).unwrap());
         assert!(set.insert("b".to_owned()).unwrap());
@@ -205,28 +241,45 @@ fn sorted_set_ordered_read_rebuilds_stale_index_with_matching_marker() {
             vec!["a".to_owned(), "b".to_owned()]
         );
         set.commit();
+        take_last_artifact().expect("commit emitted a delta")
     });
 
-    // Faithful stale state: the node-local index loses 'a' (as if a rebuild had
-    // run against a momentarily stale child list), but its marker still equals
-    // the converged full_hash and the synced children stay {a,b}. NOT a cleared
-    // index — the marker is deliberately left matching.
+    // Manufacture the false positive: index loses 'a' (as if a rebuild ran
+    // against a momentarily stale child list) but the marker stays == the
+    // converged full_hash and the synced children stay {a,b}.
     drop_sorted_index_entry_for_testing(b"a");
 
+    // CONTROL: the O(1) marker-only read cannot detect this — it serves the
+    // stale subset {b} because the marker matches. This is the observed bug.
     with_runtime_env(env_for(&state, [1u8; 32]), || {
         let set = Root::<SortedSet<String, MainStorage>>::fetch().expect("state present");
-        // Children are fully present & enumerable — the real node saw the same.
         assert!(set.contains("a").unwrap(), "child 'a' is present");
         assert_eq!(set.len().unwrap(), 2, "both children enumerable");
-        // Before the fix: marker == current full_hash → rebuild skipped → the
-        // stale index serves only {b}. After the fix: index count (1) != live
-        // count (2) → rebuild → the full set in order.
+        assert_eq!(
+            set.iter().unwrap().collect::<Vec<String>>(),
+            vec!["b".to_owned()],
+            "control: with a matching marker the O(1) read serves the stale subset"
+        );
+    });
+
+    // Drive the REAL receive/apply path: replay the collection's own child links.
+    // Idempotent (same node), so full_hash is unchanged — only the marker clear
+    // can heal the read.
+    with_runtime_env(env_for(&state, [1u8; 32]), || {
+        replay_child_links::<MainStorage>(&delta);
+    });
+
+    // After the apply invalidated the marker, the next ordered read rebuilds and
+    // serves the full converged set. Fails if `apply_action`'s `index_meta_clear`
+    // is removed (marker still matches → stale {b}).
+    with_runtime_env(env_for(&state, [1u8; 32]), || {
+        let set = Root::<SortedSet<String, MainStorage>>::fetch().expect("state present");
         let got: Vec<String> = set.iter().unwrap().collect();
         assert_eq!(
             got,
             vec!["a".to_owned(), "b".to_owned()],
-            "ordered iter() served a subset of converged state — the stale index \
-             was trusted because its full_hash marker matched (sdk-js#87)"
+            "ordered iter() still served a stale subset — the sync/apply path did \
+             not invalidate the ordered-index marker (sdk-js#87)"
         );
         // first/last are index-backed too and must agree after the self-heal.
         assert_eq!(set.first().unwrap(), Some("a".to_owned()));
@@ -234,15 +287,15 @@ fn sorted_set_ordered_read_rebuilds_stale_index_with_matching_marker() {
     });
 }
 
-/// SortedMap: same shape. `range`/`first`/`last`/`page` are the index-backed
-/// readers (`keys`/`entries` sort in memory), so they are what a stale index
-/// corrupts — and what must self-heal despite a matching marker.
+/// SortedMap: same shape. `range`/`first`/`last` are the index-backed readers,
+/// so they are what a stale index corrupts and what must heal once the apply
+/// path invalidates the marker.
 #[test]
-fn sorted_map_ordered_read_rebuilds_stale_index_with_matching_marker() {
+fn sorted_map_apply_invalidates_stale_index_marker() {
     reset_environment();
     let state: SharedState = Rc::new(RefCell::new(HashMap::new()));
 
-    with_runtime_env(env_for(&state, [1u8; 32]), || {
+    let delta = with_runtime_env(env_for(&state, [1u8; 32]), || {
         let mut map = Root::new(SortedMap::<String, String, MainStorage>::new);
         assert!(map
             .insert("a".to_owned(), "A".to_owned())
@@ -258,15 +311,29 @@ fn sorted_map_ordered_read_rebuilds_stale_index_with_matching_marker() {
             vec!["a".to_owned(), "b".to_owned()]
         );
         map.commit();
+        take_last_artifact().expect("commit emitted a delta")
     });
 
     drop_sorted_index_entry_for_testing(b"a");
 
+    // CONTROL: stale subset served because the marker matches.
     with_runtime_env(env_for(&state, [1u8; 32]), || {
         let map = Root::<SortedMap<String, String, MainStorage>>::fetch().expect("state present");
         assert!(map.contains("a").unwrap(), "entry 'a' is present");
         assert_eq!(map.len().unwrap(), 2, "both entries enumerable");
-        // Index-backed ordered read: subset before the fix, full set after.
+        assert_eq!(
+            map.range(..).unwrap().collect::<Vec<(String, String)>>(),
+            vec![("b".to_owned(), "B".to_owned())],
+            "control: with a matching marker the O(1) range() serves the stale subset"
+        );
+    });
+
+    with_runtime_env(env_for(&state, [1u8; 32]), || {
+        replay_child_links::<MainStorage>(&delta);
+    });
+
+    with_runtime_env(env_for(&state, [1u8; 32]), || {
+        let map = Root::<SortedMap<String, String, MainStorage>>::fetch().expect("state present");
         let ordered: Vec<(String, String)> = map.range(..).unwrap().collect();
         assert_eq!(
             ordered,
@@ -274,8 +341,8 @@ fn sorted_map_ordered_read_rebuilds_stale_index_with_matching_marker() {
                 ("a".to_owned(), "A".to_owned()),
                 ("b".to_owned(), "B".to_owned())
             ],
-            "index-backed range() served a subset of converged state — the stale \
-             index was trusted because its full_hash marker matched (sdk-js#87)"
+            "index-backed range() still served a stale subset — the sync/apply \
+             path did not invalidate the ordered-index marker (sdk-js#87)"
         );
         assert_eq!(map.first().unwrap(), Some(("a".to_owned(), "A".to_owned())));
         assert_eq!(map.last().unwrap(), Some(("b".to_owned(), "B".to_owned())));

--- a/crates/storage/tests/sorted_index_convergence.rs
+++ b/crates/storage/tests/sorted_index_convergence.rs
@@ -44,7 +44,8 @@ use std::rc::Rc;
 
 use calimero_storage::collections::{Root, SortedMap, SortedSet};
 use calimero_storage::env::{
-    clear_sorted_index_for_testing, reset_environment, with_runtime_env, RuntimeEnv,
+    clear_sorted_index_for_testing, drop_sorted_index_entry_for_testing, reset_environment,
+    with_runtime_env, RuntimeEnv,
 };
 use calimero_storage::store::{Key, MainStorage};
 
@@ -159,5 +160,124 @@ fn sorted_map_ordered_read_converges_on_second_node() {
                 ("b".to_owned(), "B".to_owned())
             ]
         );
+    });
+}
+
+// === Stale-index-with-matching-marker (the deeper bug #3323 did not fix) ===
+//
+// #3323 made the validity marker node-local, so a peer no longer inherits
+// another node's marker. But that only fixes the case where the receiving node's
+// index is *fresh* (marker absent → rebuild fires). The real 2-node merobox run
+// (sdk-js#87, AFTER #3323 merged) showed a subtler state on the receiving node:
+// its index had been built for a *subset* of the element set (`{b}`) and its
+// marker had been stamped to the *converged* `full_hash` (`H({a,b})`). So
+// `index_marker_current()` returned `true` even though the index content
+// (`{b}`) disagreed with the live, fully-synced element set (`{a,b}`):
+//   - `contains('a')` = true   (direct child lookup)
+//   - `len()`         = 2      (children linked & enumerable)
+//   - `iter()`        = ['b']  (stale ordered index served forever)
+// The `full_hash` marker is therefore an unreliable staleness signal: the index
+// can be stale while the marker matches. The fix cross-checks the persisted
+// index entry count against the live element count and rebuilds on disagreement.
+//
+// These tests construct that faithful state directly: build the full collection
+// + index + marker, then drop ONE index entry while leaving the marker and the
+// synced children intact (`drop_sorted_index_entry_for_testing`). That is the
+// exact "index = {b}, children = {a,b}, marker == current full_hash" condition;
+// it exercises the real `ensure_index` trigger rather than a cleared index.
+
+/// SortedSet: an index that holds a stale subset while its marker still equals
+/// the converged `full_hash` must still serve the full set in order — the
+/// ordered reader has to notice the index disagrees with the live element count
+/// and rebuild, not trust the matching marker.
+#[test]
+fn sorted_set_ordered_read_rebuilds_stale_index_with_matching_marker() {
+    reset_environment();
+    let state: SharedState = Rc::new(RefCell::new(HashMap::new()));
+
+    // Build the full set: index = {a,b}, marker = H({a,b}), state converged.
+    with_runtime_env(env_for(&state, [1u8; 32]), || {
+        let mut set = Root::new(SortedSet::<String, MainStorage>::new);
+        assert!(set.insert("a".to_owned()).unwrap());
+        assert!(set.insert("b".to_owned()).unwrap());
+        assert_eq!(
+            set.iter().unwrap().collect::<Vec<_>>(),
+            vec!["a".to_owned(), "b".to_owned()]
+        );
+        set.commit();
+    });
+
+    // Faithful stale state: the node-local index loses 'a' (as if a rebuild had
+    // run against a momentarily stale child list), but its marker still equals
+    // the converged full_hash and the synced children stay {a,b}. NOT a cleared
+    // index — the marker is deliberately left matching.
+    drop_sorted_index_entry_for_testing(b"a");
+
+    with_runtime_env(env_for(&state, [1u8; 32]), || {
+        let set = Root::<SortedSet<String, MainStorage>>::fetch().expect("state present");
+        // Children are fully present & enumerable — the real node saw the same.
+        assert!(set.contains("a").unwrap(), "child 'a' is present");
+        assert_eq!(set.len().unwrap(), 2, "both children enumerable");
+        // Before the fix: marker == current full_hash → rebuild skipped → the
+        // stale index serves only {b}. After the fix: index count (1) != live
+        // count (2) → rebuild → the full set in order.
+        let got: Vec<String> = set.iter().unwrap().collect();
+        assert_eq!(
+            got,
+            vec!["a".to_owned(), "b".to_owned()],
+            "ordered iter() served a subset of converged state — the stale index \
+             was trusted because its full_hash marker matched (sdk-js#87)"
+        );
+        // first/last are index-backed too and must agree after the self-heal.
+        assert_eq!(set.first().unwrap(), Some("a".to_owned()));
+        assert_eq!(set.last().unwrap(), Some("b".to_owned()));
+    });
+}
+
+/// SortedMap: same shape. `range`/`first`/`last`/`page` are the index-backed
+/// readers (`keys`/`entries` sort in memory), so they are what a stale index
+/// corrupts — and what must self-heal despite a matching marker.
+#[test]
+fn sorted_map_ordered_read_rebuilds_stale_index_with_matching_marker() {
+    reset_environment();
+    let state: SharedState = Rc::new(RefCell::new(HashMap::new()));
+
+    with_runtime_env(env_for(&state, [1u8; 32]), || {
+        let mut map = Root::new(SortedMap::<String, String, MainStorage>::new);
+        assert!(map
+            .insert("a".to_owned(), "A".to_owned())
+            .unwrap()
+            .is_none());
+        assert!(map
+            .insert("b".to_owned(), "B".to_owned())
+            .unwrap()
+            .is_none());
+        // Warm the index via an index-backed reader.
+        assert_eq!(
+            map.range(..).unwrap().map(|(k, _)| k).collect::<Vec<_>>(),
+            vec!["a".to_owned(), "b".to_owned()]
+        );
+        map.commit();
+    });
+
+    drop_sorted_index_entry_for_testing(b"a");
+
+    with_runtime_env(env_for(&state, [1u8; 32]), || {
+        let map = Root::<SortedMap<String, String, MainStorage>>::fetch().expect("state present");
+        assert!(map.contains("a").unwrap(), "entry 'a' is present");
+        assert_eq!(map.len().unwrap(), 2, "both entries enumerable");
+        // Index-backed ordered read: subset before the fix, full set after.
+        let ordered: Vec<(String, String)> = map.range(..).unwrap().collect();
+        assert_eq!(
+            ordered,
+            vec![
+                ("a".to_owned(), "A".to_owned()),
+                ("b".to_owned(), "B".to_owned())
+            ],
+            "index-backed range() served a subset of converged state — the stale \
+             index was trusted because its full_hash marker matched (sdk-js#87)"
+        );
+        assert_eq!(map.first().unwrap(), Some(("a".to_owned(), "A".to_owned())));
+        assert_eq!(map.last().unwrap(), Some(("b".to_owned(), "B".to_owned())));
     });
 }

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -52,6 +52,7 @@ wasm_imports! {
         // `collection_id`; lives in its own non-synced column, never in `State`.
         fn storage_index_meta_set(key: Ref<Buffer<'_>>, value: Ref<Buffer<'_>>) -> Bool;
         fn storage_index_meta_get(key: Ref<Buffer<'_>>, register_id: RegisterId) -> Bool;
+        fn storage_index_meta_clear(key: Ref<Buffer<'_>>) -> Bool;
         // --
         // Private storage functions (node-local, NOT synchronized)
         fn private_storage_read(key: Ref<Buffer<'_>>, register_id: RegisterId) -> Bool;


### PR DESCRIPTION
## Problem

`SortedSet`/`SortedMap` keep a **node-local ordered index** (`Column::SortedIndex`) that backs `range`/`prefix`/`iter`/`first`/`last`, guarded by a **node-local validity marker** (`Column::SortedIndexMeta`, made node-local in #3323). An ordered read rebuilds the index only when the stamped marker `!=` the collection's current `full_hash`.

That marker can run **ahead of the enumerable child list**. Sync/merge applies child entities to a collection's merkle children **without** going through `Collection::insert` and **without** touching the node-local index or its marker. A rebuild that ran while the child list was momentarily a subset stamped the marker to the *converged* `full_hash` while the index still held only that subset — so `index_marker_current()` is a permanent false positive and the ordered readers serve a stale subset of fully-converged, enumerable data.

Empirical (real 2-node merobox run, AFTER #3323; surfaced via calimero-network/calimero-sdk-js#87) on node 2: `contains('a')=true`, `len()=2`, but `iter()=['b']`.

## Why the earlier approach on this branch is superseded

The first commit cross-checked the persisted index entry count against `len()` on **every ordered read**. Superseded because (1) the `full_hash` marker is an unreliable staleness signal, and (2) a read-side count check can't be O(1) — `len()` is itself O(n).

## The fix: invalidate-on-sync, O(1) reads

- **Reads are O(1)** (`ensure_index`, both collections): marker-only — one meta read, no scan, no child-list load.
- **Correctness moves to the write/apply side.** `Interface::apply_action` (add/update) and `apply_delete_ref_action` (remove) **clear the parent collection's node-local marker** whenever a synced delta links/unlinks a child. The next ordered read rebuilds once. The add-path clear is before `save_internal` so it also fires on the idempotent HashComparison re-delivery. Clearing a non-sorted parent's (absent) marker is a no-op — no "is this sorted?" detection.
- Local `insert` is untouched (already leaves the marker stale, rebuilds on next read).

## Reaching the real store on every path (the JS / host-side fix)

The ordered index + marker live in different stores depending on where the collection runs:

- **Rust WASM apps**: `__calimero_sync_next` runs `Root::sync`/`apply_action` **in-guest** (SDK macro), so index ops reach RocksDB via the `storage_index_*` host functions. The `index_meta_clear` primitive is wired guest→host→`ContextStorage`→RocksDB (`StorageAdaptor::index_meta_clear` → `env::storage_index_meta_clear` → `sys` → runtime host fn → `Storage::index_meta_del` → `ContextStorage`).
- **JS apps + native HashComparison apply**: `SortedSet`/`SortedMap` run **host-side, natively** (`js_crdt_sortedset_*` → `SortedSet::<MainStorage>::iter`; delta/HashComparison apply → native `Interface::apply_action`). On the native build, `MainStorage`'s index ops go through `calimero_storage::env`, which — because `RuntimeEnv` bridged only read/write/remove — fell back to a **process-thread-local mock**, not the durable, context-scoped RocksDB columns. #3323 wired only the guest path. So a JS `SortedSet`'s ordered read and its sync-apply marker clear could target different stores, and the converged set stayed stale on the ordered readers (this is #87).

Fix: add an optional ordered-index bridge to `RuntimeEnv` (`IndexCallbacks`: set/remove/remove_prefix/scan/last/meta_set/meta_get/meta_clear). When installed, the native `calimero_storage::env` index ops route to the host store; when absent (pure `calimero-storage` unit tests) they keep using the mock. Both production host paths opt in:

- runtime `build_runtime_env` → `ContextStorage` (RocksDB `SortedIndex`/`SortedIndexMeta`) — the JS `js_crdt_*` host fns and `apply_storage_delta`.
- node `storage_bridge::create_runtime_env` → `Store` `raw_*` on those columns with context-id scoping — the HashComparison apply.

Now every native `SortedSet`/`SortedMap` read and every apply-time `index_meta_clear` share one durable, cross-thread-coherent RocksDB store, so the invalidate-on-sync clear actually invalidates the marker the next ordered read checks — **including for JS apps**. `RuntimeEnv::new` keeps its signature (index defaults to `None`); only the two host bridges opt in via `.with_index`.

## Regression tests

- `crates/storage/tests/sorted_index_convergence.rs` — reproduces the false positive, asserts the O(1) read serves the stale subset (control), then drives `Interface::apply_action` (replaying the collection's own delta) and asserts the read heals. Covers `SortedSet` and `SortedMap`. Idempotent replay keeps `full_hash` fixed so only the marker clear can heal — proving it load-bearing.
- `crates/node/primitives/src/sync/storage_bridge.rs` — **host-side (RocksDB) regression for the JS path**: builds the set through the bridged `create_runtime_env` so index+marker live in `Column::SortedIndex`/`SortedIndexMeta`, wipes the `SortedIndex` rows while keeping the marker (the false positive), asserts the control read serves the stale subset, then drives native `apply_action` whose `index_meta_clear` invalidates the RocksDB marker, and asserts the next read heals.

Load-bearing evidence (both suites), captured by temporarily removing the `apply_action` clear:

```
# storage-crate test:
  left: [("b","B")]   right: [("a","A"),("b","B")]   → FAILED
# host-side (RocksDB) test:
  left: []            right: ["a","b"]                → FAILED
# with the fix: all pass.
```

## DoD

- `cargo fmt --check` ✓
- `cargo clippy -p calimero-storage -p calimero-store -p calimero-context -p calimero-node -p calimero-node-primitives -p calimero-runtime -- -D warnings` ✓
- `cargo test -p calimero-storage -p calimero-store -p calimero-context -p calimero-node-primitives` ✓ (all suites green)
- `cargo check -p calimero-node -p merod` ✓

## Residual notes

- The `RuntimeEnv` index bridge is what makes the native host-side ordered index durable and context-scoped (RocksDB), replacing the prior process-thread-local mock — this also fixes a latent gap where the native mock keyed the index by `collection` without a context prefix (cross-context collision) and was not persisted across restarts.
- Over-invalidation is safe and cheap: the clear fires on every applied child link (incl. idempotent re-deliveries), but a converged read rebuilds **once** regardless.
- Guest (Rust WASM) apps must be rebuilt against the new SDK to import the guest `storage_index_meta_clear` host fn; the host provides a superset, so older apps still load and behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
