### PR TITLE
ci(release): publish the kv-store bundle as a release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,7 +340,6 @@ jobs:
   # structurally cannot escape into real distribution.
   release-app-bundle:
     name: Release App Bundle
-    if: needs.prepare.outputs.binary_release == 'true'
     runs-on: ubuntu-latest
     needs: [prepare]
     concurrency:
@@ -368,7 +367,10 @@ jobs:
       - name: Build the kv-store bundle
         run: cargo mero bundle --dev --no-icon --app-version "${{ needs.prepare.outputs.version }}" --manifest-path apps/kv-store/Cargo.toml --output dist/kv-store-test-fixture.mpk
 
+      # Gated like `release-binaries`: a PR builds the bundle (so a break in
+      # `cargo mero bundle` fails the PR that caused it) but publishes nothing.
       - name: Upload the bundle to the release
+        if: needs.prepare.outputs.binary_release == 'true'
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,6 +326,58 @@ jobs:
           prerelease: ${{ needs.prepare.outputs.prerelease }}
           target_commit: ${{ needs.prepare.outputs.target_commit }}
 
+  # Publishes the kv-store demo app as a signed .mpk release asset, so a
+  # downstream SDK e2e (mero-js, mero-react) can fetch an app bundle from the
+  # SAME tag it fetches `merod` from, instead of committing a binary fixture
+  # that silently rots as the manifest schema moves. It also gives the release
+  # its only end-to-end exercise of `cargo-mero`: the toolchain is shipped as a
+  # binary below, but nothing else in this workflow actually runs `bundle`.
+  #
+  # Signed with the dev key on purpose. The dev seed is well-known and
+  # deterministic, so the bundle's ApplicationId -- hash(package, signer) -- is
+  # stable across every release, which is what makes it usable as a test
+  # fixture. The registry refuses dev-signed bundles, so this artifact
+  # structurally cannot escape into real distribution.
+  release-app-bundle:
+    name: Release App Bundle
+    if: needs.prepare.outputs.binary_release == 'true'
+    runs-on: ubuntu-latest
+    needs: [prepare]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}-${{ needs.prepare.outputs.version }}
+      cancel-in-progress: true
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Rust CI
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+          shared-key: release-app-bundle
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Setup cargo mero
+        uses: ./.github/actions/setup-cargo-mero
+
+      - name: Build the kv-store bundle
+        run: cargo mero bundle --dev --no-icon --app-version "${{ needs.prepare.outputs.version }}" --manifest-path apps/kv-store/Cargo.toml --output dist/kv-store-test-fixture.mpk
+
+      - name: Upload the bundle to the release
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/kv-store-test-fixture.mpk
+          tag: ${{ needs.prepare.outputs.version }}
+          release_name: ${{ needs.prepare.outputs.version }}
+          prerelease: ${{ needs.prepare.outputs.prerelease }}
+          target_commit: ${{ needs.prepare.outputs.target_commit }}
+
   release-crates:
     name: Release Crates
     if: needs.prepare.outputs.crate_release == 'true'


### PR DESCRIPTION
## What

Adds a `release-app-bundle` job that builds the kv-store demo app with `cargo mero bundle` and uploads the signed `.mpk` alongside the binary tarballs.

## Why

**1. Downstream SDK e2e fixtures rot silently.**

`mero-js` and `mero-react` need an installable app to exercise their hooks against a live node, so they commit a `.mpk` fixture. That fixture is frozen while their CI floats `merod` to the latest release (`gh release list --limit 1`), so the two drift apart until the node rejects the bundle.

That is not hypothetical — it just happened. The fixture on `mero-react` predated the change making manifest artifact hashes required, and `merod` 0.11.0-rc.24 refuses it at parse time:

```
failed to parse manifest.json: invalid type: null, expected a string
  crates/node/primitives/src/client/application/bundle.rs:177
```

Reproduced locally against a released rc.24: install returns HTTP 500, and the whole e2e suite fails at `setupFixture`. Rebuilding the bundle from `master` and installing that instead makes it pass. The fixture had also drifted well beyond the hash — `wasm.path` moved `kv_store.wasm` → `app.wasm`, `name` moved under `metadata`, `migrations` disappeared, `handlers`/`links` appeared.

Publishing the bundle lets those suites fetch the app from the **same tag** they already fetch `merod` from, so the two cannot diverge. Their workflows already compute that tag.

**2. The release never exercises `cargo-mero`.**

`cargo-mero` ships from this workflow as a release binary and via Homebrew, but nothing here ever runs `bundle`. The app workflows cover it pre-merge; this adds the check on the release commit itself, and the artifact is the proof it produced something installable.

## On the dev key

Deliberate, not a shortcut:

- The dev seed is well-known and deterministic (`SHA-256("calimero-dev-signing-key-v1")`), so the ApplicationId — `hash(package, signer)`, per `install.rs:192` — is **stable across every release**. A production key would churn the app id whenever the signing secret rotated, which is the opposite of what a fixture wants.
- The node imposes no signer policy: install checks artifact hash integrity and the self-signature, nothing else. A dev-signed bundle installs cleanly (verified against rc.24).
- The registry **refuses** dev-signed bundles, so this artifact structurally cannot escape into real distribution.

Only one artifact is published, for the same reason. `hash(package, signer)` means the same package signed with two different keys yields two different ApplicationIds — two apps that no node considers related. Shipping both a dev- and a production-signed bundle would put two same-named `.mpk`s on the release page that silently install as different apps.

## Verification

Ran the exact job command against `master` locally:

```
cargo mero bundle --dev --no-icon --app-version 0.11.0-rc.24 \
  --manifest-path apps/kv-store/Cargo.toml --output dist/kv-store-test-fixture.mpk
```

- produces a 201 KiB bundle with real sha256 for both `app.wasm` and `abi.json`
- ApplicationId `Cfow1SkzdqiVvzy6MzBME9g6b4sgwBtetGHiBgfC9QHc`, identical whether `--app-version` is `0.0.0` or the release version, confirming appVersion does not affect app identity
- installs into a released rc.24 node via `installDevApplication`; `mero-react`'s e2e smoke suite passes against it

The job mirrors `build-apps` in `e2e-rust-apps.yml` (same `setup-rust-ci` + `setup-cargo-mero` actions) and `release-binaries` for the upload, and is gated on the same `binary_release` output.
