### PR TITLE
fix(api)!: tell the caller why a context failed to initialize

### DIFF
--- a/crates/context/src/error.rs
+++ b/crates/context/src/error.rs
@@ -38,6 +38,24 @@ pub enum ContextError {
         message: String,
     },
 
+    /// The application's `init` did not complete, so no context was created.
+    ///
+    /// Carries the guest's own message, which is the only thing that says what
+    /// was actually wrong — almost always that the `initializationParams` do
+    /// not match `init`'s signature. `#[app::init]` cannot return a `Result`
+    /// (the macro rejects it), so the only way it fails is a guest panic, and
+    /// the SDK's panic hook routes every one of those through `panic_utf8`;
+    /// the message is therefore never empty.
+    ///
+    /// Typed for the same reason as [`Self::NotAGroupMember`]: it is a caller
+    /// precondition, not a server fault, and callers map it to a `400` rather
+    /// than letting it fall through to a generic `500` that says nothing.
+    #[error("application initialization failed: {message}")]
+    InitFailed {
+        /// The guest's panic message, verbatim.
+        message: String,
+    },
+
     /// This node is not a member of the group the operation targets.
     ///
     /// A legitimate client-side precondition (the node hasn't joined the

--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -24,6 +24,8 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use tracing::{debug, error, warn};
 
+use crate::error::ContextError;
+
 use super::execute::execute;
 use super::execute::storage::{ContextPrivateStorage, ContextStorage};
 use crate::handlers::execute::{persist_signed_signatures, sign_authorized_actions};
@@ -376,7 +378,19 @@ async fn create_context(
     )
     .await?;
 
-    if let Some(res) = outcome.returns? {
+    // Map the guest's failure to a TYPED error instead of letting `?` push a
+    // bare `FunctionCallError` up as an untyped report. `parse_api_error`
+    // refuses to echo untyped errors to the caller — rightly, they can carry
+    // store paths and key material — so this path used to answer
+    // `500 {"error":"Internal server error"}` with the reason available
+    // nowhere but the node's own log. The guest's message is app-authored and
+    // is the whole diagnosis (almost always: the initializationParams do not
+    // match `init`'s signature), so it is safe and necessary to surface.
+    let returns = outcome.returns.map_err(|err| ContextError::InitFailed {
+        message: err.to_string(),
+    })?;
+
+    if let Some(res) = returns {
         bail!(
             "context initialization returned a value, but it should not: {:?}",
             res

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -636,6 +636,20 @@ pub fn parse_api_error(err: Report) -> ApiError {
             message: err.to_string(),
         };
     }
+    // The application's own `init` refused the call — nearly always because the
+    // `initializationParams` do not match its signature. That is the caller's
+    // input, not a server fault, and the guest's message is the only thing that
+    // says what was wrong. Without this arm it falls through to the generic 500
+    // below and the reason exists nowhere but the node's log, which is not
+    // something an API client can read.
+    if let Some(calimero_context::error::ContextError::InitFailed { .. }) =
+        err.downcast_ref::<calimero_context::error::ContextError>()
+    {
+        return ApiError {
+            status_code: StatusCode::BAD_REQUEST,
+            message: err.to_string(),
+        };
+    }
     match err.downcast::<ApiError>() {
         Ok(api_error) => api_error,
         // An untyped error is an unexpected internal failure. Don't echo its
@@ -829,6 +843,26 @@ mod parse_api_error_tests {
         assert!(
             api.message.contains("not a member"),
             "expected the typed reason to reach the client, got: {}",
+            api.message
+        );
+    }
+
+    /// The whole point of the typed variant: a caller that got the init params
+    /// wrong must be told so. Before this, the same case answered
+    /// `500 {"error":"Internal server error"}` and the reason lived only in the
+    /// node's log.
+    #[test]
+    fn init_failure_maps_to_400_carrying_the_guest_message() {
+        let err = calimero_context::error::ContextError::InitFailed {
+            message: "guest panicked: init: failed to deserialize arguments: \
+                      missing field `name`"
+                .to_owned(),
+        };
+        let api = parse_api_error(err.into());
+        assert_eq!(api.status_code, StatusCode::BAD_REQUEST);
+        assert!(
+            api.message.contains("missing field `name`"),
+            "the guest's own diagnosis is the only useful part; got: {}",
             api.message
         );
     }


### PR DESCRIPTION
Creating a context runs the application's `init`. When that rejects the call, the node answers:

```
500 {"error":"Internal server error"}
```

…and nothing else. The reason exists only in the node's own log, which an API client cannot read. So every consumer whose `initializationParams` don't match `init`'s signature — the common case — has no way to find out from the API what was wrong.

## The suppression is right; the classification wasn't

`parse_api_error` refuses to echo untyped errors because they can carry store paths and key material. That's correct. The bug is that **an init failure was never typed**, so it fell into that bucket alongside genuine internal faults.

`ContextError::InitFailed` now carries the guest's own message, and `parse_api_error` maps it to a **400** — the same treatment `NotAGroupMember` already gets, and for the same reason: this is a caller precondition, not a server fault.

The message is **app-authored, not node internals**, so surfacing it leaks nothing the caller didn't supply. And it can't be empty: `#[app::init]` cannot return a `Result` (the macro rejects it), so the only way init fails is a guest panic, and the SDK's panic hook routes every panic through `panic_utf8`.

A caller now gets:

```
400 {"error":"application initialization failed: guest panicked: init: failed to
     deserialize arguments (expected { name, ... }): Error(\"missing field `name`\")"}
```

## Why this is worth doing

This has already cost real debugging time downstream. admin-dashboard had to grow an entire ABI-driven form — reading `GET /applications/:id/abi` and generating one control per `init` parameter — specifically so a user could not produce this 500, because when they did there was nothing to tell them. That workaround is still worth having, but it exists to route around a missing error message.

Verified still present at `0.11.0-rc.23` and on `master` as of `97972ba30`; no open PR addresses it.

## Breaking

Marked `!` because a documented status code changes: this case answered `500` and now answers `400`. Anything treating it as a retryable server error should treat it as a client error.

## ⚠️ Not built locally

CI is the first thing to compile this. The change is three files: the new variant, the `map_err` at the call site, and the `parse_api_error` arm plus a regression test alongside the existing `not_a_group_member_maps_to_403_with_message`.