### PR TITLE
test(e2e): delete 34 identity captures nothing reads

### DIFF
--- a/workflows/app-migration/00-single-group-migration-baseline.yml
+++ b/workflows/app-migration/00-single-group-migration-baseline.yml
@@ -53,12 +53,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key (for teardown)
-    type: node_identity
-    node: app-migration-baseline-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup on node 1
     # Open visibility lets node 2 materialise its inherited membership
     # via `join_subgroup_inheritance`.

--- a/workflows/app-migration/01-namespace-cascade-migration.yml
+++ b/workflows/app-migration/01-namespace-cascade-migration.yml
@@ -67,12 +67,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key (for teardown)
-    type: node_identity
-    node: app-migration-cascade-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create descendant Open subgroup on node 1
     # Open visibility lets node 2 materialise its inherited membership
     # via `join_subgroup_inheritance` instead of needing an

--- a/workflows/app-migration/02-scenario-additive-field.yml
+++ b/workflows/app-migration/02-scenario-additive-field.yml
@@ -55,12 +55,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-additive-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-additive-1

--- a/workflows/app-migration/03-scenario-remove-field.yml
+++ b/workflows/app-migration/03-scenario-remove-field.yml
@@ -55,12 +55,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-remove-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-remove-1

--- a/workflows/app-migration/04-scenario-rename-field.yml
+++ b/workflows/app-migration/04-scenario-rename-field.yml
@@ -51,12 +51,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-rename-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-rename-1

--- a/workflows/app-migration/05-scenario-change-type.yml
+++ b/workflows/app-migration/05-scenario-change-type.yml
@@ -51,12 +51,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-typechange-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-typechange-1

--- a/workflows/app-migration/06-scenario-new-method.yml
+++ b/workflows/app-migration/06-scenario-new-method.yml
@@ -53,12 +53,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-newmethod-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-newmethod-1

--- a/workflows/app-migration/07-scenario-new-enum-variant.yml
+++ b/workflows/app-migration/07-scenario-new-enum-variant.yml
@@ -52,12 +52,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-newenum-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-newenum-1

--- a/workflows/app-migration/08-scenario-pure-bugfix.yml
+++ b/workflows/app-migration/08-scenario-pure-bugfix.yml
@@ -54,12 +54,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-bugfix-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-bugfix-1

--- a/workflows/app-migration/09-scenario-crdt-native.yml
+++ b/workflows/app-migration/09-scenario-crdt-native.yml
@@ -64,12 +64,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-crdt-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-crdt-1

--- a/workflows/app-migration/10-scenario-struct-to-enum.yml
+++ b/workflows/app-migration/10-scenario-struct-to-enum.yml
@@ -53,12 +53,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-struct2enum-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-struct2enum-1

--- a/workflows/app-migration/11-scenario-field-split.yml
+++ b/workflows/app-migration/11-scenario-field-split.yml
@@ -53,12 +53,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-split-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-split-1

--- a/workflows/app-migration/12-scenario-field-remove-archive.yml
+++ b/workflows/app-migration/12-scenario-field-remove-archive.yml
@@ -58,12 +58,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-archive-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-archive-1

--- a/workflows/app-migration/13-scenario-invariant-reshuffle.yml
+++ b/workflows/app-migration/13-scenario-invariant-reshuffle.yml
@@ -60,12 +60,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-reshuffle-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-reshuffle-1

--- a/workflows/app-migration/14-cascade-status-rpc.yml
+++ b/workflows/app-migration/14-cascade-status-rpc.yml
@@ -56,12 +56,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key (for teardown)
-    type: node_identity
-    node: app-migration-status-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create descendant Open subgroup on node 1
     type: create_group_in_namespace
     node: app-migration-status-1

--- a/workflows/app-migration/15-scenario-authored-map.yml
+++ b/workflows/app-migration/15-scenario-authored-map.yml
@@ -45,12 +45,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-authmap-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-authmap-1

--- a/workflows/app-migration/16-scenario-user-storage.yml
+++ b/workflows/app-migration/16-scenario-user-storage.yml
@@ -42,12 +42,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-userstore-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-userstore-1

--- a/workflows/app-migration/17-scenario-frozen-storage.yml
+++ b/workflows/app-migration/17-scenario-frozen-storage.yml
@@ -44,12 +44,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-frozen-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-frozen-1

--- a/workflows/app-migration/18-scenario-shared-storage.yml
+++ b/workflows/app-migration/18-scenario-shared-storage.yml
@@ -42,12 +42,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-shared-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-shared-1

--- a/workflows/app-migration/19-scenario-authored-vector.yml
+++ b/workflows/app-migration/19-scenario-authored-vector.yml
@@ -42,12 +42,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-authvec-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-authvec-1

--- a/workflows/app-migration/20-scenario-unordered-set.yml
+++ b/workflows/app-migration/20-scenario-unordered-set.yml
@@ -45,12 +45,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-uset-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-uset-1

--- a/workflows/app-migration/21-reads-available-during-upgrade.yml
+++ b/workflows/app-migration/21-reads-available-during-upgrade.yml
@@ -47,12 +47,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key (for teardown)
-    type: node_identity
-    node: app-migration-reads-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create descendant subgroup
     type: create_group_in_namespace
     node: app-migration-reads-1

--- a/workflows/app-migration/22-scenario-identity-downgrade.yml
+++ b/workflows/app-migration/22-scenario-identity-downgrade.yml
@@ -48,12 +48,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key (for teardown)
-    type: node_identity
-    node: app-migration-iddowngrade-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup on node 1
     type: create_group_in_namespace
     node: app-migration-iddowngrade-1

--- a/workflows/app-migration/26-owner-driven-authored.yml
+++ b/workflows/app-migration/26-owner-driven-authored.yml
@@ -70,12 +70,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key (for teardown)
-    type: node_identity
-    node: app-migration-owner-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create descendant Open subgroup on node 1
     type: create_group_in_namespace
     node: app-migration-owner-1

--- a/workflows/app-migration/28-get-migration-status.yml
+++ b/workflows/app-migration/28-get-migration-status.yml
@@ -63,12 +63,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key (for teardown)
-    type: node_identity
-    node: app-migration-mstatus-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create descendant Open subgroup on node 1
     type: create_group_in_namespace
     node: app-migration-mstatus-1

--- a/workflows/app-migration/29-migration-check-pass.yml
+++ b/workflows/app-migration/29-migration-check-pass.yml
@@ -49,12 +49,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key (for teardown)
-    type: node_identity
-    node: app-migration-check-pass-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create descendant subgroup
     type: create_group_in_namespace
     node: app-migration-check-pass-1

--- a/workflows/app-migration/30-migration-check-fail-abort.yml
+++ b/workflows/app-migration/30-migration-check-fail-abort.yml
@@ -63,12 +63,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key (for teardown)
-    type: node_identity
-    node: app-migration-check-fail-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create descendant subgroup
     type: create_group_in_namespace
     node: app-migration-check-fail-1

--- a/workflows/app-migration/31-admin-abort-logical.yml
+++ b/workflows/app-migration/31-admin-abort-logical.yml
@@ -71,12 +71,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key (for teardown)
-    type: node_identity
-    node: app-migration-admin-abort-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create descendant subgroup
     type: create_group_in_namespace
     node: app-migration-admin-abort-1

--- a/workflows/app-migration/32-authored-migrate-ux.yml
+++ b/workflows/app-migration/32-authored-migrate-ux.yml
@@ -51,12 +51,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key (for teardown)
-    type: node_identity
-    node: app-migration-ux-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create descendant Open subgroup on node 1
     type: create_group_in_namespace
     node: app-migration-ux-1

--- a/workflows/app-migration/33-authored-remaining-count.yml
+++ b/workflows/app-migration/33-authored-remaining-count.yml
@@ -59,12 +59,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key (for teardown)
-    type: node_identity
-    node: app-migration-authored-count-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create descendant subgroup
     type: create_group_in_namespace
     node: app-migration-authored-count-1

--- a/workflows/app-migration/35-two-namespaces-coexist.yml
+++ b/workflows/app-migration/35-two-namespaces-coexist.yml
@@ -42,12 +42,6 @@ steps:
     outputs:
       namespace_a: namespaceId
 
-  - name: Capture admin key (for teardown)
-    type: node_identity
-    node: app-migration-coexist-1
-    outputs:
-      admin_key_a: publicKey
-
   - name: Create subgroup in namespace A
     type: create_group_in_namespace
     node: app-migration-coexist-1

--- a/workflows/app-migration/36-chained-catchup.yml
+++ b/workflows/app-migration/36-chained-catchup.yml
@@ -42,12 +42,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-chained-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-chained-1

--- a/workflows/app-migration/37-stranded-resync.yml
+++ b/workflows/app-migration/37-stranded-resync.yml
@@ -57,12 +57,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key
-    type: node_identity
-    node: app-migration-strand-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup under namespace
     type: create_group_in_namespace
     node: app-migration-strand-1

--- a/workflows/app-migration/39-missing-abi-refused.yml
+++ b/workflows/app-migration/39-missing-abi-refused.yml
@@ -54,12 +54,6 @@ steps:
     outputs:
       namespace_id: namespaceId
 
-  - name: Capture admin key (for teardown)
-    type: node_identity
-    node: app-migration-missing-abi-1
-    outputs:
-      admin_key: publicKey
-
   - name: Create Open subgroup on node 1
     type: create_group_in_namespace
     node: app-migration-missing-abi-1


### PR DESCRIPTION
Every app-migration scenario opened with **"Capture admin key (for teardown)"** and exported `admin_key`. Nothing in any of them ever references `{{admin_key}}` — the teardown they were named for takes no requester, and the scenarios end on `stop_all_nodes`. Each was an HTTP round trip per run whose only effect was a variable nobody read.

**34 steps across 34 files, −204 lines.**

## They were not always inert

Under the step they used to be — `get_namespace_identity` — the call 404'd for a namespace this node had never joined, so it doubled as an implicit *"the join landed"* gate. Deleting them **then** would have removed a real check. `node_identity` (#3522) answers regardless of participation, so since that migration they gate nothing, and the only thing left to remove is the round trip. That is why this is a separate PR from the migration rather than part of it.

## Checked before deleting, not after

| check | result |
| --- | --- |
| `node_identity` steps in `workflows/app-migration` | 35 |
| …whose `outputs` are read somewhere | **1** — `strand_2_key` in `37-stranded-resync`, kept |
| …read nowhere | 34, removed |

The `outputs:` names are the only readable handles: merobox's `_export_variables` says it "handles only custom outputs — no automatic exports", so the per-step auto-name templates (`identity_public_key_{node_name}`) are advisory metadata rather than runtime variables. I grepped for them anyway — no scenario references one. And every remaining `{{…}}` in those files resolves to a definition in the same file, so nothing was reading these under another name.

## Verification

| gate | result |
| --- | --- |
| all 35 app-migration scenarios through merobox's `WorkflowConfig` | ✓ 0 invalid |
| `scripts/lint-e2e-convergence.py` | ✓ 129 scanned, no new races |
| `scripts/check-scenario-coverage.py` | ✓ 128/129 registered, 1 baselined (unchanged) |

The app-migration matrix on this PR is the real proof: 34 scenarios that each lost a step still have to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)