### PR TITLE
feat(account): revoke a device with only the account root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6284,7 +6284,9 @@ version = "0.1.0"
 dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
+ "borsh",
  "bs58",
+ "calimero-account",
  "calimero-blobstore",
  "calimero-build-utils",
  "calimero-config",

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use actix::Message;
-use calimero_account::{AccountGenesis, AccountId, DeviceId, KemPublicKey};
+use calimero_account::{AccountGenesis, AccountId, DeviceId, KemPublicKey, SignedDeviceRevocation};
 use calimero_context_config::types::{AppKey, ContextGroupId, SignedGroupOpenInvitation};
 use calimero_context_config::VisibilityMode;
 use calimero_primitives::application::ApplicationId;
@@ -921,15 +921,33 @@ impl PairDeviceCompleteResponse {
 
 /// Withdraw a device from an account, terminally.
 ///
-/// Authorized either by this node being a group admin, or by it holding the
-/// account root that owns the device — the latter mints a self-certifying proof
-/// so the owner never needs an admin to disown their own lost machine.
+/// Three ways to be authorized, and the third is why `proof` exists:
+///
+/// - this node is a group **admin**;
+/// - this node holds the **account root** that owns the device, so it can mint a
+///   self-certifying proof itself;
+/// - a proof minted **elsewhere** is supplied here. The root stays wherever it is
+///   — on paper, on a replacement laptop — and this node only publishes.
+///
+/// The third case is the lost-device story. Without it the authority to revoke
+/// existed but could only be exercised from a node that already held the root in
+/// its store, which is precisely the machine that is gone.
 #[derive(Debug)]
 pub struct RevokeDeviceRequest {
     /// The namespace the device is being withdrawn from.
     pub namespace_id: ContextGroupId,
     /// The device losing its binding. Its id is spent for good.
     pub device: DeviceId,
+    /// A revocation proof minted outside this node, if the caller has one.
+    ///
+    /// `None` keeps the original behaviour: the node mints a proof when it owns
+    /// the account, and otherwise revokes on its admin authority.
+    ///
+    /// Supplying one does not widen what a revocation can do. The proof only
+    /// attests that its signer holds the root of the account it *names*; tying
+    /// that account to this device is the stored binding's job, checked here and
+    /// again by every replica that applies the op.
+    pub proof: Option<SignedDeviceRevocation>,
 }
 
 /// What the revocation withdrew.

--- a/crates/context/src/handlers/revoke_device.rs
+++ b/crates/context/src/handlers/revoke_device.rs
@@ -46,6 +46,7 @@ impl Handler<RevokeDeviceRequest> for ContextManager {
         RevokeDeviceRequest {
             namespace_id,
             device,
+            proof: supplied_proof,
         }: RevokeDeviceRequest,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
@@ -82,18 +83,53 @@ impl Handler<RevokeDeviceRequest> for ContextManager {
         };
         let account = target.account;
 
-        if !is_admin && !target.self_service {
+        // A proof minted elsewhere is verified HERE, before anything is published,
+        // against the account the group's own binding names. Refusing beats
+        // publishing: the apply path treats an unverifiable proof as a deterministic
+        // refusal that records nothing and returns `Ok`, so a bad one would leave the
+        // operator with a successful-looking call, no revocation on any replica, and
+        // nothing anywhere saying why.
+        //
+        // Verifying against `target.account` rather than the account inside the proof
+        // is what stops a proof for one account authorising a device bound to
+        // another — the same tie the apply path enforces, checked early so the error
+        // reaches whoever can act on it.
+        let supplied_proof = match supplied_proof {
+            Some(proof) => match proof.authorises(account, device) {
+                Ok(()) => Some(proof),
+                Err(err) => {
+                    return ActorResponse::reply(Err(eyre::eyre!(
+                        "the supplied revocation proof does not authorise withdrawing \
+                         {device} from {account}: {err}. A proof is only valid for the \
+                         one account and device it names, and {namespace_id:?} has this \
+                         device bound to {account}"
+                    )))
+                }
+            },
+            None => None,
+        };
+
+        // Three ways to be authorized. The proof is checked first because it is the
+        // only one that needs no authority from this node at all — it carries its own.
+        if supplied_proof.is_none() && !is_admin && !target.self_service {
             return ActorResponse::reply(Err(eyre::eyre!(
                 "this node is neither an admin of {namespace_id:?} nor the holder of the \
-                 account that owns {device}; revoking somebody else's device requires admin"
+                 account that owns {device}, and no revocation proof was supplied. Either \
+                 revoke as an admin, or mint a proof from the account root \
+                 (`merod account revoke-proof`) and pass it here"
             )));
         }
 
-        // Mint the proof only on the self-service path, which is the only one that
-        // needs it — an admin revokes on the group's authority and may hold no
+        // A supplied proof is used as given — re-minting would need the root, which
+        // is the thing this path exists to do without.
+        //
+        // Otherwise mint one only on the self-service path, which is the only one
+        // that needs it: an admin revokes on the group's authority and may hold no
         // account root at all, so consulting one unconditionally refused every
         // admin that had never run `account create`.
-        let proof = if target.self_service {
+        let proof = if let Some(proof) = supplied_proof {
+            Some(proof)
+        } else if target.self_service {
             match device_repo.account_root() {
                 Ok(Some(root)) => {
                     let genesis = root.genesis_for(&namespace_id);

--- a/crates/meroctl/src/cli/account/revoke.rs
+++ b/crates/meroctl/src/cli/account/revoke.rs
@@ -18,6 +18,11 @@ use crate::cli::Environment;
 /// without an admin — it attaches a root-signed proof. That path cannot rotate
 /// the key (only an admin may), so the device stops writing at once but can
 /// still read until an admin rotates. The command reports which happened.
+///
+/// Or pass `--proof` with a proof minted offline by `merod account revoke-proof`.
+/// That is the case where the account root is not on any node — it lives on paper
+/// — and the machine that held the device is gone. The node this runs against
+/// needs no authority of its own; it only publishes.
 #[derive(Clone, Debug, Parser)]
 #[command(about = "Withdraw a device from an account")]
 pub struct RevokeCommand {
@@ -30,16 +35,39 @@ pub struct RevokeCommand {
         help = "The device ID to revoke, 64 hex chars"
     )]
     pub device_id: String,
+
+    /// A revocation proof from `merod account revoke-proof`, or `@PATH` to read
+    /// one from a file.
+    ///
+    /// `@PATH` exists because the blob is long enough that a shell history entry
+    /// is an awkward place for it, not because it is secret — it authorises this
+    /// one revocation and nothing else.
+    #[clap(long, value_name = "HEX|@PATH")]
+    pub proof: Option<String>,
 }
 
 impl RevokeCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
+        let proof = match self.proof {
+            // Trimmed because a file written by `revoke-proof > file` ends in a
+            // newline, and hex with a trailing newline is not hex.
+            Some(raw) => Some(match raw.strip_prefix('@') {
+                Some(path) => std::fs::read_to_string(path)
+                    .map_err(|err| eyre::eyre!("failed to read the proof from {path}: {err}"))?
+                    .trim()
+                    .to_owned(),
+                None => raw.trim().to_owned(),
+            }),
+            None => None,
+        };
+
         let client = environment.client()?;
         let response = client
             .revoke_device(
                 &self.namespace_id,
                 RevokeDeviceApiRequest {
                     device_id: self.device_id,
+                    proof,
                 },
             )
             .await?;

--- a/crates/merod/AGENTS.md
+++ b/crates/merod/AGENTS.md
@@ -61,6 +61,10 @@ merod --node node1 account export --out backup.txt --allow-plaintext-file
 merod --node node1 account import [--from backup.txt] [--force]
 ```
 
+Export prints the phrase on the **first line** (so `head -1` is the secret),
+then the root's public key, then any derived account ids. Only the first line is
+sensitive; the account ids are what writer sets already name.
+
 `--force` **drops the device rows belonging to the root it replaces**, and reports
 which namespaces they were in. Not housekeeping: a device row is keyed by namespace
 alone and enrolment refuses to replace a *linked* row naming a different account, so
@@ -76,10 +80,6 @@ state where a new root sits beside the old root's rows.
 creation, so reusing a path would write the phrase into whatever permissions were
 already there, and a pre-planted symlink could redirect it. On a platform with no
 mode to set, the command says so instead of claiming owner-only.
-
-Export prints the phrase on the **first line** (so `head -1` is the secret),
-then the root's public key, then any derived account ids. Only the first line is
-sensitive; the account ids are what writer sets already name.
 
 ### Revoking a device with only the root
 

--- a/crates/merod/AGENTS.md
+++ b/crates/merod/AGENTS.md
@@ -28,8 +28,9 @@ cargo test -p merod
 
 ```
 merod --node <name> <subcommand>
-├── account       # Back up / restore the account root (export, import).
-│                 # Opens the store directly — the node must be STOPPED.
+├── account       # Account root: export, import, revoke-proof.
+│                 # export/import open the store directly — node must be STOPPED.
+│                 # revoke-proof needs no node at all with --from.
 ├── init          # Initialize node configuration (mints the embedded-auth
 │                 # admin root key from --admin-user + password via
 │                 # file/stdin/env; --no-admin defers)
@@ -39,12 +40,13 @@ merod --node <name> <subcommand>
 └── kms           # Key management service
 ```
 
-## Account root backup (`merod account`)
+## Account root: backup, restore, offline revocation (`merod account`)
 
 The account root is the only key that can certify a replacement device after every
-device is lost, so these two commands are the whole recovery story. Both open the
-datastore directly, which means the node must be **stopped** (RocksDB's lock is
-exclusive) and a KMS-encrypted store is refused rather than misread.
+device is lost, so this family of commands is the whole recovery story. `export`
+and `import` open the datastore directly, which means the node must be **stopped**
+(RocksDB's lock is exclusive) and a KMS-encrypted store is refused rather than
+misread; `revoke-proof` needs no store at all when given `--from`.
 
 ```bash
 # Print the 24-word phrase to stdout. Add --namespace (repeatable, optional) to
@@ -79,6 +81,27 @@ Export prints the phrase on the **first line** (so `head -1` is the secret),
 then the root's public key, then any derived account ids. Only the first line is
 sensitive; the account ids are what writer sets already name.
 
+### Revoking a device with only the root
+
+```bash
+# Sign a device revocation offline. --from reads the phrase, so this needs no
+# node, no home and no init — the lost-device case. Prints a hex proof.
+merod account revoke-proof --namespace <NS> --device <DEVICE_ID> --from phrase.txt
+
+# Without --from, the root comes from this node's store (so: stopped).
+merod --node node1 account revoke-proof --namespace <NS> --device <DEVICE_ID>
+```
+
+The proof is self-certifying, so any member node can publish it and needs no
+authority of its own: `meroctl account revoke <NS> --device-id <D> --proof @file`.
+It is not a secret — it authorises exactly one revocation of one device. What it
+cannot do is name a device the account does not own (the stored binding is checked
+before publishing and again on every replica) or rotate the scope key (admin only).
+
+`--namespace` is required because an account id is per-namespace: the same root
+owns a different account in each, and a proof for the wrong one verifies against
+its own genesis while authorising nothing.
+
 Full model, the recovery procedure, and what does *not* come back:
 [protocol/accounts](../../docs/src/content/docs/protocol/accounts.mdx#backing-up-and-recovering-an-account).
 
@@ -94,7 +117,7 @@ src/
 │   ├── config.rs     # Config modifications
 │   ├── auth.rs       # `merod auth set-admin` (offline admin-key mint)
 │   ├── admin_creds.rs# Shared --admin-user/password-file/stdin resolution
-│   ├── account.rs    # `merod account export|import` (recovery phrase)
+│   ├── account.rs    # `merod account export|import|revoke-proof`
 │   ├── kms.rs        # KMS subcommand
 │   ├── validation.rs # Validation helpers
 │   └── auth_mode.rs  # Authentication mode handling

--- a/crates/merod/Cargo.toml
+++ b/crates/merod/Cargo.toml
@@ -17,6 +17,7 @@ const_format.workspace = true
 dirs.workspace = true
 ed25519-consensus.workspace = true
 eyre.workspace = true
+borsh.workspace = true
 hex.workspace = true
 ic-agent.workspace = true
 libp2p.workspace = true
@@ -53,6 +54,7 @@ calimero-primitives = { workspace = true, features = ["borsh"] }
 mero-auth = { path = "../auth" }
 sigstore = { version = "0.13.0", default-features = false, features = ["verify", "cosign", "sigstore-trust-root", "rustls-tls"] }
 x509-cert = "0.2.5"
+calimero-account = { version = "0.0.0", path = "../account" }
 calimero-governance-store = { version = "0.0.0", path = "../governance-store" }
 
 [build-dependencies]

--- a/crates/merod/src/cli/account.rs
+++ b/crates/merod/src/cli/account.rs
@@ -41,6 +41,8 @@ enum AccountSubcommands {
     Export(ExportCommand),
     /// Restore an account root from a recovery phrase
     Import(ImportCommand),
+    /// Sign a device revocation offline, to be published by any node
+    RevokeProof(RevokeProofCommand),
 }
 
 #[derive(Debug, Parser)]
@@ -72,12 +74,133 @@ pub struct ImportCommand {
     force: bool,
 }
 
+/// Sign a revocation for a device using only the account root.
+///
+/// The gap this closes: revoking a device needs the account's authority, and a
+/// user who has merely *lost* a device still has it — but the only code path that
+/// minted a proof required the acting node to hold the root in its own store. So
+/// the authority existed and could not be exercised, which is the case the whole
+/// account plane is for.
+///
+/// **The proof is self-certifying**, which is what makes an offline command
+/// possible at all: it carries the genesis and the root-key chain, so a verifier
+/// checks it from the account id alone with no folded state. It therefore does not
+/// matter which node publishes it, and the root never has to reach one — this
+/// prints a blob, and `meroctl account revoke --proof` hands it to any member.
+///
+/// With `--from` it needs no node at all: no home, no store, no init. That is the
+/// lost-laptop case exactly — a replacement machine, a `merod` binary, and the
+/// words. Without it, the root is read from this node's store, so the node must be
+/// stopped.
+///
+/// **It cannot check that the device belongs to the account.** That takes group
+/// state this command deliberately does not have, and it is not a hole: the
+/// publishing node — and every replica applying the op — requires the stored
+/// binding to name this account before a proof authorises anything. A proof for
+/// somebody else's device is refused there, not here.
+///
+/// **Epoch 0 only.** The proof is signed at key epoch 0 with an empty handoff
+/// chain, matching the node-side path. An account whose root has been rotated
+/// needs the chain up to the signing epoch, and nothing in this CLI can produce
+/// one yet.
+#[derive(Debug, Parser)]
+pub struct RevokeProofCommand {
+    /// The namespace the device is being withdrawn from (hex).
+    ///
+    /// Required because an account id is per-namespace: the same root owns a
+    /// different account in each, and a proof names exactly one.
+    #[arg(long = "namespace", value_name = "NAMESPACE_ID")]
+    namespace: String,
+
+    /// The device to revoke, 64 hex chars.
+    #[arg(long = "device", value_name = "HEX")]
+    device: String,
+
+    /// Read the root from a recovery phrase at PATH instead of this node's store.
+    ///
+    /// Skips the datastore entirely, so it works on a machine with no node.
+    #[arg(long, value_name = "PATH")]
+    from: Option<camino::Utf8PathBuf>,
+}
+
 impl AccountCommand {
     pub async fn run(self, root_args: &RootArgs) -> EyreResult<()> {
         match self.action {
             AccountSubcommands::Export(cmd) => cmd.run(root_args).await,
             AccountSubcommands::Import(cmd) => cmd.run(root_args).await,
+            AccountSubcommands::RevokeProof(cmd) => cmd.run(root_args).await,
         }
+    }
+}
+
+impl RevokeProofCommand {
+    async fn run(self, root_args: &RootArgs) -> EyreResult<()> {
+        let namespace = parse_namespace(&self.namespace)?;
+        let device = parse_device(&self.device)?;
+
+        // Parse the phrase before opening anything, as `import` does: a typo should
+        // fail on its own terms rather than after a store has been opened.
+        let root = match &self.from {
+            Some(path) => {
+                let phrase: Zeroizing<String> =
+                    Zeroizing::new(std::fs::read_to_string(path).wrap_err_with(|| {
+                        format!("Failed to read the recovery phrase from {path}")
+                    })?);
+                AccountRoot::from_mnemonic(&phrase)?
+            }
+            None => {
+                let store = open_store(root_args).await?;
+                // Not `ensure_account_root`: minting one here would sign a proof
+                // with a key that owns nothing, and it would verify against itself
+                // while authorising nothing anywhere.
+                NodeDeviceRepository::new(&store)
+                    .account_root()
+                    .wrap_err("Failed to read the account root")?
+                    .ok_or_else(|| {
+                        eyre::eyre!(
+                            "This node has no account root, so it can prove nothing \
+                             about any account. Pass --from with the recovery phrase \
+                             for the account that owns the device."
+                        )
+                    })?
+            }
+        };
+
+        let account = root.account_for(&namespace);
+        let revocation =
+            calimero_account::sign_device_revocation(root.signing_key(), account, device, 0)
+                .map_err(|err| eyre::eyre!("failed to sign the revocation: {err}"))?;
+        let proof = calimero_account::SignedDeviceRevocation {
+            genesis: root.genesis_for(&namespace),
+            chain: vec![],
+            revocation,
+        };
+
+        let encoded = hex::encode(borsh::to_vec(&proof).wrap_err("Failed to encode the proof")?);
+
+        println!("{encoded}");
+        println!();
+        println!("Account:   {account}");
+        println!("Device:    {device}");
+        println!("Namespace: {}", self.namespace);
+        println!();
+        println!(
+            "Publish it from any node that is a member of the namespace and has \
+             folded the device's link:"
+        );
+        println!();
+        println!(
+            "  meroctl account revoke {} --device-id {} --proof <the hex above>",
+            self.namespace, self.device
+        );
+        println!();
+        println!(
+            "The proof is not a secret — it authorises exactly this one revocation \
+             and nothing else. Only an admin can rotate the scope key, so until one \
+             does, the revoked device stops writing but can still read."
+        );
+
+        Ok(())
     }
 }
 
@@ -352,6 +475,19 @@ fn write_owner_only(path: &camino::Utf8Path, contents: &str) -> EyreResult<bool>
     Ok(false)
 }
 
+/// Parse a hex `DeviceId`.
+///
+/// Separate from [`parse_namespace`] only so the error names the right argument:
+/// `revoke-proof` takes both as 64 hex characters, and "not 32 bytes" without a
+/// name is a coin flip.
+fn parse_device(raw: &str) -> EyreResult<calimero_account::DeviceId> {
+    let bytes = hex::decode(raw.trim()).wrap_err_with(|| format!("device '{raw}' is not hex"))?;
+    let bytes: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| eyre::eyre!("device '{raw}' is not 32 bytes (64 hex characters)"))?;
+    Ok(calimero_account::DeviceId::from(bytes))
+}
+
 /// Parse a hex namespace id, with a message that says which argument was wrong —
 /// `export` takes several and a bare "invalid hex" would not say which.
 fn parse_namespace(raw: &str) -> EyreResult<ContextGroupId> {
@@ -361,4 +497,117 @@ fn parse_namespace(raw: &str) -> EyreResult<ContextGroupId> {
         .try_into()
         .map_err(|_| eyre::eyre!("namespace '{raw}' is not 32 bytes (64 hex characters)"))?;
     Ok(ContextGroupId::from(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use calimero_account::DeviceId;
+
+    use super::*;
+
+    /// A fixed root, so these tests assert on derivation rather than on a key that
+    /// changes per run. Not a secret: it owns nothing anywhere.
+    const PHRASE: &str = "legal winner thank year wave sausage worth useful legal winner \
+                          thank year wave sausage worth useful legal winner thank year \
+                          wave sausage worth title";
+
+    fn root() -> AccountRoot {
+        AccountRoot::from_mnemonic(PHRASE).expect("the fixture phrase must parse")
+    }
+
+    fn namespace(byte: u8) -> ContextGroupId {
+        ContextGroupId::from([byte; 32])
+    }
+
+    /// Mint a proof exactly as `revoke-proof` does, and hand back the wire form.
+    fn minted(ns: &ContextGroupId, device: DeviceId) -> String {
+        let root = root();
+        let revocation = calimero_account::sign_device_revocation(
+            root.signing_key(),
+            root.account_for(ns),
+            device,
+            0,
+        )
+        .expect("signing must succeed");
+        let proof = calimero_account::SignedDeviceRevocation {
+            genesis: root.genesis_for(ns),
+            chain: vec![],
+            revocation,
+        };
+        hex::encode(borsh::to_vec(&proof).expect("borsh must encode"))
+    }
+
+    fn decoded(wire: &str) -> calimero_account::SignedDeviceRevocation {
+        borsh::from_slice(&hex::decode(wire).expect("hex must decode")).expect("borsh must decode")
+    }
+
+    /// The whole point of printing the proof: it has to survive being copied
+    /// through a terminal and back. Hex and borsh are both exact, so this is
+    /// really asserting that the *pair* round-trips and still verifies.
+    #[test]
+    fn a_printed_proof_still_authorises_after_a_round_trip_through_hex() {
+        let ns = namespace(0xAA);
+        let device = DeviceId::from([0x42; 32]);
+
+        let proof = decoded(&minted(&ns, device));
+
+        proof
+            .authorises(root().account_for(&ns), device)
+            .expect("a proof minted for this account and device must authorise it");
+    }
+
+    /// The realistic operator error, and the reason `--namespace` is required
+    /// rather than optional: one root owns a DIFFERENT account in every namespace,
+    /// so a proof minted against the wrong one is well-formed, verifies against
+    /// its own genesis, and authorises nothing where it is published.
+    ///
+    /// Worth a test because the failure is otherwise invisible until the publish
+    /// step, where it reads as a permissions problem rather than a typo.
+    #[test]
+    fn a_proof_minted_for_another_namespace_does_not_authorise() {
+        let device = DeviceId::from([0x42; 32]);
+        let proof = decoded(&minted(&namespace(0xAA), device));
+
+        let elsewhere = root().account_for(&namespace(0xBB));
+        assert_ne!(
+            elsewhere,
+            root().account_for(&namespace(0xAA)),
+            "one root must own different accounts in different namespaces, or this \
+             test proves nothing"
+        );
+
+        let _ = proof
+            .authorises(elsewhere, device)
+            .expect_err("a proof for another namespace's account must be refused");
+    }
+
+    /// A proof names one device. Reusing it against another is the case that would
+    /// turn a single revocation into a way to spend any replica id.
+    #[test]
+    fn a_proof_does_not_authorise_a_different_device() {
+        let ns = namespace(0xAA);
+        let proof = decoded(&minted(&ns, DeviceId::from([0x42; 32])));
+
+        let _ = proof
+            .authorises(root().account_for(&ns), DeviceId::from([0x43; 32]))
+            .expect_err("a proof for one device must not authorise another");
+    }
+
+    #[test]
+    fn parse_device_names_the_argument_it_rejected() {
+        let err = parse_device("nothex")
+            .expect_err("must reject non-hex")
+            .to_string();
+        assert!(err.contains("device"), "{err}");
+
+        let err = parse_device("aabb")
+            .expect_err("must reject a short id")
+            .to_string();
+        assert!(err.contains("32 bytes"), "{err}");
+
+        // Trailing whitespace is what a copy-paste actually delivers.
+        let device = parse_device(&format!("  {}  \n", "42".repeat(32)))
+            .expect("a padded but valid id must parse");
+        assert_eq!(device, DeviceId::from([0x42; 32]));
+    }
 }

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2144,6 +2144,19 @@ pub struct PairDeviceCompleteApiResponse {
 pub struct RevokeDeviceApiRequest {
     /// Hex-encoded `DeviceId` to withdraw (32 bytes).
     pub device_id: String,
+    /// A hex-encoded, borsh-serialized `SignedDeviceRevocation` minted elsewhere.
+    ///
+    /// Present when the account root that owns the device is not on this node —
+    /// the lost-device case, where the proof is signed offline (`merod account
+    /// revoke-proof`) and this node only publishes it. Omit it to keep the
+    /// original behaviour: the node mints its own proof if it owns the account,
+    /// and otherwise revokes as an admin.
+    ///
+    /// Not a credential, and not a secret: it authorises this one revocation of
+    /// this one device, and only alongside a stored binding that already names the
+    /// same account.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proof: Option<String>,
 }
 
 impl Validate for RevokeDeviceApiRequest {
@@ -2160,6 +2173,24 @@ impl Validate for RevokeDeviceApiRequest {
                 field: "deviceId",
                 reason: "not valid hex".to_owned(),
             });
+        }
+        // Hex only. Whether the bytes decode as a proof, and whether that proof
+        // verifies, are checked where the account is known — validation here has no
+        // access to it, and a "valid" verdict that only meant "decodes" would be
+        // more misleading than no check at all. An empty string is rejected because
+        // it is always a caller mistake: omit the field instead.
+        if let Some(proof) = &self.proof {
+            if proof.is_empty() {
+                errors.push(ValidationError::InvalidHexEncoding {
+                    field: "proof",
+                    reason: "empty; omit the field entirely if you have no proof".to_owned(),
+                });
+            } else if hex::decode(proof).is_err() {
+                errors.push(ValidationError::InvalidHexEncoding {
+                    field: "proof",
+                    reason: "not valid hex".to_owned(),
+                });
+            }
         }
         errors
     }

--- a/crates/server/src/admin/handlers/namespaces/revoke_device.rs
+++ b/crates/server/src/admin/handlers/namespaces/revoke_device.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use axum::extract::Path;
 use axum::response::IntoResponse;
 use axum::Extension;
-use calimero_account::DeviceId;
+use calimero_account::{DeviceId, SignedDeviceRevocation};
 use calimero_context_client::group::RevokeDeviceRequest;
 use calimero_server_primitives::admin::{
     RevokeDeviceApiRequest, RevokeDeviceApiResponse, RevokeDeviceApiResponseData,
@@ -15,12 +15,31 @@ use crate::admin::handlers::validation::ValidatedJson;
 use crate::admin::service::{parse_api_error, ApiError, ApiResponse};
 use crate::AdminState;
 
+/// Decode a hex, borsh-encoded [`SignedDeviceRevocation`].
+///
+/// The error text names the stage that failed, because the two are different
+/// mistakes: bad hex is a transport or copy-paste problem, while hex that is not a
+/// proof usually means the wrong blob was pasted.
+fn decode_proof(raw: &str) -> Result<SignedDeviceRevocation, String> {
+    let bytes = hex::decode(raw.trim()).map_err(|err| format!("proof is not valid hex: {err}"))?;
+    borsh::from_slice(&bytes).map_err(|err| {
+        format!(
+            "proof is valid hex but not a revocation proof: {err}. It should be the \
+             output of `merod account revoke-proof`."
+        )
+    })
+}
+
 /// Withdraw a device from an account, terminally.
 ///
 /// An admin may revoke any device; the account holder may revoke its own with a
 /// root-signed proof. Only the admin path rotates the scope key, so a
 /// self-service revocation stops the device writing at once and leaves it able
 /// to read until an admin rotates — reported back rather than hidden.
+///
+/// The proof may also arrive from the **caller**, minted offline by whoever holds
+/// the account root. That is the lost-device path: the root never reaches a node,
+/// and the node publishing the revocation needs no authority of its own.
 pub async fn handler(
     Path(namespace_id_str): Path<String>,
     Extension(state): Extension<Arc<AdminState>>,
@@ -45,13 +64,34 @@ pub async fn handler(
         }
     };
 
-    info!(namespace_id = %namespace_id_str, device = %req.device_id, "revoking a device");
+    // Decoded here rather than in `validate`, which cannot see the account and so
+    // could only confirm the string is hex. A proof that does not deserialize is a
+    // caller error worth naming precisely — the alternative is publishing an op
+    // whose proof every replica silently declines to honour.
+    let proof = match req.proof.as_deref().map(decode_proof).transpose() {
+        Ok(proof) => proof,
+        Err(message) => {
+            return ApiError {
+                status_code: StatusCode::BAD_REQUEST,
+                message,
+            }
+            .into_response();
+        }
+    };
+
+    info!(
+        namespace_id = %namespace_id_str,
+        device = %req.device_id,
+        with_proof = proof.is_some(),
+        "revoking a device"
+    );
 
     let result = state
         .ctx_client
         .revoke_device(RevokeDeviceRequest {
             namespace_id,
             device: DeviceId::from(device),
+            proof,
         })
         .await
         .map_err(parse_api_error);

--- a/docs/src/content/docs/protocol/accounts.mdx
+++ b/docs/src/content/docs/protocol/accounts.mdx
@@ -267,6 +267,48 @@ The proof accepts **any** epoch its carried chain resolves, not merely the newes
 
 **Cutting off authorship is not enough on its own.** A revoked device already holds the current scope key, so without a rotation it stops writing and goes on reading — a silent reader. The rotation therefore rides on the same operation. Only an admin may rotate (peers accept a rotation sidecar only from an admin at the cut), so a self-service revocation locks the device out of writing immediately and leaves the rotation owed.
 
+### Revoking with only the account root
+
+The lost-device case, and the one the account plane exists for. Revoking is the
+account's authority, and someone who has merely *lost* a device still holds it —
+but the code path that mints a proof reads the root from the acting node's own
+store, and that node is the one that is gone.
+
+What makes the offline route possible is that the proof is **self-certifying**: it
+carries the genesis and the root-key chain, so a verifier checks it from the
+account id alone. Nothing about it depends on *where* it was made, so the root
+never has to reach a node.
+
+```bash
+# Wherever the root is. --from reads the recovery phrase, so this needs no node,
+# no home and no init: a fresh machine, the merod binary, and the words.
+merod account revoke-proof --namespace <NAMESPACE_ID> --device <DEVICE_ID> \
+  --from phrase.txt
+
+# Then, from any node that is a member and has folded the device's link:
+meroctl account revoke <NAMESPACE_ID> --device-id <DEVICE_ID> --proof @proof.hex
+```
+
+The publishing node needs **no authority of its own** — not admin, not the
+account. It is a relay. Which is also why the node holding the revoked device
+being offline is irrelevant: nothing asks it anything.
+
+Two things the proof deliberately cannot do:
+
+- **Name a device that is not the account's.** A proof only attests that its
+  signer holds the root of the account it *names*; choosing a `DeviceId` to write
+  beside it is free. Tying the two together is the stored binding's job, checked
+  before publishing and again by every replica that applies the operation. Without
+  that check, anyone holding any account root could spend any replica id for good.
+- **Rotate the scope key.** Only an admin may, so — exactly as with the on-node
+  self-service path — the device stops writing immediately and can read until an
+  admin rotates.
+
+Because the account id is per-namespace, `--namespace` is required. One root owns
+a different account in each, so a proof minted against the wrong one is
+well-formed, verifies against its own genesis, and authorises nothing where it is
+published.
+
 ## Per-device authorization
 
 A paired device signs with its own namespace identity, which is a member of nothing. Its right to author comes entirely from the account its certificate binds it to:
@@ -536,7 +578,7 @@ than just the key round trip.
 - **Revocation latency is per scope.** A scope that has not folded the revocation still honours the old binding. Inherent to causal revocation.
 - **Self-service revocation cannot rotate.** The device stops writing at once but can read until an admin rotates.
 - **Pairing is only as good as the channel the confirmation code travels on.** `pair-init` signs a statement over the account, the device id and both keys, and `pair-complete` refuses to certify key material that does not carry it — so nobody can swap the KEM key under a captured device id, which is what previously made the exchange only as safe as the channel carrying it. What a signature cannot settle is a *wholesale* substitution: an attacker that replaces both keys and re-signs with its own produces a statement that verifies, because nothing on the certifying side commits to the genuine keys in advance. Binding the keys into the `DeviceId` would fix it and is deliberately unavailable — the id excludes them so a device survives key rotation. What closes it instead is the confirmation code: a 64-bit value over exactly what gets certified, which `pair-complete` **requires** and checks against the keys that arrived, so the comparison cannot be skipped. It is 64 bits and not the six digits that would be pleasant to read aloud because the attacker knows the genuine code and can grind its own keypairs offline until one matches — the width is the work factor. What remains is not a gap in the check but in the channel: a code pasted alongside the keys it describes was rewritten by the same hand, so the code has to reach the account holder some other way — read out, or over a channel the payload did not take.
-- **Root-side revocation has no operator surface.** Revoking a device requires the account's authority, which a user who merely *lost* the device still has — and recovering from the offline root works in principle, since an account id is recomputable from its root alone. But no CLI or admin endpoint drives it, so today that is a capability rather than a feature. A device cannot revoke itself: if it could, compromising it would hand the attacker a revocation primitive instead of taking one away.
+- **A device cannot revoke itself.** If it could, compromising one would hand the attacker a revocation primitive instead of taking one away. Revoking is the account's authority, exercised from elsewhere — see [Revoking with only the account root](#revoking-with-only-the-account-root).
 - **Key-delivery fan-out is quadratic in group size.** `current_key_recipients` resolves devices per member, and each resolution scans the group's bindings, so a rotation costs on the order of members × devices. It runs at rotation and join time — never per operation — and each recipient already needs a KEM wrap, which dominates. Hoisting one binding scan out of the loop collapses it when group sizes justify the change.
 - **A member with no live device cannot self-recover.** Re-enrolling needs an encrypted group operation, which needs the key — so they depend on an admin to re-deliver it or to publish the replacement link. If they could re-key themselves, revocation would mean nothing.
 - **Member-addressed delivery remains reachable by admin action.** Re-admission and an explicit key delivery both wrap to a member identity, so an admin can hand a key to a node still running a revoked device. An explicit privileged act, not an automatic path.


### PR DESCRIPTION
Closes #3354. Rebased onto master now that #3362 has landed (`c01e2e9c2`), so this is a plain two-commit PR against master — no stacking left.

## The gap

Revoking a device is the account's authority, and someone who has merely *lost* a device still holds it. But the only code path that minted a revocation proof read the root from **the acting node's own store** — which is precisely the machine that is gone. The authority existed and could not be exercised, so the lost-device story that motivates the account plane was a capability rather than a feature.

## Why an offline route works at all

The proof is already self-certifying: it carries the genesis and the root-key chain, and `verify_device_revocation` checks it from the account id alone with no folded state. Nothing about it depends on *where* it was minted — so the root never has to reach a node, and the node that publishes needs no authority of its own.

```bash
# Wherever the root is. --from reads the phrase, so: no node, no home, no init.
merod account revoke-proof --namespace <NS> --device <DEVICE_ID> --from phrase.txt

# From any member node that has folded the device's link.
meroctl account revoke <NS> --device-id <DEVICE_ID> --proof @proof.hex
```

That also settles the issue's "works when the node holding the device is offline" criterion by construction: nothing asks that node anything.

## The one part worth reviewing closely

The supplied proof is verified **before publishing**, against the account the group's own binding names — *not* the account inside the proof:

```rust
Some(proof) => match proof.authorises(account, device) {   // account = target.account
```

A proof attests only that its signer holds the root of the account it *names*; choosing a foreign `DeviceId` to write beside it is free. Tying the two together is the stored binding's job. `apply_device_unlinked` already enforces this (`device_belongs_to_account`, added earlier with the comment "the same hole the admin path was gated for, arriving by the other door"), so this adds no new authority — a proof for somebody else's device is refused here *and* there.

Checking here too is not redundant belt-and-braces. On the apply side an unverifiable proof is a **deterministic refusal that records nothing and returns `Ok`** — no retry, no error. Publish one and the operator sees a successful call, no revocation on any replica, and nothing anywhere saying why. Refusing early is the difference between a diagnosable error and silence.

## Tests

`cargo test -p merod --bins account` — 4 passing, aimed at reachable mistakes rather than coverage:

| test | what it pins |
| --- | --- |
| `a_printed_proof_still_authorises_after_a_round_trip_through_hex` | the wire form survives being copied through a terminal |
| `a_proof_minted_for_another_namespace_does_not_authorise` | the realistic operator error — one root owns a *different* account per namespace, so a wrong-`--namespace` proof is well-formed, verifies against its own genesis, and authorises nothing. This is why `--namespace` is required, not optional |
| `a_proof_does_not_authorise_a_different_device` | the case that would turn one revocation into a way to spend any replica id |
| `parse_device_names_the_argument_it_rejected` | both ids are 64 hex chars, so an unnamed "not 32 bytes" is a coin flip; also that a pasted id with trailing whitespace parses |

`cargo fmt --check` and `clippy -D warnings` clean across every touched crate (`--all-targets`).

## Landing-order warning — read before merging

`calimero-client-py` tracks core's **master** branch and constructs `RevokeDeviceApiRequest` as a struct literal, so adding the `proof` field **breaks its build the moment this merges** (E0063). Unavoidable — there is no way to add a field without breaking external literal construction — and the fix is the client-py change we want anyway: the same commit adds the `proof` parameter the merobox step needs. It should follow immediately.

## Not in this PR

**The merobox e2e.** It needs `account_revoke` to accept a `proof:`, which needs that client-py binding, which can only be written once this is on master. Following #3362's pattern: core → client-py → merobox → the scenario. The scenario is the honest end-to-end proof (wipe the device's node, revoke from the root elsewhere, show the tombstone stuck) and it is worth landing as a real one rather than approximating it with a script step.

**Root rotation.** The proof is signed at key epoch 0 with an empty chain, matching the existing node-side path. An account whose root has rotated needs the chain up to the signing epoch; documented on the command rather than silently producing a proof that cannot verify.

## Docs

- `protocol/accounts`: new "Revoking with only the account root" section — the commands, why the publishing node needs no authority, and the two things the proof deliberately cannot do (name a device the account does not own; rotate the scope key). The "root-side revocation has no operator surface" known limit is **replaced** by it, and the surviving limit narrowed to the real one: a device cannot revoke itself, deliberately, because otherwise compromising it would hand the attacker a revocation primitive.
- `crates/merod/AGENTS.md`: the subcommand, and that `--from` needs no store.
