### PR TITLE
refactor(logs): move per-operation logs to the level they belong at

### DIFF
--- a/apps/scaffolding-e2e/workflows/sorted-set-concurrent-convergence.yml
+++ b/apps/scaffolding-e2e/workflows/sorted-set-concurrent-convergence.yml
@@ -30,10 +30,14 @@ force_pull_image: false
 # Passed verbatim to each node container as RUST_LOG (merobox manager.py sets
 # `"RUST_LOG": log_level`). Global `info` keeps the log readable while the three
 # targeted channels surface the decisive path: the storage ordered-index
-# instrumentation this branch adds (`sorted_index_dbg`), the rest of the storage
-# merge/apply layer, and the node sync (HashComparison / deferred-root-merge)
-# path #3333 localizes to.
-log_level: "info,calimero_storage::sorted_index_dbg=debug,calimero_storage=debug,calimero_node::sync=debug"
+# instrumentation (`sorted_index_dbg`), the rest of the storage merge/apply
+# layer, and the node sync (HashComparison / deferred-root-merge) path this
+# scenario localizes.
+#
+# `sorted_index_dbg=trace`, not `=debug`: the probe fires once per apply, so it
+# sits at trace and every other scenario is spared it. This scenario is the one
+# that wants it, and asks for it by name.
+log_level: "info,calimero_storage::sorted_index_dbg=trace,calimero_storage=debug,calimero_node::sync=debug"
 
 auth_mode: embedded
 

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -488,7 +488,7 @@ impl ContextRegistry {
         .with_application_version(application_version)
         .with_name(name);
 
-        tracing::debug!(
+        tracing::trace!(
             %context_id,
             dag_heads_count = meta.dag_heads.len(),
             "Loaded context from database"

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -2,7 +2,7 @@ use crate::{
     errors::HostError,
     logic::{sys, VMHostFunctions, VMLogicResult},
 };
-use tracing::{debug, trace};
+use tracing::trace;
 
 impl VMHostFunctions<'_> {
     /// Reads a value from the persistent storage.
@@ -52,7 +52,7 @@ impl VMHostFunctions<'_> {
                 logic.registers.set(logic.limits, dest_register_id, value)
             })?;
 
-            debug!(
+            trace!(
                 target: "runtime::host::storage",
                 op = "read",
                 key_len = key.len(),
@@ -64,7 +64,7 @@ impl VMHostFunctions<'_> {
             return Ok(1);
         }
 
-        debug!(
+        trace!(
             target: "runtime::host::storage",
             op = "read",
             key_len = key.len(),
@@ -131,7 +131,7 @@ impl VMHostFunctions<'_> {
                 logic.registers.set(logic.limits, dest_register_id, value)
             })?;
 
-            debug!(
+            trace!(
                 target: "runtime::host::storage",
                 op = "remove",
                 key_len = key.len(),
@@ -143,7 +143,7 @@ impl VMHostFunctions<'_> {
             return Ok(1);
         }
 
-        debug!(
+        trace!(
             target: "runtime::host::storage",
             op = "remove",
             key_len = key.len(),
@@ -230,7 +230,7 @@ impl VMHostFunctions<'_> {
                 logic.registers.set(logic.limits, dest_register_id, evicted)
             })?;
 
-            debug!(
+            trace!(
                 target: "runtime::host::storage",
                 op = "write",
                 dest_register_id,
@@ -241,7 +241,7 @@ impl VMHostFunctions<'_> {
             return Ok(1);
         }
 
-        debug!(
+        trace!(
             target: "runtime::host::storage",
             op = "write",
             dest_register_id,
@@ -297,7 +297,7 @@ impl VMHostFunctions<'_> {
         // Access private storage
         let logic = self.borrow_logic();
         let Some(ref private_storage) = logic.private_storage else {
-            debug!(
+            trace!(
                 target: "runtime::host::private_storage",
                 "private_storage_read: no private storage available"
             );
@@ -310,7 +310,7 @@ impl VMHostFunctions<'_> {
                 logic.registers.set(logic.limits, dest_register_id, value)
             })?;
 
-            debug!(
+            trace!(
                 target: "runtime::host::private_storage",
                 op = "read",
                 key_len = key.len(),
@@ -322,7 +322,7 @@ impl VMHostFunctions<'_> {
             return Ok(1);
         }
 
-        debug!(
+        trace!(
             target: "runtime::host::private_storage",
             op = "read",
             key_len = key.len(),
@@ -385,7 +385,7 @@ impl VMHostFunctions<'_> {
                 logic.registers.set(logic.limits, dest_register_id, value)
             })?;
 
-            debug!(
+            trace!(
                 target: "runtime::host::private_storage",
                 op = "remove",
                 key_len = key.len(),
@@ -397,7 +397,7 @@ impl VMHostFunctions<'_> {
             return Ok(1);
         }
 
-        debug!(
+        trace!(
             target: "runtime::host::private_storage",
             op = "remove",
             key_len = key.len(),
@@ -490,7 +490,7 @@ impl VMHostFunctions<'_> {
         })?;
 
         if written {
-            debug!(
+            trace!(
                 target: "runtime::host::private_storage",
                 op = "write",
                 key_len,
@@ -500,7 +500,7 @@ impl VMHostFunctions<'_> {
             return Ok(1);
         }
 
-        debug!(
+        trace!(
             target: "runtime::host::private_storage",
             "private_storage_write: no private storage available"
         );

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -600,7 +600,7 @@ where
     /// marker and skips its own rebuild of converged-but-unindexed data.
     fn stamp_index_marker(&self) {
         let full = self.current_full_hash();
-        tracing::debug!(
+        tracing::trace!(
             target: "calimero_storage::sorted_index_dbg",
             collection = %self.inner.id(),
             hash = %hex::encode(full),
@@ -616,7 +616,7 @@ where
         let full = self.current_full_hash();
         let stored = S::index_meta_get(self.inner.id());
         let current = stored.as_deref() == Some(&full[..]);
-        tracing::debug!(
+        tracing::trace!(
             target: "calimero_storage::sorted_index_dbg",
             collection = %self.inner.id(),
             current_full_hash = %hex::encode(full),
@@ -656,7 +656,7 @@ where
                 .into_iter()
                 .map(|(order_key, _id)| order_key)
                 .collect();
-        tracing::debug!(
+        tracing::trace!(
             target: "calimero_storage::sorted_index_dbg",
             %collection,
             desired_len = desired.len(),

--- a/crates/storage/src/collections/sorted_set.rs
+++ b/crates/storage/src/collections/sorted_set.rs
@@ -351,7 +351,7 @@ where
     /// the synced state — so a peer never inherits this node's marker.
     fn stamp_index_marker(&self) {
         let full = self.current_full_hash();
-        tracing::debug!(
+        tracing::trace!(
             target: "calimero_storage::sorted_index_dbg",
             collection = %self.inner.id(),
             hash = %hex::encode(full),
@@ -366,7 +366,7 @@ where
         let full = self.current_full_hash();
         let stored = S::index_meta_get(self.inner.id());
         let current = stored.as_deref() == Some(&full[..]);
-        tracing::debug!(
+        tracing::trace!(
             target: "calimero_storage::sorted_index_dbg",
             collection = %self.inner.id(),
             current_full_hash = %hex::encode(full),
@@ -395,7 +395,7 @@ where
                 .into_iter()
                 .map(|(order_key, _id)| order_key)
                 .collect();
-        tracing::debug!(
+        tracing::trace!(
             target: "calimero_storage::sorted_index_dbg",
             %collection,
             desired_len = desired.len(),

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -43,7 +43,7 @@ use borsh::{from_slice, to_vec};
 use calimero_account::AccountId;
 use calimero_primitives::identity::PublicKey;
 use sha2::{Digest, Sha256};
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 
 use crate::address::Id;
 use crate::constants;
@@ -2325,7 +2325,7 @@ impl<S: StorageAdaptor> Interface<S> {
                 ancestors,
                 metadata,
             } => {
-                debug!(
+                trace!(
                     %id,
                     ancestor_ids = ?ancestors.iter().map(|a| a.id()).collect::<Vec<_>>(),
                     created_at = metadata.created_at,
@@ -2457,7 +2457,7 @@ impl<S: StorageAdaptor> Interface<S> {
                 // and this arm returns early). Clearing a non-sorted parent's
                 // marker is a no-op, so no "is this sorted?" check is needed.
                 if let Some(parent) = parent {
-                    tracing::debug!(
+                    tracing::trace!(
                         target: "calimero_storage::sorted_index_dbg",
                         child = %id,
                         parent = %parent.id(),
@@ -2465,7 +2465,7 @@ impl<S: StorageAdaptor> Interface<S> {
                     );
                     let _ = S::index_meta_clear(parent.id());
                 } else {
-                    tracing::debug!(
+                    tracing::trace!(
                         target: "calimero_storage::sorted_index_dbg",
                         child = %id,
                         "APPLY_ADD parent=None, marker clear SKIPPED"
@@ -2608,8 +2608,6 @@ impl<S: StorageAdaptor> Interface<S> {
                 Self::apply_delete_ref_action(id, deleted_at)?;
             }
         };
-
-        debug!("Interface::apply_action completed");
 
         Ok(())
     }
@@ -2776,7 +2774,7 @@ impl<S: StorageAdaptor> Interface<S> {
             // marker so a `SortedSet`/`SortedMap` rebuilds its ordered index on
             // the next read rather than serving the removed element. No-op for a
             // non-sorted parent.
-            tracing::debug!(
+            tracing::trace!(
                 target: "calimero_storage::sorted_index_dbg",
                 child = %id,
                 parent = %parent_id,
@@ -3817,7 +3815,7 @@ impl<S: StorageAdaptor> Interface<S> {
 
             match result {
                 Ok(merged) => {
-                    debug!(
+                    trace!(
                         target: "storage::merge",
                         %id,
                         crdt_type = ?crdt_type,


### PR DESCRIPTION
Third of the log-audit follow-ups, after #3501 (library noise) and #3502 (user data). This one is about **our** logs and only about levels — no line is removed for being wrong, one is removed for being empty.

## What was measured

20 node logs, 6 e2e scenarios, 598 MB. Our `calimero_*`/`runtime`/`storage` targets are 34.7 MB of that, and it splits DEBUG 84.2% / INFO 15.7% / WARN 0.2% / ERROR 0.0%. Five shapes are most of the DEBUG mass — share is of our 34.7 MB:

| target | lines | MB | share | change |
|---|---:|---:|---:|---|
| `runtime::host::storage` | 36,912 | 9.6 | 27.8% | debug → trace (whole file) |
| `calimero_context_client` — “Loaded context from database” | 5,761 | 1.5 | 4.4% | debug → trace |
| `calimero_storage::sorted_index_dbg` | 3,190 | 0.8 | 2.4% | debug → trace, scenario updated |
| `storage::merge` — “Successfully merged non-root entity” | 2,308 | 0.9 | 2.7% | debug → trace |
| `calimero_storage::interface` — “preparing to upsert” | 3,179 | 0.8 | 2.3% | debug → trace |
| `calimero_storage::interface` — “apply_action completed” | 3,947 | 0.6 | 1.8% | **deleted** |

None of these is wrong to have. They are wrong to have at `debug`, where they arrive by the tens of thousands and bury the lines that say what the node decided. `trace` is one `RUST_LOG` away for anyone who wants them.

## The host-storage file already showed the intended shape

Every function in `host_functions/storage.rs` has a `trace!` on entry and a `debug!` on outcome. But the outcome of a *single host call* is not a debug-level event, and this particular line cannot be made useful by keeping it:

```
DEBUG runtime::host::storage: storage_read hit op="read" key_len=32 value_len=123 dest_register_id=4294967294
```

`dest_register_id` is the constant `4294967294` on **all 27,246** of them. There is no key, no context id, no request — nothing to correlate against, at any volume. So the whole file moves to trace rather than one half of each pair.

## `apply_action` logged three times per action

“preparing to upsert” → the outcome → a bare `debug!("Interface::apply_action completed")`. The enter half moves to trace; the trailing “completed” is deleted, because it carries no fields at all — the outcome line already reports everything it was announcing.

## On `sorted_index_dbg` — deliberately not deleted

My first read of this was that the probe had outlived its investigation and should go. That was wrong: `apps/scaffolding-e2e/workflows/sorted-set-concurrent-convergence.yml` **names it explicitly** in its `log_level` and documents it as the instrumentation the scenario relies on.

So it stays, at `trace`, and that scenario is updated to `sorted_index_dbg=trace`. A scenario that asks for a channel by name can ask for it at trace just as easily — and every *other* scenario stops carrying 3,190 lines of it.

## Verification

```
cargo fmt --check                                                    → clean
cargo clippy -p calimero-runtime -p calimero-storage \
  -p calimero-context-client --all-targets \
  --features calimero-storage/testing -- -D warnings                 → clean
cargo test -p calimero-storage -p calimero-runtime \
  --features calimero-storage/testing                                → all green (690 + 149 + others)
```

No behavioural change beyond log levels, so the e2e suite is the real check — in particular `sorted-set-concurrent-convergence`, whose instrumentation this PR moves.

## Still open from the audit

- **#3503** — the `libp2p_mdns`/`netlink_proto` shutdown busy-loop: 76% of all e2e log bytes and a pegged core per shutdown. Much larger than everything here.
- **The sync stack's INFO narration** — each transition logged at two or three layers, and 500 of 608 no-op syncs emit 4 INFO lines while the one informative line (`No sync needed: root hashes match`) sits at DEBUG. That one changes what operators see by default, so it is worth its own PR and its own argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
