### PR TITLE
fix(node): hold the context lock across the heartbeat root re-anchor

### DIFF
--- a/crates/node/src/handlers/network_event/heartbeat.rs
+++ b/crates/node/src/handlers/network_event/heartbeat.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
-use actix::{AsyncContext, WrapFuture};
+use actix::{ActorFutureExt, AsyncContext, WrapFuture};
 use calimero_primitives::context::ContextId;
 use tracing::{debug, error, info, warn};
 
@@ -48,81 +48,107 @@ pub(super) fn handle_hash_heartbeat(
         let their_heads_set: HashSet<_> = their_dag_heads.iter().collect();
 
         if our_heads_set == their_heads_set && our_context.root_hash != their_root_hash {
-            // #2319 — before reporting a real divergence, reconcile the
-            // cached `ContextMeta.root_hash` with the live index. The
-            // cache is populated from the WASM-returned root_hash at the
-            // end of each method execution; a concurrent sync apply
-            // (HashComparison `EntityPush`, level-sync leaf push, etc.)
-            // can advance the actual index right after WASM returns but
-            // before the cache is written, leaving the cache pointing
-            // at a pre-recalc full_hash while the index has already
-            // moved on. The two nodes still converge in storage, but
-            // the heartbeat sees the stale caches and fires
+            // Before reporting a real divergence, reconcile the cached
+            // `ContextMeta.root_hash` with the live index. The cache is
+            // populated from the WASM-returned root_hash at the end of each
+            // method execution; a concurrent sync apply (HashComparison
+            // `EntityPush`, level-sync leaf push, etc.) can advance the actual
+            // index right after WASM returns but before the cache is written,
+            // leaving the cache pointing at a pre-recalc full_hash while the
+            // index has already moved on. The two nodes still converge in
+            // storage, but the heartbeat sees the stale caches and fires
             // DIVERGENCE.
             //
-            // Re-read the live full_hash from the index. If it matches
-            // either the peer's hash or our prior cache, refresh the
-            // cache and skip the false-positive divergence event; only
-            // a *post-refresh* hash mismatch is a real divergence.
+            // The recompute and the republish run inside ONE hold of the
+            // per-context execution lock. Read-then-write without it is a
+            // lost-update: a WASM execute committing between the two writes its
+            // fresh root and then has it overwritten by the older value read
+            // here, rolling `ContextMeta.root_hash` BACKWARDS onto a state the
+            // node no longer has. That field backs every peer-facing
+            // convergence signal — this heartbeat compare, sync protocol
+            // selection, and the `contextStateHash` the admin API serves — so a
+            // rollback makes the node re-advertise a pre-write root and can
+            // make a peer's write-then-wait observe false convergence. The
+            // executor holds this same lock across execution and its root-hash
+            // persist, so taking it here makes the pair atomic against that
+            // path.
             //
-            // Residual TOCTOU: a concurrent apply landing between
-            // `compute_root_hash` and `force_root_hash` can leave the
-            // cache transiently stale again. This doesn't eliminate
-            // the false-positive class — it narrows the window from
-            // "until the next WASM execution" to "until the next
-            // heartbeat tick" (also when the next ContextMeta write
-            // happens). The next heartbeat self-heals via this same
-            // branch, so we accept the residual window rather than
-            // double-reading.
-            let our_hash = match context_client.compute_root_hash(&context_id) {
-                Ok(live) => {
-                    let live_hash = calimero_primitives::hash::Hash::from(live);
-                    if live_hash != our_context.root_hash {
+            // Taking an async lock means the divergence evaluation moves into
+            // the spawned continuation, which is where `&mut NodeManager`
+            // (metric + streak state) is available again.
+            //
+            // Consequence of deferring: two heartbeats for the same
+            // (context, peer) could in principle have overlapping
+            // continuations, miscounting the persistence streak. It needs lock
+            // acquisition to outlast the ~30s heartbeat period, and the streak
+            // only gates whether a divergence is logged at `warn` or `error` —
+            // an advisory signal, not a correctness one. Serialising it would
+            // cost per-(context, peer) in-flight state to buy nothing the log
+            // reader would notice, so the cheaper trade is taken deliberately.
+            let cc = context_client.clone();
+            let cached_root = our_context.root_hash;
+            let their_heads_for_dump = their_dag_heads.clone();
+            let refresh = async move {
+                let _guard = cc.acquire_lock(&context_id).await;
+                match cc.compute_root_hash(&context_id) {
+                    Ok(live) => {
+                        let live_hash = calimero_primitives::hash::Hash::from(live);
+                        if live_hash != cached_root {
+                            debug!(
+                                %context_id,
+                                ?source,
+                                cached_hash = ?cached_root,
+                                live_hash = ?live_hash,
+                                "Heartbeat divergence: cache stale vs live index, refreshing"
+                            );
+                            if let Err(err) = cc.force_root_hash(&context_id, live_hash) {
+                                // `warn`, not `debug`: a single failure here is
+                                // usually a benign concurrent context delete,
+                                // but a *persistent* failure leaves the cache
+                                // stale and produces a stream of false-positive
+                                // DIVERGENCE events on every heartbeat. Surface
+                                // it where ops can see it without log filtering.
+                                warn!(
+                                    %context_id,
+                                    ?source,
+                                    %err,
+                                    "Heartbeat divergence: failed to refresh cached root hash"
+                                );
+                            }
+                        }
+                        Some(live_hash)
+                    }
+                    Err(err) => {
                         debug!(
                             %context_id,
                             ?source,
-                            cached_hash = ?our_context.root_hash,
-                            live_hash = ?live_hash,
-                            "Heartbeat divergence: cache stale vs live index, refreshing"
+                            %err,
+                            "Heartbeat divergence: failed to read live root hash; using cache"
                         );
-                        if let Err(err) = context_client.force_root_hash(&context_id, live_hash) {
-                            // `warn`, not `debug`: a single failure here
-                            // is usually a benign concurrent context
-                            // delete, but a *persistent* failure leaves
-                            // the cache stale and produces a stream of
-                            // false-positive DIVERGENCE events on every
-                            // heartbeat. Surface it where ops can see it
-                            // without log filtering.
-                            warn!(
-                                %context_id,
-                                ?source,
-                                %err,
-                                "Heartbeat divergence: failed to refresh cached root hash"
-                            );
-                        }
-                        if live_hash == their_root_hash {
-                            // Converged once the cache caught up — drop any
-                            // streak so a later transient starts fresh at WARN.
-                            let _ = manager.divergence_streak.remove(&(context_id, source));
-                            return;
-                        }
+                        None
                     }
-                    // Use live_hash as the authoritative "our hash" — the
-                    // cached value may be stale (and the refresh above
-                    // may itself have failed); the live index is the
-                    // truth we want in the divergence log for triage.
-                    live_hash
                 }
-                Err(err) => {
-                    debug!(
-                        %context_id,
-                        ?source,
-                        %err,
-                        "Heartbeat divergence: failed to read live root hash; using cache"
-                    );
-                    our_context.root_hash
+                // `_guard` drops here, releasing the context lock before the
+                // continuation runs any of the reporting below.
+            }
+            .into_actor(manager)
+            .map(move |live, manager: &mut NodeManager, ctx: &mut actix::Context<NodeManager>| {
+                let context_client = manager.clients.context.clone();
+                let their_dag_heads = their_heads_for_dump;
+                // Use the live hash as the authoritative "our hash" — the cached
+                // value may be stale (and the refresh may itself have failed);
+                // the live index is the truth we want in the divergence log for
+                // triage.
+                let our_hash = live.unwrap_or(cached_root);
+
+                // Converged once the cache caught up — drop any streak so a
+                // later transient starts fresh at WARN. Reachable only when the
+                // cache WAS stale, since this branch is entered on
+                // `cached_root != their_root_hash`.
+                if live.is_some() && our_hash == their_root_hash {
+                    let _ = manager.divergence_streak.remove(&(context_id, source));
+                    return;
                 }
-            };
 
             // #2319: surface divergence as a metric (`sync_root_hash_divergence_detected_total`)
             // so vmagent can alert on the rate without grepping logs —
@@ -281,6 +307,8 @@ pub(super) fn handle_hash_heartbeat(
                     .into_actor(manager),
                 );
             }
+            });
+            let _ignored = ctx.spawn(refresh);
             return;
         }
 


### PR DESCRIPTION
Follow-up to #3449, which fixed this same defect in the HashComparison path and explicitly deferred this one.

## The defect

The heartbeat's stale-cache repair reads the live index with `compute_root_hash` and writes it back with `force_root_hash`, holding no lock:

```rust
let our_hash = match context_client.compute_root_hash(&context_id) {
    Ok(live) => {
        let live_hash = Hash::from(live);
        if live_hash != our_context.root_hash {
            context_client.force_root_hash(&context_id, live_hash)   // <- read at T0, written at T1
```

A WASM execute committing between the two writes its fresh root and then has it overwritten by the older value read here, rolling `ContextMeta.root_hash` **backwards** onto a state the node no longer has.

That field backs every peer-facing convergence signal — this heartbeat compare, sync protocol selection, and the `contextStateHash` the admin API serves. So a rollback makes the node re-advertise a pre-write root, and a peer doing write-then-wait can observe false convergence against it.

## Why now, having deferred it

The identical shape in the HC end-of-session re-anchor was doing exactly this in production CI: it rolled the root back over a concurrent write, and an e2e write-then-wait passed on the stale hash (`✓ All targets synced after 0.00s (1 attempts)!`), then read from a peer that had not received the delta. That was #3449.

This site's window is genuinely narrower — two adjacent calls with no DAG walk between — which is why #3449 left it alone, and the code carried a comment conceding the residual TOCTOU as self-healing on the next tick. But narrower is not closed, and the failure mode is a *silently wrong convergence signal* rather than a visible error, so it does not announce itself when it happens.

## The fix

Hold the per-context execution lock across the recompute and the republish. The executor holds that same lock across execution and its root-hash persist, so the pair is now atomic against it — whichever order the two interleave, the last writer is the one with the freshest read.

Taking an async lock means the divergence evaluation moves into a spawned continuation (`.into_actor(manager).map(|live, manager, ctx| …)`), which is where `&mut NodeManager` — the divergence metric and the persistence streak — is available again. Behaviour is otherwise preserved: same convergence early-return, same metric, same streak gating, same dump, same recovery sync at the threshold tick.

The obsolete "Residual TOCTOU … we accept the residual window" comment is replaced with what now holds.

## Trade-off, deliberately taken

Deferring the evaluation means two heartbeats for the same `(context, peer)` could in principle have overlapping continuations and miscount the persistence streak. It requires lock acquisition to outlast the ~30s heartbeat period, and the streak only decides whether a divergence logs at `warn` or `error`. Serialising it would cost per-`(context, peer)` in-flight state to buy nothing a log reader would notice. Noted in the code rather than left for someone to rediscover.

## Verification

`cargo fmt`, `cargo check`, and `cargo clippy -p calimero-node --all-targets --features calimero-storage/testing -- -D warnings` are clean.

No new test. Same reason given in #3449: the `sync_sim` harness passes `context_client: None` throughout, so the lock plumbing is unreachable there, and reproducing a lost update that needs a WASM execute to land inside a two-call window is not something the existing harnesses can drive deterministically. This is a narrowing of a race whose observable form was already fixed and evidenced in #3449; the e2e suite is the regression surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)