### PR TITLE
chore: cut release 0.11.0-rc.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.22"
+version = "0.11.0-rc.23"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Cut to move the `merod:prerelease` container tag past the twelve commits merged since rc.22.

## Why a release is the mechanism

merobox runs its scenarios against `merod:prerelease` (`DEFAULT_IMAGE` in `merobox/commands/constants.py`), and **that tag only moves when this version changes** — `docker_release` gates on a version bump. Without a cut, every scenario keeps exercising a node that predates all of the below.

## Breaking

**#3470 — `POST /admin-api/namespaces/:ns/account` is gone.** Enrolment is implicit: every join path enrols by construction, so the endpoint published a link for a device that was already linked. What kept it alive was its return value — five scenarios called it purely for `outputs:`, after the join had already enrolled them, because `deviceId` and the account root had no other source. `GET /admin-api/identity` is that query now. `accountNonce` goes with it (32 zeros kept only so an older typed client could decode a response that no longer exists).

Anything calling that endpoint must read `GET /admin-api/identity` instead. Requires `calimero-client-py >= 0.6.28` and `merobox >= 0.6.55`, both released and now enforced by the CI floor (#3483).

## Behaviour a scenario can observe

| | |
| --- | --- |
| **#3462** | a stranded member recovers off the beacon it cannot verify — the dropped beacons become the recovery trigger |
| **#3466** | a peer is re-dialed from the address cache when the discovery book empties on a wave-close disconnect |

Both close variants of #3406 (`group-join-mesh-not-ready`), whose failure rate went from 4-of-7 runs to green.

## The rest

Cleanups, module splits and CI gates that do not alter runtime behaviour:

```
d158677b8 chore(store): drop the blobstore example, which cannot compile (#3480)
60eac7e59 chore: drop three features nothing can enable (#3481)
4c8891087 test(e2e): register account-facts-cross-namespace (#3482)
36eeb469b ci: require merobox 0.6.55 for its bundled client-py (#3483)
e48a463eb chore(server): drop JoinContextApiRequest, which no handler reads (#3479)
f3d79dafb fix(test): stop three races in the self-leave rotation test (#3477)
cb4e3e71a chore(server): drop the node-minted JWT and challenge wire types (#3475)
6812f9743 refactor(authz): split lib.rs into per-concern modules (#3474)
730f08d69 refactor(account): split lib.rs into per-concern modules (#3473)
5450e10de fix(e2e): capture outputs the response actually carries (#3476)
7e3436565 ci: fail when a merobox scenario runs in no matrix (#3463)
```

## The change

One line, `[workspace.metadata.workspaces].version` — the field whose own comment reads "bump this when cutting a release", matching the rc.22 cut (`25b1967b0`) exactly.

```
-version = "0.11.0-rc.22"
+version = "0.11.0-rc.23"
```

`Cargo.lock` does not pin the workspace version, so nothing else needs regenerating — also matching rc.22, which touched `Cargo.toml` alone.