### PR TITLE
feat(api): serve installed application abi via admin endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,6 +1688,7 @@ dependencies = [
  "calimero-store",
  "calimero-tee-attestation",
  "calimero-utils-actix",
+ "calimero-wasm-abi",
  "chrono",
  "color-eyre",
  "eyre",

--- a/crates/server/AGENTS.md
+++ b/crates/server/AGENTS.md
@@ -109,6 +109,7 @@ DELETE /admin-api/contexts/:id        # Delete context
 GET  /admin-api/applications          # List apps
 POST /admin-api/install-application   # Install app
 GET  /admin-api/applications/:id      # Get app
+GET  /admin-api/applications/:id/abi  # Embedded WASM ABI manifest (optional ?service_name=)
 
 POST /admin-api/contexts/:id/join     # Join context
 ```

--- a/crates/server/AGENTS.md
+++ b/crates/server/AGENTS.md
@@ -172,6 +172,8 @@ pub fn admin_router() -> Router<AppState> {
 }
 ```
 
+When adding a new `.route(...)`, regenerate `crates/server/endpoints.json` via `UPDATE_MANIFEST=1 cargo test -p calimero-server --test route_manifest`, and cover the endpoint with a mero-js e2e hit or a reasoned entry in coverage-baseline.json.
+
 ## Key Files
 
 | File                                                     | Purpose                 |

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -45,6 +45,7 @@ calimero-primitives.workspace = true
 calimero-server-primitives.workspace = true
 calimero-store = { workspace = true, features = ["serde"] }
 calimero-tee-attestation.workspace = true
+calimero-wasm-abi.workspace = true
 mero-auth.workspace = true
 
 [features]

--- a/crates/server/endpoints.json
+++ b/crates/server/endpoints.json
@@ -6,6 +6,7 @@
   "DELETE /admin-api/namespaces/:namespace_id",
   "GET /admin-api/applications",
   "GET /admin-api/applications/:application_id",
+  "GET /admin-api/applications/:application_id/abi",
   "GET /admin-api/applications/:application_id/versions",
   "GET /admin-api/blobs",
   "GET /admin-api/blobs/:blob_id",

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -236,7 +236,8 @@ pub struct GetApplicationAbiQuery {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetApplicationAbiResponse {
-    /// The application's `wasm-abi/1` manifest, verbatim.
+    /// The application's `wasm-abi/1` manifest, verbatim - read from the app
+    /// row's latest-fetched bytecode, not any context's pinned version.
     pub data: serde_json::Value,
 }
 

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -226,6 +226,26 @@ impl GetApplicationResponse {
         }
     }
 }
+
+// No `rename_all`: the query key on the wire is `service_name`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct GetApplicationAbiQuery {
+    pub service_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetApplicationAbiResponse {
+    /// The application's `wasm-abi/1` manifest, verbatim.
+    pub data: serde_json::Value,
+}
+
+impl GetApplicationAbiResponse {
+    #[must_use]
+    pub const fn new(data: serde_json::Value) -> Self {
+        Self { data }
+    }
+}
 // -------------------------------------------- Context API --------------------------------------------
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/server/src/admin/handlers/applications.rs
+++ b/crates/server/src/admin/handlers/applications.rs
@@ -1,4 +1,5 @@
 pub mod get_application;
+pub mod get_application_abi;
 pub mod install_application;
 pub mod install_dev_application;
 pub mod list_application_versions;

--- a/crates/server/src/admin/handlers/applications/get_application_abi.rs
+++ b/crates/server/src/admin/handlers/applications/get_application_abi.rs
@@ -17,7 +17,7 @@ pub async fn handler(
     Query(query): Query<GetApplicationAbiQuery>,
     Extension(state): Extension<Arc<AdminState>>,
 ) -> impl IntoResponse {
-    info!(application_id=%application_id, "Getting application ABI");
+    info!(application_id=%application_id, service_name=?query.service_name, "Getting application ABI");
 
     let application = match state.node_client.get_application(&application_id) {
         Ok(Some(application)) => application,
@@ -83,7 +83,7 @@ pub async fn handler(
         .into_response(),
         EmbeddedSchema::Absent => ApiError {
             status_code: StatusCode::BAD_REQUEST,
-            message: "application has no embedded ABI; rebuild it with `cargo mero build`"
+            message: "application has no usable embedded ABI (absent or malformed); rebuild it with `cargo mero build`"
                 .to_owned(),
         }
         .into_response(),

--- a/crates/server/src/admin/handlers/applications/get_application_abi.rs
+++ b/crates/server/src/admin/handlers/applications/get_application_abi.rs
@@ -1,0 +1,165 @@
+use std::sync::Arc;
+
+use axum::extract::{Path, Query};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Extension;
+use calimero_primitives::application::ApplicationId;
+use calimero_server_primitives::admin::{GetApplicationAbiQuery, GetApplicationAbiResponse};
+use calimero_wasm_abi::embed::{read_embedded_state_schema_versioned, EmbeddedSchema};
+use tracing::{error, info};
+
+use crate::admin::service::{parse_api_error, ApiError, ApiResponse};
+use crate::AdminState;
+
+pub async fn handler(
+    Path(application_id): Path<ApplicationId>,
+    Query(query): Query<GetApplicationAbiQuery>,
+    Extension(state): Extension<Arc<AdminState>>,
+) -> impl IntoResponse {
+    info!(application_id=%application_id, "Getting application ABI");
+
+    let application = match state.node_client.get_application(&application_id) {
+        Ok(Some(application)) => application,
+        Ok(None) => {
+            return ApiError {
+                status_code: StatusCode::NOT_FOUND,
+                message: "Application not found".to_owned(),
+            }
+            .into_response();
+        }
+        Err(err) => {
+            error!(application_id=%application_id, error=?err, "Failed to get application");
+            return parse_api_error(err).into_response();
+        }
+    };
+
+    let service_names: Vec<String> = application.services.keys().cloned().collect();
+    let service = match resolve_service(&service_names, query.service_name.as_deref()) {
+        Ok(service) => service,
+        Err(message) => {
+            return ApiError {
+                status_code: StatusCode::BAD_REQUEST,
+                message,
+            }
+            .into_response();
+        }
+    };
+
+    let wasm = match state
+        .node_client
+        .application_bytes_from_blob(&application.blob.bytecode, service.as_deref())
+        .await
+    {
+        Ok(Some(wasm)) => wasm,
+        Ok(None) => {
+            return ApiError {
+                status_code: StatusCode::NOT_FOUND,
+                message: "Application bytecode not found".to_owned(),
+            }
+            .into_response();
+        }
+        Err(err) => {
+            error!(application_id=%application_id, error=?err, "Failed to load application bytecode");
+            return parse_api_error(err).into_response();
+        }
+    };
+
+    match read_embedded_state_schema_versioned(&wasm) {
+        EmbeddedSchema::Supported(manifest) => match serde_json::to_value(&manifest) {
+            Ok(abi) => ApiResponse {
+                payload: GetApplicationAbiResponse::new(abi),
+            }
+            .into_response(),
+            Err(err) => {
+                error!(application_id=%application_id, error=?err, "Failed to serialize ABI manifest");
+                parse_api_error(err.into()).into_response()
+            }
+        },
+        EmbeddedSchema::UnsupportedVersion(version) => ApiError {
+            status_code: StatusCode::BAD_REQUEST,
+            message: format!("unsupported ABI schema version {version}"),
+        }
+        .into_response(),
+        EmbeddedSchema::Absent => ApiError {
+            status_code: StatusCode::BAD_REQUEST,
+            message: "application has no embedded ABI; rebuild it with `cargo mero build`"
+                .to_owned(),
+        }
+        .into_response(),
+    }
+}
+
+/// Picks the service whose wasm carries the ABI, validating against the app
+/// record so bad requests 400 with the available names instead of 500ing.
+fn resolve_service(names: &[String], requested: Option<&str>) -> Result<Option<String>, String> {
+    let available = || names.join(", ");
+    match requested {
+        None if names.is_empty() => Ok(None),
+        None if names.len() == 1 => Ok(Some(names[0].clone())),
+        None => Err(format!(
+            "application has multiple services; pass service_name (available: {})",
+            available()
+        )),
+        Some(_) if names.is_empty() => {
+            Err("application has no named services; omit service_name".to_owned())
+        }
+        Some(name) if names.iter().any(|n| n == name) => Ok(Some(name.to_owned())),
+        Some(name) => Err(format!(
+            "service \"{name}\" not found (available: {})",
+            available()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_service;
+
+    fn names(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    #[test]
+    fn no_services_and_no_request_targets_the_default_blob() {
+        assert_eq!(resolve_service(&[], None), Ok(None));
+    }
+
+    #[test]
+    fn no_services_but_a_requested_name_is_rejected() {
+        let err = resolve_service(&[], Some("api")).unwrap_err();
+        assert!(err.contains("has no named services"), "got: {err}");
+    }
+
+    #[test]
+    fn a_single_service_is_selected_implicitly() {
+        let names = names(&["api"]);
+        assert_eq!(resolve_service(&names, None), Ok(Some("api".to_owned())));
+    }
+
+    #[test]
+    fn multiple_services_without_a_name_lists_them() {
+        let names = names(&["api", "worker"]);
+        let err = resolve_service(&names, None).unwrap_err();
+        assert!(err.contains("api") && err.contains("worker"), "got: {err}");
+    }
+
+    #[test]
+    fn a_known_name_is_selected() {
+        let names = names(&["api", "worker"]);
+        assert_eq!(
+            resolve_service(&names, Some("worker")),
+            Ok(Some("worker".to_owned()))
+        );
+    }
+
+    #[test]
+    fn an_unknown_name_lists_what_exists() {
+        let names = names(&["api", "worker"]);
+        let err = resolve_service(&names, Some("web")).unwrap_err();
+        assert!(
+            err.contains("web") && err.contains("api") && err.contains("worker"),
+            "got: {err}"
+        );
+    }
+}

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -20,8 +20,8 @@ use tracing::info;
 use super::handlers::{alias, blob, groups, namespaces, tee};
 use super::storage::ssl::get_ssl;
 use crate::admin::handlers::applications::{
-    get_application, install_application, install_dev_application, list_application_versions,
-    list_applications, uninstall_application,
+    get_application, get_application_abi, install_application, install_dev_application,
+    list_application_versions, list_applications, uninstall_application,
 };
 use crate::admin::handlers::context::{
     create_context, delete_context, get_context, get_context_group, get_context_identities,
@@ -99,6 +99,10 @@ pub(crate) fn setup(
         .route(
             "/applications/:application_id",
             get(get_application::handler).delete(uninstall_application::handler),
+        )
+        .route(
+            "/applications/:application_id/abi",
+            get(get_application_abi::handler),
         )
         .route(
             "/applications/:application_id/versions",

--- a/docs/src/content/docs/operate/admin-api.mdx
+++ b/docs/src/content/docs/operate/admin-api.mdx
@@ -212,6 +212,7 @@ rather than assume the event stream is a complete, gap-free log.
 | POST | `/admin-api/install-dev-application` | Install a local dev application. |
 | GET | `/admin-api/applications` | List installed applications. |
 | GET | `/admin-api/applications/:application_id` | Get one application. |
+| GET | `/admin-api/applications/:application_id/abi` | Get the application's embedded WASM ABI manifest (optional `?service_name=`). |
 | DELETE | `/admin-api/applications/:application_id` | Uninstall an application. |
 | GET | `/admin-api/applications/:application_id/versions` | List versions of an installed application. |
 


### PR DESCRIPTION
## Summary

Adds `GET /admin-api/applications/:application_id/abi?service_name=<name>`, returning the embedded `calimero_abi_v1` manifest of an installed application, so ABI-driven clients can introspect an app's methods without downloading and unpacking its blob.

- Composes the existing `NodeClient::application_bytes_from_blob` (bundle/raw-wasm resolution, per-service extraction) with `calimero-wasm-abi`'s `read_embedded_state_schema_versioned`.
- `service_name` is validated against the application record before touching the blob, so bad requests return a 400 listing the available services instead of a generic 500.
- The response is `{"data": <wasm-abi/1 manifest>}`, read from the app row's latest-fetched bytecode.
- The route sits in `protected_routes` and falls under the admin default-deny (it does not match the anchored `APPLICATION_REGEX`).

| Case | Status |
| --- | --- |
| Installed app with an embedded ABI | 200 with the manifest |
| Unknown application or missing bytecode | 404 |
| Unknown or ambiguous `service_name`, or `service_name` on a service-less app | 400 listing the available services |
| No usable embedded ABI (absent or malformed) | 400 with a `cargo mero build` hint |
| ABI schema from a newer toolchain | 400 naming the version |

sdk-ref: feat/get-application-abi

## Test plan

- Unit tests on the service-name resolver covering all six resolution/rejection cases.
- `route_manifest` gate: `endpoints.json` regenerated via `UPDATE_MANIFEST=1`, with the test observed failing before regeneration and passing after.
- `cargo fmt --check`, `cargo clippy -- -A warnings`, and the full `calimero-server`/`calimero-server-primitives` test suites pass.
- Live verification on a node built from this branch with kv-store installed: 200 with `schema_version: "wasm-abi/1"` and 11 methods, 200 status-only, 400 for `?service_name=bogus`, 404 for an unknown application id.
- Paired mero-js branch `feat/get-application-abi` adds `getApplicationAbi()` and a coverage e2e hit exercising the 200 and 400 paths against a merod built from this branch (107 e2e tests passed locally).
