### PR TITLE
refactor(api): return only members from the group member listing

### DIFF
--- a/apps/scaffolding-e2e/workflows/group-join-via-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-join-via-inheritance.yml
@@ -174,8 +174,7 @@ steps:
   # subgroup members on node-2's own node must still include node-2:
   # the admin-api handler unions the stored rows with
   # `enumerate_inherited_members`. Before the fix this assertion fails
-  # — node-2's identity appeared only in `selfIdentity`, never in
-  # `members[]`.
+  # — an inherited member was absent from `members[]` entirely.
 
   - name: 'Node-2 lists subgroup members (issue #2371)'
     type: list_group_members
@@ -189,9 +188,8 @@ steps:
     statements:
       # node-2 joined `subgroup` via inheritance and holds no explicit
       # `GroupMember` row. Before the #2371 fix it was absent from
-      # `members[]` (surfaced only in `selfIdentity`); the admin-api
-      # handler now unions inherited members in, so node-2 must appear
-      # in the listed members.
+      # `members[]`; the admin-api handler now unions inherited members
+      # in, so node-2 must appear in the listed members.
       #
       # Compared by ACCOUNT, not by the `memberPublicKey` the join step
       # returns: the listing names members by the principal their rows are

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -180,6 +180,52 @@ async fn list_group_members() {
     assert!(resp.members.is_empty());
 }
 
+/// A caller has to be able to find itself in a member list.
+///
+/// The listing carries no self-field, so the way to do it is to ask the account
+/// endpoint who this node is and match that against `members[]`. Both sides are
+/// accounts, which is the whole point: the listing used to answer with the
+/// node's signing key, and a key never matches an account no matter how a
+/// client compares them.
+#[tokio::test]
+async fn a_caller_finds_itself_by_matching_its_account() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/admin-api/namespaces/{GID}/account")))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"data": {
+                "accountId": ZERO_HEX_ACCOUNT,
+                "namespaceId": GID,
+                "deviceId": null,
+            }})),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/admin-api/groups/{GID}/members")))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"members": [
+                {"identity": ZERO_HEX_ACCOUNT, "role": "Admin"},
+            ]})),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = make_client(&Url::parse(&server.uri()).unwrap());
+    let me = client.get_namespace_account(GID).await.unwrap();
+    let members = client.list_group_members(GID).await.unwrap();
+
+    assert!(
+        members
+            .members
+            .iter()
+            .any(|m| m.identity.to_string() == me.data.account_id),
+        "a node's own account must be findable among the members it is returned",
+    );
+}
+
 #[tokio::test]
 async fn add_group_members() {
     let server = MockServer::start().await;

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -161,9 +161,6 @@ impl Message for ListGroupMembersRequest {
 #[derive(Clone, Debug)]
 pub struct ListGroupMembersResponse {
     pub members: Vec<GroupMemberEntry>,
-    /// The node's own group-level identity (SignerId) so the client knows
-    /// which member in the list represents the current node.
-    pub self_identity: PublicKey,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/context/src/handlers/list_group_members.rs
+++ b/crates/context/src/handlers/list_group_members.rs
@@ -120,10 +120,7 @@ impl Handler<ListGroupMembersRequest> for ContextManager {
                 })
                 .collect();
 
-            Ok(ListGroupMembersResponse {
-                members: entries,
-                self_identity: node_identity,
-            })
+            Ok(ListGroupMembersResponse { members: entries })
         })();
 
         ActorResponse::reply(result)

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1632,10 +1632,6 @@ impl Validate for RemoveGroupMembersApiRequest {
 #[serde(rename_all = "camelCase")]
 pub struct ListGroupMembersApiResponse {
     pub members: Vec<GroupMemberApiEntry>,
-    /// The calling node's own group-level identity (SignerId), so clients
-    /// can identify which entry in `members` represents the current user.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub self_identity: Option<PublicKey>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/server/src/admin/handlers/groups/list_group_members.rs
+++ b/crates/server/src/admin/handlers/groups/list_group_members.rs
@@ -54,10 +54,7 @@ pub async fn handler(
                 })
                 .collect();
             ApiResponse {
-                payload: ListGroupMembersApiResponse {
-                    members: entries,
-                    self_identity: Some(resp.self_identity),
-                },
+                payload: ListGroupMembersApiResponse { members: entries },
             }
             .into_response()
         }

--- a/crates/server/src/admin/handlers/groups/list_subgroups.rs
+++ b/crates/server/src/admin/handlers/groups/list_subgroups.rs
@@ -31,9 +31,8 @@ pub async fn handler(
     // the parent group — NOT from the JWT subject. The JWT's `sub` is a
     // node-level key fingerprint that doesn't parse as a `PublicKey`
     // (see calimero_server::auth — emits a WARN and skips the
-    // AuthenticatedKey extension). Using `resolve_namespace_identity`
-    // matches what `list_group_members` already does to populate
-    // `selfIdentity`.
+    // AuthenticatedKey extension), so the node's namespace identity is the
+    // only thing here that resolves to a governance principal.
     // Visibility is decided per account, so this node's namespace identity is
     // resolved to one. An identity bound to no account here sees the same as no
     // identity at all: every Restricted child stays hidden.


### PR DESCRIPTION
Part of #3425. First slice: the group member listing stops answering "who am I".

## The defect

`ListGroupMembersResponse` carried `selfIdentity` — the calling node's group-level
signing key — so a client could tell which entry in `members[]` represented itself.
It never could. Entries are keyed by `AccountId`; `selfIdentity` is a `PublicKey`.
Both are 32 bytes, both cross the wire as strings, and an account is a one-way hash
of a genesis, so no amount of comparing recovers one from the other. A client
looking for itself finds nothing and concludes it is not a member — no error
anywhere.

That is #3402. The root cause is structural: a collection response was carrying the
caller's identity. "List the members" and "who am I" are different questions, and
answering the second inside the first is what let a mismatched id space in.

## The change

The listing returns members only. A caller that needs to locate itself asks
`GET /admin-api/namespaces/{ns}/account` and compares account to account — one id
space, nothing to convert.

This is deliberately *not* the shape of the earlier attempt (#3423, closed), which
added `selfAccount` beside `selfIdentity`. That leaves the caller choosing between
two self-fields, only one of which is comparable to the list.

## Proof

`a_caller_finds_itself_by_matching_its_account` in `crates/client/src/tests.rs`
drives the documented path against a mock: fetch the account, list the members,
match. A/B — feeding the account endpoint a bs58 value instead of hex (the old
wrong id space) fails the assertion:

```
test tests::a_caller_finds_itself_by_matching_its_account ... FAILED
a node's own account must be findable among the members it is returned
```

and passes with the account rendered as an account.

## Breaking change

sdk-ref: fix/3425-drop-signing-key-from-api

Any client reading `selfIdentity` loses it. No merobox scenario captures the field,
and the only two in-repo mentions were prose describing a past bug, both corrected
here — but the **mero-js e2e suite did assert on it**, and caught this on the first
CI run:

```
FAIL tests/e2e/admin-api.test.ts > Group Management > should list group members
AssertionError: expected undefined to be truthy
  173|      expect(response.selfIdentity).toBeTruthy();
```

Paired fix: calimero-network/mero-js@`fix/3425-drop-signing-key-from-api`, picked up
by the `sdk-ref` above. It drops the field from `ListGroupMembersResponseData` and
replaces the e2e assertion with the *replacement* path — ask `getNamespaceIdentity`
who this node is, match its account against `members[].identity`. `NamespaceIdentity`
gains the `account` core already returns, which is what makes that match possible.

So the end-to-end claim of this PR is now covered against a real node, not only by
the wiremock test below.

## What this slice does not do

`GET /admin-api/namespaces/{ns}/identity` stays for now. Removing it is the next
slice and is larger than it looks: **44 merobox scenarios** use the
`get_namespace_identity` step, and 38 of them read `publicKey` from it — mostly as
`requester` for context calls. So the signing key does need a home; #3425's open
question is answered, and the answer is a device resource rather than deletion.
That slice needs a merobox change first.

Verified: `cargo fmt --check`, `cargo clippy --workspace --all-targets --features
calimero-storage/testing -- -D warnings`, `cargo check --workspace --all-targets`,
and the affected crate tests.

