### PR TITLE
fix(sync): make the gov-divergence pull outcome visible where the trigger is

### DIFF
--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1620,7 +1620,15 @@ impl SyncManager {
                     // flags a pull that delivered nothing (best-effort failure or an
                     // already-converged peer), which the `Ok(None)` below would
                     // otherwise hide as "entities already in sync".
-                    debug!(
+                    //
+                    // `info!`, matching the trigger above it, because a correlation
+                    // is worthless when only one of the pair is visible: the e2e
+                    // filter is `calimero_=info` and no scenario raises it, so at
+                    // `debug!` this never reached the logs it was written for. A
+                    // storm showed 178 triggers on one context with no way to tell
+                    // whether a single pull moved any ops. Same volume as the
+                    // trigger, and both are only frequent when something is wrong.
+                    info!(
                         marker = "gov_divergence_pull_complete",
                         %context_id,
                         %chosen_peer,
@@ -1737,7 +1745,10 @@ impl SyncManager {
                                 let ops_pulled = self
                                     .pull_namespace_governance(context_id, chosen_peer)
                                     .await;
-                                debug!(
+                                // `info!` for the same reason as the pre-sync
+                                // site: the outcome has to be visible wherever the
+                                // trigger is, or the pair cannot be correlated.
+                                info!(
                                     marker = "gov_divergence_pull_complete",
                                     %context_id,
                                     %chosen_peer,


### PR DESCRIPTION
One-line-per-site log level change, found while diagnosing #2716.

## The problem

`gov_divergence_pull_triggered` is `info!`. Its counterpart `gov_divergence_pull_complete` — the one carrying **`ops_pulled`** — was `debug!`. The e2e filter is `merod=info,calimero_=info` and no scenario raises `RUST_LOG`, so the completion marker never appeared in any CI log.

Its own comment states the purpose:

> Completion marker so the e2e report (and operators) can correlate the trigger with its outcome — `ops_pulled == 0` flags a pull that delivered nothing (best-effort failure or an already-converged peer), which the `Ok(None)` below would otherwise hide as "entities already in sync".

A correlation where only one side is visible isn't one. Verified: **zero** occurrences of `gov_divergence_pull_complete` in a failing job's logs.

## Why it matters now

#2716's diagnostic just showed a failing run with **178 corrective governance pulls against a single context** in 90 seconds — a scope stuck in a loop — and no way to tell whether a single pull moved any ops. That is the fork in the diagnosis:

- `ops_pulled == 0` throughout → the peer has nothing to give, the retry is futile by construction, and the cause is upstream of the pull.
- `ops_pulled > 0` while `scope_root` still differs → ops arrive and the fold doesn't converge on them, pointing back at #2716's original root cause.

Without this, the next occurrence tells us nothing new.

## Volume

Not a concern. The trigger already emits at `info!`, so this pairs an existing line rather than introducing a new source; both are only frequent when something is already wrong, which is when you want them.

Deliberately kept off #3362 (the account-root PR this surfaced on) — different crate, different CI paths, unrelated review surface.

`cargo fmt --check` and `clippy -D warnings` clean on `calimero-node`.
