### PR TITLE
feat(runtime): js_crdt_delete_collection host fn for orphan cleanup

### DIFF
--- a/crates/runtime/HOST_FUNCTIONS.md
+++ b/crates/runtime/HOST_FUNCTIONS.md
@@ -366,6 +366,7 @@ A **writer set** crosses the ABI as a buffer of concatenated 32-byte public keys
 | `js_crdt_shared_writable_by_me` | `(cell_id_ptr: u64) -> i32` | Whether the current executor is in the writer set (`1`/`0`). |
 | `js_crdt_shared_is_frozen` | `(cell_id_ptr: u64) -> i32` | Whether the writer set is frozen (`1`/`0`). |
 | `js_crdt_shared_rotate_writers` | `(cell_id_ptr: u64, writers_ptr: u64) -> i32` | Writer-gated. Rotates the writer set to the given keys. Returns `1` on success; `-1` with an `ActionNotAllowed` message in register `0` for a non-writer, a frozen cell, or an empty target set. |
+| `js_crdt_delete_collection` | `(id_ptr: u64, register_id: u64) -> i32` | Deletes a root-level collection entity by id and unlinks it from the root (cascades the subtree; rejects Frozen; enforces `Shared` writer authority). Used by the JS SDK to reclaim the random-id collection orphaned by deterministic-id reassignment. Returns `1` if an entity was deleted, `0` if none existed (idempotent), or `-1` with an error message in the register. |
 
 > **Deferred (not in this bridge):** per-writer **OpMask** capabilities (`grant_capability` /
 > `revoke_capability` / `rotate_writers_scoped`, exposing `WRITE`/`DELETE`/`ADMIN` granularity) and

--- a/crates/runtime/src/logic/host_functions/js_collections.rs
+++ b/crates/runtime/src/logic/host_functions/js_collections.rs
@@ -939,6 +939,14 @@ impl VMHostFunctions<'_> {
         })
     }
 
+    pub fn js_crdt_delete_collection(
+        &mut self,
+        id_ptr: u64,
+        register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| host.crdt_delete_collection(id_ptr, register_id))
+    }
+
     fn crdt_map_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
         let outcome =
             panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsUnorderedMap, String> {
@@ -3775,6 +3783,35 @@ impl VMHostFunctions<'_> {
         }
     }
 
+    /// Delete a root-level collection entity by id and unlink it from the root.
+    ///
+    /// Used by the JS SDK's deterministic-id reassignment to reclaim the
+    /// random-id collection that is orphaned when a top-level `@State` field is
+    /// re-opened at its deterministic id. Every JS collection is created as a
+    /// child of [`Id::root()`], so the orphan is always a root child.
+    ///
+    /// Delegates to [`Interface::remove_child_from`], which cascades the subtree,
+    /// refuses to delete Frozen data (which peers would reject, causing a
+    /// split-brain), and enforces writer authority for a `Shared` cell — so a
+    /// caller can only delete a collection it legitimately created. The
+    /// reassignment runs on fresh state, where the create and this delete land in
+    /// the same genesis delta, so every replica converges with no orphan.
+    ///
+    /// Returns 1 if an entity was deleted, 0 if none existed at that id
+    /// (idempotent), or -1 with an error message in `dest_register_id`.
+    fn crdt_delete_collection(&mut self, id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
+        let id = match self.read_map_id(id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match Interface::<MainStorage>::remove_child_from(Id::root(), id) {
+            Ok(true) => Ok(1),
+            Ok(false) => Ok(0),
+            Err(err) => self.write_error_message(dest_register_id, err.to_string()),
+        }
+    }
+
     /// Reads a writer set (a buffer of concatenated 32-byte public keys) from
     /// guest memory, returning a decoding error string if the length is not a
     /// multiple of 32.
@@ -4561,6 +4598,45 @@ mod tests {
     const VALUE_DESC_PTR: u64 = 300;
     const WRITERS_DATA_PTR: u64 = 4000;
     const WRITERS_DESC_PTR: u64 = 400;
+
+    /// Deleting a collection removes it from the root's children: the first
+    /// delete reports it removed one entity, and a second delete of the same id
+    /// is a no-op — proving the orphan is gone. Mirrors how the JS SDK reclaims
+    /// the random-id collection orphaned by deterministic-id reassignment.
+    #[test]
+    fn test_js_crdt_delete_collection_removes_and_is_idempotent() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        let id: [u8; 32] = [9u8; 32];
+        host.borrow_memory()
+            .write(ID_DATA_PTR, &id)
+            .expect("write id");
+        prepare_guest_buf_descriptor(&host, ID_DESC_PTR, ID_DATA_PTR, id.len() as u64);
+
+        // Create a collection at the id (a root child).
+        assert_eq!(
+            host.js_crdt_map_new_with_id(ID_DESC_PTR, 1).unwrap(),
+            0,
+            "constructor should succeed"
+        );
+
+        // First delete removes it.
+        assert_eq!(
+            host.js_crdt_delete_collection(ID_DESC_PTR, 2).unwrap(),
+            1,
+            "first delete removes the collection"
+        );
+
+        // Second delete finds nothing — idempotent, proving it was unlinked.
+        assert_eq!(
+            host.js_crdt_delete_collection(ID_DESC_PTR, 3).unwrap(),
+            0,
+            "second delete is a no-op"
+        );
+    }
 
     /// A `*_new_with_id` constructor must place the collection at exactly the
     /// caller-supplied id, and two handles built at the same id must address the

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -216,6 +216,8 @@ impl VMLogic<'_> {
             fn js_crdt_shared_is_frozen(cell_id_ptr: u64) -> i32;
             fn js_crdt_shared_rotate_writers(cell_id_ptr: u64, writers_ptr: u64) -> i32;
 
+            fn js_crdt_delete_collection(id_ptr: u64, register_id: u64) -> i32;
+
             fn js_user_storage_new(register_id: u64) -> i32;
             fn js_user_storage_new_with_id(id_ptr: u64, register_id: u64) -> i32;
             fn js_user_storage_insert(


### PR DESCRIPTION
## Summary

Adds a host function the JS SDK needs to clean up a benign storage artifact.

The JS SDK instantiates each top-level `@State` collection at a **random** id, then re-opens it at a **deterministic** id (so every replica addresses the same CRDT entity). The original random-id entity is left **orphaned** in storage — a fresh, empty collection with no data. It's harmless (no correctness/convergence effect), but it's a tiny artifact per deterministic-id field. Tracked as calimero-sdk-js#94.

This PR adds the primitive; the JS SDK wiring (calling it during deterministic-id reassignment) is a follow-up, exactly as the SharedStorage host fns (#3340) landed before their JS wrapper.

## What's here

`js_crdt_delete_collection(id_ptr, register_id) -> i32`:

- Deletes a **root-level** collection entity by id and unlinks it from the root. Every JS collection is created as a child of `Id::root()`, so the orphan is always a root child.
- Delegates to `Interface::remove_child_from`, which **cascades the subtree**, **refuses to delete Frozen data** (peers reject its `DeleteRef` → split-brain), and **enforces writer authority for a `Shared` cell** — so a caller can only delete a collection it legitimately created.
- **Idempotent**: `1` if an entity was deleted, `0` if none existed at that id, `-1` with an error message in the register.

## Convergence safety

The JS SDK calls this only during deterministic-id reassignment, which runs on **fresh (genesis) state** — the create and this delete land in the **same genesis delta**, so every replica converges with no orphan. A hydrated node has its field already at the deterministic id and skips reassignment entirely, so it never issues a standalone delete. The cross-node convergence is validated end-to-end in the JS SDK follow-up (merobox), where the wiring actually runs.

## Test

- Unit test `test_js_crdt_delete_collection_removes_and_is_idempotent`: create a collection, delete it (→ 1), delete again (→ 0), proving it was unlinked.
- `cargo test -p calimero-runtime` green, `fmt`/`clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)