### PR TITLE
feat(bundle): add handlers.slug to the manifest (app-id-safe)

### DIFF
--- a/crates/node/primitives/src/bundle/mod.rs
+++ b/crates/node/primitives/src/bundle/mod.rs
@@ -51,6 +51,23 @@ pub struct BundleLinks {
     pub docs: Option<String>,
 }
 
+/// Deep-link handler declarations for the application.
+///
+/// Lets an app declare its own deep-link `slug` (e.g. `mero-chat`) so links
+/// like `https://links.calimero.network/<slug>/join` and
+/// `calimero://<slug>/join` resolve to the right app. When absent, the desktop
+/// falls back to kebab-casing the app name.
+///
+/// This block is a sibling of `metadata` in the manifest, NOT nested inside it,
+/// so it is deliberately outside the raw-wasm application-id derivation
+/// (`hash(bytecode, size, source, metadata)`).
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BundleHandlers {
+    #[serde(default)]
+    pub slug: Option<String>,
+}
+
 /// Cryptographic signature of the manifest
 ///
 /// The signature is computed over the SHA-256 hash of the canonical manifest bytes (RFC 8785 JCS) with the `signature` field excluded.
@@ -99,6 +116,11 @@ pub struct BundleManifest {
 
     #[serde(default)]
     pub metadata: Option<BundleMetadata>,
+
+    /// Deep-link handler declarations. Sibling of `metadata`, so it does not
+    /// participate in the raw-wasm application-id derivation.
+    #[serde(default)]
+    pub handlers: Option<BundleHandlers>,
 
     #[serde(default)]
     pub interfaces: Option<BundleInterfaces>,
@@ -187,6 +209,7 @@ impl BundleManifest {
             signer_id: _,
             min_runtime_version: _,
             metadata: _,
+            handlers: _,
             interfaces: _,
             links: _,
             signature: _,
@@ -268,5 +291,105 @@ impl BundleManifest {
         }
 
         Ok(serde_json::to_vec(&serde_json::Value::Object(obj))?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use calimero_primitives::application::ApplicationId;
+    use calimero_primitives::hash::Hash;
+
+    use super::*;
+
+    /// A minimal manifest JSON with the given optional `handlers` block spliced
+    /// in verbatim. Everything else is held constant so the only difference
+    /// between two produced manifests is the presence of `handlers`.
+    fn manifest_json(handlers_block: &str) -> String {
+        format!(
+            r#"{{
+                "version": "1.0",
+                "package": "com.example.deeplink",
+                "appVersion": "1.0.0",
+                "minRuntimeVersion": "0.1.0",
+                "metadata": {{
+                    "name": "Mero Chat"
+                }},
+                {handlers_block}
+                "wasm": {{ "path": "app.wasm", "hash": "00", "size": 10 }},
+                "migrations": []
+            }}"#
+        )
+    }
+
+    #[test]
+    fn deserializes_handlers_slug() {
+        let manifest: BundleManifest =
+            serde_json::from_str(&manifest_json(r#""handlers": { "slug": "mero-chat" },"#))
+                .expect("manifest with handlers should deserialize");
+
+        let handlers = manifest.handlers.expect("handlers should be present");
+        assert_eq!(handlers.slug.as_deref(), Some("mero-chat"));
+    }
+
+    #[test]
+    fn handlers_defaults_to_none_when_absent() {
+        let manifest: BundleManifest = serde_json::from_str(&manifest_json(""))
+            .expect("manifest without handlers should deserialize");
+
+        assert!(
+            manifest.handlers.is_none(),
+            "handlers must default to None when the block is absent"
+        );
+    }
+
+    #[test]
+    fn handlers_absent_block_and_empty_slug_deserialize() {
+        // An empty `handlers: {}` block yields Some(handlers) with slug == None
+        // thanks to the field-level `#[serde(default)]`.
+        let manifest: BundleManifest =
+            serde_json::from_str(&manifest_json(r#""handlers": {},"#)).unwrap();
+        let handlers = manifest.handlers.expect("empty handlers block present");
+        assert!(handlers.slug.is_none());
+    }
+
+    /// The deep-link `handlers` field is a sibling of `metadata`, so it must NOT
+    /// leak into the display metadata JSON (which is what raw-wasm installs hash
+    /// into the application-id). This proves both that `metadata` is unchanged
+    /// and that the derived raw-wasm app-id is identical with vs without a
+    /// `handlers` block.
+    #[test]
+    fn handlers_does_not_affect_metadata_or_app_id() {
+        let with_handlers: BundleManifest =
+            serde_json::from_str(&manifest_json(r#""handlers": { "slug": "mero-chat" },"#))
+                .unwrap();
+        let without_handlers: BundleManifest = serde_json::from_str(&manifest_json("")).unwrap();
+
+        // 1. The serialized display metadata must be byte-for-byte identical.
+        let meta_with = with_handlers.to_metadata_json().unwrap();
+        let meta_without = without_handlers.to_metadata_json().unwrap();
+        assert_eq!(
+            meta_with, meta_without,
+            "handlers must not change the display metadata bytes"
+        );
+
+        // 2. Re-derive the raw-wasm application-id the same way
+        //    `NodeClient::install_raw_wasm` does — hash(bytecode, size, source,
+        //    metadata) — and assert it is identical for both manifests.
+        let bytecode = Hash::new(b"fake wasm bytecode");
+        let size: u64 = 18;
+        // `install_raw_wasm` stores the source as a string in `ApplicationMeta`,
+        // so hash the string form here.
+        let source = "file:///app.wasm".to_owned();
+
+        let derive = |metadata: &[u8]| -> ApplicationId {
+            let components = (&bytecode, size, &source, &metadata.to_vec());
+            ApplicationId::from(*Hash::hash_borsh(&components).unwrap())
+        };
+
+        assert_eq!(
+            derive(&meta_with),
+            derive(&meta_without),
+            "handlers must not change the derived raw-wasm application-id"
+        );
     }
 }

--- a/crates/node/primitives/tests/bundle_installation.rs
+++ b/crates/node/primitives/tests/bundle_installation.rs
@@ -65,6 +65,7 @@ fn create_test_bundle(
         signer_id: Some(signer_id),
         min_runtime_version: "0.1.0".to_string(),
         metadata: None,
+        handlers: None,
         interfaces: None,
         wasm: Some(calimero_node_primitives::bundle::BundleArtifact {
             path: "app.wasm".to_string(),
@@ -447,6 +448,7 @@ fn create_test_bundle_custom_wasm_path(
         signer_id: Some(signer_id),
         min_runtime_version: "0.1.0".to_string(),
         metadata: None,
+        handlers: None,
         interfaces: None,
         wasm: Some(calimero_node_primitives::bundle::BundleArtifact {
             path: wasm_path.to_string(),
@@ -1419,6 +1421,7 @@ fn create_test_bundle_with_key(
         signer_id: Some(signer_id),
         min_runtime_version: "0.1.0".to_string(),
         metadata: None,
+        handlers: None,
         interfaces: None,
         wasm: Some(calimero_node_primitives::bundle::BundleArtifact {
             path: "app.wasm".to_string(),


### PR DESCRIPTION
## What

Adds an optional `handlers` block to `BundleManifest` with a single `slug: Option<String>` field, letting an application declare a friendly deep-link slug in its bundle manifest.

`handlers` is a **sibling of `metadata`**, not nested inside it. This is deliberate: raw-wasm installs derive the application-id from the display-metadata bytes, so anything under `metadata` changes the app-id. Keeping `handlers` a sibling means declaring/changing a deep-link slug never shifts the derived app-id.

## Details

- New `BundleHandlers { slug: Option<String> }` struct (after `BundleLinks`).
- New `handlers: Option<BundleManifest>` field on `BundleManifest`, placed right after `metadata`.
- `to_metadata_json` **intentionally excludes** `handlers` — it must not leak into the display metadata JSON that raw-wasm installs hash into the application-id. The `handlers_does_not_affect_metadata_or_app_id` test guards this (byte-identical metadata + identical derived app-id with vs without a `handlers` block).
- Tests: `deserializes_handlers_slug`, `handlers_defaults_to_none_when_absent`, `handlers_absent_block_and_empty_slug_deserialize`, `handlers_does_not_affect_metadata_or_app_id`.

This is the clean re-apply of a change that previously lived on a stale, heavily-diverged branch; only the 2-file bundle-manifest change is included here.

## Verification

- `cargo test -p calimero-node-primitives` — 340 passed, 0 failed (bundle handlers tests green).
- `rustup run 1.88.0 cargo fmt --check` — clean.
- `cargo clippy -p calimero-node-primitives -- -A warnings` — clean.