### PR TITLE
feat(runtime): JS host functions for SharedStorage

### DIFF
--- a/crates/runtime/HOST_FUNCTIONS.md
+++ b/crates/runtime/HOST_FUNCTIONS.md
@@ -341,6 +341,37 @@ non-owner `update`/`tombstone` returns `-1` with an ownership error message writ
 | `js_crdt_authored_vector_iter` | `(vector_id_ptr: u64, register_id: u64) -> i32` | Iterates all values in insertion order (`[count][len,value]...`). |
 | `js_crdt_authored_vector_len` | `(vector_id_ptr: u64, register_id: u64) -> i32` | Gets the entry count including tombstoned slots (`u64`, little-endian). |
 
+#### Shared Storage Operations
+
+A group-writable single byte value guarded by a rotatable **writer set** (`SharedStorage`,
+i.e. `PermissionedStorage<T, WriterSetAcl>` over a byte value). Any member of the writer set may
+read and `set` the value; the set is rotated by a current writer via `rotate_writers`. Both `set`
+and `rotate_writers` are **writer-gated**: a caller not in the current writer set is rejected with
+`-1` and an `ActionNotAllowed` message written to register `0` (the authoritative check is the
+merge-time signature verification against the writer set). The executor identity is taken from the
+per-execution env, so no identity argument is threaded through. The byte value rides a
+last-write-wins register internally so concurrent writes from different writers converge by HLC
+timestamp.
+
+A **writer set** crosses the ABI as a buffer of concatenated 32-byte public keys — the caller passes
+`count * 32` bytes; `js_crdt_shared_writers` emits the same encoding (decode `len / 32` keys).
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `js_crdt_shared_new` | `(writers_ptr: u64, frozen: u32, register_id: u64) -> i32` | Creates a new shared byte cell with the given writer set (concatenated 32-byte keys) and `frozen` flag (`0`/`1`). Writes the 32-byte id to the register; returns `0`. |
+| `js_crdt_shared_new_with_id` | `(id_ptr: u64, writers_ptr: u64, frozen: u32, register_id: u64) -> i32` | As above, at a caller-supplied deterministic 32-byte id. |
+| `js_crdt_shared_set` | `(cell_id_ptr: u64, value_ptr: u64) -> i32` | Writer-gated. Replaces the value. Returns `1` on success; `-1` with an `ActionNotAllowed` message in register `0` for a non-writer. |
+| `js_crdt_shared_get` | `(cell_id_ptr: u64, register_id: u64) -> i32` | Reads the current value into the register (`1` found, `0` never-written with a cleared register). |
+| `js_crdt_shared_writers` | `(cell_id_ptr: u64, register_id: u64) -> i32` | Writes the current writer set as concatenated 32-byte keys to the register; returns `1`. |
+| `js_crdt_shared_writable_by_me` | `(cell_id_ptr: u64) -> i32` | Whether the current executor is in the writer set (`1`/`0`). |
+| `js_crdt_shared_is_frozen` | `(cell_id_ptr: u64) -> i32` | Whether the writer set is frozen (`1`/`0`). |
+| `js_crdt_shared_rotate_writers` | `(cell_id_ptr: u64, writers_ptr: u64) -> i32` | Writer-gated. Rotates the writer set to the given keys. Returns `1` on success; `-1` with an `ActionNotAllowed` message in register `0` for a non-writer, a frozen cell, or an empty target set. |
+
+> **Deferred (not in this bridge):** per-writer **OpMask** capabilities (`grant_capability` /
+> `revoke_capability` / `rotate_writers_scoped`, exposing `WRITE`/`DELETE`/`ADMIN` granularity) and
+> **`SharedStorage<Collection>` nesting** (a group-writable map/set/vector rather than a single byte
+> value). Both are planned follow-ups.
+
 ### User & Frozen Storage (JS)
 
 #### User Storage

--- a/crates/runtime/src/logic/host_functions/js_collections.rs
+++ b/crates/runtime/src/logic/host_functions/js_collections.rs
@@ -11,7 +11,8 @@ use calimero_storage::{
     interface::{Interface, StorageError},
     js::{
         JsAuthoredMap, JsAuthoredVector, JsCounter, JsFrozenStorage, JsLwwRegister, JsPnCounter,
-        JsRga, JsSortedMap, JsSortedSet, JsUnorderedMap, JsUnorderedSet, JsUserStorage, JsVector,
+        JsRga, JsSharedStorage, JsSortedMap, JsSortedSet, JsUnorderedMap, JsUnorderedSet,
+        JsUserStorage, JsVector,
     },
     store::MainStorage,
 };
@@ -25,6 +26,8 @@ use tracing::{debug, warn};
 use super::system::build_runtime_env;
 
 const COLLECTION_ID_LEN: usize = 32;
+/// Byte length of an Ed25519 public key, the unit of a serialized writer set.
+const PUBLIC_KEY_LEN: usize = 32;
 
 impl VMHostFunctions<'_> {
     fn make_runtime_env(&mut self) -> VMLogicResult<RuntimeEnv> {
@@ -858,6 +861,81 @@ impl VMHostFunctions<'_> {
     ) -> VMLogicResult<i32> {
         self.invoke_with_storage_env(|host| {
             host.crdt_authored_vector_len(vector_id_ptr, dest_register_id)
+        })
+    }
+
+    /// Creates a new group-writable shared byte cell with the given writer set
+    /// (a buffer of concatenated 32-byte public keys) and returns its identifier.
+    pub fn js_crdt_shared_new(
+        &mut self,
+        writers_ptr: u64,
+        frozen: u32,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_shared_new(writers_ptr, frozen, dest_register_id)
+        })
+    }
+
+    /// Creates a new shared byte cell at a caller-supplied deterministic id.
+    pub fn js_crdt_shared_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        writers_ptr: u64,
+        frozen: u32,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_shared_new_with_id(id_ptr, writers_ptr, frozen, dest_register_id)
+        })
+    }
+
+    /// Replaces the value. Writer-gated: a non-writer is rejected with
+    /// `ActionNotAllowed` (written to register 0).
+    pub fn js_crdt_shared_set(&mut self, cell_id_ptr: u64, value_ptr: u64) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_shared_set(cell_id_ptr, value_ptr))
+    }
+
+    /// Reads the current value into the register (status 1), or clears it if no
+    /// value has been written (status 0).
+    pub fn js_crdt_shared_get(
+        &mut self,
+        cell_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_shared_get(cell_id_ptr, dest_register_id))
+    }
+
+    /// Writes the current writer set as concatenated 32-byte public keys to the
+    /// register (the JS side decodes `len / 32` keys).
+    pub fn js_crdt_shared_writers(
+        &mut self,
+        cell_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_shared_writers(cell_id_ptr, dest_register_id))
+    }
+
+    /// Returns whether the current executor is in the writer set (1) or not (0).
+    pub fn js_crdt_shared_writable_by_me(&mut self, cell_id_ptr: u64) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_shared_writable_by_me(cell_id_ptr))
+    }
+
+    /// Returns whether the writer set is frozen (1) or not (0).
+    pub fn js_crdt_shared_is_frozen(&mut self, cell_id_ptr: u64) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_shared_is_frozen(cell_id_ptr))
+    }
+
+    /// Rotates the writer set to the given keys (concatenated 32-byte public
+    /// keys). Writer-gated: a non-writer (or a frozen/empty rotation) is rejected
+    /// with `ActionNotAllowed` (written to register 0).
+    pub fn js_crdt_shared_rotate_writers(
+        &mut self,
+        cell_id_ptr: u64,
+        writers_ptr: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_shared_rotate_writers(cell_id_ptr, writers_ptr)
         })
     }
 
@@ -3492,6 +3570,235 @@ impl VMHostFunctions<'_> {
         }
     }
 
+    fn crdt_shared_new(
+        &mut self,
+        writers_ptr: u64,
+        frozen: u32,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let writers = match self.read_writer_set(writers_ptr)? {
+            Ok(writers) => writers,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+        let frozen = frozen != 0;
+
+        let outcome = panic::catch_unwind(AssertUnwindSafe(
+            move || -> Result<JsSharedStorage, String> {
+                let mut cell = JsSharedStorage::new(writers, frozen);
+                save_js_shared_instance(&mut cell)?;
+                Ok(cell)
+            },
+        ));
+
+        match outcome {
+            Ok(Ok(cell)) => {
+                self.write_register_bytes(dest_register_id, cell.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn crdt_shared_new_with_id(
+        &mut self,
+        id_ptr: u64,
+        writers_ptr: u64,
+        frozen: u32,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let id = match self.read_map_id(id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let writers = match self.read_writer_set(writers_ptr)? {
+            Ok(writers) => writers,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+        let frozen = frozen != 0;
+
+        let outcome = panic::catch_unwind(AssertUnwindSafe(
+            move || -> Result<JsSharedStorage, String> {
+                let mut cell = JsSharedStorage::new_with_id(id, writers, frozen);
+                save_js_shared_instance(&mut cell)?;
+                Ok(cell)
+            },
+        ));
+
+        match outcome {
+            Ok(Ok(cell)) => {
+                self.write_register_bytes(dest_register_id, cell.id().as_bytes())?;
+                Ok(0)
+            }
+            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+            Err(payload) => self.write_error_message(
+                dest_register_id,
+                panic_payload_to_string(payload.as_ref(), "unknown panic"),
+            ),
+        }
+    }
+
+    fn crdt_shared_set(&mut self, cell_id_ptr: u64, value_ptr: u64) -> VMLogicResult<i32> {
+        let cell_id = match self.read_map_id(cell_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let value = self.read_buffer(value_ptr)?;
+
+        let mut cell = match load_js_shared_instance(cell_id) {
+            Ok(cell) => cell,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        // Writer-gated: `set` returns `ActionNotAllowed` when the current
+        // executor is not in the writer set; surface it verbatim in register 0.
+        match cell.set(&value) {
+            Ok(()) => match save_js_shared_instance(&mut cell) {
+                Ok(()) => Ok(1),
+                Err(message) => self.write_error_message(0, message),
+            },
+            Err(err) => self.write_error_message(0, err),
+        }
+    }
+
+    fn crdt_shared_get(&mut self, cell_id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
+        let cell_id = match self.read_map_id(cell_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let cell = match load_js_shared_instance(cell_id) {
+            Ok(cell) => cell,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match cell.get() {
+            Ok(Some(value)) => {
+                self.write_register_bytes(dest_register_id, &value)?;
+                Ok(1)
+            }
+            Ok(None) => {
+                self.clear_register(dest_register_id)?;
+                Ok(0)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    fn crdt_shared_writers(
+        &mut self,
+        cell_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let cell_id = match self.read_map_id(cell_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let cell = match load_js_shared_instance(cell_id) {
+            Ok(cell) => cell,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        // Concatenated 32-byte keys; the JS side decodes `len / 32` entries.
+        let writers = cell.writers();
+        let mut buffer = Vec::with_capacity(writers.len().saturating_mul(PUBLIC_KEY_LEN));
+        for writer in &writers {
+            buffer.extend_from_slice(writer);
+        }
+
+        self.write_register_bytes(dest_register_id, &buffer)?;
+        Ok(1)
+    }
+
+    fn crdt_shared_writable_by_me(&mut self, cell_id_ptr: u64) -> VMLogicResult<i32> {
+        let cell_id = match self.read_map_id(cell_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let cell = match load_js_shared_instance(cell_id) {
+            Ok(cell) => cell,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        Ok(i32::from(cell.writable_by_me()))
+    }
+
+    fn crdt_shared_is_frozen(&mut self, cell_id_ptr: u64) -> VMLogicResult<i32> {
+        let cell_id = match self.read_map_id(cell_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let cell = match load_js_shared_instance(cell_id) {
+            Ok(cell) => cell,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        Ok(i32::from(cell.is_frozen()))
+    }
+
+    fn crdt_shared_rotate_writers(
+        &mut self,
+        cell_id_ptr: u64,
+        writers_ptr: u64,
+    ) -> VMLogicResult<i32> {
+        let cell_id = match self.read_map_id(cell_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let writers = match self.read_writer_set(writers_ptr)? {
+            Ok(writers) => writers,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        let mut cell = match load_js_shared_instance(cell_id) {
+            Ok(cell) => cell,
+            Err(message) => return self.write_error_message(0, message),
+        };
+
+        // Writer-gated: a non-writer rotation (or a frozen/empty target) yields
+        // `ActionNotAllowed`; surface it verbatim in register 0.
+        match cell.rotate_writers(writers) {
+            Ok(()) => match save_js_shared_instance(&mut cell) {
+                Ok(()) => Ok(1),
+                Err(message) => self.write_error_message(0, message),
+            },
+            Err(err) => self.write_error_message(0, err),
+        }
+    }
+
+    /// Reads a writer set (a buffer of concatenated 32-byte public keys) from
+    /// guest memory, returning a decoding error string if the length is not a
+    /// multiple of 32.
+    fn read_writer_set(&mut self, ptr: u64) -> VMLogicResult<Result<Vec<[u8; 32]>, String>> {
+        let bytes = self.read_buffer(ptr)?;
+        if bytes.len() % PUBLIC_KEY_LEN != 0 {
+            return Ok(Err(format!(
+                "writer set must be a concatenation of {}-byte keys (received {} bytes)",
+                PUBLIC_KEY_LEN,
+                bytes.len()
+            )));
+        }
+
+        let writers = bytes
+            .chunks_exact(PUBLIC_KEY_LEN)
+            .map(|chunk| {
+                let mut key = [0u8; PUBLIC_KEY_LEN];
+                key.copy_from_slice(chunk);
+                key
+            })
+            .collect();
+        Ok(Ok(writers))
+    }
+
     fn read_map_id(&mut self, map_id_ptr: u64) -> VMLogicResult<Result<Id, String>> {
         // SAFETY: `sys::Buffer<'_>` is a vetted `GuestAbiType` ABI descriptor (a `#[repr(C)]`
         //         layout of `u64`-shaped fields), so reinterpreting the guest bytes as
@@ -4180,6 +4487,49 @@ fn save_js_authored_vector_instance(vector: &mut JsAuthoredVector) -> Result<(),
     }
 }
 
+fn load_js_shared_instance(id: Id) -> Result<JsSharedStorage, String> {
+    match JsSharedStorage::load(id) {
+        Ok(Some(cell)) => {
+            debug!(
+                target: "runtime::shared_storage",
+                cell_id = %id.to_string(),
+                "loaded JsSharedStorage from storage"
+            );
+            Ok(cell)
+        }
+        Ok(None) => {
+            let missing_id = id.to_string();
+            warn!(
+                target: "runtime::shared_storage",
+                cell_id = %missing_id,
+                "JsSharedStorage not found in storage"
+            );
+            // Unlike the other wrappers, a shared cell cannot be recreated on the
+            // fly: its writer set is only known at construction, and inventing an
+            // empty one would silently make the cell unwritable. A missing cell
+            // means the id was referenced before `new`/`new_with_id` persisted it,
+            // which is a caller error — surface it rather than paper over it.
+            Err(format!("JsSharedStorage {missing_id} not found in storage"))
+        }
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+fn save_js_shared_instance(cell: &mut JsSharedStorage) -> Result<(), String> {
+    match cell.save() {
+        Ok(_) => Ok(()),
+        Err(StorageError::CannotCreateOrphan(_)) => {
+            ensure_root_index_internal().map_err(|err| err.to_string())?;
+            match Interface::<MainStorage>::add_child_to(Id::root(), cell) {
+                Ok(_) => Ok(()),
+                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
+                Err(err) => Err(err.to_string()),
+            }
+        }
+        Err(err) => Err(err.to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::logic::{
@@ -4196,6 +4546,8 @@ mod tests {
     const KEY_DESC_PTR: u64 = 200;
     const VALUE_DATA_PTR: u64 = 3000;
     const VALUE_DESC_PTR: u64 = 300;
+    const WRITERS_DATA_PTR: u64 = 4000;
+    const WRITERS_DESC_PTR: u64 = 400;
 
     /// A `*_new_with_id` constructor must place the collection at exactly the
     /// caller-supplied id, and two handles built at the same id must address the
@@ -4993,6 +5345,320 @@ mod tests {
             "tombstoned slot is returned as ZERO value bytes — JS deserialize \
              then hits end-of-input trying to decode a self-describing value \
              out of nothing (calimero-sdk-js#88)"
+        );
+    }
+
+    /// Concatenates 32-byte public keys into the writer-set ABI buffer.
+    fn writers_buf(keys: &[[u8; 32]]) -> Vec<u8> {
+        keys.iter().flat_map(|k| k.iter().copied()).collect()
+    }
+
+    /// Builds a fresh `VMLogic`/host over `storage` with `executor` as the
+    /// current identity. The returned `Store` must be kept alive alongside the
+    /// closure's use of the host (mirrors the AuthoredMap non-owner test).
+    macro_rules! shared_host {
+        ($storage:expr, $limits:expr, $executor:expr, $body:expr) => {{
+            let context = VMContext::new(Cow::Owned(vec![]), [0u8; DIGEST_SIZE], $executor);
+            let mut store = Store::default();
+            let memory =
+                wasmer::Memory::new(&mut store, wasmer::MemoryType::new(1, None, false)).unwrap();
+            let mut logic = VMLogic::new($storage, None, context, $limits, None);
+            let _ = logic.with_memory(memory);
+            let mut host = logic.host_functions(store.as_store_mut());
+            #[allow(clippy::redundant_closure_call)]
+            $body(&mut host)
+        }};
+    }
+
+    /// SharedStorage: a writer can set/get, `writers()` reflects the initial set,
+    /// `writable_by_me` is true for the writer, and `is_frozen` reflects the
+    /// constructor flag.
+    #[test]
+    fn test_js_crdt_shared_set_get_writers_writable_and_frozen() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let alice: [u8; 32] = [0xA1; 32];
+        let id: [u8; 32] = [0x51; 32];
+
+        shared_host!(
+            &mut storage,
+            &limits,
+            alice,
+            |host: &mut crate::logic::VMHostFunctions<'_>| {
+                put_buffer(host, ID_DESC_PTR, ID_DATA_PTR, &id);
+                put_buffer(
+                    host,
+                    WRITERS_DESC_PTR,
+                    WRITERS_DATA_PTR,
+                    &writers_buf(&[alice]),
+                );
+
+                // Construct an unfrozen cell writable by alice.
+                assert_eq!(
+                    host.js_crdt_shared_new_with_id(ID_DESC_PTR, WRITERS_DESC_PTR, 0, 1)
+                        .unwrap(),
+                    0,
+                    "constructor should succeed"
+                );
+                assert_eq!(
+                    host.borrow_logic().registers.get(1).unwrap(),
+                    &id,
+                    "returned id must equal the caller-supplied id"
+                );
+
+                // alice is a writer.
+                assert_eq!(host.js_crdt_shared_writable_by_me(ID_DESC_PTR).unwrap(), 1);
+                // not frozen.
+                assert_eq!(host.js_crdt_shared_is_frozen(ID_DESC_PTR).unwrap(), 0);
+
+                // set → get round-trip.
+                put_buffer(host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"hello");
+                assert_eq!(
+                    host.js_crdt_shared_set(ID_DESC_PTR, VALUE_DESC_PTR)
+                        .unwrap(),
+                    1,
+                    "writer set must succeed"
+                );
+                let reg = 2u64;
+                assert_eq!(host.js_crdt_shared_get(ID_DESC_PTR, reg).unwrap(), 1);
+                assert_eq!(host.borrow_logic().registers.get(reg).unwrap(), b"hello");
+
+                // writers() returns the initial set (one 32-byte key = alice).
+                let reg2 = 3u64;
+                assert_eq!(host.js_crdt_shared_writers(ID_DESC_PTR, reg2).unwrap(), 1);
+                assert_eq!(host.borrow_logic().registers.get(reg2).unwrap(), &alice);
+            }
+        );
+    }
+
+    /// SharedStorage writer-gating: a non-writer's `set` is rejected with an
+    /// ownership/writer error and `writable_by_me` is false; after the writer
+    /// rotates them in, the new writer can set. The non-writer path is exercised
+    /// by a second VM (different `executor_public_key`) over the SAME storage.
+    #[test]
+    fn test_js_crdt_shared_non_writer_rejected_then_rotation_grants() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let alice: [u8; 32] = [0xA1; 32];
+        let bob: [u8; 32] = [0xB0; 32];
+        let id: [u8; 32] = [0x52; 32];
+
+        // --- Alice: create with herself as sole writer, set a value. ---
+        shared_host!(
+            &mut storage,
+            &limits,
+            alice,
+            |host: &mut crate::logic::VMHostFunctions<'_>| {
+                put_buffer(host, ID_DESC_PTR, ID_DATA_PTR, &id);
+                put_buffer(
+                    host,
+                    WRITERS_DESC_PTR,
+                    WRITERS_DATA_PTR,
+                    &writers_buf(&[alice]),
+                );
+                assert_eq!(
+                    host.js_crdt_shared_new_with_id(ID_DESC_PTR, WRITERS_DESC_PTR, 0, 1)
+                        .unwrap(),
+                    0
+                );
+                put_buffer(host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"v1");
+                assert_eq!(
+                    host.js_crdt_shared_set(ID_DESC_PTR, VALUE_DESC_PTR)
+                        .unwrap(),
+                    1
+                );
+            }
+        );
+
+        // --- Bob: not a writer — cannot set, and writable_by_me is false. ---
+        shared_host!(
+            &mut storage,
+            &limits,
+            bob,
+            |host: &mut crate::logic::VMHostFunctions<'_>| {
+                put_buffer(host, ID_DESC_PTR, ID_DATA_PTR, &id);
+                assert_eq!(host.js_crdt_shared_writable_by_me(ID_DESC_PTR).unwrap(), 0);
+
+                put_buffer(host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"v2");
+                let res = host
+                    .js_crdt_shared_set(ID_DESC_PTR, VALUE_DESC_PTR)
+                    .unwrap();
+                assert_eq!(res, -1, "non-writer set must be rejected");
+                let msg = String::from_utf8(host.borrow_logic().registers.get(0).unwrap().to_vec())
+                    .unwrap();
+                // The `PermissionedStorage` API gate rejects first ("Action not
+                // allowed: Executor is not authorised …"), before the inner
+                // `WriterSetCell`'s writer-specific message.
+                assert!(
+                    msg.to_lowercase().contains("not allowed")
+                        || msg.to_lowercase().contains("authoris"),
+                    "error should signal an authorization failure, got: {msg}"
+                );
+
+                // The value is unchanged.
+                let reg = 1u64;
+                assert_eq!(host.js_crdt_shared_get(ID_DESC_PTR, reg).unwrap(), 1);
+                assert_eq!(host.borrow_logic().registers.get(reg).unwrap(), b"v1");
+            }
+        );
+
+        // --- Alice: rotate the writer set to add Bob. ---
+        shared_host!(
+            &mut storage,
+            &limits,
+            alice,
+            |host: &mut crate::logic::VMHostFunctions<'_>| {
+                put_buffer(host, ID_DESC_PTR, ID_DATA_PTR, &id);
+                put_buffer(
+                    host,
+                    WRITERS_DESC_PTR,
+                    WRITERS_DATA_PTR,
+                    &writers_buf(&[alice, bob]),
+                );
+                assert_eq!(
+                    host.js_crdt_shared_rotate_writers(ID_DESC_PTR, WRITERS_DESC_PTR)
+                        .unwrap(),
+                    1,
+                    "current writer may rotate"
+                );
+            }
+        );
+
+        // --- Bob: now a writer — can set. ---
+        shared_host!(
+            &mut storage,
+            &limits,
+            bob,
+            |host: &mut crate::logic::VMHostFunctions<'_>| {
+                put_buffer(host, ID_DESC_PTR, ID_DATA_PTR, &id);
+                assert_eq!(
+                    host.js_crdt_shared_writable_by_me(ID_DESC_PTR).unwrap(),
+                    1,
+                    "bob is a writer after rotation"
+                );
+                put_buffer(host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"v2");
+                assert_eq!(
+                    host.js_crdt_shared_set(ID_DESC_PTR, VALUE_DESC_PTR)
+                        .unwrap(),
+                    1,
+                    "new writer may set"
+                );
+                let reg = 1u64;
+                assert_eq!(host.js_crdt_shared_get(ID_DESC_PTR, reg).unwrap(), 1);
+                assert_eq!(host.borrow_logic().registers.get(reg).unwrap(), b"v2");
+            }
+        );
+    }
+
+    /// SharedStorage: a cell constructed `frozen` reports `is_frozen` and rejects
+    /// any writer-set rotation.
+    #[test]
+    fn test_js_crdt_shared_frozen_blocks_rotation() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let alice: [u8; 32] = [0xA1; 32];
+        let bob: [u8; 32] = [0xB0; 32];
+        let id: [u8; 32] = [0x53; 32];
+
+        shared_host!(
+            &mut storage,
+            &limits,
+            alice,
+            |host: &mut crate::logic::VMHostFunctions<'_>| {
+                put_buffer(host, ID_DESC_PTR, ID_DATA_PTR, &id);
+                put_buffer(
+                    host,
+                    WRITERS_DESC_PTR,
+                    WRITERS_DATA_PTR,
+                    &writers_buf(&[alice]),
+                );
+                // frozen = 1.
+                assert_eq!(
+                    host.js_crdt_shared_new_with_id(ID_DESC_PTR, WRITERS_DESC_PTR, 1, 1)
+                        .unwrap(),
+                    0
+                );
+                assert_eq!(host.js_crdt_shared_is_frozen(ID_DESC_PTR).unwrap(), 1);
+
+                put_buffer(
+                    host,
+                    WRITERS_DESC_PTR,
+                    WRITERS_DATA_PTR,
+                    &writers_buf(&[alice, bob]),
+                );
+                let res = host
+                    .js_crdt_shared_rotate_writers(ID_DESC_PTR, WRITERS_DESC_PTR)
+                    .unwrap();
+                assert_eq!(res, -1, "rotation on a frozen cell must fail");
+                let msg = String::from_utf8(host.borrow_logic().registers.get(0).unwrap().to_vec())
+                    .unwrap();
+                assert!(
+                    msg.to_lowercase().contains("frozen"),
+                    "error should mention frozen, got: {msg}"
+                );
+            }
+        );
+    }
+
+    /// A `*_new_with_id` constructor must place the shared cell at exactly the
+    /// caller-supplied id, and two handles built at the same id must address the
+    /// same storage entity (set via one, read via another).
+    #[test]
+    fn test_js_crdt_shared_new_with_id_is_deterministic_and_shared() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let alice: [u8; 32] = [0xA1; 32];
+        let id: [u8; 32] = [0x54; 32];
+
+        shared_host!(
+            &mut storage,
+            &limits,
+            alice,
+            |host: &mut crate::logic::VMHostFunctions<'_>| {
+                put_buffer(host, ID_DESC_PTR, ID_DATA_PTR, &id);
+                put_buffer(
+                    host,
+                    WRITERS_DESC_PTR,
+                    WRITERS_DATA_PTR,
+                    &writers_buf(&[alice]),
+                );
+
+                // First handle at the deterministic id.
+                let reg_a = 1u64;
+                assert_eq!(
+                    host.js_crdt_shared_new_with_id(ID_DESC_PTR, WRITERS_DESC_PTR, 0, reg_a)
+                        .unwrap(),
+                    0
+                );
+                assert_eq!(host.borrow_logic().registers.get(reg_a).unwrap(), &id);
+
+                // Second handle at the SAME id.
+                let reg_b = 2u64;
+                assert_eq!(
+                    host.js_crdt_shared_new_with_id(ID_DESC_PTR, WRITERS_DESC_PTR, 0, reg_b)
+                        .unwrap(),
+                    0
+                );
+                assert_eq!(host.borrow_logic().registers.get(reg_b).unwrap(), &id);
+
+                // Set through the id, then read back via the shared id.
+                put_buffer(host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"payload");
+                assert_eq!(
+                    host.js_crdt_shared_set(ID_DESC_PTR, VALUE_DESC_PTR)
+                        .unwrap(),
+                    1
+                );
+                let reg_c = 3u64;
+                assert_eq!(
+                    host.js_crdt_shared_get(ID_DESC_PTR, reg_c).unwrap(),
+                    1,
+                    "value must be found via the shared id"
+                );
+                assert_eq!(
+                    host.borrow_logic().registers.get(reg_c).unwrap(),
+                    b"payload"
+                );
+            }
         );
     }
 }

--- a/crates/runtime/src/logic/host_functions/js_collections.rs
+++ b/crates/runtime/src/logic/host_functions/js_collections.rs
@@ -3780,6 +3780,19 @@ impl VMHostFunctions<'_> {
     /// multiple of 32.
     fn read_writer_set(&mut self, ptr: u64) -> VMLogicResult<Result<Vec<[u8; 32]>, String>> {
         let bytes = self.read_buffer(ptr)?;
+        // Reject an empty writer set at the decode boundary. A cell created with
+        // no writers could never be written to, and `rotate_writers` refuses an
+        // empty set, so it could never be recovered — the cell would be bricked
+        // for good. This mirrors the guard `WriterSetCell::rotate_writers` already
+        // applies, closing the gap on the construction path (`shared_new` /
+        // `shared_new_with_id`) that goes through this same decode helper.
+        if bytes.is_empty() {
+            return Ok(Err(
+                "writer set must not be empty (a cell with no writers can never be \
+                 written to or recovered)"
+                    .to_string(),
+            ));
+        }
         if bytes.len() % PUBLIC_KEY_LEN != 0 {
             return Ok(Err(format!(
                 "writer set must be a concatenation of {}-byte keys (received {} bytes)",
@@ -5427,6 +5440,52 @@ mod tests {
                 let reg2 = 3u64;
                 assert_eq!(host.js_crdt_shared_writers(ID_DESC_PTR, reg2).unwrap(), 1);
                 assert_eq!(host.borrow_logic().registers.get(reg2).unwrap(), &alice);
+            }
+        );
+    }
+
+    /// A cell must not be constructible with an empty writer set: with no
+    /// writers, `set`/`rotate_writers` could never succeed (rotate refuses an
+    /// empty set), so the cell would be permanently bricked. Both constructors
+    /// decode the writer buffer via `read_writer_set`, which rejects it.
+    #[test]
+    fn test_js_crdt_shared_empty_writer_set_rejected() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let alice: [u8; 32] = [0xA1; 32];
+        let id: [u8; 32] = [0x52; 32];
+
+        shared_host!(
+            &mut storage,
+            &limits,
+            alice,
+            |host: &mut crate::logic::VMHostFunctions<'_>| {
+                put_buffer(host, ID_DESC_PTR, ID_DATA_PTR, &id);
+                // Empty writer buffer (zero keys).
+                put_buffer(host, WRITERS_DESC_PTR, WRITERS_DATA_PTR, &writers_buf(&[]));
+
+                // new_with_id must refuse and surface an error (-1), not brick a cell.
+                let reg = 1u64;
+                assert_eq!(
+                    host.js_crdt_shared_new_with_id(ID_DESC_PTR, WRITERS_DESC_PTR, 0, reg)
+                        .unwrap(),
+                    -1,
+                    "empty writer set must be rejected"
+                );
+                let message =
+                    String::from_utf8(host.borrow_logic().registers.get(reg).unwrap().to_vec())
+                        .unwrap();
+                assert!(
+                    message.to_lowercase().contains("empty"),
+                    "error should explain the empty writer set, got: {message}"
+                );
+
+                // The random-id constructor rejects it too.
+                assert_eq!(
+                    host.js_crdt_shared_new(WRITERS_DESC_PTR, 0, 2u64).unwrap(),
+                    -1,
+                    "empty writer set must be rejected by shared_new as well"
+                );
             }
         );
     }

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -202,6 +202,20 @@ impl VMLogic<'_> {
             fn js_crdt_authored_vector_iter(vector_id_ptr: u64, register_id: u64) -> i32;
             fn js_crdt_authored_vector_len(vector_id_ptr: u64, register_id: u64) -> i32;
 
+            fn js_crdt_shared_new(writers_ptr: u64, frozen: u32, register_id: u64) -> i32;
+            fn js_crdt_shared_new_with_id(
+                id_ptr: u64,
+                writers_ptr: u64,
+                frozen: u32,
+                register_id: u64,
+            ) -> i32;
+            fn js_crdt_shared_set(cell_id_ptr: u64, value_ptr: u64) -> i32;
+            fn js_crdt_shared_get(cell_id_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_shared_writers(cell_id_ptr: u64, register_id: u64) -> i32;
+            fn js_crdt_shared_writable_by_me(cell_id_ptr: u64) -> i32;
+            fn js_crdt_shared_is_frozen(cell_id_ptr: u64) -> i32;
+            fn js_crdt_shared_rotate_writers(cell_id_ptr: u64, writers_ptr: u64) -> i32;
+
             fn js_user_storage_new(register_id: u64) -> i32;
             fn js_user_storage_new_with_id(id_ptr: u64, register_id: u64) -> i32;
             fn js_user_storage_insert(

--- a/crates/storage/src/js.rs
+++ b/crates/storage/src/js.rs
@@ -4,13 +4,16 @@
 //! [`Data`](crate::entities::Data) trait so they can be persisted through the
 //! existing storage interface while being convenient to expose via FFI.
 
+use std::collections::BTreeSet;
+
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate as calimero_storage;
 use crate::collections::{
     error::StoreError, AuthoredMap, AuthoredVector, Counter as StorageCounter, FrozenStorage,
-    LwwRegister as StorageLwwRegister, ReplicatedGrowableArray, SortedMap as StorageSortedMap,
-    SortedSet as StorageSortedSet, UnorderedMap, UnorderedSet, UserStorage, Vector,
+    LwwRegister as StorageLwwRegister, Op, ReplicatedGrowableArray, SharedStorage,
+    SortedMap as StorageSortedMap, SortedSet as StorageSortedSet, UnorderedMap, UnorderedSet,
+    UserStorage, Vector,
 };
 use crate::entities::{Element, Metadata};
 use crate::store::MainStorage;
@@ -1673,6 +1676,155 @@ impl Default for JsAuthoredVector {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// The value type held inside a [`JsSharedStorage`].
+///
+/// `SharedStorage<T>` requires `T: Mergeable`, and a bare `Vec<u8>` is
+/// intentionally NOT `Mergeable` (primitive/byte types have no conflict-free
+/// merge rule). The byte value is therefore held in a last-write-wins register:
+/// concurrent writes from different writers converge deterministically by HLC
+/// timestamp. `Option` distinguishes "never written" (`None`) from a value that
+/// was explicitly set to the empty byte string (`Some(vec![])`).
+type SharedByteValue = StorageLwwRegister<Option<Vec<u8>>>;
+
+/// Group-writable single byte value with a rotatable writer set, exposed to
+/// JavaScript environments.
+///
+/// Wraps [`SharedStorage`] (`= PermissionedStorage<T, WriterSetAcl>`): any
+/// member of the writer set may read and [`set`](Self::set) the value, the
+/// writer set is rotatable by a current writer via
+/// [`rotate_writers`](Self::rotate_writers), and every write is verified at
+/// merge against the current set. A non-writer's `set`/`rotate_writers` is
+/// rejected with `ActionNotAllowed` at the API surface (and, authoritatively, at
+/// merge). The current executor identity is resolved from `env::executor_id()`,
+/// which the runtime installs per-execution — no identity argument is threaded
+/// through the byte API.
+///
+/// The byte value rides an LWW register (see [`SharedByteValue`]) so concurrent
+/// writes converge. OpMask per-writer capabilities and `SharedStorage<Collection>`
+/// nesting are intentionally NOT exposed here (deferred to a follow-up).
+#[derive(Debug, AtomicUnit, BorshSerialize, BorshDeserialize)]
+pub struct JsSharedStorage {
+    shared: SharedStorage<SharedByteValue>,
+
+    #[storage]
+    storage: Element,
+}
+
+impl JsSharedStorage {
+    /// Creates a new group-writable byte cell with the given initial writer set.
+    ///
+    /// `writers` are 32-byte public keys; `frozen` permanently rejects writer-set
+    /// rotation when `true` (genesis-immutable).
+    #[must_use]
+    pub fn new(writers: Vec<[u8; 32]>, frozen: bool) -> Self {
+        Self {
+            shared: SharedStorage::new(writer_set(writers), frozen),
+            storage: Element::new(None),
+        }
+    }
+
+    /// Rehydrates a shared byte cell using a known identifier.
+    ///
+    /// Mirrors the other `new_with_id` wrappers: the runtime persists the freshly
+    /// created instance immediately so subsequent loads succeed. Two handles
+    /// built at the same id address the same backing storage.
+    #[must_use]
+    pub fn new_with_id(id: Id, writers: Vec<[u8; 32]>, frozen: bool) -> Self {
+        Self {
+            shared: SharedStorage::new(writer_set(writers), frozen),
+            storage: Element::new(Some(id)),
+        }
+    }
+
+    /// Returns the unique identifier of this collection.
+    #[must_use]
+    pub fn id(&self) -> Id {
+        self.storage.id()
+    }
+
+    /// Replaces the value. The executor must be in the current writer set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] with `ActionNotAllowed` if the current executor is
+    /// not a writer, or any underlying storage error.
+    pub fn set(&mut self, value: &[u8]) -> Result<(), StoreError> {
+        self.storage.update();
+        let _previous = self
+            .shared
+            .insert(StorageLwwRegister::new(Some(value.to_vec())))?;
+        Ok(())
+    }
+
+    /// Returns the current value, or `None` if nothing has been written yet.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] when the underlying value read fails.
+    pub fn get(&self) -> Result<Option<Vec<u8>>, StoreError> {
+        Ok(self.shared.get()?.get().clone())
+    }
+
+    /// Returns the current writer set as 32-byte public keys.
+    #[must_use]
+    pub fn writers(&self) -> Vec<[u8; 32]> {
+        self.shared
+            .writers()
+            .into_iter()
+            .map(|pk| *pk.as_ref())
+            .collect()
+    }
+
+    /// Returns whether the current executor is in the writer set (may `set`).
+    #[must_use]
+    pub fn writable_by_me(&self) -> bool {
+        let me: PublicKey = crate::env::executor_id().into();
+        self.shared.can(&me, Op::Write)
+    }
+
+    /// Returns whether the writer set is frozen (rotation permanently rejected).
+    #[must_use]
+    pub fn is_frozen(&self) -> bool {
+        self.shared.is_frozen()
+    }
+
+    /// Rotates the writer set. Must be called by a current writer; rejected if
+    /// frozen or if `writers` is empty. Authenticated at merge.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] with `ActionNotAllowed` if frozen, if `writers` is
+    /// empty, or if the current executor is not a current writer.
+    pub fn rotate_writers(&mut self, writers: Vec<[u8; 32]>) -> Result<(), StoreError> {
+        self.storage.update();
+        self.shared.rotate_writers(writer_set(writers))
+    }
+
+    /// Persists the shared cell using the provided interface.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] produced by the storage interface.
+    pub fn save(&mut self) -> Result<bool, StorageError> {
+        Interface::<MainStorage>::save(self)
+    }
+
+    /// Loads a shared cell by identifier using the provided interface.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] if the shared cell cannot be fetched from storage.
+    pub fn load(id: Id) -> Result<Option<Self>, StorageError> {
+        Interface::<MainStorage>::find_by_id::<Self>(id)
+    }
+}
+
+/// Decodes a list of 32-byte public keys into the `BTreeSet<PublicKey>` the
+/// writer-set constructors take.
+fn writer_set(writers: Vec<[u8; 32]>) -> BTreeSet<PublicKey> {
+    writers.into_iter().map(PublicKey::from).collect()
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]


### PR DESCRIPTION
Adds the host-fn bridge for **SharedStorage** — a group-writable single byte value guarded by a rotatable **writer set** — so the JS Service SDK can wrap it. Phase 2b of the JS CRDT-type expansion after #3318 (PNCounter/RGA/SortedMap/SortedSet) and #3321 (AuthoredMap/AuthoredVector).

## What's added

**`JsSharedStorage` wrapper** (`crates/storage/src/js.rs`) over `SharedStorage<LwwRegister<Option<Vec<u8>>>>`.
- A bare `Vec<u8>` is intentionally **not** `Mergeable` (primitives have no conflict-free merge rule), so the byte value rides a last-write-wins register: concurrent writes from different writers converge deterministically by HLC timestamp. `Option` distinguishes never-written (`None`) from an explicit empty value.
- Byte-oriented delegates: `set`, `get`, `writers`, `writable_by_me`, `is_frozen`, `rotate_writers`, plus `new`/`new_with_id`/`id`/`save`/`load`.

**Host functions** (`js_collections.rs` + `imports.rs`):

| Function | Signature |
|---|---|
| `js_crdt_shared_new` | `(writers_ptr, frozen: u32, register_id) -> i32` |
| `js_crdt_shared_new_with_id` | `(id_ptr, writers_ptr, frozen: u32, register_id) -> i32` |
| `js_crdt_shared_set` | `(cell_id_ptr, value_ptr) -> i32` |
| `js_crdt_shared_get` | `(cell_id_ptr, register_id) -> i32` |
| `js_crdt_shared_writers` | `(cell_id_ptr, register_id) -> i32` |
| `js_crdt_shared_writable_by_me` | `(cell_id_ptr) -> i32` |
| `js_crdt_shared_is_frozen` | `(cell_id_ptr) -> i32` |
| `js_crdt_shared_rotate_writers` | `(cell_id_ptr, writers_ptr) -> i32` |

- **Writer sets cross the ABI as concatenated 32-byte public keys** (`count * 32` bytes in; `js_crdt_shared_writers` emits the same encoding, decode `len / 32`).
- `set`/`rotate_writers` are **writer-gated**: a non-writer (or a frozen/empty rotation) is rejected with `-1` and an `ActionNotAllowed` message in register `0`, mirroring the authored owner-only ops. The authoritative check remains the merge-time signature verification.
- `CrdtType::SharedStorage` (tag 11) already exists and is `is_special_storage`; the byte-value case needed no extra `RotationLog`/`SharedMember` wiring — rotation persistence rides the existing storage machinery.

**Merge-mode finding:** unlike the `JsRga` fix, no typed-error guard is needed. The only node-local HLC stamping happens in `LwwRegister::new`/`set`, which already zero the timestamp under `env::in_merge_mode()` (deterministic, no `panic!`), and host functions run during app execution, not sync-apply.

## Tests (`js_collections.rs` harness)

- set→get round-trip by a writer; `writers()` returns the initial set; `writable_by_me`/`is_frozen` reflect state.
- non-writer `set` rejected (`ActionNotAllowed`), `writable_by_me` false — via a second VM with a different `executor_public_key` over the same backing storage.
- `rotate_writers` adds a writer, after which the new writer can `set`.
- frozen cell blocks rotation.
- `new_with_id` determinism/shared-backing check.

## Verify

`cargo fmt --check`, `cargo clippy -p calimero-runtime -p calimero-storage -- -D warnings`, `cargo test -p calimero-runtime` / `-p calimero-storage`, and `cargo check -p calimero-node` all pass.

## Deferred (out of scope, documented)

- **OpMask per-writer capabilities** (`grant_capability`/`revoke_capability`/`rotate_writers_scoped`).
- **`SharedStorage<Collection>` nesting** (group-writable map/set/vector rather than a single byte value).

JS wrappers land in a follow-up. Refs calimero-network/calimero-sdk-js#83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)