### PR TITLE
docs: point Related Repositories at mero-js, add cargo-mero

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ The docs live in [`docs/`](docs/) (Astro Starlight).
 
 - [calimero-network/merobox](https://github.com/calimero-network/merobox) -- E2E testing framework
 - [calimero-network/mero-tee](https://github.com/calimero-network/mero-tee) -- TEE infrastructure (KMS, locked images)
-- [calimero-network/calimero-client-js](https://github.com/calimero-network/calimero-client-js) -- JavaScript client
+- [calimero-network/cargo-mero](https://github.com/calimero-network/cargo-mero) -- `cargo mero` app toolchain (scaffold, build, test, bundle)
+- [calimero-network/mero-js](https://github.com/calimero-network/mero-js) -- JavaScript/TypeScript client
 - [calimero-network/calimero-client-py](https://github.com/calimero-network/calimero-client-py) -- Python client
 
 ## License


### PR DESCRIPTION
`README.md`'s **Related Repositories** list links [`calimero-client-js`](https://github.com/calimero-network/calimero-client-js), which was archived on 2026-04-23 and superseded by [`mero-js`](https://github.com/calimero-network/mero-js). Anyone following it from the core README lands on a dead SDK.

Also adds [`cargo-mero`](https://github.com/calimero-network/cargo-mero) to the list — it's the entry point for building an app against `crates/sdk` and wasn't mentioned.

```diff
 - [calimero-network/merobox](...) -- E2E testing framework
 - [calimero-network/mero-tee](...) -- TEE infrastructure (KMS, locked images)
-- [calimero-network/calimero-client-js](...) -- JavaScript client
+- [calimero-network/cargo-mero](...) -- `cargo mero` app toolchain (scaffold, build, test, bundle)
+- [calimero-network/mero-js](...) -- JavaScript/TypeScript client
 - [calimero-network/calimero-client-py](...) -- Python client
```

Companion to calimero-network/.github#3, which fixes the same stale link (plus three other archived repos) on the org profile page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)