### PR TITLE
fix(api)!: drop governanceOp from both join responses

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -46,9 +46,25 @@ runs:
         #            the typed binding with "node identity read failed" — before
         #            any HTTP call, which is why the node logs showed no request
         #            at all. merobox#337 stopped the two pins drifting.
-        # When this next moves: if the bundled client-py no longer requires
-        # upgradePolicy, delete UPGRADE_POLICY_COMPAT (crates/server/primitives).
-        MIN_MEROBOX="0.6.55"
+        #   0.6.56 — the bundled `calimero-client-py` is >= 0.6.29, which is the
+        #            first release compiled against a core that made
+        #            `governanceOp` optional on the join responses. Below this the
+        #            bundled client rejects a join from a node that has retired
+        #            the field, with a serde `missing field` error before any
+        #            scenario logic runs — every scenario that joins a namespace
+        #            fails at the join step (#3485). 0.6.56 also drops the
+        #            `requester` step field with the DTOs that lost it (#3492).
+        # UPGRADE_POLICY_COMPAT: the previous note here said to delete it once the
+        # bundled client-py stopped requiring `upgradePolicy`. It has — nothing in
+        # client-py master sends or reads the field — but deleting the shim is a
+        # response-shape change of exactly the class #3485 turned out to be:
+        # `mero-js` types `upgradePolicy: string` and `swift-sdk` declares it
+        # non-optional on a synthesized `Codable`, so removing it needs the same
+        # SDK-then-client-py-then-merobox sequence rather than a rider on this
+        # bump. Core's own struct has carried `#[serde(default)]` on the field
+        # since before rc.21, so a client compiled from core survives its
+        # removal; the two hand-written SDKs are what need the coordination.
+        MIN_MEROBOX="0.6.56"
 
         case "$(uname -m)" in
           x86_64) MEROBOX_ARCH="linux-x86-64" ;;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@
   on a published crate and posted to `admin-api/groups/claim-invitation`, a
   route with no handler anywhere, so any caller got a 404. Direct
   request-response join replaced the relay it belonged to ([#3450])
+- **`governanceOp`** from both join responses (`POST admin-api/groups/join`,
+  `POST admin-api/namespaces/:namespace_id/join`), along with
+  `JoinGroupResponse::governance_op_bytes`. **Breaking** for
+  `calimero-server-primitives` and for any client that decodes the response
+  into a type with a required field of that name — but the node only ever sent
+  `""` there, the last piece of the relay #3450 removed, so no working caller
+  can depend on its value. Read `memberAccount` for the principal the join
+  produced. Matching SDK releases drop the field from `mero-js` and
+  `swift-sdk` ([#3485])
 
 ### Changed
 
@@ -789,4 +798,5 @@ Integrations:
 [#3440]: https://github.com/calimero-network/core/pull/3440
 [#3450]: https://github.com/calimero-network/core/pull/3450
 [#3485]: https://github.com/calimero-network/core/issues/3485
+[#3528]: https://github.com/calimero-network/core/pull/3528
 [#3530]: https://github.com/calimero-network/core/pull/3530

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,14 @@
   into a type with a required field of that name — but the node only ever sent
   `""` there, the last piece of the relay #3450 removed, so no working caller
   can depend on its value. Read `memberAccount` for the principal the join
-  produced. Matching SDK releases drop the field from `mero-js` and
-  `swift-sdk` ([#3485])
+  produced.
+
+  Every pinned decoder was updated first, because one of them runs our own
+  E2E: `mero-js` 11.2.0 and `swift-sdk` dropped the field, `calimero-client-py`
+  0.6.29 rebuilt against the tolerance added in [#3530], and merobox 0.6.56
+  bundles that client — so `MIN_MEROBOX` moves to 0.6.56 here, the floor at
+  which a join against a node without the field still decodes ([#3485],
+  [#3528])
 
 ### Changed
 

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -557,8 +557,7 @@ async fn join_namespace() {
                 // member it just became and the key for everything still keyed
                 // by one — and the two render differently, so a fixture carrying
                 // only one would not catch a field wired to the wrong space.
-                "memberAccount": ZERO_HEX_ACCOUNT,
-                "governanceOp": "deadbeef"
+                "memberAccount": ZERO_HEX_ACCOUNT
             }
         })))
         .expect(1)

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -302,13 +302,6 @@ pub struct JoinGroupResponse {
     /// metadata, removal), and the account is a hash of the key that no caller
     /// can compute for itself.
     pub member_account: AccountId,
-    /// Always empty. This carried a serialized `SignedGroupOp` back when a join
-    /// had to be relayed to the inviting node; direct request-response join
-    /// replaced that, so the sole construction site sets `vec![]` and no reader
-    /// consumes it. It still reaches clients as `governanceOp: ""` on the group
-    /// and namespace join responses, so retiring it is an SDK-visible wire
-    /// change rather than a local cleanup.
-    pub governance_op_bytes: Vec<u8>,
 }
 
 #[derive(Debug)]

--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -745,7 +745,6 @@ impl Handler<JoinGroupRequest> for ContextManager {
                     group_id,
                     member_identity: joiner_identity,
                     member_account,
-                    governance_op_bytes: vec![],
                 })
             }
             .into_actor(self),

--- a/crates/server/primitives/fixtures/wire/groups/join.res.json
+++ b/crates/server/primitives/fixtures/wire/groups/join.res.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "groupId": "7c9a0b1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f900112233",
+    "memberAccount": "aa11bb22cc33dd44ee55ff6677889900aabbccddeeff00112233445566778899",
+    "memberIdentity": "4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw"
+  }
+}

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2096,12 +2096,6 @@ pub struct JoinGroupApiResponseData {
     /// The account that key joined as, 64 hex characters — the id every
     /// member-addressing endpoint expects. See `NodeIdentityApiResponseData`.
     pub member_account: String,
-    /// Always `""`. Retained on the wire only so clients compiled against an
-    /// older copy of this struct keep deserializing a join response; the
-    /// `default` is what lets a client built from here survive its removal.
-    /// Nothing produces a value and nothing reads one.
-    #[serde(default)]
-    pub governance_op: String,
 }
 
 // ---- List All Groups ----
@@ -2619,21 +2613,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn join_response_deserializes_without_governance_op() {
-        // The shape a node serves once the field is retired. `calimero-client-py`
-        // compiles this struct from core's master branch and ships as a prebuilt
-        // wheel inside merobox, so a join response that dropped the key used to
-        // fail every scenario that joins a namespace with a serde `missing field`
-        // error from a client nobody had rebuilt yet. This is the tolerance that
-        // lets such a client outlive the field.
+    fn join_response_ignores_a_governance_op_from_an_older_node() {
+        // The mirror of the tolerance this replaces. `governanceOp` is gone from
+        // the struct, so the risk is no longer a client that misses the field but
+        // a client that meets it: a node predating the removal still sends it, and
+        // this type must read such a response rather than reject it as unknown.
         let json = serde_json::json!({
             "groupId": hex::encode([0xCC; 32]),
             "memberIdentity": PublicKey::from([0xBB; 32]),
             "memberAccount": hex::encode([0xDD; 32]),
+            "governanceOp": "",
         });
 
         let resp: JoinGroupApiResponseData = serde_json::from_value(json).unwrap();
-        assert_eq!(resp.governance_op, "");
         assert_eq!(resp.member_account, hex::encode([0xDD; 32]));
     }
 

--- a/crates/server/primitives/tests/wire_fixtures.rs
+++ b/crates/server/primitives/tests/wire_fixtures.rs
@@ -17,7 +17,8 @@ use serde_json::Value;
 
 use calimero_server_primitives::admin::{
     CreateContextRequest, CreateContextResponseData, GetGroupUpgradeStatusApiResponse,
-    ReparentGroupApiRequest, ReparentGroupApiResponse, UpgradeGroupApiResponse,
+    JoinGroupApiResponse, ReparentGroupApiRequest, ReparentGroupApiResponse,
+    UpgradeGroupApiResponse,
 };
 use calimero_server_primitives::jsonrpc::{ExecutionRequest, ExecutionResponse};
 
@@ -81,6 +82,11 @@ macro_rules! wire_fixtures {
 wire_fixtures! {
     create_context_req: CreateContextRequest => "contexts/create_context.req.json",
     create_context_res: CreateContextResponseData => "contexts/create_context.res.json",
+    // Shared by `POST groups/join` and `POST namespaces/:id/join`, which build the
+    // same DTO. The key and the account are deliberately unequal and rendered in
+    // different alphabets, so a field crossed between the two spaces shows up as a
+    // diff rather than round-tripping cleanly.
+    join_res: JoinGroupApiResponse => "groups/join.res.json",
     reparent_req: ReparentGroupApiRequest => "groups/reparent.req.json",
     reparent_res: ReparentGroupApiResponse => "groups/reparent.res.json",
     // Populated counters, not nulls: these three are `Option`, so a renamed

--- a/crates/server/src/admin/handlers/groups/join_group.rs
+++ b/crates/server/src/admin/handlers/groups/join_group.rs
@@ -37,7 +37,6 @@ pub async fn handler(
                         group_id: group_id_hex,
                         member_identity: resp.member_identity,
                         member_account: resp.member_account.to_string(),
-                        governance_op: hex::encode(&resp.governance_op_bytes),
                     },
                 },
             }

--- a/crates/server/src/admin/handlers/namespaces/join_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/join_namespace.rs
@@ -75,7 +75,6 @@ pub async fn handler(
                         group_id: group_id_hex,
                         member_identity: resp.member_identity,
                         member_account: resp.member_account.to_string(),
-                        governance_op: hex::encode(&resp.governance_op_bytes),
                     },
                 },
             }


### PR DESCRIPTION
Closes #3485

## What

`POST /admin-api/groups/join` and `POST /admin-api/namespaces/:namespace_id/join` returned `governanceOp` on every successful join, always `""`. `JoinGroupResponse::governance_op_bytes` had a single construction site that hardcoded `vec![]`; both handlers hex-encoded that into the wire field.

It is the last piece of a superseded model in which a joiner handed a signed `JoinWithInvitationClaim` back for an orchestrator to relay to the inviting node. Direct request-response join replaced that — the inviting node applies the op itself over the stream — and the relay endpoint was never built. #3450 removed its client method and DTOs but deliberately left the wire field, since dropping it is an SDK-visible break.

## Decision: remove, not populate

The issue leaves two branches open. Nothing in the tree suggests the relay returns: `join_credential.rs` documents three cleartext join paths, none of which relays. Populating would mean inventing a producer for a value with no consumer.

Nothing reads it — I grepped every repo in the workspace (core, mero-js, swift-sdk, client-py, merobox, mdma, mero-tee, tauri-app, mero-mcp, mero-react). Every occurrence outside the type declarations is a **test mock inventing a plausible value** for a field that is always empty: `"deadbeef"` here in `crates/client/src/tests.rs`, `'op-hex'` in mero-js, `'MemberAdded'` in mero-react. That is the failure mode the issue predicts for integrators, already reproduced by our own fixtures. `meroctl`'s `Report` never printed it.

Callers that need the principal a join produced read `memberAccount`, which both handlers already return.

## Changes

- Remove `governance_op_bytes` from `JoinGroupResponse`, its initializer, `governance_op` from the DTO, and the two `hex::encode` call sites.
- Drop the field from the `calimero-client` mock.
- **Add a wire fixture** for the join response. The issue's checkbox was a no-op as written — `fixtures/wire/groups/` held only `reparent.*`, so `UPDATE_FIXTURES=1` regenerated nothing. Now the next change to this shape fails a Docker-free test naming the drift instead of reaching the SDKs unannounced. The fixture's key and account are deliberately unequal and rendered in different alphabets, so a field crossed between the two spaces diverges rather than round-tripping.
- CHANGELOG entry under `[Unreleased] → Removed`, marked breaking.

## Coordination

Both shipped SDKs typed the field non-optional and are also missing `memberAccount`; matching PRs fix both:

- calimero-network/mero-js#103
- calimero-network/swift-sdk#20

**Merge those first.** Swift is the reason: a synthesized `Codable` with a non-optional `governanceOp` fails the whole join response with `keyNotFound` once the server stops sending it, not just that one value. Both SDKs ignore unknown JSON keys, so they land cleanly against nodes that still send it. Same asymmetry inside core: the DTO has no `deny_unknown_fields`, so a new client reads an old server fine, while an old pinned `calimero-client` against a new node errors on the missing field — a clean break on the rc line, consistent with #3450.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets` on the touched crates, `cargo check --workspace --all-targets`, and `cargo test -p calimero-client -p calimero-server-primitives -p calimero-context` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)