### PR TITLE
fix(authz)!: reinstate the join checks the bridge was blocking, and retire legacy_account_id

### DIFF
--- a/crates/authz/src/authorize.rs
+++ b/crates/authz/src/authorize.rs
@@ -122,15 +122,7 @@ pub fn authorize(op: &Op, acl_at_cut: &AclView) -> Result<(), Rejected> {
             cert,
             ..
         } => {
-            // Cryptographic admissibility only. The two cross-checks the
-            // `DeviceLinked` arm adds are deliberately absent and cannot be
-            // reinstated here: a bridged join op's `authorship` is
-            // `legacy_authorship(signer)`, whose device is DERIVED from the
-            // stand-in rather than enrolled, so both the device-key and the
-            // account comparison would fail on a perfectly honest join. And
-            // `is_scope_member(verified.account)` cannot hold either — the whole
-            // point of a join is that the account is not a member yet.
-            let _verified = admit_device_link(
+            let verified = admit_device_link(
                 &acl_at_cut.accounts,
                 &acl_at_cut.devices,
                 &acl_at_cut.revoked_devices,
@@ -138,6 +130,31 @@ pub fn authorize(op: &Op, acl_at_cut: &AclView) -> Result<(), Rejected> {
                 chain,
                 cert,
             )?;
+            // The same possession check the `DeviceLinked` arm makes, which a
+            // join could not carry while its authorship was derived from the
+            // signing key: the device it names was fiction, so comparing against
+            // it refused every honest join. The op now names the device its
+            // certificate grants, so requiring the join to be signed BY that
+            // device is decidable — and without it, anyone who observed a
+            // certificate could replay it and join on the real device's behalf.
+            if op.authorship.device_key != verified.sign_pk
+                || op.authorship.device != verified.device
+            {
+                return Err(Rejected::DeviceKeyStale {
+                    device: verified.device,
+                });
+            }
+            // And that the account it joins as is the one the certificate
+            // grants to, rather than any account the payload cared to name.
+            if op.author() != verified.account {
+                return Err(Rejected::DeviceAccountMismatch {
+                    device: verified.device,
+                    bound: verified.account,
+                    claimed: op.author(),
+                });
+            }
+            // `is_scope_member(verified.account)` still cannot be required — the
+            // whole point of a join is that the account is not a member yet.
             if acl_at_cut.is_group_admin(&op.author(), *group) {
                 Ok(())
             } else {

--- a/crates/authz/src/tests/authorize.rs
+++ b/crates/authz/src/tests/authorize.rs
@@ -4,14 +4,16 @@
 
 use std::collections::BTreeMap;
 
-use calimero_account::{AccountId, RootKeyHandoff};
+use calimero_account::{AccountId, DeviceId, KemPublicKey, RootKeyHandoff};
 use calimero_context_config::types::ContextGroupId;
-use calimero_op::OpPayload;
+use calimero_op::{Authorship, Op, OpPayload, ScopeId};
 use calimero_primitives::context::GroupMemberRole;
 use calimero_storage::address::Id;
 use calimero_storage::entities::OpMask;
 
-use super::support::{bind_account, bind_test_devices, membership_view, op_with, view_with_writer};
+use super::support::{
+    bind_account, bind_test_devices, hlc0, membership_view, op_with, view_with_writer,
+};
 use crate::authorize::authorize;
 use crate::error::Rejected;
 use crate::view::AclView;
@@ -284,5 +286,83 @@ fn explicit_acl_overrides_default_write_for_restricted_objects() {
         Err(Rejected::NotPermitted {
             required: OpMask::WRITE
         })
+    );
+}
+
+/// **A join must be signed by the device its certificate grants to.**
+///
+/// This arm ran the cryptographic admissibility check and nothing else, because
+/// while an op's authorship was derived from its signing key the device it
+/// named was fiction — comparing against it refused every honest join, so the
+/// comparison was removed and a comment left in its place. Now that a projected
+/// op carries the device its certificate names, the check is decidable again.
+///
+/// What it stops: a certificate is public once observed. Without requiring
+/// possession of the granted key, anyone who saw one could replay it and join
+/// on the real device's behalf. Here the certificate is perfectly valid and the
+/// op is simply authored by somebody else's device — an admin's, no less, so
+/// the policy gate below would wave it through.
+#[test]
+fn a_join_replayed_by_another_device_is_refused() {
+    let admin = AccountId::from([1u8; 32]);
+    let group = ContextGroupId::from([9u8; 32]);
+
+    let root_sk = calimero_primitives::identity::PrivateKey::from([0x11u8; 32]);
+    let genesis = calimero_account::AccountGenesis::new(root_sk.public_key());
+    let joiner_key = calimero_primitives::identity::PrivateKey::from([0x22u8; 32]).public_key();
+    let granted_device = DeviceId::from([0x4D; 32]);
+    let cert = calimero_account::sign_device_cert(
+        &root_sk,
+        genesis.account_id(),
+        granted_device,
+        &joiner_key,
+        &KemPublicKey::from([0x2B; 32]),
+        0,
+        0,
+    )
+    .expect("sign the device cert");
+
+    let payload = OpPayload::MemberJoinedWithDevice {
+        group,
+        member: genesis.account_id(),
+        role: GroupMemberRole::Member,
+        genesis: genesis.clone(),
+        chain: vec![],
+        cert: cert.clone(),
+    };
+
+    // Authored by the ADMIN's device rather than the granted one: the replay.
+    let replayed = op_with(admin, payload.clone());
+    let view = bind_account(
+        membership_view(group, genesis.account_id(), GroupMemberRole::Admin),
+        admin,
+    );
+    assert!(
+        matches!(
+            authorize(&replayed, &view),
+            Err(Rejected::DeviceKeyStale { .. })
+        ),
+        "a join carrying somebody else's certificate must be refused for not \
+         being signed by the device that certificate grants to"
+    );
+
+    // The same op, authored by the device the certificate actually names, is
+    // admitted — so the check above rejects the replay rather than the join.
+    let honest = Op::new(
+        ScopeId::from([0u8; 32]),
+        vec![],
+        Authorship {
+            account: genesis.account_id(),
+            device: granted_device,
+            device_key: joiner_key,
+        },
+        hlc0(),
+        payload,
+        [0u8; 32],
+        [0u8; 64],
+    );
+    assert!(
+        authorize(&honest, &view).is_ok(),
+        "the honest join must still pass, or the check above proves nothing"
     );
 }

--- a/crates/authz/src/tests/authorize.rs
+++ b/crates/authz/src/tests/authorize.rs
@@ -326,9 +326,9 @@ fn a_join_replayed_by_another_device_is_refused() {
         group,
         member: genesis.account_id(),
         role: GroupMemberRole::Member,
-        genesis: genesis.clone(),
+        genesis,
         chain: vec![],
-        cert: cert.clone(),
+        cert,
     };
 
     // Authored by the ADMIN's device rather than the granted one: the replay.

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -26,7 +26,7 @@ use calimero_governance_store::{
     NamespaceDagService, NamespaceOpLogService, NamespaceRepository,
 };
 use calimero_op::{Op, OpPayload, ScopeId};
-use calimero_op_adapter::{legacy_account_id, set_writers_payload};
+use calimero_op_adapter::set_writers_payload;
 use calimero_primitives::context::{ContextId, GroupMemberRole};
 use calimero_primitives::identity::PublicKey;
 use calimero_projection::ScopeState;
@@ -113,41 +113,17 @@ type AuthCutContext = (
 /// precisely what `denied_members` and `accounts_by_endorsing_member` avoid: it can
 /// only be populated while observing bindings, so it comes back empty after a
 /// projection rebuild and silently reverts every device to the fallback.
-fn account_for_author(view: &calimero_authz::AclView, key: &PublicKey) -> AccountId {
-    // An explicit binding wins over the derived id. A folded `DeviceLinked` is a
-    // signed statement about THIS key; `legacy_account_id` is a guess that names a
-    // real principal nowhere now that the live plane keys every row by account.
-    //
-    // This order is the reverse of what it was, and the reversal is the point.
-    // While membership was key-keyed, preferring the binding made a member who
-    // enrolled a device resolve to an account the rows did not know, and the
-    // member vanished — so the derived id had to win. Keying the rows by account
-    // removes that hazard and introduces the mirror one: stale key-derived ids
-    // still enter this view (`SubgroupCreated.admin` folds one), and letting them
-    // win makes the founder stop being admin of its own namespace the moment it
-    // creates a subgroup. Every peer then refuses what the founder signs while
-    // the founder accepts it — which is a `scope_root` split, not a hiccup.
-    if let Some(binding) = view
-        .devices
+fn account_for_author(view: &calimero_authz::AclView, key: &PublicKey) -> Option<AccountId> {
+    // A folded `DeviceLinked` is a signed statement that this key speaks for an
+    // account. There is no second answer any more: the stand-in that used to be
+    // returned here named a principal nowhere, since every row on this plane is
+    // account-keyed, and every caller below turned it into "not authorized" one
+    // step later. Returning `None` says that directly instead of routing it
+    // through an account nobody has heard of.
+    view.devices
         .values()
         .find(|binding| binding.sign_pk == *key)
-    {
-        return binding.account;
-    }
-    // No binding folded for this key, so all that is left is the stand-in. It
-    // names a real principal nowhere — every row on this plane is account-keyed —
-    // which is the correct answer for an author nobody has heard of: the
-    // authorization queries downstream all resolve it to "no".
-    //
-    // There used to be a `view_knows_author` check here, asking whether the
-    // derived id was one the view recognised. It could not change the outcome —
-    // both arms returned the same value — and it has not been able to since the
-    // binding/derived precedence was reversed. Measured before removing it: over
-    // the fold-equivalence suites the fallback is taken 13 times, and the only 4
-    // where the derived id WAS recognised come from a fixture that seeds the
-    // namespace's genesis admin as a stand-in itself. Production writes real
-    // accounts at every `admin_identity` site.
-    legacy_account_id(key)
+        .map(|binding| binding.account)
 }
 
 fn build_op(
@@ -1504,12 +1480,8 @@ impl ScopeProjections {
             .flatten()
             .unwrap_or(0);
         if view.as_ref().is_some_and(|v| {
-            v.is_member_at_cut(
-                group,
-                &account_for_author(v, author),
-                root,
-                default_cap_base,
-            )
+            account_for_author(v, author)
+                .is_some_and(|account| v.is_member_at_cut(group, &account, root, default_cap_base))
         }) {
             return Some(true);
         }
@@ -1653,12 +1625,8 @@ impl ScopeProjections {
             .flatten()
             .unwrap_or(0);
         Some(self.acl_view_at(&scope, heads).is_some_and(|v| {
-            v.is_member_at_cut(
-                group,
-                &account_for_author(&v, author),
-                root,
-                default_cap_base,
-            )
+            account_for_author(&v, author)
+                .is_some_and(|account| v.is_member_at_cut(group, &account, root, default_cap_base))
         }))
     }
 
@@ -1677,7 +1645,10 @@ impl ScopeProjections {
         heads: &[[u8; 32]],
     ) -> Option<bool> {
         let (view, root, _) = self.auth_cut_context(store, group, heads)?;
-        Some(view.is_authorized_admin(group, &account_for_author(&view, author), root))
+        Some(
+            account_for_author(&view, author)
+                .is_some_and(|account| view.is_authorized_admin(group, &account, root)),
+        )
     }
 
     /// Is `member` an admin of `group` at the cut? The account-typed sibling of
@@ -1726,10 +1697,15 @@ impl ScopeProjections {
         heads: &[[u8; 32]],
     ) -> Option<bool> {
         let (view, root, default_cap_base) = self.auth_cut_context(store, group, heads)?;
-        if view.is_authorized_admin(group, &account_for_author(&view, author), root) {
+        // An author no binding speaks for holds no capability and is no admin:
+        // there is no account to look either up against.
+        let Some(account) = account_for_author(&view, author) else {
+            return Some(false);
+        };
+        if view.is_authorized_admin(group, &account, root) {
             return Some(true);
         }
-        let folded = view.capability(&group, &account_for_author(&view, author));
+        let folded = view.capability(&group, &account);
         let effective = if folded != 0 {
             folded
         } else {
@@ -1882,7 +1858,7 @@ impl ScopeProjections {
         // with the decision it is meant to explain.
         let author_in_any = view
             .as_ref()
-            .is_some_and(|v| v.is_scope_member(&account_for_author(v, author)));
+            .is_some_and(|v| account_for_author(v, author).is_some_and(|a| v.is_scope_member(&a)));
         // Is the DECISION group folded at all, and how big? Distinguishes
         // "subgroup membership never folded" (group absent / size 0 — a
         // decrypt/sync gap) from "folded but author absent" (re-add / deny-list).
@@ -1949,7 +1925,7 @@ impl ScopeProjections {
         // key was a member and the role lookup found nobody, which is the
         // "member at cut but role unresolved" the caller then logged before
         // guessing `Member`.
-        let account = account_for_author(&view, member);
+        let account = account_for_author(&view, member)?;
         match view.member_path_at_cut(group, &account, root, default_cap_base) {
             calimero_authz::MemberPathAtCut::None => None,
             calimero_authz::MemberPathAtCut::Direct { role } => Some(role),

--- a/crates/context/tests/projection_membership_equivalence.rs
+++ b/crates/context/tests/projection_membership_equivalence.rs
@@ -814,28 +814,24 @@ fn a_folded_join_device_does_not_hide_an_inherited_admin() {
 
     // The admin is a direct member of the ROOT ONLY — its subgroup access is
     // inherited, exactly like the namespace owner in the scenario.
-    // Keyed by the KEY-derived account throughout this test, unlike the suites
-    // above. Its whole premise is that the admin has no folded presence, so the
-    // projection can only reach it through the out-of-band root — and that path
-    // compares the ROOT's `admin_identity` against what a key resolves to with
-    // nothing folded, which is this derivation. An enrolment-derived account
-    // would be unreachable there, and the test would fail for its setup rather
-    // than for the behaviour it guards.
+    //
+    // Keyed by the admin's REAL account, and its device link folded, because
+    // that is what production looks like: `admin_identity` is a real account at
+    // every site that writes it, and a founder reaches the view through the
+    // credential its `NamespaceCreated` carries. This test used to seed BOTH
+    // sides as key-derived stand-ins, so the out-of-band root matched what a
+    // bare key resolved to — the two agreed only because they were the same
+    // derivation, which no production namespace reproduces.
+    let admin_credential = real_join_account_for(&admin, [0x6C; 32]);
+    let admin_account = admin_credential.cert.account;
     MetaRepository::new(&store)
-        .save(&ns, &meta(calimero_op_adapter::legacy_account_id(&admin)))
+        .save(&ns, &meta(admin_account))
         .unwrap();
     MetaRepository::new(&store)
-        .save(
-            &subgroup,
-            &meta(calimero_op_adapter::legacy_account_id(&admin)),
-        )
+        .save(&subgroup, &meta(admin_account))
         .unwrap();
     MembershipRepository::new(&store)
-        .add_member(
-            &ns,
-            &calimero_op_adapter::legacy_account_id(&admin),
-            GroupMemberRole::Admin,
-        )
+        .add_member(&ns, &admin_account, GroupMemberRole::Admin)
         .unwrap();
     NamespaceRepository::new(&store)
         .nest(&ns, &subgroup)
@@ -861,27 +857,22 @@ fn a_folded_join_device_does_not_hide_an_inherited_admin() {
         [0xBF; 32],
     );
 
-    // Baseline: before any join folds, the admin inherits into the subgroup.
-    assert_eq!(
-        proj.member_at_cut(&store, subgroup, &admin, &[s2]),
-        Some(true),
-        "baseline: the root admin reaches an Open child by inheritance"
-    );
-
-    // The ADMIN's OWN device folds — the case that matters. The genesis admin has
-    // no membership OP anywhere: it is seeded as a store row and reaches the
-    // folded view only through the out-of-band `root` parameter, keyed by
-    // `legacy_account_id`. So it is exactly the principal `account_for_author`'s
-    // own precedence guard cannot see.
+    // The admin's own credential folds first, because that is the only way a key
+    // becomes attributable: a namespace's founder reaches the view through the
+    // credential its `NamespaceCreated` carries. Asserting the baseline before
+    // ANY credential folded — as this test used to — asks whether a bare key
+    // with no binding is an admin, and the honest answer is that nobody knows
+    // who that key is. It read as "yes" only while a stand-in derived from the
+    // key was compared against a root seeded with the same derivation.
     let admin_join_open = SignedNamespaceOp::sign(
         &admin_sk,
         ns.to_bytes().into(),
         vec![],
         7,
         NamespaceOp::Root(RootOp::MemberJoinedOpen {
-            member: calimero_op_adapter::legacy_account_id(&admin),
+            member: admin_account,
             group_id: subgroup.to_bytes().into(),
-            account: real_join_account_for(&admin, [0x7A; 32]),
+            account: admin_credential,
         }),
     )
     .expect("sign admin open-join");
@@ -894,12 +885,12 @@ fn a_folded_join_device_does_not_hide_an_inherited_admin() {
         &[s2],
     ));
 
+    // Baseline: with its own device bound, the admin inherits into the Open
+    // child, and folding that device did not un-member it.
     assert_eq!(
         proj.member_at_cut(&store, subgroup, &admin, &[id0]),
         Some(true),
-        "folding the admin's OWN device must not un-member it: membership on this \
-         plane is keyed by the stand-in, and the genesis admin is known only \
-         through the out-of-band root"
+        "baseline: the root admin reaches an Open child by inheritance"
     );
 
     // The joiner joins the namespace carrying a credential that really folds.
@@ -916,7 +907,7 @@ fn a_folded_join_device_does_not_hide_an_inherited_admin() {
     )
     .expect("sign join_ns");
     let id1 = [0xB1; 32];
-    proj.ingest_op(&op_from_namespace_op(&join_ns, None, id1, hlc(1), &[s2]));
+    proj.ingest_op(&op_from_namespace_op(&join_ns, None, id1, hlc(1), &[id0]));
 
     // ...and then into the Open subgroup by inheritance, credential and all.
     let join_sub = SignedNamespaceOp::sign(


### PR DESCRIPTION
Slice C2 of #3414, stacked on #3495. Two commits: the hardening the bridge was
blocking, and the first half of the deletion.

## 1. A join must be signed by the device its certificate grants

`authorize`'s `MemberJoinedWithDevice` arm ran cryptographic admissibility and
nothing else. The two cross-checks its `DeviceLinked` sibling makes had been
removed, with a comment explaining why they could not be there:

> a bridged join op's `authorship` is `legacy_authorship(signer)`, whose device
> is DERIVED from the stand-in rather than enrolled, so both the device-key and
> the account comparison would fail on a perfectly honest join.

That was accurate. It stopped being accurate in #3495, where a projected op
began carrying the device its own certificate names — so both checks are
decidable, and both are back.

The first stops the replay `DeviceLinked` already names: a certificate is
public once observed, so without requiring possession of the granted key,
anyone who saw one could join on the real device's behalf. The second pins the
account to the one the certificate grants to rather than whatever the payload
named. `is_scope_member(verified.account)` stays absent — the point of a join
is that the account is not a member yet.

**This arm had no test at all**, which is how checks documented as absent
stayed absent. It has one now, driving a valid certificate replayed by an
*admin's* device, so the policy gate below would have waved it through on its
own. The honest join is asserted alongside, or the refusal would prove only
that something was rejected.

## 2. An author nobody can name resolves to nobody

`account_for_author` fell back to `legacy_account_id(key)` when no binding
spoke for a key. That stand-in named a principal nowhere, and all six callers
turned it into "not authorized" one step later anyway. It returns `Option` now.
`legacy_account_id` has no production callers left as a result.

### The interesting part: this exposes #3489, it does not cause it

`a_folded_join_device_does_not_hide_an_inherited_admin` went red at its
**baseline**, before any behaviour it guards. Its premise was an admin seeded
as a store row with no folded credential, and it passed only because both sides
of the comparison were the same derivation — the fixture wrote
`admin_identity = legacy_account_id(&admin)` *and* the author resolved to that
same stand-in. They agreed because they were one function of one key.

Production does not reproduce that: `admin_identity` is a real account at every
site that writes it, so a derived stand-in never equalled it there. The
fallback was rescuing this fixture, not a production path — an admin with a
real account and no folded credential was **already** unresolvable. That is
#3489.

The fixture now folds the admin's own credential first, the way a founder
reaches the view through the credential its `NamespaceCreated` carries, and
asserts the same property afterwards: another member's device folding must not
disturb an inherited admin. That is what the test is named for, and it still
proves it — now against a principal production could actually have.

## What is left of the bridge

`writer_account` and `legacy_authorship`. The latter cannot simply go: an op
carrying **no** credential — a rotation entry, most governance ops — has no
account to honestly name, and `Op::authorship.account` is a required field.
Removing it needs `account` to become optional, or to be trusted only for
credential-bearing ops. That is a change to `crates/op` and a separate
decision, so the fallback stays for those ops rather than being papered over.

## Verification

`cargo fmt --check`, `clippy --workspace --all-targets -D warnings`,
`cargo test --workspace`, and the `mock-attestation` suite all pass.

Both new tests were verified to **fail without their fix** — by disabling the
fix and watching them go red, not by assuming. The `authorize` test passes on
both paths otherwise, so this mattered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
