### PR TITLE
fix(storage): say which signature check refused an action, not just that one did

### DIFF
--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -764,6 +764,37 @@ impl<S: StorageAdaptor> Interface<S> {
         verdict
     }
 
+    /// Refuse an action's signature, naming WHICH of the apply path's checks
+    /// fired.
+    ///
+    /// Twelve distinct rejections in `apply_action` all return the same
+    /// `InvalidSignature`, whose Display names three storage types and no arm —
+    /// so a failure in the field says only "one of a dozen things went wrong
+    /// with one of three storage types". `verify_snapshot_entity_signature` was
+    /// given a discriminator for exactly this reason, but it sits on the
+    /// SNAPSHOT path; HashComparison applies through `apply_action` and never
+    /// reaches it, which is why reading that field yields nothing on the
+    /// failure everyone has actually been chasing.
+    ///
+    /// `reason` is the field to read first. It names the check, not the
+    /// symptom: `signer-not-in-writer-set` and `storage-type-changed` are
+    /// different investigations that were previously indistinguishable.
+    fn reject_action_signature(
+        reason: &'static str,
+        id: &crate::address::Id,
+        metadata: &crate::entities::Metadata,
+    ) -> StorageError {
+        tracing::warn!(
+            %id,
+            reason,
+            storage_type = crate::entities::storage_type_name(&metadata.storage_type),
+            signature = crate::entities::signature_shape(&metadata.storage_type),
+            crdt_type = ?metadata.crdt_type,
+            "action signature rejected while applying"
+        );
+        StorageError::InvalidSignature
+    }
+
     /// The verdict itself. Split out so [`Self::verify_snapshot_entity_signature`]
     /// can log every rejection in one place — several arms bail early, so a tail
     /// log on the public function would miss them.
@@ -1509,7 +1540,11 @@ impl<S: StorageAdaptor> Interface<S> {
                         );
 
                         if !verification_result {
-                            return Err(StorageError::InvalidSignature);
+                            return Err(Self::reject_action_signature(
+                                "stale-action-unauthenticated",
+                                id,
+                                metadata,
+                            ));
                         }
 
                         // Strictly stale: signature verified, but our
@@ -1685,7 +1720,11 @@ impl<S: StorageAdaptor> Interface<S> {
                             &payload,
                             ctx.signer_account,
                         ) else {
-                            return Err(StorageError::InvalidSignature);
+                            return Err(Self::reject_action_signature(
+                                "shared-signer-not-in-writer-set",
+                                id,
+                                metadata,
+                            ));
                         };
                         // Operation-granularity gate: the signer is a current
                         // writer, but must also hold the capability for THIS op.
@@ -1836,7 +1875,11 @@ impl<S: StorageAdaptor> Interface<S> {
                             &payload,
                             ctx.signer_account,
                         ) else {
-                            return Err(StorageError::InvalidSignature);
+                            return Err(Self::reject_action_signature(
+                                "sharedmember-signer-not-in-writer-set",
+                                id,
+                                metadata,
+                            ));
                         };
                         // Operation-granularity gate (member resolves the anchor's masks).
                         Self::enforce_op_mask(
@@ -1921,7 +1964,11 @@ impl<S: StorageAdaptor> Interface<S> {
                             } => {
                                 // Check it matches the owner on record
                                 if *owner != existing_owner {
-                                    return Err(StorageError::InvalidSignature);
+                                    return Err(Self::reject_action_signature(
+                                        "user-owner-mismatch",
+                                        id,
+                                        metadata,
+                                    ));
                                 }
 
                                 let sig_data =
@@ -1968,7 +2015,11 @@ impl<S: StorageAdaptor> Interface<S> {
                                     &payload,
                                 );
                                 if !verification_result {
-                                    return Err(StorageError::InvalidSignature);
+                                    return Err(Self::reject_action_signature(
+                                        "user-signature-absent",
+                                        id,
+                                        metadata,
+                                    ));
                                 }
 
                                 // Replay protection: nonce is the
@@ -1986,7 +2037,11 @@ impl<S: StorageAdaptor> Interface<S> {
                             }
                             _ => {
                                 // Action metadata is not User, but existing is.
-                                return Err(StorageError::InvalidSignature);
+                                return Err(Self::reject_action_signature(
+                                    "storage-type-changed-to-user",
+                                    id,
+                                    metadata,
+                                ));
                             }
                         }
                     }
@@ -2004,7 +2059,11 @@ impl<S: StorageAdaptor> Interface<S> {
                                 // Action's claimed writers must match stored — delete is
                                 // not a rotation channel.
                                 if action_writers != existing_writers {
-                                    return Err(StorageError::InvalidSignature);
+                                    return Err(Self::reject_action_signature(
+                                        "shared-rotation-channel-misuse",
+                                        id,
+                                        metadata,
+                                    ));
                                 }
 
                                 let sig_data =
@@ -2041,7 +2100,11 @@ impl<S: StorageAdaptor> Interface<S> {
                                     &payload,
                                     ctx.signer_account,
                                 ) else {
-                                    return Err(StorageError::InvalidSignature);
+                                    return Err(Self::reject_action_signature(
+                                        "shared-signature-absent",
+                                        id,
+                                        metadata,
+                                    ));
                                 };
                                 // Operation-granularity gate: deletes need DELETE.
                                 Self::enforce_op_mask(&signer, OpMask::DELETE, existing_writers)?;
@@ -2076,7 +2139,11 @@ impl<S: StorageAdaptor> Interface<S> {
                             }
                             _ => {
                                 // Action metadata is not Shared, but existing is.
-                                return Err(StorageError::InvalidSignature);
+                                return Err(Self::reject_action_signature(
+                                    "storage-type-changed-to-shared",
+                                    id,
+                                    metadata,
+                                ));
                             }
                         }
                     }
@@ -2094,7 +2161,11 @@ impl<S: StorageAdaptor> Interface<S> {
                                 // The action's claimed anchor must match stored —
                                 // delete is not a re-anchor channel.
                                 if *action_anchor != existing_anchor {
-                                    return Err(StorageError::InvalidSignature);
+                                    return Err(Self::reject_action_signature(
+                                        "shared-delete-reanchor-misuse",
+                                        id,
+                                        metadata,
+                                    ));
                                 }
 
                                 let sig_data =
@@ -2128,7 +2199,11 @@ impl<S: StorageAdaptor> Interface<S> {
                                     &payload,
                                     ctx.signer_account,
                                 ) else {
-                                    return Err(StorageError::InvalidSignature);
+                                    return Err(Self::reject_action_signature(
+                                        "sharedmember-signature-absent",
+                                        id,
+                                        metadata,
+                                    ));
                                 };
                                 // Operation-granularity gate: deletes need DELETE.
                                 Self::enforce_op_mask(&signer, OpMask::DELETE, &existing_writers)?;
@@ -2152,7 +2227,11 @@ impl<S: StorageAdaptor> Interface<S> {
                             }
                             _ => {
                                 // Action metadata is not SharedMember, but existing is.
-                                return Err(StorageError::InvalidSignature);
+                                return Err(Self::reject_action_signature(
+                                    "storage-type-changed-to-sharedmember",
+                                    id,
+                                    metadata,
+                                ));
                             }
                         }
                     }


### PR DESCRIPTION
Diagnostics for #3376. **No behaviour change** — every rejection returns exactly the error it did before.

## The problem this fixes

`Interface::apply_action` has **twelve** distinct rejections that all return the same `StorageError::InvalidSignature`. Its `Display` is:

```
Invalid signature for signed storage (User, Shared or SharedMember)
```

Three storage types, no arm. A failure in the field says "one of a dozen things went wrong with one of three storage types" — which is roughly the position #3376 has been stuck in for six closed hypotheses.

## Why the existing instrumentation cannot help

#3381 added a `signature=` discriminator for exactly this reason, and the triage notes on #3376 say to **read `signature=` first**. But it was added to `verify_snapshot_entity_signature`, and `crates/node/src/sync/snapshot.rs` is its *only* caller — that is the **snapshot** path. HashComparison applies through `apply_action` and never reaches it.

So on the failing path the field is never emitted. From a real occurrence on a recent PR run:

| marker | count |
| --- | --- |
| `Invalid signature for signed storage (User, Shared or SharedMember)` | **184** |
| `snapshot entity signature rejected` (the instrumented one) | **0** |

Following the documented triage step yields nothing, and it looks like missing logs rather than instrumentation pointed at the wrong arm.

## What this does

Routes all twelve sites through one `reject_action_signature` helper that emits a structured warning with the entity id, storage type, signature shape, CRDT type, and a **`reason=`** naming the check that fired:

| `reason` | what it means |
| --- | --- |
| `stale-action-unauthenticated` | stale nonce on an action that never authenticated |
| `shared-signer-not-in-writer-set` | signer resolved against the causal writer set and was absent |
| `sharedmember-signer-not-in-writer-set` | same, against the anchor-resolved set |
| `user-owner-mismatch` | signature does not match the owner on record |
| `user-signature-absent` / `shared-signature-absent` / `sharedmember-signature-absent` | signed storage arrived with no signature |
| `storage-type-changed-to-user` / `-shared` / `-sharedmember` | the action's storage type disagrees with the stored entity's |
| `shared-rotation-channel-misuse` | a non-rotation write on the rotation channel |
| `shared-delete-reanchor-misuse` | a delete used as a re-anchor |

The point is that `reason` names the **check**, not the symptom. `signer-not-in-writer-set` and `storage-type-changed-to-sharedmember` are entirely different investigations that were previously indistinguishable — and given #3376's signature is a `SharedMember` leaf, telling those two apart is most of the remaining question.

## Why diagnostics rather than a fix

Six hypotheses on #3376 are closed and the triage note is explicit that the next step is *one clean occurrence*, not another guess. The occurrence has been reachable all along — the field to read just was not being written on the path that fires. This makes the next occurrence answer the question instead of producing a seventh hypothesis.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings`, and `cargo test --workspace` (227 suites) all clean. `calimero-storage`'s own 690 tests pass unchanged, which is the intended result: this alters no verdict, only what is said about one.
