### PR TITLE
fix(node): pull governance from the beacon that proved a peer is there

### DIFF
--- a/crates/node/src/handlers/network_event/readiness.rs
+++ b/crates/node/src/handlers/network_event/readiness.rs
@@ -72,6 +72,24 @@ fn beacon_indicates_divergence(
     (local_has_state || is_namespace_member) && dag_head != [0u8; 32] && !head_op_present_locally
 }
 
+/// Which of the two beacon paths asked for a governance pull.
+///
+/// One value rather than an `Option<PeerId>` alongside the signer, because the
+/// two would have to agree and nothing could enforce it — passing one peer as the
+/// pull target and a different one as the beacon's signer would compile and then
+/// pull from the wrong place. The signer is always known, so it is passed
+/// unconditionally and this says only what to do with it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BeaconTrigger {
+    /// The beacon did not verify, but its admission proof did. Only its signer
+    /// holds the not-yet-gossiped join op, so the pull targets that signer and
+    /// nobody else — and takes the provable path's own debounce slot.
+    ProvableAdmission,
+    /// The beacon verified. Any member that applied the op can serve it, so the
+    /// pull prefers a subscriber and falls back to the signer.
+    EstablishedMember,
+}
+
 /// Per-namespace debounce gate. Returns `true` (and records `now`) when
 /// no beacon-triggered sync fired for `namespace_id` within
 /// [`NS_BEACON_SYNC_DEBOUNCE`]; returns `false` otherwise.
@@ -120,7 +138,8 @@ pub(super) fn handle_readiness_beacon(
                 ctx,
                 beacon.namespace_id.to_bytes(),
                 beacon.dag_head,
-                Some(peer_id),
+                BeaconTrigger::ProvableAdmission,
+                peer_id,
             );
             return;
         }
@@ -175,7 +194,7 @@ pub(super) fn handle_readiness_beacon(
                 let _ignored = ctx.spawn(
                     async move {
                         let ops = sync_manager
-                            .sync_namespace_from_peer(stranded_ns, Some(peer_id))
+                            .sync_namespace_from_peer(stranded_ns, Some(peer_id), None)
                             .await;
                         debug!(
                             %peer_id,
@@ -220,7 +239,14 @@ pub(super) fn handle_readiness_beacon(
         "readiness beacon received"
     );
 
-    spawn_beacon_divergence_sync(manager, ctx, namespace_id, beacon.dag_head, None);
+    spawn_beacon_divergence_sync(
+        manager,
+        ctx,
+        namespace_id,
+        beacon.dag_head,
+        BeaconTrigger::EstablishedMember,
+        peer_id,
+    );
 
     if let Some(addr) = &manager.readiness_addr {
         addr.do_send(ApplyBeaconLocal { namespace_id });
@@ -255,15 +281,14 @@ fn spawn_beacon_divergence_sync(
     ctx: &mut actix::Context<NodeManager>,
     namespace_id: [u8; 32],
     dag_head: [u8; 32],
-    source: Option<PeerId>,
+    trigger: BeaconTrigger,
+    beacon_peer: PeerId,
 ) {
     let datastore = manager.datastore.clone();
-    let node_client = manager.clients.node.clone();
     let sync_manager = manager.managers.sync.clone();
-    let debounce = if source.is_some() {
-        manager.ns_provable_beacon_sync_debounce.clone()
-    } else {
-        manager.ns_beacon_sync_debounce.clone()
+    let debounce = match trigger {
+        BeaconTrigger::ProvableAdmission => manager.ns_provable_beacon_sync_debounce.clone(),
+        BeaconTrigger::EstablishedMember => manager.ns_beacon_sync_debounce.clone(),
     };
     let _ignored = ctx.spawn(
         async move {
@@ -345,17 +370,18 @@ fn spawn_beacon_divergence_sync(
             info!(
                 namespace_id = %hex::encode(namespace_id),
                 dag_head = %hex::encode(dag_head),
-                ?source,
+                ?trigger,
+                %beacon_peer,
                 "beacon advertises an unknown namespace DAG head; \
                  triggering governance sync"
             );
-            match source {
+            match trigger {
                 // Issues the same `NamespaceBackfillRequest` with empty
-                // `delta_ids` ("give me everything"), but against `source`
-                // directly rather than an arbitrary subscriber.
-                Some(peer) => {
+                // `delta_ids` ("give me everything"), but against the beacon's
+                // signer directly rather than an arbitrary subscriber.
+                BeaconTrigger::ProvableAdmission => {
                     let ops = sync_manager
-                        .sync_namespace_from_peer(namespace_id, Some(peer))
+                        .sync_namespace_from_peer(namespace_id, Some(beacon_peer), None)
                         .await;
                     if ops == 0 {
                         // The pull delivered nothing, so give the slot back
@@ -366,19 +392,42 @@ fn spawn_beacon_divergence_sync(
                             .remove(&namespace_id);
                         debug!(
                             namespace_id = %hex::encode(namespace_id),
-                            %peer,
+                            %beacon_peer,
                             "provable-admission pull returned no ops; released the debounce slot"
                         );
                     }
                 }
-                None => {
-                    if let Err(err) = node_client.sync_namespace(namespace_id).await {
-                        warn!(
-                            ?err,
-                            namespace_id = %hex::encode(namespace_id),
-                            "beacon-triggered namespace governance sync failed"
-                        );
-                    }
+                // The established-member path: prefer a subscriber, because any
+                // member that applied the op can serve it. But name the beacon's
+                // own signer as the fallback, because discovery can come up empty
+                // while that signer is demonstrably reachable — its beacon just
+                // verified, which is proof of membership, of being caught up, and
+                // of being able to reach us, all at once. Asking an empty
+                // subscriber table and giving up is how a node stays stranded with
+                // the answer talking to it every few seconds.
+                //
+                // Run inline rather than queueing through `NodeClient::sync_namespace`,
+                // because the queue carries a namespace id and nothing else — there
+                // is nowhere to put the fallback peer without widening that channel
+                // and every constructor of it.
+                //
+                // The slot is deliberately NOT released on a zero-op pull, unlike
+                // the arm above. That arm's pull is targeted, so an empty result is
+                // a fact about the peer that beaconed; this one usually goes to
+                // whichever subscriber discovery picked, so an empty result says
+                // nothing about the beacon's signer and releasing on it would let
+                // every beacon re-trigger a pull. The debounce window IS the retry
+                // interval here: the next beacon after it re-evaluates from scratch.
+                BeaconTrigger::EstablishedMember => {
+                    let ops = sync_manager
+                        .sync_namespace_from_peer(namespace_id, None, Some(beacon_peer))
+                        .await;
+                    debug!(
+                        namespace_id = %hex::encode(namespace_id),
+                        %beacon_peer,
+                        ops,
+                        "beacon-triggered namespace governance pull finished"
+                    );
                 }
             }
         }

--- a/crates/node/src/provable_beacon_e2e.rs
+++ b/crates/node/src/provable_beacon_e2e.rs
@@ -217,9 +217,14 @@ async fn provable_pull_does_not_consume_the_member_debounce_slot() {
     // A seeded member's beacon verifies, so it takes the established-member arm
     // and claims that arm's slot. Nothing releases it: the member pull is not
     // targeted, so a zero-op result says nothing about the peer that beaconed.
+    //
+    // It pulls from `member_peer` because there are no namespace-topic
+    // subscribers in this harness, and that arm now names the beacon's own signer
+    // as its fallback rather than giving up — the whole point of the fallback.
+    let member_peer = PeerId::random();
     deliver(
         &node,
-        PeerId::random(),
+        member_peer,
         signed_beacon(&admin_sk, now_millis(), None),
     )
     .await;
@@ -241,8 +246,10 @@ async fn provable_pull_does_not_consume_the_member_debounce_slot() {
     .await;
     assert_eq!(
         stream_opens(&node),
-        vec![joiner_peer],
-        "an in-window member sync must not block the provable pull"
+        vec![member_peer, joiner_peer],
+        "an in-window member sync must not block the provable pull — and the \
+         member pull itself must have reached the beacon's signer, since \
+         discovery had nobody to offer"
     );
 }
 

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1849,7 +1849,7 @@ impl SyncManager {
             );
             return 0;
         };
-        self.sync_namespace_from_peer(namespace_id, Some(peer))
+        self.sync_namespace_from_peer(namespace_id, Some(peer), None)
             .await
     }
 
@@ -3881,7 +3881,7 @@ impl super::protocol_selector::ProtocolDispatch for SyncManager {
 #[async_trait::async_trait(?Send)]
 impl super::driver::SyncDriverDispatch for SyncManager {
     async fn sync_namespace_from_peer(&self, namespace_id: [u8; 32]) -> usize {
-        SyncManager::sync_namespace_from_peer(self, namespace_id, None).await
+        SyncManager::sync_namespace_from_peer(self, namespace_id, None, None).await
     }
 
     async fn initiate_namespace_join(

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -377,7 +377,7 @@ impl SyncManager {
             if !should_backfill_governance(self.node_state.governance_pending_len(&context_id)) {
                 return;
             }
-            self.sync_namespace_from_peer(namespace_id, Some(peer))
+            self.sync_namespace_from_peer(namespace_id, Some(peer), None)
                 .await;
         }
 
@@ -408,7 +408,7 @@ impl SyncManager {
                 {
                     break;
                 }
-                self.sync_namespace_from_peer(namespace_id, Some(peer))
+                self.sync_namespace_from_peer(namespace_id, Some(peer), None)
                     .await;
             }
         }
@@ -1295,29 +1295,66 @@ impl SyncManager {
     /// on any best-effort failure (no peer, stream/​send/​recv error, unexpected
     /// response), so a caller correcting a divergence can tell whether the pull
     /// actually delivered anything rather than treating it as a silent no-op.
+    ///
+    /// `fallback` is a peer to use **only when discovery finds nobody**, and it is
+    /// deliberately a separate argument from `peer` rather than a second way to
+    /// spell the same thing. `peer = Some(_)` means "ask this one and no other";
+    /// `fallback` means "prefer a subscriber, but do not give up if the subscriber
+    /// table is empty".
+    ///
+    /// That distinction is load-bearing because the table can be empty while a
+    /// perfectly good peer is talking to us. Discovery reads gossipsub's record of
+    /// who subscribes to the namespace topic, and that record is not always
+    /// complete — a node that restarts with an unchanged `PeerId` may never be
+    /// told what its peers follow (see `calimero_network`'s `subscription_repair`).
+    /// Without a fallback this returns `0` while a reachable, caught-up member is
+    /// beaconing at us every few seconds, and a governance op that needs a parent
+    /// stays buffered for want of anyone to ask.
+    ///
+    /// Only pass a `fallback` that is known to hold this namespace: a peer whose
+    /// readiness beacon just verified qualifies, an arbitrary connected peer does
+    /// not — a non-member stores only the [`StoredNamespaceEntry::Opaque`]
+    /// skeleton, so pulling from one delivers nothing and burns the attempt.
     pub(crate) async fn sync_namespace_from_peer(
         &self,
         namespace_id: [u8; 32],
         peer: Option<PeerId>,
+        fallback: Option<PeerId>,
     ) -> usize {
         use calimero_node_primitives::sync::{InitPayload, MessagePayload, StreamMessage};
 
         let peer = match peer {
             Some(p) => p,
             None => {
-                let topic = libp2p::gossipsub::TopicHash::from_raw(format!(
-                    "ns/{}",
-                    hex::encode(namespace_id)
-                ));
-                let peers = self.sync_network.subscribed_peers(topic).await;
-                let Some(p) = peers.first().copied() else {
-                    debug!(
-                        namespace_id = %hex::encode(namespace_id),
-                        "no mesh peers for namespace sync"
-                    );
-                    return 0;
-                };
-                p
+                match discover_namespace_pull_peer(
+                    self.sync_network.as_ref(),
+                    namespace_id,
+                    fallback,
+                )
+                .await
+                {
+                    NamespacePullPeer::Subscriber(p) => p,
+                    // Logged unconditionally, and at `info`: this is the branch
+                    // that says discovery was broken and something else carried
+                    // the pull, which is exactly what a later reader needs to
+                    // tell "the fallback rescued it" from "it never ran".
+                    NamespacePullPeer::Fallback(p) => {
+                        info!(
+                            namespace_id = %hex::encode(namespace_id),
+                            peer = %p,
+                            "no subscribers for the namespace topic; falling back to a peer \
+                             known to hold this namespace"
+                        );
+                        p
+                    }
+                    NamespacePullPeer::Nobody => {
+                        debug!(
+                            namespace_id = %hex::encode(namespace_id),
+                            "no mesh peers for namespace sync"
+                        );
+                        return 0;
+                    }
+                }
             }
         };
 
@@ -1970,6 +2007,44 @@ async fn fetch_open_subgroup_key(
 /// One walk over `peers`, asking each for the subgroup key.
 ///
 /// Returns on the first peer that yields one. The caller decides whether to walk
+/// Which peer a namespace pull should go to when the caller named none.
+///
+/// Three outcomes rather than an `Option<PeerId>`, so the *reason* survives to
+/// the caller: "a subscriber" and "the fallback" both yield a peer, but only the
+/// second one means discovery was broken, and that difference is what the log
+/// has to say out loud.
+#[derive(Debug, Eq, PartialEq)]
+enum NamespacePullPeer {
+    /// Discovery worked: a peer gossipsub records as following the namespace topic.
+    Subscriber(PeerId),
+    /// Discovery found nobody, and the caller supplied someone known to hold the
+    /// namespace. Reaching this arm means the subscriber table is wrong, not that
+    /// the node is alone.
+    Fallback(PeerId),
+    /// Nobody to ask.
+    Nobody,
+}
+
+/// Pick a peer to pull namespace governance from, preferring a real subscriber.
+///
+/// A free function over the [`SyncNetwork`](crate::sync::network::SyncNetwork)
+/// trait rather than a `SyncManager` method, so a test can drive the empty-table
+/// case against a scripted mock instead of booting a node — the same shape
+/// [`fetch_open_subgroup_key_once`] uses.
+async fn discover_namespace_pull_peer(
+    network: &dyn crate::sync::network::SyncNetwork,
+    namespace_id: [u8; 32],
+    fallback: Option<PeerId>,
+) -> NamespacePullPeer {
+    let topic = libp2p::gossipsub::TopicHash::from_raw(format!("ns/{}", hex::encode(namespace_id)));
+    let peers = network.subscribed_peers(topic).await;
+    match (peers.first().copied(), fallback) {
+        (Some(p), _) => NamespacePullPeer::Subscriber(p),
+        (None, Some(p)) => NamespacePullPeer::Fallback(p),
+        (None, None) => NamespacePullPeer::Nobody,
+    }
+}
+
 /// again, which is why the outcome distinguishes "everybody answered and nobody
 /// has it" from "somebody never answered" — see [`KeyFetchRound`].
 ///
@@ -2489,5 +2564,71 @@ mod joiner_credential_tests {
     fn an_absent_credential_is_refused() {
         let joiner = PublicKey::from([0x11; 32]);
         assert!(SyncManager::verified_joiner_account(&[], &joiner).is_err());
+    }
+}
+
+#[cfg(test)]
+mod namespace_pull_peer_tests {
+    //! Peer selection for a namespace pull, and specifically the case the
+    //! selection exists for: gossipsub's subscriber table can be EMPTY while a
+    //! peer that holds the namespace is reachable and talking to us.
+    //!
+    //! Driven against a scripted [`MockSyncNetwork`] rather than a booted node,
+    //! the same shape the open-subgroup key round uses.
+
+    use libp2p::gossipsub::TopicHash;
+    use libp2p::PeerId;
+
+    use super::{discover_namespace_pull_peer, NamespacePullPeer};
+    use crate::sync::network::mock::MockSyncNetwork;
+
+    const NS: [u8; 32] = [0x5c; 32];
+
+    fn ns_topic() -> TopicHash {
+        TopicHash::from_raw(format!("ns/{}", hex::encode(NS)))
+    }
+
+    #[tokio::test]
+    async fn a_subscriber_is_preferred_over_the_fallback() {
+        let subscriber = PeerId::random();
+        let fallback = PeerId::random();
+        let mock = MockSyncNetwork::default();
+        let _ = mock.push_subscribed_peers_for(ns_topic(), vec![subscriber]);
+
+        assert_eq!(
+            discover_namespace_pull_peer(&mock, NS, Some(fallback)).await,
+            NamespacePullPeer::Subscriber(subscriber),
+            "a working subscriber table must decide it; the fallback is a last \
+             resort, not a preference",
+        );
+    }
+
+    /// The regression. Before the fallback existed this returned "nobody" and the
+    /// pull did not happen — while the peer that could serve it was beaconing at
+    /// us every few seconds.
+    #[tokio::test]
+    async fn an_empty_subscriber_table_still_reaches_the_fallback() {
+        let fallback = PeerId::random();
+        let mock = MockSyncNetwork::default();
+        let _ = mock.push_subscribed_peers_for(ns_topic(), vec![]);
+
+        assert_eq!(
+            discover_namespace_pull_peer(&mock, NS, Some(fallback)).await,
+            NamespacePullPeer::Fallback(fallback),
+            "an empty table means the table is wrong, not that the node is alone",
+        );
+    }
+
+    #[tokio::test]
+    async fn without_a_fallback_an_empty_table_is_still_nobody() {
+        let mock = MockSyncNetwork::default();
+        let _ = mock.push_subscribed_peers_for(ns_topic(), vec![]);
+
+        assert_eq!(
+            discover_namespace_pull_peer(&mock, NS, None).await,
+            NamespacePullPeer::Nobody,
+            "callers that supply no fallback keep the old behaviour exactly — \
+             this must not start guessing at a peer on its own",
+        );
     }
 }


### PR DESCRIPTION
Closes #3507. Follow-up to #3508, which fixed the *cause* of one way a node's subscriber table goes empty; this makes the recovery work regardless of the cause.

## What was wrong

`sync_namespace_from_peer(ns, None)` resolves a peer by asking gossipsub which peers subscribe to the namespace topic, and returns `0` when that set is empty:

```rust
// crates/node/src/sync/manager/namespace_sync.rs
let peers = self.sync_network.subscribed_peers(topic).await;
let Some(p) = peers.first().copied() else {
    debug!(…, "no mesh peers for namespace sync");
    return 0;
};
```

The readiness-beacon handler is the caller that suffers for it. A **verified** beacon proves its signer is a namespace member, is caught up, and is reachable *right now* — and the handler had its `PeerId` in hand and threw it away, queueing an untargeted sync that then found nobody to ask:

```rust
spawn_beacon_divergence_sync(manager, ctx, namespace_id, beacon.dag_head, None);
//                                                                       ^^^^
```

`None` was deliberate and documented, and it is right whenever the subscriber table is trustworthy. When it is not, the one signal that could recover the node is discarded in favour of a lookup that cannot succeed.

## Evidence this is real, not symmetry

From master run [32020832043](https://github.com/calimero-network/core/actions/runs/32020832043), `revoke-node-2` over its 31-second life:

```
no mesh peers for namespace sync   ×34   — once per arriving beacon
```

Every one of those had a reachable, caught-up member on the other end of the beacon that triggered it. Meanwhile the node held a governance revocation buffered for want of a parent it could not pull, and the scenario failed on the downstream assertion.

The #3508 validation run confirmed the shape survives that fix: `revoke-node-2` still logged `no mesh peers for namespace sync` ×10 in its first 8 seconds, and the fold that saved it rode on the direct-to-source backfill — the same path that failed with `sending stopped by peer: error 0` in the original failure. That is the gap this closes.

## The fix

A `fallback` peer, used **only when discovery finds nobody**, kept as a separate argument from the explicit target:

* `peer = Some(_)` — ask this one and no other.
* `fallback` — prefer a subscriber, but do not give up if the table is empty.

Only a peer known to hold the namespace qualifies. An arbitrary connected peer does not: a non-member stores only the `Opaque` skeleton, so pulling from one delivers nothing and burns the attempt. A verified beacon's signer does qualify, which is what makes the beacon handler the natural caller.

Peer selection is extracted as a free function over the `SyncNetwork` trait returning a three-way `NamespacePullPeer`, so the *reason* survives to the caller — "a subscriber" and "the fallback" both yield a peer, but only the second means discovery was broken, and the log has to say that out loud (at `info`, unconditionally).

## Two things this deliberately does not do

**The member arm does not release its debounce slot on a zero-op pull**, unlike the provable arm. That arm's pull is targeted, so an empty result is a fact about the peer that beaconed. This one usually goes to whichever subscriber discovery picked, so an empty result says nothing about the signer, and releasing on it would let every beacon re-trigger a pull. The debounce window *is* the retry interval here.

An earlier revision of this change did release it, and `provable_pull_does_not_consume_the_member_debounce_slot` caught it — the invariant was already encoded in a test, with the reason written down. Worth knowing that test is load-bearing.

**It does not thread the fallback through `NodeClient::sync_namespace`.** That queue carries a namespace id and nothing else; widening it would touch every constructor across five files and the driver's retry map. The arm runs the pull inline instead, exactly as the provable arm already does.

## Also: one less way to get it wrong

`spawn_beacon_divergence_sync` took `source: Option<PeerId>`, which meant two things at once — *which* peer to target, and *which* debounce slot to claim. Adding the signer alongside it would have created a pair that must agree with nothing to enforce it: pass one peer as the target and a different one as the signer and it compiles, then pulls from the wrong place. It now takes a `BeaconTrigger` (`ProvableAdmission` / `EstablishedMember`) plus the signer, which is always known.

## Tests

Three cases against a scripted `MockSyncNetwork`, driving the selection directly rather than booting a node — the shape `fetch_open_subgroup_key_once` already uses:

```
test …namespace_pull_peer_tests::a_subscriber_is_preferred_over_the_fallback ... ok
test …namespace_pull_peer_tests::an_empty_subscriber_table_still_reaches_the_fallback ... ok
test …namespace_pull_peer_tests::without_a_fallback_an_empty_table_is_still_nobody ... ok
```

The middle one is the regression. Reverting the fallback arm to the pre-fix `(None, _) => Nobody`:

```
assertion `left == right` failed: an empty table means the table is wrong,
                                 not that the node is alone
  left: Nobody
 right: Fallback(PeerId("1AeXhWLNRUkq3t5CLVgTzzHyfm7fbXdm3ennNEdX9zHCT5"))
```

The third pins that callers supplying no fallback keep the old behaviour exactly — this must not start guessing at a peer on its own.

`provable_pull_does_not_consume_the_member_debounce_slot` is updated rather than merely repaired: it now asserts the member pull reached the beacon's signer (`[member_peer, joiner_peer]`), because with no subscribers in that harness the fallback is what carries it. Its original guarantee — that the two arms cannot silence each other — is unchanged.

## Checks

* `cargo fmt --check` ✅
* `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` ✅
* `cargo test -p calimero-node` ✅ (475 lib + 370 integration, incl. `sync_sim` 322)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
