### PR TITLE
chore(storage): drop stale merge-registry dispatch TODO

### DIFF
--- a/crates/storage/src/merge/registry.rs
+++ b/crates/storage/src/merge/registry.rs
@@ -305,10 +305,11 @@ pub fn try_merge_registered(
     existing_ts: u64,
     incoming_ts: u64,
 ) -> MergeRegistryResult {
-    // For now, we don't have type information at runtime.
-    // TODO: Store type hints with root entity for O(1) dispatch (see issue #1993)
-
-    // Try each registered merge function until one succeeds (O(n) where n = registered types).
+    // There is no runtime type information to dispatch on: `TypeId` is
+    // process-local, so it cannot be persisted alongside the root entity and
+    // read back to select a merge function directly. Dispatch is therefore by
+    // trial-deserialize — try each registered merge function until one succeeds
+    // (O(n) where n = registered types).
     //
     // Iteration order over the HashMap is unspecified, but this is sound because
     // a module registers exactly one root state type (the `#[app::state]` type),


### PR DESCRIPTION
Closes #2518.

## What

Removes the stale TODO in `try_merge_registered`:

```rust
// For now, we don't have type information at runtime.
// TODO: Store type hints with root entity for O(1) dispatch (see issue #1993)
```

It points at a closed issue and at a premise that was already settled as unworkable: `TypeId` is process-local, so it can't be persisted with the root entity and read back to pick a merge function. In its place is a self-contained note saying why dispatch is by trial-deserialize, which leaves the existing paragraph on the single-registrant invariant intact.

Comment-only change. No behavior, no API surface.

## Why the loop stays

#2518 also proposed collapsing the `registry.iter()` loop to single-entry dispatch. Declining that half deliberately:

- It buys nothing measurable. `#[app::state]` registers exactly one type per module (`crates/sdk/macros/src/state.rs:736`), so `n == 1` in production; the tests have since converged on one registering type per test binary (`merge_registry_integration.rs`, `merge_registry_concurrent.rs`) with `clear_merge_registry()` under `#[serial]` in the unit tests. The loop is already O(1) in every path.
- It would be slightly worse. `values().next()` picks one function arbitrarily and returns `AllFunctionsFailed` for anything else, whereas the loop tries both and succeeds if a second type ever gets registered. That's a free fallback to give up for no gain.
- Both `MergeRegistryResult` variants have to stay regardless: `test_no_merge_function_registered_returns_error` matches `NoFunctionsRegistered`, and the concurrent integration test matches both arms.

The invariant the "simplification" would encode is already documented in prose right above the loop, which is the durable version of it.

## Test plan

- `cargo fmt --check` clean.
- No other `#1993` references remain in `crates/`, `apps/`, or `docs/`.
- Affected suites unchanged and expected green: `merge_registry_integration`, `merge_registry_concurrent`, `merge_integration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)