### PR TITLE
docs(protocol): which scope key protects a context, and how to isolate one

### DIFF
--- a/docs/src/content/docs/protocol/security-model.mdx
+++ b/docs/src/content/docs/protocol/security-model.mdx
@@ -7,6 +7,7 @@ sidebar:
 ---
 
 import SeqDiagram from '../../../components/SeqDiagram.astro';
+import { Steps, Aside } from '@astrojs/starlight/components';
 
 This page states, plainly, what Calimero protects against and what it does not. The protocol has no consensus and no quorum: security rests on **signatures** (who authored an operation), **membership** (who is allowed to write), and **encryption keys** (who is allowed to read). Get those three right and the rest of the model follows.
 
@@ -127,6 +128,41 @@ Two caveats follow directly from this design and are worth stating loudly:
 - **Past ciphertext under the old key remains decryptable to anyone who held the old key.** Rotation changes the *next* key; it does not re-encrypt history.
 
 Mechanics and the rotation-log bookkeeping are in [Key Rotation](/protocol/key-rotation/).
+
+## Which scope key protects a context
+
+A context has no key of its own. Its state deltas are encrypted under the key of the **group the context belongs to**, and which key that is depends on that group's visibility chain (`crates/context/src/handlers/execute/mod.rs`, mirroring the same choice in the governance publisher):
+
+| The context's group | Encrypted under |
+| --- | --- |
+| A **Restricted** subgroup, or any subgroup behind a Restricted ancestor | That subgroup's **own** key |
+| An **Open** subgroup on a fully-Open chain to the namespace | The **namespace** key |
+| The namespace root itself | The namespace key |
+
+Two consequences follow, and both routinely surprise people:
+
+- **Contexts in the same group share one key.** There is no cryptographic wall between them. Which contexts a member may touch is an *authorization* decision — the membership walk — layered over a crypto boundary drawn at the group.
+- **`leave-context` has no cryptographic effect whatsoever.** It is a node-local opt-out: it stops sync and unsubscribes from the topic, and it rotates nothing, because there is no per-context key to rotate. A node that left a context still holds the group key and can still read that context's traffic if it obtains the ciphertext another way. See [Context Lifecycle](/protocol/context-lifecycle/).
+
+### Giving a context its own crypto boundary
+
+If a context needs cryptographic isolation from its siblings — and real forward secrecy when a member leaves *it* specifically — **put that context in its own Restricted subgroup**. This is the supported way to get it, and it needs no machinery that does not already exist:
+
+<Steps>
+
+1. The context's deltas are encrypted under that subgroup's own key rather than the namespace key, so namespace members outside the subgroup cannot read them at all.
+
+2. `leave-group` on that subgroup records a rotation debt (`group_rotates_on_departure`), which a remaining admin discharges automatically.
+
+3. The departing member is excluded from the fresh key and cannot read what the context writes afterwards.
+
+</Steps>
+
+So the unit of cryptographic isolation is the **Restricted subgroup**, and one context per subgroup is what makes "leaving this context" mean something cryptographically. Sharing a subgroup across several contexts is the cheaper arrangement — one key to deliver, one to rotate — and it is the right choice when those contexts sit inside the same trust boundary anyway.
+
+<Aside type="caution">
+Reaching for an **Open** subgroup instead does not buy this. An Open subgroup on a fully-Open chain is encrypted with the namespace key, which every namespace member already holds, so leaving it revokes authorization but not read access — and a rotation there would mint a key nothing uses. [Key Rotation](/protocol/key-rotation/) covers when a departure rotates and when it is skipped.
+</Aside>
 
 ## What is NOT protected
 


### PR DESCRIPTION
Answers #2282 by documenting the pattern that already provides what the issue asks for.

## The gap

Nothing in the docs said which key a context's data is encrypted under. `encryption.mdx` says "group/scope key" throughout without resolving *which* scope, and the actual selection rule — Restricted subgroup uses its own key, an Open chain inherits the namespace key — appears only as a rotation *skip-rule* in `key-rotation.mdx`, phrased from the rotation side rather than as "this is your crypto boundary."

That leaves two things unsaid that are easy to get wrong:

- contexts sharing a group **share one key**, so there is no cryptographic wall between them — access between contexts is authorization layered over a boundary drawn at the group;
- **`leave-context` rotates nothing**, because there is no per-context key to rotate. A node that left keeps the group key.

## The pattern

It also hid the answer to a question that does come up, and is what #2282 is really asking: how do you give one context a crypto boundary of its own? **Put it in its own Restricted subgroup.** No new machinery — its deltas encrypt under that subgroup's key, and `leave-group` on it records a rotation debt a remaining admin discharges, which excludes the leaver from what the context writes next.

Reaching for an *Open* subgroup instead looks equivalent and is not (namespace key, so leaving revokes authorization but not read access), so that trap is called out right where the pattern is.

Added as a new section in `security-model.mdx`, after "Forward secrecy on removal" — it is a statement about the boundary of read access, and that chapter is where readers go for what is and isn't protected.

## Why this rather than per-context keying

#2282 costs per-context keying at "~5000+ LOC and 6+ weeks… essentially building a different encryption model." That was accurate when it was filed, but keys are no longer flat per-group: `group_rotates_on_departure` (`crates/governance-store/src/pending_rotation.rs`) documents a scope-key hierarchy where Restricted subgroups already hold their own key, with per-recipient wrapping, epoch convergence, and rotation-on-departure all built. So the guarantee is reachable by composition today, and documenting that seemed better value than a multi-month keying project.

What genuinely remains unbuilt is only the flat case — *N* contexts sharing one Restricted subgroup still share its key. Whether that's worth per-context keying is a product question about read-isolation between contexts, and notably not a question about leaving at all.

## Verification

`npm run check` in `docs/` — 80 pages built, internal links OK. Rendered `dist/protocol/security-model/index.html` read back to confirm the table, `<Steps>`, and `<Aside>` all render (the chapter needed the Starlight component import added).

Docs-only; no code changes.

Related: #3538 fixes the stale self-leave rotation claims in the neighbouring chapters; #3543 proves the forward-secrecy property on ciphertext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)