### PR TITLE
fix(sync)!: name a namespace joiner by credential before serving it anything

### DIFF
--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -218,8 +218,33 @@ impl Handler<JoinGroupRequest> for ContextManager {
                 // Previously this was a hard `?`, so a join attempted before the
                 // mesh formed aborted before writing the joiner's membership row
                 // and left the node not-a-member (the reported symptom).
+                // Built BEFORE the request, not after: the responder needs it to
+                // name this joiner's account, and the deny-list gate it feeds
+                // runs before any state is served. The same credential is
+                // published with `MemberJoinedAt` further below.
+                let joiner_credential_bytes = match crate::join_credential::build(
+                    &datastore,
+                    &namespace_id.into(),
+                    &joiner_identity,
+                ) {
+                    Ok(credential) => borsh::to_vec(&*credential)?,
+                    Err(e) => {
+                        // Without one the responder cannot name us, and a
+                        // responder on this version refuses rather than guess.
+                        return Err(e.wrap_err(
+                            "join: could not build the account credential the responder \
+                             needs to authorize this join",
+                        ));
+                    }
+                };
+
                 let join_result = match node_client
-                    .request_namespace_join(namespace_id, invitation_bytes, joiner_identity)
+                    .request_namespace_join(
+                        namespace_id,
+                        invitation_bytes,
+                        joiner_identity,
+                        joiner_credential_bytes,
+                    )
                     .await
                 {
                     Ok(bundle) => bundle,

--- a/crates/node/primitives/src/client.rs
+++ b/crates/node/primitives/src/client.rs
@@ -43,6 +43,9 @@ pub struct NamespaceJoinParams {
     pub namespace_id: [u8; 32],
     pub invitation_bytes: Vec<u8>,
     pub joiner_public_key: PublicKey,
+    /// Borsh-serialized `JoinAccountCredential`, so the responder can name this
+    /// joiner's ACCOUNT before it serves any state. See the wire variant.
+    pub joiner_credential_bytes: Vec<u8>,
 }
 
 /// Parameters for a direct open-subgroup join request (issue #2357).
@@ -122,12 +125,14 @@ impl SyncClient {
         namespace_id: [u8; 32],
         invitation_bytes: Vec<u8>,
         joiner_public_key: PublicKey,
+        joiner_credential_bytes: Vec<u8>,
     ) -> eyre::Result<JoinBundle> {
         let (tx, rx) = oneshot::channel();
         let params = NamespaceJoinParams {
             namespace_id,
             invitation_bytes,
             joiner_public_key,
+            joiner_credential_bytes,
         };
         self.ns_join_tx
             .send((params, tx))
@@ -866,9 +871,15 @@ impl NodeClient {
         namespace_id: [u8; 32],
         invitation_bytes: Vec<u8>,
         joiner_public_key: PublicKey,
+        joiner_credential_bytes: Vec<u8>,
     ) -> eyre::Result<JoinBundle> {
         self.sync_client
-            .request_namespace_join(namespace_id, invitation_bytes, joiner_public_key)
+            .request_namespace_join(
+                namespace_id,
+                invitation_bytes,
+                joiner_public_key,
+                joiner_credential_bytes,
+            )
             .await
     }
 

--- a/crates/node/primitives/src/sync/wire.rs
+++ b/crates/node/primitives/src/sync/wire.rs
@@ -361,6 +361,21 @@ pub enum InitPayload {
         invitation_bytes: Vec<u8>,
         /// The joiner's public key for ECDH key wrapping
         joiner_public_key: PublicKey,
+        /// Borsh-serialized `JoinAccountCredential` — genesis, root-key chain,
+        /// and the device cert for `joiner_public_key`.
+        ///
+        /// Carried so the responder can NAME the requester before it serves
+        /// anything. The re-entry and deny-list rows are keyed by account, and
+        /// a request that arrives as a bare key leaves a previously-denied
+        /// account unnameable whenever it presents a device this responder holds
+        /// no binding for — so the gate could not read its own deny row, and
+        /// backfill plus the wrapped group key went out ahead of the apply-time
+        /// check that does reject them.
+        ///
+        /// The responder verifies it rather than trusting it, and must check the
+        /// cert names this same `joiner_public_key`: an unbound credential could
+        /// otherwise be replayed by anyone who observed one.
+        joiner_credential_bytes: Vec<u8>,
     },
 
     /// Direct request to materialise inherited membership in an Open

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -3535,12 +3535,14 @@ impl SyncManager {
             namespace_id,
             ref invitation_bytes,
             joiner_public_key,
+            ref joiner_credential_bytes,
         } = &payload
         {
             self.handle_namespace_join_request(
                 *namespace_id,
                 invitation_bytes,
                 *joiner_public_key,
+                joiner_credential_bytes,
                 stream,
                 nonce,
             )
@@ -4145,6 +4147,7 @@ mod init_pop_gate_tests {
                 namespace_id: [0; 32],
                 invitation_bytes: vec![],
                 joiner_public_key: [0; 32].into(),
+                joiner_credential_bytes: vec![],
             },
             InitPayload::OpenSubgroupJoinRequest {
                 namespace_id: [0; 32],

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -485,6 +485,51 @@ impl SyncManager {
         Ok(())
     }
 
+    /// Name the joiner behind a `NamespaceJoinRequest`, or say why not.
+    ///
+    /// Verification only — nothing is written. The responder needs the account
+    /// before it decides whether to serve anything, and applying the binding
+    /// first would let an unauthorized request mutate state on its way to being
+    /// refused.
+    ///
+    /// Three things have to hold, and the third is the one that is easy to miss:
+    ///
+    /// 1. the genesis hashes to the account the certificate claims, so the
+    ///    credential cannot name an account it does not descend from;
+    /// 2. the certificate chains to that genesis through the root-key handoffs
+    ///    (`verify_device_cert`, the same check the apply path runs);
+    /// 3. the certificate names THIS request's `joiner_public_key`. Without it a
+    ///    credential is a bearer token: anyone who observed one could replay it
+    ///    and be admitted as its owner, which is a worse hole than the one this
+    ///    check closes.
+    fn verified_joiner_account(
+        credential_bytes: &[u8],
+        joiner_public_key: &PublicKey,
+    ) -> Result<calimero_account::AccountId, String> {
+        let credential: calimero_context_client::local_governance::JoinAccountCredential =
+            borsh::from_slice(credential_bytes).map_err(|e| format!("undecodable: {e}"))?;
+
+        if credential.genesis.account_id() != credential.cert.account {
+            return Err("genesis does not derive the account the certificate claims".to_owned());
+        }
+
+        let verified = calimero_account::verify_device_cert(
+            credential.cert.account,
+            &credential.genesis,
+            &credential.chain,
+            &credential.cert,
+        )
+        .map_err(|e| format!("{e}"))?;
+
+        if AsRef::<[u8; 32]>::as_ref(&verified.sign_pk)
+            != AsRef::<[u8; 32]>::as_ref(joiner_public_key)
+        {
+            return Err("certificate names a different signing key than the request".to_owned());
+        }
+
+        Ok(credential.cert.account)
+    }
+
     /// Handle an incoming NamespaceJoinRequest on the responder side.
     ///
     /// Validates the invitation, wraps the group key for the joiner,
@@ -494,6 +539,7 @@ impl SyncManager {
         namespace_id: [u8; 32],
         invitation_bytes: &[u8],
         joiner_public_key: PublicKey,
+        joiner_credential_bytes: &[u8],
         stream: &mut Stream,
         nonce: Nonce,
     ) -> eyre::Result<()> {
@@ -578,48 +624,47 @@ impl SyncManager {
         // perfectly ordinary re-sync or a retried join round — and since a
         // successful join consumes the invitation, gating them would reject every
         // repeat request they ever make with their own invitation.
-        // The joiner is named by key on the wire; the row names its account.
-        // A key with no binding here holds no row, which is what `false` says.
-        let joiner_account = calimero_governance_store::member_account_in_namespace(
-            &store,
-            &group_id,
-            &joiner_public_key,
-        )
-        .ok()
-        .flatten();
-        let already_member = joiner_account.is_some_and(|account| {
-            MembershipRepository::new(&store)
-                .has_direct_member(&group_id, &account)
-                .unwrap_or(false)
-        });
-        let admission = match (already_member, joiner_account) {
-            (true, _) => Ok(()),
-            (false, Some(account)) => ReentryRepository::new(&store).require_invitation_admits(
+        // The joiner is named by KEY on the wire and the rows are keyed by
+        // ACCOUNT, so the request carries the credential that bridges the two —
+        // and this responder verifies it rather than trusting it.
+        //
+        // Refusing an unverifiable credential is the whole point. When the gate
+        // could not name a requester it admitted them, so a denied account that
+        // presented a device this responder held no binding for had its deny row
+        // go unread, and collected the backfill and the wrapped group key ahead
+        // of the apply-time check that does reject it.
+        let joiner_account =
+            match Self::verified_joiner_account(joiner_credential_bytes, &joiner_public_key) {
+                Ok(account) => account,
+                Err(reason) => {
+                    let msg = StreamMessage::Message {
+                        sequence_id: 0,
+                        payload: MessagePayload::NamespaceJoinRejected {
+                            reason: format!("join credential rejected: {reason}"),
+                        },
+                        next_nonce: nonce,
+                    };
+                    crate::sync::stream::send(stream, &msg, None).await?;
+                    return Ok(());
+                }
+            };
+
+        let already_member = MembershipRepository::new(&store)
+            .has_direct_member(&group_id, &joiner_account)
+            .unwrap_or(false);
+        // Skipped for an identity that is already a member: the block governs
+        // RE-ENTRY, and a current member is not re-entering. They land here on a
+        // perfectly ordinary re-sync or a retried join round — and since a
+        // successful join consumes the invitation, gating them would reject every
+        // repeat request they ever make with their own invitation.
+        let admission = if already_member {
+            Ok(())
+        } else {
+            ReentryRepository::new(&store).require_invitation_admits(
                 &group_id,
-                &account,
+                &joiner_account,
                 invitation.invitation.invitation_nonce,
-            ),
-            // The join request carries a key and an invitation, not a
-            // credential, so a first-time joiner names an account this responder
-            // cannot yet resolve. Both rows the gate reads — the re-entry block
-            // and the consumed-invitation marker — are keyed by that account, so
-            // for a genuine first-timer neither row can exist and there is
-            // nothing here to check.
-            //
-            // It is lenient in one case, and knowingly: a denied account can
-            // present a device key this responder holds no binding for, and its
-            // deny row goes unread because we cannot name whose it is. What that
-            // buys the holder is the backfill and the wrapped key served below,
-            // ahead of the apply-time check that does have the credential and
-            // does reject them. It is not a regression — the gate was keyed by
-            // KEY before, so a fresh key walked past it just the same, and
-            // keying by account is what lets a denied account's OTHER devices be
-            // caught at all. Closing it needs the join request to carry the
-            // joiner's credential so the responder can name the principal before
-            // it serves anything, which is a wire change and needs its own
-            // version gate — see the "join-sync admission skips the deny-list
-            // check" issue.
-            (false, None) => Ok(()),
+            )
         };
         if let Err(err) = admission {
             warn!(
@@ -679,27 +724,17 @@ impl SyncManager {
         // Pre-register the joiner as a group member so that when it opens a sync
         // stream, this node's membership check passes immediately.
         //
-        // Only possible for a joiner whose account we can already name — a
-        // re-join, typically. A first-time joiner presents a key and an
-        // invitation but no credential, and the membership row names an account,
-        // so there is nothing to write the row under. That costs the
-        // optimisation, not the join: the joiner's own `MemberJoinedAt` carries
-        // the credential and writes the row when it applies, and until then
-        // `has_member`'s key-keyed `ContextIdentity` arm still answers.
-        match joiner_account {
-            Some(account) => {
-                if let Err(e) = MembershipRepository::new(&store).add_member(
-                    &group_id,
-                    &account,
-                    calimero_primitives::context::GroupMemberRole::Member,
-                ) {
-                    warn!(%e, "failed to pre-register joiner as group member");
-                }
-            }
-            None => debug!(
-                %joiner_public_key,
-                "joiner names no account here yet; leaving its member row to its own join op"
-            ),
+        // Unconditional now: the request carries a verified credential, so every
+        // joiner that reaches this line — first-timer included — has an account
+        // to key the row under. It used to be skipped whenever the account could
+        // not be named, which was exactly the first-join case the optimisation
+        // exists for.
+        if let Err(e) = MembershipRepository::new(&store).add_member(
+            &group_id,
+            &joiner_account,
+            calimero_primitives::context::GroupMemberRole::Member,
+        ) {
+            warn!(%e, "failed to pre-register joiner as group member");
         }
 
         let context_ids = enumerate_group_contexts(&store, &group_id, 0, usize::MAX)?;
@@ -1148,6 +1183,7 @@ impl SyncManager {
                     namespace_id: params.namespace_id,
                     invitation_bytes: params.invitation_bytes.clone(),
                     joiner_public_key: params.joiner_public_key,
+                    joiner_credential_bytes: params.joiner_credential_bytes.clone(),
                 },
                 next_nonce: rand::thread_rng().gen(),
             };
@@ -2335,5 +2371,123 @@ mod open_subgroup_key_tests {
             "the per-peer tally must survive into the final error, and must show \
              the single round that actually ran: {msg}"
         );
+    }
+}
+
+/// The credential check that decides whether a join request gets named at all.
+///
+/// Every case here is a rejection the responder must make BEFORE it wraps the
+/// group key or serves backfill — the point of carrying a credential is that
+/// the deny-list gate downstream has an account to read its rows under.
+#[cfg(test)]
+mod joiner_credential_tests {
+    use calimero_account::{sign_device_cert, AccountGenesis, DeviceId, KemPublicKey};
+    use calimero_context_client::local_governance::JoinAccountCredential;
+    use calimero_primitives::identity::{PrivateKey, PublicKey};
+    use rand::rngs::OsRng;
+
+    use super::SyncManager;
+
+    /// An account root plus a credential certifying `sign_pk` under it.
+    fn credential_for(sign_pk: &PublicKey) -> (JoinAccountCredential, AccountGenesis) {
+        let root_sk = PrivateKey::random(&mut OsRng);
+        let genesis = AccountGenesis::new(root_sk.public_key(), [0x5A; 16]);
+        let cert = sign_device_cert(
+            &root_sk,
+            genesis.account_id(),
+            DeviceId::from([0xD1; 32]),
+            sign_pk,
+            &KemPublicKey::from([0x2B; 32]),
+            0,
+            0,
+        )
+        .expect("the account root signs its own device cert");
+        (
+            JoinAccountCredential {
+                genesis,
+                chain: vec![],
+                cert,
+            },
+            genesis,
+        )
+    }
+
+    #[test]
+    fn a_credential_certifying_the_requesting_key_names_its_account() {
+        let joiner = PublicKey::from([0x11; 32]);
+        let (credential, genesis) = credential_for(&joiner);
+
+        let account =
+            SyncManager::verified_joiner_account(&borsh::to_vec(&credential).unwrap(), &joiner)
+                .expect("a well-formed credential for this key must resolve");
+
+        assert_eq!(
+            account,
+            genesis.account_id(),
+            "the resolved account must be the one the genesis derives, not one the \
+             certificate merely claims"
+        );
+    }
+
+    /// The replay guard, and the reason the check is not just `verify_device_cert`.
+    ///
+    /// A credential travels in the clear inside a join request, so any peer that
+    /// has served one holds a copy. If the responder did not tie it to the key
+    /// making THIS request, that copy would be a bearer token: replay it and be
+    /// admitted as its owner — including past a deny-list entry, which is worse
+    /// than the gap this whole change closes.
+    #[test]
+    fn a_credential_for_a_different_key_is_refused() {
+        let owner = PublicKey::from([0x11; 32]);
+        let (credential, _) = credential_for(&owner);
+
+        let attacker = PublicKey::from([0x22; 32]);
+        let err =
+            SyncManager::verified_joiner_account(&borsh::to_vec(&credential).unwrap(), &attacker)
+                .expect_err(
+                    "a credential certifying someone else's key must not name this requester",
+                );
+
+        assert!(
+            err.contains("different signing key"),
+            "the refusal should say the certificate is for another key: {err}"
+        );
+    }
+
+    /// The certificate names the account; the genesis is what PROVES it. A
+    /// credential pairing one account's genesis with a certificate claiming
+    /// another is how a requester would try to wear an account it cannot derive.
+    #[test]
+    fn a_genesis_that_does_not_derive_the_claimed_account_is_refused() {
+        let joiner = PublicKey::from([0x11; 32]);
+        let (mut credential, _) = credential_for(&joiner);
+        let (other, _) = credential_for(&joiner);
+        credential.genesis = other.genesis;
+
+        let err =
+            SyncManager::verified_joiner_account(&borsh::to_vec(&credential).unwrap(), &joiner)
+                .expect_err("a genesis from another account must not certify this one");
+
+        assert!(
+            err.contains("genesis does not derive"),
+            "the refusal should name the mismatch: {err}"
+        );
+    }
+
+    #[test]
+    fn undecodable_credential_bytes_are_refused_not_ignored() {
+        let joiner = PublicKey::from([0x11; 32]);
+        let err = SyncManager::verified_joiner_account(b"not a credential", &joiner)
+            .expect_err("garbage must refuse rather than fall through to an unnamed admit");
+        assert!(err.contains("undecodable"), "{err}");
+    }
+
+    /// An empty credential is what an older initiator effectively sends. It must
+    /// refuse, not admit: "could not name them" was precisely the condition that
+    /// used to skip the deny-list check.
+    #[test]
+    fn an_absent_credential_is_refused() {
+        let joiner = PublicKey::from([0x11; 32]);
+        assert!(SyncManager::verified_joiner_account(&[], &joiner).is_err());
     }
 }


### PR DESCRIPTION
Closes #3397.

A namespace join request named its sender by signing key, while the rows that decide admission — the re-entry block and the consumed-invitation marker — are keyed by account. So whenever the responder held no binding for the presented device, it could not name the requester, and the `(false, None)` arm admitted them.

That is not hypothetical for the case that matters: **a denied account presenting a newly-enrolled device is exactly the request the responder cannot name.** Its deny row exists, under a name the responder cannot compute. It then wrapped the group key and served backfill, ahead of the apply-time check that does reject the join.

## The fix

`NamespaceJoinRequest` now carries the joiner's `JoinAccountCredential` — genesis, root-key chain, and the device cert for the key making the request. The responder verifies it and derives the account **before** it serves anything, then runs `require_invitation_admits` against that account. The unnamed-admit arm is gone; there is no lenient path left.

`verified_joiner_account` checks three things, and the third is the one that is easy to miss:

1. the genesis hashes to the account the certificate claims — so a credential cannot wear an account it does not descend from;
2. the certificate chains to that genesis through the root-key handoffs (`verify_device_cert`, the same check the apply path runs);
3. **the certificate names this request's `joiner_public_key`.** A credential travels in the clear inside a join request, so every peer that has served one holds a copy. Without this tie it is a bearer token — replay it and be admitted as its owner, past their deny-list entry. That would be a worse hole than the one being closed.

Nothing is written during verification. Applying the binding first would let an unauthorized request mutate state on its way to being refused.

Two things fall out of always having an account:

- the joiner pre-registration is now unconditional. It used to be skipped whenever the account could not be named — which was precisely the first-join case the optimisation exists for.
- `join_group` builds the credential *before* the request rather than after, and fails the join if it cannot. The same credential is still published with `MemberJoinedAt`.

## On the version gate

The issue asked for one. There is nothing to gate, and the reasoning changed twice while investigating:

Borsh encodes a variant tag then that variant's fields, so adding a field to `NamespaceJoinRequest` breaks **only that message**. Blob sync, HashComparison, delta requests and snapshots interoperate between versions untouched. An old 3-field request reads a length prefix out of the nonce bytes and errors cleanly rather than mis-parsing.

That failure is also exactly what should happen: an old node cannot supply a credential, so it must not be admitted. A bounded "admit if the peer sent no credential" path would be indistinguishable on the wire from the attack — a denied account simply omits it — so it would preserve the vulnerability behind a flag.

I briefly considered bumping `CALIMERO_STREAM_PROTOCOL`. That would partition *all* stream traffic between versions to gate a break confined to one message type — strictly worse, and not done.

And there is no running network, so none of this is live anyway.

## Verification

- 5 new tests covering each refusal: valid credential resolves to the genesis-derived account; a credential for a **different** key is refused (the replay guard); a genesis that does not derive the claimed account is refused; undecodable bytes are refused rather than falling through; an absent credential is refused, since "could not name them" was the original bug.
- `cargo test --workspace --no-fail-fast` green; `fmt --check` and `clippy -D warnings` clean.

