### PR TITLE
chore(primitives)!: delete the pre-account DID identity model

### DIFF
--- a/crates/client/src/client/contexts.rs
+++ b/crates/client/src/client/contexts.rs
@@ -4,10 +4,9 @@ use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
 use calimero_server_primitives::admin::{
     CreateContextRequest, CreateContextResponse, DeleteContextApiRequest, DeleteContextResponse,
-    GetContextClientKeysResponse, GetContextIdentitiesResponse, GetContextResponse,
-    GetContextStorageResponse, GetContextsResponse, ResyncContextApiRequest,
-    ResyncContextApiResponse, SyncContextResponse, UpdateContextApplicationRequest,
-    UpdateContextApplicationResponse,
+    GetContextIdentitiesResponse, GetContextResponse, GetContextStorageResponse,
+    GetContextsResponse, ResyncContextApiRequest, ResyncContextApiResponse, SyncContextResponse,
+    UpdateContextApplicationRequest, UpdateContextApplicationResponse,
 };
 use eyre::Result;
 
@@ -93,17 +92,6 @@ where
         };
 
         let response = self.connection.get(&endpoint).await?;
-        Ok(response)
-    }
-
-    pub async fn get_context_client_keys(
-        &self,
-        context_id: &ContextId,
-    ) -> Result<GetContextClientKeysResponse> {
-        let response = self
-            .connection
-            .get(&format!("admin-api/contexts/{context_id}/client-keys"))
-            .await?;
         Ok(response)
     }
 

--- a/crates/meroctl/src/cli/context/get.rs
+++ b/crates/meroctl/src/cli/context/get.rs
@@ -24,9 +24,6 @@ pub enum GetSubcommand {
     #[command(about = "Get context information")]
     Info,
 
-    #[command(about = "Get client keys")]
-    ClientKeys,
-
     #[command(about = "Get storage information")]
     Storage,
 }
@@ -44,10 +41,6 @@ impl GetCommand {
         match self.command {
             GetSubcommand::Info => {
                 let response = client.get_context(&context_id).await?;
-                environment.output.write(&response);
-            }
-            GetSubcommand::ClientKeys => {
-                let response = client.get_context_client_keys(&context_id).await?;
                 environment.output.write(&response);
             }
             GetSubcommand::Storage => {

--- a/crates/meroctl/src/output/contexts.rs
+++ b/crates/meroctl/src/output/contexts.rs
@@ -1,9 +1,8 @@
 use calimero_server_primitives::admin::{
     CreateContextResponse, DeleteContextResponse, GenerateContextIdentityResponse,
-    GetContextClientKeysResponse, GetContextIdentitiesResponse, GetContextResponse,
-    GetContextStorageResponse, GetContextUsersResponse, GetContextsResponse, GetPeersCountResponse,
-    GrantPermissionResponse, RevokePermissionResponse, SyncContextResponse,
-    UpdateContextApplicationResponse,
+    GetContextIdentitiesResponse, GetContextResponse, GetContextStorageResponse,
+    GetContextsResponse, GetPeersCountResponse, GrantPermissionResponse, RevokePermissionResponse,
+    SyncContextResponse, UpdateContextApplicationResponse,
 };
 use calimero_server_primitives::jsonrpc::Response;
 use comfy_table::{Cell, Color, Table};
@@ -59,46 +58,6 @@ impl Report for GetContextResponse {
         ]);
 
         println!("{table}");
-    }
-}
-
-impl Report for GetContextUsersResponse {
-    fn report(&self) {
-        if self.data.context_users.is_empty() {
-            println!("No users found in context");
-        } else {
-            let mut table = Table::new();
-            let _ = table.set_header(vec![
-                Cell::new("User ID").fg(Color::Blue),
-                Cell::new("Type").fg(Color::Blue),
-            ]);
-
-            for user in &self.data.context_users {
-                let _ = table.add_row(vec![format!("{:?}", user), "Context User".to_owned()]);
-            }
-
-            println!("{table}");
-        }
-    }
-}
-
-impl Report for GetContextClientKeysResponse {
-    fn report(&self) {
-        if self.data.client_keys.is_empty() {
-            println!("No client keys found in context");
-        } else {
-            let mut table = Table::new();
-            let _ = table.set_header(vec![
-                Cell::new("Signing Key").fg(Color::Blue),
-                Cell::new("Created At").fg(Color::Blue),
-            ]);
-
-            for key in &self.data.client_keys {
-                let _ = table.add_row(vec![key.signing_key.clone(), key.created_at.to_string()]);
-            }
-
-            println!("{table}");
-        }
     }
 }
 

--- a/crates/primitives/AGENTS.md
+++ b/crates/primitives/AGENTS.md
@@ -33,7 +33,7 @@ There is no `default` feature (`default = []`); `borsh` is opt-in. The dev-profi
 src/
 ├── lib.rs          # `pub mod` list only - no re-exports, no prelude
 ├── hash.rs          # Hash - the 32-byte digest every ID newtype wraps
-├── identity.rs      # PrivateKey, PublicKey, Did, RootKey, ClientKey, ContextUser
+├── identity.rs      # PrivateKey, PublicKey, AccountId, DeviceId
 ├── context.rs        # ContextId, Context, ContextConfigParams, GroupMemberRole
 ├── application.rs    # ApplicationId, SignerId, AppKey, Application, ApplicationBlob, Version (semver), ApplicationSource
 ├── blobs.rs           # BlobId, BlobInfo, BlobMetadata
@@ -70,7 +70,6 @@ src/
 | `MetadataRecord` | `metadata` | Group/member/context metadata (`name`, opaque `data` map, `updated_at`, `updated_by`) | serde (`camelCase`) + borsh |
 | `SyncState` | `sync_status` | Coarse sync phase for RPC + WS event | serde, internally tagged `state`; no borsh |
 | `NodeEvent`/`ContextEvent`/... | `events` | WebSocket event envelope and payloads | serde only, tagged JSON |
-| `Did`/`RootKey`/`ClientKey`/`ContextUser` | `identity` | DID-adjacent identity records | serde only, `#[non_exhaustive]` |
 | `Context` | `context` | Snapshot of a context's id/app/root-hash/DAG-heads/version/name | serde (`camelCase`), `#[non_exhaustive]` builder methods |
 | `GroupMemberRole` | `context` | `Admin`/`Member`/`ReadOnly`/`ReadOnlyTee` | serde + borsh, deliberately NOT `#[non_exhaustive]` |
 

--- a/crates/primitives/src/identity.rs
+++ b/crates/primitives/src/identity.rs
@@ -13,7 +13,6 @@ use thiserror::Error;
 #[cfg(feature = "rand")]
 use zeroize::Zeroize;
 
-use crate::context::ContextId;
 use crate::hash::{Hash, HashError};
 
 use ed25519_dalek::{Signature, SignatureError, Signer, SigningKey, VerifyingKey};
@@ -180,72 +179,6 @@ impl FromStr for PublicKey {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self(s.parse().map_err(InvalidPublicKey)?))
     }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
-pub struct Did {
-    pub id: String,
-    pub root_keys: Vec<RootKey>,
-    pub client_keys: Vec<ClientKey>,
-}
-
-impl Did {
-    #[must_use]
-    pub const fn new(id: String, root_keys: Vec<RootKey>, client_keys: Vec<ClientKey>) -> Self {
-        Self {
-            id,
-            root_keys,
-            client_keys,
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
-pub struct RootKey {
-    pub signing_key: String,
-    pub wallet_address: String,
-    pub created_at: u64,
-}
-
-impl RootKey {
-    #[must_use]
-    pub const fn new(signing_key: String, wallet_address: String, created_at: u64) -> Self {
-        Self {
-            signing_key,
-            wallet_address,
-            created_at,
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct ClientKey {
-    pub signing_key: String,
-    pub created_at: u64,
-    pub context_id: Option<ContextId>,
-}
-
-impl ClientKey {
-    #[must_use]
-    pub const fn new(signing_key: String, created_at: u64, context_id: Option<ContextId>) -> Self {
-        Self {
-            signing_key,
-            created_at,
-            context_id,
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct ContextUser {
-    pub user_id: String,
-    pub joined_at: u64,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -5,7 +5,7 @@ use calimero_primitives::alias::Alias;
 use calimero_primitives::application::{Application, ApplicationId};
 use calimero_primitives::context::{Context, ContextId, GroupMemberRole};
 use calimero_primitives::hash::Hash;
-use calimero_primitives::identity::{AccountId, ClientKey, ContextUser, PublicKey};
+use calimero_primitives::identity::{AccountId, PublicKey};
 use calimero_primitives::metadata::MetadataRecord;
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
@@ -382,46 +382,6 @@ pub struct ListAliasesResponse<T> {
 impl<T> ListAliasesResponse<T> {
     pub fn new(data: BTreeMap<Alias<T>, T>) -> Self {
         Self { data }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct GetContextClientKeysResponseData {
-    pub client_keys: Vec<ClientKey>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct GetContextClientKeysResponse {
-    pub data: GetContextClientKeysResponseData,
-}
-
-impl GetContextClientKeysResponse {
-    pub const fn new(client_keys: Vec<ClientKey>) -> Self {
-        Self {
-            data: GetContextClientKeysResponseData { client_keys },
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct GetContextUsersResponseData {
-    pub context_users: Vec<ContextUser>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct GetContextUsersResponse {
-    pub data: GetContextUsersResponseData,
-}
-
-impl GetContextUsersResponse {
-    pub const fn new(context_users: Vec<ContextUser>) -> Self {
-        Self {
-            data: GetContextUsersResponseData { context_users },
-        }
     }
 }
 


### PR DESCRIPTION
`crates/primitives/src/identity.rs` held **two unrelated generations of identity side by side**, with nothing marking which was which. Read top to bottom they look like one model, which is what prompted this — the question was "why is identity split between `calimero-account` and `calimero-primitives`", and the answer turned out to be that it isn't; something else was sitting in the same file.

## What went

`Did`, `RootKey`, `ClientKey`, `ContextUser`. `RootKey` carries a `wallet_address`, which dates it to wallet-login, before accounts existed. They answer the same question the account model answers now, in a different shape.

Nothing used them:

| | references outside `identity.rs` |
| --- | --- |
| `Did` | **0** — one doc line, one false positive (`"Did not dial"`) |
| `RootKey` | **0** |
| `ClientKey` | only inside a response type |
| `ContextUser` | only inside a response type |

And one of those is worse than dead code: **`meroctl context get <ctx> client-keys` is a shipped subcommand that 404s.** It calls `admin-api/contexts/{id}/client-keys`, which does not exist in `endpoints.json` or anywhere in the server. Real client keys live in the auth service, which has its own `KeyManager`, its own `client_key:` storage prefix and its own `/auth/client-keys` API — none of which touch these types.

Removed with them: `GetContextClientKeysResponse`, `GetContextUsersResponse`, the client method for the missing route, the `ClientKeys` subcommand, and both `meroctl` renderers. Net −176 lines.

## What stays, and why it is not the same thing

`AccountId` and `DeviceId` stay in this crate deliberately. `calimero-account` depends on `calimero-primitives`, and the ids are named in client-facing event payloads defined here, so they cannot originate in the account crate; it re-exports them instead. The account **model** — genesis, certificates, handoff chains, revocation — is in `calimero-account`.

That split is a dependency direction with a stated reason, not a leftover. The `Did` types were the leftover, and they were confusing precisely because they shared a file with it.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings`, the affected crate tests, and `--test route_manifest` all pass.