### PR TITLE
ci: require merobox 0.6.55 for its bundled client-py

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -36,9 +36,19 @@ runs:
         #            does NOT reuse the revoked id, which has no literal to compare
         #            against; below this the statement is unrecognised, which reads
         #            as a failing assertion rather than an unsupported one.
+        #   0.6.55 — the bundled `calimero-client-py` is finally >= 0.6.28. The
+        #            binary is built with `pip install -r requirements.txt` then
+        #            PyInstaller, so requirements.txt decides what ships —
+        #            pyproject.toml does not. At 0.6.54 the two had drifted
+        #            (pyproject >=0.6.27, requirements >=0.6.24,<0.6.26), so the
+        #            released binary carried a client-py too old for the
+        #            `node_identity` step and every account scenario failed inside
+        #            the typed binding with "node identity read failed" — before
+        #            any HTTP call, which is why the node logs showed no request
+        #            at all. merobox#337 stopped the two pins drifting.
         # When this next moves: if the bundled client-py no longer requires
         # upgradePolicy, delete UPGRADE_POLICY_COMPAT (crates/server/primitives).
-        MIN_MEROBOX="0.6.52"
+        MIN_MEROBOX="0.6.55"
 
         case "$(uname -m)" in
           x86_64) MEROBOX_ARCH="linux-x86-64" ;;


### PR DESCRIPTION
The `MIN_MEROBOX` floor sat at 0.6.52 while the suite had come to depend on 0.6.55, and nothing enforced the gap: CI downloads `releases/latest`, so it works by coincidence of timing rather than as a checked precondition. A contributor pinning an older merobox locally, or a release being yanked, would surface as five unrelated-looking scenario failures.

## What 0.6.55 buys

The first release whose bundled `calimero-client-py` is `>= 0.6.28`.

The binary is built with `pip install -r requirements.txt` then PyInstaller, so **`requirements.txt` decides what ships — `pyproject.toml` does not.** At v0.6.54 the two had drifted:

| file at v0.6.54 | pin |
|---|---|
| `pyproject.toml` | `calimero-client-py>=0.6.27` |
| **`requirements.txt`** | **`>=0.6.24,<0.6.26`** |

So the released binary carried a client-py too old for the `node_identity` step. Every account scenario failed identically with `node identity read failed`, milliseconds in — **before any HTTP call**, which is why the node logs showed no request for the endpoint at all. merobox#337 ("stop the two dependency pins drifting") fixed it, released in 0.6.55, where both files now read `>=0.6.28`.

## Why a comment and not just a number

The block above `MIN_MEROBOX` records what each bump bought — 0.6.43 for the auth env forwarding, 0.6.50 for root `node_exec`, 0.6.52 for `json_not_equal`. This adds 0.6.55 in the same form, including the requirements-vs-pyproject detail, because the failure it prevents is genuinely hard to read backwards: the symptom appears in core's e2e, the cause is a packaging pin in another repo, and the node-side logs are silent by construction.

## Verification

The action YAML parses, and the floor comparison is unchanged in form (`sort -V` against the installed version). Verified against the released tag rather than merobox master:

```
$ git show v0.6.55:requirements.txt | grep client-py
calimero-client-py>=0.6.28
$ git show v0.6.55:pyproject.toml  | grep client-py
    "calimero-client-py>=0.6.28",
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)