### PR TITLE
fix(merodb): correct the schema descriptors

### DIFF
--- a/tools/merodb/README.md
+++ b/tools/merodb/README.md
@@ -250,12 +250,12 @@ The tool supports all Calimero RocksDB column families:
 
 The tool automatically detects and decodes known Calimero types using Borsh deserialization:
 
-- **ContextMeta**: `{ application: ApplicationId, root_hash: Hash }`
-- **ContextConfig**: `{ protocol, network, contract, proxy_contract, application_revision, members_revision }`
-- **ContextIdentity**: `{ private_key: Option<[u8; 32]>, sender_key: Option<[u8; 32]> }`
-- **BlobMeta**: `{ size: u64, hash: [u8; 32], links: Box<[BlobId]> }`
-- **ApplicationMeta**: `{ bytecode: BlobId, size: u64, source: Box<str>, metadata: Box<[u8]>, compiled: BlobId }`
-- **ContextDagDelta**: `{ delta_id, parents, actions, timestamp, hlc, applied }` with detailed HLC breakdown
+- **ContextMeta**: `{ application: ApplicationId, root_hash: Hash, dag_heads: Vec<Hash>, service_name: Option<Box<str>> }`
+- **ContextConfig**: `{ application_revision: u64, members_revision: u64 }`
+- **ContextIdentity**: `{ private_key: Option<[u8; 32]> }`
+- **BlobMeta**: `{ size: u64, hash: [u8; 32], links: Box<[BlobId]>, refs: u32 }`
+- **ApplicationMeta**: `{ bytecode: BlobId, size: u64, source: Box<str>, metadata: Box<[u8]>, compiled: BlobId, package: Box<str>, version: Box<str>, signer_id: Box<str>, services: Vec<ServiceMeta>, state_version: u32 }`
+- **ContextDagDelta**: `{ delta_id, parents, actions, hlc, applied, expected_root_hash, events, author_id, governance_position_blob }` with detailed HLC breakdown
 
 ### Unknown Data
 

--- a/tools/merodb/README.md
+++ b/tools/merodb/README.md
@@ -255,7 +255,7 @@ The tool automatically detects and decodes known Calimero types using Borsh dese
 - **ContextIdentity**: `{ private_key: Option<[u8; 32]> }`
 - **BlobMeta**: `{ size: u64, hash: [u8; 32], links: Box<[BlobId]>, refs: u32 }`
 - **ApplicationMeta**: `{ bytecode: BlobId, size: u64, source: Box<str>, metadata: Box<[u8]>, compiled: BlobId, package: Box<str>, version: Box<str>, signer_id: Box<str>, services: Vec<ServiceMeta>, state_version: u32 }`
-- **ContextDagDelta**: `{ delta_id, parents, actions, hlc, applied, expected_root_hash, events, author_id, governance_position_blob }` with detailed HLC breakdown
+- **ContextDagDelta**: `{ delta_id, parents, actions, hlc, applied, expected_root_hash, events, author_id, governance_position_blob, delta_signature }` with detailed HLC breakdown
 
 ### Unknown Data
 

--- a/tools/merodb/src/types.rs
+++ b/tools/merodb/src/types.rs
@@ -108,13 +108,13 @@ impl Column {
     /// Get value structure description
     pub const fn value_structure(&self) -> &'static str {
         match self {
-            Self::Meta => "ContextMeta { application: ApplicationId, root_hash: Hash, dag_heads: Vec<Hash> }",
-            Self::Config => "ContextConfig { protocol, network, contract, proxy_contract, application_revision, members_revision }",
+            Self::Meta => "ContextMeta { application: ApplicationId, root_hash: Hash, dag_heads: Vec<Hash>, service_name: Option<Box<str>> }",
+            Self::Config => "ContextConfig { application_revision: u64, members_revision: u64 }",
             Self::Identity => "ContextIdentity { private_key: Option<[u8; 32]> }",
             Self::State => "Raw bytes (application-specific state)",
-            Self::Delta => "ContextDagDelta { delta_id, parents, actions, hlc, applied, expected_root_hash }",
-            Self::Blobs => "BlobMeta { size: u64, hash: [u8; 32], links: Box<[BlobId]> }",
-            Self::Application => "ApplicationMeta { bytecode: BlobId, size: u64, source: Box<str>, metadata: Box<[u8]>, compiled: BlobId, package: Box<str>, version: Box<str> }",
+            Self::Delta => "ContextDagDelta { delta_id, parents, actions, hlc, applied, expected_root_hash, events, author_id, governance_position_blob }",
+            Self::Blobs => "BlobMeta { size: u64, hash: [u8; 32], links: Box<[BlobId]>, refs: u32 }",
+            Self::Application => "ApplicationMeta { bytecode: BlobId, size: u64, source: Box<str>, metadata: Box<[u8]>, compiled: BlobId, package: Box<str>, version: Box<str>, signer_id: Box<str>, services: Vec<ServiceMeta>, state_version: u32 }",
             Self::Alias => "Hash (32 bytes) - can point to ContextId, PublicKey, or ApplicationId",
             Self::Generic => "Raw bytes (generic key-value storage)",
         }

--- a/tools/merodb/src/types.rs
+++ b/tools/merodb/src/types.rs
@@ -112,7 +112,7 @@ impl Column {
             Self::Config => "ContextConfig { application_revision: u64, members_revision: u64 }",
             Self::Identity => "ContextIdentity { private_key: Option<[u8; 32]> }",
             Self::State => "Raw bytes (application-specific state)",
-            Self::Delta => "ContextDagDelta { delta_id, parents, actions, hlc, applied, expected_root_hash, events, author_id, governance_position_blob }",
+            Self::Delta => "ContextDagDelta { delta_id, parents, actions, hlc, applied, expected_root_hash, events, author_id, governance_position_blob, delta_signature }",
             Self::Blobs => "BlobMeta { size: u64, hash: [u8; 32], links: Box<[BlobId]>, refs: u32 }",
             Self::Application => "ApplicationMeta { bytecode: BlobId, size: u64, source: Box<str>, metadata: Box<[u8]>, compiled: BlobId, package: Box<str>, version: Box<str>, signer_id: Box<str>, services: Vec<ServiceMeta>, state_version: u32 }",
             Self::Alias => "Hash (32 bytes) - can point to ContextId, PublicKey, or ApplicationId",


### PR DESCRIPTION
## Summary

`merodb schema` exists to tell an operator what is in the database. It was describing types that no longer look like that.

The headline case: the `Config` column advertised

```
ContextConfig { protocol, network, contract, proxy_contract, application_revision, members_revision }
```

but `calimero_store::types::context::ContextConfig` has held exactly two fields since the external-chain model was removed:

```rust
pub struct ContextConfig {
    pub application_revision: u64,
    pub members_revision: u64,
}
```

Four of the six advertised fields have **never been written by any `merod`**. An operator or support engineer reading the schema mid-incident would go looking for bytes that do not exist.

The tool already contradicted itself: `parse_context_config` (`types.rs:308`) emits the correct two keys, so `merodb schema` and `merodb get` disagreed about the same column.

## Full set of corrections

`value_structure()` is reachable — `main.rs` → `schema::generate_schema()` → `column.value_structure()` — so every one of these is printed to operators.

| column | was missing / wrong |
| --- | --- |
| `Config` | named 4 fields that do not exist |
| `Meta` | missing `service_name` |
| `Delta` | missing `events`, `author_id`, `governance_position_blob` |
| `Blobs` | missing `refs` |
| `Application` | missing `signer_id`, `services`, `state_version` |

All corrected in `tools/merodb/src/types.rs` and mirrored in `tools/merodb/README.md`.

## One correction in the other direction

The README described `ContextIdentity` as `{ private_key, sender_key }`. It does not carry `sender_key` — that field lives on a **group** key type (`crates/store/src/key/group/mod.rs:1194`), while the Identity column decodes `calimero_store::types::context::ContextIdentity`, which holds only `private_key`. Here the **code descriptor was right and the README was wrong**, so the README is corrected to match rather than the other way round.

Worth stating plainly because the audit that surfaced this had it backwards, and reading the decoder (`parse_context_identity` → `StoreContextIdentity`) is what settled which of the two was authoritative.

## What was deliberately left alone

`Self::Generic`'s descriptor documents a backward-compatibility shape (*"OR ContextId + DeltaId for backwards compatibility with older delta storage"*). That is correct and load-bearing for reading old data — not drift, and not "cleaned" by symmetry with the others.

## Verification

- `cargo check -p merodb` ✅
- `cargo fmt --check` ✅
- Every corrected descriptor was read off the live struct definition in `crates/store/src/types/{context,blobs,application}.rs`, not inferred

Found with the `unreachable-subsystems` skill (#3438).

🤖 Generated with [Claude Code](https://claude.com/claude-code)