### PR TITLE
test(migration): assert migrated state, not the version string the binary reports

### DIFF
--- a/workflows/app-migration/00-single-group-migration-baseline.yml
+++ b/workflows/app-migration/00-single-group-migration-baseline.yml
@@ -188,10 +188,22 @@ steps:
     type: wait
     seconds: 15
 
-  - name: Read upgrade status
+  - name: Read the subgroup's upgrade record
     type: get_group_upgrade_status
     node: app-migration-baseline-1
     group_id: "{{group_id}}"
+    outputs:
+      up_status: status
+      up_to_version: toVersion
+
+  - name: Assert the record names the v2 target
+    # Only these two fields carry a value on a per-context upgrade: contexts
+    # swap on demand, so `completedAt` and the counters stay null. Whether the
+    # state actually migrated is the rollup's question, asserted below.
+    type: json_assert
+    statements:
+      - 'equal("{{up_status}}", "completed")'
+      - 'equal("{{up_to_version}}", "2.0.0")'
 
   # These reads TRIGGER each node's lazy migration: schema_info is not
   # a state op, so `maybe_lazy_upgrade` fires on each node, migrating
@@ -212,27 +224,47 @@ steps:
     outputs:
       v2_schema_node2: result
 
-  # Both nodes self-migrated via the lazy path — assert the migration
-  # logs on EACH after its triggering read above.
-  - name: Assert lazy migration ran on node 1
-    type: assert_log_present
-    nodes:
-      - app-migration-baseline-1
-    patterns:
-      - "performing lazy upgrade before execution"
-      - "Executing migration"
-      - "Migrated state written successfully"
-    min_matches: 1
+  # schema_info cannot prove a migration ran: the version string it returns is a
+  # constant compiled into the v2 binary, so it reads "2.0.0" over un-migrated
+  # v1 bytes too. The rollup carries each member's ABI STATE version instead.
+  - name: Wait for both members to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-baseline-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
-  - name: Assert lazy migration ran on node 2 (receiver self-migrated)
-    type: assert_log_present
-    nodes:
-      - app-migration-baseline-2
-    patterns:
-      - "performing lazy upgrade before execution"
-      - "Executing migration"
-      - "Migrated state written successfully"
-    min_matches: 1
+  - name: Read the migration-status rollup on node 1 (admin)
+    type: get_migration_status
+    node: app-migration-baseline-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      mig_target: target_version
+      mig_expected: expected_members
+      mig_total: total
+      mig_migrated: migrated
+      mig_failed: failed
+      mig_below_target: reported_below_target
+      mig_missing: reported_missing
+      mig_residue: residue_total
+
+  - name: Assert each member migrated its own state, with no residue left
+    type: json_assert
+    statements:
+      # The inherited Open-subgroup member is pinned into the cohort, so a
+      # cohort of 1 would mean node 2's state was never being waited on.
+      - "equal({{mig_expected}}, 2)"
+      - "equal({{mig_total}}, 2)"
+      - "equal({{mig_migrated}}, 2)"
+      - "equal({{mig_failed}}, 0)"
+      # A u32 ABI state version, not the "2.0.0" bundle semver the schema_info
+      # reads compare against.
+      - "equal({{mig_target}}, 2)"
+      # Recomputed from each member's raw report, not read back from core's own
+      # all_migrated, so a rollup with the wrong comparison still fails here.
+      - "equal({{mig_below_target}}, 0)"
+      - "equal({{mig_missing}}, 0)"
+      - "equal({{mig_residue}}, 0)"
 
   - name: Assert v2 schema on node 1 (v1 data preserved + notes seeded)
     type: json_assert

--- a/workflows/app-migration/00-single-group-migration-baseline.yml
+++ b/workflows/app-migration/00-single-group-migration-baseline.yml
@@ -11,10 +11,10 @@ description: >
   on node 1 AND mirrors the post-migration schema_info on node 2 to
   prove cross-node convergence via context-sync gossip.
 
-  Acts as the regression guard for #2433: that PR changed Root<T>
-  merge semantics, breaking write_migration_state's save_raw call
-  with MergeFailure(NoMergeFunctionRegistered). Pre-fix this
-  workflow fails at the upgrade_group step; post-fix it passes.
+  Acts as the regression guard for Root<T> merge semantics: a change
+  there once broke write_migration_state's save_raw call with
+  MergeFailure(NoMergeFunctionRegistered), which this workflow catches
+  at the upgrade_group step.
 
 no_docker: false
 nuke_on_start: true
@@ -62,7 +62,7 @@ steps:
 
   - name: Create Open subgroup on node 1
     # Open visibility lets node 2 materialise its inherited membership
-    # via `join_subgroup_inheritance` (issue #2357 endpoint).
+    # via `join_subgroup_inheritance`.
     type: create_group_in_namespace
     node: app-migration-baseline-1
     namespace_id: "{{namespace_id}}"

--- a/workflows/app-migration/00-single-group-migration-baseline.yml
+++ b/workflows/app-migration/00-single-group-migration-baseline.yml
@@ -1,4 +1,4 @@
-name: 00 — Single-group migration baseline (v1 → v2, 2-node)
+name: 00 - Single-group migration baseline (v1 → v2, 2-node)
 description: >
   2-node end-to-end baseline migration. Node 1 (admin) installs
   migration-suite-v1, creates a namespace + one Open subgroup + one
@@ -162,7 +162,7 @@ steps:
 
   - name: Assert both versions share one application id (bundle same-id)
     # Same-package bundles derive ApplicationId = hash(package, signer),
-    # so the second install MUST dedup onto the first id — the upgrade
+    # so the second install MUST dedup onto the first id - the upgrade
     # below then exercises the same-id (blob-only) propagation path.
     type: json_assert
     statements:

--- a/workflows/app-migration/01-namespace-cascade-migration.yml
+++ b/workflows/app-migration/01-namespace-cascade-migration.yml
@@ -292,16 +292,8 @@ steps:
   #      asserts node 2's lazy migration explicitly.
   #
   # So node 2 DOES run `migrate_v1_to_v2` — just via the lazy path, not
-  # the eager propagator. This step is intentionally emitter-scoped.
-  - name: Assert migration ran on node 1
-    type: assert_log_present
-    nodes:
-      - app-migration-cascade-1
-    patterns:
-      - "Executing migration"
-      - "migrate_v1_to_v2"
-      - "Migrated state written successfully"
-    min_matches: 1
+  # the eager propagator. Both triggers land on the same reported ABI state
+  # version, asserted together in Phase 7b''.
 
   # Phase 7b': Receiver-side cascade apply log on EACH node
   # separately.
@@ -356,20 +348,48 @@ steps:
     outputs:
       v2_schema_node2: result
 
-  # Phase 7b'': Receiver-side migration ran ON node 2 (lazy upgrade).
-  # Proves node 2 self-migrated rather than passively receiving state
-  # — the lazy path logs `performing lazy upgrade before execution`
-  # then the same `Executing migration` / `Migrated state written
-  # successfully` lines the emitter's eager propagator logs.
-  - name: Assert lazy migration ran on node 2 (receiver self-migrated)
-    type: assert_log_present
-    nodes:
-      - app-migration-cascade-2
-    patterns:
-      - "performing lazy upgrade before execution"
-      - "Executing migration"
-      - "Migrated state written successfully"
-    min_matches: 1
+  # Phase 7b'': proves node 2 self-migrated rather than passively receiving
+  # state. A migration is a whole-root replacement and is never gossiped, so
+  # node 2's reported state version can only reach the target by migrating its
+  # own bytes. schema_info cannot say that: it reads "2.0.0" either way.
+  - name: Wait for both members to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-cascade-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
+  - name: Read the migration-status rollup on node 1 (admin)
+    type: get_migration_status
+    node: app-migration-cascade-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      mig_target: target_version
+      mig_expected: expected_members
+      mig_total: total
+      mig_migrated: migrated
+      mig_failed: failed
+      mig_below_target: reported_below_target
+      mig_missing: reported_missing
+      mig_residue: residue_total
+
+  - name: Assert each member migrated its own state, with no residue left
+    type: json_assert
+    statements:
+      # The inherited Open-subgroup member is pinned into the cohort, so a
+      # cohort of 1 would mean node 2's state was never being waited on.
+      - "equal({{mig_expected}}, 2)"
+      - "equal({{mig_total}}, 2)"
+      - "equal({{mig_migrated}}, 2)"
+      - "equal({{mig_failed}}, 0)"
+      # A u32 ABI state version, not the "2.0.0" bundle semver the schema_info
+      # reads compare against.
+      - "equal({{mig_target}}, 2)"
+      # Recomputed from each member's raw report, not read back from core's own
+      # all_migrated, so a rollup with the wrong comparison still fails here.
+      - "equal({{mig_below_target}}, 0)"
+      - "equal({{mig_missing}}, 0)"
+      - "equal({{mig_residue}}, 0)"
 
   - name: Assert v2 schema on node 1 (v1 data preserved + notes seeded)
     type: json_assert

--- a/workflows/app-migration/01-namespace-cascade-migration.yml
+++ b/workflows/app-migration/01-namespace-cascade-migration.yml
@@ -1,4 +1,4 @@
-name: 01 — Namespace-cascade migration (v1 → v2, 2-node, cascade=true)
+name: 01 - Namespace-cascade migration (v1 → v2, 2-node, cascade=true)
 description: >
   Multi-node namespace-rooted cascade upgrade. Node 1 (admin) creates a
   namespace + one descendant subgroup + one context, invites node 2,
@@ -14,7 +14,7 @@ description: >
     - `create_group::handle` (originator-side derivation)
     - `group_created::apply` (remote-peer parent inheritance)
     - `create_group_invitation` + `join_group` (invitation-side
-      bootstrap of joiner's local meta — without this, node 2's
+      bootstrap of joiner's local meta - without this, node 2's
       local subgroup app_key would seed to [0u8; 32] and the
       cascade predicate would silently skip the subtree on node 2,
       diverging from node 1)
@@ -38,14 +38,14 @@ steps:
   # Phase 1: Install the v1 BUNDLE on the ADMIN node only.
   #
   # Realistic distribution: only the admin (node 1) holds the bytecode.
-  # Node 2 never runs install_application — it obtains v1 automatically
+  # Node 2 never runs install_application - it obtains v1 automatically
   # when it joins the context (blob announced for the context, fetched
   # over BlobShare on first execution), and v2 when the cascade upgrade
   # announces the target blob (pulled during node 2's lazy migration).
   #
   # Bundles derive ApplicationId = hash(package, signer): v1 and v2 share
   # one package, so they install under the SAME id and the upgrade moves
-  # only the bytecode blob — the realistic app-update shape. The v2
+  # only the bytecode blob - the realistic app-update shape. The v2
   # install therefore happens LATER (right before the cascade), as an
   # in-place version bump; installing it earlier would flip node 1's
   # bytecode before the v1 phase runs.
@@ -58,7 +58,7 @@ steps:
       app_v1: applicationId
 
   # Phase 2: Node 1 builds namespace + subgroup + context. NO
-  # pre-cascade alignment — cascade should work straight out of
+  # pre-cascade alignment - cascade should work straight out of
   # create_namespace + create_group_in_namespace.
   - name: Create namespace on node 1 (anchors app_v1)
     type: create_namespace
@@ -114,7 +114,7 @@ steps:
       namespace_invitation: invitation
 
   - name: Wait for subgroup visibility + context-registered ops to gossip
-    # Same rationale as group-join-via-inheritance.yml — node 2 needs
+    # Same rationale as group-join-via-inheritance.yml - node 2 needs
     # to see the Open-visibility row and the context-registered op
     # before its inheritance materialisation can succeed.
     type: wait
@@ -207,7 +207,7 @@ steps:
 
   - name: Assert both versions share one application id (bundle same-id)
     # Same-package bundles derive ApplicationId = hash(package, signer),
-    # so the second install MUST dedup onto the first id — the upgrade
+    # so the second install MUST dedup onto the first id - the upgrade
     # below then exercises the same-id (blob-only) propagation path.
     type: json_assert
     statements:
@@ -226,7 +226,7 @@ steps:
   # Fixed wait, NOT wait_for_sync: cascade is published async, and
   # the per-context migration propagator spawns after publish. A
   # root_hash-based wait_for_sync polled here exits in 0.00s
-  # vacuously synced — both nodes still hold the identical v1 root
+  # vacuously synced - both nodes still hold the identical v1 root
   # at the first poll because node 1's local migration hasn't
   # rewritten its root yet, so there's nothing to "wait" for. The
   # fixed wait covers (a) gossip propagation of the atomic
@@ -285,13 +285,13 @@ steps:
   #   2. Lazy on-access (every receiver): a receiver applies the gossiped
   #      `CascadeUpgrade` op to flip its local `GroupMeta`
   #      (target_application_id + app_key → v2), then SELF-migrates on its
-  #      next context access. The migrated state is NOT gossiped — a
+  #      next context access. The migrated state is NOT gossiped - a
   #      migration is a full root replacement, not a CRDT-mergeable delta
   #      (`clear_pending_delta`), so each receiver must re-run the migrate
   #      fn against its own byte-identical v1 state. Phase 7b'' below
   #      asserts node 2's lazy migration explicitly.
   #
-  # So node 2 DOES run `migrate_v1_to_v2` — just via the lazy path, not
+  # So node 2 DOES run `migrate_v1_to_v2` - just via the lazy path, not
   # the eager propagator. Both triggers land on the same reported ABI state
   # version, asserted together in Phase 7b''.
 
@@ -305,7 +305,7 @@ steps:
   # namespace root + 1 descendant subgroup = 2 log lines per node.
   # Per-node assertions (rather than a single aggregated check) catch
   # the asymmetric regression where node 1 applies but node 2 silently
-  # drops the op — that case would still satisfy any aggregated
+  # drops the op - that case would still satisfy any aggregated
   # threshold but is exactly the bug this PR's `app_key` fix triangle
   # prevents.
   - name: Assert cascade apply log on node 1 (emitter)

--- a/workflows/app-migration/01-namespace-cascade-migration.yml
+++ b/workflows/app-migration/01-namespace-cascade-migration.yml
@@ -76,8 +76,8 @@ steps:
 
   - name: Create descendant Open subgroup on node 1
     # Open visibility lets node 2 materialise its inherited membership
-    # via `join_subgroup_inheritance` (issue #2357 endpoint) instead
-    # of needing an admin-signed group invitation per descendant.
+    # via `join_subgroup_inheritance` instead of needing an
+    # admin-signed group invitation per descendant.
     type: create_group_in_namespace
     node: app-migration-cascade-1
     namespace_id: "{{namespace_id}}"
@@ -127,7 +127,7 @@ steps:
     invitation: "{{namespace_invitation}}"
 
   - name: Node 2 materialises subgroup membership via inheritance
-    # Open subgroup + inherited member: this endpoint (issue #2357)
+    # Open subgroup + inherited member: this endpoint
     # publishes MemberJoinedOpen, fetches the subgroup key via the
     # direct-stream protocol, and returns once KeyDelivery lands so
     # the subsequent join_context can decrypt traffic immediately.

--- a/workflows/app-migration/02-scenario-additive-field.yml
+++ b/workflows/app-migration/02-scenario-additive-field.yml
@@ -226,27 +226,47 @@ steps:
     outputs:
       v2_schema_node2: result
 
-  # Both nodes self-migrated via the lazy path — assert the migration
-  # logs on EACH after its triggering read above.
-  - name: Assert lazy migration ran on node 1
-    type: assert_log_present
-    nodes:
-      - app-migration-additive-1
-    patterns:
-      - "performing lazy upgrade before execution"
-      - "Executing migration"
-      - "Migrated state written successfully"
-    min_matches: 1
+  # schema_info cannot prove a migration ran: the version string it returns is a
+  # constant compiled into the v2 binary, so it reads "2.0.0" over un-migrated
+  # v1 bytes too. The rollup carries each member's ABI STATE version instead.
+  - name: Wait for both members to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-additive-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
-  - name: Assert lazy migration ran on node 2 (receiver self-migrated)
-    type: assert_log_present
-    nodes:
-      - app-migration-additive-2
-    patterns:
-      - "performing lazy upgrade before execution"
-      - "Executing migration"
-      - "Migrated state written successfully"
-    min_matches: 1
+  - name: Read the migration-status rollup on node 1 (admin)
+    type: get_migration_status
+    node: app-migration-additive-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      mig_target: target_version
+      mig_expected: expected_members
+      mig_total: total
+      mig_migrated: migrated
+      mig_failed: failed
+      mig_below_target: reported_below_target
+      mig_missing: reported_missing
+      mig_residue: residue_total
+
+  - name: Assert each member migrated its own state, with no residue left
+    type: json_assert
+    statements:
+      # The inherited Open-subgroup member is pinned into the cohort, so a
+      # cohort of 1 would mean node 2's state was never being waited on.
+      - "equal({{mig_expected}}, 2)"
+      - "equal({{mig_total}}, 2)"
+      - "equal({{mig_migrated}}, 2)"
+      - "equal({{mig_failed}}, 0)"
+      # A u32 ABI state version, not the "2.0.0" bundle semver the schema_info
+      # reads compare against.
+      - "equal({{mig_target}}, 2)"
+      # Recomputed from each member's raw report, not read back from core's own
+      # all_migrated, so a rollup with the wrong comparison still fails here.
+      - "equal({{mig_below_target}}, 0)"
+      - "equal({{mig_missing}}, 0)"
+      - "equal({{mig_residue}}, 0)"
 
   - name: Assert v2 schema on node 1 (additive field seeded, v1 data preserved)
     type: json_assert

--- a/workflows/app-migration/02-scenario-additive-field.yml
+++ b/workflows/app-migration/02-scenario-additive-field.yml
@@ -1,11 +1,11 @@
-name: 02 — Scenario "additive field" (v1 → v2-add-field, 2-node)
+name: 02 - Scenario "additive field" (v1 → v2-add-field, 2-node)
 description: >
   2-node per-context migration for the additive-field scenario.
   v1 → v2-add-field adds a `notes: LwwRegister<String>` to the state
   struct; `migrate_v1_to_v2` preserves every v1 field and seeds the
   new `notes` field. Topology: namespace + one Open subgroup + one
   context in the subgroup. Upgrade is `upgrade_group(group=subgroup,
-  target=v2)` — per-context (cascade=false), not namespace-cascade
+  target=v2)` - per-context (cascade=false), not namespace-cascade
   (that's `01`); the node resolves `migrate_v1_to_v2` from the target
   bundle's embedded ABI. Acts as the additive row of the per-scenario
   matrix.
@@ -30,12 +30,12 @@ steps:
   # Phase 1: Install v1 + v2 binaries on the ADMIN node only.
   #
   # Realistic distribution: only the admin (node 1) is given the
-  # bytecode. Node 2 never runs install_application — it must obtain
+  # bytecode. Node 2 never runs install_application - it must obtain
   # both versions automatically:
   #   - v1 when it joins the context (the app blob is announced for the
   #     context and fetched over BlobShare on first execution), and
   #   - v2 when node 1 upgrades the group (upgrade_group announces the
-  #     target blob; node 2 pulls it during its lazy migration — the
+  #     target blob; node 2 pulls it during its lazy migration - the
   #     sync-gate intentionally leaves BlobShare open for this).
   # App ids are content-addressed (blob_id of the bytecode), so node 1's
   # captured app_v1/app_v2 ids are exactly the ids node 2 resolves.
@@ -165,7 +165,7 @@ steps:
       - 'json_subset({{v1_schema}}, {"output": {"schema_version": "1.0.0", "description": "additive-scenario", "counter": "2"}})'
 
   # Negative: v2-only setter not yet callable under v1.
-  - name: Negative — set_notes is not exported by v1
+  - name: Negative - set_notes is not exported by v1
     type: call
     node: app-migration-additive-1
     context_id: "{{ctx_id}}"
@@ -176,7 +176,7 @@ steps:
 
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
   # The upgrade sets the target + migration method on the subgroup meta
-  # and returns without running a propagator — each node self-migrates on
+  # and returns without running a propagator - each node self-migrates on
   # its next access below.
   - name: Install migration-suite-v2-add-field on node 1
     type: install_application
@@ -189,7 +189,7 @@ steps:
 
   - name: Assert both versions share one application id (bundle same-id)
     # Same-package bundles derive ApplicationId = hash(package, signer),
-    # so the second install MUST dedup onto the first id — the upgrade
+    # so the second install MUST dedup onto the first id - the upgrade
     # below then exercises the same-id (blob-only) propagation path.
     type: json_assert
     statements:

--- a/workflows/app-migration/09-scenario-crdt-native.yml
+++ b/workflows/app-migration/09-scenario-crdt-native.yml
@@ -238,27 +238,47 @@ steps:
     outputs:
       v2_schema_node2: result
 
-  # Both nodes self-migrated via the lazy path — assert the migration
-  # logs on EACH after its triggering read above.
-  - name: Assert lazy migration ran on node 1
-    type: assert_log_present
-    nodes:
-      - app-migration-crdt-1
-    patterns:
-      - "performing lazy upgrade before execution"
-      - "Executing migration"
-      - "Migrated state written successfully"
-    min_matches: 1
+  # schema_info cannot prove a migration ran: the version string it returns is a
+  # constant compiled into the v2 binary, so it reads "2.0.0" over un-migrated
+  # v1 bytes too. The rollup carries each member's ABI STATE version instead.
+  - name: Wait for both members to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-crdt-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
-  - name: Assert lazy migration ran on node 2 (receiver self-migrated)
-    type: assert_log_present
-    nodes:
-      - app-migration-crdt-2
-    patterns:
-      - "performing lazy upgrade before execution"
-      - "Executing migration"
-      - "Migrated state written successfully"
-    min_matches: 1
+  - name: Read the migration-status rollup on node 1 (admin)
+    type: get_migration_status
+    node: app-migration-crdt-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      mig_target: target_version
+      mig_expected: expected_members
+      mig_total: total
+      mig_migrated: migrated
+      mig_failed: failed
+      mig_below_target: reported_below_target
+      mig_missing: reported_missing
+      mig_residue: residue_total
+
+  - name: Assert each member migrated its own state, with no residue left
+    type: json_assert
+    statements:
+      # The inherited Open-subgroup member is pinned into the cohort, so a
+      # cohort of 1 would mean node 2's state was never being waited on.
+      - "equal({{mig_expected}}, 2)"
+      - "equal({{mig_total}}, 2)"
+      - "equal({{mig_migrated}}, 2)"
+      - "equal({{mig_failed}}, 0)"
+      # A u32 ABI state version, not the "2.0.0" bundle semver the schema_info
+      # reads compare against.
+      - "equal({{mig_target}}, 2)"
+      # Recomputed from each member's raw report, not read back from core's own
+      # all_migrated, so a rollup with the wrong comparison still fails here.
+      - "equal({{mig_below_target}}, 0)"
+      - "equal({{mig_missing}}, 0)"
+      - "equal({{mig_residue}}, 0)"
 
   - name: Assert v2 schema on node 1 (tags seeded during migrate from 3 item keys, v1 data preserved)
     type: json_assert

--- a/workflows/app-migration/09-scenario-crdt-native.yml
+++ b/workflows/app-migration/09-scenario-crdt-native.yml
@@ -1,4 +1,4 @@
-name: 09 — Scenario "crdt-native" (v1 → v2-add-crdt-collection, 2-node)
+name: 09 - Scenario "crdt-native" (v1 → v2-add-crdt-collection, 2-node)
 description: >
   2-node per-context migration for the CRDT-collection-typed field
   scenario. v1 → v2 adds a `tags: Vector<LwwRegister<String>>` to the
@@ -10,11 +10,11 @@ description: >
   `tags` Vector during migrate from the sorted v1 item keys. Topology:
   namespace + one Open subgroup + one context in the subgroup. Upgrade
   is `upgrade_group(group=subgroup, target=v2, migrate=migrate_v1_to_v2)`
-  — per-context (cascade=false). Acts as the CRDT-collection-add row of
+  - per-context (cascade=false). Acts as the CRDT-collection-add row of
   the per-scenario matrix.
 
   Cross-node determinism: a `Vector` populated INSIDE a migrate is the
-  hard case — `push` mints `Id::random()` element ids on the live path,
+  hard case - `push` mints `Id::random()` element ids on the live path,
   but migrate re-runs independently on every node and emits no delta, so
   random ids would diverge and double up on the next sync. The SDK
   re-keys migrate-seeded Vector elements by append index (and zeroes the
@@ -180,7 +180,7 @@ steps:
       - 'json_subset({{v1_schema}}, {"output": {"schema_version": "1.0.0", "title": "crdt-scenario-doc", "tag_count": 0}})'
 
   # Negative: v2-only method not yet callable under v1.
-  - name: Negative — push_tag is not exported by v1
+  - name: Negative - push_tag is not exported by v1
     type: call
     node: app-migration-crdt-1
     context_id: "{{ctx_id}}"
@@ -201,7 +201,7 @@ steps:
 
   - name: Assert both versions share one application id (bundle same-id)
     # Same-package bundles derive ApplicationId = hash(package, signer),
-    # so the second install MUST dedup onto the first id — the upgrade
+    # so the second install MUST dedup onto the first id - the upgrade
     # below then exercises the same-id (blob-only) propagation path.
     type: json_assert
     statements:
@@ -313,7 +313,7 @@ steps:
   # and seeded `tags` from the same sorted v1 keys [k1,k2,k3]. Read the
   # seeded values back on each node by index to confirm identical
   # ordering/content. (Element-id divergence is caught by the post-sync
-  # tag_count below, not here — get_tag reads by position.)
+  # tag_count below, not here - get_tag reads by position.)
   - name: Read seeded tag(0) on node 1
     type: call
     node: app-migration-crdt-1
@@ -421,7 +421,7 @@ steps:
     outputs:
       tag_count_after_node2: result
 
-  - name: Assert five tags on node 2 — divergent migrate ids would inflate this
+  - name: Assert five tags on node 2 - divergent migrate ids would inflate this
     type: json_assert
     statements:
       - 'json_equal({{tag_count_after_node2}}, {"output": 5})'

--- a/workflows/app-migration/11-scenario-field-split.yml
+++ b/workflows/app-migration/11-scenario-field-split.yml
@@ -212,27 +212,47 @@ steps:
     outputs:
       v2_schema_node2: result
 
-  # Both nodes self-migrated via the lazy path — assert the migration
-  # logs on EACH after its triggering read above.
-  - name: Assert lazy migration ran on node 1
-    type: assert_log_present
-    nodes:
-      - app-migration-split-1
-    patterns:
-      - "performing lazy upgrade before execution"
-      - "Executing migration"
-      - "Migrated state written successfully"
-    min_matches: 1
+  # schema_info cannot prove a migration ran: the version string it returns is a
+  # constant compiled into the v2 binary, so it reads "2.0.0" over un-migrated
+  # v1 bytes too. The rollup carries each member's ABI STATE version instead.
+  - name: Wait for both members to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-split-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
-  - name: Assert lazy migration ran on node 2 (receiver self-migrated)
-    type: assert_log_present
-    nodes:
-      - app-migration-split-2
-    patterns:
-      - "performing lazy upgrade before execution"
-      - "Executing migration"
-      - "Migrated state written successfully"
-    min_matches: 1
+  - name: Read the migration-status rollup on node 1 (admin)
+    type: get_migration_status
+    node: app-migration-split-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      mig_target: target_version
+      mig_expected: expected_members
+      mig_total: total
+      mig_migrated: migrated
+      mig_failed: failed
+      mig_below_target: reported_below_target
+      mig_missing: reported_missing
+      mig_residue: residue_total
+
+  - name: Assert each member migrated its own state, with no residue left
+    type: json_assert
+    statements:
+      # The inherited Open-subgroup member is pinned into the cohort, so a
+      # cohort of 1 would mean node 2's state was never being waited on.
+      - "equal({{mig_expected}}, 2)"
+      - "equal({{mig_total}}, 2)"
+      - "equal({{mig_migrated}}, 2)"
+      - "equal({{mig_failed}}, 0)"
+      # A u32 ABI state version, not the "2.0.0" bundle semver the schema_info
+      # reads compare against.
+      - "equal({{mig_target}}, 2)"
+      # Recomputed from each member's raw report, not read back from core's own
+      # all_migrated, so a rollup with the wrong comparison still fails here.
+      - "equal({{mig_below_target}}, 0)"
+      - "equal({{mig_missing}}, 0)"
+      - "equal({{mig_residue}}, 0)"
 
   - name: Assert v2 schema on node 1 (address parsed into three fields, name preserved)
     type: json_assert

--- a/workflows/app-migration/11-scenario-field-split.yml
+++ b/workflows/app-migration/11-scenario-field-split.yml
@@ -1,4 +1,4 @@
-name: 11 — Scenario "field split" (v1 → v2-field-split, 2-node)
+name: 11 - Scenario "field split" (v1 → v2-field-split, 2-node)
 description: >
   2-node per-context migration for the field-split scenario.
   v1 carries a single `address: LwwRegister<String>` field; v2 splits
@@ -8,7 +8,7 @@ description: >
   back to street = whole address with city/postcode empty.
   Topology: namespace + one Open subgroup + one context in the
   subgroup. Upgrade is `upgrade_group(group=subgroup, target=v2,
-  migrate=migrate_v1_to_v2)` — per-context (cascade=false). Acts as
+  migrate=migrate_v1_to_v2)` - per-context (cascade=false). Acts as
   the schema-reshape row of the per-scenario matrix. Cross-node
   assertions prove the split-field shape reaches node 2 via context-
   sync gossip.
@@ -111,7 +111,7 @@ steps:
     context_id: "{{ctx_id}}"
 
   # Phase 4: Write v1 state on node 1, wait for node 2 to catch up.
-  - name: Write v1 state — set_name
+  - name: Write v1 state - set_name
     type: call
     node: app-migration-split-1
     context_id: "{{ctx_id}}"
@@ -119,7 +119,7 @@ steps:
     args:
       name: "customer-7"
 
-  - name: Write v1 state — set_address (3-part comma-separated)
+  - name: Write v1 state - set_address (3-part comma-separated)
     type: call
     node: app-migration-split-1
     context_id: "{{ctx_id}}"
@@ -150,7 +150,7 @@ steps:
       - 'json_subset({{v1_schema}}, {"output": {"schema_version": "1.0.0", "name": "customer-7", "address": "221B Baker Street, London, NW1 6XE"}})'
 
   # Negative: v2-only setter not yet callable under v1.
-  - name: Negative — set_street is not exported by v1
+  - name: Negative - set_street is not exported by v1
     type: call
     node: app-migration-split-1
     context_id: "{{ctx_id}}"
@@ -161,7 +161,7 @@ steps:
 
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
   # The upgrade sets the target + migration method on the subgroup meta
-  # and returns without running a propagator — each node self-migrates on
+  # and returns without running a propagator - each node self-migrates on
   # its next access below.
   - name: Install scenario-field-split-v2 on node 1
     type: install_application
@@ -174,7 +174,7 @@ steps:
 
   - name: Assert both versions share one application id (bundle same-id)
     # Same-package bundles derive ApplicationId = hash(package, signer),
-    # so the second install MUST dedup onto the first id — the upgrade
+    # so the second install MUST dedup onto the first id - the upgrade
     # below then exercises the same-id (blob-only) propagation path.
     type: json_assert
     statements:
@@ -313,7 +313,7 @@ steps:
       - 'json_subset({{v2_schema_after_node2}}, {"output": {"postcode": "NW1 6XF"}})'
 
   # Negative: v1-only setter is no longer callable under v2.
-  - name: Negative — set_address is gone in v2
+  - name: Negative - set_address is gone in v2
     type: call
     node: app-migration-split-1
     context_id: "{{ctx_id}}"

--- a/workflows/app-migration/12-scenario-field-remove-archive.yml
+++ b/workflows/app-migration/12-scenario-field-remove-archive.yml
@@ -225,27 +225,47 @@ steps:
     outputs:
       v2_schema_node2: result
 
-  # Both nodes self-migrated via the lazy path — assert the migration
-  # logs on EACH after its triggering read above.
-  - name: Assert lazy migration ran on node 1
-    type: assert_log_present
-    nodes:
-      - app-migration-archive-1
-    patterns:
-      - "performing lazy upgrade before execution"
-      - "Executing migration"
-      - "Migrated state written successfully"
-    min_matches: 1
+  # schema_info cannot prove a migration ran: the version string it returns is a
+  # constant compiled into the v2 binary, so it reads "2.0.0" over un-migrated
+  # v1 bytes too. The rollup carries each member's ABI STATE version instead.
+  - name: Wait for both members to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-archive-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
-  - name: Assert lazy migration ran on node 2 (receiver self-migrated)
-    type: assert_log_present
-    nodes:
-      - app-migration-archive-2
-    patterns:
-      - "performing lazy upgrade before execution"
-      - "Executing migration"
-      - "Migrated state written successfully"
-    min_matches: 1
+  - name: Read the migration-status rollup on node 1 (admin)
+    type: get_migration_status
+    node: app-migration-archive-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      mig_target: target_version
+      mig_expected: expected_members
+      mig_total: total
+      mig_migrated: migrated
+      mig_failed: failed
+      mig_below_target: reported_below_target
+      mig_missing: reported_missing
+      mig_residue: residue_total
+
+  - name: Assert each member migrated its own state, with no residue left
+    type: json_assert
+    statements:
+      # The inherited Open-subgroup member is pinned into the cohort, so a
+      # cohort of 1 would mean node 2's state was never being waited on.
+      - "equal({{mig_expected}}, 2)"
+      - "equal({{mig_total}}, 2)"
+      - "equal({{mig_migrated}}, 2)"
+      - "equal({{mig_failed}}, 0)"
+      # A u32 ABI state version, not the "2.0.0" bundle semver the schema_info
+      # reads compare against.
+      - "equal({{mig_target}}, 2)"
+      # Recomputed from each member's raw report, not read back from core's own
+      # all_migrated, so a rollup with the wrong comparison still fails here.
+      - "equal({{mig_below_target}}, 0)"
+      - "equal({{mig_missing}}, 0)"
+      - "equal({{mig_residue}}, 0)"
 
   - name: Assert v2 schema on node 1 (legacy archived, name + counter preserved)
     type: json_assert

--- a/workflows/app-migration/12-scenario-field-remove-archive.yml
+++ b/workflows/app-migration/12-scenario-field-remove-archive.yml
@@ -1,15 +1,15 @@
-name: 12 — Scenario "field remove with archive" (v1 → v2-archive, 2-node)
+name: 12 - Scenario "field remove with archive" (v1 → v2-archive, 2-node)
 description: >
   2-node per-context migration for the field-remove-with-archive
   scenario. v1 carries a `legacy_note: LwwRegister<String>` that v2
-  drops from the active schema — but the migration ARCHIVES the v1
+  drops from the active schema - but the migration ARCHIVES the v1
   value into a new `archived_legacy: UnorderedMap<String,
   LwwRegister<String>>` keyed by "latest", so data isn't lost (it just
   moves out of the active schema into an explicit archive sibling).
   This differs from `03-scenario-remove-field`, which drops the v1
   value outright. Topology: namespace + one Open subgroup + one
   context in the subgroup. Upgrade is `upgrade_group(group=subgroup,
-  target=v2, migrate=migrate_v1_to_v2)` — per-context (cascade=false).
+  target=v2, migrate=migrate_v1_to_v2)` - per-context (cascade=false).
 
   Bug-2 cross-node guard: node 2 reads the new `archived_legacy` map
   via `get_archived("latest")` to prove the migration's storage
@@ -174,7 +174,7 @@ steps:
 
   # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
   # The upgrade sets the target + migration method on the subgroup meta
-  # and returns without running a propagator — each node self-migrates on
+  # and returns without running a propagator - each node self-migrates on
   # its next access below.
   - name: Install scenario-field-remove-archive-v2 on node 1
     type: install_application
@@ -187,7 +187,7 @@ steps:
 
   - name: Assert both versions share one application id (bundle same-id)
     # Same-package bundles derive ApplicationId = hash(package, signer),
-    # so the second install MUST dedup onto the first id — the upgrade
+    # so the second install MUST dedup onto the first id - the upgrade
     # below then exercises the same-id (blob-only) propagation path.
     type: json_assert
     statements:
@@ -274,7 +274,7 @@ steps:
       - 'json_subset({{v2_schema_node1}}, {"output": {"name": "contract-A", "counter": 3}})'
       - 'json_subset({{v2_schema_node1}}, {"output": {"archived_latest": "legacy-data-do-not-discard"}})'
 
-  - name: Assert v2 schema on node 2 (bug-2 guard — archive map reached node 2)
+  - name: Assert v2 schema on node 2 (bug-2 guard - archive map reached node 2)
     type: json_assert
     statements:
       - 'json_subset({{v2_schema_node2}}, {"output": {"schema_version": "2.0.0"}})'
@@ -312,7 +312,7 @@ steps:
       - 'json_equal({{archived_value_node2}}, {"output": "legacy-data-do-not-discard"})'
 
   # Negative: v1-only setter no longer exported by v2.
-  - name: Negative — set_legacy_note (v1) is gone in v2
+  - name: Negative - set_legacy_note (v1) is gone in v2
     type: call
     node: app-migration-archive-1
     context_id: "{{ctx_id}}"
@@ -322,7 +322,7 @@ steps:
     expected_failure: true
 
   # Negative: v1-only getter no longer exported by v2.
-  - name: Negative — get_legacy_note (v1) is gone in v2
+  - name: Negative - get_legacy_note (v1) is gone in v2
     type: call
     node: app-migration-archive-1
     context_id: "{{ctx_id}}"

--- a/workflows/app-migration/28-get-migration-status.yml
+++ b/workflows/app-migration/28-get-migration-status.yml
@@ -1,7 +1,7 @@
-name: 28 — get_migration_status rollup substrate (PR-6c, node-log validated)
+name: 28 - get_migration_status rollup (PR-6c)
 description: >
-  Migration-status visibility across a 2-node namespace, validated against
-  node logs (PR-6c tasks 6c.7/6c.8/6c.9/6c.10 + 6c.11).
+  Migration-status visibility across a 2-node namespace, validated against the
+  admin rollup itself (PR-6c tasks 6c.7/6c.8/6c.9/6c.10 + 6c.11).
 
   Completion visibility is ephemeral signed TTL gossip, NOT replicated
   governance state: each node periodically publishes a signed
@@ -14,34 +14,25 @@ description: >
   with no fresh heartbeat is `unknown` and keeps `all_migrated = false` (no
   false green). Observability only — never a gate.
 
-  This scenario drives a migration across the 2-node namespace and node-log
-  validates the heartbeat substrate the rollup reads (the rollup arithmetic
-  itself — pinning, unknown-safety, all_migrated — is unit-covered in task
-  6c.9: unknown_member_blocks_all_migrated / cohort_pinned_ignores_post_expand_joiner
-  / all_migrated_true_only_when_every_pinned_member_v2_residue0):
+  This scenario drives a migration across the 2-node namespace and reads the
+  rollup the heartbeats feed, at both of its edges:
 
-    - While both members are online and converged at v2, each node EMITS its
-      own signed heartbeat and CACHES the peer's — proving both cohort rows
-      populate, the precondition for `all_migrated = true`.
-    - A signature/membership-failing heartbeat is dropped on ingest (the gate
-      that keeps an unsigned/non-member peer out of any rollup).
+    - While both members are online and converged at v2, every cohort row is
+      populated from a fresh heartbeat. Node 2's row can only be non-unknown if
+      node 2 EMITTED and node 1 INGESTED past the signature/membership gate, so
+      emit, cache and the drop path are asserted through their state
+      consequence rather than through log lines.
     - When node 2 goes offline its heartbeats stop arriving at node 1; with no
       fresh heartbeat its cohort row ages out of the TTL window and the rollup
       reports it `unknown`, keeping `all_migrated = false` — the no-false-green
-      contract.
+      contract. `fleetCompletedAt` is durable and must NOT follow it back down.
+
+  The rollup's own arithmetic is additionally unit-covered in task 6c.9
+  (unknown_member_blocks_all_migrated / cohort_pinned_ignores_post_expand_joiner
+  / all_migrated_true_only_when_every_pinned_member_v2_residue0).
 
   Because migration_v2 defaults ON (PR-6b task 6b.8), the heartbeat emit +
   ingest run natively — no merobox feature flag is needed.
-
-  Scope note: the `get_migration_status` rollup is reachable over the admin
-  route GET /groups/:namespace_id/migration-status (task 6c.10) and its
-  arithmetic is unit-covered in task 6c.9. There is no merobox step that polls
-  that route yet (cf. the get_cascade_status step shipped for #2524), so this
-  e2e node-log-validates the heartbeat gossip substrate the rollup consumes —
-  emit, signed+membership-gated ingest, and the offline → unknown transition —
-  rather than asserting JSON from a merobox step that does not exist. When a
-  migration-status poll step lands this scenario gains the direct rollup
-  assertions (expected_members, unknown==1, allMigrated==false).
 
 no_docker: false
 nuke_on_start: true
@@ -207,38 +198,50 @@ steps:
     type: wait
     seconds: 40
 
-  # Phase 6: NODE-LOG VALIDATION — the explicit requirement for scenario 28.
+  # Phase 6: THE ROLLUP - the route this scenario is named after.
   #
-  # (a) Each node EMITS its own signed migration heartbeat (the publish twin
-  #     of the cache). Asserted on both nodes independently.
-  - name: Assert node 1 emitted a migration heartbeat
-    type: assert_log_present
-    nodes:
-      - app-migration-mstatus-1
-    patterns:
-      - "migration heartbeat emitted"
-    min_matches: 1
+  # (a) Node 2's row can only be non-unknown if node 2 emitted and node 1
+  #     ingested past the signature + cohort-membership gate, so emit, cache
+  #     and the drop gate are asserted through their state consequence.
+  - name: Read the migration-status rollup on node 1 (admin)
+    type: get_migration_status
+    node: app-migration-mstatus-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      ms_target: target_version
+      ms_expected: expected_members
+      ms_total: total
+      ms_migrated: migrated
+      ms_unknown: unknown
+      ms_failed: failed
+      ms_all_migrated: all_migrated
+      ms_below_target: reported_below_target
+      ms_missing: reported_missing
+      ms_residue: residue_total
 
-  - name: Assert node 2 emitted a migration heartbeat
-    type: assert_log_present
-    nodes:
-      - app-migration-mstatus-2
-    patterns:
-      - "migration heartbeat emitted"
-    min_matches: 1
+  - name: Assert both cohort rows converged at the target ABI state version
+    type: json_assert
+    statements:
+      - "equal({{ms_expected}}, 2)"
+      - "equal({{ms_total}}, 2)"
+      - "equal({{ms_migrated}}, 2)"
+      # A heartbeat refused at the sig/membership gate leaves its member
+      # unknown, so this is the falsifiable direction of the drop path.
+      - "equal({{ms_unknown}}, 0)"
+      - "equal({{ms_failed}}, 0)"
+      - "equal({{ms_residue}}, 0)"
+      # The target is a u32 ABI state version, not a bundle semver.
+      - "equal({{ms_target}}, 2)"
+      # Recomputed from each member's raw report, so a rollup that claims
+      # everyone migrated on the wrong comparison still fails here.
+      - "equal({{ms_below_target}}, 0)"
+      - "equal({{ms_missing}}, 0)"
+      - "equal({{ms_all_migrated}}, true)"
 
-  # (b) Each node CACHED the peer's signed heartbeat — both cohort rows
-  #     populate, the precondition for all_migrated. The ingest path only logs
-  #     this AFTER passing the sig + cohort-membership gate, so a cached
-  #     heartbeat is a verified one.
-  - name: Assert node 1 cached the peer's verified heartbeat
-    type: assert_log_present
-    nodes:
-      - app-migration-mstatus-1
-    patterns:
-      - "migration heartbeat cached"
-    min_matches: 1
-
+  # (b) Node 2's own half of the cache stays a log assertion: the rollup route
+  #     is admin-gated and node 2 is a plain inherited member, so it cannot read
+  #     it, and the one member-visible surface (MigrationProgress) is edge-
+  #     triggered behind every edge this scenario has.
   - name: Assert node 2 cached the peer's verified heartbeat
     type: assert_log_present
     nodes:
@@ -246,18 +249,6 @@ steps:
     patterns:
       - "migration heartbeat cached"
     min_matches: 1
-
-  # (c) No heartbeat that failed signature/membership verification was ever
-  #     admitted to a cache — the gate that keeps an unsigned/non-member peer
-  #     out of any rollup. With both peers legitimate members, the drop path
-  #     must NEVER fire.
-  - name: Assert no heartbeat was admitted past a failed sig/membership check
-    type: assert_log_absent
-    nodes:
-      - app-migration-mstatus-1
-      - app-migration-mstatus-2
-    patterns:
-      - "MigrationHeartbeat failed verification (sig/membership); dropping"
 
   # Phase 7: NODE 2 GOES OFFLINE → it becomes `unknown` in node 1's rollup.
   # Once node 2 stops publishing, its cohort row at node 1 ages past the 60s
@@ -270,16 +261,47 @@ steps:
     type: wait
     seconds: 75
 
-  # node 1 keeps emitting its own heartbeat while node 2 is dark — proving the
-  # emitter is alive and that the ONLY reason node 2 is unknown is its silence,
-  # not an emitter stall.
-  - name: Assert node 1 is still emitting heartbeats while node 2 is offline
-    type: assert_log_present
-    nodes:
-      - app-migration-mstatus-1
-    patterns:
-      - "migration heartbeat emitted"
-    min_matches: 2
+  # The no-false-green contract, read off the rollup rather than an emitter log
+  # line: node 1 folds its OWN row in locally, so it stays migrated while the
+  # silent peer ages past the TTL. A stalled emitter shows node 1 unknown too.
+  - name: Read the rollup on node 1 after node 2 goes dark
+    type: get_migration_status
+    node: app-migration-mstatus-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      dark_total: total
+      dark_migrated: migrated
+      dark_unknown: unknown
+      dark_all_migrated: all_migrated
+      dark_missing: reported_missing
+
+  - name: Assert node 2 aged out to unknown and took all_migrated with it
+    type: json_assert
+    statements:
+      - "equal({{dark_total}}, 2)"
+      - "equal({{dark_migrated}}, 1)"
+      - "equal({{dark_unknown}}, 1)"
+      # A member with no report at all is a different failure from one
+      # reporting the wrong version; collapsing them loses this phase.
+      - "equal({{dark_missing}}, 1)"
+      - "equal({{dark_all_migrated}}, false)"
+
+  - name: Assert the convergence stamp did NOT follow all_migrated back down
+    # Raw HTTP, not a capture: client-py 0.6.24 deserializes this response into
+    # a struct with no fleetCompletedAt, so the key never survives the client.
+    # Paths carry no `data.` prefix - this route serializes at the top level.
+    # `present` is the non-null assertion: the field is skip_serializing_if
+    # none, so core omits it until this node has watched the cohort converge.
+    # all_migrated has just lapsed above; this stamp is durable.
+    type: assert_api_response
+    node: app-migration-mstatus-1
+    path: /admin-api/groups/{{namespace_id}}/migration-status
+    present:
+      - fleetCompletedAt
+    match:
+      rollup.allMigrated: false
+      rollup.unknown: 1
+      expectedMembers: 2
 
   # The departed node's stale-schema fence must never have silently dropped a
   # delta during the migration window either.

--- a/workflows/app-migration/28-get-migration-status.yml
+++ b/workflows/app-migration/28-get-migration-status.yml
@@ -9,10 +9,10 @@ description: >
   and local residue counts; peers verify the Ed25519 signature AND cohort
   membership, then upsert it into a 60s-TTL cache. The admin route
   `GET /groups/:namespace_id/migration-status` rolls the freshest heartbeat
-  per pinned-cohort member into `all_migrated` — which flips true ONLY when
+  per pinned-cohort member into `all_migrated` - which flips true ONLY when
   EVERY member reports `schema_version >= target && residue == 0`. A member
   with no fresh heartbeat is `unknown` and keeps `all_migrated = false` (no
-  false green). Observability only — never a gate.
+  false green). Observability only - never a gate.
 
   This scenario drives a migration across the 2-node namespace and reads the
   rollup the heartbeats feed, at both of its edges:
@@ -24,7 +24,7 @@ description: >
       consequence rather than through log lines.
     - When node 2 goes offline its heartbeats stop arriving at node 1; with no
       fresh heartbeat its cohort row ages out of the TTL window and the rollup
-      reports it `unknown`, keeping `all_migrated = false` — the no-false-green
+      reports it `unknown`, keeping `all_migrated = false` - the no-false-green
       contract. `fleetCompletedAt` is durable and must NOT follow it back down.
 
   The rollup's own arithmetic is additionally unit-covered in task 6c.9
@@ -32,7 +32,7 @@ description: >
   / all_migrated_true_only_when_every_pinned_member_v2_residue0).
 
   Because migration_v2 defaults ON (PR-6b task 6b.8), the heartbeat emit +
-  ingest run natively — no merobox feature flag is needed.
+  ingest run natively - no merobox feature flag is needed.
 
 no_docker: false
 nuke_on_start: true
@@ -152,7 +152,7 @@ steps:
 
   - name: Assert both versions share one application id (bundle same-id)
     # Same-package bundles derive ApplicationId = hash(package, signer),
-    # so the second install MUST dedup onto the first id — the upgrade
+    # so the second install MUST dedup onto the first id - the upgrade
     # below then exercises the same-id (blob-only) propagation path.
     type: json_assert
     statements:

--- a/workflows/app-migration/28-get-migration-status.yml
+++ b/workflows/app-migration/28-get-migration-status.yml
@@ -1,7 +1,7 @@
-name: 28 - get_migration_status rollup (PR-6c)
+name: 28 - get_migration_status rollup
 description: >
   Migration-status visibility across a 2-node namespace, validated against the
-  admin rollup itself (PR-6c tasks 6c.7/6c.8/6c.9/6c.10 + 6c.11).
+  admin rollup itself.
 
   Completion visibility is ephemeral signed TTL gossip, NOT replicated
   governance state: each node periodically publishes a signed
@@ -27,12 +27,12 @@ description: >
       reports it `unknown`, keeping `all_migrated = false` - the no-false-green
       contract. `fleetCompletedAt` is durable and must NOT follow it back down.
 
-  The rollup's own arithmetic is additionally unit-covered in task 6c.9
-  (unknown_member_blocks_all_migrated / cohort_pinned_ignores_post_expand_joiner
-  / all_migrated_true_only_when_every_pinned_member_v2_residue0).
+  The rollup's own arithmetic is additionally unit-covered by
+  unknown_member_blocks_all_migrated / cohort_pinned_ignores_post_expand_joiner
+  / all_migrated_true_only_when_every_pinned_member_v2_residue0.
 
-  Because migration_v2 defaults ON (PR-6b task 6b.8), the heartbeat emit +
-  ingest run natively - no merobox feature flag is needed.
+  Because migration_v2 defaults ON, the heartbeat emit + ingest run natively -
+  no merobox feature flag is needed.
 
 no_docker: false
 nuke_on_start: true

--- a/workflows/app-migration/32-authored-migrate-ux.yml
+++ b/workflows/app-migration/32-authored-migrate-ux.yml
@@ -1,4 +1,4 @@
-name: 32 - One-tap migrate_my_entries (PR-6e, node-log validated)
+name: 32 - One-tap migrate_my_entries (node-log validated)
 description: >
   The explicit, one-signature "migrate my authored data" flow, on top of the
   6c owner-driven convert. After a namespace cascades v1 → v2, each owner's

--- a/workflows/app-migration/32-authored-migrate-ux.yml
+++ b/workflows/app-migration/32-authored-migrate-ux.yml
@@ -307,12 +307,40 @@ steps:
       - 'json_equal({{local_n1a}}, {"output": 2})'
       - 'json_equal({{local_n2a}}, {"output": 2})'
 
-  # Phase 7b: give the converted deltas time to gossip + apply on the peer.
-  # (wait_for_sync can return instantly on a trivially-matching DAG-head check,
-  # racing the convert delta, so wait explicitly before cross-node assertions.)
-  - name: Wait for converted notes to replicate as normal signed deltas
-    type: wait
-    seconds: 15
+  # Phase 7b: CAUSAL BARRIER for the cross-node reads in Phase 9.
+  #
+  # The convert re-stamps each entry without changing its value, so it leaves
+  # the context root hash where it was and a wait_for_sync over that hash
+  # returns on its first poll whether or not the convert replicated. An INSERT
+  # does move the hash, and each barrier insert is causally after that node's
+  # own convert, so converging on it implies the convert landed. Do not replace
+  # these with a bare wait: the gate is the point.
+  - name: Node 1 writes a barrier note after its convert
+    type: call
+    node: app-migration-ux-1
+    context_id: "{{ctx_id}}"
+    method: set_note
+    args:
+      key: "n1-barrier"
+      text: "node1-post-convert-barrier"
+
+  - name: Node 2 writes a barrier note after its convert
+    type: call
+    node: app-migration-ux-2
+    context_id: "{{ctx_id}}"
+    method: set_note
+    args:
+      key: "n2-barrier"
+      text: "node2-post-convert-barrier"
+
+  - name: Wait for both barrier notes, and the converts before them, to converge
+    type: wait_for_sync
+    context_id: "{{ctx_id}}"
+    nodes:
+      - app-migration-ux-1
+      - app-migration-ux-2
+    timeout: 90
+    trigger_sync: true
 
   # Phase 8: NEGATIVE node-log validation.
   - name: Assert the owner gate never tripped on either node
@@ -333,22 +361,8 @@ steps:
 
   # Phase 9: CONVERGENCE — every note is at schema 2 on BOTH nodes, and values
   # are preserved. node 2 sees node 1's converted notes at v2 (the convert
-  # replicated as ordinary signed deltas).
-  # Phase 9 asserts CROSS-NODE convergence, so it has to wait for it. Without
-  # this, the reads below race the deltas they are asserting on: node 1's own
-  # note is local and node 1's note on node 2 has had the whole convert phase to
-  # propagate, but node 2's note on node 1 is the last write to travel and reads
-  # back `null` under CI load — a failure that looks like a migration bug and is
-  # really a missing barrier.
-  - name: Wait for the converted notes to converge on both nodes
-    type: wait_for_sync
-    context_id: "{{ctx_id}}"
-    nodes:
-      - app-migration-ux-1
-      - app-migration-ux-2
-    timeout: 90
-    trigger_sync: true
-
+  # replicated as ordinary signed deltas). The barrier in Phase 7b is what makes
+  # these reads a convergence assertion rather than a timing one.
   - name: Read node 1's note schema_version AFTER convert (node 1)
     type: call
     node: app-migration-ux-1

--- a/workflows/app-migration/32-authored-migrate-ux.yml
+++ b/workflows/app-migration/32-authored-migrate-ux.yml
@@ -1,9 +1,9 @@
-name: 32 — One-tap migrate_my_entries (PR-6e, node-log validated)
+name: 32 - One-tap migrate_my_entries (PR-6e, node-log validated)
 description: >
   The explicit, one-signature "migrate my authored data" flow, on top of the
   6c owner-driven convert. After a namespace cascades v1 → v2, each owner's
   identity-gated AuthoredMap notes are carried through but stay stamped at the
-  v1 schema (1) — below the v2 target (2) — until re-signed. Instead of waiting
+  v1 schema (1) - below the v2 target (2) - until re-signed. Instead of waiting
   for an organic per-entry edit, each owner calls the SDK-macro-generated
   `migrate_my_entries()` export ONCE; it sweeps every note that owner owns and
   is still below target, re-writing each through the owner-driven convert
@@ -11,7 +11,7 @@ description: >
 
   Discriminating assertions:
     - PRE-convert: each carried note reports note_schema_version == 1 (carried,
-      not yet converted) — proving migrate alone does NOT convert authored data.
+      not yet converted) - proving migrate alone does NOT convert authored data.
     - The one-tap call is OWNER-SCOPED: node 1's call converts only its 2 notes
       (converted == 2), node 2's only its 1 (converted == 1); neither touches
       the other's. remaining == 0 after each owner's single call.
@@ -171,7 +171,7 @@ steps:
 
   - name: Assert both versions share one application id (bundle same-id)
     # Same-package bundles derive ApplicationId = hash(package, signer),
-    # so the second install MUST dedup onto the first id — the upgrade
+    # so the second install MUST dedup onto the first id - the upgrade
     # below then exercises the same-id (blob-only) propagation path.
     type: json_assert
     statements:
@@ -229,7 +229,7 @@ steps:
     statements:
       - 'json_subset({{v2_schema_node1}}, {"output": {"schema_version": "2.0.0", "note_count": 3}})'
 
-  # Phase 6b: PRE-convert — carried notes are still stamped at v1 (schema 1).
+  # Phase 6b: PRE-convert - carried notes are still stamped at v1 (schema 1).
   # This proves migrate alone does NOT convert identity-gated data; it waits
   # for the owner. (If this read itself converted, the value would be 2.)
   - name: Read node 1's own note schema_version BEFORE convert
@@ -277,7 +277,7 @@ steps:
       - 'json_equal({{convert_node2}}, {"output": {"converted": 1, "remaining": 0}})'
 
   # Phase 7a: RACE-FREE PERSISTENCE ORACLE. Each node reads its OWN note right
-  # after its OWN one-tap — no replication involved. This is the authoritative
+  # after its OWN one-tap - no replication involved. This is the authoritative
   # proof the convert actually PERSISTED the re-stamp on the originator (a
   # `converted` count alone is computed before the guard save and would not
   # catch an LWW-dropped write). If these are 2, the convert works.
@@ -359,7 +359,7 @@ steps:
     patterns:
       - "Dropping state delta — HLC fence: stale schema after cascade migration"
 
-  # Phase 9: CONVERGENCE — every note is at schema 2 on BOTH nodes, and values
+  # Phase 9: CONVERGENCE - every note is at schema 2 on BOTH nodes, and values
   # are preserved. node 2 sees node 1's converted notes at v2 (the convert
   # replicated as ordinary signed deltas). The barrier in Phase 7b is what makes
   # these reads a convergence assertion rather than a timing one.
@@ -437,7 +437,7 @@ steps:
       - "owner-driven convert: re-stamped identity-gated entry schema_version"
     min_matches: 1
 
-  # Phase 9b: IDEMPOTENT — a second one-tap on node 1 converts nothing.
+  # Phase 9b: IDEMPOTENT - a second one-tap on node 1 converts nothing.
   - name: Node 1 calls migrate_my_entries again (idempotent)
     type: call
     node: app-migration-ux-1

--- a/workflows/app-migration/36-chained-catchup.yml
+++ b/workflows/app-migration/36-chained-catchup.yml
@@ -260,7 +260,9 @@ steps:
       - 'json_subset({{item_node2}}, {"output": "v1-value"})'
 
   # Each node replayed TWO ladder hops, each migration executed in its
-  # own release's binary.
+  # own release's binary. The hop COUNT stays a log assertion: core exposes the
+  # current and target state version but nothing about the path between them,
+  # so a one-shot v2 -> v4 jump would satisfy every API assertion available.
   - name: Assert chained replay ran on node 1
     type: assert_log_present
     nodes:
@@ -280,6 +282,47 @@ steps:
       - "Executing migration"
       - "Migrated state written successfully"
     min_matches: 2
+
+  # Where the replay landed. The "4.0.0" the schema_info reads compare against
+  # is a constant compiled into the v4 binary, so it reads the same for a node
+  # that loaded v4 over state left at v2. A member stalled on an intermediate
+  # rung is visible in the rollup's ABI state version and nowhere else.
+  - name: Wait for both members to report the v4 target state version
+    type: assert_migration_complete
+    node: app-migration-chained-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
+  - name: Read the migration-status rollup on node 1 (admin)
+    type: get_migration_status
+    node: app-migration-chained-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      mig_target: target_version
+      mig_expected: expected_members
+      mig_total: total
+      mig_migrated: migrated
+      mig_failed: failed
+      mig_below_target: reported_below_target
+      mig_missing: reported_missing
+      mig_min_reported: min_reported_schema_version
+      mig_residue: residue_total
+
+  - name: Assert both members finished the ladder rather than stalling on a rung
+    type: json_assert
+    statements:
+      - "equal({{mig_expected}}, 2)"
+      - "equal({{mig_total}}, 2)"
+      - "equal({{mig_migrated}}, 2)"
+      - "equal({{mig_failed}}, 0)"
+      # The subgroup's record targets state version 4, the last rung.
+      - "equal({{mig_target}}, 4)"
+      # A member stranded at v2 or v3 lands here, not in the semver reads.
+      - "equal({{mig_below_target}}, 0)"
+      - "equal({{mig_missing}}, 0)"
+      - "equal({{mig_min_reported}}, 4)"
+      - "equal({{mig_residue}}, 0)"
 
   # Phase 7: post-catch-up convergence — writes still flow both ways.
   - name: Write post-catchup item on node 1

--- a/workflows/app-migration/36-chained-catchup.yml
+++ b/workflows/app-migration/36-chained-catchup.yml
@@ -1,15 +1,15 @@
-name: 36 — Chained catch-up via the upgrade ladder (v2 → v3 → v4, 2-node)
+name: 36 - Chained catch-up via the upgrade ladder (v2 → v3 → v4, 2-node)
 description: >
   A member left behind for SEVERAL releases catches up in one access by
-  replaying the group's upgrade ladder — each hop in THAT release's own
+  replaying the group's upgrade ladder - each hop in THAT release's own
   bytecode, methods resolved per hop from the two blobs' embedded ABIs.
 
   Both nodes activate v2 once (their contexts gain the v2 activation
   marker). The admin then upgrades the subgroup v2 -> v3 -> v4 while NO
   context is accessed anywhere: every context is now two rungs below the
   group. A single read on each node must run migrate_v2_to_v3 inside the
-  v3 binary and then migrate_v3_to_v4 inside the v4 binary — never the
-  group-level (last-hop) method against v2 state — landing on the v4
+  v3 binary and then migrate_v3_to_v4 inside the v4 binary - never the
+  group-level (last-hop) method against v2 state - landing on the v4
   schema with all data carried through the chain. Node 2 never installs
   anything: it pulls each rung's blob over BlobShare as it replays.
 
@@ -139,7 +139,7 @@ steps:
     trigger_sync: true
 
   # Phase 4: v1 -> v2, and ACTIVATE on both nodes: each context's read
-  # runs its own lazy migration and records the v2 activation marker —
+  # runs its own lazy migration and records the v2 activation marker -
   # the rung the chained replay below resumes from.
   - name: Install migration-suite-v2 on node 1
     type: install_application
@@ -181,7 +181,7 @@ steps:
       - 'json_subset({{v2_schema_node1}}, {"output": {"schema_version": "2.0.0"}})'
       - 'json_subset({{v2_schema_node2}}, {"output": {"schema_version": "2.0.0"}})'
 
-  # Phase 5: v2 -> v3 -> v4 with NO context access anywhere — every
+  # Phase 5: v2 -> v3 -> v4 with NO context access anywhere - every
   # context falls two rungs behind the group.
   - name: Install migration-suite-v3 on node 1
     type: install_application
@@ -324,7 +324,7 @@ steps:
       - "equal({{mig_min_reported}}, 4)"
       - "equal({{mig_residue}}, 0)"
 
-  # Phase 7: post-catch-up convergence — writes still flow both ways.
+  # Phase 7: post-catch-up convergence - writes still flow both ways.
   - name: Write post-catchup item on node 1
     type: call
     node: app-migration-chained-1

--- a/workflows/app-migration/37-stranded-resync.yml
+++ b/workflows/app-migration/37-stranded-resync.yml
@@ -270,16 +270,6 @@ steps:
     statements:
       - 'json_subset({{strand_schema_node2}}, {"output": {"schema_version": "1.0.0"}})'
 
-  # Terminal strand signal — the blocked hop fell back to the current app.
-  # (NOT "replaying upgrade ladder hop", which also fires on the attempt.)
-  - name: Assert node 2 logged the blocked ladder hop
-    type: assert_log_present
-    nodes:
-      - app-migration-strand-2
-    patterns:
-      - "ladder hop blocked; proceeding with current application"
-    min_matches: 1
-
   # Let node 2 emit a migration heartbeat carrying its stranded marker so the
   # rollup reflects the failure (heartbeat is interval-driven; see scenario 28).
   - name: Settle for node 2's stranded heartbeat
@@ -297,13 +287,26 @@ steps:
     namespace_id: "{{namespace_id}}"
     outputs:
       strand_failed: failed
+      strand_total: total
+      strand_migrated: migrated
+      strand_reasons: failure_reasons
+      strand_min_reported: min_reported_schema_version
 
-  - name: Assert exactly node 2 surfaces as failed in the rollup
+  - name: Assert exactly node 2 stranded, for the blocked-ladder reason
     # Node 1's cohort rollup: node 1 is at v3 (migrated), node 2 is stranded
     # (NoMigrationPath) -> failed == 1. Mirrors scenario 14's numeric asserts.
     type: json_assert
     statements:
       - "equal({{strand_failed}}, 1)"
+      - "equal({{strand_total}}, 2)"
+      - "equal({{strand_migrated}}, 1)"
+      # The named reason, which the count alone does not give: no_migration_path
+      # is the blocked-ladder case, distinct from check_aborted and apply_failed.
+      # Sorted, so it does not depend on member ordering the API never promised.
+      - 'json_equal({{strand_reasons}}, ["no_migration_path"])'
+      # Node 2 is still holding v1 state, so the lowest reported ABI state
+      # version across the cohort is 1 while node 1 sits at the v3 target.
+      - "equal({{strand_min_reported}}, 1)"
 
   # Phase 8: RECOVER — resync node 2 from a peer. force=true because node 2
   # still holds local DAG heads (its v1 state) that the snapshot discards.
@@ -321,14 +324,6 @@ steps:
       # merobox renders the response's JSON bool as the Python str "True"
       # (capital) when templated into a string, so compare against "True".
       - 'equal("{{resync_started}}", "True")'
-
-  - name: Assert node 2 logged the resync request
-    type: assert_log_present
-    nodes:
-      - app-migration-strand-2
-    patterns:
-      - "context resync requested"
-    min_matches: 1
 
   - name: Wait for the snapshot to settle on node 2
     type: wait_for_sync
@@ -379,6 +374,31 @@ steps:
     namespace_id: "{{namespace_id}}"
     timeout_seconds: 90
     poll_interval: 5
+
+  - name: Read the recovered rollup on node 1 (admin)
+    type: get_migration_status
+    node: app-migration-strand-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      recovered_target: target_version
+      recovered_failed: failed
+      recovered_below_target: reported_below_target
+      recovered_missing: reported_missing
+      recovered_min_reported: min_reported_schema_version
+      recovered_reasons: failure_reasons
+
+  - name: Assert node 2 came back at the v3 target with its marker cleared
+    # all_migrated above is core's own answer; these are recomputed from each
+    # member's raw report, so they falsify it: the resync only counts if node
+    # 2's REPORTED version moved 1 -> 3 and its strand reason went away.
+    type: json_assert
+    statements:
+      - "equal({{recovered_target}}, 3)"
+      - "equal({{recovered_failed}}, 0)"
+      - "equal({{recovered_below_target}}, 0)"
+      - "equal({{recovered_missing}}, 0)"
+      - "equal({{recovered_min_reported}}, 3)"
+      - "json_equal({{recovered_reasons}}, [])"
 
   # Teardown guard: no deserialization failures anywhere across the run.
   - name: Assert no deserialization failures anywhere

--- a/workflows/app-migration/37-stranded-resync.yml
+++ b/workflows/app-migration/37-stranded-resync.yml
@@ -1,14 +1,14 @@
-name: 37 — Stranded context recovers via resync (intermediate blob unobtainable, 2-node)
+name: 37 - Stranded context recovers via resync (intermediate blob unobtainable, 2-node)
 description: >
   A behind member is STRANDED when an upgrade-ladder rung's bytecode is
-  unobtainable, and recovers via an operator-initiated state resync — the
+  unobtainable, and recovers via an operator-initiated state resync - the
   headline "nobody stranded" path (migrations-v2 PR-4b).
 
   node-1 advances a context v1 -> v2 -> v3 (activating each rung in its own
   binary), so it holds v3 state and all three blobs. node-2 joins at v1, syncs
-  v1 state, learns of the v3 target, but never accesses — it stays at v1. The
+  v1 state, learns of the v3 target, but never accesses - it stays at v1. The
   v2 (INTERMEDIATE) blob is then deleted on every holder (node-1 + node-2's
-  pre-stage) with `delete_blob` (admin API — cascades the parent metadata + every
+  pre-stage) with `delete_blob` (admin API - cascades the parent metadata + every
   chunk file + chunk metadata, so the bytecode is truly gone); the v3 blob stays
   intact on node-1.
 
@@ -17,7 +17,7 @@ description: >
   NoMigrationPath: the access SUCCEEDS serving the current (v1) application
   (logged "ladder hop blocked; proceeding with current application"), and the
   context surfaces as `state: "failed"` / `migration_failed: "no_migration_path"`
-  in the migration-status rollup. It is stranded — v1 -> v2 -> v3 is impassable
+  in the migration-status rollup. It is stranded - v1 -> v2 -> v3 is impassable
   because v2 is gone.
 
   Recovery: `resync_context force=true` on node-2 adopts node-1's full v3-state
@@ -114,7 +114,7 @@ steps:
     node: app-migration-strand-2
     context_id: "{{ctx_id}}"
 
-  # Phase 3: seed v1 state; node 2 converges on it (passive sync — no access,
+  # Phase 3: seed v1 state; node 2 converges on it (passive sync - no access,
   # so node 2 never triggers a migration and stays at v1).
   - name: Write v1 description
     type: call
@@ -188,7 +188,7 @@ steps:
     type: wait
     seconds: 15
 
-  - name: Activate v2 on node 1 only (node 2 stays at v1 — never accessed)
+  - name: Activate v2 on node 1 only (node 2 stays at v1 - never accessed)
     type: call
     node: app-migration-strand-1
     context_id: "{{ctx_id}}"
@@ -235,9 +235,9 @@ steps:
     statements:
       - 'json_subset({{v3_schema_node1}}, {"output": {"schema_version": "3.0.0"}})'
 
-  # Phase 6: STRAND — delete the v2 intermediate blob on every holder via the
+  # Phase 6: STRAND - delete the v2 intermediate blob on every holder via the
   # admin API (`delete_blob` cascades parent metadata + chunk files + chunk
-  # metadata, so the bytecode is truly unobtainable — `delete_blob_on_disk` only
+  # metadata, so the bytecode is truly unobtainable - `delete_blob_on_disk` only
   # rm's the parent-id path, a no-op for chunked blobs). node 1 is past v2 (at
   # v3) so it no longer needs it; node 2 may have pre-staged it over BlobShare
   # (missing_ok covers the case it did not). The v3 blob on node 1 stays intact.
@@ -278,7 +278,7 @@ steps:
 
   # Read the rollup on node 1: the migration-status endpoint requires the group
   # admin (node 1 created the namespace), and the admin's rollup aggregates every
-  # member's heartbeat — so node 2's stranded marker surfaces here once its
+  # member's heartbeat - so node 2's stranded marker surfaces here once its
   # heartbeat has gossiped (the settle wait above covers that). Node 2 is an
   # inherited Open-subgroup member, not an admin, so it cannot read the rollup.
   - name: Read migration-status rollup on node 1 (admin)
@@ -308,7 +308,7 @@ steps:
       # version across the cohort is 1 while node 1 sits at the v3 target.
       - "equal({{strand_min_reported}}, 1)"
 
-  # Phase 8: RECOVER — resync node 2 from a peer. force=true because node 2
+  # Phase 8: RECOVER - resync node 2 from a peer. force=true because node 2
   # still holds local DAG heads (its v1 state) that the snapshot discards.
   - name: Resync node 2 from a peer (adopts node 1's v3-state snapshot)
     type: resync_context

--- a/workflows/app-migration/37-stranded-resync.yml
+++ b/workflows/app-migration/37-stranded-resync.yml
@@ -2,7 +2,7 @@ name: 37 - Stranded context recovers via resync (intermediate blob unobtainable,
 description: >
   A behind member is STRANDED when an upgrade-ladder rung's bytecode is
   unobtainable, and recovers via an operator-initiated state resync - the
-  headline "nobody stranded" path (migrations-v2 PR-4b).
+  headline "nobody stranded" path.
 
   node-1 advances a context v1 -> v2 -> v3 (activating each rung in its own
   binary), so it holds v3 state and all three blobs. node-2 joins at v1, syncs


### PR DESCRIPTION
## Summary

Nine app-migration workflows proved a migration by reading `schema_info` and comparing it to `"2.0.0"`. That string is a constant compiled into the v2 binary, so it answers the same for a node serving v2 code over un-migrated v1 bytes, and it is a bundle semver where the cohort rollup compares a u32 ABI state version. They asserted on the axis the original rollup defect lived on and never on the axis that exposes it.

Each now polls the migration-status rollup and asserts every member's *reported* state version reached the target with zero residue. The `reported_below_target` / `reported_missing` / `residue_total` aggregates are recomputed from the raw member rows rather than read back from core's own `allMigrated`, so a rollup converging on the wrong comparison fails them while still claiming everyone migrated.

| # | Was | Now proves |
| --- | --- | --- |
| 00 | 2 log greps; one `get_group_upgrade_status` with no `outputs:` and no assertion | Both members reported state version 2, zero residue; the upgrade record names the v2 target and reached `completed` |
| 01 | 2 log greps (eager propagator + lazy receiver) | Both triggers landed on the same axis: each node's own reported state version reached the target |
| 02, 09, 11, 12 | 2 log greps each | Both members reported state version 2, zero residue |
| 28 | 6 log greps; named after a route it never called | The rollup at both edges: converged (`expectedMembers` 2, `reported_below_target` 0, `targetVersion` 2), then node 2 dark (`unknown` 1, `allMigrated` false) with `fleetCompletedAt` still stamped |
| 36 | 2 log greps for the ladder hops | Both members landed on state version 4 rather than stalling on an intermediate rung |
| 37 | 2 log greps | The strand's named reason (`failure_reasons == ["no_migration_path"]`) and, after recovery, node 2's reported version moving 1 to 3 with the marker cleared |

Workflow 28's stale scope note ("there is no merobox step that polls that route yet") is deleted; it stopped being true at calimero-client-py 0.6.19. `fleetCompletedAt` is asserted over raw HTTP because client-py 0.6.24 drops the key on deserialize, so no typed capture of it can assert anything.

Workflow 32's sync gate was vacuous. The owner-driven convert re-stamps and re-signs an entry without changing its value, so it leaves the context root hash exactly where it was; a `wait_for_sync` over that hash compared a value the convert cannot move and returned on its first poll whether or not the convert had replicated. Both nodes now insert a note after converting, which does move the root hash and is causally after that node's convert delta, so the peer cannot converge on the hash without having applied the convert first.

Kept as log assertions, with the reason recorded at each site: 36's ladder hop *count* (core exposes the current and target state version and nothing about the path between them), 28's node-2 heartbeat cache (the rollup route is admin-gated and node 2 is a plain inherited member), and the borsh and HLC-fence guards, whose failure modes produce no counter, field or event.

## Blocked on a merobox release

These workflows use `get_migration_status` aggregates from #326, `assert_api_response` from #327, and the summariser fix from #329, none of which have shipped. Core CI resolves merobox from `releases/latest` against a `MIN_MEROBOX` floor of 0.6.52, so it will reject the new fields and the new step type until merobox releases. **Merging before that release reddens core CI.**

The receiver-side rollup assertions additionally require the installed-version heal from #3412; without it a receiver that has migrated still reports the pre-migration state version.

## Test plan

All ten run locally against `merod:baseline-arm64` (native arm64, this branch plus the #3412 heal), merobox at `fix/summarizer-absent-vs-null`, strictly serial.

| Workflow | Result |
| --- | --- |
| 00, 01, 02, 09, 11, 12, 32, 36, 37, 28 | PASS (69s, 70s, 70s, 69s, 69s, 69s, 39s, 96s, 104s, 166s) |

Every new assertion was broken and observed red before being restored:

- **02, receiver never migrates** (node 2's lazy-migration trigger removed): `timed out after 19 poll(s) - 1/2 migrated, 1 in-progress, 0 unknown, 0 failed - 1 member(s) below target state version 2 (min reported: 1)`, while the `schema_info == "2.0.0"` assertions on the way there stayed green.
- **32, node 2 never converts**: `left={'output': 1}` against `{"output": 2}` - deterministic where the old vacuous gate produced a racy `None` - and the barrier gate polled twice instead of returning on attempt 1.
- **37, wrong strand reason**: `left=['no_migration_path']` against `["check_aborted"]`.
- **28, stamp expected absent**: `fleetCompletedAt: expected the key to be absent, it is present with 1786648355`, in a body carrying `"allMigrated": false, "migrated": 1, "unknown": 1` and a dark member with no `report` at all.
