### PR TITLE
fix(abi): keep the ABI machinery out of wasm builds, and gate wasm size in CI

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -11,6 +11,7 @@ on:
       - "apps/**"
       - "e2e-tests/**"
       - "tools/**"
+      - "scripts/check-wasm-size.sh"
       - ".github/workflows/ci-checks.yml"
 
 env:
@@ -132,3 +133,38 @@ jobs:
       # env -u CARGO_TARGET_DIR: each fixture must build into its own cached target dir.
       - name: Run pipeline e2e
         run: env -u CARGO_TARGET_DIR cargo test -p cargo-mero --test pipeline -- --ignored --test-threads 1
+
+  # The fuzzy suite installs profiling-built wasms but never runs on a PR;
+  # this is the PR-time guard against a module merod refuses to load.
+  wasm-size:
+    name: WASM size gate
+    runs-on: ubuntu-24.04-8cpu
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Rust CI
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+          shared-key: wasm-size
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Setup cargo mero
+        uses: ./.github/actions/setup-cargo-mero
+
+      # WASM_PROFILING skips wasm-opt, so these are the largest builds of these
+      # apps anyone ships, matching what fuzzy-load-test.yml hands to a node.
+      - name: Build the fuzzy apps with profiling
+        env:
+          WASM_PROFILING: "true"
+        run: |
+          cargo mero build --manifest-path apps/kv-store/Cargo.toml
+          cargo mero build --manifest-path apps/kv-store-with-handlers/Cargo.toml
+          cargo mero build --manifest-path apps/scaffolding-e2e/Cargo.toml
+
+      - name: Check wasm sizes against the runtime module-size limit
+        run: ./scripts/check-wasm-size.sh

--- a/.github/workflows/fuzzy-load-test.yml
+++ b/.github/workflows/fuzzy-load-test.yml
@@ -36,6 +36,8 @@ on:
   # via `scripts/determine-image-tag.sh`. Other PR paths skip both —
   # they keep their cheap default behaviour. Same-repo PRs only;
   # `prepare.outputs.docker_push` keeps fork PRs from pushing.
+  # `crates/**`/`apps/**` stay off on purpose (cost); the size regression a PR
+  # must catch is covered by ci-checks.yml's `wasm-size` job.
   pull_request:
     paths:
       - "scripts/profiling/**"
@@ -135,14 +137,14 @@ jobs:
         env:
           WASM_PROFILING: "true"
 
-      - name: Verify WASM files exist
+      # Covers existence too; an oversized module fails here with a size,
+      # not 20 minutes later as an opaque context-creation error.
+      - name: Verify WASM files exist and fit the runtime module-size limit
         run: |
           ls -la apps/kv-store/res/
           ls -la apps/kv-store-with-handlers/res/
           ls -la apps/scaffolding-e2e/res/
-          test -f apps/kv-store/res/kv_store.wasm
-          test -f apps/kv-store-with-handlers/res/kv_store_with_handlers.wasm
-          test -f apps/scaffolding-e2e/res/scaffolding_e2e.wasm
+          ./scripts/check-wasm-size.sh
 
       # Use artifacts for same-run handoff between jobs (faster than cache for this use case)
       - name: Upload build artifacts

--- a/crates/account/Cargo.toml
+++ b/crates/account/Cargo.toml
@@ -16,4 +16,7 @@ sha2.workspace = true
 thiserror.workspace = true
 
 calimero-primitives = { workspace = true, features = ["borsh"] }
+
+# Host-only: ABI extraction runs against a native build, never inside the wasm.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 calimero-wasm-abi.workspace = true

--- a/crates/account/src/lib.rs
+++ b/crates/account/src/lib.rs
@@ -198,6 +198,7 @@ macro_rules! content_address_id {
             }
         }
 
+        #[cfg(not(target_arch = "wasm32"))]
         ::calimero_wasm_abi::impl_bytes32_abi!($name);
 
         impl core::fmt::Display for $name {

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -11,7 +11,6 @@ publish = true
 [dependencies]
 bs58.workspace = true
 borsh = { workspace = true, features = ["derive"], optional = true }
-calimero-wasm-abi.workspace = true
 ed25519-dalek.workspace = true
 eyre.workspace = true
 hex.workspace = true
@@ -23,6 +22,10 @@ sha2.workspace = true
 thiserror.workspace = true
 url = { workspace = true, features = ["serde"] }
 zeroize = { workspace = true, features = ["derive"] }
+
+# Host-only: ABI extraction runs against a native build, never inside the wasm.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+calimero-wasm-abi.workspace = true
 
 [dev-dependencies]
 hex.workspace = true

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_arch = "wasm32"))]
 mod abi_type;
 pub mod alias;
 pub mod application;

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -18,11 +18,15 @@ calimero-prelude.workspace = true
 calimero-primitives = { workspace = true, features = ["borsh"] }
 calimero-sdk-macros.workspace = true
 calimero-sys.workspace = true
-calimero-wasm-abi.workspace = true
 tracing = { workspace = true, optional = true }
 # Uses the `fmt` + `registry` features (both on by default); inherits the
 # workspace's feature set since `workspace = true` can't override it.
 tracing-subscriber = { workspace = true, optional = true }
+
+# ABI description is a host-build concern: the manifest is extracted by running
+# the app natively. Linking it into the wasm only bloats the module.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+calimero-wasm-abi.workspace = true
 
 [features]
 # Routes `tracing` macro output (`info!`/`debug!`/… from the app and any crate

--- a/crates/sdk/macros/src/abi_type.rs
+++ b/crates/sdk/macros/src/abi_type.rs
@@ -45,7 +45,11 @@ pub fn derive(input: DeriveInput) -> TokenStream {
     }
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    // ABI description runs only on the host (extraction, tests). Compiling it
+    // into the wasm is dead weight that pushed unoptimized profiling builds
+    // past the runtime's module size limit.
     quote! {
+        #[cfg(not(target_arch = "wasm32"))]
         impl #impl_generics ::calimero_sdk::abi::AbiType for #ident #ty_generics #where_clause {
             fn type_ref(
                 __reg: &mut ::calimero_sdk::abi::TypeRegistry,

--- a/crates/sdk/macros/src/event.rs
+++ b/crates/sdk/macros/src/event.rs
@@ -150,6 +150,8 @@ fn generate_abi_events_impl(
         .collect();
 
     quote! {
+        // Host-only like every ABI description impl: never in the wasm.
+        #[cfg(not(target_arch = "wasm32"))]
         impl #impl_generics ::calimero_sdk::abi::AbiEvents for #ident #ty_generics #where_clause {
             fn abi_events(
                 __reg: &mut ::calimero_sdk::abi::TypeRegistry,

--- a/crates/sdk/macros/src/logic.rs
+++ b/crates/sdk/macros/src/logic.rs
@@ -73,7 +73,7 @@ impl LogicImpl<'_> {
             #[allow(unexpected_cfgs, non_snake_case)]
             #[doc(hidden)]
             pub mod #module {
-                #[cfg(any(calimero_abi, test))]
+                #[cfg(all(any(calimero_abi, test), not(target_arch = "wasm32")))]
                 #[doc(hidden)]
                 pub fn __calimero_abi() -> ::calimero_sdk::abi::Manifest {
                     use super::*;
@@ -125,7 +125,7 @@ impl LogicImpl<'_> {
                 /// are `cdylib`s and cannot be run, so extraction rides the
                 /// test harness; without the variable set this is a no-op, so
                 /// an app's own `cargo test` is unaffected.
-                #[cfg(test)]
+                #[cfg(all(test, not(target_arch = "wasm32")))]
                 #[test]
                 fn __calimero_abi_dump() {
                     let ::core::result::Result::Ok(__path) =

--- a/crates/sdk/src/event.rs
+++ b/crates/sdk/src/event.rs
@@ -360,6 +360,7 @@ impl AppEventExt for NoEvent {}
 
 /// An app that declares no `emits` still names an event type in its ABI
 /// codegen; describing this one yields no entries.
+#[cfg(not(target_arch = "wasm32"))]
 impl crate::abi::AbiEvents for NoEvent {
     fn abi_events(_reg: &mut crate::abi::TypeRegistry) -> Vec<crate::abi::Event> {
         vec![]

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -32,9 +32,17 @@ pub mod testing;
 pub mod types;
 /// The ABI description surface apps and generated code use.
 pub mod abi {
+    // The derive stays on every target: `#[app::state]` and `#[app::event]`
+    // name it unconditionally, and its output is what carries the host gate.
     pub use calimero_sdk_macros::AbiType;
+
+    // The manifest is assembled by a host build (`cargo mero build` runs the
+    // app's extraction entry point), so none of this belongs in the wasm.
+    #[cfg(not(target_arch = "wasm32"))]
     pub use calimero_wasm_abi::abi_type::{AbiEvents, AbiType, TypeRegistry};
+    #[cfg(not(target_arch = "wasm32"))]
     pub use calimero_wasm_abi::manifest_builder::ManifestBuilder;
+    #[cfg(not(target_arch = "wasm32"))]
     pub use calimero_wasm_abi::schema::{
         CollectionType, CrdtCollectionType, Event, Field, Manifest, Method, MethodIntent,
         Parameter, ScalarType, TypeDef, TypeRef, Variant, XCallCallers,

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -24,9 +24,10 @@ tracing.workspace = true
 
 calimero-sdk.workspace = true
 calimero-storage-macros.workspace = true
-calimero-wasm-abi.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# Host-only: ABI extraction runs against a native build, never inside the wasm.
+calimero-wasm-abi.workspace = true
 ed25519-dalek.workspace = true
 rand.workspace = true
 

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -43,6 +43,7 @@ pub use crdt_meta::{CrdtMeta, CrdtType, Decomposable, Mergeable, StorageKey, Sto
 // silently breaking, and `tests/derive_mergeable.rs` exercises the re-exported
 // derive through this exact path.
 pub use calimero_sdk::app::Mergeable;
+#[cfg(not(target_arch = "wasm32"))]
 mod abi_type;
 pub mod composite_key;
 mod crdt_impls;

--- a/scripts/check-wasm-size.sh
+++ b/scripts/check-wasm-size.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Fail if an app wasm is too big for merod's module-size limit.
+# Usage: check-wasm-size.sh [wasm ...]   (default: the apps the fuzzy suite installs)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ "$#" -gt 0 ]; then
+    wasms=("$@")
+else
+    wasms=(
+        apps/kv-store/res/kv_store.wasm
+        apps/kv-store-with-handlers/res/kv_store_with_handlers.wasm
+        apps/scaffolding-e2e/res/scaffolding_e2e.wasm
+    )
+fi
+
+# Read from the runtime's own default rather than restating it, so a bump there
+# moves this gate with it.
+LIMITS_RS="crates/runtime/src/logic.rs"
+limit_mib="$(sed -n 's/^const DEFAULT_MAX_MODULE_SIZE_MIB: u64 = \([0-9]\{1,\}\);.*/\1/p' "$LIMITS_RS")"
+if [ -z "$limit_mib" ]; then
+    echo "ERROR: could not read DEFAULT_MAX_MODULE_SIZE_MIB from $LIMITS_RS" >&2
+    exit 1
+fi
+limit=$((limit_mib * 1024 * 1024))
+
+# Trip at 90% so growth surfaces here while there is still room to land a fix,
+# not on the first byte past the cliff.
+budget=$((limit * 9 / 10))
+
+oversized=0
+for wasm in "${wasms[@]}"; do
+    if [ ! -f "$wasm" ]; then
+        echo "ERROR: $wasm not found (build the apps first)" >&2
+        exit 1
+    fi
+    size="$(wc -c <"$wasm" | tr -d '[:space:]')"
+    pct=$((size * 100 / limit))
+    if [ "$size" -le "$budget" ]; then
+        printf 'ok:      %s (%s bytes, %s%% of the limit)\n' "$wasm" "$size" "$pct"
+    else
+        printf 'TOO BIG: %s (%s bytes, %s%% of the limit)\n' "$wasm" "$size" "$pct" >&2
+        oversized=1
+    fi
+done
+
+if [ "$oversized" -ne 0 ]; then
+    echo "" >&2
+    echo "FAIL: budget is $budget bytes, 90% of the runtime's ${limit}-byte" >&2
+    echo "max_module_size (DEFAULT_MAX_MODULE_SIZE_MIB = $limit_mib in $LIMITS_RS)." >&2
+    echo "merod refuses to create a context from a module past $limit bytes." >&2
+    exit 1
+fi
+
+echo "All ${#wasms[@]} app wasm(s) within $budget bytes (90% of the ${limit}-byte max_module_size)."


### PR DESCRIPTION
## Summary

Since #3364 merged, the `Fuzzy Load Test` workflow fails at context creation: the app-profiling kv-store wasm grew from 18.2MB to 28.4MB and crossed the runtime's 20,971,520-byte `max_module_size`.

Root cause: #3364 added `calimero-wasm-abi` as an unconditional dependency of `calimero-sdk`/`-primitives`/`-storage`/`-account`, which pulled `wasmparser` and `semver` into every app's wasm compilation. `wasm-ld` garbage-collects their dead code (the code section grew by 1,215 bytes), but DWARF debug sections are copied wholesale once a library is linked - and the app-profiling profile keeps debug info (for perf attribution) and skips wasm-opt, so it alone absorbed ~9.9MB of debug records describing code that is not in the binary. Release builds strip symbols, which is why every size check on the PR stayed at ~490KB, and the fuzzy workflow does not run on pull requests, so nothing caught it pre-merge.

The fix removes the cause and adds the missing gate:

- **`calimero-wasm-abi` is now a host-only dependency** (`[target.'cfg(not(target_arch = "wasm32"))'.dependencies]`) of the four crates, with matching `cfg` gates on the hand-written impl modules, the sdk's `abi` re-export surface, and the macro-generated `AbiType`/`AbiEvents`/`__calimero_abi` output. The manifest is extracted from a host build, so nothing ABI-related belongs in the wasm. The `#[derive(AbiType)]` re-export stays unconditional: injected derives must resolve on every target while expanding to nothing on wasm.
- **`scripts/check-wasm-size.sh`** profiling-builds the three fuzzy apps and fails at 90% of `max_module_size`, parsing the limit from `crates/runtime`'s own constant so the gate cannot drift from the runtime. It runs as a `wasm-size` job in the `CI` workflow on every relevant PR, and in the fuzzy workflow's build job so a breach fails in minutes with a sized error instead of later as an opaque `create_context` failure. Running the full fuzzy lanes on PRs was evaluated and rejected (queued 150-minute self-hosted lanes, fork-secret gaps, and PR runs would fuzz master's merod image); the reasoning is recorded in that workflow's trigger comment.

Sizes: profiling kv-store 28,434,897 → 18,180,550 bytes (+0.12% vs the pre-#3364 baseline of 18,158,466); release kv-store 491,529 bytes; manifests byte-identical. Note the pre-existing headroom problem this exposes: the baseline was already at 86% of the limit (`scaffolding-e2e` at 87%), so the gate firing early on future growth is intended signal.

## Test plan

- `WASM_PROFILING=true cargo mero build` for kv-store, kv-store-with-handlers, scaffolding-e2e, then `./scripts/check-wasm-size.sh` (passes; verified it FAILS against the pre-fix 28MB build)
- `cargo tree --target wasm32-unknown-unknown` for kv-store and scaffolding-e2e: zero occurrences of `wasm-abi`/`wasmparser`/`semver`
- `cargo test` across calimero-wasm-abi, sdk, sdk-macros, storage, primitives, account, cargo-mero: 0 failures
- `bash scripts/build-all-apps.sh` + `check-embedded-abi.sh` (all 20 wasms carry `calimero_abi_v1`) + `verify-abi.sh` + state-schema triangle: green; `git diff` shows no golden changes
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check` clean