### PR TITLE
fix(runtime)!: env::executor_id resolves to the account, not the device

### DIFF
--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -588,7 +588,7 @@ impl VMHostFunctions<'_> {
         Ok(())
     }
 
-    /// `device_id` under its former name, for WASM built before the split.
+    /// `account_id` under the pre-split name, for WASM built before the split.
     ///
     /// **A linking shim, not an API.** `calimero-sys` does not declare it, so no
     /// app compiled against the current SDK can import it and `env::executor_id()`
@@ -599,14 +599,28 @@ impl VMHostFunctions<'_> {
     /// instantiation, which is a 500 on the first context creation and looks
     /// nothing like an ABI change.
     ///
-    /// It returns the DEVICE, which is exactly what those blobs were getting.
-    /// Removable once every consumer that pins a pre-split blob has rebuilt.
+    /// **It returns the ACCOUNT.** Before the split one identity served both
+    /// roles, so a shim has to choose which of the two a stale blob meant, and
+    /// the choice is not symmetric. An app reaching for an identity is doing
+    /// ownership: `AuthoredMap`, a writer set, `Map<identity, Vote>`. Handing
+    /// those a device is the failure this split exists to end — every key of such
+    /// a map silently becomes per-installation, so one person voting from a phone
+    /// and a laptop counts twice, and nothing errors.
+    ///
+    /// The opposite mistake is real but not reachable from here: a CRDT replica
+    /// slot does need the device, and giving it an account would collapse two
+    /// installations onto one slot. Those slots are seeded inside the storage
+    /// layer from the execution's device, never through this import — so no
+    /// counter or HLC seed is resolved by calling it.
+    ///
+    /// Removable outright once every consumer that pins a pre-split blob has
+    /// rebuilt; `env::account_id()` is what they should be calling.
     ///
     /// # Errors
     ///
     /// * `HostError::InvalidMemoryAccess` if the register operation fails (e.g., exceeds limits).
     pub fn executor_id(&mut self, dest_register_id: u64) -> VMLogicResult<()> {
-        self.device_id(dest_register_id)
+        self.account_id(dest_register_id)
     }
 
     /// Writes the xcall origin (the source context id) into `dest_register_id`
@@ -1628,6 +1642,54 @@ mod tests {
                 .unwrap(),
             *account.as_bytes(),
             "the account register must carry the account, not the device"
+        );
+    }
+
+    /// **`executor_id` resolves to the ACCOUNT, not the device.**
+    ///
+    /// The pre-split name served one identity that later became two, so this shim
+    /// has to choose which a stale blob meant. An app reaching for an identity is
+    /// doing ownership — `AuthoredMap`, a writer set, `Map<identity, Vote>` — and
+    /// giving those a device makes every key per-installation, so one person on a
+    /// phone and a laptop counts twice and nothing errors.
+    ///
+    /// The device and the account are deliberately different values here. If they
+    /// were equal this would pass whichever the shim returned.
+    #[test]
+    fn executor_id_resolves_to_the_account_not_the_device() {
+        let context_id = [3u8; DIGEST_SIZE];
+        let device = [5u8; DIGEST_SIZE];
+        let account = calimero_account::AccountId::from([7u8; DIGEST_SIZE]);
+        assert_ne!(
+            &device,
+            account.as_bytes(),
+            "precondition: the two must differ, or this proves nothing"
+        );
+
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let context = VMContext::new(Cow::Owned(vec![]), context_id, device, account);
+        let mut logic = VMLogic::new(&mut storage, None, context, &limits, None);
+        let mut store = Store::default();
+        let memory =
+            wasmer::Memory::new(&mut store, wasmer::MemoryType::new(1, None, false)).unwrap();
+        let _ = logic.with_memory(memory);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        host.executor_id(1).unwrap();
+        assert_eq!(
+            host.borrow_logic().registers.get(1).unwrap(),
+            account.as_bytes(),
+            "a pre-split blob asking for an identity must get the account"
+        );
+
+        // And `device_id` still answers with the device, so the split is intact
+        // rather than both names having collapsed onto one value.
+        host.device_id(2).unwrap();
+        assert_eq!(
+            host.borrow_logic().registers.get(2).unwrap(),
+            &device,
+            "device_id must still be the device"
         );
     }
 

--- a/crates/sys/AGENTS.md
+++ b/crates/sys/AGENTS.md
@@ -50,7 +50,7 @@ This crate defines one wire format for the boundary between a WASM guest (an app
 Grouped by concern, as declared in the `wasm_imports!` block:
 
 - **Panics**: `panic`, `panic_utf8`
-- **Registers / context**: `register_len`, `read_register`, `context_id`, `executor_id`, `xcall_origin`
+- **Registers / context**: `register_len`, `read_register`, `context_id`, `account_id`, `device_id`, `xcall_origin` (this crate declares no `executor_id`; the host keeps that name as a pre-split alias, so a guest built against this crate cannot import it)
 - **Execution I/O**: `input`, `value_return`, `emit_migration_witness`, `log_utf8`, `emit`, `emit_with_handler`
 - **Cross-context calls**: `xcall`
 - **Commit**: `commit`

--- a/crates/wasm-abi/src/schema.rs
+++ b/crates/wasm-abi/src/schema.rs
@@ -331,7 +331,7 @@ pub enum CollectionCategory {
     /// Per-executor / per-position (`Counter`, `ReplicatedGrowableArray`).
     /// Converges only if the migrate body replays it deterministically.
     Replayable,
-    /// Ownership / writer-set derived from `env::executor_id()` (`AuthoredMap`,
+    /// Ownership / writer-set derived from `env::account_id()` (`AuthoredMap`,
     /// `AuthoredVector`, `SharedStorage`). A naive rebuild diverges, and a
     /// downgrade to a non-identity-gated type silently strips authorship / ACL.
     IdentityGated,
@@ -769,7 +769,7 @@ mod tests {
         assert_eq!(collection_category(&Counter), Replayable);
         assert_eq!(collection_category(&ReplicatedGrowableArray), Replayable);
 
-        // Identity-gated: ownership/writer-set is derived from env::executor_id(),
+        // Identity-gated: ownership/writer-set is derived from env::account_id(),
         // so a naive rebuild diverges and a downgrade silently strips provenance.
         assert_eq!(collection_category(&AuthoredMap), IdentityGated);
         assert_eq!(collection_category(&AuthoredVector), IdentityGated);


### PR DESCRIPTION
`env::executor_id` is a linking shim for WASM built before the account/device
split. The pre-split name served **one** identity that later became two, so the
shim has to choose which of the two a stale blob meant. It chose the device.
That is the wrong half.

## Why the account

An app reaching for an identity is doing ownership — `AuthoredMap`, a writer set,
`Map<identity, Vote>`. Handing those a device is the exact failure the split
exists to end: every key of such a map silently becomes per-installation, so one
person writing from a phone and a laptop counts twice, **and nothing errors**.

A silent double-count is worse than a link error, and the blobs importing this
name are precisely the ones written before anybody had to think about which
identity they meant.

## The opposite mistake, checked rather than waved away

A CRDT replica slot genuinely does need the device, and giving it an account
would collapse two installations onto one slot — losing updates instead of
double-counting them. That hazard is real but **not reachable through this
import**: replica slots are seeded inside the storage layer from the execution's
device, never by calling `executor_id`. No counter or HLC seed is resolved here.

## A doc that was wrong is now right

`wasm-abi`'s schema said identity-gated collections derive ownership "from
`env::executor_id()`" — false for as long as the shim returned a device, and it
is the text that tells people which collections are identity-gated. Corrected,
and pointed at `env::account_id()`, which is what a rebuilt app should call.

## Test

Asserts the account is returned **and** that `device_id` still answers with the
device, with the two seeded to different values so it cannot pass whichever way
the shim went. Verified failing on the old behaviour by reverting the one-line
change and watching it go red, rather than assuming it would.

## Follow-up

#3509 — delete the shim outright. `env::account_id()` and `env::device_id()` both
exist and `calimero-sys` declares neither `executor_id` nor any alias, so nothing
needs it once the blobs importing it are rebuilt. That issue also records the
loud-failure hazard (`UnknownImport` at instantiation reads as a 500 on first
context creation, not as an ABI change) and flags
`update_application`'s `executor_identity: PublicKey` — a migration attributed to
a bare key, which is the same shape as the bugs fixed in #3494 / #3500 / #3505
and wants its own look.

## Verification

`cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, the
`mock-attestation` clippy run, and `cargo test --workspace` all pass — clean
first pass, no flakes.

`--exclude cargo-mero` on the workspace run: that crate holds
`bundle_produces_signed_mpk`, which needs a wasm32 fixture and an isolated target
dir and which CI's own main Rust job skips for that reason. The dedicated
`cargo-mero-e2e` job still runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
