### PR TITLE
fix(context): install the activated bundle so the rollup reports the executed version

### DIFF
--- a/crates/context/src/activation.rs
+++ b/crates/context/src/activation.rs
@@ -32,6 +32,24 @@ pub fn record_activation(store: &Store, context_id: &ContextId, blob: [u8; 32]) 
     }
 }
 
+/// The blob a context executes but was never installed from, or `None` when
+/// its application row already agrees. A peer that converges by activation
+/// (lazy upgrade, cascade) loads the target bytecode by blob key and never
+/// runs the install, so the row - and `ApplicationMeta.state_version`, which
+/// the migration rollup reads as "what version is this context on" - stays
+/// pinned to the last bundle this node did install.
+pub fn uninstalled_activated_blob(store: &Store, context_id: &ContextId) -> Option<[u8; 32]> {
+    let activated = activated_blob(store, context_id)?;
+    let handle = store.handle();
+    let meta = handle
+        .get(&calimero_store::key::ContextMeta::new(*context_id))
+        .ok()
+        .flatten()?;
+    let application = handle.get(&meta.application).ok().flatten()?;
+    let installed: [u8; 32] = *application.bytecode.blob_id().as_ref();
+    (installed != activated).then_some(activated)
+}
+
 /// The next upgrade rung a context bound to `bound` must replay from the
 /// group's ladder, or `None` when it is already at the group's current
 /// bytecode. The LAST occurrence of `bound` positions the context (an
@@ -244,6 +262,64 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(meta.application.application_id(), new);
+    }
+
+    /// Build a context bound to `application_id`, whose row was installed from
+    /// blob `installed`.
+    fn context_installed_from(store: &Store, ctx: ContextId, installed: [u8; 32]) {
+        use calimero_store::key::{ApplicationMeta as ApplicationMetaKey, BlobMeta};
+        use calimero_store::types::{ApplicationMeta, ContextMeta, PackageInfo};
+
+        let application_id = ApplicationId::from([0xAA; 32]);
+        let mut handle = store.handle();
+        handle
+            .put(
+                &calimero_store::key::ContextMeta::new(ctx),
+                &ContextMeta::new(
+                    ApplicationMetaKey::new(application_id),
+                    [0u8; 32],
+                    vec![],
+                    None,
+                ),
+            )
+            .unwrap();
+        handle
+            .put(
+                &ApplicationMetaKey::new(application_id),
+                &ApplicationMeta::new(
+                    BlobMeta::new(installed.into()),
+                    0,
+                    "http://example.com".into(),
+                    Box::default(),
+                    BlobMeta::new([0u8; 32].into()),
+                    PackageInfo {
+                        package: "pkg".into(),
+                        version: "1.0.0".into(),
+                        signer_id: "signer".into(),
+                        state_version: 1,
+                    },
+                ),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn uninstalled_activated_blob_flags_only_a_row_left_behind() {
+        let store = store();
+        let ctx = ContextId::from([0x44; 32]);
+        context_installed_from(&store, ctx, [0x01; 32]);
+
+        // No marker: the row is all there is, nothing to heal.
+        assert_eq!(uninstalled_activated_blob(&store, &ctx), None);
+
+        // Converged by activation alone: the context executes 0x02 while its
+        // row still records the 0x01 bundle it installed.
+        record_activation(&store, &ctx, [0x02; 32]);
+        assert_eq!(uninstalled_activated_blob(&store, &ctx), Some([0x02; 32]));
+
+        // Healed: the row now records what the marker points at.
+        context_installed_from(&store, ctx, [0x02; 32]);
+        assert_eq!(uninstalled_activated_blob(&store, &ctx), None);
     }
 
     #[test]

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -567,7 +567,7 @@ impl Handler<ExecuteRequest> for ContextManager {
                 }
                 Either::Right(parts) => parts,
             };
-            match action {
+            let upgraded = match action {
                 // Replay the group's upgrade ladder hop by hop, re-resolving
                 // after each committed hop. The per-access budget bounds a
                 // pathological marker-write failure loop; a longer ladder
@@ -773,7 +773,31 @@ impl Handler<ExecuteRequest> for ContextManager {
                         .boxed_local()
                     }
                 }
-            }
+            };
+
+            // Every arm above binds execution to the activated blob without
+            // ever running the install, so heal the application row once the
+            // ladder has settled - otherwise the rollup keeps reporting this
+            // context on the last version this node installed.
+            upgraded
+                .then(move |result, act, _ctx| {
+                    let datastore = act.datastore.clone();
+                    let node_client = act.node_client.clone();
+                    async move {
+                        (
+                            result,
+                            install_activated_blob(&datastore, &node_client, &context_id).await,
+                        )
+                    }
+                    .into_actor(act)
+                })
+                .map(|(result, installed), act, _ctx| {
+                    if let Some(application_id) = installed {
+                        act.evict_application_caches(application_id);
+                    }
+                    result
+                })
+                .boxed_local()
         });
 
         // Re-fetch context after possible lazy upgrade (application_id may have changed)
@@ -1835,6 +1859,53 @@ async fn ensure_blob_local(
             false
         }
     }
+}
+
+/// Reinstall the application row in place from the blob this context just
+/// activated, so `ApplicationMeta` (what the migration rollup reads) reports
+/// the version the context actually executes. Returns the reinstalled id so
+/// the caller can evict its now-stale cache entry. Best-effort: a row left
+/// behind only misreports the version, it never changes what executes.
+async fn install_activated_blob(
+    datastore: &Store,
+    node_client: &NodeClient,
+    context_id: &ContextId,
+) -> Option<ApplicationId> {
+    let blob = crate::activation::uninstalled_activated_blob(datastore, context_id)?;
+    let blob_id = calimero_primitives::blobs::BlobId::from(blob);
+    if !node_client.has_blob(&blob_id).unwrap_or(false) {
+        return None;
+    }
+    // The row's own source: an in-place reinstall re-derives the same bundle
+    // id, it does not re-point the context anywhere new.
+    let source = installed_source(datastore, context_id)?;
+    match node_client
+        .install_application_from_bundle_blob(&blob_id, &source)
+        .await
+    {
+        Ok(application_id) => {
+            info!(%context_id, %blob_id, %application_id, "installed activated bytecode in place");
+            Some(application_id)
+        }
+        Err(err) => {
+            warn!(%context_id, %blob_id, %err, "activated bytecode not installable; reported version will lag until the next install");
+            None
+        }
+    }
+}
+
+/// The source URL recorded on a context's current application row.
+fn installed_source(
+    datastore: &Store,
+    context_id: &ContextId,
+) -> Option<calimero_primitives::application::ApplicationSource> {
+    let handle = datastore.handle();
+    let meta = handle
+        .get(&key::ContextMeta::new(*context_id))
+        .ok()
+        .flatten()?;
+    let application = handle.get(&meta.application).ok().flatten()?;
+    application.source.parse().ok()
 }
 
 /// Store-level executing-blob resolution for a context: its activation

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -1428,6 +1428,81 @@ mod tests {
         assert!(emit, "residue drop must edge-trigger");
     }
 
+    /// The rollup reads the version off the application row, so a peer that
+    /// converged by activation alone - it executes the target bytecode but
+    /// never ran the install - reports its OLD version until the row is healed.
+    #[test]
+    fn loaded_version_lags_until_the_activated_blob_is_installed() {
+        use calimero_primitives::context::ContextId;
+        use calimero_store::db::InMemoryDB;
+        use calimero_store::key::{ApplicationMeta as ApplicationMetaKey, BlobMeta};
+        use calimero_store::types::{ApplicationMeta, ContextMeta, PackageInfo};
+        use std::sync::Arc;
+
+        const V1_BLOB: [u8; 32] = [0x01; 32];
+        const V2_BLOB: [u8; 32] = [0x02; 32];
+
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let context_id = ContextId::from([0x77u8; 32]);
+        let application_id = calimero_primitives::application::ApplicationId::from([0xAAu8; 32]);
+
+        let install = |blob: [u8; 32], state_version: u32| {
+            let mut handle = store.handle();
+            handle
+                .put(
+                    &calimero_store::key::ContextMeta::new(context_id),
+                    &ContextMeta::new(
+                        ApplicationMetaKey::new(application_id),
+                        [0u8; 32],
+                        vec![],
+                        None,
+                    ),
+                )
+                .unwrap();
+            handle
+                .put(
+                    &ApplicationMetaKey::new(application_id),
+                    &ApplicationMeta::new(
+                        BlobMeta::new(blob.into()),
+                        0,
+                        "http://example.com".into(),
+                        Box::default(),
+                        BlobMeta::new([0u8; 32].into()),
+                        PackageInfo {
+                            package: "pkg".into(),
+                            version: "1.0.0".into(),
+                            signer_id: "signer".into(),
+                            state_version,
+                        },
+                    ),
+                )
+                .unwrap();
+        };
+
+        install(V1_BLOB, 1);
+        calimero_context::activation::record_activation(&store, &context_id, V2_BLOB);
+
+        assert_eq!(
+            loaded_context_version(&store, &context_id),
+            Some(1),
+            "an un-healed row keeps the rollup on the last installed version"
+        );
+        assert_eq!(
+            calimero_context::activation::uninstalled_activated_blob(&store, &context_id),
+            Some(V2_BLOB),
+            "the heal must fire for exactly this context"
+        );
+
+        // What the in-place install of the activated blob writes.
+        install(V2_BLOB, 2);
+
+        assert_eq!(loaded_context_version(&store, &context_id), Some(2));
+        assert_eq!(
+            calimero_context::activation::uninstalled_activated_blob(&store, &context_id),
+            None
+        );
+    }
+
     #[test]
     fn facts_for_namespace_reads_target_from_upgrade_record() {
         // The on-change driver computes the node's advertised facts from local

--- a/crates/node/src/sync/snapshot.rs
+++ b/crates/node/src/sync/snapshot.rs
@@ -1187,7 +1187,8 @@ impl SyncManager {
         // the SAME in-place install the normal blob-share path runs
         // (`install_bundle_after_blob_sharing`) against the blob the activation
         // marker now points at, so the peer's installed version matches the
-        // adopted one — exactly as a normally-upgraded peer ends up.
+        // adopted one. The lazy-upgrade path heals the same way: only a peer
+        // that installed the bundle itself gets there without help.
         if let Some(bound) = calimero_context::activation::activated_blob(
             self.context_client.datastore(),
             &context_id,


### PR DESCRIPTION
## Summary

A peer that converges through the lazy-upgrade path acquires the target bytecode by blob key and executes it under the activation marker, deliberately bypassing the application row. It never runs the install, so `ApplicationMeta.state_version` - the value `loaded_context_version` reads as "what version is this context on" - stays pinned to the last bundle that peer installed. For a same-id bundle upgrade `finalize_application_update` rewrites only `ContextMeta`, so nothing repairs it afterwards, and a peer that fully migrated reports `in_progress` for as long as the node runs. `all_migrated` never goes green, and the fleet report is permanently wrong on the common deployment path.

The resync/snapshot path already solved this by re-running the in-place install against the blob the activation marker points at. The lazy-upgrade path has the identical gap and was never patched, so this applies the same heal there, once, after the upgrade ladder settles - covering the `Replay` and `SingleJump` arms in one place rather than at each commit site. The heal is guarded on the row actually disagreeing with the marker, so it is a no-op for peers that did install, and the lazy trigger stops firing as soon as the marker matches the group target, so it runs at most once per upgrade.

Healing the row was preferred over pointing the report at `calimero_context::activation::activated_blob`: it matches the established precedent and fixes every consumer of `ApplicationMeta`, not just migration-status, leaving one source of truth for a context's version.

The snapshot comment's closing clause claimed the resync heal ends up "exactly as a normally-upgraded peer ends up" - the wrong assumption that hid this, since a lazily-upgraded peer never installs either. Corrected in place.

## Test plan

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p calimero-node -p calimero-context -p calimero-context-client`
- New unit coverage: `uninstalled_activated_blob_flags_only_a_row_left_behind` (the heal decision: fires only when the row trails the marker, silent for a marker-less or already-healed context) and `loaded_version_lags_until_the_activated_blob_is_installed` (pins the coupling - the rollup reads the row, so an un-healed row keeps reporting the last installed version).
- E2E, 2-node namespace cascade v1 to v2 (`migration-status` rollup asserted over the admin route), arm64 image built from this branch:
  - before: `assert_migration_complete` times out - `1/2 migrated, 1 in-progress, 0 unknown, 0 failed`
  - after: `2/2 migrated, 0 in-progress, 0 unknown, 0 failed`, `allMigrated=true`, `migrated=2`, `total=2`, `targetVersion=2`