### PR TITLE
fix(sync): re-anchor the HC root under the context lock

### DIFF
--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -752,20 +752,57 @@ async fn run_initiator_impl<T: SyncTransport>(
         );
     }
 
-    // core#2716: re-anchor the context's persisted `root_hash` to the
-    // freshly-merged storage merkle. `context.root_hash` (the value read by
-    // the heartbeat, the sync-manager's protocol selector, and the admin RPC
-    // that e2e `wait_for_sync` polls) is only updated on the WASM execute /
-    // delta forward-apply path — NOT when a HashComparison session converges
-    // storage via CRDT merge (`entities_pushed`/`entities_merged`). That left
-    // the two roots permanently split: the storage merkle converged across
-    // nodes while each node's context root stayed at its last locally-executed
-    // delta's `expected_root_hash`, so `wait_for_sync` never observed
-    // convergence. Persisting the storage merkle here restores the invariant
+    // Re-anchor the context's persisted `root_hash` to the freshly-merged
+    // storage merkle. `context.root_hash` (the value read by the heartbeat, the
+    // sync-manager's protocol selector, and the admin RPC that e2e
+    // `wait_for_sync` polls) is only updated on the WASM execute / delta
+    // forward-apply path — NOT when a HashComparison session converges storage
+    // via CRDT merge (`entities_pushed`/`entities_merged`). That left the two
+    // roots permanently split: the storage merkle converged across nodes while
+    // each node's context root stayed at its last locally-executed delta's
+    // `expected_root_hash`, so `wait_for_sync` never observed convergence.
+    // Persisting the storage merkle here restores the invariant
     // `context.root_hash == storage merkle root` after every HC session.
-    if local_root_hash != [0u8; 32] {
-        if let Some(cc) = context_client {
-            if let Err(e) = cc.force_root_hash(&context_id, Hash::from(local_root_hash)) {
+    //
+    // The merkle root is re-read HERE, under the per-context execution lock,
+    // and published in the same critical section — deliberately NOT reusing the
+    // `local_root_hash` captured above for the convergence verdict. That capture
+    // happens before the `local_scope_root` governance DAG walk, which is a
+    // multi-millisecond RocksDB traversal; a local WASM execute that commits in
+    // that window advances both the merkle and `ContextMeta.root_hash`, and
+    // writing the captured value would roll the context root BACKWARDS onto a
+    // state the node no longer has. The observable damage is worse than a stale
+    // number: every peer-facing convergence signal (heartbeat compare, protocol
+    // selection, `contextStateHash`) then reports the pre-write root, so an
+    // e2e write-then-wait sees all nodes "agree" on the old hash and proceeds
+    // before the write has propagated. The executor holds this same lock across
+    // execution and its root-hash persist, so taking it makes read+write atomic
+    // against that path.
+    if let Some(cc) = context_client {
+        let reanchor = apply_under_context_lock(Some(cc), context_id, &runtime_env, || {
+            let live_root = get_local_root_hash_for_context(context_id)?;
+
+            if live_root == [0u8; 32] {
+                return Ok(None);
+            }
+
+            cc.force_root_hash(&context_id, Hash::from(live_root))?;
+
+            Ok::<_, eyre::Report>(Some(live_root))
+        })
+        .await;
+
+        match reanchor {
+            Ok(Some(live_root)) if live_root != local_root_hash => {
+                debug!(
+                    %context_id,
+                    session_root = %hex::encode(&local_root_hash[..8]),
+                    live_root = %hex::encode(&live_root[..8]),
+                    "storage merkle advanced during the session tail; re-anchored to the live root"
+                );
+            }
+            Ok(_) => {}
+            Err(e) => {
                 warn!(
                     %context_id, %e,
                     "failed to re-anchor context root_hash to storage merkle after HC merge"


### PR DESCRIPTION
Closes #3448

## The bug

`run_initiator_impl` re-anchors `ContextMeta.root_hash` to the storage merkle at the end of every HashComparison session. It read the merkle root, then ran the `local_scope_root` governance DAG walk (a multi-millisecond RocksDB traversal), then blind-wrote the value it had read.

Neither the read nor the write held the per-context execution lock — `apply_under_context_lock` wraps only the per-leaf applies. A local WASM execute that committed in that window got clobbered, and the node's persisted root moved **backwards** onto a state it no longer had.

`ContextMeta.root_hash` backs every peer-facing convergence signal: the heartbeat compare, sync protocol selection, and the `contextStateHash` the admin API serves. So the rollback made a node re-advertise its pre-write root — and an e2e write-then-wait saw all three nodes "agree" on the stale hash and read from a peer that had not received the delta yet.

## Evidence

Run [31853143163](https://github.com/calimero-network/core/actions/runs/31853143163/job/94934406335), `Test (scaffolding-e2e)`, step `Get author on node-1` → `"Inner key not found"`.

node-2's log, 4.6ms apart:

```
08.003065  execute: Updating context root_hash  old=ETTWh85..  new=ADbdP8ut..   <- set_metadata("author")
08.007662  client:  Setting root hash           old=ADbdP8ut..  new=ETTWh85..   <- HC rolls it back
08.007718  hash_comparison_protocol: HashComparison sync complete
```

merobox then polled and got the pre-write hash from all three nodes:

```
Wait for sync after node-2 metadata set
  ✓ All targets synced after 0.00s (1 attempts)!     <- every other sync in the run took 2 attempts / ~0.17s
    context=…: ETTWh85NEgxsePGkGRqtP6eFfByiKEn1udPgSCmaBTiQ
```

No data was lost — node-1 reached the correct root `ADbdP8ut` at `08.058`; the read at `08.042` was 16ms early.

Same rollback, same step, in run [31852844438](https://github.com/calimero-network/core/actions/runs/31852844438) seven minutes earlier:

```
execute: Updating context root_hash  old=757GxJ..  new=59RHdF..
+6ms HC: Setting root hash           old=59RHdF..  new=757GxJ..
```

Run [31838274140](https://github.com/calimero-network/core/actions/runs/31838274140) shows the same `synced after 0.00s (1 attempts)` tell before failing on `Assert PN-Counter is 1 on node-1`. **That log line immediately before a failing step is the grep signature for this bug.**

### Independently reproduced in a second workflow

`Test (group-join-via-inheritance)` in the same run 31853143163 fails the same way, which rules out anything scaffolding-specific. Node-2 (the inherited joiner) wrote while an HC session that had started 1.2s earlier was in its tail:

```
23.7364  execute: Updating context root_hash  old=GjwJqSQ3..  new=2c2gunDF..   <- set{from_joiner: node2_msg}
23.7370  client:  Sending state delta         root_hash=2c2gunDF..
23.7456  client:  Setting root hash           old=2c2gunDF..  new=GjwJqSQ3..   <- HC rolls it back
```

`Setting root hash` appears exactly **once** in node-2's entire log — the rollback. merobox then saw both nodes on `GjwJqSQ3` and passed instantly:

```
Round 2 sync
  ✓ All targets synced after 0.00s (1 attempts)!
✗ Assertion #4: contains({{node1_read_joiner}}, "node2_msg") failed (left={'output': None}, right='node2_msg')
```

Again no loss: node-1 received the delta at `23.785` and applied it to root `2c2gunDF` at `23.809` — 54ms after the read.

## Second job, same root cause

`Test (group-join-via-inheritance)` fails in the same run with the same signature — `✓ All targets synced after 0.00s (1 attempts)!` immediately before `Assert both directions converged` fails on `contains({{node1_read_joiner}}, "node2_msg")`.

Its node-2 log shows the identical rollback:

```
execute: Updating context root_hash  old=GJCLyj..  new=GjwJqS..
execute: Updating context root_hash  old=GjwJqS..  new=2c2gun..   <- the "node2_msg" write
HC:      Setting root hash           old=2c2gun..  new=GjwJqS..   <- rolled back
```

So this one bug accounts for both failing e2e jobs. Both are green on this PR.

## The fix

Re-read the merkle root inside the per-context execution lock and publish it in the same critical section, instead of writing the value captured before the DAG walk. The executor holds that same lock across execution and its root-hash persist, so the last writer is now always the one with the freshest read, whichever order the two paths interleave.

Also logs at `debug` when the merkle moved during the session tail — that line firing is positive proof the race is being hit and absorbed.

## Not in this PR

- **`heartbeat.rs:88` has the same read→write shape** (`compute_root_hash` → `force_root_hash`) and can also publish a stale root. Left alone: its window is two adjacent calls with no DAG walk between, it only runs on the already-diverged path, and the existing comment documents it as self-healing on the next tick. Fixing it means restructuring a sync actix handler into a spawned future to `await` the lock — bigger and riskier than that defect warrants. Worth a follow-up.
- **No new unit test.** The `sync_sim` harness passes `context_client: None` throughout, so this branch is unreachable in tests, and there is no existing way to build a real `ContextClient` (actix context-manager actor + store + runtime) at that layer. Building one would test the lock plumbing more than the fix.

## Validation

`cargo check` and `cargo clippy --all-targets` clean on `calimero-node`. Because the flake hits roughly 1 in 3 master runs, the real signal is repeated green `scaffolding-e2e` runs on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)