### PR TITLE
chore(context-config): drop the orphaned Capability enum

### DIFF
--- a/crates/context/config/src/types.rs
+++ b/crates/context/config/src/types.rs
@@ -527,22 +527,6 @@ impl ReprBytes for VerifyingKey {
     }
 }
 
-#[derive(Eq, Ord, Copy, Clone, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
-#[expect(clippy::exhaustive_enums, reason = "Considered to be exhaustive")]
-pub enum Capability {
-    ManageApplication,
-    ManageMembers,
-    Proxy,
-}
-
-impl Capability {
-    /// Returns the bitmask for this capability (single bit set).
-    #[must_use]
-    pub const fn as_bit(self) -> u8 {
-        1 << (self as u8)
-    }
-}
-
 /// The structure represents an open invitation payload that allows any party to claim it.
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Deserialize, Serialize)]
 pub struct InvitationFromMember {


### PR DESCRIPTION
## Summary

`Capability` and `Capability::as_bit()` in `crates/context/config/src/types.rs` lost their last consumers **from two directions at once**, and only became removable once both landed:

- **#3440** removed the per-context capability DTOs, taking the `calimero_context_config::types::Capability` imports in `server/primitives/src/admin/mod.rs` and `meroctl/src/cli/context/identity.rs`
- **#3444** removed `ContextRequestKind::{Grant, Revoke}`, the enum's only remaining use inside its own crate

Neither PR could remove it alone — each left the other's consumer standing, which is why both deliberately kept it. That's now resolved. **−16 lines.**

## Evidence

Every remaining `\bCapability\b` hit in `crates/`, `apps/` and `tools/`, all read:

| hit | what it is |
| --- | --- |
| `context/config/src/types.rs:532` | the definition |
| `context/config/src/types.rs:538` | its own `impl` |
| `meroctl/src/output/groups.rs:603` | `Cell::new("Capability")` — a table header string |
| `projection/src/lib.rs:947`, `op-adapter/src/lib.rs:330,1093`, `authz/src/lib.rs:389,842`, `governance-store/src/tests.rs:2366` | code comments ("Capability plane", "Capability holders are checked…") |
| `apps/scaffolding-e2e/workflows/group-capabilities.yml:65` | a YAML comment describing the bitmask |

`as_bit` has **zero** callers — its only occurrence is its own definition.

## What looks similar but is alive

**`MemberCapabilities`** (`crates/context/config/src/lib.rs`) — the current model, a typed u32 bitset with 60+ import sites across `governance-store`, `authz`, `projection`, `op`, `op-adapter`, `server` and `meroctl`. It lives in the *same crate* as the enum being removed.

The bit positions are the discriminator, and they settle it. `mero-js/src/capabilities.ts` declares:

```ts
MANAGE_MEMBERS: 1 << 3,
MANAGE_APPLICATION: 1 << 4,
```

which matches `MemberCapabilities::MANAGE_MEMBERS = Self(1 << 3)` and `MANAGE_APPLICATION = Self(1 << 4)` exactly. The dead enum's `as_bit()` would instead put `ManageApplication` at bit 0 and `ManageMembers` at bit 1. Same names, different bits — the SDK mirrors the live bitset, not this enum, so removing it is not an SDK-visible change.

## Verification

- `cargo check --workspace --all-targets` ✅
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` ✅ exit 0

Found with the `unreachable-subsystems` skill (#3438).

🤖 Generated with [Claude Code](https://claude.com/claude-code)