### PR TITLE
test(op-adapter): name principals directly where the key was only a route to one

### DIFF
--- a/crates/op-adapter/src/lib.rs
+++ b/crates/op-adapter/src/lib.rs
@@ -549,6 +549,20 @@ mod tests {
     /// `payload_from_root_op` FOLDS, and the bridge deliberately still keys
     /// membership by `legacy_account_id(member)` until slice B moves the live plane
     /// too — so nothing here reads the credential, it only has to be present.
+    /// The [`Authorship`] for an op whose author is named directly.
+    ///
+    /// [`legacy_authorship`] derives the account by hashing the signing key, which
+    /// couples a test to the stand-in bridge even when all it wanted was "some
+    /// author". This states the principal and the key separately, which is what
+    /// the two fields actually mean.
+    fn authorship_of(account: AccountId, device_key: PublicKey) -> Authorship {
+        Authorship {
+            account,
+            device: DeviceId::from(*account.as_bytes()),
+            device_key,
+        }
+    }
+
     /// A credential that actually VERIFIES for `sign_pk`. The filler fixture
     /// above cannot fold a device now that the shared predicate checks the
     /// certificate, so any test asserting the device half needs this one.
@@ -655,7 +669,7 @@ mod tests {
             [7u8; 32],
             ScopeId::from([9u8; 32]),
             vec![],
-            legacy_authorship(root.public_key()),
+            authorship_of(AccountId::from([0xA0; 32]), root.public_key()),
             hlc(1),
             payload,
             [0u8; 32],
@@ -745,7 +759,7 @@ mod tests {
             [7u8; 32],
             ScopeId::from([9u8; 32]),
             vec![],
-            legacy_authorship(root.public_key()),
+            authorship_of(AccountId::from([0xA0; 32]), root.public_key()),
             hlc(1),
             payload_from_group_op(
                 group,
@@ -765,7 +779,7 @@ mod tests {
             [8u8; 32],
             ScopeId::from([9u8; 32]),
             vec![[7u8; 32]],
-            legacy_authorship(root.public_key()),
+            authorship_of(AccountId::from([0xA0; 32]), root.public_key()),
             hlc(2),
             OpPayload::DeviceRevoked { account, device },
             [0u8; 32],
@@ -929,7 +943,7 @@ mod tests {
             });
             let payload = set_writers_payload(object, entries.last().expect("just pushed"));
             let parents: Vec<[u8; 32]> = prev_id.into_iter().collect();
-            let authorship = legacy_authorship(admin);
+            let authorship = authorship_of(AccountId::from([1u8; 32]), admin);
             let id = Op::compute_id(scope, &parents, &authorship, &h, &payload);
             ops.push(Op::from_parts(
                 id, scope, parents, authorship, h, payload, [0u8; 32], [0u8; 64],
@@ -989,7 +1003,7 @@ mod tests {
         let op = Op::new(
             scope,
             vec![],
-            legacy_authorship(admin),
+            authorship_of(AccountId::from([1u8; 32]), admin),
             entry.delta_hlc,
             payload,
             [0u8; 32],
@@ -1380,15 +1394,19 @@ mod tests {
     fn membership_plane_fold_add_remove_readd() {
         let scope = ScopeId::from([0u8; 32]);
         let group = ContextGroupId::from([3u8; 32]);
-        let admin = PublicKey::from([1u8; 32]);
-        let m = PublicKey::from([0x55; 32]);
+        // Principals, named. This test folds add/remove/re-add on the membership
+        // plane, which is keyed by account — the keys it used to hash through the
+        // legacy stand-in were only a route to one.
+        let admin_key = PublicKey::from([1u8; 32]);
+        let admin = AccountId::from([1u8; 32]);
+        let m = AccountId::from([0x55; 32]);
 
         let build = |ns: u64, payload: OpPayload| -> Op {
             let h = hlc(ns);
             Op::new(
                 scope,
                 vec![],
-                legacy_authorship(admin),
+                authorship_of(admin, admin_key),
                 h,
                 payload,
                 [0u8; 32],
@@ -1402,49 +1420,33 @@ mod tests {
                 10,
                 OpPayload::MemberAdded {
                     group,
-                    member: legacy_account_id(&m),
+                    member: m,
                     role: GroupMemberRole::Member,
                 },
             ),
-            build(
-                20,
-                OpPayload::MemberRemoved {
-                    group,
-                    member: legacy_account_id(&m),
-                },
-            ),
+            build(20, OpPayload::MemberRemoved { group, member: m }),
             build(
                 30,
                 OpPayload::MemberAdded {
                     group,
-                    member: legacy_account_id(&m),
+                    member: m,
                     role: GroupMemberRole::Admin,
                 },
             ),
         ];
         let groups = ScopeState::from_ops(&ops).acl_view().groups;
         assert_eq!(
-            groups
-                .get(&group)
-                .and_then(|g| g.get(&legacy_account_id(&m))),
+            groups.get(&group).and_then(|g| g.get(&m)),
             Some(&GroupMemberRole::Admin),
             "re-add after remove wins with the new role"
         );
 
         // Same set ending in Remove@40 → member absent.
         let mut ops2 = ops;
-        ops2.push(build(
-            40,
-            OpPayload::MemberRemoved {
-                group,
-                member: legacy_account_id(&m),
-            },
-        ));
+        ops2.push(build(40, OpPayload::MemberRemoved { group, member: m }));
         let groups2 = ScopeState::from_ops(&ops2).acl_view().groups;
         assert_eq!(
-            groups2
-                .get(&group)
-                .and_then(|g| g.get(&legacy_account_id(&m))),
+            groups2.get(&group).and_then(|g| g.get(&m)),
             None,
             "final removal drops the member"
         );


### PR DESCRIPTION
Second fixture slice of #3414, on top of #3419 (now on master).

Eleven fixtures reached the stand-in bridge to get an `AccountId` or an `Authorship` for an op that needed *an* author, not a particular one. None of them assert anything about the derivation:

- `membership_plane_fold_add_remove_readd` checks roles across add/remove/re-add
- the `SetWriters` tests check writer sets, which already name accounts directly
- the `DeviceLinked` tests check that a payload folds into a binding

Hashing a key to reach a principal was a detour that coupled them to a bridge they never exercised. They now name the principal.

A local `authorship_of(account, device_key)` states the two fields separately, which is what they mean — **an account authorizes, a key signs**. `legacy_authorship` derives the first from the second, which is exactly the conflation the account plane exists to remove.

## Four uses stay, deliberately

They are *about* the bridge rather than incidental to it:

- an account derived from a device key is **not** the real account and **not** a member — the reason a binding has to be consulted at all;
- a revoked device **falls back to speaking only for itself**, and a writer set naming a stand-in keeps matching (the documented footgun, asserted rather than assumed).

Those assertions stop being expressible once the derivation goes, so they belong with its deletion — slice C — not with this conversion. Trying to "convert" them would just be deleting coverage while pretending otherwise.

## Progress on #3414

19 of 62 code references now gone (8 in #3419, 11 here), none of them from production. Remaining bulk is `scope_projection`'s inline suite (~21) and the two hard fixtures in `projection_membership_equivalence` — one needing genesis-fold plus parent threading, one (`an_explicit_binding_outranks_the_key_derived_stand_in`) that should be deleted rather than converted.

## Verification

`calimero-op-adapter` and `calimero-context` suites green (13 suites), `clippy -D warnings` clean, `fmt --check` clean.