### PR TITLE
fix(store): bound WAL retention and flush every column family

### DIFF
--- a/crates/store/impl/rocksdb/src/lib.rs
+++ b/crates/store/impl/rocksdb/src/lib.rs
@@ -45,6 +45,7 @@
 //! method:
 //! - `max_open_files`: Controls file descriptor usage (default: 256)
 //! - Block cache: 128MB LRU cache for frequently accessed blocks
+//! - `max_total_wal_size`: Bounds write-ahead log retention (default: 256MB)
 //!
 //! If you need to adjust these settings, modify the `Options` in `RocksDB::open()`.
 
@@ -73,6 +74,23 @@ const DEFAULT_MAX_OPEN_FILES: i32 = 256;
 /// The block cache stores frequently accessed data blocks in memory,
 /// reducing disk I/O for hot data.
 const DEFAULT_BLOCK_CACHE_SIZE: usize = 128 * 1024 * 1024;
+
+/// Cap on the total size of write-ahead logs kept on disk (256MB).
+///
+/// RocksDB retains every WAL back to the oldest UNFLUSHED memtable across all
+/// column families, so a family that is written to rarely pins every log
+/// written since it last flushed — however much that is. With the per-family
+/// `write_buffer_size` at its 64MB default and 20+ families, cold ones such as
+/// `Meta` or `Generic` can go days without reaching that threshold while `State`
+/// flushes thousands of times, so the WAL grows without bound.
+///
+/// Observed on a real node before this cap: 19GB of WAL guarding 109MB of SST
+/// data, growing ~10GB/day, pinned by two families that had last flushed two
+/// days earlier. Setting this makes RocksDB flush whichever family holds the
+/// oldest log once the total crosses the cap, which lets the old logs be
+/// deleted. 256MB is far above normal steady-state need here and still bounds
+/// the directory.
+const DEFAULT_MAX_TOTAL_WAL_SIZE: u64 = 256 * 1024 * 1024;
 
 /// RocksDB database wrapper implementing the `Database` trait.
 ///
@@ -128,6 +146,11 @@ impl Database<'_> for RocksDB {
 
         // Configure block cache for better read performance.
         // This cache stores frequently accessed data blocks in memory.
+        // Bound the write-ahead log. Without this RocksDB keeps every WAL back
+        // to the oldest unflushed memtable, so one rarely-written column family
+        // pins them all (see DEFAULT_MAX_TOTAL_WAL_SIZE).
+        options.set_max_total_wal_size(DEFAULT_MAX_TOTAL_WAL_SIZE);
+
         let cache = rocksdb::Cache::new_lru_cache(DEFAULT_BLOCK_CACHE_SIZE);
         let mut block_opts = rocksdb::BlockBasedOptions::default();
         block_opts.set_block_cache(&cache);
@@ -264,7 +287,18 @@ impl Database<'_> for RocksDB {
         // durable WAL still covers every write. Called on controlled shutdown;
         // `Drop` runs the same sequence for the abrupt path.
         self.db.flush_wal(true)?;
-        self.db.flush()?;
+
+        // Every column family, not `self.db.flush()`. That maps to the C API's
+        // `rocksdb_flush`, which flushes the DEFAULT family only — and nothing
+        // in this store writes to `default`. So the previous call flushed an
+        // always-empty family while every real one (State, Delta, Blobs, ...)
+        // kept its memtable, and with it the WALs those memtables pin.
+        let handles = Column::iter()
+            .map(|column| self.try_cf_handle(column))
+            .collect::<EyreResult<Vec<_>>>()?;
+        self.db
+            .flush_cfs_opt(&handles, &rocksdb::FlushOptions::default())?;
+
         Ok(())
     }
 

--- a/crates/store/impl/rocksdb/src/tests.rs
+++ b/crates/store/impl/rocksdb/src/tests.rs
@@ -389,3 +389,58 @@ fn test_delete_range_drops_only_in_range_keys() {
         }
     }
 }
+
+#[test]
+fn flush_drains_every_column_family_not_only_default() {
+    // `DB::flush()` maps to the C API's `rocksdb_flush`, which flushes the
+    // DEFAULT column family only — and nothing in this store ever writes to
+    // `default`. A flush built on it therefore drained an always-empty family
+    // while every real one kept its memtable, and RocksDB retains every
+    // write-ahead log back to the oldest unflushed memtable. On a real node
+    // that left 19GB of WAL guarding 109MB of data, growing ~10GB/day.
+    //
+    // Asserting on the memtable rather than on disk size keeps this fast and
+    // deterministic: if the flush reaches this family, its active memtable is
+    // empty afterwards.
+    let dir = TempDir::with_prefix("_calimero_store_flush").expect("tempdir should be created");
+
+    let dir_path = dir
+        .path()
+        .to_owned()
+        .try_into()
+        .expect("path conversion should succeed");
+
+    let config = StoreConfig::new(dir_path);
+
+    let db = RocksDB::open(&config).expect("db should open");
+
+    let key = Slice::from(&b"key"[..]);
+    let value = Slice::from(&b"value"[..]);
+
+    db.put(Column::Identity, (&key).into(), (&value).into())
+        .expect("put should succeed");
+
+    let active_entries = |db: &RocksDB| {
+        let cf_handle = db
+            .try_cf_handle(Column::Identity)
+            .expect("cf handle should resolve");
+
+        db.db
+            .property_int_value_cf(cf_handle, "rocksdb.num-entries-active-mem-table")
+            .expect("property should be readable")
+            .expect("property should be reported")
+    };
+
+    assert!(
+        active_entries(&db) > 0,
+        "the write should still be buffered in Identity's memtable before the flush"
+    );
+
+    db.flush().expect("flush should succeed");
+
+    assert_eq!(
+        active_entries(&db),
+        0,
+        "flush must drain non-default column families, else their WAL is never released"
+    );
+}


### PR DESCRIPTION
## The symptom

A node's store directory reached **19 GB while holding 109 MB of data**:

| | files | size | share |
|---|---|---|---|
| `*.log` (write-ahead log) | 315 | **19.23 G** | 99.3% |
| `*.sst` (actual data) | 33 | 109 M | 0.5% |

Growing at **~10.7 GB/day** (108 WAL files one day, 170 the next). That fills a disk in days — which is how it was found.

## Why it grew without bound

RocksDB retains every WAL back to the oldest **unflushed** memtable across all column families. Two things stopped that point from advancing.

**1. `max_total_wal_size` was unset** (`0` = unlimited), so nothing ever forced a flush to release logs. With 22 column families each on the 64 MB default `write_buffer_size`, a family only flushes when its own memtable fills.

On the affected node, flush counts were:

```
State              4524      ← hot, flushes constantly
Meta / Generic       10 each ← cold
Config / Identity / Blobs   4 each
```

and last-flush points:

```
Meta, Generic    Aug 17 18:23    next log file 4502
State            Aug 19 13:32    next log file 5213
```

The oldest WAL on disk was `004502.log` — **exactly** `Meta`/`Generic`'s last flush point. Two tiny, cold families pinned 19 GB of logs describing writes that were already durable in the SSTs.

Capped at 256 MB, which is far above steady-state need for a store whose real data is ~109 MB, and lets RocksDB flush whichever family holds the oldest log once the total crosses it.

**2. `flush()` only flushed the default column family.** It called `DB::flush()`, which maps to the C API's `rocksdb_flush` — default CF only; the binding exposes `flush_cf`/`flush_cfs_opt` separately for a reason. Nothing in this store writes to `default`, so the call meant to drain memtables on controlled shutdown drained an always-empty family and left all 21 real ones (`State`, `Delta`, `Blobs`, `Group`, …) holding their memtables, and with them the WALs those memtables pin. The doc comment said "then flush memtables to SST"; it didn't.

## Verification

- **The regression test is not vacuous.** It writes to a non-default column, flushes, and requires that family's active memtable to be empty. Reverting the flush change fails it with `left: 1, right: 0` — the old code demonstrably leaves the write behind.
- **The cap reaches a real database.** Opening a fresh store and reading its `OPTIONS` file gives `max_total_wal_size=268435456`, where an affected node reports `0`.
- `cargo test -p calimero-store-rocksdb` — 7 passed; `cargo clippy --all-targets -- -D warnings` — clean; `cargo fmt --check` (1.88 toolchain) — clean.

## Existing nodes

No migration needed and no data loss: RocksDB replays the WAL on open and deletes the logs once flushed (`avoid_flush_during_recovery` is `0`), so an oversized directory collapses to its SST size after one restart. That one restart is slow in proportion to the backlog.
