### PR TITLE
chore(server): drop JoinContextApiRequest, which no handler reads

### DIFF
--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2269,18 +2269,6 @@ pub struct SyncGroupApiResponseData {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct JoinContextApiRequest {
-    pub context_id: ContextId,
-}
-
-impl Validate for JoinContextApiRequest {
-    fn validate(&self) -> Vec<ValidationError> {
-        Vec::new()
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct JoinContextApiResponse {
     pub data: JoinContextApiResponseData,
 }


### PR DESCRIPTION
## Summary

`JoinContextApiRequest` is a one-field request body for an endpoint that takes no body. Two references in the entire repo, both in the file that defines it:

```
crates/server/primitives/src/admin/mod.rs:2272  pub struct JoinContextApiRequest
crates/server/primitives/src/admin/mod.rs:2276  impl Validate for JoinContextApiRequest
```

## Why it is unreachable

Unlike most islands in this sweep, **the route is alive** — `POST /admin-api/contexts/:context_id/join` is registered and working. It simply reads the id from the path rather than a body:

```rust
pub async fn handler(
    Path(context_id_str): Path<String>,
    Extension(state): Extension<Arc<AdminState>>,
) -> impl IntoResponse {
```

No `ValidatedJson<JoinContextApiRequest>` extractor, and correspondingly the client calls it with `post_no_body`:

```rust
.post_no_body(&format!("admin-api/contexts/{context_id}/join"))
```

So the missing anchor is not a route but an **extractor**. The type outlived a signature change from body to path parameter, and has had nothing to deserialize into it since. Its `Validate` impl returns an empty `Vec` and is the only other reference — the trait-impl trap again.

## What looks similar but is alive

`JoinContextApiResponse` and `JoinContextApiResponseData` sit five lines below in the same file and are fully alive: `join_context.rs` constructs them and `meroctl/src/output/groups.rs` reports them. Same `JoinContextApi*` prefix, opposite fate — which is why the family name is not a safe unit to reason about. The `// ---- Join Context ----` banner stays with them.

Every other `*ApiRequest` in the file **is** pulled through a `ValidatedJson<…>` extractor by a live handler; this was the only orphan of its kind.

## Verification

- `cargo check --workspace --all-targets` ✅
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` ✅ exit 0
- `cargo test -p calimero-server-primitives --test wire_fixtures` ✅ 6/6 — unchanged, no field on a live route touched

Found with the `unreachable-subsystems` skill (#3438).

🤖 Generated with [Claude Code](https://claude.com/claude-code)