### PR TITLE
feat(storage)!: own an authored entry by account, not by device

### DIFF
--- a/apps/kv-store-with-user-and-frozen-storage/src/lib.rs
+++ b/apps/kv-store-with-user-and-frozen-storage/src/lib.rs
@@ -6,7 +6,7 @@ use calimero_sdk::abi::AbiType;
 use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::Serialize;
-use calimero_sdk::PublicKey;
+use calimero_sdk::{AccountId, PublicKey};
 use calimero_storage::collections::Mergeable;
 use calimero_storage::collections::{FrozenStorage, LwwRegister, UnorderedMap, UserStorage};
 use thiserror::Error;
@@ -17,11 +17,11 @@ pub struct KvStore {
     items: UnorderedMap<String, LwwRegister<String>>,
 
     // Simple user-owned data (e.g., a user's profile name)
-    // Stores: UnorderedMap<PublicKey, LwwRegister<String>>
+    // Stores: UnorderedMap<AccountId, LwwRegister<String>>
     user_items_simple: UserStorage<LwwRegister<String>>,
 
     // Nested user-owned data (e.g., a user's private key-value store)
-    // Stores: UnorderedMap<PublicKey, UnorderedMap<String, LwwRegister<String>>>
+    // Stores: UnorderedMap<AccountId, UnorderedMap<String, LwwRegister<String>>>
     user_items_nested: UserStorage<NestedMap>,
 
     // Content-addressable, immutable data
@@ -152,7 +152,10 @@ impl KvStore {
     }
 
     /// Gets the simple string value for a *specific* user.
-    pub fn get_user_simple_for(&self, user_key: PublicKey) -> app::Result<Option<String>> {
+    ///
+    /// Named by ACCOUNT: user storage is keyed per person, so this reaches the
+    /// one slot every device of theirs writes to.
+    pub fn get_user_simple_for(&self, user_key: AccountId) -> app::Result<Option<String>> {
         app::log!("Getting simple value for specific user {:?}", user_key);
         Ok(self
             .user_items_simple

--- a/apps/kv-store-with-user-and-frozen-storage/src/lib.rs
+++ b/apps/kv-store-with-user-and-frozen-storage/src/lib.rs
@@ -151,6 +151,14 @@ impl KvStore {
         Ok(self.user_items_simple.get()?.map(|v| v.get().clone()))
     }
 
+    /// This node's account, hex-encoded — what user storage is keyed by.
+    ///
+    /// Exists for the e2e: an account is derived from the node's root rather
+    /// than carried on the wire, so a scenario has no other way to learn one.
+    pub fn my_account(&self) -> app::Result<String> {
+        Ok(AccountId::from(calimero_sdk::env::account_id()).to_string())
+    }
+
     /// Gets the simple string value for a *specific* user.
     ///
     /// Named by ACCOUNT: user storage is keyed per person, so this reaches the

--- a/apps/kv-store-with-user-and-frozen-storage/workflows/test_user_storage.yml
+++ b/apps/kv-store-with-user-and-frozen-storage/workflows/test_user_storage.yml
@@ -111,6 +111,18 @@ steps:
     timeout: 60
     trigger_sync: true
 
+  # User storage is keyed by ACCOUNT, and an account is derived from a node's
+  # root rather than carried on the wire — a member public key is a different id
+  # space and the app refuses it. So each account is read off the node that owns
+  # it, before the other node reads that user's slot.
+  - name: Read node-1's account
+    type: call
+    node: new-calimero-node-1
+    context_id: '{{context_id}}'
+    method: my_account
+    outputs:
+      node1_account: result.output
+
   # Step 11: Node2: get simple user storage for a specific user
   - name: Node 2 - Simple user storage get test for a specific user
     type: call
@@ -118,7 +130,7 @@ steps:
     context_id: '{{context_id}}'
     method: get_user_simple_for
     args:
-      user_key: "{{member_public_key}}"
+      user_key: "{{node1_account}}"
     outputs:
       node2_simple_value_res_specific_user: result
 
@@ -160,6 +172,14 @@ steps:
     timeout: 60
     trigger_sync: true
 
+  - name: Read node-2's account
+    type: call
+    node: new-calimero-node-2
+    context_id: '{{context_id}}'
+    method: my_account
+    outputs:
+      node2_account: result.output
+
   # Step 14: Node1: get simple user storage for Node 2 user
   - name: Node 1 - Simple user storage get test for a specific user (from Node2)
     type: call
@@ -167,7 +187,7 @@ steps:
     context_id: '{{context_id}}'
     method: get_user_simple_for
     args:
-      user_key: "{{public_key_new-calimero-node-2}}"
+      user_key: "{{node2_account}}"
     outputs:
       node1_simple_value_res_from_node2: result
 

--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -669,7 +669,9 @@ impl E2eKvStore {
         Ok(self.user_items_simple.get()?.map(|v| v.get().clone()))
     }
 
-    pub fn get_user_simple_for(&self, user_key: PublicKey) -> app::Result<Option<String>> {
+    /// Named by ACCOUNT: user storage is keyed per person, so this reaches the
+    /// one slot every device of theirs writes to.
+    pub fn get_user_simple_for(&self, user_key: AccountId) -> app::Result<Option<String>> {
         app::log!("Getting simple value for specific user {:?}", user_key);
         Ok(self
             .user_items_simple

--- a/apps/scaffolding-e2e/workflows/e2e.yml
+++ b/apps/scaffolding-e2e/workflows/e2e.yml
@@ -470,6 +470,17 @@ steps:
 
   # USER STORAGE - SIMPLE
 
+  # User storage is keyed by ACCOUNT, and an account is derived from a node's
+  # root rather than carried on the wire — so a reader has to be told it by the
+  # node that owns it.
+  - name: Read node-1's account
+    type: call
+    node: e2e-node-1
+    context_id: "{{context_id}}"
+    method: my_account
+    outputs:
+      node1_account: result.output
+
   # Node 1 sets their user storage first
   - name: Set user simple value on node-1
     type: call
@@ -510,7 +521,7 @@ steps:
     context_id: "{{context_id}}"
     method: get_user_simple_for
     args:
-      user_key: "{{node1_key}}"
+      user_key: "{{node1_account}}"
     outputs:
       node1_profile_from_node2: result
 
@@ -526,7 +537,7 @@ steps:
     context_id: "{{context_id}}"
     method: get_user_simple_for
     args:
-      user_key: "{{node1_key}}"
+      user_key: "{{node1_account}}"
     outputs:
       node1_profile_from_node3: result
 

--- a/apps/scaffolding-e2e/workflows/e2e.yml
+++ b/apps/scaffolding-e2e/workflows/e2e.yml
@@ -563,6 +563,18 @@ steps:
     outputs:
       node2_profile: result
 
+  # As with node-1 above: user storage is keyed by ACCOUNT, and an account is
+  # derived from a node's root rather than carried on the wire, so it has to be
+  # read off the node that owns it. A member public key is a different id space
+  # and the app refuses it.
+  - name: Read node-2's account
+    type: call
+    node: e2e-node-2
+    context_id: "{{context_id}}"
+    method: my_account
+    outputs:
+      node2_account: result.output
+
   - name: Assert node-2 profile
     type: json_assert
     statements:
@@ -586,7 +598,7 @@ steps:
     context_id: "{{context_id}}"
     method: get_user_simple_for
     args:
-      user_key: "{{public_key_e2e-node-2}}"
+      user_key: "{{node2_account}}"
     outputs:
       node2_profile_from_node1: result
 
@@ -602,7 +614,7 @@ steps:
     context_id: "{{context_id}}"
     method: get_user_simple_for
     args:
-      user_key: "{{public_key_e2e-node-2}}"
+      user_key: "{{node2_account}}"
     outputs:
       node2_profile_from_node3: result
 

--- a/apps/scaffolding-e2e/workflows/hashcomparison-shared-user-reconcile.yml
+++ b/apps/scaffolding-e2e/workflows/hashcomparison-shared-user-reconcile.yml
@@ -274,6 +274,22 @@ steps:
     type: wait
     seconds: 8
 
+  # By ACCOUNT: user storage is keyed per person, and an account is derived from
+  # a node's root rather than carried on the wire, so it has to be read off the
+  # node that owns it.
+  #
+  # Read BEFORE the reconciliation barrier, though it only reads node-1's own
+  # local root and converges nothing. The convergence lint counts any `call` as a
+  # mutation, so leaving it after the barrier made the cross-node read below look
+  # like it raced a node-1 write.
+  - name: Read node-1's account
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: my_account
+    outputs:
+      node1_account: result.output
+
   - name: Wait for context reconciliation
     type: wait_for_sync
     context_id: '{{ctx}}'
@@ -301,17 +317,6 @@ steps:
     namespace_id: '{{ns}}'
     outputs:
       node1_id: publicKey
-
-  # By ACCOUNT: user storage is keyed per person, and an account is derived from
-  # a node's root rather than carried on the wire, so it has to be read off the
-  # node that owns it.
-  - name: Read node-1's account
-    type: call
-    node: e2e-node-1
-    context_id: '{{ctx}}'
-    method: my_account
-    outputs:
-      node1_account: result.output
 
   - name: Read node-1's User entity from node-2
     type: call

--- a/apps/scaffolding-e2e/workflows/hashcomparison-shared-user-reconcile.yml
+++ b/apps/scaffolding-e2e/workflows/hashcomparison-shared-user-reconcile.yml
@@ -302,13 +302,24 @@ steps:
     outputs:
       node1_id: publicKey
 
+  # By ACCOUNT: user storage is keyed per person, and an account is derived from
+  # a node's root rather than carried on the wire, so it has to be read off the
+  # node that owns it.
+  - name: Read node-1's account
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: my_account
+    outputs:
+      node1_account: result.output
+
   - name: Read node-1's User entity from node-2
     type: call
     node: e2e-node-2
     context_id: '{{ctx}}'
     method: get_user_simple_for
     args:
-      user_key: '{{node1_id}}'
+      user_key: '{{node1_account}}'
     outputs:
       user_read_from_node2: result
 

--- a/apps/scaffolding-e2e/workflows/hashcomparison-shared-user-reconcile.yml
+++ b/apps/scaffolding-e2e/workflows/hashcomparison-shared-user-reconcile.yml
@@ -183,6 +183,23 @@ steps:
   #     reconnect step, anything node-1 writes is invisible to
   #     node-2 over libp2p. ---
 
+  # By ACCOUNT: user storage is keyed per person, and an account is derived from
+  # a node's root rather than carried on the wire, so it has to be read off the
+  # node that owns it.
+  #
+  # Read here, before the partition, rather than beside the read that consumes
+  # it. node-1's account is fixed from startup, so nothing about this depends on
+  # sync — and placing it after the heal put a call between the reconciliation
+  # barrier and the cross-node read, which is both a convergence-lint finding and
+  # one more thing in flight while the partition is closing.
+  - name: Read node-1's account
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: my_account
+    outputs:
+      node1_account: result.output
+
   - name: Partition node-2 from the bridge
     type: script
     script: scripts/disconnect-node-from-bridge.sh
@@ -273,22 +290,6 @@ steps:
   - name: Wait for libp2p mesh reformation
     type: wait
     seconds: 8
-
-  # By ACCOUNT: user storage is keyed per person, and an account is derived from
-  # a node's root rather than carried on the wire, so it has to be read off the
-  # node that owns it.
-  #
-  # Read BEFORE the reconciliation barrier, though it only reads node-1's own
-  # local root and converges nothing. The convergence lint counts any `call` as a
-  # mutation, so leaving it after the barrier made the cross-node read below look
-  # like it raced a node-1 write.
-  - name: Read node-1's account
-    type: call
-    node: e2e-node-1
-    context_id: '{{ctx}}'
-    method: my_account
-    outputs:
-      node1_account: result.output
 
   - name: Wait for context reconciliation
     type: wait_for_sync

--- a/apps/scaffolding-e2e/workflows/shared-storage-account-writers-two-devices.yml
+++ b/apps/scaffolding-e2e/workflows/shared-storage-account-writers-two-devices.yml
@@ -44,13 +44,18 @@ description: >
        it could not name, would drop this write — and a receiver that accepted
        it unresolved would let any key claim any account.
 
-    5. Stamps stay per device while the gate moves to accounts. The phone may
-       write the shared value (an account gate) and may NOT update the laptop's
-       authored entry (a per-device owner stamp), and the laptop still can. Both
-       halves matter: authorization keyed by device breaks step 4, and stamps
-       keyed by account make the phone the owner of the laptop's entry, so two
-       devices of one person silently overwrite each other's per-writer state.
-       Both mistakes compile — `AccountId` and `PublicKey` are both 32 bytes.
+    5. The authored plane, which is the same account gate over a different
+       principal. The phone updates an entry the LAPTOP filed, with no grant of
+       its own: an authored entry's owner is the account, so one person reaches
+       their own note from either machine. The signature still names the phone's
+       key, so this only passes if the receiver resolves that key to Alice's
+       account — the same resolution step 4 needs, on a second plane.
+
+       What stays per device is the per-writer state underneath: an LWW
+       tiebreak, a counter slot, an HLC seed. Moving THOSE onto accounts is what
+       makes two devices of one person clobber each other, and it is a different
+       mistake from this one. Both compile — `AccountId` and `PublicKey` are
+       both 32 bytes.
 
   What this does NOT cover (intentionally):
     * A deferral: a receiver that has not yet folded the binding must retry
@@ -390,29 +395,23 @@ steps:
     timeout: 60
     trigger_sync: true
 
-  # Same account, different device — and an authored entry's owner is the DEVICE.
-  # This must fail even though the phone may write the shared value above, which
-  # is exactly the gates-vs-stamps split. If stamps were account-keyed this
-  # would succeed, and one person's devices would clobber each other silently.
-  - name: The phone cannot update the laptop's authored entry
+  # Same account, different device — and an authored entry's owner is the
+  # ACCOUNT. So this SUCCEEDS, and that is the feature: one person reaches their
+  # own note from either machine. It used to be asserted the other way, when the
+  # owner stamp was the device id.
+  #
+  # It is also the step that needs the receiver-side resolution. The phone's
+  # action is signed by a key that appears in no owner stamp anywhere; a receiver
+  # has to resolve that key to Alice's account before it can match the entry's
+  # owner. This is the authored-plane twin of the shared-writer step above.
+  - name: The phone updates the laptop's authored entry
     type: call
     node: shared-account-node-3
     context_id: '{{context_id}}'
     method: authored_update
     args:
       key: notes
-      value: phone-should-not-land
-    expected_failure: true
-
-  # The other half: the owner check refuses the phone specifically, not everyone.
-  - name: The laptop can still update its own authored entry
-    type: call
-    node: shared-account-node-2
-    context_id: '{{context_id}}'
-    method: authored_update
-    args:
-      key: notes
-      value: laptop-wrote-this-again
+      value: phone-wrote-this
 
   - name: Settle before reading the authored entry cross-node
     type: wait_for_sync
@@ -434,10 +433,10 @@ steps:
     outputs:
       authored_n1: result
 
-  - name: Only the owning device's update landed
+  - name: The second device's update landed, and propagated
     type: json_assert
     statements:
-      - 'json_equal({{authored_n1}}, {"output": "laptop-wrote-this-again"})'
+      - 'json_equal({{authored_n1}}, {"output": "phone-wrote-this"})'
 
   # ── Phase 8: the identity relationship behind all of it ───────────
 

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -283,7 +283,7 @@ mod borsh_layout_round_trip {
     fn user_round_trips() {
         let owner = [0x11; 32];
         let decoded = round_trip(StorageType::User {
-            owner: PublicKey::from(owner),
+            owner: calimero_account::AccountId::from(owner),
             signature_data: Some(SignatureData {
                 signature: [0x22; 64],
                 nonce: 42,

--- a/crates/context/src/handlers/execute/signing.rs
+++ b/crates/context/src/handlers/execute/signing.rs
@@ -64,14 +64,21 @@ pub(crate) fn sign_authorized_actions(
         // (NLL), freeing `action` for the immutable `payload_for_signing` below.
         let should_sign = match &mut metadata.storage_type {
             StorageType::User {
-                owner,
                 signature_data: Some(sig_data),
+                ..
             } => {
-                let ours = *owner == executor_pk && sig_data.signature == [0; 64];
-                if ours {
+                // Placeholder-only, exactly like the two arms below, and for the
+                // same reason: the authorization decision was already made at
+                // write time (storage stamps a placeholder only for the owner's
+                // own entries). `owner` is an account now, so it cannot be
+                // compared against the executor's key here — and the key it CAN
+                // be compared against is `sig_data.signer`, which storage
+                // stamped with this same device.
+                let placeholder = sig_data.signature == [0; 64];
+                if placeholder {
                     sig_data.nonce = nonce;
                 }
-                ours
+                placeholder
             }
             StorageType::Shared {
                 signature_data: Some(sig_data),

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -180,7 +180,10 @@ pub fn wire_authorization_for(
 /// Extract the claimed author of a sync'd leaf from its wire-carried
 /// authorization, when the storage type admits one.
 ///
-/// * `User { owner, .. }` → `owner` is the author by definition.
+/// * `User` → the author is `signature_data.signer`, same as the two below.
+///   Its `owner` names the ACCOUNT allowed to change the entry, and an account
+///   is not a key this membership check can use — the device that actually
+///   wrote it is the signer.
 /// * `Shared { signature_data: Some(SignatureData { signer: Some(pk), .. }), .. }`
 ///   → the signature names its signer, which is the author. When `signer`
 ///   is `None` there is no author to name, so this returns `None` and the
@@ -193,12 +196,59 @@ fn extract_author_from_leaf_authorization(
     authorization: Option<&StorageType>,
 ) -> Option<PublicKey> {
     match authorization? {
-        StorageType::User { owner, .. } => Some(*owner),
-        StorageType::Shared { signature_data, .. }
+        StorageType::User { signature_data, .. }
+        | StorageType::Shared { signature_data, .. }
         | StorageType::SharedMember { signature_data, .. } => {
             signature_data.as_ref().and_then(|sd| sd.signer)
         }
         StorageType::Public | StorageType::Frozen => None,
+    }
+}
+
+/// Does a `User` leaf's author actually own it?
+///
+/// The ownership half of the authored-entry gate, and it lives here rather than
+/// in `calimero-storage` because it is the half that needs device→account
+/// bindings — which this crate can read and that one cannot. On the delta path
+/// storage answers it itself, from the account the node resolved at the action's
+/// causal cut. The sync repair paths (HashComparison, snapshot, level-wise)
+/// carry no cut, so storage defers there and this runs instead; see
+/// `Interface::user_action_authorized`.
+///
+/// Without it the account flip would have been a straight downgrade on those
+/// paths: `owner` used to BE the key the signature verified against, so a
+/// repaired leaf was cryptographically bound to its owner even with no bindings
+/// in hand. Once `owner` is an account that binding has to be re-made by
+/// resolving the signer, and any context member could otherwise overwrite
+/// another member's authored entry by pushing it over HC.
+///
+/// Non-`User` leaves pass straight through — they have no owner to check. So
+/// does a leaf whose group or binding cannot be resolved: that is this node not
+/// having folded the author's enrolment yet, not a claim that the author is an
+/// impostor, and the membership check above has already run.
+fn user_leaf_author_is_its_owner(
+    store: &Store,
+    context_id: &ContextId,
+    leaf: &TreeLeafData,
+    author: &PublicKey,
+) -> bool {
+    let Some(StorageType::User { owner, .. }) = leaf.metadata.authorization.as_ref() else {
+        return true;
+    };
+    let Ok(Some(group_id)) = calimero_governance_store::get_group_for_context(store, context_id)
+    else {
+        return true;
+    };
+    match calimero_governance_store::member_account_in_namespace(store, &group_id, author) {
+        Ok(Some(account)) => {
+            let owns = account == *owner;
+            if !owns {
+                crate::node_metrics::record_hc_leaf_drop("not-entry-owner");
+            }
+            owns
+        }
+        // Unresolvable, not disproven — see the doc above.
+        Ok(None) | Err(_) => true,
     }
 }
 
@@ -253,7 +303,7 @@ pub fn is_leaf_currently_authorized(
     };
     match calimero_governance_store::is_currently_authorized_for_context(store, context_id, &author)
     {
-        Ok(true) => true,
+        Ok(true) => user_leaf_author_is_its_owner(store, context_id, leaf, &author),
         Ok(false) => {
             // Expected outcome under churn (post-removal authorship,
             // ReadOnly role); track separately from lookup errors so
@@ -1131,16 +1181,37 @@ mod tests {
     }
 
     #[test]
-    fn extract_author_user_returns_owner() {
-        let owner = PublicKey::from([7u8; 32]);
+    fn extract_author_user_returns_the_signer_not_the_owner() {
+        // `owner` names the ACCOUNT allowed to change the entry; the author this
+        // gate needs is the KEY that wrote it, because membership is checked per
+        // key. The two are deliberately unrelated here — returning the owner
+        // would hand a 32-byte account id to a membership lookup that expects a
+        // signing key, and it would silently answer "not a member".
+        let signer = PublicKey::from([7u8; 32]);
         let st = StorageType::User {
-            owner,
-            signature_data: None,
+            owner: calimero_account::AccountId::from([0x7A; 32]),
+            signature_data: Some(SignatureData {
+                signer: Some(signer),
+                signature: [0u8; 64],
+                nonce: 0,
+            }),
         };
         assert_eq!(
             extract_author_from_leaf_authorization(Some(&st)),
-            Some(owner),
+            Some(signer),
         );
+    }
+
+    #[test]
+    fn extract_author_user_without_a_signer_returns_none() {
+        // Same deferral as the `Shared` arm below: an authorization naming no
+        // signer yields no author, and `apply_action`'s signature check is what
+        // refuses it.
+        let st = StorageType::User {
+            owner: calimero_account::AccountId::from([0x7A; 32]),
+            signature_data: None,
+        };
+        assert_eq!(extract_author_from_leaf_authorization(Some(&st)), None);
     }
 
     #[test]

--- a/crates/storage/AGENTS.md
+++ b/crates/storage/AGENTS.md
@@ -203,17 +203,31 @@ bytes, so confusing them **compiles**, and most tests pass either way.
 | **Gate** — "may this person write?" | `env::account_id()` | a writer set names people, so one grant covers every device they hold |
 | **Stamp** — "who wrote this?" | `env::device_id()` | per-writer state: two devices sharing a counter slot or an HLC seed lose each other's writes |
 
-The boundary is **per file**, not per symbol: `shared.rs`, `access_control.rs` and
-`permissioned.rs` are entirely principals; `user.rs` and `authored_*.rs` are
-entirely stamps. Do not run a blanket `PublicKey → AccountId` replace — it builds,
-and it silently moves owner stamps onto accounts.
+The boundary is **per file for most of the tree, and per symbol in two places.**
+`shared.rs`, `access_control.rs` and `permissioned.rs` are entirely principals.
+`user.rs` and `authored_*.rs` hold BOTH: an entry's `owner` is a gate — it decides
+who may `update`/`remove` — so it is an `AccountId`, while the device that wrote
+the entry is stamped on `signature_data.signer`. Everything else in those files
+that reads `device_id()` (an LWW tiebreak, a counter slot, an HLC seed) is still a
+stamp and must stay one.
+
+Still do not run a blanket `PublicKey → AccountId` replace: it builds, and it
+would sweep those per-writer stamps onto accounts, where two devices of one person
+share a counter slot and lose each other's writes.
 
 A signature can only name a **key**, so the bridge is
 `ApplyContext.signer_account`: the account that key speaks for, resolved by the
 NODE at the write's causal cut and passed in. This crate has no store and no cut,
 so it cannot resolve one itself, and it must never fall back to the locally
-executing account — a remote action would then authorize itself. `None` is a
-refusal.
+executing account — a remote action would then authorize itself.
+
+`None` means "this path could not resolve it", and what that costs depends on the
+gate. For a `Shared` writer set it is a refusal. For a `User` owner it DEFERS —
+the sync repair paths (HashComparison, snapshot, level-wise) apply through an
+`ApplyContext::empty()` and refusing there would drop every legitimately repaired
+entry. The ownership check for those runs in `calimero-node`
+(`is_leaf_currently_authorized`), which has the bindings this crate lacks.
+Signature authenticity is enforced here on every path, because that needs none.
 
 **The caller owes a contract this crate cannot check:** `signer_account` must be
 the resolution of *that action's own* signer. Storage verifies the signature under

--- a/crates/storage/src/action.rs
+++ b/crates/storage/src/action.rs
@@ -277,20 +277,25 @@ fn hash_authorization_for_payload(hasher: &mut Sha256, metadata: &Metadata) {
             signature_data,
         } => {
             hasher.update([2u8]); // type tag
-            hasher.update(owner.as_ref() as &[u8; 32]);
+            hasher.update(owner.as_bytes());
             // sig-data presence tag — see "Domain separation" in the
             // function doc.
             if let Some(sig_data) = signature_data.as_ref() {
                 hasher.update([1u8]);
                 hasher.update(sig_data.nonce.to_le_bytes());
-                // `User` deliberately does NOT commit to
-                // `sig_data.signer`: there is exactly one owner, the
-                // verifier always uses `owner` directly, and the hint
-                // is unused on this path (only `Shared` uses it for
-                // O(1) writer-set lookup). Keeping the User payload
-                // shape independent of the optional hint avoids a
-                // class of "signer field set to a different value but
-                // still passes verify" footguns at zero cost.
+                // `User` commits to `sig_data.signer`, exactly as `Shared`
+                // does. It did not have to when `owner` was itself the
+                // verification key: there was one owner, the verifier used it
+                // directly, and the field was an unused hint. Now `owner` is an
+                // account and `signer` is the key the signature is checked
+                // against, so leaving it out of the payload would sign a
+                // statement that does not name its own author.
+                if let Some(signer) = sig_data.signer {
+                    hasher.update([1u8]); // signer-present tag
+                    hasher.update(signer.as_ref() as &[u8; 32]);
+                } else {
+                    hasher.update([0u8]); // signer-absent tag
+                }
             } else {
                 hasher.update([0u8]);
             }
@@ -388,7 +393,7 @@ mod tests {
         }
     }
 
-    fn meta_user(owner: PublicKey, nonce: u64) -> Metadata {
+    fn meta_user(owner: AccountId, nonce: u64) -> Metadata {
         Metadata {
             created_at: 100,
             updated_at: nonce.into(),
@@ -459,7 +464,7 @@ mod tests {
 
     #[test]
     fn payload_differs_on_nonce_change() {
-        let owner = PublicKey::from([0x10; 32]);
+        let owner = AccountId::from([0x10; 32]);
         let id = Id::new([0xAA; 32]);
         let a = upsert(id, b"v".to_vec(), vec![], meta_user(owner, 1));
         let b = upsert(id, b"v".to_vec(), vec![], meta_user(owner, 2));
@@ -513,7 +518,7 @@ mod tests {
         // (or vice versa) at apply time.
         let id = Id::new([0xAA; 32]);
         let data = b"v".to_vec();
-        let owner = PublicKey::from([0x10; 32]);
+        let owner = AccountId::from([0x10; 32]);
 
         let a = upsert(id, data.clone(), vec![], meta_public());
         let b = upsert(id, data.clone(), vec![], meta_user(owner, 1));
@@ -673,7 +678,7 @@ mod tests {
         // but for the User branch. Both branches now have the same
         // sig-data presence-tag shape.
         let id = Id::new([0xAA; 32]);
-        let owner = PublicKey::from([0x10; 32]);
+        let owner = AccountId::from([0x10; 32]);
 
         let mut unsigned = meta_user(owner, 0);
         if let StorageType::User {

--- a/crates/storage/src/collections/authored_common.rs
+++ b/crates/storage/src/collections/authored_common.rs
@@ -5,22 +5,29 @@
 //! (key vs index, reject-on-collision vs slot-return, delete vs tombstone) live
 //! in each collection's own file.
 //!
-//! The owner is the **device**, not the account. Authorship here is a claim about
-//! which replica wrote an entry, and the gate it feeds ("only the author may
-//! update this") is enforced against a stored `PublicKey`. Re-keying it onto an
-//! account would let one device edit an entry another device of the same account
-//! wrote — a different feature, and one that needs the writer-set plumbing rather
-//! than a swapped id.
+//! The owner is the **account**, not the device. Authorship here feeds an
+//! access-control gate ("only the author may change this entry"), and access
+//! control names people: someone who wrote an entry from their phone can edit it
+//! from their laptop, because both devices speak for one account. Keying the gate
+//! on a device key made a second device of the same person a stranger to their
+//! own data.
+//!
+//! This is the authorization half only. The per-replica identities CRDT mechanics
+//! depend on — an LWW register's tiebreak, a counter's per-actor slot, an HLC
+//! seed — stay on [`env::device_id`] and must: two devices of one account writing
+//! concurrently have to remain distinguishable or they share a slot and lose each
+//! other's writes. Which device wrote an entry is still recorded, as the
+//! `signature_data.signer` its signature verifies against.
 
-use calimero_primitives::identity::PublicKey;
+use calimero_account::AccountId;
 
 use crate::entities::StorageType;
 use crate::env;
 
-/// Return the current writer as a `PublicKey` — the value that gets
+/// Return the current writer as an `AccountId` — the value that gets
 /// stamped onto every new author-tracked entry.
-pub(super) fn current_writer() -> PublicKey {
-    env::device_id().into()
+pub(super) fn current_writer() -> AccountId {
+    AccountId::from(env::account_id())
 }
 
 /// Build the `StorageType::User { owner }` stamp for the current writer.
@@ -34,7 +41,12 @@ pub(super) fn make_owner_stamp() -> StorageType {
 
 /// Predicate: the current writer matches `owner`.
 /// Called by every gated mutation (`update`, `remove`, `tombstone`).
-pub(super) fn writer_matches_owner(owner: &PublicKey) -> bool {
+///
+/// This is the local, pre-write half of the gate — it answers for the account
+/// executing right now. The authoritative half runs at apply, where a remote
+/// write's signer is resolved to its account at the action's causal cut and
+/// compared against the stored `owner`.
+pub(super) fn writer_matches_owner(owner: &AccountId) -> bool {
     &current_writer() == owner
 }
 
@@ -50,23 +62,21 @@ mod tests {
 
     #[test]
     #[serial]
-    fn current_writer_returns_env_device_id() {
-        env::with_device_id([42; 32], || {
-            let expected: PublicKey = [42; 32].into();
-            assert_eq!(current_writer(), expected);
+    fn current_writer_returns_env_account_id() {
+        env::with_account_id([42; 32], || {
+            assert_eq!(current_writer(), AccountId::from([42; 32]));
         });
     }
 
     #[test]
     #[serial]
-    fn make_owner_stamp_uses_current_executor() {
-        env::with_device_id([42; 32], || match make_owner_stamp() {
+    fn make_owner_stamp_uses_current_account() {
+        env::with_account_id([42; 32], || match make_owner_stamp() {
             StorageType::User {
                 owner,
                 signature_data,
             } => {
-                let expected: PublicKey = [42; 32].into();
-                assert_eq!(owner, expected);
+                assert_eq!(owner, AccountId::from([42; 32]));
                 assert!(
                     signature_data.is_none(),
                     "freshly-built stamp must not carry signature_data"
@@ -78,19 +88,65 @@ mod tests {
 
     #[test]
     #[serial]
-    fn owner_check_accepts_matching_executor() {
-        env::with_device_id([42; 32], || {
-            let owner: PublicKey = [42; 32].into();
-            assert!(writer_matches_owner(&owner));
+    fn owner_check_accepts_matching_account() {
+        env::with_account_id([42; 32], || {
+            assert!(writer_matches_owner(&AccountId::from([42; 32])));
         });
     }
 
     #[test]
     #[serial]
-    fn owner_check_rejects_mismatched_executor() {
-        env::with_device_id([42; 32], || {
-            let owner: PublicKey = [99; 32].into();
-            assert!(!writer_matches_owner(&owner));
+    fn owner_check_rejects_a_different_account() {
+        env::with_account_id([42; 32], || {
+            assert!(!writer_matches_owner(&AccountId::from([99; 32])));
+        });
+    }
+
+    /// The whole point of the change: one person, two machines.
+    ///
+    /// Fails before authorship moved onto accounts — the stamp was the device id,
+    /// so moving the device moved the owner and the second machine was refused
+    /// its own entry.
+    #[test]
+    #[serial]
+    fn a_second_device_of_the_same_account_still_owns_the_entry() {
+        let stamped =
+            env::with_device_id([1; 32], || env::with_account_id([42; 32], make_owner_stamp));
+        let StorageType::User { owner, .. } = stamped else {
+            panic!("expected StorageType::User");
+        };
+
+        // Same person, different machine. Only the device moves.
+        env::with_device_id([2; 32], || {
+            env::with_account_id([42; 32], || {
+                assert!(
+                    writer_matches_owner(&owner),
+                    "a second device of the owning account must be able to edit the entry"
+                );
+            });
+        });
+    }
+
+    /// The guard on the test above: "any device may edit" would satisfy it too.
+    #[test]
+    #[serial]
+    fn a_device_of_another_account_does_not_own_the_entry() {
+        let stamped =
+            env::with_device_id([1; 32], || env::with_account_id([42; 32], make_owner_stamp));
+        let StorageType::User { owner, .. } = stamped else {
+            panic!("expected StorageType::User");
+        };
+
+        // Same machine id as the owner's, deliberately: it is the ACCOUNT that
+        // must decide, so holding the device fixed and moving the account is the
+        // only way to prove the device is not what is being read.
+        env::with_device_id([1; 32], || {
+            env::with_account_id([99; 32], || {
+                assert!(
+                    !writer_matches_owner(&owner),
+                    "a different account must not be able to edit someone else's entry"
+                );
+            });
         });
     }
 }

--- a/crates/storage/src/collections/authored_map.rs
+++ b/crates/storage/src/collections/authored_map.rs
@@ -1,9 +1,9 @@
 //! Shared-keyspace map with per-entry ownership.
 //!
 //! `AuthoredMap<K, V>` exposes an `UnorderedMap<K, V>` whose entries each carry
-//! a `StorageType::User { owner }` stamp set to the inserter's public key.
-//! Any context member can insert a new key; only the inserter can update or
-//! remove their own entries. Reads are unrestricted.
+//! a `StorageType::User { owner }` stamp set to the inserter's ACCOUNT. Any
+//! context member can insert a new key; only the owning account can update or
+//! remove its entries — from any of its devices. Reads are unrestricted.
 //!
 //! The per-entry authorization is enforced at merge time in
 //! `Interface::apply_action` (see `interface.rs`). Local `update`/`remove`
@@ -21,7 +21,7 @@
 use std::collections::BTreeMap;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use calimero_primitives::identity::PublicKey;
+use calimero_account::AccountId;
 
 use super::crdt_meta::{CrdtMeta, CrdtType, Mergeable, StorageStrategy};
 use super::{compute_id, StoreError, UnorderedMap, ValueRef};
@@ -30,12 +30,11 @@ use crate::index::Index;
 use crate::interface::StorageError;
 use crate::store::{MainStorage, StorageAdaptor};
 
-/// A map keyed by `K` where each entry is owned by the public key that
-/// inserted it.
+/// A map keyed by `K` where each entry is owned by the account that inserted it.
 ///
 /// Internally an `UnorderedMap<K, V>`. Each entry's `StorageType` is
-/// `User { owner }`, set at insert time from `env::device_id()`. Only the
-/// owner can `update` or `remove` their entry.
+/// `User { owner }`, set at insert time from `env::account_id()`. Only that
+/// account can `update` or `remove` the entry, from any device it holds.
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct AuthoredMap<K, V, S: StorageAdaptor = MainStorage>
 where
@@ -203,11 +202,11 @@ where
         self.inner.contains(k)
     }
 
-    /// Returns the public key of the owner of `k`, if any.
+    /// Returns the account that owns of `k`, if any.
     ///
     /// # Errors
     /// Returns any underlying storage error.
-    pub fn owner_of(&self, k: &K) -> Result<Option<PublicKey>, StoreError> {
+    pub fn owner_of(&self, k: &K) -> Result<Option<AccountId>, StoreError> {
         let id = self.entry_id(k);
         let metadata = <Index<S>>::get_metadata(id).map_err(StoreError::StorageError)?;
         Ok(metadata.and_then(|m| match m.storage_type {
@@ -346,7 +345,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use calimero_primitives::identity::PublicKey;
+    use calimero_account::AccountId;
     use serial_test::serial;
 
     use super::AuthoredMap;
@@ -375,21 +374,25 @@ mod tests {
         );
     }
 
-    fn pk(bytes: [u8; 32]) -> PublicKey {
-        bytes.into()
+    /// The tests name the OWNER, and an owner is an account.
+    fn acct(bytes: [u8; 32]) -> AccountId {
+        AccountId::from(bytes)
     }
 
     #[test]
     #[serial]
     fn insert_stamps_current_executor_as_owner() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("apple".to_owned(), 1).expect("insert");
 
         assert_eq!(map.get(&"apple".to_owned()).unwrap(), Some(1));
-        assert_eq!(map.owner_of(&"apple".to_owned()).unwrap(), Some(pk(ALICE)));
+        assert_eq!(
+            map.owner_of(&"apple".to_owned()).unwrap(),
+            Some(acct(ALICE))
+        );
         assert_eq!(map.len().unwrap(), 1);
     }
 
@@ -397,7 +400,7 @@ mod tests {
     #[serial]
     fn insert_rejects_existing_key() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("apple".to_owned(), 1).unwrap();
@@ -416,26 +419,29 @@ mod tests {
     #[serial]
     fn update_by_owner_succeeds() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("apple".to_owned(), 1).unwrap();
         map.update(&"apple".to_owned(), 42).expect("owner update");
 
         assert_eq!(map.get(&"apple".to_owned()).unwrap(), Some(42));
-        assert_eq!(map.owner_of(&"apple".to_owned()).unwrap(), Some(pk(ALICE)));
+        assert_eq!(
+            map.owner_of(&"apple".to_owned()).unwrap(),
+            Some(acct(ALICE))
+        );
     }
 
     #[test]
     #[serial]
     fn update_by_non_owner_rejected() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("apple".to_owned(), 1).unwrap();
 
-        env::set_device_id(BOB);
+        env::set_account_id(BOB);
         let err = map
             .update(&"apple".to_owned(), 99)
             .expect_err("non-owner update must fail");
@@ -444,14 +450,17 @@ mod tests {
             "error should mention ownership, got: {err}"
         );
         assert_eq!(map.get(&"apple".to_owned()).unwrap(), Some(1));
-        assert_eq!(map.owner_of(&"apple".to_owned()).unwrap(), Some(pk(ALICE)));
+        assert_eq!(
+            map.owner_of(&"apple".to_owned()).unwrap(),
+            Some(acct(ALICE))
+        );
     }
 
     #[test]
     #[serial]
     fn update_missing_key_errors() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut map = Root::new(AuthoredMap::<String, u64>::new);
         let err = map
@@ -468,7 +477,7 @@ mod tests {
     #[serial]
     fn remove_by_owner_succeeds() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("apple".to_owned(), 1).unwrap();
@@ -483,12 +492,12 @@ mod tests {
     #[serial]
     fn remove_by_non_owner_rejected() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("apple".to_owned(), 1).unwrap();
 
-        env::set_device_id(BOB);
+        env::set_account_id(BOB);
         let err = map
             .remove(&"apple".to_owned())
             .expect_err("non-owner remove must fail");
@@ -500,7 +509,7 @@ mod tests {
     #[serial]
     fn remove_missing_key_is_none() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut map = Root::new(AuthoredMap::<String, u64>::new);
         assert_eq!(map.remove(&"ghost".to_owned()).unwrap(), None);
@@ -513,18 +522,21 @@ mod tests {
 
         let mut map = Root::new(AuthoredMap::<String, u64>::new);
 
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
         map.insert("alice_key".to_owned(), 1).unwrap();
 
-        env::set_device_id(BOB);
+        env::set_account_id(BOB);
         map.insert("bob_key".to_owned(), 2).unwrap();
 
         assert_eq!(map.len().unwrap(), 2);
         assert_eq!(
             map.owner_of(&"alice_key".to_owned()).unwrap(),
-            Some(pk(ALICE))
+            Some(acct(ALICE))
         );
-        assert_eq!(map.owner_of(&"bob_key".to_owned()).unwrap(), Some(pk(BOB)));
+        assert_eq!(
+            map.owner_of(&"bob_key".to_owned()).unwrap(),
+            Some(acct(BOB))
+        );
 
         // Bob cannot overwrite Alice's key via insert (it already exists).
         let err = map.insert("alice_key".to_owned(), 99);
@@ -535,7 +547,7 @@ mod tests {
         assert!(map.remove(&"alice_key".to_owned()).is_err());
 
         // Alice still sees her original value.
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
         assert_eq!(map.get(&"alice_key".to_owned()).unwrap(), Some(1));
     }
 
@@ -553,10 +565,19 @@ mod tests {
     /// compiles and every other test in this file still passes.
     #[test]
     #[serial]
-    fn two_devices_of_one_account_own_their_entries_separately() {
+    fn two_devices_of_one_account_share_ownership_of_its_entries() {
         // One account; two of its devices. The account is unlike either device id
-        // on purpose — where they matched, a device-keyed stamp would satisfy
-        // every assertion below.
+        // on purpose — where they matched, this could not tell an account-keyed
+        // stamp from a device-keyed one.
+        //
+        // This assertion used to run the other way: the phone was refused the
+        // laptop's entry, on the grounds that an account-keyed stamp would "let
+        // two devices clobber each other's per-writer state". That conflated two
+        // things. Per-writer state — an LWW register's tiebreak, a counter's
+        // slot, an HLC seed — is keyed on `device_id` and still is; nothing here
+        // moved it. The owner stamp is not per-writer state, it is an
+        // access-control principal, and refusing a person their own data on a
+        // second machine was the bug, not the protection.
         const ACCOUNT: [u8; 32] = [0xAC; 32];
         const LAPTOP: [u8; 32] = [0xD1; 32];
         const PHONE: [u8; 32] = [0xD2; 32];
@@ -572,21 +593,27 @@ mod tests {
         notes.insert("from-phone".to_owned(), 2).unwrap();
 
         assert_eq!(notes.len().unwrap(), 2, "neither device's entry was lost");
+        // The ACCOUNT owns both — not the machine that happened to type them.
         assert_eq!(
             notes.owner_of(&"from-laptop".to_owned()).unwrap(),
-            Some(pk(LAPTOP))
+            Some(acct(ACCOUNT))
         );
         assert_eq!(
             notes.owner_of(&"from-phone".to_owned()).unwrap(),
-            Some(pk(PHONE))
+            Some(acct(ACCOUNT))
         );
 
-        // Still the phone, and still the same account as the laptop.
+        // Still the phone, and that is the point: one person, either machine.
+        notes
+            .update(&"from-laptop".to_owned(), 99)
+            .expect("a second device of the owning account may edit its entry");
+        assert_eq!(notes.get(&"from-laptop".to_owned()).unwrap(), Some(99));
+
+        // The guard: "any device may edit" would pass everything above.
+        env::set_account_id([0xEE; 32]);
         assert!(
-            notes.update(&"from-laptop".to_owned(), 99).is_err(),
-            "one account, but the phone is not the laptop: an account-keyed stamp \
-             would let this succeed and let two devices clobber each other's \
-             per-writer state"
+            notes.update(&"from-laptop".to_owned(), 1234).is_err(),
+            "a different account must still be refused someone else's entry"
         );
     }
 
@@ -594,7 +621,7 @@ mod tests {
     #[serial]
     fn owner_of_missing_key_is_none() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let map = Root::new(AuthoredMap::<String, u64>::new);
         assert_eq!(map.owner_of(&"ghost".to_owned()).unwrap(), None);
@@ -632,7 +659,7 @@ mod tests {
         }
 
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         // Insert at the default (unversioned 0) target — the "v1" stamp.
         let mut map = Root::new(AuthoredMap::<String, u64>::new);
@@ -689,7 +716,7 @@ mod tests {
         }
 
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut map = Root::new(AuthoredMap::<String, LwwRegister<String>>::new);
         map.insert("k".to_owned(), LwwRegister::new("v1".to_owned()))
@@ -715,7 +742,7 @@ mod tests {
     #[serial]
     fn entry_schema_version_and_ownership_reflect_stored_metadata() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("apple".to_owned(), 1).unwrap();
@@ -729,11 +756,11 @@ mod tests {
         assert!(map.owned_by_me(&"apple".to_owned()).unwrap());
 
         // A different executor is not the owner.
-        env::set_device_id(BOB);
+        env::set_account_id(BOB);
         assert!(!map.owned_by_me(&"apple".to_owned()).unwrap());
 
         // Absent key: no version, not owned.
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
         assert_eq!(map.entry_schema_version(&"ghost".to_owned()).unwrap(), None);
         assert!(!map.owned_by_me(&"ghost".to_owned()).unwrap());
     }
@@ -742,12 +769,12 @@ mod tests {
     #[serial]
     fn entries_contains_all_inserted_pairs() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut map = Root::new(AuthoredMap::<String, u64>::new);
         map.insert("a".to_owned(), 1).unwrap();
         map.insert("b".to_owned(), 2).unwrap();
-        env::set_device_id(BOB);
+        env::set_account_id(BOB);
         map.insert("c".to_owned(), 3).unwrap();
 
         let pairs: Vec<_> = map.entries().unwrap().collect();
@@ -770,9 +797,9 @@ mod tests {
         env::reset_for_testing();
 
         let mut map = Root::new(|| AuthoredMap::<String, u64>::new_with_field_name("entries"));
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
         map.insert("apple".to_owned(), 1).expect("alice insert");
-        env::set_device_id(BOB);
+        env::set_account_id(BOB);
         map.insert("banana".to_owned(), 2).expect("bob insert");
 
         // Simulate the macro-driven id canonicalisation.
@@ -783,13 +810,19 @@ mod tests {
         assert_eq!(map.get(&"banana".to_owned()).unwrap(), Some(2));
         assert_eq!(map.len().unwrap(), 2);
         // Owner stamps survive (not re-stamped to the calling executor).
-        assert_eq!(map.owner_of(&"apple".to_owned()).unwrap(), Some(pk(ALICE)));
-        assert_eq!(map.owner_of(&"banana".to_owned()).unwrap(), Some(pk(BOB)));
+        assert_eq!(
+            map.owner_of(&"apple".to_owned()).unwrap(),
+            Some(acct(ALICE))
+        );
+        assert_eq!(map.owner_of(&"banana".to_owned()).unwrap(), Some(acct(BOB)));
 
         // Idempotent: a second reassign is a no-op and still preserves everything.
         map.reassign_deterministic_id("entries");
-        assert_eq!(map.owner_of(&"apple".to_owned()).unwrap(), Some(pk(ALICE)));
-        assert_eq!(map.owner_of(&"banana".to_owned()).unwrap(), Some(pk(BOB)));
+        assert_eq!(
+            map.owner_of(&"apple".to_owned()).unwrap(),
+            Some(acct(ALICE))
+        );
+        assert_eq!(map.owner_of(&"banana".to_owned()).unwrap(), Some(acct(BOB)));
         assert_eq!(map.len().unwrap(), 2);
     }
 
@@ -803,9 +836,9 @@ mod tests {
         env::reset_for_testing();
 
         let mut map = Root::new(AuthoredMap::<String, u64>::new);
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
         map.insert("apple".to_owned(), 1).expect("alice insert");
-        env::set_device_id(BOB);
+        env::set_account_id(BOB);
         map.insert("banana".to_owned(), 2).expect("bob insert");
 
         // Random inner id != deterministic id => real clear+reinsert (not the
@@ -815,7 +848,10 @@ mod tests {
         assert_eq!(map.get(&"apple".to_owned()).unwrap(), Some(1));
         assert_eq!(map.get(&"banana".to_owned()).unwrap(), Some(2));
         assert_eq!(map.len().unwrap(), 2);
-        assert_eq!(map.owner_of(&"apple".to_owned()).unwrap(), Some(pk(ALICE)));
-        assert_eq!(map.owner_of(&"banana".to_owned()).unwrap(), Some(pk(BOB)));
+        assert_eq!(
+            map.owner_of(&"apple".to_owned()).unwrap(),
+            Some(acct(ALICE))
+        );
+        assert_eq!(map.owner_of(&"banana".to_owned()).unwrap(), Some(acct(BOB)));
     }
 }

--- a/crates/storage/src/collections/authored_vector.rs
+++ b/crates/storage/src/collections/authored_vector.rs
@@ -1,7 +1,7 @@
 //! Ordered shared-keyspace vector with per-entry ownership.
 //!
 //! `AuthoredVector<V>` exposes a `Vector<V>` whose entries each carry a
-//! `StorageType::User { owner }` stamp set to the pusher's public key at
+//! `StorageType::User { owner }` stamp set to the pusher's account at
 //! `push` time. Any context member can push a new entry at the end; only the
 //! entry's author can update or tombstone it. There is intentionally no
 //! physical `remove` — shifting indices would complicate concurrent-push
@@ -20,7 +20,7 @@
 use std::collections::BTreeMap;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use calimero_primitives::identity::PublicKey;
+use calimero_account::AccountId;
 
 use super::crdt_meta::{CrdtMeta, CrdtType, Mergeable, StorageStrategy};
 use super::{StoreError, ValueRef, Vector};
@@ -32,7 +32,7 @@ use crate::store::{MainStorage, StorageAdaptor};
 /// A vector where each position is owned by the public key that pushed it.
 ///
 /// Internally a `Vector<V>`. Each entry's `StorageType` is `User { owner }`
-/// set at push time from `env::device_id()`. Only the owner can `update`
+/// set at push time from `env::account_id()`. Only the owner can `update`
 /// or `tombstone` their entry.
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct AuthoredVector<V, S: StorageAdaptor = MainStorage>
@@ -165,11 +165,11 @@ where
         Ok(self.inner.get(index)?.map(ValueRef::into_inner))
     }
 
-    /// Returns the public key of the owner at `index`, if the slot exists.
+    /// Returns the account that owns at `index`, if the slot exists.
     ///
     /// # Errors
     /// Returns any underlying storage error.
-    pub fn owner_of(&self, index: usize) -> Result<Option<PublicKey>, StoreError> {
+    pub fn owner_of(&self, index: usize) -> Result<Option<AccountId>, StoreError> {
         let Some(id) = self.inner.entry_id_at(index)? else {
             return Ok(None);
         };
@@ -239,7 +239,7 @@ where
         self.inner.entry_id_at(index)
     }
 
-    fn require_owner(&self, index: usize) -> Result<(crate::address::Id, PublicKey), StoreError> {
+    fn require_owner(&self, index: usize) -> Result<(crate::address::Id, AccountId), StoreError> {
         // Out-of-bounds is surfaced as `InvalidData` rather than `ActionNotAllowed`:
         // the latter is reserved for authorization failures on valid addresses, and
         // `NotFound` takes an `Id` that we do not have for an unmapped index.
@@ -338,7 +338,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use calimero_primitives::identity::PublicKey;
+    use calimero_account::AccountId;
     use serial_test::serial;
 
     use super::AuthoredVector;
@@ -365,15 +365,16 @@ mod tests {
         );
     }
 
-    fn pk(bytes: [u8; 32]) -> PublicKey {
-        bytes.into()
+    /// The tests name the OWNER, and an owner is an account.
+    fn acct(bytes: [u8; 32]) -> AccountId {
+        AccountId::from(bytes)
     }
 
     #[test]
     #[serial]
     fn entry_schema_version_and_ownership_reflect_stored_metadata() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut v = Root::new(AuthoredVector::<u64>::new);
         v.push(7).expect("push");
@@ -386,11 +387,11 @@ mod tests {
         assert!(v.owned_by_me(0).unwrap());
 
         // A different executor is not the owner.
-        env::set_device_id(BOB);
+        env::set_account_id(BOB);
         assert!(!v.owned_by_me(0).unwrap());
 
         // Out-of-bounds slot: no version, not owned.
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
         assert_eq!(v.entry_schema_version(99).unwrap(), None);
         assert!(!v.owned_by_me(99).unwrap());
     }
@@ -399,13 +400,13 @@ mod tests {
     #[serial]
     fn push_stamps_current_executor_as_owner() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut v = Root::new(AuthoredVector::<u64>::new);
         let idx = v.push(7).expect("push");
         assert_eq!(idx, 0);
         assert_eq!(v.get(0).unwrap(), Some(7));
-        assert_eq!(v.owner_of(0).unwrap(), Some(pk(ALICE)));
+        assert_eq!(v.owner_of(0).unwrap(), Some(acct(ALICE)));
         assert_eq!(v.len().unwrap(), 1);
     }
 
@@ -416,53 +417,53 @@ mod tests {
 
         let mut v = Root::new(AuthoredVector::<u64>::new);
 
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
         let a = v.push(1).unwrap();
-        env::set_device_id(BOB);
+        env::set_account_id(BOB);
         let b = v.push(2).unwrap();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
         let c = v.push(3).unwrap();
 
         assert_eq!((a, b, c), (0, 1, 2));
-        assert_eq!(v.owner_of(0).unwrap(), Some(pk(ALICE)));
-        assert_eq!(v.owner_of(1).unwrap(), Some(pk(BOB)));
-        assert_eq!(v.owner_of(2).unwrap(), Some(pk(ALICE)));
+        assert_eq!(v.owner_of(0).unwrap(), Some(acct(ALICE)));
+        assert_eq!(v.owner_of(1).unwrap(), Some(acct(BOB)));
+        assert_eq!(v.owner_of(2).unwrap(), Some(acct(ALICE)));
     }
 
     #[test]
     #[serial]
     fn update_by_owner_succeeds() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut v = Root::new(AuthoredVector::<u64>::new);
         v.push(7).unwrap();
         v.update(0, 42).expect("owner update");
         assert_eq!(v.get(0).unwrap(), Some(42));
-        assert_eq!(v.owner_of(0).unwrap(), Some(pk(ALICE)));
+        assert_eq!(v.owner_of(0).unwrap(), Some(acct(ALICE)));
     }
 
     #[test]
     #[serial]
     fn update_by_non_owner_rejected() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut v = Root::new(AuthoredVector::<u64>::new);
         v.push(7).unwrap();
 
-        env::set_device_id(BOB);
+        env::set_account_id(BOB);
         let err = v.update(0, 99).expect_err("non-owner update must fail");
         assert!(err.to_string().to_lowercase().contains("owner"));
         assert_eq!(v.get(0).unwrap(), Some(7));
-        assert_eq!(v.owner_of(0).unwrap(), Some(pk(ALICE)));
+        assert_eq!(v.owner_of(0).unwrap(), Some(acct(ALICE)));
     }
 
     #[test]
     #[serial]
     fn update_out_of_bounds_errors() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut v = Root::new(AuthoredVector::<u64>::new);
         let err = v.update(5, 1).expect_err("out-of-bounds update must fail");
@@ -473,7 +474,7 @@ mod tests {
     #[serial]
     fn tombstone_by_owner_writes_default() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut v = Root::new(AuthoredVector::<u64>::new);
         v.push(7).unwrap();
@@ -482,19 +483,19 @@ mod tests {
         assert_eq!(v.get(0).unwrap(), Some(0));
         // Position and owner are preserved.
         assert_eq!(v.len().unwrap(), 1);
-        assert_eq!(v.owner_of(0).unwrap(), Some(pk(ALICE)));
+        assert_eq!(v.owner_of(0).unwrap(), Some(acct(ALICE)));
     }
 
     #[test]
     #[serial]
     fn tombstone_by_non_owner_rejected() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut v = Root::new(AuthoredVector::<u64>::new);
         v.push(7).unwrap();
 
-        env::set_device_id(BOB);
+        env::set_account_id(BOB);
         let err = v.tombstone(0).expect_err("non-owner tombstone must fail");
         assert!(err.to_string().to_lowercase().contains("owner"));
         assert_eq!(v.get(0).unwrap(), Some(7));
@@ -504,12 +505,12 @@ mod tests {
     #[serial]
     fn iter_yields_all_values_in_insertion_order() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let mut v = Root::new(AuthoredVector::<u64>::new);
         v.push(10).unwrap();
         v.push(20).unwrap();
-        env::set_device_id(BOB);
+        env::set_account_id(BOB);
         v.push(30).unwrap();
 
         let items: Vec<u64> = v.iter().unwrap().collect();
@@ -520,7 +521,7 @@ mod tests {
     #[serial]
     fn owner_of_out_of_bounds_is_none() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
 
         let v = Root::new(AuthoredVector::<u64>::new);
         assert_eq!(v.owner_of(0).unwrap(), None);

--- a/crates/storage/src/collections/user.rs
+++ b/crates/storage/src/collections/user.rs
@@ -1,7 +1,12 @@
 //! User-centric storage wrapper.
 //!
-//! Provides an `UnorderedMap<PublicKey, T>` where the current user can
-//! only `insert` into their own key-slot (`env::device_id()`).
+//! Provides an `UnorderedMap<AccountId, T>` where the current user can only
+//! `insert` into their own slot (`env::account_id()`).
+//!
+//! Keyed by ACCOUNT, so "this user's data" means the person's, not the machine's:
+//! their phone and their laptop reach one slot instead of each holding a copy the
+//! other cannot see. Which device performed a given write is still recorded, on
+//! the entry's `signature_data.signer`.
 
 use super::crdt_meta::{CrdtMeta, CrdtType, Mergeable, StorageStrategy};
 use super::{StoreError, UnorderedMap, ValueRef};
@@ -9,19 +14,17 @@ use crate::entities::{ChildInfo, Data, Element, StorageType};
 use crate::env;
 use crate::store::{MainStorage, StorageAdaptor};
 use borsh::{BorshDeserialize, BorshSerialize};
-// TODO: possibly replace with the prelude's lighter implementation of `PublicKey` to not utilize
-// the whole `calimero_primitives` dependency.
-use calimero_primitives::identity::PublicKey;
+use calimero_account::AccountId;
 use std::collections::BTreeMap;
 
-/// A wrapper for user-owned storage, mapping PublicKeys to data.
+/// A wrapper for user-owned storage, mapping accounts to data.
 ///
-/// Under the hood, this is an `UnorderedMap<PublicKey, T>`.
+/// Under the hood, this is an `UnorderedMap<AccountId, T>`.
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct UserStorage<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor = MainStorage> {
     /// The underlying map storing user data.
     #[borsh(bound(serialize = "", deserialize = ""))]
-    inner: UnorderedMap<PublicKey, T, S>,
+    inner: UnorderedMap<AccountId, T, S>,
     /// The storage element for this UserStorage instance itself.
     storage: Element,
 }
@@ -109,12 +112,16 @@ where
     where
         T: 'static,
     {
-        let executor_public_key: PublicKey = env::device_id().into();
+        // One account, one slot — and the same account stamped as the owner that
+        // gates it. Slot and stamp have to agree: keying the slot by device while
+        // gating by account would hand each of a person's machines its own entry
+        // that all of them may edit.
+        let owner = AccountId::from(env::account_id());
 
         // Construct the StorageType. It will be signed later, on the upper levels by
         // `ContextManager`.
         let storage_type = StorageType::User {
-            owner: executor_public_key,
+            owner,
             signature_data: None,
             //signature_data: Some(crate::entities::SignatureData {
             //    nonce: 0,
@@ -124,7 +131,7 @@ where
 
         // Call the new method on UnorderedMap
         self.inner
-            .insert_with_storage_type(executor_public_key, value, storage_type, None)
+            .insert_with_storage_type(owner, value, storage_type, None)
     }
 }
 
@@ -133,11 +140,11 @@ where
     T: BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    /// Returns an iterator over all `(PublicKey, value)` entries.
+    /// Returns an iterator over all `(AccountId, value)` entries.
     ///
     /// # Errors
     /// Returns a `StoreError` if the storage operation fails.
-    pub fn entries(&self) -> Result<impl Iterator<Item = (PublicKey, T)> + '_, StoreError> {
+    pub fn entries(&self) -> Result<impl Iterator<Item = (AccountId, T)> + '_, StoreError> {
         self.inner.entries()
     }
 
@@ -146,18 +153,15 @@ where
     /// # Errors
     /// Returns a `StoreError` if the storage operation fails.
     pub fn get(&self) -> Result<Option<T>, StoreError> {
-        let executor_public_key: PublicKey = env::device_id().into();
-        Ok(self
-            .inner
-            .get(&executor_public_key)?
-            .map(ValueRef::into_inner))
+        let executor_account = AccountId::from(env::account_id());
+        Ok(self.inner.get(&executor_account)?.map(ValueRef::into_inner))
     }
 
-    /// Gets the data for a *specific* user's PublicKey.
+    /// Gets the data for a *specific* user's account.
     ///
     /// # Errors
     /// Returns a `StoreError` if the storage operation fails.
-    pub fn get_for_user(&self, user_key: &PublicKey) -> Result<Option<T>, StoreError> {
+    pub fn get_for_user(&self, user_key: &AccountId) -> Result<Option<T>, StoreError> {
         Ok(self.inner.get(user_key)?.map(ValueRef::into_inner))
     }
 
@@ -166,15 +170,15 @@ where
     /// # Errors
     /// Returns a `StoreError` if the storage operation fails.
     pub fn contains_current_user(&self) -> Result<bool, StoreError> {
-        let executor_public_key: PublicKey = env::device_id().into();
-        self.inner.contains(&executor_public_key)
+        let executor_account = AccountId::from(env::account_id());
+        self.inner.contains(&executor_account)
     }
 
     /// Checks if data exists for a specific user.
     ///
     /// # Errors
     /// Returns a `StoreError` if the storage operation fails.
-    pub fn contains_user(&self, user_key: &PublicKey) -> Result<bool, StoreError> {
+    pub fn contains_user(&self, user_key: &AccountId) -> Result<bool, StoreError> {
         self.inner.contains(user_key)
     }
 
@@ -183,8 +187,8 @@ where
     /// # Errors
     /// Returns a `StoreError` if the storage operation fails.
     pub fn remove(&mut self) -> Result<Option<T>, StoreError> {
-        let executor_public_key: PublicKey = env::device_id().into();
-        self.inner.remove(&executor_public_key)
+        let executor_account = AccountId::from(env::account_id());
+        self.inner.remove(&executor_account)
     }
 }
 

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -354,7 +354,10 @@ impl Element {
     }
 
     /// Helper to set the storage domain to `User`.
-    pub fn set_user_domain(&mut self, owner: PublicKey) {
+    ///
+    /// `owner` is the ACCOUNT that may later change this entry, not the device
+    /// writing it now — see [`StorageType::User`].
+    pub fn set_user_domain(&mut self, owner: AccountId) {
         self.metadata.storage_type = StorageType::User {
             owner,
             signature_data: None, // Will be signed later
@@ -439,11 +442,15 @@ pub struct SignatureData {
     /// Nonce (counter/timestamp) to avoid replaying attacks.
     pub nonce: u64,
     /// Which key produced the signature. `Option` for wire compatibility
-    /// only — a signed `Shared`/`SharedMember` write that names nobody is
-    /// rejected as `InvalidSignature`, because resolving the author is what
-    /// makes "is this principal a writer?" a separate question from "does
-    /// this signature verify?". Ignored for `User`, where the owner is
-    /// already known.
+    /// only — a signed `Shared`/`SharedMember`/`User` write that names nobody
+    /// is rejected as `InvalidSignature`, because resolving the author is what
+    /// makes "is this principal authorized?" a separate question from "does
+    /// this signature verify?".
+    ///
+    /// Required for `User` too, now that its `owner` is an account: an account
+    /// is a content hash, so it cannot be the key a signature verifies against.
+    /// This field is that key, and it is also the record of which of the
+    /// owner's devices wrote the entry.
     pub signer: Option<PublicKey>,
 }
 
@@ -595,9 +602,23 @@ pub enum StorageType {
     Public,
     /// Verifiable, user-signed, synchronized storage.
     User {
-        /// The owner of the data where this storage type is applied.
-        owner: PublicKey,
-        /// A signature and nonce for the data. The signature should be done by the `owner`.
+        /// The **account** that owns this entry — the principal the "only the
+        /// author may change it" gate is enforced against.
+        ///
+        /// An account, not a device key, so a person editing from their laptop
+        /// can still change what they wrote from their phone. Authorship is an
+        /// access-control question, and access control names people; the
+        /// per-replica identities that CRDT mechanics need (an LWW tiebreak, a
+        /// counter slot, an HLC seed) stay on [`crate::env::device_id`] and are
+        /// untouched by this — see its doc for why they must.
+        ///
+        /// Which DEVICE wrote the entry is not lost: it is
+        /// [`SignatureData::signer`], the key the signature actually verifies
+        /// against.
+        owner: AccountId,
+        /// A signature and nonce for the data. The signature is produced by one
+        /// of `owner`'s device keys, named in [`SignatureData::signer`] — an
+        /// `AccountId` is a content hash and nothing signs as one.
         signature_data: Option<SignatureData>,
     },
     /// Data that can be set only once, can'be modified or deleted.

--- a/crates/storage/src/env.rs
+++ b/crates/storage/src/env.rs
@@ -467,11 +467,16 @@ pub fn context_id() -> [u8; 32] {
 /// attributes writes to.
 ///
 /// Every use of it in this crate is a per-replica question: an LWW register's
-/// tiebreak `node_id`, a counter's per-actor slot, an HLC instance seed, an
-/// author-tracked entry's owner. None of those may become an account: two devices
-/// of one account acting concurrently must stay distinguishable, or they share a
-/// counter slot and an HLC seed and silently lose each other's writes. Per-person
-/// aggregation belongs above storage, on `account_id()`.
+/// tiebreak `node_id`, a counter's per-actor slot, an HLC instance seed. None of
+/// those may become an account: two devices of one account acting concurrently
+/// must stay distinguishable, or they share a counter slot and an HLC seed and
+/// silently lose each other's writes.
+///
+/// An author-tracked entry's `owner` used to be on this list and is not any more.
+/// It gates who may change the entry, which is a question about a person, so it
+/// reads [`account_id`]; the device that wrote it is recorded separately, as the
+/// signer its signature verifies against. Nothing about per-replica state moved
+/// with it.
 ///
 /// In WASM, this calls the host function. In tests, returns a fixed value.
 #[must_use]

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -690,6 +690,50 @@ impl<S: StorageAdaptor> Interface<S> {
         crate::env::ed25519_verify(&sig_data.signature, signer.digest(), payload)
     }
 
+    /// Verify a [`User`](StorageType::User) action: the signature under the key
+    /// it names, and then that key's account against the stored `owner`.
+    ///
+    /// Two questions, deliberately separate, because `owner` stopped being a key
+    /// the moment it became an account — a content hash verifies nothing. The
+    /// signature is checked against [`SignatureData::signer`], and whether that
+    /// device speaks for `owner` is answered by `signer_account`, which the node
+    /// resolved at this action's causal cut.
+    ///
+    /// `signer_account` is never defaulted to the locally executing account: a
+    /// remote action would otherwise authorize itself. It is the same bridge,
+    /// and the same contract, that the `Shared` writer-set check runs on — see
+    /// [`ApplyContext::signer_account`].
+    ///
+    /// **`None` defers the ownership half; it does not satisfy it.** The sync
+    /// repair paths (HashComparison, snapshot, level-wise) apply through an
+    /// [`ApplyContext::empty`] because they carry no cut to resolve a signer's
+    /// account at, and resolving against whatever this receiver has folded would
+    /// answer a different question than the author did. Refusing there would
+    /// drop every legitimately repaired `User` entity instead; the `Shared` and
+    /// `SharedMember` arms take exactly this deferral, for exactly this reason.
+    ///
+    /// What makes the deferral safe is that it is not the only gate. The node
+    /// resolves a repaired leaf's author against the bindings — which live there
+    /// and not here — before handing it to this crate;
+    /// `calimero-node`'s `is_leaf_currently_authorized` checks that author's
+    /// membership AND, for a `User` leaf, that the author's account is the
+    /// entry's `owner`. Signature authenticity is still enforced here, on every
+    /// path, because that needs no bindings at all.
+    fn user_action_authorized(
+        sig_data: &crate::entities::SignatureData,
+        payload: &[u8],
+        owner: &AccountId,
+        signer_account: Option<&AccountId>,
+    ) -> bool {
+        if !Self::snapshot_signature_verifies(sig_data, payload) {
+            return false;
+        }
+        match signer_account {
+            Some(account) => account == owner,
+            None => true,
+        }
+    }
+
     /// Verify the writer's signature on a snapshot-supplied entity
     /// against the access-control rules in its metadata.
     ///
@@ -859,7 +903,17 @@ impl<S: StorageAdaptor> Interface<S> {
                 if sig_data.signature == [0u8; 64] {
                     return Err(StorageError::InvalidSignature);
                 }
-                if crate::env::ed25519_verify(&sig_data.signature, owner.digest(), &payload) {
+                // Signature only, like the two arms below. `owner` is an account
+                // and an account is a content hash, so it is not a key anything
+                // can verify against — the signature is checked against the
+                // device key the action names, and whether that device speaks
+                // for `owner` is a separate question this path cannot ask. A
+                // snapshot leaf carries no cut to resolve the signer's account
+                // at, and resolving it against whatever this receiver has folded
+                // would ask a different question than the author answered.
+                // Authorship is re-established the moment a delta writes it.
+                let _ = owner;
+                if Self::snapshot_signature_verifies(sig_data, &payload) {
                     Ok(())
                 } else {
                     Err(StorageError::InvalidSignature)
@@ -1533,10 +1587,11 @@ impl<S: StorageAdaptor> Interface<S> {
                         // unauthenticated stale action should still
                         // reject as `InvalidSignature`, not silently
                         // disappear.
-                        let verification_result = crate::env::ed25519_verify(
-                            &sig_data.signature,
-                            owner.digest(),
+                        let verification_result = Self::user_action_authorized(
+                            sig_data,
                             &payload,
+                            owner,
+                            ctx.signer_account.as_ref(),
                         );
 
                         if !verification_result {
@@ -2009,10 +2064,11 @@ impl<S: StorageAdaptor> Interface<S> {
                                 // tie. Using `<` here unifies the tiebreak
                                 // across all storage types.
                                 let payload = action.payload_for_signing();
-                                let verification_result = crate::env::ed25519_verify(
-                                    &sig_data.signature,
-                                    owner.digest(),
+                                let verification_result = Self::user_action_authorized(
+                                    sig_data,
                                     &payload,
+                                    owner,
+                                    ctx.signer_account.as_ref(),
                                 );
                                 if !verification_result {
                                     return Err(Self::reject_action_signature(
@@ -2030,7 +2086,7 @@ impl<S: StorageAdaptor> Interface<S> {
                                 let last_nonce = *existing_metadata.updated_at;
                                 if new_nonce < last_nonce {
                                     return Err(StorageError::NonceReplay(Box::new((
-                                        *owner.as_ref(),
+                                        *owner.as_bytes(),
                                         new_nonce,
                                     ))));
                                 }
@@ -2916,14 +2972,18 @@ impl<S: StorageAdaptor> Interface<S> {
 
         // If this is a local user action, set the nonce
         if let StorageType::User { owner, .. } = metadata.storage_type {
-            if *owner == crate::env::device_id() {
+            if owner == AccountId::from(crate::env::account_id()) {
                 // Use the deletion timestamp as the nonce
                 metadata.storage_type = StorageType::User {
                     owner,
                     signature_data: Some(SignatureData {
                         signature: [0; 64], // Placeholder, added by signer
                         nonce: deleted_at,
-                        signer: None, // owner is already known for User
+                        // The DEVICE writing on the owner's behalf. Required
+                        // now that `owner` is an account: an account is a
+                        // content hash, so it is not what the signature
+                        // verifies against.
+                        signer: Some(crate::env::device_id().into()),
                     }),
                 };
             }
@@ -3880,14 +3940,16 @@ impl<S: StorageAdaptor> Interface<S> {
         // `apply_action`), so unconditionally stamping here is safe:
         // it only fires when the executor is the owner.
         if let StorageType::User { owner, .. } = metadata.storage_type {
-            if *owner == crate::env::device_id() {
+            if owner == AccountId::from(crate::env::account_id()) {
                 let nonce = *metadata.updated_at;
                 metadata.storage_type = StorageType::User {
                     owner,
                     signature_data: Some(SignatureData {
                         signature: [0; 64], // Placeholder, added by signer
                         nonce,
-                        signer: None, // owner is already known for User
+                        // The DEVICE writing on the owner's behalf — see the
+                        // matching stamp on the delete path.
+                        signer: Some(crate::env::device_id().into()),
                     }),
                 };
                 // Owner-driven convert (PR-6c): the owner's own write re-stamps

--- a/crates/storage/src/js.rs
+++ b/crates/storage/src/js.rs
@@ -18,7 +18,6 @@ use crate::collections::{
 use crate::entities::{Element, Metadata};
 use crate::store::MainStorage;
 use crate::{address::Id, Interface, StorageError};
-use calimero_primitives::identity::PublicKey;
 
 use calimero_account::AccountId;
 /// Macro support for deriving storage traits on the wrapper types.
@@ -609,7 +608,7 @@ impl Default for JsCounter {
 
 /// A byte-oriented user storage wrapper that integrates with Calimero storage.
 ///
-/// The storage maps PublicKeys (32 bytes) to raw byte arrays (`Vec<u8>`).
+/// The storage maps accounts (32 bytes) to raw byte arrays (`Vec<u8>`).
 /// This enables JavaScript runtimes to use UserStorage with proper StorageType::User
 /// metadata for security checks.
 #[derive(Debug, AtomicUnit, BorshSerialize, BorshDeserialize)]
@@ -681,14 +680,16 @@ impl JsUserStorage {
         self.user_storage.get()
     }
 
-    /// Retrieves the value for a specific user's PublicKey, if present.
+    /// Retrieves the value for a specific user's account, if present.
+    ///
+    /// `user_key` is an `AccountId`'s bytes — the person, not one of their
+    /// devices.
     ///
     /// # Errors
     ///
     /// Propagates [`StoreError`] when the underlying storage read fails.
     pub fn get_for_user(&self, user_key: &[u8; 32]) -> Result<Option<Vec<u8>>, StoreError> {
-        let public_key: PublicKey = (*user_key).into();
-        self.user_storage.get_for_user(&public_key)
+        self.user_storage.get_for_user(&AccountId::from(*user_key))
     }
 
     /// Checks whether data exists for the current executor.
@@ -706,8 +707,7 @@ impl JsUserStorage {
     ///
     /// Propagates [`StoreError`] if the existence check fails.
     pub fn contains_user(&self, user_key: &[u8; 32]) -> Result<bool, StoreError> {
-        let public_key: PublicKey = (*user_key).into();
-        self.user_storage.contains_user(&public_key)
+        self.user_storage.contains_user(&AccountId::from(*user_key))
     }
 
     /// Returns all user/value pairs currently stored.
@@ -715,7 +715,7 @@ impl JsUserStorage {
     /// # Errors
     ///
     /// Propagates [`StoreError`] if reading from storage fails.
-    pub fn entries(&self) -> Result<Vec<(PublicKey, Vec<u8>)>, StoreError> {
+    pub fn entries(&self) -> Result<Vec<(AccountId, Vec<u8>)>, StoreError> {
         let iter = self.user_storage.entries()?;
         Ok(iter.collect())
     }
@@ -738,7 +738,7 @@ impl JsUserStorage {
         let iter = self.entries()?;
         Ok(iter
             .into_iter()
-            .map(|(public_key, value)| (*public_key.as_ref(), value))
+            .map(|(account, value)| (*account.as_bytes(), value))
             .collect())
     }
 
@@ -1459,7 +1459,10 @@ impl JsAuthoredMap {
     ///
     /// Propagates [`StoreError`] if reading entry metadata fails.
     pub fn owner_of(&self, key: &[u8]) -> Result<Option<[u8; 32]>, StoreError> {
-        Ok(self.map.owner_of(&key.to_vec())?.map(|pk| *pk.as_ref()))
+        Ok(self
+            .map
+            .owner_of(&key.to_vec())?
+            .map(|account| *account.as_bytes()))
     }
 
     /// Returns whether the current executor owns `key`. False for absent keys.
@@ -1614,7 +1617,10 @@ impl JsAuthoredVector {
     ///
     /// Propagates [`StoreError`] if reading slot metadata fails.
     pub fn owner_of(&self, index: usize) -> Result<Option<[u8; 32]>, StoreError> {
-        Ok(self.vector.owner_of(index)?.map(|pk| *pk.as_ref()))
+        Ok(self
+            .vector
+            .owner_of(index)?
+            .map(|account| *account.as_bytes()))
     }
 
     /// Returns whether the current executor owns the slot at `index`. False for
@@ -1882,7 +1888,7 @@ mod roundtrip_tests {
     #[serial]
     fn js_vector_value_roundtrips_byte_identically() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
         ensure_root_index();
 
         let mut v = JsVector::new();
@@ -1902,7 +1908,7 @@ mod roundtrip_tests {
     #[serial]
     fn js_authored_vector_iter_roundtrips_byte_identically() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
         ensure_root_index();
 
         let mut v = JsAuthoredVector::new();
@@ -1938,7 +1944,7 @@ mod roundtrip_tests {
     #[serial]
     fn js_authored_map_value_roundtrips_byte_identically() {
         env::reset_for_testing();
-        env::set_device_id(ALICE);
+        env::set_account_id(ALICE);
         ensure_root_index();
 
         let key = b"post-1";

--- a/crates/storage/src/tests/authored_primitives.rs
+++ b/crates/storage/src/tests/authored_primitives.rs
@@ -7,7 +7,6 @@
 //! tampered writes — the central security guarantee of these primitives.
 
 use borsh::to_vec;
-use calimero_primitives::identity::PublicKey;
 use ed25519_dalek::SigningKey;
 use serial_test::serial;
 
@@ -18,7 +17,8 @@ use crate::env;
 use crate::error::StorageError;
 use crate::interface::{ApplyContext, Interface};
 use crate::store::MainStorage;
-use crate::tests::common::{create_test_keypair, sign_action};
+use crate::tests::common::{create_test_keypair, create_test_owner, sign_action};
+use calimero_account::AccountId;
 
 type MainInterface = Interface<MainStorage>;
 
@@ -39,7 +39,7 @@ const FORGED_NONCE_OFFSET_NS: u64 = 1_000_000_000;
 fn build_signed_update_for(
     id: crate::address::Id,
     data: Vec<u8>,
-    claimed_owner: PublicKey,
+    claimed_owner: AccountId,
     signing_key: &SigningKey,
     nonce: u64,
 ) -> Action {
@@ -92,7 +92,7 @@ fn build_signed_update_for(
 /// stored owner, then checks the signature against `claimed_owner`.
 fn build_signed_delete_for(
     id: crate::address::Id,
-    claimed_owner: PublicKey,
+    claimed_owner: AccountId,
     signing_key: &SigningKey,
     deleted_at: u64,
 ) -> Action {
@@ -145,11 +145,11 @@ fn build_signed_delete_for(
 fn authored_map_update_with_forged_owner_claim_is_rejected() {
     env::reset_for_testing();
 
-    let (alice_sk, alice_pk) = create_test_keypair();
+    let (alice_sk, alice_account) = create_test_owner();
     let (bob_sk, _bob_pk) = create_test_keypair();
 
     // Alice inserts the entry (stamped owner = Alice).
-    env::set_device_id(*alice_pk.digest());
+    env::set_account_id(*alice_account.as_bytes());
     let mut map = Root::new(AuthoredMap::<String, u64>::new);
     map.insert("apple".to_owned(), 1).expect("alice insert");
 
@@ -157,11 +157,11 @@ fn authored_map_update_with_forged_owner_claim_is_rejected() {
 
     // Bob forges an Update claiming to be Alice. He has to sign with Alice's
     // identity as declared in metadata — but he doesn't hold Alice's key, so
-    // he signs with his own. The signature verification against alice_pk fails.
+    // he signs with his own. The signature verification against Alice's key fails.
     let forged = build_signed_update_for(
         entry_id,
         to_vec(&("apple".to_owned(), 99u64)).unwrap(),
-        alice_pk,
+        alice_account,
         &bob_sk,
         env::time_now().saturating_add(FORGED_NONCE_OFFSET_NS),
     );
@@ -183,10 +183,10 @@ fn authored_map_update_with_forged_owner_claim_is_rejected() {
 fn authored_map_delete_by_non_owner_is_rejected() {
     env::reset_for_testing();
 
-    let (_alice_sk, alice_pk) = create_test_keypair();
-    let (bob_sk, bob_pk) = create_test_keypair();
+    let (_alice_sk, alice_account) = create_test_owner();
+    let (bob_sk, bob_account) = create_test_owner();
 
-    env::set_device_id(*alice_pk.digest());
+    env::set_account_id(*alice_account.as_bytes());
     let mut map = Root::new(AuthoredMap::<String, u64>::new);
     map.insert("apple".to_owned(), 1).expect("alice insert");
 
@@ -197,7 +197,7 @@ fn authored_map_delete_by_non_owner_is_rejected() {
     // path rejects before even trying the signature check.
     let forged = build_signed_delete_for(
         entry_id,
-        bob_pk,
+        bob_account,
         &bob_sk,
         env::time_now().saturating_add(FORGED_NONCE_OFFSET_NS),
     );
@@ -214,10 +214,10 @@ fn authored_map_delete_by_non_owner_is_rejected() {
 fn authored_vector_update_with_forged_owner_claim_is_rejected() {
     env::reset_for_testing();
 
-    let (_alice_sk, alice_pk) = create_test_keypair();
+    let (_alice_sk, alice_account) = create_test_owner();
     let (bob_sk, _bob_pk) = create_test_keypair();
 
-    env::set_device_id(*alice_pk.digest());
+    env::set_account_id(*alice_account.as_bytes());
     let mut v = Root::new(AuthoredVector::<u64>::new);
     v.push(7).expect("alice push");
 
@@ -229,7 +229,7 @@ fn authored_vector_update_with_forged_owner_claim_is_rejected() {
     let forged = build_signed_update_for(
         entry_id,
         to_vec(&99u64).unwrap(),
-        alice_pk,
+        alice_account,
         &bob_sk,
         env::time_now().saturating_add(FORGED_NONCE_OFFSET_NS),
     );
@@ -246,10 +246,10 @@ fn authored_vector_update_with_forged_owner_claim_is_rejected() {
 fn authored_vector_delete_by_non_owner_is_rejected() {
     env::reset_for_testing();
 
-    let (_alice_sk, alice_pk) = create_test_keypair();
-    let (bob_sk, bob_pk) = create_test_keypair();
+    let (_alice_sk, alice_account) = create_test_owner();
+    let (bob_sk, bob_account) = create_test_owner();
 
-    env::set_device_id(*alice_pk.digest());
+    env::set_account_id(*alice_account.as_bytes());
     let mut v = Root::new(AuthoredVector::<u64>::new);
     v.push(7).expect("alice push");
 
@@ -260,7 +260,7 @@ fn authored_vector_delete_by_non_owner_is_rejected() {
 
     let forged = build_signed_delete_for(
         entry_id,
-        bob_pk,
+        bob_account,
         &bob_sk,
         env::time_now().saturating_add(FORGED_NONCE_OFFSET_NS),
     );

--- a/crates/storage/src/tests/common.rs
+++ b/crates/storage/src/tests/common.rs
@@ -283,6 +283,18 @@ pub fn create_test_keypair() -> (SigningKey, PublicKey) {
     (signing_key, public_key)
 }
 
+/// A signing key and the ACCOUNT it speaks for — the pair a `User` entry needs.
+///
+/// The account comes from [`account_of_key`], which hashes in its own domain, so
+/// it is never equal to the key's own bytes. That inequality is the point: a test
+/// that used the key as both signer and owner would pass whether the gate is
+/// keyed by account or by device, and so could not tell the two apart.
+pub fn create_test_owner() -> (SigningKey, AccountId) {
+    let (signing_key, _) = create_test_keypair();
+    let account = account_of_key(&signing_key);
+    (signing_key, account)
+}
+
 /// Helper to sign an action with the given signing key.
 pub fn sign_action(action: &Action, signing_key: &SigningKey) -> [u8; 64] {
     let payload = action.payload_for_signing();
@@ -293,7 +305,7 @@ pub fn sign_action(action: &Action, signing_key: &SigningKey) -> [u8; 64] {
 /// Helper to create a User storage action (Add) with proper signature.
 pub fn create_signed_user_add_action(
     signing_key: &SigningKey,
-    owner: PublicKey,
+    owner: AccountId,
     id: Id,
     data: Vec<u8>,
     nonce: u64,
@@ -309,7 +321,9 @@ pub fn create_signed_user_add_action(
             signature_data: Some(SignatureData {
                 signature: [0; 64], // Placeholder
                 nonce,
-                signer: None,
+                // The key the signature verifies against. `owner` is an account
+                // now, so this is no longer optional.
+                signer: Some(pubkey_of(signing_key)),
             }),
         },
         crdt_type: None,
@@ -340,7 +354,9 @@ pub fn create_signed_user_add_action(
             *signature_data = Some(SignatureData {
                 signature,
                 nonce,
-                signer: None,
+                // Must match what the payload was hashed over — the stamp above
+                // named this key, so re-stating it here keeps the two in step.
+                signer: Some(pubkey_of(signing_key)),
             });
         }
     }
@@ -609,7 +625,7 @@ pub fn build_signed_member_delete(
 /// Helper to create a User storage Update action with proper signature.
 pub fn create_signed_user_update_action(
     signing_key: &SigningKey,
-    owner: PublicKey,
+    owner: AccountId,
     id: Id,
     data: Vec<u8>,
     nonce: u64,
@@ -625,7 +641,7 @@ pub fn create_signed_user_update_action(
             signature_data: Some(SignatureData {
                 signature: [0; 64],
                 nonce,
-                signer: None,
+                signer: Some(pubkey_of(signing_key)),
             }),
         },
         crdt_type: None,
@@ -654,7 +670,9 @@ pub fn create_signed_user_update_action(
             *signature_data = Some(SignatureData {
                 signature,
                 nonce,
-                signer: None,
+                // Must match what the payload was hashed over — the stamp above
+                // named this key, so re-stating it here keeps the two in step.
+                signer: Some(pubkey_of(signing_key)),
             });
         }
     }

--- a/crates/storage/src/tests/entities.rs
+++ b/crates/storage/src/tests/entities.rs
@@ -7,6 +7,7 @@ use velcro::btree_map;
 use super::*;
 use crate::interface::MainInterface;
 use crate::tests::common::{Page, Paragraph, Paragraphs, Person};
+use calimero_account::AccountId;
 
 #[cfg(test)]
 mod collection__public_methods {
@@ -418,17 +419,12 @@ mod metadata__needs_owner_convert {
     use super::*;
     use crate::entities::needs_owner_convert;
 
-    /// A `PublicKey` for an entry owner / shared writer in the predicate tests.
-    fn key(byte: u8) -> PublicKey {
-        PublicKey::from([byte; 32])
-    }
-
     /// `Metadata` stamped `User { owner }` with the given `schema_version`
     /// (`None` ⇒ legacy/unmarked, treated as v0).
     fn user_meta(schema: Option<u32>) -> Metadata {
         let mut m = Metadata::new(1, 1);
         m.storage_type = StorageType::User {
-            owner: key(0xAA),
+            owner: AccountId::from([0xAA; 32]),
             signature_data: None,
         };
         m.schema_version = schema;

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -1250,8 +1250,8 @@ mod hashing {
 /// modifying either copy, update the other to keep them in sync.
 mod minimal_struct_layout_compat {
     use borsh::BorshDeserialize;
+    use calimero_account::AccountId;
     use calimero_primitives::crdt::CrdtType;
-    use calimero_primitives::identity::PublicKey;
 
     use crate::address::Id;
     use crate::entities::{ChildInfo, Metadata, SignatureData, StorageType};
@@ -1423,7 +1423,7 @@ mod minimal_struct_layout_compat {
 
     #[test]
     fn round_trip_user_storage_with_signature() {
-        let owner: PublicKey = [0xDD_u8; 32].into();
+        let owner = AccountId::from([0xDD_u8; 32]);
         let sig_data = SignatureData {
             signature: [0xEE; 64],
             nonce: 42,
@@ -1714,11 +1714,11 @@ mod verify_snapshot_entity_signature_tests {
             "signed-but-unnamed-signer"
         );
 
-        // ...but NOT for `User`, which verifies against `owner` and ignores the
-        // hint. Reporting a finding here would be the mislabel that matters.
+        // ...and for `User` too, now that its `owner` is an account and the
+        // signature verifies against the named signer like every other arm.
         assert_eq!(
             signature_shape(&StorageType::User {
-                owner: signer,
+                owner: AccountId::from([0xA1; 32]),
                 signature_data: sig(real, None),
             }),
             "signed"
@@ -1808,7 +1808,6 @@ mod update_signature_in_place_tests {
     use std::collections::BTreeSet;
 
     use calimero_account::AccountId;
-    use calimero_primitives::identity::PublicKey;
 
     use crate::address::Id;
     use crate::entities::{ChildInfo, Metadata, SignatureData, StorageType};
@@ -1836,7 +1835,7 @@ mod update_signature_in_place_tests {
         }
     }
 
-    fn user_signed(owner: PublicKey, sig: [u8; 64]) -> StorageType {
+    fn user_signed(owner: AccountId, sig: [u8; 64]) -> StorageType {
         StorageType::User {
             owner,
             signature_data: Some(SignatureData {
@@ -1892,7 +1891,7 @@ mod update_signature_in_place_tests {
     fn rejects_placeholder_signature_user() {
         // Same guard, User variant.
         let id = Id::new([0x22; 32]);
-        let owner = PublicKey::from([0xBB; 32]);
+        let owner = AccountId::from([0xBB; 32]);
         let result = <Interface<MockedStorage<3010>>>::update_signature_in_place(
             id,
             user_signed(owner, [0u8; 64]),
@@ -1949,7 +1948,7 @@ mod update_signature_in_place_tests {
         // place — which is what `persist_signed_signatures` now relies on for
         // DeleteRef actions.
         type S = MockedStorage<3013>;
-        let owner = PublicKey::from([0xCD; 32]);
+        let owner = AccountId::from([0xCD; 32]);
         let id = Id::new([0x25; 32]);
 
         // Seed a User-owned entity in the index, then tombstone it. It starts

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -11,7 +11,7 @@ use crate::constants::DRIFT_TOLERANCE_NANOS;
 use crate::entities::{Data, Element, SignatureData, StorageType};
 use crate::env::time_now;
 use crate::store::MockedStorage;
-use crate::tests::common::{Page, Paragraph};
+use crate::tests::common::{create_test_owner, Page, Paragraph};
 
 const ONE_SEC_NANOS: u64 = 1_000_000_000;
 
@@ -607,14 +607,15 @@ mod user_storage_signature_verification {
     use super::*;
     use crate::env;
     use crate::tests::common::{
-        create_signed_user_add_action, create_signed_user_update_action, create_test_keypair,
+        account_of_key, apply_ctx_for, create_signed_user_add_action,
+        create_signed_user_update_action, create_test_keypair,
     };
 
     #[test]
     fn user_action_with_valid_signature_succeeds() {
         env::reset_for_testing();
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
 
         // Create user-owned page
         let mut element = Element::root();
@@ -639,7 +640,7 @@ mod user_storage_signature_verification {
     fn user_action_with_invalid_signature_fails() {
         env::reset_for_testing();
 
-        let (_, owner) = create_test_keypair();
+        let (_, owner) = create_test_owner();
         let (wrong_signing_key, _) = create_test_keypair(); // Different key
 
         let mut element = Element::root();
@@ -649,12 +650,17 @@ mod user_storage_signature_verification {
 
         let nonce = env::time_now();
 
-        // Sign with WRONG key
+        // Signed by a key that is genuinely valid — just not one of the owner's.
+        // With `owner` an account, "wrong signer" is no longer a signature
+        // failure: the signature verifies fine under the key it names. What
+        // rejects it is that the key resolves to a DIFFERENT account, which only
+        // a resolved context can say. An empty context defers to the node-side
+        // gate instead; see `Interface::user_action_authorized`.
         let action =
             create_signed_user_add_action(&wrong_signing_key, owner, page.id(), serialized, nonce);
 
-        // Invalid signature should fail
-        let result = MainInterface::apply_action(action, &ApplyContext::empty());
+        let result =
+            MainInterface::apply_action(action, &apply_ctx_for(account_of_key(&wrong_signing_key)));
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidSignature) => {}
@@ -666,7 +672,7 @@ mod user_storage_signature_verification {
     fn user_action_without_signature_fails() {
         env::reset_for_testing();
 
-        let (_, owner) = create_test_keypair();
+        let (_, owner) = create_test_owner();
 
         let mut element = Element::root();
         element.set_user_domain(owner);
@@ -711,7 +717,7 @@ mod user_storage_signature_verification {
     fn user_action_with_corrupted_signature_fails() {
         env::reset_for_testing();
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
 
         let mut element = Element::root();
         element.set_user_domain(owner);
@@ -751,7 +757,7 @@ mod user_storage_signature_verification {
         crate::tests::common::register_test_merge_functions();
         env::reset_for_testing();
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
 
         // First, create the entity
         let mut element = Element::root();
@@ -802,7 +808,8 @@ mod user_storage_replay_protection {
     use super::*;
     use crate::env;
     use crate::tests::common::{
-        create_signed_user_add_action, create_signed_user_update_action, create_test_keypair,
+        account_of_key, apply_ctx_for, create_signed_user_add_action,
+        create_signed_user_update_action, create_test_keypair,
     };
 
     #[test]
@@ -837,7 +844,7 @@ mod user_storage_replay_protection {
         // exercise the right code path.
         env::reset_for_testing();
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
 
         let mut element = Element::root();
         element.set_user_domain(owner);
@@ -856,7 +863,7 @@ mod user_storage_replay_protection {
                 signature_data: Some(SignatureData {
                     signature: [0u8; 64], // placeholder, set below
                     nonce: hlc,
-                    signer: None,
+                    signer: Some(crate::tests::common::pubkey_of(&signing_key)),
                 }),
             },
             crdt_type: None,
@@ -929,7 +936,7 @@ mod user_storage_replay_protection {
         // `equal_nonce_delete_wins_like_public` (equal-HLC).
         env::reset_for_testing();
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
 
         let mut element = Element::root();
         element.set_user_domain(owner);
@@ -976,7 +983,7 @@ mod user_storage_replay_protection {
         // silently accept unauthenticated stale traffic.
         env::reset_for_testing();
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
         let (wrong_signing_key, _) = create_test_keypair();
 
         let mut element = Element::root();
@@ -1008,10 +1015,13 @@ mod user_storage_replay_protection {
             page.element().created_at(),
         );
 
-        let result = MainInterface::apply_action(action2, &ApplyContext::empty());
+        let result = MainInterface::apply_action(
+            action2,
+            &apply_ctx_for(account_of_key(&wrong_signing_key)),
+        );
         assert!(
             matches!(result, Err(StorageError::InvalidSignature)),
-            "stale upsert with invalid signature must reject as InvalidSignature, got {result:?}"
+            "stale upsert from a non-owner must reject as InvalidSignature, got {result:?}"
         );
     }
 
@@ -1020,7 +1030,7 @@ mod user_storage_replay_protection {
         crate::tests::common::register_test_merge_functions();
         env::reset_for_testing();
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
 
         let mut element = Element::root();
         element.set_user_domain(owner);
@@ -1063,7 +1073,7 @@ mod user_storage_replay_protection {
     fn out_of_order_nonces_are_silently_skipped_for_upsert() {
         env::reset_for_testing();
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
 
         let mut element = Element::root();
         element.set_user_domain(owner);
@@ -2691,20 +2701,18 @@ mod timestamp_drift_protection {
 /// - Delete actions for User storage
 #[cfg(test)]
 mod storage_type_edge_cases {
-    use calimero_primitives::identity::PublicKey;
     use ed25519_dalek::SigningKey;
 
     use super::*;
     use crate::address::Id;
     use crate::env;
     use crate::tests::common::{
-        create_signed_user_add_action, create_signed_user_update_action, create_test_keypair,
-        sign_action,
+        create_signed_user_add_action, create_signed_user_update_action, sign_action,
     };
 
     fn create_signed_delete_action(
         signing_key: &SigningKey,
-        owner: PublicKey,
+        owner: AccountId,
         id: Id,
         nonce: u64,
     ) -> Action {
@@ -2718,7 +2726,7 @@ mod storage_type_edge_cases {
                 signature_data: Some(SignatureData {
                     signature: [0; 64],
                     nonce,
-                    signer: None,
+                    signer: Some(crate::tests::common::pubkey_of(signing_key)),
                 }),
             },
             crdt_type: None,
@@ -2746,7 +2754,7 @@ mod storage_type_edge_cases {
                 *signature_data = Some(SignatureData {
                     signature,
                     nonce,
-                    signer: None,
+                    signer: Some(crate::tests::common::pubkey_of(signing_key)),
                 });
             }
         }
@@ -2758,8 +2766,8 @@ mod storage_type_edge_cases {
     fn user_update_with_different_owner_fails() {
         env::reset_for_testing();
 
-        let (signing_key1, owner1) = create_test_keypair();
-        let (signing_key2, owner2) = create_test_keypair();
+        let (signing_key1, owner1) = create_test_owner();
+        let (signing_key2, owner2) = create_test_owner();
 
         // Create entity owned by owner1
         let mut element = Element::root();
@@ -2804,7 +2812,7 @@ mod storage_type_edge_cases {
     fn user_delete_with_valid_signature_succeeds() {
         env::reset_for_testing();
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
 
         // Create user-owned entity
         let mut element = Element::root();
@@ -2834,8 +2842,8 @@ mod storage_type_edge_cases {
     fn user_delete_with_wrong_owner_fails() {
         env::reset_for_testing();
 
-        let (signing_key1, owner1) = create_test_keypair();
-        let (signing_key2, owner2) = create_test_keypair();
+        let (signing_key1, owner1) = create_test_owner();
+        let (signing_key2, owner2) = create_test_owner();
 
         // Create entity owned by owner1
         let mut element = Element::root();
@@ -2866,7 +2874,7 @@ mod storage_type_edge_cases {
     fn user_delete_without_signature_fails() {
         env::reset_for_testing();
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
 
         // Create user-owned entity
         let mut element = Element::root();
@@ -2921,7 +2929,7 @@ mod storage_type_edge_cases {
 
         sleep(Duration::from_millis(2));
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
 
         // Try to update to User storage - should fail
         let nonce = env::time_now();
@@ -2951,7 +2959,7 @@ mod storage_type_edge_cases {
     fn cannot_change_user_to_public_storage() {
         env::reset_for_testing();
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
 
         // Create user-owned entity
         let mut element = Element::root();
@@ -3005,7 +3013,7 @@ mod storage_type_edge_cases {
         crate::tests::common::register_test_merge_functions();
         env::reset_for_testing();
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
 
         // Create user-owned entity
         let mut element = Element::root();
@@ -3072,7 +3080,7 @@ mod storage_type_edge_cases {
         crate::tests::common::register_test_merge_functions();
         env::reset_for_testing();
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
 
         let mut element = Element::root();
         element.set_user_domain(owner);
@@ -3102,7 +3110,7 @@ mod storage_type_edge_cases {
                 signature_data: Some(SignatureData {
                     signature: [0; 64],
                     nonce: stored,
-                    signer: None,
+                    signer: Some(crate::tests::common::pubkey_of(&signing_key)),
                 }),
             },
             crdt_type: None,
@@ -3128,7 +3136,7 @@ mod storage_type_edge_cases {
                 *sd = Some(SignatureData {
                     signature,
                     nonce: stored,
-                    signer: None,
+                    signer: Some(crate::tests::common::pubkey_of(&signing_key)),
                 });
             }
         }
@@ -3191,7 +3199,7 @@ mod owner_driven_convert {
 
     /// Seed a `User` entry owned by `owner` (schema_version `None`, the legacy
     /// unmarked shape) as a child of the root, returning its `Id`.
-    fn seed_stale_user_entry(signing_key: &ed25519_dalek::SigningKey, owner: PublicKey) -> Id {
+    fn seed_stale_user_entry(signing_key: &ed25519_dalek::SigningKey, owner: AccountId) -> Id {
         let root = crate::tests::common::setup_root_for_main();
 
         // A non-root child so its id is distinct from the registered Public root.
@@ -3252,7 +3260,7 @@ mod owner_driven_convert {
         env::reset_for_testing();
         calimero_sdk::app::register_schema_version::<V2>();
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
         let id = seed_stale_user_entry(&signing_key, owner);
 
         let stored = Index::<MainStorage>::get_metadata(id).unwrap().unwrap();
@@ -3273,7 +3281,7 @@ mod owner_driven_convert {
             field_name: None,
             schema_version: None,
         };
-        env::with_device_id(*owner, || {
+        env::with_account_id(*owner.as_bytes(), || {
             assert!(!env::in_merge_mode(), "convert must run on the normal path");
             MainInterface::save_raw(id, b"v2-bytes".to_vec(), convert_meta)
                 .expect("owner convert write");
@@ -3306,7 +3314,7 @@ mod owner_driven_convert {
         env::reset_for_testing();
         calimero_sdk::app::register_schema_version::<V2>();
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
         let (_, not_owner) = create_test_keypair();
         let id = seed_stale_user_entry(&signing_key, owner);
 
@@ -3346,7 +3354,7 @@ mod owner_driven_convert {
         env::reset_for_testing();
         calimero_sdk::app::register_schema_version::<V2>();
 
-        let (signing_key, owner) = create_test_keypair();
+        let (signing_key, owner) = create_test_owner();
         let id = seed_stale_user_entry(&signing_key, owner);
         let stored = Index::<MainStorage>::get_metadata(id).unwrap().unwrap();
         let new_nonce = stored.updated_at() + 1_000_000;
@@ -3369,7 +3377,7 @@ mod owner_driven_convert {
         // as a fresh, monotonic, owner-signed delta — exactly the security
         // hazard PR-6c must avoid. Drive the owner write under
         // `with_merge_mode` and assert the entry stays unconverted.
-        let out = env::with_device_id(*owner, || {
+        let out = env::with_account_id(*owner.as_bytes(), || {
             env::with_merge_mode(|| MainInterface::save_raw(id, b"v2".to_vec(), convert_meta))
         });
         assert!(out.is_ok(), "the write itself still succeeds in merge mode");
@@ -3393,7 +3401,7 @@ mod owner_driven_convert {
     /// `ChildInfo` (for building a subsequent signed `Action::Update`).
     fn seed_user_entry_on<S: crate::store::StorageAdaptor>(
         signing_key: &ed25519_dalek::SigningKey,
-        owner: PublicKey,
+        owner: AccountId,
     ) -> (Id, crate::entities::ChildInfo) {
         let root_id = Id::root();
         let root_meta = Metadata::default();
@@ -3421,7 +3429,7 @@ mod owner_driven_convert {
                 signature_data: Some(SignatureData {
                     signature: [0; 64],
                     nonce,
-                    signer: None,
+                    signer: Some(crate::tests::common::pubkey_of(signing_key)),
                 }),
             },
             crdt_type: None,
@@ -3468,7 +3476,7 @@ mod owner_driven_convert {
         env::reset_for_testing();
         calimero_sdk::app::register_schema_version::<V2>();
 
-        let (owner_sk, owner) = create_test_keypair();
+        let (owner_sk, owner) = create_test_owner();
 
         // Replica B starts with the legacy unmarked entry (the pre-convert shape).
         let (id, root) = seed_user_entry_on::<ReplicaB>(&owner_sk, owner);
@@ -3489,7 +3497,7 @@ mod owner_driven_convert {
                 signature_data: Some(SignatureData {
                     signature: [0; 64],
                     nonce: new_nonce,
-                    signer: None,
+                    signer: Some(crate::tests::common::pubkey_of(&owner_sk)),
                 }),
             },
             crdt_type: None,

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -14,7 +14,7 @@ use crate::collections::{
 use crate::env;
 use crate::merge::{clear_merge_registry, merge_root_state, register_crdt_merge};
 use borsh::{BorshDeserialize, BorshSerialize};
-use calimero_primitives::identity::PublicKey;
+use calimero_account::AccountId;
 use serial_test::serial;
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
@@ -139,11 +139,12 @@ fn test_user_storage_reassign_deterministic_id_preserves_entries() {
     use crate::collections::UserStorage;
 
     env::reset_for_testing();
-    env::set_device_id([0x11; 32]);
+    env::set_account_id([0x11; 32]);
 
     let mut storage = UserStorage::<u64>::new();
     let _ = storage.insert(7).expect("initial insert should succeed");
-    let owner_key: PublicKey = [0x11; 32].into();
+    // UserStorage is keyed by ACCOUNT — the person whose slot this is.
+    let owner_key = AccountId::from([0x11; 32]);
     assert_eq!(
         storage
             .get_for_user(&owner_key)
@@ -159,11 +160,11 @@ fn test_user_storage_reassign_deterministic_id_preserves_entries() {
         Some(7)
     );
 
-    env::set_device_id([0x22; 32]);
+    env::set_account_id([0x22; 32]);
     let _ = storage
         .insert(11)
         .expect("second user insert should succeed");
-    let second_key: PublicKey = [0x22; 32].into();
+    let second_key = AccountId::from([0x22; 32]);
     assert_eq!(
         storage
             .get_for_user(&second_key)


### PR DESCRIPTION
Write a note from your phone and you could not edit it from your laptop. `AuthoredMap`/`AuthoredVector` stamped each entry with the inserting **device's** key and gated `update`/`remove` on it, so a second machine was a stranger to its own data. `UserStorage` had it twice over — a per-device slot as well as a per-device stamp — so "this user's data" meant "this machine's".

Authorship is an access-control question, and access control names people. This makes `StorageType::User.owner` an `AccountId` and keys `UserStorage` by one, so slot and gate agree. It is the storage-plane counterpart of #3391, which did the same for governance.

## Why it is bigger than a type swap

`owner` was doing two jobs, and only one survives: it was **also** the ed25519 key the signature verified against (`ed25519_verify(.., owner.digest(), ..)`), and an account is a content hash that verifies nothing.

So authentication and authorization split the way `Shared` already splits them:

- the signature is checked against `signature_data.signer` — now required for `User`, and the permanent record of **which device** wrote the entry, so no information is lost;
- `ApplyContext.signer_account`, the node's resolution of that key **at the action's causal cut**, is checked against `owner`;
- `payload_for_signing` commits to `signer`, which it did not have to when `owner` was itself the verifying key.

## The part that was not obvious

The sync repair paths — HashComparison, snapshot, level-wise — apply through an `ApplyContext::empty()`, because they carry no cut to resolve a signer's account at. Storage cannot ask the ownership question there, and refusing would drop every legitimately repaired `User` entity. (`hashcomparison-shared-user-reconcile` exists precisely to exercise that path.)

Deferring alone would have made this a **downgrade**: `owner` used to be the verifying key, so a repaired leaf was cryptographically bound to its owner with no bindings in hand. Once `owner` is an account, any context member could push another member's authored entry over HC.

So the ownership half moves to the node, which has the bindings and is already running the membership half three lines above. `is_leaf_currently_authorized` now resolves the author's key to its account and compares it against the leaf's `owner`. Unresolvable stays permissive — that is this node not having folded the author's enrolment, not evidence of an impostor.

## What deliberately did NOT move

The per-replica identities CRDT mechanics need — an LWW register's tiebreak, a counter's per-actor slot, an HLC seed — stay on `device_id`, and must: two devices of one person writing concurrently have to stay distinguishable or they share a slot and lose each other's writes. Nothing keys an authored entry's id off its owner, so convergence is untouched.

## Two tests existed to prevent this, and both are inverted

- `two_devices_of_one_account_own_their_entries_separately` refused the phone the laptop's entry, justified as stopping devices from "clobbering each other's per-writer state". That conflated the gate with the state — see above; the state never moved. Now `..._share_ownership_of_its_entries`, with a guard that a **different** account is still refused (without it, "any device may edit" would pass too).
- Step 5 of `shared-storage-account-writers-two-devices` asserted the same over the real wire. The phone now updates the laptop's note and the assertion checks it propagated — which also exercises the new receiver-side resolution on the authored plane, the twin of what step 4 does for writer sets.

Test identities derive the account from a different domain than the key (`create_test_owner` → `account_of_key`), so a green suite cannot be green because the two happened to be equal.

## Compatibility

`StorageType::User.owner` changes meaning with an **identical borsh layout** — both ids are 32 bytes — so nothing fails to decode; a pre-change entry simply reads a device key as an account id and ends up owned by nobody.

Originally written as "ships with the #3346 flag day". That was wrong on two counts: #3346 closed COMPLETED when #3391 merged (it *was* the flag day, and it has happened), and there is no running network — so there is no deployed data to migrate and no mixed-version pair to break.

The only thing to know: **wipe local node data** when picking this branch up, or authored entries written before it will silently have an owner that matches nobody.

`get_user_simple_for` is account-typed, so `e2e.yml` and `hashcomparison-shared-user-reconcile.yml` read `my_account` off the owning node instead of passing a public key.

## Verification

- `cargo test --workspace --no-fail-fast`: **227 suites, 0 failures** (689 in `calimero-storage`)
- `cargo fmt --check` and `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` clean
- Dependency sweep first: the migration scenarios compare `owner_of` to `owner_of` (value-agnostic, unaffected), and the multi-node scenarios use separate nodes = separate accounts, so the distinctness they rely on is preserved.

