### PR TITLE
test(migration): pin the stranded rollup to the sentinel, and name who is stuck

### DIFF
--- a/workflows/app-migration/37-stranded-resync.yml
+++ b/workflows/app-migration/37-stranded-resync.yml
@@ -104,6 +104,15 @@ steps:
     namespace_id: "{{namespace_id}}"
     invitation: "{{namespace_invitation}}"
 
+  # The identity the rollup keys node 2's member row by, so the stranded member
+  # can be asserted by name rather than by position.
+  - name: Capture node 2 key
+    type: get_namespace_identity
+    node: app-migration-strand-2
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      strand_2_key: publicKey
+
   - name: Node 2 materialises subgroup membership via inheritance
     type: join_subgroup_inheritance
     node: app-migration-strand-2
@@ -290,6 +299,7 @@ steps:
       strand_total: total
       strand_migrated: migrated
       strand_reasons: failure_reasons
+      strand_stuck: stuck_members
       strand_min_reported: min_reported_schema_version
 
   - name: Assert exactly node 2 stranded, for the blocked-ladder reason
@@ -304,9 +314,14 @@ steps:
       # is the blocked-ladder case, distinct from check_aborted and apply_failed.
       # Sorted, so it does not depend on member ordering the API never promised.
       - 'json_equal({{strand_reasons}}, ["no_migration_path"])'
-      # Node 2 is still holding v1 state, so the lowest reported ABI state
-      # version across the cohort is 1 while node 1 sits at the v3 target.
-      - "equal({{strand_min_reported}}, 1)"
+      # 0, not node 2's real v1: a context the upgrade gate still owes reports
+      # the 0 sentinel, because its application row records what was INSTALLED
+      # and can sit ahead of the state. No version is reported until the node
+      # has actually converged, so the number can never read as done.
+      - "equal({{strand_min_reported}}, 0)"
+      # Which member is stuck - the sentinel deliberately says nothing about
+      # who, so identity is asserted separately or the count is all we have.
+      - 'json_equal({{strand_stuck}}, ["{{strand_2_key}}"])'
 
   # Phase 8: RECOVER - resync node 2 from a peer. force=true because node 2
   # still holds local DAG heads (its v1 state) that the snapshot discards.
@@ -386,11 +401,14 @@ steps:
       recovered_missing: reported_missing
       recovered_min_reported: min_reported_schema_version
       recovered_reasons: failure_reasons
+      recovered_stuck: stuck_members
 
   - name: Assert node 2 came back at the v3 target with its marker cleared
     # all_migrated above is core's own answer; these are recomputed from each
     # member's raw report, so they falsify it: the resync only counts if node
-    # 2's REPORTED version moved 1 -> 3 and its strand reason went away.
+    # 2's REPORTED version left the 0 sentinel for 3 - the cohort reports a
+    # real version only once every member has converged - and its strand
+    # reason went away, leaving nobody named as stuck.
     type: json_assert
     statements:
       - "equal({{recovered_target}}, 3)"
@@ -399,6 +417,7 @@ steps:
       - "equal({{recovered_missing}}, 0)"
       - "equal({{recovered_min_reported}}, 3)"
       - "json_equal({{recovered_reasons}}, [])"
+      - "json_equal({{recovered_stuck}}, [])"
 
   # Teardown guard: no deserialization failures anywhere across the run.
   - name: Assert no deserialization failures anywhere


### PR DESCRIPTION
## Summary

Scenario 37 and the rollup disagreed about the same number, and the scenario was wrong.

`migrated_context_version` returns the `0` sentinel for a context whose upgrade gate still owes it, because the application row records what was **installed** and can sit ahead of the state — reporting it is how a node claims a version it never migrated to. Scenario 37 asserted `min_reported_schema_version == 1`, node 2's real state, so it failed with `left=0 right='1'`.

The rule this settles: **the cohort reports a real version only once every member has converged; otherwise `0`, plus who is stuck.** The sentinel can never read as done while a member is behind.

Relaxing `1 → 0` on its own would only make the assertion looser, so the identity it deliberately omits is now pinned too. `failure_reasons` said *what* went wrong; nothing said *which member*, and the per-member rows only answered it positionally, under an ordering the API never promised. Scenario 37 now captures node 2's namespace identity and asserts the stuck member by name, and the recovered half asserts nobody is left named.

## Test plan

- `37-stranded-resync` run natively on arm64 (`merod` built from this branch), passing end to end:
  - `strand_min_reported: 0` while node 2 is stranded
  - `strand_stuck: ['CJnSRDZfLFiuZf8njQ42twvuJT2TohUVcjnTm6aLyLYN']`, equal to the captured `strand_2_key`
  - `strand_failed: 1`, `strand_reasons: ['no_migration_path']`
  - after resync: `recovered_min_reported: 3`, `recovered_stuck: []`, `recovered_failed: 0`
- The workflow parses (`yaml.safe_load`, 47 steps).

## Dependency

The `stuck_members` capture needs merobox `feat/migration-report-and-expected-error` (#326), which is unreleased. Scenario 37 already could not pass on released merobox 0.6.52 — its `strand_reasons` and `strand_min_reported` captures do not exist there either, so the placeholders stay literal and compare unequal. This scenario goes green in CI only after the merobox stack ships and `MIN_MEROBOX` is bumped; it is verified locally against merobox from source in the meantime.