### PR TITLE
fix(projection)!: attribute an op to the credential it carries, and reinstate the join checks that unblocks

### DIFF
--- a/crates/authz/src/authorize.rs
+++ b/crates/authz/src/authorize.rs
@@ -122,15 +122,7 @@ pub fn authorize(op: &Op, acl_at_cut: &AclView) -> Result<(), Rejected> {
             cert,
             ..
         } => {
-            // Cryptographic admissibility only. The two cross-checks the
-            // `DeviceLinked` arm adds are deliberately absent and cannot be
-            // reinstated here: a bridged join op's `authorship` is
-            // `legacy_authorship(signer)`, whose device is DERIVED from the
-            // stand-in rather than enrolled, so both the device-key and the
-            // account comparison would fail on a perfectly honest join. And
-            // `is_scope_member(verified.account)` cannot hold either — the whole
-            // point of a join is that the account is not a member yet.
-            let _verified = admit_device_link(
+            let verified = admit_device_link(
                 &acl_at_cut.accounts,
                 &acl_at_cut.devices,
                 &acl_at_cut.revoked_devices,
@@ -138,6 +130,31 @@ pub fn authorize(op: &Op, acl_at_cut: &AclView) -> Result<(), Rejected> {
                 chain,
                 cert,
             )?;
+            // The same possession check the `DeviceLinked` arm makes, which a
+            // join could not carry while its authorship was derived from the
+            // signing key: the device it names was fiction, so comparing against
+            // it refused every honest join. The op now names the device its
+            // certificate grants, so requiring the join to be signed BY that
+            // device is decidable — and without it, anyone who observed a
+            // certificate could replay it and join on the real device's behalf.
+            if op.authorship.device_key != verified.sign_pk
+                || op.authorship.device != verified.device
+            {
+                return Err(Rejected::DeviceKeyStale {
+                    device: verified.device,
+                });
+            }
+            // And that the account it joins as is the one the certificate
+            // grants to, rather than any account the payload cared to name.
+            if op.author() != verified.account {
+                return Err(Rejected::DeviceAccountMismatch {
+                    device: verified.device,
+                    bound: verified.account,
+                    claimed: op.author(),
+                });
+            }
+            // `is_scope_member(verified.account)` still cannot be required — the
+            // whole point of a join is that the account is not a member yet.
             if acl_at_cut.is_group_admin(&op.author(), *group) {
                 Ok(())
             } else {

--- a/crates/authz/src/tests/authorize.rs
+++ b/crates/authz/src/tests/authorize.rs
@@ -4,14 +4,16 @@
 
 use std::collections::BTreeMap;
 
-use calimero_account::{AccountId, RootKeyHandoff};
+use calimero_account::{AccountId, DeviceId, KemPublicKey, RootKeyHandoff};
 use calimero_context_config::types::ContextGroupId;
-use calimero_op::OpPayload;
+use calimero_op::{Authorship, Op, OpPayload, ScopeId};
 use calimero_primitives::context::GroupMemberRole;
 use calimero_storage::address::Id;
 use calimero_storage::entities::OpMask;
 
-use super::support::{bind_account, bind_test_devices, membership_view, op_with, view_with_writer};
+use super::support::{
+    bind_account, bind_test_devices, hlc0, membership_view, op_with, view_with_writer,
+};
 use crate::authorize::authorize;
 use crate::error::Rejected;
 use crate::view::AclView;
@@ -284,5 +286,83 @@ fn explicit_acl_overrides_default_write_for_restricted_objects() {
         Err(Rejected::NotPermitted {
             required: OpMask::WRITE
         })
+    );
+}
+
+/// **A join must be signed by the device its certificate grants to.**
+///
+/// This arm ran the cryptographic admissibility check and nothing else, because
+/// while an op's authorship was derived from its signing key the device it
+/// named was fiction — comparing against it refused every honest join, so the
+/// comparison was removed and a comment left in its place. Now that a projected
+/// op carries the device its certificate names, the check is decidable again.
+///
+/// What it stops: a certificate is public once observed. Without requiring
+/// possession of the granted key, anyone who saw one could replay it and join
+/// on the real device's behalf. Here the certificate is perfectly valid and the
+/// op is simply authored by somebody else's device — an admin's, no less, so
+/// the policy gate below would wave it through.
+#[test]
+fn a_join_replayed_by_another_device_is_refused() {
+    let admin = AccountId::from([1u8; 32]);
+    let group = ContextGroupId::from([9u8; 32]);
+
+    let root_sk = calimero_primitives::identity::PrivateKey::from([0x11u8; 32]);
+    let genesis = calimero_account::AccountGenesis::new(root_sk.public_key());
+    let joiner_key = calimero_primitives::identity::PrivateKey::from([0x22u8; 32]).public_key();
+    let granted_device = DeviceId::from([0x4D; 32]);
+    let cert = calimero_account::sign_device_cert(
+        &root_sk,
+        genesis.account_id(),
+        granted_device,
+        &joiner_key,
+        &KemPublicKey::from([0x2B; 32]),
+        0,
+        0,
+    )
+    .expect("sign the device cert");
+
+    let payload = OpPayload::MemberJoinedWithDevice {
+        group,
+        member: genesis.account_id(),
+        role: GroupMemberRole::Member,
+        genesis,
+        chain: vec![],
+        cert,
+    };
+
+    // Authored by the ADMIN's device rather than the granted one: the replay.
+    let replayed = op_with(admin, payload.clone());
+    let view = bind_account(
+        membership_view(group, genesis.account_id(), GroupMemberRole::Admin),
+        admin,
+    );
+    assert!(
+        matches!(
+            authorize(&replayed, &view),
+            Err(Rejected::DeviceKeyStale { .. })
+        ),
+        "a join carrying somebody else's certificate must be refused for not \
+         being signed by the device that certificate grants to"
+    );
+
+    // The same op, authored by the device the certificate actually names, is
+    // admitted — so the check above rejects the replay rather than the join.
+    let honest = Op::new(
+        ScopeId::from([0u8; 32]),
+        vec![],
+        Authorship {
+            account: genesis.account_id(),
+            device: granted_device,
+            device_key: joiner_key,
+        },
+        hlc0(),
+        payload,
+        [0u8; 32],
+        [0u8; 64],
+    );
+    assert!(
+        authorize(&honest, &view).is_ok(),
+        "the honest join must still pass, or the check above proves nothing"
     );
 }

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -2044,6 +2044,27 @@ mod tests {
 
     use super::*;
 
+    /// A **real** account for `sign_pk` — minted from a genesis the way
+    /// production does, not derived from the signing key by the bridge. That
+    /// distinction is the whole point of these fixtures: a plane that only works
+    /// because the account happens to be a function of the key proves nothing
+    /// about a plane keyed by real accounts.
+    ///
+    /// Deterministic in `sign_pk`, so every mention of the same key inside a test
+    /// names the same account without threading a value through.
+    fn test_account(sign_pk: &PublicKey) -> calimero_account::AccountId {
+        calimero_account::AccountGenesis::new(test_root_sk(sign_pk).public_key()).account_id()
+    }
+
+    /// The root key behind [`test_account`]. Distinct from `sign_pk` itself — an
+    /// account whose root IS the signing key would hide exactly the confusion
+    /// these tests exist to catch.
+    fn test_root_sk(sign_pk: &PublicKey) -> calimero_primitives::identity::PrivateKey {
+        let mut seed = **sign_pk;
+        seed[0] ^= 0xA5;
+        calimero_primitives::identity::PrivateKey::from(seed)
+    }
+
     fn hlc(ns: u64) -> HybridTimestamp {
         HybridTimestamp::new(Timestamp::new(
             NTP64(ns),
@@ -2068,7 +2089,7 @@ mod tests {
     /// `MemberJoinedOpen` inheritance proof.
     fn member_joined(group: ContextGroupId, member: PublicKey) -> RootOp {
         RootOp::MemberJoined {
-            member: legacy_account_id(&member),
+            member: test_account(&member),
             signed_invitation: SignedGroupOpenInvitation {
                 inviter_account: None,
                 invitation: GroupInvitationFromAdmin {
@@ -2205,7 +2226,7 @@ mod tests {
                 ns,
                 signer,
                 RootOp::AdminChanged {
-                    new_admin: legacy_account_id(&signer),
+                    new_admin: test_account(&signer),
                 },
             ),
             None,
@@ -2217,7 +2238,7 @@ mod tests {
         assert_eq!(
             op.payload,
             OpPayload::AdminChanged {
-                new_admin: legacy_account_id(&signer),
+                new_admin: test_account(&signer),
             }
         );
     }
@@ -2271,9 +2292,11 @@ mod tests {
         let op = op_from_rotation_entry(object, scope, &entry).expect("signed rotation maps");
         assert_eq!(
             op.author(),
-            legacy_account_id(&signer),
+            calimero_op_adapter::legacy_account_id(&signer),
             "author is the rotation signer, and a rotation entry names a KEY — so \
-             the adapter derives the author rather than resolving a binding"
+             the adapter derives the author rather than resolving a binding. This \
+             is an assertion ABOUT the bridge, so it stays until `build_op` gets a \
+             real credential to attribute the op to."
         );
         assert_eq!(op.hlc, hlc(5));
         assert_eq!(
@@ -2319,7 +2342,7 @@ mod tests {
             vec![],
             OpPayload::MemberAdded {
                 group,
-                member: legacy_account_id(&member),
+                member: test_account(&member),
                 role: GroupMemberRole::Member,
             },
         );
@@ -2328,7 +2351,7 @@ mod tests {
             vec![add.id()],
             OpPayload::MemberRemoved {
                 group,
-                member: legacy_account_id(&member),
+                member: test_account(&member),
             },
         );
 
@@ -2342,7 +2365,7 @@ mod tests {
         assert_eq!(
             pre.groups
                 .get(&group)
-                .and_then(|m| m.get(&legacy_account_id(&member))),
+                .and_then(|m| m.get(&test_account(&member))),
             Some(&GroupMemberRole::Member),
         );
 
@@ -2351,7 +2374,7 @@ mod tests {
         assert_eq!(
             post.groups
                 .get(&group)
-                .and_then(|m| m.get(&legacy_account_id(&member))),
+                .and_then(|m| m.get(&test_account(&member))),
             None
         );
 
@@ -2393,7 +2416,7 @@ mod tests {
             10,
             vec![],
             OpPayload::AdminChanged {
-                new_admin: legacy_account_id(&admin),
+                new_admin: test_account(&admin),
             },
         );
         reg.ingest_op(&admin_op);
@@ -2410,7 +2433,7 @@ mod tests {
             vec![admin_op.id()],
             OpPayload::MemberAdded {
                 group,
-                member: legacy_account_id(&member),
+                member: test_account(&member),
                 role: GroupMemberRole::Member,
             },
         ));
@@ -2442,23 +2465,16 @@ mod tests {
 
         let mut reg = ScopeProjections::new();
         // Before the join: nothing recorded.
-        assert_eq!(
-            reg.role_of(&ns_scope, &group, &legacy_account_id(&member)),
-            None
-        );
+        assert_eq!(reg.role_of(&ns_scope, &group, &test_account(&member)), None);
         reg.ingest_op(&join);
         // After: the member is recorded for the group, under the namespace scope.
         assert_eq!(
-            reg.role_of(&ns_scope, &group, &legacy_account_id(&member)),
+            reg.role_of(&ns_scope, &group, &test_account(&member)),
             Some(GroupMemberRole::Member),
         );
         // A different namespace's scope is unaffected (isolation across namespaces).
         assert_eq!(
-            reg.role_of(
-                &ScopeId::from([0xEE; 32]),
-                &group,
-                &legacy_account_id(&member)
-            ),
+            reg.role_of(&ScopeId::from([0xEE; 32]), &group, &test_account(&member)),
             None,
         );
     }
@@ -2477,7 +2493,7 @@ mod tests {
         let add = op_from_namespace_op(
             &signed_group(ns, signer, group),
             Some(&GroupOp::MemberAdded {
-                member: legacy_account_id(&member),
+                member: test_account(&member),
                 role: GroupMemberRole::Admin,
             }),
             [0xAB; 32],
@@ -2493,7 +2509,7 @@ mod tests {
         let mut reg = ScopeProjections::new();
         reg.ingest_op(&add);
         assert_eq!(
-            reg.role_of(&ns_scope, &group, &legacy_account_id(&member)),
+            reg.role_of(&ns_scope, &group, &test_account(&member)),
             Some(GroupMemberRole::Admin),
         );
 
@@ -2501,7 +2517,7 @@ mod tests {
         let remove = op_from_namespace_op(
             &signed_group(ns, signer, group),
             Some(&GroupOp::MemberRemoved {
-                member: legacy_account_id(&member),
+                member: test_account(&member),
                 expected_group_state_hash: [0u8; 32],
                 expected_context_state_hashes: Vec::new(),
             }),
@@ -2510,10 +2526,7 @@ mod tests {
             &[[0xAB; 32]],
         );
         reg.ingest_op(&remove);
-        assert_eq!(
-            reg.role_of(&ns_scope, &group, &legacy_account_id(&member)),
-            None
-        );
+        assert_eq!(reg.role_of(&ns_scope, &group, &test_account(&member)), None);
 
         // A truly out-of-model group op folds as a Noop node (still recorded).
         let other = op_from_namespace_op(
@@ -2550,7 +2563,7 @@ mod tests {
                 ns,
                 signer,
                 RootOp::AdminChanged {
-                    new_admin: legacy_account_id(&signer),
+                    new_admin: test_account(&signer),
                 },
             ),
             None,
@@ -2572,7 +2585,7 @@ mod tests {
         assert!(
             view.groups
                 .get(&group)
-                .is_some_and(|m| m.contains_key(&legacy_account_id(&member))),
+                .is_some_and(|m| m.contains_key(&test_account(&member))),
             "member must be visible at the namespace-head cut"
         );
     }

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -26,7 +26,7 @@ use calimero_governance_store::{
     NamespaceDagService, NamespaceOpLogService, NamespaceRepository,
 };
 use calimero_op::{Op, OpPayload, ScopeId};
-use calimero_op_adapter::{legacy_account_id, set_writers_payload};
+use calimero_op_adapter::set_writers_payload;
 use calimero_primitives::context::{ContextId, GroupMemberRole};
 use calimero_primitives::identity::PublicKey;
 use calimero_projection::ScopeState;
@@ -113,41 +113,17 @@ type AuthCutContext = (
 /// precisely what `denied_members` and `accounts_by_endorsing_member` avoid: it can
 /// only be populated while observing bindings, so it comes back empty after a
 /// projection rebuild and silently reverts every device to the fallback.
-fn account_for_author(view: &calimero_authz::AclView, key: &PublicKey) -> AccountId {
-    // An explicit binding wins over the derived id. A folded `DeviceLinked` is a
-    // signed statement about THIS key; `legacy_account_id` is a guess that names a
-    // real principal nowhere now that the live plane keys every row by account.
-    //
-    // This order is the reverse of what it was, and the reversal is the point.
-    // While membership was key-keyed, preferring the binding made a member who
-    // enrolled a device resolve to an account the rows did not know, and the
-    // member vanished — so the derived id had to win. Keying the rows by account
-    // removes that hazard and introduces the mirror one: stale key-derived ids
-    // still enter this view (`SubgroupCreated.admin` folds one), and letting them
-    // win makes the founder stop being admin of its own namespace the moment it
-    // creates a subgroup. Every peer then refuses what the founder signs while
-    // the founder accepts it — which is a `scope_root` split, not a hiccup.
-    if let Some(binding) = view
-        .devices
+fn account_for_author(view: &calimero_authz::AclView, key: &PublicKey) -> Option<AccountId> {
+    // A folded `DeviceLinked` is a signed statement that this key speaks for an
+    // account. There is no second answer any more: the stand-in that used to be
+    // returned here named a principal nowhere, since every row on this plane is
+    // account-keyed, and every caller below turned it into "not authorized" one
+    // step later. Returning `None` says that directly instead of routing it
+    // through an account nobody has heard of.
+    view.devices
         .values()
         .find(|binding| binding.sign_pk == *key)
-    {
-        return binding.account;
-    }
-    // No binding folded for this key, so all that is left is the stand-in. It
-    // names a real principal nowhere — every row on this plane is account-keyed —
-    // which is the correct answer for an author nobody has heard of: the
-    // authorization queries downstream all resolve it to "no".
-    //
-    // There used to be a `view_knows_author` check here, asking whether the
-    // derived id was one the view recognised. It could not change the outcome —
-    // both arms returned the same value — and it has not been able to since the
-    // binding/derived precedence was reversed. Measured before removing it: over
-    // the fold-equivalence suites the fallback is taken 13 times, and the only 4
-    // where the derived id WAS recognised come from a fixture that seeds the
-    // namespace's genesis admin as a stand-in itself. Production writes real
-    // accounts at every `admin_identity` site.
-    legacy_account_id(key)
+        .map(|binding| binding.account)
 }
 
 fn build_op(
@@ -1504,12 +1480,8 @@ impl ScopeProjections {
             .flatten()
             .unwrap_or(0);
         if view.as_ref().is_some_and(|v| {
-            v.is_member_at_cut(
-                group,
-                &account_for_author(v, author),
-                root,
-                default_cap_base,
-            )
+            account_for_author(v, author)
+                .is_some_and(|account| v.is_member_at_cut(group, &account, root, default_cap_base))
         }) {
             return Some(true);
         }
@@ -1653,12 +1625,8 @@ impl ScopeProjections {
             .flatten()
             .unwrap_or(0);
         Some(self.acl_view_at(&scope, heads).is_some_and(|v| {
-            v.is_member_at_cut(
-                group,
-                &account_for_author(&v, author),
-                root,
-                default_cap_base,
-            )
+            account_for_author(&v, author)
+                .is_some_and(|account| v.is_member_at_cut(group, &account, root, default_cap_base))
         }))
     }
 
@@ -1677,7 +1645,10 @@ impl ScopeProjections {
         heads: &[[u8; 32]],
     ) -> Option<bool> {
         let (view, root, _) = self.auth_cut_context(store, group, heads)?;
-        Some(view.is_authorized_admin(group, &account_for_author(&view, author), root))
+        Some(
+            account_for_author(&view, author)
+                .is_some_and(|account| view.is_authorized_admin(group, &account, root)),
+        )
     }
 
     /// Is `member` an admin of `group` at the cut? The account-typed sibling of
@@ -1726,10 +1697,15 @@ impl ScopeProjections {
         heads: &[[u8; 32]],
     ) -> Option<bool> {
         let (view, root, default_cap_base) = self.auth_cut_context(store, group, heads)?;
-        if view.is_authorized_admin(group, &account_for_author(&view, author), root) {
+        // An author no binding speaks for holds no capability and is no admin:
+        // there is no account to look either up against.
+        let Some(account) = account_for_author(&view, author) else {
+            return Some(false);
+        };
+        if view.is_authorized_admin(group, &account, root) {
             return Some(true);
         }
-        let folded = view.capability(&group, &account_for_author(&view, author));
+        let folded = view.capability(&group, &account);
         let effective = if folded != 0 {
             folded
         } else {
@@ -1882,7 +1858,7 @@ impl ScopeProjections {
         // with the decision it is meant to explain.
         let author_in_any = view
             .as_ref()
-            .is_some_and(|v| v.is_scope_member(&account_for_author(v, author)));
+            .is_some_and(|v| account_for_author(v, author).is_some_and(|a| v.is_scope_member(&a)));
         // Is the DECISION group folded at all, and how big? Distinguishes
         // "subgroup membership never folded" (group absent / size 0 — a
         // decrypt/sync gap) from "folded but author absent" (re-add / deny-list).
@@ -1949,7 +1925,7 @@ impl ScopeProjections {
         // key was a member and the role lookup found nobody, which is the
         // "member at cut but role unresolved" the caller then logged before
         // guessing `Member`.
-        let account = account_for_author(&view, member);
+        let account = account_for_author(&view, member)?;
         match view.member_path_at_cut(group, &account, root, default_cap_base) {
             calimero_authz::MemberPathAtCut::None => None,
             calimero_authz::MemberPathAtCut::Direct { role } => Some(role),

--- a/crates/context/tests/projection_membership_equivalence.rs
+++ b/crates/context/tests/projection_membership_equivalence.rs
@@ -22,6 +22,7 @@ use calimero_context_config::{MemberCapabilities, VisibilityMode};
 use calimero_governance_store::{
     self, CapabilitiesRepository, MembershipRepository, MetaRepository, NamespaceRepository,
 };
+use calimero_op::ScopeId;
 use calimero_primitives::context::GroupMemberRole;
 use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
@@ -814,28 +815,24 @@ fn a_folded_join_device_does_not_hide_an_inherited_admin() {
 
     // The admin is a direct member of the ROOT ONLY — its subgroup access is
     // inherited, exactly like the namespace owner in the scenario.
-    // Keyed by the KEY-derived account throughout this test, unlike the suites
-    // above. Its whole premise is that the admin has no folded presence, so the
-    // projection can only reach it through the out-of-band root — and that path
-    // compares the ROOT's `admin_identity` against what a key resolves to with
-    // nothing folded, which is this derivation. An enrolment-derived account
-    // would be unreachable there, and the test would fail for its setup rather
-    // than for the behaviour it guards.
+    //
+    // Keyed by the admin's REAL account, and its device link folded, because
+    // that is what production looks like: `admin_identity` is a real account at
+    // every site that writes it, and a founder reaches the view through the
+    // credential its `NamespaceCreated` carries. This test used to seed BOTH
+    // sides as key-derived stand-ins, so the out-of-band root matched what a
+    // bare key resolved to — the two agreed only because they were the same
+    // derivation, which no production namespace reproduces.
+    let admin_credential = real_join_account_for(&admin, [0x6C; 32]);
+    let admin_account = admin_credential.cert.account;
     MetaRepository::new(&store)
-        .save(&ns, &meta(calimero_op_adapter::legacy_account_id(&admin)))
+        .save(&ns, &meta(admin_account))
         .unwrap();
     MetaRepository::new(&store)
-        .save(
-            &subgroup,
-            &meta(calimero_op_adapter::legacy_account_id(&admin)),
-        )
+        .save(&subgroup, &meta(admin_account))
         .unwrap();
     MembershipRepository::new(&store)
-        .add_member(
-            &ns,
-            &calimero_op_adapter::legacy_account_id(&admin),
-            GroupMemberRole::Admin,
-        )
+        .add_member(&ns, &admin_account, GroupMemberRole::Admin)
         .unwrap();
     NamespaceRepository::new(&store)
         .nest(&ns, &subgroup)
@@ -861,45 +858,53 @@ fn a_folded_join_device_does_not_hide_an_inherited_admin() {
         [0xBF; 32],
     );
 
-    // Baseline: before any join folds, the admin inherits into the subgroup.
-    assert_eq!(
-        proj.member_at_cut(&store, subgroup, &admin, &[s2]),
-        Some(true),
-        "baseline: the root admin reaches an Open child by inheritance"
-    );
-
-    // The ADMIN's OWN device folds — the case that matters. The genesis admin has
-    // no membership OP anywhere: it is seeded as a store row and reaches the
-    // folded view only through the out-of-band `root` parameter, keyed by
-    // `legacy_account_id`. So it is exactly the principal `account_for_author`'s
-    // own precedence guard cannot see.
-    let admin_join_open = SignedNamespaceOp::sign(
+    // The admin's credential folds at the ROOT, and nowhere near the subgroup.
+    //
+    // A key only becomes attributable once some op binds it, and the binding
+    // lives in the namespace-wide view — so an admin needs a credential folded
+    // SOMEWHERE in the namespace, not in the child. Folding it at the root is
+    // what production looks like and it keeps the case honest: the admin still
+    // has no folded presence in the subgroup, so reaching it can only be the
+    // inheritance walk. Folding an open-join into the subgroup instead would
+    // hand the admin a direct presence there and prove something easier.
+    let admin_join_root = SignedNamespaceOp::sign(
         &admin_sk,
         ns.to_bytes().into(),
         vec![],
         7,
-        NamespaceOp::Root(RootOp::MemberJoinedOpen {
-            member: calimero_op_adapter::legacy_account_id(&admin),
-            group_id: subgroup.to_bytes().into(),
-            account: real_join_account_for(&admin, [0x7A; 32]),
+        NamespaceOp::Root(RootOp::MemberJoined {
+            member: admin_account,
+            signed_invitation: sign_invitation(&admin_sk, ns, 2, [0x77; 32]),
+            account: admin_credential,
         }),
     )
-    .expect("sign admin open-join");
+    .expect("sign admin root-join");
     let id0 = [0xB7; 32];
     proj.ingest_op(&op_from_namespace_op(
-        &admin_join_open,
+        &admin_join_root,
         None,
         id0,
         hlc(1),
         &[s2],
     ));
 
+    // #3489's criterion, exactly: a namespace admin with a REAL enrolled account
+    // inherits into an Open subgroup created by another member, holding no folded
+    // presence in that subgroup at all.
     assert_eq!(
         proj.member_at_cut(&store, subgroup, &admin, &[id0]),
         Some(true),
-        "folding the admin's OWN device must not un-member it: membership on this \
-         plane is keyed by the stand-in, and the genesis admin is known only \
-         through the out-of-band root"
+        "baseline: the root admin reaches an Open child by inheritance"
+    );
+    assert!(
+        !proj
+            .acl_view_at(&ScopeId::from(ns.to_bytes()), &[id0])
+            .expect("scope fed")
+            .groups
+            .get(&subgroup)
+            .is_some_and(|m| m.contains_key(&admin_account)),
+        "and it must reach it WITHOUT a folded row in the subgroup, or the \
+         assertion above would be proving direct membership"
     );
 
     // The joiner joins the namespace carrying a credential that really folds.
@@ -916,7 +921,7 @@ fn a_folded_join_device_does_not_hide_an_inherited_admin() {
     )
     .expect("sign join_ns");
     let id1 = [0xB1; 32];
-    proj.ingest_op(&op_from_namespace_op(&join_ns, None, id1, hlc(1), &[s2]));
+    proj.ingest_op(&op_from_namespace_op(&join_ns, None, id1, hlc(1), &[id0]));
 
     // ...and then into the Open subgroup by inheritance, credential and all.
     let join_sub = SignedNamespaceOp::sign(
@@ -1200,5 +1205,72 @@ fn an_explicit_binding_outranks_the_key_derived_stand_in() {
         Some(true),
         "the binding must still decide who this key is, or the founder resolves \
          to a principal the account-keyed rows have never heard of"
+    );
+}
+
+/// **A join is attributed to the account its certificate names, not to a
+/// stand-in derived from its signing key.**
+///
+/// This is the property the whole bridge deletion turns on. While
+/// `op_from_namespace_op` synthesised authorship with
+/// `legacy_authorship(signer)`, a join op's `device` was a reinterpretation of
+/// the derived account's bytes — a device that was never enrolled and holds no
+/// key. `calimero_authz::authorize` says so at its `MemberJoinedWithDevice`
+/// arm, where two cross-checks its `DeviceLinked` sibling runs are documented
+/// as impossible precisely because "both the device-key and the account
+/// comparison would fail on a perfectly honest join".
+///
+/// So this asserts the three things those checks need: the op is attributed to
+/// the certified account, to the certified device, and to the key that signed
+/// it. Assert the stand-in is a *different* account too — otherwise the first
+/// assertion could pass for the wrong reason.
+#[test]
+fn a_join_is_attributed_to_the_account_its_certificate_names() {
+    let joiner_sk = PrivateKey::random(&mut OsRng);
+    let joiner = joiner_sk.public_key();
+    let ns = ContextGroupId::from([0x21; 32]);
+    let group = ContextGroupId::from([0x22; 32]);
+
+    let credential = real_join_account_for(&joiner, [0x4D; 32]);
+    let certified_account = credential.cert.account;
+    let certified_device = credential.cert.device;
+
+    let join = SignedNamespaceOp::sign(
+        &joiner_sk,
+        ns.to_bytes().into(),
+        vec![],
+        1,
+        NamespaceOp::Root(RootOp::MemberJoinedOpen {
+            member: certified_account,
+            group_id: group.to_bytes().into(),
+            account: credential,
+        }),
+    )
+    .expect("sign the join");
+
+    let op = op_from_namespace_op(&join, None, [0x9C; 32], hlc(1), &[]);
+
+    assert_eq!(
+        op.author(),
+        certified_account,
+        "the op must name the account the certificate grants to, since that is \
+         what `authorize` compares its verified account against"
+    );
+    assert_eq!(
+        op.device(),
+        certified_device,
+        "and the enrolled device, which is the CRDT replica slot — a fabricated \
+         one makes every account share a single slot"
+    );
+    assert_eq!(
+        *op.device_key(),
+        joiner,
+        "and the key that actually signed it, so possession can be required"
+    );
+    assert_ne!(
+        certified_account,
+        calimero_op_adapter::legacy_account_id(&joiner),
+        "the stand-in must differ from the certified account, or the assertions \
+         above would hold no matter which one was used"
     );
 }

--- a/crates/governance-store/src/unified_op_decode.rs
+++ b/crates/governance-store/src/unified_op_decode.rs
@@ -8,9 +8,9 @@
 //! op-store can never lag the gov-DAG). `calimero-context` re-exports these so the
 //! existing projection callers keep compiling unchanged.
 
-use calimero_context_client::local_governance::{NamespaceOp, SignedNamespaceOp};
+use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
 use calimero_dag::CausalDelta;
-use calimero_op::{Op, OpPayload, ScopeId};
+use calimero_op::{Authorship, Op, OpPayload, ScopeId};
 use calimero_op_adapter::{legacy_authorship, payload_from_group_op, payload_from_root_op};
 use calimero_primitives::identity::PublicKey;
 use calimero_storage::logical_clock::HybridTimestamp;
@@ -28,7 +28,7 @@ use calimero_context_client::local_governance::GroupOp;
 fn build_op(
     id: [u8; 32],
     scope: ScopeId,
-    author: PublicKey,
+    authorship: Authorship,
     hlc: HybridTimestamp,
     parents: &[[u8; 32]],
     payload: OpPayload,
@@ -37,7 +37,7 @@ fn build_op(
         id,
         scope,
         parents.to_vec(),
-        legacy_authorship(author),
+        authorship,
         hlc,
         payload,
         [0u8; 32],
@@ -66,6 +66,52 @@ fn build_op(
 /// `GroupOp` for a `NamespaceOp::Group` (via
 /// [`crate::decrypt_group_op`]), or `None` when it couldn't be decrypted — in
 /// which case the node is still recorded as `Noop`.
+/// The authorship an op **carries**, when it carries one.
+///
+/// A join or a device link names its own account and device in a root-signed
+/// [`DeviceCert`]. Reading it here is what lets the projected op be attributed
+/// to the principal that actually authored it, instead of to a stand-in derived
+/// from the signing key — and a derived stand-in is why the
+/// `MemberJoinedWithDevice` arm of `calimero_authz::authorize` cannot currently
+/// run the two cross-checks its `DeviceLinked` sibling does.
+///
+/// The certificate is *read*, not trusted: `authorize` verifies it against the
+/// account plane at the cut before any of this is believed. Reading it here
+/// only decides who the op claims to be, which is exactly what that check then
+/// confirms.
+///
+/// `None` for every other op — those carry no credential, and their author is
+/// resolved from the folded view by `account_for_author` rather than from the
+/// op itself.
+fn carried_authorship(
+    op: &NamespaceOp,
+    decrypted_group_op: Option<&GroupOp>,
+    signer: PublicKey,
+) -> Option<Authorship> {
+    let cert = match op {
+        NamespaceOp::Root(
+            RootOp::MemberJoined { account, .. }
+            | RootOp::MemberJoinedOpen { account, .. }
+            | RootOp::MemberJoinedAt { account, .. }
+            | RootOp::NamespaceCreated { account, .. }
+            | RootOp::MemberJoinedViaTeeAttestation { account, .. },
+        ) => &account.cert,
+        // A device link rides an ENCRYPTED group op, so its certificate is only
+        // legible once the op decrypts. An undecryptable one folds to a `Noop`
+        // and keeps the stand-in — it carries no readable claim to attribute to.
+        NamespaceOp::Group { .. } => match decrypted_group_op? {
+            GroupOp::AccountDeviceLinked { cert, .. } => cert,
+            _ => return None,
+        },
+        _ => return None,
+    };
+    Some(Authorship {
+        account: cert.account,
+        device: cert.device,
+        device_key: signer,
+    })
+}
+
 #[must_use]
 pub fn op_from_namespace_op(
     signed: &SignedNamespaceOp,
@@ -100,10 +146,16 @@ pub fn op_from_namespace_op(
         // preserving causal structure without inventing a payload.
         _ => OpPayload::Noop,
     };
+    // The op's own certificate when it has one, and the stand-in only when it
+    // does not. That ordering is the fix: a join used to be attributed to an
+    // account derived from its signing key, so the device it named was fiction
+    // and no check downstream could compare against it.
+    let authorship = carried_authorship(&signed.op, decrypted_group_op, signed.signer)
+        .unwrap_or_else(|| legacy_authorship(signed.signer));
     build_op(
         id,
         ScopeId::from(signed.namespace_id.to_bytes()),
-        signed.signer,
+        authorship,
         hlc,
         parents,
         payload,


### PR DESCRIPTION
**All of #3414 except the last of the bridge.** #3498 and #3495 were each merged
into their base branch rather than into master, so this single PR now carries the
whole arc: slice B (fixtures), C1 (attribution) and C2 (the join checks +
`account_for_author`). Merging this lands it all.

Retitled accordingly — it started as the test-only slice, and squash-merging it
under `test(projection):` would have put two breaking behavioural changes on
master under a `test` prefix.

### Slice B, the base commit

The suites that prove the unified projection matches the live resolvers were
naming principals with `legacy_account_id(&key)` — the very bridge this deletes.
A plane that works only because the account is a function of the key proves
nothing about a plane keyed by real accounts, so 18 fixtures now mint an account
from a genesis the way production does. `test_account` is deterministic in the
signing key, and its root key is deliberately **not** the signing key.

Left on the bridge deliberately: the sites that *assert* it rather than use it
incidentally (the op-adapter `writer_account` tests, and the rotation-entry
author assertion). Converting those would have made them pass for the wrong
reason.

## The problem

`op_from_namespace_op` built every projected op with `legacy_authorship(signer)`,
so a join was attributed to an account derived by hashing its signing key, and
to a `device` that was that account's bytes reinterpreted — a device never
enrolled, holding no key, and **identical for every op the account authors**.
`DeviceId` is the CRDT replica slot and the HLC seed, so that is one synthetic
slot per account rather than one per installation.

## The op already carries the answer

`MemberJoined`, `MemberJoinedOpen`, `MemberJoinedAt`, `NamespaceCreated` and
`MemberJoinedViaTeeAttestation` each ride a `JoinAccountCredential`; a device
link rides a `DeviceCert` on an encrypted group op. `carried_authorship` reads
the certificate and attributes the op to the account and device it names,
falling back to the stand-in only where no credential is carried (an
undecryptable group op included — it carries no readable claim).

The certificate is **read**, not trusted. `calimero_authz::authorize` verifies
it against the account plane at the cut before any of it is believed. Reading
it decides who the op *claims* to be, which is exactly what that check then
confirms — and what it could not confirm before, because a claim derived from
the signing key can only ever agree with itself.

## What this unblocks

`authorize`'s `MemberJoinedWithDevice` arm documents two cross-checks that its
`DeviceLinked` sibling runs as impossible:

> a bridged join op's `authorship` is `legacy_authorship(signer)`, whose device
> is DERIVED from the stand-in rather than enrolled, so both the device-key and
> the account comparison would fail on a perfectly honest join.

Both become possible once the op names its real device. Reinstating them — the
replay protection `DeviceLinked` calls out, where anyone who observed a
certificate could mint a binding on the real device's behalf — is C2, together
with deleting the four bridge functions.

---

## A join must be signed by the device its certificate grants

`authorize`'s `MemberJoinedWithDevice` arm ran cryptographic admissibility and
nothing else. The two cross-checks its `DeviceLinked` sibling makes had been
removed, with a comment explaining why they could not be there:

> a bridged join op's `authorship` is `legacy_authorship(signer)`, whose device
> is DERIVED from the stand-in rather than enrolled, so both the device-key and
> the account comparison would fail on a perfectly honest join.

That was accurate. It stopped being accurate in #3495, where a projected op
began carrying the device its own certificate names — so both checks are
decidable, and both are back.

The first stops the replay `DeviceLinked` already names: a certificate is
public once observed, so without requiring possession of the granted key,
anyone who saw one could join on the real device's behalf. The second pins the
account to the one the certificate grants to rather than whatever the payload
named. `is_scope_member(verified.account)` stays absent — the point of a join
is that the account is not a member yet.

**This arm had no test at all**, which is how checks documented as absent
stayed absent. It has one now, driving a valid certificate replayed by an
*admin's* device, so the policy gate below would have waved it through on its
own. The honest join is asserted alongside, or the refusal would prove only
that something was rejected.

## 2. An author nobody can name resolves to nobody

`account_for_author` fell back to `legacy_account_id(key)` when no binding
spoke for a key. That stand-in named a principal nowhere, and all six callers
turned it into "not authorized" one step later anyway. It returns `Option` now.
`legacy_account_id` has no production callers left as a result.

### The interesting part: this exposes #3489, it does not cause it

`a_folded_join_device_does_not_hide_an_inherited_admin` went red at its
**baseline**, before any behaviour it guards. Its premise was an admin seeded
as a store row with no folded credential, and it passed only because both sides
of the comparison were the same derivation — the fixture wrote
`admin_identity = legacy_account_id(&admin)` *and* the author resolved to that
same stand-in. They agreed because they were one function of one key.

Production does not reproduce that: `admin_identity` is a real account at every
site that writes it, so a derived stand-in never equalled it there. The
fallback was rescuing this fixture, not a production path — an admin with a
real account and no folded credential was **already** unresolvable. That is
#3489.

The fixture now folds the admin's own credential first, the way a founder
reaches the view through the credential its `NamespaceCreated` carries, and
asserts the same property afterwards: another member's device folding must not
disturb an inherited admin. That is what the test is named for, and it still
proves it — now against a principal production could actually have.

## What is left of the bridge

`writer_account` and `legacy_authorship`. The latter cannot simply go: an op
carrying **no** credential — a rotation entry, most governance ops — has no
account to honestly name, and `Op::authorship.account` is a required field.
Removing it needs `account` to become optional, or to be trusted only for
credential-bearing ops. That is a change to `crates/op` and a separate
decision, so the fallback stays for those ops rather than being papered over.

## Rebased onto the crate split

Rebased onto `e1e94f65b` (the op-adapter per-plane split). No conflicts — none of
these commits touch `op-adapter`, and the file sets before and after the rebase
are identical, checked rather than assumed. Convenient side effect: the split put
all three bridge functions in `crates/op-adapter/src/legacy.rs`, so the remainder
can go as a file.

The rebase also carries an improvement to the #3489 fixture over what #3498
merged — see the last section above: it folds the admin's credential at the ROOT
rather than as an open-join into the subgroup, and asserts the absence of a
folded subgroup row. The earlier version granted the admin a direct presence in
the child and so proved something easier than inheritance.

## #3489

Settled as a fixture artifact, with evidence, in
https://github.com/calimero-network/core/issues/3489#issuecomment-5313095910.
`NamespaceCreated` carries a `JoinAccountCredential`, so a founder is bound from
genesis onward and the "real account, no folded credential" state this issue
describes is not one a live namespace reaches. The one place it IS reachable is
pre-credential alpha data, which is a flag-day concern belonging to #3414.

#3472 is untouched and unverified here — it needs a merobox TEE harness build.

## Verification

`cargo fmt --check`, `clippy --workspace --all-targets -D warnings`,
`cargo test --workspace`, and the `mock-attestation` suite all pass on the
rebased stack.

Both new tests were verified to **fail without their fix**, by disabling the fix
and watching them go red rather than assuming. The `authorize` one passes on
both paths otherwise, so this mattered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
