### PR TITLE
refactor(api)!: drop upgradePolicy from the namespace and group responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Removed
 
+- **`upgradePolicy`** from the namespace and group-info responses (`GET
+  admin-api/namespaces`, `.../namespaces/:id`, `.../namespaces/for-application/:id`,
+  `admin-api/groups/:id`), along with the `UPGRADE_POLICY_COMPAT` constant that
+  filled it. The concept went server-side in #3393; the key survived only for
+  clients that declared it required, and its own doc named the condition for
+  removal — a merobox bundling a client-py built off post-merge master, with
+  `MIN_MEROBOX` naming it. merobox 0.6.56 and client-py 0.6.29 satisfy both.
+  It always held `"LazyOnAccess"`, so no caller can depend on its value.
+  Requests are unaffected: released nodes still require the field on
+  `POST admin-api/namespaces` and `POST admin-api/groups`, and both SDKs keep
+  sending it ([#3485])
+
 - **`meroctl context identity grant` / `revoke`** and the per-context
   capability request/response types behind them. The commands were shipped and
   advertised in `context --help`, but had no route, client method or handler and

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -14,11 +14,6 @@ use url::Url;
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct Empty;
 
-/// Constant compat key: the released calimero-client-py merobox bundles rejects
-/// group/namespace responses that omit it. Delete once merobox ships a client-py
-/// built off post-merge master and MIN_MEROBOX (.github/actions/setup-merobox) names it.
-pub const UPGRADE_POLICY_COMPAT: &str = "LazyOnAccess";
-
 // -------------------------------------------- Application API --------------------------------------------
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -1285,9 +1280,6 @@ pub struct GroupInfoApiResponseData {
     pub group_id: String,
     pub app_key: String,
     pub target_application_id: ApplicationId,
-    /// Compat shim, always [`UPGRADE_POLICY_COMPAT`].
-    #[serde(default)]
-    pub upgrade_policy: String,
     pub member_count: u64,
     pub context_count: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2847,9 +2839,6 @@ pub struct NamespaceApiResponse {
     pub namespace_id: String,
     pub app_key: String,
     pub target_application_id: String,
-    /// Compat shim, always [`UPGRADE_POLICY_COMPAT`].
-    #[serde(default)]
-    pub upgrade_policy: String,
     pub created_at: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,

--- a/crates/server/src/admin/handlers/groups/get_group_info.rs
+++ b/crates/server/src/admin/handlers/groups/get_group_info.rs
@@ -4,9 +4,7 @@ use axum::extract::Path;
 use axum::response::IntoResponse;
 use axum::Extension;
 use calimero_context_client::group::GetGroupInfoRequest;
-use calimero_server_primitives::admin::{
-    GroupInfoApiResponse, GroupInfoApiResponseData, UPGRADE_POLICY_COMPAT,
-};
+use calimero_server_primitives::admin::{GroupInfoApiResponse, GroupInfoApiResponseData};
 use tracing::{error, info};
 
 use super::{parse_group_id, upgrade_info_to_api_data};
@@ -41,7 +39,6 @@ pub async fn handler(
                         group_id: hex::encode(info.group_id.to_bytes()),
                         app_key: hex::encode(info.app_key.to_bytes()),
                         target_application_id: info.target_application_id,
-                        upgrade_policy: UPGRADE_POLICY_COMPAT.to_owned(),
                         member_count: info.member_count,
                         context_count: info.context_count,
                         active_upgrade,

--- a/crates/server/src/admin/handlers/namespaces/get_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/get_namespace.rs
@@ -5,7 +5,6 @@ use axum::extract::Path;
 use axum::response::IntoResponse;
 use axum::Extension;
 use calimero_context_client::group::GetNamespaceIdentityRequest;
-use calimero_server_primitives::admin::UPGRADE_POLICY_COMPAT;
 use reqwest::StatusCode;
 use tracing::{error, info};
 
@@ -77,7 +76,6 @@ pub async fn handler(
                         namespace_id: hex::encode(ns.namespace_id.to_bytes()),
                         app_key: hex::encode(ns.app_key.to_bytes()),
                         target_application_id: ns.target_application_id.to_string(),
-                        upgrade_policy: UPGRADE_POLICY_COMPAT.to_owned(),
                         created_at: ns.created_at,
                         name: ns.name,
                         member_count: ns.member_count,

--- a/crates/server/src/admin/handlers/namespaces/list.rs
+++ b/crates/server/src/admin/handlers/namespaces/list.rs
@@ -5,7 +5,7 @@ use axum::response::IntoResponse;
 use axum::Extension;
 use calimero_context_client::group::ListNamespacesRequest;
 use calimero_server_primitives::admin::{
-    ListNamespacesApiResponse, ListNamespacesQuery, NamespaceApiResponse, UPGRADE_POLICY_COMPAT,
+    ListNamespacesApiResponse, ListNamespacesQuery, NamespaceApiResponse,
 };
 use tracing::{error, info};
 
@@ -48,7 +48,6 @@ pub async fn handler(
                     namespace_id: hex::encode(ns.namespace_id.to_bytes()),
                     app_key: hex::encode(ns.app_key.to_bytes()),
                     target_application_id: ns.target_application_id.to_string(),
-                    upgrade_policy: UPGRADE_POLICY_COMPAT.to_owned(),
                     created_at: ns.created_at,
                     name: ns.name,
                     member_count: ns.member_count,

--- a/crates/server/src/admin/handlers/namespaces/list_for_application.rs
+++ b/crates/server/src/admin/handlers/namespaces/list_for_application.rs
@@ -7,7 +7,6 @@ use calimero_context_client::group::ListNamespacesForApplicationRequest;
 use calimero_primitives::application::ApplicationId;
 use calimero_server_primitives::admin::{
     ListNamespacesApiResponse, ListNamespacesForApplicationQuery, NamespaceApiResponse,
-    UPGRADE_POLICY_COMPAT,
 };
 use reqwest::StatusCode;
 use tracing::{error, info};
@@ -66,7 +65,6 @@ pub async fn handler(
                     namespace_id: hex::encode(ns.namespace_id.to_bytes()),
                     app_key: hex::encode(ns.app_key.to_bytes()),
                     target_application_id: ns.target_application_id.to_string(),
-                    upgrade_policy: UPGRADE_POLICY_COMPAT.to_owned(),
                     created_at: ns.created_at,
                     name: ns.name,
                     member_count: ns.member_count,


### PR DESCRIPTION
The follow-up #3485 left open. **Blocked on** calimero-network/mero-js#104 and calimero-network/swift-sdk#22 — merge those first.

## Why now

`UPGRADE_POLICY_COMPAT` fills `upgradePolicy` with the constant `"LazyOnAccess"` on four endpoints. The concept went server-side in #3393; the key survived for clients that declared the field required. Its own doc named the exit condition:

> Delete once merobox ships a client-py built off post-merge master and `MIN_MEROBOX` (`.github/actions/setup-merobox`) names it.

Both halves now hold: merobox 0.6.56 bundles `calimero-client-py` 0.6.29, built off master, and #3528 moved `MIN_MEROBOX` to 0.6.56.

## Endpoints

`GET admin-api/namespaces`, `.../namespaces/:id`, `.../namespaces/for-application/:id`, `admin-api/groups/:id`.

## Requests are untouched

A released node still declares the field **required** on `POST admin-api/namespaces` and `POST admin-api/groups` and rejects a body without it. Both SDKs keep sending it. That shim is gated on which node releases are supported, not on which clients exist, so it has a longer life than this one and is deliberately out of scope.

## Ordering, and why it is shorter than #3485's

The two hand-written SDKs go first, because they typed the field required — swift-sdk especially, where a synthesized `Codable` fails the *whole* response with `keyNotFound`.

There is no compiled-client gate this time: core's struct has carried `#[serde(default)]` on the field since before rc.21, so `calimero-client-py` has always tolerated its absence, and merobox reads namespace data as plain dicts. That is the difference from `governanceOp`, where the client-py struct required the field and took a four-repo sequence to unblock.

## Scope check

The only other `upgrade_policy` left in the tree is a store-layer test pinning that a record written before the *stored* format dropped the tag fails loudly rather than decoding into garbage — a different concern, kept.

Two related findings, handled elsewhere:

- **swift-sdk had a dead `updateGroupSettings`** PATCHing `/admin-api/groups/{id}`; core has no PATCH routes at all. Removed in swift-sdk#22 along with `UpdateGroupSettingsRequest`, whose every field (`upgradePolicy`, `requester`) had already been deleted from core.
- **merobox needed nothing** — it dropped the whole upgrade-policy surface in merobox#318.

## Verification

`cargo fmt --check`, `cargo check --workspace --all-targets`, `cargo test -p calimero-server-primitives -p calimero-server` all green. `UPDATE_FIXTURES=1` leaves the wire fixtures unchanged — no committed fixture covered these endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)