### PR TITLE
fix(projection): resolve an op's signer, instead of fabricating one

### DIFF
--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use actix::{ActorResponse, Handler, Message, WrapFuture};
 use calimero_context_client::messages::{ApplySignedNamespaceOpRequest, NamespaceApplyOutcome};
+use calimero_context_config::types::ContextGroupId;
 use calimero_dag::AddDeltaOutcome;
 
 use crate::governance_dag::{signed_namespace_op_to_delta, NamespaceGovernanceApplier};
@@ -81,9 +82,18 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                         // op has nothing to decrypt and folds as `Noop`.
                         _ => None,
                     };
-                    let shadow_op = crate::scope_projection::op_from_namespace_op(
+                    // Resolved from the store, not derived from the key: the op
+                    // has just applied, and it could not have unless the signer's
+                    // binding was present — so every node agrees on this value.
+                    let signer_binding = calimero_governance_store::signer_binding_for(
+                        &compare_store,
+                        &ContextGroupId::from(namespace_id.to_bytes()),
+                        &signed_op.signer,
+                    );
+                    let shadow_op = calimero_governance_store::op_from_namespace_op_with_binding(
                         &signed_op,
                         decrypted.as_ref(),
+                        signer_binding,
                         delta_id,
                         delta_hlc,
                         &delta_parents,

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1028,8 +1028,23 @@ impl Handler<ExecuteRequest> for ContextManager {
                                 continue;
                             };
                             for entry in &log.entries {
+                                // Same resolution the apply and backfill paths
+                                // use: a rotation entry names a KEY, and the
+                                // writer plane is keyed by account.
+                                let signer_binding = entry.signer.and_then(|signer| {
+                                    calimero_governance_store::signer_binding_for(
+                                        &xcall_datastore,
+                                        &calimero_context_config::types::ContextGroupId::from(
+                                            *context_id.digest(),
+                                        ),
+                                        &signer,
+                                    )
+                                });
                                 if let Some(op) = crate::scope_projection::op_from_rotation_entry(
-                                    *object, scope, entry,
+                                    *object,
+                                    scope,
+                                    entry,
+                                    signer_binding,
                                 ) {
                                     ops.push(op);
                                 }

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1216,13 +1216,23 @@ impl ScopeProjections {
                 // nothing to decrypt and folds as `Noop`.
                 _ => None,
             };
-            ops.push(op_from_namespace_op(
-                &signed,
-                decrypted.as_ref(),
-                delta.id,
-                delta.hlc,
-                &delta.parents,
-            ));
+            // Same resolution the apply path uses, so a backfilled op and a
+            // live-folded one are attributed identically.
+            let signer_binding = calimero_governance_store::signer_binding_for(
+                store,
+                &ContextGroupId::from(namespace_id),
+                &signed.signer,
+            );
+            ops.push(
+                calimero_governance_store::op_from_namespace_op_with_binding(
+                    &signed,
+                    decrypted.as_ref(),
+                    signer_binding,
+                    delta.id,
+                    delta.hlc,
+                    &delta.parents,
+                ),
+            );
         }
         Some(ops)
     }

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -129,16 +129,29 @@ fn account_for_author(view: &calimero_authz::AclView, key: &PublicKey) -> Option
 fn build_op(
     id: [u8; 32],
     scope: ScopeId,
+    signer_binding: Option<(calimero_account::AccountId, calimero_account::DeviceId)>,
     author: PublicKey,
     hlc: HybridTimestamp,
     parents: &[[u8; 32]],
     payload: OpPayload,
 ) -> Op {
+    // A rotation-log entry names a KEY, so without the caller's resolution this
+    // op is attributed to a stand-in — and `SetWriters` is gated on
+    // `is_owner(op.author(), object)`, where the owner is a real account. Every
+    // rotation-derived writer-set op would be refused as `NotOwner`.
+    let authorship = signer_binding.map_or_else(
+        || calimero_op_adapter::legacy_authorship(author),
+        |(account, device)| calimero_op::Authorship {
+            account,
+            device,
+            device_key: author,
+        },
+    );
     Op::from_parts(
         id,
         scope,
         parents.to_vec(),
-        calimero_op_adapter::legacy_authorship(author),
+        authorship,
         hlc,
         payload,
         [0u8; 32],
@@ -163,12 +176,18 @@ fn build_op(
 /// layer, below the projection, so the independent feed needs storage to
 /// surface applied rotations rather than re-deriving them from the resolver.
 #[must_use]
-pub fn op_from_rotation_entry(object: Id, scope: ScopeId, entry: &RotationLogEntry) -> Option<Op> {
+pub fn op_from_rotation_entry(
+    object: Id,
+    scope: ScopeId,
+    entry: &RotationLogEntry,
+    signer_binding: Option<(calimero_account::AccountId, calimero_account::DeviceId)>,
+) -> Option<Op> {
     let author = entry.signer?;
     let payload = set_writers_payload(object, entry);
     Some(build_op(
         entry.delta_id,
         scope,
+        signer_binding,
         author,
         entry.delta_hlc,
         &[],
@@ -2275,14 +2294,33 @@ mod tests {
             writers_nonce: 1,
         };
 
-        let op = op_from_rotation_entry(object, scope, &entry).expect("signed rotation maps");
+        // Told who the signer is, the op names the real account — which matters
+        // because `SetWriters` is gated on `is_owner(op.author(), object)` against
+        // a real owner, so a stand-in author is refused as `NotOwner`.
+        let signer_account = calimero_account::AccountId::from([0xA7; 32]);
+        let signer_device = calimero_account::DeviceId::from([0xD7; 32]);
+        let op =
+            op_from_rotation_entry(object, scope, &entry, Some((signer_account, signer_device)))
+                .expect("signed rotation maps");
         assert_eq!(
             op.author(),
+            signer_account,
+            "the op must name the account the signing key speaks for"
+        );
+        assert_eq!(op.device(), signer_device, "and the device that signed it");
+        assert_ne!(
+            signer_account,
             calimero_op_adapter::legacy_account_id(&signer),
-            "author is the rotation signer, and a rotation entry names a KEY — so \
-             the adapter derives the author rather than resolving a binding. This \
-             is an assertion ABOUT the bridge, so it stays until `build_op` gets a \
-             real credential to attribute the op to."
+            "precondition: the stand-in differs, so the assertion above cannot \
+             hold whichever value was used"
+        );
+        // Without the caller's resolution it still stands in — the state that made
+        // every rotation-derived writer-set op unauthorizable.
+        assert_eq!(
+            op_from_rotation_entry(object, scope, &entry, None)
+                .expect("still maps")
+                .author(),
+            calimero_op_adapter::legacy_account_id(&signer),
         );
         assert_eq!(op.hlc, hlc(5));
         assert_eq!(
@@ -2300,7 +2338,7 @@ mod tests {
             signer: None,
             ..entry
         };
-        assert!(op_from_rotation_entry(object, scope, &unsigned).is_none());
+        assert!(op_from_rotation_entry(object, scope, &unsigned, None).is_none());
     }
 
     #[test]

--- a/crates/context/tests/projection_membership_equivalence.rs
+++ b/crates/context/tests/projection_membership_equivalence.rs
@@ -1274,3 +1274,119 @@ fn a_join_is_attributed_to_the_account_its_certificate_names() {
          above would hold no matter which one was used"
     );
 }
+
+/// **A key rotation authored by an enrolled device must actually absorb.**
+///
+/// The fold gates `AccountKeysRotated` on `handoff.account == op.authorship.account`
+/// — deliberately, because `from_ops` and the sync convergence path fold raw logs
+/// without `authorize`, and that check is what stops a stranger absorbing into a
+/// victim's epoch slot.
+///
+/// But `GroupOp::AccountKeysRotated` carries no credential, so the production
+/// converter has nothing to attribute the op to and stamps
+/// `legacy_authorship(signer)` — a stand-in derived from the signing key. A
+/// stand-in never equals the real `handoff.account`, so the comparison fails on
+/// an honest rotation and the handoff is dropped.
+///
+/// `crates/projection/tests/account_plane.rs` misses this because its fixture
+/// builds `Authorship` from a device that knows its own account, supplying the
+/// truthful value production fabricates. This drives the real converter instead.
+#[test]
+fn a_rotation_by_an_enrolled_device_absorbs_through_the_real_converter() {
+    let ns = ContextGroupId::from([0x51; 32]);
+    let group = ContextGroupId::from([0x52; 32]);
+
+    // An account with a real genesis, and a device certified by its root key.
+    let root_sk = PrivateKey::from([0x61u8; 32]);
+    let genesis = calimero_account::AccountGenesis::new(root_sk.public_key());
+    let account = genesis.account_id();
+    let device_sk = PrivateKey::from([0x62u8; 32]);
+    let device_key = device_sk.public_key();
+    let cert = calimero_account::sign_device_cert(
+        &root_sk,
+        account,
+        calimero_account::DeviceId::from([0x63; 32]),
+        &device_key,
+        &calimero_account::KemPublicKey::from([0x64; 32]),
+        0,
+        0,
+    )
+    .expect("sign the device cert");
+
+    let mut proj = ScopeProjections::new();
+
+    // The device links, so the binding is folded and the account is known.
+    let link_env = ns_group_envelope(ns.to_bytes(), device_key, group);
+    let link = GroupOp::AccountDeviceLinked {
+        genesis,
+        chain: vec![],
+        cert,
+        endorsement: calimero_account::sign_account_endorsement(&device_sk, account)
+            .expect("endorse"),
+    };
+    let link_id = [0xC1; 32];
+    proj.ingest_op(&op_from_namespace_op(
+        &link_env,
+        Some(&link),
+        link_id,
+        hlc(1),
+        &[],
+    ));
+
+    // That device now rotates its account's root key.
+    let handoff = calimero_account::sign_root_key_handoff(
+        &root_sk,
+        account,
+        0,
+        &PrivateKey::from([0x65u8; 32]).public_key(),
+    )
+    .expect("sign handoff");
+    let rot_env = ns_group_envelope(ns.to_bytes(), device_key, group);
+    let rotation = GroupOp::AccountKeysRotated { handoff };
+    let rot_id = [0xC2; 32];
+    // The production path: the caller resolves the signer's binding and passes
+    // it, exactly as the apply handler and the backfill now do.
+    let rot_op = calimero_governance_store::op_from_namespace_op_with_binding(
+        &rot_env,
+        Some(&rotation),
+        Some((account, cert.device)),
+        rot_id,
+        hlc(2),
+        &[link_id],
+    );
+
+    // Told who signed, the converter names the real account.
+    assert_eq!(
+        rot_op.author(),
+        account,
+        "the op must be attributed to the rotating account, not to a stand-in"
+    );
+    // And the stand-in it would otherwise have used is a different account — so
+    // the assertion below cannot pass by coincidence.
+    assert_ne!(
+        calimero_op_adapter::legacy_account_id(&device_key),
+        account,
+        "precondition: the derived stand-in differs from the real account"
+    );
+    let unattributed =
+        op_from_namespace_op(&rot_env, Some(&rotation), [0xC3; 32], hlc(2), &[link_id]);
+    assert_ne!(
+        unattributed.author(),
+        account,
+        "precondition: without the binding the converter still stands in, which is \
+         what silently dropped every rotation"
+    );
+
+    proj.ingest_op(&rot_op);
+
+    let view = proj
+        .acl_view_at(&ScopeId::from(ns.to_bytes()), &[rot_id])
+        .expect("scope fed");
+    assert_eq!(
+        view.accounts.get(&account).map(|a| a.epoch),
+        Some(1),
+        "the rotation must have been absorbed: the account's epoch should have \
+         advanced to 1. If this is 0 or None, the fold compared the handoff's \
+         real account against the converter's stand-in and dropped the rotation."
+    );
+}

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -66,6 +66,7 @@ mod permission_checker;
 mod reentry;
 mod tee;
 pub mod unified_op_decode;
+pub use crate::unified_op_decode::{op_from_namespace_op_with_binding, signer_binding_for};
 mod upgrade_ladder;
 mod upgrades;
 use self::local_state::{op_log_contains_content_hash, persist_group_governance_progress};

--- a/crates/governance-store/src/namespace/op_log.rs
+++ b/crates/governance-store/src/namespace/op_log.rs
@@ -156,9 +156,15 @@ impl<'a> NamespaceOpLogService<'a> {
             _ => None,
         };
 
-        let unified_op = crate::unified_op_decode::op_from_namespace_op(
+        let signer_binding = crate::unified_op_decode::signer_binding_for(
+            self.store,
+            &self.namespace_id.to_bytes().into(),
+            &signed.signer,
+        );
+        let unified_op = crate::unified_op_decode::op_from_namespace_op_with_binding(
             signed,
             decrypted.as_ref(),
+            signer_binding,
             delta.id,
             delta.hlc,
             &delta.parents,

--- a/crates/governance-store/src/unified_op_decode.rs
+++ b/crates/governance-store/src/unified_op_decode.rs
@@ -8,6 +8,7 @@
 //! op-store can never lag the gov-DAG). `calimero-context` re-exports these so the
 //! existing projection callers keep compiling unchanged.
 
+use calimero_account::{AccountId, DeviceId};
 use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
 use calimero_dag::CausalDelta;
 use calimero_op::{Authorship, Op, OpPayload, ScopeId};
@@ -16,6 +17,25 @@ use calimero_primitives::identity::PublicKey;
 use calimero_storage::logical_clock::HybridTimestamp;
 
 use calimero_context_client::local_governance::GroupOp;
+
+/// The account and device `sign_pk` speaks for in `namespace`, as the live
+/// bindings record it.
+///
+/// The one resolution every producer of a projected op should use, so they cannot
+/// disagree about who authored it. Returns `None` for a key with no live binding —
+/// a joiner whose own join is what creates one, or pre-credential data — and the
+/// caller then gets the stand-in rather than a fabricated claim to a real account.
+pub fn signer_binding_for(
+    store: &calimero_store::Store,
+    namespace: &calimero_context_config::types::ContextGroupId,
+    sign_pk: &PublicKey,
+) -> Option<(AccountId, DeviceId)> {
+    crate::AccountBindingRepository::new(store)
+        .binding_for_sign_pk(namespace, sign_pk)
+        .ok()
+        .flatten()
+        .map(|binding| (binding.account, binding.device))
+}
 
 /// Assemble an [`Op`] that **mirrors a source-DAG op**: its `id` and `parents`
 /// are the source delta's own id/parents, *not* a fresh [`Op::compute_id`]. This
@@ -120,6 +140,24 @@ pub fn op_from_namespace_op(
     hlc: HybridTimestamp,
     parents: &[[u8; 32]],
 ) -> Op {
+    op_from_namespace_op_with_binding(signed, decrypted_group_op, None, id, hlc, parents)
+}
+
+/// [`op_from_namespace_op`], told who the signer is.
+///
+/// Every production producer should use this one. The bare version attributes an
+/// op with no carried credential to a stand-in derived from its signing key, and
+/// a stand-in is not the account any row is keyed by — so a fold that compares
+/// the two (`AccountKeysRotated` does) silently drops the op.
+#[must_use]
+pub fn op_from_namespace_op_with_binding(
+    signed: &SignedNamespaceOp,
+    decrypted_group_op: Option<&GroupOp>,
+    signer_binding: Option<(AccountId, DeviceId)>,
+    id: [u8; 32],
+    hlc: HybridTimestamp,
+    parents: &[[u8; 32]],
+) -> Op {
     let payload = match &signed.op {
         // `MemberJoinedOpen` is an open-subgroup inheritance-join PROOF, not a
         // direct membership: live's apply requires `check_path == Inherited` and
@@ -146,11 +184,32 @@ pub fn op_from_namespace_op(
         // preserving causal structure without inventing a payload.
         _ => OpPayload::Noop,
     };
-    // The op's own certificate when it has one, and the stand-in only when it
-    // does not. That ordering is the fix: a join used to be attributed to an
-    // account derived from its signing key, so the device it named was fiction
-    // and no check downstream could compare against it.
+    // Three answers, in the only order that can work.
+    //
+    // The op's own certificate first: a joiner has no binding yet — its join is
+    // what creates one — so only the credential it carries can name it.
+    //
+    // Then the binding the CALLER resolved, which covers an established device
+    // whose op carries no credential. `AccountKeysRotated` is that case, and
+    // getting a stand-in there meant the fold compared a real `handoff.account`
+    // against a derived one and silently dropped every rotation.
+    //
+    // The stand-in last, for a key nothing knows: pre-credential data.
+    //
+    // Resolving the binding in the CALLER is what makes it safe. Both producers
+    // have already APPLIED this op, and an op cannot apply unless the signer's
+    // binding is present — so every node that folds it resolves the same account.
+    // Resolving inside the fold would not be safe: the fold walks raw logs in
+    // arrival order, so reading a binding there answers "has the link folded
+    // yet" and splits the root by delivery order.
     let authorship = carried_authorship(&signed.op, decrypted_group_op, signed.signer)
+        .or_else(|| {
+            signer_binding.map(|(account, device)| Authorship {
+                account,
+                device,
+                device_key: signed.signer,
+            })
+        })
         .unwrap_or_else(|| legacy_authorship(signed.signer));
     build_op(
         id,


### PR DESCRIPTION
Two producers of projected ops fabricated their author, and each fabrication
broke a different downstream check. One cause, two symptoms, one fix applied
twice.

# 1. Every account key rotation was silently discarded

`GroupOp::AccountKeysRotated` carries no credential, so `op_from_namespace_op`
had nothing to attribute the op to and stamped `legacy_authorship(signer)` — a
stand-in derived from the signing key. The fold then gates absorption on

```rust
if handoff.account == op.authorship.account {
    self.absorb_handoff(*handoff);
}
```

A stand-in never equals the real account, so the comparison failed on every
honest rotation. Reproduced on clean master: the account exists, the handoff is
validly signed by the outgoing root key, the authoring device is properly
enrolled with a root-signed `DeviceCert` and a valid endorsement — and the
epoch stays at `0`.

#3494 does not cover this. It attributes ops from their **carried** credential,
and a rotation carries none.

## Why the gate stays

It is not paranoia, and removing it would be the wrong fix. The walk verifies
handoff signatures, so correctness does not rest on this check — but
`absorb_handoff` trims a capped slot, and its own comment explains that trimming
is only safe while a slot is unwritable by strangers:

> Trimming to a fixed size is only safe because a slot is no longer writable by
> strangers […] a bare rotation is refused unless its author IS the account. So
> an over-full slot means that account authored the padding, and the only chain
> it can truncate is its own.

So the comparison has to become meaningful rather than disappear.

## The fix

Authorship now has three answers, in the only order that works:

```rust
carried_authorship(&signed.op, decrypted_group_op, signed.signer)   // its own certificate
    .or_else(|| signer_binding.map(...))                            // the caller's resolution
    .unwrap_or_else(|| legacy_authorship(signed.signer))            // stand-in, last resort
```

Credential first is forced, not stylistic: a joiner has **no** binding yet — its
join is what creates one — so only the carried credential can name it. The
resolved binding then covers an established device whose op carries no
credential, which is the rotation case.

**Resolving in the caller is what makes this safe, and the placement is the
whole point.** Every producer has already *applied* the op, and an op
cannot apply unless the signer's binding is present — so every node that folds
it resolves the same account.

Resolving *inside the fold* would not be safe, and this repo has the scar:
a few lines above the arm, a revoked device used to store either the binding's
account or the payload's claim depending on which had folded first, and that
value is hashed into `governance_hash` — so it **split the root by arrival
order**. The fold walks raw logs, so a binding read there answers "has the link
folded yet."

## Shape

- `signer_binding_for(store, namespace, sign_pk)` — one resolution all
  producers share, so they cannot disagree about who authored an op.
- `op_from_namespace_op_with_binding(...)` as a **second entry point**, with the
  existing one delegating with `None`. Deliberate: changing the arity meant
  editing ~38 call sites, and doing that mechanically corrupted files, so the
  bare version stays and carries a doc note about what it gives up.
- Four producers wired: the apply handler, the projection backfill, the op-log
  persist path, and `execute`'s rotation-log feed.

## The test, and why the suite missed this

`crates/projection/tests/account_plane.rs` builds `Authorship` from a fixture
device that already knows its own account — supplying the truthful value
production fabricates. That is how a total failure of key rotation sat green.

The new test drives the real converter instead. It also asserts that the
stand-in **differs** from the real account, and that the unattributed path still
produces one, so the main assertion cannot pass by coincidence. Verified failing
(`epoch 0` vs `1`) on master before the fix, rather than assumed.

# 2. Every rotation-derived writer set was unauthorizable as its own owner

`op_from_rotation_entry` builds the projected `SetWriters` op from a
rotation-log entry, and an entry names a **key** — so it stamped
`legacy_authorship(signer)` too. `authorize` gates that payload on

```rust
is_owner(&op.author(), *object)
```

and an object's owner is a real `AccountId`, so every rotation-derived writer
set is refused as `NotOwner`.

Same fix, safe for the same reason: `execute` already holds the datastore and
reaches this point having applied the delta the rotation came from, so the
binding is present and every node resolves the same account.

The test for this arm asserted the stand-in **on purpose** — #3494 left it that
way with a note that it should change once `build_op` had something real to
attribute an op to. It now asserts the resolved account and device, that the
stand-in differs from that account, and that the unattributed path still stands
in.

## Taken together

Three downstream checks were being broken by the same fabrication: a rotation
dropped by the account-plane fold, a join whose device could not be
cross-checked (#3494), and a writer set refused to its own owner. The bridge was
never one bug — it was one cause.

All four producers now resolve through a single `signer_binding_for`, so they
cannot disagree about who authored an op.

## Verification

`cargo fmt --check`, `clippy --workspace --all-targets -D warnings`,
`cargo test --workspace`, and the `mock-attestation` suite pass. Rebased onto
`8317a4cce`; the `unified_op_decode` conflict with #3494 is resolved into the
chain above, and both tests pass together (10/10 in that suite).

Relates to #3414. Does **not** finish the bridge, and the reason is specific
rather than a vague flag day:

- `writer_account`'s fallback is reachable in a real ordering window.
  `account_for_group` calls `participate_in`, which provisions a namespace
  *signing key*, then looks up the *binding* — which exists only once the node's
  device-link op has applied. The comment above it describes exactly that hazard
  for context creation. Deleting the fallback changes what a node writes as
  inside that window, and `device_account_at_cut` is required to agree with
  `env::account_id()`, so the two can only move together.
- `legacy_authorship` remains for pre-credential data: a key nothing has ever
  bound, which is the alpha flag day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
