### PR TITLE
fix(test): stop three races in the self-leave rotation test

### DIFF
--- a/crates/context/src/rotation_listener.rs
+++ b/crates/context/src/rotation_listener.rs
@@ -38,6 +38,7 @@
 //!
 //! Both funnel into the same idempotent request, so they can overlap harmlessly.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
 use calimero_context_client::client::ContextClient;
@@ -56,6 +57,27 @@ struct HandleState {
 }
 
 static HANDLE: Mutex<Option<HandleState>> = Mutex::new(None);
+
+/// Bumped on every successful `spawn`, so a caller can tell whether the
+/// listener it started is still the one running.
+///
+/// The listener is a process-global singleton bound to one `Store`, and
+/// `spawn` rebinds it. In production that is what you want — one node, one
+/// store. Under a parallel test binary it means any test that boots a node
+/// silently takes the listener away from whatever test was using it, and the
+/// symptom lands far away: a pending rotation that nobody discharges, which
+/// reads as a broken op-event → listener → rotate → publish chain.
+///
+/// Exposing the generation lets a test say which of the two it hit instead of
+/// blaming the chain. See `#[serial(boot_test_node)]` on every test that boots
+/// a node — that guard is what keeps this from happening, and this counter is
+/// how a future gap in it announces itself.
+static GENERATION: AtomicU64 = AtomicU64::new(0);
+
+/// The current listener generation. See [`GENERATION`].
+pub fn generation() -> u64 {
+    GENERATION.load(Ordering::SeqCst)
+}
 
 /// Start the rotation listener. Returns immediately; it runs as a detached task.
 ///
@@ -80,6 +102,7 @@ pub fn spawn(store: Store, context_client: ContextClient) {
     })
     .abort_handle();
     *slot = Some(HandleState { abort });
+    let _ = GENERATION.fetch_add(1, Ordering::SeqCst);
 }
 
 /// Abort the listener. For tests and graceful shutdown; safe if none is running.

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -3417,38 +3417,81 @@ async fn self_leave_drives_a_real_key_rotation_on_a_remaining_admin() {
         "the leaver's membership row must be removed by the leave itself"
     );
 
-    // ...and the forward-secrecy debt is recorded, because the leaver could not have
-    // rotated for themselves.
+    // ...and the forward-secrecy debt is either still owed or already paid, because the
+    // leaver could not have rotated for themselves.
+    //
+    // Deliberately NOT `is_pending == true`. The row is transient by design: the
+    // rotation listener is concurrently racing to discharge it, which is the behaviour
+    // this test exists to prove. Asserting the row is still there asserts that the
+    // listener has NOT run yet — the opposite of what the test wants — and fails
+    // whenever it is quick. Either state is correct here; what must not happen is
+    // neither (a leave that recorded no debt and rotated nothing), which the key
+    // assertion at the end catches.
+    let debt_owed = PendingRotationRepository::new(&node.store)
+        .is_pending(
+            &sub_gid,
+            &calimero_context::test_support::account_for(&leaver_pk),
+        )
+        .expect("is_pending");
+    let already_paid = GroupKeyring::new(&node.store, sub_gid)
+        .load_current_key_record()
+        .expect("read the subgroup key")
+        .is_some_and(|k| k.key_id != key_before.key_id);
     assert!(
-        PendingRotationRepository::new(&node.store)
-            .is_pending(
-                &sub_gid,
-                &calimero_context::test_support::account_for(&leaver_pk)
-            )
-            .expect("is_pending"),
-        "the leave must record a pending rotation — nothing else will ever prompt one"
+        debt_owed || already_paid,
+        "the leave must record a pending rotation (or the listener must already have \
+         discharged it) — nothing else will ever prompt one"
     );
 
     // Now the part only this test covers: the listener fires on this node (a remaining
     // admin), publishes the rotation, and the pending row is discharged. Nothing here
     // is driven by the test — it is the production listener reacting to the op-event.
+    //
+    // The listener is a process-global singleton and every `boot_test_node` rebinds it
+    // to that node's store, so a concurrently-booting test steals it and this wait times
+    // out with the chain perfectly intact. Capture the generation to tell the two apart
+    // rather than leaving the next reader to re-derive it (as #3434 did).
+    let listener_generation = calimero_context::rotation_listener::generation();
     let store = node.store.clone();
+    let key_before_id = key_before.key_id;
     let cleared = wait_until(|| {
-        // A read error counts as "still pending" so a transient store fault cannot be
-        // mistaken for a successful rotation.
-        !PendingRotationRepository::new(&store)
+        // Wait for the OUTCOME, not the bookkeeping. The two land through different
+        // appliers: the new key rides as a sidecar on the enclosing namespace op and is
+        // stored by the namespace layer, while `GroupKeyRotated`'s own apply only clears
+        // the pending row (it "mutates no governance state" by design). Waiting on the
+        // row alone therefore returns in the window where the debt is discharged but the
+        // key has not landed yet, and the key assertion below fails on a rotation that
+        // was merely still in flight.
+        //
+        // A read error counts as "not yet" so a transient store fault cannot be mistaken
+        // for a successful rotation.
+        let discharged = !PendingRotationRepository::new(&store)
             .is_pending(
                 &sub_gid,
                 &calimero_context::test_support::account_for(&leaver_pk),
             )
-            .unwrap_or(true)
+            .unwrap_or(true);
+        let rekeyed = GroupKeyring::new(&store, sub_gid)
+            .load_current_key_record()
+            .ok()
+            .flatten()
+            .is_some_and(|k| k.key_id != key_before_id);
+        discharged && rekeyed
     })
     .await;
+    let rebound = calimero_context::rotation_listener::generation() != listener_generation;
     assert!(
         cleared,
-        "the rotation listener never discharged the pending rotation — the chain \
-         (op-event → listener → rotate_group_key handler → publisher) is broken, and the \
-         departed member would keep the subgroup key indefinitely"
+        "the rotation listener never discharged the pending rotation. {}",
+        if rebound {
+            "The listener was REBOUND to another store while this test ran (generation \
+             changed), so it was no longer watching this node — the chain is fine. Some \
+             test booted a node without #[serial(boot_test_node)]; add it there."
+        } else {
+            "The listener stayed bound to this node, so the chain (op-event → listener → \
+             rotate_group_key handler → publisher) is genuinely broken, and the departed \
+             member would keep the subgroup key indefinitely."
+        }
     );
 
     // The rotation was real: a fresh key, at a strictly higher epoch, is now current.

--- a/crates/node/src/provable_beacon_e2e.rs
+++ b/crates/node/src/provable_beacon_e2e.rs
@@ -33,6 +33,7 @@ use crate::readiness::{
     ReadinessState, ReadinessTier,
 };
 use crate::test_node_harness::{boot_test_node, TestNode};
+use serial_test::serial;
 
 const NS: [u8; 32] = [42u8; 32];
 
@@ -161,6 +162,7 @@ fn member_slot_claimed(node: &TestNode) -> bool {
 }
 
 #[actix::test]
+#[serial(boot_test_node)]
 async fn provable_beacon_pulls_from_its_signer_and_never_caches() {
     let node = boot_test_node().await;
     let admin_sk = PrivateKey::random(&mut rand::thread_rng());
@@ -205,6 +207,7 @@ async fn provable_beacon_pulls_from_its_signer_and_never_caches() {
 }
 
 #[actix::test]
+#[serial(boot_test_node)]
 async fn provable_pull_does_not_consume_the_member_debounce_slot() {
     let node = boot_test_node().await;
     let admin_sk = PrivateKey::random(&mut rand::thread_rng());
@@ -244,6 +247,7 @@ async fn provable_pull_does_not_consume_the_member_debounce_slot() {
 }
 
 #[actix::test]
+#[serial(boot_test_node)]
 async fn a_provable_pull_that_returns_nothing_gives_its_slot_back() {
     let node = boot_test_node().await;
     let admin_sk = PrivateKey::random(&mut rand::thread_rng());
@@ -272,6 +276,7 @@ async fn a_provable_pull_that_returns_nothing_gives_its_slot_back() {
 }
 
 #[actix::test]
+#[serial(boot_test_node)]
 async fn unprovable_beacon_pulls_nothing() {
     let node = boot_test_node().await;
     let admin_sk = PrivateKey::random(&mut rand::thread_rng());
@@ -410,6 +415,7 @@ async fn emit_beacon(addr: &actix::Addr<ReadinessManager>) {
 /// tests above start their own actor and post `PendingRepublish` directly, so a
 /// break anywhere in that routing would leave every one of them green.
 #[actix::test]
+#[serial(boot_test_node)]
 async fn a_queued_join_reaches_the_wire_through_the_node_client() {
     let node = boot_test_node().await;
     let joiner_sk = PrivateKey::random(&mut rand::thread_rng());
@@ -444,6 +450,7 @@ async fn a_queued_join_reaches_the_wire_through_the_node_client() {
 }
 
 #[actix::test]
+#[serial(boot_test_node)]
 async fn queued_join_rides_the_next_beacon_as_its_admission_proof() {
     let node = boot_test_node().await;
     let joiner_sk = PrivateKey::random(&mut rand::thread_rng());
@@ -479,6 +486,7 @@ async fn queued_join_rides_the_next_beacon_as_its_admission_proof() {
 }
 
 #[actix::test]
+#[serial(boot_test_node)]
 async fn beacon_carries_no_proof_without_a_queued_join() {
     let node = boot_test_node().await;
     let joiner_sk = PrivateKey::random(&mut rand::thread_rng());


### PR DESCRIPTION
Closes #3434.

The failure always blamed production: *"the chain (op-event → listener → rotate_group_key handler → publisher) is broken"*. **The chain was never broken.** Three separate test races were, each hidden behind the one before it — which is why a single-cause diagnosis never held.

## 1. A stolen listener

The rotation listener is a **process-global singleton**, and `boot_test_node` starts a `ContextManager` whose `started()` runs `rotation_listener::shutdown(); spawn(...)` — so every boot rebinds it to that node's store.

| file | boots | `#[serial(boot_test_node)]` |
|---|---|---|
| `local_governance_node_e2e.rs` | 17 | 17 ✓ |
| `cascade_dispatch_e2e.rs` | 8 | 8 ✓ |
| **`provable_beacon_e2e.rs`** | **7** | **0** ✗ |

A `provable_beacon_e2e` test booting concurrently took the listener away from this test, so its pending rotation was never discharged. That matches every observation in the issue: ~1-in-4 parallel, 490/490 single-threaded, passes alone.

Guarding those seven moved the rate to **1 in 20** — better, and not a fix. That residue was the next bug.

## 2. Waiting on bookkeeping instead of the outcome

The failure moved to the key assertion:

```
assertion `left != right` failed: the group's current key must actually CHANGE
```

The row and the key land through **different appliers**. `GroupKeyRotated`'s apply only clears the pending row — it *"mutates no governance state"* by design — while the new key rides as a sidecar on the enclosing namespace op and is stored by the **namespace layer**. Waiting on the row therefore returns in the window between the two, and the key assertion fires on a rotation still in flight.

The wait now requires the **key id to change**, not just the row to clear.

## 3. Requiring a row that is designed to disappear

The failure then moved *earlier*, to the precondition:

```
"the leave must record a pending rotation — nothing else will ever prompt one"
```

That asserts the row still **exists** after the leave — but the listener is racing to discharge it, which is the behaviour under test. A quick listener failed the precondition. It now accepts *owed or already paid*; the key assertion at the end is what proves neither happened.

**2 and 3 are one mistake mirrored:** a row that exists to be drained immediately was treated as a stable observable — once by waiting on it, once by requiring it.

## Diagnosability

Added a listener `generation()` counter, bumped per `spawn`. The wait's failure message now distinguishes:

* **REBOUND** — the listener moved to another store mid-test, so some test booted a node without the serial guard; the chain is fine
* **stayed bound** — the chain is genuinely broken

The reporter spent time diagnosing a regression that did not exist and settled it only by running master four times. The next reader gets told which it is.

## Verification

**25 consecutive clean runs** of `cargo test -p calimero-node --features mock-attestation --lib`.

Stated honestly: against the original 1-in-4 that is ~0.08% residual, but against the post-guard 1-in-20 a clean 25 is only ~28% — so the aggregate count alone is strong evidence for race 1 and moderate for 2 and 3. What I weigh more is that **races 2 and 3 were each directly observed failing** (at runs 10 and 5 of earlier rounds) and did not recur past those points once fixed.

`cargo fmt` and `cargo clippy -p calimero-node -p calimero-context --all-targets --features calimero-storage/testing,mock-attestation -- -D warnings` clean.

### Cost

The seven newly-guarded tests now serialise against the 25 that already were, so the `mock-attestation` job is somewhat slower. That is the price of a process-global singleton bound to one store. The alternative — making the listener non-global — is a production change to solve a test-isolation problem, which did not seem the right trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)