### PR TITLE
fix(node): let a stranded joiner pull from a beacon it cannot yet verify

### DIFF
--- a/crates/governance-store/src/governance_broadcast.rs
+++ b/crates/governance-store/src/governance_broadcast.rs
@@ -223,6 +223,59 @@ pub fn verify_readiness_beacon(store: &Store, beacon: &SignedReadinessBeacon) ->
     signer_is_namespace_member(store, beacon.namespace_id, &beacon.peer_pubkey)
 }
 
+/// Whether THIS node is a member of `namespace_id` that holds no governance
+/// state yet — stranded, and unable to verify anyone.
+///
+/// The mirror of [`beacon_admission_provable`], and it exists for the mirrored
+/// circularity. That one lets an established member pull from a joiner it
+/// cannot yet recognise. This one lets a joiner pull from an established member
+/// it cannot yet recognise: [`verify_readiness_beacon`] requires the signer to
+/// be a known member, and a node that has applied no governance ops knows no
+/// members — so it drops every beacon, including the ones advertising exactly
+/// the state that would end that condition.
+///
+/// A join whose direct request found no reachable peer lands precisely here: it
+/// records membership, gets no key and no ops, and is then deaf to the only
+/// pull trigger it has.
+///
+/// Membership is read from this node's own namespace IDENTITY, not from the
+/// membership rows — the rows are the governance state it is missing, so
+/// requiring them would restate the circularity. The identity is written by the
+/// join before any of that exists, which is what makes it usable here and what
+/// keeps a stranger to the namespace out.
+///
+/// Grants nothing, exactly as its mirror does not: no membership row, no cache
+/// entry, no trust in the beacon's contents. It says only that pulling
+/// governance from this peer is worth a round trip. The beacon's signature is
+/// still checked by the caller, the pull is authenticated, the caller's
+/// debounce rate-limits it, and every op fetched still faces the full apply
+/// path. A node with no state risks nothing but the round trip.
+#[must_use]
+pub fn receiver_is_stranded_in_namespace(store: &Store, namespace_id: NamespaceId) -> bool {
+    let group_id = ContextGroupId::from(namespace_id.to_bytes());
+
+    // Ours to join at all? Absent identity ⇒ not our namespace ⇒ stay deaf.
+    if !matches!(
+        crate::NamespaceRepository::new(store).identity_record(&group_id),
+        Ok(Some(_))
+    ) {
+        return false;
+    }
+
+    // Stranded only while we hold nothing. An established member already
+    // passes `verify_readiness_beacon` and must keep going through it, so that
+    // this never widens the gate for a node that can actually check.
+    let handle = store.handle();
+    match handle.get(&calimero_store::key::NamespaceGovHead::new(
+        namespace_id.to_bytes(),
+    )) {
+        Ok(Some(head)) => !head.dag_heads.iter().any(|h| *h != [0u8; 32]),
+        Ok(None) => true,
+        // A failed read is datastore-level: claim nothing.
+        Err(_) => false,
+    }
+}
+
 /// Whether a beacon whose signer is not (yet) a known member carries an
 /// invitation proving it was admitted to the namespace.
 ///

--- a/crates/governance-store/src/governance_broadcast/tests.rs
+++ b/crates/governance-store/src/governance_broadcast/tests.rs
@@ -961,3 +961,78 @@ async fn a_resolvable_non_member_is_refused_not_deferred() {
         "a resolvable non-member is a genuine refusal"
     );
 }
+
+// ---------------------------------------------------------------------------
+// receiver_is_stranded_in_namespace — the joiner's half of the beacon
+// circularity. See `beacon_admission_provable` for the established member's.
+// ---------------------------------------------------------------------------
+
+/// Give this node a namespace identity — what a join writes before it holds any
+/// governance state, and the only thing a stranded node can be recognised by.
+fn plant_own_identity(store: &Store, namespace_id: NamespaceId) {
+    let sk = PrivateKey::random(&mut rand::thread_rng());
+    crate::NamespaceRepository::new(store)
+        .store_identity(
+            &ContextGroupId::from(namespace_id.to_bytes()),
+            &sk.public_key(),
+            &[7u8; 32],
+            &[9u8; 32],
+        )
+        .expect("store identity");
+}
+
+/// **The case that left `group-join-mesh-not-ready` unable to converge.**
+///
+/// A join whose direct request found no reachable peer records membership and
+/// returns with no key and no ops. `verify_readiness_beacon` needs the signer to
+/// be a known member, and this node knows no members — so every beacon is
+/// dropped, including the ones advertising the state that would end that.
+#[tokio::test]
+async fn a_member_holding_no_governance_state_is_stranded() {
+    let store = empty_store();
+    let ns_id: NamespaceId = [42u8; 32].into();
+    plant_own_identity(&store, ns_id);
+
+    assert!(
+        receiver_is_stranded_in_namespace(&store, ns_id),
+        "a member with no governance head must be allowed to pull"
+    );
+}
+
+/// The guard that keeps this from widening the gate generally: an established
+/// member has state, so it keeps going through `verify_readiness_beacon` and
+/// this escape hatch never opens for it.
+#[tokio::test]
+async fn a_member_that_holds_state_is_not_stranded() {
+    let store = empty_store();
+    let ns_id: NamespaceId = [42u8; 32].into();
+    plant_own_identity(&store, ns_id);
+
+    let mut handle = store.handle();
+    handle
+        .put(
+            &calimero_store::key::NamespaceGovHead::new(ns_id.to_bytes()),
+            &calimero_store::key::NamespaceGovHeadValue {
+                dag_heads: vec![[3u8; 32]],
+                sequence: 1,
+            },
+        )
+        .expect("plant a non-empty head");
+    drop(handle);
+
+    assert!(
+        !receiver_is_stranded_in_namespace(&store, ns_id),
+        "a node that can verify beacons must keep going through verification"
+    );
+}
+
+/// And a stranger stays deaf: no identity means this is not our namespace, so
+/// an unverifiable beacon for it is still just noise.
+#[tokio::test]
+async fn a_stranger_to_the_namespace_is_not_stranded() {
+    let store = empty_store();
+    assert!(!receiver_is_stranded_in_namespace(
+        &store,
+        [42u8; 32].into()
+    ));
+}

--- a/crates/node/src/handlers/network_event/readiness.rs
+++ b/crates/node/src/handlers/network_event/readiness.rs
@@ -21,7 +21,7 @@ use std::time::{Duration, Instant};
 use actix::{AsyncContext, WrapFuture};
 use calimero_context_client::local_governance::{ReadinessProbe, SignedReadinessBeacon};
 use calimero_governance_store::governance_broadcast::{
-    beacon_admission_provable, verify_readiness_beacon,
+    beacon_admission_provable, receiver_is_stranded_in_namespace, verify_readiness_beacon,
 };
 use calimero_governance_store::now_millis;
 use libp2p::PeerId;
@@ -110,10 +110,23 @@ pub(super) fn handle_readiness_beacon(
     beacon: SignedReadinessBeacon,
 ) {
     if !verify_readiness_beacon(&manager.datastore, &beacon) {
-        // Pull from a provable non-member instead of dropping it, targeting the
-        // signer: it is the only peer that holds its own not-yet-gossiped join op.
+        // Two ways an unverifiable beacon is still worth a pull, and they are
+        // mirror images:
+        //
+        //   * the SIGNER proves admission — an established member pulling from a
+        //     joiner it cannot yet recognise, targeting the signer because it is
+        //     the only peer holding its own not-yet-gossiped join op;
+        //   * WE are stranded — a joiner pulling from an established member it
+        //     cannot yet recognise, because verification needs membership rows
+        //     that are exactly the governance state we are missing.
+        //
+        // The second is why a node that joined while the mesh was unreachable
+        // never converged after a heal: it records membership, receives no ops,
+        // and is then deaf to the only pull trigger it has. Neither branch
+        // grants anything — see `beacon_admission_provable`.
         if beacon_ts_within_drift(beacon.ts_millis, now_millis())
-            && beacon_admission_provable(&manager.datastore, &beacon)
+            && (beacon_admission_provable(&manager.datastore, &beacon)
+                || receiver_is_stranded_in_namespace(&manager.datastore, beacon.namespace_id))
         {
             spawn_beacon_divergence_sync(
                 manager,


### PR DESCRIPTION
Refs #3406. Follow-up to #3411, which did not work — and the logs say why.

## #3411 was a no-op

It widened `beacon_indicates_divergence` so a member holding no state could act on a divergence beacon. On the merge run (`c62b3c00a`) node-2 logged **zero** governance syncs and:

```
26x  ReadinessBeacon failed verification; dropping
```

The beacon never reaches that check. The widened predicate is unreachable on the node that needs it.

## The actual circularity

`verify_readiness_beacon` = valid signature **AND** `signer_is_namespace_member`. Membership is read from rows that a node with no governance state does not have. So a stranded joiner drops **every** beacon — including the ones advertising exactly the state that would end that condition.

**It cannot verify the message that would let it fetch what it needs in order to verify messages.**

A join whose direct request finds no reachable peer lands precisely there: membership recorded, no key, no ops, and then deaf to its only pull trigger.

## The fix, and its precedent

This circularity already has a documented escape hatch in the *other* direction. `beacon_admission_provable` lets an **established member** pull from a **joiner** it cannot recognise, justified as:

> *"This grants nothing… it only tells the caller that pulling governance from this peer is worth the round trip."*

`receiver_is_stranded_in_namespace` is the mirror, for the joiner side, on identical terms.

**"Stranded"** is this node's own namespace **identity** plus an **empty governance head**:

- the *identity* is written by the join before any key or state exists, so it separates "joined but stranded" from "not our namespace" — a stranger stays deaf;
- the *empty head* keeps the hatch shut for anyone who can already verify. An established member has state and keeps going through `verify_readiness_beacon` completely unchanged.

**Nothing is granted.** No membership row, no `ReadinessCache` entry, no trust in the beacon's contents. The signature is still checked, the pull is authenticated, the caller's debounce rate-limits it, and every op fetched still faces the full apply path. A node with no state risks nothing but a round trip.

This **composes with #3411** rather than replacing it: this lets the beacon through, that lets a stateless member act on it. Both are needed, which is why #3411 alone changed nothing.

## Tested deterministically, on purpose

The scenario is **timing-dependent** — it passed on master at `28db645bf` and failed at `c62b3c00a`. A green CI run would not prove a fix and a red one would not disprove it, so the behaviour is pinned in unit tests against a real store instead:

- a member with no governance head **is** stranded (the deadlock case);
- a member that holds state is **not** — verification is not widened for anyone who can already do it;
- a stranger to the namespace is **not** — no identity, still deaf.

`cargo test -p calimero-governance-store` 583 passed · `-p calimero-node --lib` 471 passed · `fmt --check` and `clippy -D warnings` clean.

CI on the scenario is still worth watching, but treat it as one sample, not as the verdict.
