### PR TITLE
chore: drop three features nothing can enable

### DIFF
--- a/crates/projection/Cargo.toml
+++ b/crates/projection/Cargo.toml
@@ -8,11 +8,6 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
-[features]
-# Exposes the convergence + scope-isolation property harness (`testing`
-# module) for reuse by the Phase-5 migration + Phase-6 sync tests.
-testing = []
-
 [dependencies]
 sha2.workspace = true
 

--- a/crates/projection/src/lib.rs
+++ b/crates/projection/src/lib.rs
@@ -23,7 +23,7 @@ use calimero_storage::address::Id;
 use calimero_storage::entities::OpMask;
 use calimero_storage::logical_clock::HybridTimestamp;
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(test)]
 pub mod testing;
 
 /// Last-writer-wins stamp for a slot: `(hlc, generation, op_id)` of the op that

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -16,7 +16,6 @@ ed25519-dalek.workspace = true
 fragile.workspace = true
 futures-util = { workspace = true, features = ["io"] }
 ouroboros.workspace = true
-owo-colors = { workspace = true, optional = true }
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
@@ -50,5 +49,4 @@ wasmer.workspace = true
 wat.workspace = true
 
 [features]
-host-traces = ["owo-colors"]
 profiling = ["wasmer-compiler-cranelift"]

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -290,30 +290,6 @@ macro_rules! _imports {
                     mut env: wasmer::FunctionEnvMut<'_, fragile::Fragile<*mut ()>>,
                     $($arg: $arg_ty),*
                 ) -> Result<($( $returns )?), wasmer::RuntimeError> {
-                    #[cfg(feature = "host-traces")]
-                    use owo_colors::OwoColorize;
-
-                    #[cfg(feature = "host-traces")]
-                    {
-                        let params: &[String] = &[$(
-                            format!(
-                                "{}: {} = {}",
-                                stringify!($arg).fg_rgb::<253, 151, 31>(),
-                                stringify!($arg_ty).fg_rgb::<102, 217, 239>(),
-                                $arg.fg_rgb::<190, 132, 255>()
-                            )
-                        ),*][..];
-
-                        let decorator = format!(
-                            "{} {}({})",
-                            "fn".fg_rgb::<102, 217, 239>(),
-                            stringify!($func).fg_rgb::<166, 226, 46>(),
-                            params.join(", ")
-                        );
-
-                        println!("{}", decorator);
-                    };
-
                     let res = std::panic::catch_unwind(core::panic::AssertUnwindSafe(|| {
                         let (data, store) = env.data_and_store_mut();
                         let data = unsafe { &mut *(*data.get_mut()).cast::<VMLogic<'_>>() };
@@ -339,18 +315,6 @@ macro_rules! _imports {
                             location: Location::Unknown,
                         }.into())
                     });
-
-                    #[cfg(feature = "host-traces")]
-                    {
-                        #[allow(unused_mut, unused_assignments)]
-                        let mut return_ty = "()";
-                        $( return_ty = stringify!($returns); )?
-                        println!(
-                            " ⇲ {}(..) -> {} = {res:?}",
-                            stringify!($func).fg_rgb::<166, 226, 46>(),
-                            return_ty.fg_rgb::<102, 217, 239>()
-                        );
-                    }
 
                     res.map_err(|err| wasmer::RuntimeError::user(Box::new(err)))
                 }

--- a/crates/sdk/macros/Cargo.toml
+++ b/crates/sdk/macros/Cargo.toml
@@ -19,5 +19,3 @@ syn = { workspace = true, features = ["extra-traits"] }
 thiserror.workspace = true
 sha2.workspace = true
 
-[features]
-nightly = []

--- a/crates/sdk/macros/src/lib.rs
+++ b/crates/sdk/macros/src/lib.rs
@@ -24,11 +24,6 @@
 //! - Simple emission: `app::emit!(MyEvent::DataChanged { data: "hello" })`
 //! - With callback handler: `app::emit!((MyEvent::CounterUpdated { value: 42 }, "counter_handler"))`
 
-#![cfg_attr(
-    all(test, feature = "nightly"),
-    feature(non_exhaustive_omitted_patterns_lint)
-)]
-
 use macros::parse_macro_input;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;

--- a/crates/sdk/macros/src/logic/utils.rs
+++ b/crates/sdk/macros/src/logic/utils.rs
@@ -4,7 +4,6 @@ use syn::{Path, Type};
 ///
 /// Also returns T in `&T`, `&mut T`, `(&T)`, `(&mut T)`, `(&T,)`, `(&mut T,)` and groups if `deref`
 pub fn typed_path(ty: &Type, deref: bool) -> Option<&Path> {
-    #[cfg_attr(all(test, feature = "nightly"), deny(non_exhaustive_omitted_patterns))]
     #[expect(clippy::wildcard_enum_match_arm, reason = "This is reasonable here")]
     match ty {
         Type::Path(path) => Some(&path.path),


### PR DESCRIPTION
## Summary

Three crates declare a feature that no dependency edge, CI invocation, or documented command turns on. The code behind each is unreachable and — more to the point — **unlinted**, since `--all-targets` compiles a crate with its default features only.

| crate | feature | cfg sites |
| --- | --- | --- |
| `calimero-runtime` | `host-traces` | 3 |
| `calimero-sdk-macros` | `nightly` | 2 |
| `calimero-projection` | `testing` | 1 |

## `host-traces`

Gates coloured tracing at the WASM import boundary. All three dependents (`crates/context`, `crates/config`, `crates/node`) write `calimero-runtime.workspace = true` with no features, and unlike merodb's `gui` there is not even a documented command to switch it on — there is no route to enabling it short of hand-editing a manifest.

Its `optional = true` `owo-colors` goes with it. The **unconditional dev-dependency** of the same crate stays, because `crates/runtime/src/lib.rs:695` acknowledges it (`use { … owo_colors as _, … }`) — a detail worth checking before assuming one line covers both.

## `nightly`

Doubly impossible. Nothing enables it, *and* the lint it turns on — `non_exhaustive_omitted_patterns` — is nightly-only, while `rust-toolchain.toml` pins `channel = "1.88.0"` and every CI job sets `toolchain: stable`. Even if a `--features nightly` appeared tomorrow, the lint name would not resolve.

The `#[app::*]` compile-fail suites are the working version of what this was reaching for: **trybuild**, plain stable `#[test]`s under bare `cargo test`. Probably why nobody missed it.

## `projection/testing` — narrowed, not deleted

This one needed care. Its gate is:

```rust
#[cfg(any(test, feature = "testing"))]
pub mod testing;
```

The `cfg(test)` half is **live** — the harness has ten passing tests under `cargo test -p calimero-projection`. Only the *feature* arm is dead: its stated purpose, "reuse by the Phase-5 migration + Phase-6 sync tests", never materialised, and all three dependents write the dependency bare.

So the gate narrows to `#[cfg(test)]` and the module stays. A naive reading of "feature enabled nowhere → delete the code" would have removed working coverage here, which is why the audit flagged it separately from the other two.

## What looks similar but is alive

`calimero-runtime/profiling` sits in the same `[features]` table as `host-traces` and is structurally identical — a feature pulling in the same crate's optional dep — but is reached via `calimero-context/profiling`, which `release.yml:254` enables. Two sibling features in one table, one live. They are not removed together.

`calimero-storage/testing` is the counter-example to `projection/testing`: same name, same cross-crate-reuse rationale, but it *did* land its consumers — `crates/dag`'s dev-dependency and `ci-checks.yml` both enable it. Four features written for that purpose; three got their consumer, one did not.

## Verification

- `cargo check --workspace --all-targets` ✅
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` ✅ exit 0
- `cargo test --workspace --no-fail-fast` ✅ — **4,740 passed, 0 failed** across 226 binaries
- `cargo test -p calimero-projection --lib` ✅ 10 passed — the harness still builds under `cfg(test)`

Found with the `unreachable-subsystems` skill (#3438).

🤖 Generated with [Claude Code](https://claude.com/claude-code)