### PR TITLE
fix(context): re-drive and re-decode what a peer-pulled group key unlocks

### DIFF
--- a/crates/context/src/group_key_pull.rs
+++ b/crates/context/src/group_key_pull.rs
@@ -1,0 +1,267 @@
+//! Adopting a group key pulled directly from a peer.
+//!
+//! `apply_received_group_key` re-drives what a `KeyDelivery` op unlocks; the
+//! direct stream pulls (`request_namespace_join`, `request_open_subgroup_join`)
+//! carry a key too and need the same recovery.
+
+use calimero_context_config::types::ContextGroupId;
+use calimero_governance_types::NamespaceId;
+use calimero_store::Store;
+use tracing::warn;
+
+use crate::scope_projection::ScopeProjections;
+
+/// Store a peer-pulled group key and recover everything that was waiting on it.
+///
+/// A governance op applied before its key arrived is effect-skipped in the live
+/// store and frozen as a `Noop` in the unified op-store, so both planes need
+/// recovering: the re-drive re-applies the op, the re-persist re-decodes it.
+///
+/// Both recoveries are best-effort. The key is stored either way, and the
+/// key-delivery and startup sweeps retry what fails here.
+pub(crate) fn adopt_pulled_group_key(
+    store: &Store,
+    namespace_id: NamespaceId,
+    group_id: ContextGroupId,
+    group_key: &[u8; 32],
+) -> eyre::Result<[u8; 32]> {
+    let key_id =
+        calimero_governance_store::GroupKeyring::new(store, group_id).store_key(group_key)?;
+    if let Err(err) = calimero_governance_store::retry_encrypted_ops_for_group(
+        store,
+        namespace_id,
+        group_id.to_bytes(),
+    ) {
+        warn!(
+            group_id = %hex::encode(group_id.to_bytes()),
+            %err,
+            "failed to re-drive buffered encrypted ops after a direct group-key pull"
+        );
+    }
+    ScopeProjections::repersist_namespace_ops(store, namespace_id.to_bytes());
+    Ok(key_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use calimero_context_client::local_governance::{
+        GroupOp, NamespaceOp, RootOp, SignedNamespaceOp,
+    };
+    use calimero_context_config::types::ContextGroupId;
+    use calimero_context_config::VisibilityMode;
+    use calimero_governance_store::{
+        CapabilitiesRepository, GroupKeyring, MembershipRepository, MetaRepository,
+        NamespaceDagService, NamespaceOpLogService, NamespaceRepository,
+    };
+    use calimero_primitives::context::GroupMemberRole;
+    use calimero_primitives::identity::PrivateKey;
+    use calimero_store::db::InMemoryDB;
+    use calimero_store::key::GroupMetaValue;
+    use calimero_store::Store;
+    use rand::rngs::OsRng;
+
+    use super::adopt_pulled_group_key;
+
+    fn meta(admin: calimero_account::AccountId) -> GroupMetaValue {
+        GroupMetaValue {
+            app_key: [0xBB; 32],
+            target_application_id: calimero_primitives::application::ApplicationId::from(
+                [0xCC; 32],
+            ),
+            created_at: 1_700_000_000,
+            admin_identity: admin,
+            owner_identity: admin,
+            migration: None,
+            auto_join: true,
+        }
+    }
+
+    /// Put a signed op on the DAG the way a received op lands. The op-log write
+    /// also writes the unified op, decoding with whatever key is present then.
+    fn land(store: &Store, namespace: [u8; 32], op: &SignedNamespaceOp, parents: &[[u8; 32]]) {
+        let delta_id = op.content_hash().unwrap();
+        NamespaceOpLogService::new(store, namespace.into())
+            .store_signed_operation(op)
+            .unwrap();
+        NamespaceDagService::new(store, namespace.into())
+            .advance_dag_head(delta_id, parents, 0)
+            .unwrap();
+    }
+
+    /// An admin-signed invitation, so the joiner's `MemberJoined` folds into a
+    /// namespace membership row the inheritance walk can anchor on.
+    fn invitation(
+        admin_sk: &PrivateKey,
+        group: ContextGroupId,
+    ) -> calimero_context_config::types::SignedGroupOpenInvitation {
+        use sha2::{Digest, Sha256};
+        let invitation = calimero_context_config::types::GroupInvitationFromAdmin {
+            inviter_identity: calimero_context_config::types::SignerId::from(
+                *admin_sk.public_key().digest(),
+            ),
+            group_id: group,
+            expiration_timestamp: 0,
+            invitation_nonce: [0x42; 32],
+            invited_role: 1,
+        };
+        let bytes = borsh::to_vec(&invitation).unwrap();
+        let signature = admin_sk.sign(&Sha256::digest(&bytes)).unwrap();
+        calimero_context_config::types::SignedGroupOpenInvitation {
+            inviter_account: None,
+            invitation,
+            inviter_signature: hex::encode(signature.to_bytes()),
+            application_id: None,
+            app_key: None,
+        }
+    }
+
+    /// A third node cannot join a namespace through an inherited `Open` subgroup
+    /// unless a peer-pulled key recovers BOTH planes.
+    ///
+    /// The apply gate resolves the membership path from the unified op-store at
+    /// the op's causal cut, so re-driving only the live plane leaves the gate
+    /// reading the frozen `Noop` and still rejecting the join.
+    #[test]
+    fn a_pulled_key_unwedges_another_members_open_subgroup_join() {
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let mut rng = OsRng;
+
+        let owner_sk = PrivateKey::random(&mut rng);
+        let owner = owner_sk.public_key();
+        let joiner_sk = PrivateKey::random(&mut rng);
+        let joiner = joiner_sk.public_key();
+
+        let ns = ContextGroupId::from([0x4Bu8; 32]);
+        let namespace_id = ns.to_bytes();
+        let owner_account = crate::test_support::enrol(&store, &ns, &owner);
+        let joiner_account = crate::test_support::enrol(&store, &ns, &joiner);
+
+        MetaRepository::new(&store)
+            .save(&ns, &meta(owner_account))
+            .unwrap();
+        MembershipRepository::new(&store)
+            .add_member(&ns, &owner_account, GroupMemberRole::Admin)
+            .unwrap();
+        // Set before the member row: `add_member` seeds a non-admin's capability
+        // row from the group default, which is what the walk reads.
+        CapabilitiesRepository::new(&store)
+            .set_default_capabilities(
+                &ns,
+                calimero_context_config::MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS.bits(),
+            )
+            .unwrap();
+        MembershipRepository::new(&store)
+            .add_member(&ns, &joiner_account, GroupMemberRole::Member)
+            .unwrap();
+
+        let sub = ContextGroupId::from(*PrivateKey::random(&mut rng).public_key());
+        NamespaceRepository::new(&store).nest(&ns, &sub).unwrap();
+        MetaRepository::new(&store)
+            .save(&sub, &meta(owner_account))
+            .unwrap();
+
+        let created = SignedNamespaceOp::sign(
+            &owner_sk,
+            namespace_id.into(),
+            vec![],
+            1,
+            NamespaceOp::Root(RootOp::GroupCreated {
+                admin: owner_account,
+                group_id: sub.to_bytes().into(),
+                parent_id: namespace_id.into(),
+                restricted: true,
+            }),
+        )
+        .unwrap();
+        land(&store, namespace_id, &created, &[]);
+        let created_id = created.content_hash().unwrap();
+
+        let joined = SignedNamespaceOp::sign(
+            &joiner_sk,
+            namespace_id.into(),
+            vec![created_id],
+            2,
+            NamespaceOp::Root(RootOp::MemberJoined {
+                member: joiner_account,
+                signed_invitation: invitation(&owner_sk, ns),
+                account: crate::test_support::credential(&joiner),
+            }),
+        )
+        .unwrap();
+        land(&store, namespace_id, &joined, &[created_id]);
+        let joined_id = joined.content_hash().unwrap();
+
+        // The key is deliberately not stored yet, so this lands DAG-applied but
+        // effect-skipped, and freezes into the op-store as a `Noop`.
+        let ns_key = [0x5Au8; 32];
+        let flip = SignedNamespaceOp::sign(
+            &owner_sk,
+            namespace_id.into(),
+            vec![joined_id],
+            3,
+            NamespaceOp::Group {
+                group_id: sub.to_bytes().into(),
+                key_id: GroupKeyring::key_id_for(&ns_key).into(),
+                encrypted: GroupKeyring::encrypt_op(
+                    &ns_key,
+                    &GroupOp::SubgroupVisibilitySet {
+                        mode: VisibilityMode::Open,
+                    },
+                )
+                .unwrap(),
+                key_rotation: None,
+            },
+        )
+        .unwrap();
+        land(&store, namespace_id, &flip, &[joined_id]);
+        let flip_id = flip.content_hash().unwrap();
+        assert_eq!(
+            CapabilitiesRepository::new(&store)
+                .subgroup_visibility(&sub)
+                .unwrap(),
+            VisibilityMode::Restricted,
+            "precondition: the flip is invisible while the key is absent"
+        );
+
+        let join = SignedNamespaceOp::sign(
+            &joiner_sk,
+            namespace_id.into(),
+            vec![flip_id],
+            4,
+            NamespaceOp::Root(RootOp::MemberJoinedOpen {
+                member: joiner_account,
+                group_id: sub.to_bytes().into(),
+                account: crate::test_support::credential(&joiner),
+            }),
+        )
+        .unwrap();
+        let apply = |store: &Store| {
+            calimero_governance_store::apply_signed_namespace_op_at_cut(
+                store,
+                &join,
+                &[flip_id],
+                &crate::apply_authorizer::EphemeralProjectionAuthorizer::new(store),
+            )
+        };
+
+        let wedged = apply(&store).expect_err("the subgroup still reads Restricted");
+        assert!(
+            format!("{wedged:#}").contains("no membership path"),
+            "the wedge must be the membership-path rejection, got: {wedged:#}"
+        );
+
+        adopt_pulled_group_key(&store, namespace_id.into(), ns, &ns_key)
+            .expect("a peer-pulled namespace key must store");
+
+        assert_eq!(
+            CapabilitiesRepository::new(&store)
+                .subgroup_visibility(&sub)
+                .unwrap(),
+            VisibilityMode::Open,
+            "the re-drive must apply the buffered flip to the live store"
+        );
+        apply(&store).expect("the backfilled join must apply once the flip is readable");
+    }
+}

--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -278,7 +278,12 @@ impl Handler<JoinGroupRequest> for ContextManager {
                         None,
                         &envelope,
                     )?;
-                    GroupKeyring::new(&datastore, group_id).store_key(&group_key)?;
+                    crate::group_key_pull::adopt_pulled_group_key(
+                        &datastore,
+                        namespace_id.into(),
+                        group_id,
+                        &group_key,
+                    )?;
                     info!("received group key via direct join response");
                 }
 

--- a/crates/context/src/handlers/join_subgroup_inheritance.rs
+++ b/crates/context/src/handlers/join_subgroup_inheritance.rs
@@ -121,7 +121,12 @@ impl Handler<JoinSubgroupInheritanceRequest> for ContextManager {
                         None,
                         &envelope,
                     )?;
-                    let _key_id = GroupKeyring::new(&datastore, group_id).store_key(&group_key)?;
+                    let _key_id = crate::group_key_pull::adopt_pulled_group_key(
+                        &datastore,
+                        ns_id.to_bytes().into(),
+                        group_id,
+                        &group_key,
+                    )?;
                 } else {
                     info!(
                         ?group_id,

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -35,6 +35,7 @@ mod cache;
 pub mod config;
 pub mod error;
 pub mod governance_dag;
+mod group_key_pull;
 pub mod handlers;
 pub mod hlc_fence;
 pub mod join_credential;


### PR DESCRIPTION
## Summary

A group key that arrives as a `KeyDelivery` op re-drives the encrypted ops it unlocks (`apply_received_group_key`). A key **pulled** directly from a peer over a stream - `request_namespace_join`, `request_open_subgroup_join` - was stored bare. Any governance op logged before that key landed stayed effect-skipped in the live store and frozen as a `Noop` in the unified op-store, and nothing ever replayed either plane.

That caps a namespace at two members on the inherited-Open-subgroup path.

`SubgroupVisibilitySet -> Open` travels encrypted under the **namespace** key. A third node whose governance backfill outruns its own join response records the flip undecryptable and keeps reading the subgroup as `Restricted`. It then rejects the second node's `MemberJoinedOpen` as unauthorized - and a rejected op never advances the DAG head, so the node can never reach the visibility op that would make the check pass. The precondition sits behind the very op that is blocked on the precondition.

Observed before the fix: node 3 retried one delta identically on every sync round, emitted zero readiness beacons while node 2 climbed `applied_through`, and its own `join_subgroup_inheritance` returned `NotEligible`. Re-issuing `set_subgroup_visibility(open)` did not unwedge it - the new op lands where node 3 can never reach.

Two nodes never hit it: the only `MemberJoinedOpen` in the DAG is the single joiner's own, and it already holds the op that authorised it. The third node is the first to backfill somebody else's.

`adopt_pulled_group_key` stores the key and then recovers both planes: `retry_encrypted_ops_for_group` re-applies the buffered op to the live store, `repersist_namespace_ops` re-decodes it in the op-store. Both are load-bearing and fail differently - without the re-drive the joiner's own inheritance join stays ineligible, without the re-persist the at-cut apply gate keeps folding the frozen `Noop` and keeps rejecting the backfilled join.

The authorization check is unchanged. What was wrong is the state it was evaluated against.

## Test plan

- `crates/context/src/group_key_pull.rs` - regression test drives the real apply path (`apply_signed_namespace_op_at_cut` + the projection-backed authorizer): a backfilled `MemberJoinedOpen` is rejected with `no membership path` while the flip is undecryptable, and applies once the pulled key is adopted. Verified red with either half of the fix removed - dropping the re-persist fails the final apply, dropping the re-drive leaves the subgroup `Restricted`.
- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p calimero-node -p calimero-context -p calimero-governance-store` all clean.
- Three-node e2e, native arm64 image: three peers join one namespace through the inherited-Open-subgroup path (never once succeeded before), the third node reads the subgroup as Open with `memberCount: 3` and joins the context. Node 3 now advances its governance DAG and emits readiness beacons instead of retrying one delta forever.
- Full three-node cascade-migration rollup, twice consecutively: partial convergence reports `migrated: 2, unknown: 1, total: 3, allMigrated: false` with `fleetCompletedAt` absent, and after releasing the dark member `migrated: 3, unknown: 0, allMigrated: true` with `fleetCompletedAt` present. That run also needs the sibling activation-vs-install rollup fix on this base; with only this PR the join and cascade complete but a lazily-migrated member reports its install row and shows as `in_progress`.