### PR TITLE
fix(storage): don't re-stamp sorted-index marker over a stale index after sync (#3333)

### DIFF
--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -339,6 +339,17 @@ where
         // collection is itself stored (see `super::rekey`).
         super::rekey::register_rekey::<Self>();
 
+        // core#3333: capture whether the ordered index was consistent with the
+        // child set (marker current) BEFORE any mutation below. A sync-apply that
+        // linked/unlinked a child clears the marker WITHOUT populating the
+        // node-local index; if a subsequent local insert stamps the marker to the
+        // new `full_hash` it would falsely certify an index still missing that
+        // synced key and the next ordered read would serve a stale subset. Only
+        // maintain the index incrementally + stamp when it was already current;
+        // otherwise leave the marker stale so the next ordered read rebuilds from
+        // the full child set — the invariant `ensure_index` documents.
+        let index_was_current = S::index_supported() && self.index_marker_current();
+
         let id = custom_id.unwrap_or_else(|| compute_id(self.inner.id(), key.as_ref()));
 
         // Re-key any nested collections in `value` deterministically relative to
@@ -359,10 +370,14 @@ where
                 let (_, v) = &mut *entry;
                 mem::replace(v, value)
             };
-            // The key set didn't change, so the ordered index is still correct —
-            // restamp the marker to the new `full_hash` so the next ordered read
-            // stays a seek instead of forcing a needless O(n) rebuild.
-            if S::index_supported() {
+            // The key set didn't change by THIS op, so if the index was already
+            // consistent it stays correct — restamp the marker to the new
+            // `full_hash` so the next ordered read stays a seek instead of forcing
+            // a needless O(n) rebuild. But if a sync-apply had changed the child
+            // set and cleared the marker (index stale), restamping here would
+            // falsely certify a stale index (core#3333); leave it stale so the
+            // next ordered read rebuilds.
+            if index_was_current {
                 self.stamp_index_marker();
             }
             return Ok(Some(old));
@@ -380,10 +395,11 @@ where
         if let Some(order_key) = order_key {
             // Done after the inner write so the collection's `full_hash` already
             // reflects this insert when we stamp the validity marker. Only stamp
-            // if the index write was actually persisted — otherwise we leave the
-            // marker stale so the next ordered read rebuilds and self-heals,
-            // rather than trusting an index that's missing this key.
-            if S::index_put(collection, &order_key, id) {
+            // if the index was consistent before (see the `index_was_current`
+            // note above) AND the index write was actually persisted — otherwise
+            // we leave the marker stale so the next ordered read rebuilds and
+            // self-heals, rather than trusting an index missing keys.
+            if index_was_current && S::index_put(collection, &order_key, id) {
                 self.stamp_index_marker();
             }
         }
@@ -525,6 +541,13 @@ where
     {
         let id = compute_id(self.inner.id(), key.as_ref());
 
+        // Capture index consistency BEFORE the mutation (see `insert_internal`):
+        // only maintain the index incrementally + stamp when it was already
+        // current; otherwise a sync-applied child change left it stale and we
+        // must leave the marker stale so the next ordered read rebuilds
+        // (core#3333).
+        let index_was_current = S::index_supported() && self.index_marker_current();
+
         let Some(entry) = self.inner.get_mut(id)? else {
             return Ok(None);
         };
@@ -534,8 +557,9 @@ where
         // Keep the ordered index in step with the removal (no-op when the
         // adaptor doesn't back it). `entry.remove()` has already recomputed the
         // collection's `full_hash`, so the stamped marker stays valid — but only
-        // stamp if the index write landed; otherwise leave it stale to rebuild.
-        if S::index_supported() && S::index_remove(self.inner.id(), key.as_ref()) {
+        // stamp if the index was consistent before AND the index write landed;
+        // otherwise leave it stale to rebuild.
+        if index_was_current && S::index_remove(self.inner.id(), key.as_ref()) {
             self.stamp_index_marker();
         }
 
@@ -1320,6 +1344,11 @@ where
         let collection = self.map.inner.id();
         let id = compute_id(collection, self.key.as_ref());
 
+        // core#3333: capture index consistency BEFORE any mutation (see
+        // `SortedMap::insert_internal`) so a local insert after a sync-apply
+        // doesn't stamp a valid marker over a stale index.
+        let index_was_current = S::index_supported() && self.map.index_marker_current();
+
         // Re-key any nested collections in `value` deterministically relative to
         // this entry's (deterministic) id — exactly as `insert_with_storage_type`
         // does, so a nested CRDT stored via the Entry API converges across nodes.
@@ -1331,9 +1360,10 @@ where
         drop(self.map.inner.insert(Some(id), (self.key, value))?);
 
         if let Some(order_key) = order_key {
-            // Only stamp the validity marker if the index write landed; a dropped
-            // write leaves the marker stale so the next ordered read rebuilds.
-            if S::index_put(collection, &order_key, id) {
+            // Only stamp the validity marker if the index was consistent before
+            // AND the index write landed; a stale-before index or a dropped write
+            // leaves the marker stale so the next ordered read rebuilds.
+            if index_was_current && S::index_put(collection, &order_key, id) {
                 self.map.stamp_index_marker();
             }
         }

--- a/crates/storage/src/collections/sorted_set.rs
+++ b/crates/storage/src/collections/sorted_set.rs
@@ -192,15 +192,26 @@ where
 
         // Warm the ordered index for the new element (after the write, so the
         // collection's full_hash already reflects it when we stamp the marker).
+        // But maintain it INCREMENTALLY only when the index was already
+        // consistent with the child set (marker current) BEFORE this insert. A
+        // sync-apply that linked a child clears the marker WITHOUT populating the
+        // node-local index; if we then index only this new element and stamp the
+        // marker to the (now full) `full_hash`, the marker would falsely certify
+        // an index still missing that synced child, so the next ordered read
+        // would trust it and serve a stale subset (core#3333). When the index is
+        // stale, leave the marker stale so the next ordered read rebuilds from the
+        // full child set — the invariant `ensure_index` documents.
         let order_key = S::index_supported().then(|| value.as_ref().to_vec());
+        let index_was_current = order_key.is_some() && self.index_marker_current();
 
         let _ignored = self.inner.insert(Some(id), value)?;
 
         if let Some(order_key) = order_key {
-            // Only stamp the validity marker if the index write landed; a dropped
+            // Only stamp the validity marker if the index was consistent before
+            // AND the index write landed; either a stale-before index or a dropped
             // write leaves the marker stale so the next ordered read rebuilds and
-            // self-heals rather than trusting an index missing this element.
-            if S::index_put(collection, &order_key, id) {
+            // self-heals rather than trusting an index missing elements.
+            if index_was_current && S::index_put(collection, &order_key, id) {
                 self.stamp_index_marker();
             }
         }
@@ -267,15 +278,22 @@ where
     {
         let id = compute_id(self.inner.id(), value.as_ref());
 
+        // Capture index consistency BEFORE the mutation (see `insert`): only
+        // maintain the index incrementally + stamp when it was already current;
+        // otherwise a sync-applied child change left it stale and we must leave
+        // the marker stale so the next ordered read rebuilds (core#3333).
+        let index_was_current = S::index_supported() && self.index_marker_current();
+
         let Some(entry) = self.inner.get_mut(id)? else {
             return Ok(false);
         };
 
         let _ignored = entry.remove()?;
 
-        // Only stamp if the index write landed; else leave the marker stale to
-        // force a rebuild on the next ordered read.
-        if S::index_supported() && S::index_remove(self.inner.id(), value.as_ref()) {
+        // Only stamp if the index was consistent before AND the index write
+        // landed; else leave the marker stale to force a rebuild on the next
+        // ordered read.
+        if index_was_current && S::index_remove(self.inner.id(), value.as_ref()) {
             self.stamp_index_marker();
         }
 

--- a/crates/storage/tests/sorted_index_convergence.rs
+++ b/crates/storage/tests/sorted_index_convergence.rs
@@ -348,3 +348,137 @@ fn sorted_map_apply_invalidates_stale_index_marker() {
         assert_eq!(map.last().unwrap(), Some(("b".to_owned(), "B".to_owned())));
     });
 }
+
+// === #3333 REOPENED: a post-sync LOCAL insert must not re-validate a stale index ===
+//
+// #3323 made the marker node-local; the apply-path clear (above) heals a peer
+// whose index was left stale by a synced child link. Both fixes assume the ONLY
+// thing that stamps the marker *valid* is a mutation from an already-consistent
+// index (or a rebuild). But `insert`/`remove` maintain the ordered index
+// INCREMENTALLY (one `index_put`/`index_remove`) and then stamp the marker to the
+// collection's *current* `full_hash` — which already reflects any children a
+// prior sync-apply linked. So this exact interleaving reintroduces the false
+// positive that #3333 is about (surfaced JS-path-first in sdk-js#87, because the
+// JS write path applies the peer's element before the local write commits):
+//
+//   1. sync delivers converged children `{a}` but NOT the node-local index
+//      (index fresh/empty, marker absent — the "second node" state above).
+//   2. a LOCAL `insert("b")` runs: children become `{a,b}`, `index_put("b")`
+//      writes ONLY `b`, and `stamp_index_marker()` records `marker = H({a,b})`.
+//   3. the index now holds `{b}` while the marker equals the full-set hash, so
+//      `index_marker_current()` is `true` and the next ordered read SKIPS the
+//      rebuild and serves the stale subset `{b}` forever.
+//
+// This is the SAME observable state the apply tests manufacture with
+// `drop_sorted_index_entry_for_testing`, but reached through a legitimate code
+// path (sync + local write), so it is the real regression. `contains`/`len`
+// read children directly and converge; only the ordered readers diverge.
+//
+// The fix: `insert`/`remove` must only maintain the index incrementally + stamp
+// when the index was ALREADY consistent (marker current) *before* the mutation.
+// When a sync left it stale, they leave the marker stale so the next ordered
+// read rebuilds from the full child set — the invariant `ensure_index`'s own doc
+// comment already promises ("the local insert path likewise leaves the marker
+// stale, so both mutation paths funnel back through this one rebuild").
+
+/// SortedSet: after sync delivers converged children to a node with a fresh
+/// ordered index, a LOCAL insert of a new element must not stamp a valid marker
+/// over the still-unbuilt index — the next ordered read must still see the full,
+/// converged set (not just the locally-inserted element).
+#[test]
+fn sorted_set_local_insert_after_sync_does_not_hide_synced_elements() {
+    reset_environment();
+    let state: SharedState = Rc::new(RefCell::new(HashMap::new()));
+
+    // Node A builds + commits the converged element `a` (warms the shared index
+    // mock as a side effect of `insert`).
+    with_runtime_env(env_for(&state, [1u8; 32]), || {
+        let mut set = Root::new(SortedSet::<String, MainStorage>::new);
+        assert!(set.insert("a".to_owned()).unwrap());
+        set.commit();
+    });
+
+    // Node B shares node A's converged state but has a FRESH node-local index
+    // (sync never ships the index) — the "second node" state.
+    clear_sorted_index_for_testing();
+
+    // Node B now performs a LOCAL insert of a NEW element `b` BEFORE any ordered
+    // read has rebuilt its index. Pre-fix this incrementally indexes only `b` and
+    // stamps `marker = H({a,b})`, hiding the synced `a` from ordered reads.
+    with_runtime_env(env_for(&state, [2u8; 32]), || {
+        let mut set = Root::<SortedSet<String, MainStorage>>::fetch().expect("node B sees state");
+        assert!(set.insert("b".to_owned()).unwrap());
+        set.commit();
+    });
+
+    // The next ordered read on node B must converge to the FULL set. Pre-fix it
+    // returns just `["b"]` (marker current over a `{b}`-only index).
+    with_runtime_env(env_for(&state, [2u8; 32]), || {
+        let set = Root::<SortedSet<String, MainStorage>>::fetch().expect("state present");
+        // Sanity: membership + count converge (they read children directly).
+        assert!(set.contains("a").unwrap(), "synced child 'a' present");
+        assert!(set.contains("b").unwrap(), "locally-inserted 'b' present");
+        assert_eq!(set.len().unwrap(), 2, "both children enumerable");
+
+        let got: Vec<String> = set.iter().unwrap().collect();
+        assert_eq!(
+            got,
+            vec!["a".to_owned(), "b".to_owned()],
+            "ordered iter() served a stale subset: a local insert after sync \
+             re-stamped the ordered-index marker over a fresh index, hiding the \
+             synced element (core#3333)"
+        );
+        assert_eq!(set.first().unwrap(), Some("a".to_owned()));
+        assert_eq!(set.last().unwrap(), Some("b".to_owned()));
+    });
+}
+
+/// SortedMap: same shape via the key/value API. A local `insert` of a new key
+/// after sync must not hide synced keys from the index-backed ordered readers.
+#[test]
+fn sorted_map_local_insert_after_sync_does_not_hide_synced_entries() {
+    reset_environment();
+    let state: SharedState = Rc::new(RefCell::new(HashMap::new()));
+
+    with_runtime_env(env_for(&state, [1u8; 32]), || {
+        let mut map = Root::new(SortedMap::<String, String, MainStorage>::new);
+        assert!(map
+            .insert("a".to_owned(), "A".to_owned())
+            .unwrap()
+            .is_none());
+        map.commit();
+    });
+
+    clear_sorted_index_for_testing();
+
+    with_runtime_env(env_for(&state, [2u8; 32]), || {
+        let mut map =
+            Root::<SortedMap<String, String, MainStorage>>::fetch().expect("node B sees state");
+        assert!(map
+            .insert("b".to_owned(), "B".to_owned())
+            .unwrap()
+            .is_none());
+        map.commit();
+    });
+
+    with_runtime_env(env_for(&state, [2u8; 32]), || {
+        let map = Root::<SortedMap<String, String, MainStorage>>::fetch().expect("state present");
+        assert!(map.contains("a").unwrap(), "synced entry 'a' present");
+        assert!(map.contains("b").unwrap(), "locally-inserted 'b' present");
+        assert_eq!(map.len().unwrap(), 2, "both entries enumerable");
+
+        let ordered: Vec<(String, String)> = map.range(..).unwrap().collect();
+        assert_eq!(
+            ordered,
+            vec![
+                ("a".to_owned(), "A".to_owned()),
+                ("b".to_owned(), "B".to_owned())
+            ],
+            "index-backed range() served a stale subset: a local insert after \
+             sync re-stamped the ordered-index marker over a fresh index, hiding \
+             the synced entry (core#3333)"
+        );
+        assert_eq!(map.first().unwrap(), Some(("a".to_owned(), "A".to_owned())));
+        assert_eq!(map.last().unwrap(), Some(("b".to_owned(), "B".to_owned())));
+    });
+}


### PR DESCRIPTION
## Summary

`SortedSet`/`SortedMap` keep a **node-local** ordered index (`Column::SortedIndex`) guarded by a validity marker (`Column::SortedIndexMeta`) that holds the collection's `full_hash` as of the last (re)build. An ordered read (`iter`/`keys`/`range`/`first`/`last`) rebuilds the index only when `marker != current full_hash`.

`#3323` made the marker node-local and `#3328` made the sync/apply path (`Interface::apply_action` / `apply_delete_ref_action`) **clear** the marker whenever it links/unlinks a child. Both assume the only thing that stamps the marker *valid* is a mutation from an already-consistent index (or a rebuild). But `insert`/`remove` maintain the index **incrementally** (one `index_put`/`index_remove`) and then stamp the marker to the collection's **current** `full_hash` — which already reflects any children a prior sync-apply linked.

So a **local write that follows a sync re-stamps a valid marker over a stale index**:

1. sync delivers converged children `{a}` but **not** the node-local index (index fresh/empty, marker cleared).
2. local `insert("b")`: children become `{a,b}`, `index_put` writes only `b`, `stamp` records `marker = H({a,b})`.
3. index holds `{b}` while `marker == full-set hash`, so `index_marker_current()` is `true` → the next ordered read **skips the rebuild and serves the stale subset `{b}` forever**.

`contains`/`len` read the child list directly and converge; only the ordered readers diverge — the exact #3333 symptom.

### Why it surfaced JS-path-first (calimero-sdk-js#87)

The bug needs the peer's element applied **before** the local write commits. A Rust structured-root app's deferred root-merge is a silent no-op (`Entry<T>` framing vs bare decode), so its concurrent workflow inserts locally *before* the peer's element arrives and converges. The JS root path runs the real `__calimero_merge_root_state` + `write_pre_merged_root_state`, and its write path applies the peer's element first — deterministically hitting the sync-then-local-insert interleaving. The marker/index code is shared, so the fix is at the storage layer and covers both.

## Fix

Only maintain the ordered index incrementally + stamp the marker when the index was **already consistent with the child set (marker current) BEFORE the mutation**. When a sync left it stale, leave the marker stale so the next ordered read rebuilds from the full child set — exactly the invariant `ensure_index`'s own doc comment already promises ("the local insert path likewise leaves the marker stale, so both mutation paths funnel back through this one rebuild").

Steady-state single-writer stays O(1); the post-sync rebuild happens once on the next ordered read. Covers every incremental stamp site: `SortedSet` insert/remove, `SortedMap` insert (new-key + value-update restamp) / remove / `Entry` API. `clear()` is untouched (it empties both index and children, so it stays consistent).

- `crates/storage/src/collections/sorted_set.rs` — `insert`, `remove`
- `crates/storage/src/collections/sorted_map.rs` — `insert_internal` (new-key + value-update restamp), `remove`, `VacantEntry::insert`

## Reproduction & validation (in-process, decisive)

New regression tests in `crates/storage/tests/sorted_index_convergence.rs` drive the exact mechanism through the legitimate sync+local-insert path (node A commits `{a}`; node B gets converged state with a fresh index, then locally inserts `b`):

- `sorted_set_local_insert_after_sync_does_not_hide_synced_elements`
- `sorted_map_local_insert_after_sync_does_not_hide_synced_entries`

**Before** the fix (bug reproduced — membership converges, ordered read stale):
```
sorted_set_local_insert_after_sync_does_not_hide_synced_elements ... FAILED
  left: ["b"]      right: ["a", "b"]
sorted_map_local_insert_after_sync_does_not_hide_synced_entries ... FAILED
  left: [("b","B")]  right: [("a","A"), ("b","B")]
```

**After** the fix (whole suite, incl. the pre-existing #3323/#3328 coverage):
```
running 6 tests
test sorted_set_ordered_read_converges_on_second_node ... ok
test sorted_map_ordered_read_converges_on_second_node ... ok
test sorted_set_local_insert_after_sync_does_not_hide_synced_elements ... ok
test sorted_map_local_insert_after_sync_does_not_hide_synced_entries ... ok
test sorted_map_apply_invalidates_stale_index_marker ... ok
test sorted_set_apply_invalidates_stale_index_marker ... ok
test result: ok. 6 passed; 0 failed
```

Full `cargo test -p calimero-storage`: **677 + all suites pass**. `cargo fmt --check` and `cargo clippy -p calimero-storage --all-targets -- -D warnings` clean.

## Real-node (JS) validation — status

The JS reproduction on real merod is being captured in **calimero-network/calimero-sdk-js#92** (draft): it re-enables the concurrent `SortedSet` ordered-read assertion (`allTags == ["a","b"]`) against the instrumented `merod:edge` and dumps the node `sorted_index_dbg` trace. Final JS-repro validation (both nodes converge to `["a","b"]`) is inherently pending this fix merging and the `merod:edge` image rebuilding, after which sdk-js#92's assertion should pass with the SortedSet check restored. The in-process reproduction above is faithful to the identical mechanism the node trace shows (`CHECK ... marker_current=true` skipping the rebuild over a subset index).

Closes #3333

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Real-node trace confirmation (instrumented `merod:edge`, sdk-js#92)

The JS reproduction ran in calimero-network/calimero-sdk-js#92 against the instrumented `merod:edge`; the concurrent `SortedSet` ordered-read assertion (`allTags == ["a","b"]`) **diverged** (reproduced #3333), and the node `sorted_index_dbg` trace pins the mechanism exactly. For the `tags` SortedSet inner collection `bd379f75…`:

**Divergent node (node-2) — marker re-stamped by a local insert after the apply cleared it:**
```
19:45:10.025  APPLY_ADD clearing parent marker child=8826372c… parent=bd379f75…      # sync links peer's element → marker cleared
19:45:10.050  STAMP index marker  collection=bd379f75… hash=c928cdd8…  SortedSet      # LOCAL insert re-stamps to converged full_hash
19:45:10.358  CHECK index marker  collection=bd379f75… current_full_hash=c928cdd8…
              stored_marker=Some("c928cdd8…")  marker_current=true  SortedSet         # ordered read SKIPS rebuild → stale subset
```

**Converged node (node-1) — marker left cleared, so the read rebuilds:**
```
19:45:10.325  CHECK index marker  collection=bd379f75… current_full_hash=c928cdd8…
              stored_marker=None  marker_current=false  SortedSet
19:45:10.325  REBUILD index (desired = child-list snapshot) collection=bd379f75…
              desired_len=2  existing_len=1  SortedSet                                 # child list has BOTH; index had 1 → rebuild
19:45:10.325  STAMP index marker  collection=bd379f75… hash=c928cdd8…  SortedSet
```

Both nodes compute the identical converged `current_full_hash=c928cdd8…` (the child list holds both elements — hence `contains`/`len` agree, and node-1's rebuild reports `desired_len=2`). The only difference is node-2's marker was re-stamped to that hash by its **local insert** (the `STAMP` at `.050`, immediately after the `APPLY_ADD` clear at `.025`), so `index_marker_current()` returns `true` and the ordered read never rebuilds — while node-1's marker stayed `None` and its read rebuilds (`existing_len=1 → desired_len=2`). This is mechanism **(a)** from the investigation and matches the in-process reproduction line-for-line. The fix removes exactly that local re-stamp when the index was not already consistent.

_Trace-repro PR (diagnostic, not for merge): calimero-network/calimero-sdk-js#92._
