### PR TITLE
refactor(store): dedup prefix_upper_bound into a shared helper

### DIFF
--- a/crates/context/src/handlers/execute/storage.rs
+++ b/crates/context/src/handlers/execute/storage.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use calimero_primitives::context::ContextId;
+use calimero_primitives::utils::prefix_upper_bound;
 use calimero_runtime::store::{Key, Storage, Value};
 use calimero_store::db::Column;
 use calimero_store::layer::temporal::Temporal;
@@ -36,21 +37,6 @@ pub struct ContextStorage {
     // for read-heavy contexts).
     // todo! revisit the shape of WriteLayer to own keys (since they are now fixed-sized)
     keys: RefCell<HashMap<[u8; 32], Arc<key::ContextState>>>,
-}
-
-/// The exclusive upper bound for a byte prefix (smallest key not starting with
-/// `prefix`) — used to scan/clear "all keys under this prefix".
-fn prefix_upper_bound(prefix: &[u8]) -> Vec<u8> {
-    let mut end = prefix.to_vec();
-    while let Some(&last) = end.last() {
-        if last == 0xFF {
-            let _ = end.pop();
-        } else {
-            *end.last_mut().expect("non-empty") += 1;
-            return end;
-        }
-    }
-    vec![0xFF; prefix.len() + 1]
 }
 
 /// Node-local private storage that is NOT synchronized across nodes.

--- a/crates/node/primitives/src/sync/storage_bridge.rs
+++ b/crates/node/primitives/src/sync/storage_bridge.rs
@@ -32,6 +32,7 @@ use std::rc::Rc;
 
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
+use calimero_primitives::utils::prefix_upper_bound;
 use calimero_storage::env::{IndexCallbacks, RuntimeEnv};
 use calimero_storage::store::Key;
 use calimero_store::db::Column;
@@ -72,21 +73,6 @@ pub fn create_runtime_env(
         *executor_id.as_ref(),
     )
     .with_index(create_index_callbacks(store, context_id))
-}
-
-/// The exclusive upper bound for a byte prefix (smallest key not starting with
-/// `prefix`) — mirrors `ContextStorage`'s helper for range-clearing a prefix.
-fn index_prefix_upper_bound(prefix: &[u8]) -> Vec<u8> {
-    let mut end = prefix.to_vec();
-    while let Some(&last) = end.last() {
-        if last == 0xFF {
-            let _ = end.pop();
-        } else {
-            *end.last_mut().expect("non-empty") += 1;
-            return end;
-        }
-    }
-    vec![0xFF; prefix.len() + 1]
 }
 
 /// Build ordered-index host callbacks bridging `calimero-storage`'s node-local
@@ -134,7 +120,7 @@ fn create_index_callbacks(store: &Store, context_id: ContextId) -> IndexCallback
         let store = store.clone();
         Rc::new(move |prefix: &[u8]| {
             let lo = scoped(&ctx, prefix);
-            let hi = index_prefix_upper_bound(&lo);
+            let hi = prefix_upper_bound(&lo);
             store
                 .raw_delete_range(Column::SortedIndex, &lo, &hi)
                 .is_ok()
@@ -460,12 +446,7 @@ mod tests {
         // Sanity: the ordered index really is in RocksDB (bridge is wired), not
         // the mock — there is at least one SortedIndex row for this context.
         let index_rows = store
-            .raw_scan(
-                Column::SortedIndex,
-                &ctx,
-                &index_prefix_upper_bound(&ctx),
-                None,
-            )
+            .raw_scan(Column::SortedIndex, &ctx, &prefix_upper_bound(&ctx), None)
             .unwrap();
         assert!(
             !index_rows.is_empty(),
@@ -476,14 +457,14 @@ mod tests {
         // context (index is now a strict subset — empty) but LEAVE the marker in
         // SortedIndexMeta intact, so `index_marker_current()` still returns true.
         store
-            .raw_delete_range(Column::SortedIndex, &ctx, &index_prefix_upper_bound(&ctx))
+            .raw_delete_range(Column::SortedIndex, &ctx, &prefix_upper_bound(&ctx))
             .unwrap();
         assert!(
             !store
                 .raw_scan(
                     Column::SortedIndexMeta,
                     &ctx,
-                    &index_prefix_upper_bound(&ctx),
+                    &prefix_upper_bound(&ctx),
                     None
                 )
                 .unwrap()

--- a/crates/primitives/src/utils.rs
+++ b/crates/primitives/src/utils.rs
@@ -1,5 +1,40 @@
 use core::iter;
 
+/// The exclusive upper bound for a byte prefix: the smallest key that does NOT
+/// start with `prefix` — the `hi` of a half-open `[prefix, hi)` range that
+/// covers exactly "all keys under this prefix", used for prefix scans and
+/// range-clears against an ordered byte keyspace (e.g. RocksDB / `BTreeMap`).
+///
+/// It increments the last non-`0xFF` byte and drops the all-`0xFF` tail. For
+/// the degenerate all-`0xFF` (or empty) prefix — where no finite successor
+/// exists — it falls back to a longer all-`0xFF` key, which still upper-bounds
+/// the scan.
+///
+/// ## Examples
+///
+/// ```
+/// use calimero_primitives::utils::prefix_upper_bound;
+///
+/// assert_eq!(prefix_upper_bound(b"abc"), b"abd".to_vec());
+/// // A trailing 0xFF is dropped, then the preceding byte is bumped.
+/// assert_eq!(prefix_upper_bound(&[0x01, 0xFF]), vec![0x02]);
+/// // All-0xFF has no finite successor: fall back to a longer all-0xFF key.
+/// assert_eq!(prefix_upper_bound(&[0xFF, 0xFF]), vec![0xFF, 0xFF, 0xFF]);
+/// ```
+#[must_use]
+pub fn prefix_upper_bound(prefix: &[u8]) -> Vec<u8> {
+    let mut end = prefix.to_vec();
+    while let Some(last) = end.last_mut() {
+        if *last == 0xFF {
+            let _ = end.pop();
+        } else {
+            *last += 1;
+            return end;
+        }
+    }
+    vec![0xFF; prefix.len() + 1]
+}
+
 /// Creates an iterator that finds and compacts segments of a Rust type name.
 ///
 /// This function scans a path, discarding segments that do not contain generic
@@ -62,7 +97,32 @@ pub fn compact_path(path: &str) -> impl Iterator<Item = &str> {
 mod tests {
     use core::any::{type_name, type_name_of_val};
 
-    use super::compact_path;
+    use super::{compact_path, prefix_upper_bound};
+
+    #[test]
+    fn prefix_upper_bound_normal() {
+        // Bumps the last byte; the result is the first key not under `prefix`.
+        assert_eq!(prefix_upper_bound(b"abc"), b"abd".to_vec());
+        assert_eq!(prefix_upper_bound(&[0x00]), vec![0x01]);
+        assert_eq!(prefix_upper_bound(&[0x01, 0x02]), vec![0x01, 0x03]);
+    }
+
+    #[test]
+    fn prefix_upper_bound_trailing_ff() {
+        // Trailing 0xFF bytes are dropped, then the preceding byte is bumped.
+        assert_eq!(prefix_upper_bound(&[0x01, 0xFF]), vec![0x02]);
+        assert_eq!(prefix_upper_bound(&[0x01, 0xFF, 0xFF]), vec![0x02]);
+    }
+
+    #[test]
+    fn prefix_upper_bound_all_ff() {
+        // No finite successor exists: fall back to a longer all-0xFF key that
+        // still upper-bounds the scan.
+        assert_eq!(prefix_upper_bound(&[0xFF]), vec![0xFF, 0xFF]);
+        assert_eq!(prefix_upper_bound(&[0xFF, 0xFF]), vec![0xFF, 0xFF, 0xFF]);
+        // Empty prefix has no last byte either.
+        assert_eq!(prefix_upper_bound(&[]), vec![0xFF]);
+    }
 
     #[test]
     fn test_compact_path() {

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -1,5 +1,6 @@
 //! Storage operations.
 
+use calimero_primitives::utils::prefix_upper_bound;
 use sha2::{Digest, Sha256};
 
 use crate::address::Id;
@@ -379,23 +380,6 @@ fn index_key(collection: Id, order_key: &[u8]) -> Vec<u8> {
     key.extend_from_slice(collection.as_bytes());
     key.extend_from_slice(order_key);
     key
-}
-
-/// The exclusive upper bound for a byte prefix: the smallest key that does NOT
-/// start with `prefix` (used to scan "all keys under this prefix"). For the
-/// all-`0xFF` corner (astronomically unlikely for a 32-byte id) we fall back to
-/// a longer all-`0xFF` key, which still bounds the scan.
-fn prefix_upper_bound(prefix: &[u8]) -> Vec<u8> {
-    let mut end = prefix.to_vec();
-    while let Some(last) = end.last_mut() {
-        if *last == 0xFF {
-            let _ = end.pop();
-        } else {
-            *last += 1;
-            return end;
-        }
-    }
-    vec![0xFF; prefix.len() + 1]
 }
 
 /// Map raw `(composite_key, entry_id_bytes)` scan hits back to


### PR DESCRIPTION
## What

The byte-prefix upper-bound helper — "the smallest key that does not start with `prefix`", with the all-`0xFF` fallback — was copy-pasted in three places:

- `crates/storage/src/store.rs` — `fn prefix_upper_bound`
- `crates/context/src/handlers/execute/storage.rs` — `fn prefix_upper_bound`
- `crates/node/primitives/src/sync/storage_bridge.rs` — `fn index_prefix_upper_bound`

The third copy was flagged in the **#3328** review. This extracts the helper into a single shared location and points all three sites at it, removing the now-dead local copies.

## Shared home: `calimero_primitives::utils::prefix_upper_bound`

`calimero-primitives` is the lowest common crate all three already depend on, so **no new dependency edge** is added. The natural low-level KV home, `calimero-store`, is deliberately **not** a dependency of `calimero-storage` (the CRDT layer talks to storage only through host callbacks), so it could not serve as the shared home without introducing a new edge.

## Behavior

Identical. The three copies were algorithmically equivalent (one used `end.last_mut()` directly, the other two `end.last()` + `.last_mut().expect(...)` — same result). No call site logic changes.

## Tests

Adds a unit test for the shared fn covering a normal prefix, a prefix ending in `0xFF`, and the all-`0xFF` prefix, plus a doctest.

- `cargo fmt --check` — clean
- `cargo clippy -p calimero-store -p calimero-storage -p calimero-context -p calimero-node-primitives --all-targets -- -D warnings` — clean
- `cargo test -p calimero-store -p calimero-storage -p calimero-context` — pass
- `cargo test -p calimero-primitives utils` (new unit tests + doctest) — pass
- `cargo check -p calimero-node` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)