### PR TITLE
chore: cut release 0.11.0-rc.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.23"
+version = "0.11.0-rc.24"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Bumps `[workspace.metadata.workspaces].version` to `0.11.0-rc.24`. One line, same shape as every previous cut (`7a25641c`, `25b1967b`, `da787d2b`).

**16 commits since rc.23**, notably:

- **`54d4b6ce` ephemeral presence (#3427)** — transient encrypted presence/cursor/typing state that gossips between nodes with **no WASM run and no DAG growth**. Envelopes are ed25519-signed with a freshness stamp; only the current group key is accepted, so key rotation evicts. Subscribing replays current presence to that connection. New JSON-RPC `set_ephemeral`; presence changes ride the existing WS/SSE event stream behind the same authorization gate as context events.
- `c4743ccb` sync: authenticate state-delta parents by re-deriving the content address
- `330e8589` **breaking**: drop `governanceOp` from both join responses
- `97972ba3` deps: bump the shipped h2 past RUSTSEC-2026-0258
- `0b735af2` blobstore: serialise blob refcount updates per content id
- `cc8f83b4` node: cap concurrently in-flight state-delta jobs
- `441a1860` **breaking**: tell the caller why a context failed to initialize
- plus governance/migration test hardening and protocol docs

**Downstream note.** This is the first release carrying presence, which unblocks two things that were waiting on it: `mero-js`'s "E2E (vs released merod)" job can now exercise `mero.ephemeral` against a real node, and `mero-react`'s `useEphemeral` can move off its local structural type declarations once a `mero-js` release ships on top of this.

Three surfaces move in this RC: `330e8589` (join responses), `441a1860` (context-init error reporting) and `54d4b6ce` (new `SetEphemeral*` on `calimero-server-primitives`). Consumers pinning that crate — mero-tee at a git rev — need a coordinated bump covering all three, not just presence.

Verified on this branch: manifest parses (`cargo metadata`), `cargo check --workspace` clean.

