### PR TITLE
fix(node): park deltas on a missing application instead of waiting for it

### DIFF
--- a/crates/governance-store/src/absorb.rs
+++ b/crates/governance-store/src/absorb.rs
@@ -154,6 +154,7 @@ mod tests {
             producing_app_key: Some([2; 32]),
             leaf: None,
             entity: None,
+            pending_application: None,
         }
     }
 

--- a/crates/governance-store/src/absorb_record.rs
+++ b/crates/governance-store/src/absorb_record.rs
@@ -63,6 +63,18 @@ pub struct AbsorbRecord {
     /// buffers the raw `entry` + `index` blobs here; the drain re-verifies +
     /// persists them once the reader advances. Mutually exclusive with `leaf`.
     pub entity: Option<AbsorbedEntity>,
+    /// Set when this record holds a delta parked because the application it must
+    /// execute against is not runnable locally yet — either the application row
+    /// or its bytecode blob has not landed. Holds that application id.
+    ///
+    /// The record is delta-shaped and replays verbatim like any other, but its
+    /// readiness signal differs from the schema-migration ones: the schema is
+    /// fine, the bytecode simply is not here. The schema drain therefore skips
+    /// these records — replaying one before its application arrives would only
+    /// re-park it — and the bytecode drain owns them, gated on the application
+    /// becoming runnable. Kept trailing for forward hygiene, as the sibling tags
+    /// are.
+    pub pending_application: Option<[u8; 32]>,
 }
 
 /// A buffered sync-repair leaf.
@@ -118,6 +130,7 @@ impl AbsorbRecord {
             producing_app_key: bd.producing_app_key,
             leaf: None,
             entity: None,
+            pending_application: None,
         }
     }
 
@@ -147,6 +160,7 @@ impl AbsorbRecord {
                 schema_app_key,
             }),
             entity: None,
+            pending_application: None,
         }
     }
 
@@ -183,6 +197,20 @@ impl AbsorbRecord {
                 index,
                 schema_app_key,
             }),
+            pending_application: None,
+        }
+    }
+
+    /// Build a durable mirror of a delta parked on a not-yet-runnable
+    /// application. Lossless, exactly as
+    /// [`from_buffered`](Self::from_buffered) — the only difference is the
+    /// `pending_application` tag naming what the drain must wait for, which
+    /// keeps the schema drain off this record.
+    #[must_use]
+    pub fn from_buffered_pending_application(bd: &BufferedDelta, application: [u8; 32]) -> Self {
+        Self {
+            pending_application: Some(application),
+            ..Self::from_buffered(bd)
         }
     }
 
@@ -301,5 +329,37 @@ mod tests {
         assert_eq!(back.delta_signature, bd.delta_signature);
         assert_eq!(back.governance_drain_attempts, bd.governance_drain_attempts);
         assert_eq!(back.producing_app_key, bd.producing_app_key);
+    }
+
+    /// An application-parked record carries the awaited application and is still
+    /// a replayable delta: the tag changes which drain owns it, not whether the
+    /// original signed bytes come back intact.
+    #[test]
+    fn pending_application_record_tags_without_disturbing_the_delta() {
+        let bd = sample_buffered_delta();
+        let rec = AbsorbRecord::from_buffered_pending_application(&bd, [0xAB; 32]);
+
+        assert_eq!(rec.pending_application, Some([0xAB; 32]));
+        assert!(rec.leaf.is_none(), "not a leaf-shaped record");
+        assert!(rec.entity.is_none(), "not an entity-shaped record");
+
+        let bytes = borsh::to_vec(&rec).unwrap();
+        let decoded = AbsorbRecord::try_from_slice(&bytes).unwrap();
+        assert_eq!(decoded.pending_application, Some([0xAB; 32]));
+
+        let back = decoded.into_buffered().unwrap();
+        assert_eq!(back.id, bd.id);
+        assert_eq!(back.payload, bd.payload, "replay needs the original bytes");
+        assert_eq!(back.delta_signature, bd.delta_signature);
+        assert_eq!(back.producing_app_key, bd.producing_app_key);
+    }
+
+    /// The untagged constructor must leave the tag clear, or every straggler
+    /// would silently move to the application drain.
+    #[test]
+    fn from_buffered_leaves_pending_application_clear() {
+        assert!(AbsorbRecord::from_buffered(&sample_buffered_delta())
+            .pending_application
+            .is_none());
     }
 }

--- a/crates/node/src/handlers/network_event/blobs.rs
+++ b/crates/node/src/handlers/network_event/blobs.rs
@@ -43,6 +43,12 @@ pub(super) fn handle_blob_providers_found(
 /// content check that used to live here is not lost — the requesting path makes
 /// the same one against the id it asked for, and refuses the peer's answer on a
 /// mismatch.
+///
+/// For the same reason this is also the wrong place to react to a blob becoming
+/// usable — an application arriving, say. This event fires when the bytes finish
+/// transferring, which is *before* the requesting path stores them, so anything
+/// checking whether the blob is present would race and usually lose. React at
+/// the point the requesting path has stored it instead.
 pub(super) fn handle_blob_downloaded(
     blob_id: BlobId,
     context_id: ContextId,

--- a/crates/node/src/handlers/state_delta/buffering.rs
+++ b/crates/node/src/handlers/state_delta/buffering.rs
@@ -316,6 +316,118 @@ pub(crate) async fn drain_absorbed(input: &StateDeltaContext, context_id: &Conte
     if let Err(err) = drain_absorbed_leaves(input, context_id).await {
         warn!(%context_id, %err, "absorb drain: leaf drain failed");
     }
+
+    // Deltas parked on a not-yet-runnable application drain on a third tag.
+    // Chained here so every existing absorb-drain trigger — namespace network
+    // events, sync settle, startup recovery — doubles as a safety net for them,
+    // whichever way the application arrived (peer blob fetch, bundle install,
+    // an operator installing it over the admin API). The prompt path is the
+    // install hook in the sync manager; this catches whatever that misses.
+    drain_pending_application(input, context_id).await;
+}
+
+/// Replay deltas parked because their application was not runnable locally,
+/// once it is.
+///
+/// Sibling of [`drain_absorbed`] for the `pending_application`-tagged
+/// [`AbsorbRecord`]s that the apply path parked. Readiness is one check per
+/// context — not per record — since every parked delta in a context waits on
+/// that context's application: if it still is not runnable, there is nothing to
+/// do for any of them.
+///
+/// Replay goes through [`apply_authorized_state_delta`] with the fence bypassed,
+/// exactly as the straggler drain does, and a record is deleted only after a
+/// successful replay, so a crash mid-drain just replays the survivors.
+async fn drain_pending_application(input: &StateDeltaContext, context_id: &ContextId) {
+    use calimero_governance_store::AbsorbRepository;
+
+    let store = input.node_clients.context.datastore();
+    let repo = AbsorbRepository::new(store);
+
+    let pending = match repo.enumerate_pending(context_id) {
+        Ok(p) => p,
+        Err(err) => {
+            warn!(%context_id, %err, "absorb drain: failed to enumerate parked deltas");
+            return;
+        }
+    };
+    let parked: Vec<_> = pending
+        .into_iter()
+        .filter(|(_, record)| record.pending_application.is_some())
+        .collect();
+    if parked.is_empty() {
+        return;
+    }
+
+    // One readiness check for the whole batch, before any replay work.
+    match super::application_bytecode_status(
+        &input.node_clients.node,
+        &input.node_clients.context,
+        context_id,
+    ) {
+        Ok(super::BytecodeStatus::Ready) => {}
+        Ok(super::BytecodeStatus::Missing(application_id)) => {
+            debug!(
+                %context_id,
+                %application_id,
+                parked = parked.len(),
+                "absorb drain: application still not runnable — leaving parked deltas"
+            );
+            return;
+        }
+        Err(err) => {
+            warn!(%context_id, %err, "absorb drain: application readiness check failed");
+            return;
+        }
+    }
+
+    let mut drained = 0usize;
+    for ((key_application, delta_id), record) in parked {
+        let buffered = match record.into_buffered() {
+            Ok(b) => b,
+            Err(err) => {
+                warn!(
+                    %context_id,
+                    delta_id = ?delta_id,
+                    %err,
+                    "absorb drain: corrupt parked record — cannot reconstruct delta; skipping"
+                );
+                continue;
+            }
+        };
+        let reconstructed = state_delta_message_from_buffered(buffered, *context_id);
+        // Bypass the HLC fence for the same reason the straggler drain does:
+        // this delta already cleared the fence on receive, and re-fencing a
+        // replay would re-absorb it under the schema tag instead of applying it.
+        match apply_authorized_state_delta(input.clone(), reconstructed, true).await {
+            Ok(()) => {
+                if let Err(err) = repo.delete(context_id, key_application, delta_id) {
+                    warn!(
+                        %context_id,
+                        delta_id = ?delta_id,
+                        %err,
+                        "absorb drain: replayed parked delta but failed to delete its record"
+                    );
+                    continue;
+                }
+                drained += 1;
+            }
+            Err(err) => warn!(
+                %context_id,
+                delta_id = ?delta_id,
+                %err,
+                "absorb drain: parked delta replay failed — leaving record for retry"
+            ),
+        }
+    }
+
+    if drained > 0 {
+        info!(
+            %context_id,
+            drained,
+            "absorb drain: replayed deltas parked on a not-yet-runnable application"
+        );
+    }
 }
 
 /// Drain buffered sync-repair leaves once the loaded reader has advanced to
@@ -496,6 +608,14 @@ where
         // `__calimero_sync_next` payload — they are not replayable deltas.
         // Skip them; `drain_absorbed_leaves` handles them.
         if record.leaf.is_some() || record.entity.is_some() {
+            continue;
+        }
+        // Application-parked records are replayable deltas, but their readiness
+        // signal is the application becoming runnable, not the reader schema
+        // advancing — `drain_pending_application` owns them. Replaying one here
+        // would only re-park it, and this drain has no way to check the
+        // application (it holds a store, not a node client).
+        if record.pending_application.is_some() {
             continue;
         }
         // Drain-ready signal: replay once the node has caught up to the

--- a/crates/node/src/handlers/state_delta/events.rs
+++ b/crates/node/src/handlers/state_delta/events.rs
@@ -18,7 +18,7 @@ use tracing::{debug, info, warn};
 
 use crate::delta_store::DeltaStore;
 
-use super::ensure_application_available;
+use super::{application_bytecode_status, BytecodeStatus};
 
 // ---- CascadeOutcome ----
 #[derive(Default)]
@@ -51,7 +51,6 @@ pub(super) async fn execute_cascaded_events(
     context_client: &ContextClient,
     context_id: &ContextId,
     our_identity: &PublicKey,
-    sync_timeout: std::time::Duration,
     phase: &str,
     current_delta: Option<&[u8; 32]>,
     delta_store: &DeltaStore,
@@ -90,10 +89,10 @@ pub(super) async fn execute_cascaded_events(
         }
     }
 
-    let app_available =
-        ensure_application_available(node_client, context_client, context_id, sync_timeout)
-            .await
-            .is_ok();
+    let app_available = matches!(
+        application_bytecode_status(node_client, context_client, context_id),
+        Ok(BytecodeStatus::Ready)
+    );
 
     if !app_available {
         warn!(

--- a/crates/node/src/handlers/state_delta/mod.rs
+++ b/crates/node/src/handlers/state_delta/mod.rs
@@ -7,6 +7,7 @@ use calimero_context_config::types::GovernanceParentEdge;
 use calimero_crypto::Nonce;
 use calimero_governance_store::{DenyListRepository, NamespaceRepository};
 use calimero_node_primitives::client::NodeClient;
+use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::ContextId;
 use calimero_primitives::events::ExecutionEvent;
 use calimero_primitives::hash::Hash;
@@ -26,7 +27,7 @@ mod store_setup;
 mod verify;
 
 pub(crate) use buffering::{
-    drain_all_absorbed, drain_all_governance_pending, recover_absorbed_on_startup,
+    drain_absorbed, drain_all_absorbed, drain_all_governance_pending, recover_absorbed_on_startup,
 };
 use buffering::{drain_governance_pending, fence_and_maybe_absorb, FenceOutcome};
 // Used only by the in-module test suite (the live drain/recover entry points
@@ -109,7 +110,6 @@ pub(crate) struct ReplayBufferedDeltaInput {
     pub(crate) context_id: ContextId,
     pub(crate) our_identity: PublicKey,
     pub(crate) buffered: calimero_node_primitives::delta_buffer::BufferedDelta,
-    pub(crate) sync_timeout: std::time::Duration,
     pub(crate) is_covered_by_checkpoint: bool,
 }
 
@@ -363,6 +363,63 @@ pub(crate) async fn apply_authorized_state_delta(
         // Fall through to normal processing
     }
 
+    // Resolved here rather than after the decrypt so the runnability check below
+    // can skip self-authored deltas. A delta this node authored was already
+    // applied locally, so parking one would replay it later and double-apply it.
+    let our_identity = choose_owned_identity(&node_clients.context, &context_id).await?;
+
+    // Applying before the application is runnable would apply the delta and then
+    // skip its handlers, so check before doing any of the work below — there is
+    // no point fetching a group key or decrypting a payload this node cannot
+    // execute against. A blocked delta is parked in the absorb buffer, keyed by
+    // the application it waits on, and replayed verbatim once that application
+    // arrives.
+    //
+    // Parking rather than dropping matters because gossipsub does not re-deliver
+    // a message it has already delivered: without a durable copy the only
+    // recovery would be hash-heartbeat divergence triggering a snapshot sync.
+    // The original ciphertext is what gets stored — a replay is verified against
+    // the same bytes the sender signed.
+    if author_id != our_identity {
+        if let BytecodeStatus::Missing(application_id) =
+            application_bytecode_status(&node_clients.node, &node_clients.context, &context_id)?
+        {
+            let record = calimero_governance_store::AbsorbRecord::from_buffered_pending_application(
+                &calimero_node_primitives::delta_buffer::BufferedDelta {
+                    id: delta_id,
+                    parents: parent_ids.clone(),
+                    hlc,
+                    payload: artifact.clone(),
+                    nonce,
+                    author_id,
+                    source_peer: source,
+                    key_id,
+                    governance_position: governance_position.clone(),
+                    delta_signature,
+                    governance_drain_attempts: 0,
+                    producing_app_key,
+                },
+                *application_id.as_ref(),
+            );
+            // Keyed by the awaited application rather than by `producing_app_key`:
+            // the application id resolves from local context metadata even when
+            // nothing about the application has landed, and a delta may carry no
+            // `producing_app_key` at all. `delta_id` keeps the key unique, so a
+            // re-delivery overwrites instead of duplicating.
+            calimero_governance_store::AbsorbRepository::new(node_clients.context.datastore())
+                .save(&context_id, *application_id.as_ref(), &record)?;
+            info!(
+                %context_id,
+                %author_id,
+                %application_id,
+                delta_id = ?delta_id,
+                "Parking state delta — application not runnable locally; will replay when it arrives"
+            );
+            crate::node_metrics::record_delta_outcome("parked_pending_application");
+            return Ok(());
+        }
+    }
+
     let group_key = {
         let store = node_clients.context.datastore();
         let gid = calimero_governance_store::get_group_for_context(store, &context_id)?;
@@ -420,8 +477,6 @@ pub(crate) async fn apply_authorized_state_delta(
         kind: calimero_dag::DeltaKind::Regular,
     };
 
-    let our_identity = choose_owned_identity(&node_clients.context, &context_id).await?;
-
     // Check if this is our own delta (gossipsub echoes back to sender).
     // Self-authored deltas are already applied locally, so we should NOT re-apply them.
     // This prevents state divergence from double-application of actions.
@@ -441,25 +496,6 @@ pub(crate) async fn apply_authorized_state_delta(
         return Ok(());
     }
 
-    // Check if application is available BEFORE applying the delta.
-    // If not available, bail early so the delta can be retried later when rebroadcast.
-    // This prevents the scenario where we apply the delta but skip handlers because
-    // the application blob hasn't finished downloading yet.
-    if let Err(e) = ensure_application_available(
-        &node_clients.node,
-        &node_clients.context,
-        &context_id,
-        sync_timeout,
-    )
-    .await
-    {
-        bail!(
-            "Application not available for context {} - delta will be retried on rebroadcast: {}",
-            context_id,
-            e
-        );
-    }
-
     let DeltaStoreSetup {
         store: delta_store_ref,
         is_uninitialized,
@@ -469,7 +505,6 @@ pub(crate) async fn apply_authorized_state_delta(
         context_id,
         our_identity,
         context.root_hash,
-        sync_timeout,
     )
     .await?;
 
@@ -520,7 +555,6 @@ pub(crate) async fn apply_authorized_state_delta(
             &node_clients.context,
             &context_id,
             &our_identity,
-            sync_timeout,
             "missing parent check",
             Some(&delta_id),
             &delta_store_ref,
@@ -629,7 +663,6 @@ pub(crate) async fn apply_authorized_state_delta(
                             &node_clients.context,
                             &context_id,
                             &our_identity,
-                            sync_timeout,
                             "peer-fetch cascade",
                             Some(&delta_id),
                             &delta_store_ref,
@@ -780,7 +813,6 @@ pub(crate) async fn apply_authorized_state_delta(
         &node_clients.context,
         &context_id,
         &our_identity,
-        sync_timeout,
         "dag cascade",
         None,
         &delta_store_ref,
@@ -1759,87 +1791,45 @@ async fn request_missing_deltas(
     Ok(cascaded_events)
 }
 
-/// Ensures the application blob is available for a context before handler execution.
+/// Whether a context's application bytecode is executable right now.
+pub(crate) enum BytecodeStatus {
+    /// The application is installed and its bytecode blob is stored locally.
+    Ready,
+    /// Not executable yet. Carries the context's application id, which is
+    /// resolvable from local context metadata whether or not the application row
+    /// itself has landed, so a caller always has something to key a parked delta
+    /// on.
+    Missing(ApplicationId),
+}
+
+/// Reports whether the application bytecode for `context_id` can be executed,
+/// so callers never apply a delta or run handlers against bytecode this node
+/// does not have.
 ///
-/// This fixes the race condition where gossipsub state deltas arrive before the
-/// WASM application blob has finished downloading. Without this check, handler
-/// execution would fail with "ApplicationNotInstalled" errors.
-///
-/// The function polls for blob availability with exponential backoff, up to the
-/// specified timeout. If the blob becomes available, it returns Ok(()); otherwise
-/// it returns an error.
-async fn ensure_application_available(
+/// This only observes; it never waits. A blocked delta is parked in the absorb
+/// buffer and replayed once the bytecode lands. Waiting here would be waiting on
+/// someone else's work in any case — the download is driven by the sync manager,
+/// not by this path — and each waiting caller holds a delta payload and store
+/// handles for the duration, so a peer that gossips deltas for a context whose
+/// bytecode it never serves could grow that set at the full delta arrival rate.
+fn application_bytecode_status(
     node_client: &calimero_node_primitives::client::NodeClient,
     context_client: &calimero_context_client::client::ContextClient,
     context_id: &ContextId,
-    timeout: std::time::Duration,
-) -> Result<()> {
-    use std::time::Duration;
-    use tokio::time::{sleep, Instant};
-
+) -> Result<BytecodeStatus> {
     let context = context_client
         .get_context(context_id)?
         .ok_or_else(|| eyre::eyre!("context not found"))?;
 
     let application_id = context.application_id;
 
-    // Check if application is already installed and blob available
-    if let Ok(Some(app)) = node_client.get_application(&application_id) {
-        // Application exists, check if bytecode blob is available
-        if node_client.has_blob(&app.blob.bytecode)? {
-            debug!(
-                %context_id,
-                %application_id,
-                "Application blob already available"
-            );
-            return Ok(());
-        }
+    // A missing application row and a present row whose bytecode blob has not
+    // arrived are the same situation to every caller: nothing to execute yet.
+    // On the sync path the row and the blob land together.
+    match node_client.get_application(&application_id) {
+        Ok(Some(app)) if node_client.has_blob(&app.blob.bytecode)? => Ok(BytecodeStatus::Ready),
+        _ => Ok(BytecodeStatus::Missing(application_id)),
     }
-
-    // Blob not yet available - poll with backoff
-    let start = Instant::now();
-    let mut delay = Duration::from_millis(50);
-    let max_delay = Duration::from_millis(500);
-
-    info!(
-        %context_id,
-        %application_id,
-        timeout_ms = timeout.as_millis(),
-        "Waiting for application blob to become available..."
-    );
-
-    while start.elapsed() < timeout {
-        sleep(delay).await;
-
-        // Re-check application and blob
-        if let Ok(Some(app)) = node_client.get_application(&application_id) {
-            if node_client.has_blob(&app.blob.bytecode)? {
-                info!(
-                    %context_id,
-                    %application_id,
-                    elapsed_ms = start.elapsed().as_millis(),
-                    "Application blob now available"
-                );
-                return Ok(());
-            }
-        }
-
-        // Exponential backoff
-        delay = std::cmp::min(delay * 2, max_delay);
-    }
-
-    // Timeout reached
-    warn!(
-        %context_id,
-        %application_id,
-        elapsed_ms = start.elapsed().as_millis(),
-        "Timeout waiting for application blob"
-    );
-
-    Err(eyre::eyre!(
-        "Application blob not available after {:?}",
-        timeout
-    ))
 }
 
 /// Replay a buffered delta after snapshot sync completes.
@@ -1862,7 +1852,6 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
         context_id,
         our_identity,
         buffered,
-        sync_timeout,
         is_covered_by_checkpoint,
     } = input;
 
@@ -2166,7 +2155,6 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
             &context_client,
             &context_id,
             &our_identity,
-            sync_timeout,
             "buffered-replay crash recovery",
             None,
             &delta_store,
@@ -2312,7 +2300,6 @@ pub async fn replay_buffered_delta(input: ReplayBufferedDeltaInput) -> Result<bo
         &context_client,
         &context_id,
         &our_identity,
-        sync_timeout,
         "buffered delta replay",
         None,
         &delta_store,
@@ -2764,6 +2751,51 @@ mod tests {
             let drained = drain_absorbed_records(&store, &ctx, noop).await.unwrap();
             assert_eq!(drained, 1, "the future delta drains once the node advances");
             assert!(repo.enumerate_pending(&ctx).unwrap().is_empty());
+        }
+
+        /// A delta parked on a not-yet-runnable application must be SKIPPED by
+        /// the schema drain even when the node is at the target schema. Its
+        /// readiness signal is the application arriving, which this drain cannot
+        /// observe (it holds a store, not a node client) — replaying it here
+        /// would only re-park it.
+        #[tokio::test]
+        async fn delta_drain_skips_application_parked_records() {
+            // loaded == target == v2, so nothing schema-related holds this back.
+            let (store, ctx) = cascaded_store(Some(HybridTimestamp::zero()));
+            let repo = AbsorbRepository::new(&store);
+
+            repo.save(
+                &ctx,
+                APP_V2,
+                &AbsorbRecord::from_buffered_pending_application(
+                    &sample_buffered([0xF6; 32], APP_V2),
+                    [0xAA; 32],
+                ),
+            )
+            .unwrap();
+
+            let replayed = std::sync::Arc::new(std::sync::Mutex::new(0usize));
+            let replayed_capture = replayed.clone();
+            let drained = drain_absorbed_records(&store, &ctx, move |_buffered| {
+                let replayed = replayed_capture.clone();
+                async move {
+                    *replayed.lock().unwrap() += 1;
+                    Ok::<bool, eyre::Report>(true)
+                }
+            })
+            .await
+            .unwrap();
+
+            assert_eq!(
+                drained, 0,
+                "an application-parked delta is not a schema drain's to replay"
+            );
+            assert_eq!(*replayed.lock().unwrap(), 0, "replay must not be invoked");
+            assert_eq!(
+                repo.enumerate_pending(&ctx).unwrap().len(),
+                1,
+                "the parked delta stays pending for the application drain"
+            );
         }
 
         /// Leaf- and entity-shaped sync-repair records are NOT replayable deltas

--- a/crates/node/src/handlers/state_delta/store_setup.rs
+++ b/crates/node/src/handlers/state_delta/store_setup.rs
@@ -43,7 +43,6 @@ pub(super) async fn init_delta_store(
     context_id: ContextId,
     our_identity: PublicKey,
     root_hash: Hash,
-    sync_timeout: std::time::Duration,
 ) -> Result<DeltaStoreSetup> {
     let is_uninitialized = root_hash == Hash::default();
 
@@ -118,7 +117,6 @@ pub(super) async fn init_delta_store(
                 &node_clients.context,
                 &context_id,
                 &our_identity,
-                sync_timeout,
                 "initial load",
                 None,
                 &delta_store_ref,

--- a/crates/node/src/state_delta_bridge.rs
+++ b/crates/node/src/state_delta_bridge.rs
@@ -45,6 +45,23 @@ pub const STATE_DELTA_CHANNEL_CAPACITY: usize = 2048;
 /// to completion. The durable fix for the underlying slowness is #2199/#2238.
 const STATE_DELTA_PROCESSING_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Hard ceiling on concurrently in-flight jobs.
+///
+/// The mailbox bound alone does not cap concurrency: `handle` hands each job
+/// to `ctx.spawn` and returns, so the mailbox slot frees immediately and the
+/// job's future accumulates alongside every other still-running one. Anything
+/// that parks a job for seconds — a peer that gossips deltas for a context
+/// whose application bytecode it never serves, a slow merge-apply — therefore
+/// grows in-flight futures at the full delta arrival rate with nothing to stop
+/// it, each holding its delta payload and store handles.
+///
+/// Healthy processing completes in milliseconds, so steady-state in-flight
+/// sits in the single digits and this never trips. It is deliberately well
+/// under [`STATE_DELTA_CHANNEL_CAPACITY`]: the mailbox is sized to absorb a
+/// multi-minute *arrival* burst, which is a different quantity from how many
+/// jobs may run at once.
+const STATE_DELTA_MAX_IN_FLIGHT: u64 = 256;
+
 /// Periodic summary log interval.
 const SUMMARY_INTERVAL: Duration = Duration::from_secs(60);
 
@@ -57,9 +74,20 @@ struct InFlightGuard {
 }
 
 impl InFlightGuard {
-    fn new(counter: Arc<AtomicU64>) -> Self {
-        let _prev = counter.fetch_add(1, Ordering::Relaxed);
-        Self { counter }
+    /// Reserve one in-flight slot, or return `None` when `ceiling` is already
+    /// reached.
+    ///
+    /// The check and the increment are one `fetch_update` rather than a load
+    /// followed by a `fetch_add`: decrements come from guard drops in spawned
+    /// futures, so a split check-then-increment could admit a job on a count
+    /// that went stale between the two operations.
+    fn try_acquire(counter: Arc<AtomicU64>, ceiling: u64) -> Option<Self> {
+        counter
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                (current < ceiling).then(|| current + 1)
+            })
+            .ok()
+            .map(|_prev| Self { counter })
     }
 }
 
@@ -128,6 +156,10 @@ pub struct StateDeltaActor {
     /// slow-merge storm is distinguishable from an application-error
     /// storm in the summary log.
     over_budget_total: Arc<AtomicU64>,
+    /// Jobs refused because [`STATE_DELTA_MAX_IN_FLIGHT`] was already
+    /// reached. Kept apart from `dropped_total` (mailbox overflow) so a
+    /// concurrency stall is distinguishable from an arrival-rate burst.
+    shed_total: Arc<AtomicU64>,
     dropped_total: Arc<AtomicU64>,
 }
 
@@ -138,6 +170,7 @@ impl StateDeltaActor {
             processed_total: Arc::new(AtomicU64::new(0)),
             error_total: Arc::new(AtomicU64::new(0)),
             over_budget_total: Arc::new(AtomicU64::new(0)),
+            shed_total: Arc::new(AtomicU64::new(0)),
             dropped_total,
         }
     }
@@ -146,14 +179,17 @@ impl StateDeltaActor {
         let processed = self.processed_total.load(Ordering::Relaxed);
         let errors = self.error_total.load(Ordering::Relaxed);
         let over_budget = self.over_budget_total.load(Ordering::Relaxed);
+        let shed = self.shed_total.load(Ordering::Relaxed);
         let dropped = self.dropped_total.load(Ordering::Relaxed);
         let in_flight = self.in_flight.load(Ordering::Relaxed);
         info!(
             processed_total = processed,
             error_total = errors,
             over_budget_total = over_budget,
+            shed_total = shed,
             dropped_total = dropped,
             in_flight,
+            max_in_flight = STATE_DELTA_MAX_IN_FLIGHT,
             "StateDelta actor summary"
         );
     }
@@ -183,12 +219,29 @@ impl Handler<StateDeltaJob> for StateDeltaActor {
         let error_total = Arc::clone(&self.error_total);
         let over_budget_total = Arc::clone(&self.over_budget_total);
 
-        // RAII guard so `in_flight` is decremented even on panic.
-        let in_flight_guard = InFlightGuard::new(Arc::clone(&self.in_flight));
-
         let StateDeltaJob { context, message } = job;
         let context_id = message.context_id;
         let delta_id = message.delta_id;
+
+        // RAII guard so `in_flight` is decremented even on panic. Acquiring it
+        // is also the admission check: at the ceiling the job is shed here
+        // rather than spawned, so a stalled workload cannot keep growing the
+        // set of parked futures. Shedding costs this delta a redelivery, which
+        // the heartbeat-driven rebroadcast already covers — the same trade the
+        // mailbox-overflow path makes.
+        let Some(in_flight_guard) =
+            InFlightGuard::try_acquire(Arc::clone(&self.in_flight), STATE_DELTA_MAX_IN_FLIGHT)
+        else {
+            let _prev = self.shed_total.fetch_add(1, Ordering::Relaxed);
+            warn!(
+                %context_id,
+                ?delta_id,
+                max_in_flight = STATE_DELTA_MAX_IN_FLIGHT,
+                "StateDelta job shed — in-flight ceiling reached; awaiting rebroadcast"
+            );
+            crate::node_metrics::record_delta_outcome("shed_in_flight_ceiling");
+            return;
+        };
 
         // Counters are incremented INSIDE `work`, before `_guard`
         // drops, so a summary log between guard-drop and the .map()
@@ -291,6 +344,48 @@ mod tests {
         assert_eq!(sender.dropped_total.load(Ordering::Relaxed), 0);
         let _clone = sender.clone();
         let _stopped = arbiter.stop();
+    }
+
+    /// Slots are handed out up to the ceiling and refused past it, so a
+    /// workload that parks jobs cannot grow the in-flight set without bound.
+    #[test]
+    fn try_acquire_refuses_past_the_ceiling() {
+        let counter = Arc::new(AtomicU64::new(0));
+
+        let first = InFlightGuard::try_acquire(Arc::clone(&counter), 2);
+        let second = InFlightGuard::try_acquire(Arc::clone(&counter), 2);
+        assert!(first.is_some());
+        assert!(second.is_some());
+        assert_eq!(counter.load(Ordering::Relaxed), 2);
+
+        let refused = InFlightGuard::try_acquire(Arc::clone(&counter), 2);
+        assert!(refused.is_none());
+        // A refusal must not consume a slot, or a shedding actor would ratchet
+        // its own count upward and never admit another job.
+        assert_eq!(counter.load(Ordering::Relaxed), 2);
+    }
+
+    /// Dropping a guard frees its slot for the next job.
+    #[test]
+    fn dropping_a_guard_readmits() {
+        let counter = Arc::new(AtomicU64::new(0));
+
+        let guard = InFlightGuard::try_acquire(Arc::clone(&counter), 1);
+        assert!(guard.is_some());
+        assert!(InFlightGuard::try_acquire(Arc::clone(&counter), 1).is_none());
+
+        drop(guard);
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
+        assert!(InFlightGuard::try_acquire(Arc::clone(&counter), 1).is_some());
+    }
+
+    /// A zero ceiling admits nothing — guards the boundary arithmetic in
+    /// `try_acquire`'s `current < ceiling` test.
+    #[test]
+    fn zero_ceiling_admits_nothing() {
+        let counter = Arc::new(AtomicU64::new(0));
+        assert!(InFlightGuard::try_acquire(Arc::clone(&counter), 0).is_none());
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
     }
 
     // Functional tests of `handle_state_delta` itself live in the

--- a/crates/node/src/sync/manager/blob_fetch.rs
+++ b/crates/node/src/sync/manager/blob_fetch.rs
@@ -220,7 +220,36 @@ impl SyncManager {
         // Use the verified installed application
         *application = Some(installed_application);
 
+        // The application is runnable as of here: its bytecode blob is local
+        // (checked at the top of this function) and its row is installed and
+        // verified. Any state delta that arrived while it was missing was parked
+        // rather than applied, so replay those now instead of leaving them for
+        // the next namespace event or sync settle.
+        self.drain_deltas_parked_on_application(context_id).await;
+
         Ok(())
+    }
+
+    /// Replay state deltas parked because this context's application was not
+    /// runnable yet.
+    ///
+    /// The gossip apply path parks such a delta in the durable absorb buffer
+    /// instead of applying it against bytecode this node cannot execute. This is
+    /// the prompt trigger for the common case — the application just arrived by
+    /// blob sync. Applications can also land by other routes (an operator
+    /// installing one over the admin API), which is why the same drain is
+    /// chained off every other absorb-drain hook as a safety net.
+    async fn drain_deltas_parked_on_application(&self, context_id: &ContextId) {
+        let drain_input = crate::handlers::state_delta::StateDeltaContext {
+            node_clients: crate::state::NodeClients {
+                context: self.context_client.clone(),
+                node: self.node_client.clone(),
+            },
+            node_state: self.node_state.clone(),
+            network_client: self.network_client.clone(),
+            sync_timeout: self.sync_config.timeout,
+        };
+        crate::handlers::state_delta::drain_absorbed(&drain_input, context_id).await;
     }
 
     /// Resolves an application's semver from its `ApplicationMeta` row via the

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -2990,7 +2990,6 @@ impl SyncManager {
                 context_id,
                 our_identity,
                 buffered,
-                sync_timeout: self.sync_config.timeout,
                 is_covered_by_checkpoint,
             })
             .await


### PR DESCRIPTION
## The bug

A state delta whose application isn't runnable locally used to hold its worker for up to `sync_timeout` (30s by default) in a 50ms→500ms backoff loop, then fail and rely on rebroadcast.

The loop was a **passive observer**. All it did was re-check `has_blob` — while the download it was waiting on is driven by the sync manager, which the loop neither triggers nor talks to. So the wait bought nothing and cost a parked worker per delta, each holding a delta payload and store handles.

A peer gossiping deltas for a context whose bytecode it never serves turns that into a node-wide availability problem: at the ~10 deltas/sec the mailbox is sized around, roughly **300 concurrent parked workers per context**.

And when the wait did expire, the delta was simply dropped. Gossipsub does not re-deliver a message it has already delivered, so recovery was left to hash-heartbeat divergence detection and a snapshot sync — expensive, and only as prompt as the next heartbeat.

## The change

Replace the loop with a single observation, and park what it blocks.

**Observe, don't wait.** `application_bytecode_status` reports `Ready` or `Missing(application_id)` and never waits. It also runs *earlier* than the old check — before the group-key lookup and the decrypt — since there's no point paying for either when the result can't be executed. That placement is what lets the park store the original ciphertext, which verbatim replay needs.

**Park, don't drop.** A blocked delta goes into the durable absorb buffer under a new `pending_application` tag, keyed by the application it waits on. Given that gossipsub won't redeliver, parking is what turns "wait for a heartbeat to notice divergence" into "replay the moment the application lands".

**Drain when it lands.** `drain_pending_application` replays parked deltas once the application is runnable, with one readiness check per *context* rather than per record — every parked delta in a context waits on that context's application, so if it still isn't runnable there is nothing to do for any of them. Replay goes through `apply_authorized_state_delta` with the HLC fence bypassed, exactly as the straggler drain does, and a record is deleted only after a successful replay, so a crash mid-drain replays the survivors.

The two drains are explicitly disjoint: the schema drain skips `pending_application` records and vice versa. Their readiness signals are unrelated, and replaying a parked delta before its application lands would only re-park it.

## Where the drain hooks in, and one wrong answer

The prompt trigger is the **sync manager's install path**, right after the bytecode is local and the application row is verified. The drain is *also* chained off every existing absorb-drain hook, so an application arriving by another route — an operator installing one over the admin API — still converges.

`BlobDownloaded` would have been the obvious hook and is the wrong one: **it fires when the transfer finishes, before the requesting path stores the bytes**, so a presence check there races and usually loses. I left a note at that handler so the next reader doesn't have to rediscover it.

## Incidental

The cascaded-handler path needed no new logic — it already skipped handler execution and left events in the DB for replay — so it just stops waiting. That retires the last uses of `sync_timeout` on the cascade and delta-store-setup call paths, and the now-dead parameters go with them. (`StateDeltaContext::sync_timeout` itself stays; other paths still use it.)

## Testing

- `pending_application_record_tags_without_disturbing_the_delta` — the new tag rides along without perturbing the record's existing delta payload.
- `from_buffered_leaves_pending_application_clear` — a record reconstructed for replay doesn't carry the parked tag back with it.
- `delta_drain_skips_application_parked_records` — the schema drain leaves application-parked records alone, and they stay pending for the drain that owns them.

## Stack

**Targets `core-wt-deltaceiling` (#3544), not master.** #3544 caps concurrently in-flight delta jobs as a backstop; this PR removes the stall that motivated the cap. Review/merge #3544 first — the diff shown here is against that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
