### PR TITLE
ci(e2e): stop uploading the node data dir that never uploaded

### DIFF
--- a/.github/workflows/e2e-rust-apps-release.yml
+++ b/.github/workflows/e2e-rust-apps-release.yml
@@ -370,31 +370,6 @@ jobs:
 
           echo "failed=$failed" >> $GITHUB_OUTPUT
 
-      # `merod` runs as root inside its container and creates its data dir
-      # 0700, so the unprivileged runner user cannot read back what the nodes
-      # wrote. `upload-artifact` treats that as fatal — it aborts zip creation
-      # on the first EACCES and fails the job — so this workflow reported
-      # failure on runs where all ten scenarios passed:
-      #
-      #   Error: EACCES: permission denied, open
-      #     '.../scaffolding-e2e/data/e2e-node-1/e2e-node-1/auth/000048.log'
-      #   Error: An error has occurred during zip creation for the artifact
-      #
-      # A permanently-red workflow is worse than no workflow: it trains readers
-      # to skip it, so the run where a scenario genuinely breaks looks the same
-      # as every other day.
-      #
-      # Relax the mode only (not ownership), and only for these throwaway
-      # per-run node directories. `a+rX` grants directory traversal without
-      # marking regular files executable. Kept as its own step rather than
-      # folded into the run above so a `cancelled()` run still skips it with
-      # the upload it feeds. `|| true` because a scenario that never started a
-      # node leaves no directory, which `if-no-files-found: warn` already
-      # covers.
-      - name: Make node data readable for artifact upload
-        if: ${{ !cancelled() }}
-        run: sudo chmod -R a+rX apps/scaffolding-e2e/data || true
-
       - name: Upload Workflow Data Artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
@@ -405,7 +380,6 @@ jobs:
             apps/scaffolding-e2e/res/abi.json
             apps/scaffolding-e2e/dist/*.mpk
             apps/scaffolding-e2e/res/state-schema.json
-            apps/scaffolding-e2e/data/
             apps/xcall-example/res/*.wasm
             apps/xcall-example/res/abi.json
           retention-days: 7


### PR DESCRIPTION
Follow-up to #3467, which fixed the same red workflow by widening permissions. This drops the path instead, and removes the `sudo chmod` that #3467 added.

## Why revisit something just merged

#3467's stated justification was that keeping the upload "keeps whatever debugging value the node state has." **That premise does not hold.** Checking the artifact listing on every recent run:

```
run 31898382492: data-artifacts=0
run 31897704128: data-artifacts=0
run 31897403505: data-artifacts=0
run 31895660717: data-artifacts=0
run 31895101856: data-artifacts=0
```

`apps/scaffolding-e2e/data/` has been listed in the artifact path since #2278 (2026-05-06) and has **never once produced an artifact**. Nothing can depend on it, because it has never existed to download — while costing a red job on every run for three months.

Across the last 100 runs of this workflow: **76 failures, 0 successes.**

## What the `data/` upload actually costs

`merod` runs as root inside its container and creates that directory `0700`, so the unprivileged runner user cannot read it back. `upload-artifact` aborts zip creation on the first `EACCES` and fails the whole job:

```
Error: EACCES: permission denied, open
  '.../scaffolding-e2e/data/e2e-node-1/e2e-node-1/auth/000048.log'
Error: An error has occurred during zip creation for the artifact
```

#3467 made that readable with `sudo chmod -R a+rX`. That works, but it spends a recursive privileged `chmod` in CI to keep collecting something no one has ever received.

## What replaces it

Nothing — and nothing is lost. The `Upload Docker Logs` step in the same job carries the node logs people actually debug from, and it has been succeeding all along. Node RocksDB/auth state is not what anyone reads for a scenario failure.

If release-run node state is ever genuinely wanted, it should come back as a **working** upload — a deliberate decision with a verified artifact, not a path that silently fails.

## Verification

Workflow still parses; the upload step retains its five real paths (wasm, abi.json, .mpk, state-schema.json, xcall wasm/abi) and the chmod step is gone.

Note that #3467 merged shortly before this was raised, so its fix has not yet had a run to prove itself — no execution of this workflow has occurred since. Either change makes the job green; this one also removes the privileged `chmod` and the dead path. If you would rather keep the upload and revisit later, closing this is a reasonable call — the workflow is not left broken either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)