### PR TITLE
chore(server): drop the node-minted JWT and challenge wire types

### DIFF
--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -596,70 +596,6 @@ impl GetPeersCountResponse {
     }
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct JwtTokenRequest {
-    pub context_id: ContextId,
-    pub executor_public_key: String,
-}
-
-impl JwtTokenRequest {
-    #[must_use]
-    pub const fn new(context_id: ContextId, executor_public_key: String) -> Self {
-        Self {
-            context_id,
-            executor_public_key,
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct JwtRefreshRequest {
-    pub refresh_token: String,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct NodeChallenge {
-    #[serde(flatten)]
-    pub message: NodeChallengeMessage,
-    pub node_signature: String,
-}
-
-impl NodeChallenge {
-    #[must_use]
-    pub const fn new(message: NodeChallengeMessage, node_signature: String) -> Self {
-        Self {
-            message,
-            node_signature,
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct NodeChallengeMessage {
-    pub nonce: String,
-    pub context_id: Option<ContextId>,
-    pub timestamp: i64,
-}
-
-impl NodeChallengeMessage {
-    #[must_use]
-    pub const fn new(nonce: String, context_id: Option<ContextId>, timestamp: i64) -> Self {
-        Self {
-            nonce,
-            context_id,
-            timestamp,
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncContextResponse {
@@ -1220,52 +1156,6 @@ impl Validate for TeeAttestRequest {
         // Nonce must be exactly 64 hex characters (32 bytes)
         if let Some(e) = validate_hex_string(&self.nonce, "nonce", 32) {
             errors.push(e);
-        }
-
-        errors
-    }
-}
-
-impl Validate for JwtTokenRequest {
-    fn validate(&self) -> Vec<ValidationError> {
-        let mut errors = Vec::new();
-
-        // executor_public_key should be a reasonable length
-        if self.executor_public_key.len() > 128 {
-            errors.push(ValidationError::StringTooLong {
-                field: "executor_public_key",
-                max: 128,
-                actual: self.executor_public_key.len(),
-            });
-        }
-
-        if self.executor_public_key.is_empty() {
-            errors.push(ValidationError::EmptyField {
-                field: "executor_public_key",
-            });
-        }
-
-        errors
-    }
-}
-
-impl Validate for JwtRefreshRequest {
-    fn validate(&self) -> Vec<ValidationError> {
-        let mut errors = Vec::new();
-
-        // Refresh tokens are typically JWTs which shouldn't exceed a reasonable size
-        if self.refresh_token.len() > 4096 {
-            errors.push(ValidationError::StringTooLong {
-                field: "refresh_token",
-                max: 4096,
-                actual: self.refresh_token.len(),
-            });
-        }
-
-        if self.refresh_token.is_empty() {
-            errors.push(ValidationError::EmptyField {
-                field: "refresh_token",
-            });
         }
 
         errors


### PR DESCRIPTION
## Summary

`JwtTokenRequest`, `JwtRefreshRequest`, `NodeChallenge` and `NodeChallengeMessage` date from when the node minted its own JWTs and signed login challenges. Authentication moved out to the `mero-auth` service, which has its own DTOs on its own router; the node server only *verifies* bearer tokens (`crates/server/src/auth.rs`) and never issues them.

**−110 lines, single file.**

## The tightest island in the audit

All **eleven** references are inside the file that defines them:

```
$ grep -rn 'JwtTokenRequest|JwtRefreshRequest|NodeChallenge' . --exclude-dir=.git --exclude-dir=target
crates/server/primitives/src/admin/mod.rs:602   pub struct JwtTokenRequest
crates/server/primitives/src/admin/mod.rs:607   impl JwtTokenRequest
crates/server/primitives/src/admin/mod.rs:620   pub struct JwtRefreshRequest
crates/server/primitives/src/admin/mod.rs:627   pub struct NodeChallenge
crates/server/primitives/src/admin/mod.rs:629       pub message: NodeChallengeMessage
crates/server/primitives/src/admin/mod.rs:633   impl NodeChallenge
crates/server/primitives/src/admin/mod.rs:635       pub const fn new(...)
crates/server/primitives/src/admin/mod.rs:646   pub struct NodeChallengeMessage
crates/server/primitives/src/admin/mod.rs:652   impl NodeChallengeMessage
crates/server/primitives/src/admin/mod.rs:1229  impl Validate for JwtTokenRequest
crates/server/primitives/src/admin/mod.rs:1252  impl Validate for JwtRefreshRequest
```

Four struct definitions, three `::new` impls, one field reference (`NodeChallenge` flattens `NodeChallengeMessage`), and two `Validate` impls. Nothing outside that file — not a route, not a handler, not a test, not even an `AGENTS.md` line. Most islands in this sweep had at least a doc echo; this one has nothing.

**Anchors proven absent:** no `token`/`refresh`/`challenge`/`login`/`jwt` path among the entries in `endpoints.json`, no matching `.route(` in `crates/server/src`, and `crates/auth` — the only thing that could plausibly want them — does not reference them at all.

## What made it look alive

The two `Validate` impls contain real logic, not stubs: a 128-byte cap and an empty check on `executor_public_key`, and a 4096-byte cap on `refresh_token`. A reader skimming the file sees working validation. But nothing constructs either request, so the impls and the types they guard are equally unreachable — the "trait impls as the whole point" trap.

## What looks similar but is alive

- **`calimero_client::JwtToken`** (`crates/client/src/storage.rs`) is a different type in a different crate, and is what `calimero-client-py` wraps. Untouched.
- **`crates/auth`** is the live authentication surface: `api/handlers/{auth,client_keys,root_keys}.rs` and `auth/token/jwt.rs`, with their own DTOs on their own router, plus a contract test. None of it imports from `calimero_server_primitives::admin`.
- **`crates/server/src/auth.rs`** is alive — the `AuthGuardService` verify side, mounted at four points. It consumes bearer tokens; it does not mint them.
- **`TeeAttestRequest`'s `Validate` impl sits between the two removed ones** in the same block and is routed at `POST /admin-api/tee/attest`. The dead impls are interleaved with a live one, which is why "the whole `Validate` block is stale" would have been the wrong conclusion.

## Verification

- `cargo check --workspace --all-targets` ✅
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` ✅ exit 0
- `cargo test -p calimero-server-primitives --test wire_fixtures` ✅ 6/6 — unchanged, since no field on a live route was touched

Found with the `unreachable-subsystems` skill (#3438).

🤖 Generated with [Claude Code](https://claude.com/claude-code)