### PR TITLE
chore: cut release 0.11.0-rc.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.21"
+version = "0.11.0-rc.22"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Cut to move the `merod:prerelease` container tag past #3468.

## Why a release is the fix

merobox runs its scenarios against `merod:prerelease` (`DEFAULT_IMAGE` in `merobox/commands/constants.py`), and **that tag only moves when this version changes**. The #3468 run pushed `merod:edge` and `merod:a1c7bf6` but **not** `prerelease`, because `docker_release` gates on a version bump:

| run | tags pushed |
| --- | --- |
| rc.21 cut (`da787d2b`) | `0.11.0-rc.21`, `prerelease`, `edge`, sha |
| #3468 (`a1c7bf62`) | `edge`, sha |

So `prerelease` still points at rc.21, and ten TEE scenarios fail against a node predating the field they read:

```
OUTPUT_CAPTURE_FAILED: Step 'TEE fleet-join attempt 1': output 'tee_account' captures 'account'
```

Nothing is wrong with those scenarios or with #3468 — the node under test is three commits too old.

## Worth a follow-up

merobox's CI comments state in several places that "docker mode runs against `merod:edge` (master)". The default is `prerelease`. The comments describe an intent the code does not implement, and that mismatch is what makes this failure mode confusing to diagnose. Whether merobox should track master or the latest rc is a real decision — this PR does not make it, it just uses the mechanism that exists.

## Unblocks

1. **merobox#335** — TEE assertions by account
2. **merobox#331** — release 0.6.54, shipping the `node_identity` step
3. **#3470** — deletes `create_account`, and needs that step released

## Verification

One line, matching the rc.21 cut exactly (no lockfile churn). `cargo metadata` resolves `metadata.workspaces.version = 0.11.0-rc.22`, which is the field the release workflow reads. `cargo fmt --check` and `cargo check --workspace` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)