### PR TITLE
fix(storage): make a rejected snapshot signature say which storage type failed

### DIFF
--- a/crates/node/tests/dag_causal_shared_e2e.rs
+++ b/crates/node/tests/dag_causal_shared_e2e.rs
@@ -496,9 +496,10 @@ async fn post_rotation_forgery_by_revoked_writer_rejected() {
     // authorization at the cut rather than a mismatched principal.
     applier.set_author(bob).await;
     let result = dag.add_delta(d3, &applier).await;
-    // `StorageError::InvalidSignature` displays as "Invalid signature for
-    // user-owned data" — match on the rejection, not the exact prose, so
-    // doc-string changes don't break this probe.
+    // Match on the rejection, not the exact prose, so a change to
+    // `StorageError::InvalidSignature`'s Display text does not break this probe.
+    // That text HAS changed (it used to name "user-owned data", which misdescribed
+    // every real occurrence), and this assertion survived it — which is the point.
     assert!(
         matches!(&result, Err(calimero_dag::DagError::ApplyFailed(ApplyError::Application(msg))) if msg.contains("Invalid signature")),
         "post-rotation forgery by revoked writer must be rejected with InvalidSignature; got {result:?}"

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -443,8 +443,8 @@ where
         // `or_else`/collection-first while the other unioned), two nodes
         // resolved DIFFERENT writer sets for the same anchor (collection on the
         // originator, side store on a reconcile-only receiver), so a value
-        // signed against one set failed verification on the other ("Invalid
-        // signature for user-owned data") and the cluster split-brained on the
+        // signed against one set failed verification on the other
+        // (`StorageError::InvalidSignature`) and the cluster split-brained on the
         // value entry under concurrent rotation. One resolver ⇒ one writer set.
         crate::interface::Interface::<S>::resolve_anchor_writers(self.inner.id())
     }

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -536,6 +536,24 @@ impl BorshDeserialize for OpMask {
     }
 }
 
+/// A short, stable name for a [`StorageType`] variant, for logs.
+///
+/// Exists because [`StorageError::InvalidSignature`](crate::error::StorageError)
+/// is returned by three different arms of snapshot verification and cannot say
+/// which. Naming the variant at the rejection site is what turns "invalid
+/// signature somewhere" into something actionable — see core#3376, where the
+/// error's own text pointed at the wrong arm.
+#[must_use]
+pub const fn storage_type_name(storage_type: &StorageType) -> &'static str {
+    match storage_type {
+        StorageType::Public => "Public",
+        StorageType::Frozen => "Frozen",
+        StorageType::User { .. } => "User",
+        StorageType::Shared { .. } => "Shared",
+        StorageType::SharedMember { .. } => "SharedMember",
+    }
+}
+
 /// Defines the type of storage and its associated authorization rules.
 /// Enum to define the storage domain and its associated data.
 #[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -52,7 +52,16 @@ pub enum StorageError {
     InvalidTimestamp(u64, u64),
 
     /// The provided signature for an action is invalid.
-    #[error("Invalid signature for user-owned data")]
+    ///
+    /// Returned by the `User`, `Shared` **and** `SharedMember` arms of
+    /// `Interface::verify_snapshot_entity_signature`, so the text deliberately
+    /// does not name one of them. It used to read "for user-owned data", which
+    /// cost real time on core#3376: every failure there was a `SharedMember`
+    /// leaf, and the message pointed the investigation at `User` storage for two
+    /// rounds. The storage type and entity id are logged at the rejection site
+    /// instead — a single error variant cannot carry them without touching 25
+    /// return sites and the wire-visible serialization below.
+    #[error("Invalid signature for signed storage (User, Shared or SharedMember)")]
     InvalidSignature,
 
     /// The action's claimed ancestor merkle hash does not match the receiver's

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -733,6 +733,35 @@ impl<S: StorageAdaptor> Interface<S> {
         data: &[u8],
         metadata: &crate::entities::Metadata,
     ) -> Result<(), StorageError> {
+        let verdict = Self::verify_snapshot_entity_signature_inner(id, data, metadata);
+        if verdict.is_err() {
+            // Name the storage type and the entity, because the error variant
+            // cannot. One `InvalidSignature` is returned by three different arms,
+            // and on core#3376 every rejection was a `SharedMember` while the
+            // error text said "user-owned data" — the investigation went to the
+            // wrong arm twice. A rejection here aborts the whole HashComparison
+            // session, so it is worth a line: without it the only way to learn
+            // which entity failed is to download the node-log artifact and read
+            // the DEBUG line that happens to precede the warning.
+            tracing::warn!(
+                %id,
+                storage_type = crate::entities::storage_type_name(&metadata.storage_type),
+                crdt_type = ?metadata.crdt_type,
+                "snapshot entity signature rejected; the HashComparison session \
+                 using this leaf cannot complete"
+            );
+        }
+        verdict
+    }
+
+    /// The verdict itself. Split out so [`Self::verify_snapshot_entity_signature`]
+    /// can log every rejection in one place — several arms bail early, so a tail
+    /// log on the public function would miss them.
+    fn verify_snapshot_entity_signature_inner(
+        id: crate::address::Id,
+        data: &[u8],
+        metadata: &crate::entities::Metadata,
+    ) -> Result<(), StorageError> {
         use crate::action::Action;
         use crate::entities::StorageType;
 
@@ -2344,8 +2373,8 @@ impl<S: StorageAdaptor> Interface<S> {
                 // leaf (HashComparison ships the entity's own index
                 // `storage_type` as the wire authorization) that NO peer — nor the
                 // node itself on a pushed-back leaf — could verify: the residual
-                // concurrent-rotation `SharedMember` "Invalid signature for
-                // user-owned data" split-brain (two writers stamp the same HLC on
+                // concurrent-rotation `SharedMember` `InvalidSignature`
+                // split-brain (two writers stamp the same HLC on
                 // different content; the equal-HLC `lww_pick` keeps one side's
                 // bytes while the signature stayed the other's).
                 //

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -1871,6 +1871,168 @@ mod shared_storage_rotation_authentication {
             "a leaf whose signature does not cover its data must be rejected"
         );
     }
+
+    /// **Falsification test for core#3376 — the hypothesis it tests is WRONG, and
+    /// this pins why.**
+    ///
+    /// The hypothesis was: a `SharedMember` whose stored value is a CRDT *merge
+    /// output* keeps the earlier writer's signature over bytes nobody signed,
+    /// because the receiver-side coupling in `apply_action` re-couples
+    /// `{data, signature}` only when the stored bytes equal the INCOMING write's,
+    /// and a merge output equals neither input.
+    ///
+    /// It does not happen, for a reason worth recording: the built-in mergeable
+    /// CRDTs are **collection-backed**. `Counter` is two `UnorderedMap` handles, so
+    /// its serialized form is a pair of ids and a merge mutates *child* entities,
+    /// never the entity's own bytes. The parent's `data` is therefore stable across
+    /// a merge, so data and signature cannot decouple this way — there is no third
+    /// value for the gate to miss.
+    ///
+    /// So this test asserts the coupling HOLDS, and exists to stop a future change
+    /// from quietly introducing the decoupling it was written to look for: an
+    /// inline-valued mergeable type, or a merge that rewrites the parent's bytes,
+    /// would break it and should be considered against #3376 before landing.
+    ///
+    /// What remains unexplained about #3376, and where to look next: the coupling
+    /// patch is **best-effort** — the comment at the call site says an
+    /// "identity/placeholder mismatch returns `Err`, which means this was not a
+    /// same-record signed update — leave the stored signature". The data has
+    /// already been written by then. Any path that changes the bytes and then fails
+    /// to patch leaves exactly the decoupled leaf #3376 observes.
+    #[test]
+    fn a_mergeable_shared_member_keeps_its_data_and_signature_coupled() {
+        use calimero_primitives::crdt::CrdtType;
+
+        use crate::collections::Counter;
+        use crate::entities::{Metadata, SignatureData};
+
+        env::reset_for_testing();
+        let root = setup_root_for_main();
+
+        let alice_sk = make_signing_key(0xA1);
+        let alice = account_of_key(&alice_sk);
+        let bob_sk = make_signing_key(0xB0);
+        let bob = account_of_key(&bob_sk);
+
+        let anchor = Id::new([0xA0; 32]);
+        let member = Id::new([0x3E; 32]);
+        let writers: BTreeSet<_> = [alice, bob].into_iter().collect();
+
+        let n0 = env::time_now();
+        MainInterface::apply_action(
+            build_signed_shared_action(
+                true,
+                anchor,
+                b"anchor".to_vec(),
+                writers,
+                n0,
+                &alice_sk,
+                vec![root.clone()],
+            ),
+            &apply_ctx_for(alice),
+        )
+        .expect("anchor bootstrap must apply");
+
+        // Two disjoint GCounter contributions — different handles, and a merge
+        // would union their children.
+        let counter_bytes = |device: u8, count: u64| -> Vec<u8> {
+            env::set_device_id([device; 32]);
+            let mut counter = Counter::<false>::new();
+            for _ in 0..count {
+                counter.increment().expect("increment");
+            }
+            borsh::to_vec(&counter).expect("counter must serialize")
+        };
+        let alice_data = counter_bytes(0xA1, 3);
+        let bob_data = counter_bytes(0xB0, 5);
+        assert_ne!(
+            alice_data, bob_data,
+            "the two contributions must differ or nothing is being merged"
+        );
+
+        // A `SharedMember` carrying a MERGEABLE crdt_type. The shared helper
+        // hardcodes `crdt_type: None`, which takes the LWW path and never reaches a
+        // merge, so the metadata is built locally.
+        let signed_member = |data: Vec<u8>, hlc: u64, sk: &SigningKey| {
+            let metadata = Metadata {
+                created_at: hlc,
+                updated_at: hlc.into(),
+                storage_type: StorageType::SharedMember {
+                    anchor,
+                    signature_data: Some(SignatureData {
+                        signature: [0; 64],
+                        nonce: hlc,
+                        signer: Some(pubkey_of(sk)),
+                    }),
+                },
+                crdt_type: Some(CrdtType::GCounter),
+                field_name: None,
+                schema_version: None,
+            };
+            let mut action = crate::action::Action::Add {
+                id: member,
+                data,
+                // Every applied member action needs an ancestor chain; without one
+                // the index has nothing to attach to and apply fails
+                // `IndexNotFound`.
+                ancestors: vec![root.clone()],
+                metadata,
+            };
+            let payload = action.payload_for_signing();
+            let signature = {
+                use ed25519_dalek::Signer as _;
+                sk.sign(&payload).to_bytes()
+            };
+            if let crate::action::Action::Add { metadata, .. } = &mut action {
+                if let StorageType::SharedMember {
+                    signature_data: Some(sd),
+                    ..
+                } = &mut metadata.storage_type
+                {
+                    sd.signature = signature;
+                }
+            }
+            action
+        };
+
+        // Alice writes, then Bob writes concurrently at the SAME HLC — the case the
+        // coupling comment names ("two writers stamp the same HLC on different
+        // content").
+        let hlc = n0 + 1_000_000;
+        MainInterface::apply_action(
+            signed_member(alice_data.clone(), hlc, &alice_sk),
+            &apply_ctx_for(alice),
+        )
+        .expect("alice's member write must apply");
+        MainInterface::apply_action(
+            signed_member(bob_data.clone(), hlc, &bob_sk),
+            &apply_ctx_for(bob),
+        )
+        .expect("bob's concurrent member write must apply");
+
+        let stored_data =
+            MainInterface::find_by_id_raw(member).expect("the member entity must exist");
+        let stored_meta = <Index<MainStorage>>::get_metadata(member)
+            .expect("index read")
+            .expect("the member must be indexed");
+
+        // The load-bearing observation: the parent's own bytes are still one
+        // writer's, not a third value. A merge moved children, not this.
+        assert!(
+            stored_data == alice_data || stored_data == bob_data,
+            "a collection-backed CRDT's parent bytes are a handle and must survive a \
+             merge unchanged; a third value here means the premise of this test \
+             changed and #3376's merge-output hypothesis needs re-testing"
+        );
+
+        // And therefore the leaf still verifies: whichever side's bytes are stored,
+        // the coupling left (or patched) the matching signature.
+        MainInterface::verify_snapshot_entity_signature(member, &stored_data, &stored_meta).expect(
+            "a merged SharedMember leaf must still verify — if this starts failing, \
+             the data/signature coupling has been broken and #3376's cause may now \
+             genuinely be a merge output",
+        );
+    }
 }
 
 /// Tests for Frozen storage verification.


### PR DESCRIPTION
Diagnostics only, no behaviour change. Falls out of #3376, where the error text cost two rounds of investigation.

## The problem

`StorageError::InvalidSignature` displayed as **"Invalid signature for user-owned data"**. That single variant is returned by the `User`, `Shared` **and** `SharedMember` arms of `verify_snapshot_entity_signature` — so the message named one arm and said nothing about which actually failed.

On #3376 every rejection was a `SharedMember` leaf — **60 of 60** sampled, unanimous across both nodes — and the text pointed the investigation at `User` storage. Two comments elsewhere in the tree quote the old prose as though it identified the storage type, which would teach the next reader the same wrong thing.

## What changed

- **Display text names all three arms.** The `Serialize` impl's output is deliberately left as `"Invalid signature"` — it is wire-visible.
- **A `warn!` at the rejection site** with the storage type, entity id and `crdt_type`. The variant cannot carry them without touching 25 return sites and that serialization; a rejection aborts the entire HashComparison session, so it earns a line. Without it, the only way to learn which entity failed is to download the node-log artifact and read whichever DEBUG line happens to precede the warning — which is literally how #3376 was narrowed.
- **`entities::storage_type_name`**, so the log has something stable to print.
- Three stale comments corrected.

Implemented as a thin public wrapper over a private `_inner`, because several arms return early on the `[0; 64]` placeholder and a tail log on the existing function would have missed exactly those paths.

## Verification

- 687 `calimero-storage` tests pass; `clippy -D warnings` and `cargo fmt --check` clean.
- The one test asserting on this error (`crates/node/tests/dag_causal_shared_e2e.rs`) already matched the substring rather than the prose, deliberately — so it survived the change, which is the behaviour that comment was written to guarantee.
- Same verdicts, same variant, same serialized string.

## Related finding, recorded on #3376

While reading this path I found what looks like the actual #3376 defect, already half-documented in `interface.rs`: the receiver-side signature/data coupling patches the signature only when the **stored bytes equal the incoming `data`** — i.e. when the incoming write won LWW outright. A **CRDT merge output equals neither side**, so the gate skips it and the leaf is shipped as `{merged data, old signature}`, which no peer can verify. Details on the issue; deliberately not fixed here, since that is a behaviour change wanting its own review.
