### PR TITLE
chore: cut release 0.11.0-rc.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.20"
+version = "0.11.0-rc.21"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Bumps the shared workspace version to `0.11.0-rc.21`.

`[workspace.metadata.workspaces] version` in `Cargo.toml`, one line — the same shape as the rc.20 cut (35799596). `[workspace.package] version` stays `0.0.0`; it is managed by cargo-workspaces (see `docs/RELEASE.md`).

**Leave this open.** Opened for review only — do not merge or tag until Fran says so, since merging is what triggers the release.

## What is on master since rc.20

`git log 0.11.0-rc.20..master` — 9 commits:

| | |
|---|---|
| #3393 | `refactor!` delete the upgrade policy concept; carry the target state version on cascades |
| #3392 | compare ABI state versions in the migration rollup, not semver majors |
| #3386 | blobstore: write blob chunks atomically, stop storing a download twice |
| #3389 | governance: resolve a member key to the account it speaks for |
| #3390 | deps: bump js-yaml 4.2.0 → 4.3.1 in /docs |
| #3387 | governance: admit an attested fleet replica in the clear so it can carry a credential |
| #3388 | storage: say which signature check refused an action |
| #3385 | node: back off missing-parent delta fetches to a peer that keeps failing |
| #3382 | governance: enrol a joiner's device in the same apply as its membership |

## Heads-up

**#3393 is a breaking change** (`refactor!`) — the upgrade policy concept is gone and the target state version now rides on cascades. Anything downstream that read the upgrade policy needs to move before it pins rc.21.

## Downstream

`tauri-app` desktop `v0.0.84` is prepared against this tag (calimero-network/tauri-app#183) and cannot be tagged until rc.21 is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
