### PR TITLE
fix: compare ABI state versions in the migration rollup, not semver majors

### DIFF
--- a/.github/workflows/sync-regression.yml
+++ b/.github/workflows/sync-regression.yml
@@ -54,10 +54,9 @@ jobs:
     # Same runner class as e2e-rust-apps so cold-start performance is
     # comparable and we share the rust-ci cache.
     runs-on: ubuntu-24.04-8cpu
-    # 15-min cap is generous: the workflow's own timeouts are 30s per
-    # `wait_for_sync`, so a regression fails in ~30s. The cap is for the
-    # cold-build steps (merod image + WASM) plus a safety margin.
-    timeout-minutes: 15
+    # Sized for the cold-build steps (merod image + cargo-mero + WASM), which
+    # alone run ~14 min; the regression itself fails in ~30s.
+    timeout-minutes: 25
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,7 @@ dependencies = [
  "calimero-storage",
  "calimero-store",
  "calimero-utils-actix",
+ "calimero-wasm-abi",
  "camino",
  "clap",
  "dashmap 6.1.0",

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -732,7 +732,6 @@ async fn get_migration_status() {
                 "report": {
                     "schemaVersion": 1,
                     "residueAuto": 0,
-                    "residueIdentity": 2,
                     "syncedUpToHlc": 0,
                     "reportedAt": 100,
                     "authoredRemaining": 2,

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -2747,6 +2747,7 @@ mod get_context_version_tests {
                 package: "com.test.app".into(),
                 version: "2.1.0".into(),
                 signer_id: "signer".into(),
+                state_version: 0,
             },
         );
         let cid = ContextId::from([0x07; 32]);

--- a/crates/context/primitives/src/client/sync.rs
+++ b/crates/context/primitives/src/client/sync.rs
@@ -334,6 +334,7 @@ impl ContextClient {
                             package: String::new().into_boxed_str(),
                             version: String::new().into_boxed_str(),
                             signer_id: String::new().into_boxed_str(),
+                            state_version: 0,
                         },
                     );
                     handle.put(&app_key, &stub_meta)?;

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -1359,8 +1359,6 @@ pub struct MemberMigrationReport {
     pub schema_version: u32,
     /// Unconverted Convergent ("auto") entries the member still has pending.
     pub residue_auto: u64,
-    /// Unconverted identity-gated entries the member still has pending.
-    pub residue_identity: u64,
     /// Governance HLC the member has synced/applied through.
     pub synced_up_to_hlc: u64,
     /// Member-signed millis-since-epoch from the heartbeat itself.
@@ -1429,7 +1427,7 @@ impl MigrationFailureKind {
 /// The migration state the rollup assigns a pinned-cohort member.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MemberMigrationState {
-    /// Reported `schema_version >= target` with both residue counts at 0.
+    /// Reported `schema_version >= target` with `residue_auto` at 0.
     Migrated,
     /// Reported a fresh heartbeat but is still behind the target version or
     /// carrying residue.
@@ -1476,7 +1474,7 @@ pub struct MigrationStatusRollup {
     pub failed: usize,
     pub total: usize,
     /// `true` iff **every** pinned-cohort member reported
-    /// `schema_version >= target && residue_auto == 0 && residue_identity == 0`.
+    /// `schema_version >= target && residue_auto == 0`.
     /// Any `unknown`, `failed`, or in-progress member keeps this `false`.
     pub all_migrated: bool,
     /// Count of pinned-cohort members reporting `authored_remaining > 0` — i.e.
@@ -1525,8 +1523,8 @@ pub struct MigrationStatus {
 ///
 /// Pure and side-effect free — this is observability only and never gates
 /// correctness or progress. `all_migrated` is `true` IFF every pinned-cohort
-/// member reported `schema_version >= target_version` with both residue counts
-/// at 0; a single `unknown` or in-progress member keeps it `false`.
+/// member reported `schema_version >= target_version` with `residue_auto` at 0;
+/// a single `unknown` or in-progress member keeps it `false`.
 pub fn compute_migration_status_rollup(
     target_version: u32,
     cohort_pinned_at_hlc: Option<HybridTimestamp>,
@@ -1582,10 +1580,7 @@ pub fn compute_migration_status_rollup(
                 if r.authored_remaining > 0 {
                     members_pending_signature += 1;
                 }
-                if r.schema_version >= target_version
-                    && r.residue_auto == 0
-                    && r.residue_identity == 0
-                {
+                if r.schema_version >= target_version && r.residue_auto == 0 {
                     migrated += 1;
                     MemberMigrationState::Migrated
                 } else {
@@ -1642,12 +1637,8 @@ mod migration_status_tests {
 
     /// A heartbeat report whose freshest sync position is well past any pin
     /// used in these tests, so the pin overlay keeps the member in-cohort.
-    fn report(
-        schema_version: u32,
-        residue_auto: u64,
-        residue_identity: u64,
-    ) -> MemberMigrationReport {
-        report_synced(schema_version, residue_auto, residue_identity, u64::MAX)
+    fn report(schema_version: u32, residue_auto: u64) -> MemberMigrationReport {
+        report_synced(schema_version, residue_auto, u64::MAX)
     }
 
     /// Build a report whose `synced_up_to_hlc` is a `NamespaceGovHead.sequence`
@@ -1657,13 +1648,11 @@ mod migration_status_tests {
     fn report_synced(
         schema_version: u32,
         residue_auto: u64,
-        residue_identity: u64,
         synced_up_to_seq: u64,
     ) -> MemberMigrationReport {
         MemberMigrationReport {
             schema_version,
             residue_auto,
-            residue_identity,
             synced_up_to_hlc: synced_up_to_seq,
             reported_at: 0,
             authored_remaining: 0,
@@ -1675,7 +1664,7 @@ mod migration_status_tests {
     fn report_failed(kind: MigrationFailureKind) -> MemberMigrationReport {
         MemberMigrationReport {
             migration_failed: Some(kind),
-            ..report(1, 0, 0)
+            ..report(1, 0)
         }
     }
 
@@ -1685,7 +1674,7 @@ mod migration_status_tests {
         let pb = pk(0xB2);
         let st = compute_migration_status_rollup(2, None, None, &[pa, pb], |peer| {
             if *peer == pa {
-                Some(report(2, 0, 0)) // migrated
+                Some(report(2, 0)) // migrated
             } else {
                 Some(report_failed(MigrationFailureKind::CheckAborted))
             }
@@ -1707,7 +1696,7 @@ mod migration_status_tests {
         let pb = pk(0xB2);
         let st = compute_migration_status_rollup(2, None, None, &[pa, pb], |peer| {
             if *peer == pa {
-                Some(report(2, 0, 0))
+                Some(report(2, 0))
             } else {
                 Some(report_failed(MigrationFailureKind::NoMigrationPath))
             }
@@ -1751,8 +1740,8 @@ mod migration_status_tests {
     fn unknown_member_blocks_all_migrated() {
         let (a, b, c) = (pk(0xA), pk(0xB), pk(0xC));
         let mut reports = BTreeMap::new();
-        let _ = reports.insert(a, report(2, 0, 0));
-        let _ = reports.insert(b, report(2, 0, 0));
+        let _ = reports.insert(a, report(2, 0));
+        let _ = reports.insert(b, report(2, 0));
         // C absent — no fresh heartbeat.
 
         let st = compute_migration_status_rollup(2, None, None, &[a, b, c], |peer| {
@@ -1789,14 +1778,14 @@ mod migration_status_tests {
         let pin_seq = 10u64;
         let mut reports = BTreeMap::new();
         // A,B,C synced at/after the pinned expand-entry sequence -> in-cohort.
-        let _ = reports.insert(a, report_synced(2, 0, 0, pin_seq + 2));
-        let _ = reports.insert(b, report_synced(2, 0, 0, pin_seq + 5));
-        let _ = reports.insert(c, report_synced(2, 0, 0, pin_seq));
+        let _ = reports.insert(a, report_synced(2, 0, pin_seq + 2));
+        let _ = reports.insert(b, report_synced(2, 0, pin_seq + 5));
+        let _ = reports.insert(c, report_synced(2, 0, pin_seq));
         // D's freshest sync position (head sequence 9) is BELOW the pinned
         // expand-entry sequence (10) -> a joiner whose governance head trails
         // the migration cut, excluded by the overlay even though it carries
         // residue and is behind on version.
-        let _ = reports.insert(d, report_synced(1, 5, 5, pin_seq - 1));
+        let _ = reports.insert(d, report_synced(1, 5, pin_seq - 1));
 
         // Display HLC fence in its own (physical-time) space — must not affect
         // the overlay, which keys on `pin_seq`.
@@ -1837,8 +1826,8 @@ mod migration_status_tests {
         let (a, b) = (pk(0xA), pk(0xB));
         let mut reports = BTreeMap::new();
         // Real gov-head sequences, both at/after the expand-entry sequence (10).
-        let _ = reports.insert(a, report_synced(2, 0, 0, 12));
-        let _ = reports.insert(b, report_synced(2, 0, 0, 11));
+        let _ = reports.insert(a, report_synced(2, 0, 12));
+        let _ = reports.insert(b, report_synced(2, 0, 11));
 
         // A large display HLC (NTP64 physical time) alongside a small sequence
         // pin — the exact mismatch the old `.get_time().as_u64()` comparison hit.
@@ -1871,7 +1860,7 @@ mod migration_status_tests {
         let (a, b) = (pk(0xA), pk(0xB));
         let mut reports = BTreeMap::new();
         // A reports a head sequence past the pin.
-        let _ = reports.insert(a, report_synced(2, 0, 0, 20));
+        let _ = reports.insert(a, report_synced(2, 0, 20));
         // B absent.
 
         let st = compute_migration_status_rollup(2, None, Some(10), &[a, b], |peer| {
@@ -1884,22 +1873,22 @@ mod migration_status_tests {
     }
 
     /// `all_migrated` is true only when every pinned member reports
-    /// `v >= target` with both residue counts at 0.
+    /// `v >= target` with `residue_auto` at 0.
     #[test]
     fn all_migrated_true_only_when_every_pinned_member_v2_residue0() {
         let (a, b, c) = (pk(0xA), pk(0xB), pk(0xC));
 
         // All migrated -> green.
         let all_ok =
-            compute_migration_status_rollup(2, None, None, &[a, b, c], |_| Some(report(2, 0, 0)));
+            compute_migration_status_rollup(2, None, None, &[a, b, c], |_| Some(report(2, 0)));
         assert!(all_ok.rollup.all_migrated);
         assert_eq!(all_ok.rollup.migrated, 3);
 
-        // One member still carries identity residue -> in_progress, not green.
+        // One member still carries auto residue -> in_progress, not green.
         let mut reports = BTreeMap::new();
-        let _ = reports.insert(a, report(2, 0, 0));
-        let _ = reports.insert(b, report(2, 0, 0));
-        let _ = reports.insert(c, report(2, 0, 1));
+        let _ = reports.insert(a, report(2, 0));
+        let _ = reports.insert(b, report(2, 0));
+        let _ = reports.insert(c, report(2, 1));
         let with_residue = compute_migration_status_rollup(2, None, None, &[a, b, c], |peer| {
             reports.get(peer).copied()
         });
@@ -1914,9 +1903,9 @@ mod migration_status_tests {
 
         // One member behind target version -> in_progress, not green.
         let mut behind = BTreeMap::new();
-        let _ = behind.insert(a, report(2, 0, 0));
-        let _ = behind.insert(b, report(1, 0, 0));
-        let _ = behind.insert(c, report(2, 0, 0));
+        let _ = behind.insert(a, report(2, 0));
+        let _ = behind.insert(b, report(1, 0));
+        let _ = behind.insert(c, report(2, 0));
         let behind_status = compute_migration_status_rollup(2, None, None, &[a, b, c], |peer| {
             behind.get(peer).copied()
         });
@@ -1950,7 +1939,6 @@ mod migration_status_tests {
         let zero_stamp = MemberMigrationReport {
             schema_version: 2,
             residue_auto: 0,
-            residue_identity: 0,
             synced_up_to_hlc: u64::MAX,
             reported_at: 0,
             authored_remaining: 0,
@@ -1994,7 +1982,6 @@ mod migration_status_tests {
                     Some(MemberMigrationReport {
                         schema_version: 2,
                         residue_auto: 0,
-                        residue_identity: 0,
                         synced_up_to_hlc: 5,
                         reported_at: 1_000,
                         authored_remaining: 0,
@@ -2004,7 +1991,6 @@ mod migration_status_tests {
                     Some(MemberMigrationReport {
                         schema_version: 1, // still on the 10.1.3 binary
                         residue_auto: 1,
-                        residue_identity: 0,
                         synced_up_to_hlc: 5,
                         reported_at: 1_000,
                         authored_remaining: 0,

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -1974,4 +1974,51 @@ mod migration_status_tests {
         assert_eq!(a_row.state, MemberMigrationState::Migrated);
         assert_eq!(a_row.report.expect("report kept").reported_at, 0);
     }
+
+    /// The bug this PR fixes: a same-major release where one member has not
+    /// swapped. Before the fix both sides resolved to 10 and this rolled up
+    /// all_migrated. Now the target is state 2 and the laggard reports state 1.
+    #[test]
+    fn same_major_release_does_not_report_a_laggard_as_migrated() {
+        let migrated_peer = pk(0xA1);
+        let laggard_peer = pk(0xB2);
+        let closure = vec![migrated_peer, laggard_peer];
+
+        let status = compute_migration_status_rollup(
+            2, // target ABI state version, from a 10.2.0 bundle
+            None,
+            None,
+            &closure,
+            |peer| {
+                if *peer == migrated_peer {
+                    Some(MemberMigrationReport {
+                        schema_version: 2,
+                        residue_auto: 0,
+                        residue_identity: 0,
+                        synced_up_to_hlc: 5,
+                        reported_at: 1_000,
+                        authored_remaining: 0,
+                        migration_failed: None,
+                    })
+                } else {
+                    Some(MemberMigrationReport {
+                        schema_version: 1, // still on the 10.1.3 binary
+                        residue_auto: 1,
+                        residue_identity: 0,
+                        synced_up_to_hlc: 5,
+                        reported_at: 1_000,
+                        authored_remaining: 0,
+                        migration_failed: None,
+                    })
+                }
+            },
+        );
+
+        assert_eq!(status.rollup.migrated, 1);
+        assert_eq!(status.rollup.total, 2);
+        assert!(
+            !status.rollup.all_migrated,
+            "a member still on the old binary must not count as migrated"
+        );
+    }
 }

--- a/crates/context/src/handlers/abort_migration.rs
+++ b/crates/context/src/handlers/abort_migration.rs
@@ -221,6 +221,7 @@ mod tests {
             status: GroupUpgradeStatus::Completed { completed_at: None },
             cascade_hlc: None,
             cascade_seq: None,
+            to_state_version: 2,
         }
     }
 

--- a/crates/context/src/handlers/execute/upgrade_gate.rs
+++ b/crates/context/src/handlers/execute/upgrade_gate.rs
@@ -262,6 +262,7 @@ mod tests {
                         package: String::new().into_boxed_str(),
                         version: String::new().into_boxed_str(),
                         signer_id: String::new().into_boxed_str(),
+                        state_version: 0,
                     },
                 ),
             )

--- a/crates/context/src/handlers/get_migration_status.rs
+++ b/crates/context/src/handlers/get_migration_status.rs
@@ -145,16 +145,6 @@ impl Handler<GetMigrationStatusRequest> for ContextManager {
     }
 }
 
-/// Parse the leading integer of a semver `to_version` ("2", "2.0.0") into the
-/// `u32` schema-version a heartbeat reports. Best-effort: a non-numeric leading
-/// component yields `None`.
-fn parse_schema_version(version: &str) -> Option<u32> {
-    version
-        .split('.')
-        .next()
-        .and_then(|major| major.trim().parse::<u32>().ok())
-}
-
 /// Derive the `target_version` the cohort is rolled up against from the group's
 /// local upgrade record.
 ///
@@ -176,7 +166,12 @@ fn parse_schema_version(version: &str) -> Option<u32> {
 fn derive_target_version(upgrade: Option<&calimero_store::key::GroupUpgradeValue>) -> u32 {
     match upgrade {
         None => 0,
-        Some(record) => parse_schema_version(&record.to_version).unwrap_or(u32::MAX),
+        // `0` means the target's ABI was unreadable. It must NOT collapse to a
+        // satisfied target: every member reporting `>= 0` would be trivially
+        // migrated, a false green over a real migration. Pin to MAX so no real
+        // version satisfies it until the record is replaced by a resolvable one.
+        Some(record) if record.to_state_version == 0 => u32::MAX,
+        Some(record) => record.to_state_version,
     }
 }
 
@@ -222,7 +217,7 @@ mod tests {
     use calimero_store::key::GroupMetaValue;
     use calimero_store::Store;
 
-    use super::{authorize_migration_status, collect_migration_cohort, parse_schema_version};
+    use super::{authorize_migration_status, collect_migration_cohort};
 
     fn meta(admin: PublicKey) -> GroupMetaValue {
         GroupMetaValue {
@@ -299,15 +294,6 @@ mod tests {
             cohort.len() > direct_count,
             "cohort must exceed the direct-row count (inherited member included)"
         );
-    }
-
-    #[test]
-    fn parse_schema_version_reads_major() {
-        assert_eq!(parse_schema_version("2"), Some(2));
-        assert_eq!(parse_schema_version("2.0.0"), Some(2));
-        assert_eq!(parse_schema_version("11.3.1"), Some(11));
-        assert_eq!(parse_schema_version("v2"), None);
-        assert_eq!(parse_schema_version(""), None);
     }
 
     /// The handler gates `GetMigrationStatusRequest` on admin authority (the
@@ -430,6 +416,52 @@ mod tests {
             u32::MAX,
             "an unparseable pending target must not collapse to 0 (false green)"
         );
+    }
+
+    /// A record targeting semver 10.2.0 at ABI state 2 must roll up against 2.
+    /// Parsing the semver yields 10, which every member on major 10 trivially
+    /// satisfies — the false green this PR exists to remove.
+    #[test]
+    fn target_version_reads_the_abi_state_version() {
+        let record = calimero_store::key::GroupUpgradeValue {
+            from_version: "10.1.3".to_owned(),
+            to_version: "10.2.0".to_owned(),
+            migration: None,
+            initiated_at: 0,
+            initiated_by: PublicKey::from([0x01; 32]),
+            status: calimero_store::key::GroupUpgradeStatus::InProgress {
+                total: 1,
+                completed: 0,
+                failed: 0,
+            },
+            cascade_hlc: None,
+            cascade_seq: None,
+            to_state_version: 2,
+        };
+
+        assert_eq!(super::derive_target_version(Some(&record)), 2);
+    }
+
+    /// An unresolvable target must be unsatisfiable, never trivially satisfied.
+    #[test]
+    fn unresolvable_target_state_version_pins_to_max() {
+        let record = calimero_store::key::GroupUpgradeValue {
+            from_version: "10.1.3".to_owned(),
+            to_version: "10.2.0".to_owned(),
+            migration: None,
+            initiated_at: 0,
+            initiated_by: PublicKey::from([0x01; 32]),
+            status: calimero_store::key::GroupUpgradeStatus::InProgress {
+                total: 1,
+                completed: 0,
+                failed: 0,
+            },
+            cascade_hlc: None,
+            cascade_seq: None,
+            to_state_version: 0,
+        };
+
+        assert_eq!(super::derive_target_version(Some(&record)), u32::MAX);
     }
 
     /// The cohort target must reflect a SUBGROUP's own upgrade record, not just

--- a/crates/context/src/handlers/get_migration_status.rs
+++ b/crates/context/src/handlers/get_migration_status.rs
@@ -349,6 +349,7 @@ mod tests {
     fn upgrade_record(
         from: &str,
         to: &str,
+        to_state_version: u32,
         status: calimero_store::key::GroupUpgradeStatus,
     ) -> calimero_store::key::GroupUpgradeValue {
         calimero_store::key::GroupUpgradeValue {
@@ -360,6 +361,7 @@ mod tests {
             status,
             cascade_hlc: None,
             cascade_seq: None,
+            to_state_version,
         }
     }
 
@@ -382,6 +384,7 @@ mod tests {
         let rec = upgrade_record(
             "1",
             "2",
+            2,
             calimero_store::key::GroupUpgradeStatus::Completed { completed_at: None },
         );
         assert_eq!(super::derive_target_version(Some(&rec)), 2);
@@ -393,6 +396,7 @@ mod tests {
         let rec = upgrade_record(
             "1",
             "2",
+            2,
             calimero_store::key::GroupUpgradeStatus::InProgress {
                 total: 1,
                 completed: 0,
@@ -414,6 +418,7 @@ mod tests {
         let rec = upgrade_record(
             "1",
             "v2",
+            0,
             calimero_store::key::GroupUpgradeStatus::InProgress {
                 total: 1,
                 completed: 0,
@@ -456,6 +461,7 @@ mod tests {
                 &upgrade_record(
                     "1",
                     "3",
+                    3,
                     calimero_store::key::GroupUpgradeStatus::InProgress {
                         total: 1,
                         completed: 0,

--- a/crates/context/src/handlers/get_migration_status.rs
+++ b/crates/context/src/handlers/get_migration_status.rs
@@ -153,16 +153,15 @@ impl Handler<GetMigrationStatusRequest> for ContextManager {
 ///   trivially at target (the SDK's unversioned default is `0`), so a converged
 ///   cohort rolls up to `all_migrated`. Reporting `0` here is correct, NOT a
 ///   bogus "no migration to compare against" sentinel.
-/// * `Some(record)` — the group is at / heading to `record.to_version`. For a
-///   `Completed` record that is the version it reached (current); for an
-///   `InProgress` one it is the pending destination. Either way the cohort
-///   rolls up against `to_version`.
+/// * `Some(record)` — the group is at / heading to `record.to_state_version`.
+///   For a `Completed` record that is the version it reached (current); for an
+///   `InProgress` one it is the pending destination.
 ///
-/// A `Some(record)` whose `to_version` does not parse to a `u32` must NOT
-/// collapse to `0`: doing so makes every member reporting `schema_version >= 0`
-/// (all of them) trivially "migrated" — a false green over a real migration.
-/// An unknowable target pins to [`u32::MAX`] so no real version satisfies it and
-/// `all_migrated` stays false until the record is replaced by a parseable one.
+/// A `Some(record)` whose `to_state_version` is `0` (unresolvable) must NOT
+/// collapse to `0` as a target: doing so makes every member reporting
+/// `schema_version >= 0` (all of them) trivially "migrated" — a false green
+/// over a real migration. An unresolvable target pins to [`u32::MAX`] so no
+/// real version satisfies it until the record is replaced by a resolvable one.
 fn derive_target_version(upgrade: Option<&calimero_store::key::GroupUpgradeValue>) -> u32 {
     match upgrade {
         None => 0,

--- a/crates/context/src/handlers/get_migration_status.rs
+++ b/crates/context/src/handlers/get_migration_status.rs
@@ -391,32 +391,6 @@ mod tests {
         assert_eq!(super::derive_target_version(Some(&rec)), 2);
     }
 
-    /// Regression: a PENDING (`InProgress`) record whose `to_version` does not
-    /// parse to a `u32` (e.g. a "v2"-style or otherwise non-numeric semver)
-    /// must NOT collapse to target `0`. Target `0` would make every member
-    /// reporting `schema_version >= 0` (i.e. all of them) trivially "migrated"
-    /// — a FALSE GREEN in the middle of a real pending migration. An
-    /// unknowable pending target pins to `u32::MAX` so no real version can
-    /// satisfy it and `all_migrated` stays false until the migration resolves.
-    #[test]
-    fn target_version_in_progress_unparseable_to_version_is_not_false_green() {
-        let rec = upgrade_record(
-            "1",
-            "v2",
-            0,
-            calimero_store::key::GroupUpgradeStatus::InProgress {
-                total: 1,
-                completed: 0,
-                failed: 0,
-            },
-        );
-        assert_eq!(
-            super::derive_target_version(Some(&rec)),
-            u32::MAX,
-            "an unparseable pending target must not collapse to 0 (false green)"
-        );
-    }
-
     /// A record targeting semver 10.2.0 at ABI state 2 must roll up against 2.
     /// Parsing the semver yields 10, which every member on major 10 trivially
     /// satisfies — the false green this PR exists to remove.

--- a/crates/context/src/handlers/update_application/mod.rs
+++ b/crates/context/src/handlers/update_application/mod.rs
@@ -1821,6 +1821,7 @@ mod tests {
                 package: "com.test.app".into(),
                 version: "1.0.0".into(),
                 signer_id: signer_id.into(),
+                state_version: 0,
             },
         )
     }

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -427,9 +427,10 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                 }
                 // Finish the record the synchronous section wrote: without the
                 // target's state version the rollup can never call this satisfied.
-                let to_state_version = blob_max_state_version(&node_client, target_blob)
-                    .await
-                    .unwrap_or_default();
+                let to_state_version = recorded_state_version(
+                    blob_max_state_version(&node_client, target_blob).await,
+                    target_blob,
+                );
                 let repo = UpgradesRepository::new(&datastore_for_canary);
                 if let Some(mut value) = repo.load(&group_id)? {
                     value.to_state_version = to_state_version;
@@ -743,6 +744,20 @@ async fn blob_max_state_version(
     max_sv
 }
 
+/// Records an unreadable target ABI as the `0` sentinel, which the rollup pins
+/// to `u32::MAX` — status stays red rather than falsely green.
+fn recorded_state_version(resolved: Option<u32>, blob: [u8; 32]) -> u32 {
+    resolved.unwrap_or_else(|| {
+        warn!(
+            blob = %calimero_primitives::blobs::BlobId::from(blob),
+            "no readable ABI state version for the upgrade target; recording the 0 \
+             (unresolvable) sentinel — migration status stays incomplete until a \
+             record with a resolvable target replaces it"
+        );
+        0
+    })
+}
+
 /// The blob's embedded schema (single/first service), for the per-rung
 /// identity-downgrade gate. `Absent` when the blob is missing/unreadable.
 async fn resolve_blob_schema(
@@ -779,7 +794,7 @@ async fn plan_emit_ladder(
 ) -> eyre::Result<(Vec<EmitRung>, u32)> {
     let from_sv = blob_max_state_version(node_client, current_app_key).await;
     let to_sv = blob_max_state_version(node_client, target_blob).await;
-    let target_state_version = to_sv.unwrap_or_default();
+    let target_state_version = recorded_state_version(to_sv, target_blob);
     let multi_hop = matches!((from_sv, to_sv), (Some(f), Some(t)) if t > f + 1);
     if !multi_hop {
         let migration =
@@ -1761,9 +1776,10 @@ fn dispatch_cascade(
         };
         // Every matched descendant lands on the same target blob, so one
         // resolution covers the whole cascade.
-        let target_state_version = blob_max_state_version(&node_client_for_publish, new_app_key)
-            .await
-            .unwrap_or_default();
+        let target_state_version = recorded_state_version(
+            blob_max_state_version(&node_client_for_publish, new_app_key).await,
+            new_app_key,
+        );
         let migration_bytes_for_publish = migration.as_ref().map(|m| m.method.as_bytes().to_vec());
         let has_migration = migration.is_some();
         // L1 identity-downgrade gate: refuse a migration cascade that strips

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -167,6 +167,9 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                 },
                 cascade_hlc: None,
                 cascade_seq: None,
+                // Unresolvable here: reading the target's ABI needs an async
+                // blob read. The async block below overwrites this record.
+                to_state_version: 0,
             };
             if let Err(err) = UpgradesRepository::new(&self.datastore).save(&group_id, &inprogress)
             {
@@ -180,7 +183,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                     // and one-hop upgrades; a multi-version target discovers
                     // installed intermediates so the group moves rung by rung
                     // and behind members replay the same sequence.
-                    let rungs = {
+                    let (rungs, target_state_version) = {
                         let target_blob = target_blob_bytes
                             .ok_or_else(|| eyre::eyre!("target application not found"))?;
                         let target_size = app_meta_for_contract
@@ -288,6 +291,7 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                         status: completed_status.clone(),
                         cascade_hlc: None,
                         cascade_seq: None,
+                        to_state_version: target_state_version,
                     };
 
                     UpgradesRepository::new(&datastore).save(&group_id, &upgrade_value)?;
@@ -366,6 +370,9 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
             status: initial_status.clone(),
             cascade_hlc: None,
             cascade_seq: None,
+            // Stamped with the resolved value by the canary task below, which
+            // can do the async blob read this synchronous section cannot.
+            to_state_version: 0,
         };
 
         if let Err(err) = UpgradesRepository::new(&self.datastore).save(&group_id, &upgrade_value) {
@@ -417,6 +424,16 @@ impl Handler<UpgradeGroupRequest> for ContextManager {
                          run under the LazyOnAccess upgrade policy",
                         declared.method
                     );
+                }
+                // Finish the record the synchronous section wrote: without the
+                // target's state version the rollup can never call this satisfied.
+                let to_state_version = blob_max_state_version(&node_client, target_blob)
+                    .await
+                    .unwrap_or_default();
+                let repo = UpgradesRepository::new(&datastore_for_canary);
+                if let Some(mut value) = repo.load(&group_id)? {
+                    value.to_state_version = to_state_version;
+                    repo.save(&group_id, &value)?;
                 }
             }
             {
@@ -750,6 +767,9 @@ async fn resolve_blob_schema(
 /// and validates every consecutive pair with the same single-hop rules, so
 /// an admin moves a group several versions in one action while behind
 /// members replay the identical rung sequence.
+///
+/// Returns the ladder alongside the target's ABI state version (`0` when
+/// unreadable), which the caller records on the group's upgrade record.
 async fn plan_emit_ladder(
     node_client: &calimero_node_primitives::client::NodeClient,
     application_id: &ApplicationId,
@@ -757,19 +777,23 @@ async fn plan_emit_ladder(
     target_blob: [u8; 32],
     target_size: u64,
     force_code_only: bool,
-) -> eyre::Result<Vec<EmitRung>> {
+) -> eyre::Result<(Vec<EmitRung>, u32)> {
     let from_sv = blob_max_state_version(node_client, current_app_key).await;
     let to_sv = blob_max_state_version(node_client, target_blob).await;
+    let target_state_version = to_sv.unwrap_or_default();
     let multi_hop = matches!((from_sv, to_sv), (Some(f), Some(t)) if t > f + 1);
     if !multi_hop {
         let migration =
             resolve_upgrade_from_abis(node_client, current_app_key, target_blob, force_code_only)
                 .await?;
-        return Ok(vec![EmitRung {
-            app_key: target_blob,
-            size: target_size,
-            migration,
-        }]);
+        return Ok((
+            vec![EmitRung {
+                app_key: target_blob,
+                size: target_size,
+                migration,
+            }],
+            target_state_version,
+        ));
     }
     let (from_sv, to_sv) = (from_sv.unwrap_or_default(), to_sv.unwrap_or_default());
 
@@ -811,7 +835,7 @@ async fn plan_emit_ladder(
         size: target_size,
         migration,
     });
-    Ok(rungs)
+    Ok((rungs, target_state_version))
 }
 
 /// An installed release considered for an intermediate rung of a multi-hop
@@ -1736,6 +1760,11 @@ fn dispatch_cascade(
             }
             resolved
         };
+        // Every matched descendant lands on the same target blob, so one
+        // resolution covers the whole cascade.
+        let target_state_version = blob_max_state_version(&node_client_for_publish, new_app_key)
+            .await
+            .unwrap_or_default();
         let migration_bytes_for_publish = migration.as_ref().map(|m| m.method.as_bytes().to_vec());
         let has_migration = migration.is_some();
         // L1 identity-downgrade gate: refuse a migration cascade that strips
@@ -1772,12 +1801,12 @@ fn dispatch_cascade(
         .await?;
         report.observe("upgrade_group", "CascadeUpgrade");
 
-        Ok::<_, eyre::Report>(migration)
+        Ok::<_, eyre::Report>((migration, target_state_version))
     }
     .into_actor(actor);
 
     ActorResponse::r#async(publish_task.map(move |publish_result, act, ctx| {
-        let migration = publish_result?;
+        let (migration, target_state_version) = publish_result?;
         let migration_bytes = migration.as_ref().map(|m| m.method.as_bytes().to_vec());
 
         // After successful publish + local apply, spawn one propagator
@@ -1813,6 +1842,7 @@ fn dispatch_cascade(
                 },
                 cascade_hlc: Some(cascade_hlc),
                 cascade_seq,
+                to_state_version: target_state_version,
             };
             if let Err(err) = UpgradesRepository::new(&datastore).save(gid, &upgrade_value) {
                 error!(
@@ -2227,6 +2257,7 @@ mod tests {
                     },
                     cascade_hlc: None,
                     cascade_seq: None,
+                    to_state_version: 1,
                 },
             )
             .expect("save in-progress record");

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -767,9 +767,8 @@ async fn resolve_blob_schema(
 /// and validates every consecutive pair with the same single-hop rules, so
 /// an admin moves a group several versions in one action while behind
 /// members replay the identical rung sequence.
-///
-/// Returns the ladder alongside the target's ABI state version (`0` when
-/// unreadable), which the caller records on the group's upgrade record.
+/// Also returns the target's ABI state version (`0` when unreadable), which
+/// the caller records on the group's upgrade record.
 async fn plan_emit_ladder(
     node_client: &calimero_node_primitives::client::NodeClient,
     application_id: &ApplicationId,

--- a/crates/context/tests/hlc_fence.rs
+++ b/crates/context/tests/hlc_fence.rs
@@ -131,6 +131,7 @@ fn install_application(store: &Store, app_id: ApplicationId, app_key: [u8; 32]) 
             package: "hlc-fence-test-pkg".to_owned().into_boxed_str(),
             version: "1.0.0".to_owned().into_boxed_str(),
             signer_id: "hlc-fence-test-signer".to_owned().into_boxed_str(),
+            state_version: 0,
         },
     );
     store

--- a/crates/context/tests/hlc_fence.rs
+++ b/crates/context/tests/hlc_fence.rs
@@ -74,6 +74,7 @@ fn upgrade_with_hlc(cascade_hlc: Option<HybridTimestamp>) -> GroupUpgradeValue {
         status: GroupUpgradeStatus::Completed { completed_at: None },
         cascade_hlc,
         cascade_seq: None,
+        to_state_version: 2,
     }
 }
 

--- a/crates/governance-store/src/governance_broadcast.rs
+++ b/crates/governance-store/src/governance_broadcast.rs
@@ -267,7 +267,7 @@ pub fn beacon_admission_provable(store: &Store, beacon: &SignedReadinessBeacon) 
 /// checked via [`SignedMigrationHeartbeat::verify_signature`] (which uses
 /// the canonical `MIGRATION_HEARTBEAT_SIGN_DOMAIN || borsh(SignableMigrationHeartbeat)`
 /// payload and rejects field-substitution replays such as zeroing
-/// `residue_identity` to fake completion), and the `peer_pubkey` must be a
+/// `residue_auto` to fake completion), and the `peer_pubkey` must be a
 /// member of the heartbeat's namespace cohort. The membership check reuses
 /// [`namespace_pubkeys`], which includes the meta admin even when the admin
 /// has no member row.

--- a/crates/governance-store/src/governance_broadcast/tests.rs
+++ b/crates/governance-store/src/governance_broadcast/tests.rs
@@ -785,14 +785,13 @@ fn signed_heartbeat(
     sk: &PrivateKey,
     namespace_id: NamespaceId,
     schema_version: u32,
-    residue_identity: u64,
+    residue_auto: u64,
 ) -> SignedMigrationHeartbeat {
     let mut hb = SignedMigrationHeartbeat {
         namespace_id,
         peer_pubkey: sk.public_key(),
         schema_version,
-        residue_auto: 0,
-        residue_identity,
+        residue_auto,
         synced_up_to_hlc: 42,
         ts_millis: 1_700_000_000_000,
         signature: [0u8; 64],
@@ -836,7 +835,7 @@ async fn verify_migration_heartbeat_rejects_non_member_signer() {
 #[tokio::test]
 async fn verify_migration_heartbeat_rejects_bad_signature() {
     // Short-circuit on signature failure before consulting membership: a
-    // tampered heartbeat (e.g. residue_identity zeroed to fake completion)
+    // tampered heartbeat (e.g. residue_auto zeroed to fake completion)
     // must never be cached even from a known member.
     let store = empty_store();
     let sk = PrivateKey::random(&mut rand::thread_rng());
@@ -844,7 +843,7 @@ async fn verify_migration_heartbeat_rejects_bad_signature() {
     plant_namespace_member(&store, ns_id.into(), &sk.public_key());
 
     let mut hb = signed_heartbeat(&sk, ns_id.into(), 2, 5);
-    hb.residue_identity = 0; // tamper after signing — sig no longer covers body
+    hb.residue_auto = 0; // tamper after signing — sig no longer covers body
     assert!(!verify_migration_heartbeat(&store, &hb));
 }
 

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -1735,6 +1735,7 @@ impl<'a> NamespaceGovernance<'a> {
                             package: String::new().into_boxed_str(),
                             version: String::new().into_boxed_str(),
                             signer_id: String::new().into_boxed_str(),
+                            state_version: 0,
                         },
                     );
                     let mut wh = self.store.handle();

--- a/crates/governance-store/src/ops/group/cascade_upgrade.rs
+++ b/crates/governance-store/src/ops/group/cascade_upgrade.rs
@@ -122,6 +122,9 @@ pub(crate) fn apply(
             status: GroupUpgradeStatus::Completed { completed_at: None },
             cascade_hlc: None,
             cascade_seq: None,
+            // The op carries no state version, so a fresh record has none to
+            // resolve — same reason `to_version` defaults empty here.
+            to_state_version: 0,
         });
         // Reflect THIS cascade's migration bytes on an existing record too, so
         // the record's `migration` matches the `GroupMeta.migration` we just

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -1950,6 +1950,7 @@ fn save_load_delete_upgrade() {
         },
         cascade_hlc: None,
         cascade_seq: None,
+        to_state_version: 2,
     };
 
     UpgradesRepository::new(&store)
@@ -1988,6 +1989,7 @@ fn enumerate_in_progress_upgrades_filters_completed() {
                 },
                 cascade_hlc: None,
                 cascade_seq: None,
+                to_state_version: 2,
             },
         )
         .unwrap();
@@ -2006,6 +2008,7 @@ fn enumerate_in_progress_upgrades_filters_completed() {
                 },
                 cascade_hlc: None,
                 cascade_seq: None,
+                to_state_version: 2,
             },
         )
         .unwrap();

--- a/crates/governance-store/src/upgrades.rs
+++ b/crates/governance-store/src/upgrades.rs
@@ -100,6 +100,7 @@ mod tests {
             status,
             cascade_hlc: None,
             cascade_seq: None,
+            to_state_version: 2,
         }
     }
 

--- a/crates/governance-types/src/wire.rs
+++ b/crates/governance-types/src/wire.rs
@@ -169,8 +169,8 @@ impl SignedReadinessBeacon {
 
 /// Body of a migration heartbeat — every field except the signature.
 /// Borsh-serialized inside [`SignedMigrationHeartbeat::signable_bytes`] so
-/// the Ed25519 signature covers all seven fields and field-substitution
-/// replays (e.g. zeroing `residue_identity` to fake a completed migration)
+/// the Ed25519 signature covers all six fields and field-substitution
+/// replays (e.g. zeroing `residue_auto` to fake a completed migration)
 /// are detected at verification time.
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct SignableMigrationHeartbeat {
@@ -180,8 +180,6 @@ pub struct SignableMigrationHeartbeat {
     pub schema_version: u32,
     /// Unconverted Convergent ("auto") contexts still pending (from the 6a marker).
     pub residue_auto: u64,
-    /// Unconverted identity-gated entries still pending (from the 6c.6 local scan).
-    pub residue_identity: u64,
     /// Governance HLC the publisher has synced/applied through.
     pub synced_up_to_hlc: u64,
     pub ts_millis: u64,
@@ -193,9 +191,9 @@ pub struct SignableMigrationHeartbeat {
 /// gossip, NOT replicated governance state, and must never be treated as a
 /// migration gate.
 ///
-/// `residue_auto == 0 && residue_identity == 0 && schema_version >= target`
-/// across every pinned cohort member is what a rollup reads as "all migrated";
-/// the signature prevents a peer from forging another peer's completion.
+/// `residue_auto == 0 && schema_version >= target` across every pinned cohort
+/// member is what a rollup reads as "all migrated"; the signature prevents a
+/// peer from forging another peer's completion.
 // MAINTENANCE: this struct has a hand-written `BorshDeserialize` (below) that
 // reads these fields positionally. If you ADD / REMOVE / REORDER any field
 // here, update that impl in lockstep (new fields go AFTER migration_failed as
@@ -208,7 +206,6 @@ pub struct SignedMigrationHeartbeat {
     pub peer_pubkey: PublicKey,
     pub schema_version: u32,
     pub residue_auto: u64,
-    pub residue_identity: u64,
     pub synced_up_to_hlc: u64,
     pub ts_millis: u64,
     pub signature: [u8; 64],
@@ -217,8 +214,8 @@ pub struct SignedMigrationHeartbeat {
     /// signable body: it is best-effort advisory telemetry (decision #3), not a
     /// migration gate — the signed residue_* fields cover completion. Appended
     /// as the trailing field so a heartbeat from an older node (which omits it)
-    /// still deserializes (EOF ⇒ 0) and verifies against the unchanged 7-field
-    /// signed body — full mixed-fleet compatibility, no version discriminator.
+    /// still deserializes (EOF ⇒ 0) and verifies against the unchanged signed
+    /// body — full mixed-fleet compatibility, no version discriminator.
     pub authored_remaining: u64,
     /// Self-reported migration-failure reason as a discriminant: `0` = none,
     /// `1` = the developer's migration-check aborted, `2` = the migrate apply
@@ -265,9 +262,9 @@ fn read_trailing<R: borsh::io::Read, const N: usize>(
 // FIELD ORDER CONTRACT: borsh is positional (no field names), so this reader
 // MUST deserialize the prefix fields in the exact order the derived
 // `BorshSerialize` above writes them — namespace_id, peer_pubkey, schema_version,
-// residue_auto, residue_identity, synced_up_to_hlc, ts_millis, signature — then
-// the trailing authored_remaining, then migration_failed. Reordering/adding a
-// field above without updating this reader silently misreads. The round-trip +
+// residue_auto, synced_up_to_hlc, ts_millis, signature — then the trailing
+// authored_remaining, then migration_failed. Reordering/adding a field above
+// without updating this reader silently misreads. The round-trip +
 // mixed-fleet tests (which serialize via the derive and deserialize via this
 // impl) guard against such a desync; keep them in step. A future field should
 // go AFTER migration_failed (another trailing read) or behind a discriminant.
@@ -277,7 +274,6 @@ impl BorshDeserialize for SignedMigrationHeartbeat {
         let peer_pubkey = PublicKey::deserialize_reader(reader)?;
         let schema_version = u32::deserialize_reader(reader)?;
         let residue_auto = u64::deserialize_reader(reader)?;
-        let residue_identity = u64::deserialize_reader(reader)?;
         let synced_up_to_hlc = u64::deserialize_reader(reader)?;
         let ts_millis = u64::deserialize_reader(reader)?;
         let signature = <[u8; 64]>::deserialize_reader(reader)?;
@@ -291,7 +287,6 @@ impl BorshDeserialize for SignedMigrationHeartbeat {
             peer_pubkey,
             schema_version,
             residue_auto,
-            residue_identity,
             synced_up_to_hlc,
             ts_millis,
             signature,
@@ -310,7 +305,6 @@ impl SignedMigrationHeartbeat {
             peer_pubkey: self.peer_pubkey,
             schema_version: self.schema_version,
             residue_auto: self.residue_auto,
-            residue_identity: self.residue_identity,
             synced_up_to_hlc: self.synced_up_to_hlc,
             ts_millis: self.ts_millis,
         }
@@ -691,7 +685,6 @@ mod tests {
             peer_pubkey: sk.public_key(),
             schema_version: 2,
             residue_auto: 5,
-            residue_identity: 3,
             synced_up_to_hlc: 99,
             ts_millis: 1_700_000_000_000,
             signature: [0u8; 64],
@@ -706,16 +699,15 @@ mod tests {
     }
 
     #[test]
-    fn signed_migration_heartbeat_rejects_residue_identity_flip() {
-        // Field-substitution attack: rewriting `residue_identity` to 0 to
+    fn signed_migration_heartbeat_rejects_residue_auto_flip() {
+        // Field-substitution attack: rewriting `residue_auto` to 0 to
         // fake a completed migration must break the signature.
         let sk = PrivateKey::random(&mut rand::thread_rng());
         let mut hb = SignedMigrationHeartbeat {
             namespace_id: [7u8; 32].into(),
             peer_pubkey: sk.public_key(),
             schema_version: 2,
-            residue_auto: 0,
-            residue_identity: 4,
+            residue_auto: 4,
             synced_up_to_hlc: 99,
             ts_millis: 1_700_000_000_000,
             signature: [0u8; 64],
@@ -726,10 +718,10 @@ mod tests {
             .sign(&hb.signable_bytes().expect("signable"))
             .expect("sign")
             .to_bytes();
-        hb.residue_identity = 0; // tampered after signing
+        hb.residue_auto = 0; // tampered after signing
         assert!(
             hb.verify_signature().is_err(),
-            "verify must reject mutated `residue_identity`"
+            "verify must reject mutated `residue_auto`"
         );
     }
 
@@ -745,7 +737,6 @@ mod tests {
             peer_pubkey: sk.public_key(),
             schema_version: 2,
             residue_auto: 0,
-            residue_identity: 0,
             synced_up_to_hlc: 50,
             ts_millis: 1_700_000_000_000,
             signature: [0u8; 64],
@@ -766,7 +757,7 @@ mod tests {
 
         // Old-format heartbeat: drop BOTH trailing fields (authored_remaining
         // u64 + migration_failed u8). Both default to 0 and the signature (over
-        // the unchanged 7-field body) still verifies.
+        // the unchanged signed body) still verifies.
         let legacy = &bytes[..bytes.len() - core::mem::size_of::<u64>() - 1];
         let old = SignedMigrationHeartbeat::try_from_slice(legacy).expect("de legacy");
         assert_eq!(old.authored_remaining, 0, "absent trailing field ⇒ 0");
@@ -797,7 +788,6 @@ mod tests {
             peer_pubkey: sk.public_key(),
             schema_version: 2,
             residue_auto: 0,
-            residue_identity: 0,
             synced_up_to_hlc: 50,
             ts_millis: 1_700_000_000_000,
             signature: [0u8; 64],
@@ -845,7 +835,6 @@ mod tests {
             peer_pubkey: sk.public_key(),
             schema_version: 2,
             residue_auto: 0,
-            residue_identity: 0,
             synced_up_to_hlc: 99,
             ts_millis: 1_700_000_000_000,
         };
@@ -856,7 +845,6 @@ mod tests {
             peer_pubkey: hb_unsigned.peer_pubkey,
             schema_version: hb_unsigned.schema_version,
             residue_auto: hb_unsigned.residue_auto,
-            residue_identity: hb_unsigned.residue_identity,
             synced_up_to_hlc: hb_unsigned.synced_up_to_hlc,
             ts_millis: hb_unsigned.ts_millis,
             signature,
@@ -877,7 +865,6 @@ mod tests {
             peer_pubkey: sk.public_key(),
             schema_version: 2,
             residue_auto: 7,
-            residue_identity: 1,
             synced_up_to_hlc: 1234,
             ts_millis: 42,
             signature: [5u8; 64],
@@ -891,7 +878,6 @@ mod tests {
                 assert_eq!(hb.namespace_id.to_bytes(), [3u8; 32]);
                 assert_eq!(hb.schema_version, 2);
                 assert_eq!(hb.residue_auto, 7);
-                assert_eq!(hb.residue_identity, 1);
                 assert_eq!(hb.synced_up_to_hlc, 1234);
             }
             other => panic!("wrong variant: {other:?}"),

--- a/crates/node/primitives/Cargo.toml
+++ b/crates/node/primitives/Cargo.toml
@@ -38,6 +38,7 @@ calimero-network-primitives.workspace = true
 calimero-storage.workspace = true
 calimero-store.workspace = true
 calimero-utils-actix.workspace = true
+calimero-wasm-abi.workspace = true
 flate2.workspace = true
 hex.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/node/primitives/src/client/application/install.rs
+++ b/crates/node/primitives/src/client/application/install.rs
@@ -148,6 +148,8 @@ impl NodeClient {
                 package: package.to_owned().into_boxed_str(),
                 version: version.to_owned().into_boxed_str(),
                 signer_id: String::new().into_boxed_str(),
+                // Raw wasm has no manifest and no guaranteed ABI.
+                state_version: 0,
             },
         );
 
@@ -229,7 +231,15 @@ impl NodeClient {
         let version = &manifest.app_version;
 
         let mut services = Vec::new();
+        let mut max_state_version = 0;
         for artifact in &wasm {
+            // Before the name guard: an unnamed single-service artifact still
+            // carries a state version.
+            if let Some(schema) =
+                calimero_wasm_abi::embed::read_embedded_state_schema(&artifact.bytes)
+            {
+                max_state_version = max_state_version.max(schema.state_version_or_default());
+            }
             let Some(name) = &artifact.name else { continue };
             let (svc_blob_id, _svc_size) = self
                 .add_blob(
@@ -254,6 +264,7 @@ impl NodeClient {
                 package: package.as_str().into(),
                 version: version.as_str().into(),
                 signer_id: verified.signer_id().into(),
+                state_version: max_state_version,
             },
             services,
         )

--- a/crates/node/primitives/src/messages.rs
+++ b/crates/node/primitives/src/messages.rs
@@ -95,8 +95,6 @@ pub struct MigrationStatusReport {
     pub schema_version: u32,
     /// Unconverted Convergent ("auto") entries the member still has pending.
     pub residue_auto: u64,
-    /// Unconverted identity-gated entries the member still has pending.
-    pub residue_identity: u64,
     /// Governance HLC the member has synced/applied through.
     pub synced_up_to_hlc: u64,
     /// Member-signed millis-since-epoch from the heartbeat itself.

--- a/crates/node/src/cascade_dispatch_e2e.rs
+++ b/crates/node/src/cascade_dispatch_e2e.rs
@@ -158,7 +158,13 @@ fn provision_group(
 /// `new_app_key = app_meta.bytecode.blob_id()` for the target — so
 /// driving the test's target app_key through this field is what makes
 /// the apply arm rewrite descendants to `APP_KEY_V2`.
-fn install_application(store: &Store, app_id: ApplicationId, app_key: [u8; 32], version: &str) {
+fn install_application(
+    store: &Store,
+    app_id: ApplicationId,
+    app_key: [u8; 32],
+    version: &str,
+    state_version: u32,
+) {
     let bytecode_blob = key::BlobMeta::new(calimero_primitives::blobs::BlobId::from(app_key));
     // `compiled` is unused on the cascade path (cascade-time blob
     // announce only references `bytecode`), so reusing `bytecode_blob`
@@ -173,7 +179,7 @@ fn install_application(store: &Store, app_id: ApplicationId, app_key: [u8; 32], 
             package: "cascade-test-pkg".to_owned().into_boxed_str(),
             version: version.to_owned().into_boxed_str(),
             signer_id: "cascade-test-signer".to_owned().into_boxed_str(),
-            state_version: 0,
+            state_version,
         },
     );
     let mut handle = store.handle();
@@ -260,10 +266,17 @@ fn provision_namespace(
         .nest(&ns, &g2)
         .expect("nest g2");
 
-    install_application(store, app_id_v1(), blobs.v1, "0.1.0");
-    install_application(store, app_id_v2(), target_v2_key, "0.2.0");
+    // `target_v2_key` is one of the two ABI state versions blobs.v2 embeds:
+    // 1 for the code-only pair, 2 for the migration-declaring release.
+    let target_v2_sv = if target_v2_key == blobs.v2_migrating {
+        2
+    } else {
+        1
+    };
+    install_application(store, app_id_v1(), blobs.v1, "0.1.0", 1);
+    install_application(store, app_id_v2(), target_v2_key, "0.2.0", target_v2_sv);
     if g2_on_other {
-        install_application(store, app_id_other(), blobs.other, "0.1.0-other");
+        install_application(store, app_id_other(), blobs.other, "0.1.0-other", 1);
     }
 
     let ctx_ns = ContextId::from([0xC0; 32]);
@@ -821,7 +834,7 @@ async fn lazy_upgrade_emits_multi_hop_ladder() {
     let app_id = app_id_v1();
     // The shared row holds the LATEST release (v3) — bundle ids are
     // version-stable, so the row is where a same-id upgrade targets.
-    install_application(&node.store, app_id, blobs.v3, "0.3.0");
+    install_application(&node.store, app_id, blobs.v3, "0.3.0", 3);
 
     let gid = ContextGroupId::from([0x71; 32]);
     provision_group(
@@ -899,7 +912,7 @@ async fn lazy_upgrade_multi_hop_missing_intermediate_rejects_with_floor() {
     let blobs = seed_ladder_bundles(&node).await;
 
     let app_id = app_id_v1();
-    install_application(&node.store, app_id, blobs.v3, "0.3.0");
+    install_application(&node.store, app_id, blobs.v3, "0.3.0", 3);
 
     let gid = ContextGroupId::from([0x73; 32]);
     provision_group(

--- a/crates/node/src/cascade_dispatch_e2e.rs
+++ b/crates/node/src/cascade_dispatch_e2e.rs
@@ -505,6 +505,7 @@ async fn cascade_dispatch_e2e_write_gate_blocks_state_ops() {
                 },
                 cascade_hlc: None,
                 cascade_seq: None,
+                to_state_version: 1,
             },
         )
         .expect("save_group_upgrade InProgress for G1");

--- a/crates/node/src/cascade_dispatch_e2e.rs
+++ b/crates/node/src/cascade_dispatch_e2e.rs
@@ -173,6 +173,7 @@ fn install_application(store: &Store, app_id: ApplicationId, app_key: [u8; 32], 
             package: "cascade-test-pkg".to_owned().into_boxed_str(),
             version: version.to_owned().into_boxed_str(),
             signer_id: "cascade-test-signer".to_owned().into_boxed_str(),
+            state_version: 0,
         },
     );
     let mut handle = store.handle();

--- a/crates/node/src/handlers/network_event/namespace.rs
+++ b/crates/node/src/handlers/network_event/namespace.rs
@@ -108,7 +108,6 @@ pub(super) fn handle_namespace_governance_delta(
                 peer = %heartbeat.peer_pubkey,
                 schema_version = heartbeat.schema_version,
                 residue_auto = heartbeat.residue_auto,
-                residue_identity = heartbeat.residue_identity,
                 "migration heartbeat cached"
             );
             return;

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -2666,6 +2666,7 @@ mod tests {
                     package: "".into(),
                     version: "".into(),
                     signer_id: "".into(),
+                    state_version: 0,
                 },
             );
             let ctx_meta = ContextMeta::new(app_key, [0; 32], vec![], None);

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -2434,6 +2434,7 @@ mod tests {
                             status: GroupUpgradeStatus::Completed { completed_at: None },
                             cascade_hlc: Some(cascade_hlc),
                             cascade_seq: None,
+                            to_state_version: 2,
                         },
                     )
                     .expect("save group upgrade");

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -435,6 +435,7 @@ async fn create_restricted_subgroup(
             package: "test-package".into(),
             version: "0.0.0".into(),
             signer_id: "test-signer".into(),
+            state_version: 0,
         },
     );
     node.store
@@ -532,6 +533,7 @@ async fn create_born_open_subgroup(
             package: "test-package".into(),
             version: "0.0.0".into(),
             signer_id: "test-signer".into(),
+            state_version: 0,
         },
     );
     node.store
@@ -854,6 +856,7 @@ async fn root_admitted_tee_auto_follows_open_subgroup_context() {
             package: "stub-package".into(),
             version: "0.0.0".into(),
             signer_id: "stub-signer".into(),
+            state_version: 0,
         },
     );
     node.store
@@ -1096,6 +1099,7 @@ async fn integrated_tee_lifecycle_open_replication_and_scoped_root_cascade() {
             package: "stub-package".into(),
             version: "0.0.0".into(),
             signer_id: "stub-signer".into(),
+            state_version: 0,
         },
     );
     node.store
@@ -1482,6 +1486,7 @@ async fn born_open_subgroup_no_direct_tee_row_but_inherits_replication() {
             package: "stub-package".into(),
             version: "0.0.0".into(),
             signer_id: "stub-signer".into(),
+            state_version: 0,
         },
     );
     node.store
@@ -2593,6 +2598,7 @@ async fn drive_open_auto_follow_replication(
             package: "stub-package".into(),
             version: "0.0.0".into(),
             signer_id: "stub-signer".into(),
+            state_version: 0,
         },
     );
     node.store

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -505,9 +505,9 @@ pub fn compute_namespace_migration_facts(
 
     // No resolvable loaded context ⇒ fall back to the target (the no-loaded-state
     // path; the no-record baseline already resolves the target to `0`). But never
-    // advertise the unparseable-target sentinel (`u32::MAX`) as a LOADED reader
+    // advertise the unresolvable-target sentinel (`u32::MAX`) as a LOADED reader
     // version — it is an all_migrated-gate marker ("no real version satisfies an
-    // unparseable target"), not a version this node loaded. Report the honest
+    // unresolvable target"), not a version this node loaded. Report the honest
     // unknown `0` instead; the gate stays conservative (0 < MAX ⇒ not migrated).
     let schema_version = match min_loaded {
         Some(loaded) => loaded,

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -1326,6 +1326,7 @@ mod tests {
                 package: "loaded-test-pkg".to_owned().into_boxed_str(),
                 version: version.to_owned().into_boxed_str(),
                 signer_id: "loaded-test-signer".to_owned().into_boxed_str(),
+                state_version: 0,
             },
         );
         let mut handle = store.handle();

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -347,11 +347,12 @@ fn parse_major_version(version: &str) -> Option<u32> {
         .and_then(|major| major.trim().parse::<u32>().ok())
 }
 
-/// Resolve a single context's LOADED reader version: the major version of the
-/// `ApplicationMeta` its `ContextMeta.application` points at. This is the schema
-/// the node can actually read *right now* (the binary it has swapped to), NOT
-/// the replicated migration target. `None` when the context/application row is
-/// missing or its version string does not parse.
+/// Resolve a single context's LOADED reader version: the ABI state version of
+/// the `ApplicationMeta` its `ContextMeta.application` points at. This is the
+/// schema the node can actually read right now, NOT the replicated migration
+/// target and NOT the bundle semver — a 10.1.3 to 10.2.0 release may or may
+/// not move the state version, and only the state version gates readability.
+/// `None` when the context or application row is missing.
 fn loaded_context_version(
     datastore: &Store,
     context_id: &calimero_primitives::context::ContextId,
@@ -362,7 +363,7 @@ fn loaded_context_version(
         .ok()
         .flatten()?;
     let app_meta = handle.get(&ctx_meta.application).ok().flatten()?;
-    parse_major_version(&app_meta.version)
+    Some(app_meta.state_version)
 }
 
 /// Every group in a namespace's tree: the namespace-root group plus every
@@ -1286,14 +1287,22 @@ mod tests {
     }
 
     /// Register a context under `ns` whose locally-loaded `ApplicationMeta`
-    /// declares `version`. This is the binary the node has actually swapped to
-    /// — the value the facts must report, distinct from the migration target.
-    fn install_loaded_context(store: &Store, ns: [u8; 32], ctx: [u8; 32], version: &str) {
+    /// declares `version` (the bundle semver) and `state_version` (the ABI
+    /// state version) — the value the facts must report is `state_version`,
+    /// distinct from both the semver and the migration target.
+    fn install_loaded_context(
+        store: &Store,
+        ns: [u8; 32],
+        ctx: [u8; 32],
+        version: &str,
+        state_version: u32,
+    ) {
         install_loaded_context_in_group(
             store,
             &calimero_context_config::types::ContextGroupId::from(ns),
             ctx,
             version,
+            state_version,
         );
     }
 
@@ -1305,6 +1314,7 @@ mod tests {
         group_id: &calimero_context_config::types::ContextGroupId,
         ctx: [u8; 32],
         version: &str,
+        state_version: u32,
     ) {
         use calimero_primitives::application::ApplicationId;
         use calimero_store::key::{
@@ -1326,7 +1336,7 @@ mod tests {
                 package: "loaded-test-pkg".to_owned().into_boxed_str(),
                 version: version.to_owned().into_boxed_str(),
                 signer_id: "loaded-test-signer".to_owned().into_boxed_str(),
-                state_version: 0,
+                state_version,
             },
         );
         let mut handle = store.handle();
@@ -1387,7 +1397,7 @@ mod tests {
             .unwrap();
 
         // ...but this node's loaded binary still reads v1.
-        install_loaded_context(&store, ns, [0xC1u8; 32], "1.0.0");
+        install_loaded_context(&store, ns, [0xC1u8; 32], "1.0.0", 1);
 
         let facts = compute_namespace_migration_facts(&store, ns);
         assert_eq!(
@@ -1433,13 +1443,37 @@ mod tests {
             .unwrap();
 
         // Loaded binary IS at v2.
-        install_loaded_context(&store, ns, [0xC2u8; 32], "2.0.0");
+        install_loaded_context(&store, ns, [0xC2u8; 32], "2.0.0", 2);
 
         let facts = compute_namespace_migration_facts(&store, ns);
         assert_eq!(facts.schema_version, 2, "loaded binary at v2 reports v2");
         assert_eq!(
             facts.residue_auto, 0,
             "a context at the target version contributes no residue_auto"
+        );
+    }
+
+    /// A realistic release pair: both semvers share major 10, but the state
+    /// version moved 1 -> 2. Reading the semver major makes a node that has NOT
+    /// swapped report 10 and satisfy a target of 10 — a false green over a real
+    /// migration. The loaded reader version must be the ABI state version.
+    #[test]
+    fn facts_report_abi_state_version_not_semver_major() {
+        use calimero_store::db::InMemoryDB;
+        use std::sync::Arc;
+
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let ns = [0x91u8; 32];
+
+        // Semver 10.1.3, but ABI state version 1 — the loaded binary has NOT
+        // moved past state 1 even though its release major reads 10.
+        install_loaded_context(&store, ns, [0xE6u8; 32], "10.1.3", 1);
+
+        let facts = compute_namespace_migration_facts(&store, ns);
+
+        assert_eq!(
+            facts.schema_version, 1,
+            "must report the ABI state version, not the semver major (10)"
         );
     }
 
@@ -1491,7 +1525,7 @@ mod tests {
         let below = Store::new(Arc::new(InMemoryDB::owned()));
         let ns = [0x79u8; 32];
         save_v2_target(&below, ns);
-        install_loaded_context(&below, ns, [0xD1u8; 32], "1.0.0");
+        install_loaded_context(&below, ns, [0xD1u8; 32], "1.0.0", 1);
         set_marker(&below, [0xD1u8; 32], MigrationFailureKind::CheckAborted);
         assert_eq!(
             compute_namespace_migration_facts(&below, ns).migration_failed,
@@ -1503,7 +1537,7 @@ mod tests {
         // NOT honored (self-healing — a recovered context never reports failed).
         let healed = Store::new(Arc::new(InMemoryDB::owned()));
         save_v2_target(&healed, ns);
-        install_loaded_context(&healed, ns, [0xD2u8; 32], "2.0.0");
+        install_loaded_context(&healed, ns, [0xD2u8; 32], "2.0.0", 2);
         set_marker(&healed, [0xD2u8; 32], MigrationFailureKind::CheckAborted);
         assert_eq!(
             compute_namespace_migration_facts(&healed, ns).migration_failed,
@@ -1635,7 +1669,7 @@ mod tests {
             .nest(&ContextGroupId::from(ns), &subgroup)
             .unwrap();
         let ctx = [0xE1u8; 32];
-        install_loaded_context_in_group(&store, &subgroup, ctx, "1.0.0");
+        install_loaded_context_in_group(&store, &subgroup, ctx, "1.0.0", 1);
 
         // The node stranded at v1 (NoMigrationPath) — the marker is persisted on
         // the subgroup context.
@@ -1712,7 +1746,7 @@ mod tests {
             .nest(&ContextGroupId::from(ns), &subgroup)
             .unwrap();
         let ctx = [0xE2u8; 32];
-        install_loaded_context_in_group(&store, &subgroup, ctx, "1.0.0");
+        install_loaded_context_in_group(&store, &subgroup, ctx, "1.0.0", 1);
         store
             .handle()
             .put(
@@ -1761,7 +1795,7 @@ mod tests {
             .nest(&ContextGroupId::from(ns), &subgroup)
             .unwrap();
         let ctx = [0xE4u8; 32];
-        install_loaded_context_in_group(&store, &subgroup, ctx, "1.0.0");
+        install_loaded_context_in_group(&store, &subgroup, ctx, "1.0.0", 1);
         store
             .handle()
             .put(
@@ -1799,7 +1833,7 @@ mod tests {
             .nest(&ContextGroupId::from(ns), &subgroup)
             .unwrap();
         let ctx = [0xE5u8; 32];
-        install_loaded_context_in_group(&store, &subgroup, ctx, "1.0.0");
+        install_loaded_context_in_group(&store, &subgroup, ctx, "1.0.0", 1);
         store
             .handle()
             .put(
@@ -1865,7 +1899,7 @@ mod tests {
             .nest(&ContextGroupId::from(ns), &subgroup)
             .unwrap();
         let ctx = [0xE3u8; 32];
-        install_loaded_context_in_group(&store, &subgroup, ctx, "1.0.0");
+        install_loaded_context_in_group(&store, &subgroup, ctx, "1.0.0", 1);
         store
             .handle()
             .put(

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -58,9 +58,6 @@ pub struct CacheEntry {
     pub schema_version: u32,
     /// Unconverted Convergent ("auto") contexts the peer still has pending.
     pub residue_auto: u64,
-    /// Unconverted identity-gated entries the peer still has pending
-    /// (the peer's local-derived residue scan from Task 6c.6).
-    pub residue_identity: u64,
     /// Governance HLC the peer has synced/applied through.
     pub synced_up_to_hlc: u64,
     /// Peer's self-reported pending-authored count (sum across its namespace
@@ -90,7 +87,6 @@ pub fn cache_entry_to_report(entry: &CacheEntry) -> MigrationStatusReport {
     MigrationStatusReport {
         schema_version: entry.schema_version,
         residue_auto: entry.residue_auto,
-        residue_identity: entry.residue_identity,
         synced_up_to_hlc: entry.synced_up_to_hlc,
         reported_at: entry.ts_millis,
         authored_remaining: entry.authored_remaining,
@@ -203,7 +199,6 @@ impl MigrationStatusCache {
             CacheEntry {
                 schema_version: hb.schema_version,
                 residue_auto: hb.residue_auto,
-                residue_identity: hb.residue_identity,
                 synced_up_to_hlc: hb.synced_up_to_hlc,
                 authored_remaining: hb.authored_remaining,
                 migration_failed: hb.migration_failed,
@@ -265,21 +260,19 @@ impl MigrationStatusCache {
 /// heartbeat. Computed locally at emit time and signed into a
 /// [`SignedMigrationHeartbeat`] body.
 ///
-/// `residue_identity` is this node's local-derived count of unconverted
-/// identity-gated entries (Task 6c.6); `residue_auto` is the matching count
-/// for Convergent contexts (the 6a marker). A node reporting both at 0 with
-/// `schema_version >= target` is what a rollup reads as "this member migrated".
+/// `residue_auto` is this node's count of unconverted Convergent contexts (the
+/// 6a marker). A node reporting it at 0 with `schema_version >= target` is what
+/// a rollup reads as "this member migrated".
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MigrationFacts {
     pub schema_version: u32,
     pub residue_auto: u64,
-    pub residue_identity: u64,
     pub synced_up_to_hlc: u64,
     /// Sum across this node's namespace contexts of each context's owner's
     /// identity-gated entries still below target (the node-local count the
     /// context handler persists into `ContextMeta.authored_remaining`). u64
-    /// like the residue fields (a per-namespace sum of per-context u32 counts).
-    /// Best-effort self-report — distinct from `residue_identity` (still 0).
+    /// like `residue_auto` (a per-namespace sum of per-context u32 counts).
+    /// Best-effort self-report.
     pub authored_remaining: u64,
     /// Set when one of this namespace's contexts has a migration-failure marker
     /// persisted (migration-check aborted or apply errored) AND that context is
@@ -294,9 +287,9 @@ pub struct MigrationFacts {
 ///
 /// Mirrors the readiness "edge-trigger on tier transition" pattern: a peer
 /// should re-advertise immediately when its *reported state* changes —
-/// here when `schema_version`, `residue_auto`, `residue_identity`,
-/// `authored_remaining`, or `migration_failed` flips — rather than waiting up
-/// to a full periodic interval. `synced_up_to_hlc`
+/// here when `schema_version`, `residue_auto`, `authored_remaining`, or
+/// `migration_failed` flips — rather than waiting up to a full periodic
+/// interval. `synced_up_to_hlc`
 /// is intentionally NOT an edge trigger: it advances on every applied op and
 /// would defeat the purpose of debouncing to the periodic tick; the periodic
 /// beat carries its latest value.
@@ -307,7 +300,6 @@ pub fn should_emit_on_change(last: Option<MigrationFacts>, current: MigrationFac
         Some(prev) => {
             prev.schema_version != current.schema_version
                 || prev.residue_auto != current.residue_auto
-                || prev.residue_identity != current.residue_identity
                 || prev.authored_remaining != current.authored_remaining
                 || prev.migration_failed != current.migration_failed
         }
@@ -428,24 +420,6 @@ fn resolve_group_target_version(
 /// still trails the target — each pending whole-root (Convergent/Replayable)
 /// rebuild. A context is atomically v1-or-v2 (the PR-6a/6b whole-root path), so
 /// "loaded < target" is exactly its outstanding auto-residue.
-///
-/// `residue_identity` is computed by INVOKING the 6c.6 residue scan
-/// ([`residue_identity_count`] → [`count_unconverted_identity_gated`]). At this
-/// production seam the scan runs over [`CommittedStateScan`], an honest
-/// empty-keyspace [`IterableStorage`] binding: real context state lives in the
-/// wasm `MainStorage`, whose host exposes no committed-state key-iteration (the
-/// `MainStorage` `IterableStorage` impl is intentionally absent — see
-/// `calimero_storage::store`), so the scan completes over zero keys and reports
-/// the conservative `0`. That `0` is safe because any not-yet-swapped context is
-/// already surfaced by `schema_version < target` + `residue_auto`, which keep
-/// `all_migrated` false (the cohort's `unknown`-safety covers silent members).
-/// The scan path is exercised end-to-end against an iterable adaptor by
-/// `residue_identity_count_invokes_the_scan`, so swapping `CommittedStateScan`
-/// for a key-iterating committed-state adaptor is the only change needed to
-/// begin reporting true per-context residue.
-///
-/// [`IterableStorage`]: calimero_storage::store::IterableStorage
-/// [`count_unconverted_identity_gated`]: calimero_storage::index::Index::count_unconverted_identity_gated
 #[must_use]
 pub fn compute_namespace_migration_facts(
     datastore: &Store,
@@ -541,18 +515,9 @@ pub fn compute_namespace_migration_facts(
         None => root_target,
     };
 
-    // Invoke the 6c.6 residue scan over the iterable adaptor bound at this seam.
-    // The production binding is `CommittedStateScan` — an honest empty-keyspace
-    // adaptor — because the wasm host exposes no committed-state key-iteration
-    // yet, so the scan resolves to the conservative `0`. The scan call is real
-    // (exercised against `MockedStorage` in tests) and ready to count true
-    // residue the moment the node binds a key-iterating committed-state adaptor.
-    let residue_identity = residue_identity_count::<CommittedStateScan>(root_target);
-
     MigrationFacts {
         schema_version,
         residue_auto,
-        residue_identity,
         synced_up_to_hlc: 0,
         authored_remaining,
         migration_failed,
@@ -597,7 +562,6 @@ pub fn self_migration_report(
         MigrationStatusReport {
             schema_version: facts.schema_version,
             residue_auto: facts.residue_auto,
-            residue_identity: facts.residue_identity,
             synced_up_to_hlc: facts.synced_up_to_hlc,
             reported_at: now_millis,
             authored_remaining: facts.authored_remaining,
@@ -616,66 +580,6 @@ fn more_severe_failure(
     match acc {
         Some(prev) if prev.to_u8() >= next.to_u8() => prev,
         _ => next,
-    }
-}
-
-/// Invoke the 6c.6 residue scan ([`count_unconverted_identity_gated`]) over the
-/// iterable context-storage adaptor `S` and return the count of identity-gated
-/// entries still trailing `target_version` (the node's local-derived
-/// `residue_identity` telemetry). A scan error degrades to `0` — residue is
-/// observability only and must never block on a transient read failure; the
-/// `schema_version < target` + `residue_auto` signals keep the rollup
-/// conservative regardless.
-///
-/// This is the single seam through which the heartbeat facts reach the residue
-/// scan. [`compute_namespace_migration_facts`] calls it with the production
-/// [`CommittedStateScan`] adaptor (empty keyspace ⇒ `0` until the host exposes
-/// committed-state iteration), while the unit tests drive it with
-/// `MockedStorage` to prove the scan path is wired end-to-end.
-///
-/// [`count_unconverted_identity_gated`]: calimero_storage::index::Index::count_unconverted_identity_gated
-#[must_use]
-fn residue_identity_count<S>(target_version: u32) -> u64
-where
-    S: calimero_storage::store::IterableStorage,
-{
-    calimero_storage::index::Index::<S>::count_unconverted_identity_gated(target_version)
-        .map_or(0, |count| count as u64)
-}
-
-/// The production [`IterableStorage`] binding for [`residue_identity_count`].
-///
-/// The node has no committed-state key-iteration at the heartbeat-facts seam:
-/// real context state lives in the wasm `MainStorage`, whose host exposes no
-/// `storage_iter_keys` (see `calimero_storage::store` — the `MainStorage`
-/// `IterableStorage` impl is intentionally absent). Rather than special-casing
-/// the facts builder to skip the scan, we bind this honest empty-keyspace
-/// adaptor: it implements [`IterableStorage`] with zero keys, so the 6c.6 scan
-/// runs to completion and reports the conservative `0`. When a key-iterating
-/// committed-state adaptor lands, swap this binding for it and the facts begin
-/// reporting true per-context `residue_identity` with no other change.
-///
-/// [`IterableStorage`]: calimero_storage::store::IterableStorage
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-struct CommittedStateScan;
-
-impl calimero_storage::store::StorageAdaptor for CommittedStateScan {
-    fn storage_read(_key: calimero_storage::store::Key) -> Option<Vec<u8>> {
-        None
-    }
-
-    fn storage_remove(_key: calimero_storage::store::Key) -> bool {
-        false
-    }
-
-    fn storage_write(_key: calimero_storage::store::Key, _value: &[u8]) -> bool {
-        false
-    }
-}
-
-impl calimero_storage::store::IterableStorage for CommittedStateScan {
-    fn storage_iter_keys() -> Vec<calimero_storage::store::Key> {
-        Vec::new()
     }
 }
 
@@ -701,7 +605,6 @@ pub fn build_signed_heartbeat(
         peer_pubkey,
         schema_version: facts.schema_version,
         residue_auto: facts.residue_auto,
-        residue_identity: facts.residue_identity,
         synced_up_to_hlc: facts.synced_up_to_hlc,
         authored_remaining: facts.authored_remaining,
         migration_failed: facts
@@ -734,9 +637,9 @@ pub const DEFAULT_EMIT_INTERVAL: Duration = Duration::from_secs(30);
 ///
 /// Facts are computed at emit time from local state. `synced_up_to_hlc`
 /// reads the namespace governance head sequence (the same source readiness
-/// uses for `applied_through`); `schema_version`, `residue_auto`, and
-/// `residue_identity` are supplied by the node when it triggers an emit and
-/// are otherwise carried forward from the last emit (see
+/// uses for `applied_through`); `schema_version` and `residue_auto` are
+/// supplied by the node when it triggers an emit and are otherwise carried
+/// forward from the last emit (see
 /// [`MigrationFactsUpdate`]). A node that has not yet computed residue
 /// reports `0` — the honest "nothing pending locally" telemetry.
 pub struct MigrationEmitter {
@@ -884,14 +787,14 @@ impl MigrationEmitter {
         let net = self.node_client.network_client().clone();
         let log_ns = ns_id;
         let log_schema = facts.schema_version;
-        let log_residue = facts.residue_identity;
+        let log_residue = facts.residue_auto;
         let log_authored = facts.authored_remaining;
         actix::spawn(async move {
             match net.publish(topic, bytes).await {
                 Ok(_) => tracing::debug!(
                     namespace_id = %hex::encode(log_ns),
                     schema_version = log_schema,
-                    residue_identity = log_residue,
+                    residue_auto = log_residue,
                     authored_remaining = log_authored,
                     "migration heartbeat emitted"
                 ),
@@ -920,7 +823,6 @@ mod tests {
         ns: [u8; 32],
         schema_version: u32,
         residue_auto: u64,
-        residue_identity: u64,
         ts_millis: u64,
     ) -> SignedMigrationHeartbeat {
         let peer_pubkey = sk.public_key();
@@ -929,7 +831,6 @@ mod tests {
             peer_pubkey,
             schema_version,
             residue_auto,
-            residue_identity,
             synced_up_to_hlc: 0,
             ts_millis,
         };
@@ -942,7 +843,6 @@ mod tests {
             peer_pubkey,
             schema_version,
             residue_auto,
-            residue_identity,
             synced_up_to_hlc: 0,
             ts_millis,
             signature,
@@ -955,7 +855,7 @@ mod tests {
     fn verified_heartbeat_is_cached_and_readable() {
         let cache = MigrationStatusCache::default();
         let sk = PrivateKey::random(&mut rand::thread_rng());
-        let hb = signed_hb(&sk, NS, 2, 0, 0, 0);
+        let hb = signed_hb(&sk, NS, 2, 0, 0);
         // Caller verifies first; a well-formed heartbeat verifies.
         assert!(hb.verify_signature().is_ok());
         cache.insert(&hb);
@@ -966,7 +866,7 @@ mod tests {
             .peer_entry(NS, sk.public_key(), DEFAULT_HEARTBEAT_TTL)
             .expect("entry readable by (ns, peer)");
         assert_eq!(entry.schema_version, 2);
-        assert_eq!(entry.residue_identity, 0);
+        assert_eq!(entry.residue_auto, 0);
     }
 
     #[test]
@@ -976,7 +876,7 @@ mod tests {
         // Each fresh entry projects 1:1; `ts_millis` becomes `reported_at`.
         let cache = MigrationStatusCache::default();
         let sk = PrivateKey::random(&mut rand::thread_rng());
-        let hb = signed_hb(&sk, NS, 2, 1, 3, 7);
+        let hb = signed_hb(&sk, NS, 2, 1, 7);
         cache.insert(&hb);
 
         let reports = cache.migration_status_reports(NS, DEFAULT_HEARTBEAT_TTL);
@@ -987,7 +887,6 @@ mod tests {
             .expect("report keyed by peer pubkey");
         assert_eq!(report.schema_version, 2);
         assert_eq!(report.residue_auto, 1);
-        assert_eq!(report.residue_identity, 3);
         assert_eq!(report.reported_at, 7, "ts_millis projects to reported_at");
     }
 
@@ -998,7 +897,7 @@ mod tests {
         let cache = MigrationStatusCache::default();
         let sk = PrivateKey::random(&mut rand::thread_rng());
         let other_ns = [7u8; 32];
-        cache.insert(&signed_hb(&sk, other_ns, 2, 0, 0, 0));
+        cache.insert(&signed_hb(&sk, other_ns, 2, 0, 0));
 
         let reports = cache.migration_status_reports(NS, DEFAULT_HEARTBEAT_TTL);
         assert!(
@@ -1011,7 +910,7 @@ mod tests {
     fn wire_verify_signature_rejects_field_substitution() {
         // Documents the WIRE-TYPE contract `insert`'s verification-precondition
         // depends on: `SignedMigrationHeartbeat::verify_signature` covers every
-        // signed field, so flipping `residue_identity` after signing breaks it.
+        // signed field, so flipping `residue_auto` after signing breaks it.
         //
         // NOTE: this is NOT the ingest gate. The actual receiver gate is
         // `calimero_governance_store::governance_broadcast::verify_migration_heartbeat`
@@ -1021,12 +920,12 @@ mod tests {
         // unit owns. Here we only pin that the wire type's own signature check
         // (the primitive the gate is built on) catches a mutated field.
         let sk = PrivateKey::random(&mut rand::thread_rng());
-        let mut hb = signed_hb(&sk, NS, 2, 0, 5, 0);
+        let mut hb = signed_hb(&sk, NS, 2, 5, 0);
         assert!(hb.verify_signature().is_ok());
-        hb.residue_identity = 0; // tampered after signing
+        hb.residue_auto = 0; // tampered after signing
         assert!(
             hb.verify_signature().is_err(),
-            "verify_signature must reject a mutated residue_identity"
+            "verify_signature must reject a mutated residue_auto"
         );
     }
 
@@ -1034,7 +933,7 @@ mod tests {
     fn stale_entry_is_filtered_after_ttl() {
         let cache = MigrationStatusCache::default();
         let sk = PrivateKey::random(&mut rand::thread_rng());
-        cache.insert(&signed_hb(&sk, NS, 2, 0, 0, 0));
+        cache.insert(&signed_hb(&sk, NS, 2, 0, 0));
         // Drive the TTL via a very small per-call window — the same seam the
         // readiness tests use (`pick_sync_partner_excludes_stale_entries`).
         std::thread::sleep(Duration::from_millis(10));
@@ -1057,10 +956,8 @@ mod tests {
         // arrives second.
         let cache = MigrationStatusCache::default();
         let sk = PrivateKey::random(&mut rand::thread_rng());
-        let mut fresh = signed_hb(&sk, NS, 2, 0, 0, 2000);
-        fresh.residue_identity = 0;
-        let mut stale = signed_hb(&sk, NS, 1, 0, 9, 1000);
-        stale.residue_identity = 9;
+        let fresh = signed_hb(&sk, NS, 2, 0, 2000);
+        let stale = signed_hb(&sk, NS, 1, 9, 1000);
         cache.insert(&fresh);
         cache.insert(&stale); // arrives second but is older — must be dropped
         let entry = cache
@@ -1070,15 +967,15 @@ mod tests {
             entry.schema_version, 2,
             "stale heartbeat must not overwrite fresher entry from same peer"
         );
-        assert_eq!(entry.residue_identity, 0);
+        assert_eq!(entry.residue_auto, 0);
     }
 
     #[test]
     fn insert_accepts_newer_heartbeat_from_same_peer() {
         let cache = MigrationStatusCache::default();
         let sk = PrivateKey::random(&mut rand::thread_rng());
-        let older = signed_hb(&sk, NS, 1, 0, 9, 1000);
-        let newer = signed_hb(&sk, NS, 2, 0, 0, 2000);
+        let older = signed_hb(&sk, NS, 1, 9, 1000);
+        let newer = signed_hb(&sk, NS, 2, 0, 2000);
         cache.insert(&older);
         cache.insert(&newer);
         let entry = cache
@@ -1088,7 +985,7 @@ mod tests {
             entry.schema_version, 2,
             "newer heartbeat must replace older"
         );
-        assert_eq!(entry.residue_identity, 0);
+        assert_eq!(entry.residue_auto, 0);
     }
 
     #[test]
@@ -1102,13 +999,13 @@ mod tests {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_millis() as u64;
-        let poison = signed_hb(&sk, NS, 9, 0, 0, now_ms + 600_000);
+        let poison = signed_hb(&sk, NS, 9, 0, now_ms + 600_000);
         cache.insert(&poison);
         assert!(
             cache.fresh_peers(NS, DEFAULT_HEARTBEAT_TTL).is_empty(),
             "far-future heartbeat must be rejected to prevent cache poisoning"
         );
-        let legit = signed_hb(&sk, NS, 2, 0, 0, now_ms);
+        let legit = signed_hb(&sk, NS, 2, 0, now_ms);
         cache.insert(&legit);
         let entry = cache
             .peer_entry(NS, sk.public_key(), DEFAULT_HEARTBEAT_TTL)
@@ -1120,29 +1017,22 @@ mod tests {
     fn on_change_emit_fires_when_residue_changes() {
         let base = MigrationFacts {
             schema_version: 2,
-            residue_auto: 0,
-            residue_identity: 4,
+            residue_auto: 4,
             synced_up_to_hlc: 10,
             authored_remaining: 0,
             migration_failed: None,
         };
         // First-ever emit (no prior) always fires.
         assert!(should_emit_on_change(None, base));
-        // residue_identity drops 4 -> 0: on-change must fire.
+        // residue_auto drops 4 -> 0: on-change must fire.
         let drained = MigrationFacts {
-            residue_identity: 0,
+            residue_auto: 0,
             ..base
         };
         assert!(
             should_emit_on_change(Some(base), drained),
-            "residue_identity change must edge-trigger an emit"
+            "residue_auto change must edge-trigger an emit"
         );
-        // residue_auto change must also fire.
-        let auto_changed = MigrationFacts {
-            residue_auto: 1,
-            ..base
-        };
-        assert!(should_emit_on_change(Some(base), auto_changed));
         // schema_version change must fire.
         let bumped = MigrationFacts {
             schema_version: 3,
@@ -1169,7 +1059,6 @@ mod tests {
         let prev = MigrationFacts {
             schema_version: 2,
             residue_auto: 0,
-            residue_identity: 0,
             synced_up_to_hlc: 10,
             authored_remaining: 0,
             migration_failed: None,
@@ -1194,8 +1083,7 @@ mod tests {
         let mut last_emitted: HashMap<[u8; 32], MigrationFacts> = HashMap::new();
         let facts = MigrationFacts {
             schema_version: 2,
-            residue_auto: 0,
-            residue_identity: 3,
+            residue_auto: 3,
             synced_up_to_hlc: 10,
             authored_remaining: 0,
             migration_failed: None,
@@ -1226,7 +1114,7 @@ mod tests {
 
         // A residue drop is an edge.
         let drained = MigrationFacts {
-            residue_identity: 0,
+            residue_auto: 0,
             ..advanced
         };
         let emit = record_facts_update(&mut last_emitted, NS, drained);
@@ -1255,7 +1143,6 @@ mod tests {
             "no upgrade record => baseline schema version 0"
         );
         assert_eq!(facts.residue_auto, 0);
-        assert_eq!(facts.residue_identity, 0);
 
         // Record targeting v2 -> facts advertise 2.
         UpgradesRepository::new(&store)
@@ -1620,7 +1507,6 @@ mod tests {
         let facts = MigrationFacts {
             schema_version: 2,
             residue_auto: 3,
-            residue_identity: 1,
             synced_up_to_hlc: 77,
             authored_remaining: 0,
             migration_failed: None,
@@ -1632,7 +1518,6 @@ mod tests {
         assert_eq!(hb.peer_pubkey, sk.public_key());
         assert_eq!(hb.schema_version, 2);
         assert_eq!(hb.residue_auto, 3);
-        assert_eq!(hb.residue_identity, 1);
         assert_eq!(hb.synced_up_to_hlc, 77);
 
         let cache = MigrationStatusCache::default();
@@ -1640,54 +1525,7 @@ mod tests {
         let entry = cache
             .peer_entry(NS, sk.public_key(), DEFAULT_HEARTBEAT_TTL)
             .expect("built heartbeat is cacheable");
-        assert_eq!(entry.residue_identity, 1);
-    }
-
-    /// The facts builder's `residue_identity` is computed by INVOKING the 6c.6
-    /// residue scan (`Index::count_unconverted_identity_gated`), not hardcoded.
-    /// Driven here over an `IterableStorage` adaptor (`MockedStorage`) so the
-    /// wiring is exercised end-to-end: seed two stale identity-gated entries +
-    /// one already-converted + one Convergent, and the helper reports exactly
-    /// the two stale identity-gated entries. (Production binds the empty-keyspace
-    /// `CommittedStateScan`, which yields the documented conservative 0; this
-    /// proves the scan is wired and ready for a key-iterating committed-state
-    /// adaptor.)
-    #[test]
-    fn residue_identity_count_invokes_the_scan() {
-        use calimero_storage::address::Id;
-        use calimero_storage::entities::{ChildInfo, Metadata, StorageType};
-        use calimero_storage::index::Index;
-        use calimero_storage::store::MockedStorage;
-
-        type S = MockedStorage<7200>;
-
-        let owner = PublicKey::from([0xAAu8; 32]);
-        let seed_user = |id: Id, schema: Option<u32>| {
-            let mut md = Metadata::new(1, 1);
-            md.storage_type = StorageType::User {
-                owner,
-                signature_data: None,
-            };
-            md.schema_version = schema;
-            <Index<S>>::add_root(ChildInfo::new(id, [0u8; 32], md)).expect("seed user entry");
-        };
-
-        // Two stale identity-gated entries (residue), one already at target, one
-        // Convergent (Public) that must never count.
-        seed_user(Id::new([1; 32]), None);
-        seed_user(Id::new([2; 32]), Some(1));
-        seed_user(Id::new([3; 32]), Some(2));
-        let mut public_md = Metadata::new(1, 1);
-        public_md.storage_type = StorageType::Public;
-        <Index<S>>::add_root(ChildInfo::new(Id::new([4; 32]), [0u8; 32], public_md))
-            .expect("seed public entry");
-
-        assert_eq!(
-            residue_identity_count::<S>(2),
-            2,
-            "residue_identity must INVOKE the scan and count only stale \
-             identity-gated entries"
-        );
+        assert_eq!(entry.residue_auto, 3);
     }
 
     /// A context that lives in a SUBGROUP under the namespace (not a direct

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -337,16 +337,6 @@ pub fn record_facts_update(
     emit
 }
 
-/// Parse the leading integer of a semver string ("2", "2.0.0") into the `u32`
-/// schema-version a heartbeat reports. Best-effort: a non-numeric leading
-/// component yields `None`.
-fn parse_major_version(version: &str) -> Option<u32> {
-    version
-        .split('.')
-        .next()
-        .and_then(|major| major.trim().parse::<u32>().ok())
-}
-
 /// Resolve a single context's LOADED reader version: the ABI state version of
 /// the `ApplicationMeta` its `ContextMeta.application` points at. This is the
 /// schema the node can actually read right now, NOT the replicated migration

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -1275,6 +1275,7 @@ mod tests {
                     status: GroupUpgradeStatus::Completed { completed_at: None },
                     cascade_hlc: None,
                     cascade_seq: None,
+                    to_state_version: 2,
                 },
             )
             .unwrap();
@@ -1381,6 +1382,7 @@ mod tests {
                     },
                     cascade_hlc: None,
                     cascade_seq: None,
+                    to_state_version: 2,
                 },
             )
             .unwrap();
@@ -1427,6 +1429,7 @@ mod tests {
                     status: GroupUpgradeStatus::Completed { completed_at: None },
                     cascade_hlc: None,
                     cascade_seq: None,
+                    to_state_version: 2,
                 },
             )
             .unwrap();
@@ -1471,6 +1474,7 @@ mod tests {
                         },
                         cascade_hlc: None,
                         cascade_seq: None,
+                        to_state_version: 2,
                     },
                 )
                 .unwrap();
@@ -1624,6 +1628,7 @@ mod tests {
                     },
                     cascade_hlc: None,
                     cascade_seq: None,
+                    to_state_version: 2,
                 },
             )
             .unwrap();
@@ -1703,6 +1708,7 @@ mod tests {
                     },
                     cascade_hlc: None,
                     cascade_seq: None,
+                    to_state_version: 3,
                 },
             )
             .unwrap();
@@ -1857,6 +1863,7 @@ mod tests {
                     },
                     cascade_hlc: None,
                     cascade_seq: None,
+                    to_state_version: 3,
                 },
             )
             .unwrap();

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -385,7 +385,7 @@ fn namespace_tree_groups(
 }
 
 /// Resolve the migration TARGET version governing `group_id`'s contexts: the
-/// parsed `to_version` of the NEAREST upgrade record found by walking from
+/// `to_state_version` of the NEAREST upgrade record found by walking from
 /// `group_id` UP its ancestors. A subgroup upgraded directly (`upgrade_group`
 /// on the subgroup) carries its own record; a subgroup under a root/cascade
 /// upgrade inherits the ancestor's record. No record anywhere up the chain ⇒ 0.
@@ -403,7 +403,11 @@ fn resolve_group_target_version(
     let mut current = *group_id;
     for _ in 0..calimero_governance_store::MAX_NAMESPACE_DEPTH {
         if let Ok(Some(record)) = upgrades.load(&current) {
-            return parse_major_version(&record.to_version).unwrap_or(u32::MAX);
+            return if record.to_state_version == 0 {
+                u32::MAX
+            } else {
+                record.to_state_version
+            };
         }
         match namespaces.parent(&current) {
             Ok(Some(parent)) => current = parent,
@@ -416,9 +420,9 @@ fn resolve_group_target_version(
 /// Compute this node's locally-advertised migration facts for `namespace_id`.
 ///
 /// `schema_version` is the node's actually-LOADED reader version — the lowest
-/// loaded `ApplicationMeta` major version across the namespace's contexts (the
+/// loaded `ApplicationMeta` state version across the namespace's contexts (the
 /// most-behind context governs whether this node has fully swapped its binary).
-/// This is deliberately NOT the migration TARGET (`UpgradesRepository.to_version`):
+/// This is deliberately NOT the migration TARGET (`UpgradesRepository.to_state_version`):
 /// under LazyOnAccess the governance target advances ahead of the locally-loaded
 /// binary, so reporting the target would let `all_migrated` flip green before the
 /// node could read the new schema (the cursor-bot bug this fixes). With no
@@ -1283,6 +1287,76 @@ mod tests {
         assert_eq!(
             facts.schema_version, 2,
             "an upgrade record targeting v2 must advertise schema_version 2"
+        );
+    }
+
+    /// `resolve_group_target_version` must read `to_state_version`, not parse
+    /// `to_version`'s leading component: a record targeting semver 10.2.0 at
+    /// ABI state 2 must resolve to 2, not the semver's major (10). An
+    /// unresolvable state version (`0`) must pin to `u32::MAX`, never collapse
+    /// to a trivially-satisfied `0`.
+    #[test]
+    fn resolve_group_target_version_reads_state_version_not_semver_major() {
+        use calimero_context_config::types::ContextGroupId;
+        use calimero_governance_store::UpgradesRepository;
+        use calimero_store::db::InMemoryDB;
+        use calimero_store::key::{GroupUpgradeStatus, GroupUpgradeValue};
+        use std::sync::Arc;
+
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let ns = ContextGroupId::from([0x66u8; 32]);
+
+        UpgradesRepository::new(&store)
+            .save(
+                &ns,
+                &GroupUpgradeValue {
+                    from_version: "10.1.3".to_owned(),
+                    to_version: "10.2.0".to_owned(),
+                    migration: None,
+                    initiated_at: 0,
+                    initiated_by: PrivateKey::random(&mut rand::thread_rng()).public_key(),
+                    status: GroupUpgradeStatus::InProgress {
+                        total: 1,
+                        completed: 0,
+                        failed: 0,
+                    },
+                    cascade_hlc: None,
+                    cascade_seq: None,
+                    to_state_version: 2,
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            resolve_group_target_version(&store, &ns),
+            2,
+            "must read to_state_version (2), not the semver major (10)"
+        );
+
+        let unresolvable = ContextGroupId::from([0x77u8; 32]);
+        UpgradesRepository::new(&store)
+            .save(
+                &unresolvable,
+                &GroupUpgradeValue {
+                    from_version: "10.1.3".to_owned(),
+                    to_version: "10.2.0".to_owned(),
+                    migration: None,
+                    initiated_at: 0,
+                    initiated_by: PrivateKey::random(&mut rand::thread_rng()).public_key(),
+                    status: GroupUpgradeStatus::InProgress {
+                        total: 1,
+                        completed: 0,
+                        failed: 0,
+                    },
+                    cascade_hlc: None,
+                    cascade_seq: None,
+                    to_state_version: 0,
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            resolve_group_target_version(&store, &unresolvable),
+            u32::MAX,
+            "an unresolvable state version must pin to MAX, not collapse to 0"
         );
     }
 

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -339,7 +339,7 @@ pub fn record_facts_update(
 
 /// Parse the leading integer of a semver string ("2", "2.0.0") into the `u32`
 /// schema-version a heartbeat reports. Best-effort: a non-numeric leading
-/// component yields `None`. Mirrors `get_migration_status::parse_schema_version`.
+/// component yields `None`.
 fn parse_major_version(version: &str) -> Option<u32> {
     version
         .split('.')

--- a/crates/node/src/sync/manager/blob_fetch.rs
+++ b/crates/node/src/sync/manager/blob_fetch.rs
@@ -139,6 +139,7 @@ impl SyncManager {
                         package: "unknown".to_owned().into_boxed_str(),
                         version: "0.0.0".to_owned().into_boxed_str(),
                         signer_id: String::new().into_boxed_str(),
+                        state_version: 0,
                     },
                 ),
             )?;

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -4318,6 +4318,7 @@ mod pending_upgrade_tests {
                         package: "stage-pkg".to_owned().into_boxed_str(),
                         version: "1.0.0".to_owned().into_boxed_str(),
                         signer_id: "stage-signer".to_owned().into_boxed_str(),
+                        state_version: 0,
                     },
                 ),
             )
@@ -4347,6 +4348,7 @@ mod pending_upgrade_tests {
                         package: "stage-pkg".to_owned().into_boxed_str(),
                         version: "1.0.0".to_owned().into_boxed_str(),
                         signer_id: "stage-signer".to_owned().into_boxed_str(),
+                        state_version: 0,
                     },
                 ),
             )

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1730,7 +1730,6 @@ pub struct GetCascadeStatusApiResponse {
 pub struct MemberMigrationReportApiData {
     pub schema_version: u32,
     pub residue_auto: u64,
-    pub residue_identity: u64,
     pub synced_up_to_hlc: u64,
     pub reported_at: u64,
     /// Member's self-reported pending-authored count (best-effort; 6f).
@@ -3074,7 +3073,6 @@ mod tests {
                     report: Some(MemberMigrationReportApiData {
                         schema_version: 2,
                         residue_auto: 0,
-                        residue_identity: 0,
                         synced_up_to_hlc: 7,
                         reported_at: 1_700_000_000,
                         authored_remaining: 3,
@@ -3092,7 +3090,6 @@ mod tests {
                     report: Some(MemberMigrationReportApiData {
                         schema_version: 1,
                         residue_auto: 1,
-                        residue_identity: 0,
                         synced_up_to_hlc: 5,
                         reported_at: 1_700_000_001,
                         authored_remaining: 0,

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1730,6 +1730,10 @@ pub struct GetCascadeStatusApiResponse {
 pub struct MemberMigrationReportApiData {
     pub schema_version: u32,
     pub residue_auto: u64,
+    /// Always 0. Held on the wire only because the released calimero-client-py
+    /// the e2e suite runs still requires it; drop once that floor moves.
+    #[serde(default)]
+    pub residue_identity: u64,
     pub synced_up_to_hlc: u64,
     pub reported_at: u64,
     /// Member's self-reported pending-authored count (best-effort; 6f).
@@ -3073,6 +3077,7 @@ mod tests {
                     report: Some(MemberMigrationReportApiData {
                         schema_version: 2,
                         residue_auto: 0,
+                        residue_identity: 0,
                         synced_up_to_hlc: 7,
                         reported_at: 1_700_000_000,
                         authored_remaining: 3,
@@ -3090,6 +3095,7 @@ mod tests {
                     report: Some(MemberMigrationReportApiData {
                         schema_version: 1,
                         residue_auto: 1,
+                        residue_identity: 0,
                         synced_up_to_hlc: 5,
                         reported_at: 1_700_000_001,
                         authored_remaining: 0,
@@ -3116,6 +3122,9 @@ mod tests {
         assert_eq!(members[0]["report"]["schemaVersion"], 2);
         assert_eq!(members[0]["report"]["syncedUpToHlc"], 7);
         assert_eq!(members[0]["report"]["authoredRemaining"], 3);
+        // Released calimero-client-py (which the e2e suite runs) still requires
+        // this key; omitting it fails its deserialize before any assert runs.
+        assert_eq!(members[0]["report"]["residueIdentity"], 0);
         // A migrated member carries no failure reason — `migrationFailed` omitted.
         assert!(members[0]["report"].get("migrationFailed").is_none());
         // The unknown member has no fresh report — `report` is omitted.

--- a/crates/server/src/admin/handlers/groups/get_migration_status.rs
+++ b/crates/server/src/admin/handlers/groups/get_migration_status.rs
@@ -86,6 +86,7 @@ pub async fn handler(
                     report: m.report.map(|r| MemberMigrationReportApiData {
                         schema_version: r.schema_version,
                         residue_auto: r.residue_auto,
+                        residue_identity: 0,
                         synced_up_to_hlc: r.synced_up_to_hlc,
                         reported_at: r.reported_at,
                         authored_remaining: r.authored_remaining,

--- a/crates/server/src/admin/handlers/groups/get_migration_status.rs
+++ b/crates/server/src/admin/handlers/groups/get_migration_status.rs
@@ -53,7 +53,6 @@ pub async fn handler(
                     MemberMigrationReport {
                         schema_version: r.schema_version,
                         residue_auto: r.residue_auto,
-                        residue_identity: r.residue_identity,
                         synced_up_to_hlc: r.synced_up_to_hlc,
                         reported_at: r.reported_at,
                         authored_remaining: r.authored_remaining,
@@ -87,7 +86,6 @@ pub async fn handler(
                     report: m.report.map(|r| MemberMigrationReportApiData {
                         schema_version: r.schema_version,
                         residue_auto: r.residue_auto,
-                        residue_identity: r.residue_identity,
                         synced_up_to_hlc: r.synced_up_to_hlc,
                         reported_at: r.reported_at,
                         authored_remaining: r.authored_remaining,

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -1257,8 +1257,7 @@ impl<S: StorageAdaptor> Index<S> {
     /// Computing it as a pure function of each node's own converged view makes
     /// it idempotent (re-running yields the same count) and means a convert
     /// replicated to `N` nodes decrements each node's local count by exactly 1.
-    /// It feeds the migration-status rollup (Task 6c.9) as observability only,
-    /// never a gate.
+    /// Observability only, never a gate.
     ///
     /// `Public`/`Frozen` entries never count — those migrate via the Convergent
     /// whole-root path (PR-6a/6b), not by an owner re-write.
@@ -1266,13 +1265,9 @@ impl<S: StorageAdaptor> Index<S> {
     /// [`needs_owner_convert`]: crate::entities::needs_owner_convert
     ///
     /// # Visibility
-    /// `pub` so the node-side migration-status emitter
-    /// (`calimero_node::migration_status::compute_namespace_migration_facts`,
-    /// PR-6c) can compute honest per-context `residue_identity` telemetry. It is
-    /// the public residue-scan surface the heartbeat reports; the
-    /// `IterableStorage` bound keeps it callable only against an adaptor that can
-    /// enumerate keys (the node binds one per context via `with_runtime_env`),
-    /// so it cannot be misused as a wasm-app primitive.
+    /// `pub` as the residue-scan surface; the `IterableStorage` bound keeps it
+    /// callable only against a key-enumerating adaptor, never a wasm-app
+    /// primitive. No in-tree caller until committed state is key-iterable.
     ///
     /// # Errors
     /// Returns `StorageError` if an index entry cannot be loaded.

--- a/crates/store/src/key/group/mod.rs
+++ b/crates/store/src/key/group/mod.rs
@@ -1344,6 +1344,11 @@ pub struct GroupUpgradeValue {
     /// cascade_seq` like-for-like. `None` for non-cascade upgrades and pre-existing
     /// records.
     pub cascade_seq: Option<u64>,
+    /// ABI state version of the target application, from its embedded schema.
+    /// The migration rollup compares each member's loaded state version against
+    /// this. `0` means the target's ABI was unreadable, which the rollup treats
+    /// as an unsatisfiable target rather than a satisfied one.
+    pub to_state_version: u32,
 }
 
 #[cfg(feature = "borsh")]
@@ -1402,6 +1407,19 @@ impl BorshDeserialize for GroupUpgradeValue {
                 }
             }
         };
+        // Third backward-compatible trailing field. A record written before it
+        // ends right after `cascade_seq`; a clean EOF there decodes as `0`,
+        // which the migration rollup reads as "target state version unknown".
+        let to_state_version = {
+            let mut first = [0u8; 1];
+            if !read_byte(reader, &mut first)? {
+                0
+            } else {
+                let mut rest = [0u8; 3];
+                reader.read_exact(&mut rest)?;
+                u32::from_le_bytes([first[0], rest[0], rest[1], rest[2]])
+            }
+        };
         Ok(Self {
             from_version,
             to_version,
@@ -1411,6 +1429,7 @@ impl BorshDeserialize for GroupUpgradeValue {
             status,
             cascade_hlc,
             cascade_seq,
+            to_state_version,
         })
     }
 }
@@ -3385,6 +3404,7 @@ mod tests {
                 },
                 cascade_hlc: None,
                 cascade_seq: None,
+                to_state_version: 2,
             };
 
             let bytes = to_vec(&value).expect("serialize");
@@ -3392,6 +3412,7 @@ mod tests {
 
             assert_eq!(decoded.from_version, "1.0.0");
             assert_eq!(decoded.to_version, "2.0.0");
+            assert_eq!(decoded.to_state_version, 2);
             assert_eq!(decoded.migration, Some(vec![0xDE, 0xAD]));
             assert_eq!(decoded.initiated_at, value.initiated_at);
             assert_eq!(decoded.initiated_by, value.initiated_by);
@@ -3457,6 +3478,7 @@ mod tests {
                 },
                 cascade_hlc: None,
                 cascade_seq: None,
+                to_state_version: 4,
             };
 
             let bytes = to_vec(&value).expect("serialize");
@@ -3464,6 +3486,7 @@ mod tests {
 
             assert_eq!(decoded.from_version, "3.0.0");
             assert_eq!(decoded.to_version, "4.0.0");
+            assert_eq!(decoded.to_state_version, 4);
             assert_eq!(decoded.migration, None);
             match decoded.status {
                 GroupUpgradeStatus::Completed { completed_at } => {
@@ -3494,6 +3517,7 @@ mod cascade_hlc_borsh_tests {
             status: GroupUpgradeStatus::Completed { completed_at: None },
             cascade_hlc,
             cascade_seq: None,
+            to_state_version: 2,
         }
     }
 
@@ -3564,6 +3588,55 @@ mod cascade_hlc_borsh_tests {
         let decoded = GroupUpgradeValue::try_from_slice(&bytes).unwrap();
         assert_eq!(decoded.cascade_hlc, Some(HybridTimestamp::zero()));
         assert_eq!(decoded.cascade_seq, Some(12));
+    }
+
+    #[test]
+    fn group_upgrade_value_roundtrips_to_state_version() {
+        let value = GroupUpgradeValue {
+            from_version: "10.1.3".to_owned(),
+            to_version: "10.2.0".to_owned(),
+            migration: None,
+            initiated_at: 7,
+            initiated_by: PrimitivePublicKey::from([3; 32]),
+            status: GroupUpgradeStatus::InProgress {
+                total: 1,
+                completed: 0,
+                failed: 0,
+            },
+            cascade_hlc: None,
+            cascade_seq: None,
+            to_state_version: 2,
+        };
+
+        let bytes = to_vec(&value).expect("serialize");
+        let back = GroupUpgradeValue::try_from_slice(&bytes).expect("deserialize");
+
+        assert_eq!(back.to_state_version, 2);
+        assert_eq!(back.to_version, "10.2.0");
+    }
+
+    #[test]
+    fn old_format_without_to_state_version_decodes_as_zero() {
+        // A record written before `to_state_version`: it ends right after
+        // `cascade_seq`, so the field must decode as `0` (clean EOF), not error.
+        let mut legacy = to_vec(&sample(Some(HybridTimestamp::zero()))).unwrap();
+        legacy.truncate(legacy.len() - 4);
+
+        let decoded = GroupUpgradeValue::try_from_slice(&legacy).unwrap();
+        assert_eq!(decoded.to_state_version, 0);
+        assert_eq!(decoded.cascade_hlc, Some(HybridTimestamp::zero()));
+    }
+
+    #[test]
+    fn rejects_partial_to_state_version() {
+        let mut bytes = to_vec(&sample(None)).unwrap();
+        // Two of the four `u32` bytes — a truncated tail, not a legacy record.
+        bytes.truncate(bytes.len() - 2);
+
+        assert!(
+            GroupUpgradeValue::try_from_slice(&bytes).is_err(),
+            "expected Err for truncated to_state_version"
+        );
     }
 
     #[test]

--- a/crates/store/src/key/group/mod.rs
+++ b/crates/store/src/key/group/mod.rs
@@ -1318,7 +1318,7 @@ fn read_byte<R: borsh::io::Read>(reader: &mut R, buf: &mut [u8; 1]) -> borsh::io
 /// upgrades are tracked by semver version string from the local
 /// `ApplicationMeta`, not by application id.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "borsh", derive(BorshSerialize))]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct GroupUpgradeValue {
     /// Semver version of the application before the upgrade, read from the
     /// current application's `ApplicationMeta.version`.
@@ -1332,8 +1332,8 @@ pub struct GroupUpgradeValue {
     pub status: GroupUpgradeStatus,
     /// Sticky cascade fence boundary: the HLC the originating `CascadeUpgrade`
     /// op was stamped with, identical on every node that applied it. `None` for
-    /// non-cascade upgrades and pre-existing records. NEVER cleared once set
-    /// (survives `Completed`) — the boundary the state-delta HLC fence reads.
+    /// non-cascade upgrades. NEVER cleared once set (survives `Completed`) —
+    /// the boundary the state-delta HLC fence reads.
     pub cascade_hlc: Option<HybridTimestamp>,
     /// The migration's expand-entry governance position: the
     /// `NamespaceGovHead.sequence` captured when this cascade was applied.
@@ -1341,97 +1341,13 @@ pub struct GroupUpgradeValue {
     /// monotonic governance-op counter — the SAME number space the migration
     /// heartbeat's `synced_up_to_hlc` (`= head.sequence`) lives in, so the
     /// migration-status rollup pins the cohort by comparing `synced_up_to_hlc <
-    /// cascade_seq` like-for-like. `None` for non-cascade upgrades and pre-existing
-    /// records.
+    /// cascade_seq` like-for-like. `None` for non-cascade upgrades.
     pub cascade_seq: Option<u64>,
     /// ABI state version of the target application, from its embedded schema.
     /// The migration rollup compares each member's loaded state version against
     /// this. `0` means the target's ABI was unreadable, which the rollup treats
     /// as an unsatisfiable target rather than a satisfied one.
     pub to_state_version: u32,
-}
-
-#[cfg(feature = "borsh")]
-impl BorshDeserialize for GroupUpgradeValue {
-    fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
-        let from_version = String::deserialize_reader(reader)?;
-        let to_version = String::deserialize_reader(reader)?;
-        let migration = Option::<Vec<u8>>::deserialize_reader(reader)?;
-        let initiated_at = u64::deserialize_reader(reader)?;
-        let initiated_by = PrimitivePublicKey::deserialize_reader(reader)?;
-        let status = GroupUpgradeStatus::deserialize_reader(reader)?;
-        // Backward-compatible trailing field: absent in pre-existing records
-        // (LazyOnAccess path writes directly to Completed, so this field must
-        // live here rather than inside InProgress).
-        let cascade_hlc = {
-            let mut first = [0u8; 1];
-            if !read_byte(reader, &mut first)? {
-                // Clean EOF — legacy record with no cascade_hlc bytes.
-                None
-            } else {
-                // At least one byte is present; it is the Option discriminant.
-                // 0 = None, 1 = Some(HybridTimestamp).
-                let tag = first[0];
-                match tag {
-                    0 => None,
-                    1 => Some(HybridTimestamp::deserialize_reader(reader)?),
-                    _ => {
-                        return Err(borsh::io::Error::new(
-                            borsh::io::ErrorKind::InvalidData,
-                            "invalid Option tag for cascade_hlc",
-                        ))
-                    }
-                }
-            }
-        };
-        // Second backward-compatible trailing field, added after `cascade_hlc`.
-        // Records written before this field decode as `None`: a clean EOF right
-        // after `cascade_hlc` (legacy and pre-`cascade_seq` records) yields
-        // `None`, mirroring the `cascade_hlc` decode above. 0 = None,
-        // 1 = Some(u64).
-        let cascade_seq = {
-            let mut first = [0u8; 1];
-            if !read_byte(reader, &mut first)? {
-                None
-            } else {
-                let tag = first[0];
-                match tag {
-                    0 => None,
-                    1 => Some(u64::deserialize_reader(reader)?),
-                    _ => {
-                        return Err(borsh::io::Error::new(
-                            borsh::io::ErrorKind::InvalidData,
-                            "invalid Option tag for cascade_seq",
-                        ))
-                    }
-                }
-            }
-        };
-        // Third backward-compatible trailing field. A record written before it
-        // ends right after `cascade_seq`; a clean EOF there decodes as `0`,
-        // which the migration rollup reads as "target state version unknown".
-        let to_state_version = {
-            let mut first = [0u8; 1];
-            if !read_byte(reader, &mut first)? {
-                0
-            } else {
-                let mut rest = [0u8; 3];
-                reader.read_exact(&mut rest)?;
-                u32::from_le_bytes([first[0], rest[0], rest[1], rest[2]])
-            }
-        };
-        Ok(Self {
-            from_version,
-            to_version,
-            migration,
-            initiated_at,
-            initiated_by,
-            status,
-            cascade_hlc,
-            cascade_seq,
-            to_state_version,
-        })
-    }
 }
 
 /// One rung of a group's upgrade ladder: the bytecode blob (`app_key`) and
@@ -3531,24 +3447,6 @@ mod cascade_hlc_borsh_tests {
     }
 
     #[test]
-    fn old_format_without_field_decodes_as_none() {
-        let mut legacy = Vec::new();
-        "1.0.0".to_owned().serialize(&mut legacy).unwrap();
-        "2.0.0".to_owned().serialize(&mut legacy).unwrap();
-        Some(vec![1u8, 2, 3]).serialize(&mut legacy).unwrap();
-        1_700_000_000u64.serialize(&mut legacy).unwrap();
-        PrimitivePublicKey::from([7u8; 32])
-            .serialize(&mut legacy)
-            .unwrap();
-        (GroupUpgradeStatus::Completed { completed_at: None })
-            .serialize(&mut legacy)
-            .unwrap();
-
-        let decoded = GroupUpgradeValue::try_from_slice(&legacy).unwrap();
-        assert_eq!(decoded.cascade_hlc, None);
-    }
-
-    #[test]
     fn roundtrips_with_none_cascade_hlc() {
         let value = sample(None);
         let bytes = to_vec(&value).unwrap();
@@ -3616,72 +3514,15 @@ mod cascade_hlc_borsh_tests {
     }
 
     #[test]
-    fn old_format_without_to_state_version_decodes_as_zero() {
-        // A record written before `to_state_version`: it ends right after
-        // `cascade_seq`, so the field must decode as `0` (clean EOF), not error.
-        let mut legacy = to_vec(&sample(Some(HybridTimestamp::zero()))).unwrap();
-        legacy.truncate(legacy.len() - 4);
-
-        let decoded = GroupUpgradeValue::try_from_slice(&legacy).unwrap();
-        assert_eq!(decoded.to_state_version, 0);
-        assert_eq!(decoded.cascade_hlc, Some(HybridTimestamp::zero()));
-    }
-
-    #[test]
     fn rejects_partial_to_state_version() {
         let mut bytes = to_vec(&sample(None)).unwrap();
-        // Two of the four `u32` bytes — a truncated tail, not a legacy record.
+        // Two of the four `u32` bytes. Any record short of the full layout must
+        // fail loud rather than decode a default.
         bytes.truncate(bytes.len() - 2);
 
-        assert!(
-            GroupUpgradeValue::try_from_slice(&bytes).is_err(),
-            "expected Err for truncated to_state_version"
-        );
-    }
-
-    #[test]
-    fn old_format_with_cascade_hlc_but_no_cascade_seq_decodes_as_none() {
-        // A record written after `cascade_hlc` was added but before `cascade_seq`:
-        // it ends right after the `cascade_hlc` Option, so `cascade_seq` must
-        // decode as `None` (clean EOF), not error.
-        let mut legacy = Vec::new();
-        "1.0.0".to_owned().serialize(&mut legacy).unwrap();
-        "2.0.0".to_owned().serialize(&mut legacy).unwrap();
-        Some(vec![1u8, 2, 3]).serialize(&mut legacy).unwrap();
-        1_700_000_000u64.serialize(&mut legacy).unwrap();
-        PrimitivePublicKey::from([7u8; 32])
-            .serialize(&mut legacy)
-            .unwrap();
-        (GroupUpgradeStatus::Completed { completed_at: None })
-            .serialize(&mut legacy)
-            .unwrap();
-        Some(HybridTimestamp::zero())
-            .serialize(&mut legacy)
-            .unwrap();
-
-        let decoded = GroupUpgradeValue::try_from_slice(&legacy).unwrap();
-        assert_eq!(decoded.cascade_hlc, Some(HybridTimestamp::zero()));
-        assert_eq!(decoded.cascade_seq, None);
-    }
-
-    #[test]
-    fn fully_legacy_record_decodes_both_trailing_fields_as_none() {
-        // A pre-`cascade_hlc` record (clean EOF after `status`) must decode BOTH
-        // trailing optionals as `None`.
-        let mut legacy = Vec::new();
-        "1.0.0".to_owned().serialize(&mut legacy).unwrap();
-        "2.0.0".to_owned().serialize(&mut legacy).unwrap();
-        Some(vec![1u8, 2, 3]).serialize(&mut legacy).unwrap();
-        1_700_000_000u64.serialize(&mut legacy).unwrap();
-        PrimitivePublicKey::from([7u8; 32])
-            .serialize(&mut legacy)
-            .unwrap();
-        (GroupUpgradeStatus::Completed { completed_at: None })
-            .serialize(&mut legacy)
-            .unwrap();
-
-        let decoded = GroupUpgradeValue::try_from_slice(&legacy).unwrap();
-        assert_eq!(decoded.cascade_hlc, None);
-        assert_eq!(decoded.cascade_seq, None);
+        // Borsh reports short input as `InvalidData`, not `UnexpectedEof`.
+        let err = GroupUpgradeValue::try_from_slice(&bytes)
+            .expect_err("expected Err for truncated to_state_version");
+        assert_eq!(err.kind(), borsh::io::ErrorKind::InvalidData);
     }
 }

--- a/crates/store/src/types/application.rs
+++ b/crates/store/src/types/application.rs
@@ -33,8 +33,8 @@ pub struct ApplicationMeta {
     pub state_version: u32,
 }
 
-// Custom deserialization: handle backwards compatibility for old data
-// that doesn't have the `services` field (added in rc.19).
+// Custom deserialization: the services EOF-branch is retained for shape only;
+// old records lacking `services` fail hard at the state_version read (clean break).
 impl BorshDeserialize for ApplicationMeta {
     fn deserialize_reader<R: Read>(reader: &mut R) -> std::io::Result<Self> {
         let bytecode = key::BlobMeta::deserialize_reader(reader)?;
@@ -46,8 +46,8 @@ impl BorshDeserialize for ApplicationMeta {
         let version = Box::<str>::deserialize_reader(reader)?;
         let signer_id = Box::<str>::deserialize_reader(reader)?;
 
-        // `services` was added after the initial schema, so old records end after
-        // `signer_id`. Try to read it; if there's no more data, default to empty.
+        // `services` was added after the initial schema; try to read it.
+        // Missing it does not gracefully degrade — the following state_version read fails.
         let services = match Vec::<ServiceMeta>::deserialize_reader(reader) {
             Ok(v) => v,
             Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => Vec::new(),

--- a/crates/store/src/types/application.rs
+++ b/crates/store/src/types/application.rs
@@ -1,5 +1,3 @@
-use std::io::Read;
-
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::entry::Borsh;
@@ -14,7 +12,7 @@ pub struct ServiceMeta {
     pub compiled: key::BlobMeta,
 }
 
-#[derive(BorshSerialize, Clone, Debug, Eq, PartialEq)]
+#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct ApplicationMeta {
     pub bytecode: key::BlobMeta,
@@ -31,50 +29,6 @@ pub struct ApplicationMeta {
     /// Max ABI state version across this application's services, `0` when none
     /// exposes a readable ABI. What the migration rollup compares, not `version`.
     pub state_version: u32,
-}
-
-// Custom deserialization: the services EOF-branch is retained for shape only;
-// old records lacking `services` fail hard at the state_version read (clean break).
-impl BorshDeserialize for ApplicationMeta {
-    fn deserialize_reader<R: Read>(reader: &mut R) -> std::io::Result<Self> {
-        let bytecode = key::BlobMeta::deserialize_reader(reader)?;
-        let size = u64::deserialize_reader(reader)?;
-        let source = Box::<str>::deserialize_reader(reader)?;
-        let metadata = Box::<[u8]>::deserialize_reader(reader)?;
-        let compiled = key::BlobMeta::deserialize_reader(reader)?;
-        let package = Box::<str>::deserialize_reader(reader)?;
-        let version = Box::<str>::deserialize_reader(reader)?;
-        let signer_id = Box::<str>::deserialize_reader(reader)?;
-
-        // `services` was added after the initial schema; try to read it.
-        // Missing it does not gracefully degrade — the following state_version read fails.
-        let services = match Vec::<ServiceMeta>::deserialize_reader(reader) {
-            Ok(v) => v,
-            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => Vec::new(),
-            Err(e)
-                if e.kind() == std::io::ErrorKind::InvalidData
-                    && e.to_string().contains("Unexpected length") =>
-            {
-                Vec::new()
-            }
-            Err(e) => return Err(e),
-        };
-
-        let state_version = u32::deserialize_reader(reader)?;
-
-        Ok(Self {
-            bytecode,
-            size,
-            source,
-            metadata,
-            compiled,
-            package,
-            version,
-            signer_id,
-            services,
-            state_version,
-        })
-    }
 }
 
 /// Identifying fields of an [`ApplicationMeta`]: who published it, what semver
@@ -173,11 +127,8 @@ mod application_meta_tests {
     use super::ApplicationMeta;
     use crate::key;
 
-    // `state_version` is read by the hand-written reader, not derived, so the
-    // round trip is what proves the two halves agree.
-    #[test]
-    fn application_meta_roundtrips_state_version() {
-        let meta = ApplicationMeta {
+    fn sample() -> ApplicationMeta {
+        ApplicationMeta {
             bytecode: key::BlobMeta::new(BlobId::from([1; 32])),
             size: 10,
             source: "test".into(),
@@ -188,7 +139,12 @@ mod application_meta_tests {
             signer_id: "did:key:zTest".into(),
             services: Vec::new(),
             state_version: 2,
-        };
+        }
+    }
+
+    #[test]
+    fn application_meta_roundtrips_state_version() {
+        let meta = sample();
 
         let bytes = borsh::to_vec(&meta).expect("serialize");
         let back = ApplicationMeta::try_from_slice(&bytes).expect("deserialize");
@@ -198,5 +154,18 @@ mod application_meta_tests {
             "state_version must survive a round trip"
         );
         assert_eq!(back.version.as_ref(), "10.1.3");
+    }
+
+    /// Pre-`state_version` records must fail loud rather than decode a default.
+    /// Both legacy shapes: missing the trailing `u32`, and missing `services` too.
+    #[test]
+    fn rejects_records_written_before_state_version() {
+        let bytes = borsh::to_vec(&sample()).expect("serialize");
+
+        for drop in [4, 8] {
+            let truncated = &bytes[..bytes.len() - drop];
+            let _err = ApplicationMeta::try_from_slice(truncated)
+                .expect_err("a record short of the full layout must not decode");
+        }
     }
 }

--- a/crates/store/src/types/application.rs
+++ b/crates/store/src/types/application.rs
@@ -28,6 +28,9 @@ pub struct ApplicationMeta {
     /// Named services within this application. Empty for single-service apps.
     /// When non-empty, `bytecode`/`compiled` above point to the first (default) service.
     pub services: Vec<ServiceMeta>,
+    /// Max ABI state version across this application's services, `0` when none
+    /// exposes a readable ABI. What the migration rollup compares, not `version`.
+    pub state_version: u32,
 }
 
 // Custom deserialization: handle backwards compatibility for old data
@@ -43,8 +46,8 @@ impl BorshDeserialize for ApplicationMeta {
         let version = Box::<str>::deserialize_reader(reader)?;
         let signer_id = Box::<str>::deserialize_reader(reader)?;
 
-        // `services` was added after the initial schema. Old records end after `signer_id`.
-        // Try to read it; if there's no more data, default to an empty Vec.
+        // `services` was added after the initial schema, so old records end after
+        // `signer_id`. Try to read it; if there's no more data, default to empty.
         let services = match Vec::<ServiceMeta>::deserialize_reader(reader) {
             Ok(v) => v,
             Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => Vec::new(),
@@ -57,6 +60,8 @@ impl BorshDeserialize for ApplicationMeta {
             Err(e) => return Err(e),
         };
 
+        let state_version = u32::deserialize_reader(reader)?;
+
         Ok(Self {
             bytecode,
             size,
@@ -67,16 +72,19 @@ impl BorshDeserialize for ApplicationMeta {
             version,
             signer_id,
             services,
+            state_version,
         })
     }
 }
 
-/// Package-manifest fields of an [`ApplicationMeta`] (name, version, signer).
+/// Identifying fields of an [`ApplicationMeta`]: who published it, what semver
+/// it claims, and what state version its ABI declares.
 #[derive(Debug, Clone)]
 pub struct PackageInfo {
     pub package: Box<str>,
     pub version: Box<str>,
     pub signer_id: Box<str>,
+    pub state_version: u32,
 }
 
 impl ApplicationMeta {
@@ -93,6 +101,7 @@ impl ApplicationMeta {
             package,
             version,
             signer_id,
+            state_version,
         } = info;
         Self {
             bytecode,
@@ -104,6 +113,7 @@ impl ApplicationMeta {
             version,
             signer_id,
             services: Vec::new(),
+            state_version,
         }
     }
 
@@ -153,4 +163,40 @@ pub struct ApplicationPreviousBlob {
 impl PredefinedEntry for key::ApplicationPreviousBlob {
     type Codec = Borsh;
     type DataType<'a> = ApplicationPreviousBlob;
+}
+
+#[cfg(test)]
+mod application_meta_tests {
+    use borsh::BorshDeserialize;
+    use calimero_primitives::blobs::BlobId;
+
+    use super::ApplicationMeta;
+    use crate::key;
+
+    // `state_version` is read by the hand-written reader, not derived, so the
+    // round trip is what proves the two halves agree.
+    #[test]
+    fn application_meta_roundtrips_state_version() {
+        let meta = ApplicationMeta {
+            bytecode: key::BlobMeta::new(BlobId::from([1; 32])),
+            size: 10,
+            source: "test".into(),
+            metadata: Box::new([]),
+            compiled: key::BlobMeta::new(BlobId::from([0; 32])),
+            package: "com.example.app".into(),
+            version: "10.1.3".into(),
+            signer_id: "did:key:zTest".into(),
+            services: Vec::new(),
+            state_version: 2,
+        };
+
+        let bytes = borsh::to_vec(&meta).expect("serialize");
+        let back = ApplicationMeta::try_from_slice(&bytes).expect("deserialize");
+
+        assert_eq!(
+            back.state_version, 2,
+            "state_version must survive a round trip"
+        );
+        assert_eq!(back.version.as_ref(), "10.1.3");
+    }
 }


### PR DESCRIPTION
## Summary

The migration-status rollup derived both sides of its "migrated" comparison from the bundle semver's major component.
Any same-major release (e.g. 10.1.3 -> 10.2.0) therefore reported every peer as migrated the moment the upgrade was recorded - `all_migrated` went green over a real migration.

The correct number is the embedded ABI's state version, which the migration engine already uses to resolve upgrade paths; the status side now reads it too.
It is recorded once at install (`ApplicationMeta.state_version`) and at upgrade emit (`GroupUpgradeValue.to_state_version`), keeping the heartbeat path synchronous.
`0` means unresolvable and inverts to an unsatisfiable target, never a satisfied one.
Every site that persists `to_state_version` now routes through one helper that logs a warning when the target's ABI cannot be read, so a rollup pinned to `u32::MAX` is diagnosable instead of silently red.

The permanently-zero `residue_identity` field is deleted: its production scan was an empty-keyspace adaptor (the wasm host exposes no committed-state key iteration), so it always reported "nothing pending" when it meant "never looked".
`authored_remaining` is the live measure and is unchanged.
The heartbeat wire, the node-side cache and the internal report type all lose it.
The admin-API response is the one exception and still carries `residueIdentity` pinned to `0`, because the released `calimero-client-py` the e2e suite runs deserializes it as a required field and is itself built from this repo's `master` - there is no single-PR ordering that drops the field on both sides and stays green.
It is marked `#[serde(default)]` so a follow-up can delete it once the merobox floor moves, without a second wire break.

Scope: the corrected rollup holds on the node that initiated the upgrade.
Cascade receivers record an unresolvable target (conservatively red) until the target state version rides the `CascadeUpgrade` op, which lands with the next PR's schema-version bump.

Breaking: heartbeat layout and stored `ApplicationMeta`/`GroupUpgradeValue` records changed with no back-compat - nodes must be wiped and re-provisioned, and mixed fleets will not cross-verify heartbeats.

## Test plan

- Regression test observed failing on unmodified master (`left: 10, right: 2`) before the fix and green after; the failure direction was re-proven by temporarily reverting the fix.
- Borsh round-trips for both new fields; truncated records fail loud as `InvalidData`.
- Both target-derivation paths (`derive_target_version`, `resolve_group_target_version`) unit-tested for the real value and the 0 -> `u32::MAX` sentinel.
- The admin response's `residueIdentity` key is pinned by the existing contract test; the assertion was proven to be a real gate by temporarily marking the field `skip_serializing` and observing `left: Null, right: 0`.
- `37-stranded-resync` is the only e2e scenario that calls the migration-status RPC and exercises the new rollup end to end.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`: 2195 passed, 0 failed.
