### PR TITLE
fix(build): keep the profiling wasm under the node's module limit

### DIFF
--- a/.github/workflows/fuzzy-load-test.yml
+++ b/.github/workflows/fuzzy-load-test.yml
@@ -135,7 +135,7 @@ jobs:
         env:
           WASM_PROFILING: "true"
 
-      - name: Verify WASM files exist
+      - name: Verify WASM files exist and fit the node's module limit
         run: |
           ls -la apps/kv-store/res/
           ls -la apps/kv-store-with-handlers/res/
@@ -143,6 +143,26 @@ jobs:
           test -f apps/kv-store/res/kv_store.wasm
           test -f apps/kv-store-with-handlers/res/kv_store_with_handlers.wasm
           test -f apps/scaffolding-e2e/res/scaffolding_e2e.wasm
+          # A wasm over the node's max_module_size is rejected at
+          # create_context, which surfaces an hour later as an opaque
+          # "create_context failed" in a fuzzy run. Fail here instead, where
+          # the number and the cause are both in front of you. Must track
+          # DEFAULT_MAX_MODULE_SIZE_MIB in crates/runtime/src/logic.rs - the
+          # limit is not operator-tunable, so CI cannot raise it.
+          max=$((20 * 1024 * 1024))
+          over=0
+          for wasm in apps/kv-store/res/kv_store.wasm \
+                      apps/kv-store-with-handlers/res/kv_store_with_handlers.wasm \
+                      apps/scaffolding-e2e/res/scaffolding_e2e.wasm; do
+            size=$(wc -c <"$wasm")
+            printf '%s: %s bytes (%d%% of the %s-byte limit)\n' \
+              "$wasm" "$size" "$((size * 100 / max))" "$max"
+            if [ "$size" -gt "$max" ]; then
+              echo "::error file=$wasm::$wasm is $size bytes, over the node's ${max}-byte max_module_size; the node will reject it at create_context"
+              over=1
+            fi
+          done
+          exit "$over"
 
       # Use artifacts for same-run handoff between jobs (faster than cache for this use case)
       - name: Upload build artifacts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -385,13 +385,22 @@ strip = false
 lto = false
 codegen-units = 1
 
-# Profile for WASM apps with profiling support
+# Profile for WASM apps with profiling support.
+#
+# No DWARF: wasmer's perfmap resolves guest frames from the wasm `name`
+# section, and the flamegraph pipeline runs perf with frame pointers and
+# `--no-inline`, so nothing here consumes `.debug_*`. Carrying it is not
+# free - it is the bulk of the module, and the node rejects any app over
+# `max_module_size` (20 MiB, DEFAULT_MAX_MODULE_SIZE_MIB in
+# crates/runtime/src/logic.rs), which is not operator-tunable. `strip`
+# must stay `"debuginfo"`, never `"symbols"`: the latter drops the `name`
+# section and profiles lose every guest function name.
 [profile.app-profiling]
 inherits = "release"
 codegen-units = 1
 opt-level = 2
 lto = true
-debug = true
-strip = false
+debug = false
+strip = "debuginfo"
 panic = "abort"
 overflow-checks = true

--- a/tools/cargo-mero/src/build.rs
+++ b/tools/cargo-mero/src/build.rs
@@ -481,8 +481,8 @@ overflow-checks = true
 [profile.app-profiling]
 inherits = "release"
 opt-level = 2
-debug = true
-strip = false"#;
+debug = false
+strip = "debuginfo""#;
 
 #[cfg(test)]
 mod tests {

--- a/tools/cargo-mero/templates/Cargo.toml.tmpl
+++ b/tools/cargo-mero/templates/Cargo.toml.tmpl
@@ -34,12 +34,16 @@ strip = "symbols"
 panic = "abort"
 overflow-checks = true
 
-# Used by `cargo mero build --profiling`: keeps debug info, skips wasm-opt.
+# Used by `cargo mero build --profiling`: skips wasm-opt. Keeps the wasm
+# `name` section - wasmer's perfmap resolves guest frames from it - but no
+# DWARF, which nothing in the profiling path reads and which is big enough to
+# push an app past the node's 20 MiB module limit. Never `strip = "symbols"`:
+# that drops the `name` section and profiles lose guest function names.
 [profile.app-profiling]
 inherits = "release"
 opt-level = 2
-debug = true
-strip = false
+debug = false
+strip = "debuginfo"
 
 # Own workspace root: without this, scaffolding inside another workspace would
 # fold the app into it and the app-* profiles above would be ignored.

--- a/tools/cargo-mero/tests/fixtures/demo-app/Cargo.toml
+++ b/tools/cargo-mero/tests/fixtures/demo-app/Cargo.toml
@@ -35,7 +35,7 @@ overflow-checks = true
 [profile.app-profiling]
 inherits = "release"
 opt-level = 2
-debug = true
-strip = false
+debug = false
+strip = "debuginfo"
 
 [workspace]

--- a/tools/cargo-mero/tests/fixtures/multi-app/Cargo.toml
+++ b/tools/cargo-mero/tests/fixtures/multi-app/Cargo.toml
@@ -36,5 +36,5 @@ overflow-checks = true
 [profile.app-profiling]
 inherits = "release"
 opt-level = 2
-debug = true
-strip = false
+debug = false
+strip = "debuginfo"


### PR DESCRIPTION
## Summary

The `Run KV Store Fuzzy Test with Profiling` job has failed on every master push since `fcc7bf262` (#3364). It is not flaky and a rerun will not clear it — the app wasm no longer fits the node's WASM module limit, so `create_context` is rejected ~40 seconds in, long before the load phase.

`[profile.app-profiling]` carried full DWARF (`debug = true`, `strip = false`). That was already 17.2 MB of `kv_store.wasm`'s 18.17 MB, against a hard 20 MiB `max_module_size` — 89% of the cap consumed by debug info. #3364 (*derive the ABI from the type system*) added ~10 MB more of it and **zero** bytes of code, pushing the module to 28.42 MB.

## Root cause

Section-level diff of the wasm artifacts from the last green run (`787fa9f5c`, run 30765988140) and the first red one (`fcc7bf262`, run 30798064777):

| section | before | after |
| --- | ---: | ---: |
| code | 0.72 MB | 0.72 MB |
| `.debug_*` | 17.24 MB | 27.52 MB |
| **total** | **18.17 MB** | **28.42 MB** |

The code section is unchanged — the new `AbiType` machinery is entirely dead-code-eliminated from the guest, but its debug info is not.

Node log from run 30824345138:

```
WARN  calimero_runtime: WASM module size limit exceeded size=28417602 max=20971520
ERROR calimero_context::handlers::execute: failed to initialize module for execution
      module size limit (max_module_size) exceeded: 28417602 bytes > 20971520 bytes limit
ERROR calimero_server::admin::handlers::context::create_context: Failed to create context
```

`max_module_size` is deliberately not operator-tunable (`crates/runtime/src/config.rs:98`), so this has to be fixed on the build side.

## The fix

Nothing in the profiling path reads guest DWARF: wasmer's perfmap resolves guest frames from the wasm `name` section (`crates/runtime/src/lib.rs:167`), and the flamegraph pipeline runs perf with frame pointers, not `--call-graph dwarf`, with `--no-inline` skipping addr2line (`scripts/profiling/start-profiling.sh:104`, `generate-flamegraph.sh:131`).

So `[profile.app-profiling]` drops it — via `strip = "debuginfo"`, **not** `"symbols"`: the latter would take the `name` section with it and every guest frame in a profile would lose its function name. A comment on the profile records why, and pins it to `DEFAULT_MAX_MODULE_SIZE_MIB`.

The same profile is duplicated in the `cargo mero new` template, in the `PROFILES_SNIPPET` cargo-mero prints when an app is missing the profile, and in two test fixtures. All four get the same change — otherwise every newly scaffolded app inherits the same cliff.

Finally, the Build Apps job now fails on an over-limit wasm and prints each app's size as a percentage of the cap. Worth having on its own: `scaffolding_e2e.wasm` was at 18.58 MB, 89% of the limit and next in line, and the failure mode it replaces is an opaque `create_context failed` an hour into a fuzzy run.

## Verification

Built locally with the fixed profile (`cargo build --target wasm32-unknown-unknown --profile app-profiling -p kv-store`):

| | before (CI artifact) | after |
| --- | ---: | ---: |
| total | 28,417,602 B (135% of cap) | **900,498 B (4% of cap)** |
| `.debug_*` | 27.52 MB | none |
| `name` section | 0.090 MB | **0.090 MB** |
| code | 0.72 MB | 0.73 MB |

The `name` section survives at the same size, so perfmap output is unaffected.

The CI guard was dry-run in bash against both artifacts — passes the fixed wasm, fails today's 28,417,602-byte one with `::error` and exit 1.

`cargo fmt --check`, `cargo clippy -p cargo-mero`, and `cargo test -p cargo-mero` (47 passed) are green, plus the `#[ignore]`d `build_produces_embedded_abi_wasm`, which compiles the edited demo-app fixture end to end.

The real proof is the fuzzy job on this PR: it touches `.github/workflows/fuzzy-load-test.yml`, so the full suite runs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
