### PR TITLE
fix(node): pull from the beacon a stranded member cannot verify

### DIFF
--- a/crates/node/src/handlers/network_event/readiness.rs
+++ b/crates/node/src/handlers/network_event/readiness.rs
@@ -124,6 +124,79 @@ pub(super) fn handle_readiness_beacon(
             );
             return;
         }
+        // Last resort before the drop: this node may be the one the beacon
+        // could have rescued.
+        //
+        // A member that joined without ever reaching a mesh peer holds its
+        // membership row but no key and no governance ops. It cannot verify ANY
+        // beacon — `verify_readiness_beacon` requires the signer to be a known
+        // member, and knowing members requires the very governance state it is
+        // missing — so it drops every one and nothing it hears can move it
+        // forward. Meanwhile the beacons themselves are proof of what it needs:
+        // a namespace peer is up, reachable, and talking to us right now.
+        //
+        // Acting on that trusts nothing new. The beacon is still refused — no
+        // membership row, no cache entry, none of its claims are believed. We
+        // use only the fact of its arrival to pick a peer, then pull through
+        // the ordinary authenticated path where every governance op must still
+        // validate on apply. The alternative, relaxing the verification above,
+        // would widen what a stranger can assert about membership; this does
+        // not.
+        //
+        // Deliberately NOT routed through `spawn_beacon_divergence_sync`: its
+        // `local_has_state` guard skips a namespace with no non-zero DAG head,
+        // which is exactly this node, and that guard is load-bearing for more
+        // than its comment describes — relaxing it regressed a batch of
+        // app-migration scenarios. So this arm does its own narrow pull and
+        // leaves the guard alone.
+        let stranded_ns = beacon.namespace_id.to_bytes();
+        let stranded = matches!(
+            calimero_governance_store::namespace_groups_member_but_keyless(
+                &manager.datastore,
+                stranded_ns.into(),
+            ),
+            Ok(ref groups) if !groups.is_empty()
+        );
+        if stranded && beacon_ts_within_drift(beacon.ts_millis, now_millis()) {
+            let allowed = {
+                let mut guard = manager
+                    .ns_stranded_beacon_sync_debounce
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                debounce_allows_sync(&mut guard, stranded_ns, Instant::now())
+            };
+            if allowed {
+                debug!(
+                    %peer_id,
+                    namespace_id = %hex::encode(beacon.namespace_id.as_bytes()),
+                    "stranded member: unverifiable beacon signals a reachable peer, pulling from it"
+                );
+                let sync_manager = manager.managers.sync.clone();
+                let _ignored = ctx.spawn(
+                    async move {
+                        let ops = sync_manager
+                            .sync_namespace_from_peer(stranded_ns, Some(peer_id))
+                            .await;
+                        debug!(
+                            %peer_id,
+                            namespace_id = %hex::encode(stranded_ns),
+                            ops,
+                            "stranded-member recovery: pulled governance from beacon signer"
+                        );
+                        sync_manager
+                            .recover_missing_group_keys(stranded_ns, Some(peer_id))
+                            .await;
+                        debug!(
+                            %peer_id,
+                            namespace_id = %hex::encode(stranded_ns),
+                            "stranded-member recovery: key pull complete"
+                        );
+                    }
+                    .into_actor(manager),
+                );
+                return;
+            }
+        }
         debug!(
             namespace_id = %hex::encode(beacon.namespace_id.as_bytes()),
             "ReadinessBeacon failed verification; dropping"

--- a/crates/node/src/manager.rs
+++ b/crates/node/src/manager.rs
@@ -139,6 +139,17 @@ pub struct NodeManager {
     /// silence exactly the member anti-entropy above. Still keyed on the
     /// namespace, never the peer: a Sybil swarm shares one budget.
     pub(crate) ns_provable_beacon_sync_debounce: Arc<Mutex<HashMap<[u8; 32], Instant>>>,
+    /// The same budget, same window, for the stranded-member arm: a node that
+    /// is a member of a group in the namespace but holds no key for it, pulling
+    /// off the *unverifiable* beacon that just arrived.
+    ///
+    /// Separate for the same reason the provable arm is: a stranded node cannot
+    /// verify any beacon, so every beacon it receives would contend for the
+    /// slot, and sharing would let that starve the two arms above. Keyed on the
+    /// namespace rather than the peer, so a Sybil swarm shares one budget — the
+    /// trigger is an unauthenticated message, and the whole point is to act on
+    /// it without trusting it.
+    pub(crate) ns_stranded_beacon_sync_debounce: Arc<Mutex<HashMap<[u8; 32], Instant>>>,
     /// Shared per-(namespace, peer) migration-heartbeat TTL cache (PR-6c
     /// Task 6c.8). The receiver-side
     /// `network_event::namespace::handle_namespace_governance_delta`
@@ -191,6 +202,7 @@ impl NodeManager {
             behind_sync_at: HashMap::new(),
             ns_beacon_sync_debounce: Arc::new(Mutex::new(HashMap::new())),
             ns_provable_beacon_sync_debounce: Arc::new(Mutex::new(HashMap::new())),
+            ns_stranded_beacon_sync_debounce: Arc::new(Mutex::new(HashMap::new())),
             migration_status_cache: Arc::new(MigrationStatusCache::default()),
             migration_emitter_addr: None,
         }


### PR DESCRIPTION
Second trigger for #3406, independent of #3453 — they can merge in either order.

## Why #3453 alone is not enough

#3453 recovers a stranded member when a peer subscribes to `ns/<id>`. That works, but the subscription event is not guaranteed to fire when it is needed. From the run that failed on that branch ([31883720288](https://github.com/calimero-network/core/actions/runs/31883720288)):

```
12:14:25.30  ns/ Subscribed event   <- the ONLY one, 56s BEFORE the join degraded
12:15:21.62  degraded join (member recorded, no key)
12:15:46.63  reconnect after heal   <- NO new Subscribed event
12:15:46.64  first dropped beacon -> 26 -> wedged for the full 120s
```

The subscription fired *before* the node became member-but-keyless, so #3453's gate correctly found nothing; the post-heal reconnect produced no fresh `Subscribed`, so it never got a second chance.

## The signal that is always there

The stranded node cannot verify **any** beacon: `verify_readiness_beacon` requires the signer to be a known member, and knowing members requires the very governance state it is missing. So it drops every one — 26 of them in the run above, each thrown away while it sat wedged.

Those dropped beacons are the missing signal. Every one is proof that a namespace peer is up, reachable, and talking to us *right now* — exactly what the stranded node needs.

## This trusts nothing new

The beacon is still refused: no membership row, no cache entry, none of its claims believed. Only the **fact of its arrival** is used, to pick a peer to pull from through the ordinary authenticated path, where every governance op must still validate on apply.

That is the distinction from #3413, which relaxed beacon verification itself and broke 27 app-migration scenarios. Relaxing verification widens what a stranger can assert about membership. Adding a trigger does not.

## Guards

* **Gated on the stranded condition** (`namespace_groups_member_but_keyless`) — a healthy node never reaches this arm, and the predicate goes false the moment recovery lands, so it stops on its own.
* **Its own debounce map**, not shared with the established-member or provable-admission arms. A stranded node cannot verify *any* beacon, so every beacon it receives would contend for a shared slot and starve the member anti-entropy path.
* **Keyed on namespace, never peer** — a Sybil swarm shares one budget. The trigger is an unauthenticated message and is treated as one.
* **Clock-drift bound** reused from the provable-admission arm, so a replayed beacon is not a trigger.

## Deliberately not reusing `spawn_beacon_divergence_sync`

The obvious move is to route this through the existing helper for beacons that fail verification. It cannot be: its `local_has_state` guard skips a namespace with no non-zero DAG head, which is *precisely* the stranded node this fixes.

That guard is load-bearing for more than its comment describes — relaxing it is what regressed the app-migration scenarios in #3413. So this arm does its own narrow pull and leaves the guard untouched. Noted in the code so the next reader does not re-derive it the hard way.

## Verification

`cargo fmt`, `cargo check`, `cargo clippy -p calimero-node --all-targets --features calimero-storage/testing -- -D warnings` clean.

Validation is by repeated `group-join-mesh-not-ready` runs, with per-run classification from the joiner's log (`dropped` beacon count and whether the recovery path logged). Baseline on post-#3449 master: **4 of 7 runs wedge, and wedging is terminal — 0 of 4 recover.** Results will be posted here as they land; this PR should not be judged on a single green run, since roughly half of all runs never enter the failure mode at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)