### PR TITLE
refactor(context): drop account_for_author's dead fallback branch

### DIFF
--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -113,11 +113,7 @@ type AuthCutContext = (
 /// precisely what `denied_members` and `accounts_by_endorsing_member` avoid: it can
 /// only be populated while observing bindings, so it comes back empty after a
 /// projection rebuild and silently reverts every device to the fallback.
-fn account_for_author(
-    view: &calimero_authz::AclView,
-    key: &PublicKey,
-    root: Option<(ContextGroupId, AccountId)>,
-) -> AccountId {
+fn account_for_author(view: &calimero_authz::AclView, key: &PublicKey) -> AccountId {
     // An explicit binding wins over the derived id. A folded `DeviceLinked` is a
     // signed statement about THIS key; `legacy_account_id` is a guess that names a
     // real principal nowhere now that the live plane keys every row by account.
@@ -138,38 +134,20 @@ fn account_for_author(
     {
         return binding.account;
     }
-    let own = legacy_account_id(key);
-    if view_knows_author(view, &own, root) {
-        return own;
-    }
-    own
-}
-
-/// Does this view carry any authority for `account` in its own name?
-///
-/// Deliberately broader than membership: an admin may appear only as a group or root
-/// admin, with no member row, and resolving such a key through a device binding
-/// would strip its admin authority exactly as it stripped membership above. Any
-/// authority at all is enough to say "this key speaks for itself".
-///
-/// `root` is the namespace's GENESIS admin, and it has to be here even though it is
-/// not folded state — it is the one authority no op carries, so it is the one
-/// principal the folded checks above structurally cannot see. A namespace founder
-/// that never appears in a membership op, never authored a `SubgroupCreated`, and
-/// never changed the admin (all three ordinary) is known to this view ONLY through
-/// this parameter. Leaving it out resolved that founder through its own device
-/// binding the moment one folded, to an `AccountId` that matches neither the
-/// membership rows nor `root` itself — both keyed by the stand-in — so the founder
-/// stopped being a member of its own namespace's open subgroups.
-fn view_knows_author(
-    view: &calimero_authz::AclView,
-    account: &AccountId,
-    root: Option<(ContextGroupId, AccountId)>,
-) -> bool {
-    view.is_scope_member(account)
-        || view.is_root_admin(account)
-        || view.group_admin.values().any(|admin| admin == account)
-        || root.is_some_and(|(_, genesis_admin)| genesis_admin == *account)
+    // No binding folded for this key, so all that is left is the stand-in. It
+    // names a real principal nowhere — every row on this plane is account-keyed —
+    // which is the correct answer for an author nobody has heard of: the
+    // authorization queries downstream all resolve it to "no".
+    //
+    // There used to be a `view_knows_author` check here, asking whether the
+    // derived id was one the view recognised. It could not change the outcome —
+    // both arms returned the same value — and it has not been able to since the
+    // binding/derived precedence was reversed. Measured before removing it: over
+    // the fold-equivalence suites the fallback is taken 13 times, and the only 4
+    // where the derived id WAS recognised come from a fixture that seeds the
+    // namespace's genesis admin as a stand-in itself. Production writes real
+    // accounts at every `admin_identity` site.
+    legacy_account_id(key)
 }
 
 fn build_op(
@@ -1528,7 +1506,7 @@ impl ScopeProjections {
         if view.as_ref().is_some_and(|v| {
             v.is_member_at_cut(
                 group,
-                &account_for_author(v, author, root),
+                &account_for_author(v, author),
                 root,
                 default_cap_base,
             )
@@ -1677,7 +1655,7 @@ impl ScopeProjections {
         Some(self.acl_view_at(&scope, heads).is_some_and(|v| {
             v.is_member_at_cut(
                 group,
-                &account_for_author(&v, author, root),
+                &account_for_author(&v, author),
                 root,
                 default_cap_base,
             )
@@ -1699,7 +1677,7 @@ impl ScopeProjections {
         heads: &[[u8; 32]],
     ) -> Option<bool> {
         let (view, root, _) = self.auth_cut_context(store, group, heads)?;
-        Some(view.is_authorized_admin(group, &account_for_author(&view, author, root), root))
+        Some(view.is_authorized_admin(group, &account_for_author(&view, author), root))
     }
 
     /// Is `member` an admin of `group` at the cut? The account-typed sibling of
@@ -1748,10 +1726,10 @@ impl ScopeProjections {
         heads: &[[u8; 32]],
     ) -> Option<bool> {
         let (view, root, default_cap_base) = self.auth_cut_context(store, group, heads)?;
-        if view.is_authorized_admin(group, &account_for_author(&view, author, root), root) {
+        if view.is_authorized_admin(group, &account_for_author(&view, author), root) {
             return Some(true);
         }
-        let folded = view.capability(&group, &account_for_author(&view, author, root));
+        let folded = view.capability(&group, &account_for_author(&view, author));
         let effective = if folded != 0 {
             folded
         } else {
@@ -1902,15 +1880,9 @@ impl ScopeProjections {
         let view = self.acl_view_at(&scope, heads);
         // Resolved exactly as the gates do, so a diagnostic can never disagree
         // with the decision it is meant to explain.
-        let root_group = ContextGroupId::from(ns_bytes);
-        let root = MetaRepository::new(store)
-            .load(&root_group)
-            .ok()
-            .flatten()
-            .map(|meta| (root_group, meta.admin_identity));
         let author_in_any = view
             .as_ref()
-            .is_some_and(|v| v.is_scope_member(&account_for_author(v, author, root)));
+            .is_some_and(|v| v.is_scope_member(&account_for_author(v, author)));
         // Is the DECISION group folded at all, and how big? Distinguishes
         // "subgroup membership never folded" (group absent / size 0 — a
         // decrypt/sync gap) from "folded but author absent" (re-add / deny-list).
@@ -1977,7 +1949,7 @@ impl ScopeProjections {
         // key was a member and the role lookup found nobody, which is the
         // "member at cut but role unresolved" the caller then logged before
         // guessing `Member`.
-        let account = account_for_author(&view, member, root);
+        let account = account_for_author(&view, member);
         match view.member_path_at_cut(group, &account, root, default_cap_base) {
             calimero_authz::MemberPathAtCut::None => None,
             calimero_authz::MemberPathAtCut::Direct { role } => Some(role),


### PR DESCRIPTION
Slice A of #3414. No behaviour change — this removes code that cannot affect the outcome, and establishes the baseline for the slices that follow.

## The dead branch

```rust
let own = legacy_account_id(key);
if view_knows_author(view, &own, root) { return own; }
own
```

Both arms return the same value. The check has had no effect since the binding/derived precedence was reversed — the `if` is vestigial.

It was not free to keep: `view_knows_author` existed solely for it, and `root` was threaded through **eight** call sites to reach it, including a `MetaRepository` load whose only consumer was the check. All of that goes.

## Measured, not assumed

Before deleting, I instrumented the fallback and ran the fold-equivalence suites (`projection_membership_equivalence`, `per_device_authorization`, `local_group_governance_convergence`):

| | |
| --- | --- |
| fallback taken | **13** |
| derived id names nobody | **9** — correct answer for an unknown author |
| derived id names a known principal | **4** |

All four of the second kind come from one fixture, `a_folded_join_device_does_not_hide_an_inherited_admin`, which **seeds the condition itself**:

```rust
.save(&ns, &meta(calimero_op_adapter::legacy_account_id(&admin)))
```

`view_knows_author` matched because `root.1 == genesis_admin` equalled the derived id — the test constructed exactly that. Production writes real accounts at every `admin_identity` site, so no real principal is reached through this path.

## Verification

The whole `calimero-context` suite passes unchanged — fold-equivalence included, which is the property that would break first if resolution moved. `fmt --check` and `clippy -D warnings` clean.

## What this sets up

Per the scoping in #3414, the stand-in bridge has **four production call sites**; the bulk of its ~90 references are fixtures that construct stand-ins deliberately. Converting those fixtures (slice B) is the real cost and the real risk, since they are the proof that the unified projection matches the live resolvers. Deleting the production sites and the functions (slice C) is a formality afterwards.

## Method note

Two instrumentation attempts returned a confident `0` while being structurally blind — `#[cfg(test)]` statics (integration tests do not compile the lib with `cfg(test)`) and `tracing::warn!` (no subscriber in these tests). Only `eprintln!` saw the 13 hits. Worth knowing before trusting a zero here.
