### PR TITLE
fix(api): tolerate a join response without governanceOp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@
   route with no handler anywhere, so any caller got a 404. Direct
   request-response join replaced the relay it belonged to ([#3450])
 
+### Changed
+
+- **`governanceOp` on both join responses is now optional on deserialization.**
+  The node still sends it (always `""`), so nothing changes on the wire; the
+  `serde` default is what lets a client compiled from this point survive the
+  field's removal. `calimero-client-py` builds `calimero-server-primitives`
+  from master and ships as a prebuilt wheel inside merobox, so without this a
+  removal breaks every E2E scenario that joins a namespace, on a client nobody
+  has rebuilt. Prerequisite for [#3485] ([#3530])
+
 ## [0.11.0-rc.10] - 2026-07-05
 
 > **Draft — release manager to curate.** Another large hardening release
@@ -778,3 +788,5 @@ Integrations:
 [#1522]: https://github.com/calimero-network/core/pull/1522
 [#3440]: https://github.com/calimero-network/core/pull/3440
 [#3450]: https://github.com/calimero-network/core/pull/3450
+[#3485]: https://github.com/calimero-network/core/issues/3485
+[#3530]: https://github.com/calimero-network/core/pull/3530

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2096,6 +2096,11 @@ pub struct JoinGroupApiResponseData {
     /// The account that key joined as, 64 hex characters — the id every
     /// member-addressing endpoint expects. See `NodeIdentityApiResponseData`.
     pub member_account: String,
+    /// Always `""`. Retained on the wire only so clients compiled against an
+    /// older copy of this struct keep deserializing a join response; the
+    /// `default` is what lets a client built from here survive its removal.
+    /// Nothing produces a value and nothing reads one.
+    #[serde(default)]
     pub governance_op: String,
 }
 
@@ -2612,6 +2617,25 @@ pub struct SetSubgroupVisibilityApiResponse {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn join_response_deserializes_without_governance_op() {
+        // The shape a node serves once the field is retired. `calimero-client-py`
+        // compiles this struct from core's master branch and ships as a prebuilt
+        // wheel inside merobox, so a join response that dropped the key used to
+        // fail every scenario that joins a namespace with a serde `missing field`
+        // error from a client nobody had rebuilt yet. This is the tolerance that
+        // lets such a client outlive the field.
+        let json = serde_json::json!({
+            "groupId": hex::encode([0xCC; 32]),
+            "memberIdentity": PublicKey::from([0xBB; 32]),
+            "memberAccount": hex::encode([0xDD; 32]),
+        });
+
+        let resp: JoinGroupApiResponseData = serde_json::from_value(json).unwrap();
+        assert_eq!(resp.governance_op, "");
+        assert_eq!(resp.member_account, hex::encode([0xDD; 32]));
+    }
 
     #[test]
     fn create_context_response_serializes_with_group_info() {


### PR DESCRIPTION
Prerequisite for #3485 / #3528. **No wire change** — the node still sends `governanceOp: ""` on both join responses. This only makes the field optional on *deserialization*.

## Why this is needed

#3528 removes the field. Its CI went red across essentially the whole E2E suite:

```
Join namespace failed on invite-join-regression-2:
  Client error: missing field `governanceOp` at line 1 column 233
```

That is `serde`, not a JS or Swift decoder. The chain:

- `calimero-client-py/Cargo.toml` pins `calimero-client`, `calimero-server-primitives`, `calimero-primitives` and `calimero-context-config` to `{ git = "…/core", branch = "master" }`, compiling this struct at wheel-build time.
- It publishes a **prebuilt wheel**; merobox depends on `calimero-client-py>=0.6.28` and bundles it.
- core's CI downloads a **released merobox binary** (`.github/actions/setup-merobox`, `MIN_MEROBOX=0.6.55`).

So the decoder is a compiled artifact several releases behind the node it drives, and it requires the field. Every scenario that joins a namespace fails at the join step.

This is the same break class the CHANGELOG notes for #3450, but the Rust side of it — and unlike the SDKs, it cannot be fixed by editing a type in another repo first, because the artifact that breaks was compiled from *this* struct.

## What this does

`#[serde(default)]` on `governance_op`, plus a regression test deserializing a join response that omits the key.

## Sequencing this unblocks

1. **This PR** → master.
2. In `calimero-client-py`, `cargo update` the four core git deps, then cut a wheel; then a merobox release carrying it; then bump `MIN_MEROBOX` in `setup-merobox`.

   The `cargo update` is not optional. Despite `branch = "master"` in its `Cargo.toml`, client-py's committed `Cargo.lock` pins an exact rev — `da787d2b9` (rc.21) on its master today, **41 commits behind core**. The wheel is built from the lock, so it does not track master on its own.
3. #3528 removes the field and lands green.

Without step 1 the ordering is circular: client-py builds from master, so the tolerant wheel cannot exist until the change is on master, and the removal cannot reach master while CI runs the intolerant wheel.

## Verification

`cargo fmt --check`, `cargo test -p calimero-server-primitives` green, including the new `join_response_deserializes_without_governance_op`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)