### PR TITLE
feat(governance): count at-cut authority refusals by cause

### DIFF
--- a/crates/context/src/apply_authorizer.rs
+++ b/crates/context/src/apply_authorizer.rs
@@ -18,6 +18,7 @@ use std::sync::{Arc, Mutex, PoisonError};
 
 use calimero_account::AccountId;
 use calimero_context_config::types::ContextGroupId;
+use calimero_governance_store::metrics::{record_at_cut_undecidable, UndecidableCause};
 use calimero_governance_store::{AtCutAuthorizer, AtCutMembershipPath};
 use calimero_primitives::identity::PublicKey;
 use calimero_store::Store;
@@ -175,7 +176,18 @@ impl AtCutAuthorizer for EphemeralProjectionAuthorizer<'_> {
         // A real cut. We can only decide it if the fold exists AND has the cited
         // ancestry; otherwise the gates must refuse rather than answer from live,
         // which resolves a different cut entirely.
-        self.folded(group)
-            .is_some_and(|folded| folded.0.can_resolve_cut(self.store, *group, parents))
+        //
+        // The two halves fail for unrelated reasons, so they are counted apart.
+        // `folded()` returning `None` is a store fault, not a history gap, and
+        // `can_resolve_cut` cannot see it — it is never reached — so the cause is
+        // recorded here or nowhere. Note the asymmetry with the predicates above:
+        // they read a failed fold as "defer to live", while this refuses. The
+        // refusal is what wins in practice, since the apply gates consult this
+        // before trusting a live answer.
+        let Some(folded) = self.folded(group) else {
+            record_at_cut_undecidable(UndecidableCause::FoldUnavailable);
+            return false;
+        };
+        folded.0.can_resolve_cut(self.store, *group, parents)
     }
 }

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -21,6 +21,7 @@ use std::collections::{HashMap, HashSet};
 use calimero_account::AccountId;
 use calimero_context_client::client::ContextClient;
 use calimero_context_config::types::ContextGroupId;
+use calimero_governance_store::metrics::{record_at_cut_undecidable, UndecidableCause};
 use calimero_governance_store::{
     CapabilitiesRepository, DenyListRepository, MembershipRepository, MetaRepository,
     NamespaceDagService, NamespaceOpLogService, NamespaceRepository,
@@ -329,6 +330,18 @@ pub struct ScopeProjections {
     /// Namespaces already replayed from persisted state, so `backfill_namespace`
     /// walks each governance DAG at most once (the live feed maintains it after).
     backfilled: HashSet<[u8; 32]>,
+    /// Scopes whose retained op-log has been truncated — evicted by
+    /// [`enforce_log_bound`](Self::enforce_log_bound), or cut short by the
+    /// [`MAX_BACKFILL_OPS`] walk cap. Sticky: once the oldest ops are gone, no
+    /// later ingest brings them back, so a cut older than the retained window is
+    /// unresolvable here permanently.
+    ///
+    /// Kept solely to classify an unresolvable cut
+    /// ([`UndecidableCause::LogTruncated`] rather than a transient gap). Nothing
+    /// authorization-relevant reads it: the *decision* is unchanged either way —
+    /// the gate refuses — this only distinguishes a refusal that will clear
+    /// itself from one that needs an operator.
+    truncated: HashSet<ScopeId>,
 }
 
 impl ScopeProjections {
@@ -398,6 +411,11 @@ impl ScopeProjections {
         }
         let drain = log.len() - LIVE_LOG_LOW_WATER;
         let drained_ids: Vec<[u8; 32]> = log.drain(0..drain).map(|op| op.id()).collect();
+        // Sticky, and set BEFORE the bookkeeping below so an early return can't
+        // skip it: from here on, any cut whose ancestry reaches into the dropped
+        // prefix is unresolvable on this node forever, and a refusal for that
+        // reason must not be reported as a transient backfill gap.
+        let _ = self.truncated.insert(scope);
         if let Some(seen) = self.seen.get_mut(&scope) {
             for id in &drained_ids {
                 let _ = seen.remove(id);
@@ -1382,6 +1400,16 @@ impl ScopeProjections {
     /// [`collect_namespace_ops`]: Self::collect_namespace_ops
     pub fn apply_backfill(&mut self, namespace_id: [u8; 32], ops: Vec<Op>) {
         let _ = self.backfilled.insert(namespace_id);
+        // A walk that returned the cap's worth of ops is a walk that stopped
+        // early (`collect_namespace_ops` breaks at `MAX_BACKFILL_OPS`), so the
+        // oldest history is absent and cuts reaching into it are unresolvable.
+        // Detected from the length rather than plumbed out of the walk so the
+        // `pub` collector's signature — five call sites across two crates —
+        // stays put; `ingest_op`'s own bound catches the same scope anyway once
+        // the log crosses the high-water mark.
+        if ops.len() >= MAX_BACKFILL_OPS {
+            let _ = self.truncated.insert(ScopeId::from(namespace_id));
+        }
         for op in &ops {
             self.ingest_op(op);
         }
@@ -1816,6 +1844,13 @@ impl ScopeProjections {
     /// Exposed so the apply gates can tell "no cut to resolve against" (fine — use
     /// live) apart from "the cut is real but this node hasn't folded its ancestry"
     /// (not fine — refuse, and retry when the history arrives).
+    /// This is also the ONE place an at-cut refusal is counted
+    /// (`at_cut_undecidable_total`), and deliberately not
+    /// [`auth_cut_context`](Self::auth_cut_context): the gates call that once per
+    /// predicate over a shared fold, so counting there would scale the rate with
+    /// an op's predicate count instead of with refusals. `can_resolve_cut` is
+    /// asked exactly once per apply decision, and `false` here is precisely the
+    /// answer that becomes `AuthorityUndecidable`.
     #[must_use]
     pub fn can_resolve_cut(
         &self,
@@ -1823,7 +1858,36 @@ impl ScopeProjections {
         group: ContextGroupId,
         heads: &[[u8; 32]],
     ) -> bool {
-        self.auth_cut_context(store, group, heads).is_some()
+        match self.auth_cut_context_or_cause(store, group, heads) {
+            Ok(_) => true,
+            Err(cause) => {
+                record_at_cut_undecidable(cause);
+                if cause.is_transient() {
+                    // The common, self-healing case — the op parks and retries
+                    // once sync delivers the history. Not worth an operator's
+                    // attention, and loud enough at debug to explain a park.
+                    tracing::debug!(
+                        group = ?group,
+                        ?cause,
+                        "at-cut authority undecidable; op parks for retry"
+                    );
+                } else {
+                    // Permanent: no amount of sync brings a dropped prefix back,
+                    // so this op will park on every retry and everything causally
+                    // downstream of it stalls behind it on this node. Warn —
+                    // nothing below this layer can recover it.
+                    tracing::warn!(
+                        group = ?group,
+                        ?cause,
+                        "at-cut authority permanently undecidable: the retained \
+                         op-log no longer reaches this cut, so the op cannot ever \
+                         apply here and this namespace's governance DAG will not \
+                         advance past it"
+                    );
+                }
+                false
+            }
+        }
     }
 
     fn auth_cut_context(
@@ -1832,15 +1896,33 @@ impl ScopeProjections {
         group: ContextGroupId,
         heads: &[[u8; 32]],
     ) -> Option<AuthCutContext> {
+        self.auth_cut_context_or_cause(store, group, heads).ok()
+    }
+
+    /// [`auth_cut_context`](Self::auth_cut_context) with the abstention's reason
+    /// preserved instead of collapsed to `None`.
+    ///
+    /// Split out so [`can_resolve_cut`](Self::can_resolve_cut) can report *why*
+    /// it refused. The predicates keep taking the `Option`: they act on presence
+    /// or absence and have no use for the cause, and threading it through all
+    /// five would buy nothing.
+    fn auth_cut_context_or_cause(
+        &self,
+        store: &Store,
+        group: ContextGroupId,
+        heads: &[[u8; 32]],
+    ) -> Result<AuthCutContext, UndecidableCause> {
         let namespace_id = NamespaceRepository::new(store)
             .resolve(&group)
-            .ok()?
+            .map_err(|_| UndecidableCause::NamespaceUnresolved)?
             .to_bytes();
         let scope = ScopeId::from(namespace_id);
         if !self.cut_ancestry_complete(&scope, heads) {
-            return None;
+            return Err(self.classify_unresolvable_cut(&scope, heads));
         }
-        let view = self.acl_view_at(&scope, heads)?;
+        let view = self
+            .acl_view_at(&scope, heads)
+            .ok_or(UndecidableCause::ViewUnavailable)?;
         let root_group = ContextGroupId::from(namespace_id);
         let root = MetaRepository::new(store)
             .load(&root_group)
@@ -1852,7 +1934,35 @@ impl ScopeProjections {
             .ok()
             .flatten()
             .unwrap_or(0);
-        Some((view, root, default_cap_base))
+        Ok((view, root, default_cap_base))
+    }
+
+    /// Why can't this scope's retained log resolve the cut at `heads`?
+    ///
+    /// Called only once the ancestry walk has already failed, so it never
+    /// re-walks — it reads the three cheap facts that separate the failure modes.
+    ///
+    /// Truncation is checked FIRST, and that ordering is the point of the whole
+    /// classification: a truncated log also *presents* as a missing head or a
+    /// mid-ancestry gap, because dropping the oldest prefix is exactly what makes
+    /// ancestors missing. Checking the gap shape first would file every permanent
+    /// stall under a cause that reads as "retrying, give it a moment", and hide
+    /// the one series that needs an operator.
+    fn classify_unresolvable_cut(&self, scope: &ScopeId, heads: &[[u8; 32]]) -> UndecidableCause {
+        if self.truncated.contains(scope) {
+            return UndecidableCause::LogTruncated;
+        }
+        let Some(log) = self.logs.get(scope) else {
+            return UndecidableCause::ScopeUnfed;
+        };
+        if log.is_empty() {
+            return UndecidableCause::ScopeUnfed;
+        }
+        let ids: HashSet<[u8; 32]> = log.iter().map(|op| op.id()).collect();
+        if heads.iter().any(|head| !ids.contains(head)) {
+            return UndecidableCause::HeadsMissing;
+        }
+        UndecidableCause::AncestryGap
     }
 
     /// Diagnostics for a divergence at `heads` — why does the projection NOT see
@@ -2346,6 +2456,156 @@ mod tests {
             ..entry
         };
         assert!(op_from_rotation_entry(object, scope, &unsigned, None).is_none());
+    }
+
+    /// A one-op-per-scenario walk through every history-gap cause, over the
+    /// SAME two-op ancestry (`add <- remove`) so only the projection's state
+    /// differs between cases.
+    ///
+    /// The last case is the load-bearing one: with the log shaped exactly as the
+    /// `AncestryGap` case, marking the scope truncated must change the verdict to
+    /// `LogTruncated`. Truncation is *why* the ancestor is missing, and it is
+    /// permanent, so classifying by log shape first would file a node that has
+    /// stalled forever under a cause that reads as "retrying, give it a moment".
+    #[test]
+    fn an_unresolvable_cut_is_classified_by_the_reason_it_cannot_resolve() {
+        let scope = ScopeId::from([7u8; 32]);
+        let group = ContextGroupId::from([3u8; 32]);
+        let admin = PublicKey::from([1u8; 32]);
+        let member = PublicKey::from([0x55; 32]);
+
+        let build = |ns: u64, parents: Vec<[u8; 32]>, payload: OpPayload| -> Op {
+            Op::new(
+                scope,
+                parents,
+                calimero_op::Authorship::unattributed(admin),
+                hlc(ns),
+                payload,
+                [0u8; 32],
+                [0u8; 64],
+            )
+        };
+        let add = build(
+            10,
+            vec![],
+            OpPayload::MemberAdded {
+                group,
+                member: test_account(&member),
+                role: GroupMemberRole::Member,
+            },
+        );
+        let remove = build(
+            20,
+            vec![add.id()],
+            OpPayload::MemberRemoved {
+                group,
+                member: test_account(&member),
+            },
+        );
+        let cut = [remove.id()];
+
+        // Nothing folded for this scope at all.
+        let empty = ScopeProjections::new();
+        assert_eq!(
+            empty.classify_unresolvable_cut(&scope, &cut),
+            UndecidableCause::ScopeUnfed,
+        );
+
+        // Fed, but the cited head itself hasn't arrived — the op outran its
+        // parent.
+        let mut heads_missing = ScopeProjections::new();
+        heads_missing.ingest_op(&add);
+        assert_eq!(
+            heads_missing.classify_unresolvable_cut(&scope, &cut),
+            UndecidableCause::HeadsMissing,
+        );
+
+        // The head is present, but its own parent is not: the gap is deeper in.
+        let mut gap = ScopeProjections::new();
+        gap.ingest_op(&remove);
+        assert_eq!(
+            gap.classify_unresolvable_cut(&scope, &cut),
+            UndecidableCause::AncestryGap,
+        );
+
+        // Identical log to the case above; only the truncation mark differs, and
+        // it must win.
+        let mut truncated = ScopeProjections::new();
+        truncated.ingest_op(&remove);
+        let _ = truncated.truncated.insert(scope);
+        assert_eq!(
+            truncated.classify_unresolvable_cut(&scope, &cut),
+            UndecidableCause::LogTruncated,
+            "a truncated log presents as an ancestry gap; reporting it as one \
+             would hide a permanent stall inside a transient-looking cause",
+        );
+
+        // Sanity: a complete ancestry is not classified at all — the walk
+        // succeeds, so nothing is recorded.
+        let mut complete = ScopeProjections::new();
+        complete.ingest_op(&add);
+        complete.ingest_op(&remove);
+        assert!(complete.cut_ancestry_complete(&scope, &cut));
+    }
+
+    /// Both truncation mechanisms set the sticky mark, so a cut reaching into the
+    /// dropped prefix is reported as permanent rather than as a backfill gap.
+    ///
+    /// Deliberately two separate projections: `apply_backfill`'s cap check and
+    /// `enforce_log_bound`'s eviction are independent paths that happen to reach
+    /// the same conclusion, and a single fixture would let one cover for the
+    /// other. `Noop` payloads keep both cheap — the fold ignores them, so the
+    /// cost is a log push per op and nothing else.
+    #[test]
+    fn both_truncation_paths_mark_the_scope() {
+        let scope = ScopeId::from([9u8; 32]);
+        let signer = PublicKey::from([2u8; 32]);
+        let build = |ns: u64| -> Op {
+            Op::new(
+                scope,
+                vec![],
+                calimero_op::Authorship::unattributed(signer),
+                hlc(ns),
+                OpPayload::Noop,
+                [0u8; 32],
+                [0u8; 64],
+            )
+        };
+
+        // The backfill walk stopped at its cap, so the oldest history is absent
+        // from the ops it handed back. Exactly at the cap, so the live-log bound
+        // does NOT also fire — this asserts the `apply_backfill` branch alone.
+        let capped: Vec<Op> = (0..MAX_BACKFILL_OPS as u64).map(build).collect();
+        let mut backfilled = ScopeProjections::new();
+        backfilled.apply_backfill(*scope.as_bytes(), capped);
+        assert!(
+            backfilled.truncated.contains(&scope),
+            "a capped backfill walk leaves the oldest ancestry unreachable",
+        );
+        assert_eq!(
+            backfilled.logs.get(&scope).map_or(0, Vec::len),
+            MAX_BACKFILL_OPS,
+            "at exactly the cap the live-log bound must not have evicted, or this \
+             test is proving the wrong path",
+        );
+
+        // One op past the live-log high-water mark: the feed evicts the oldest
+        // prefix, which is the mechanism that actually fires today (the op-store
+        // load the projection is now backed by is itself unbounded).
+        let mut evicted = ScopeProjections::new();
+        for ns in 0..=(MAX_LIVE_LOG_OPS as u64) {
+            evicted.ingest_op(&build(ns));
+        }
+        assert!(
+            evicted.truncated.contains(&scope),
+            "live-log eviction drops the oldest ops; cuts citing them are \
+             unresolvable from here on",
+        );
+        assert_eq!(
+            evicted.logs.get(&scope).map_or(0, Vec::len),
+            LIVE_LOG_LOW_WATER,
+            "eviction trims to the low-water mark",
+        );
     }
 
     #[test]

--- a/crates/governance-store/src/metrics.rs
+++ b/crates/governance-store/src/metrics.rs
@@ -123,6 +123,19 @@ pub(crate) struct SelfPurgeReconcileLabels {
     pub(crate) outcome: &'static str,
 }
 
+/// Why an at-cut authority question could not be decided, for
+/// `at_cut_undecidable_total`.
+///
+/// As with [`SelfPurgeReconcileLabels`], `cause` is a `&'static str` from the
+/// closed [`UndecidableCause`] enum, so the label set allocates nothing per
+/// [`record_at_cut_undecidable`] call. The label space is therefore bounded by
+/// the enum's variant count — it can never be widened by a peer's input, which
+/// matters because the recording site is driven by ops that arrive off the wire.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub(crate) struct AtCutUndecidableLabels {
+    pub(crate) cause: &'static str,
+}
+
 #[derive(Clone, Debug)]
 struct GroupStoreMetricSink {
     namespace_retry_events: Family<NamespaceRetryLabels, Counter>,
@@ -134,6 +147,7 @@ struct GroupStoreMetricSink {
     self_purge_failures: Family<SelfPurgeFailureLabels, Counter>,
     self_purge_reconcile: Family<SelfPurgeReconcileLabels, Counter>,
     self_purge_events_dropped: Counter,
+    at_cut_undecidable: Family<AtCutUndecidableLabels, Counter>,
 }
 
 static GROUP_STORE_METRICS: OnceLock<GroupStoreMetricSink> = OnceLock::new();
@@ -317,6 +331,39 @@ impl Metrics {
             self_purge_events_dropped.clone(),
         );
 
+        // The apply-time authority gate refusing to answer, sliced by cause.
+        // Deciding an op's authority means resolving it at the op's own causal
+        // cut; when the cited ancestry isn't folded here, the gate refuses
+        // (`AuthorityUndecidable`) and the op parks for retry rather than being
+        // judged against this replica's current state, which would let two
+        // replicas decide one op differently.
+        //
+        // The point of the `cause` slice is that a park is only *sometimes*
+        // transient, and the three outcomes are operationally opposite:
+        //
+        // - `scope_unfed` / `heads_missing` / `ancestry_gap` — usually a node
+        //   mid-backfill. Self-healing: the op retries once sync delivers the
+        //   history. Expect a nonzero rate during catch-up, decaying to ~zero.
+        // - `log_truncated` — the retained op-log no longer reaches the cut, so
+        //   the walk can NEVER complete. Permanent, and it does not self-heal.
+        //   A sustained rate here is the signal that a namespace's governance
+        //   history has outgrown the retained window and that node's governance
+        //   DAG has stopped advancing. This is the series to alert on.
+        // - `fold_unavailable` / `namespace_unresolved` / `view_unavailable` —
+        //   a store or mapping fault, not a history gap.
+        //
+        // A rate that never decays for a given cause means ops are parked
+        // indefinitely, not retrying successfully.
+        let at_cut_undecidable = Family::<AtCutUndecidableLabels, Counter>::default();
+        group_store_registry.register(
+            "at_cut_undecidable_total",
+            "Apply-time at-cut authority questions the gate refused to decide, \
+             sliced by cause. Transient (scope_unfed / heads_missing / \
+             ancestry_gap) decays as sync catches up; log_truncated is permanent \
+             and means that node's governance DAG has stopped advancing",
+            at_cut_undecidable.clone(),
+        );
+
         let _ = GROUP_STORE_METRICS.set(GroupStoreMetricSink {
             namespace_retry_events: namespace_retry_events.clone(),
             namespace_decode_events: namespace_decode_events.clone(),
@@ -327,6 +374,7 @@ impl Metrics {
             self_purge_failures: self_purge_failures.clone(),
             self_purge_reconcile: self_purge_reconcile.clone(),
             self_purge_events_dropped: self_purge_events_dropped.clone(),
+            at_cut_undecidable: at_cut_undecidable.clone(),
         });
 
         Self {
@@ -557,6 +605,99 @@ pub fn record_events_dropped(n: u64) {
     metrics.self_purge_events_dropped.inc_by(n);
 }
 
+/// Why an apply-time at-cut authority question could not be decided — the
+/// `cause` label of `at_cut_undecidable_total`.
+///
+/// Deciding authority at a cut asks: was this signer authorized as of the op's
+/// own parents? That question has one answer on every replica, which is why the
+/// gate must not substitute the replica-local question ("is this signer
+/// authorized right now, on me?") when it cannot resolve the cut. It refuses
+/// instead, and this records why.
+///
+/// The variants are ordered from "will fix itself" to "will not": the first four
+/// describe a history gap, of which only [`Self::LogTruncated`] is permanent.
+/// Distinguishing them is the whole point — before this, every refusal looked
+/// identical, so a node parked forever was indistinguishable from a node parked
+/// for the next two seconds.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UndecidableCause {
+    /// The projection holds no ops at all for this scope — never fed, or fed
+    /// only after this op arrived. Transient in the normal case (startup /
+    /// first contact with a namespace).
+    ScopeUnfed,
+    /// The log is non-empty but one or more of the cut's own head ids are absent
+    /// from it: the op outran its parents. Transient — the ordinary
+    /// arrive-before-your-parents case that sync then repairs.
+    HeadsMissing,
+    /// Every cited head is present, but the walk hit a missing ancestor deeper
+    /// in. The "partial frontier" the backfill walk deliberately tolerates.
+    /// Usually transient, but NOT necessarily: a node that received state by
+    /// snapshot rather than by replaying the DAG has no such history coming.
+    AncestryGap,
+    /// The retained op-log for this scope has been truncated — evicted by the
+    /// live-log bound, or cut short by the backfill walk cap — so it cannot
+    /// reach the cut and never will again. **Permanent.** The op parks forever
+    /// and that namespace's governance DAG stops advancing on this node.
+    LogTruncated,
+    /// The ephemeral fold could not be built at all (governance head unreadable
+    /// — a store fault). Not a history gap.
+    FoldUnavailable,
+    /// The group's namespace could not be resolved (a store or mapping fault).
+    /// Not a history gap.
+    NamespaceUnresolved,
+    /// The ancestry is complete, but folding it yielded no view. Should not
+    /// happen given a complete ancestry; recorded distinctly so it cannot hide
+    /// inside a history-gap series.
+    ViewUnavailable,
+}
+
+impl UndecidableCause {
+    fn as_label(self) -> &'static str {
+        match self {
+            UndecidableCause::ScopeUnfed => "scope_unfed",
+            UndecidableCause::HeadsMissing => "heads_missing",
+            UndecidableCause::AncestryGap => "ancestry_gap",
+            UndecidableCause::LogTruncated => "log_truncated",
+            UndecidableCause::FoldUnavailable => "fold_unavailable",
+            UndecidableCause::NamespaceUnresolved => "namespace_unresolved",
+            UndecidableCause::ViewUnavailable => "view_unavailable",
+        }
+    }
+
+    /// Can the refusal this cause describes resolve on its own, once sync
+    /// delivers more history?
+    ///
+    /// [`Self::LogTruncated`] cannot: the history is gone from the retained
+    /// window, so no amount of sync brings the walk back within reach. Exposed
+    /// so the recording site can log a truncation loudly (it needs an operator)
+    /// while leaving the self-healing cases quiet, and so a future caller can
+    /// branch on permanence without re-deriving the classification.
+    #[must_use]
+    pub fn is_transient(self) -> bool {
+        !matches!(self, UndecidableCause::LogTruncated)
+    }
+}
+
+/// Record one apply-time at-cut authority refusal, labeled by cause. No-op
+/// until [`Metrics::new`] has installed the process-global sink (e.g. a node
+/// started without a Prometheus registry).
+///
+/// Called from `calimero-context`'s at-cut resolution funnel — once per gate
+/// decision that refuses, NOT once per predicate: a single op consults several
+/// predicates (admin, capability, last-admin) over one fold, and counting each
+/// would inflate the rate by a factor that varies with the op's kind.
+pub fn record_at_cut_undecidable(cause: UndecidableCause) {
+    let Some(metrics) = GROUP_STORE_METRICS.get() else {
+        return;
+    };
+    metrics
+        .at_cut_undecidable
+        .get_or_create(&AtCutUndecidableLabels {
+            cause: cause.as_label(),
+        })
+        .inc();
+}
+
 #[cfg(test)]
 mod tests {
     use prometheus_client::encoding::text::encode;
@@ -597,6 +738,71 @@ mod tests {
             out.contains("context_cache_application_size 3"),
             "missing application size gauge:\n{out}"
         );
+    }
+
+    /// Every [`UndecidableCause`] round-trips to a distinct `cause` label, and
+    /// exactly one variant is classified as permanent.
+    ///
+    /// The distinctness assertion is the point: two causes collapsing to one
+    /// label would silently merge a permanent stall into a transient series, and
+    /// the whole reason this metric exists is to tell those apart. Built against
+    /// a local family rather than the process-global sink for the reason
+    /// `self_purge_failures_register_and_encode` documents below.
+    #[test]
+    fn undecidable_causes_encode_distinctly_and_only_truncation_is_permanent() {
+        let all = [
+            UndecidableCause::ScopeUnfed,
+            UndecidableCause::HeadsMissing,
+            UndecidableCause::AncestryGap,
+            UndecidableCause::LogTruncated,
+            UndecidableCause::FoldUnavailable,
+            UndecidableCause::NamespaceUnresolved,
+            UndecidableCause::ViewUnavailable,
+        ];
+
+        let labels: std::collections::HashSet<&str> = all.iter().map(|c| c.as_label()).collect();
+        assert_eq!(
+            labels.len(),
+            all.len(),
+            "two causes share a label, so one would hide inside the other's series",
+        );
+
+        let permanent: Vec<&str> = all
+            .iter()
+            .filter(|c| !c.is_transient())
+            .map(|c| c.as_label())
+            .collect();
+        assert_eq!(
+            permanent,
+            vec!["log_truncated"],
+            "only a truncated log is unrecoverable; the rest clear once sync \
+             delivers the missing history",
+        );
+
+        let mut registry = Registry::default();
+        let family = Family::<AtCutUndecidableLabels, Counter>::default();
+        registry.register(
+            "at_cut_undecidable",
+            "At-cut authority refusals by cause",
+            family.clone(),
+        );
+        for cause in all {
+            family
+                .get_or_create(&AtCutUndecidableLabels {
+                    cause: cause.as_label(),
+                })
+                .inc();
+        }
+
+        let mut out = String::new();
+        encode(&mut out, &registry).expect("encode registry");
+        for cause in all {
+            let series = format!(
+                "at_cut_undecidable_total{{cause=\"{}\"}} 1",
+                cause.as_label()
+            );
+            assert!(out.contains(&series), "missing {series}:\n{out}");
+        }
     }
 
     /// The `self_purge_failures_total` family registers against a fresh


### PR DESCRIPTION
First checkbox of #3245: instrument before choosing a design.

#3240 made apply-time authority ask one question with one answer on every replica — *was this signer authorized at the cut this op cites?* — and made the gate **refuse to answer** (`AuthorityUndecidable`) when it cannot resolve that cut, instead of silently falling back to the replica-local question *is this signer authorized right now, on me?*. Refusing is the right trade: it converted a rare silent divergence into a rare loud stall.

But the stall is only *sometimes* transient, and every refusal looked identical. This adds `context_group_store_at_cut_undecidable_total{cause}` so the self-healing case and the permanent one can be told apart.

## Before / after

Take a namespace where a capability change and a use of that capability are concurrent:

```
op1  genesis — Alice is root admin
 │
op2  Alice grants Bob admin
 │
op3  Alice removes Bob's admin          op4  Bob adds Carol
                                             parents = [op2]
```

`op4` is authorized: Bob *was* an admin as of `op2`, and every replica agrees on that forever. Deciding it requires having folded the ancestry behind `op2`.

Now two nodes both fail to decide it, for opposite reasons:

- **Node R** is mid-backfill. `op2` is still in flight. It parks `op4` and applies it thirty seconds later.
- **Node S** joined last week by snapshot sync. It holds correct current state but never received `op1`/`op2` as ops, and never will. It parks `op4` on every retry, forever — and everything causally downstream of `op4` stalls behind it.

**Before**, both nodes produce the same thing, and it is the same thing a healthy node produces during any catch-up:

```
ERROR authority undecidable for signer 9f3c… in group ContextGroupId(4a…): this node has
      not folded the ancestry of the op's causal cut, so the op cannot be authorized
      here yet — retrying once the missing history arrives
```

Note what that text promises. For node R it is accurate. For node S the missing history is never arriving, and there is no counter, no label, and nothing in the message to say so. The only symptom is a namespace that quietly stopped advancing on one node, indistinguishable from a node that is merely behind.

**After**, the two separate at the metric:

```
# node R — decays to zero as sync catches up
context_group_store_at_cut_undecidable_total{cause="heads_missing"} 12
context_group_store_at_cut_undecidable_total{cause="ancestry_gap"}  3

# node S — climbs and never decays
context_group_store_at_cut_undecidable_total{cause="ancestry_gap"}  1847
```

and a node whose retained op-log has been truncated — the case that *cannot* recover — additionally says so in plain words instead of promising a retry:

```
WARN at-cut authority permanently undecidable: the retained op-log no longer reaches
     this cut, so the op cannot ever apply here and this namespace's governance DAG
     will not advance past it  group=ContextGroupId(4a…) cause=LogTruncated
```

The operator question this answers, which was previously unanswerable:

```promql
# is anything parked permanently, anywhere?
sum by (cause) (rate(context_group_store_at_cut_undecidable_total{cause="log_truncated"}[1h])) > 0

# is a transient cause failing to decay — i.e. parked, not retrying successfully?
sum by (cause) (rate(context_group_store_at_cut_undecidable_total[6h])) > 0
```

## The causes

Seven, in three groups:

| cause | meaning | recovers? |
|---|---|---|
| `scope_unfed` | no ops folded for this scope at all | yes |
| `heads_missing` | the cut's own head ids are absent — the op outran its parents | yes |
| `ancestry_gap` | heads present, a deeper ancestor missing (the "partial frontier") | usually |
| `log_truncated` | the retained op-log cannot reach the cut and never will again | **no** |
| `fold_unavailable` | the ephemeral fold could not be built (store fault) | n/a |
| `namespace_unresolved` | the group's namespace could not be resolved | n/a |
| `view_unavailable` | ancestry complete but the fold yielded no view | n/a |

`ancestry_gap` is "usually" rather than "yes" on purpose: it is the transient case for a node mid-backfill and the permanent case for node S above, and the projection cannot distinguish those from local state alone. Separating them needs the structural work in #3245, not a label.

## Two decisions worth review

**Recorded at `can_resolve_cut`, not at the `auth_cut_context` funnel #3245 names.** The funnel is called once per predicate over a shared fold, so a single op consulting admin + capability + last-admin would count three times, and the inflation factor would vary with op kind. `can_resolve_cut` is asked exactly once per apply decision, and `false` there is precisely what becomes `AuthorityUndecidable`. `auth_cut_context` is split into a `Result`-returning inner so the cause survives; the five predicates keep taking the `Option`, since they act on presence and have no use for the reason.

**Truncation is checked before the log's shape.** A truncated log also *presents* as a missing head or a mid-ancestry gap — dropping the oldest prefix is exactly what makes ancestors missing. Classifying by shape first would file every permanent stall under a transient-looking cause and hide the one series that needs alerting. Tracked as a sticky per-scope mark set by both bounds; `an_unresolvable_cut_is_classified_by_the_reason_it_cannot_resolve` asserts that the same log shape flips verdict once the mark is set.

## One finding that revises #3245

#3245 attributes the cluster-wide case to `MAX_BACKFILL_OPS` truncating `collect_namespace_ops`. That is now the *secondary* path. Since the C3 read-flip the projection is backed by the unified op-store, and `load_scope_ops` is **unbounded** — it reads every row for the scope. What truncates today is `enforce_log_bound`: the in-memory live log evicts to 75k whenever it crosses 100k, whatever the ops' source. Both paths are instrumented, and `both_truncation_paths_mark_the_scope` covers each separately so neither can cover for the other.

## Testing

- `an_unresolvable_cut_is_classified_by_the_reason_it_cannot_resolve` — one case per history-gap cause over the same two-op ancestry, so only projection state differs; ends on the truncation-ordering assertion.
- `both_truncation_paths_mark_the_scope` — the backfill cap and live-log eviction each set the mark, in separate fixtures. `Noop` payloads keep 100k-op logs cheap (~3s for the whole module).
- `undecidable_causes_encode_distinctly_and_only_truncation_is_permanent` — every cause maps to a distinct label (two collapsing would merge a permanent stall into a transient series) and exactly one is classified permanent.
- `cargo fmt --check`, `clippy --all-targets -D warnings` on both crates, `cargo check --workspace --all-targets` clean; 806 lib tests pass, including #3240's own `unresolvable_cut_refuses_rather_than_granting_from_live`.

No behavior change: the same cuts resolve, the same refusals refuse.

## Deliberately not here

- A leading-indicator counter at the cap-hit/eviction itself — a truncation that has not yet caused a refusal is invisible to this metric.
- The structural fix (checkpointing, or op-carried proofs). Which one is worth building is what this metric exists to inform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
