### PR TITLE
test(ci): fail a scenario that reads another node's state without waiting for it

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -55,6 +55,29 @@ jobs:
     name: Build Image
     uses: ./.github/workflows/build-merod-image.yml
 
+  # ── Scenario convergence lint ──
+  # Static, no nodes, seconds not minutes — so it runs ahead of everything that
+  # boots docker and fails fast on the cheapest class of e2e bug there is.
+  #
+  # A scenario that reads another node's state without a barrier establishing the
+  # state arrived is not merely flaky; it fails with a symptom that names the wrong
+  # thing. Three did in one afternoon: a null where a schema version was expected,
+  # the literal string "undefined" reaching a base58 parser, and a key-less join.
+  # Each cost an investigation into whichever feature the PR happened to touch
+  # before the timing was even suspected.
+  #
+  # Ratcheted against scripts/e2e-convergence-baseline.txt: pre-existing findings
+  # are an accepted backlog and only a NEW one fails.
+  convergence-lint:
+    name: Scenario convergence lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+      - name: Lint merobox scenarios for unbarriered convergence reads
+        run: python3 scripts/lint-e2e-convergence.py
+
   # ── Auth seam: client-token e2e over real HTTP ──
   # Proves a client token minted the way the auth frontend mints it can call
   # the routes the SDK uses (the 0.11.0-rc.9 login-loop outage shape).

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -553,39 +553,45 @@ impl<S: StorageAdaptor> Interface<S> {
         }
     }
 
-    /// Resolve which writer in `writers` produced `sig_data`'s signature over
-    /// `payload`, returning that writer's key on success.
+    /// Resolve which writer produced `sig_data`'s signature over `payload`,
+    /// returning that writer's key on success.
     ///
-    /// Fast path: if `sig_data` carries a `signer` hint that is in `writers`,
-    /// do exactly one `ed25519_verify` against the hint. Slow path (no hint, or
-    /// a hint not in the set): linear scan over `writers`, returning the first
-    /// key whose signature verifies. `None` means no writer in the set produced
-    /// this signature — callers map that to `InvalidSignature`.
+    /// **A write must name its signer.** One `ed25519_verify` against the named
+    /// key, and the key must hold an entry in `writers`. `None` means the write
+    /// named nobody, named a non-writer, or the signature does not verify —
+    /// callers map all three to `InvalidSignature`.
     ///
-    /// This is the single source of truth for the signer-hint-then-scan
-    /// authorization check shared by every signed `Shared`/`SharedMember` arm
-    /// (upsert and delete) and the snapshot verifiers. Callers needing only a
-    /// yes/no answer use `.is_some()`; callers needing the signer for the
-    /// operation-granularity gate use the returned key directly.
+    /// The hint used to be optional, falling back to a linear scan that tried
+    /// every writer's key until one verified. Two reasons that had to go, and the
+    /// second is why this function is shaped the way it is now:
+    ///
+    /// - **It was verification amplification.** A signature that verifies under
+    ///   nobody costs one `ed25519_verify` per writer, on a path any peer can
+    ///   drive by sending a malformed delta. The `[0; 64]` placeholder bail only
+    ///   covered the trivial case.
+    /// - **A scan cannot exist once a writer set names accounts rather than
+    ///   keys.** There would be no keys to scan. Requiring the signature to name
+    ///   its author is what makes "resolve the author, then ask whether that
+    ///   principal is a writer" expressible at all — and those are two separable
+    ///   questions, which the scan conflated into one.
+    ///
+    /// This is the single source of truth for that check, shared by every signed
+    /// `Shared`/`SharedMember` arm (upsert and delete) and the snapshot verifiers.
+    /// Callers needing only a yes/no answer use `.is_some()`; callers needing the
+    /// signer for the operation-granularity gate use the returned key.
     ///
     /// The caller is responsible for the `[0; 64]` placeholder reject before
-    /// calling this — that O(1) bail avoids a full writer-set scan of
-    /// `ed25519_verify` calls on a known-bad signature.
+    /// calling this.
     fn resolve_signer(
         writers: &BTreeMap<PublicKey, OpMask>,
         sig_data: &crate::entities::SignatureData,
         payload: &[u8],
     ) -> Option<PublicKey> {
-        match sig_data.signer {
-            Some(hint) if writers.contains_key(&hint) => {
-                crate::env::ed25519_verify(&sig_data.signature, hint.digest(), payload)
-                    .then_some(hint)
-            }
-            _ => writers
-                .keys()
-                .copied()
-                .find(|w| crate::env::ed25519_verify(&sig_data.signature, w.digest(), payload)),
+        let signer = sig_data.signer?;
+        if !writers.contains_key(&signer) {
+            return None;
         }
+        crate::env::ed25519_verify(&sig_data.signature, signer.digest(), payload).then_some(signer)
     }
 
     /// Verify the writer's signature on a snapshot-supplied entity

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -1244,6 +1244,90 @@ mod shared_storage_rotation_authentication {
     }
 
     #[test]
+    fn a_shared_write_that_names_no_signer_is_refused() {
+        use crate::entities::Metadata;
+        use ed25519_dalek::Signer as _;
+
+        // The write must name its author. Verification used to fall back to trying
+        // every writer's key until one verified, which made an unverifiable
+        // signature cost one `ed25519_verify` PER WRITER on a path any peer can
+        // drive — and, more importantly, conflated two separable questions: who
+        // signed this, and is that principal a writer.
+        //
+        // Keeping them separate is what lets a writer set name accounts rather
+        // than keys: "resolve the author, then ask whether that principal may
+        // write" is expressible, while "try every key in the set" is not, because
+        // an account is not a key.
+        env::reset_for_testing();
+        let root = setup_root_for_main();
+
+        let alice_sk = make_signing_key(0xA1);
+        let alice = pubkey_of(&alice_sk);
+        let writers: BTreeSet<_> = [alice].into_iter().collect();
+        let id = Id::new([0x41; 32]);
+
+        // A genuine write by a genuine writer, accepted — the baseline that makes
+        // the rejection below meaningful rather than vacuous.
+        let good = build_signed_shared_action(
+            true,
+            id,
+            b"one".to_vec(),
+            writers.clone(),
+            env::time_now(),
+            &alice_sk,
+            vec![root],
+        );
+        MainInterface::apply_action(good, &ApplyContext::empty())
+            .expect("the baseline write must be accepted, or this test proves nothing");
+
+        // Now the same writer, but the action carries NO signer from the outset and
+        // is signed over that payload — so the signature is genuinely valid and
+        // alice genuinely is a writer. Stripping the field after signing would only
+        // have produced a payload mismatch, which proves nothing about this rule:
+        // the old scan would have found alice here and accepted the write.
+        let nonce = env::time_now() + 1_000_000;
+        let mut anonymous = crate::action::Action::Update {
+            id,
+            data: b"two".to_vec(),
+            ancestors: vec![],
+            metadata: Metadata {
+                created_at: nonce,
+                updated_at: nonce.into(),
+                storage_type: StorageType::Shared {
+                    writers: crate::entities::full_mask(writers),
+                    signature_data: Some(crate::entities::SignatureData {
+                        signature: [0; 64],
+                        nonce,
+                        signer: None,
+                    }),
+                },
+                crdt_type: None,
+                field_name: None,
+                schema_version: None,
+            },
+        };
+        let payload = anonymous.payload_for_signing();
+        let signature = alice_sk.sign(&payload).to_bytes();
+        if let crate::action::Action::Update { metadata, .. } = &mut anonymous {
+            if let StorageType::Shared {
+                signature_data: Some(sd),
+                ..
+            } = &mut metadata.storage_type
+            {
+                sd.signature = signature;
+            }
+        }
+        assert!(
+            matches!(
+                MainInterface::apply_action(anonymous, &ApplyContext::empty()),
+                Err(StorageError::InvalidSignature)
+            ),
+            "a write naming no signer must be refused even when its signature would \
+             verify under a writer — the author is not optional"
+        );
+    }
+
+    #[test]
     fn forged_shared_rotation_rejected_at_merge() {
         env::reset_for_testing();
         let root = setup_root_for_main();

--- a/scripts/e2e-convergence-baseline.txt
+++ b/scripts/e2e-convergence-baseline.txt
@@ -1,0 +1,20 @@
+# Convergence-race findings that predate `scripts/lint-e2e-convergence.py`.
+#
+# A burndown backlog, not an allowlist: each line is a scenario step that reads or
+# acts on another node's state without establishing that it arrived, so each can fail
+# intermittently and will do so with a misleading symptom (a null value, an
+# "undefined" string reaching a parser, a key-less join). They are baselined only so
+# the check could land without failing on its first run.
+#
+# Remove a line by adding a `wait_for_sync` covering the nodes involved. A stale entry
+# is reported as a notice rather than an error, so a fix never needs to touch this file
+# to go green — but leaving the line means the next regression in that step is silenced.
+apps/scaffolding-e2e/workflows/account-device-revoke-lockout.yml: R1 barrier 'Settle' omits ['account-revoke-node-3'], which mutated since the last barrier — a later step on those nodes races the sync this step was supposed to establish
+apps/scaffolding-e2e/workflows/account-device-revoke-lockout.yml: R1 barrier 'Settle the survivor's write across the remaining devices' omits ['account-revoke-node-3'], which mutated since the last barrier — a later step on those nodes races the sync this step was supposed to establish
+apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml: R1 barrier 'Wait for private-context sync between node-2 and node-3' omits ['e2e-node-1'], which mutated since the last barrier — a later step on those nodes races the sync this step was supposed to establish
+apps/scaffolding-e2e/workflows/group-private-add-then-write.yml: R1 barrier 'Initial sync to settle Root state' omits ['private-add-node-3'], which mutated since the last barrier — a later step on those nodes races the sync this step was supposed to establish
+apps/scaffolding-e2e/workflows/group-private-add-then-write.yml: R1 barrier 'Round 1 sync' omits ['private-add-node-3'], which mutated since the last barrier — a later step on those nodes races the sync this step was supposed to establish
+apps/sync-test/workflows/six-node-sync.yml: R1 barrier 'Wait for 3-node sync' omits ['sync6-4', 'sync6-5', 'sync6-6'], which mutated since the last barrier — a later step on those nodes races the sync this step was supposed to establish
+apps/sync-test/workflows/six-node-sync.yml: R1 barrier 'Wait for invitation sync' omits ['sync6-1'], which mutated since the last barrier — a later step on those nodes races the sync this step was supposed to establish
+apps/sync-test/workflows/three-node-sync.yml: R1 barrier 'Wait for Matea join to sync' omits ['sync-test-node-3'], which mutated since the last barrier — a later step on those nodes races the sync this step was supposed to establish
+workflows/app-migration/26-owner-driven-authored.yml: R2 'Read final schema_info on node 2 (both converted notes converged)' asserts cross-node convergence, but ['app-migration-owner-1'] mutated after the last barrier ('Wait for both v1 notes to sync across nodes') — the read races those writes

--- a/scripts/lint-e2e-convergence.py
+++ b/scripts/lint-e2e-convergence.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Lint merobox scenarios for convergence assertions that race the thing they assert.
+
+Three scenarios in one afternoon failed this way, all with the same shape: a step
+acts or asserts on state that another node produced, before anything established
+that the state had actually arrived. The failures are worse than flaky — they are
+*misleading*. A missing barrier surfaces as `output: None`, or as the literal string
+"undefined" reaching a base58 parser, or as "no mesh peer held the key". None of
+those name a timing problem, so each one costs a real investigation into whichever
+feature the PR happened to touch.
+
+Two rules, each derived from an observed failure rather than invented:
+
+R1 — INCOMPLETE BARRIER. A `wait_for_sync` that omits a node the scenario then uses
+     before the next barrier. This is the `account-device-revoke-lockout` bug: the
+     settle step listed nodes 1 and 2, and the very next step had the freshly paired
+     node 3 write with a key it could only have received by sync.
+
+R2 — MISSING BARRIER. A step that claims cross-node convergence with no barrier
+     between it and the last mutation. This is the `32-authored-migrate-ux` bug:
+     three reads asserted "converged" with nothing between them and the writes, and
+     the one reading the *other* node's last write returned null.
+
+R2 needs care to stay useful. A step named "Insert Hello from Node 1" *running on*
+node 1 is a write naming its own actor, not a cross-node read — flagging those was
+the first thing that made a draft of this check unusable, so a claim is only counted
+when the step runs somewhere other than the node its name points at.
+
+Enforced as a RATCHET, mirroring the endpoint-coverage gate: the findings that
+already existed when this check landed live in `scripts/e2e-convergence-baseline.txt`
+and only a NEW one fails the build. A hard gate would have failed on its first run
+against nine pre-existing findings, and a check that fails on day one gets disabled
+rather than fixed.
+
+Exit 1 on any un-baselined finding. `# lint-convergence: ok <reason>` on the step suppresses it,
+because a scenario that deliberately asserts non-convergence (a partition test
+proving a write did NOT arrive) is a legitimate exception that must state itself.
+"""
+
+from __future__ import annotations
+
+import glob
+import pathlib
+import re
+import sys
+from typing import Any
+
+import yaml
+
+BARRIER_TYPES = {"wait_for_sync"}
+# A bare `wait: seconds` is deliberately NOT a barrier. Every failure this catches
+# had one available and it did not help: a fixed sleep asserts nothing about
+# arrival, so it converts a deterministic failure into a load-dependent one.
+MUTATING_TYPES = {"call", "execute", "create_context", "join_context", "install_application"}
+# `json_assert` is deliberately absent: it carries no `node`, so there is no way to
+# tell which replica it reads. It compares values captured by earlier `call` steps,
+# and those are where the barrier question actually belongs — blaming the assert
+# reported one finding per assertion and pointed at the wrong step.
+READING_TYPES = {"call", "execute"}
+
+# Whether a `call` mutates decides whether it makes its node dirty, and getting this
+# wrong is what made a first draft unusable: read-only calls marked their own node
+# dirty, so the *next* read was flagged as racing a write that never happened.
+# Unknown methods count as READS — this check is worth having only if its findings
+# are credible, so it stays silent when it cannot tell.
+READ_METHOD = re.compile(
+    r"^(get|read|list|count|has|is|view|len|entries|iter|owner|schema|info|"
+    r"remaining|status|value|text|state)_?|_(version|info|count|owner|status)$",
+    re.I,
+)
+
+# A step whose name claims it is reading what another node produced.
+CLAIMS_CONVERGENCE = re.compile(
+    r"converg|\bsees\b|from node|other node|cross-?peer|replicat|both nodes", re.I
+)
+# The node a name points at ("... from node-2", "on node 2", "Node-3 writes").
+NAMES_NODE = re.compile(r"node[-_ ]?(\d+)", re.I)
+SUPPRESS = re.compile(r"lint-convergence:\s*ok\b", re.I)
+
+
+def step_nodes(step: dict[str, Any]) -> set[str]:
+    """Every node a step touches, whether named singly or as a list."""
+    out: set[str] = set()
+    node = step.get("node")
+    if isinstance(node, str):
+        out.add(node)
+    nodes = step.get("nodes")
+    if isinstance(nodes, list):
+        out.update(n for n in nodes if isinstance(n, str))
+    return out
+
+
+def node_ordinal(name: str) -> str | None:
+    """The trailing ordinal of a node name, which is what a step name refers to."""
+    m = NAMES_NODE.search(name)
+    return m.group(1) if m else None
+
+
+def mutates(step: dict[str, Any]) -> bool:
+    """Does this step change state, and so make its node dirty?
+
+    Non-`call` step types in `MUTATING_TYPES` always do. A `call` is judged by its
+    method name, erring toward "read" so an unrecognised method produces silence
+    rather than a false finding.
+    """
+    if step.get("type") not in {"call", "execute"}:
+        return True
+    method = str(step.get("method", ""))
+    return not READ_METHOD.search(method)
+
+
+def suppressed(step: dict[str, Any]) -> bool:
+    return any(SUPPRESS.search(str(v)) for v in step.values() if isinstance(v, str))
+
+
+def lint(path: str) -> list[str]:
+    try:
+        doc = yaml.safe_load(open(path))
+    except yaml.YAMLError as err:
+        return [f"{path}: unparseable YAML ({err})"]
+    if not isinstance(doc, dict):
+        return []
+    steps = doc.get("steps")
+    if not isinstance(steps, list):
+        return []
+
+    findings: list[str] = []
+    # Nodes that have mutated since the last barrier, and which nodes that barrier
+    # covered. A barrier resets the first and records the second.
+    dirty: set[str] = set()
+    last_barrier_covered: set[str] | None = None
+    last_barrier_name = ""
+
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        stype = step.get("type")
+        name = str(step.get("name", "<unnamed>"))
+        touched = step_nodes(step)
+
+        if stype in BARRIER_TYPES:
+            # R1: does this barrier cover everything that has changed since the last?
+            missed = dirty - touched
+            if missed and not suppressed(step):
+                findings.append(
+                    f"{path}: R1 barrier '{name}' omits {sorted(missed)}, which mutated "
+                    f"since the last barrier — a later step on those nodes races the sync "
+                    f"this step was supposed to establish"
+                )
+            dirty = set()
+            last_barrier_covered = touched
+            last_barrier_name = name
+            continue
+
+        if stype in READING_TYPES and CLAIMS_CONVERGENCE.search(name) and not suppressed(step):
+            # Only a genuine cross-node claim: the step must run somewhere other than
+            # the node its own name points at, or it is a write naming its actor.
+            target = node_ordinal(name)
+            here = {node_ordinal(n) for n in touched}
+            cross = target is None or target not in here
+            if cross:
+                if last_barrier_covered is None:
+                    findings.append(
+                        f"{path}: R2 '{name}' asserts cross-node convergence with no "
+                        f"wait_for_sync anywhere before it"
+                    )
+                elif dirty - touched:
+                    findings.append(
+                        f"{path}: R2 '{name}' asserts cross-node convergence, but "
+                        f"{sorted(dirty - touched)} mutated after the last barrier "
+                        f"('{last_barrier_name}') — the read races those writes"
+                    )
+                elif not touched <= last_barrier_covered:
+                    findings.append(
+                        f"{path}: R2 '{name}' reads on {sorted(touched - last_barrier_covered)}, "
+                        f"which the last barrier ('{last_barrier_name}') did not cover"
+                    )
+
+        if stype in MUTATING_TYPES and mutates(step):
+            dirty |= touched
+
+    return findings
+
+
+BASELINE = pathlib.Path(__file__).with_name("e2e-convergence-baseline.txt")
+
+
+def load_baseline() -> set[str]:
+    """Accepted-uncovered findings, one per line; `#` comments and blanks ignored."""
+    if not BASELINE.exists():
+        return set()
+    return {
+        line.strip()
+        for line in BASELINE.read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
+def main() -> int:
+    patterns = sys.argv[1:] or [
+        "apps/*/workflows/*.yml",
+        "workflows/**/*.yml",
+    ]
+    paths = sorted({p for pat in patterns for p in glob.glob(pat, recursive=True)})
+    if not paths:
+        print("no scenarios matched", file=sys.stderr)
+        return 1
+
+    all_findings = [f for p in paths for f in lint(p)]
+    baseline = load_baseline()
+    findings = [f for f in all_findings if f not in baseline]
+    accepted = len(all_findings) - len(findings)
+
+    print(f"scanned {len(paths)} scenario(s)")
+    if accepted:
+        print(f"{accepted} baselined (accepted) finding(s) — burndown backlog")
+    # A baseline entry that no longer matches is stale: the scenario was fixed (or
+    # renamed) and the entry now silences nothing. Reported, never fatal, so a fix
+    # is never punished with a red build.
+    for stale in sorted(baseline - set(all_findings)):
+        print(f"::notice::stale baseline entry, safe to delete: {stale}")
+    if not findings:
+        print("no new convergence races found")
+        return 0
+
+    print(f"\n{len(findings)} NEW finding(s):\n")
+    for f in findings:
+        print(f"  {f}")
+    print(
+        "\nEach is a step that reads or acts on another node's state without "
+        "establishing that it arrived.\nAdd a `wait_for_sync` covering the nodes "
+        "involved, or annotate the step with\n`# lint-convergence: ok <reason>` if it "
+        "deliberately asserts non-convergence."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Three merobox scenarios failed this way in one afternoon. The cost was never the retry — it was that **each failure named the wrong thing**:

| Symptom | What it actually was |
| --- | --- |
| `output: None` where a schema version was expected | node 2's note had not reached node 1 |
| `Invalid URL: invalid length 9` | the literal string `"undefined"` reaching a base58 parser |
| `no mesh peer held the subgroup key` | the key holder was briefly unreachable ([#3347](https://github.com/calimero-network/core/issues/3347)) |

None of those says "timing", so each bought an investigation into whichever feature the PR happened to touch. Two were on a PR that had not gone near the subsystem that failed.

## The rules

Both taken from an observed failure rather than invented:

- **R1** — a `wait_for_sync` that omits a node which mutated since the last barrier. The `account-device-revoke-lockout` bug a reviewer found: the settle step listed nodes 1 and 2, and the next step had the freshly paired node 3 write with a key it could only have received by syncing.
- **R2** — a step claiming cross-node convergence with a mutation on *another* node since the last barrier. `32-authored-migrate-ux`: three reads asserted "converged" with nothing between them and the writes, and the one reading the other node's last write returned null.

A bare `wait: seconds` deliberately does **not** count as a barrier. Every failure here had one available and it did not help — a fixed sleep asserts nothing about arrival, it just converts a deterministic failure into a load-dependent one.

## Keeping it credible

Most of the work was the false-positive rate. The first draft was useless at **82 findings over 121 scenarios**:

- `json_assert` carries no `node`, so there is no way to know which replica it reads. It compares values earlier `call` steps captured, and those are where the barrier question belongs. Blaming the assert produced one finding per assertion, pointing at the wrong step.
- Read-only `call`s were marking their node dirty, so the *next* read was flagged as racing a write that never happened. Methods are now classified by name, and an **unrecognised method counts as a read** — this check earns its place only if its findings are credible, so it stays silent when it cannot tell.
- A node's own writes are locally visible; only another node's need syncing.

That leaves **9**, all pre-existing.

## Enforcement

Ratcheted against `scripts/e2e-convergence-baseline.txt` — same shape as the endpoint-coverage gate. Only a **new** finding fails. A hard gate would have failed on its first run, and a check that fails on day one gets disabled rather than fixed. A stale baseline entry is a notice, never an error, so fixing a scenario never needs to touch the baseline to go green.

Runs before anything boots docker, so it fails in seconds rather than minutes.

## Proof it works

```
# strip the barrier added to 32-authored-migrate-ux
$ python3 scripts/lint-e2e-convergence.py
3 NEW finding(s):
  ...32-authored-migrate-ux.yml: R2 'Read node 2's note schema_version from node 1 (converged)'
     asserts cross-node convergence, but ['app-migration-ux-2'] mutated after the last barrier
EXIT=1

# restored
$ python3 scripts/lint-e2e-convergence.py
9 baselined (accepted) finding(s) — burndown backlog
no new convergence races found
EXIT=0
```

It names the exact step whose output was null in CI. It stays silent on `group-remove-from-root-revokes-inherited`, whose failure was a core retry gap rather than a missing barrier — so it is not just flagging everything that ever went red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)