### PR TITLE
fix(e2e): capture outputs the response actually carries

### DIFF
--- a/apps/scaffolding-e2e/workflows/group-join-via-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-join-via-inheritance.yml
@@ -80,7 +80,6 @@ steps:
     application_id: '{{app_id}}'
     outputs:
       namespace_id: namespaceId
-      node1_key: memberPublicKey
 
   - name: Invite node-2 to namespace
     type: create_namespace_invitation
@@ -123,6 +122,10 @@ steps:
     group_id: '{{subgroup_id}}'
     outputs:
       ctx_id: contextId
+      # The key node-1 executes context calls as. It is the context creation
+      # that mints it — namespace creation answers with a namespace id and
+      # nothing else.
+      node1_key: memberPublicKey
 
   - name: Wait for subgroup visibility + context-registered ops to propagate
     # Same rationale as group-open-self-join-key-delivery.yml: node-2

--- a/apps/scaffolding-e2e/workflows/group-membership.yml
+++ b/apps/scaffolding-e2e/workflows/group-membership.yml
@@ -246,11 +246,11 @@ steps:
     node: e2e-node-1
     group_id: '{{subgroup_id}}'
     outputs:
-      group_info: data
+      group_info_id: groupId
 
-  - name: Assert group info returned
+  - name: Assert group info describes the subgroup asked about
     type: assert
     statements:
-      - "is_set({{group_info}})"
+      - "{{group_info_id}} == {{subgroup_id}}"
 
 stop_all_nodes: false

--- a/apps/scaffolding-e2e/workflows/group-open-self-join-key-delivery.yml
+++ b/apps/scaffolding-e2e/workflows/group-open-self-join-key-delivery.yml
@@ -82,7 +82,6 @@ steps:
     application_id: '{{app_id}}'
     outputs:
       namespace_id: namespaceId
-      node1_key: memberPublicKey
 
   - name: Invite node-2 to namespace
     type: create_namespace_invitation
@@ -129,6 +128,10 @@ steps:
     group_id: '{{subgroup_id}}'
     outputs:
       ctx_id: contextId
+      # The key node-1 executes context calls as. It is the context creation
+      # that mints it — namespace creation answers with a namespace id and
+      # nothing else.
+      node1_key: memberPublicKey
 
   - name: Wait for subgroup visibility + context-registered ops to propagate
     # `set_subgroup_visibility` and `create_context` issue governance

--- a/apps/scaffolding-e2e/workflows/simple-sync.yml
+++ b/apps/scaffolding-e2e/workflows/simple-sync.yml
@@ -29,7 +29,6 @@ steps:
     outputs:
       context_id: contextId
       node1_key: memberPublicKey
-      node2_key: memberIdentity
 
   # Simple set on node-1
   - name: Set value on node-1


### PR DESCRIPTION
## Summary

**Every E2E run in the repo has been failing since 10:03 UTC today** — master and all open PRs — in scenario *setup*, before any product code runs. This fixes it.

merobox **v0.6.54** was published at 10:03:39Z, and CI installs the latest release. It contains merobox#328, *"fail a step whose outputs capture cannot bind, and an assertion holding an unresolved placeholder"*. Four scenarios have been capturing keys their step's response never returned; 0.6.53 warned, 0.6.54 fails the step:

```
❌ Step 'Create mesh with node-2' failed: [OUTPUT_CAPTURE_FAILED]
   output 'node2_key' captures 'memberIdentity', which the response does not have.
   Available: contextId, groupCreated, groupId, memberPublicKey
```

## What each capture was reaching for, and where the value really lives

| Scenario | Was | Now |
| --- | --- | --- |
| `simple-sync` | `node2_key: memberIdentity` on `create_mesh` | **deleted** — nothing read `node2_key` |
| `group-join-via-inheritance` | `node1_key: memberPublicKey` on `create_namespace` | moved to the `create_context` step on node-1 |
| `group-open-self-join-key-delivery` | same | same |
| `group-membership` | `group_info: data` on `get_group_info` | `group_info_id: groupId`, asserted equal to the subgroup asked about |

The two inheritance scenarios are the substantive ones. `create_namespace` answers with a namespace id and nothing else, so `{{node1_key}}` has never had a value — and it is passed as `executor_public_key` on three `call` steps in each scenario, plus an `is_set` assertion that was vacuous. The key node-1 executes context calls as is minted by the context creation, so the capture moves to the `create_context` step already running on node-1.

`group-membership` captured `data` — the response envelope, not a field in it — and asserted `is_set` on it, which any bound envelope satisfies. It now captures `groupId` and asserts it equals `{{subgroup_id}}`, which is the check that step was there to make.

## Verification

- Scanned **all 127 scenario YAMLs** against the response shapes the CI logs name for `create_mesh` / `create_context` / `create_namespace` / `get_group_info`: **zero** captures remain that cannot bind.
- `merobox bootstrap validate` passes on all four edited scenarios.
- The scenarios need real nodes, and the local Docker daemon isn't available, so **this PR's own E2E run is the proof** — the four jobs that fail on every other branch right now (`simple-sync`, `group-membership`, `group-join-via-inheritance`, `group-open-self-join-key-delivery`) must go green here.

## Note for reviewers

This is unrelated to, and unblocks, #3473 and #3474 — both are pure refactors whose E2E failures are entirely this. Those two need no change, just a re-run once this lands.

Two of these captures were hiding real gaps rather than being cosmetic: three `executor_public_key` values were literal `{{node1_key}}` placeholders, and one assertion could not fail. Worth a look at whether other step types carry the same latent pattern once CI is green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)