### PR TITLE
fix(node): let a member stranded without state act on a divergence beacon

### DIFF
--- a/crates/node/src/handlers/network_event/readiness.rs
+++ b/crates/node/src/handlers/network_event/readiness.rs
@@ -39,23 +39,37 @@ const NS_BEACON_SYNC_DEBOUNCE: Duration = Duration::from_secs(5);
 /// it — i.e. trigger a namespace governance sync.
 ///
 /// - `local_has_state` — this node holds a non-empty local namespace
-///   governance DAG head. When false the node is still bootstrapping or
-///   mid-join: the join flow owns the initial governance sync, and firing
-///   one here races the join handshake — it pulls governance ops before
-///   the namespace key is delivered, leaving them as undecryptable opaque
-///   skeletons that the post-key join sync then skips as duplicates. An
-///   established member (the scenario this anti-entropy targets) always
-///   has a non-empty head.
+///   governance DAG head, i.e. it is an established member. Always eligible.
+/// - `is_namespace_member` — this node holds a namespace identity but no
+///   state yet. Also eligible, and that is a change: it used to sit the
+///   round out on the grounds that "the join flow owns the initial
+///   governance sync", and that firing here would pull ops before the key
+///   arrived and leave undecryptable skeletons behind.
+///
+///   Both halves of that stopped being true. A join whose direct request
+///   found no reachable peer RETURNS — recording membership and relying on
+///   fallback, with no key and an empty head — so no join flow owns
+///   anything afterwards, and the node is excluded from the one mechanism
+///   that would have recovered it. Meanwhile `sync_namespace_from_peer`
+///   now finishes with `recover_missing_group_keys` and, when it applied
+///   anything, `drain_governance_pending_after_sync` (#2613): the key is
+///   fetched on the same round as the ops, and anything buffered
+///   undecryptable is drained once it lands. The skeleton hazard is closed
+///   by the very path this guard was blocking.
+///
+///   Cost of being wrong is one debounced sync round (~5s) against a peer
+///   that is genuinely ahead of us.
 /// - `dag_head == [0u8; 32]` — the peer has applied nothing yet; never
 ///   sync towards an empty DAG.
 /// - `head_op_present_locally` — the peer's advertised head op is already
 ///   in our DAG; we are caught up (or ahead).
 fn beacon_indicates_divergence(
     local_has_state: bool,
+    is_namespace_member: bool,
     dag_head: [u8; 32],
     head_op_present_locally: bool,
 ) -> bool {
-    local_has_state && dag_head != [0u8; 32] && !head_op_present_locally
+    (local_has_state || is_namespace_member) && dag_head != [0u8; 32] && !head_op_present_locally
 }
 
 /// Per-namespace debounce gate. Returns `true` (and records `now`) when
@@ -222,7 +236,24 @@ fn spawn_beacon_divergence_sync(
                 }
             };
             drop(handle);
-            if !beacon_indicates_divergence(local_has_state, dag_head, head_op_present) {
+            // A namespace identity is what makes this node a member of the
+            // namespace at all — it is written by the join, before any key or
+            // governance state exists. So it is exactly the signal that
+            // separates "joined, but stranded with nothing" from "not our
+            // namespace", which must still be ignored.
+            let is_namespace_member =
+                calimero_governance_store::NamespaceRepository::new(&datastore)
+                    .identity_record(&calimero_context_config::types::ContextGroupId::from(
+                        namespace_id,
+                    ))
+                    .map(|record| record.is_some())
+                    .unwrap_or(false);
+            if !beacon_indicates_divergence(
+                local_has_state,
+                is_namespace_member,
+                dag_head,
+                head_op_present,
+            ) {
                 return;
             }
             // Divergence confirmed. Claim the debounce slot atomically;
@@ -308,27 +339,45 @@ mod tests {
     #[test]
     fn divergence_true_when_head_op_absent() {
         // Established member (has local state), peer's head op missing.
-        assert!(beacon_indicates_divergence(true, [7u8; 32], false));
+        assert!(beacon_indicates_divergence(true, false, [7u8; 32], false));
     }
 
     #[test]
     fn divergence_false_when_head_op_present() {
-        assert!(!beacon_indicates_divergence(true, [7u8; 32], true));
+        assert!(!beacon_indicates_divergence(true, true, [7u8; 32], true));
     }
 
     #[test]
     fn divergence_false_for_zero_head() {
         // A peer that has applied nothing advertises a zero head; never
         // sync towards an empty DAG even though the op is "absent".
-        assert!(!beacon_indicates_divergence(true, [0u8; 32], false));
+        assert!(!beacon_indicates_divergence(true, true, [0u8; 32], false));
     }
 
     #[test]
-    fn divergence_false_when_no_local_state() {
-        // No local namespace governance head: the node is still
-        // bootstrapping / mid-join. The join flow owns the initial sync;
-        // firing here races the join handshake. Never trigger.
-        assert!(!beacon_indicates_divergence(false, [7u8; 32], false));
+    fn divergence_false_for_a_stranger_to_this_namespace() {
+        // No local state AND not a member: someone else's namespace. Ignore it.
+        assert!(!beacon_indicates_divergence(false, false, [7u8; 32], false));
+    }
+
+    /// **A member stranded with no state still pulls.**
+    ///
+    /// This is the case that deadlocked `group-join-mesh-not-ready`. A join
+    /// whose direct request found no reachable peer returns anyway — membership
+    /// recorded, no key, empty DAG head — so nothing owns the initial
+    /// governance sync afterwards. Excluding it here left the node knowing it
+    /// was behind (`we_missing=1` on every 30s heartbeat) with no way to act on
+    /// it, while the peer that had the op would not dial back because the node
+    /// was not subscribed to a context topic it had no key to join.
+    #[test]
+    fn divergence_true_for_a_member_with_no_state_yet() {
+        assert!(beacon_indicates_divergence(false, true, [7u8; 32], false));
+    }
+
+    #[test]
+    fn divergence_false_for_a_stateless_member_when_the_peer_has_nothing() {
+        // Still never sync towards an empty DAG, member or not.
+        assert!(!beacon_indicates_divergence(false, true, [0u8; 32], false));
     }
 
     #[test]


### PR DESCRIPTION
Refs #3406. `group-join-mesh-not-ready` is the last permanently-red E2E job; this cuts the link that leaves a stranded joiner unable to help itself.

## What the logs say

The heartbeat names the fault, and both peers agree on it:

```
[node-1]  we_missing=0  peer_missing=1
[node-2]  we_missing=1  peer_missing=0
```

**node-2 is missing exactly one governance op**, knows it on every 30s heartbeat for the full 120s, and never fetches it. It runs `Performing interval sync` *every second* — ~120 attempts — but those target the **context**, which it cannot materialise without a key (`dialer disconnected during materialisation wait`, over and over).

The other direction recovered fine: node-1 logged `beacon advertises an unknown namespace DAG head; triggering governance sync` and pulled from node-2. node-2 receives node-1's beacons every ~5s and never does the same.

## Why

`beacon_indicates_divergence` required `local_has_state` — a non-empty local DAG head. node-2 has none, so it sat out every round. The stated reasoning:

> the join flow owns the initial governance sync, and firing one here races the join handshake — it pulls governance ops before the namespace key is delivered, leaving them as undecryptable opaque skeletons

**Both halves have stopped holding.**

*Nobody owns it.* A join whose direct request finds no reachable peer **returns** — `recording local membership and relying on fallback`, `join response contained no group key`, `KeyDelivery timed out`. There is no join flow left to own anything, and the node is excluded from the only mechanism that would have covered it.

*The hazard is already closed.* `sync_namespace_from_peer` now ends with `recover_missing_group_keys` and, when it applied anything, `drain_governance_pending_after_sync` (#2613). The key is fetched on the same round as the ops, and anything buffered undecryptable is drained once it lands — by the very path the guard was blocking.

## The change

The predicate also admits a node holding a **namespace identity**. That is written by the join before any key or state exists, so it is exactly what separates *"joined but stranded"* from *"not our namespace"*, which must still be ignored.

Unchanged: an empty peer head is still never synced towards, and the existing ~5s debounce bounds the cost of acting on a peer that turns out not to be ahead.

## Scope — this is one of three links

The deadlock has three, each a guard added deliberately for a real reason:

1. node-2's join gets no key → no context → not on the context topic.
2. node-1 will not dial it: the namespace fallback requires context-topic subscription (`peers.rs:186`, guarding #2422's wasted dials).
3. node-2 will not pull: `local_has_state` excludes it. **← cut here**

Cutting (3) lets the stranded side pull instead of waiting to be pushed, and touches no other guard — in particular the #2422 dial filter keeps skipping those peers for context **state** sync, which is what it is for.

I cannot run merobox locally (no Docker here), so **CI is the verification** for the scenario itself. If it stays red, the remaining blocker is (2) and the logs will say so — the signature to look for is whether node-2 still reports `we_missing=1` after the heal.

## Tests

Predicate tests cover all four corners: established member pulls; stranger ignored; **stranded member now pulls** (the deadlock case); and an empty peer head is never synced towards, member or not.

`cargo test -p calimero-node --lib` 471 passed · `fmt --check` and `clippy -D warnings` clean.
