### PR TITLE
fix(storage): refuse an unnameable writer for User, as Shared already does

### DIFF
--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -513,7 +513,11 @@ async fn run_initiator_impl<T: SyncTransport>(
                 if !remote_node.deleted_children.is_empty() {
                     let applied =
                         apply_under_context_lock(context_client, context_id, &runtime_env, || {
-                            apply_remote_tombstones(&remote_node.deleted_children)
+                            apply_remote_tombstones(
+                                context_client.map(ContextClient::datastore),
+                                context_id,
+                                &remote_node.deleted_children,
+                            )
                         })
                         .await;
                     if applied > 0 {
@@ -1579,7 +1583,16 @@ pub(crate) fn get_local_tree_node(
 /// `Action::DeleteRef` path (delete-wins by HLC; signature/nonce verified for
 /// User/Shared, safe no-op when it loses or fails auth). Returns the count
 /// applied. Must be called inside a `with_runtime_env` scope.
-pub(crate) fn apply_remote_tombstones(deletions: &[EntityDeletion]) -> u64 {
+/// `store`/`context_id` are what let a tombstone for a SIGNED entity be
+/// authorized: the delete is a write like any other, so it needs the account
+/// its signer speaks for. Without them a `User`/`Shared` deletion cannot be
+/// authorized and simply stops propagating — pass `None` only where no store
+/// exists (tests).
+pub(crate) fn apply_remote_tombstones(
+    store: Option<&calimero_store::Store>,
+    context_id: ContextId,
+    deletions: &[EntityDeletion],
+) -> u64 {
     let mut applied = 0u64;
     for deletion in deletions {
         let action = calimero_storage::action::Action::DeleteRef {
@@ -1587,12 +1600,17 @@ pub(crate) fn apply_remote_tombstones(deletions: &[EntityDeletion]) -> u64 {
             deleted_at: deletion.deleted_at,
             metadata: deletion.metadata.clone(),
         };
-        if Interface::<MainStorage>::apply_action(
-            action,
-            &calimero_storage::interface::ApplyContext::empty(),
-        )
-        .is_ok()
-        {
+        let ctx = calimero_storage::interface::ApplyContext {
+            signer_account: store.and_then(|store| {
+                crate::sync::helpers::signer_account_for(
+                    store,
+                    &context_id,
+                    Some(&deletion.metadata.storage_type),
+                )
+            }),
+            ..calimero_storage::interface::ApplyContext::empty()
+        };
+        if Interface::<MainStorage>::apply_action(action, &ctx).is_ok() {
             applied += 1;
         }
     }

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -464,7 +464,18 @@ fn repair_signer_account(
     context_id: &ContextId,
     leaf: &TreeLeafData,
 ) -> Option<calimero_account::AccountId> {
-    let signer = extract_author_from_leaf_authorization(leaf.metadata.authorization.as_ref())?;
+    signer_account_for(store, context_id, leaf.metadata.authorization.as_ref())
+}
+
+/// [`repair_signer_account`] over any authorization stamp, so a tombstone —
+/// whose `Metadata` carries the storage type directly rather than in a leaf's
+/// `authorization` — resolves its signer the same way a pushed value does.
+pub(crate) fn signer_account_for(
+    store: &Store,
+    context_id: &ContextId,
+    authorization: Option<&StorageType>,
+) -> Option<calimero_account::AccountId> {
+    let signer = extract_author_from_leaf_authorization(authorization)?;
     let group_id = calimero_governance_store::get_group_for_context(store, context_id)
         .ok()
         .flatten()?;
@@ -1070,6 +1081,7 @@ pub async fn handle_entity_push_locked(
 /// A deletion that loses the LWW race or fails authorization is a safe no-op
 /// and is not counted. Returns the number applied.
 fn apply_entity_deletions(
+    store: Option<&Store>,
     context_id: ContextId,
     runtime_env: &calimero_storage::env::RuntimeEnv,
     deletions: &[EntityDeletion],
@@ -1082,7 +1094,17 @@ fn apply_entity_deletions(
                 deleted_at: deletion.deleted_at,
                 metadata: deletion.metadata.clone(),
             };
-            match Interface::<MainStorage>::apply_action(action, &ApplyContext::empty()) {
+            // A tombstone for a signed entity is authorized like any other
+            // write, so it needs the same account resolution a pushed value
+            // gets — otherwise deletes of `User`/`Shared` entities stop
+            // propagating on the repair paths.
+            let ctx = ApplyContext {
+                signer_account: store.and_then(|store| {
+                    signer_account_for(store, &context_id, Some(&deletion.metadata.storage_type))
+                }),
+                ..ApplyContext::empty()
+            };
+            match Interface::<MainStorage>::apply_action(action, &ctx) {
                 Ok(_) => applied += 1,
                 Err(e) => tracing::debug!(
                     %context_id,
@@ -1111,7 +1133,12 @@ pub async fn handle_entity_delete_push_locked(
         Some(client) => client.acquire_lock(&context_id).await,
         None => None,
     };
-    apply_entity_deletions(context_id, runtime_env, deletions)
+    apply_entity_deletions(
+        context_client.map(ContextClient::datastore),
+        context_id,
+        runtime_env,
+        deletions,
+    )
 }
 
 /// Extract a [`SignedNamespaceOp`](calimero_context_client::local_governance::SignedNamespaceOp)

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -360,7 +360,11 @@ async fn run_initiator_impl<T: SyncTransport>(
         if !remote_deleted.is_empty() {
             let applied =
                 apply_under_context_lock(context_client, context_id, &runtime_env, || {
-                    crate::sync::hash_comparison_protocol::apply_remote_tombstones(&remote_deleted)
+                    crate::sync::hash_comparison_protocol::apply_remote_tombstones(
+                        context_client.map(ContextClient::datastore),
+                        context_id,
+                        &remote_deleted,
+                    )
                 })
                 .await;
             stats.entities_merged += applied;

--- a/crates/storage/src/collections/root.rs
+++ b/crates/storage/src/collections/root.rs
@@ -347,7 +347,30 @@ where
         // Without this trace, a `Result::Err` from apply_actions surfaces
         // as a bare WASM `unreachable` trap with no clue what failed.
         match artifact {
-            StorageDelta::Actions(actions) => Self::apply_actions(actions, |_| ctx.clone()),
+            // The SDK-driven LOCAL apply: these actions are this node's own
+            // writes, so the account executing right now is the account that
+            // wrote them. Saying so is what lets the signed-storage gates run
+            // here at all — they resolve a writer by account, and a caller that
+            // names nobody is indistinguishable from a remote action whose
+            // signer this node cannot yet place, which must be refused.
+            //
+            // Not the "never fall back to the locally executing account" hazard
+            // on `ApplyContext::signer_account`: that warns against letting a
+            // REMOTE action authorize itself as whoever happens to be applying
+            // it. This branch is local by construction — `CausalActions` below
+            // is the network one, and it carries its own resolved account.
+            //
+            // An explicit `signer_account` on the way in still wins, so a caller
+            // that has already resolved one is never second-guessed.
+            StorageDelta::Actions(actions) => {
+                let local = crate::interface::ApplyContext {
+                    signer_account: ctx.signer_account.or_else(|| {
+                        Some(calimero_account::AccountId::from(crate::env::account_id()))
+                    }),
+                    ..ctx.clone()
+                };
+                Self::apply_actions(actions, |_| local.clone())
+            }
             StorageDelta::CausalActions {
                 actions,
                 delta_id,

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -730,7 +730,21 @@ impl<S: StorageAdaptor> Interface<S> {
         }
         match signer_account {
             Some(account) => account == owner,
-            None => true,
+            // Refused, matching the `Shared` and `SharedMember` arms, which bail
+            // on an unnameable writer via `resolve_signer`.
+            //
+            // This arm used to accept, from when nothing could name a signer on
+            // any path that reaches here. Both now can: a local apply states the
+            // executing account (`Root::sync`), and a repair resolves the leaf's
+            // signer (`calimero-node`'s `repair_signer_account`). So `None` no
+            // longer means "nobody asked" — it means the binding has not folded
+            // here yet, which is a retryable timing gap, not authority.
+            //
+            // Accepting it was the divergence the refusal exists to prevent: a
+            // peer that HAS folded the binding refuses the same leaf, and the two
+            // keep different state. Refusing converges them, because the leaf is
+            // re-driven once the binding lands.
+            None => false,
         }
     }
 

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -11,7 +11,7 @@ use crate::constants::DRIFT_TOLERANCE_NANOS;
 use crate::entities::{Data, Element, SignatureData, StorageType};
 use crate::env::time_now;
 use crate::store::MockedStorage;
-use crate::tests::common::{create_test_owner, Page, Paragraph};
+use crate::tests::common::{apply_ctx_for, create_test_owner, Page, Paragraph};
 
 const ONE_SEC_NANOS: u64 = 1_000_000_000;
 
@@ -628,12 +628,58 @@ mod user_storage_signature_verification {
             create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce);
 
         // Valid signature should succeed
-        assert!(MainInterface::apply_action(action, &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(action, &apply_ctx_for(owner)).is_ok());
 
         // Verify the page was added
         let retrieved = MainInterface::find_by_id::<Page>(page.id()).unwrap();
         assert!(retrieved.is_some());
         assert_eq!(retrieved.unwrap().title, "User Page");
+    }
+
+    /// **An unnameable writer is refused for `User`, exactly as for `Shared`.**
+    ///
+    /// The two arms disagreed until now: `Shared` bails in `resolve_signer` when
+    /// the signer cannot be named, while `User` accepted. That asymmetry dates
+    /// from when nothing reaching here could name a signer on any path. Both can
+    /// now — a local apply states the executing account, a repair resolves the
+    /// leaf's signer — so `None` no longer means "nobody asked", it means the
+    /// binding has not folded on this replica yet.
+    ///
+    /// Accepting it is the divergence the refusal exists to prevent: a peer that
+    /// HAS folded the binding refuses the same write, and the two keep different
+    /// state with nothing later to reconcile them.
+    #[test]
+    fn user_action_with_an_unnameable_writer_is_refused_and_retryable() {
+        env::reset_for_testing();
+
+        let (signing_key, owner) = create_test_owner();
+
+        let mut element = Element::root();
+        element.set_user_domain(owner);
+        let page = Page::new_from_element("User Page", element);
+        let serialized = to_vec(&page).unwrap();
+        let nonce = env::time_now();
+
+        let mk = || {
+            create_signed_user_add_action(&signing_key, owner, page.id(), serialized.clone(), nonce)
+        };
+
+        // Cannot name the writer → refused, and nothing is written.
+        let unnamed = MainInterface::apply_action(mk(), &ApplyContext::empty());
+        assert!(
+            matches!(unnamed, Err(StorageError::InvalidSignature)),
+            "an unnameable writer must be refused for User, not admitted: {unnamed:?}"
+        );
+        assert!(
+            MainInterface::find_by_id::<Page>(page.id())
+                .unwrap()
+                .is_none(),
+            "a refused write must leave no trace"
+        );
+
+        // A timing refusal, not a verdict: the same write applies once named.
+        MainInterface::apply_action(mk(), &apply_ctx_for(owner))
+            .expect("the refused write applies once the writer can be named");
     }
 
     #[test]
@@ -700,7 +746,7 @@ mod user_storage_signature_verification {
         };
 
         // Missing signature should fail
-        let result = MainInterface::apply_action(action, &ApplyContext::empty());
+        let result = MainInterface::apply_action(action, &apply_ctx_for(owner));
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidData(msg)) => {
@@ -744,7 +790,7 @@ mod user_storage_signature_verification {
         }
 
         // Corrupted signature should fail
-        let result = MainInterface::apply_action(action, &ApplyContext::empty());
+        let result = MainInterface::apply_action(action, &apply_ctx_for(owner));
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidSignature) => {}
@@ -768,7 +814,7 @@ mod user_storage_signature_verification {
         let nonce1 = env::time_now();
         let action1 =
             create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce1);
-        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(action1, &apply_ctx_for(owner)).is_ok());
 
         // Wait a bit to ensure different timestamp
         sleep(Duration::from_millis(2));
@@ -788,7 +834,7 @@ mod user_storage_signature_verification {
             page.element().created_at(),
         );
 
-        assert!(MainInterface::apply_action(action2, &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(action2, &apply_ctx_for(owner)).is_ok());
 
         // Verify the update
         let retrieved = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -894,13 +940,13 @@ mod user_storage_replay_protection {
         }
 
         // First apply succeeds.
-        assert!(MainInterface::apply_action(action.clone(), &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(action.clone(), &apply_ctx_for(owner)).is_ok());
 
         sleep(Duration::from_millis(2));
 
         // Re-applying the exact same signed action must be
         // idempotent — not a NonceReplay rejection.
-        let result = MainInterface::apply_action(action, &ApplyContext::empty());
+        let result = MainInterface::apply_action(action, &apply_ctx_for(owner));
         assert!(
             result.is_ok(),
             "re-applying same signed action must be idempotent, got {result:?}"
@@ -952,7 +998,7 @@ mod user_storage_replay_protection {
             serialized.clone(),
             nonce1,
         );
-        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(action1, &apply_ctx_for(owner)).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -966,7 +1012,7 @@ mod user_storage_replay_protection {
             page.element().created_at(),
         );
 
-        let result = MainInterface::apply_action(action2, &ApplyContext::empty());
+        let result = MainInterface::apply_action(action2, &apply_ctx_for(owner));
         assert!(
             result.is_ok(),
             "stale-but-signed upsert must be silently skipped, got {result:?}"
@@ -999,7 +1045,7 @@ mod user_storage_replay_protection {
             serialized.clone(),
             nonce1,
         );
-        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(action1, &apply_ctx_for(owner)).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -1040,7 +1086,7 @@ mod user_storage_replay_protection {
         let nonce1 = env::time_now();
         let action1 =
             create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce1);
-        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(action1, &apply_ctx_for(owner)).is_ok());
 
         // Multiple updates with increasing nonces
         for i in 2..=5 {
@@ -1058,7 +1104,7 @@ mod user_storage_replay_protection {
                 page.element().created_at(),
             );
             assert!(
-                MainInterface::apply_action(action, &ApplyContext::empty()).is_ok(),
+                MainInterface::apply_action(action, &apply_ctx_for(owner)).is_ok(),
                 "Update {i} should succeed"
             );
         }
@@ -1089,7 +1135,7 @@ mod user_storage_replay_protection {
             serialized1.clone(),
             first_nonce,
         );
-        assert!(MainInterface::apply_action(action_first, &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(action_first, &apply_ctx_for(owner)).is_ok());
 
         sleep(Duration::from_millis(10));
 
@@ -1110,7 +1156,7 @@ mod user_storage_replay_protection {
             page.element().created_at(),
         );
 
-        let result = MainInterface::apply_action(action_old, &ApplyContext::empty());
+        let result = MainInterface::apply_action(action_old, &apply_ctx_for(owner));
         assert!(
             result.is_ok(),
             "stale-but-signed upsert must be silently skipped, got {result:?}"
@@ -2783,7 +2829,7 @@ mod storage_type_edge_cases {
             serialized.clone(),
             nonce1,
         );
-        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(action1, &apply_ctx_for(owner1)).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -2798,7 +2844,7 @@ mod storage_type_edge_cases {
             page.element().created_at(),
         );
 
-        let result = MainInterface::apply_action(action2, &ApplyContext::empty());
+        let result = MainInterface::apply_action(action2, &apply_ctx_for(owner2));
         assert!(result.is_err());
         match result {
             Err(StorageError::ActionNotAllowed(msg)) => {
@@ -2823,7 +2869,7 @@ mod storage_type_edge_cases {
         let nonce1 = env::time_now();
         let action1 =
             create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce1);
-        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(action1, &apply_ctx_for(owner)).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -2831,7 +2877,7 @@ mod storage_type_edge_cases {
         let nonce2 = env::time_now();
         let delete_action = create_signed_delete_action(&signing_key, owner, page.id(), nonce2);
 
-        assert!(MainInterface::apply_action(delete_action, &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(delete_action, &apply_ctx_for(owner)).is_ok());
 
         // Verify entity is deleted
         let retrieved = MainInterface::find_by_id::<Page>(page.id()).unwrap();
@@ -2854,7 +2900,7 @@ mod storage_type_edge_cases {
         let nonce1 = env::time_now();
         let action1 =
             create_signed_user_add_action(&signing_key1, owner1, page.id(), serialized, nonce1);
-        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(action1, &apply_ctx_for(owner1)).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -2862,7 +2908,7 @@ mod storage_type_edge_cases {
         let nonce2 = env::time_now();
         let delete_action = create_signed_delete_action(&signing_key2, owner2, page.id(), nonce2);
 
-        let result = MainInterface::apply_action(delete_action, &ApplyContext::empty());
+        let result = MainInterface::apply_action(delete_action, &apply_ctx_for(owner2));
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidSignature) => {}
@@ -2885,7 +2931,7 @@ mod storage_type_edge_cases {
         let nonce1 = env::time_now();
         let action1 =
             create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce1);
-        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(action1, &apply_ctx_for(owner)).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -2906,7 +2952,7 @@ mod storage_type_edge_cases {
             },
         };
 
-        let result = MainInterface::apply_action(delete_action, &ApplyContext::empty());
+        let result = MainInterface::apply_action(delete_action, &apply_ctx_for(owner));
         assert!(result.is_err());
         match result {
             Err(StorageError::InvalidData(msg)) => {
@@ -2942,7 +2988,7 @@ mod storage_type_edge_cases {
             page.element().created_at(),
         );
 
-        let result = MainInterface::apply_action(action, &ApplyContext::empty());
+        let result = MainInterface::apply_action(action, &apply_ctx_for(owner));
         assert!(result.is_err());
         match result {
             Err(StorageError::ActionNotAllowed(msg)) => {
@@ -2975,7 +3021,7 @@ mod storage_type_edge_cases {
             serialized.clone(),
             nonce,
         );
-        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(action1, &apply_ctx_for(owner)).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -2995,7 +3041,7 @@ mod storage_type_edge_cases {
             },
         };
 
-        let result = MainInterface::apply_action(action2, &ApplyContext::empty());
+        let result = MainInterface::apply_action(action2, &apply_ctx_for(owner));
         assert!(result.is_err());
         match result {
             Err(StorageError::ActionNotAllowed(msg)) => {
@@ -3029,7 +3075,7 @@ mod storage_type_edge_cases {
             serialized.clone(),
             nonce1,
         );
-        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(action1, &apply_ctx_for(owner)).is_ok());
 
         sleep(Duration::from_millis(2));
 
@@ -3043,14 +3089,14 @@ mod storage_type_edge_cases {
             nonce2,
             page.element().created_at(),
         );
-        assert!(MainInterface::apply_action(action2, &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(action2, &apply_ctx_for(owner)).is_ok());
 
         sleep(Duration::from_millis(2));
 
         // Try to delete with old nonce (replay attack)
         let delete_action = create_signed_delete_action(&signing_key, owner, page.id(), nonce1);
 
-        let result = MainInterface::apply_action(delete_action, &ApplyContext::empty());
+        let result = MainInterface::apply_action(delete_action, &apply_ctx_for(owner));
         assert!(result.is_err());
         match result {
             Err(StorageError::NonceReplay(_)) => {}
@@ -3090,7 +3136,7 @@ mod storage_type_edge_cases {
         let nonce1 = env::time_now();
         let action1 =
             create_signed_user_add_action(&signing_key, owner, page.id(), serialized, nonce1);
-        assert!(MainInterface::apply_action(action1, &ApplyContext::empty()).is_ok());
+        assert!(MainInterface::apply_action(action1, &apply_ctx_for(owner)).is_ok());
 
         // The stored replay nonce after the add. Build a delete whose
         // signed nonce AND `deleted_at` both equal it — mirroring the
@@ -3142,7 +3188,7 @@ mod storage_type_edge_cases {
         }
 
         // Equal-HLC delete is accepted (not `NonceReplay`) and wins.
-        let result = MainInterface::apply_action(delete_action, &ApplyContext::empty());
+        let result = MainInterface::apply_action(delete_action, &apply_ctx_for(owner));
         assert!(
             result.is_ok(),
             "equal-HLC signed delete must be accepted (delete-wins), got {result:?}"
@@ -3246,7 +3292,7 @@ mod owner_driven_convert {
             }
         }
 
-        MainInterface::apply_action(action, &ApplyContext::empty()).expect("seed user entry");
+        MainInterface::apply_action(action, &apply_ctx_for(owner)).expect("seed user entry");
 
         // Sanity: stored entry is the legacy unmarked shape.
         let stored = Index::<MainStorage>::get_metadata(id).unwrap().unwrap();
@@ -3458,7 +3504,7 @@ mod owner_driven_convert {
         {
             *m = metadata;
         }
-        Interface::<S>::apply_action(action, &ApplyContext::empty()).expect("seed user on replica");
+        Interface::<S>::apply_action(action, &apply_ctx_for(owner)).expect("seed user on replica");
         (id, root)
     }
 
@@ -3528,7 +3574,7 @@ mod owner_driven_convert {
         }
 
         // B applies the replicated convert via the normal apply path.
-        InterfaceB::apply_action(update, &ApplyContext::empty()).expect("B applies convert delta");
+        InterfaceB::apply_action(update, &apply_ctx_for(owner)).expect("B applies convert delta");
 
         let after = Index::<ReplicaB>::get_metadata(id).unwrap().unwrap();
         assert_eq!(


### PR DESCRIPTION
Closes #3407.

## The inconsistency

`user_action_authorized` **accepted** when it could not name the writer; `Shared` and `SharedMember` **refuse** (`resolve_signer` bails on `None`). Same situation, opposite answers.

That dates from when nothing reaching those arms could name a signer on any path — accepting was the only way a `User` write ever applied. Both paths can name one now: a repair resolves the leaf's signer (#3405), and the local apply states the executing account (below). So `None` no longer means *"nobody asked"*. It means **the binding has not folded on this replica yet** — a retryable timing gap.

Accepting that is exactly the divergence the refusal exists to prevent: a peer that *has* folded the binding refuses the same write, the two keep different state, and nothing later reconciles them.

## Why it is three changes and not one line

The issue asked for a caller audit first, and the audit is what saved this. Enumerating every production `apply_action` that reaches storage with no named writer turned up three applying **tombstones** with peer-supplied metadata:

- `helpers.rs` — `apply_entity_deletions`
- `hash_comparison_protocol.rs` — the responder loop, and `apply_remote_tombstones`

Those can be `User` entities. A delete is a write like any other, so tightening alone would have **stopped User deletions propagating on the repair paths** — a bug this codebase has already had once ("HC tombstone-blind, deletes never propagate").

So, in order:

1. **`Root::sync`'s `Actions` arm names the executing account.** That branch is local by construction — `CausalActions` is the network one and carries its own resolved account. This is *not* the "never fall back to the locally executing account" hazard on `ApplyContext::signer_account`: that warns against a **remote** action authorizing itself as whoever applies it.
2. **The three tombstone sites resolve their signer**, via `signer_account_for` — #3405's resolver, generalised off `TreeLeafData` so a bare `Metadata` works too.
3. **Only then** does `None` refuse.

## On the test changes

~30 storage tests applied signed `User` actions with an unnamed writer. After the audit, no production path does that, so they now name their signer rather than being bent to pass.

Two needed reading rather than rewriting, and are worth a reviewer's eye:

- the two-owner negative tests set up `action1` as **`owner1`**, not the nearest binding in scope;
- one tombstone is `Metadata::default()` — Public, with no owner to name, so it correctly keeps an empty context.

New test `user_action_with_an_unnameable_writer_is_refused_and_retryable` pins the behaviour: refused with nothing written, then the **same** write applies once the writer can be named — demonstrably a timing refusal, not a verdict.

## Verification

`cargo test -p calimero-storage --features testing` 690 passed · `fmt --check` and `clippy -D warnings` clean · full workspace suite running.
