### PR TITLE
test(runtime): retry an empty log capture instead of reddening the check

### DIFF
--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -1225,7 +1225,18 @@ mod tests {
 
     /// Captures everything logged while `body` runs, so a test can assert on what
     /// a log line does *not* contain.
-    fn capture_logs(body: impl FnOnce()) -> String {
+    ///
+    /// `body` may run twice, so it must be repeatable. `tracing` caches callsite
+    /// interest process-wide and resolves it through whichever subscriber the
+    /// evaluating thread holds, so with ~150 tests in parallel and a subscriber
+    /// scoped to this one, a callsite can end up cached as uninteresting by a
+    /// thread that is not capturing. The capture then comes back empty, which
+    /// reads as "the audited line was never emitted" while nothing is wrong with
+    /// the code under test — a red required check for a test-harness race. An
+    /// empty capture is therefore retried once with the interest cache rebuilt
+    /// from this thread, where the capturing subscriber is the one that answers.
+    /// A line that genuinely is not emitted still fails, now twice over.
+    fn capture_logs(body: impl Fn()) -> String {
         use std::io::{Result as IoResult, Write};
         use std::sync::{Arc, Mutex};
 
@@ -1247,18 +1258,31 @@ mod tests {
             }
         }
 
-        let buffer = Arc::new(Mutex::new(Vec::new()));
-        let sink = Arc::clone(&buffer);
-        let subscriber = registry().with(
-            layer()
-                .with_ansi(false)
-                .with_writer(move || Buffer(Arc::clone(&sink))),
-        );
+        fn capture_once(body: &dyn Fn(), rebuild_interest: bool) -> String {
+            let buffer = Arc::new(Mutex::new(Vec::new()));
+            let sink = Arc::clone(&buffer);
+            let subscriber = registry().with(
+                layer()
+                    .with_ansi(false)
+                    .with_writer(move || Buffer(Arc::clone(&sink))),
+            );
 
-        tracing::subscriber::with_default(subscriber, body);
+            tracing::subscriber::with_default(subscriber, || {
+                if rebuild_interest {
+                    tracing::callsite::rebuild_interest_cache();
+                }
+                body();
+            });
 
-        let bytes = buffer.lock().expect("log buffer poisoned").clone();
-        String::from_utf8(bytes).expect("formatted output must be utf-8")
+            let bytes = buffer.lock().expect("log buffer poisoned").clone();
+            String::from_utf8(bytes).expect("formatted output must be utf-8")
+        }
+
+        let captured = capture_once(&body, false);
+        if !captured.is_empty() {
+            return captured;
+        }
+        capture_once(&body, true)
     }
 
     /// `VMLogic::new` used to Debug-print the whole `VMContext`, which carries


### PR DESCRIPTION
Closes #3526

## What

`capture_logs` retries once when a capture comes back empty, rebuilding the interest cache from the capturing thread first. The two assertions that carry the security property — the payload must not appear as text, nor as a byte array — are untouched and still run against a real capture. A line that genuinely is not emitted still fails, now twice over.

## Why a retry and not the suggested rebuild

The issue proposes calling `rebuild_interest_cache()` after installing the subscriber. I could not make the mechanism behind that suggestion reproduce, and I think the reason matters for anyone who picks this up again:

`capture_logs` builds a `Dispatch` per call, and `Dispatch::new` calls `callsite::register_dispatch`, which rebuilds interest for **every already-registered callsite** against the live dispatcher list. So the capture already self-heals a cache that was poisoned before it ran. Six targeted attempts to force an empty buffer all pass on current `master`:

| attempt | result |
| --- | --- |
| `rebuild_interest_cache()` before the capture | pass |
| callsite first registered from a subscriber-less thread, then capture | pass |
| both of the above combined | pass |
| `rebuild_interest_cache()` from another thread *during* the capture | pass |
| 8 concurrent captures on 8 threads | pass |
| 30 consecutive runs of the 151-test lib suite under load | 30× pass |

What **does** reproduce the exact CI symptom — `the line under test must have been emitted, got: ` — in **23 runs out of 25** is putting a per-thread `filter_fn` on the capture layer:

```rust
.with_filter(filter_fn(|_| SINK.with_borrow(Option::is_some)))
```

`Interest` is cached process-wide, so a filter that answers from thread-local state has one thread's answer cached for every thread; evaluated once on a non-capturing thread, the callsite is dead everywhere. I hit this while trying a process-wide-subscriber redesign — it is the shape of the bug, and a warning against a natural-looking fix. I did not ship that redesign.

So the honest position: the failure class is real and is about globally-cached interest, but the specific interleaving CI hit is not identified, and a fix aimed at the proposed mechanism would be aimed at something I disproved. A retry recovers regardless of which path emptied the buffer, cannot mask a real leak, and does not restructure test infrastructure on a guess.

`body` may now run twice, so it must be repeatable — documented on the function. The one caller constructs a VM and is.

## Criteria

- [x] An empty buffer caused by another test's subscriber state can no longer red the check — it is re-attempted with the cache rebuilt from the capturing thread.
- [x] Passes repeatedly under parallel load: 25 consecutive runs of the lib suite, plus the full crate suite (26 + 2 integration tests).
- [x] The two negative assertions are untouched.
- [x] `cargo fmt --check`, `cargo clippy -p calimero-runtime --all-targets -D warnings`, `cargo test -p calimero-runtime` green.

Verified the retry is live rather than dead code by forcing the first capture to return empty: the test still passes, on the second attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)