### PR TITLE
fix(storage): say WHY a snapshot signature was rejected, not just that it was

### DIFF
--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -536,6 +536,39 @@ impl BorshDeserialize for OpMask {
     }
 }
 
+/// Why a signature-bearing [`StorageType`] could not be verified, as a short
+/// discriminator for logs — **never** the signature bytes themselves.
+///
+/// Exists because "this leaf failed verification" is not actionable on its own.
+/// core#3376 burned six hypotheses distinguishing exactly these cases by reading
+/// code, when the rejection site knows the answer: is there signature data at all,
+/// does it name a signer (required for `Shared`/`SharedMember`, ignored for `User`
+/// where the owner is known), is it the all-zero placeholder, or did a real
+/// signature simply not verify — the last meaning the bytes and the signature
+/// genuinely disagree.
+#[must_use]
+pub fn signature_shape(storage_type: &StorageType) -> &'static str {
+    let sig = match storage_type {
+        StorageType::Public | StorageType::Frozen => return "n/a",
+        StorageType::User { signature_data, .. }
+        | StorageType::Shared { signature_data, .. }
+        | StorageType::SharedMember { signature_data, .. } => signature_data,
+    };
+    let Some(sig) = sig.as_ref() else {
+        return "absent";
+    };
+    if sig.signature == [0u8; 64] {
+        return "placeholder";
+    }
+    // `signer` is only load-bearing for the writer-set arms; `User` verifies
+    // against `owner`, so a missing signer there is normal and not a finding.
+    match (&storage_type, sig.signer) {
+        (StorageType::User { .. }, _) => "signed",
+        (_, None) => "signed-but-unnamed-signer",
+        (_, Some(_)) => "signed",
+    }
+}
+
 /// A short, stable name for a [`StorageType`] variant, for logs.
 ///
 /// Exists because [`StorageError::InvalidSignature`](crate::error::StorageError)

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -743,10 +743,20 @@ impl<S: StorageAdaptor> Interface<S> {
             // session, so it is worth a line: without it the only way to learn
             // which entity failed is to download the node-log artifact and read
             // the DEBUG line that happens to precede the warning.
+            //
+            // `signature_shape` is the discriminator, and it is the field worth
+            // having: "rejected" alone left core#3376 guessing which sub-case it
+            // was, and six hypotheses were spent deciding that from code instead
+            // of from the one place that already knows. `absent` /
+            // `placeholder` / `signed-but-unnamed-signer` each point at a
+            // different producer; `signed` means the bytes and a real signature
+            // genuinely disagree, which is a different investigation entirely.
             tracing::warn!(
                 %id,
                 storage_type = crate::entities::storage_type_name(&metadata.storage_type),
+                signature = crate::entities::signature_shape(&metadata.storage_type),
                 crdt_type = ?metadata.crdt_type,
+                data_len = data.len(),
                 "snapshot entity signature rejected; the HashComparison session \
                  using this leaf cannot complete"
             );

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -1653,6 +1653,88 @@ mod verify_snapshot_entity_signature_tests {
         }
     }
 
+    /// `signature_shape` is only useful if it never mislabels — a wrong
+    /// discriminator is worse than none, because it sends an investigation at a
+    /// producer that is not involved. core#3376 lost six rounds to exactly that
+    /// kind of misdirection from the error text.
+    #[test]
+    fn signature_shape_names_each_case() {
+        use calimero_primitives::identity::PublicKey;
+
+        use crate::entities::signature_shape;
+
+        let sig = |signature: [u8; 64], signer: Option<PublicKey>| {
+            Some(SignatureData {
+                signature,
+                nonce: 7,
+                signer,
+            })
+        };
+        let signer = PublicKey::from([0x11; 32]);
+        let real = [0x22u8; 64];
+        let writers = crate::entities::full_mask(BTreeSet::from([AccountId::from([0xAA; 32])]));
+
+        // Types that are never signature-verified.
+        assert_eq!(signature_shape(&StorageType::Public), "n/a");
+        assert_eq!(signature_shape(&StorageType::Frozen), "n/a");
+
+        // No signature data at all — a producer skipped signing entirely.
+        assert_eq!(
+            signature_shape(&StorageType::SharedMember {
+                anchor: Id::new([0xA0; 32]),
+                signature_data: None,
+            }),
+            "absent"
+        );
+
+        // The all-zero placeholder `save_raw` writes before the signing pass.
+        assert_eq!(
+            signature_shape(&StorageType::SharedMember {
+                anchor: Id::new([0xA0; 32]),
+                signature_data: sig([0u8; 64], Some(signer)),
+            }),
+            "placeholder"
+        );
+
+        // A real signature naming nobody: fatal for the writer-set arms, because
+        // resolving the author is what makes "is this a writer?" a separate
+        // question from "does this verify?".
+        assert_eq!(
+            signature_shape(&StorageType::SharedMember {
+                anchor: Id::new([0xA0; 32]),
+                signature_data: sig(real, None),
+            }),
+            "signed-but-unnamed-signer"
+        );
+        assert_eq!(
+            signature_shape(&StorageType::Shared {
+                writers: writers.clone(),
+                signature_data: sig(real, None),
+            }),
+            "signed-but-unnamed-signer"
+        );
+
+        // ...but NOT for `User`, which verifies against `owner` and ignores the
+        // hint. Reporting a finding here would be the mislabel that matters.
+        assert_eq!(
+            signature_shape(&StorageType::User {
+                owner: signer,
+                signature_data: sig(real, None),
+            }),
+            "signed"
+        );
+
+        // Fully formed: the bytes and a real signature genuinely disagree, which
+        // is a different investigation from any of the above.
+        assert_eq!(
+            signature_shape(&StorageType::SharedMember {
+                anchor: Id::new([0xA0; 32]),
+                signature_data: sig(real, Some(signer)),
+            }),
+            "signed"
+        );
+    }
+
     #[test]
     fn public_accepted_without_verify() {
         // Public entities don't require a signature.


### PR DESCRIPTION
Diagnostics only, no behaviour change. Makes #3376's next occurrence decisive.

## What was still missing

#3377 made the rejection name its **entity** and **storage type** — that closed "which arm?". It did not answer the question that actually decides the investigation: **which kind of failure**.

`signature_shape` reports one of four, and each points somewhere different:

| shape | means |
| --- | --- |
| `absent` | a producer skipped signing entirely |
| `placeholder` | the all-zero signature `save_raw` writes before the signing pass — so the pass did not cover this entity |
| `signed-but-unnamed-signer` | fatal for `Shared`/`SharedMember`, where resolving the author is what makes "is this principal a writer?" a separate question from "does this signature verify?" |
| `signed` | the bytes and a real signature genuinely disagree — a different investigation from all of the above |

#3376 spent **six hypotheses** distinguishing exactly these by reading code, when the rejection site already knows. One field replaces that.

## The test that matters

`User` is the case worth pinning rather than eyeballing: a missing signer there is **normal** — that arm verifies against `owner` and ignores the hint. Reporting `signed-but-unnamed-signer` for it would be a mislabel, and **a discriminator that mislabels is worse than none**, because it sends the reader at a producer that is not involved. That is exactly how #3376's error text cost two rounds before #3377 fixed it.

`signature_shape_names_each_case` pins all six cases, including that one.

## Nothing sensitive is logged

The shape is a `&'static str`, the signer is a public key, `data_len` is a length. No signature bytes.

## While checking the premise

I had proposed a `RUST_LOG` bump on the two carrier scenarios and then checked: **merobox already defaults every node to `log_level="debug"`** (`manager.py`). The DEBUG context around a rejection has always been captured, so verbosity was never the gap and that change would have been busywork. Noted in the commit so nobody else reaches for it.

## Verification

690 storage tests pass; `cargo fmt --check` and `clippy -D warnings` clean. Same verdicts, same variant, same serialized string.
