### PR TITLE
docs(storage): drop the writer-set scan from comments that still promise it

### DIFF
--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -182,11 +182,11 @@ pub fn wire_authorization_for(
 ///
 /// * `User { owner, .. }` → `owner` is the author by definition.
 /// * `Shared { signature_data: Some(SignatureData { signer: Some(pk), .. }), .. }`
-///   → the per-action signature carries the explicit signer. When `signer`
-///   is `None` (older actions without the hint), returns `None` — the
-///   author can't be identified without scanning the writer set, and the
-///   caller treats this as "don't enforce membership here, defer to the
-///   per-action signature check inside `apply_action`."
+///   → the signature names its signer, which is the author. When `signer`
+///   is `None` there is no author to name, so this returns `None` and the
+///   caller treats it as "don't enforce membership here, defer to the
+///   per-action signature check inside `apply_action`" — which refuses an
+///   unnamed signed write outright.
 /// * `Public` / `Frozen` / authorization absent → `None`; no author to
 ///   check (the per-action signature path verifies what's verifiable).
 fn extract_author_from_leaf_authorization(
@@ -1167,8 +1167,9 @@ mod tests {
 
     #[test]
     fn extract_author_shared_without_signer_hint_returns_none() {
-        // Older actions can omit the signer hint — caller treats `None`
-        // as "defer to per-action signature verification inside apply_action."
+        // An authorization that names no signer yields no author — caller
+        // treats `None` as "defer to per-action signature verification inside
+        // apply_action", which is where it is refused.
         let st = StorageType::Shared {
             writers: std::collections::BTreeMap::from([(
                 PublicKey::from([1u8; 32]),

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -437,11 +437,12 @@ pub struct SignatureData {
     pub signature: [u8; 64],
     /// Nonce (counter/timestamp) to avoid replaying attacks.
     pub nonce: u64,
-    /// Optional hint identifying which key produced the signature. Used by
-    /// `StorageType::Shared` to make verification O(1) (skip the per-writer
-    /// linear scan); ignored for `User` where the owner is already known.
-    /// `None` means "fall back to scanning the writer set" — older actions
-    /// without this hint still verify.
+    /// Which key produced the signature. `Option` for wire compatibility
+    /// only — a signed `Shared`/`SharedMember` write that names nobody is
+    /// rejected as `InvalidSignature`, because resolving the author is what
+    /// makes "is this principal a writer?" a separate question from "does
+    /// this signature verify?". Ignored for `User`, where the owner is
+    /// already known.
     pub signer: Option<PublicKey>,
 }
 

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -610,8 +610,8 @@ impl<S: StorageAdaptor> Interface<S> {
     /// * `User` / `Shared` with `signature_data: Some(_)` — compute
     ///   `payload_for_signing` from a synthetic `Action::Add { id,
     ///   data, ancestors: vec![], metadata }` and `ed25519_verify`
-    ///   against the writer (owner for User, signer-hint or
-    ///   writer-set scan for Shared).
+    ///   against the writer (owner for User, the signature's named
+    ///   signer for Shared).
     /// * `User` / `Shared` with `signature_data: None` — rejected as
     ///   `InvalidSignature`. After the bootstrap-signing fix
     ///   (`persist_signed_signatures` in
@@ -705,16 +705,14 @@ impl<S: StorageAdaptor> Interface<S> {
                 signature_data: Some(sig_data),
             } => {
                 // Same `[0; 64]` placeholder reject as the User arm
-                // above — particularly important for `Shared` since
-                // the writer-set scan would do up to N ed25519
-                // verifies (one per writer) before the crypto
-                // library rejects the placeholder, which is a free
-                // CPU-burn vector for a misbehaving peer.
+                // above: an all-zero signature is never valid, so
+                // refuse it here rather than paying an ed25519 verify
+                // to learn the same thing.
                 if sig_data.signature == [0u8; 64] {
                     return Err(StorageError::InvalidSignature);
                 }
-                // Fast path: signer hint + verify once. Slow path:
-                // linear scan over writers. Mirrors `apply_action`.
+                // The signature must name its signer, and that signer must
+                // be a writer — one verify, no scan. Mirrors `apply_action`.
                 if Self::resolve_signer(writers, sig_data, &payload).is_some() {
                     Ok(())
                 } else {
@@ -765,7 +763,8 @@ impl<S: StorageAdaptor> Interface<S> {
     /// arrive in a later page anyway, so the node instead resolves the writers
     /// from the anchor's own snapshot record (itself signature-verified) and
     /// passes them here. Otherwise identical to the member arm above:
-    /// placeholder reject, signer-hint fast path, else a scan over `writers`.
+    /// placeholder reject, then one verify against the signature's named
+    /// signer, which must appear in `writers`.
     ///
     /// `metadata.storage_type` must be `SharedMember`; any other variant is a
     /// caller error and is rejected as `InvalidData`.
@@ -1526,18 +1525,16 @@ impl<S: StorageAdaptor> Interface<S> {
                         // no-op; an unauthenticated stale action must
                         // still reject as InvalidSignature.
                         //
-                        // Identify the signer. Fast path: if the
-                        // action carries a `signer` hint and that
-                        // signer is in the authoritative set, do
-                        // exactly one verify. Slow path (no hint):
-                        // linear scan over authoritative writers.
+                        // Identify the signer: the action must name it,
+                        // that name must appear in the authoritative
+                        // set, and its signature must verify — one
+                        // ed25519 verify, no scan over the writer set.
+                        // A write that names nobody is refused.
                         //
-                        // Per the #2233 epic compatibility rule, the
-                        // signer hint is validated against the
-                        // *causal* writer set above, not stored —
-                        // that's already how it works here since
-                        // `authoritative_writers` is now the
-                        // DAG-causal answer when available.
+                        // The named signer is checked against the
+                        // *causal* writer set, not the stored one:
+                        // `authoritative_writers` is the DAG-causal
+                        // answer whenever the caller supplied one.
                         let payload = action.payload_for_signing();
                         let Some(signer) =
                             Self::resolve_signer(&authoritative_writers, sig_data, &payload)
@@ -1883,10 +1880,10 @@ impl<S: StorageAdaptor> Interface<S> {
                                 // types — see the User DeleteRef arm for
                                 // the full rationale.
                                 //
-                                // Identify the signer.
-                                // Fast path: if the action carries a `signer` hint and that
-                                // signer is in the authoritative set, do exactly one verify.
-                                // Slow path (no hint): linear scan (matches Add/Update arm).
+                                // Identify the signer: the delete must name it,
+                                // that name must be a writer, and its signature
+                                // must verify — one verify, no scan (matches
+                                // the Add/Update arm).
                                 let payload = action.payload_for_signing();
                                 let Some(signer) =
                                     Self::resolve_signer(existing_writers, sig_data, &payload)


### PR DESCRIPTION
Follow-up to the merge-record correction on #3348.

## Why

Stage 1 of #3344 landed on master inside #3348's squash (see [the correction comment](https://github.com/calimero-network/core/pull/3348#issuecomment-latest)): `Interface::resolve_signer` now requires a signed write to name its author — one `ed25519_verify` against the named key, and `None` when the write names nobody, a non-writer, or fails to verify. The linear scan over every writer's key is gone.

Six comments still describe that scan as current behaviour. The one that matters most is on a wire type:

```rust
/// `None` means "fall back to scanning the writer set" — older actions
/// without this hint still verify.
pub signer: Option<PublicKey>,
```

An unnamed signed `Shared` write does not verify — it is `InvalidSignature`. A reader trusting this doc would conclude the field is optional in effect, and anything built on that assumption would be wrong about where writes get refused.

## What changed

Comments only, no behaviour change:

| Site | Was | Now |
| --- | --- | --- |
| `entities.rs` `SignatureData::signer` | `None` falls back to a scan; older actions still verify | `Option` is wire compatibility only; an unnamed signed write is refused |
| `interface.rs` snapshot-writer verifier doc | "signer-hint or writer-set scan for Shared" | the signature's named signer |
| `interface.rs` snapshot `Shared` arm | placeholder reject matters because a scan costs N verifies | placeholder reject saves one verify; one verify, no scan |
| `interface.rs` snapshot-member verifier doc | "signer-hint fast path, else a scan over `writers`" | one verify against the named signer, which must be in `writers` |
| `interface.rs` `Shared` upsert arm | fast path / slow path linear scan | must name its signer, one verify, no scan |
| `interface.rs` `DeleteRef` arm | same | same |
| `node/sync/helpers.rs` `extract_author_from_leaf_authorization` | author unidentifiable without scanning; "older actions without the hint" | no author to name; the deferred check refuses it |

`resolve_signer`'s own doc already explains the scan in the past tense and why it went — left as is, since that is the one place a reader should meet it.

## Verification

`cargo fmt --check` clean. `cargo test -p calimero-storage --lib` 678 passed; `cargo test -p calimero-node --lib sync::helpers` 25 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)