### PR TITLE
ci(coverage): trade the identity route the SDK stopped calling for the one it started

### DIFF
--- a/crates/server/coverage-baseline.json
+++ b/crates/server/coverage-baseline.json
@@ -1,6 +1,6 @@
 [
   "GET /admin-api/groups/:group_id/members/:account/metadata",
-  "GET /admin-api/identity",
+  "GET /admin-api/namespaces/:namespace_id/identity",
   "GET /admin-api/ready",
   "POST /admin-api/groups/:group_id/members",
   "POST /admin-api/groups/:group_id/members/remove",


### PR DESCRIPTION
**Master is red on the endpoint-coverage ratchet.** This unblocks it.

```
New endpoint(s) with no SDK e2e coverage (add a mero-js e2e test, or add to coverage-baseline.json with a reason):
  GET /admin-api/namespaces/:namespace_id/identity
```
— [failing job](https://github.com/calimero-network/core/actions/runs/32054687994/job/95463516898)

Nothing about that route changed. **mero-js 11.1.0** (calimero-network/mero-js#101) made `getNamespaceIdentity()` delegate to the node-level `GET /admin-api/identity`, because the namespace in its path cannot change the answer. That was the route's only SDK e2e hit, so the ratchet correctly noticed it lost coverage.

## Why this is a swap, not a concession

The same release is why the net effect is neutral-to-better: `GET /admin-api/identity` is **covered now** — mero-js had no binding for it at all before #101 — so it comes *off* the accepted-uncovered list as the per-namespace one goes on. You can see both halves in the failing job's own output: it reported **11** baselined-uncovered routes against a 12-entry baseline, the missing one being `/admin-api/identity`.

| | before | after |
| --- | --- | --- |
| `GET /admin-api/identity` | baselined (uncovered) | **covered by mero-js e2e** |
| `GET /admin-api/namespaces/:namespace_id/identity` | covered | baselined (SDK no longer calls it) |

Baseline size unchanged at 12, and the ratchet is strictly tighter than before: a regression on the node-level route now fails CI, where previously it was excused.

## Transitional by design

The per-namespace route is deleted in #3518, which removes this entry along with it. An allowlist naming a route that no longer exists is exactly the staleness #3511 cleaned up, so it doesn't get to accumulate.

## Verification

Reproduced the gate locally against the failing job's own inputs — a simulated covered-set with the 11 still-baselined routes plus this one uncovered:

| baseline | result |
| --- | --- |
| master's | `exit 1` — *New endpoint(s) with no SDK e2e coverage: GET /admin-api/namespaces/:namespace_id/identity* |
| this PR's | `exit 0` — *OK: 79/91 manifest endpoints exercised; 12 baselined* |

One line changed in, one line changed out; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)