### PR TITLE
fix(deps): bump the shipped h2 past RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3886,9 +3886,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4217,7 +4217,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",

--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,14 @@ ignore = [
     { id = "RUSTSEC-2026-0119", reason = "hickory-proto, via libp2p-dns; pending libp2p upgrade" },
     { id = "RUSTSEC-2026-0097", reason = "rand, transitive; pending upstream upgrade" },
     { id = "RUSTSEC-2023-0071", reason = "rsa Marvin timing attack, transitive; no upstream fix available" },
+    # The shipped path IS fixed: hyper 1.x's h2 is bumped to 0.4.16 in this same
+    # change. What remains is h2 0.3.27 under reqwest 0.11, reached only as a
+    # BUILD dep (cached-path, in calimero-server / mero-auth) and a DEV dep
+    # (jsonschema, in calimero-wasm-abi) - neither is in merod or meroctl. The
+    # 0.3 line is unpatched upstream (the fix landed only in 0.4.16), so this
+    # cannot be lock-bumped; clearing it means moving cached-path 0.8 -> 0.10 and
+    # jsonschema 0.17 -> 0.49, both breaking, tracked separately.
+    { id = "RUSTSEC-2026-0258", reason = "h2 0.3.27 via reqwest 0.11, build+dev only; 0.3 unpatched upstream. Runtime h2 is 0.4.16" },
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

`cargo deny` is failing on every core PR since RUSTSEC-2026-0258 ("h2 unbounded empty DATA frames") was published. Two `h2` versions resolve in this workspace and they need different treatment.

| Version | Reached via | In `merod`/`meroctl`? | Patch available |
|---|---|---|---|
| `h2 0.4.13` | `hyper 1.8.1` ← `axum`, `hyper-util` | **yes** | **yes — 0.4.16** |
| `h2 0.3.27` | `reqwest 0.11` ← `cached-path` *(build-dep)*, `jsonschema` *(dev-dep)* | **no** | **none — 0.3 is unpatched** |

**Fixed:** the shipped copy, `0.4.13 → 0.4.16`.

**Ignored, with the reasoning recorded at the entry:** `0.3.27`. It is a build-dependency and a dev-dependency only, so it is in neither shipped binary, and the fix exists solely in the 0.4 line — the advisory's own suggested `cargo update -p h2` cannot reach it. Clearing it properly means `cached-path 0.8 → 0.10` and `jsonschema 0.17 → 0.49`, both breaking (the latter a 32-minor-version jump). That is a dependency migration, not an advisory fix, and belongs in its own change.

Worth flagging for review: `cargo-deny` cannot scope an ignore to a version, so this entry would also mask a future `0.4.x` regression. That trade-off is written at the ignore site rather than left implicit.

## Why the lockfile diff is 3 lines

A plain `cargo update -p h2@0.4.13` — with or without `--precise` — also re-resolved `syn 2.0.117 → 1.0.109`, `socket2 0.6.2 → 0.5.10` and `windows-sys 0.61.2 → 0.59.0`, on packages unrelated to h2 (`data-encoding-macro-internal`, `dcap-qvl`, `errno`, `nu-ansi-term`). This toolchain (1.88.0, matching `rust-toolchain.toml`) reproduces that on any lock write, so the committed lockfile was evidently produced by a cargo that resolves differently.

Rather than ship that churn inside a security fix, only the `h2` stanza and its single reference were changed. The dependency list is byte-identical between 0.4.13 and 0.4.16, so version + checksum + one reference is the whole delta.

## Test plan

- `cargo metadata --locked` — accepts the lockfile, so cargo does not want to rewrite it
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok` (was `advisories FAILED`)
- `cargo test --workspace --no-run --locked` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test -p calimero-server --lib` — 73 passing (the crate that actually carries hyper)
