### PR TITLE
fix(sync): authenticate state-delta parents by re-deriving the content address

### DIFF
--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -411,6 +411,35 @@ pub(crate) async fn apply_authorized_state_delta(
         events,
     } = decrypt_delta_actions(artifact, nonce, group_key)?;
 
+    // Content-address check. The envelope signature above binds `delta_id`, but
+    // `parent_ids` and `hlc` ride the wire OUTSIDE it, and `actions` arrive
+    // sealed under a key every member holds. Re-deriving the id from the
+    // content it is supposed to address is what extends the signature's
+    // coverage to `parent_ids`: without it, anyone able to publish on the
+    // context topic can republish a member's delta with `parent_ids` rewritten
+    // and every downstream gate still passes, because they all key off
+    // `author_id` (the honest author) rather than the publisher. An empty
+    // `parent_ids` is the worst case — it applies immediately as a
+    // disconnected head, bypassing missing-parent detection entirely.
+    //
+    // Runs after decryption because it needs `actions`, and before the DAG
+    // insert below.
+    if !calimero_storage::delta::CausalDelta::content_address_matches(
+        &delta_id,
+        &parent_ids,
+        &actions,
+        &hlc,
+    ) {
+        warn!(
+            %context_id,
+            %author_id,
+            delta_id = ?delta_id,
+            parent_count = parent_ids.len(),
+            "Rejecting state delta — id does not content-address its parents/actions"
+        );
+        return Ok(());
+    }
+
     let delta = calimero_dag::CausalDelta {
         id: delta_id,
         parents: parent_ids,
@@ -1442,6 +1471,48 @@ async fn request_missing_deltas(
                         "Received missing parent delta"
                     );
 
+                    // Did we get the delta we asked for? Parity with the
+                    // head-pull path's identical guard in
+                    // `sync/manager/mod.rs`, whose comment already claims
+                    // parity with "the parent-fetch path's sanity check" —
+                    // a check this path never actually had. The envelope
+                    // signature below binds `storage_delta.id`, not
+                    // `missing_id`, so without this a responder holding a
+                    // legitimately signed delta can answer a request for
+                    // one id with a different delta and have it persisted
+                    // under the wrong slot.
+                    //
+                    // Placed BEFORE the genesis carve-out deliberately: that
+                    // branch skips every author-keyed check, so these two
+                    // structural checks are the ONLY thing standing between a
+                    // responder and arbitrary genesis content.
+                    if storage_delta.id != missing_id {
+                        warn!(
+                            %context_id,
+                            requested = ?missing_id,
+                            received = ?storage_delta.id,
+                            "parent-fetch: peer returned a different delta id than                              requested, dropping"
+                        );
+                        continue;
+                    }
+
+                    // And does that id content-address what arrived with it?
+                    // `missing_id` is not attacker-supplied — it came from the
+                    // `parents` of a delta this node already accepted — so
+                    // chaining these two checks authenticates the content
+                    // without needing an author, which is exactly what the
+                    // genesis branch lacks.
+                    if !storage_delta.id_matches_content() {
+                        warn!(
+                            %context_id,
+                            delta_id = ?missing_id,
+                            author = %response_author,
+                            parent_count = storage_delta.parents.len(),
+                            "parent-fetch: delta id does not content-address its                              parents/actions, dropping"
+                        );
+                        continue;
+                    }
+
                     // Genesis carve-out: the responder serves the
                     // genesis delta with the all-zeros sentinel
                     // `author_id` because the wire requires an author
@@ -2110,6 +2181,27 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
         actions,
         events,
     } = decrypt_delta_actions(buffered.payload, buffered.nonce, group_key)?;
+
+    // Content-address check — parity with the gossip apply path. A buffered
+    // delta was received over the wire and carried through snapshot-sync
+    // buffering verbatim, `parent_ids` included, so it needs the same
+    // re-derivation the live path now runs; buffering is a delay, not a
+    // trust boundary that launders the fields the signature never covered.
+    if !calimero_storage::delta::CausalDelta::content_address_matches(
+        &buffered.id,
+        &buffered.parents,
+        &actions,
+        &buffered.hlc,
+    ) {
+        warn!(
+            %context_id,
+            delta_id = ?buffered.id,
+            author = %buffered.author_id,
+            parent_count = buffered.parents.len(),
+            "Rejecting buffered state delta — id does not content-address its parents/actions"
+        );
+        return Ok(false);
+    }
 
     let delta = calimero_dag::CausalDelta {
         id: buffered.id,

--- a/crates/node/src/sync/delta_request.rs
+++ b/crates/node/src/sync/delta_request.rs
@@ -98,6 +98,40 @@ fn verify_fetched_parent(
 ) -> VerifiedParent {
     use calimero_context_config::types::GovernanceParentEdge;
 
+    // Did we get the delta we asked for? `verify_delta_signature` below is
+    // called with `delta_id` (the id we REQUESTED) while the caller persists
+    // `fetched.delta.id` (the id the responder CLAIMS) — so without this guard
+    // the signature is verified against one delta and a different one lands in
+    // the DAG. Parity with the head-pull path's guard in `sync/manager/mod.rs`.
+    //
+    // Both structural checks sit BEFORE the genesis carve-out deliberately:
+    // that branch skips every author-keyed check, so these are the only thing
+    // standing between a responder and arbitrary genesis content.
+    if fetched.delta.id != delta_id {
+        warn!(
+            %context_id,
+            requested = ?delta_id,
+            received = ?fetched.delta.id,
+            "DAG-catchup parent-pull: peer returned a different delta id than              requested, dropping"
+        );
+        return VerifiedParent::Skip;
+    }
+
+    // And does that id content-address what arrived with it? `delta_id` is not
+    // attacker-supplied — it came from the `parents` of a delta this node
+    // already accepted — so chaining these two checks authenticates the
+    // content without needing an author, which is what genesis lacks.
+    if !fetched.delta.id_matches_content() {
+        warn!(
+            %context_id,
+            delta_id = ?delta_id,
+            author = %fetched.author_id,
+            parent_count = fetched.delta.parents.len(),
+            "DAG-catchup parent-pull: delta id does not content-address its              parents/actions, dropping"
+        );
+        return VerifiedParent::Skip;
+    }
+
     // Genesis carve-out: the responder serves the genesis delta with
     // the all-zeros sentinel `author_id` because the wire requires an
     // author but genesis predates any governance op. Skip every

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -2302,6 +2302,26 @@ impl SyncManager {
                                 continue;
                             }
 
+                            // And does that id content-address what arrived
+                            // with it? The id-equality guard above proves the
+                            // responder answered the right question; this
+                            // proves it answered honestly. Needed here too
+                            // because the genesis carve-out below skips the
+                            // envelope-signature check entirely, leaving these
+                            // two structural checks as the only authentication
+                            // on that branch. `head_id` is not attacker-
+                            // supplied, so the pair chains content-addressing
+                            // off a reference this node already trusts.
+                            if !storage_delta.id_matches_content() {
+                                warn!(
+                                    %context_id,
+                                    head_id = ?head_id,
+                                    parent_count = storage_delta.parents.len(),
+                                    "DAG head pull: delta id does not content-address its                                      parents/actions, dropping"
+                                );
+                                continue;
+                            }
+
                             // Apply-time cross-DAG membership check —
                             // parity with the gossip-path check in
                             // `handle_state_delta`. `response_author` is

--- a/crates/node/tests/sync_scenarios/byzantine_delta_auth.rs
+++ b/crates/node/tests/sync_scenarios/byzantine_delta_auth.rs
@@ -32,11 +32,28 @@
 //! reject, otherwise apply. Applying is modeled as inserting the delta's
 //! entity into the real tree; a rejected delta never inserts, so the
 //! independently-computed Merkle root is provably unchanged.
+//!
+//! # Content-address gate
+//!
+//! The signature gate above binds `delta_id`, but `parent_ids` ride the wire
+//! OUTSIDE the signed payload, so a second gate re-derives the id from the
+//! content it claims to address (`CausalDelta::content_address_matches`). The
+//! `content_gate_and_apply` helper below transcribes BOTH gates, and the tests
+//! using it cover the republish attack: gossipsub messages are publisher-signed,
+//! so a delta cannot be tampered with in flight — but any node in the mesh can
+//! republish a member's delta under its own libp2p key with `parent_ids`
+//! rewritten. Every author-keyed gate still passes, because they all resolve the
+//! honest `author_id` rather than the publisher.
 
 use calimero_node_primitives::sync::delta_auth::{delta_signature_payload, verify_delta_signature};
 use calimero_primitives::context::ContextId;
 use calimero_primitives::crdt::CrdtType;
 use calimero_primitives::identity::{PrivateKey, PublicKey};
+use calimero_storage::action::Action;
+use calimero_storage::address::Id as StorageId;
+use calimero_storage::delta::CausalDelta;
+use calimero_storage::entities::Metadata;
+use calimero_storage::logical_clock::HybridTimestamp;
 
 use crate::sync_sim::prelude::*;
 
@@ -222,6 +239,188 @@ fn missing_signature_rejected_no_state_mutation() {
         b"unsigned".to_vec(),
     );
     assert!(!applied, "an unsigned delta must be rejected by the gate");
+    assert_eq!(
+        node.root_hash(),
+        root_before,
+        "rejected delta must not mutate storage: root_hash must be unchanged"
+    );
+}
+
+// =============================================================================
+// Content-address gate (parents authentication)
+// =============================================================================
+
+/// One CRDT action, so the fixtures hash a non-empty action list rather than
+/// only exercising the parents half of the preimage.
+fn fixture_actions() -> Vec<Action> {
+    vec![Action::Add {
+        id: StorageId::from([0x5A_u8; 32]),
+        data: b"payload".to_vec(),
+        ancestors: vec![],
+        metadata: Metadata::default(),
+    }]
+}
+
+/// Faithful transcription of the handler's gate chain as it now stands:
+/// envelope signature first (authorship), then the content address (the fields
+/// the signature does not cover). Mirrors the block added to
+/// `apply_authorized_state_delta` after `decrypt_delta_actions` — the check runs
+/// post-decrypt because it needs `actions`, and pre-DAG-insert because a
+/// disconnected head is exactly what it prevents.
+///
+/// Returns `true` iff BOTH gates passed and the entity reached the real Merkle
+/// tree. `parents`/`actions`/`hlc` are the values that arrived on the wire; the
+/// attacker controls them, and `delta_id` is what the signature covers.
+#[allow(clippy::too_many_arguments)]
+fn content_gate_and_apply(
+    node: &mut SimNode,
+    context_id: ContextId,
+    delta_id: [u8; 32],
+    author_id: PublicKey,
+    signature: Option<[u8; 64]>,
+    parents: &[[u8; 32]],
+    actions: &[Action],
+    hlc: &HybridTimestamp,
+    apply_entity: EntityId,
+    apply_data: Vec<u8>,
+) -> bool {
+    // Gate 1: authorship (unchanged — see `gate_and_apply`).
+    let sig = match signature {
+        Some(s) => s,
+        None => return false,
+    };
+    if verify_delta_signature(context_id, delta_id, author_id, None, &sig).is_err() {
+        return false;
+    }
+
+    // Gate 2: does the signed id actually address the content that arrived?
+    if !CausalDelta::content_address_matches(&delta_id, parents, actions, hlc) {
+        return false;
+    }
+
+    node.insert_entity(apply_entity, apply_data, CrdtType::lww_register("byz"));
+    true
+}
+
+/// Control: an honest delta — id derived from the parents and actions it
+/// carries, signed by its real author — passes both gates and advances the root.
+/// Without this the negative tests below could pass on a broken fixture.
+#[test]
+fn honest_delta_passes_both_gates_and_mutates_state() {
+    let mut node = initialized_node();
+    let context_id = node.context_id();
+    let (alice_sk, alice_pk) = alice();
+
+    let parents = vec![[0x31_u8; 32]];
+    let actions = fixture_actions();
+    let hlc = HybridTimestamp::default();
+    let delta_id = CausalDelta::compute_id(&parents, &actions, &hlc);
+
+    let payload =
+        delta_signature_payload(context_id, delta_id, alice_pk, None).expect("payload serializes");
+    let sig = alice_sk.sign(&payload).expect("sign").to_bytes();
+
+    let root_before = node.root_hash();
+    let applied = content_gate_and_apply(
+        &mut node,
+        context_id,
+        delta_id,
+        alice_pk,
+        Some(sig),
+        &parents,
+        &actions,
+        &hlc,
+        EntityId::from_u64(10),
+        b"honest".to_vec(),
+    );
+    assert!(applied, "an honest delta must pass both gates");
+    assert_ne!(
+        node.root_hash(),
+        root_before,
+        "a genuine apply must advance the Merkle root"
+    );
+}
+
+/// The #3540 attack. A republisher takes Alice's delta VERBATIM — same
+/// `delta_id`, same genuine signature, same honest `author_id` — and strips
+/// `parent_ids` to empty. The signature gate cannot see it (parents are not in
+/// the signed payload) and every author-keyed gate resolves Alice, a full
+/// member. Empty parents are the worst case: they hit the vacuously-true branch
+/// of `DagStore::can_apply` and apply immediately as a disconnected head,
+/// bypassing missing-parent detection. The content gate must catch it.
+#[test]
+fn republished_delta_with_emptied_parents_rejected_no_state_mutation() {
+    let mut node = initialized_node();
+    let context_id = node.context_id();
+    let (alice_sk, alice_pk) = alice();
+
+    let parents = vec![[0x31_u8; 32]];
+    let actions = fixture_actions();
+    let hlc = HybridTimestamp::default();
+    let delta_id = CausalDelta::compute_id(&parents, &actions, &hlc);
+
+    // Alice's real signature over her real delta — the attacker does not forge
+    // anything, it replays what Alice published.
+    let payload =
+        delta_signature_payload(context_id, delta_id, alice_pk, None).expect("payload serializes");
+    let sig = alice_sk.sign(&payload).expect("sign").to_bytes();
+
+    let root_before = node.root_hash();
+    let applied = content_gate_and_apply(
+        &mut node,
+        context_id,
+        delta_id,
+        alice_pk,
+        Some(sig),
+        &[], // <-- the only tampered field
+        &actions,
+        &hlc,
+        EntityId::from_u64(11),
+        b"disconnected-head".to_vec(),
+    );
+    assert!(
+        !applied,
+        "a delta whose parents were stripped to empty must be rejected"
+    );
+    assert_eq!(
+        node.root_hash(),
+        root_before,
+        "rejected delta must not mutate storage: root_hash must be unchanged"
+    );
+}
+
+/// Same attack, non-empty variant: re-parenting moves the causal cut that
+/// at-cut authorization resolves against, so a swapped parent set must be
+/// rejected too — the gate is about content-addressing, not just emptiness.
+#[test]
+fn republished_delta_with_swapped_parents_rejected_no_state_mutation() {
+    let mut node = initialized_node();
+    let context_id = node.context_id();
+    let (alice_sk, alice_pk) = alice();
+
+    let parents = vec![[0x31_u8; 32]];
+    let actions = fixture_actions();
+    let hlc = HybridTimestamp::default();
+    let delta_id = CausalDelta::compute_id(&parents, &actions, &hlc);
+
+    let payload =
+        delta_signature_payload(context_id, delta_id, alice_pk, None).expect("payload serializes");
+    let sig = alice_sk.sign(&payload).expect("sign").to_bytes();
+
+    let root_before = node.root_hash();
+    let applied = content_gate_and_apply(
+        &mut node,
+        context_id,
+        delta_id,
+        alice_pk,
+        Some(sig),
+        &[[0x77_u8; 32]], // a different, still non-empty, parent
+        &actions,
+        &hlc,
+        EntityId::from_u64(12),
+        b"reparented".to_vec(),
+    );
+    assert!(!applied, "a re-parented delta must be rejected");
     assert_eq!(
         node.root_hash(),
         root_before,

--- a/crates/storage/src/delta.rs
+++ b/crates/storage/src/delta.rs
@@ -108,6 +108,37 @@ impl CausalDelta {
         hasher.finalize().into()
     }
 
+    /// Whether `delta_id` actually content-addresses `parents` + `actions`.
+    ///
+    /// [`Self::compute_id`] is the producer-side binding between a delta's id
+    /// and its content, but for a long time nothing re-derived it on the
+    /// receive side. The envelope signature covers the *id* only, so a delta's
+    /// `parents` could be rewritten in flight while the signature still
+    /// verified — and an empty `parents` then applied as a disconnected DAG
+    /// head. Receivers call this before the DAG insert so `parents` and
+    /// `actions` inherit the signature that covers the id.
+    ///
+    /// Mirrors [`Self::compute_id`]'s parameter list exactly, including the
+    /// currently-unhashed `hlc`, so the two can never silently drift apart if
+    /// the preimage changes. Note that this means `hlc` is NOT authenticated by
+    /// this check today; it stays malleable on the wire and must not be relied
+    /// on as a trusted input.
+    #[must_use]
+    pub fn content_address_matches(
+        delta_id: &[u8; 32],
+        parents: &[[u8; 32]],
+        actions: &[Action],
+        hlc: &HybridTimestamp,
+    ) -> bool {
+        Self::compute_id(parents, actions, hlc) == *delta_id
+    }
+
+    /// [`Self::content_address_matches`] applied to this delta's own fields.
+    #[must_use]
+    pub fn id_matches_content(&self) -> bool {
+        Self::content_address_matches(&self.id, &self.parents, &self.actions, &self.hlc)
+    }
+
     /// Get the physical timestamp (nanoseconds since epoch).
     #[must_use]
     pub fn physical_time(&self) -> u64 {
@@ -702,5 +733,91 @@ mod borsh_roundtrip_tests {
             result.is_err(),
             "expected error for unknown tag, got {result:?}"
         );
+    }
+
+    /// A delta as an honest producer builds one: id derived from the parents
+    /// and actions it actually carries.
+    fn honest_delta(parents: Vec<[u8; 32]>) -> CausalDelta {
+        let actions = vec![make_action(1), make_action(2)];
+        let hlc = make_hlc(42);
+        CausalDelta {
+            id: CausalDelta::compute_id(&parents, &actions, &hlc),
+            parents,
+            actions,
+            hlc,
+            expected_root_hash: [0x11_u8; 32],
+        }
+    }
+
+    #[test]
+    fn content_address_matches_accepts_honest_delta() {
+        assert!(honest_delta(vec![[7_u8; 32]]).id_matches_content());
+        // Genesis, on the `[0; 32]` convention the state-delta write path uses.
+        assert!(honest_delta(vec![[0_u8; 32]]).id_matches_content());
+    }
+
+    #[test]
+    fn content_address_matches_rejects_emptied_parents() {
+        // The attack this check exists to stop: strip `parents` to empty so the
+        // delta hits the vacuously-true branch of `DagStore::can_apply` and
+        // applies immediately as a disconnected head. The signed `id` is left
+        // untouched, because the envelope signature covers it and the attacker
+        // cannot re-sign.
+        let mut delta = honest_delta(vec![[7_u8; 32]]);
+        delta.parents = vec![];
+        assert!(
+            !delta.id_matches_content(),
+            "emptied parents must not content-address the original id"
+        );
+    }
+
+    #[test]
+    fn content_address_matches_rejects_reparented_delta() {
+        // Not just the empty case — any re-parenting moves the causal cut that
+        // at-cut authorization resolves against, so a swapped non-empty parent
+        // set must be rejected too.
+        let mut delta = honest_delta(vec![[7_u8; 32]]);
+        delta.parents = vec![[9_u8; 32]];
+        assert!(!delta.id_matches_content());
+
+        // Including adding a parent alongside the genuine one.
+        let mut delta = honest_delta(vec![[7_u8; 32]]);
+        delta.parents = vec![[7_u8; 32], [9_u8; 32]];
+        assert!(!delta.id_matches_content());
+    }
+
+    #[test]
+    fn content_address_matches_rejects_swapped_actions() {
+        let mut delta = honest_delta(vec![[7_u8; 32]]);
+        delta.actions = vec![make_action(3)];
+        assert!(!delta.id_matches_content());
+    }
+
+    #[test]
+    fn content_address_survives_post_id_root_hash_mutation() {
+        // Guards the non-obvious way this check could start false-positiving on
+        // honest traffic. The rotation-log self-log leg of the local write path
+        // recomputes `expected_root_hash` AFTER `compute_id` has already run,
+        // so a check that folded the root hash into the preimage would reject
+        // every writer-set rotation. `expected_root_hash` is not in the
+        // preimage; pin that.
+        let mut delta = honest_delta(vec![[7_u8; 32]]);
+        delta.expected_root_hash = [0xEE_u8; 32];
+        assert!(
+            delta.id_matches_content(),
+            "expected_root_hash must stay outside the content address"
+        );
+    }
+
+    #[test]
+    fn content_address_does_not_cover_hlc() {
+        // Documents a KNOWN LIMIT rather than desired behaviour: `compute_id`
+        // deliberately excludes the HLC for determinism, so this check leaves
+        // `hlc` malleable on the wire. Anything that needs a trusted HLC needs
+        // a separate binding. If the preimage ever starts covering the HLC,
+        // this test failing is the intended signal to revisit that.
+        let mut delta = honest_delta(vec![[7_u8; 32]]);
+        delta.hlc = make_hlc(9_999);
+        assert!(delta.id_matches_content());
     }
 }


### PR DESCRIPTION
Closes #3540. Removes the remote-attacker pressure from #3126 (which stays open as the genesis-convention cleanup).

## The gap

A state delta's `parent_ids` were covered by nothing:

| Field | Protection before this PR |
|---|---|
| `actions`, `root_hash`, `events` | AEAD-sealed inside `artifact` — needs the group key |
| `context_id`, `delta_id`, `author_id`, `governance_position` | Ed25519 envelope signature |
| **`parent_ids`** | **nothing** |
| `hlc` | nothing (and excluded from `compute_id` by design) |

The binding already existed in principle — `CausalDelta::compute_id` hashes `parents`, and `delta_id` *is* signature-bound — it just was never enforced. `compute_id` had exactly two call sites, both on the produce side.

Gossipsub runs `MessageAuthenticity::Signed`, so this was never tamper-in-transit. The attack is **republish**: any node in the context's mesh re-publishes a member's delta under its own libp2p key, reusing the victim's `delta_id` and `delta_signature` verbatim, with `parent_ids` rewritten. It needs neither the group key nor the author's identity key.

Every existing gate misses it because they all key off `author_id` — the honest author — not the publisher:

- `verify_delta_signature` passes: the payload it reconstructs contains no parents.
- `is_read_only_for_context(context_id, author_id)` resolves the honest author → full member → passes.
- `membership_status_at(author, pos)` likewise.

So a **ReadOnly or revoked member** — precisely the identity the ReadOnly gate exists to stop from writing — could re-parent a current member's write. Stripping `parent_ids` to empty is the worst case: it hits the vacuously-true branch of `DagStore::can_apply` and applies immediately as a disconnected head, bypassing missing-parent detection and polluting head computation.

## The fix

`CausalDelta::content_address_matches`, added next to `compute_id`, called on every receive path:

- gossip apply (`handlers/state_delta/mod.rs`) — after decrypt, before the DAG insert
- buffered replay — buffering is a delay, not a trust boundary
- both parent-fetch walks (`handlers/state_delta/mod.rs`, `sync/delta_request.rs`)
- DAG head pull (`sync/manager/mod.rs`)

Its parameter list mirrors `compute_id` exactly, **including the currently-unhashed `hlc`**, so the two cannot silently drift if the preimage ever changes.

## Second defect, same root cause

Three of the four catchup paths never checked that a responder returned the delta that was **asked for**. They built the DAG delta from the responder-supplied id while verifying the signature against either that claimed id or the requested one — so a responder holding one legitimately signed delta could answer a request for another and have it persisted under the wrong slot.

`sync/manager/mod.rs` already had this guard, and its comment claimed parity with *"the parent-fetch path's sanity check"* — a check that path never had. This PR makes the claim true.

Both structural checks sit **before** the genesis carve-out deliberately. That branch skips every author-keyed check by design (genesis genuinely predates any governance op, so there is no author to check), and `is_genesis_author_sentinel` only tests whether the author pubkey is all-zeros — a value the *responder* chooses to send. So today a malicious catchup responder can serve wholly arbitrary genesis content: parents, actions, hlc, root hash, even a different id. The carve-out is right in intent but substituted *nothing* for the checks it dropped; these two now give it its first integrity check. Since the requested id comes from the `parents` of an already-accepted delta, the pair chains content-addressing off a reference the node already trusts — no author required.

## Why this is safe for honest traffic

The way this could go wrong is false-positiving on honest producers, so I traced the write path rather than assuming:

- `sign_authorized_actions` mutates `actions` and re-serializes the artifact **before** `compute_id` runs, so the hashed actions are the transmitted actions.
- The rotation-log self-log leg (#2716 leg 4) recomputes `expected_root_hash` **after** `compute_id` — but `expected_root_hash` is outside the preimage. Pinned by `content_address_survives_post_id_root_hash_mutation`, since a check that folded the root hash in would reject every writer-set rotation.
- The broadcast reuses `the_delta.id` rather than recomputing.

No wire-format change, no back-compat shim, no convention change.

## Known limit, deliberately not fixed here

`compute_id` excludes the HLC for determinism, so `hlc` stays malleable. `content_address_does_not_cover_hlc` pins that as a **known limit rather than desired behaviour**, so the test failing is the signal to revisit. Binding `hlc` and `expected_root_hash` needs a wire-format decision and is tracked as a follow-up on #3540; folding it in here would have stalled the part that ships cleanly.

## Tests

New:
- 6 unit tests on the helper (`crates/storage/src/delta.rs`): honest delta and `[0;32]` genesis accepted; emptied parents, re-parented, added-parent, swapped-actions rejected; the two invariant-pinning tests above.
- 3 gate-level tests in `byzantine_delta_auth.rs` modeling the republish attack against a **real** `calimero-storage` Merkle tree — genuine signature, genuine `delta_id`, honest `author_id`, only `parent_ids` tampered → rejected, root hash provably unchanged. Plus an honest-delta control that must advance the root, so the negatives can't pass on a broken fixture.

Existing, all green: `calimero-storage --lib` 693, `calimero-node --lib` 495, `sync_sim` 325, `calimero-context --lib` 234, plus `dag_causal_shared_e2e`, `dag_persistence`, `dag_storage_integration`, `concurrent_branches_root_hash`, `sync_protocols`. `cargo fmt --all --check` and `clippy --all-targets` clean.

**Not covered:** no merobox e2e run against real nodes. The honest-path argument above is from tracing the write path plus in-process coverage; a multi-node scenario would be the stronger check, particularly for any cascaded-delta path that re-persists actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
