### PR TITLE
test(e2e): register the 17 scenarios that ran in no matrix

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -18,6 +18,16 @@ on:
       - "apps/kv-store-with-shared-storage/**"
       - "apps/components-demo/**"
       - "apps/blobs/**"
+      - "apps/abi_conformance/**"
+      - "apps/collaborative-editor/**"
+      - "apps/kv-store-init/**"
+      - "apps/kv-store-with-handlers/**"
+      - "apps/kv-store-with-user-and-frozen-storage/**"
+      - "apps/kv-store/**"
+      - "apps/nested-crdt-test/**"
+      - "apps/private_data/**"
+      - "apps/team-metrics-custom/**"
+      - "apps/team-metrics-macro/**"
       - ".github/workflows/e2e-rust-apps.yml"
       - ".github/workflows/build-merod-image.yml"
 
@@ -30,6 +40,16 @@ on:
       - "apps/kv-store-with-shared-storage/**"
       - "apps/components-demo/**"
       - "apps/blobs/**"
+      - "apps/abi_conformance/**"
+      - "apps/collaborative-editor/**"
+      - "apps/kv-store-init/**"
+      - "apps/kv-store-with-handlers/**"
+      - "apps/kv-store-with-user-and-frozen-storage/**"
+      - "apps/kv-store/**"
+      - "apps/nested-crdt-test/**"
+      - "apps/private_data/**"
+      - "apps/team-metrics-custom/**"
+      - "apps/team-metrics-macro/**"
       - ".github/workflows/e2e-rust-apps.yml"
       - ".github/workflows/build-merod-image.yml"
 
@@ -180,6 +200,38 @@ jobs:
       - name: Build blobs app
         run: cargo mero build --manifest-path apps/blobs/Cargo.toml
 
+      - name: Build abi_conformance app
+        run: cargo mero build --manifest-path apps/abi_conformance/Cargo.toml
+
+      - name: Build collaborative-editor app
+        run: cargo mero build --manifest-path apps/collaborative-editor/Cargo.toml
+
+      - name: Build kv-store-init app
+        run: cargo mero build --manifest-path apps/kv-store-init/Cargo.toml
+
+      - name: Build kv-store-with-handlers app
+        run: cargo mero build --manifest-path apps/kv-store-with-handlers/Cargo.toml
+
+      - name: Build kv-store-with-user-and-frozen-storage app
+        run: cargo mero build --manifest-path apps/kv-store-with-user-and-frozen-storage/Cargo.toml
+
+      - name: Build kv-store app
+        run: cargo mero build --manifest-path apps/kv-store/Cargo.toml
+
+      - name: Build nested-crdt-test app
+        run: cargo mero build --manifest-path apps/nested-crdt-test/Cargo.toml
+
+      - name: Build private_data app
+        run: cargo mero build --manifest-path apps/private_data/Cargo.toml
+
+      - name: Build team-metrics-custom app
+        run: cargo mero build --manifest-path apps/team-metrics-custom/Cargo.toml
+
+      - name: Build team-metrics-macro app
+        run: cargo mero build --manifest-path apps/team-metrics-macro/Cargo.toml
+      - name: Build kv-store bundle
+        run: cargo mero bundle --dev --no-icon --app-version 0.0.0 --manifest-path apps/kv-store/Cargo.toml
+
       - name: Verify every built app wasm embeds the ABI (core#3287)
         run: ./scripts/check-embedded-abi.sh
 
@@ -203,6 +255,17 @@ jobs:
             apps/blobs/res/*.wasm
             apps/blobs/res/abi.json
             apps/blobs/res/state-schema.json
+            apps/abi_conformance/res/*
+            apps/collaborative-editor/res/*
+            apps/kv-store-init/res/*
+            apps/kv-store-with-handlers/res/*
+            apps/kv-store-with-user-and-frozen-storage/res/*
+            apps/kv-store/res/*
+            apps/nested-crdt-test/res/*
+            apps/private_data/res/*
+            apps/team-metrics-custom/res/*
+            apps/team-metrics-macro/res/*
+            apps/kv-store/dist/*.mpk
           retention-days: 1
 
   # ── Test phase: run each workflow in parallel ──
@@ -505,6 +568,60 @@ jobs:
           # always-fail because the stock merod:edge image lacks
           # iproute2 and inject_network_fault short-circuits with
           # `tc: executable file not found`.
+          # Scenarios that existed on disk but ran in no matrix. Most predate the
+          # glob-to-enumeration switch and stopped running when it landed; the
+          # newest three were written after it and never ran at all.
+          - workflow: abi-conformance
+            file: workflows/abi-conformance.yml
+            app: abi_conformance
+          - workflow: collaborative-editor
+            file: workflows/collaborative-editor.yml
+            app: collaborative-editor
+          - workflow: kv-store-init
+            file: workflows/kv-store-init.yml
+            app: kv-store-init
+          - workflow: kv-store-with-handlers
+            file: workflows/kv-store-with-handlers.yml
+            app: kv-store-with-handlers
+          - workflow: frozen-storage
+            file: workflows/test_frozen_storage.yml
+            app: kv-store-with-user-and-frozen-storage
+          - workflow: user-storage
+            file: workflows/test_user_storage.yml
+            app: kv-store-with-user-and-frozen-storage
+          - workflow: bundle-invitation
+            file: workflows/bundle-invitation-test.yml
+            app: kv-store
+          - workflow: kv-store-simple
+            file: workflows/simple-store.yml
+            app: kv-store
+          - workflow: kv-store-workflow-example
+            file: workflows/workflow-example.yml
+            app: kv-store
+          - workflow: nested-crdt
+            file: workflows/nested-crdt-test.yml
+            app: nested-crdt-test
+          - workflow: private-data-example
+            file: workflows/example.yml
+            app: private_data
+          - workflow: private-data
+            file: workflows/private-data.yml
+            app: private_data
+          - workflow: group-governance-cold-context-push-converge
+            file: workflows/group-governance-cold-context-push-converge.yml
+            app: scaffolding-e2e
+          - workflow: simple-sync
+            file: workflows/simple-sync.yml
+            app: scaffolding-e2e
+          - workflow: team-metrics-custom
+            file: workflows/team-metrics-custom.yml
+            app: team-metrics-custom
+          - workflow: team-metrics-macro
+            file: workflows/team-metrics-macro.yml
+            app: team-metrics-macro
+          - workflow: xcall-example-scenario
+            file: workflows/xcall-example.yml
+            app: xcall-example
     steps:
       - name: Checkout code
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

Seventeen merobox scenarios exist on disk, parse, use only steps merobox implements, and are still being edited — while running **nowhere**. This registers all of them.

Reconciliation before: **129 scenarios = 112 registered + 17 orphaned.** After: **0 orphaned.**

## Why they were orphaned

`dca91ae6a` (2026-02-10, #1751) replaced `merobox-workflows.yml`, which ran every scenario by glob —

```bash
cd apps
for workflow in */workflows/*.yml */workflows/*.yaml; do
    echo "$workflow" >> "$WORKFLOW_LIST"
done
```

— with the explicit matrix in this file, seeded from a subset. **Fourteen** of these ran under that glob and stopped the day it landed. No diff line named them, because what was deleted was the glob, not the scenarios.

**Three** were written *after* the switch and have never run at all:

| scenario | added | |
| --- | --- | --- |
| `workflow-example` | 2026-02-13 | three days after the switch |
| `simple-sync` | 2026-05-06 | |
| `group-governance-cold-context-push-converge` | 2026-07-23 | guards #3296 — a context going silently dark while every member is online |

That group is the more telling one: their authors wrote scenarios in a repo where "put the file in `apps/*/workflows/` and it runs" had been true for months, and nothing in the file being edited says otherwise.

**None was ever registered by name**, so nothing here reverses a deliberate exclusion. Verified per-file against CI history; the two apparent hits were substring artifacts (`example.yml` matching `blobs-example.yml`, `kv-store-with-handlers.yml` matching `workflows/fuzzy-tests/kv-store-with-handlers/fuzzy-test.yml`). The one scenario that **is** deliberately excluded — `member-removed-partition-window-reconcile`, which carries a comment giving the reason and naming its substitute unit test — stays excluded.

`apps/xcall-example/` shows the failure mode in miniature: two scenarios, `xcall.yml` registered and `xcall-example.yml` not. Same app, same directory, and neither file says which.

## What this changes

- 17 matrix entries (68 → 85)
- `cargo mero build` for the ten apps that had no build step here, plus the `cargo mero bundle` for kv-store, since `bundle-invitation-test` installs `dist/com.calimero.kv-store-0.0.0.mpk` rather than a bare wasm
- artifact upload paths for those apps
- `on: push`/`pull_request` path filters, so a change to any of them triggers the suite

Verified mechanically: all 85 matrix entries resolve to a file that exists, every app referenced by the matrix has both a build step and an artifact path, and the reconciliation reports zero orphans.

`force_pull_image: true` was left alone. Eleven of these set it, and it looked like it would fight `--image merod:local` — but `blobs.yml` is registered, green, and sets it too, so the flag is overridden by the explicit `--image`.

## Expect failures

**These have not run in six months, and three have never run.** A red job here is the finding, not a regression this PR introduces. The point of registering them in one batch is to learn which ones still hold; whatever fails then gets triaged on its own merits — fix the scenario, fix the product bug it caught, or exclude it with a stated reason like `member-removed-partition-window-reconcile` has.

## Follow-up worth doing regardless of the outcome

Nothing reconciles scenarios-on-disk against scenarios-in-matrices, which is why the count drifted three separate times: this migration, the 2026-04 parallelization that dropped `xcall-example.yml`, and every scenario added since. A CI step performing the reconciliation above — fail if any scenario is in no matrix and on no explicit opt-out list — would make the July case impossible. Same shape as the existing `check-endpoint-coverage.sh` gate for routes.

Found with the `unreachable-subsystems` skill (#3438).

🤖 Generated with [Claude Code](https://claude.com/claude-code)