### PR TITLE
test(node): answer every NetworkMessage in the stub, unblocking untestable handlers

### DIFF
--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -234,11 +234,10 @@ async fn set_member_auto_follow_handler_error_paths() {
 // just on the call failing: a handler can return the right error and still have
 // written the row on the way there.
 //
-// The delete path itself is not driven here: `delete_context` calls
-// `node_client.unsubscribe` before it reaches the signing path, and this
-// harness has no network recipient wired up. The distinction it regressed on —
-// `resolve_identity` reads, `get_or_create_identity` writes — is pinned
-// directly in `calimero-governance-store`'s namespace tests instead.
+// The delete path IS driven now. It could not be, until the stub network actor
+// answered `Unsubscribe` — `delete_context` calls it as its first act, so the
+// handler died on a dropped mailbox before reaching any logic. That is why the
+// bug below shipped: no test could reach the code that had it.
 
 /// The signer resolution refuses a group this node takes no part in, and
 /// leaves no trace of having been asked.
@@ -289,6 +288,77 @@ async fn a_governance_call_for_an_unjoined_group_writes_no_participation_row() {
             .participates_in(&gid)
             .unwrap(),
         "the refused call still marked this node as participating"
+    );
+}
+
+/// The regression that shipped in the identity collapse, now reachable.
+///
+/// `delete_context` resolved its signing key through `get_or_create_identity`,
+/// which notes participation — so deleting a context whose group this node had
+/// never joined recorded it as a participant. A stale `ContextGroupRef` is
+/// exactly the state that reaches here.
+///
+/// The row is not inert: `iter_identities` enumerates it and the sync layer
+/// walks that set, so the residue is a node syncing against a namespace it was
+/// never in. Asserted on `participates_in` and not merely on the error, because
+/// the handler returned the right error while writing the row anyway.
+#[actix::test]
+async fn deleting_a_context_for_an_unjoined_group_writes_no_participation_row() {
+    let node = boot_test_node().await;
+
+    let mut rng = OsRng;
+    let gid = ContextGroupId::from([0x5Bu8; 32]);
+    let context_id = calimero_primitives::context::ContextId::from([0x5Cu8; 32]);
+    let admin_sk = PrivateKey::random(&mut rng);
+    let admin_pk = admin_sk.public_key();
+    let admin_account = calimero_context::test_support::enrol(&node.store, &gid, &admin_pk);
+
+    calimero_governance_store::MetaRepository::new(&node.store)
+        .save(&gid, &sample_meta(admin_account))
+        .unwrap();
+    calimero_governance_store::MembershipRepository::new(&node.store)
+        .add_member(&gid, &admin_account, GroupMemberRole::Admin)
+        .unwrap();
+
+    // The context row has to exist or the handler short-circuits on
+    // `has_context` and never reaches the signing path under test.
+    {
+        let meta = calimero_store::types::ContextMeta::new(
+            calimero_store::key::ApplicationMeta::new(ApplicationId::from([0x11u8; 32])),
+            /* root_hash = */ [0x01; 32],
+            /* dag_heads = */ Vec::new(),
+            /* service_name = */ None,
+        );
+        let mut handle = node.store.handle();
+        handle
+            .put(&calimero_store::key::ContextMeta::new(context_id), &meta)
+            .expect("put ContextMeta");
+    }
+    calimero_governance_store::register_context_in_group(&node.store, &gid, &context_id).unwrap();
+
+    assert!(
+        !calimero_governance_store::NamespaceRepository::new(&node.store)
+            .participates_in(&gid)
+            .unwrap(),
+        "precondition: this node takes no part in the group"
+    );
+
+    // Admin, so authorization passes and the identity read is what refuses.
+    let err = node
+        .context_client
+        .delete_context(&context_id, Some(admin_pk))
+        .await
+        .expect_err("no identity for the group means no detach op can be signed");
+    assert!(
+        err.to_string().contains("no signing identity"),
+        "unexpected error: {err}"
+    );
+
+    assert!(
+        !calimero_governance_store::NamespaceRepository::new(&node.store)
+            .participates_in(&gid)
+            .unwrap(),
+        "a delete marked this node as participating in the group it was deleting from"
     );
 }
 

--- a/crates/node/src/test_node_harness.rs
+++ b/crates/node/src/test_node_harness.rs
@@ -71,12 +71,27 @@ impl actix::Handler<calimero_network_primitives::messages::NetworkMessage> for S
         // `MessageId` is already in scope from the module-level import; only
         // `NetworkMessage` needs bringing in here for the match arms below.
         use calimero_network_primitives::messages::NetworkMessage;
-        // The admission publish path only samples mesh/peer state and
-        // best-effort-publishes. Resolve those `outcome` oneshots with a
-        // benign default so the awaiting client future completes; drop every
-        // other variant (none are reached by the paths under test, and a
-        // dropped receiver simply surfaces `MailboxError::Closed`). `let _ =`
-        // tolerates a caller that already stopped awaiting.
+        use calimero_network_primitives::network_status::{
+            AutonatEntry, NetworkStatusSnapshot, ReachabilityKind,
+        };
+        // EVERY variant is answered, and the match is deliberately exhaustive.
+        //
+        // `NetworkClient` resolves most of these with
+        // `.expect("Mailbox not to be dropped")`, so dropping a sender does not
+        // surface as a tidy `MailboxError` — it PANICS the caller. An unhandled
+        // variant therefore does not make a code path merely untested, it makes
+        // it untestable: the handler dies before reaching its own logic.
+        //
+        // That is not hypothetical. This arm list previously stopped at the
+        // paths one set of tests happened to touch, with a comment asserting
+        // none of the others were reached. `delete_context` calls `unsubscribe`
+        // as its first act, so it could not be driven by any test at all — and a
+        // real bug shipped on that handler, found by review rather than by a
+        // test, because no test could reach it.
+        //
+        // Exhaustive, so adding a `NetworkMessage` variant fails to compile here
+        // instead of quietly re-arming the trap. `let _ =` tolerates a caller
+        // that already stopped awaiting.
         match msg {
             NetworkMessage::MeshPeerCount { outcome, .. } => {
                 let _ = outcome.send(0);
@@ -120,7 +135,54 @@ impl actix::Handler<calimero_network_primitives::messages::NetworkMessage> for S
                     .push(request.0);
                 let _ = outcome.send(Err(eyre::eyre!("stub network: no transport")));
             }
-            _ => {}
+            // Echo the topic back, mirroring `Subscribe`. `delete_context` and
+            // the self-purge cascade both unsubscribe before doing anything
+            // else, so this is what makes those handlers reachable at all.
+            NetworkMessage::Unsubscribe { request, outcome } => {
+                let _ = outcome.send(Ok(request.0));
+            }
+            // No transport, so these are no-ops that succeed. Reporting failure
+            // would be a different lie from reporting success, and success keeps
+            // best-effort callers on their normal path rather than their error
+            // path — which is the one the tests here mean to exercise.
+            NetworkMessage::Dial { outcome, .. }
+            | NetworkMessage::ListenOn { outcome, .. }
+            | NetworkMessage::Bootstrap { outcome, .. } => {
+                let _ = outcome.send(Ok(()));
+            }
+            // Nobody is subscribed and no blob is anywhere: an empty answer, not
+            // an error. A caller that treats "no peers" as a failure is exercising
+            // its real degraded path.
+            NetworkMessage::SubscribedPeers { outcome, .. } => {
+                let _ = outcome.send(Vec::new());
+            }
+            NetworkMessage::QueryBlob { outcome, .. } => {
+                let _ = outcome.send(Ok(Vec::new()));
+            }
+            NetworkMessage::RequestBlob { outcome, .. } => {
+                let _ = outcome.send(Ok(None));
+            }
+            // Best-effort and already drop-tolerant on the client side, but
+            // answered anyway so the exhaustive match stays honest.
+            NetworkMessage::SetPeerScore { outcome, .. } => {
+                let _ = outcome.send(());
+            }
+            // A snapshot of a node with no transport: itself, reachable from
+            // nowhere.
+            NetworkMessage::NetworkStatus { outcome, .. } => {
+                let _ = outcome.send(NetworkStatusSnapshot {
+                    local_peer_id: libp2p::PeerId::random(),
+                    listen_addrs: Vec::new(),
+                    external_addrs: Vec::new(),
+                    relays: Vec::new(),
+                    rendezvous: Vec::new(),
+                    direct_upgrades: Vec::new(),
+                    autonat: AutonatEntry {
+                        reachability: ReachabilityKind::Unknown,
+                        last_test: None,
+                    },
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
A handler no test can reach is not merely untested — and that is not hypothetical here.

`NetworkClient` resolves most of its messages with `.expect("Mailbox not to be dropped")`. A variant the stub network actor does not answer is therefore **not** a tidy `MailboxError`: it panics the caller. So an unhandled variant leaves a code path *untestable*, because the handler dies before reaching its own logic.

Eight variants were unanswered, behind a `_ => {}` whose comment asserted none of them were reached by the paths under test:

| variant | client behaviour if unanswered |
| --- | --- |
| `Unsubscribe`, `Dial`, `ListenOn`, `Bootstrap`, `NetworkStatus`, `QueryBlob`, `RequestBlob`, `SubscribedPeers` | **panics** |
| `SetPeerScore` | tolerates the drop |

`delete_context` calls `unsubscribe` as its **first act**, so it could not be driven by any test at all. That is why the `get_or_create_identity` regression shipped in #3439 and was caught in review rather than by a test: no test could reach the code that had it.

## What changed

Every variant is answered, and the match is **exhaustive** — adding a `NetworkMessage` variant now fails to compile here instead of quietly re-arming the trap. Same reasoning as the `GroupOp` apply dispatch, which already carries a note telling reviewers to check it on variant additions.

The defaults describe a node with no transport: nobody subscribed, no blob anywhere, dials that succeed into the void. Chosen so best-effort callers take their normal path rather than their error path, since the normal path is the one these tests mean to exercise.

## The test it unblocks

`deleting_a_context_for_an_unjoined_group_writes_no_participation_row` — deleting a context whose group this node never joined must not record it as a participant. That row is not inert: `iter_identities` enumerates it and the sync layer walks that set, so the residue is a node syncing against a namespace it was never in.

Asserted on `participates_in`, **not** on the error, because the handler returned the right error while writing the row anyway.

**Verified by reverting the fix**: the test fails with the bug present and passes without it. That is the check I could not run when the path was unreachable, and the reason this PR exists rather than just the test.

## Verification

`cargo fmt --check`, both clippy runs, `cargo test --workspace`, the `mock-attestation` suite, and `cargo build -p merodb --features gui` all pass.

The one failure under full parallel load is `self_leave_drives_a_real_key_rotation_on_a_remaining_admin` (#3434), 5/5 in isolation. Checked deliberately rather than assumed: this PR changes the stub every test in that harness runs against, so "known flake" needed re-establishing, not citing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)