### PR TITLE
fix(merodb): repair the gui build and gate it in CI

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -90,6 +90,22 @@ jobs:
         if: ${{ !cancelled() }}
         run: cargo test -p merod -p calimero-node -p calimero-tee-attestation --features mock-attestation -- --nocapture
 
+      # merodb's `gui` feature is default-OFF, and `--all-targets` skips a
+      # feature-gated target rather than failing on it, so the workspace build
+      # above never compiles `src/gui/` or the ~20 `#[cfg(feature = "gui")]`
+      # sites in main.rs/dag.rs/export.rs. Without this step that code is free
+      # to stop compiling unnoticed, which is exactly what happened: a
+      # `CollectionType::Tuple` variant was added to the ABI schema and the
+      # gui-gated match in export.rs was never updated, so `merodb --gui` — a
+      # documented debugging tool — did not build at all.
+      #
+      # This builds rather than clippies: the gui code predates any lint gate
+      # and still carries ~60 `-D warnings` findings. Tighten this to `cargo
+      # clippy … -- -D warnings` once those are cleared.
+      - name: Cargo build (merodb gui)
+        if: ${{ !cancelled() }}
+        run: cargo build -p merodb --features gui
+
       - name: Cargo check (calimero-context-config)
         if: ${{ !cancelled() }}
         run: cargo check -p calimero-context-config

--- a/tools/merodb/src/export.rs
+++ b/tools/merodb/src/export.rs
@@ -1808,7 +1808,7 @@ fn get_root_hash_from_meta(
     db: &DBWithThreadMode<SingleThreaded>,
     context_id: &[u8],
 ) -> Result<[u8; 32]> {
-    use crate::types::{parse_key, parse_value, Column};
+    use crate::types::{parse_value, Column};
 
     let meta_cf = db
         .cf_handle("Meta")
@@ -2610,11 +2610,11 @@ fn decode_state_root_bfs(
         };
 
         // For Counter fields, ensure the value is visible in the data
-        let mut field_data_final = field_data_without_children.clone();
+        let field_data_final = field_data_without_children.clone();
         if let Some(field_obj_data) = field_data_without_children.as_object() {
             if let Some(value) = field_obj_data.get("value") {
                 // If there's a value, ensure it's visible in the data
-                if let Some(field_data_final_obj) = field_data_final.as_object_mut() {
+                if field_data_final.is_object() {
                     // The value is already in field_data_without_children, so it will be in data
                     eprintln!(
                         "[decode_state_root_bfs] Field {} has value in data: {:?}",
@@ -3334,7 +3334,6 @@ fn decode_collection_entries_bfs(
         })]);
     }
 
-    let collection_root_element_id = hex::encode(collection_root_index.id.as_bytes());
     let mut entries = Vec::new();
 
     // Find all children of collection root (entries in the collection)
@@ -3710,8 +3709,6 @@ fn decode_state_field(
                 .map(|children| children.iter().collect::<Vec<_>>())
                 .unwrap_or_default();
 
-            let mut collection_root_id: Option<String> = None;
-
             // Try to match a child to this field by checking if it's a collection root
             for child_info in children {
                 let child_element_id = hex::encode(child_info.id.as_bytes());
@@ -3746,7 +3743,6 @@ fn decode_state_field(
                 // Check if this child is a collection root (EntityIndex with children)
                 if let Ok(child_index) = borsh::from_slice::<EntityIndex>(&child_value) {
                     // This is a collection root node - it matches this collection field
-                    collection_root_id = Some(child_element_id.clone());
                     used_children.insert(child_element_id);
 
                     // Now get all entries in this collection by traversing the collection root's children
@@ -3878,6 +3874,20 @@ fn decode_collection_entry(
         }
         CollectionType::List { items } => decode_list_entry(bytes, field, items, manifest)
             .map_err(|e| eyre::eyre!("Failed to decode list entry: {}", e)),
+        CollectionType::Tuple { elements } => {
+            // Borsh lays a tuple out as its elements back to back with no length
+            // prefix, so arity comes from the schema and the elements decode
+            // positionally.
+            let mut cursor = std::io::Cursor::new(bytes);
+            let mut array = Vec::with_capacity(elements.len());
+            for element in elements {
+                array.push(
+                    deserializer::deserialize_type_ref_from_cursor(&mut cursor, element, manifest)
+                        .map_err(|e| eyre::eyre!("Failed to decode tuple element: {}", e))?,
+                );
+            }
+            Ok(json!(array))
+        }
         CollectionType::Record { .. } => {
             // For RGA, individual entries are (CharKey, RgaChar) tuples, not full RGA structures
             // They should be handled by collect_rga_entries, not decoded individually

--- a/tools/merodb/src/gui/server.rs
+++ b/tools/merodb/src/gui/server.rs
@@ -13,8 +13,6 @@ use serde::Serialize;
 use tower_http::{services::ServeDir, set_header::SetResponseHeaderLayer};
 
 use crate::{abi, dag, export, types::Column};
-use calimero_wasm_abi::schema::Manifest;
-use hex;
 
 #[derive(Debug, Serialize)]
 struct ErrorResponse {


### PR DESCRIPTION
## `merodb --gui` does not compile

This started as "add a clippy line" and turned into a bug report. On master:

```
$ cargo build -p merodb --features gui
error[E0004]: non-exhaustive patterns: `&CollectionType::Tuple { .. }` not covered
    --> tools/merodb/src/export.rs:3869:11
note: `CollectionType` defined here
    --> crates/wasm-abi/src/schema.rs:383
     |     Tuple { elements: Vec<TypeRef> },
error: could not compile `merodb` (bin "merodb") due to 1 previous error
```

A `Tuple` variant was added to the ABI schema and the gui-gated match was never updated, **because nothing ever compiles it**. `merodb --gui` is documented in `tools/AGENTS.md` and the merodb README as a debugging tool, so the failure lands on whoever reaches for it mid-incident.

## Why CI never noticed

The `gui` feature is default-OFF, and `--all-targets` **skips** a target whose `required-features` are unmet rather than failing on it. So `cargo build --workspace --all-targets` and the `-D warnings` gate have never compiled `src/gui/` (997 lines) or the ~20 `#[cfg(feature = "gui")]` sites across `main.rs`, `dag.rs` and `export.rs`. The only mention of merodb anywhere in `.github/` is a CodeQL **path exclusion** for the GUI's CSS — the opposite of a gate.

## The fix

The missing arm decodes positionally through the deserializer the sibling arms already use. Borsh lays a tuple out as its elements back to back with no length prefix — arity comes from the schema — and `deserializer.rs:566` already decodes it exactly that way for the non-gui path, so this matches existing behavior rather than inventing it.

Also cleared, since they blocked the build/lint once it compiled: two unused imports, a redundant `use hex`, an unused `if let` binding (the body only logs, so the condition is all that was wanted), a computed-then-unused value, and a write-only variable.

## Why this gate builds instead of clippies

The audit that found this suggested one clippy line modelled on the existing `mock-attestation` pass. That turned out to be premature: once the code compiles, `cargo clippy -p merodb --features gui -- -D warnings` reports **~60 findings** — 50 uninlined format args, 5 too-many-arguments, 3 genuinely dead functions (`decode_field_bfs`, `decode_state_field`, `build_tree_from_root`), and a few others. Code that has never been linted does not arrive lint-clean.

So this installs the cheapest gate that would have caught the actual breakage, with a comment saying to tighten it to clippy once those are cleared. **Building is what was missing; linting is the follow-up.** Bundling 60 lint fixes into a compile-fix PR would bury the one change that matters.

## Verification

- `cargo build -p merodb --features gui` ✅ — was exit 101, now exit 0
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` ✅ exit 0 — the default gate is unaffected
- `cargo fmt --check` ✅
- `ci-checks.yml` validates as YAML

Found with the `unreachable-subsystems` skill (#3438) — specifically its "feature-gated code where the feature is enabled nowhere" heading, where the risk is not dead code but *unverified* code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)