### PR TITLE
test(network): share one event log across the autonat test's phases

### DIFF
--- a/crates/network/primitives/src/autonat_v2/mod.rs
+++ b/crates/network/primitives/src/autonat_v2/mod.rs
@@ -295,7 +295,7 @@ impl Behaviour {
 #[cfg(test)]
 mod tests {
     use core::fmt::Debug;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     use libp2p::futures::FutureExt;
 
@@ -305,89 +305,149 @@ mod tests {
 
     use super::*;
 
-    /// [`drive_until`] for callers that assert on full [`SwarmEvent`]s rather than
-    /// only behaviour events — connection lifecycle, address confirmation.
+    /// Upper bound on total silence from BOTH swarms before the interaction is
+    /// declared stuck.
     ///
-    /// Same reason for existing: a fixed count couples the outcome to the
-    /// scheduler. See [`drive_until`].
+    /// Deliberately under the 10s `SwarmExt::next_swarm_event` enforces internally:
+    /// on a wedged interaction this fires first and reports what each side managed to
+    /// produce, where the harness's own panic is a bare "Swarm did not emit an event
+    /// within 10s" with nothing to go on. It cannot be raised above 10s for the same
+    /// reason — the harness would win the race.
+    const DRIVE_QUIET_LIMIT: Duration = Duration::from_secs(9);
+
+    /// Poll both swarms until each side's events satisfy its predicate, appending
+    /// everything they produce to the caller's logs.
+    ///
+    /// The condition-driven counterpart to [`drive`], which collects a FIXED number of
+    /// events and so couples a test's outcome to the scheduler: too few arrive and it
+    /// panics inside the harness, the right number arrives in the wrong mix and the
+    /// caller's own assertion fails. Both were observed under contention.
+    ///
+    /// **The logs belong to the caller and accumulate across every phase**, which is
+    /// the part that makes this deterministic rather than merely better. Waiting for a
+    /// condition necessarily over-collects — while one side is still short, the next
+    /// phase's events can already be arriving and are appended too. Give each phase a
+    /// fresh log and those events are simply gone: the phase that wanted them is handed
+    /// an empty slice and waits for something that has already happened, until the
+    /// harness's internal timeout ends it. Measured, that costs more than it fixes.
+    /// Sharing one log per side means a phase asks "has this happened yet", and every
+    /// stop condition is a monotone fact about the run rather than about a window of it.
+    ///
+    /// One log type, full [`SwarmEvent`], for the same reason: a behaviour-only log
+    /// beside a swarm-event log reintroduces the loss at the boundary between a phase
+    /// using one and a phase using the other. Callers that want behaviour events filter
+    /// with [`behaviour_events`].
     async fn drive_swarm_until<C, S>(
         client: &mut Swarm<C>,
         server: &mut Swarm<S>,
+        client_events: &mut Vec<SwarmEvent<C::ToSwarm>>,
+        server_events: &mut Vec<SwarmEvent<S::ToSwarm>>,
+        what: &str,
         client_done: impl Fn(&[SwarmEvent<C::ToSwarm>]) -> bool,
         server_done: impl Fn(&[SwarmEvent<S::ToSwarm>]) -> bool,
-    ) -> (Vec<SwarmEvent<C::ToSwarm>>, Vec<SwarmEvent<S::ToSwarm>>)
-    where
+    ) where
         C: NetworkBehaviour + Send,
         C::ToSwarm: Debug,
         S: NetworkBehaviour + Send,
         S::ToSwarm: Debug,
     {
-        let mut client_events = Vec::new();
-        let mut server_events = Vec::new();
-        let deadline = Instant::now() + Duration::from_secs(60);
-
-        while !(client_done(&client_events) && server_done(&server_events)) {
+        while !(client_done(client_events) && server_done(server_events)) {
+            let stepped = tokio::time::timeout(DRIVE_QUIET_LIMIT, async {
+                libp2p::futures::select! {
+                    event = client.next_swarm_event().fuse() => client_events.push(event),
+                    event = server.next_swarm_event().fuse() => server_events.push(event),
+                }
+            })
+            .await;
             assert!(
-                Instant::now() < deadline,
-                "timed out before both sides produced the events under test; \
-                 client={client_events:?} server={server_events:?}"
+                stepped.is_ok(),
+                "both swarms went quiet for {DRIVE_QUIET_LIMIT:?} while waiting for \
+                 {what}\n  client saw: {client_events:?}\n  server saw: {server_events:?}"
             );
-            libp2p::futures::select! {
-                event = client.next_swarm_event().fuse() => client_events.push(event),
-                event = server.next_swarm_event().fuse() => server_events.push(event),
-            }
         }
-
-        (client_events, server_events)
     }
 
-    /// Poll both swarms until each side's behaviour events satisfy its predicate.
+    /// The behaviour events in a swarm-event log, in arrival order.
     ///
-    /// The condition-driven counterpart to [`drive`], which collects a FIXED number
-    /// of events and so couples a test's outcome to the scheduler: too few arrive
-    /// and it panics inside the harness, the right number arrives in the wrong mix
-    /// and the caller's own assertion fails. Both were observed under contention.
-    ///
-    /// Bounded by a deadline rather than left to hang, because a test that never
-    /// returns is worse than one that fails: the panic carries everything collected
-    /// so far, which is what a diagnosis needs.
-    async fn drive_until<C, S>(
-        client: &mut Swarm<C>,
-        server: &mut Swarm<S>,
-        client_done: impl Fn(&[C::ToSwarm]) -> bool,
-        server_done: impl Fn(&[S::ToSwarm]) -> bool,
-    ) -> (Vec<C::ToSwarm>, Vec<S::ToSwarm>)
-    where
-        C: NetworkBehaviour + Send,
-        C::ToSwarm: Debug,
-        S: NetworkBehaviour + Send,
-        S::ToSwarm: Debug,
-    {
-        let mut client_events = Vec::new();
-        let mut server_events = Vec::new();
-        let deadline = Instant::now() + Duration::from_secs(60);
+    /// Borrowed rather than cloned: the enums `#[derive(NetworkBehaviour)]` generates
+    /// are not `Clone`, and neither is `identify::Event`.
+    fn behaviour_events<T>(events: &[SwarmEvent<T>]) -> Vec<&T> {
+        events
+            .iter()
+            .filter_map(|e| match e {
+                SwarmEvent::Behaviour(event) => Some(event),
+                _ => None,
+            })
+            .collect()
+    }
 
-        while !(client_done(&client_events) && server_done(&server_events)) {
-            assert!(
-                Instant::now() < deadline,
-                "timed out before both sides produced the events under test; \
-                 client={client_events:?} server={server_events:?}"
-            );
-            libp2p::futures::select! {
-                event = client.next_swarm_event().fuse() => {
-                    if let SwarmEvent::Behaviour(event) = event {
-                        client_events.push(event);
-                    }
-                }
-                event = server.next_swarm_event().fuse() => {
-                    if let SwarmEvent::Behaviour(event) = event {
-                        server_events.push(event);
-                    }
-                }
-            }
+    /// How many `identify::Event::Received` exchanges this side observed.
+    fn identify_exchanges<T>(
+        events: &[SwarmEvent<T>],
+        pick: fn(&T) -> Option<&identify::Event>,
+    ) -> usize {
+        identify_infos(events, pick).len()
+    }
+
+    /// The identify infos this side received, in arrival order.
+    ///
+    /// `pick` is a `fn` rather than a closure so it stays generic over the borrow's
+    /// lifetime and one of them can serve several event logs.
+    fn identify_infos<'a, T>(
+        events: &'a [SwarmEvent<T>],
+        pick: fn(&'a T) -> Option<&'a identify::Event>,
+    ) -> Vec<&'a identify::Info> {
+        behaviour_events(events)
+            .into_iter()
+            .filter_map(pick)
+            .filter_map(|e| match e {
+                identify::Event::Received { info, .. } => Some(info),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn switchable_identify(event: &SwitchableNatEvent) -> Option<&identify::Event> {
+        match event {
+            SwitchableNatEvent::Identify(event) => Some(event),
+            _ => None,
         }
+    }
 
-        (client_events, server_events)
+    fn server_identify(event: &ServerEvent) -> Option<&identify::Event> {
+        match event {
+            ServerEvent::Identify(event) => Some(event),
+            _ => None,
+        }
+    }
+
+    /// Did the switchable observe that its peer speaks the autonat server side?
+    fn saw_server_support(events: &[SwarmEvent<SwitchableNatEvent>]) -> bool {
+        behaviour_events(events).into_iter().any(|e| {
+            matches!(
+                e,
+                SwitchableNatEvent::Autonat(Event::PeerHasServerSupport { .. })
+            )
+        })
+    }
+
+    /// Has the peer gone entirely, rather than just one of its connections?
+    ///
+    /// `num_established` counts what is left to that peer, so the close carrying `0` is
+    /// the last one. Waiting for it drains every close the disconnect produces without
+    /// having to know how many connections there were — and leaving one queued is not
+    /// harmless, because `SwarmExt::listen` panics on any event it did not expect, so a
+    /// straggler fails the NEXT phase instead of this one.
+    fn saw_full_disconnect<T>(events: &[SwarmEvent<T>]) -> bool {
+        events.iter().any(|e| {
+            matches!(
+                e,
+                SwarmEvent::ConnectionClosed {
+                    num_established: 0,
+                    ..
+                }
+            )
+        })
     }
 
     #[derive(NetworkBehaviour)]
@@ -567,44 +627,25 @@ mod tests {
         // wrong MIX — which is both failure modes seen in #3488, from one cause.
         // Waiting on the events themselves makes the outcome a function of what the
         // swarms do rather than of how the scheduler interleaved them.
-        let (switchable_events, server_events) = drive_until(
+        // One log per side for the whole test; see `drive_swarm_until` on why they are
+        // shared across phases rather than per phase.
+        let mut switchable_events = Vec::new();
+        let mut server_events = Vec::new();
+
+        drive_swarm_until(
             &mut switchable,
             &mut server,
-            |sw: &[SwitchableNatEvent]| {
-                sw.iter()
-                    .filter(|e| {
-                        matches!(
-                            e,
-                            SwitchableNatEvent::Identify(identify::Event::Received { .. })
-                        )
-                    })
-                    .count()
-                    >= 2
-                    && sw.iter().any(|e| {
-                        matches!(
-                            e,
-                            SwitchableNatEvent::Autonat(Event::PeerHasServerSupport { .. })
-                        )
-                    })
-            },
-            |srv: &[ServerEvent]| {
-                srv.iter()
-                    .filter(|e| {
-                        matches!(e, ServerEvent::Identify(identify::Event::Received { .. }))
-                    })
-                    .count()
-                    >= 2
-            },
+            &mut switchable_events,
+            &mut server_events,
+            "two identify exchanges each way, and the switchable observing autonat support",
+            |sw| identify_exchanges(sw, switchable_identify) >= 2 && saw_server_support(sw),
+            |srv| identify_exchanges(srv, server_identify) >= 2,
         )
         .await;
-        let (switchable_events, server_events) = (&switchable_events[..], &server_events[..]);
 
         // Switchable must have observed the server's autonat server support at some point.
         assert!(
-            switchable_events.iter().any(|e| matches!(
-                e,
-                SwitchableNatEvent::Autonat(Event::PeerHasServerSupport { .. })
-            )),
+            saw_server_support(&switchable_events),
             "Switchable should observe server's autonat support, got: {switchable_events:?}"
         );
 
@@ -612,29 +653,19 @@ mod tests {
         // are causally ordered (the second only happens after the switchable gains the
         // dial-back protocol), so indexing them is safe even though autonat events may
         // interleave around them.
-        let srv_infos: Vec<_> = switchable_events
-            .iter()
-            .filter_map(|e| match e {
-                SwitchableNatEvent::Identify(identify::Event::Received { info, .. }) => Some(info),
-                _ => None,
-            })
-            .collect();
-        let switchable_infos: Vec<_> = server_events
-            .iter()
-            .filter_map(|e| match e {
-                ServerEvent::Identify(identify::Event::Received { info, .. }) => Some(info),
-                _ => None,
-            })
-            .collect();
+        let srv_infos = identify_infos(&switchable_events, switchable_identify);
+        let switchable_infos = identify_infos(&server_events, server_identify);
 
-        assert_eq!(
-            srv_infos.len(),
-            2,
+        // At least two, not exactly two: the wait guarantees both exchanges have
+        // happened, and a third arriving alongside them is not a protocol-change
+        // failure. What the assertions below are about is the CONTENT of the first and
+        // the second, which is unaffected by anything landing after.
+        assert!(
+            srv_infos.len() >= 2,
             "expected two server identify exchanges, got: {switchable_events:?}"
         );
-        assert_eq!(
-            switchable_infos.len(),
-            2,
+        assert!(
+            switchable_infos.len() >= 2,
             "expected two switchable identify exchanges, got: {server_events:?}"
         );
 
@@ -685,29 +716,23 @@ mod tests {
         // Wait for server to complete the AutoNAT test. The address confirmation and the
         // trailing autonat behaviour event can arrive in either order, so locate the
         // confirmation by value rather than by position.
-        let (switchable_events, server_events) = drive_swarm_until(
+        drive_swarm_until(
             &mut switchable,
             &mut server,
-            |sw: &[SwarmEvent<SwitchableNatEvent>]| {
+            &mut switchable_events,
+            &mut server_events,
+            "the switchable's address to be confirmed and the server to report its probe",
+            |sw| {
                 sw.iter()
                     .any(|e| matches!(e, SwarmEvent::ExternalAddrConfirmed { .. }))
             },
-            |srv: &[SwarmEvent<ServerEvent>]| {
-                srv.iter()
-                    .any(|e| matches!(e, SwarmEvent::Behaviour(ServerEvent::Autonat(_))))
+            |srv| {
+                behaviour_events(srv)
+                    .into_iter()
+                    .any(|e| matches!(e, ServerEvent::Autonat(_)))
             },
         )
         .await;
-        let switchable_events = &switchable_events[..];
-        // The autonat result is located by value, as before — only the waiting
-        // changed, not what is asserted.
-        let server_events: Vec<ServerEvent> = server_events
-            .into_iter()
-            .filter_map(|e| match e {
-                SwarmEvent::Behaviour(event) => Some(event),
-                _ => None,
-            })
-            .collect();
 
         let confirmed_addr = switchable_events
             .iter()
@@ -719,10 +744,19 @@ mod tests {
                 panic!("expected ExternalAddrConfirmed, got: {switchable_events:?}")
             });
 
-        match &server_events[0] {
-            ServerEvent::Autonat(event) => assert!(matches!(event.result, Ok(()))),
-            other => panic!("expected server autonat result, got: {other:?}"),
-        }
+        // Located by value, not by position: the shared log holds everything the server
+        // produced, so `[0]` is whatever happened to arrive first.
+        let probe_ok = behaviour_events(&server_events)
+            .into_iter()
+            .find_map(|e| match e {
+                ServerEvent::Autonat(event) => Some(matches!(event.result, Ok(()))),
+                _ => None,
+            });
+        assert_eq!(
+            probe_ok,
+            Some(true),
+            "expected a successful server autonat probe, got: {server_events:?}"
+        );
 
         // Now switch to server mode
         switchable.behaviour_mut().autonat.enable_server().unwrap();
@@ -749,45 +783,33 @@ mod tests {
 
         // Disconnect from the server
         switchable.disconnect_peer_id(server_id).unwrap();
-        // Wait for the disconnect to complete. Both sides observe two connection-closed
-        // events; the order they're drained in is irrelevant.
-        let (switchable_events, server_events) = drive_swarm_until(
+        // Wait for the disconnect to complete on both sides.
+        //
+        // Safe to evaluate over the shared log: nothing closes a connection before the
+        // explicit `disconnect_peer_id` above, so a close in the log can only be this one.
+        drive_swarm_until(
             &mut switchable,
             &mut server,
-            |sw: &[SwarmEvent<SwitchableNatEvent>]| {
-                sw.iter()
-                    .filter(|e| matches!(e, SwarmEvent::ConnectionClosed { .. }))
-                    .count()
-                    >= 2
-            },
-            |srv: &[SwarmEvent<ServerEvent>]| {
-                srv.iter()
-                    .filter(|e| matches!(e, SwarmEvent::ConnectionClosed { .. }))
-                    .count()
-                    >= 2
-            },
+            &mut switchable_events,
+            &mut server_events,
+            "both sides to observe the peer fully disconnecting",
+            saw_full_disconnect,
+            saw_full_disconnect,
         )
         .await;
-        let (switchable_events, server_events) = (&switchable_events[..], &server_events[..]);
-        // Both sides saw the disconnect. The old assertion was `all(ConnectionClosed)`,
-        // which held only because a fixed 2-event window happened to contain nothing
-        // else — "no other event arrived" is not a property of a disconnect, it is a
-        // property of how long we happened to look, which is what made this flake.
-        fn closed<T>(events: &[SwarmEvent<T>]) -> usize {
-            events
-                .iter()
-                .filter(|e| matches!(e, SwarmEvent::ConnectionClosed { .. }))
-                .count()
-        }
-        assert_eq!(
-            closed(switchable_events),
-            2,
-            "switchable must observe both connections closing, got: {switchable_events:?}"
+        // Both sides saw the peer go. The original assertion was `all(ConnectionClosed)`,
+        // which held only because a fixed 2-event window happened to contain nothing else
+        // — "no other event arrived" is not a property of a disconnect, it is a property
+        // of how long we happened to look. Counting the closes instead is the same
+        // mistake one step removed: it is a fact about how many connections existed, not
+        // about whether the peer is gone. `num_established: 0` says that directly.
+        assert!(
+            saw_full_disconnect(&switchable_events),
+            "switchable must observe the server fully disconnecting, got: {switchable_events:?}"
         );
-        assert_eq!(
-            closed(server_events),
-            2,
-            "server must observe both connections closing, got: {server_events:?}"
+        assert!(
+            saw_full_disconnect(&server_events),
+            "server must observe the switchable fully disconnecting, got: {server_events:?}"
         );
 
         // NOTE: there's a bug in the code that causes the autonat behaviour to not work correctly


### PR DESCRIPTION
**Rebased onto master and rescoped.** #3517 landed the same idea — conditions instead of fixed counts — while this was open. It cut the failure rate substantially but did not close it. This is now a one-commit follow-up on top of it, so the diff reads against #3517 rather than against the original test.

## The residual flake, measured

Same machine, same load (8 cores, 12 busy loops), 40 runs each, back to back:

| | failures |
|---|---|
| master (#3517) | **4 / 40** |
| this change | **0 / 40** |

For reference, the original pre-#3517 test scored 9/25 under the same load, in two distinct modes — so #3517 removed most of it. What is left is one mode, and it does not look like what it is:

```
panicked at libp2p-swarm-test-0.6.0/src/lib.rs:333:
Swarm did not emit an event within 10s
```

That reads as CPU starvation. It is not. It is a phase waiting for something that was already thrown away.

## Why conditions alone are not enough

Waiting for a condition **necessarily over-collects**. While one side is still short of its condition, the next phase's events are already arriving, and they get appended to *this* phase's log.

#3517 gives each phase a fresh log, so those events are then gone. The phase that wanted them is handed an empty slice and waits for something that has already happened, until the harness's internal timeout ends it. It is the same coupling the fixed counts had, displaced by one step: the outcome still depends on where the scheduler happened to put a phase boundary.

I hit this while building the change and it is worth seeing, because the symptom is so misleading — an intermediate version of *this* branch scored **13/25**, worse than the code it was fixing, with:

```
both swarms went quiet for 9s while waiting for the switchable's address to be
confirmed and the server to report its probe
  switchable saw: []
  server saw: []
```

Zero events on both sides. Not silence — consumption.

## The change

The event logs become the **caller's** and accumulate across every phase. A phase asks "has this happened yet", and every stop condition is a monotone fact about the run rather than about a window of it.

One log type, full `SwarmEvent`, for the same reason: a behaviour-only log beside a swarm-event log loses events at the boundary between a phase using one and a phase using the other. So #3517's behaviour-only `drive_until` folds into `drive_swarm_until` plus a `behaviour_events` filter.

## Two consequences of a shared log, both deliberate

**The disconnect phase waits for the close carrying `num_established: 0`** instead of counting two closes. Counting is the same mistake once removed — it is a fact about how many connections existed, not about whether the peer is gone.

It also has to be the *last* close specifically. Stopping earlier leaves a close queued, and `SwarmExt::listen` panics on any event it did not expect, so the straggler fails the **next** phase instead:

```
Unexpected event while waiting for `NewListenAddr`: ConnectionClosed { … num_established: 0 … }
```

That was another observed intermediate state, not a hypothetical.

**The identify assertions take `>= 2` rather than `== 2`.** The wait already guarantees both exchanges happened; a third landing alongside them is not a protocol-change failure. What the assertions are about is the *content* of the first and the second, and every one of those is unchanged: first exchange shows the server advertising dial-request and the switchable with no autonat protocols, second shows the server without autonat and the switchable advertising dial-back.

## One limit worth stating

`SwarmExt::next_swarm_event` hard-codes a 10s panic internally, so no restructuring makes this test survive unbounded CPU starvation — past some oversubscription the harness gives up before the interaction completes. The quiet limit is therefore 9s, just under it, so a genuinely wedged run reports what each side managed to produce rather than the harness's bare message.

## Checks

* `cargo fmt --check` ✅
* `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` ✅
* `cargo test -p calimero-network-primitives` ✅ (14 tests), plus the load runs above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
