### PR TITLE
fix(auth): mint client key ids that cannot collide

### DIFF
--- a/crates/auth/src/api/handlers/client_keys.rs
+++ b/crates/auth/src/api/handlers/client_keys.rs
@@ -3,10 +3,9 @@ use std::sync::Arc;
 use axum::extract::{Extension, Path};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
-use chrono::Utc;
 use serde::Deserialize;
-use sha2::{Digest, Sha256};
 use tracing::error;
+use uuid::Uuid;
 use validator::Validate;
 
 use super::auth::{error_response, success_response};
@@ -131,23 +130,6 @@ pub async fn generate_client_key_handler(
         None => "".to_string(),
     };
 
-    //TODO decide final approach for context ID and Identity
-    // // Check if admin permission is requested
-    // let has_admin_permission = request
-    //     .permissions
-    //     .as_ref()
-    //     .map(|perms| perms.contains(&"admin".to_string()))
-    //     .unwrap_or(false);
-
-    // // Allow empty context_id and context_identity only if admin permission is requested
-    // if !has_admin_permission && (context_id.is_empty() || context_identity.is_empty()) {
-    //     return error_response(
-    //         StatusCode::BAD_REQUEST,
-    //         "Context ID and context identity must contain valid characters",
-    //         None,
-    //     );
-    // }
-
     // Get and validate root key
     let root_key = match state.0.key_manager.get_key(&root_key_id).await {
         Ok(Some(key)) if !key.is_valid() => {
@@ -167,12 +149,7 @@ pub async fn generate_client_key_handler(
         Ok(Some(key)) => key,
     };
 
-    let timestamp = Utc::now().timestamp();
-
-    let mut hasher = Sha256::new();
-    hasher.update(format!("client:{context_id}:{context_identity}:{timestamp}").as_bytes());
-    let hash = hasher.finalize();
-    let client_id = hex::encode(hash);
+    let client_id = Uuid::new_v4().to_string();
 
     // Build permissions list starting with required context permission
     // Only add context permission if context_id and context_identity are not empty
@@ -291,6 +268,103 @@ pub async fn delete_client_handler(
                 "Failed to get client key",
                 None,
             )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::{header, HeaderValue};
+
+    use super::*;
+    use crate::auth::rate_limit::LoginRateLimiter;
+    use crate::auth::token::TokenManager;
+    use crate::embedded::default_config;
+    use crate::secrets::SecretManager;
+    use crate::storage::{KeyManager, MemoryStorage, Storage};
+    use crate::utils::AuthMetrics;
+    use crate::AuthService;
+
+    async fn admin_state() -> (Arc<AppState>, HeaderMap) {
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new());
+        let secret_manager = Arc::new(SecretManager::new(Arc::clone(&storage)));
+        secret_manager.initialize().await.unwrap();
+
+        let config = default_config();
+        let token_manager =
+            TokenManager::new(config.jwt.clone(), Arc::clone(&storage), secret_manager);
+        let key_manager = KeyManager::new(Arc::clone(&storage));
+
+        let root = Key::new_root_key_with_permissions(
+            "test-public-key".to_string(),
+            "user_password".to_string(),
+            vec!["admin".to_string()],
+            None,
+        );
+        let _ = key_manager.set_key("root-1", &root).await.unwrap();
+
+        let (access, _refresh) = token_manager
+            .generate_token_pair("root-1".to_string(), vec!["admin".to_string()], None)
+            .await
+            .unwrap();
+
+        let mut headers = HeaderMap::new();
+        let _ = headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {access}")).unwrap(),
+        );
+
+        let state = Arc::new(AppState {
+            auth_service: AuthService::new(vec![], token_manager.clone()),
+            storage,
+            key_manager,
+            token_generator: token_manager,
+            config,
+            metrics: AuthMetrics::new(),
+            login_rate_limiter: Arc::new(LoginRateLimiter::default()),
+        });
+
+        (state, headers)
+    }
+
+    #[tokio::test]
+    async fn back_to_back_mints_do_not_overwrite_each_other() {
+        let (state, headers) = admin_state().await;
+
+        for _ in 0..2 {
+            let response = generate_client_key_handler(
+                Extension(Arc::clone(&state)),
+                headers.clone(),
+                ValidatedJson(GenerateClientKeyRequest {
+                    context_id: None,
+                    context_identity: None,
+                    permissions: Some(vec!["admin".to_string()]),
+                    target_node_url: None,
+                }),
+            )
+            .await
+            .into_response();
+
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+
+        let clients = state.key_manager.list_keys(KeyType::Client).await.unwrap();
+        assert_eq!(
+            clients.len(),
+            2,
+            "two admin-scoped mints in the same second must yield two distinct keys, got {clients:?}"
+        );
+
+        for (client_id, _) in &clients {
+            assert!(
+                state
+                    .key_manager
+                    .get_key(client_id)
+                    .await
+                    .unwrap()
+                    .is_some(),
+                "minted key {client_id} must be retrievable"
+            );
         }
     }
 }

--- a/crates/auth/src/auth/token/jwt.rs
+++ b/crates/auth/src/auth/token/jwt.rs
@@ -5,9 +5,8 @@ use axum::http::HeaderMap;
 use chrono::{Duration, Utc};
 use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use url::Url;
-use {hex, uuid};
+use uuid::Uuid;
 
 use crate::config::JwtConfig;
 use crate::secrets::{SecretManager, SecretType};
@@ -270,7 +269,7 @@ impl TokenManager {
             aud: self.config.issuer.clone(),
             exp: exp.timestamp() as u64,
             iat: now.timestamp() as u64,
-            jti: uuid::Uuid::new_v4().to_string(),
+            jti: Uuid::new_v4().to_string(),
             token_type,
             permissions,
             node_url,
@@ -930,11 +929,7 @@ impl TokenManager {
             }
             // For client tokens, rotate the key ID
             KeyType::Client => {
-                // Generate new client ID
-                let timestamp = Utc::now().timestamp();
-                let mut hasher = Sha256::new();
-                hasher.update(format!("refresh:{}:{}", claims.sub, timestamp).as_bytes());
-                let new_client_id = hex::encode(hasher.finalize());
+                let new_client_id = Uuid::new_v4().to_string();
 
                 // Log only short id prefixes; the full client key ids are
                 // sensitive and add noise to debug logs.


### PR DESCRIPTION
Closes #3337.

## Summary

`POST /admin/client-key` derived the new key's id from a SHA-256 over
`client:{context_id}:{context_identity}:{unix_seconds}`. Both context fields are
absent for a plain admin-scoped key, so the hashed input reduces to
`client:::<second>` - identical for any two such mints in the same second,
regardless of caller. `KeyManager::set_key` is an unconditional put, so the
second mint silently replaced the first.

Two silent failure modes followed: two callers each believing they hold a
distinct credential while sharing one, and a mint-then-revoke-previous flow (the
standard "replace the agent's credential" pattern) revoking the key it had just
issued, with a `200` on both calls.

`client_id` is now a random UUID, so the id is collision-free by construction
and no mint can overwrite a stored key. The refresh-rotation path in `jwt.rs`
built its target id the same way (`refresh:{sub}:{unix_seconds}`) and gets the
same treatment; that file already used `Uuid::new_v4` for the token `jti`.

Existing keys are unaffected. `client_id` is opaque - a suffix in
`client_key:{id}` and a JWT `sub`. Nothing parses it as hex or checks its
length, so stored 64-hex ids keep resolving alongside new UUIDs, and no
migration is needed.

## Test plan

New regression test `back_to_back_mints_do_not_overwrite_each_other` mints twice
through `generate_client_key_handler` with no delay and asserts two distinct
client keys are stored and both retrievable.

With the old derivation restored, it fails:

```text
test api::handlers::client_keys::tests::back_to_back_mints_do_not_overwrite_each_other ... FAILED

assertion `left == right` failed: two admin-scoped mints in the same second must
yield two distinct keys, got [("1df875c063b6e2433153...", Key { key_type: Client,
root_key_id: Some("root-1"), name: Some("Context Client -  ()"), .. })]
  left: 1
 right: 2
```

With the fix:

```text
test api::handlers::client_keys::tests::back_to_back_mints_do_not_overwrite_each_other ... ok
```

Gates on `mero-auth`:

- `cargo fmt --check` - passes
- `cargo test -p mero-auth` - 169 + 6 passed, 0 failed
- `cargo clippy -p mero-auth --all-targets -- -A warnings` - clean