### PR TITLE
fix(migration): record the state version a member activates, so it stops reporting the install row

### DIFF
--- a/crates/context/src/activation.rs
+++ b/crates/context/src/activation.rs
@@ -32,6 +32,32 @@ pub fn record_activation(store: &Store, context_id: &ContextId, blob: [u8; 32]) 
     }
 }
 
+/// The ABI state version the context's activated bytecode declares, if it was
+/// resolvable when the activation was recorded.
+pub fn activated_state_version(store: &Store, context_id: &ContextId) -> Option<u32> {
+    store
+        .handle()
+        .get(&calimero_store::key::ContextActivatedStateVersion::new(
+            *context_id,
+        ))
+        .ok()
+        .flatten()
+        .map(|v| v.state_version)
+}
+
+/// Record the state version `context_id`'s newly-activated bytecode declares.
+/// Best-effort, like [`record_activation`]: without it the rollup falls back to
+/// the install row, which under-reports rather than over-reports.
+pub fn record_activated_state_version(store: &Store, context_id: &ContextId, state_version: u32) {
+    let mut handle = store.handle();
+    if let Err(err) = handle.put(
+        &calimero_store::key::ContextActivatedStateVersion::new(*context_id),
+        &calimero_store::types::ContextActivatedStateVersion { state_version },
+    ) {
+        debug!(%context_id, %err, "failed to record activated state version");
+    }
+}
+
 /// Whether this context's STATE has reached the bytecode its group records as
 /// current (`marker == group.app_key`), or `None` when there is no group
 /// bytecode signal to compare against - no group, no meta, or a zero `app_key`.

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1553,17 +1553,25 @@ impl ContextManager {
             // true) rather than wedge this lazy member. force only relaxes the
             // absent-evidence arm: a rung whose ABI declares a migration still
             // resolves and runs it.
-            crate::handlers::upgrade_group::resolve_upgrade_from_abis(
+            let migration = crate::handlers::upgrade_group::resolve_upgrade_from_abis(
                 &node_client,
                 bound,
                 rung_app_key,
                 true,
             )
-            .await
+            .await?;
+            // The rung's declared state version, recorded with the activation
+            // marker below: the upgrade record that carries `to_state_version`
+            // never leaves the node that ran `upgrade_group`, so this is the
+            // only version signal a member has for state it has migrated.
+            let state_version =
+                crate::handlers::upgrade_group::blob_max_state_version(&node_client, rung_app_key)
+                    .await;
+            Ok::<_, eyre::Report>((migration, state_version))
         }
         .into_actor(self)
         .then(move |resolved, act, _ctx| {
-            let migration = match resolved {
+            let (migration, activated_state_version) = match resolved {
                 Ok(m) => m,
                 Err(err) => {
                     // Rung blob unobtainable or its ABI unreadable: the context
@@ -1616,6 +1624,13 @@ impl ContextManager {
                                 &context_id,
                                 rung_app_key,
                             );
+                            if let Some(state_version) = activated_state_version {
+                                crate::activation::record_activated_state_version(
+                                    &datastore,
+                                    &context_id,
+                                    state_version,
+                                );
+                            }
                             Ok(())
                         }
                         .into_actor(act)
@@ -1661,6 +1676,13 @@ impl ContextManager {
                     )
                     .await?;
                     crate::activation::record_activation(&datastore, &context_id, rung_app_key);
+                    if let Some(state_version) = activated_state_version {
+                        crate::activation::record_activated_state_version(
+                            &datastore,
+                            &context_id,
+                            state_version,
+                        );
+                    }
                     clear_migration_failed(&datastore, context_id);
                     Ok(())
                 }

--- a/crates/context/src/handlers/upgrade_group.rs
+++ b/crates/context/src/handlers/upgrade_group.rs
@@ -437,7 +437,7 @@ struct EmitRung {
 
 /// Max `state_version` across the blob's services, from its embedded ABIs.
 /// `None` when no service exposes an ABI — single-hop rules own that case.
-async fn blob_max_state_version(
+pub(crate) async fn blob_max_state_version(
     node_client: &calimero_node_primitives::client::NodeClient,
     blob: [u8; 32],
 ) -> Option<u32> {

--- a/crates/node/src/migration_status.rs
+++ b/crates/node/src/migration_status.rs
@@ -417,7 +417,15 @@ fn migrated_context_version(
         && calimero_context::activation::activated_at_group_target(datastore, context_id)
             == Some(true)
     {
-        return Some(app_meta.state_version.max(target));
+        // `target` lifts this only on the node that ran `upgrade_group` - the
+        // upgrade record it reads is never replicated. The install row cannot
+        // stand in: it is keyed per `ApplicationId`, so a same-id bundle upgrade
+        // leaves it at the version this node first installed. The version
+        // recorded when the context activated its bytecode is what a member has.
+        let activated =
+            calimero_context::activation::activated_state_version(datastore, context_id)
+                .unwrap_or_default();
+        return Some(app_meta.state_version.max(target).max(activated));
     }
     Some(app_meta.state_version)
 }
@@ -1887,6 +1895,42 @@ mod tests {
             facts.schema_version, 2,
             "a context executing the target bytecode is at the target schema, \
              whatever the install-tracking application row still records"
+        );
+        assert_eq!(
+            facts.residue_auto, 0,
+            "a migrated context is not outstanding residue"
+        );
+    }
+
+    /// The same migrated context, on a member instead of the initiator. Only
+    /// `upgrade_group` writes the upgrade record and it runs on one node, so a
+    /// member resolves its target as `0` and the marker path's `max(target)`
+    /// lifts nothing - leaving the stale install row as the reported version.
+    /// A node that executes the group's bytecode is at that bytecode's schema
+    /// whether or not it was the one that started the upgrade.
+    #[test]
+    fn facts_report_the_target_for_a_member_that_never_received_the_upgrade_record() {
+        use calimero_context_config::types::ContextGroupId;
+        use calimero_store::db::InMemoryDB;
+        use std::sync::Arc;
+
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let ns = [0xB4u8; 32];
+        let ctx = [0xC8u8; 32];
+
+        // No `save_v2_upgrade_record` - that record is initiator-local.
+        seed_bundle_group_meta(&store, &ContextGroupId::from(ns), ctx, V2_BLOB);
+        install_loaded_context(&store, ns, ctx, "1.0.0", 1);
+        install_bundle_over_context(&store, ctx, V1_BLOB, 1);
+        // What the ladder hop records when it activates the rung.
+        calimero_context::activation::record_activation(&store, &ctx.into(), V2_BLOB);
+        calimero_context::activation::record_activated_state_version(&store, &ctx.into(), 2);
+
+        let facts = compute_namespace_migration_facts(&store, ns);
+        assert_eq!(
+            facts.schema_version, 2,
+            "a member executing the group's bytecode must report its schema, \
+             not the install row it never moved"
         );
         assert_eq!(
             facts.residue_auto, 0,

--- a/crates/store/src/db.rs
+++ b/crates/store/src/db.rs
@@ -92,6 +92,14 @@ pub enum Column {
     /// NOT synchronized; auto-created from `Column::iter()` (no DB migration).
     ContextExecutingBlob,
     ContextActivatedBlob,
+    /// Node-local per-context record of the ABI state version the activated
+    /// bytecode declares, resolved from its embedded schema when the context
+    /// activates it. The upgrade record that carries `to_state_version` is only
+    /// ever written by the node running `upgrade_group`, so this is the sole
+    /// local version signal a member has for state it has actually migrated.
+    /// Own column for the same `context_id`-only collision reason as above.
+    /// NOT synchronized; auto-created from `Column::iter()` (no DB migration).
+    ContextActivatedStateVersion,
     /// Node-local per-application breadcrumb of the bytecode blob an in-place
     /// (same-id) bundle install overwrote — the source for the executing-blob
     /// pin above and the L1 downgrade gate's pre-install ABI. Own column: the

--- a/crates/store/src/key.rs
+++ b/crates/store/src/key.rs
@@ -28,9 +28,10 @@ pub use blobs::BlobMeta;
 pub use calimero_primitives::context::GroupMemberRole;
 use component::KeyComponents;
 pub use context::{
-    ContextActivatedBlob, ContextAuthoredRemaining, ContextConfig, ContextDagDelta,
-    ContextExecutingBlob, ContextIdentity, ContextLeftMarker, ContextMeta, ContextMigrationFailed,
-    ContextPrivateState, ContextResyncRequested, ContextState, ScopeUnifiedOp,
+    ContextActivatedBlob, ContextActivatedStateVersion, ContextAuthoredRemaining, ContextConfig,
+    ContextDagDelta, ContextExecutingBlob, ContextIdentity, ContextLeftMarker, ContextMeta,
+    ContextMigrationFailed, ContextPrivateState, ContextResyncRequested, ContextState,
+    ScopeUnifiedOp,
 };
 pub use generic::{Generic, FRAGMENT_SIZE, SCOPE_SIZE};
 pub use group::{

--- a/crates/store/src/key/context.rs
+++ b/crates/store/src/key/context.rs
@@ -312,6 +312,52 @@ impl Debug for ContextActivatedBlob {
     }
 }
 
+/// Per-context activated state-version key: the ABI state version the blob in
+/// [`ContextActivatedBlob`] declares. One key per context, in its own column.
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+pub struct ContextActivatedStateVersion(Key<ContextId>);
+
+impl ContextActivatedStateVersion {
+    #[must_use]
+    pub fn new(context_id: PrimitiveContextId) -> Self {
+        Self(Key((*context_id).into()))
+    }
+
+    #[must_use]
+    pub fn context_id(&self) -> PrimitiveContextId {
+        (*AsRef::<[_; 32]>::as_ref(&self.0)).into()
+    }
+}
+
+impl AsKeyParts for ContextActivatedStateVersion {
+    type Components = (ContextId,);
+
+    fn column() -> Column {
+        Column::ContextActivatedStateVersion
+    }
+
+    fn as_key(&self) -> &Key<Self::Components> {
+        (&self.0).into()
+    }
+}
+
+impl FromKeyParts for ContextActivatedStateVersion {
+    type Error = Infallible;
+
+    fn try_from_parts(parts: Key<Self::Components>) -> Result<Self, Self::Error> {
+        Ok(Self(*<&_>::from(&parts)))
+    }
+}
+
+impl Debug for ContextActivatedStateVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ContextActivatedStateVersion")
+            .field("id", &self.context_id())
+            .finish()
+    }
+}
+
 #[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 pub struct ContextConfig(Key<ContextId>);

--- a/crates/store/src/types.rs
+++ b/crates/store/src/types.rs
@@ -11,9 +11,9 @@ mod group;
 pub use application::{ApplicationMeta, ApplicationPreviousBlob, PackageInfo, ServiceMeta};
 pub use blobs::BlobMeta;
 pub use context::{
-    ContextActivatedBlob, ContextAuthoredRemaining, ContextConfig, ContextDagDelta,
-    ContextExecutingBlob, ContextIdentity, ContextLeftMarker, ContextMeta, ContextMigrationFailed,
-    ContextPrivateState, ContextState, ScopeUnifiedOp,
+    ContextActivatedBlob, ContextActivatedStateVersion, ContextAuthoredRemaining, ContextConfig,
+    ContextDagDelta, ContextExecutingBlob, ContextIdentity, ContextLeftMarker, ContextMeta,
+    ContextMigrationFailed, ContextPrivateState, ContextState, ScopeUnifiedOp,
 };
 pub use generic::GenericData;
 

--- a/crates/store/src/types/context.rs
+++ b/crates/store/src/types/context.rs
@@ -375,3 +375,21 @@ impl PredefinedEntry for key::ContextActivatedBlob {
     type Codec = Borsh;
     type DataType<'a> = ContextActivatedBlob;
 }
+
+/// Value for [`key::ContextActivatedStateVersion`]: the ABI state version the
+/// activated bytecode declares, recorded beside the activation marker because
+/// the install row is per-`ApplicationId` and a same-id bundle upgrade never
+/// moves it. Node-local; a missing row means the version was unresolvable.
+#[derive(BorshDeserialize, BorshSerialize, Clone, Copy, Debug, Eq, PartialEq)]
+#[expect(
+    clippy::exhaustive_structs,
+    reason = "single marker value; additions would need a migration"
+)]
+pub struct ContextActivatedStateVersion {
+    pub state_version: u32,
+}
+
+impl PredefinedEntry for key::ContextActivatedStateVersion {
+    type Codec = Borsh;
+    type DataType<'a> = ContextActivatedStateVersion;
+}


### PR DESCRIPTION
## Summary

A namespace member that had migrated its state kept advertising the version it first installed, so the fleet never converged.

`upgrade_group` is the only writer of the upgrade record carrying `to_state_version`, and it runs solely on the node that initiates the upgrade. The ops that do replicate (`TargetApplicationSet`, `GroupMigrationSet`) carry group metadata only. So on every other member `resolve_group_target_version` returns `0`, `migrated_context_version`'s marker path computes `state_version.max(0)`, and the result is `ApplicationMeta.state_version` — a row keyed per `ApplicationId`, which a same-id bundle upgrade never moves.

Observed on a two-node fleet: the member runs `migrate_v1_to_v2`, logs `Migration completed successfully`, serves `schema_version 2.0.0` over RPC, and emits `heartbeat schema_version=1 residue_auto=0` indefinitely. `residue_auto=0` while sitting below target is the tell that the locally-resolved target is `0`.

This records the ABI state version beside the activation marker when a ladder hop activates a rung, and has the rollup read it. The precondition for using it is unchanged (`marker == group.app_key`), so this only corrects the number reported by a context already proven converged.

Advancing the shared install row instead was rejected: that row is shared by every context on the application id, including ones that never migrated, which is the false green it was deliberately split from.

## Test plan

- New unit test `facts_report_the_target_for_a_member_that_never_received_the_upgrade_record` — the initiator-side test minus the upgrade record. Watched it fail on the unfixed tree (`left: 1, right: 2`, matching the value the node put on the wire) before the fix landed.
- The two false-green guards still pass unchanged: `facts_hold_below_target_when_the_bundle_is_installed_but_the_state_is_not` and `facts_hold_below_target_for_a_marker_less_context_the_gate_still_owes`.
- `cargo test -p calimero-store -p calimero-context -p calimero-node --lib`: 233 + 488 + 71 pass.
- `cargo fmt --all --check` and `cargo clippy --all-features` clean on the touched crates.
- app-migration workflows 00/01/02/09/11/12/22/28/36/37 are the end-to-end gate; they currently fail on `feat/migration-events` for this defect.