### PR TITLE
test(governance): prove self-leave forward secrecy on ciphertext

### DIFF
--- a/crates/governance-store/src/test_fixtures.rs
+++ b/crates/governance-store/src/test_fixtures.rs
@@ -30,6 +30,20 @@ pub(super) fn test_account_root() -> (PrivateKey, calimero_account::AccountGenes
     (root_sk, genesis)
 }
 
+/// The agreement secret a fixture-issued device holds, derived from the device
+/// seed so any test can recover it.
+///
+/// Production mints this pair on the node and certifies only the public half, so a
+/// fixture that invented a `kem_pk` with no private counterpart produced devices
+/// that could never open an envelope addressed to them. That is not a cosmetic
+/// gap: it silently made every "the recipient cannot decrypt this" assertion pass
+/// for the wrong reason, since no device in the crate could decrypt anything.
+/// Deriving both halves from the seed keeps the fixture faithful and lets a test
+/// assert the positive direction too.
+pub(super) fn device_kem_secret(device: [u8; 32]) -> calimero_crypto::X25519SecretKey {
+    calimero_crypto::X25519SecretKey::from(device)
+}
+
 /// Certify `sign_pk` as `device` under an existing account root.
 pub(super) fn join_account_for(
     root_sk: &PrivateKey,
@@ -43,7 +57,9 @@ pub(super) fn join_account_for(
         genesis.account_id(),
         calimero_account::DeviceId::from(device),
         sign_pk,
-        &calimero_account::KemPublicKey::from([0x2B; 32]),
+        // The real public half of `device_kem_secret(device)`, so an envelope
+        // sealed to this device can actually be opened by a test holding it.
+        &calimero_account::KemPublicKey::from(*device_kem_secret(device).public_key().as_bytes()),
         0,
         device_epoch,
     )
@@ -279,6 +295,20 @@ pub(super) fn enrol_member(
         .record_endorser(namespace, account, &account)
         .expect("record the endorser");
     account
+}
+
+/// The [`crate::DeviceSecret`] belonging to a member enrolled by [`enrol_member`].
+///
+/// [`real_join_account`] derives the device id from the signing key and
+/// [`device_kem_secret`] derives the agreement secret from that same device id, so
+/// this reconstructs what the member's own node would hold — which is what lets a
+/// test open an envelope addressed to that device, and prove the leaver's cannot.
+pub(super) fn device_secret_for(sign_pk: &PublicKey) -> crate::DeviceSecret {
+    let device: [u8; 32] = *sign_pk.as_ref();
+    crate::DeviceSecret {
+        device: calimero_account::DeviceId::from(device),
+        kem_secret: device_kem_secret(device),
+    }
 }
 
 /// Shortcut for nesting one group under another inside tests, unwrapping

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -9720,30 +9720,34 @@ mod self_leave_rotation_crypto {
         );
 
         // The leaver cannot unwrap what was never wrapped for them: even handed the
-        // whole rotation, no envelope decrypts under their key.
+        // whole rotation, no envelope opens under the secret their own node holds.
+        //
+        // This goes through `unwrap_any` with the leaver's real `DeviceSecret`, which
+        // is the call their node would actually make. Reaching for the
+        // member-addressed `unwrap_for_recipient` here would assert a failure that
+        // every device-addressed envelope produces anyway — a variant mismatch — and
+        // would pass just as happily if the rotation HAD wrapped a key for the
+        // leaver's device.
+        let leaver_device = crate::test_fixtures::device_secret_for(&leaver);
         for envelope in &rotation.envelopes {
             assert!(
-                GroupKeyring::unwrap_for_recipient(
+                GroupKeyring::unwrap_any(
                     &leaver_sk,
+                    Some(&leaver_device),
                     &ns_gid.to_bytes(),
                     Some(&admin_pk),
                     envelope,
                 )
                 .is_err(),
-                "no envelope in the rotation may be unwrappable by the departed member"
+                "no envelope in the rotation may open under the departed member's own \
+                 device secret — that is the whole of what forward secrecy buys here"
             );
         }
 
-        // ...while the member who stayed is addressed by one of them. The
-        // envelopes are DEVICE-addressed, so this checks the device the stayer's
-        // binding names rather than a member key.
-        //
-        // What it deliberately does NOT do is unwrap: the credential fixture
-        // pins a placeholder `kem_pk` with no private half, so no test in this
-        // crate can decrypt a device-addressed envelope. The leaver-side check
-        // above still bites (it asserts a failure), but the positive direction —
-        // "the envelope a remaining member gets actually opens" — has no
-        // coverage until the fixture mints a real X25519 pair per device.
+        // ...while the member who stayed is addressed by one of them, and that
+        // envelope actually OPENS. Asserting only that an envelope names their
+        // device would not distinguish a correct rotation from one that sealed
+        // gibberish to the right address.
         let stayer_device = crate::AccountBindingRepository::new(&store)
             .live_bindings(&ns_gid)
             .expect("read bindings")
@@ -9751,14 +9755,226 @@ mod self_leave_rotation_crypto {
             .find(|b| b.account == stayer_account)
             .expect("the stayer is bound")
             .device;
-        assert!(
-            rotation
-                .envelopes
-                .iter()
-                .any(|e| matches!(e.recipient, calimero_governance_types::EnvelopeRecipient::Device { device, .. } if device == stayer_device)),
-            "a remaining member must be addressed by an envelope, or the rotation \
-             locks them out of their own group"
+        let stayer_envelope = rotation
+            .envelopes
+            .iter()
+            .find(|e| matches!(e.recipient, calimero_governance_types::EnvelopeRecipient::Device { device, .. } if device == stayer_device))
+            .expect(
+                "a remaining member must be addressed by an envelope, or the rotation \
+                 locks them out of their own group",
+            );
+        let opened = GroupKeyring::unwrap_any(
+            &stayer_sk,
+            Some(&crate::test_fixtures::device_secret_for(&stayer)),
+            &ns_gid.to_bytes(),
+            Some(&admin_pk),
+            stayer_envelope,
+        )
+        .expect("the envelope addressed to a remaining member must open under its secret");
+        assert_eq!(
+            opened, new_key,
+            "the envelope must carry the very key the admin minted — a rotation that \
+             delivers anything else locks the whole group out instead of just the leaver"
         );
+    }
+
+    #[test]
+    fn the_leavers_retained_key_cannot_read_what_the_group_writes_next() {
+        // The property the whole mechanism exists for, asserted on ciphertext rather
+        // than on bookkeeping. Everything else in this module checks that the right
+        // rows move and the right envelopes go out; this checks the only thing a user
+        // cares about — that after the rotation lands, the key the leaver kept on its
+        // disk no longer reads the group's traffic.
+        //
+        // Driven end to end: two stores (the admin's node and the leaver's), the real
+        // apply path for the leave, the real recipient/wrap path for the rotation, and
+        // the real op encryption on both sides.
+        let admin_store = test_store();
+        let leaver_store = test_store();
+        let ns_id = [0xB3u8; 32];
+        let ns_gid = ContextGroupId::from(ns_id);
+
+        // Both replicas fold the same membership. `bootstrap_namespace_with_admin_account`
+        // mints its own admin key per store, so the admin identity is taken from the
+        // store that will actually sign the rotation.
+        let ((admin_sk, admin_pk), admin) =
+            crate::test_fixtures::bootstrap_namespace_with_admin_account(&admin_store, ns_id);
+        let _ = crate::test_fixtures::bootstrap_namespace_with_admin_account(&leaver_store, ns_id);
+
+        let stayer_sk = PrivateKey::random(&mut OsRng);
+        let stayer = stayer_sk.public_key();
+        let leaver_sk = PrivateKey::random(&mut OsRng);
+        let leaver = leaver_sk.public_key();
+
+        let mut leaver_account = None;
+        for store in [&admin_store, &leaver_store] {
+            let stayer_account = enrol_member(store, &ns_gid, &stayer);
+            let account = enrol_member(store, &ns_gid, &leaver);
+            MembershipRepository::new(store)
+                .add_member(&ns_gid, &stayer_account, GroupMemberRole::Member)
+                .unwrap();
+            MembershipRepository::new(store)
+                .add_member(&ns_gid, &account, GroupMemberRole::Member)
+                .unwrap();
+            leaver_account = Some(account);
+        }
+        let leaver_account = leaver_account.expect("enrolled on both replicas");
+
+        // The key everyone holds before the departure. The leaver keeps a copy of this
+        // forever — deleting it is not something the group can enforce.
+        let key_before: [u8; 32] = OsRng.gen();
+        GroupKeyring::new(&admin_store, ns_gid)
+            .store_key_with_epoch(&key_before, 1)
+            .unwrap();
+        GroupKeyring::new(&leaver_store, ns_gid)
+            .store_key_with_epoch(&key_before, 1)
+            .unwrap();
+
+        // Precondition: while still a member, the leaver really can read the group's
+        // traffic. Without this the negative assertion at the end proves nothing — a
+        // decrypt that never worked would "fail" just as convincingly.
+        let before_op = calimero_governance_types::GroupOp::TargetApplicationSet {
+            app_key: calimero_context_config::types::AppKey::from([0x11; 32]),
+            target_application_id: ApplicationId::from([0x12; 32]),
+        };
+        let sealed_before = GroupKeyring::encrypt_op(&key_before, &before_op).expect("encrypt");
+        let leaver_key_before = GroupKeyring::new(&leaver_store, ns_gid)
+            .load_current_key()
+            .unwrap()
+            .expect("the leaver holds the pre-departure key")
+            .1;
+        assert!(
+            GroupKeyring::decrypt_op(&leaver_key_before, &sealed_before).is_ok(),
+            "precondition: a member must be able to read the group before it leaves, or \
+             the post-departure failure below is not evidence of anything"
+        );
+
+        // --- The leave, through the real apply path, on both replicas. ---
+        let leave = SignedGroupOp::sign(
+            &leaver_sk,
+            ns_gid.to_bytes().into(),
+            vec![],
+            1,
+            calimero_governance_types::GroupOp::MemberLeft {
+                member: leaver_account,
+                expected_group_state_hash: [0u8; 32],
+                expected_context_state_hashes: Vec::new(),
+            },
+        )
+        .expect("sign MemberLeft");
+        for store in [&admin_store, &leaver_store] {
+            apply_local_signed_group_op(store, &leave).expect("apply MemberLeft");
+            assert!(
+                crate::PendingRotationRepository::new(store)
+                    .is_pending(&ns_gid, &leaver_account)
+                    .unwrap(),
+                "every replica folds the debt, which is what lets any remaining admin \
+                 pick the work up"
+            );
+        }
+
+        // --- The remaining admin discharges it. ---
+        let key_after: [u8; 32] = OsRng.gen();
+        assert_ne!(key_before, key_after);
+        let admin_ring = GroupKeyring::new(&admin_store, ns_gid);
+        let entitled = admin_ring.current_key_recipients().expect("recipients");
+        assert!(
+            !entitled.iter().any(|e| e.member == leaver_account),
+            "the departed member's row is gone, so the recipient list must no longer \
+             name them — this is where the exclusion actually happens"
+        );
+        let recipients: Vec<KeyRecipient> = entitled.into_iter().map(|e| e.recipient).collect();
+        let rotation = admin_ring
+            .build_rotation(&key_after, &admin_sk, &recipients)
+            .expect("build rotation");
+        admin_ring.store_key_with_epoch(&key_after, 2).unwrap();
+
+        // The leaver's node receives the rotation like any other replica — it is on the
+        // wire, not addressed away from them — and can open none of it.
+        let leaver_device = crate::test_fixtures::device_secret_for(&leaver);
+        for envelope in &rotation.envelopes {
+            assert!(
+                GroupKeyring::unwrap_any(
+                    &leaver_sk,
+                    Some(&leaver_device),
+                    &ns_gid.to_bytes(),
+                    Some(&admin_pk),
+                    envelope,
+                )
+                .is_err(),
+                "the leaver sees the rotation go past and must not be able to open any \
+                 envelope in it"
+            );
+        }
+
+        // --- What the group writes next. ---
+        let after_op = calimero_governance_types::GroupOp::TargetApplicationSet {
+            app_key: calimero_context_config::types::AppKey::from([0x21; 32]),
+            target_application_id: ApplicationId::from([0x22; 32]),
+        };
+        let sealed_after = GroupKeyring::encrypt_op(&key_after, &after_op).expect("encrypt");
+
+        // The leaver still holds `key_before` — nothing took it away. It no longer reads.
+        assert!(
+            GroupKeyring::decrypt_op(&key_before, &sealed_after).is_err(),
+            "THE PROPERTY: the key the leaver retained must not decrypt anything the \
+             group writes after the rotation. If this ever passes, a self-leave has \
+             stopped providing forward secrecy at all."
+        );
+
+        // ...and the member who stayed reads it fine, using only the key it recovered
+        // from its own envelope. A rotation that locked everyone out would satisfy the
+        // assertion above for the wrong reason.
+        let stayer_envelope = rotation
+            .envelopes
+            .iter()
+            .find(|e| {
+                GroupKeyring::unwrap_any(
+                    &stayer_sk,
+                    Some(&crate::test_fixtures::device_secret_for(&stayer)),
+                    &ns_gid.to_bytes(),
+                    Some(&admin_pk),
+                    e,
+                )
+                .is_ok()
+            })
+            .expect("the member who stayed must be addressed by some envelope");
+        let stayer_key = GroupKeyring::unwrap_any(
+            &stayer_sk,
+            Some(&crate::test_fixtures::device_secret_for(&stayer)),
+            &ns_gid.to_bytes(),
+            Some(&admin_pk),
+            stayer_envelope,
+        )
+        .expect("already established to open");
+        assert_eq!(stayer_key, key_after);
+        assert!(
+            GroupKeyring::decrypt_op(&stayer_key, &sealed_after).is_ok(),
+            "a member who stayed must still read the group with the key the rotation \
+             delivered — otherwise the rotation is a group-wide lockout, not a revocation"
+        );
+
+        // Discharging the debt clears the worklist, so no admin rotates again for a
+        // departure already paid for.
+        let discharge = SignedGroupOp::sign(
+            &admin_sk,
+            ns_gid.to_bytes().into(),
+            vec![],
+            1,
+            calimero_governance_types::GroupOp::GroupKeyRotated {
+                departed: leaver_account,
+            },
+        )
+        .expect("sign GroupKeyRotated");
+        apply_local_signed_group_op(&admin_store, &discharge)
+            .expect("the admin's rotation applies");
+        assert!(
+            !crate::PendingRotationRepository::new(&admin_store)
+                .is_pending(&ns_gid, &leaver_account)
+                .unwrap(),
+            "the debt is settled once the rotation lands"
+        );
+        let _ = admin;
     }
 
     #[test]


### PR DESCRIPTION
Closes the last open acceptance criterion of #2281 — *"verify new content is undecryptable with the leaver's old key"* — and fixes a test that could not fail.

## The vacuous assertion

`self_leave_rotation_crypto` looked like it already covered the leaver-side exclusion:

```rust
GroupKeyring::unwrap_for_recipient(&leaver_sk, &ns_gid.to_bytes(), Some(&admin_pk), envelope).is_err()
```

That is the **member**-addressed unwrap, and `current_key_recipients` produces **device**-addressed envelopes. It was asserting a variant mismatch, not an exclusion.

Demonstrated: stop filtering the leaver out of the recipient list — wrap the new key for the departing member, the exact bug this is meant to catch — and the whole test still passes:

```
test tests::self_leave_rotation_crypto::the_rotation_wraps_the_new_key_for_everyone_except_the_leaver ... ok
```

## Root cause: the fixture

`test_fixtures::join_account_for` certified `KemPublicKey::from([0x2B; 32])` — a public key with no private half. No device in the crate could open an envelope sealed to it, so *every* "the recipient cannot decrypt this" assertion held for the wrong reason, and the positive direction was untestable. The module's own comment recorded this as a known limitation:

> the credential fixture pins a placeholder `kem_pk` with no private half, so no test in this crate can decrypt a device-addressed envelope … the positive direction … has no coverage until the fixture mints a real X25519 pair per device.

This mints the real pair, derived from the device seed so it stays deterministic and recoverable, plus `device_secret_for` to reconstruct what a member's own node would hold.

## What that buys

- **Leaver-side check now bites** — goes through `unwrap_any` with the leaver's real `DeviceSecret`, so it fails because the envelope isn't theirs.
- **Positive direction covered for the first time** — a remaining member's envelope opens *and* carries the key the admin minted, distinguishing a correct rotation from a group-wide lockout.
- **New test `the_leavers_retained_key_cannot_read_what_the_group_writes_next`** — two stores, real apply path, assertion on ciphertext:
  1. precondition: the leaver *can* read the group while still a member (without this the later failure proves nothing);
  2. real `MemberLeft` applied on both replicas, debt folded on both;
  3. the leaver sees the rotation go past and opens no envelope in it;
  4. its retained key does not decrypt what the group writes next;
  5. the member who stayed does, using only the key it recovered from its own envelope.

## Mutation-checked

Every assertion was verified to fail when the property it guards is broken:

| Mutation | Result |
|---|---|
| Group keeps writing under the old key | ✅ fails on `THE PROPERTY` |
| Rotation also wraps for the leaver's device | ✅ fails on the leaver-side check |
| Leaver not excluded, fixed assertion | ✅ fails |
| Leaver not excluded, **original** assertion | ❌ passes — the defect this PR fixes |

## Verification

`cargo test -p calimero-governance-store` — 572 passed. `cargo test -p calimero-context` — all green (the fixture change is crate-internal, but `calimero-context` builds on these rows). `cargo fmt --check` and `cargo clippy --all-targets` clean.

Tests and fixtures only; no production code changed.

Note on scope: #2281 asked for a merobox two-node scenario. No admin API exposes `key_id` or the pending-rotation row, so a workflow-level test can only assert membership — which `group-leave-member.yml` already does. This asserts the actual crypto instead. Exposing `key_id` on `get_group_info` would make a workflow-level assertion possible and is worth considering separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)