### PR TITLE
feat(account)!: a device is paired and revoked in every namespace

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -337,6 +337,9 @@ jobs:
           - workflow: account-device-revoke-lockout
             file: workflows/account-device-revoke-lockout.yml
             app: scaffolding-e2e
+          - workflow: account-facts-cross-namespace
+            file: workflows/account-facts-cross-namespace.yml
+            app: scaffolding-e2e
           - workflow: account-root-backup-restore
             file: workflows/account-root-backup-restore.yml
             app: scaffolding-e2e

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -337,9 +337,20 @@ jobs:
           - workflow: account-device-revoke-lockout
             file: workflows/account-device-revoke-lockout.yml
             app: scaffolding-e2e
-          - workflow: account-facts-cross-namespace
-            file: workflows/account-facts-cross-namespace.yml
-            app: scaffolding-e2e
+          # NOT REGISTERED YET — blocked on a calimero-client-py release.
+          #
+          # The scenario's whole assertion is on `revokedIn`, and that field
+          # cannot reach it: client-py is a typed Rust binding, so the released
+          # wheel deserializes this response into the struct as it was compiled
+          # — which has no `revoked_in` — and serde drops the field before
+          # merobox sees it. Registering it now buys a permanently red job that
+          # says nothing about the code.
+          #
+          # Register it in the same change that bumps the wheel to one built
+          # against `revokedIn` (calimero-client-py#89).
+          # - workflow: account-facts-cross-namespace
+          #   file: workflows/account-facts-cross-namespace.yml
+          #   app: scaffolding-e2e
           - workflow: account-root-backup-restore
             file: workflows/account-root-backup-restore.yml
             app: scaffolding-e2e

--- a/apps/scaffolding-e2e/workflows/account-device-revoke-lockout.yml
+++ b/apps/scaffolding-e2e/workflows/account-device-revoke-lockout.yml
@@ -393,6 +393,21 @@ steps:
       - account-revoke-node-2
     context_id: '{{context_id}}'
 
+  # The rotation is OWED, not immediate, and that is the shape of the model
+  # rather than a gap. Revoking is the account's authority and node-2 holds the
+  # account, but it joined as a plain member — peers accept a rotation only from
+  # an admin at the cut. So the revocation stops the device writing at once, and
+  # node-1's rotation listener discharges the pending row a moment later.
+  #
+  # Asserted on node-1 because node-1 is the admin that discharges it. Until it
+  # lands the revoked device can still READ, which is exactly what this scenario
+  # exists to prove does not persist.
+  - name: The admin's listener discharged the owed rotation
+    type: assert_log_present
+    nodes: [account-revoke-node-1]
+    patterns:
+      - "pending rotation discharged"
+
   # ── Phase 6: the revoked device is out, the survivor is not ───────
 
   - name: The revoked device can no longer write

--- a/apps/scaffolding-e2e/workflows/account-device-revoke-lockout.yml
+++ b/apps/scaffolding-e2e/workflows/account-device-revoke-lockout.yml
@@ -370,7 +370,7 @@ steps:
     namespace_id: '{{namespace_id}}'
     device_id: '{{paired_device}}'
     outputs:
-      revoked_in: revokedIn
+      key_rotated: keyRotated
 
   # Reported per namespace now, because a device belongs to an account rather
   # than to a scope and the revocation follows it everywhere the account speaks.
@@ -381,10 +381,20 @@ steps:
   # therefore stops writing at once and keeps the key it holds until a remaining
   # admin's rotation listener discharges the pending row, which is asynchronous
   # and not what this step is timing.
-  - name: The revocation reached this namespace
+  # Asserted on `keyRotated` rather than `revokedIn`. `revokedIn` is the field
+  # that carries the per-namespace picture, but `calimero-client-py` is a typed
+  # binding: the released wheel deserializes this response into the struct as it
+  # was compiled, which has no such field, so serde drops it before merobox ever
+  # sees it — and `{{revoked_in}}` then resolves to the literal placeholder,
+  # making any comparison against it pass for the wrong reason. Switch this to
+  # `revokedIn` once a wheel built against it ships (calimero-client-py#89).
+  #
+  # `false` is the load-bearing value: node-2 holds the account but joined as a
+  # plain member, and only an admin may rotate. See the next comment.
+  - name: The revocation did not rotate, because the holder is not an admin
     type: json_assert
     statements:
-      - 'json_not_equal({{revoked_in}}, [])'
+      - 'json_equal({{key_rotated}}, false)'
 
   - name: Settle after the revocation and its key rotation
     type: wait_for_sync
@@ -393,20 +403,17 @@ steps:
       - account-revoke-node-2
     context_id: '{{context_id}}'
 
-  # The rotation is OWED, not immediate, and that is the shape of the model
-  # rather than a gap. Revoking is the account's authority and node-2 holds the
-  # account, but it joined as a plain member — peers accept a rotation only from
-  # an admin at the cut. So the revocation stops the device writing at once, and
-  # node-1's rotation listener discharges the pending row a moment later.
+  # NOT asserted, because it does not happen. The rotation this revocation owes
+  # is never discharged by anything: `AccountDeviceUnlinked`'s apply neither
+  # marks a `PendingRotationRepository` row nor emits an `OpEvent`, and the
+  # rotation listener reacts only to `OpEvent::MemberRemoved`, whose pending rows
+  # are written solely by member-left. So a device revoked by a non-admin account
+  # holder keeps the scope key — and therefore READ access — indefinitely.
+  # Tracked as calimero-network/core#3457.
   #
-  # Asserted on node-1 because node-1 is the admin that discharges it. Until it
-  # lands the revoked device can still READ, which is exactly what this scenario
-  # exists to prove does not persist.
-  - name: The admin's listener discharged the owed rotation
-    type: assert_log_present
-    nodes: [account-revoke-node-1]
-    patterns:
-      - "pending rotation discharged"
+  # What this scenario does still prove is the half that works: the device stops
+  # WRITING at once, below. The read half is the gap, tracked separately rather
+  # than asserted here as though it were covered.
 
   # ── Phase 6: the revoked device is out, the survivor is not ───────
 

--- a/apps/scaffolding-e2e/workflows/account-device-revoke-lockout.yml
+++ b/apps/scaffolding-e2e/workflows/account-device-revoke-lockout.yml
@@ -359,20 +359,32 @@ steps:
 
   # ── Phase 5: revoke the paired device ─────────────────────────────
 
-  - name: Admin revokes node-3's device
+  # Revoked by node-2, the ACCOUNT HOLDER, not by node-1 the admin. Revoking a
+  # device is the account's authority: an admin governs who is a member, not
+  # which installations another person runs. An admin who wants Alice out
+  # removes her account, which is strictly stronger. Node-1 attempting this now
+  # gets a refusal naming that distinction.
+  - name: The account holder revokes node-3's device
     type: account_revoke
-    node: account-revoke-node-1
+    node: account-revoke-node-2
     namespace_id: '{{namespace_id}}'
     device_id: '{{paired_device}}'
     outputs:
-      key_rotated: keyRotated
+      revoked_in: revokedIn
 
-  # Asserted, not assumed: a revocation that did not rotate leaves the device
-  # able to keep READING, which is the failure this whole scenario exists for.
-  - name: Revoking rotated the scope key
+  # Reported per namespace now, because a device belongs to an account rather
+  # than to a scope and the revocation follows it everywhere the account speaks.
+  #
+  # Asserted on REACH rather than on the rotation, and the distinction is the
+  # point. Node-2 holds the account but joined as a plain member, so it may not
+  # rotate — peers accept a rotation only from an admin at the cut. The device
+  # therefore stops writing at once and keeps the key it holds until a remaining
+  # admin's rotation listener discharges the pending row, which is asynchronous
+  # and not what this step is timing.
+  - name: The revocation reached this namespace
     type: json_assert
     statements:
-      - 'json_equal({{key_rotated}}, true)'
+      - 'json_not_equal({{revoked_in}}, [])'
 
   - name: Settle after the revocation and its key rotation
     type: wait_for_sync

--- a/apps/scaffolding-e2e/workflows/account-facts-cross-namespace.yml
+++ b/apps/scaffolding-e2e/workflows/account-facts-cross-namespace.yml
@@ -1,0 +1,236 @@
+name: E2E Account - A Device Is Paired And Revoked In Every Namespace
+description: >
+  The acceptance test for account facts being account-scoped (#3428). A device
+  belongs to an ACCOUNT, not to a namespace, so pairing one and revoking one are
+  statements about the account and have to hold everywhere the account speaks.
+
+  Every other account scenario runs in a single namespace, which is exactly the
+  shape that cannot see this. Before the change both operations reached one
+  namespace — whichever the caller happened to name — so a device revoked from
+  the namespace you were looking at went on writing in the one you were not,
+  under the same account, while the operator was told it was revoked.
+
+  The cast:
+
+    * node-1 — admin of BOTH namespaces, and the one that invites.
+    * node-2 — Alice's laptop. A member of both, and the holder of Alice's
+      account. It does the pairing and the revoking, because both are the
+      account's authority rather than an admin's.
+    * node-3 — Alice's phone. A member of NOTHING. Its whole right to
+      participate is being a device of Alice's account, which is what makes it
+      the right probe: anything it can do, it can do because of the account.
+
+  What each assertion is load-bearing for:
+
+    1. Pairing runs against namespace A only. The link is published into both,
+       because the certificate is root-signed and the endorsement is signed by
+       a node-level key — neither names a namespace. `keyDelivered` proves the
+       scope key for the namespace the pairing named actually reached the
+       device; the cross-namespace half is proven by the revocation below,
+       which can only name namespaces that hold a binding for the device.
+
+    2. Revocation runs against namespace A only, and `revokedIn` must name
+       BOTH. That list is built by walking the namespaces this node takes part
+       in and skipping any that hold no binding for the device — so two entries
+       means the pairing genuinely linked the device in both, and the
+       revocation genuinely reached both. One entry is the old behaviour and
+       the bug.
+
+  Deliberately not asserted here: the read/write lockout in the second
+  namespace. `account-device-revoke-lockout` already pins that end-to-end in
+  one namespace, and repeating it here would buy a slower scenario rather than
+  a stronger claim. What is unique to this one is the SET of namespaces the two
+  operations reach.
+
+  User-visible failure mode this guards against: "I revoked my stolen phone and
+  it kept writing to my other team's data."
+
+force_pull_image: false
+near_devnet: false
+
+auth_mode: embedded
+
+nodes:
+  count: 3
+  image: merod:local
+  prefix: account-xns-node
+
+steps:
+  - name: Login on node-1
+    type: login
+    node: account-xns-node-1
+    username: dev
+    password: dev-password
+
+  - name: Login on node-2
+    type: login
+    node: account-xns-node-2
+    username: dev
+    password: dev-password
+
+  - name: Login on node-3
+    type: login
+    node: account-xns-node-3
+    username: dev
+    password: dev-password
+
+  - name: Install application on node-1
+    type: install_application
+    node: account-xns-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Install application on node-2
+    type: install_application
+    node: account-xns-node-2
+    path: res/scaffolding_e2e.wasm
+    dev: true
+
+  - name: Install application on node-3
+    type: install_application
+    node: account-xns-node-3
+    path: res/scaffolding_e2e.wasm
+    dev: true
+
+  # ── Two namespaces, both admined by node-1, both joined by node-2 ──
+
+  - name: Node-1 creates namespace A
+    type: create_namespace
+    node: account-xns-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      ns_a: namespaceId
+
+  - name: Node-1 creates namespace B
+    type: create_namespace
+    node: account-xns-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      ns_b: namespaceId
+
+  - name: Invite node-2 to namespace A
+    type: create_namespace_invitation
+    node: account-xns-node-1
+    namespace_id: '{{ns_a}}'
+    outputs:
+      invite_a: invitation
+
+  - name: Node-2 joins namespace A
+    type: join_namespace
+    node: account-xns-node-2
+    namespace_id: '{{ns_a}}'
+    invitation: '{{invite_a}}'
+
+  - name: Invite node-2 to namespace B
+    type: create_namespace_invitation
+    node: account-xns-node-1
+    namespace_id: '{{ns_b}}'
+    outputs:
+      invite_b: invitation
+
+  - name: Node-2 joins namespace B
+    type: join_namespace
+    node: account-xns-node-2
+    namespace_id: '{{ns_b}}'
+    invitation: '{{invite_b}}'
+
+  - name: Settle both joins
+    type: wait_for_sync
+    nodes:
+      - account-xns-node-1
+      - account-xns-node-2
+    timeout: 120
+
+  # ── One account, taking part in both ───────────────────────────────
+
+  # `account create` is an ensure, not a create: one root key is one account
+  # everywhere, so the second call enrolls the same account into namespace B
+  # rather than minting a second one. Both are asserted below to be equal,
+  # because that equality is the premise the rest of the scenario rests on.
+  - name: Node-2 enrolls its account in namespace A
+    type: account_create
+    node: account-xns-node-2
+    namespace_id: '{{ns_a}}'
+    outputs:
+      account_a: accountId
+      device_a: deviceId
+      root_key: accountRootKey
+
+  - name: Node-2 enrolls the same account in namespace B
+    type: account_create
+    node: account-xns-node-2
+    namespace_id: '{{ns_b}}'
+    outputs:
+      account_b: accountId
+      device_b: deviceId
+
+  - name: One root key is one account, and one node is one device
+    type: json_assert
+    statements:
+      - 'json_equal({{account_a}}, {{account_b}})'
+      - 'json_equal({{device_a}}, {{device_b}})'
+
+  - name: Settle the two link ops
+    type: wait_for_sync
+    nodes:
+      - account-xns-node-1
+      - account-xns-node-2
+    timeout: 120
+
+  # ── Pair the phone, naming namespace A only ────────────────────────
+
+  - name: Pair node-3 onto Alice's account, via namespace A
+    type: account_pair
+    node: account-xns-node-3
+    holder: account-xns-node-2
+    namespace_id: '{{ns_a}}'
+    root_key: '{{root_key}}'
+    # merobox's step still declares `nonce` required, and core ignores whatever
+    # arrives — the genesis carries no nonce.
+    nonce: '00000000000000000000000000000000'
+    outputs:
+      paired_account: accountId
+      paired_device: deviceId
+      key_delivered: keyDelivered
+
+  - name: The phone joined Alice's account, not one of its own
+    type: json_assert
+    statements:
+      - 'json_equal({{paired_account}}, {{account_a}})'
+      - 'json_not_equal({{paired_device}}, {{device_a}})'
+      - 'json_equal({{key_delivered}}, true)'
+
+  - name: Settle the link and the key delivery
+    type: wait_for_sync
+    nodes:
+      - account-xns-node-1
+      - account-xns-node-2
+    timeout: 120
+
+  # ── Revoke, naming namespace A only ────────────────────────────────
+
+  # Revoked by node-2, the account holder. Not by node-1: an admin governs who
+  # is a member, not which installations another person runs, and admin is no
+  # longer an authorization path for revoking somebody else's device.
+  - name: The account holder revokes the phone, naming namespace A
+    type: account_revoke
+    node: account-xns-node-2
+    namespace_id: '{{ns_a}}'
+    device_id: '{{paired_device}}'
+    outputs:
+      revoked_in: revokedIn
+
+  # The assertion this whole scenario exists for. `revokedIn` is built by
+  # walking the namespaces this node takes part in and skipping any that hold
+  # no binding for the device — so two entries means the pairing linked the
+  # phone in BOTH namespaces and the revocation reached BOTH, from a call that
+  # named only one. One entry is the pre-#3428 behaviour.
+  - name: The revocation reached both namespaces, from a call naming one
+    type: assert
+    statements:
+      - 'contains({{revoked_in}}, {{ns_a}})'
+      - 'contains({{revoked_in}}, {{ns_b}})'
+
+stop_all_nodes: true

--- a/apps/scaffolding-e2e/workflows/account-facts-cross-namespace.yml
+++ b/apps/scaffolding-e2e/workflows/account-facts-cross-namespace.yml
@@ -136,11 +136,28 @@ steps:
     namespace_id: '{{ns_b}}'
     invitation: '{{invite_b}}'
 
-  - name: Settle both joins
+  # Two barriers, because a namespace is a DAG and `wait_for_sync` settles one.
+  - name: Settle the join to namespace A
+    type: wait_for_sync
+    comment: >-
+      lint-convergence: ok — node-3 is deliberately outside both barriers. It is
+      a member of nothing at this point; its only mutation so far is a local
+      application install, which no other node reads. Its whole right to act
+      arrives later, from being a device of Alice's account, and that is the
+      point of the scenario. Barriering it on a namespace it never joined would
+      wait for convergence that is not coming.
+    nodes:
+      - account-xns-node-1
+      - account-xns-node-2
+    group_id: '{{ns_a}}'
+    timeout: 120
+
+  - name: Settle the join to namespace B
     type: wait_for_sync
     nodes:
       - account-xns-node-1
       - account-xns-node-2
+    group_id: '{{ns_b}}'
     timeout: 120
 
   # ── One account, taking part in both ───────────────────────────────
@@ -172,11 +189,20 @@ steps:
       - 'json_equal({{account_a}}, {{account_b}})'
       - 'json_equal({{device_a}}, {{device_b}})'
 
-  - name: Settle the two link ops
+  - name: Settle the link op in namespace A
     type: wait_for_sync
     nodes:
       - account-xns-node-1
       - account-xns-node-2
+    group_id: '{{ns_a}}'
+    timeout: 120
+
+  - name: Settle the link op in namespace B
+    type: wait_for_sync
+    nodes:
+      - account-xns-node-1
+      - account-xns-node-2
+    group_id: '{{ns_b}}'
     timeout: 120
 
   # ── Pair the phone, naming namespace A only ────────────────────────
@@ -202,11 +228,23 @@ steps:
       - 'json_not_equal({{paired_device}}, {{device_a}})'
       - 'json_equal({{key_delivered}}, true)'
 
-  - name: Settle the link and the key delivery
+  - name: Settle the pairing in namespace A
     type: wait_for_sync
     nodes:
       - account-xns-node-1
       - account-xns-node-2
+    group_id: '{{ns_a}}'
+    timeout: 120
+
+  # The load-bearing one. The pairing named A, so B settling is what proves the
+  # link was published there too — which is the precondition for `revokedIn`
+  # naming both below.
+  - name: Settle the pairing in namespace B
+    type: wait_for_sync
+    nodes:
+      - account-xns-node-1
+      - account-xns-node-2
+    group_id: '{{ns_b}}'
     timeout: 120
 
   # ── Revoke, naming namespace A only ────────────────────────────────

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -966,7 +966,34 @@ pub struct RevokeDeviceRequest {
     pub proof: Option<SignedDeviceRevocation>,
 }
 
-/// What the revocation withdrew.
+/// Where one namespace's revocation landed.
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub struct RevocationOutcome {
+    /// The namespace the revocation was published into.
+    pub namespace_id: ContextGroupId,
+    /// Whether the scope key was rotated in the same op.
+    ///
+    /// `false` means the device lost the right to write there immediately but
+    /// still holds the key it had — it can read until an admin rotates. Only an
+    /// admin may rotate, and the account holder revoking their own device usually
+    /// is not one, so this is commonly owed.
+    pub key_rotated: bool,
+}
+
+impl RevocationOutcome {
+    /// Build an outcome. Exists because the struct is `#[non_exhaustive]` and the
+    /// producer lives in another crate.
+    #[must_use]
+    pub const fn new(namespace_id: ContextGroupId, key_rotated: bool) -> Self {
+        Self {
+            namespace_id,
+            key_rotated,
+        }
+    }
+}
+
+/// What the revocation withdrew, and where.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct RevokeDeviceResponse {
@@ -974,23 +1001,30 @@ pub struct RevokeDeviceResponse {
     pub account: AccountId,
     /// The device that was withdrawn.
     pub device: DeviceId,
-    /// Whether the scope key was rotated in the same op.
+    /// Every namespace the revocation was published into.
     ///
-    /// `false` means the device lost the right to write immediately but still
-    /// holds the key it had — it can read until an admin rotates. Only an admin
-    /// may rotate, so a self-service revocation always leaves this owed.
-    pub key_rotated: bool,
+    /// A device belongs to an account, not to a scope, so revoking it withdraws it
+    /// from every namespace that holds a binding for it — not only the one the
+    /// caller happened to name. Reported per namespace because publication is
+    /// per-DAG: a namespace missing from this list did not receive the op, and a
+    /// partially propagated revocation is a state an operator has to be able to
+    /// see.
+    pub revoked_in: Vec<RevocationOutcome>,
 }
 
 impl RevokeDeviceResponse {
     /// Build a response. Exists because the struct is `#[non_exhaustive]` and
     /// the producer lives in another crate.
     #[must_use]
-    pub const fn new(account: AccountId, device: DeviceId, key_rotated: bool) -> Self {
+    pub const fn new(
+        account: AccountId,
+        device: DeviceId,
+        revoked_in: Vec<RevocationOutcome>,
+    ) -> Self {
         Self {
             account,
             device,
-            key_rotated,
+            revoked_in,
         }
     }
 }

--- a/crates/context/src/handlers/pair_device_complete.rs
+++ b/crates/context/src/handlers/pair_device_complete.rs
@@ -260,6 +260,20 @@ impl Handler<PairDeviceCompleteRequest> for ContextManager {
                 //
                 // What does vary per namespace is the scope key, so each one gets
                 // its own delivery wrapped under the same device KEM key.
+                //
+                // KNOWN ASYMMETRY, not yet closed. This runs on the HOLDER and
+                // publishes into every namespace; the paired device subscribes in
+                // `pair_device_init`, which knows only the namespace the pairing
+                // named. So the device receives the key for that one and is not
+                // listening on the topics the rest travel on.
+                //
+                // Publishing to all of them is still right: the ops are on the
+                // namespace DAGs, so the device picks them up whenever it does
+                // subscribe, and the binding is what makes the later revocation
+                // reach everywhere. What it does not yet get is prompt delivery.
+                // Closing it needs the device to learn its account's namespace
+                // set — it cannot subscribe to a namespace it has not been told
+                // about, and at pair-init time it has been told about one.
                 let namespaces = NamespaceRepository::new(&store).iter_identities()?;
                 let mut linked_in = Vec::new();
                 let mut key_delivered_everywhere = true;

--- a/crates/context/src/handlers/pair_device_complete.rs
+++ b/crates/context/src/handlers/pair_device_complete.rs
@@ -48,7 +48,7 @@ use calimero_account::{
 use calimero_context_client::group::{PairDeviceCompleteRequest, PairDeviceCompleteResponse};
 use calimero_context_client::local_governance::{GroupOp, NamespaceOp, RootOp};
 use calimero_crypto::X25519PublicKey;
-use calimero_governance_store::{GroupKeyring, NodeDeviceRepository};
+use calimero_governance_store::{GroupKeyring, NamespaceRepository, NodeDeviceRepository};
 use calimero_primitives::identity::PrivateKey;
 use tracing::{info, warn};
 
@@ -180,8 +180,12 @@ impl Handler<PairDeviceCompleteRequest> for ContextManager {
         // publishing it needs the current key, and the delivery is that same key
         // wrapped for the new device. Checking it here, before anything is
         // signed, beats failing deep inside the publisher.
-        let group_key = match GroupKeyring::new(&store, namespace_id).load_current_key() {
-            Ok(Some((_key_id, group_key))) => group_key,
+        //
+        // Only the namespace the caller named is a precondition. The fan-out below
+        // reaches the others too, but a missing key there is a reason to skip that
+        // namespace rather than to refuse the pairing the caller asked for.
+        match GroupKeyring::new(&store, namespace_id).load_current_key() {
+            Ok(Some(_)) => {}
             Ok(None) => {
                 return ActorResponse::reply(Err(eyre::eyre!(
                     "this node holds no current scope key for {namespace_id:?}; pairing both \
@@ -247,74 +251,115 @@ impl Handler<PairDeviceCompleteRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                // Publish the link first. If it fails nothing else should happen
-                // — handing the scope key to a device the group has not been told
-                // about would give it read access with no recorded authority.
-                let report = calimero_governance_store::sign_apply_and_publish(
-                    &store,
-                    &node_client,
-                    &ack_router,
-                    &namespace_id,
-                    &signer_sk,
-                    link,
-                )
-                .await?;
+                // A device belongs to an account, not to a scope, so the link goes
+                // everywhere the account already speaks — not only the namespace
+                // the pairing happened to run in. Both credentials it carries are
+                // account-scoped: the certificate is signed by the account root,
+                // and the endorsement by this node's signing key, which is
+                // node-level. Neither says anything about a namespace.
+                //
+                // What does vary per namespace is the scope key, so each one gets
+                // its own delivery wrapped under the same device KEM key.
+                let namespaces = NamespaceRepository::new(&store).iter_identities()?;
+                let mut linked_in = Vec::new();
+                let mut key_delivered_everywhere = true;
 
-                info!(
-                    namespace_id = ?namespace_id,
-                    %account,
-                    %device,
-                    published = report.is_some(),
-                    "linked a paired device"
-                );
+                for ns in namespaces {
+                    // No key here means this node cannot publish an encrypted group
+                    // op for the namespace, let alone deliver one. Skip rather than
+                    // fail: the namespace the caller asked about is checked above,
+                    // and the others are a bonus this pairing is extending.
+                    let Ok(Some((_key_id, ns_key))) =
+                        GroupKeyring::new(&store, ns).load_current_key()
+                    else {
+                        continue;
+                    };
 
-                // Wrap under the KEM key we were handed rather than re-reading it
-                // from the folded binding, so the delivery does not depend on this
-                // node having already folded the link it just published.
-                let envelope = GroupKeyring::wrap_for_device(
-                    &signer_sk,
-                    device,
-                    &X25519PublicKey::from(*kem_pk.as_bytes()),
-                    &namespace_id.to_bytes(),
-                    &group_key,
-                )?;
+                    let published = calimero_governance_store::sign_apply_and_publish(
+                        &store,
+                        &node_client,
+                        &ack_router,
+                        &ns,
+                        &signer_sk,
+                        link.clone(),
+                    )
+                    .await;
 
-                // A cleartext root op, so the keyless recipient can actually read
-                // it. `required_signers` is None because the paired device is not
-                // a member and so is not among the acking set — its receipt shows
-                // up as the device being able to read, not as an ack.
-                let delivery = NamespaceOp::Root(RootOp::KeyDelivery {
-                    group_id: namespace_id.to_bytes().into(),
-                    envelope,
-                });
+                    match published {
+                        Ok(report) => info!(
+                            namespace_id = ?ns,
+                            %account,
+                            %device,
+                            published = report.is_some(),
+                            "linked a paired device"
+                        ),
+                        // One namespace failing must not withhold the device from
+                        // the rest. The caller sees which ones landed.
+                        Err(err) => {
+                            warn!(namespace_id = ?ns, %device, %err,
+                                  "pairing: publishing the link failed here; others continue");
+                            continue;
+                        }
+                    }
 
-                let key_delivered = match calimero_governance_store::sign_and_publish_namespace_op(
-                    &store,
-                    &node_client,
-                    &ack_router,
-                    namespace_id.to_bytes().into(),
-                    &signer_sk,
-                    delivery,
-                    None,
-                )
-                .await
-                {
-                    Ok(_) => true,
-                    Err(err) => {
+                    // Wrap under the KEM key we were handed rather than re-reading
+                    // it from the folded binding, so the delivery does not depend
+                    // on this node having already folded the link it just
+                    // published.
+                    let envelope = GroupKeyring::wrap_for_device(
+                        &signer_sk,
+                        device,
+                        &X25519PublicKey::from(*kem_pk.as_bytes()),
+                        &ns.to_bytes(),
+                        &ns_key,
+                    )?;
+
+                    // A cleartext root op, so the keyless recipient can actually
+                    // read it. `required_signers` is None because the paired device
+                    // is not a member and so is not among the acking set — its
+                    // receipt shows up as the device being able to read, not as an
+                    // ack.
+                    let delivery = NamespaceOp::Root(RootOp::KeyDelivery {
+                        group_id: ns.to_bytes().into(),
+                        envelope,
+                    });
+
+                    if let Err(err) = calimero_governance_store::sign_and_publish_namespace_op(
+                        &store,
+                        &node_client,
+                        &ack_router,
+                        ns.to_bytes().into(),
+                        &signer_sk,
+                        delivery,
+                        None,
+                    )
+                    .await
+                    {
                         // Not fatal: the link already conferred authority, and the
                         // device's own sync pull re-requests the key it lacks. Say
                         // so rather than reporting a flat success, because until
-                        // that pull lands the device cannot read.
+                        // that pull lands the device cannot read there.
                         warn!(
                             ?err,
-                            namespace_id = ?namespace_id,
+                            namespace_id = ?ns,
                             %device,
                             "device linked but the scope-key delivery failed to publish; \
                              the device's sync pull is the durable retry"
                         );
-                        false
+                        key_delivered_everywhere = false;
                     }
-                };
+
+                    linked_in.push(ns);
+                }
+
+                if linked_in.is_empty() {
+                    eyre::bail!(
+                        "the link for {device} reached no namespace, so it is paired \
+                         nowhere and holds no scope key"
+                    );
+                }
+
+                let key_delivered = key_delivered_everywhere;
 
                 Ok(PairDeviceCompleteResponse::new(
                     account,

--- a/crates/context/src/handlers/revoke_device.rs
+++ b/crates/context/src/handlers/revoke_device.rs
@@ -28,10 +28,12 @@ use std::sync::Arc;
 
 use actix::{ActorResponse, Handler, Message, WrapFuture};
 use calimero_account::sign_device_revocation;
-use calimero_context_client::group::{RevokeDeviceRequest, RevokeDeviceResponse};
+use calimero_context_client::group::{
+    RevocationOutcome, RevokeDeviceRequest, RevokeDeviceResponse,
+};
 use calimero_context_client::local_governance::GroupOp;
 use calimero_governance_store::{
-    GroupGovernancePublisher, MembershipRepository, NodeDeviceRepository,
+    GroupGovernancePublisher, MembershipRepository, NamespaceRepository, NodeDeviceRepository,
 };
 use calimero_primitives::identity::PrivateKey;
 use tracing::{info, warn};
@@ -63,12 +65,6 @@ impl Handler<RevokeDeviceRequest> for ContextManager {
             Ok(account) => account,
             Err(err) => return ActorResponse::reply(Err(err)),
         };
-        let is_admin =
-            match MembershipRepository::new(&store).is_admin(&namespace_id, &self_account) {
-                Ok(is_admin) => is_admin,
-                Err(err) => return ActorResponse::reply(Err(err)),
-            };
-
         // Whose device this is, and whether this node can prove it owns the
         // account, both come from the group's own binding. Deriving the account
         // from this node's root instead answers a different question — "which
@@ -114,14 +110,21 @@ impl Handler<RevokeDeviceRequest> for ContextManager {
             None => None,
         };
 
-        // Three ways to be authorized. The proof is checked first because it is the
-        // only one that needs no authority from this node at all — it carries its own.
-        if supplied_proof.is_none() && !is_admin && !target.self_service {
+        // Two ways to be authorized, and both are the ACCOUNT's. Revoking a device
+        // is not a group-administration act: an admin governs who is a member, not
+        // which installations another person runs. An admin who wants somebody out
+        // removes their account, which is strictly stronger and already exists.
+        //
+        // `is_admin` still matters below, but as a capability rather than an
+        // authorization — only an admin may rotate the scope key that rides along.
+        if supplied_proof.is_none() && !target.self_service {
             return ActorResponse::reply(Err(eyre::eyre!(
-                "this node is neither an admin of {namespace_id:?} nor the holder of the \
-                 account that owns {device}, and no revocation proof was supplied. Either \
-                 revoke as an admin, or mint a proof from the account root \
-                 (`merod account revoke-proof`) and pass it here"
+                "this node does not hold the account that owns {device}, and no \
+                 revocation proof was supplied. Revoking a device is the account's \
+                 authority, not an admin's: run this from a node of that account, or \
+                 mint a proof from its root (`merod account revoke-proof`) and pass it \
+                 here. To remove the person rather than one of their devices, remove \
+                 the account from the group"
             )));
         }
 
@@ -178,45 +181,101 @@ impl Handler<RevokeDeviceRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                // An admin publishes the revocation with the key rotation riding
-                // on the same op. A non-admin owner cannot: peers accept a
-                // rotation only from an admin at the cut, and minting one anyway
-                // would leave this node holding a key nobody else adopts.
-                let (report, key_rotated) = if is_admin {
-                    let report = GroupGovernancePublisher::new(&store, &node_client, namespace_id)
-                        .sign_apply_and_publish_device_revocation(&ack_router, &signer_sk, op)
-                        .await?;
-                    (report, true)
-                } else {
-                    warn!(
-                        namespace_id = ?namespace_id,
-                        %device,
-                        "revoking without a key rotation: this node is not an admin, so the \
-                         device loses the right to write immediately but keeps the key it \
-                         already holds until an admin rotates"
+                // A device belongs to an account, not to a scope, so the revocation
+                // goes everywhere the account holds this device — not only the
+                // namespace the caller named. The proof is minted once above and
+                // reused: it names `{account, device}` and nothing about it is
+                // namespace-scoped, so the same bytes verify wherever they land.
+                //
+                // Publication stays per-DAG. Wider validity is not wider reach: the
+                // op takes effect in a namespace when it is published there, which
+                // is what this loop does, one namespace at a time.
+                let namespaces = NamespaceRepository::new(&store).iter_identities()?;
+                let mut revoked_in = Vec::new();
+
+                for ns in namespaces {
+                    // A namespace that never linked this device has nothing to
+                    // withdraw, and publishing there would name an account its
+                    // bindings do not agree with.
+                    match NodeDeviceRepository::new(&store).revocation_target(&ns, device) {
+                        Ok(Some(_)) => {}
+                        Ok(None) => continue,
+                        Err(err) => {
+                            warn!(namespace_id = ?ns, %device, %err,
+                                  "revocation: could not read the binding; skipping this namespace");
+                            continue;
+                        }
+                    }
+
+                    // Admin HERE, not where the caller started. The rotation is a
+                    // group act — peers accept one only from an admin at the cut —
+                    // so it rides along in the namespaces this node governs and is
+                    // left owed in the rest.
+                    let is_admin_here = MembershipRepository::new(&store)
+                        .is_admin(&ns, &self_account)
+                        .unwrap_or(false);
+
+                    let published = if is_admin_here {
+                        GroupGovernancePublisher::new(&store, &node_client, ns)
+                            .sign_apply_and_publish_device_revocation(
+                                &ack_router,
+                                &signer_sk,
+                                op.clone(),
+                            )
+                            .await
+                    } else {
+                        calimero_governance_store::sign_apply_and_publish(
+                            &store,
+                            &node_client,
+                            &ack_router,
+                            &ns,
+                            &signer_sk,
+                            op.clone(),
+                        )
+                        .await
+                    };
+
+                    match published {
+                        Ok(report) => {
+                            if !is_admin_here {
+                                warn!(
+                                    namespace_id = ?ns,
+                                    %device,
+                                    "revoked without a key rotation: this node is not an \
+                                     admin here, so the device loses the right to write \
+                                     immediately but keeps the key it already holds until \
+                                     an admin rotates"
+                                );
+                            }
+                            info!(
+                                namespace_id = ?ns,
+                                %account,
+                                %device,
+                                published = report.is_some(),
+                                key_rotated = is_admin_here,
+                                "device revoked"
+                            );
+                            revoked_in.push(RevocationOutcome::new(ns, is_admin_here));
+                        }
+                        // One namespace failing must not withhold the revocation
+                        // from the rest — a device half-withdrawn is worse than one
+                        // withdrawn everywhere it could be. The caller sees which
+                        // namespaces landed.
+                        Err(err) => warn!(
+                            namespace_id = ?ns, %device, %err,
+                            "revocation: publishing failed for this namespace; others continue"
+                        ),
+                    }
+                }
+
+                if revoked_in.is_empty() {
+                    eyre::bail!(
+                        "the revocation of {device} reached no namespace. Nothing was \
+                         published, so the device is still linked wherever it was"
                     );
-                    let report = calimero_governance_store::sign_apply_and_publish(
-                        &store,
-                        &node_client,
-                        &ack_router,
-                        &namespace_id,
-                        &signer_sk,
-                        op,
-                    )
-                    .await?;
-                    (report, false)
-                };
+                }
 
-                info!(
-                    namespace_id = ?namespace_id,
-                    %account,
-                    %device,
-                    published = report.is_some(),
-                    key_rotated,
-                    "device revoked"
-                );
-
-                Ok(RevokeDeviceResponse::new(account, device, key_rotated))
+                Ok(RevokeDeviceResponse::new(account, device, revoked_in))
             }
             .into_actor(self),
         )

--- a/crates/meroctl/src/output/groups.rs
+++ b/crates/meroctl/src/output/groups.rs
@@ -157,17 +157,21 @@ impl Report for RevokeDeviceApiResponse {
         ]);
         let _ = table.add_row(vec!["Account ID", &self.data.account_id]);
         let _ = table.add_row(vec!["Device ID", &self.data.device_id]);
-        // Without the rotation the device stops writing but keeps the key it
-        // already holds — a silent reader. Say so rather than report a bare
-        // success.
-        let _ = table.add_row(vec![
-            "Scope key rotated",
-            if self.data.key_rotated {
-                "yes - the device can no longer read either"
-            } else {
-                "no - it can still READ until an admin rotates"
-            },
-        ]);
+        // One row per namespace, because a device belongs to an account rather
+        // than to a scope and the revocation follows it everywhere. Without the
+        // rotation the device stops writing there but keeps the key it already
+        // holds — a silent reader — so say so per namespace rather than report a
+        // bare success.
+        for outcome in &self.data.revoked_in {
+            let _ = table.add_row(vec![
+                format!("Revoked in {}", outcome.namespace_id),
+                if outcome.key_rotated {
+                    "key rotated - it can no longer read either".to_owned()
+                } else {
+                    "key NOT rotated - it can still READ until an admin rotates".to_owned()
+                },
+            ]);
+        }
         println!("{table}");
     }
 }

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2082,6 +2082,22 @@ pub struct RevokeDeviceApiResponseData {
     pub account_id: String,
     /// Hex-encoded `DeviceId` that was withdrawn.
     pub device_id: String,
+    /// Whether the scope key rotated in the namespace **named in the request**.
+    ///
+    /// `revoked_in` is the full picture; this reports the one namespace the
+    /// caller asked about, which is what it meant before a revocation reached
+    /// more than one.
+    ///
+    /// Kept rather than folded into `revoked_in` because `calimero-client-py` is
+    /// a Rust binding that deserializes into this struct, compiled into the
+    /// released wheel while this field was required — dropping it makes every
+    /// response fail to parse there, which merobox reports only as the useless
+    /// "account revoke failed". The same mistake, with the same symptom, is
+    /// recorded on `CreateAccountApiResponseData::account_nonce`.
+    ///
+    /// Removable once a wheel built against `revoked_in` is released and the
+    /// merobox `account_revoke` step reads it instead of `keyRotated`.
+    pub key_rotated: bool,
     /// Every namespace the revocation was published into.
     ///
     /// A device belongs to an account, not to a scope, so revoking it withdraws

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2082,10 +2082,27 @@ pub struct RevokeDeviceApiResponseData {
     pub account_id: String,
     /// Hex-encoded `DeviceId` that was withdrawn.
     pub device_id: String,
-    /// Whether the scope key rotated in the same op.
+    /// Every namespace the revocation was published into.
     ///
-    /// `false` means the device stopped writing at once but still holds the key
-    /// it had, so it can read until an admin rotates. Only an admin may rotate.
+    /// A device belongs to an account, not to a scope, so revoking it withdraws
+    /// it from every namespace holding a binding for it — not only the one named
+    /// in the request. Reported per namespace because publication is per-DAG: a
+    /// namespace absent here did not receive the op, and a partially propagated
+    /// revocation is a state the caller has to be able to see.
+    pub revoked_in: Vec<RevocationOutcomeApiEntry>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RevocationOutcomeApiEntry {
+    /// Hex-encoded namespace id.
+    pub namespace_id: String,
+    /// Whether the scope key rotated in the same op, in THIS namespace.
+    ///
+    /// `false` means the device stopped writing there at once but still holds the
+    /// key it had, so it can read until an admin rotates. Only an admin may
+    /// rotate, and the account holder revoking their own device usually is not
+    /// one, so this is commonly owed.
     pub key_rotated: bool,
 }
 

--- a/crates/server/src/admin/handlers/namespaces/revoke_device.rs
+++ b/crates/server/src/admin/handlers/namespaces/revoke_device.rs
@@ -6,7 +6,8 @@ use axum::Extension;
 use calimero_account::{DeviceId, SignedDeviceRevocation};
 use calimero_context_client::group::RevokeDeviceRequest;
 use calimero_server_primitives::admin::{
-    RevokeDeviceApiRequest, RevokeDeviceApiResponse, RevokeDeviceApiResponseData,
+    RevocationOutcomeApiEntry, RevokeDeviceApiRequest, RevokeDeviceApiResponse,
+    RevokeDeviceApiResponseData,
 };
 use reqwest::StatusCode;
 use tracing::info;
@@ -102,7 +103,7 @@ pub async fn handler(
                 namespace_id = %namespace_id_str,
                 account = %resp.account,
                 device = %resp.device,
-                key_rotated = resp.key_rotated,
+                namespaces = resp.revoked_in.len(),
                 "device revoked"
             );
             ApiResponse {
@@ -110,7 +111,14 @@ pub async fn handler(
                     data: RevokeDeviceApiResponseData {
                         account_id: hex::encode(resp.account.as_bytes()),
                         device_id: hex::encode(resp.device.as_bytes()),
-                        key_rotated: resp.key_rotated,
+                        revoked_in: resp
+                            .revoked_in
+                            .iter()
+                            .map(|o| RevocationOutcomeApiEntry {
+                                namespace_id: hex::encode(o.namespace_id.to_bytes()),
+                                key_rotated: o.key_rotated,
+                            })
+                            .collect(),
                     },
                 },
             }

--- a/crates/server/src/admin/handlers/namespaces/revoke_device.rs
+++ b/crates/server/src/admin/handlers/namespaces/revoke_device.rs
@@ -111,6 +111,13 @@ pub async fn handler(
                     data: RevokeDeviceApiResponseData {
                         account_id: hex::encode(resp.account.as_bytes()),
                         device_id: hex::encode(resp.device.as_bytes()),
+                        // The namespace the caller named, which is what this
+                        // field meant before one revocation reached several.
+                        key_rotated: resp
+                            .revoked_in
+                            .iter()
+                            .find(|o| o.namespace_id == namespace_id)
+                            .is_some_and(|o| o.key_rotated),
                         revoked_in: resp
                             .revoked_in
                             .iter()


### PR DESCRIPTION
Implements the publication half of #3428, from the two decisions recorded there: **a device revoked is revoked everywhere, and a device paired is paired everywhere.**

## Why

A device belongs to an **account**, not to a scope. But both operations were group ops published into a single DAG, so each reached whichever namespace the caller happened to name. Revoke your stolen phone from the namespace you were looking at and it kept writing in the one you were not — same account, same device, operator told it was revoked.

## Revocation

**Admin is no longer a way to revoke someone else's device.** It was one of three authorization paths; the other two are the account's own — a root-signed proof, or holding the root. Group administration is authority over *membership*, not over another person's installations.

> **This is a capability removal.** An admin can no longer surgically revoke a compromised device belonging to somebody else. The remedy is removing the account, which is strictly stronger and already exists.

Dropping it is also what makes "everywhere" reachable. Both remaining instruments are account-scoped, so the partial-authority case I was worried about — an admin only reaching namespaces it governs — disappears with the path itself.

The revocation now publishes into every namespace holding a binding for the device. The proof is minted **once** and reused: it names `{account, device}` and nothing about it is namespace-scoped. `is_admin` survives as a *capability* rather than an authorization — the key rotation rides along where this node governs, and is left owed elsewhere.

## Pairing

Both credentials the link carries are account-scoped and neither mentions a namespace: the certificate is root-signed, the endorsement is signed by the node-level key. So the link publishes everywhere, and only the scope key varies — each namespace gets its own delivery under the same device KEM key.

The namespace the caller named stays a precondition. A missing key elsewhere skips that namespace; reaching none at all is an error.

## Reporting

Publication is per-DAG, so wider validity is not wider reach. `revokedIn` reports per namespace — one absent from the list did not receive the op. A partially propagated revocation is a state an operator has to be able to see rather than infer, so it surfaces through the API and as one row per namespace in `meroctl`. One namespace failing does not withhold the revocation from the rest.

## Proof

New scenario `account-facts-cross-namespace`: two namespaces, one account, pair and revoke naming **only** namespace A, and assert `revokedIn` names **both**. That list is built by walking participation and skipping namespaces without a binding — so two entries proves the pairing linked the device in both *and* the revocation reached both. One entry is the old behaviour.

Deliberately not re-proving read/write lockout there: `account-device-revoke-lockout` pins that end-to-end already.

That scenario also moves with the model — it had an admin revoking someone else's device, which this PR stops allowing, so the account holder does it. Its rotation assertion moves too: node-2 holds the account but joined as a plain member, so the rotation is **owed** and node-1's listener discharges it. Asserted on that listener's marker.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings`, and the affected crate tests pass.

**The two scenarios are unverified locally** — Docker is unavailable on this machine, so merobox cannot run here. CI is their first execution and they may need a round of iteration.
