### PR TITLE
docs(storage): effective_writers is receiver-resolved, not sender-supplied

### DIFF
--- a/crates/node/src/handlers/state_delta/crypto.rs
+++ b/crates/node/src/handlers/state_delta/crypto.rs
@@ -161,7 +161,18 @@ pub(super) fn decrypt_delta_actions(
             actions,
             events: sealed.events,
         }),
-        _ => bail!("Expected Actions variant in state delta"),
+        // A `CausalActions` artifact carries the writer set that the Shared
+        // verifier will authorize against. Accepting one off the wire would
+        // hand that decision to whoever sealed it: a group-key holder names
+        // itself a writer of any Shared object and its own signature then
+        // verifies against its own set. This node resolves the writer set for
+        // itself, from its own rotation log at the delta's causal cut, when it
+        // re-wraps these actions for the guest — so the only variant that may
+        // arrive here is the bare action list.
+        calimero_storage::delta::StorageDelta::CausalActions { .. } => bail!(
+            "state delta carried the CausalActions variant; a peer-supplied \
+             writer set is never trusted"
+        ),
     }
 }
 
@@ -210,6 +221,67 @@ mod tests {
         // Garbage ciphertext should fail to decrypt/deserialize
         let result = decrypt_delta_actions(vec![1, 2, 3, 4], nonce, sender_key);
         assert!(result.is_err());
+    }
+
+    /// A group-key holder seals a `CausalActions` artifact whose writer set
+    /// names only itself, for an entity it is not a writer of. Nothing
+    /// downstream re-derives that set — `Root::sync` feeds it straight to the
+    /// Shared verifier as the authoritative answer — so the wire boundary is
+    /// where it has to die. If this ever returns `Ok`, any group member can
+    /// write to any Shared object.
+    #[test]
+    fn decrypt_delta_actions_rejects_peer_supplied_writer_set() {
+        use std::collections::{BTreeMap, BTreeSet};
+
+        use calimero_storage::address::Id;
+        use calimero_storage::entities::OpMask;
+        use calimero_storage::logical_clock::HybridTimestamp;
+        use calimero_storage::tests::common::{build_signed_shared_action, pubkey_of};
+        use ed25519_dalek::SigningKey;
+
+        let mut rng = thread_rng();
+        let sender_key = PrivateKey::random(&mut rng);
+        let shared_key = SharedKey::from_sk(&sender_key);
+
+        // The attacker holds the group key (so AEAD proves nothing about
+        // authorization here) and signs a write to someone else's entity.
+        let attacker = SigningKey::from_bytes(&[7u8; 32]);
+        let attacker_pk = pubkey_of(&attacker);
+        let victim_entity = Id::new([42u8; 32]);
+        let action = build_signed_shared_action(
+            false,
+            victim_entity,
+            b"attacker-write".to_vec(),
+            BTreeSet::from([attacker_pk]),
+            1_000,
+            &attacker,
+            vec![],
+        );
+
+        let mut effective_writers = BTreeMap::new();
+        let _ =
+            effective_writers.insert(victim_entity, BTreeMap::from([(attacker_pk, OpMask::FULL)]));
+
+        let storage_delta = StorageDelta::CausalActions {
+            actions: vec![action],
+            delta_id: [1u8; 32],
+            delta_hlc: HybridTimestamp::default(),
+            effective_writers,
+        };
+        let sealed = SealedDeltaPayload {
+            root_hash: Hash::from([0u8; 32]),
+            artifact: borsh::to_vec(&storage_delta).expect("serialize"),
+            events: None,
+        };
+        let plaintext = borsh::to_vec(&sealed).expect("serialize");
+        let (nonce, cipher) = shared_key.encrypt(plaintext).expect("encryption failed");
+
+        let err = decrypt_delta_actions(cipher, nonce, sender_key)
+            .expect_err("a wire-supplied writer set must be refused");
+        assert!(
+            err.to_string().contains("never trusted"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/storage/src/delta.rs
+++ b/crates/storage/src/delta.rs
@@ -131,11 +131,22 @@ impl CausalDelta {
 /// - [`StorageDelta::Actions`] — local apply, snapshot leaf push,
 ///   SDK→host commits. The verifier falls back to v2 stored-writers
 ///   semantics for `Shared` actions in this variant.
-/// - [`StorageDelta::CausalActions`] — DAG-causal sync (#2266). The
-///   sync layer pre-resolves the writer set per Shared entity using
-///   the rotation log + DAG ancestry; the receiver's verifier
-///   validates Shared signatures against that pre-resolved set
-///   instead of stored writers.
+/// - [`StorageDelta::CausalActions`] — DAG-causal apply. The writer set
+///   per Shared entity is pre-resolved from the rotation log + DAG
+///   ancestry and the verifier validates Shared signatures against that
+///   set instead of stored writers.
+///
+/// # This is a host→guest envelope, not a peer→peer one
+///
+/// Only `Actions` crosses the network. `CausalActions` is built by the
+/// *applying* node (`ContextStorageApplier::apply`) and handed straight to
+/// the guest's sync entrypoint, because its writer set is an authorization
+/// input: whoever chooses it decides who may write. A peer that could
+/// choose it would name itself a writer of any Shared object and its
+/// signature would then verify against its own set. So the receive paths
+/// accept the `Actions` variant only — `decrypt_delta_actions` refuses
+/// anything else — and the applying node re-wraps those actions with a set
+/// it resolved itself.
 ///
 /// Wire tags are assigned by hand (see the [`BorshSerialize`]/
 /// [`BorshDeserialize`] impls below): `Actions` = 0, `CausalActions` = 2.
@@ -150,10 +161,10 @@ pub enum StorageDelta {
     ///
     /// `effective_writers` carries the pre-resolved writer set for
     /// every `Shared` entity touched by `actions`, computed by the
-    /// sender's sync layer via
-    /// `rotation_log_reader::writers_at(rotation_log, delta.parents, happens_before)`.
-    /// Entries for non-Shared entities are omitted (the verifier
-    /// doesn't consult them).
+    /// *applying* node — never by the sender — via
+    /// `rotation_log_reader::writers_at_authenticated(rotation_log, delta.parents, happens_before, verify)`
+    /// over its own copy of the rotation log. Entries for non-Shared
+    /// entities are omitted (the verifier doesn't consult them).
     CausalActions {
         /// Actions to apply.
         actions: Vec<Action>,
@@ -165,10 +176,12 @@ pub enum StorageDelta {
         /// the rotation-log write hook for sibling tiebreak (ADR 0001).
         delta_hlc: HybridTimestamp,
         /// Pre-resolved writer set per Shared entity touched by
-        /// `actions`. The receiver's verifier validates Shared
-        /// signatures against the entry for the action's entity id;
-        /// non-Shared entities (User / Frozen / Public) are absent
-        /// from the map.
+        /// `actions`. The verifier validates Shared signatures against
+        /// the entry for the action's entity id; non-Shared entities
+        /// (User / Frozen / Public) are absent from the map.
+        ///
+        /// Trusted, and only because it never comes off the wire — see
+        /// the variant docs above.
         effective_writers: BTreeMap<Id, BTreeMap<PublicKey, OpMask>>,
     },
 }

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -97,6 +97,20 @@ fn is_opaque_root_crdt_type(crdt_type: &Option<crate::collections::crdt_meta::Cr
 /// - `effective_writers: Some(set)` → caller pre-resolved the
 ///   ADR-0001-compliant writer set as of the delta's causal point.
 ///   The Shared verifier MUST validate against this set.
+///
+///   This set is the authorization decision itself, so storage takes it on
+///   trust and the caller owes it two properties. It must be resolved from
+///   the *local* rotation log — a set chosen by whoever authored the delta
+///   would let a peer name itself a writer of any Shared object and then
+///   satisfy the signature check against its own set (a signature proves
+///   possession of a key, never whose key it is). And it must be resolved
+///   with `writers_at_authenticated`, not `writers_at`, because the
+///   rotation log rides ordinary sync: each entry earns its place only when
+///   its signer held ADMIN in the set resolved just before it. The node's
+///   `ContextStorageApplier::apply` is the only production caller that
+///   passes `Some`, and it does both — which is also why the sync paths
+///   refuse a wire-supplied `StorageDelta::CausalActions` outright rather
+///   than forwarding the writer set it carries.
 /// - `effective_writers: None` → caller has no DAG context (snapshot
 ///   leaf push, local apply, tests). The verifier falls back to the
 ///   entity's currently-stored `metadata.storage_type.writers` (v2
@@ -108,8 +122,9 @@ fn is_opaque_root_crdt_type(crdt_type: &Option<crate::collections::crdt_meta::Cr
 pub struct ApplyContext {
     /// Pre-resolved authoritative writer set for `Shared` actions. When
     /// `Some`, the verifier validates the signature against this set and
-    /// skips the v2 stored-writers fallback. Resolved by the node sync
-    /// layer per #2266.
+    /// skips the v2 stored-writers fallback. Resolved by the applying
+    /// node's own sync layer from its own rotation log; see the trust
+    /// contract on the type docs before adding a caller that passes `Some`.
     pub effective_writers: Option<BTreeMap<PublicKey, OpMask>>,
 
     /// Hash of the `CausalDelta` containing the action being applied. Used


### PR DESCRIPTION
Closes #3349.

## What was verified

#3349 asked whether a receiver trusts a sender-supplied `effective_writers` — the per-`Shared`-entity writer set the verifier authorizes against. **It does not, because a sender cannot supply one.** The trace:

- **Gossip receive.** `decrypt_delta_actions` (`crates/node/src/handlers/state_delta/crypto.rs`) accepts `StorageDelta::Actions` only; every other variant is refused after decryption.
- **Sync / DAG-catchup receive.** The wire type is `calimero_storage::delta::CausalDelta`, whose payload is `actions: Vec<Action>`. There is no field for a writer set.
- **Where the set comes from.** The *applying* node builds the `CausalActions` envelope itself in `ContextStorageApplier::apply` (`crates/node/src/delta_store.rs`), resolving each Shared entity from its own rotation log at `delta.parents` via `rotation_log_reader::writers_at_authenticated`. That fold admits a rotation entry only when its signer held `OpMask::ADMIN` in the set resolved immediately before it *and* the signature verifies — which is required because the rotation log itself rides ordinary, untrusted sync.
- **JSON-RPC is not a side door.** `execute_request` builds the method payload with `serde_json::to_vec`, so those bytes cannot borsh-decode as tag 2.

`CausalActions` is a host→guest envelope, not a peer→peer one. The pattern #3344 reverted to — receiver resolves the principal locally at the delta's cut — is what this path already does.

## What this PR changes

No behaviour change. The docs claimed the opposite of the truth, which is the part that was actually dangerous:

1. `crates/storage/src/delta.rs` — the field doc said the set was "computed by the sender's sync layer". Corrected to the applying node, with a section on why the variant never crosses the network.
2. `crates/storage/src/interface.rs` — `ApplyContext::effective_writers` now carries the trust contract: it is trusted, it is safe only because it is locally resolved, and it must be resolved with `writers_at_authenticated` rather than `writers_at`.
3. `crates/node/src/handlers/state_delta/crypto.rs` — the catch-all `_ => bail!` is now an explicit `CausalActions` arm, so a future variant must be classified rather than falling into a wildcard, plus a regression test.

## Proof

New test `decrypt_delta_actions_rejects_peer_supplied_writer_set`: a group-key holder (so AEAD proves nothing about authorization) seals a `CausalActions` artifact carrying a signed write to an entity it does not own, with `effective_writers` naming itself sole writer. The decrypt must refuse.

Before (match arm flipped to accept the variant, to confirm the test bites):

```
thread '...decrypt_delta_actions_rejects_peer_supplied_writer_set' panicked at
crates/node/src/handlers/state_delta/crypto.rs:283:14:
a wire-supplied writer set must be refused: DecryptedDelta { ... Shared { writers:
{PublicKey(Hash("GmaDrppBC7P5ARKV8g3djiwP89vz1jLK23V2GBjuAEGB")): OpMask(7)} ... }
test result: FAILED. 3 passed; 1 failed
```

After:

```
test handlers::state_delta::crypto::tests::decrypt_delta_actions_rejects_peer_supplied_writer_set ... ok
test result: ok. 4 passed; 0 failed
```

`cargo fmt --check` clean; `cargo clippy -p calimero-storage -p calimero-node --all-targets` clean.

## Issue criteria

- [x] A test in which a delta arrives carrying a writer set that names a non-writer, and the write is refused — at the wire boundary, which is where such a delta dies. `rotation_log_reader::authenticated_fold_rejects_unauthorized_rotation` already covers the same refusal one layer in, on the log the receiver resolves from.
- [x] `ApplyContext::effective_writers`' doc states explicitly that it is trusted and what makes that safe.
- [x] No fix needed — resolution is already receiver-side at the delta's cut, and an entity with no resolvable rotation log is omitted from the map rather than granted.

## Adjacent, checked and not filed

When `effective_writers` is `None` (HashComparison repair, snapshot-leaf apply) the fallback is stored writers, then the action's own claimed writers. The claim only wins for an entity unknown locally: `verify_action_update` refuses any storage-type change on an existing entity, so this is entity bootstrapping and not a route to taking over an existing object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)