### PR TITLE
fix(network): re-dial from the peer cache when the book is empty

### DIFF
--- a/crates/network/src/discovery.rs
+++ b/crates/network/src/discovery.rs
@@ -178,6 +178,16 @@ impl NetworkManager {
     /// redundant dials. Errors are debug-logged; a genuine failure resurfaces
     /// as `OutgoingConnectionError`, which records the dial failure and leaves
     /// the parallel rendezvous recovery to carry the peer.
+    /// Still-fresh cached addresses for `peer_id`, most-recent-first.
+    ///
+    /// The reconnect fallback for the disconnect path, whose discovery-book
+    /// lookup goes empty once `remove_peer` has run for an earlier
+    /// `ConnectionClosed` on the same peer.
+    pub(crate) fn peer_cache_addrs_for(&self, peer_id: &PeerId) -> Vec<Multiaddr> {
+        self.peer_cache
+            .addrs_for(peer_id, self.now_unix_secs(), PEER_CACHE_TTL_SECS)
+    }
+
     pub(crate) fn redial_direct(&mut self, peer_id: PeerId, addrs: Vec<Multiaddr>) {
         if addrs.is_empty() {
             return;

--- a/crates/network/src/discovery/peer_cache.rs
+++ b/crates/network/src/discovery/peer_cache.rs
@@ -196,6 +196,32 @@ impl PeerAddrCache {
         out
     }
 
+    /// Still-fresh cached addresses for one peer, most-recent-first.
+    ///
+    /// The reconnect fallback for a peer the discovery book no longer holds
+    /// addresses for. `DiscoveryState::remove_peer` runs on the FIRST
+    /// disconnect and drops the book's addresses, so a peer that disconnects
+    /// more than once — connections closing in waves as keepalives expire at
+    /// different times — has an empty book by the second event, and the
+    /// re-dial that fires there has nothing to dial. This cache is not cleared
+    /// on disconnect (it is TTL'd, and its whole purpose is surviving one), so
+    /// it still knows where the peer was.
+    ///
+    /// Empty when the peer was never connected directly, or its entry aged
+    /// out; the caller then falls through to rendezvous recovery as before.
+    pub(crate) fn addrs_for(
+        &self,
+        peer_id: &PeerId,
+        now_secs: u64,
+        ttl_secs: u64,
+    ) -> Vec<Multiaddr> {
+        self.peers
+            .get(peer_id)
+            .filter(|p| now_secs.saturating_sub(p.last_seen_secs) <= ttl_secs)
+            .map(|p| p.addrs.clone())
+            .unwrap_or_default()
+    }
+
     /// All currently-cached, still-fresh peers, sorted by `peer_id`. A
     /// test-only inspection helper for the cache contents; production dials the
     /// recency-capped [`startup_dial_set`](Self::startup_dial_set) instead.
@@ -360,6 +386,46 @@ mod tests {
             entry.addrs[0],
             addr("/ip4/1.2.3.4/tcp/0"),
             "re-recorded addr moved to front"
+        );
+    }
+
+    /// The disconnect-path fallback: the cache must still hand back a peer's
+    /// addresses after the discovery book has dropped them, which is the whole
+    /// reason the second `ConnectionClosed` for a peer could not re-dial.
+    #[test]
+    fn addrs_for_returns_fresh_addresses_most_recent_first() {
+        let mut c = PeerAddrCache::default();
+        c.record(peer(1), addr("/ip4/1.2.3.4/tcp/1"), 100);
+        c.record(peer(1), addr("/ip4/5.6.7.8/tcp/2"), 110);
+
+        let got = c.addrs_for(&peer(1), 120, 1000);
+        assert_eq!(
+            got,
+            vec![addr("/ip4/5.6.7.8/tcp/2"), addr("/ip4/1.2.3.4/tcp/1")],
+            "most-recent address is dialed first"
+        );
+    }
+
+    #[test]
+    fn addrs_for_is_empty_for_unknown_or_stale_peers() {
+        let mut c = PeerAddrCache::default();
+        c.record(peer(1), addr("/ip4/1.2.3.4/tcp/1"), 100);
+
+        assert!(
+            c.addrs_for(&peer(2), 120, 1000).is_empty(),
+            "peer we never connected to directly yields nothing, so the caller \
+             falls through to rendezvous recovery"
+        );
+        // now=2000, ttl=1000 → last seen 1900s ago → stale.
+        assert!(
+            c.addrs_for(&peer(1), 2000, 1000).is_empty(),
+            "an aged-out entry is not dialed"
+        );
+        // Boundary: exactly at the TTL is still fresh.
+        assert_eq!(
+            c.addrs_for(&peer(1), 1100, 1000).len(),
+            1,
+            "entry exactly at the TTL edge is kept"
         );
     }
 

--- a/crates/network/src/handlers/stream/swarm.rs
+++ b/crates/network/src/handlers/stream/swarm.rs
@@ -204,7 +204,37 @@ impl StreamHandler<FromSwarm> for NetworkManager {
                         // flake. Empty for a purely relayed/NAT'd peer (their
                         // relayed address is never stored in the book), so those
                         // correctly fall through to the rendezvous path alone.
-                        let direct_addrs = self.discovery.state.peer_direct_addrs(&peer_id);
+                        let mut direct_addrs = self.discovery.state.peer_direct_addrs(&peer_id);
+
+                        // Fall back to the peer cache when the book has
+                        // nothing. `remove_peer` below drops the book's
+                        // addresses, and a peer's connections close in waves as
+                        // their keepalives expire at different times — so the
+                        // SECOND `ConnectionClosed` for the same peer captures
+                        // an empty list, and both the immediate re-dial and all
+                        // four re-fires below carry nothing to dial.
+                        //
+                        // That second event is the one that matters. A
+                        // partition drops the first connections while the
+                        // network is still down (the dial fires and fails), and
+                        // the stragglers close *after* the heal — precisely when
+                        // a dial would have succeeded. The cache is not cleared
+                        // on disconnect and is TTL'd rather than lifecycle'd, so
+                        // it still knows where the peer was.
+                        //
+                        // Still empty for a peer we never reached directly, so
+                        // relayed/NAT'd peers fall through to the rendezvous
+                        // path exactly as before.
+                        if direct_addrs.is_empty() {
+                            direct_addrs = self.peer_cache_addrs_for(&peer_id);
+                            if !direct_addrs.is_empty() {
+                                debug!(
+                                    %peer_id,
+                                    addrs = direct_addrs.len(),
+                                    "discovery book empty on disconnect; re-dialing from the peer cache"
+                                );
+                            }
+                        }
 
                         self.discovery.state.remove_peer(&peer_id);
 


### PR DESCRIPTION
Closes the residual `group-join-mesh-not-ready` failure left after #3462. Root cause is transport, not governance.

## What happens

A peer's connections do not all close at once — keepalives on separate connections expire at different times, so one peer produces several `ConnectionClosed` events seconds apart.

The first event captures the peer's direct addresses, re-dials (#3301), and then calls `remove_peer`, which drops those addresses from the discovery book. **Every later event for the same peer captures an empty list**, so `redial_direct` returns early and all four delayed re-fires (5s/15s/30s/60s) carry nothing to dial.

The later event is the one that matters:

```
13:43:10.68  partition applied
13:43:20.71  first connections close   -> addrs captured, dial fires INTO THE OUTAGE and fails
                                       -> remove_peer() empties the book
13:44:01.81  heal
13:44:20.72  stragglers close          -> book is empty, nothing to dial
             ... no dial issued for the rest of the run ...
13:46:22     'Wait for governance convergence after heal' fails at 120s
```

Node-2 issued **21 dials all run, none after 13:44:20**. Node-1 correspondingly saw 0 subscribers and logged **38 × `ReadinessBeacon publish failed — NoPeersSubscribedToTopic`**.

With no connection there are no beacons, so no governance-layer recovery can fire either — this is why #3462's trigger (and #3453's) could not help: there is no message flowing to trigger on.

## The fix

When the discovery book has nothing on disconnect, fall back to `PeerAddrCache`. That cache is TTL'd rather than tied to the connection lifecycle — surviving a disconnect is exactly why it exists — and it still holds the address the book just dropped.

Peers we never reached directly are absent from it, so relayed/NAT'd peers keep falling through to the rendezvous path unchanged. Dials remain deduped at the swarm level (`DisconnectedAndNotDialing`), and stale cached addresses that fail are evicted by the existing failure threshold.

## Why not the alternatives

* **Don't call `remove_peer` on disconnect** — it does more than hold addresses (role indices, failure counters); changing its lifecycle to fix a dial is a much wider blast radius than adding a fallback read.
* **Rely on rendezvous recovery** — `on_regular_peer_disconnected` returns `ReachabilityActions::none()` when there are no rendezvous peers, and its own doc says so ("Empty-action no-op if we have no rendezvous peers to query"). A 2-node cluster has none. This is a real gap beyond CI: any deployment without rendezvous infrastructure that loses a connection never reconnects on its own.

## Tests

Two unit tests on the new lookup: most-recent-first ordering, and empty for unknown / aged-out peers including the TTL boundary. `cargo test -p calimero-network --lib`: **113 passed, 0 failed**. `cargo fmt` and `cargo clippy -p calimero-network --all-targets -- -D warnings` clean.

The end-to-end effect is validated by repeated `group-join-mesh-not-ready` runs; results posted below as they land. Note that roughly half of all runs never enter the failure mode, so a green run alone proves little — the signal to look for is a dial issued after the post-heal disconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)