### PR TITLE
chore(context-config): drop the on-chain contract request protocol

### DIFF
--- a/crates/context/AGENTS.md
+++ b/crates/context/AGENTS.md
@@ -151,7 +151,7 @@ rg -n "enum UpgradeAction" src/migration_plan.rs
 
 ## Sub-crates
 
-- **`crates/context/config`** (`calimero-context-config`) - Wire/API request types (`Request`, `ContextRequestKind`, `GroupRequestKind`, `SystemRequest`), `VisibilityMode`, the `MemberCapabilities` bitset, the `[context.config]` node-config shape (`ClientConfig`/`ClientSigner`/`LocalConfig`), and the `Repr`/`ReprBytes` transmute machinery used to move typed ids across borsh/serde/bs58 boundaries.
+- **`crates/context/config`** (`calimero-context-config`) - The typed id newtypes (`ContextId`, `ContextGroupId`, `ContextIdentity`, `SignerId`, `AppKey`, `ApplicationId`), the invitation wire types (`InvitationFromMember`, `SignedOpenInvitation`, `GroupInvitationFromAdmin`, `SignedGroupOpenInvitation`), `GovernanceParentEdge`, `VisibilityMode`, the `MemberCapabilities` bitset, `MAX_NAMESPACE_DEPTH`, the `[context.config]` node-config shape (`ClientConfig`/`ClientSigner`/`LocalConfig`), and the `Repr`/`ReprBytes` transmute machinery used to move typed ids across borsh/serde/bs58 boundaries.
 - **`crates/context/primitives`** (`calimero-context-client`) - The `ContextClient`/`ContextRegistry` facade, `ContextGuard`/`ContextAtomic` (the per-context lock guard type shared with `calimero-context`), every `*Request`/`*Response` message type and the `ContextMessage` actix envelope, group-related types (`group.rs`), and the local-governance wire types (`SignedGroupOp`, `SignedNamespaceOp`, `AckRouter`).
 
 Part of [crates/](../AGENTS.md).

--- a/crates/context/config/src/lib.rs
+++ b/crates/context/config/src/lib.rs
@@ -1,20 +1,10 @@
 #![allow(single_use_lifetimes, reason = "False positive")]
 
-use std::borrow::Cow;
-
 use serde::{Deserialize, Serialize};
 
 pub mod client_config;
 pub mod repr;
 pub mod types;
-
-use repr::Repr;
-use types::{
-    AppKey, Application, Capability, ContextGroupId, ContextId, ContextIdentity,
-    ExpirationTimestamp, SignedRevealPayload, SignerId,
-};
-
-pub type Timestamp = u64;
 
 /// Inclusive bound on the namespace/subgroup parent-chain walk (group →
 /// namespace root, and the subgroup-inheritance walk). The deepest legal
@@ -24,110 +14,6 @@ pub type Timestamp = u64;
 /// `calimero-governance-store`, `calimero-context-client`, and `calimero-authz`,
 /// which all walk the same parent chain.
 pub const MAX_NAMESPACE_DEPTH: usize = 16;
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[serde(deny_unknown_fields)]
-#[non_exhaustive]
-pub struct Request<'a> {
-    pub signer_id: Repr<SignerId>,
-    pub nonce: u64,
-
-    #[serde(borrow, flatten)]
-    pub kind: RequestKind<'a>,
-}
-
-impl<'a> Request<'a> {
-    #[must_use]
-    pub fn new(signer_id: SignerId, kind: RequestKind<'a>, nonce: u64) -> Self {
-        Request {
-            signer_id: Repr::new(signer_id),
-            kind,
-            nonce,
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "scope", content = "params")]
-#[expect(clippy::exhaustive_enums, reason = "Considered to be exhaustive")]
-pub enum RequestKind<'a> {
-    #[serde(borrow)]
-    Context(ContextRequest<'a>),
-    #[serde(borrow)]
-    Group(GroupRequest<'a>),
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[serde(deny_unknown_fields)]
-#[non_exhaustive]
-pub struct ContextRequest<'a> {
-    pub context_id: Repr<ContextId>,
-
-    #[serde(borrow, flatten)]
-    pub kind: ContextRequestKind<'a>,
-}
-
-impl<'a> ContextRequest<'a> {
-    #[must_use]
-    pub const fn new(context_id: Repr<ContextId>, kind: ContextRequestKind<'a>) -> Self {
-        ContextRequest { context_id, kind }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "scope", content = "params")]
-#[serde(deny_unknown_fields)]
-#[expect(clippy::exhaustive_enums, reason = "Considered to be exhaustive")]
-pub enum ContextRequestKind<'a> {
-    Add {
-        author_id: Repr<ContextIdentity>,
-        #[serde(borrow)]
-        application: Application<'a>,
-    },
-    UpdateApplication {
-        #[serde(borrow)]
-        application: Application<'a>,
-    },
-    AddMembers {
-        members: Cow<'a, [Repr<ContextIdentity>]>,
-    },
-    RemoveMembers {
-        members: Cow<'a, [Repr<ContextIdentity>]>,
-    },
-    CommitOpenInvitation {
-        commitment_hash: String,
-        expiration_timestamp: ExpirationTimestamp,
-    },
-    RevealOpenInvitation {
-        payload: SignedRevealPayload,
-    },
-    Grant {
-        capabilities: Cow<'a, [(Repr<ContextIdentity>, Capability)]>,
-    },
-    Revoke {
-        capabilities: Cow<'a, [(Repr<ContextIdentity>, Capability)]>,
-    },
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[serde(deny_unknown_fields)]
-#[non_exhaustive]
-pub struct GroupRequest<'a> {
-    pub group_id: Repr<ContextGroupId>,
-
-    #[serde(borrow, flatten)]
-    pub kind: GroupRequestKind<'a>,
-}
-
-impl<'a> GroupRequest<'a> {
-    #[must_use]
-    pub const fn new(group_id: Repr<ContextGroupId>, kind: GroupRequestKind<'a>) -> Self {
-        GroupRequest { group_id, kind }
-    }
-}
 
 /// Visibility mode for a subgroup within its parent group.
 ///
@@ -349,65 +235,6 @@ impl<'de> serde::Deserialize<'de> for MemberCapabilities {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Ok(Self(u32::deserialize(deserializer)?))
     }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "scope", content = "params")]
-#[serde(deny_unknown_fields)]
-#[expect(clippy::exhaustive_enums, reason = "Considered to be exhaustive")]
-pub enum GroupRequestKind<'a> {
-    Create {
-        app_key: Repr<AppKey>,
-        #[serde(borrow)]
-        target_application: Application<'a>,
-    },
-    Delete,
-    AddMembers {
-        members: Cow<'a, [Repr<SignerId>]>,
-    },
-    RemoveMembers {
-        members: Cow<'a, [Repr<SignerId>]>,
-    },
-    RegisterContext {
-        context_id: Repr<ContextId>,
-    },
-    UnregisterContext {
-        context_id: Repr<ContextId>,
-    },
-    SetTargetApplication {
-        #[serde(borrow)]
-        target_application: Application<'a>,
-        migration_method: Option<String>,
-    },
-    /// Pre-approve a specific context to register via its proxy contract.
-    /// Must be called by a group admin before the proxy path is exercised.
-    ApproveContextRegistration {
-        context_id: Repr<ContextId>,
-    },
-    /// Join a context within a group using group membership as authorization.
-    /// Caller must be a group member; the context must belong to the group.
-    JoinContextViaGroup {
-        context_id: Repr<ContextId>,
-        new_member: Repr<ContextIdentity>,
-    },
-    /// Set capability bits for a specific member (admin-only).
-    SetMemberCapabilities {
-        member: Repr<SignerId>,
-        capabilities: u32,
-    },
-    /// Set the default capability bits for new members (admin-only).
-    SetDefaultCapabilities {
-        default_capabilities: u32,
-    },
-}
-
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
-#[serde(tag = "scope", content = "params")]
-#[serde(deny_unknown_fields)]
-#[expect(clippy::exhaustive_enums, reason = "Considered to be exhaustive")]
-pub enum SystemRequest {
-    #[serde(rename_all = "camelCase")]
-    SetValidityThreshold { threshold_ms: Timestamp },
 }
 
 #[cfg(test)]

--- a/crates/context/config/src/repr.rs
+++ b/crates/context/config/src/repr.rs
@@ -42,30 +42,6 @@ impl<T> Repr<T> {
     pub fn into_inner(self) -> T {
         self.inner
     }
-
-    /// Reinterprets `&[T]` as `&[Repr<T>]` without copying.
-    ///
-    /// Safe because `Repr<T>` is `#[repr(transparent)]` over `T`, meaning they
-    /// share identical size, alignment, and ABI. The inline `const` assertions
-    /// verify this at compile time per monomorphization so that removing
-    /// `#[repr(transparent)]` would become a compile error rather than UB.
-    pub fn slice_from_inner(slice: &[T]) -> &[Self] {
-        const {
-            assert!(
-                core::mem::size_of::<T>() == core::mem::size_of::<Repr<T>>(),
-                "Repr<T> size mismatch — is #[repr(transparent)] still present?"
-            )
-        };
-        const {
-            assert!(
-                core::mem::align_of::<T>() == core::mem::align_of::<Repr<T>>(),
-                "Repr<T> alignment mismatch — is #[repr(transparent)] still present?"
-            )
-        };
-        // SAFETY: `Repr<T>` is `#[repr(transparent)]` over `T`; identical
-        // layout is enforced by the const assertions above.
-        unsafe { &*(core::ptr::from_ref::<[T]>(slice) as *const [Self]) }
-    }
 }
 
 impl<T: ReprBytes> Display for Repr<T> {

--- a/crates/context/config/src/types.rs
+++ b/crates/context/config/src/types.rs
@@ -1,60 +1,14 @@
-use core::convert::Infallible;
-use core::fmt;
-use core::fmt::{Debug, Display, Formatter};
-use core::marker::PhantomData;
-use std::borrow::Cow;
+use core::fmt::Debug;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use bs58::decode::Result as Bs58Result;
-use ed25519_dalek::{Signature, SignatureError, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, SignatureError, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use thiserror::Error as ThisError;
 
-use crate::repr::{self, LengthMismatch, Repr, ReprBytes, ReprTransmute};
+use crate::repr::{self, LengthMismatch, ReprBytes};
 
 pub type ExpirationTimestamp = u64;
-pub type Revision = u64;
-
-#[derive(
-    BorshDeserialize,
-    BorshSerialize,
-    Clone,
-    Debug,
-    Deserialize,
-    Eq,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-)]
-#[non_exhaustive]
-pub struct Application<'a> {
-    pub id: Repr<ApplicationId>,
-    pub blob: Repr<BlobId>,
-    pub size: u64,
-    #[serde(borrow)]
-    pub source: ApplicationSource<'a>,
-    pub metadata: ApplicationMetadata<'a>,
-}
-
-impl<'a> Application<'a> {
-    #[must_use]
-    pub const fn new(
-        id: Repr<ApplicationId>,
-        blob: Repr<BlobId>,
-        size: u64,
-        source: ApplicationSource<'a>,
-        metadata: ApplicationMetadata<'a>,
-    ) -> Self {
-        Application {
-            id,
-            blob,
-            size,
-            source,
-            metadata,
-        }
-    }
-}
 
 #[derive(
     Eq,
@@ -191,23 +145,6 @@ impl From<[u8; 32]> for ContextId {
     fn from(value: [u8; 32]) -> Self {
         Self(Identity(value))
     }
-}
-
-#[derive(
-    Eq,
-    Ord,
-    Debug,
-    Clone,
-    PartialEq,
-    PartialOrd,
-    BorshSerialize,
-    BorshDeserialize,
-    Serialize,
-    Deserialize,
-)]
-pub struct ContextStorageEntry {
-    pub key: Vec<u8>,
-    pub value: Vec<u8>,
 }
 
 #[derive(
@@ -520,27 +457,6 @@ impl From<[u8; 32]> for AppKey {
 }
 
 #[derive(Eq, Ord, Copy, Debug, Clone, PartialEq, PartialOrd, BorshSerialize, BorshDeserialize)]
-pub struct BlobId(Identity);
-
-impl ReprBytes for BlobId {
-    type EncodeBytes<'a> = [u8; 32];
-    type DecodeBytes = [u8; 32];
-
-    type Error = LengthMismatch;
-
-    fn as_bytes(&self) -> Self::EncodeBytes<'_> {
-        self.0.as_bytes()
-    }
-
-    fn from_bytes<F>(f: F) -> repr::Result<Self, Self::Error>
-    where
-        F: FnOnce(&mut Self::DecodeBytes) -> Bs58Result<usize>,
-    {
-        ReprBytes::from_bytes(f).map(Self)
-    }
-}
-
-#[derive(Eq, Ord, Copy, Debug, Clone, PartialEq, PartialOrd, BorshSerialize, BorshDeserialize)]
 pub struct ApplicationId(Identity);
 
 impl ReprBytes for ApplicationId {
@@ -558,52 +474,6 @@ impl ReprBytes for ApplicationId {
         F: FnOnce(&mut Self::DecodeBytes) -> Bs58Result<usize>,
     {
         ReprBytes::from_bytes(f).map(Self)
-    }
-}
-
-#[derive(
-    BorshDeserialize,
-    BorshSerialize,
-    Clone,
-    Debug,
-    Default,
-    Deserialize,
-    Eq,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-)]
-#[expect(clippy::exhaustive_structs, reason = "Exhaustive")]
-pub struct ApplicationSource<'a>(#[serde(borrow)] pub Cow<'a, str>);
-
-impl ApplicationSource<'_> {
-    #[must_use]
-    pub fn to_owned(self) -> ApplicationSource<'static> {
-        ApplicationSource(Cow::Owned(self.0.into_owned()))
-    }
-}
-
-#[derive(
-    BorshDeserialize,
-    BorshSerialize,
-    Clone,
-    Debug,
-    Default,
-    Deserialize,
-    Eq,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-)]
-#[expect(clippy::exhaustive_structs, reason = "Exhaustive")]
-pub struct ApplicationMetadata<'a>(#[serde(borrow)] pub Repr<Cow<'a, [u8]>>);
-
-impl ApplicationMetadata<'_> {
-    #[must_use]
-    pub fn to_owned(self) -> ApplicationMetadata<'static> {
-        ApplicationMetadata(Repr::new(Cow::Owned(self.0.into_inner().into_owned())))
     }
 }
 
@@ -673,97 +543,6 @@ impl Capability {
     }
 }
 
-#[derive(Eq, Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Signed<T> {
-    payload: Repr<Box<[u8]>>,
-    signature: Repr<Signature>,
-
-    #[serde(skip)]
-    _priv: PhantomData<T>,
-}
-
-#[derive(ThisError)]
-#[non_exhaustive]
-pub enum ConfigError<E> {
-    #[error("invalid signature")]
-    InvalidSignature,
-    #[error("json error: {0}")]
-    ParseError(#[from] serde_json::Error),
-    #[error("derivation error: {0}")]
-    DerivationError(E),
-    #[error(transparent)]
-    VerificationKeyParseError(#[from] repr::ReprError<VerificationKeyParseError>),
-}
-
-impl<E: Display> Debug for ConfigError<E> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        Display::fmt(self, f)
-    }
-}
-
-impl<T: Serialize> Signed<T> {
-    pub fn new<R, F>(payload: &T, sign: F) -> Result<Self, ConfigError<R::Error>>
-    where
-        R: IntoResult<Signature>,
-        F: FnOnce(&[u8]) -> R,
-    {
-        let payload = serde_json::to_vec(&payload)?.into_boxed_slice();
-
-        let signature = sign(&payload)
-            .into_result()
-            .map_err(ConfigError::DerivationError)?;
-
-        Ok(Self {
-            payload: Repr::new(payload),
-            signature: Repr::new(signature),
-            _priv: PhantomData,
-        })
-    }
-}
-
-pub trait IntoResult<T> {
-    type Error;
-
-    fn into_result(self) -> Result<T, Self::Error>;
-}
-
-impl<T> IntoResult<T> for T {
-    type Error = Infallible;
-
-    fn into_result(self) -> Result<T, Self::Error> {
-        Ok(self)
-    }
-}
-
-impl<T, E> IntoResult<T> for Result<T, E> {
-    type Error = E;
-
-    fn into_result(self) -> Result<T, Self::Error> {
-        self
-    }
-}
-
-impl<'a, T: Deserialize<'a>> Signed<T> {
-    pub fn parse<R, F>(&'a self, f: F) -> Result<T, ConfigError<R::Error>>
-    where
-        R: IntoResult<SignerId>,
-        F: FnOnce(&T) -> R,
-    {
-        let parsed = serde_json::from_slice(&self.payload)?;
-
-        let bytes = f(&parsed)
-            .into_result()
-            .map_err(ConfigError::DerivationError)?;
-
-        let key = bytes
-            .rt::<VerifyingKey>()
-            .map_err(ConfigError::VerificationKeyParseError)?;
-
-        key.verify(&self.payload, &self.signature)
-            .map_or(Err(ConfigError::InvalidSignature), |()| Ok(parsed))
-    }
-}
-
 /// The structure represents an open invitation payload that allows any party to claim it.
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Deserialize, Serialize)]
 pub struct InvitationFromMember {
@@ -805,26 +584,6 @@ pub struct SignedOpenInvitation {
     /// Group ID that owns this context.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub group_id: Option<[u8; 32]>,
-}
-
-// The full payload Bob reveals in the second transaction
-#[derive(Debug, Deserialize, Clone, Serialize)]
-pub struct RevealPayloadData {
-    /// Signed open invitation
-    pub signed_open_invitation: SignedOpenInvitation,
-    /// The identity of the member that is going to be invited (invitee).
-    /// The owner of the identity should insert this field himself and then
-    /// sign the whole structure, and wrapping it into `SignedRevealPayload`.
-    pub new_member_identity: ContextIdentity,
-}
-
-// This is the final object submitted to the `reveal` method.
-#[derive(Debug, Deserialize, Clone, Serialize)]
-pub struct SignedRevealPayload {
-    /// The data that is needed to join the context.
-    pub data: RevealPayloadData,
-    /// The invitee's signature over the `data` (`RevealPayloadData`).
-    pub invitee_signature: String,
 }
 
 /// An open invitation payload for joining a context group.


### PR DESCRIPTION
## Summary

The signed JSON request envelope a node used to submit to the `ContextConfig` smart contract. Local group governance (`SignedGroupOp` / `SignedNamespaceOp` over gossip) replaced it, and the transports that carried it were removed — but the request vocabulary was left in place. **−441 lines.**

`crates/context/config/Cargo.toml` now depends only on `bs58, calimero-account, borsh, ed25519-dalek, serde, serde_json, thiserror`: no reqwest, no RPC client, no signer plumbing. Nothing constructs a `Request`, and there is no transport that could send one — `Signed<T>::new`, the function that would sign one for submission, has no callers, so the request types cannot even be serialized for transport.

**Removed** — `lib.rs`: `Timestamp`, `Request`, `RequestKind`, `ContextRequest`, `ContextRequestKind` (8 variants), `GroupRequest`, `GroupRequestKind` (11 variants), `SystemRequest`. `types.rs`: `Application`, `ApplicationSource`, `ApplicationMetadata`, `BlobId`, `ContextStorageEntry`, `Signed<T>`, `ConfigError`, `IntoResult`, `RevealPayloadData`, `SignedRevealPayload`, `Revision`. `repr.rs`: `slice_from_inner`, which existed to build the `Cow<[Repr<ContextIdentity>]>` that `ContextRequestKind::AddMembers` took.

## Evidence

For `RequestKind`, `ContextRequest`, `ContextRequestKind`, `GroupRequest`, `GroupRequestKind` and `SystemRequest`, references outside the defining file: **zero**. For the family as a whole the only external reference was one line of `crates/context/AGENTS.md` describing them as "Wire/API request types" — the AGENTS.md echo, fixed in the second commit here so the crate is described by what it still contains.

Two counts that lied, both resolved by reading:

- **`Timestamp` showed 111 hits and `Request` 208.** All are `ExpirationTimestamp`, `boundary_timestamp`, `ExecutionRequest`, `SyncStatusRequest` and similar. Qualified uses of `calimero_context_config::{Timestamp, Request}`: **none**. `Timestamp`'s only consumer was `SystemRequest::SetValidityThreshold`.
- **`SignedOpenInvitation` appeared to reference `Application`.** It says "Application ID" and "Application source" in *doc comments*; the fields are `Option<[u8; 32]>` and `Option<String>`. No live type depends on anything removed here.

I also enumerated every symbol any crate imports from `calimero_context_config`. The used set is exactly `ContextGroupId, MemberCapabilities, VisibilityMode, MAX_NAMESPACE_DEPTH, SignedGroupOpenInvitation, GroupInvitationFromAdmin, GovernanceParentEdge, AppKey, SignerId, InvitationFromMember, SignedOpenInvitation, Capability, ApplicationId, client_config, repr` — every removed item is outside it, and nothing imports the bare `types` module wholesale.

Persistence: these are JSON-RPC contract-call payloads, never persisted. No borsh row in `calimero-store` is typed on any of them, so no migration path is involved.

## Deliberately kept

**`Capability` and `as_bit()`.** `ContextRequestKind::{Grant, Revoke}` were their last consumers *inside this crate*, but two importers remained on master. Both are removed by #3440, so `Capability` becomes fully dead once that lands — a small follow-up, deliberately not forced into either PR.

Also spared, all in the same three files: `MemberCapabilities` (60+ import sites), `VisibilityMode`, `MAX_NAMESPACE_DEPTH`, `GovernanceParentEdge`, the four invitation types, and the whole `Repr`/`ReprBytes` machinery apart from the one dead helper. `SignedRevealPayload`/`RevealPayloadData` sit *adjacent* to the live invitation types and are the dead two-transaction on-chain reveal flow — adjacent lines, opposite fates.

## Verification

- `cargo check --workspace --all-targets` ✅
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` ✅ exit 0
- `cargo test --workspace` ✅ — 4,759 passed, 0 failed, 227 binaries

Found with the `unreachable-subsystems` skill (#3438).

🤖 Generated with [Claude Code](https://claude.com/claude-code)