### PR TITLE
fix(node): name a repair-pushed leaf's signer so HashComparison can repair signed entities

### DIFF
--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -1220,7 +1220,10 @@ impl E2eKvStore {
     }
 
     pub fn authored_get_owner(&self, key: String) -> app::Result<Option<String>> {
-        Ok(self.authored_items.owner_of(&key)?.map(|pk| pk.to_string()))
+        Ok(self
+            .authored_items
+            .owner_of(&key)?
+            .map(|account| account.to_string()))
     }
 
     pub fn authored_len(&self) -> app::Result<usize> {
@@ -1331,7 +1334,10 @@ impl E2eKvStore {
     }
 
     pub fn authored_vec_get_owner(&self, index: usize) -> app::Result<Option<String>> {
-        Ok(self.authored_vec.owner_of(index)?.map(|pk| pk.to_string()))
+        Ok(self
+            .authored_vec
+            .owner_of(index)?
+            .map(|account| account.to_string()))
     }
 
     pub fn authored_vec_entries(&self) -> app::Result<Vec<String>> {

--- a/apps/scaffolding-e2e/workflows/hashcomparison-shared-user-reconcile.yml
+++ b/apps/scaffolding-e2e/workflows/hashcomparison-shared-user-reconcile.yml
@@ -312,13 +312,6 @@ steps:
   #     back with downgraded provenance. Post-redesign, name + data
   #     match the LWW winner of the two writes node-1 issued. ---
 
-  - name: Node-1 reports its identity (used to read its User entity)
-    type: get_namespace_identity
-    node: e2e-node-1
-    namespace_id: '{{ns}}'
-    outputs:
-      node1_id: publicKey
-
   - name: Read node-1's User entity from node-2
     type: call
     node: e2e-node-2
@@ -363,8 +356,13 @@ steps:
       - 'json_equal({{authored_read_from_node2}}, {"output": "bio-final"})'
 
   # AuthoredMap exposes the owner of each entry — confirm it is
-  # node-1's identity, not the default-Public fallback that the
+  # node-1's ACCOUNT, not the default-Public fallback that the
   # v1 silent storage-type-flip bug would have produced.
+  #
+  # By account since #3399: an entry is owned by the person, so that a second
+  # device of theirs can edit it. This compared against the node's bs58 signing
+  # key until now, and went stale silently — the step was simply never reached,
+  # because reconciliation timed out three steps earlier.
   - name: Read AuthoredMap entry owner from node-2
     type: call
     node: e2e-node-2
@@ -378,7 +376,7 @@ steps:
   - name: Assert AuthoredMap entry owner is node-1
     type: json_assert
     statements:
-      - 'json_equal({{authored_owner_from_node2}}, {"output": "{{node1_id}}"})'
+      - 'json_equal({{authored_owner_from_node2}}, {"output": "{{node1_account}}"})'
 
   # And the pre-partition baseline state is still present on
   # node-2 — reconcile must not have wiped pre-divergence writes.

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -440,6 +440,39 @@ pub enum LeafOutcome {
 ///
 /// Must be called inside a `with_runtime_env(...)` scope (it delegates to
 /// [`apply_leaf_with_crdt_merge`] on the apply branch).
+/// The account a repair-pushed leaf's signer speaks for, for
+/// [`ApplyContext::signer_account`].
+///
+/// A signed leaf carries the KEY that signed it; the writer set it must be
+/// checked against names ACCOUNTS. Storage cannot bridge the two — it has no
+/// bindings — so the node resolves it here and passes the answer in.
+///
+/// Resolving live is sound for this one question, and only because a device is
+/// bound to exactly one account for its whole life (`BindingRejected::
+/// AccountReassignment`). Two nodes that both know a binding therefore always
+/// agree, whatever their fold depth; the only variance is knowing versus not
+/// knowing yet. That is unlike the writer SET, which genuinely changes over
+/// time — and which storage already resolves deterministically, as of the
+/// leaf's own HLC, from the anchor's rotation log.
+///
+/// `None` means the binding has not folded here yet. Storage refuses on `None`,
+/// which is the right answer: the leaf is re-driven by the next repair round
+/// once the binding lands, so both peers converge on the same verdict instead
+/// of one accepting what the other rejects.
+fn repair_signer_account(
+    store: &Store,
+    context_id: &ContextId,
+    leaf: &TreeLeafData,
+) -> Option<calimero_account::AccountId> {
+    let signer = extract_author_from_leaf_authorization(leaf.metadata.authorization.as_ref())?;
+    let group_id = calimero_governance_store::get_group_for_context(store, context_id)
+        .ok()
+        .flatten()?;
+    calimero_governance_store::member_account_in_namespace(store, &group_id, &signer)
+        .ok()
+        .flatten()
+}
+
 pub fn apply_leaf_with_crdt_merge_gated(
     store: &Store,
     context_id: ContextId,
@@ -473,11 +506,31 @@ pub fn apply_leaf_with_crdt_merge_gated(
             return Ok(LeafOutcome::Buffered);
         }
     }
-    apply_leaf_with_crdt_merge(context_id, leaf)?;
+    let signer_account = repair_signer_account(store, &context_id, leaf);
+    apply_leaf_with_crdt_merge_as(context_id, leaf, signer_account)?;
     Ok(LeafOutcome::Applied)
 }
 
+/// [`apply_leaf_with_crdt_merge_as`] for a caller that cannot name the signer's
+/// account — no store in scope, or a test.
+///
+/// A signed leaf applied this way is REFUSED by storage and re-driven on the
+/// next repair round. Prefer the gated entry point, which resolves it.
 pub fn apply_leaf_with_crdt_merge(context_id: ContextId, leaf: &TreeLeafData) -> Result<()> {
+    apply_leaf_with_crdt_merge_as(context_id, leaf, None)
+}
+
+/// Apply a repair-pushed leaf as `signer_account`.
+///
+/// The account is the node's half of the writer check: storage verifies the
+/// signature under the key the leaf names, then checks that account against the
+/// writer set resolved as of the leaf's own HLC. Passing `None` leaves storage
+/// unable to name the writer, so it refuses — see [`repair_signer_account`].
+pub fn apply_leaf_with_crdt_merge_as(
+    context_id: ContextId,
+    leaf: &TreeLeafData,
+    signer_account: Option<calimero_account::AccountId>,
+) -> Result<()> {
     let entity_id = Id::new(leaf.key);
     let root_id = Id::new(*context_id.as_ref());
 
@@ -731,11 +784,16 @@ pub fn apply_leaf_with_crdt_merge(context_id: ContextId, leaf: &TreeLeafData) ->
         }
     };
 
-    // #2266: snapshot leaf push has no `CausalDelta` in scope — these
-    // bytes come from a peer who already verified them. Empty ctx →
-    // verifier falls back to v2 stored-writers, which is the safe
-    // semantic for already-verified replicated state.
-    Interface::<MainStorage>::apply_action(action, &ApplyContext::empty())?;
+    // No `CausalDelta` in scope (#2266): a repair carries state, not an op, so
+    // there are no parents and `effective_writers` stays `None` — storage then
+    // resolves the writer set as of this leaf's own HLC. What the node supplies
+    // is the other half, the account its signer speaks for, without which the
+    // writer check cannot run at all.
+    let ctx = ApplyContext {
+        signer_account,
+        ..ApplyContext::empty()
+    };
+    Interface::<MainStorage>::apply_action(action, &ctx)?;
     Ok(())
 }
 


### PR DESCRIPTION
Refs #3376. HashComparison could not repair a signed `Shared`/`SharedMember` entity — the one thing it is invoked for.

## Before

Two nodes diverge, HashComparison finds the differing entities, one pushes the other its copy of a leaf — and the receiver rejects it. Both directions, forever, so the repair never lands and HC falls back to DAG catchup on every attempt.

From one failing run's node logs: **174 rejections, every one identical.**

```
action signature rejected while applying
  id=ae87c628…9a73763
  reason="sharedmember-signer-not-in-writer-set"
  storage_type="SharedMember"   signature="signed"
```

One entity, one reason, `signature="signed"` on every line, split 89 / 85 across the two peers each refusing the other's copy.

**The signature was never the problem.** It surfaces to the caller as `InvalidSignature`, which is why the search kept looking at signatures — but the signature verifies. What failed was naming the **writer**.

A writer set names ACCOUNTS. A signature names a KEY. Storage bridges the two through `ApplyContext.signer_account` — and on the repair path that was always `None`:

```rust
let signer  = sig_data.signer?;
let account = signer_account?;   // ← always None here. Bails.
if !writers.contains_key(&account) { return None; }
```

Not because resolution failed — **because nobody attempted it.** `ApplyContext::empty()` hardcodes `signer_account: None`, and every repair path passes it. So the lookup could not run, and a check that cannot run fails closed. When writer sets became account-keyed, this check did not get stricter; it became unanswerable.

## After

The node answers it, because the node is where the bindings live:

- `repair_signer_account()` resolves the leaf's signer to its account, inside `apply_leaf_with_crdt_merge_gated` — where the store is already in scope for the membership gate a few lines above.
- `apply_leaf_with_crdt_merge_as()` passes it into the `ApplyContext`.
- Storage's existing `resolve_signer` then works unchanged: verify the signature under the named key, then check that account against the writer set.

**`crates/storage` is not touched by this PR.**

## Why resolving it live is sound

Two questions look similar and are not:

| question | changes over time? | how it is answered |
| --- | --- | --- |
| which accounts may write here? | **yes** | already resolved deterministically as of the leaf's own HLC, from the anchor's rotation log (`resolve_local_as_of`) |
| which account does this key speak for? | **no** | resolved live — safe, see below |

A device is bound to exactly one account for its entire life (`BindingRejected::AccountReassignment` — *"A device may not be moved between accounts"*). So two nodes that both know a binding always agree, whatever their fold depth. There is no "different answers" case, only *knows* versus *does not know yet*.

Both halves are therefore deterministic, and the real writer check runs on repairs exactly as it does on deltas.

## Nothing is weakened

- A validly-signed leaf from a **non-writer** is still refused on repair. It is not accepted and reconciled later — it is refused, as on the gossip path.
- An **unfolded binding** still refuses, and the leaf is re-driven on the next repair round. Two peers converge on one verdict rather than one accepting what the other rejects.
- Tampering was always caught and still is: the signature commits to id, data, nonce and owner.

An earlier version of this PR took a different route — deferring the writer question on repair paths, on the mistaken grounds that resolving live would cause divergence. That would have let a group member push a validly-signed value for an entity it holds no write grant on. It is gone; the reasoning that killed it is the table above.

## Second commit

Fixing the repair let `hashcomparison-shared-user-reconcile` clear the reconciliation barrier and run ~30 steps further, which exposed a stale assertion from #3399: `authored_get_owner` returns an account now, but the scenario still compared it to the node's bs58 signing key. It had been broken since #3399 merged and was invisible, because reconciliation died three steps before it. Fixed, along with removing the `get_namespace_identity` step that fed it and now has no reader.

Swept the other scenarios rather than spot-fixing — the app-migration authored cases compare `owner_of` to `owner_of`, so they are value-agnostic and unaffected.

## Verification

`cargo test -p calimero-node --lib` 469 passed · `cargo test -p calimero-storage --features testing` 689 passed · `fmt --check` and `clippy -D warnings` clean.
