### PR TITLE
fix(merod): stop libraries drowning the node's own log

### DIFF
--- a/crates/merod/src/main.rs
+++ b/crates/merod/src/main.rs
@@ -43,14 +43,64 @@ async fn main() -> EyreResult<()> {
     command.run().await
 }
 
+/// The filter used when `RUST_LOG` says nothing.
+///
+/// `mero_auth` is included so embedded-auth startup messages (notably the
+/// how-to-provision notice on an un-provisioned node) are visible by default.
+const DEFAULT_DIRECTIVES: &str = "merod=info,calimero_=info,mero_auth=info";
+
+/// Targets turned down ahead of every filter, so that a blanket `RUST_LOG=debug`
+/// still produces a log a human can read.
+///
+/// Measured over both node logs of one healthy e2e run (4.87 MB): together these
+/// three are 40.8% of the bytes, and none of them describe anything the node did.
+///
+/// - `cranelift_codegen` (31.2%, 7,808 lines) — the wasm compiler narrating its
+///   own optimisation passes, function by function; compiling one app emits
+///   ~7,800 lines in ~400ms. Volume is not the worst of it. The burst lands
+///   *during* a compile, so it is what the log consists of at exactly the moment
+///   a node that dies inside `create_context` has to be explained from its log
+///   alone.
+/// - `multistream_select` (6.2%, 896 lines) — protocol negotiation announcing
+///   every success four times over (proposed, confirming, sent confirmed,
+///   received confirmation) for protocols that were never in doubt. A
+///   negotiation that genuinely fails still surfaces as a swarm-level upgrade or
+///   connection error, which is not touched here.
+/// - `libp2p_core::transport::choice` (3.3%, 18 lines at ~9 KB each) — which
+///   transport in the list did not handle an address, spelling out the entire
+///   monomorphised transport type to say so. Trying each transport in turn is how
+///   that transport works, so this is routine. Scoped to the one module: its
+///   sibling `libp2p_core::upgrade` reports real TLS/noise upgrade failures.
+///
+/// `warn` rather than `off`: none of the three has said anything at warn or above
+/// in 6.6 MB of captured logs, so the entire flood sits below that line and
+/// leaving the level open costs nothing if one of them ever has something real to
+/// report.
+///
+/// Prepended rather than appended: a target-specific directive beats the blanket
+/// level regardless of order, while an explicit `RUST_LOG=<target>=debug` names
+/// the same target and so wins by coming later. Both halves of that, and the
+/// warn-still-gets-through property, are pinned by the tests below.
+///
+/// Deliberately NOT included, despite being the next largest: `libp2p_gossipsub`
+/// (12.1%) is mesh formation — `HEARTBEAT: Mesh low`, `Updating mesh`, peer
+/// counts — which is the evidence mesh-join and mesh-scoring bugs are diagnosed
+/// from, and `libp2p_swarm`'s connection-closed lines are how a peer's death is
+/// spotted at all.
+const QUIET_TARGETS: &str =
+    "cranelift_codegen=warn,multistream_select=warn,libp2p_core::transport::choice=warn";
+
+/// Builds the tracing filter from `RUST_LOG`, or the default when it is unset
+/// or blank.
+fn log_directives(rust_log: Option<&str>) -> String {
+    match rust_log {
+        Some(value) if !value.trim().is_empty() => format!("{QUIET_TARGETS},{value}"),
+        _ => format!("{QUIET_TARGETS},{DEFAULT_DIRECTIVES}"),
+    }
+}
+
 fn setup() -> EyreResult<()> {
-    let directives = match var("RUST_LOG") {
-        Ok(value) if !value.trim().is_empty() => value,
-        // mero_auth is included so embedded-auth startup messages (notably
-        // the how-to-provision notice on an un-provisioned node) are visible
-        // by default.
-        _ => "merod=info,calimero_=info,mero_auth=info".to_owned(),
-    };
+    let directives = log_directives(var("RUST_LOG").ok().as_deref());
 
     registry()
         .with(EnvFilter::builder().parse(directives)?)
@@ -117,4 +167,167 @@ fn setup_panic_hook() {
 
         prev_hook(panic_info);
     }));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Result as IoResult, Write};
+    use std::sync::{Arc, Mutex};
+
+    use super::{log_directives, DEFAULT_DIRECTIVES};
+    use tracing_subscriber::fmt::layer;
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::{registry, EnvFilter};
+
+    /// A `MakeWriter` sink that keeps the formatted output in memory.
+    struct Buffer(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for Buffer {
+        fn write(&mut self, bytes: &[u8]) -> IoResult<usize> {
+            self.0
+                .lock()
+                .expect("log buffer poisoned")
+                .extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> IoResult<()> {
+            Ok(())
+        }
+    }
+
+    /// Emits one line per quieted target at both `debug` and `warn`, plus a node
+    /// line, and returns whatever `directives` let through.
+    ///
+    /// Asserting on real emitted output rather than on the directive string is
+    /// the point: the precedence being pinned here is `EnvFilter`'s, not ours.
+    /// The targets are literals because a callsite's metadata is static — they
+    /// cannot be parameterised at runtime.
+    fn emit_under(directives: &str) -> String {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&buffer);
+
+        let subscriber = registry()
+            .with(
+                EnvFilter::builder()
+                    .parse(directives)
+                    .expect("directives must parse"),
+            )
+            .with(
+                layer()
+                    .with_ansi(false)
+                    .with_writer(move || Buffer(Arc::clone(&sink))),
+            );
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug!(target: "cranelift_codegen::context", "compiler chatter");
+            tracing::debug!(target: "multistream_select::dialer_select", "negotiation chatter");
+            tracing::debug!(target: "libp2p_core::transport::choice", "transport chatter");
+
+            tracing::warn!(target: "cranelift_codegen::context", "compiler complaint");
+            tracing::warn!(target: "multistream_select::dialer_select", "negotiation complaint");
+            tracing::warn!(target: "libp2p_core::transport::choice", "transport complaint");
+
+            // Kept loud: mesh formation and connection teardown are how mesh-join
+            // bugs and a peer's death are diagnosed.
+            tracing::debug!(target: "libp2p_gossipsub::behaviour", "HEARTBEAT: Mesh low");
+            tracing::debug!(target: "libp2p_swarm", "Connection closed with error");
+            tracing::debug!(target: "libp2p_core::upgrade::apply", "Failed to upgrade outbound stream");
+
+            tracing::info!(target: "calimero_node::sync", "performing interval sync");
+        });
+
+        let bytes = buffer.lock().expect("log buffer poisoned").clone();
+        String::from_utf8(bytes).expect("formatted output must be utf-8")
+    }
+
+    const CHATTER: [&str; 3] = [
+        "compiler chatter",
+        "negotiation chatter",
+        "transport chatter",
+    ];
+
+    #[test]
+    fn blanket_debug_drops_every_quieted_target() {
+        let output = emit_under(&log_directives(Some("debug")));
+
+        for chatter in CHATTER {
+            assert!(
+                !output.contains(chatter),
+                "{chatter:?} must stay quiet under a blanket debug, got: {output}"
+            );
+        }
+    }
+
+    #[test]
+    fn blanket_debug_still_keeps_everything_worth_reading() {
+        let output = emit_under(&log_directives(Some("debug")));
+
+        for kept in [
+            "performing interval sync",
+            "HEARTBEAT: Mesh low",
+            "Connection closed with error",
+            "Failed to upgrade outbound stream",
+        ] {
+            assert!(
+                output.contains(kept),
+                "{kept:?} must survive the quieting, got: {output}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_quieted_target_can_still_raise_a_warning() {
+        let output = emit_under(&log_directives(Some("debug")));
+
+        for complaint in [
+            "compiler complaint",
+            "negotiation complaint",
+            "transport complaint",
+        ] {
+            assert!(
+                output.contains(complaint),
+                "{complaint:?} must get through — these are turned down to warn, \
+                 not off, got: {output}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_explicit_directive_opts_a_quieted_target_back_in() {
+        for (directive, chatter) in [
+            ("cranelift_codegen=debug", "compiler chatter"),
+            ("multistream_select=debug", "negotiation chatter"),
+            ("libp2p_core::transport::choice=debug", "transport chatter"),
+        ] {
+            let output = emit_under(&log_directives(Some(directive)));
+            assert!(
+                output.contains(chatter),
+                "{directive:?} must opt {chatter:?} back in, got: {output}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unset_or_blank_rust_log_falls_back_to_the_defaults() {
+        for unset in [None, Some(""), Some("   ")] {
+            let directives = log_directives(unset);
+            assert!(
+                directives.ends_with(DEFAULT_DIRECTIVES),
+                "{unset:?} must fall back to the defaults, got: {directives}"
+            );
+
+            let output = emit_under(&directives);
+            assert!(
+                output.contains("performing interval sync"),
+                "the default filter must show calimero_ info lines, got: {output}"
+            );
+            for chatter in CHATTER {
+                assert!(
+                    !output.contains(chatter),
+                    "the default filter must not show {chatter:?}, got: {output}"
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## The problem

merobox sets `RUST_LOG=debug` on every e2e node, which turns on three **library** targets that between them are **40.8% of the bytes** in a captured node log — and none of them describe anything the node did.

Measured across both node logs of one healthy run (4.87 MB total), attributing each line to its actual tracing target:

| target | lines | MB | % bytes | bytes/line |
|---|---:|---:|---:|---:|
| `cranelift_codegen` | 7,808 | 1.52 | 31.2% | 194 |
| `multistream_select` | 896 | 0.30 | 6.2% | 339 |
| `libp2p_core::transport::choice` | 18 | 0.16 | 3.3% | **8,964** |
| **combined** | **8,722** | **1.99** | **40.8%** | |

**`cranelift_codegen`** — the wasm compiler narrating its own optimisation passes, function by function. One app compile emits ~7,800 lines in ~400ms:

```
DEBUG cranelift_codegen::context: egraph stats: Stats { pure_inst: 2698, pure_inst_deduped: 1134, … }
DEBUG cranelift_codegen::machinst::compile: Number of lowered vcode instructions: 1109
DEBUG cranelift_codegen::remove_constant_phis: do_remove_constant_phis: done, 1 iters.
```

Volume is not the worst of it. The burst lands *during* a compile, so it is what a node's log consists of at exactly the moment it matters most. In [run 32009600527](https://github.com/calimero-network/core/actions/runs/32009600527/job/95327825548) a node died inside `create_context` and the only thing available to explain it was its log — whose final line is a compiler statistic, with the node's own lines buried thousands of lines back.

**`multistream_select`** — announces every successful negotiation four times over. Every distinct message it produced across 6.6 MB of logs was one of these four, for protocols that were never in doubt:

```
Dialer: Proposed protocol: /calimero/stream/0.0.2
Listener: confirming protocol: /calimero/stream/0.0.2
Listener: sent confirmed protocol: /calimero/stream/0.0.2
Dialer: Received confirmation for protocol: /calimero/stream/0.0.2
```

A negotiation that genuinely fails still surfaces as a swarm-level upgrade or connection error, which is not touched here.

**`libp2p_core::transport::choice`** — 18 lines, but ~9 KB *each*, because it spells out the entire monomorphised transport type to report which transport in the list didn't handle an address. Trying each transport in turn is how that transport works, so this is routine. Scoped to the one module deliberately: its sibling `libp2p_core::upgrade` reports real TLS/noise upgrade failures and stays loud.

## The change

```rust
const QUIET_TARGETS: &str =
    "cranelift_codegen=warn,multistream_select=warn,libp2p_core::transport::choice=warn";
```

**`warn`, not `off`** — none of the three said anything at warn or above anywhere in 6.6 MB of captured logs, so the entire flood sits below that line. Leaving the level open costs nothing today and keeps the door open if one of them ever has something real to report.

**Prepended, not appended**, and that ordering is the design:

- a **target-specific** directive beats a blanket level regardless of position, so `RUST_LOG=debug` still shows everything else;
- an **explicit** `RUST_LOG=cranelift_codegen=debug` names the same target and so wins by coming later.

## What is deliberately left loud

Volume was the search, not the criterion — usefulness decided the list. The next two largest sources are both kept, and a test asserts they survive:

- **`libp2p_gossipsub` (12.1%, 3,343 lines)** — `HEARTBEAT: Mesh low. Topic contains: 1 needs: 4`, `Updating mesh, new mesh: {}`, `RANDOM PEERS: Got 0 peers`. This is mesh formation, i.e. the evidence mesh-join and mesh-scoring bugs are diagnosed from.
- **`libp2p_swarm`** — its `Connection closed with error … UnexpectedEof` lines were the single most valuable piece of evidence in the investigation that prompted this PR: they are how one node noticing another node's death shows up at all.
- **All `calimero_*` targets (~42%)** — the product's own logs. There are chatty spots (per-chunk `blob_protocol` lines, `Loaded context from database` 567×) but trimming our own logging is a product decision, not log hygiene, and does not belong in this PR.

## Proof

Five tests in `crates/merod/src/main.rs`. They assert on **real emitted output** — a subscriber built from the directives, ten events, and what came out the other side — rather than on the directive string, because the precedence being relied on is `EnvFilter`'s, not ours:

- `blanket_debug_drops_every_quieted_target`
- `blanket_debug_still_keeps_everything_worth_reading` — gossipsub, swarm, `libp2p_core::upgrade`, and node lines all survive
- `a_quieted_target_can_still_raise_a_warning` — the point of `warn` over `off`
- `an_explicit_directive_opts_a_quieted_target_back_in` — all three targets
- `an_unset_or_blank_rust_log_falls_back_to_the_defaults`

```
cargo test -p merod --bins   → 64 passed
cargo fmt --check            → clean
cargo clippy -p merod --all-targets -- -D warnings                            → clean
cargo clippy -p merod --all-targets --features mock-attestation -- -D warnings → clean
```

The default filter (`merod=info,calimero_=info,mero_auth=info`) was already target-scoped and so never showed any of this; the fix matters for anyone who sets a blanket level — every e2e node, and every `RUST_LOG=debug merod run`.

## Related

[merobox#338](https://github.com/calimero-network/merobox/pull/338) (merged) is the other half of the same investigation: it records *why* a node stopped — exit code, `OOMKilled` — instead of leaving a log that simply ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
