### PR TITLE
fix(governance): resolve a signer's account at the op's cut, not from live rows

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -1,40 +1,20 @@
 name: Setup Merobox
 description: "Install the merobox release binary (Linux only)"
 
-inputs:
-  artifact:
-    description: >
-      Name of a same-repo artifact holding a prebuilt `merobox` binary. When set,
-      that binary is installed instead of the published release, which is how the
-      suite runs against a merobox that has not shipped yet. The floor check below
-      is skipped with it: an unreleased build has no meaningful version to compare,
-      and the point of passing it is that the release is not good enough.
-    required: false
-    default: ""
+# There is deliberately no "install a prebuilt artifact instead" input. Pointing
+# the suite at an unreleased merobox is occasionally useful while a fix is in
+# flight, but an artifact installed by name is a binary every downstream step
+# then executes with full access to node data dirs, and a same-repo artifact name
+# is not an authenticated identity — any job that can upload under that name
+# substitutes it. The release path below is verified against its published
+# `.sha256`, and that guarantee is the reason this is the only path. Testing
+# against an unshipped merobox means shipping it first, to a pre-release if need
+# be; the floor below is a floor precisely so that is cheap.
 
 runs:
   using: "composite"
   steps:
-    - name: Download prebuilt merobox
-      if: inputs.artifact != ''
-      uses: actions/download-artifact@v8
-      with:
-        name: ${{ inputs.artifact }}
-        path: /tmp/merobox-prebuilt
-
-    - name: Install prebuilt merobox
-      if: inputs.artifact != ''
-      shell: bash
-      run: |
-        set -euo pipefail
-        mkdir -p "$HOME/.local/bin"
-        install -m 0755 /tmp/merobox-prebuilt/merobox "$HOME/.local/bin/merobox"
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        export PATH="$HOME/.local/bin:$PATH"
-        merobox --version
-
     - name: Install merobox
-      if: inputs.artifact == ''
       shell: bash
       run: |
         set -euo pipefail

--- a/crates/context/config/src/types.rs
+++ b/crates/context/config/src/types.rs
@@ -899,10 +899,24 @@ pub struct SignedGroupOpenInvitation {
     /// does — silently drop the field and invalidate the signature with it,
     /// forcing a lockstep client release for a value that is only a hint.
     ///
-    /// Unsigned is safe here because it is not authority: a wrong value seeds a
-    /// wrong admin in local meta and then self-heals, since `NamespaceCreated`
-    /// genesis is authoritative and overwrites it on arrival. `None` simply
-    /// skips the seeding, which is what happened before the field existed.
+    /// Unsigned is safe only because no joiner treats it as authority, and that
+    /// is a constraint on joiners rather than a property of the field. It is
+    /// chosen by whatever relayed the invitation: `inviter_signature` covers the
+    /// inner [`GroupInvitationFromAdmin`], not this envelope.
+    ///
+    /// So a joiner may record it where it confers nothing and stops being read
+    /// once real state lands — `MembershipRepository::set_bootstrap_inviter`,
+    /// consulted only while the group's `admin_identity` is still the
+    /// placeholder — and may NOT write it as `admin_identity`, as an Admin
+    /// membership row, or anywhere else a later gate reads as a grant.
+    ///
+    /// An earlier version of this doc claimed the seeding self-heals because
+    /// `NamespaceCreated` genesis overwrites it. It does not: genesis keys its
+    /// established-check on `admin_identity != placeholder`, so a seeded value
+    /// makes genesis a no-op and pins itself permanently on that node.
+    ///
+    /// `None` skips the hint entirely, which is what happened before the field
+    /// existed and costs only a slower cold start.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inviter_account: Option<calimero_account::AccountId>,
     /// Application ID for the group (unsigned bootstrap field).

--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -90,9 +90,10 @@ impl Handler<JoinGroupRequest> for ContextManager {
 
                 if MetaRepository::new(&datastore).load(&group_id)?.is_none() {
                     // From the invitation ENVELOPE, and optional there: it is a
-                    // bootstrap hint, not authority. `None` simply skips the
-                    // admin seeding — the state before the field existed, which
-                    // `NamespaceCreated` genesis repairs on arrival anyway.
+                    // bootstrap hint, and it is treated as one — recorded in a
+                    // node-local row below, never seeded as this group's admin.
+                    // See the seeding site for why "genesis repairs it anyway"
+                    // is not true.
                     let inviter_account = invitation.inviter_account;
                     // The invitation carries the application id so joiners
                     // pre-populate `GroupMetaValue` with the real value:
@@ -136,11 +137,28 @@ impl Handler<JoinGroupRequest> for ContextManager {
                             _ => [0u8; 32],
                         }
                     });
-                    // The joiner has synced nothing yet, so it cannot resolve the
-                    // inviter's key to an account itself. Absent the hint, the
-                    // placeholder stands until genesis arrives and overwrites it.
-                    let seeded_admin =
-                        inviter_account.unwrap_or_else(calimero_governance_store::placeholder_admin_identity);
+                    // The placeholder, never `invitation.inviter_account`.
+                    //
+                    // That hint rides in the UNSIGNED envelope —
+                    // `inviter_signature` covers the inner
+                    // `GroupInvitationFromAdmin` only — so anything that can
+                    // relay an invitation can choose it. Seeding it made it this
+                    // node's `admin_identity`, the local root of trust for
+                    // `is_admin` and for beacon, ack and heartbeat verification.
+                    //
+                    // The field's own docs called that safe because genesis
+                    // overwrites a wrong value. It does not: `namespace_created`
+                    // keys its established-check on
+                    // `admin_identity != placeholder` and is a no-op once one is
+                    // set, so an attacker-chosen account would have been
+                    // permanent on this node rather than reconciled.
+                    //
+                    // The head start the hint exists for is kept, in the
+                    // node-local bootstrap row written below — which confers no
+                    // authority and stops being read the moment a real admin
+                    // exists. This mirrors `join_namespace` in `calimero-node`,
+                    // the other entry point into this same cold-start window.
+                    let seeded_admin = calimero_governance_store::placeholder_admin_identity();
                     let meta = calimero_store::key::GroupMetaValue {
                         admin_identity: seeded_admin,
                         owner_identity: seeded_admin,
@@ -152,23 +170,24 @@ impl Handler<JoinGroupRequest> for ContextManager {
                     };
                     MetaRepository::new(&datastore).save(&group_id, &meta)?;
 
-                    // Add the namespace admin to the member list so joining
-                    // nodes see the creator in /admin-api/groups/:id/members.
-                    // Direct-row check: see joiner-side guard below for
-                    // why inheritance-aware `check_group_membership`
-                    // would be unsafe here.
-                    // Only when the hint named someone: seeding a member row for
-                    // the placeholder would invent a principal.
-                    if let Some(inviter_account) = inviter_account {
-                        if !MembershipRepository::new(&datastore)
-                            .has_direct_member(&group_id, &inviter_account)?
-                        {
-                            MembershipRepository::new(&datastore).add_member(
-                                &group_id,
-                                &inviter_account,
-                                calimero_primitives::context::GroupMemberRole::Admin,
-                            )?;
-                        }
+                    // The hint goes to its own node-local row, not to a
+                    // membership row.
+                    //
+                    // Recorded at all because a joiner that has applied no DAG
+                    // ops verifies nothing it receives — including the inviter's
+                    // readiness beacons, which are the trigger that would fetch
+                    // the state ending that condition. `namespace_accounts`
+                    // admits this hint while the admin is still the placeholder,
+                    // which is exactly the cold-start window and no longer.
+                    //
+                    // An earlier version wrote an Admin MEMBERSHIP row from it
+                    // instead. That row outlives the window — nothing retracts
+                    // it once genesis names the real admin — so an unsigned
+                    // field chosen by whoever relayed the invitation became a
+                    // durable grant.
+                    if let Some(hint) = inviter_account {
+                        MembershipRepository::new(&datastore)
+                            .set_bootstrap_inviter(group_id.to_bytes().into(), hint)?;
                     }
                 }
 

--- a/crates/governance-store/src/ops/group/context.rs
+++ b/crates/governance-store/src/ops/group/context.rs
@@ -113,8 +113,16 @@ impl<'a> GroupApplyCtx<'a> {
     ///
     /// `None` is always a refusal, never a fallback. A key bound to no account
     /// here is not the member it claims to be, so it cannot act as them.
+    ///
+    /// Resolved through the checker rather than off the binding rows directly,
+    /// because those rows fold like any other projected state. A bare live read
+    /// makes the answer depend on how far THIS replica has folded, so a peer
+    /// that has the signer's device-link op and one that does not would reach
+    /// opposite verdicts on the same signed self-op — one applies it, the other
+    /// refuses it, and nothing later reconciles them. The checker parks that op
+    /// instead, and a park is retried once the ancestry arrives.
     pub(crate) fn signer_account(&self) -> EyreResult<Option<AccountId>> {
-        crate::member_account_in_namespace(self.store, self.group_id, self.signer)
+        self.permissions.account_for_signer(self.signer)
     }
 
     /// Whether the op's signer is acting on their own behalf — the shared

--- a/crates/governance-store/src/ops/namespace/group_created.rs
+++ b/crates/governance-store/src/ops/namespace/group_created.rs
@@ -106,7 +106,18 @@ pub(crate) fn apply(
     // Resolved once for both the meta pin and the Admin row below. They must
     // agree — same signer, same parent — and each resolution is a binding-column
     // scan, so doing it twice bought nothing but the chance of drifting apart.
-    let Some(creator) = crate::member_account_in_namespace(store, &parent_gid, &op.signer)? else {
+    //
+    // Resolved through the permission checker, not off live binding rows: those
+    // rows are folded state like any other, so a bare live read would let a
+    // replica that has not yet folded the creator's device-link op answer
+    // `NotMember` for an op its peer admitted — a permanent, fold-order-dependent
+    // divergence in projected state. The checker parks instead, and the op is
+    // retried when the ancestry arrives. It resolves against the parent, which is
+    // where the authority that admitted this op lives.
+    let Some(creator) = ctx
+        .permissions_for(parent_gid)
+        .account_for_signer(&op.signer)?
+    else {
         bail!(crate::MembershipError::NotMember {
             group_id: hex::encode(parent_gid.to_bytes()),
             identity: format!("{}", op.signer),

--- a/crates/governance-store/src/permission_checker.rs
+++ b/crates/governance-store/src/permission_checker.rs
@@ -161,6 +161,27 @@ impl<'a> PermissionChecker<'a> {
         })
     }
 
+    /// The account `signer` speaks for, for an apply path that must NAME the
+    /// signer rather than merely judge it — and must reach the same name on
+    /// every replica.
+    ///
+    /// The public form of [`live_account_or_park`](Self::live_account_or_park),
+    /// with the soundness gate the authority checks put in front of their own
+    /// live fallbacks. Both parks matter and they cover different gaps: the gate
+    /// refuses to answer at a cut the projection cannot resolve, and the inner
+    /// park refuses to call an unresolvable signer a stranger before this
+    /// namespace has any authority to have been a stranger to. What survives
+    /// both is a `None` that means genuinely unbound, which a caller may safely
+    /// turn into a rejection.
+    ///
+    /// A caller that only asks "is this signer authorized" wants
+    /// [`is_admin`](Self::is_admin) instead — it answers from the projection
+    /// without resolving a name at all.
+    pub fn account_for_signer(&self, signer: &PublicKey) -> EyreResult<Option<AccountId>> {
+        self.ensure_live_fallback_is_sound(signer)?;
+        self.live_account_or_park(signer)
+    }
+
     pub fn is_admin(&self, identity: &PublicKey) -> EyreResult<bool> {
         // Decide from the PROJECTION at the op's causal cut — admin authority as of the
         // op's own parents, which is the same answer on every replica.
@@ -448,9 +469,22 @@ impl<'a> PermissionChecker<'a> {
     /// which kept compiling after the flip because both ids are 32 bytes: the
     /// comparison simply stopped ever being true, silently narrowing this gate
     /// to admins only.
+    /// Admin is asked FIRST, and not for style: it answers from the projection at
+    /// the op's own cut, so an admin never reaches the resolution below at all.
+    /// Only a signer with no admin authority needs naming, and that naming is
+    /// held to the same soundness gate every other branch in this file uses —
+    /// binding rows fold like any other projected state, so resolving `signer`
+    /// off live rows at an unresolvable cut lets two replicas at different fold
+    /// depths disagree about `is_self` for one signed op: one accepts the
+    /// self-service change, the other rejects it as neither admin nor self.
+    /// [`account_for_signer`](Self::account_for_signer) parks that op instead,
+    /// and a parked op is retried once the ancestry lands.
     pub fn require_admin_or_self(&self, signer: &PublicKey, member: &AccountId) -> EyreResult<()> {
-        let is_self = self.live_account(signer)?.as_ref() == Some(member);
-        if !is_self && !self.is_admin(signer)? {
+        if self.is_admin(signer)? {
+            return Ok(());
+        }
+        let is_self = self.account_for_signer(signer)?.as_ref() == Some(member);
+        if !is_self {
             bail!(CapabilitiesError::Unauthorized {
                 group_id: format!("{:?}", self.group_id),
                 operation: "set member alias (admin or self only)".into(),

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -9489,6 +9489,59 @@ mod undecidable_authority_parks {
         );
     }
 
+    /// The self-branch of `require_admin_or_self` resolves the signer's account,
+    /// and binding rows fold like any other projected state — so at a cut this
+    /// replica cannot resolve, reading them live would let it answer `is_self`
+    /// differently from a peer at another fold depth, for one signed op. Park
+    /// instead: a park is retried when the ancestry lands, a denial is forever.
+    #[test]
+    fn unresolvable_cut_parks_the_self_branch_instead_of_denying_it() {
+        let signer_pk = PublicKey::from([0x11; 32]);
+        let store = test_store();
+        let gid = test_group_id();
+        // A real member acting on their own row — the live rows would GRANT, and
+        // the pre-fix code returned that verdict without checking whether the
+        // cut it was answering for could be resolved at all.
+        let signer = enrol_member(&store, &gid, &signer_pk);
+        MembershipRepository::new(&store)
+            .add_member(&gid, &signer, GroupMemberRole::Member)
+            .unwrap();
+
+        let err = PermissionChecker::new(&store, gid)
+            .with_apply_auth(&CUT, &UnresolvableAuthorizer)
+            .require_admin_or_self(&signer_pk, &signer)
+            .expect_err("an unresolvable cut must not be answered from live bindings");
+        assert_undecidable(&err);
+
+        // Same store, same rows, same signer: only the cut differs. This pins
+        // that the park is about the CUT and not about the gate having become
+        // unreachable — a fix that simply broke self-service would also make the
+        // assertion above pass.
+        PermissionChecker::new(&store, gid)
+            .require_admin_or_self(&signer_pk, &signer)
+            .expect("a resolvable cut still admits the member acting on themselves");
+    }
+
+    /// An admin never reaches the resolution at all: `is_admin` answers from the
+    /// projection at the cut, so the gate is decided before any binding row is
+    /// read. Pinning it keeps the branch order load-bearing — reversing it would
+    /// park admins behind a lookup whose answer cannot change the verdict.
+    #[test]
+    fn admin_passes_admin_or_self_at_cut_without_resolving_bindings() {
+        let admin_pk = PublicKey::from([0x12; 32]);
+        let store = test_store();
+        let gid = test_group_id();
+        // Deliberately NOT enrolled: with no binding, the signer's account is
+        // unresolvable, so a gate that consulted it before asking the authorizer
+        // could only park or deny.
+        let target = AccountId::from([0x99; 32]);
+
+        PermissionChecker::new(&store, gid)
+            .with_apply_auth(&CUT, &FixedAuthorizer(true))
+            .require_admin_or_self(&admin_pk, &target)
+            .expect("an at-cut admin verdict decides the gate on its own");
+    }
+
     #[test]
     fn unresolvable_cut_refuses_rather_than_denying_from_live() {
         // The load-bearing direction. Live rows would DENY, and the old code turned

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -3354,7 +3354,15 @@ impl SyncManager {
 
         // `has_member`'s account-keyed arm needs the account the peer's key acts
         // as; this crate can resolve it, `calimero-context-client` cannot.
-        let their_account = {
+        //
+        // Re-resolved at every attempt rather than captured once. The whole point
+        // of the retries below is that the peer may have joined DURING the
+        // intervening catch-up — which is exactly when their binding first
+        // becomes resolvable here. A value read before the catch-up would carry
+        // its own staleness into every retry, so the account-keyed arm would keep
+        // being handed the `None` that provoked the catch-up in the first place
+        // and only the key-keyed fallback could rescue a peer who did just join.
+        let their_account = || {
             let store = self.context_client.datastore();
             calimero_governance_store::get_group_for_context(store, &context_id)
                 .ok()
@@ -3371,7 +3379,7 @@ impl SyncManager {
         };
         if !self
             .context_client
-            .has_member(&context_id, &their_identity, their_account)?
+            .has_member(&context_id, &their_identity, their_account())?
             && !is_inherited_member()?
         {
             _updated = Some(
@@ -3382,7 +3390,7 @@ impl SyncManager {
 
             if !self
                 .context_client
-                .has_member(&context_id, &their_identity, their_account)?
+                .has_member(&context_id, &their_identity, their_account())?
                 && !is_inherited_member()?
             {
                 // The peer may have just published MemberAdded for themselves
@@ -3402,7 +3410,7 @@ impl SyncManager {
 
                 if !self
                     .context_client
-                    .has_member(&context_id, &their_identity, their_account)?
+                    .has_member(&context_id, &their_identity, their_account())?
                     && !is_inherited_member()?
                 {
                     // Catch-up didn't resolve it (peer returned nothing, peer

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -603,10 +603,22 @@ impl SyncManager {
             // credential, so a first-time joiner names an account this responder
             // cannot yet resolve. Both rows the gate reads — the re-entry block
             // and the consumed-invitation marker — are keyed by that account, so
-            // neither can exist for a principal we cannot name, and admitting is
-            // the accurate answer rather than a lenient one. The authoritative
-            // gate is the apply of the joiner's own `MemberJoinedAt`, which
-            // carries the credential and re-runs this check against it.
+            // for a genuine first-timer neither row can exist and there is
+            // nothing here to check.
+            //
+            // It is lenient in one case, and knowingly: a denied account can
+            // present a device key this responder holds no binding for, and its
+            // deny row goes unread because we cannot name whose it is. What that
+            // buys the holder is the backfill and the wrapped key served below,
+            // ahead of the apply-time check that does have the credential and
+            // does reject them. It is not a regression — the gate was keyed by
+            // KEY before, so a fresh key walked past it just the same, and
+            // keying by account is what lets a denied account's OTHER devices be
+            // caught at all. Closing it needs the join request to carry the
+            // joiner's credential so the responder can name the principal before
+            // it serves anything, which is a wire change and needs its own
+            // version gate — see the "join-sync admission skips the deny-list
+            // check" issue.
             (false, None) => Ok(()),
         };
         if let Err(err) = admission {

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1586,6 +1586,24 @@ impl Validate for AddGroupMembersApiRequest {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupMemberApiInput {
+    /// The only KEY-typed principal left on `/groups/:id/members`: every other
+    /// verb on this resource — the GET listing, remove, and the role /
+    /// capabilities / metadata / auto-follow updates — names members by
+    /// [`AccountId`]. A caller therefore has to know which encoding each
+    /// endpoint wants, and the two are rendered differently (bs58 vs 64-hex)
+    /// specifically so a mix-up fails loudly instead of resolving to the wrong
+    /// principal.
+    ///
+    /// It is a key because an add is the one call whose subject may not have an
+    /// account here yet. An operator adding someone holds the key that person
+    /// signs with; the account is a hash of a genesis this node learns only once
+    /// they have joined, so requiring one would make the endpoint uncallable in
+    /// exactly the case it exists for. The apply resolves this key to the
+    /// account the row is keyed by, and the listing is where the caller reads
+    /// that account back.
+    ///
+    /// This converges on accounts once an add can name an account that does not
+    /// exist locally yet.
     pub identity: PublicKey,
     pub role: GroupMemberRole,
 }


### PR DESCRIPTION
Follow-up to #3391. These are the review findings raised on that PR that arrived after its last push, so they did not make the merge.

## What this fixes

**Account resolution at the op's cut, not from live rows** (the substantive one). Binding rows fold like any other projected state, so naming a signer off them makes the answer depend on how far *this* replica happens to have folded. Two peers at different fold depths then reach opposite verdicts on one signed op — one applies it, the other refuses — and nothing later reconciles them. Three sites asked that question live:

- `require_admin_or_self` now asks the admin gate **first**, which decides at the cut and never needs a name at all; only a non-admin signer gets resolved, through a new `account_for_signer` carrying the same `ensure_live_fallback_is_sound` gate every other branch in that file uses.
- `GroupApplyCtx::signer_account` — the shared resolver behind *every* group-op "admin or self" gate — routes through the same call. This was not flagged directly, but it is the same defect with wider blast radius.
- `group_created` resolves its creator that way instead of scanning bindings directly.

A park is the point: it is retried once the ancestry arrives, where a denial is permanent.

**The unsigned inviter hint, on the `join_group` path.** #3391 fixed this for `join_namespace`; `join_group` is the other entry point into the same cold-start window and still seeded `inviter_account` as the group's `admin_identity` plus an Admin membership row. That field rides in the *unsigned* envelope, so anything relaying an invitation chooses it — and the "genesis overwrites a wrong value" justification in its own doc is false: genesis keys its established-check on `admin_identity != placeholder`, so a seeded value makes genesis a **no-op** and pins itself permanently as that node's local root of trust. The hint now goes to the same node-local bootstrap row `join_namespace` uses, and the doc is corrected.

**Stale account across the sync retries.** `verify_inbound_member` resolved `their_account` once and reused it across the two retries that follow a catch-up — the retries that exist precisely because the peer may have joined *during* that catch-up, which is when their binding first becomes resolvable.

**CI + API surface.** The `setup-merobox` `artifact` input installed a same-repo artifact with no checksum while the release path verifies a published `.sha256`; nothing has passed it since the producing job was removed, so it is deleted rather than grown a checksum. And `GroupMemberApiInput::identity`'s rationale for being the last key-typed principal on `/groups/:id/members` now lives on the type.

## Deliberately not fixed here

- **Join-sync admission skips the deny-list check for an unresolvable joiner** → #3397. Real, but not a regression (the gate was key-keyed before, so a fresh device key walked past it identically) and closing it needs the join request to carry a credential — a wire change with its own version gate. The comment at that arm now states the residual risk plainly instead of calling the admission accurate.
- **`ZERO_HEX_ACCOUNT` "wrong length"** — invalid finding. The literal is exactly 64 characters; the `Rust` job parses it on every run.

## Verification

- New regression test A/B'd against the previous logic: `unresolvable_cut_parks_the_self_branch_instead_of_denying_it` **fails** on the old code, passes here. A second test pins the branch order, so an at-cut admin verdict keeps deciding the gate without a lookup.
- `cargo test --workspace --no-fail-fast`: **227 suites, 0 failures**.
- `cargo fmt --check` and `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` clean.
