### PR TITLE
fix(tee): report the account a replica speaks for on fleet-join

### DIFF
--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -933,6 +933,17 @@ pub struct FleetJoinResponse {
     pub group_id: String,
     pub namespace_id: String,
     pub public_key: String,
+    /// Hex-encoded `AccountId` this replica speaks for.
+    ///
+    /// `public_key` is its signing key, which is NOT what a member listing
+    /// reports — membership is recorded against the account. Without this a
+    /// caller cannot check that the replica was admitted, because it has no way
+    /// to turn the key it was given into the id the listing uses.
+    ///
+    /// `serde(default)` so a response from a node predating the field still
+    /// decodes here rather than failing outright.
+    #[serde(default)]
+    pub account: String,
     pub admitted: bool,
     /// `true` if the node successfully published `MemberSetAutoFollow` for
     /// itself after admission. `false` means admission succeeded but the

--- a/crates/server/src/admin/handlers/tee/fleet_join.rs
+++ b/crates/server/src/admin/handlers/tee/fleet_join.rs
@@ -136,6 +136,13 @@ pub async fn handler(
             }
         };
 
+    // Captured before `account` moves into the broadcast below. Reported because
+    // the caller cannot derive it: membership is recorded against the ACCOUNT a
+    // key speaks for, so a caller holding only `public_key` has nothing it can
+    // match a member listing against, and no endpoint maps one to the other from
+    // outside the node that owns it.
+    let account_id = account.cert.account;
+
     let broadcast = BroadcastMessage::TeeAttestationAnnounce {
         quote_bytes: attestation.quote_bytes,
         public_key: our_public_key,
@@ -461,6 +468,7 @@ pub async fn handler(
             "group_id": req.group_id,
             "namespace_id": hex::encode(ns_id.to_bytes()),
             "public_key": our_public_key.to_string(),
+            "account": hex::encode(account_id.as_bytes()),
             "admitted": admitted,
             "auto_follow_enabled": auto_follow_enabled,
             "contexts_joined": contexts_joined,


### PR DESCRIPTION
Ten TEE scenarios are red on merobox master, and this is why.

`assert_tee_member` compares fleet-join's `public_key` against the `identity` in a member listing. That listing now names members by **account** — deliberately, and that stays. But fleet-join returns only the signing key, and **no endpoint maps one to the other from outside the node that owns it**, so the comparison can never succeed. The assertion reports that a replica was never admitted when it was.

The handler already computes the account, to put in the announcement. This returns what it already had, captured before `account` moves into the broadcast.

## Why fix it here rather than in merobox

The information does not exist on the merobox side. The owner node runs the assertion and holds no mapping from the replica's key to its account; `GET /namespaces/:ns/identity` answers only for the node asking. Any merobox-side fix would be guessing.

## `FleetJoinResponse`

Worth flagging for review: the handler builds its body with `serde_json::json!` and does **not** use `FleetJoinResponse`, which is a hand-maintained parallel declaration consumed by `calimero-client` and `meroctl`. I updated it to match, with `#[serde(default)]` so a typed client reading a response from a node predating the field decodes it as empty rather than failing outright — the direction that matters, since a missing field is fatal to a typed client while an unknown one is ignored.

That the two can drift at all is a latent trap, but widening the scope to fix it belongs in its own change.

## Follow-up

A merobox PR moves the TEE scenarios onto `account`, which turns those ten jobs green and unblocks the 0.6.54 release (#331) that core is waiting on.

## Verification

`cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, server + primitives tests, and `--test route_manifest` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)