### PR TITLE
chore(client)!: drop the claim-invitation relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   capability request/response types behind them. The commands were shipped and
   advertised in `context --help`, but had no route, client method or handler and
   always errored. Use `meroctl group members set-caps` instead ([#3440])
+- **`Client::claim_group_invitation`** and the
+  `ClaimGroupInvitationApi{Request,Response,ResponseData}` types. **Breaking**
+  for `calimero-client` and `calimero-server-primitives`: the method was `pub`
+  on a published crate and posted to `admin-api/groups/claim-invitation`, a
+  route with no handler anywhere, so any caller got a 404. Direct
+  request-response join replaced the relay it belonged to ([#3450])
 
 ## [0.11.0-rc.10] - 2026-07-05
 
@@ -771,3 +777,4 @@ Integrations:
 [#1521]: https://github.com/calimero-network/core/pull/1521
 [#1522]: https://github.com/calimero-network/core/pull/1522
 [#3440]: https://github.com/calimero-network/core/pull/3440
+[#3450]: https://github.com/calimero-network/core/pull/3450

--- a/crates/client/src/client/group.rs
+++ b/crates/client/src/client/group.rs
@@ -5,8 +5,6 @@ use eyre::Result;
 use calimero_server_primitives::admin::AbortMigrationApiResponse;
 use calimero_server_primitives::admin::AddGroupMembersApiRequest;
 use calimero_server_primitives::admin::AddGroupMembersApiResponse;
-use calimero_server_primitives::admin::ClaimGroupInvitationApiRequest;
-use calimero_server_primitives::admin::ClaimGroupInvitationApiResponse;
 use calimero_server_primitives::admin::DeleteGroupApiRequest;
 use calimero_server_primitives::admin::DeleteGroupApiResponse;
 use calimero_server_primitives::admin::DetachContextFromGroupApiRequest;
@@ -174,17 +172,6 @@ where
         let response = self
             .connection
             .get(&format!("admin-api/groups/{group_id}/subgroups"))
-            .await?;
-        Ok(response)
-    }
-
-    pub async fn claim_group_invitation(
-        &self,
-        request: ClaimGroupInvitationApiRequest,
-    ) -> Result<ClaimGroupInvitationApiResponse> {
-        let response = self
-            .connection
-            .post("admin-api/groups/claim-invitation", request)
             .await?;
         Ok(response)
     }

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -314,9 +314,12 @@ pub struct JoinGroupResponse {
     /// metadata, removal), and the account is a hash of the key that no caller
     /// can compute for itself.
     pub member_account: AccountId,
-    /// Serialized `SignedGroupOp` (borsh) containing the `JoinWithInvitationClaim`.
-    /// The orchestrator must relay this to the inviting node's claim-invitation
-    /// endpoint so the member is registered on the remote side.
+    /// Always empty. This carried a serialized `SignedGroupOp` back when a join
+    /// had to be relayed to the inviting node; direct request-response join
+    /// replaced that, so the sole construction site sets `vec![]` and no reader
+    /// consumes it. It still reaches clients as `governanceOp: ""` on the group
+    /// and namespace join responses, so retiring it is an SDK-visible wire
+    /// change rather than a local cleanup.
     pub governance_op_bytes: Vec<u8>,
 }
 

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2244,32 +2244,6 @@ pub struct JoinGroupApiResponseData {
     pub governance_op: String,
 }
 
-// ---- Claim Group Invitation ----
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ClaimGroupInvitationApiRequest {
-    pub governance_op: String,
-}
-
-impl Validate for ClaimGroupInvitationApiRequest {
-    fn validate(&self) -> Vec<ValidationError> {
-        Vec::new()
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ClaimGroupInvitationApiResponse {
-    pub data: ClaimGroupInvitationApiResponseData,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ClaimGroupInvitationApiResponseData {
-    pub success: bool,
-}
-
 // ---- List All Groups ----
 
 #[derive(Clone, Debug, Deserialize)]


### PR DESCRIPTION
## Summary

An invitation claim used to be **relayed**: the joiner produced a signed `JoinWithInvitationClaim`, handed it back as hex, and an orchestrator posted it to the *inviting* node so the membership registered on the remote side. Direct request-response join replaced that model — and the endpoint on the receiving end was never built.

Removes `Client::claim_group_invitation` plus `ClaimGroupInvitationApiRequest` (and its `impl Validate`), `ClaimGroupInvitationApiResponse` and `ClaimGroupInvitationApiResponseData`.

## Two missing anchors, not one

`Client::claim_group_invitation` posts to `admin-api/groups/claim-invitation`:

- **No route.** Absent from `endpoints.json` and from every `.route(` in `crates/server/src`.
- **No handler to route to.** Unlike an unrouted-but-implemented handler, there is no implementation anywhere — `crates/server/src` and `crates/context/src` contain nothing for claim-invitation.

All twelve references in the tree were the island citing itself (6 client-side, 5 type definitions) plus one doc comment. Zero server-side, zero CLI, zero tests, and zero across `mero-js`, `calimero-client-js`, `calimero-client-py`, `merobox`, `admin-dashboard`, `mero-react` and `swift-sdk`.

**This is user-visible:** the method is `pub` on `Client` in the published `calimero-client` crate, so any external Rust consumer calling it gets a 404.

## The payload it existed to carry is structurally empty

`crates/context/src/handlers/join_group.rs` is the **only** construction site of `JoinGroupResponse`, and it hardcodes:

```rust
governance_op_bytes: vec![],
```

which the two live join handlers then `hex::encode` into `governanceOp: ""`. The log line beside it reads *"member joined group via direct request-response"* — the peer-to-peer join superseded the relay, so there is nothing left to relay.

## What was deliberately kept, and why the doc comment changed

`governance_op_bytes` **stays**. It still reaches clients as `governanceOp` on two *live* routes (`POST /admin-api/groups/join` and `POST /admin-api/namespaces/:id/join`), and both shipped SDKs type it non-optional:

- `mero-js/src/admin-api/admin-types.ts:480,883` — `governanceOp: string`
- `swift-sdk/Sources/MeroKit/Admin/AdminTypes.swift:620` — `public let governanceOp: String`

mero-js's unit tests even mock it as `'op-hex'`, as if it carried a value. Retiring it is a coordinated two-SDK release, not a cleanup, so it is out of scope here.

But its doc comment was actively wrong — it instructed callers to *"relay this to the inviting node's claim-invitation endpoint"*, an endpoint that never existed and whose last trace this PR removes. It now states what is true: always empty, no reader, and retiring it is an SDK-visible wire change. That turns a booby trap into a documented follow-up.

## Verification

- `cargo check --workspace --all-targets` ✅
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` ✅ exit 0
- `cargo test -p calimero-server-primitives --test wire_fixtures` ✅ 6/6 — unchanged, since no field on a live route was touched

Rebased onto current master; the resolution against #3439 drops **both** sides of an adjacent-method conflict (master removed `register_group_signing_key`, this removes `claim_group_invitation`), leaving `list_subgroups` → `upgrade_group`.

Found with the `unreachable-subsystems` skill (#3438).

🤖 Generated with [Claude Code](https://claude.com/claude-code)