### PR TITLE
fix(api): return the caller's ACCOUNT so it can find itself in a member list

### DIFF
--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -180,6 +180,44 @@ async fn list_group_members() {
     assert!(resp.members.is_empty());
 }
 
+/// **A caller can find itself in the listing.**
+///
+/// `members[].identity` is an ACCOUNT and `selfIdentity` is a signing KEY, so
+/// the documented way to answer "which of these is me" —
+/// `members.any(|m| m.identity == self_identity)` — became permanently false
+/// when members started being named by account. Downstream that reads as an
+/// admin rendering as a plain user and a joined channel rendering as unjoined:
+/// both gates fail closed, silently.
+///
+/// `selfAccount` is the answer, and it has to arrive in the same id space the
+/// entries use. This pins the wire field and the comparison together, because
+/// the two halves are only useful as a pair.
+#[tokio::test]
+async fn list_group_members_lets_the_caller_find_itself() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/admin-api/groups/{GID}/members")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "members": [
+                { "identity": ZERO_HEX_ACCOUNT, "role": "Admin" },
+            ],
+            "selfAccount": ZERO_HEX_ACCOUNT,
+            "selfIdentity": "11111111111111111111111111111111",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = make_client(&Url::parse(&server.uri()).unwrap());
+    let resp = client.list_group_members(GID).await.unwrap();
+
+    let me = resp.self_account.expect("the node reports its own account");
+    assert!(
+        resp.members.iter().any(|m| m.identity == me),
+        "a node must be able to find itself among the members it is listed in"
+    );
+}
+
 #[tokio::test]
 async fn add_group_members() {
     let server = MockServer::start().await;

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -161,8 +161,17 @@ impl Message for ListGroupMembersRequest {
 #[derive(Clone, Debug)]
 pub struct ListGroupMembersResponse {
     pub members: Vec<GroupMemberEntry>,
-    /// The node's own group-level identity (SignerId) so the client knows
-    /// which member in the list represents the current node.
+    /// The node's own ACCOUNT — the entry in `members` that represents it.
+    ///
+    /// This is the field to compare against [`GroupMemberEntry::identity`].
+    /// `self_identity` below cannot be: entries are accounts, an account is a
+    /// one-way hash of a genesis, and no amount of key-matching recovers it.
+    pub self_account: AccountId,
+    /// The node's own group-level signing key.
+    ///
+    /// **Not comparable to [`GroupMemberEntry::identity`]** — different id
+    /// space. Kept because a caller that needs the key it signs with has no
+    /// other source for it; use `self_account` to find yourself in the list.
     pub self_identity: PublicKey,
 }
 

--- a/crates/context/src/handlers/list_group_members.rs
+++ b/crates/context/src/handlers/list_group_members.rs
@@ -120,8 +120,16 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
                 })
                 .collect();
 
+            // Resolved unconditionally, not just on the branch that needed it for
+            // the membership gate: this is the only value a client can compare
+            // against `members[].identity` to find itself, and returning the
+            // signing key alone made that comparison silently always false.
+            let self_account =
+                crate::member_account::require(&self.datastore, &group_id, &node_identity)?;
+
             Ok(ListGroupMembersResponse {
                 members: entries,
+                self_account,
                 self_identity: node_identity,
             })
         })();

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1632,8 +1632,19 @@ impl Validate for RemoveGroupMembersApiRequest {
 #[serde(rename_all = "camelCase")]
 pub struct ListGroupMembersApiResponse {
     pub members: Vec<GroupMemberApiEntry>,
-    /// The calling node's own group-level identity (SignerId), so clients
-    /// can identify which entry in `members` represents the current user.
+    /// The calling node's own ACCOUNT — the entry in `members` that is it.
+    ///
+    /// **This is the field to match on.** Entries are accounts (64 hex), so
+    /// comparing them against `selfIdentity` below never matches: that is a
+    /// bs58 signing key, and an account is a one-way hash no key recovers.
+    /// A client asking "which of these is me" wants this one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub self_account: Option<AccountId>,
+    /// The calling node's own group-level signing key.
+    ///
+    /// **Not comparable to `members[].identity`** — different id space. Kept
+    /// for callers that need the key they sign with; use `selfAccount` to find
+    /// yourself in the list.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub self_identity: Option<PublicKey>,
 }

--- a/crates/server/src/admin/handlers/groups/list_group_members.rs
+++ b/crates/server/src/admin/handlers/groups/list_group_members.rs
@@ -56,6 +56,7 @@ pub async fn handler(
             ApiResponse {
                 payload: ListGroupMembersApiResponse {
                     members: entries,
+                    self_account: Some(resp.self_account),
                     self_identity: Some(resp.self_identity),
                 },
             }


### PR DESCRIPTION
Closes #3402. This is fallout from #3391 — my change — and it is client-facing.

## The bug

`ListGroupMembersResponse` mixes two id spaces. `members[].identity` became an `AccountId` when governance principals flipped to accounts; `self_identity` stayed a signing key. So the documented way to answer *"which of these is me"*:

```rust
members.iter().any(|m| m.identity == self_identity)
```

is now **permanently false**. An account is a one-way hash of a genesis; no amount of key-matching recovers it.

**It fails closed and silently, which is the damaging part.** In `mero-chat` that same comparison drives `isDirectMember` and the role lookup behind the admin UI — so an admin renders as a plain user and a joined channel renders as unjoined, with nothing in the response suggesting anything is wrong.

## The fix

`self_account: AccountId` is added **alongside** `self_identity`, not in place of it:

- **`selfAccount`** — the field to match against entries. Documented as such.
- **`selfIdentity`** — kept, and re-documented as *not comparable* to `members[].identity`. A caller that needs the key it signs with has no other source for it; removing it would relocate the breakage rather than end it.

The handler already computed this value via `member_account::require`, but only on the branch that needed it for the membership gate. It is now resolved unconditionally, because it is the answer to the question the response exists to answer.

## On the test

`list_group_members_lets_the_caller_find_itself` pins the wire field and the comparison **together**, since the two halves are only useful as a pair.

It is A/B verified: removing `selfAccount` from the mock response makes it fail; restoring it makes it pass. That check mattered here — a test asserting "`Some(x)` was found among the members" can pass while proving nothing, which is close to how the original bug survived.

## Compatibility

Additive on the wire (`skip_serializing_if = "Option::is_none"`), so an existing client keeps deserializing. It does not *fix* such a client — one still comparing `selfIdentity` against entries stays broken — but that client is broken today, and `mero-js` 9.0.1 already documents `identity` as the account.

## Verification

16 suites green across `calimero-client`, `calimero-context` and `calimero-server`; `clippy -D warnings` and `fmt --check` clean.