### PR TITLE
test(context): name principals directly in the op-log persistence fixtures

### DIFF
--- a/crates/context/src/unified_applier.rs
+++ b/crates/context/src/unified_applier.rs
@@ -144,17 +144,19 @@ mod tests {
     async fn dag_releases_out_of_order_ops_and_the_projection_converges() {
         let scope = ScopeId::from([0xA1; 32]);
         let group = ContextGroupId::from([3u8; 32]);
-        let member = PublicKey::from([0x55; 32]);
-        let admin = PublicKey::from([1u8; 32]);
+        // Principals, named directly. This test is about the op log persisting and
+        // replaying to the same projection, so what the payloads need is an
+        // `AccountId` — it used to reach one by hashing a key through the legacy
+        // stand-in, which coupled a persistence test to a bridge it never exercised.
+        let member = calimero_account::AccountId::from([0x55; 32]);
+        let admin = calimero_account::AccountId::from([1u8; 32]);
 
         // A causal chain spanning the admin, membership, ACL, and data planes.
         let op_admin = op(
             scope,
             10,
             vec![],
-            OpPayload::AdminChanged {
-                new_admin: calimero_op_adapter::legacy_account_id(&admin),
-            },
+            OpPayload::AdminChanged { new_admin: admin },
         );
         let op_member = op(
             scope,
@@ -162,7 +164,7 @@ mod tests {
             vec![op_admin.id()],
             OpPayload::MemberAdded {
                 group,
-                member: calimero_op_adapter::legacy_account_id(&member),
+                member,
                 role: GroupMemberRole::Member,
             },
         );
@@ -172,12 +174,7 @@ mod tests {
             vec![op_member.id()],
             OpPayload::SetWriters {
                 object: Id::new([9u8; 32]),
-                writers: [(
-                    calimero_op_adapter::legacy_account_id(&member),
-                    OpMask::FULL,
-                )]
-                .into_iter()
-                .collect(),
+                writers: [(member, OpMask::FULL)].into_iter().collect(),
             },
         );
         let op_put = op(

--- a/crates/context/src/unified_op_store.rs
+++ b/crates/context/src/unified_op_store.rs
@@ -147,16 +147,18 @@ mod tests {
 
         let scope = ScopeId::from([0xA1; 32]);
         let group = ContextGroupId::from([3u8; 32]);
-        let member = PublicKey::from([0x55; 32]);
-        let admin = PublicKey::from([1u8; 32]);
+        // Principals, named directly. This test is about the op log persisting and
+        // replaying to the same projection, so what the payloads need is an
+        // `AccountId` — it used to reach one by hashing a key through the legacy
+        // stand-in, which coupled a persistence test to a bridge it never exercised.
+        let member = calimero_account::AccountId::from([0x55; 32]);
+        let admin = calimero_account::AccountId::from([1u8; 32]);
 
         let op_admin = op(
             scope,
             10,
             vec![],
-            OpPayload::AdminChanged {
-                new_admin: calimero_op_adapter::legacy_account_id(&admin),
-            },
+            OpPayload::AdminChanged { new_admin: admin },
         );
         let op_member = op(
             scope,
@@ -164,7 +166,7 @@ mod tests {
             vec![op_admin.id()],
             OpPayload::MemberAdded {
                 group,
-                member: calimero_op_adapter::legacy_account_id(&member),
+                member,
                 role: GroupMemberRole::Member,
             },
         );
@@ -174,12 +176,7 @@ mod tests {
             vec![op_member.id()],
             OpPayload::SetWriters {
                 object: Id::new([9u8; 32]),
-                writers: [(
-                    calimero_op_adapter::legacy_account_id(&member),
-                    OpMask::FULL,
-                )]
-                .into_iter()
-                .collect(),
+                writers: [(member, OpMask::FULL)].into_iter().collect(),
             },
         );
         let ops = [&op_admin, &op_member, &op_writers];


### PR DESCRIPTION
First fixture slice of #3414.

`unified_op_store` and `unified_applier` each reached for an `AccountId` by hashing a `PublicKey` through `legacy_account_id`. Neither test is about that bridge — both persist a causal chain of mixed-plane ops, reload from a fresh handle, and assert the replayed projection matches an in-memory fold of the same ops.

What those payloads need is a **principal**. The key was a detour to reach one, and it coupled two persistence tests to a bridge they never exercised. They now name principals directly: same values, same assertions, 8 references gone. `PublicKey` stays in both files for the op author, which genuinely is a key.

## Two corrections to the scoping on #3414, found while doing this

**`per_device_authorization.rs` needs no conversion.** Two of its hits are comments, one is a test name, and its single code use exercises the *binding* branch — the assertion right after it proves the binding is `Some`. I had planned it as the first slice; it is a no-op.

**The production surface is five call sites, not four.** My per-file script split each file on `#[cfg(test)]` and, for files with no test module, fell through to counting everything as test — the inverse of the truth. It hid two production sites:

- `governance-store/src/unified_op_decode.rs:40` — a `build_op` twin of `scope_projection`'s
- `governance-store/src/node_device.rs:306` — `account_for_group`, which is **what this node writes as** (the value behind `env::account_id()`)

The second reorders the remaining risk: it is the origin of the documented footgun that a writer set seeded before its writer enrolled holds the stand-in. It deserves its own change and its own reasoning rather than riding along with the projection sites.

## Verification

Full `calimero-context` suite green (11 suites), `clippy -D warnings` clean, `fmt --check` clean.