### PR TITLE
ci(e2e): make node data readable before uploading it

### DIFF
--- a/.github/workflows/e2e-rust-apps-release.yml
+++ b/.github/workflows/e2e-rust-apps-release.yml
@@ -370,6 +370,31 @@ jobs:
 
           echo "failed=$failed" >> $GITHUB_OUTPUT
 
+      # `merod` runs as root inside its container and creates its data dir
+      # 0700, so the unprivileged runner user cannot read back what the nodes
+      # wrote. `upload-artifact` treats that as fatal — it aborts zip creation
+      # on the first EACCES and fails the job — so this workflow reported
+      # failure on runs where all ten scenarios passed:
+      #
+      #   Error: EACCES: permission denied, open
+      #     '.../scaffolding-e2e/data/e2e-node-1/e2e-node-1/auth/000048.log'
+      #   Error: An error has occurred during zip creation for the artifact
+      #
+      # A permanently-red workflow is worse than no workflow: it trains readers
+      # to skip it, so the run where a scenario genuinely breaks looks the same
+      # as every other day.
+      #
+      # Relax the mode only (not ownership), and only for these throwaway
+      # per-run node directories. `a+rX` grants directory traversal without
+      # marking regular files executable. Kept as its own step rather than
+      # folded into the run above so a `cancelled()` run still skips it with
+      # the upload it feeds. `|| true` because a scenario that never started a
+      # node leaves no directory, which `if-no-files-found: warn` already
+      # covers.
+      - name: Make node data readable for artifact upload
+        if: ${{ !cancelled() }}
+        run: sudo chmod -R a+rX apps/scaffolding-e2e/data || true
+
       - name: Upload Workflow Data Artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
`E2E - Rust Apps (Released Image)` has been red on master while **every scenario passed**.

## What actually failed

Not a scenario — the artifact upload:

```
Error: EACCES: permission denied, open
  '.../apps/scaffolding-e2e/data/e2e-node-1/e2e-node-1/auth/000048.log'
Error: An error has occurred during zip creation for the artifact
```

`merod` runs as root inside its container and creates its data dir `0700`, so the unprivileged runner user cannot read back what the nodes wrote. `upload-artifact` aborts zip creation on the first `EACCES` and fails the job.

In [run 31898382492](https://github.com/calimero-network/core/actions/runs/31898382492): **10 scenarios completed successfully, 0 workflow failures**, job red. The sibling `Upload Docker Logs` step succeeded in the same run — only the data-dir artifact is affected.

## Why it is worth fixing rather than tolerating

A permanently-red workflow is worse than no workflow. It trains readers to skip it, so the run where a scenario genuinely breaks looks exactly like every other day.

## The fix

`sudo chmod -R a+rX apps/scaffolding-e2e/data` immediately before the upload.

* **Mode only, not ownership**, and only these throwaway per-run node directories.
* **`a+rX`** (capital X) so directories become traversable without marking regular files executable.
* **Its own step**, so a `cancelled()` run skips it together with the upload it feeds.
* **`|| true`** because a scenario that never started a node leaves no directory — already covered by `if-no-files-found: warn`.

## Why not just drop the path

Only this workflow uploads `scaffolding-e2e/data/`; the main `e2e-rust-apps.yml` uploads docker logs alone, which is why it never hit this. Dropping the path would also fix the error, but it would quietly narrow what a release run captures — a debugging decision worth making deliberately, not as a side effect of fixing a permission bug. Fixing the permission keeps the artifact intact.

Verified the workflow still parses and the step lands in the `test` job with the intended `if:` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)