### PR TITLE
perf(governance): resolve signer bindings once per loop, not once per op

### DIFF
--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1017,6 +1017,16 @@ impl Handler<ExecuteRequest> for ContextManager {
                     // can never affect execution.
                     if let Some((objects, delta_id)) = &acl_shadow_objects {
                         let scope = calimero_op::ScopeId::from(*context_id.digest());
+                        // Hoisted out of BOTH loops: every rotation entry of every
+                        // touched anchor resolves against the same binding set, and
+                        // the per-entry form rescanned the whole column for each
+                        // one. This runs on the write path of every state op.
+                        let signer_bindings = calimero_governance_store::signer_bindings_in(
+                            &xcall_datastore,
+                            &calimero_context_config::types::ContextGroupId::from(
+                                *context_id.digest(),
+                            ),
+                        );
                         let mut ops = Vec::new();
                         for object in objects {
                             let Some(log) = crate::scope_projection::load_rotation_log_direct(
@@ -1031,15 +1041,9 @@ impl Handler<ExecuteRequest> for ContextManager {
                                 // Same resolution the apply and backfill paths
                                 // use: a rotation entry names a KEY, and the
                                 // writer plane is keyed by account.
-                                let signer_binding = entry.signer.and_then(|signer| {
-                                    calimero_governance_store::signer_binding_for(
-                                        &xcall_datastore,
-                                        &calimero_context_config::types::ContextGroupId::from(
-                                            *context_id.digest(),
-                                        ),
-                                        &signer,
-                                    )
-                                });
+                                let signer_binding = entry
+                                    .signer
+                                    .and_then(|signer| signer_bindings.get(&signer).copied());
                                 if let Some(op) = crate::scope_projection::op_from_rotation_entry(
                                     *object,
                                     scope,

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1176,6 +1176,15 @@ impl ScopeProjections {
         };
 
         let op_log = NamespaceOpLogService::new(store, namespace_id.into());
+        // One scan for the whole walk. The per-op form rescanned the binding
+        // column for every op the walk stepped over, and the walk is capped at
+        // `MAX_BACKFILL_OPS` — so a deep namespace paid that scan tens of
+        // thousands of times to read a set the loop never changes (it holds no
+        // lock and writes no bindings).
+        let signer_bindings = calimero_governance_store::signer_bindings_in(
+            store,
+            &ContextGroupId::from(namespace_id),
+        );
         let mut visited: HashSet<[u8; 32]> = HashSet::new();
         let mut queue: std::collections::VecDeque<[u8; 32]> = heads.into_iter().collect();
         let mut ops = Vec::new();
@@ -1237,11 +1246,7 @@ impl ScopeProjections {
             };
             // Same resolution the apply path uses, so a backfilled op and a
             // live-folded one are attributed identically.
-            let signer_binding = calimero_governance_store::signer_binding_for(
-                store,
-                &ContextGroupId::from(namespace_id),
-                &signed.signer,
-            );
+            let signer_binding = signer_bindings.get(&signed.signer).copied();
             ops.push(
                 calimero_governance_store::op_from_namespace_op_with_binding(
                     &signed,

--- a/crates/governance-store/src/account_bindings.rs
+++ b/crates/governance-store/src/account_bindings.rs
@@ -7,7 +7,7 @@
 //! materialized rows rather than a fold, because that is how the shipping
 //! governance wire works.
 //!
-//! Three rules earn their place here, and each one is a bug that
+//! Four rules earn their place here, and each one is a bug that
 //! `crates/projection/tests/account_plane.rs` caught before this existed:
 //!
 //! 1. **Revocation is its own row family, and it is terminal.** A revocation
@@ -450,6 +450,12 @@ impl<'a> AccountBindingRepository<'a> {
     /// to `None` — revocation therefore withdraws the right to author, not only
     /// the right to receive keys.
     ///
+    /// **For one key.** A caller resolving *several* signers against the same
+    /// group must use
+    /// [`live_bindings_by_sign_pk`](Self::live_bindings_by_sign_pk) instead: this
+    /// searches a full scan, so calling it in a loop rescans the binding column
+    /// once per item and makes the loop quadratic in the group's device count.
+    ///
     /// # Errors
     /// Propagates the store scan failure.
     pub fn binding_for_sign_pk(
@@ -536,6 +542,42 @@ impl<'a> AccountBindingRepository<'a> {
         let mut out: BTreeMap<AccountId, Vec<DeviceBinding>> = BTreeMap::new();
         for binding in self.live_bindings(group)? {
             out.entry(binding.account).or_default().push(binding);
+        }
+        Ok(out)
+    }
+
+    /// [`live_bindings`](Self::live_bindings) keyed by each device's certified
+    /// signing key — one scan for every signer in the group.
+    ///
+    /// The batch form of
+    /// [`binding_for_sign_pk`](Self::binding_for_sign_pk), for the callers that
+    /// attribute *many* signatures against one group: the projection backfill
+    /// resolves a signer per governance op, and the ACL shadow resolves one per
+    /// rotation-log entry. Each of those searched a fresh scan, so a walk of *n*
+    /// ops over a group with *d* devices read the binding column *n × d* times to
+    /// answer questions that share a single answer set.
+    ///
+    /// Built from the filtered list rather than from the raw rows, so the
+    /// read-time rules — revocation, root-key supersession, and the replica-seed
+    /// reduction that is a function of the whole set — hold exactly as they do for
+    /// a single lookup. This is also why there is no reverse *key family* here: a
+    /// point index from `sign_pk` could not answer whether the device it names
+    /// survives a seed collision without reading the devices it collides with.
+    ///
+    /// Nothing constrains two devices to distinct signing keys, so a duplicate
+    /// resolves to the **first** binding in scan order — the same one
+    /// `binding_for_sign_pk`'s search returns, which is what makes this
+    /// substitutable for it.
+    ///
+    /// # Errors
+    /// Propagates the store scan failure.
+    pub fn live_bindings_by_sign_pk(
+        &self,
+        group: &ContextGroupId,
+    ) -> EyreResult<BTreeMap<PublicKey, DeviceBinding>> {
+        let mut out: BTreeMap<PublicKey, DeviceBinding> = BTreeMap::new();
+        for binding in self.live_bindings(group)? {
+            let _ = out.entry(binding.sign_pk).or_insert(binding);
         }
         Ok(out)
     }
@@ -1399,6 +1441,125 @@ mod tests {
             member_account_for_device_key(&store, &gid, &device_sign_pk).expect("resolve"),
             None,
             "a revoked device must stop being a route into the group"
+        );
+    }
+    #[test]
+    fn the_sign_pk_map_answers_every_lookup_the_single_search_does() {
+        // The substitutability the batch form exists for. It replaces
+        // `binding_for_sign_pk` at the loop call sites, so the two have to agree
+        // on every state a signing key can be in — live, revoked, superseded, and
+        // never linked at all. Building the map from the raw rows instead of from
+        // the filtered list would pass a "live device resolves" check and quietly
+        // resurrect the other three.
+        let store = test_store();
+        let gid = test_group_id();
+        let repo = AccountBindingRepository::new(&store);
+
+        // Two accounts, so the map has to key on the signing key rather than
+        // collapse to one account's devices.
+        let a = genesis_for(1);
+        let b = genesis_for(2);
+        let _ = repo
+            .apply_link(&gid, &a, &[], &cert_for(&a, &key(1), 5, 0, 0))
+            .expect("store")
+            .expect("admitted");
+        let revoked = cert_for(&a, &key(1), 6, 0, 0);
+        let _ = repo
+            .apply_link(&gid, &a, &[], &revoked)
+            .expect("store")
+            .expect("admitted");
+        repo.apply_revocation(&gid, revoked.device).expect("revoke");
+        let _ = repo
+            .apply_link(&gid, &b, &[], &cert_for(&b, &key(2), 7, 0, 0))
+            .expect("store")
+            .expect("admitted");
+
+        // A third account whose root rotates, superseding its epoch-0 device.
+        let c = genesis_for(3);
+        let _ = repo
+            .apply_link(&gid, &c, &[], &cert_for(&c, &key(3), 8, 0, 0))
+            .expect("store")
+            .expect("admitted");
+        let handoff = sign_root_key_handoff(&key(3), c.account_id(), 0, &key(4).public_key())
+            .expect("sign handoff");
+        repo.apply_rotation(&gid, &handoff)
+            .expect("store")
+            .expect("rotated");
+
+        let map = repo.live_bindings_by_sign_pk(&gid).expect("map");
+        for seed in [5u8, 6, 7, 8, 99] {
+            let sign_pk = key(seed).public_key();
+            assert_eq!(
+                map.get(&sign_pk).copied(),
+                repo.binding_for_sign_pk(&gid, &sign_pk).expect("search"),
+                "the two forms disagree about the device signing with key({seed})"
+            );
+        }
+        // Live: the two unrevoked, unsuperseded devices — not the other three keys.
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn a_device_dropped_by_the_seed_reduction_is_absent_from_the_sign_pk_map() {
+        // Why the batch form is a map built over the filtered list and NOT a
+        // reverse `sign_pk -> device` key family. The seed rule is a function of
+        // the whole stored set: whether this device is live depends on the OTHER
+        // devices sharing its HLC seed. A point index could return the loser's
+        // row without ever reading the row that beats it, so it would hand
+        // authorship to a device the live view excludes.
+        let g = genesis_for(1);
+        let account = g.account_id();
+
+        // Forge two ids sharing a seed, as
+        // `two_devices_sharing_a_replica_seed_converge_on_the_lower_id_either_order`
+        // does — the seed is the id's first 16 bytes.
+        let mut low = [0u8; 32];
+        low[..16].copy_from_slice(&[0xAA; 16]);
+        let mut high = low;
+        high[31] = 0xFF;
+        let (low, high) = (DeviceId::from(low), DeviceId::from(high));
+        assert!(low < high);
+
+        let cert_for_device = |device: DeviceId, seed: u8| {
+            sign_device_cert(
+                &key(1),
+                account,
+                device,
+                &key(seed).public_key(),
+                &KemPublicKey::from([seed; 32]),
+                0,
+                0,
+            )
+            .expect("sign")
+        };
+
+        let store = test_store();
+        let gid = test_group_id();
+        let repo = AccountBindingRepository::new(&store);
+        let _ = repo
+            .apply_link(&gid, &g, &[], &cert_for_device(low, 5))
+            .expect("store");
+        let _ = repo
+            .apply_link(&gid, &g, &[], &cert_for_device(high, 6))
+            .expect("store");
+
+        let map = repo.live_bindings_by_sign_pk(&gid).expect("map");
+        let (winner, loser) = (key(5).public_key(), key(6).public_key());
+        assert_eq!(
+            map.get(&winner).map(|b| b.device),
+            Some(low),
+            "the surviving device must be reachable by its signing key"
+        );
+        assert_eq!(
+            map.get(&loser),
+            None,
+            "the device the seed reduction dropped must not be reachable at all"
+        );
+        // And the single-lookup form says the same, which is the invariant the
+        // hoisted call sites depend on.
+        assert_eq!(
+            repo.binding_for_sign_pk(&gid, &loser).expect("search"),
+            None
         );
     }
 }

--- a/crates/governance-store/src/lib.rs
+++ b/crates/governance-store/src/lib.rs
@@ -66,7 +66,9 @@ mod permission_checker;
 mod reentry;
 mod tee;
 pub mod unified_op_decode;
-pub use crate::unified_op_decode::{op_from_namespace_op_with_binding, signer_binding_for};
+pub use crate::unified_op_decode::{
+    op_from_namespace_op_with_binding, signer_binding_for, signer_bindings_in, SignerBindings,
+};
 mod upgrade_ladder;
 mod upgrades;
 use self::local_state::{op_log_contains_content_hash, persist_group_governance_progress};

--- a/crates/governance-store/src/unified_op_decode.rs
+++ b/crates/governance-store/src/unified_op_decode.rs
@@ -25,6 +25,10 @@ use calimero_context_client::local_governance::GroupOp;
 /// disagree about who authored it. Returns `None` for a key with no live binding —
 /// a joiner whose own join is what creates one, or pre-credential data — and the
 /// caller then gets the stand-in rather than a fabricated claim to a real account.
+///
+/// **For one op.** A producer attributing *many* ops in the same namespace should
+/// build [`signer_bindings_in`] once and read that instead — this resolves against
+/// a fresh scan of the binding column every call.
 pub fn signer_binding_for(
     store: &calimero_store::Store,
     namespace: &calimero_context_config::types::ContextGroupId,
@@ -35,6 +39,35 @@ pub fn signer_binding_for(
         .ok()
         .flatten()
         .map(|binding| (binding.account, binding.device))
+}
+
+/// Every signing key `namespace` can attribute an op to, mapped to the account and
+/// device it speaks for.
+///
+/// Look a signer up with `bindings.get(&sign_pk).copied()`; an absent key means
+/// exactly what [`signer_binding_for`]'s `None` means, so a caller reading this map
+/// reaches the same stand-in for the same ops.
+pub type SignerBindings = std::collections::BTreeMap<PublicKey, (AccountId, DeviceId)>;
+/// [`signer_binding_for`] for every signer at once, in a single scan.
+///
+/// Hoist this out of any loop that attributes more than one op: the per-op form
+/// rescans the whole binding column each time, so *n* ops over a group with *d*
+/// devices cost *n × d* reads for one answer set that does not change as the loop
+/// runs.
+///
+/// An unreadable store yields an EMPTY map rather than an error, which degrades the
+/// same way the per-op form's `.ok()` does — every signer resolves to the stand-in.
+/// Callers here are shadow/backfill producers with no channel to fail into.
+pub fn signer_bindings_in(
+    store: &calimero_store::Store,
+    namespace: &calimero_context_config::types::ContextGroupId,
+) -> SignerBindings {
+    crate::AccountBindingRepository::new(store)
+        .live_bindings_by_sign_pk(namespace)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(sign_pk, binding)| (sign_pk, (binding.account, binding.device)))
+        .collect()
 }
 
 /// Assemble an [`Op`] that **mirrors a source-DAG op**: its `id` and `parents`


### PR DESCRIPTION
## Summary

Item 2 of #3355. `AccountBindingRepository::binding_for_sign_pk` reads like a bounded lookup, but it searches a **full scan** of the group's binding column:

```rust
pub fn binding_for_sign_pk(&self, group, sign_pk) -> EyreResult<Option<DeviceBinding>> {
    Ok(self.live_bindings(group)?.into_iter().find(|b| b.sign_pk == *sign_pk))
}
```

Three producers called it inside a loop that holds `group` constant, so the real cost is *items × devices* — the same shape #3320's review flagged for the key-delivery fan-out and fixed with `live_devices_by_account`. This applies that fix to the sites it didn't cover.

## Before and after, with one example

A namespace with **3 devices** and a governance history of **4 ops**, being backfilled by `collect_namespace_ops`:

**Before** — every op re-derives the whole live set to answer one signer:

```
op #1 → live_bindings(): scan tombstones, scan 3 binding keys, 3 gets, epoch reads → find(sign_pk=A)
op #2 → live_bindings(): scan tombstones, scan 3 binding keys, 3 gets, epoch reads → find(sign_pk=B)
op #3 → live_bindings(): scan tombstones, scan 3 binding keys, 3 gets, epoch reads → find(sign_pk=A)
op #4 → live_bindings(): scan tombstones, scan 3 binding keys, 3 gets, epoch reads → find(sign_pk=C)
                                    4 scans of the same unchanged column
```

**After** — one derivation, four map lookups:

```
once   → live_bindings() → { A: dev1, B: dev2, C: dev3 }
op #1 → map.get(A)   op #2 → map.get(B)   op #3 → map.get(A)   op #4 → map.get(C)
                                    1 scan, 0 further reads
```

At 4 ops and 3 devices that's 4 scans → 1. The walk is capped at `MAX_BACKFILL_OPS = 100_000`, so on a real namespace the same substitution is tens of thousands of scans → 1, and the loop reads a set it cannot change: it takes no lock and writes no bindings.

## What changed

- **`live_bindings_by_sign_pk`** on `AccountBindingRepository` — `live_bindings` keyed by each device's certified signing key, one scan for every signer in the group. Sibling of the existing `live_devices_by_account`.
- **`signer_bindings_in`** + the `SignerBindings` alias in `unified_op_decode` — the batch form of `signer_binding_for`, so op-attribution callers get `(AccountId, DeviceId)` without reaching for the repository. Degrades on an unreadable store the same way the per-op form's `.ok()` does: an empty map, every signer to the stand-in.
- **Hoisted at `crates/context/src/scope_projection.rs:1179`** — the projection backfill walk, one call for the whole walk instead of one per op.
- **Hoisted at `crates/context/src/handlers/execute/mod.rs:1020`** — the ACL shadow, out of *both* the anchor loop and the rotation-entry loop. This one is on the write path of every `is_state_op` execution.
- Doc warnings on `binding_for_sign_pk` and `signer_binding_for` pointing at the batch forms — the omission that let three call sites use the per-item form in a loop. `devices_of` already carries the equivalent warning.
- Drive-by: the module docs said "Three rules earn their place here" and then listed four.

`binding_for_sign_pk` stays for the genuine single-shot callers (`namespace/op_log.rs:159`, `handlers/apply_signed_namespace_op.rs:88`) — one scan per applied op is fine.

## Why a map over the filtered list, and not a reverse key family

#3355 proposes a `sign_pk → device` index and weighs it as "every filter still has to be applied to whatever it returns — so it only helps the found-early case." Revocation and supersession are indeed row-local, but there's a fourth read-time rule that isn't — `account_bindings.rs:346`:

```rust
let mut by_seed: BTreeMap<[u8; 16], DeviceBinding> = BTreeMap::new();
for binding in out {
    by_seed.entry(binding.device.hlc_seed())
        .and_modify(|kept| if binding.device < kept.device { *kept = binding })
        .or_insert(binding);
}
```

Replica-seed uniqueness (module rule 4) is **set-valued**: whether a device is live depends on the *other* devices sharing its HLC seed, and it is deliberately decided on read because the apply-time version was order-dependent in the direction it didn't check ("high-then-low left both devices live").

So a point index from `sign_pk` cannot answer "is this device live" — it would return the loser's row without ever reading the row that beats it, handing authorship to a device the live view excludes. Making it correct needs a companion `hlc_seed → devices` family plus the reduction over that bucket, plus the tombstone and epoch reads: two new key families, two write paths to keep consistent, and still not a single `get`. It also pushes work back toward apply time, which is where rules 3 and 4 came from as bugs.

Building the map over `live_bindings`' post-reduction output gets the same asymptotics for free and cannot drift from the single-lookup answer. Same conclusion `accounts_by_endorsing_member` already documents for its own direction ("a reverse map ... would come back empty after a projection rebuild"). **Recommend #3355 record the index as declined on that basis.**

## Proof

Two tests in `crates/governance-store/src/account_bindings.rs`:

- `the_sign_pk_map_answers_every_lookup_the_single_search_does` — three accounts, one revoked device, one superseded by a root rotation, one key never linked; asserts `map.get(k) == binding_for_sign_pk(k)` for **every** state a signing key can be in. Building the map from raw rows instead of the filtered list passes a naive "live device resolves" check and quietly resurrects the other three; this catches that.
- `a_device_dropped_by_the_seed_reduction_is_absent_from_the_sign_pk_map` — two devices forged to share an HLC seed; the loser must be unreachable through both forms. This is the invariant a reverse key family would break.

```
$ cargo test -p calimero-governance-store
test result: ok. 571 passed; 0 failed

$ cargo test -p calimero-context
test result: ok. 233 passed; 0 failed          # + all 10 integration binaries green,
                                               # incl. op_store_reconstruction (3) and
                                               # per_device_authorization (6), which cover
                                               # the backfill attribution path directly

$ cargo fmt --check                            # clean
$ cargo clippy -p calimero-governance-store -p calimero-context --all-targets \
    --features calimero-storage/testing -- -D warnings   # clean
$ cargo check --workspace                      # clean
```

## One honest note on behaviour

Under a *concurrent* binding write, the hoisted form is not bit-identical to the old one: the walk now attributes every op against one snapshot, where before op #1 could see the old binding set and op #50,000 a newer one. That is the better of the two — a torn read across a walk produced an internally inconsistent op set — and both loops are already re-run by design (`namespace_to_refresh` re-walks, and the op-store repersists once a late group key arrives). With no concurrent write, which is the normal case, the results are identical.

## Out of scope

`device_author_is_member_at_cut` (`scope_projection.rs:1432`) also calls `binding_for_sign_pk`, but per authored write rather than in a loop — one scan, the acceptable case. Its neighbouring `endorsers_of` is *not* a second wide scan; it scans prefix `(group, account)`, bounded by one account's endorsers.

## Criteria for resolving (#3355)

- [x] `current_key_recipients` resolves bindings once per call — already landed in #3320 itself (`fcc74a1b7`, `live_devices_by_account`)
- [x] A decision recorded on the reverse index — declined, with rule 4 as the reason; revisit only if profiling shows a *single* lookup on the per-op authz path dominating, which is a different fix
- [x] `crates/account` split on the three seams — #3473

The remaining criterion in #3355, "the fan-out order pinned by a test", I'd suggest dropping: envelope order carries no meaning on the receive path (a recipient searches the bundle for its own envelope), and the existing tests correctly pin the recipient *set*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
