### PR TITLE
fix(runtime): stop writing user data into the node's log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,6 +1593,7 @@ dependencies = [
  "tokio-stream",
  "toml 0.8.23",
  "tracing",
+ "tracing-subscriber",
  "ureq",
  "wasmer",
  "wasmer-compiler-cranelift",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -40,6 +40,7 @@ name = "demo"
 
 [dev-dependencies]
 assert-json-diff.workspace = true
+tracing-subscriber.workspace = true
 eyre.workspace = true
 owo-colors.workspace = true
 rand.workspace = true

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -32,6 +32,7 @@ use calimero_account::AccountId;
 use calimero_context_config::types::GovernanceParentEdge;
 use calimero_node_primitives::client::NodeClient;
 use calimero_primitives::common::DIGEST_SIZE;
+use calimero_primitives::hash::Hash;
 use calimero_sys as sys;
 use ouroboros::self_referencing;
 use serde::Serialize;
@@ -582,9 +583,18 @@ impl<'a> VMLogic<'a> {
         limits: &'a VMLimits,
         node_client: Option<NodeClient>,
     ) -> Self {
+        // Fields are named one by one rather than Debug-printing `context`.
+        // `VMContext::input` holds the call's arguments — user data the operator
+        // is not supposed to see — so `?context` put every method's payload in
+        // the node's log. It was also unreadable and enormous: `Cow<[u8]>` Debugs
+        // as a decimal byte array, so a small JSON body arrived as
+        // `[123, 34, 107, ...]` at ~9 KB per line. The length is the part that
+        // answers a question; the bytes never were.
         debug!(
             target: "runtime::logic",
-            context = ?context,
+            context_id = %Hash::from(context.context_id),
+            executor = %Hash::from(context.executor_public_key),
+            input_len = context.input.len(),
             limits = ?limits,
             has_node_client = node_client.is_some(),
             has_private_storage = private_storage.is_some(),
@@ -1212,6 +1222,80 @@ mod tests {
 
     // Export macros to the module level, so it can be reused in other host functions' tests.
     pub(super) use setup_vm;
+
+    /// Captures everything logged while `body` runs, so a test can assert on what
+    /// a log line does *not* contain.
+    fn capture_logs(body: impl FnOnce()) -> String {
+        use std::io::{Result as IoResult, Write};
+        use std::sync::{Arc, Mutex};
+
+        use tracing_subscriber::fmt::layer;
+        use tracing_subscriber::prelude::*;
+        use tracing_subscriber::registry;
+
+        struct Buffer(Arc<Mutex<Vec<u8>>>);
+        impl Write for Buffer {
+            fn write(&mut self, bytes: &[u8]) -> IoResult<usize> {
+                self.0
+                    .lock()
+                    .expect("log buffer poisoned")
+                    .extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> IoResult<()> {
+                Ok(())
+            }
+        }
+
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&buffer);
+        let subscriber = registry().with(
+            layer()
+                .with_ansi(false)
+                .with_writer(move || Buffer(Arc::clone(&sink))),
+        );
+
+        tracing::subscriber::with_default(subscriber, body);
+
+        let bytes = buffer.lock().expect("log buffer poisoned").clone();
+        String::from_utf8(bytes).expect("formatted output must be utf-8")
+    }
+
+    /// `VMLogic::new` used to Debug-print the whole `VMContext`, which carries
+    /// the call's arguments — so every execution wrote its payload into the
+    /// node's log, where an operator is not supposed to see user data. It also
+    /// rendered as a decimal byte array, at roughly 9 KB a line.
+    #[test]
+    fn vmlogic_new_does_not_log_the_call_payload() {
+        // Recognizable in both renderings: as text, and as the decimal bytes a
+        // `Cow<[u8]>` Debugs into.
+        let payload = br#"{"key":"topsecret"}"#.to_vec();
+        let text = String::from_utf8(payload.clone()).expect("payload is utf-8");
+        let as_debug_bytes = format!("{payload:?}");
+
+        let output = capture_logs(|| {
+            let mut storage = SimpleMockStorage::new();
+            let limits = VMLimits::default();
+            let (_logic, _store) = setup_vm!(&mut storage, &limits, payload.clone());
+        });
+
+        assert!(
+            output.contains("VMLogic::new"),
+            "the line under test must have been emitted, got: {output}"
+        );
+        assert!(
+            output.contains(&format!("input_len={}", payload.len())),
+            "the payload length is what should be logged, got: {output}"
+        );
+        assert!(
+            !output.contains(&text),
+            "the payload must not appear as text, got: {output}"
+        );
+        assert!(
+            !output.contains(&as_debug_bytes),
+            "the payload must not appear as a byte array, got: {output}"
+        );
+    }
 
     /// Helper to write a similar to `sys::Buffer` struct representation to memory.
     /// Simulates a WASM guest preparing a memory descriptor for a host call.

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -515,14 +515,18 @@ impl VMHostFunctions<'_> {
         }
         self.with_logic_mut(|logic| logic.logs.push(message.clone()));
 
-        // The message itself is deliberately not repeated here. It is already
-        // pushed onto `logic.logs` above and returned to the caller in the
-        // execution outcome, which is where it belongs: the app's own log line
-        // is written by app code over app state, so it can hold anything the
-        // app was given, and a node operator is not supposed to see user data.
-        // Copying it into the node's log put it in a place with a different
-        // audience and a different retention — a CI artifact, a support bundle —
-        // for no diagnostic gain the count does not already provide.
+        // Split by audience. The app's own log line is written by app code over
+        // app state, so it can hold anything the app was given — and a node
+        // operator is not supposed to see user data. It is already returned to
+        // the caller in the execution outcome, which is the audience entitled to
+        // it, so the node's log keeps the shape of the line and not its content.
+        //
+        // The content stays available at `trace`, because reading guest output
+        // in a node log is a real way to debug an app. That level is the whole
+        // point: it is off by default AND off under a blanket `RUST_LOG=debug`,
+        // which is what every e2e node runs and what gets uploaded as a CI
+        // artifact. Someone who wants it asks for it by name with
+        // `RUST_LOG=runtime::guest::log=trace`.
         let total_logs = self.borrow_logic().logs.len();
         info!(
             target: "runtime::guest::log",
@@ -530,6 +534,12 @@ impl VMHostFunctions<'_> {
             total_logs,
             message_len = message.len(),
             "guest log (js_std_d_print)"
+        );
+        trace!(
+            target: "runtime::guest::log",
+            total_logs,
+            message = %message,
+            "guest log message (js_std_d_print)"
         );
 
         Ok(0)
@@ -860,16 +870,22 @@ impl VMHostFunctions<'_> {
         let total_logs = self.borrow_logic().logs.len();
         let interesting = message.contains("[dispatcher]") || message.contains("QuickJS");
 
-        // As in `js_std_d_print`: the message goes to the caller via
-        // `logic.logs`, not into the operator's log. `interesting` still says
-        // whether it was a dispatcher/QuickJS line, which is what this flag was
-        // for, and needs no user data to answer.
+        // As in `js_std_d_print`: shape at info, content at trace. `interesting`
+        // still says whether this was a dispatcher/QuickJS line, which is what
+        // the flag was for and needs no user data to answer.
         info!(
             target: "runtime::guest::log",
             interesting,
             total_logs,
             message_len = message.len(),
             "guest log"
+        );
+        trace!(
+            target: "runtime::guest::log",
+            interesting,
+            total_logs,
+            message = %message,
+            "guest log message"
         );
 
         Ok(())

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -515,12 +515,20 @@ impl VMHostFunctions<'_> {
         }
         self.with_logic_mut(|logic| logic.logs.push(message.clone()));
 
+        // The message itself is deliberately not repeated here. It is already
+        // pushed onto `logic.logs` above and returned to the caller in the
+        // execution outcome, which is where it belongs: the app's own log line
+        // is written by app code over app state, so it can hold anything the
+        // app was given, and a node operator is not supposed to see user data.
+        // Copying it into the node's log put it in a place with a different
+        // audience and a different retention — a CI artifact, a support bundle —
+        // for no diagnostic gain the count does not already provide.
         let total_logs = self.borrow_logic().logs.len();
         info!(
             target: "runtime::guest::log",
             interesting = false,
             total_logs,
-            message = %message,
+            message_len = message.len(),
             "guest log (js_std_d_print)"
         );
 
@@ -852,11 +860,15 @@ impl VMHostFunctions<'_> {
         let total_logs = self.borrow_logic().logs.len();
         let interesting = message.contains("[dispatcher]") || message.contains("QuickJS");
 
+        // As in `js_std_d_print`: the message goes to the caller via
+        // `logic.logs`, not into the operator's log. `interesting` still says
+        // whether it was a dispatcher/QuickJS line, which is what this flag was
+        // for, and needs no user data to answer.
         info!(
             target: "runtime::guest::log",
             interesting,
             total_logs,
-            message = %message,
+            message_len = message.len(),
             "guest log"
         );
 


### PR DESCRIPTION
Found while auditing our own logs for secret leakage. **No key material leaks** — that part of the codebase is in good shape (details at the bottom). But three log sites copy **application data** into the operator's log, which the privacy model says an operator never sees.

## The leaks

**`VMLogic::new` logged every call's arguments.** It Debug-printed the whole `VMContext`, and `VMContext.input` is the call payload:

```
DEBUG runtime::logic: VMLogic::new context=VMContext { input: [123, 34, 107, 101, 121, 34, 58, 34, …
```

That is a JSON body rendered as the decimal byte array a `Cow<[u8]>` Debugs into — so it is simultaneously a privacy leak, unreadable, and enormous. Measured across a 6-scenario corpus: **240 lines, 2.1 MB, ~9 KB each, 6.1% of all `calimero_*` log bytes.** It now names `context_id`, `executor` and `input_len`; the length was the only part that ever answered a question.

**The two guest-log sites re-emitted the app's own log line into the node's log** (`log_utf8` and `js_std_d_print`, both `message = %message`). The message is already pushed onto `logic.logs` and returned to the caller in the execution outcome — that is the audience entitled to it. Copying it into the node log moves user data into a place with different readers and different retention, for no diagnostic gain. Both now log `message_len`; `log_utf8` keeps its `interesting` flag, which never needed the content to compute.

## On severity

These are quiet only by accident. The default filter is `merod=info,calimero_=info,mero_auth=info` — no directive matches `runtime::*`, so with default settings none of this prints. But any widened `RUST_LOG` turns all three on, **every e2e node runs at `RUST_LOG=debug`, and those logs are uploaded as CI artifacts.** So the exposure is real in exactly the situation where logs get collected, retained and shared.

## Proof

New test `vmlogic_new_does_not_log_the_call_payload` builds a `VMLogic` with the payload `{"key":"topsecret"}` and asserts the captured log output contains `input_len=19` and contains the payload **neither as text nor as its byte-array rendering**. Verified as a real regression test by restoring the old line:

```
# with `context = ?context` restored
test logic::tests::vmlogic_new_does_not_log_the_call_payload ... FAILED
  panicked at crates/runtime/src/logic.rs:1284 — the payload must not appear as text

# with the fix
test logic::tests::vmlogic_new_does_not_log_the_call_payload ... ok
```

```
cargo test -p calimero-runtime --lib                                    → 150 passed
cargo fmt --check                                                       → clean
cargo clippy -p calimero-runtime --all-targets -- -D warnings            → clean
cargo deny check licenses sources                                       → licenses ok, sources ok
```

`tracing-subscriber` is added as a **dev**-dependency (already a workspace dep, used by `merod`) so the test can capture emitted output rather than assert on a format string.

## What the audit cleared

Recording this so the next person does not repeat the search. Scanned 598 MB of captured node logs (20 logs, 6 scenarios) plus every log call site in `crates/`:

- **`PrivateKey`, `SharedKey`, `X25519SecretKey` all have hand-written redacting `Debug`** (`f.pad("PrivateKey")`, `SharedKey([redacted])`, `X25519SecretKey([redacted])`), with zeroize-on-drop; `PrivateKey` deliberately has no `Clone`/`Copy` and a single audited `as_bytes()`.
- **No log macro anywhere interpolates `as_bytes()`.**
- **No seed phrase / mnemonic / root key is ever logged** — zero call sites.
- **mero-auth logs only *about* secrets** (type, rotation, failure), never a token or password value.
- **No JWT-shaped token anywhere in 598 MB.** The single `eyJ` substring hit was a false positive inside a hex blob.
- **Every ≥64-hex field in the captured logs is an identifier or hash** — `message_id`, `namespace_id`, `node_id`, `key_id` (an auth key *identifier*), `owner`, `topic`.
- **Storage values are logged as lengths, not contents** (`value_len`, `input_len`), which is the pattern the three sites above were breaking.

## Follow-ups from the same audit, not in this PR

- A shutdown busy-loop in `libp2p_mdns`/`netlink_proto` that is **76% of all e2e log bytes** and spins a core for ~5 s per shutdown — filed separately, since it is a defect rather than log hygiene.
- The sync stack logs each state transition at two or three layers, and 500 of 608 no-op syncs still emit 4 INFO lines while the informative line sits at DEBUG.
- Per-operation hot paths (`runtime::host::storage`, 27.8% of our bytes) belong at TRACE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: guest log content kept, at `trace`

Review raised the right question — if the app's message is gone from the node log, can you still debug what an app did? Removing it outright took away a real route: reading guest output in a node log is how JS dispatcher problems get found, which is exactly what the `interesting = contains("[dispatcher]") || contains("QuickJS")` flag beside it exists for. Count and length cannot replace that.

So both guest sites now split by level instead of dropping content:

- **`info`** keeps the shape — `interesting`, `total_logs`, `message_len`.
- **`trace`** carries the message.

`trace` is the whole point: it is off by default **and** off under a blanket `RUST_LOG=debug` — which is what every e2e node runs and what gets uploaded as a CI artifact. So app data stays out of routinely-collected logs while staying one named directive away for whoever is actually debugging:

```
RUST_LOG=runtime::guest::log=trace
```

**The `VMLogic::new` payload dump is not restored in any form**, because for "what was called" it was redundant as well as leaky. `execute` already logs, one layer up:

```rust
info!(%context_id, method, "Executing method in context");                 // ← INFO: in the DEFAULT log
debug!(%context_id, %executor, method, payload_len, atomic, "Execution request details");
```

and the `rpc_request` span attaches `method` + `context_id` to every line in the request's scope. For "what failed", nothing in this PR touches `"Execution outcome details"` (`status`, `old_root_hash`, `new_root_hash`, `artifact_len`, `logs_count`, `events_count`, `xcalls_count`), `"Method execution completed"`, the cross-context error lines, or the panic hook.
