### PR TITLE
feat(cargo-mero): add --features to build and bundle

### DIFF
--- a/docs/src/content/docs/build/cargo-mero.mdx
+++ b/docs/src/content/docs/build/cargo-mero.mdx
@@ -137,6 +137,34 @@ meroctl app install --path dist/<package>.mpk ...   # 5. install on a node (mero
 
 </Steps>
 
+## Cargo features
+
+`build` and `bundle` take cargo's feature flags, spelled the way cargo spells them - comma or space separated, repeatable:
+
+```bash
+cargo mero build --features schema_v2
+cargo mero bundle --dev --features "schema_v2 telemetry" --no-default-features
+```
+
+They reach `cargo build` and the `cargo metadata` call the ABI is emitted against, so the embedded `calimero_abi_v1` section always describes the schema the bytecode was compiled with.
+That pairing is the point: a wasm and an ABI that disagree do not fail the build, they produce a wrong migration plan at upgrade time, because the node resolves upgrades from the embedded section alone.
+
+Features gate **top-level items**, which is how one crate carries two schema versions:
+
+```rust
+#[cfg(not(feature = "schema_v2"))]
+#[app::state(version = 1)]
+pub struct State { /* ... */ }
+
+#[cfg(feature = "schema_v2")]
+#[app::state(version = 2)]
+pub struct StateV2 { /* ... */ }
+```
+
+A `#[cfg]` on a struct field, an enum variant, or a method inside an `#[app::logic]` block is *not* applied to the ABI, so express a variant as whole gated items rather than gated members.
+
+In a multi-service workspace all services compile in one `cargo build`, so a feature only one service declares is fine: it applies to that service and is ignored by the rest.
+
 ## Metadata reference
 
 Bundle metadata comes from a `[package.metadata.calimero]` table in the app's `Cargo.toml`.

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -77,6 +77,8 @@ cargo-mero/
 - The `tests/pipeline.rs` end-to-end tests are all `#[ignore]`d because they scaffold and compile fresh crates (slow, and `new_build_test_bundle_ladder` needs network for the git SDK deps). Run them with `cargo test -p cargo-mero -- --ignored`.
 - Bumping the scaffolded SDK version touches two files in lockstep: `DEFAULT_SDK_VERSION` in `src/main.rs` and the version assertions in `src/new.rs` tests.
 - `services` is a workspace-only key: it is rejected under a `[package.metadata.calimero]` table, only accepted under `[workspace.metadata.calimero]`.
+- `--features` is resolved once and used for both the compile and the ABI emit (`workspace::FeatureArgs` feeds `cargo build` and `cargo metadata`). Keep them together: a wasm and an embedded ABI that disagree fail silently, as a wrong migration plan.
+- The ABI emitter cfg-filters top-level items only. A `#[cfg]` on a struct field, enum variant, or `#[app::logic]` method still lands in the ABI.
 
 ## merodb - Database Tool
 

--- a/tools/cargo-mero/README.md
+++ b/tools/cargo-mero/README.md
@@ -58,6 +58,34 @@ See [SIGNING.md](SIGNING.md).
 Installs the bundle on a running `merod` node.
 The node derives the `ApplicationId` from the bundle's `package` and signer (see [SIGNING.md](SIGNING.md)).
 
+## Cargo features
+
+`build` and `bundle` take cargo's feature flags, spelled the way cargo spells them - comma or space separated, repeatable:
+
+```bash
+cargo mero build --features schema_v2
+cargo mero bundle --dev --features "schema_v2 telemetry" --no-default-features
+```
+
+They reach `cargo build` and the `cargo metadata` call the ABI is emitted against, so the embedded `calimero_abi_v1` section always describes the schema the bytecode was compiled with.
+That pairing is the point: a wasm and an ABI that disagree do not fail the build, they produce a wrong migration plan at upgrade time, because the node resolves upgrades from the embedded section alone.
+
+Features gate **top-level items**, which is how one crate carries two schema versions:
+
+```rust
+#[cfg(not(feature = "schema_v2"))]
+#[app::state(version = 1)]
+pub struct State { /* ... */ }
+
+#[cfg(feature = "schema_v2")]
+#[app::state(version = 2)]
+pub struct StateV2 { /* ... */ }
+```
+
+A `#[cfg]` on a struct field, an enum variant, or a method inside an `#[app::logic]` block is *not* applied to the ABI, so express a variant as whole gated items rather than gated members.
+
+In a multi-service workspace all services compile in one `cargo build`, so a feature only one service declares is fine: it applies to that service and is ignored by the rest.
+
 ## Metadata reference
 
 Bundle metadata comes from a `[package.metadata.calimero]` table in the app's `Cargo.toml` (or `[workspace.metadata.calimero]` for a multi-service workspace).

--- a/tools/cargo-mero/src/build.rs
+++ b/tools/cargo-mero/src/build.rs
@@ -45,7 +45,7 @@ pub fn run_all(args: &BuildArgs) -> Result<Vec<BuiltWasm>> {
 }
 
 fn run_inner(args: &BuildArgs, all_services: bool) -> Result<Vec<BuiltWasm>> {
-    let metadata = workspace::metadata_for(args.manifest_path.as_deref())?;
+    let metadata = workspace::metadata_for(args.manifest_path.as_deref(), &args.features)?;
 
     let profiling =
         args.profiling || matches!(std::env::var("WASM_PROFILING").as_deref(), Ok("true"));
@@ -59,9 +59,11 @@ fn run_inner(args: &BuildArgs, all_services: bool) -> Result<Vec<BuiltWasm>> {
     ensure_wasm_target()?;
     ensure_profile(&metadata.workspace_root, profile)?;
 
+    cargo_build(&targets, profile, args)?;
+
     let mut built = Vec::with_capacity(targets.len());
     for target in targets {
-        built.push(build_one(&metadata, &target, profile, !profiling, args)?);
+        built.push(build_one(&metadata, &target, profile, !profiling)?);
     }
     Ok(built)
 }
@@ -380,13 +382,9 @@ fn build_one(
     target: &Target,
     profile: &str,
     optimize: bool,
-    args: &BuildArgs,
 ) -> Result<BuiltWasm> {
     let crate_name = &target.crate_name;
     let underscored = crate_name.replace('-', "_");
-
-    println!("• building {crate_name} (--profile {profile})");
-    cargo_build(crate_name, profile, args)?;
 
     let artifact = metadata
         .target_directory
@@ -457,18 +455,21 @@ fn canonicalize_abi(manifest: &mut serde_json::Value) {
     }
 }
 
-fn cargo_build(crate_name: &str, profile: &str, args: &BuildArgs) -> Result<()> {
+/// Compile every target in one invocation. Cargo rejects a plain `--features`
+/// naming a feature the one selected package lacks, but accepts it whenever some
+/// selected package has it - and a multi-service workspace routinely gates only
+/// one service's schema.
+fn cargo_build(targets: &[Target], profile: &str, args: &BuildArgs) -> Result<()> {
+    let names: Vec<&str> = targets.iter().map(|t| t.crate_name.as_str()).collect();
+    println!("• building {} (--profile {profile})", names.join(", "));
+
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
     let mut cmd = Command::new(cargo);
-    cmd.args([
-        "build",
-        "--target",
-        TARGET,
-        "--profile",
-        profile,
-        "-p",
-        crate_name,
-    ]);
+    cmd.args(["build", "--target", TARGET, "--profile", profile]);
+    for name in &names {
+        cmd.args(["-p", name]);
+    }
+    args.features.apply_to(&mut cmd);
     if let Some(mp) = &args.manifest_path {
         cmd.arg("--manifest-path").arg(mp);
     }
@@ -476,7 +477,7 @@ fn cargo_build(crate_name: &str, profile: &str, args: &BuildArgs) -> Result<()> 
 
     let status = cmd.status().wrap_err("failed to spawn `cargo build`")?;
     if !status.success() {
-        bail!("`cargo build` failed for `{crate_name}`");
+        bail!("`cargo build` failed for `{}`", names.join(", "));
     }
     Ok(())
 }
@@ -576,22 +577,59 @@ mod tests {
     "#;
 
     /// Write `sources` into `<root>/src` and emit into `<root>/res`.
-    fn emit_into(root: &Utf8PathBuf, sources: &[(&str, &str)]) -> Utf8PathBuf {
+    fn emit_into(
+        root: &Utf8PathBuf,
+        sources: &[(&str, &str)],
+        features: &BTreeSet<String>,
+    ) -> Utf8PathBuf {
         std::fs::create_dir_all(root.join("src")).unwrap();
         for (name, body) in sources {
             std::fs::write(root.join("src").join(name), body).unwrap();
         }
         let res = root.join("res");
         std::fs::create_dir_all(&res).unwrap();
-        emit_abi(root, &res, &BTreeSet::new()).expect("emit_abi");
+        emit_abi(root, &res, features).expect("emit_abi");
         res
+    }
+
+    /// A `#[cfg(feature)]`-gated state root must reach the ABI only when that
+    /// feature is active: `--features` picks the schema the wasm is compiled
+    /// with, and the embedded ABI has to describe that same schema.
+    #[test]
+    fn emit_abi_follows_the_active_feature_set() {
+        const VERSIONED_APP: &str = r#"
+            #[cfg(not(feature = "schema_v2"))]
+            #[app::state(version = 1)]
+            pub struct State { x: u32 }
+            #[cfg(feature = "schema_v2")]
+            #[app::state(version = 2)]
+            pub struct StateV2 { x: u32, y: u32 }
+            #[app::logic]
+            impl State {
+                #[app::init] pub fn init() -> State { State { x: 0 } }
+            }
+        "#;
+
+        let state_root = |features: &BTreeSet<String>| {
+            let tmp = tempfile::tempdir().unwrap();
+            let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+            let res = emit_into(&root, &[("lib.rs", VERSIONED_APP)], features);
+            let schema: serde_json::Value =
+                serde_json::from_slice(&std::fs::read(res.join("state-schema.json")).unwrap())
+                    .unwrap();
+            schema["state_root"].as_str().unwrap().to_owned()
+        };
+
+        assert_eq!(state_root(&BTreeSet::new()), "State");
+        let on: BTreeSet<String> = ["schema_v2".to_owned()].into_iter().collect();
+        assert_eq!(state_root(&on), "StateV2");
     }
 
     #[test]
     fn emit_abi_writes_both_artifacts() {
         let tmp = tempfile::tempdir().unwrap();
         let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
-        let res = emit_into(&root, &[("lib.rs", MINIMAL_APP)]);
+        let res = emit_into(&root, &[("lib.rs", MINIMAL_APP)], &BTreeSet::new());
 
         let abi: serde_json::Value =
             serde_json::from_slice(&std::fs::read(res.join("abi.json")).unwrap()).unwrap();

--- a/tools/cargo-mero/src/bundle.rs
+++ b/tools/cargo-mero/src/bundle.rs
@@ -32,7 +32,7 @@ pub fn run(args: &BundleArgs) -> Result<PathBuf> {
     // Resolve signing first: a missing or bad key must fail before a long build.
     let sign_mode = resolve_sign_mode(args)?;
 
-    let metadata = workspace::metadata_for(args.manifest_path.as_deref())?;
+    let metadata = workspace::metadata_for(args.manifest_path.as_deref(), &args.features)?;
     let base = base_dir(&metadata, args);
     let bundle_meta = resolve_meta(&metadata, &base, args)?;
 
@@ -42,6 +42,7 @@ pub fn run(args: &BundleArgs) -> Result<PathBuf> {
         profiling: args.profiling,
         package: None,
         manifest_path: args.manifest_path.clone(),
+        features: args.features.clone(),
     })?;
 
     let staging = prepare_staging(&base)?;

--- a/tools/cargo-mero/src/main.rs
+++ b/tools/cargo-mero/src/main.rs
@@ -82,6 +82,9 @@ struct BuildArgs {
     /// Path to the app's Cargo.toml
     #[arg(long)]
     manifest_path: Option<Utf8PathBuf>,
+
+    #[command(flatten)]
+    features: workspace::FeatureArgs,
 }
 
 #[derive(clap::Args)]
@@ -126,6 +129,9 @@ struct BundleArgs {
     /// Path to the app's Cargo.toml
     #[arg(long)]
     manifest_path: Option<Utf8PathBuf>,
+
+    #[command(flatten)]
+    features: workspace::FeatureArgs,
 }
 
 // These mirror the standalone mero-abi / mero-sign binaries rather than sharing
@@ -335,6 +341,26 @@ mod tests {
             "Cargo.toml"
         ])
         .is_ok());
+    }
+
+    #[test]
+    fn feature_flags_parse_on_both_build_and_bundle() {
+        // Cargo's own spelling: comma or space separated, and repeatable.
+        for cmd in ["build", "bundle"] {
+            assert!(Cargo::try_parse_from(["cargo", "mero", cmd, "--features", "a,b"]).is_ok());
+            assert!(Cargo::try_parse_from(["cargo", "mero", cmd, "--features", "a b"]).is_ok());
+            assert!(Cargo::try_parse_from([
+                "cargo",
+                "mero",
+                cmd,
+                "--features",
+                "a",
+                "--features",
+                "b",
+                "--no-default-features"
+            ])
+            .is_ok());
+        }
     }
 
     #[test]

--- a/tools/cargo-mero/src/test_cmd.rs
+++ b/tools/cargo-mero/src/test_cmd.rs
@@ -46,7 +46,10 @@ fn assemble_cargo_test_args(manifest_path: Option<&Utf8Path>, user_args: &[Strin
 /// Best-effort warning, never blocks: a missing `testing` feature means the
 /// TestHost tests won't build, but `cargo test` will say so loudly on its own.
 fn preflight(args: &TestArgs) {
-    if let Ok(metadata) = workspace::metadata_for(args.manifest_path.as_deref()) {
+    // Default features: this only inspects dev-dependencies, which no feature
+    // selection changes.
+    let features = workspace::FeatureArgs::default();
+    if let Ok(metadata) = workspace::metadata_for(args.manifest_path.as_deref(), &features) {
         if let Some(hint) = missing_testing_feature(&metadata, args.manifest_path.as_deref()) {
             eprintln!("warning: {hint}");
         }

--- a/tools/cargo-mero/src/workspace.rs
+++ b/tools/cargo-mero/src/workspace.rs
@@ -83,7 +83,60 @@ fn canonical(dir: &Utf8Path) -> Utf8PathBuf {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use super::*;
+
+    /// `--features` and `--no-default-features` must both reach `cargo metadata`.
+    /// They are independent knobs on `MetadataCommand`, so neither can drop the
+    /// other; if one did, the ABI would be emitted for a different feature set
+    /// than the wasm is compiled with.
+    #[test]
+    fn metadata_applies_features_and_no_default_features_together() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = Utf8Path::from_path(tmp.path()).unwrap();
+        std::fs::create_dir(dir.join("src")).unwrap();
+        std::fs::write(dir.join("src/lib.rs"), "").unwrap();
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            "[package]\nname = \"feature-probe\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\
+             \n[features]\ndefault = [\"baseline\"]\nbaseline = []\nschema_v2 = []\n\n[workspace]\n",
+        )
+        .unwrap();
+        let manifest = dir.join("Cargo.toml");
+
+        let resolved = |args: &FeatureArgs| {
+            let metadata = metadata_for(Some(&manifest), args).expect("cargo metadata");
+            let pkg = metadata
+                .packages
+                .iter()
+                .find(|p| p.name.as_str() == "feature-probe")
+                .unwrap();
+            let resolve = metadata.resolve.as_ref().unwrap();
+            let node = resolve.nodes.iter().find(|n| n.id == pkg.id).unwrap();
+            node.features
+                .iter()
+                .map(ToString::to_string)
+                .collect::<BTreeSet<_>>()
+        };
+
+        let defaults = resolved(&FeatureArgs::default());
+        assert!(defaults.contains("default"), "got {defaults:?}");
+        assert!(!defaults.contains("schema_v2"), "got {defaults:?}");
+
+        let both = resolved(&FeatureArgs {
+            features: vec!["schema_v2".to_owned()],
+            no_default_features: true,
+        });
+        assert!(
+            both.contains("schema_v2"),
+            "--no-default-features must not drop --features, got {both:?}"
+        );
+        assert!(
+            !both.contains("default") && !both.contains("baseline"),
+            "--features must not drop --no-default-features, got {both:?}"
+        );
+    }
 
     #[test]
     fn manifest_dir_resolves_a_noncanonical_path() {

--- a/tools/cargo-mero/src/workspace.rs
+++ b/tools/cargo-mero/src/workspace.rs
@@ -2,14 +2,50 @@
 //! directory. The `[metadata.calimero]` schema itself lives in `meta`.
 
 use camino::{Utf8Path, Utf8PathBuf};
-use cargo_metadata::{Metadata, MetadataCommand, Package};
+use cargo_metadata::{CargoOpt, Metadata, MetadataCommand, Package};
 use eyre::{Context, Result};
 
-/// Run `cargo metadata`, scoped to `manifest_path` when given.
-pub fn metadata_for(manifest_path: Option<&Utf8Path>) -> Result<Metadata> {
+/// Cargo's feature-selection flags, shared by `build` and `bundle`.
+///
+/// They must reach `cargo metadata` as well as `cargo build`: the ABI is emitted
+/// against the resolve graph, so a build-only flag would embed an ABI describing
+/// a different schema than the bytecode it ships with.
+#[derive(clap::Args, Clone, Default)]
+pub struct FeatureArgs {
+    /// Cargo features to activate, comma or space separated (repeatable)
+    #[arg(long, value_name = "FEATURES")]
+    features: Vec<String>,
+
+    /// Do not activate the `default` feature
+    #[arg(long)]
+    no_default_features: bool,
+}
+
+impl FeatureArgs {
+    /// Spell these flags onto a `cargo` command line. Values pass through
+    /// verbatim; cargo itself splits them on commas and spaces.
+    pub fn apply_to(&self, cmd: &mut std::process::Command) {
+        for features in &self.features {
+            cmd.arg("--features").arg(features);
+        }
+        if self.no_default_features {
+            cmd.arg("--no-default-features");
+        }
+    }
+}
+
+/// Run `cargo metadata`, scoped to `manifest_path` when given and resolved
+/// against the same features the build will use.
+pub fn metadata_for(manifest_path: Option<&Utf8Path>, features: &FeatureArgs) -> Result<Metadata> {
     let mut cmd = MetadataCommand::new();
     if let Some(path) = manifest_path {
         let _ = cmd.manifest_path(path);
+    }
+    if !features.features.is_empty() {
+        let _ = cmd.features(CargoOpt::SomeFeatures(features.features.clone()));
+    }
+    if features.no_default_features {
+        let _ = cmd.features(CargoOpt::NoDefaultFeatures);
     }
     cmd.exec().wrap_err("failed to run `cargo metadata`")
 }

--- a/tools/cargo-mero/tests/fixtures/multi-app/crates/svc-a/Cargo.toml
+++ b/tools/cargo-mero/tests/fixtures/multi-app/crates/svc-a/Cargo.toml
@@ -9,6 +9,11 @@ edition.workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+# svc-b deliberately does NOT declare this: `--features schema_v2` has to build
+# the whole workspace anyway.
+schema_v2 = []
+
 [dependencies]
 calimero-sdk = { path = "../../../../../../../crates/sdk" }
 calimero-storage = { path = "../../../../../../../crates/storage" }

--- a/tools/cargo-mero/tests/fixtures/multi-app/crates/svc-a/src/lib.rs
+++ b/tools/cargo-mero/tests/fixtures/multi-app/crates/svc-a/src/lib.rs
@@ -1,11 +1,13 @@
 use calimero_sdk::app;
 use calimero_storage::collections::{LwwRegister, UnorderedMap};
 
+#[cfg(not(feature = "schema_v2"))]
 #[app::state]
 pub struct SvcA {
     items: UnorderedMap<String, LwwRegister<String>>,
 }
 
+#[cfg(not(feature = "schema_v2"))]
 #[app::logic]
 impl SvcA {
     #[app::init]
@@ -22,5 +24,39 @@ impl SvcA {
 
     pub fn get(&self, key: &str) -> app::Result<Option<String>> {
         Ok(self.items.get(key)?.map(|v| v.get().clone()))
+    }
+}
+
+/// Alternate schema behind `schema_v2`, mirroring how a real app expresses a
+/// migration target: a distinct state root plus a method only this version has.
+#[cfg(feature = "schema_v2")]
+#[app::state]
+pub struct SvcAV2 {
+    items: UnorderedMap<String, LwwRegister<String>>,
+    revision: LwwRegister<u64>,
+}
+
+#[cfg(feature = "schema_v2")]
+#[app::logic]
+impl SvcAV2 {
+    #[app::init]
+    pub fn init() -> SvcAV2 {
+        SvcAV2 {
+            items: UnorderedMap::new(),
+            revision: LwwRegister::new(0),
+        }
+    }
+
+    pub fn set(&mut self, key: String, value: String) -> app::Result<()> {
+        self.items.insert(key, value.into())?;
+        Ok(())
+    }
+
+    pub fn get(&self, key: &str) -> app::Result<Option<String>> {
+        Ok(self.items.get(key)?.map(|v| v.get().clone()))
+    }
+
+    pub fn revision(&self) -> app::Result<u64> {
+        Ok(*self.revision.get())
     }
 }

--- a/tools/cargo-mero/tests/pipeline.rs
+++ b/tools/cargo-mero/tests/pipeline.rs
@@ -48,6 +48,71 @@ fn new_build_test_bundle_ladder() {
     assert!(mpk.exists(), "expected bundle at {}", mpk.display());
 }
 
+/// The `calimero_abi_v1` section read back off the built wasm - the only copy
+/// the node consults when it resolves a migration plan.
+fn embedded_abi(wasm_path: &Path) -> serde_json::Value {
+    let wasm = std::fs::read(wasm_path).unwrap();
+    let section = wasmparser::Parser::new(0)
+        .parse_all(&wasm)
+        .filter_map(Result::ok)
+        .find_map(|p| match p {
+            wasmparser::Payload::CustomSection(s) if s.name() == "calimero_abi_v1" => {
+                Some(s.data().to_vec())
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("{} must carry calimero_abi_v1", wasm_path.display()));
+    serde_json::from_slice(&section).expect("calimero_abi_v1 section must be valid JSON")
+}
+
+/// The wasm's exported function names, i.e. what the bytecode actually offers.
+fn wasm_exports(wasm_path: &Path) -> Vec<String> {
+    let wasm = std::fs::read(wasm_path).unwrap();
+    wasmparser::Parser::new(0)
+        .parse_all(&wasm)
+        .filter_map(Result::ok)
+        .filter_map(|p| match p {
+            wasmparser::Payload::ExportSection(s) => Some(s),
+            _ => None,
+        })
+        .flat_map(|s| s.into_iter().filter_map(Result::ok))
+        .map(|e| e.name.to_owned())
+        .collect()
+}
+
+/// `--features` has to reach the compile AND the ABI emit, or the bundle ships
+/// bytecode and a `calimero_abi_v1` section that describe different schemas -
+/// which surfaces as a silently wrong migration plan, not a build error.
+#[test]
+#[ignore = "slow: compiles the fixture services twice"]
+fn features_select_the_same_schema_in_the_wasm_and_the_embedded_abi() {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/multi-app");
+    let build = |extra: &[&str]| {
+        let status = Command::new(env!("CARGO_BIN_EXE_cargo-mero"))
+            .args(["mero", "build"])
+            .args(extra)
+            .current_dir(&fixture)
+            .status()
+            .unwrap();
+        assert!(status.success(), "cargo mero build {extra:?} failed");
+    };
+    let svc_a = fixture.join("crates/svc-a/res/svc_a.wasm");
+    let svc_b = fixture.join("crates/svc-b/res/svc_b.wasm");
+
+    build(&["--features", "schema_v2"]);
+    assert_eq!(embedded_abi(&svc_a)["state_root"], "SvcAV2");
+    assert!(
+        wasm_exports(&svc_a).contains(&"revision".to_owned()),
+        "the wasm itself must be the v2 build, not just its ABI"
+    );
+    // svc-b does not declare `schema_v2`, and must still be built and embedded.
+    assert_eq!(embedded_abi(&svc_b)["state_root"], "SvcB");
+
+    build(&[]);
+    assert_eq!(embedded_abi(&svc_a)["state_root"], "SvcA");
+    assert!(!wasm_exports(&svc_a).contains(&"revision".to_owned()));
+}
+
 #[test]
 #[ignore = "slow: compiles the fixture app"]
 fn build_produces_embedded_abi_wasm() {
@@ -59,22 +124,9 @@ fn build_produces_embedded_abi_wasm() {
         .unwrap();
     assert!(status.success());
 
-    let wasm = std::fs::read(fixture.join("res/demo_app.wasm")).unwrap();
-    let section = wasmparser::Parser::new(0)
-        .parse_all(&wasm)
-        .filter_map(Result::ok)
-        .find_map(|p| match p {
-            wasmparser::Payload::CustomSection(s) if s.name() == "calimero_abi_v1" => {
-                Some(s.data().to_vec())
-            }
-            _ => None,
-        })
-        .expect("built wasm must carry calimero_abi_v1");
-
     // A non-empty `methods` array proves the full ABI was embedded, and that
     // canonicalization ran: the fixture's methods are declared unsorted.
-    let manifest: serde_json::Value =
-        serde_json::from_slice(&section).expect("calimero_abi_v1 section must be valid JSON");
+    let manifest = embedded_abi(&fixture.join("res/demo_app.wasm"));
     let methods = manifest["methods"]
         .as_array()
         .expect("embedded ABI must have a methods array");


### PR DESCRIPTION
## Summary

`cargo mero` could not build an app with non-default cargo features, so an app that selects a schema variant that way (a v2 migration-target bundle, say) had to stay on a hand-rolled `build-bundle.sh`.

The ABI emitter was already feature-aware: `resolved_features()` reads the activated set out of `cargo_metadata`'s resolve graph, and `crate_sources` / `emit_abi` gate items on it via `item_cfg_active`. The gap was narrower than it looks: nothing ever passed `--features`, so cargo resolved defaults, and the compile and the ABI were *consistently* wrong. Nothing failed loudly.

Changes:

- `--features <FEATURES>` and `--no-default-features` on `build` and `bundle`, spelled the way cargo spells them (comma or space separated, repeatable). They live in one `workspace::FeatureArgs` that both commands flatten in, so the two cannot drift apart.
- Forwarded to `cargo build`, so the wasm is actually compiled with them.
- Forwarded to `cargo metadata`, so `resolved_features()` reports the same set the build used and the emitted ABI describes the same schema as the bytecode.
- Services now compile in a single `cargo build` invocation. Cargo rejects a plain `--features` naming a feature the one selected package lacks, but accepts it when several packages are selected, and a multi-service workspace routinely gates only one service's schema.
- `bundle` passes its features into `build::run_all`, so multi-service bundles honour the flag.

`--all-features` was left out: nothing needs it, and it is trivial to add later.

### Why the two must be resolved together

This is the whole point of the change rather than an implementation detail. If the compile enables `schema_v2` but the ABI is emitted from the default resolve graph, the bundle ships bytecode and an ABI that disagree. That is not a build error. The node resolves migration plans from the embedded `calimero_abi_v1` section alone, so the failure surfaces as a silently wrong migration at upgrade time.

### Known limitation, documented not changed

The emitter cfg-filters **top-level items only** (`file.items.retain(item_cfg_active)`). A `#[cfg]` on a struct field, an enum variant, or a method inside an `#[app::logic]` block is not applied to the ABI. That predates this change and is unaffected by it, but it now matters to anyone reaching for `--features`, so it is called out in the README, the docs site page, and `tools/AGENTS.md`. Express a schema variant as whole gated items.

## Test plan

**Unit** - `build::tests::emit_abi_follows_the_active_feature_set`: a `#[cfg(feature)]`-gated `#[app::state]` reaches the emitted state schema only when its feature is active (`State` vs `StateV2`).

**CLI** - `feature_flags_parse_on_both_build_and_bundle`: `--features a,b`, `--features "a b"`, repeated `--features`, and `--no-default-features`, on both subcommands.

**End to end** - `features_select_the_same_schema_in_the_wasm_and_the_embedded_abi` (in `tests/pipeline.rs`, which CI runs via `--ignored`). The `multi-app` fixture's `svc-a` gained a `schema_v2` variant; `svc-b` deliberately does not declare the feature. The test builds both ways and asserts against the wasm itself, not the emitter:

- reads the `calimero_abi_v1` custom section back off the built wasm and asserts `state_root` is `SvcAV2` with the feature and `SvcA` without it
- asserts the wasm's **export section** contains `revision` (a v2-only method) with the feature and not without, which is what catches the ABI moving while the bytecode does not
- asserts `svc-b` still builds and embeds, proving a feature only one service declares does not break the others

Both halves were verified to be real gates by breaking each in turn:

| break | result |
| --- | --- |
| drop `features.apply_to(&mut cmd)` in `cargo_build` (ABI moves, wasm does not) | fails at the `revision` export assertion |
| drop `CargoOpt::SomeFeatures` in `metadata_for` (wasm moves, ABI does not) | fails `left: "SvcA"` vs `right: "SvcAV2"` |

**Against the real motivating case** - built a multi-service app's docs service both ways with the new flag and diffed the embedded section read back out of each wasm:

```
+  "migrations": [ { "fromVersion": 1, "method": "migrate_v1_to_v2" } ],
-  "state_version": 1,
+  "state_version": 2,
+  { "name": "default_sort_order", "type": { "crdt_type": "lww_register", ... } }
```

The bytecode differs too (583038 vs 588229 bytes), so the wasm and its ABI moved together.

**Gates**

```
cargo fmt --check
cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings
cargo test -p cargo-mero                 # 55 passed
cargo check --workspace --all-targets
```