### PR TITLE
fix(ci): lint convergence in nested scenario directories

### DIFF
--- a/scripts/lint-e2e-convergence.py
+++ b/scripts/lint-e2e-convergence.py
@@ -198,7 +198,7 @@ def load_baseline() -> set[str]:
 
 def main() -> int:
     patterns = sys.argv[1:] or [
-        "apps/*/workflows/*.yml",
+        "apps/*/workflows/**/*.yml",
         "workflows/**/*.yml",
     ]
     paths = sorted({p for pat in patterns for p in glob.glob(pat, recursive=True)})


### PR DESCRIPTION
## Summary

One character. `scripts/lint-e2e-convergence.py` globbed

```python
"apps/*/workflows/*.yml",
```

and `*` does not cross a directory separator, so any scenario one level deeper was never scanned. That silently excluded `apps/scaffolding-e2e/workflows/auto-follow/` — **five scenarios that do run in the CI matrix**:

- `auto-follow-on-context-registered.yml`
- `auto-follow-backfill-on-join.yml`
- `auto-follow-flag-flipped-late.yml`
- `asymmetric-context-membership.yml`
- `no-unknown-context-rejection-spam.yml`

They had zero entries in `scripts/e2e-convergence-baseline.txt` — not because they were clean, but because nothing had looked at them.

The second pattern, `workflows/**/*.yml`, was already recursive. Only the `apps/` one was wrong.

## Effect

```
$ python3 scripts/lint-e2e-convergence.py
scanned 129 scenario(s)          # was 124
9 baselined (accepted) finding(s) — burndown backlog
no new convergence races found
```

The five newly covered files produce **no new findings**, so this needs no baseline churn. The gap had not yet cost anything — the point is that a gate which had quietly stopped covering part of its intended surface now covers it again.

## Why this is worth a PR of its own

It is the mirror image of the orphaned-scenario problem: there, scenarios exist and the *runtime* gate never runs them; here, scenarios run and the *static* gate never reads them. Both are cases where a check looks green because it is measuring less than you think, which is exactly the class the `unreachable-subsystems` skill (#3438) is aimed at — the audit found it while enumerating glob-based anchors, and it is the one finding where the fix is smaller than the sentence describing it.

## Verification

- `python3 scripts/lint-e2e-convergence.py` ✅ exit 0
- Glob diff confirmed explicitly: 83 → 88 matches under `apps/`, the five added paths all in `auto-follow/`
- No baseline entries added or removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)