### PR TITLE
feat(governance): resolve a member key to the account it speaks for

### DIFF
--- a/crates/governance-store/src/account_bindings.rs
+++ b/crates/governance-store/src/account_bindings.rs
@@ -160,6 +160,45 @@ pub fn member_account_for_device_key(
     Ok(None)
 }
 
+/// The account a **member key** speaks for in the namespace owning `group`.
+///
+/// The resolution the governance planes need when they stop naming keys and
+/// start naming accounts. Distinct from [`member_account_for_device_key`] in two
+/// ways that both matter:
+///
+/// * **It resolves at the NAMESPACE, not at `group`.** Bindings are
+///   namespace-keyed, so a member added to a subgroup was bound when it joined
+///   the namespace — asking the subgroup would find nothing and refuse an
+///   add that is perfectly legitimate.
+/// * **It asks only whether the key is bound**, not whether some endorser is a
+///   member of the decision group. Whether the account may be *added* here is
+///   the caller's question; this one only answers *who* it is.
+///
+/// # `None` must fail closed
+///
+/// `None` means this namespace has never seen a credential for `member_key`, so
+/// there is no account to name. Callers must refuse rather than fall back to a
+/// key-derived stand-in: the stand-in is exactly the bridge the account plane
+/// exists to remove, and a fallback would keep it alive at the one site where
+/// it is hardest to notice — a grant that looks recorded and matches nothing.
+///
+/// Post-enrolment-at-join every member of a namespace is bound by construction,
+/// so `None` is a real anomaly (an unenrolled straggler, or a key that never
+/// joined) rather than an ordinary state to paper over.
+///
+/// # Errors
+/// Propagates the namespace resolution or the binding scan.
+pub fn member_account_in_namespace(
+    store: &Store,
+    group: &ContextGroupId,
+    member_key: &PublicKey,
+) -> EyreResult<Option<AccountId>> {
+    let namespace = crate::NamespaceRepository::new(store).resolve(group)?;
+    Ok(AccountBindingRepository::new(store)
+        .binding_for_sign_pk(&namespace, member_key)?
+        .map(|binding| binding.account))
+}
+
 /// A device binding that is currently in force.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct DeviceBinding {

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -78,7 +78,8 @@ pub use self::authorizer::{
 pub use self::capabilities::CapabilitiesRepository;
 
 pub use self::account_bindings::{
-    member_account_for_device_key, AccountBindingRepository, BindingRejected, DeviceBinding,
+    member_account_for_device_key, member_account_in_namespace, AccountBindingRepository,
+    BindingRejected, DeviceBinding,
 };
 pub use self::context_registration::ContextRegistrationService;
 pub use self::context_tree::ContextTreeService;

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -7003,3 +7003,109 @@ fn a_tee_admission_with_a_stranger_credential_binds_nothing() {
         "the admission itself still stands"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Resolving a member key to the account it speaks for.
+//
+// The lookup the governance planes will use once they name accounts instead of
+// keys. What these pin is the part that is easy to get subtly wrong: WHERE the
+// answer is read from, and what happens when there is no answer.
+// ---------------------------------------------------------------------------
+
+/// A subgroup member resolves through the NAMESPACE binding, not the subgroup.
+///
+/// Every direct add in practice targets a subgroup and names someone who joined
+/// the namespace earlier. Bindings are namespace-keyed, so asking the subgroup
+/// would find nothing and refuse an add that is entirely legitimate.
+#[test]
+fn a_member_resolves_through_the_namespace_binding_not_the_subgroup() {
+    use calimero_context_config::VisibilityMode;
+
+    let store = test_store();
+    let namespace_id = [0xF1u8; 32];
+    let subgroup_id = [0xF2u8; 32];
+    let ns_gid = ContextGroupId::from(namespace_id);
+    let sub_gid = ContextGroupId::from(subgroup_id);
+    let (_admin_sk, admin_pk) = bootstrap_namespace_with_admin(&store, namespace_id);
+
+    nest_for_test(&store, &ns_gid, &sub_gid);
+    MetaRepository::new(&store)
+        .save(&sub_gid, &sample_meta_with_admin(admin_pk))
+        .expect("seed subgroup meta");
+    CapabilitiesRepository::new(&store)
+        .set_subgroup_visibility(&sub_gid, VisibilityMode::Restricted)
+        .expect("set visibility");
+
+    let member_sk = PrivateKey::random(&mut rand::rngs::OsRng);
+    let member = member_sk.public_key();
+    let account = crate::test_fixtures::real_join_account(&member);
+    let account_id = account.cert.account;
+
+    // Bound at the namespace, exactly as a join records it.
+    crate::AccountBindingRepository::new(&store)
+        .apply_link(&ns_gid, &account.genesis, &account.chain, &account.cert)
+        .expect("store")
+        .expect("admitted");
+
+    assert_eq!(
+        crate::member_account_in_namespace(&store, &sub_gid, &member).expect("resolve"),
+        Some(account_id),
+        "a subgroup lookup must resolve through the namespace the subgroup belongs to"
+    );
+    assert_eq!(
+        crate::member_account_in_namespace(&store, &ns_gid, &member).expect("resolve"),
+        Some(account_id),
+        "and the namespace itself resolves identically"
+    );
+}
+
+/// An unbound key resolves to `None`, so callers can refuse rather than invent.
+///
+/// The whole point of the `None`: a caller that fell back to a key-derived
+/// stand-in would keep the bridge alive at the site where it is hardest to
+/// notice — a grant that looks recorded and matches nothing.
+#[test]
+fn an_unbound_member_key_resolves_to_nothing() {
+    let store = test_store();
+    let namespace_id = [0xF3u8; 32];
+    let ns_gid = ContextGroupId::from(namespace_id);
+    let (_admin_sk, _admin_pk) = bootstrap_namespace_with_admin(&store, namespace_id);
+
+    let stranger = PrivateKey::random(&mut rand::rngs::OsRng).public_key();
+    assert_eq!(
+        crate::member_account_in_namespace(&store, &ns_gid, &stranger).expect("resolve"),
+        None,
+        "a key this namespace has never seen a credential for names no account"
+    );
+}
+
+/// A revoked device stops resolving — revocation withdraws the principal too.
+#[test]
+fn a_revoked_device_resolves_to_nothing() {
+    let store = test_store();
+    let namespace_id = [0xF4u8; 32];
+    let ns_gid = ContextGroupId::from(namespace_id);
+    let (_admin_sk, _admin_pk) = bootstrap_namespace_with_admin(&store, namespace_id);
+
+    let member_sk = PrivateKey::random(&mut rand::rngs::OsRng);
+    let member = member_sk.public_key();
+    let account = crate::test_fixtures::real_join_account(&member);
+
+    let bindings = crate::AccountBindingRepository::new(&store);
+    let binding = bindings
+        .apply_link(&ns_gid, &account.genesis, &account.chain, &account.cert)
+        .expect("store")
+        .expect("admitted");
+    assert!(crate::member_account_in_namespace(&store, &ns_gid, &member)
+        .expect("resolve")
+        .is_some());
+
+    bindings
+        .apply_revocation(&ns_gid, binding.device)
+        .expect("revoke");
+    assert_eq!(
+        crate::member_account_in_namespace(&store, &ns_gid, &member).expect("resolve"),
+        None,
+        "a revoked device names no account, so a grant to it cannot be minted"
+    );
+}


### PR DESCRIPTION
Groundwork for #3346 **slice B**, which moves the governance planes off member keys and onto accounts. **Pure addition — nothing calls it yet, so no behaviour changes.**

Split out on its own because slice B's main commit is unavoidably large and atomic (changing the wire type forces the op-adapter keying and `MembershipRepository` to move together — decoupling them is exactly what broke twice). This is the one piece that can land ahead of it and be reviewed on its own terms.

## What it is

```rust
member_account_in_namespace(store, group, member_key) -> EyreResult<Option<AccountId>>
```

Two differences from the existing `member_account_for_device_key`, both load-bearing:

**It resolves at the NAMESPACE, not the decision group.** Bindings are namespace-keyed, so a member added to a subgroup was bound when it joined the *namespace*. Asking the subgroup finds nothing and would refuse an add that is entirely legitimate.

That is not hypothetical — it is the shape of every direct add in the suite. All 16 `add_group_members` steps across the e2e scenarios target a **subgroup**, and name someone who joined the namespace by invitation earlier. Had the resolver asked the decision group, slice B would have broken every one of them.

**It asks only whether the key is bound**, not whether some endorser is a member of the decision group. Whether the account may be added *here* is the caller's question; this one answers only *who it is*.

## `None` must fail closed

`None` means this namespace has never seen a credential for the key, so there is no account to name. Callers must refuse rather than fall back to a key-derived stand-in.

That is the whole point. A fallback would keep the legacy bridge alive at the site where it is hardest to notice — a grant that looks recorded and matches nothing, surfacing far from the code that minted it. Since [enrolment-at-join](https://github.com/calimero-network/core/pull/3382) every namespace member is bound by construction, so `None` is a real anomaly (an unenrolled straggler, a key that never joined) rather than an ordinary state to paper over.

The doc comment says this explicitly, because the next person to add a call site is the one who needs to know it.

## Tests

Three cases, each pinning something that decides correctness:

- a subgroup member resolves **through the namespace binding** — the case that would have broken every direct add;
- an unbound key resolves to **nothing**, so callers can refuse rather than invent;
- a **revoked** device stops resolving — revocation withdraws the principal, not merely the right to receive keys.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings`, `cargo clippy -p merod --all-targets --features mock-attestation -- -D warnings`, `cargo test --workspace` (227 suites), and `cargo test -p calimero-node --features mock-attestation` — all clean.

## What comes next in slice B

- **PR 2 (the flip)** — 17 principal fields on `GroupOp`/`RootOp` from `PublicKey` to `AccountId`, ~52 producer sites resolving through this helper, `SIGNED_GROUP_OP_SCHEMA_VERSION` 9 → 10. Atomic by necessity.
- **PR 3 (delete the bridge)** — `legacy_account_id` (79 refs), `legacy_authorship` (15), `account_for_author` (12), `writer_account` (7), plus two things earlier slices left behind as explicitly bridge-shaped: the genesis-admin guard in `view_knows_author`, and `MemberJoinedWithDevice`'s placeholder authorization rule.
