### PR TITLE
refactor(logs): log what a sync concluded, not every stage it passed

### DIFF
--- a/crates/node/src/handlers/network_event/readiness.rs
+++ b/crates/node/src/handlers/network_event/readiness.rs
@@ -212,7 +212,7 @@ pub(super) fn handle_readiness_beacon(
     // (Phase 8.1). Must run AFTER `cache.insert` so a waiter that
     // re-checks the cache on wakeup sees the new entry.
     manager.readiness_notify.notify(namespace_id);
-    info!(
+    debug!(
         namespace_id = %hex::encode(namespace_id),
         peer = %peer_pubkey,
         applied_through,

--- a/crates/node/src/readiness.rs
+++ b/crates/node/src/readiness.rs
@@ -801,7 +801,7 @@ impl ReadinessManager {
         let log_strong = strong;
         actix::spawn(async move {
             match net.publish(topic, bytes).await {
-                Ok(_) => tracing::info!(
+                Ok(_) => tracing::debug!(
                     namespace_id = %hex::encode(log_ns),
                     applied_through = log_applied,
                     strong = log_strong,

--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -701,7 +701,7 @@ impl SyncManager {
         stream: &mut Stream,
         _nonce: Nonce,
     ) -> Result<()> {
-        info!(
+        debug!(
             %context_id,
             "Handling DAG heads request from peer"
         );
@@ -712,7 +712,7 @@ impl SyncManager {
             .get_context(&context_id)?
             .ok_or_eyre("Context not found")?;
 
-        info!(
+        debug!(
             %context_id,
             heads_count = context.dag_heads.len(),
             root_hash = %context.root_hash,

--- a/crates/node/src/sync/driver.rs
+++ b/crates/node/src/sync/driver.rs
@@ -271,7 +271,7 @@ impl SyncDriver {
                     continue;
                 }
                 Some((ctx, peer)) = self.ctx_sync_rx.recv() => {
-                    info!(?ctx, ?peer, "Received sync request");
+                    debug!(?ctx, ?peer, "Received sync request");
 
                     requested_ctx = ctx;
                     requested_peer = peer;
@@ -399,7 +399,7 @@ impl SyncDriver {
                 }
             };
 
-            info!(%context_id, "Scheduled sync");
+            debug!(%context_id, "Scheduled sync");
 
             // Phase 2: dispatch BEFORE mutating state — so a
             // `Full`/`Closed` outcome leaves the per-context tracking

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -228,7 +228,7 @@ async fn run_initiator_impl<T: SyncTransport>(
     session_peer: Option<PublicKey>,
     init_pop: Option<InitProof>,
 ) -> Result<HashComparisonStats> {
-    info!(%context_id, "Starting HashComparison sync (initiator)");
+    debug!(%context_id, "Starting HashComparison sync (initiator)");
 
     let mut stats = HashComparisonStats::default();
 
@@ -811,7 +811,7 @@ async fn run_initiator_impl<T: SyncTransport>(
         }
     }
 
-    info!(
+    debug!(
         %context_id,
         nodes_compared = stats.nodes_compared,
         entities_merged = stats.entities_merged,

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -750,7 +750,7 @@ impl SyncManager {
             }
         };
 
-        info!(
+        debug!(
             %context_id,
             peer_count = peers.len(),
             attempts = final_attempt,
@@ -1171,7 +1171,7 @@ impl SyncManager {
     ) -> eyre::Result<(PeerId, SyncProtocol)> {
         let start = Instant::now();
 
-        info!(%context_id, %peer_id, "Attempting to sync with peer");
+        debug!(%context_id, %peer_id, "Attempting to sync with peer");
 
         // Metrics: every sync attempt goes through this chokepoint, so
         // `sync_start / sync_complete / sync_failure` here covers every
@@ -1201,7 +1201,7 @@ impl SyncManager {
 
         let took = start.elapsed();
 
-        info!(%context_id, %peer_id, ?took, ?protocol, "Sync with peer completed successfully");
+        debug!(%context_id, %peer_id, ?took, ?protocol, "Sync with peer completed successfully");
 
         // Use the variant-only `SyncProtocolKind` for the protocol label
         // so it matches the fixed `KNOWN_PROTOCOLS` set in
@@ -1641,7 +1641,7 @@ impl SyncManager {
                 }
             }
 
-            info!(
+            debug!(
                 %context_id,
                 %chosen_peer,
                 protocol = ?selection.protocol,
@@ -1866,7 +1866,7 @@ impl SyncManager {
             .await?;
 
         let is_uninitialized = *context.root_hash == [0; 32];
-        info!(
+        debug!(
             %context_id,
             %chosen_peer,
             is_uninitialized,

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -220,7 +220,7 @@ impl ProtocolSelector {
                 Ok(Some(result))
             }
             SyncProtocol::HashComparison { root_hash, .. } => {
-                info!(
+                debug!(
                     %context_id,
                     reason = %selection.reason,
                     "Starting HashComparison sync"
@@ -248,7 +248,7 @@ impl ProtocolSelector {
                 .await
                 {
                     Ok(stats) => {
-                        info!(
+                        debug!(
                             %context_id,
                             nodes_compared = stats.nodes_compared,
                             entities_merged = stats.entities_merged,

--- a/crates/node/src/sync/session.rs
+++ b/crates/node/src/sync/session.rs
@@ -33,7 +33,7 @@ use calimero_primitives::events::{
 use calimero_primitives::sync_status::SyncState as SyncPhase;
 use dashmap::DashMap;
 use tokio::time::Instant;
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use super::manager::{NoPeersAvailable, PeerNotMaterialized};
 use super::tracking::{SyncProtocol as TrackingSyncProtocol, SyncState};
@@ -481,7 +481,7 @@ impl SessionTracker {
             Some(s) => match result {
                 Ok(Ok(ref protocol)) => {
                     s.on_success(peer_id, TrackingSyncProtocol::from(protocol));
-                    info!(
+                    debug!(
                         %context_id,
                         ?took,
                         ?protocol,

--- a/crates/server/src/admin/handlers/context/get_context.rs
+++ b/crates/server/src/admin/handlers/context/get_context.rs
@@ -6,7 +6,7 @@ use axum::Extension;
 use calimero_primitives::context::ContextId;
 use calimero_server_primitives::admin::GetContextResponse;
 use reqwest::StatusCode;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use crate::admin::service::{parse_api_error, ApiError, ApiResponse};
 use crate::AdminState;
@@ -15,7 +15,7 @@ pub async fn handler(
     Path(context_id): Path<ContextId>,
     Extension(state): Extension<Arc<AdminState>>,
 ) -> impl IntoResponse {
-    info!(context_id=%context_id, "Getting context");
+    debug!(context_id=%context_id, "Getting context");
 
     // todo! experiment with Interior<Store>: WriteLayer<Interior>
     let context = state

--- a/crates/server/src/admin/handlers/context/sync.rs
+++ b/crates/server/src/admin/handlers/context/sync.rs
@@ -5,7 +5,7 @@ use axum::response::IntoResponse;
 use axum::Extension;
 use calimero_primitives::context::ContextId;
 use calimero_server_primitives::admin::SyncContextResponse;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use crate::admin::service::{parse_api_error, ApiResponse};
 use crate::AdminState;
@@ -17,7 +17,7 @@ pub async fn handler(
     let context_id = context_id.map(|Path(c)| c);
 
     if let Some(ref ctx_id) = context_id {
-        info!(context_id=%ctx_id, "Syncing context");
+        debug!(context_id=%ctx_id, "Syncing context");
     } else {
         info!("Syncing all contexts");
     }
@@ -27,7 +27,7 @@ pub async fn handler(
     match result {
         Ok(()) => {
             if let Some(ref ctx_id) = context_id {
-                info!(context_id=%ctx_id, "Context sync completed successfully");
+                debug!(context_id=%ctx_id, "Context sync completed successfully");
             } else {
                 info!("All contexts sync completed successfully");
             }


### PR DESCRIPTION
Last of the log-audit follow-ups, after #3501, #3502 and #3504. This is the one that changes **what operators see by default**, so it is separate and the specific judgement call is called out below for argument.

## The problem

The default filter is `merod=info,calimero_=info,mero_auth=info`, so INFO from our crates is what ships to every operator, forever. Measured over 20 node logs from 6 scenarios: **15,321 INFO lines from our targets, 53% of them sync and readiness chatter.**

The fault is not that sync logs too much. It is that **every layer of the sync stack logs the same state transition.** One session is 19 INFO lines:

| transition | logged by | lines |
|---|---|---:|
| a sync was requested | `admin::handlers::context::sync` ×2 · `sync::driver` ×2 | 4 |
| a session is starting | `sync::manager` — “Peer discovery yielded candidates”, “Attempting to sync”, “Starting sync session” | 3 |
| HashComparison began | `sync::protocol_selector` **and** `sync::hash_comparison_protocol` | 2 |
| HashComparison finished | `sync::hash_comparison_protocol` **and** `sync::protocol_selector` | 2 |
| the session finished | `sync::manager` ×2 **and** `sync::session` | 3 |

And the sharper version — what an *idle* tick costs. Of the **608** sessions that reached protocol selection, **500 concluded there was nothing to do**. Each still emitted four INFO lines, while the one line that says why sits at DEBUG, filtered out:

```
08:46:17.423111  INFO  calimero_node::sync::manager: Attempting to sync with peer …
08:46:17.423266  INFO  calimero_node::sync::manager: Starting sync session …
08:46:17.450051  INFO  calimero_node::sync::manager: Protocol selected …
08:46:17.450268 DEBUG  …::protocol_selector: No sync needed: root hashes match   ← the informative line, filtered out
08:46:17.450520  INFO  calimero_node::sync::manager: Sync with peer completed successfully …
```

So the default operator log says "a sync happened" four times and withholds that it was a no-op.

## The change

19 call sites move from `info!` to `debug!`. Every one is **narration** — a stage a sync passed through, saying nothing about what it concluded:

- `sync::driver` — “Scheduled sync”, “Received sync request”
- `sync::manager` — “Peer discovery yielded candidates”, “Attempting to sync with peer”, “Starting sync session”, “Protocol selected”, “Sync with peer completed successfully”
- `sync::delta_request` — “Sending DAG heads to peer”, “Handling DAG heads request from peer”
- `sync::protocol_selector` / `sync::hash_comparison_protocol` — the duplicated “Starting HashComparison sync” and “HashComparison sync complete/completed successfully”
- `sync::session` — “Sync finished successfully”
- readiness — “readiness beacon received” (1,179 lines: a periodic beacon), “readiness beacon emitted”
- `server::admin::handlers::context` — “Syncing context”, “Context sync completed successfully”, “Getting context” (per-request lines on read endpoints)

**Kept at INFO** — the outcomes:

- `Sync session complete (DAG sync performed)` — a sync that actually did something
- `scope_root still differs post-sync — pulling governance from peer`
- `received namespace governance ops from peer`, `post-sync governance pull issued`
- every WARN and ERROR, untouched

Net effect: **an idle sync tick is silent at INFO**, and a sync that changed something logs one line.

## The judgement call, stated plainly

I did **not** promote `No sync needed: root hashes match` to INFO, although my own audit write-up suggested it. At 500 occurrences in a two-minute run that would trade four noisy lines for one noisy line. "Sync is alive" is a metrics question, not a logging one, and there is already a Prometheus surface for it. If you would rather have that heartbeat in the log, it is a one-word change — say so and I will make it.

I also **demoted rather than deleted** the duplicated transitions. Collapsing them so one event is logged by one layer is the right end state, but it is a behavioural cleanup with its own review surface, and demotion alone achieves the operator-facing goal. Happy to do it as a follow-up.

## Safety check

Scenarios assert on log markers, so before touching anything I grepped every one of these 19 messages across `apps/*/workflows`, `workflows/` and `.github/workflows/`:

```
--- scan complete        # zero matches: no scenario or CI gate greps for any of them
```

## Verification

```
cargo fmt --check                                                      → clean
cargo clippy -p calimero-node -p calimero-server --all-targets \
  --features calimero-storage/testing -- -D warnings                   → clean
cargo test -p calimero-node --features calimero-storage/testing        → see CI
```

The real check is the e2e suite plus `sync-regression`, which this touches by path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
