### PR TITLE
feat(migration): report the account each cohort replica speaks for

### DIFF
--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -1475,10 +1475,27 @@ impl MemberMigrationState {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MemberMigrationStatus {
     pub peer: PublicKey,
+    /// The account `peer` speaks for. The cohort is a set of REPLICAS, so one
+    /// account can appear under several peers - this is what lets a caller
+    /// group a person's devices, and the only key that joins these rows to
+    /// `list_group_members` (which is account-keyed and carries the name).
+    pub account: AccountId,
     /// The member's reported facts, or `None` when it has no fresh heartbeat
     /// (in which case `state == Unknown`).
     pub report: Option<MemberMigrationReport>,
     pub state: MemberMigrationState,
+}
+
+/// One replica in a migration cohort: the device key that reports, and the
+/// account it speaks for.
+///
+/// Named rather than a `(PublicKey, AccountId)` tuple because both are 32-byte
+/// opaque ids and nothing downstream objects if they are swapped - it would
+/// simply name a principal that exists nowhere.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CohortMember {
+    pub peer: PublicKey,
+    pub account: AccountId,
 }
 
 /// Rollup counters across the pinned cohort.
@@ -1551,7 +1568,7 @@ pub fn compute_migration_status_rollup(
     target_version: u32,
     cohort_pinned_at_hlc: Option<HybridTimestamp>,
     cohort_pinned_at_seq: Option<u64>,
-    closure: &[PublicKey],
+    closure: &[CohortMember],
     mut report_for: impl FnMut(&PublicKey) -> Option<MemberMigrationReport>,
 ) -> MigrationStatus {
     let mut members = Vec::with_capacity(closure.len());
@@ -1561,7 +1578,8 @@ pub fn compute_migration_status_rollup(
     let mut failed = 0usize;
     let mut members_pending_signature = 0usize;
 
-    for peer in closure {
+    for &CohortMember { peer, account } in closure {
+        let peer = &peer;
         let report = report_for(peer);
 
         // Pin overlay: a member whose freshest heartbeat proves it synced only
@@ -1613,6 +1631,7 @@ pub fn compute_migration_status_rollup(
         };
         members.push(MemberMigrationStatus {
             peer: *peer,
+            account,
             report,
             state,
         });
@@ -1650,12 +1669,23 @@ mod migration_status_tests {
     use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
 
     use super::{
-        compute_migration_status_rollup, MemberMigrationReport, MemberMigrationState,
-        MigrationFailureKind,
+        compute_migration_status_rollup, AccountId, CohortMember, MemberMigrationReport,
+        MemberMigrationState, MigrationFailureKind,
     };
 
     fn pk(b: u8) -> PublicKey {
         PublicKey::from([b; 32])
+    }
+
+    /// A cohort entry for `peer`, on its own account. The rollup keys every
+    /// count off `peer`, so a distinct account per device is the neutral
+    /// default; the two-devices-one-account case is asserted explicitly in
+    /// `two_devices_on_one_account_are_two_rows`.
+    fn one(peer: PublicKey) -> CohortMember {
+        CohortMember {
+            peer,
+            account: AccountId::from(*peer),
+        }
     }
 
     /// A heartbeat report whose freshest sync position is well past any pin
@@ -1691,11 +1721,63 @@ mod migration_status_tests {
         }
     }
 
+    /// The cohort counts REPLICAS, and the account is what identifies the
+    /// person behind them.
+    ///
+    /// A caller holding only `peer` cannot name a member: peers render bs58 and
+    /// `list_group_members` is keyed by 64-hex accounts, so the two name
+    /// different principals and nothing errors when they are confused. Carrying
+    /// the account is what lets a caller say "one of alice's two devices is
+    /// stuck" rather than printing a key.
+    #[test]
+    fn two_devices_on_one_account_are_two_rows_naming_one_member() {
+        let laptop = pk(0xA1);
+        let phone = pk(0xA2);
+        let alice = AccountId::from([0xAA; 32]);
+
+        let st = compute_migration_status_rollup(
+            2,
+            None,
+            None,
+            &[
+                CohortMember {
+                    peer: laptop,
+                    account: alice,
+                },
+                CohortMember {
+                    peer: phone,
+                    account: alice,
+                },
+            ],
+            |peer| {
+                // The laptop migrated; the phone has not reported at all.
+                (*peer == laptop).then(|| report(2, 0))
+            },
+        );
+
+        assert_eq!(st.rollup.total, 2, "the cohort counts devices, not people");
+        assert_eq!(st.rollup.migrated, 1);
+        assert_eq!(st.rollup.unknown, 1);
+        assert!(
+            !st.rollup.all_migrated,
+            "one device still outstanding keeps the fleet un-migrated"
+        );
+        assert!(
+            st.members.iter().all(|m| m.account == alice),
+            "both rows name the same member, which is what groups them"
+        );
+        assert_eq!(
+            st.members.iter().map(|m| m.peer).collect::<Vec<_>>(),
+            vec![laptop, phone],
+            "and each row keeps its own device key"
+        );
+    }
+
     #[test]
     fn failed_member_surfaces_as_failed_not_in_progress() {
         let pa = pk(0xA1);
         let pb = pk(0xB2);
-        let st = compute_migration_status_rollup(2, None, None, &[pa, pb], |peer| {
+        let st = compute_migration_status_rollup(2, None, None, &[one(pa), one(pb)], |peer| {
             if *peer == pa {
                 Some(report(2, 0)) // migrated
             } else {
@@ -1717,7 +1799,7 @@ mod migration_status_tests {
         // exactly like the other failure kinds.
         let pa = pk(0xA1);
         let pb = pk(0xB2);
-        let st = compute_migration_status_rollup(2, None, None, &[pa, pb], |peer| {
+        let st = compute_migration_status_rollup(2, None, None, &[one(pa), one(pb)], |peer| {
             if *peer == pa {
                 Some(report(2, 0))
             } else {
@@ -1767,9 +1849,10 @@ mod migration_status_tests {
         let _ = reports.insert(b, report(2, 0));
         // C absent — no fresh heartbeat.
 
-        let st = compute_migration_status_rollup(2, None, None, &[a, b, c], |peer| {
-            reports.get(peer).copied()
-        });
+        let st =
+            compute_migration_status_rollup(2, None, None, &[one(a), one(b), one(c)], |peer| {
+                reports.get(peer).copied()
+            });
 
         assert_eq!(st.rollup.unknown, 1);
         assert_eq!(st.rollup.migrated, 2);
@@ -1816,7 +1899,7 @@ mod migration_status_tests {
             2,
             cascade_hlc_at(7_600_000_000_000_000_000),
             Some(pin_seq),
-            &[a, b, c, d],
+            &[one(a), one(b), one(c), one(d)],
             |peer| reports.get(peer).copied(),
         );
 
@@ -1858,7 +1941,7 @@ mod migration_status_tests {
             2,
             cascade_hlc_at(7_600_000_000_000_000_000),
             Some(10),
-            &[a, b],
+            &[one(a), one(b)],
             |peer| reports.get(peer).copied(),
         );
 
@@ -1886,7 +1969,7 @@ mod migration_status_tests {
         let _ = reports.insert(a, report_synced(2, 0, 20));
         // B absent.
 
-        let st = compute_migration_status_rollup(2, None, Some(10), &[a, b], |peer| {
+        let st = compute_migration_status_rollup(2, None, Some(10), &[one(a), one(b)], |peer| {
             reports.get(peer).copied()
         });
 
@@ -1903,7 +1986,9 @@ mod migration_status_tests {
 
         // All migrated -> green.
         let all_ok =
-            compute_migration_status_rollup(2, None, None, &[a, b, c], |_| Some(report(2, 0)));
+            compute_migration_status_rollup(2, None, None, &[one(a), one(b), one(c)], |_| {
+                Some(report(2, 0))
+            });
         assert!(all_ok.rollup.all_migrated);
         assert_eq!(all_ok.rollup.migrated, 3);
 
@@ -1912,9 +1997,10 @@ mod migration_status_tests {
         let _ = reports.insert(a, report(2, 0));
         let _ = reports.insert(b, report(2, 0));
         let _ = reports.insert(c, report(2, 1));
-        let with_residue = compute_migration_status_rollup(2, None, None, &[a, b, c], |peer| {
-            reports.get(peer).copied()
-        });
+        let with_residue =
+            compute_migration_status_rollup(2, None, None, &[one(a), one(b), one(c)], |peer| {
+                reports.get(peer).copied()
+            });
         assert!(!with_residue.rollup.all_migrated);
         assert_eq!(with_residue.rollup.in_progress, 1);
         let c_row = with_residue
@@ -1929,9 +2015,10 @@ mod migration_status_tests {
         let _ = behind.insert(a, report(2, 0));
         let _ = behind.insert(b, report(1, 0));
         let _ = behind.insert(c, report(2, 0));
-        let behind_status = compute_migration_status_rollup(2, None, None, &[a, b, c], |peer| {
-            behind.get(peer).copied()
-        });
+        let behind_status =
+            compute_migration_status_rollup(2, None, None, &[one(a), one(b), one(c)], |peer| {
+                behind.get(peer).copied()
+            });
         assert!(!behind_status.rollup.all_migrated);
         assert_eq!(behind_status.rollup.in_progress, 1);
 
@@ -1969,7 +2056,8 @@ mod migration_status_tests {
         };
         assert_eq!(zero_stamp.reported_at, 0, "modeling a now_ms == 0 clock");
 
-        let st = compute_migration_status_rollup(2, None, None, &[a, b], |_| Some(zero_stamp));
+        let st =
+            compute_migration_status_rollup(2, None, None, &[one(a), one(b)], |_| Some(zero_stamp));
 
         // The zero-stamp reports are counted as migrated, not discarded.
         assert_eq!(st.rollup.total, 2);
@@ -1993,7 +2081,7 @@ mod migration_status_tests {
     fn same_major_release_does_not_report_a_laggard_as_migrated() {
         let migrated_peer = pk(0xA1);
         let laggard_peer = pk(0xB2);
-        let closure = vec![migrated_peer, laggard_peer];
+        let closure = vec![one(migrated_peer), one(laggard_peer)];
 
         let status = compute_migration_status_rollup(
             2, // target ABI state version, from a 10.2.0 bundle

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -1475,10 +1475,8 @@ impl MemberMigrationState {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MemberMigrationStatus {
     pub peer: PublicKey,
-    /// The account `peer` speaks for. The cohort is a set of REPLICAS, so one
-    /// account can appear under several peers - this is what lets a caller
-    /// group a person's devices, and the only key that joins these rows to
-    /// `list_group_members` (which is account-keyed and carries the name).
+    /// The account `peer` speaks for; one account can appear under several
+    /// peers. Joins these rows to the account-keyed `list_group_members`.
     pub account: AccountId,
     /// The member's reported facts, or `None` when it has no fresh heartbeat
     /// (in which case `state == Unknown`).
@@ -1487,11 +1485,8 @@ pub struct MemberMigrationStatus {
 }
 
 /// One replica in a migration cohort: the device key that reports, and the
-/// account it speaks for.
-///
-/// Named rather than a `(PublicKey, AccountId)` tuple because both are 32-byte
-/// opaque ids and nothing downstream objects if they are swapped - it would
-/// simply name a principal that exists nowhere.
+/// account it speaks for. Named rather than a tuple because both are 32-byte
+/// opaque ids that would silently swap.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CohortMember {
     pub peer: PublicKey,
@@ -1677,10 +1672,8 @@ mod migration_status_tests {
         PublicKey::from([b; 32])
     }
 
-    /// A cohort entry for `peer`, on its own account. The rollup keys every
-    /// count off `peer`, so a distinct account per device is the neutral
-    /// default; the two-devices-one-account case is asserted explicitly in
-    /// `two_devices_on_one_account_are_two_rows`.
+    /// A cohort entry for `peer`, on its own account - the neutral default,
+    /// since the rollup keys every count off `peer`.
     fn one(peer: PublicKey) -> CohortMember {
         CohortMember {
             peer,
@@ -1721,14 +1714,8 @@ mod migration_status_tests {
         }
     }
 
-    /// The cohort counts REPLICAS, and the account is what identifies the
-    /// person behind them.
-    ///
-    /// A caller holding only `peer` cannot name a member: peers render bs58 and
-    /// `list_group_members` is keyed by 64-hex accounts, so the two name
-    /// different principals and nothing errors when they are confused. Carrying
-    /// the account is what lets a caller say "one of alice's two devices is
-    /// stuck" rather than printing a key.
+    /// The cohort counts replicas, so two devices are two rows - but both must
+    /// name the same account, which is what groups them back into one member.
     #[test]
     fn two_devices_on_one_account_are_two_rows_naming_one_member() {
         let laptop = pk(0xA1);

--- a/crates/context/src/handlers/get_migration_status.rs
+++ b/crates/context/src/handlers/get_migration_status.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeSet;
 use actix::{ActorResponse, Handler, Message};
 use calimero_account::AccountId;
 use calimero_context_client::group::{
-    compute_migration_status_rollup, GetMigrationStatusRequest, MemberMigrationReport,
-    MigrationStatus,
+    compute_migration_status_rollup, CohortMember, GetMigrationStatusRequest,
+    MemberMigrationReport, MigrationStatus,
 };
 use calimero_context_config::types::ContextGroupId;
 use calimero_governance_store::{MembershipRepository, NamespaceRepository, UpgradesRepository};
@@ -26,7 +26,7 @@ use crate::ContextManager;
 pub fn collect_migration_cohort(
     store: &calimero_store::Store,
     namespace_id: &ContextGroupId,
-) -> eyre::Result<Vec<PublicKey>> {
+) -> eyre::Result<Vec<CohortMember>> {
     // `collect_descendants` EXCLUDES the starting group, so we prepend it.
     let mut groups = vec![*namespace_id];
     groups.extend(NamespaceRepository::new(store).collect_descendants(namespace_id)?);
@@ -46,15 +46,19 @@ pub fn collect_migration_cohort(
     // bindings of its own — reading them there returns nothing and the cohort
     // comes back empty, which reads as "every member has migrated".
     let anchor = NamespaceRepository::new(store).resolve(namespace_id)?;
-    let expand = |accounts: std::collections::BTreeSet<AccountId>| -> eyre::Result<Vec<PublicKey>> {
-        let bindings = calimero_governance_store::AccountBindingRepository::new(store)
-            .live_bindings(&anchor)?;
-        Ok(bindings
-            .iter()
-            .filter(|binding| accounts.contains(&binding.account))
-            .map(|binding| binding.sign_pk)
-            .collect())
-    };
+    let expand =
+        |accounts: std::collections::BTreeSet<AccountId>| -> eyre::Result<Vec<CohortMember>> {
+            let bindings = calimero_governance_store::AccountBindingRepository::new(store)
+                .live_bindings(&anchor)?;
+            Ok(bindings
+                .iter()
+                .filter(|binding| accounts.contains(&binding.account))
+                .map(|binding| CohortMember {
+                    peer: binding.sign_pk,
+                    account: binding.account,
+                })
+                .collect())
+        };
 
     if let Some(projected) =
         crate::scope_projection::ScopeProjections::member_identities_subtree_ephemeral(
@@ -332,11 +336,13 @@ mod tests {
 
         // The cohort over the subtree rooted at the child must include BOTH.
         let cohort = collect_migration_cohort(&store, &child).unwrap();
+        // Compare on `peer`: the cohort now carries the account alongside it.
+        let peers: Vec<_> = cohort.iter().map(|m| m.peer).collect();
         assert!(
-            cohort.contains(&inherited),
+            peers.contains(&inherited),
             "inherited Open-subgroup member must be in the cohort, not dropped by count()"
         );
-        assert!(cohort.contains(&direct));
+        assert!(peers.contains(&direct));
         assert_eq!(cohort.len(), 2);
         assert!(
             cohort.len() > direct_count,

--- a/crates/context/src/handlers/get_migration_status.rs
+++ b/crates/context/src/handlers/get_migration_status.rs
@@ -336,7 +336,6 @@ mod tests {
 
         // The cohort over the subtree rooted at the child must include BOTH.
         let cohort = collect_migration_cohort(&store, &child).unwrap();
-        // Compare on `peer`: the cohort now carries the account alongside it.
         let peers: Vec<_> = cohort.iter().map(|m| m.peer).collect();
         assert!(
             peers.contains(&inherited),

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1519,10 +1519,8 @@ pub struct MemberMigrationStatusApiEntry {
     /// The reporting device key, bs58. A member with two devices appears twice.
     pub peer: PublicKey,
     /// The account `peer` speaks for, 64 hex. Joins these rows to the
-    /// account-keyed `GET /groups/:id/members`, which carries `name`.
-    ///
-    /// `None` only from a node predating the field; defaulting it instead would
-    /// name a principal that exists nowhere.
+    /// account-keyed `GET /groups/:id/members`. `None` only from a node
+    /// predating the field - a default would name a principal that exists nowhere.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account: Option<AccountId>,
     /// The member's freshest reported facts, or `null` when it has no fresh
@@ -2682,12 +2680,8 @@ mod tests {
         assert!(!resp.group_created);
     }
 
-    /// A node predating `account` omits it, and a newer client must still parse
-    /// that response rather than fail the whole read.
-    ///
-    /// The absent case has to stay ABSENT, not default to a zero account: that
-    /// would hand the caller a principal-shaped value naming nobody, which is
-    /// the exact confusion the field was added to remove.
+    /// A node predating `account` omits it and must still parse. Absent stays
+    /// absent: a zero account would name a principal that exists nowhere.
     #[test]
     fn a_member_entry_without_an_account_still_deserializes() {
         let json = serde_json::json!({

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1535,7 +1535,13 @@ pub struct MemberMigrationStatusApiEntry {
     /// Without it a caller holds a signing key and cannot name the human it
     /// belongs to, because the two encodings name different principals and
     /// nothing errors when they are confused.
-    pub account: AccountId,
+    ///
+    /// `Option` for the deserialize side only: a node predating this field omits
+    /// it, and a client must still parse that response. A zero account instead
+    /// would hand the caller a principal-shaped value naming nobody - the very
+    /// confusion this field exists to remove. A node that has it always sends it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account: Option<AccountId>,
     /// The member's freshest reported facts, or `null` when it has no fresh
     /// heartbeat (in which case `state == "unknown"`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2693,6 +2699,33 @@ mod tests {
         assert!(!resp.group_created);
     }
 
+    /// A node predating `account` omits it, and a newer client must still parse
+    /// that response rather than fail the whole read.
+    ///
+    /// The absent case has to stay ABSENT, not default to a zero account: that
+    /// would hand the caller a principal-shaped value naming nobody, which is
+    /// the exact confusion the field was added to remove.
+    #[test]
+    fn a_member_entry_without_an_account_still_deserializes() {
+        let json = serde_json::json!({
+            "targetVersion": 2,
+            "expectedMembers": 1,
+            "rollup": {
+                "migrated": 1, "inProgress": 0, "unknown": 0, "failed": 0,
+                "total": 1, "allMigrated": true, "membersPendingSignature": 0
+            },
+            "members": [{ "peer": PublicKey::from([0x11; 32]), "state": "migrated" }]
+        });
+
+        let resp: GetMigrationStatusApiResponse =
+            serde_json::from_value(json).expect("an older node's response must still parse");
+
+        assert_eq!(
+            resp.members[0].account, None,
+            "absent must stay absent - a zero account would name nobody"
+        );
+    }
+
     #[test]
     fn migration_status_response_serializes_rollup_and_members() {
         // The `get_migration_status` admin route (Task 6c.10) returns this
@@ -2720,7 +2753,7 @@ mod tests {
             members: vec![
                 MemberMigrationStatusApiEntry {
                     peer: migrated_peer,
-                    account: AccountId::from(*migrated_peer),
+                    account: Some(AccountId::from(*migrated_peer)),
                     report: Some(MemberMigrationReportApiData {
                         schema_version: 2,
                         residue_auto: 0,
@@ -2734,13 +2767,13 @@ mod tests {
                 },
                 MemberMigrationStatusApiEntry {
                     peer: unknown_peer,
-                    account: AccountId::from(*unknown_peer),
+                    account: Some(AccountId::from(*unknown_peer)),
                     report: None,
                     state: "unknown".into(),
                 },
                 MemberMigrationStatusApiEntry {
                     peer: failed_peer,
-                    account: AccountId::from(*failed_peer),
+                    account: Some(AccountId::from(*failed_peer)),
                     report: Some(MemberMigrationReportApiData {
                         schema_version: 1,
                         residue_auto: 1,

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1524,8 +1524,18 @@ pub struct MemberMigrationReportApiData {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MemberMigrationStatusApiEntry {
-    /// The cohort member.
+    /// The cohort member: the DEVICE key that reports, bs58. A person holding
+    /// two devices appears twice.
     pub peer: PublicKey,
+    /// The account `peer` speaks for, 64 hex.
+    ///
+    /// The cohort is a set of replicas, so this is what groups a person's
+    /// devices, and it is the only field that joins these rows to
+    /// `GET /groups/:id/members` - which is account-keyed and carries `name`.
+    /// Without it a caller holds a signing key and cannot name the human it
+    /// belongs to, because the two encodings name different principals and
+    /// nothing errors when they are confused.
+    pub account: AccountId,
     /// The member's freshest reported facts, or `null` when it has no fresh
     /// heartbeat (in which case `state == "unknown"`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2710,6 +2720,7 @@ mod tests {
             members: vec![
                 MemberMigrationStatusApiEntry {
                     peer: migrated_peer,
+                    account: AccountId::from(*migrated_peer),
                     report: Some(MemberMigrationReportApiData {
                         schema_version: 2,
                         residue_auto: 0,
@@ -2723,11 +2734,13 @@ mod tests {
                 },
                 MemberMigrationStatusApiEntry {
                     peer: unknown_peer,
+                    account: AccountId::from(*unknown_peer),
                     report: None,
                     state: "unknown".into(),
                 },
                 MemberMigrationStatusApiEntry {
                     peer: failed_peer,
+                    account: AccountId::from(*failed_peer),
                     report: Some(MemberMigrationReportApiData {
                         schema_version: 1,
                         residue_auto: 1,

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1524,17 +1524,10 @@ pub struct MemberMigrationReportApiData {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MemberMigrationStatusApiEntry {
-    /// The cohort member: the DEVICE key that reports, bs58. A person holding
-    /// two devices appears twice.
+    /// The reporting device key, bs58. A member with two devices appears twice.
     pub peer: PublicKey,
-    /// The account `peer` speaks for, 64 hex.
-    ///
-    /// The cohort is a set of replicas, so this is what groups a person's
-    /// devices, and it is the only field that joins these rows to
-    /// `GET /groups/:id/members` - which is account-keyed and carries `name`.
-    /// Without it a caller holds a signing key and cannot name the human it
-    /// belongs to, because the two encodings name different principals and
-    /// nothing errors when they are confused.
+    /// The account `peer` speaks for, 64 hex. Joins these rows to the
+    /// account-keyed `GET /groups/:id/members`, which carries `name`.
     pub account: AccountId,
     /// The member's freshest reported facts, or `null` when it has no fresh
     /// heartbeat (in which case `state == "unknown"`).

--- a/crates/server/src/admin/handlers/groups/get_migration_status.rs
+++ b/crates/server/src/admin/handlers/groups/get_migration_status.rs
@@ -69,6 +69,7 @@ pub async fn handler(
                 .into_iter()
                 .map(|m| MemberMigrationStatusApiEntry {
                     peer: m.peer,
+                    account: m.account,
                     report: m.report.map(|r| MemberMigrationReportApiData {
                         schema_version: r.schema_version,
                         residue_auto: r.residue_auto,

--- a/crates/server/src/admin/handlers/groups/get_migration_status.rs
+++ b/crates/server/src/admin/handlers/groups/get_migration_status.rs
@@ -69,7 +69,7 @@ pub async fn handler(
                 .into_iter()
                 .map(|m| MemberMigrationStatusApiEntry {
                     peer: m.peer,
-                    account: m.account,
+                    account: Some(m.account),
                     report: m.report.map(|r| MemberMigrationReportApiData {
                         schema_version: r.schema_version,
                         residue_auto: r.residue_auto,


### PR DESCRIPTION
## Summary

**The problem:** `GET /groups/:id/migration-status` lists who has migrated, but each row only carries `peer` - a device signing key.
Every other member-facing API (`list_group_members`, display names, remove, role updates) is keyed by account.
So a caller gets a row saying "device `3xF9...` is stuck" and has no way to turn that into "alice".
Worse, both are 32 bytes, so confusing the two does not error - it just names a principal that exists nowhere.

**The fix:** carry the account that was already in hand.
`collect_migration_cohort` was already filtering bindings on `binding.account`, then throwing it away and keeping only `sign_pk`:

```rust
.filter(|binding| accounts.contains(&binding.account))
.map(|binding| binding.sign_pk)          // account discarded here
```

It now keeps both in a small `CohortMember { peer, account }` struct - named rather than a `(PublicKey, AccountId)` tuple precisely because a swap would compile, run, and name nobody.
That account flows through the rollup into the API response as a new `account` field.

**Effect:** a caller can join migration rows to `GET /groups/:id/members` (account-keyed, and already carrying `name`) and say "one of alice's two devices has not migrated".
Purely additive on the wire, so existing consumers are unaffected and mero-js can pick it up in a minor.

## Test plan

New: `two_devices_on_one_account_are_two_rows_naming_one_member` - two devices sharing one account, one migrated and one silent.
Asserts the cohort counts devices (`total == 2`), that the fleet stays un-migrated, that both rows name the same account, and that each keeps its own key.

Watched failing: deriving the account from the key instead of carrying it (`AccountId::from(**peer)`, the exact mistake the field prevents) fails with "both rows name the same member, which is what groups them".

- `cargo test -p calimero-context-client --lib` - 36 passing
- `cargo clippy --workspace --all-targets -- -D warnings` - clean
- `cargo fmt --check`, `cargo test --workspace --no-run` - clean

CI runs the full suite; local runs were cut short by a disk constraint after the gates above passed.
