### PR TITLE
refactor(authz)!: one subgroup climb, one possession check, refusals that name their cause

### DIFF
--- a/crates/authz/AGENTS.md
+++ b/crates/authz/AGENTS.md
@@ -30,23 +30,23 @@ cargo test -p calimero-authz inherited_membership_requires_open_chain_and_cap --
 | `AclView` | struct | The authorization-relevant slice of projected state at a causal cut - what `authorize` decides against |
 | `AclView::may(author, entity, required)` | fn | Data-plane check: explicit per-object ACL if one exists, else default-write-by-membership |
 | `AclView::is_scope_member(author)` | fn | Is `author` in any group in this view (backs default-write) |
-| `AclView::is_member_at_cut(group, author, root, default_cap_base)` | fn | Membership at the cut: direct, group-admin, or inherited over an open-subgroup chain |
+| `AclView::is_member_at_cut(group, author, root, default_cap_base)` | fn | Membership at the cut: direct, group-admin, or inherited over an open-subgroup chain. Defined as `member_path_at_cut(..) != None` |
 | `AclView::is_authorized_admin(group, author, root)` | fn | Admin authority at the cut: group admin, root admin, or admin of an ancestor over the open chain |
-| `AclView::member_path_at_cut(...)` | fn | Same walk as `is_member_at_cut`, returns the role-bearing `MemberPathAtCut` for enumeration callers |
+| `AclView::member_path_at_cut(...)` | fn | The walk itself; returns the role-bearing `MemberPathAtCut` for enumeration callers. `is_member_at_cut` is this with the role discarded |
 | `AclView::capability(group, member)` | fn | Effective capability bitmask: member override, else group default, else `0` |
 | `AclView::is_owner(author, object)` | fn | Owner = holds `OpMask::ADMIN` on `object` (confers writer-set rotation rights) |
 | `AclView::is_group_admin(author, group)` | fn | Folded group admin (subgroup creator / `Admin`-role holder) |
 | `AclView::is_root_admin(author)` | fn | Is `author` the scope's `root_admin` at the cut |
 | `MemberPathAtCut` | enum | `None` / `Direct { role }` / `Inherited { anchor, via_admin }` - how `author` reaches membership |
 | `SubgroupEdge` | struct | `{ parent: ScopeId, restricted: bool }` - a live subgroup's tree position + visibility at the cut |
-| `Rejected` | enum (`ThisError`) | `NotPermitted { required: OpMask }` / `NotOwner` / `NotGroupAdmin` / `NotRootAdmin` - one rejection type for every plane |
+| `Rejected` | enum (`ThisError`) | `NotPermitted { entity, required }` / `NotOwner` / `NotGroupAdmin` / `NotRootAdmin` - one rejection type for every plane |
 | `AccountBinding` | struct | `{ epoch, root_pk }` - an account's resolved root key at the cut |
 | `DeviceBinding` | struct | `{ account, sign_pk, kem_pk, device_epoch, key_epoch }` - a device's binding in force at the cut |
-| `admit_device_link(accounts, devices, revoked, genesis, chain, cert)` | fn | The single definition of when a `DeviceLinked` credential takes effect; shared with the projection's fold |
-| `fold_device_link(devices, revoked, genesis, chain, cert)` | fn | The order-independent half of the above - every rule more folding cannot change |
-| `admit_key_rotation(accounts, handoff)` | fn | When an `AccountKeysRotated` handoff continues the chain in force at the cut |
+| `AclView::admit_device_link(genesis, chain, cert)` | fn | The single definition of when a `DeviceLinked` credential takes effect; the at-cut half, shared with the projection's fold |
+| `fold_device_link(devices, revoked, genesis, chain, cert)` | fn | The order-independent half of the above - every rule more folding cannot change. Stays a free function: its caller is the fold, which is *building* the state a view is read from and has no `AclView` to pass |
+| `AclView::admit_key_rotation(handoff)` | fn | When an `AccountKeysRotated` handoff continues the chain in force at the cut |
 
-Three constants shape the rules above but are **crate-private**, so they are pinned by name here rather than importable: `DEFAULT_MEMBER_MASK` (`WRITE|DELETE`, what a plain member holds on a non-restricted entity), `CAN_JOIN_OPEN_SUBGROUPS` (mirrors `MemberCapabilities`, gates inherited membership), `MAX_NAMESPACE_DEPTH` (bound on the inheritance walk, sourced from `calimero-context-config`).
+`AclView::open_ancestors` is the crate-private climb all three inheritance questions share (yields the Open-reachable ancestors, nearest first, bounded by `MAX_NAMESPACE_DEPTH`, stopping at a `restricted` edge). Three constants also shape the rules above but are **crate-private**, so they are pinned by name here rather than importable: `DEFAULT_MEMBER_MASK` (`WRITE|DELETE`, what a plain member holds on a non-restricted entity), `CAN_JOIN_OPEN_SUBGROUPS` (mirrors `MemberCapabilities`, gates inherited membership), `MAX_NAMESPACE_DEPTH` (bound on the inheritance walk, sourced from `calimero-context-config`).
 
 ## How the pieces interact
 
@@ -72,13 +72,13 @@ walks the DAG — and the answer is a `Result`, never a mutation:
                                                  ├── owner ───▶ is_owner()
                                                  ├── group ───▶ is_group_admin()
                                                  ├── root ────▶ is_root_admin()
-                                                 ├── account ─▶ admit_device_link()
-                                                 │              admit_key_rotation()
+                                                 ├── account ─▶ view.admit_device_link()
+                                                 │              view.admit_key_rotation()
                                                  │
                                         Ok(()) ◀─┴─▶ Rejected
 ```
 
-**The rule that is deliberately shared.** `admit_device_link` has two callers in
+**The rule that is deliberately shared.** The link rule has two callers in
 two crates, and that is the whole point — a rule stated twice is how one node
 authorizes an op its peer folds differently, which is a `scope_root` divergence:
 
@@ -87,7 +87,7 @@ authorizes an op its peer folds differently, which is a `scope_root` divergence:
    decides at ONE fixed cut            walks ops ONE AT A TIME
         │                                          │
         ▼                                          │
-   admit_device_link                               │
+   AclView::admit_device_link                      │
         │  = fold_device_link + the supersession   │
         │    check, which needs a cut to mean      │
         ▼    anything                              ▼
@@ -145,7 +145,7 @@ never asks the inheritance questions itself; `crates/context` is what calls them
 
 - `calimero-op` defines the shared vocabulary this crate matches on: `Op`, `OpPayload`, `ScopeId`. `calimero-authz` takes `Op` as an opaque input and never constructs one.
 - `calimero-projection` (`ScopeState::acl_view_at`) is the *only* producer of `AclView` in the real system: it folds the op log up to a causal cut into the `acl` / `groups` / `root_admin` / `default_caps` / `member_caps` / `subgroups` / `group_admin` maps this crate reads. This crate deliberately has no code path that reads a live store - swapping in a synthetic `AclView` (as the unit tests do) fully exercises the decision logic.
-- `crates/context` (`scope_projection.rs`, `apply_authorizer.rs`) is the consumer: it calls `AclView::is_authorized_admin` / `is_member_at_cut` / `member_path_at_cut` directly (bypassing the `authorize` top-level match) wherever it needs a raw authority check outside the op-apply path, and re-exports `MemberPathAtCut` variants into its own `AtCutMembershipPath`.
+- `crates/context` (`scope_projection.rs`, `apply_authorizer.rs`) is the consumer: it filters its candidate set with `is_member_at_cut` and then resolves each survivor's role with `member_path_at_cut`, so those two agreeing is load-bearing - which is why one is now defined in terms of the other. It calls `AclView::is_authorized_admin` / `is_member_at_cut` / `member_path_at_cut` directly (bypassing the `authorize` top-level match) wherever it needs a raw authority check outside the op-apply path, and re-exports `MemberPathAtCut` variants into its own `AtCutMembershipPath`.
 - `calimero-governance-store` is a separate, legacy governance path; it depends on `calimero-op` (for `unified_op_decode`) but not on `calimero-authz` - it is not part of the unified-log authorization flow this crate guards.
 
 ## JIT Index
@@ -174,22 +174,25 @@ Every public item is re-exported flat from `src/lib.rs`, so `calimero_authz::Acl
 | Path | What's there |
 | --- | --- |
 | `src/lib.rs` | Crate docs (the WHY), module declarations, and the flat `pub use` facade |
-| `src/authorize.rs` | `authorize`, `required_mask_for`, `check_data`, and the `check_device_speaks_for_author` precondition |
+| `src/authorize.rs` | `authorize`, `required_mask_for`, `check_data`, `check_op_is_the_certified_device` (the possession half both credential arms share), and the `check_device_speaks_for_author` precondition |
 | `src/view.rs` | `AclView` + `AccountBinding` / `DeviceBinding` / `SubgroupEdge`, `DEFAULT_MEMBER_MASK`, and the single-lookup predicates |
-| `src/inheritance.rs` | The subgroup-tree walk: `is_member_at_cut`, `is_authorized_admin`, `member_path_at_cut`, `MemberPathAtCut` |
-| `src/admission.rs` | `admit_device_link`, `fold_device_link`, `admit_key_rotation` - the rules shared with the projection's fold |
+| `src/inheritance.rs` | The shared subgroup-tree climb (`open_ancestors`) and the three questions over it: `is_member_at_cut`, `is_authorized_admin`, `member_path_at_cut`, `MemberPathAtCut` |
+| `src/admission.rs` | `AclView::admit_device_link`, `AclView::admit_key_rotation`, `fold_device_link` - the rules shared with the projection's fold |
 | `src/error.rs` | `Rejected` |
 | `src/tests.rs` | Declares the test tree; every test in the crate lives under `src/tests/` |
 | `src/tests/<module>.rs` | Tests for the module of the same name, reaching it through `crate::` paths |
 | `src/tests/support.rs` | Shared fixtures (`op_with`, `bind_account`, `bind_test_devices`, `view_with_writer`, `inheritance_view`, `membership_view`) |
+| `src/tests/inheritance_climb.rs` | The pre-refactor walks, kept verbatim as oracles, swept over every small tree against the shared climb |
 
 ## Invariants and Gotchas
 
-- **`required_mask_for` returns `Option`, not `OpMask::NONE`, on purpose**: the empty mask is contained by *every* mask, so a `NONE` requirement fed into `AclView::may` would authorize anyone. `None` makes that misuse a type error instead of a silent bypass. `authorize` itself doesn't call `required_mask_for` - each data arm inlines its literal mask so there's no `Option::unwrap` that could panic or silently fall through if the arms ever drift; the function stays as the public helper for external callers.
+- **`required_mask_for` returns `Option`, not `OpMask::NONE`, on purpose**: the empty mask is contained by *every* mask, so a `NONE` requirement fed into `AclView::may` would authorize anyone. `None` makes that misuse a type error instead of a silent bypass. `authorize` itself doesn't call `required_mask_for` - each data arm inlines its literal mask so there's no `Option::unwrap` that could panic or silently fall through if the arms ever drift. That leaves the payload→mask mapping written twice, so `required_mask_for_agrees_with_the_mask_authorize_enforces` pins the two together by comparing the helper's answer against the mask `authorize` reports refusing on. The helper currently has **no callers outside this crate**; the drift test is what earns it its keep.
 - **`DEFAULT_MEMBER_MASK` excludes `ADMIN` deliberately**: any scope member can `Put`/`Delete` a non-restricted entity, but rotating its writer set (`SetWriters`) always requires an explicit ownership grant. A single compromised member can wipe default data but can't lock others out of it.
 - **Ownership == holding `OpMask::ADMIN`** (`is_owner` is literally `may(author, object, ADMIN)`). If owner ever needs to diverge from admin/writer capability, this is the one place to change.
 - **The inheritance walk is at-cut, not live**: a membership the cut revokes is not granted, even if the revocation is later in wall-clock time than when the op was authored - this is the whole reason the walk is duplicated here instead of reusing a live-store membership check. See the `inherited_membership_requires_open_chain_and_cap` test's "THE over-auth case" for the scenario this guards against.
-- **`is_member_at_cut` vs `is_authorized_admin` vs `member_path_at_cut` walk order differs by necessity**: `member_path_at_cut` checks the direct row before the admin carve-out (so a stored role wins when an identity is both a stored member and the genesis admin, matching live's `list` semantics); `is_member_at_cut` only needs a bool so its order doesn't matter. Don't unify them without re-checking both call sites.
+- **The three inheritance questions share one climb, and only their success conditions differ**: `AclView::open_ancestors` is the loop; `member_path_at_cut` checks the direct row before the admin carve-out (so a stored role wins when an identity is both a stored member and the genesis admin, matching live's `list` semantics), and `is_member_at_cut` is now literally that walk with the role discarded. The order that once differed between them only ever decided which *role* was reported, never *whether* the author was a member - `src/tests/inheritance_climb.rs` keeps the pre-refactor walks as independent oracles and sweeps every small tree to hold that. Do not refactor those oracles to share code with the crate; a duplicate is the whole point of an oracle.
+- **`is_authorized_admin` is the one place the GLOBAL root admin counts**: admin *authority* reaches every group, but membership does not - the root admin is a member of a subgroup only over the open chain, never of a Restricted one. `is_membership_admin` is therefore deliberately narrower than the admin predicate `is_authorized_admin` builds.
+- **"Account unknown" and "wrong epoch" are separate rotation refusals**: `RotationAccountUnknown` means nothing has linked a device of the account into this scope, `RotationNotContinuous { expected, found }` means it is known and the handoff starts at the wrong epoch. They shared one variant until they were split; `calimero-governance-store`'s `BindingRejected::RotationNotContinuous` still conflates the same two causes on the legacy governance path.
 - **`root: Option<(ContextGroupId, PublicKey)>` is the one un-folded fact**: the namespace's genesis admin has no governance op (it's set at backfill), so every membership/admin function takes it as an explicit out-of-band parameter rather than expecting it in `AclView`.
 - **An open-subgroup self-join (`MemberJoinedOpen`) is never folded as a direct row**: it's deliberately re-derived by the inheritance walk each time, so removing the anchor ancestor correctly revokes it - folding it as a direct membership would make it survive the anchor's removal.
 - **Restricted edges are a hard wall**: hitting one anywhere in the walk stops it immediately, even if an admin sits further up the chain past the wall.

--- a/crates/authz/src/admission.rs
+++ b/crates/authz/src/admission.rs
@@ -1,91 +1,137 @@
 //! Credential admission — the rules [`crate::authorize`] and the projection's
 //! fold must agree on, defined once so they cannot drift.
 //!
-//! Duplicating any rule here in two places is exactly how one node authorizes an
-//! op its peer folds differently, and that is a `scope_root` divergence.
+//! # Why it is shaped this way
+//!
+//! **One definition, two callers, two planes.** Stating a rule here and again in
+//! the projection is exactly how one node authorizes an op its peer folds
+//! differently, and that is a `scope_root` divergence — the two planes would
+//! disagree about the same op with no later op to reconcile them.
+//!
+//! **Why the rule is split in two.** The two callers need it at different
+//! moments, and only one of them has a cut:
+//!
+//! - [`AclView::admit_device_link`] is what `authorize` calls. It decides against
+//!   a fixed causal cut, so "has this signing epoch been superseded *at the cut*"
+//!   is a well-defined question and is asked here.
+//! - [`fold_device_link`] is what the projection's fold calls, walking ops one at
+//!   a time. The same supersession question there would read whichever epoch
+//!   happened to be folded so far, making admission depend on delivery order and
+//!   the projection non-convergent. The fold therefore records the link and
+//!   filters superseded ones out when the view is read, once the final epoch is
+//!   known.
+//!
+//! Both paths agree on the observable state; they just get there in the order
+//! each can afford. Everything in [`fold_device_link`] is monotone — a tombstone
+//! is never removed, a device is never un-assigned from its account, an epoch only
+//! rises — which is what lets any fold order reach the same result.
+//!
+//! **The at-cut half takes `&self`, the fold half does not.** `authorize` always
+//! holds an [`AclView`]; the fold is *building* the state a view is later read
+//! from and has no view to offer. That is the whole reason one is a method and the
+//! other stays a free function, rather than both taking the maps loose.
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use calimero_account::{
-    AccountGenesis, AccountId, DeviceCert, DeviceId, RootKeyHandoff, VerifiedDeviceCert,
-};
+use calimero_account::{AccountGenesis, DeviceCert, DeviceId, RootKeyHandoff, VerifiedDeviceCert};
 
 use crate::error::Rejected;
-use crate::view::{AccountBinding, DeviceBinding};
+use crate::view::{AclView, DeviceBinding};
 
-/// Decide whether a `DeviceLinked` credential takes effect at a cut.
-///
-/// **This is the single definition of the rule.** Both [`crate::authorize`] and the
-/// projection's fold call it, so the log can never contain a link the state
-/// ignored, nor fold a link authorization refused. Duplicating the rule in two
-/// places is exactly how one node authorizes an op its peer folds differently,
-/// and that is a `scope_root` divergence.
-///
-/// The checks, in order:
-/// 1. the credential is internally valid — the genesis addresses the claimed
-///    account and the handoff chain carries valid signatures up to the
-///    certificate's epoch (`calimero-account`);
-/// 2. the signing epoch has not been superseded at this cut, so rotating the
-///    root key actually withdraws the old key's authority instead of merely
-///    adding a new key beside it;
-/// 3. the device has not been revoked — read from the grow-only revoked set,
-///    which is what makes a revocation that folds *before* its link still win;
-/// 4. a device is never reassigned to another account;
-/// 5. a re-link strictly advances the device's rotation epoch, so an old
-///    certificate cannot be replayed to reinstate a retired key;
-/// 6. on first link, no other device in the scope already claims the same
-///    replica seed prefix — which turns RGA id uniqueness from a birthday
-///    argument into a checked invariant.
-///
-/// Deliberately **not** checked here: whether the account is a member of the
-/// scope. That is policy rather than credential validity, it only bears on the
-/// authorization decision, and leaving it out keeps the fold a pure function of
-/// already-authorized ops.
-///
-/// # Errors
-/// The `Credential*` / `Device*` variants of [`Rejected`], one per rule above.
-pub fn admit_device_link(
-    accounts: &BTreeMap<AccountId, AccountBinding>,
-    devices: &BTreeMap<DeviceId, DeviceBinding>,
-    revoked: &BTreeSet<DeviceId>,
-    genesis: &AccountGenesis,
-    chain: &[RootKeyHandoff],
-    cert: &DeviceCert,
-) -> Result<VerifiedDeviceCert, Rejected> {
-    let verified = fold_device_link(devices, revoked, genesis, chain, cert)?;
+impl AclView {
+    /// Decide whether a `DeviceLinked` credential takes effect at this cut.
+    ///
+    /// The checks, in order:
+    /// 1. the credential is internally valid — the genesis addresses the claimed
+    ///    account and the handoff chain carries valid signatures up to the
+    ///    certificate's epoch (`calimero-account`);
+    /// 2. the signing epoch has not been superseded at this cut, so rotating the
+    ///    root key actually withdraws the old key's authority instead of merely
+    ///    adding a new key beside it;
+    /// 3. the device has not been revoked — read from the grow-only revoked set,
+    ///    which is what makes a revocation that folds *before* its link still win;
+    /// 4. a device is never reassigned to another account;
+    /// 5. a re-link strictly advances the device's rotation epoch, so an old
+    ///    certificate cannot be replayed to reinstate a retired key;
+    /// 6. on first link, no other device in the scope already claims the same
+    ///    replica seed prefix — which turns RGA id uniqueness from a birthday
+    ///    argument into a checked invariant.
+    ///
+    /// Deliberately **not** checked here: whether the account is a member of the
+    /// scope. That is policy rather than credential validity, it only bears on the
+    /// authorization decision, and leaving it out keeps the fold a pure function
+    /// of already-authorized ops — `authorize`'s `DeviceLinked` arm is what asks
+    /// the membership question.
+    ///
+    /// # Errors
+    /// The `Credential*` / `Device*` variants of [`Rejected`], one per rule above.
+    pub fn admit_device_link(
+        &self,
+        genesis: &AccountGenesis,
+        chain: &[RootKeyHandoff],
+        cert: &DeviceCert,
+    ) -> Result<VerifiedDeviceCert, Rejected> {
+        let verified =
+            fold_device_link(&self.devices, &self.revoked_devices, genesis, chain, cert)?;
 
-    // Supersession is checked HERE and not in [`fold_device_link`], because the
-    // two callers need it at different moments. `authorize` decides against a
-    // fixed causal cut, so "has this epoch been superseded *at the cut*" is a
-    // well-defined question. The fold walks ops one at a time, where the same
-    // question would read whatever epoch happened to be folded so far — making
-    // admission depend on delivery order, and the projection non-convergent.
-    // The fold therefore records the link and filters superseded ones out when
-    // the view is read, once the final epoch is known. Both paths agree on the
-    // observable state; they just get there in the order each can afford.
-    if let Some(binding) = accounts.get(&verified.account) {
-        if verified.key_epoch < binding.epoch {
-            return Err(Rejected::CredentialSuperseded {
-                signed: verified.key_epoch,
-                current: binding.epoch,
-            });
+        // Step 2, the one check that needs a cut to mean anything — see the module
+        // docs for why it cannot live in the fold half.
+        if let Some(binding) = self.accounts.get(&verified.account) {
+            if verified.key_epoch < binding.epoch {
+                return Err(Rejected::CredentialSuperseded {
+                    signed: verified.key_epoch,
+                    current: binding.epoch,
+                });
+            }
         }
+
+        Ok(verified)
     }
 
-    Ok(verified)
+    /// Decide whether an `AccountKeysRotated` handoff takes effect at this cut.
+    ///
+    /// Admissible only if the scope already knows the account (it learned the
+    /// genesis from a device link) and the handoff continues the chain from the
+    /// epoch currently in force, signed by the key currently in force.
+    ///
+    /// # Errors
+    /// [`Rejected::RotationAccountUnknown`] when the scope has no chain for the
+    /// account, [`Rejected::RotationNotContinuous`] when the handoff starts at the
+    /// wrong epoch, or [`Rejected::RotationSignatureInvalid`] when the outgoing key
+    /// did not sign it.
+    pub fn admit_key_rotation(&self, handoff: &RootKeyHandoff) -> Result<(), Rejected> {
+        let Some(binding) = self.accounts.get(&handoff.account) else {
+            return Err(Rejected::RotationAccountUnknown {
+                account: handoff.account,
+            });
+        };
+        if handoff.from_epoch != binding.epoch {
+            return Err(Rejected::RotationNotContinuous {
+                expected: binding.epoch,
+                found: handoff.from_epoch,
+            });
+        }
+        if binding
+            .root_pk
+            .verify_raw_signature(&handoff.payload(), &handoff.signature)
+            .is_err()
+        {
+            return Err(Rejected::RotationSignatureInvalid);
+        }
+        Ok(())
+    }
 }
 
-/// The order-independent half of [`admit_device_link`] — every rule whose
+/// The order-independent half of [`AclView::admit_device_link`] — every rule whose
 /// answer cannot change as more ops fold in.
 ///
-/// Each check here is monotone: a revocation tombstone is never removed, a
-/// device is never un-assigned from its account, and the device epoch only ever
-/// rises. So folding these in any order reaches the same result, which is what
-/// keeps `scope_root` convergent.
+/// Takes the two maps loose rather than an [`AclView`] because its caller is the
+/// projection's fold, which is *building* the state a view is later read from and
+/// has none to pass. See the module docs.
 ///
 /// # Errors
 /// The `Credential*` / `Device*` variants of [`Rejected`], excluding
-/// [`Rejected::CredentialSuperseded`] — see [`admit_device_link`].
+/// [`Rejected::CredentialSuperseded`] — see [`AclView::admit_device_link`].
 pub fn fold_device_link(
     devices: &BTreeMap<DeviceId, DeviceBinding>,
     revoked: &BTreeSet<DeviceId>,
@@ -127,34 +173,4 @@ pub fn fold_device_link(
     }
 
     Ok(verified)
-}
-
-/// Decide whether an `AccountKeysRotated` handoff takes effect at a cut.
-///
-/// Shared by [`crate::authorize`] and the fold, for the same no-drift reason as
-/// [`admit_device_link`]. A rotation is admissible only if the scope already
-/// knows the account (it learned the genesis from a device link) and the
-/// handoff continues the chain from the epoch currently in force, signed by the
-/// key currently in force.
-///
-/// # Errors
-/// [`Rejected::RotationNotContinuous`] or [`Rejected::RotationSignatureInvalid`].
-pub fn admit_key_rotation(
-    accounts: &BTreeMap<AccountId, AccountBinding>,
-    handoff: &RootKeyHandoff,
-) -> Result<(), Rejected> {
-    let Some(binding) = accounts.get(&handoff.account) else {
-        return Err(Rejected::RotationNotContinuous);
-    };
-    if handoff.from_epoch != binding.epoch {
-        return Err(Rejected::RotationNotContinuous);
-    }
-    if binding
-        .root_pk
-        .verify_raw_signature(&handoff.payload(), &handoff.signature)
-        .is_err()
-    {
-        return Err(Rejected::RotationSignatureInvalid);
-    }
-    Ok(())
 }

--- a/crates/authz/src/authorize.rs
+++ b/crates/authz/src/authorize.rs
@@ -4,14 +4,50 @@
 //! for the account it claims, and does that account hold the authority the
 //! payload needs. Everything else in the crate exists to answer one of those two
 //! questions.
+//!
+//! # Why it is shaped this way
+//!
+//! **Stage one is resolved from the cut, never from live store.** `Op::verify`
+//! already proved the signature genuine; that is integrity, not authority. Only
+//! the cut knows which links and revocations are in force, and a verdict that
+//! depended on receiver state would let two nodes disagree about the same op and
+//! diverge on `scope_root`.
+//!
+//! **Two payloads skip stage one, and only those two.** `DeviceLinked` is the op
+//! that *establishes* a binding, so it cannot be asked to present one; its own
+//! admission rules stand in. `MemberJoinedWithDevice` carries its credential for
+//! the same reason, at the one cut where the binding provably cannot have folded
+//! yet — the op establishing it is this one. Both then make the possession check
+//! in [`check_op_is_the_certified_device`], which is the part that keeps the
+//! exemption from becoming a hole.
+//!
+//! **The data arms inline their masks instead of calling
+//! [`required_mask_for`].** Each arm carries its literal required mask, so there
+//! is no `Option` to unwrap and no fallback arm that could silently deny — or
+//! panic — if the arms ever drift. The cost is that the payload→mask mapping
+//! exists twice; `required_mask_for_agrees_with_the_mask_authorize_enforces` is
+//! what keeps the copies honest, since a comment cannot.
+//!
+//! **The `MemberJoinedWithDevice` arm fails closed for an ordinary self-service
+//! join, on purpose.** A join's real warrant is the admin-signed invitation, and
+//! `OpPayload` has nowhere to put one — so this gate cannot decide a join in the
+//! affirmative, and a gate that cannot decide must refuse rather than guess. A
+//! genuine non-admin joiner is therefore rejected. That is survivable only
+//! because the live governance apply is what actually gates a join today;
+//! `authorize` has no caller on the join path.
+//!
+//! **Do not wire `authorize` into the join path until the invitation is carried
+//! in the payload** — doing so would refuse every self-service join. The
+//! credential half IS decidable from the op alone, so it is decided here rather
+//! than deferred: without it the arm would accept whatever bytes the payload
+//! carried, which is a worse trap than refusing.
 
-use calimero_account::AccountId;
+use calimero_account::{AccountId, VerifiedDeviceCert};
 use calimero_context_config::types::ContextGroupId;
 use calimero_op::{Op, OpPayload};
 use calimero_storage::address::Id;
 use calimero_storage::entities::OpMask;
 
-use crate::admission::{admit_device_link, admit_key_rotation};
 use crate::error::Rejected;
 use crate::view::AclView;
 
@@ -22,6 +58,9 @@ use crate::view::AclView;
 /// contained by *every* mask, so a `NONE` requirement fed to [`AclView::may`]
 /// would authorize anyone — a footgun if a non-data payload ever reached a
 /// `may` check. `None` makes that misuse impossible to express.
+///
+/// `authorize` does not call this — see the module docs — so it is a helper for
+/// callers outside the decision, held to the same answer by test.
 #[must_use]
 pub fn required_mask_for(payload: &OpPayload) -> Option<OpMask> {
     match payload {
@@ -41,8 +80,38 @@ fn check_data(
     if acl_at_cut.may(author, entity, required) {
         Ok(())
     } else {
-        Err(Rejected::NotPermitted { required })
+        Err(Rejected::NotPermitted { entity, required })
     }
+}
+
+/// The possession half of a credential-bearing op: was it authored by the very
+/// device the certificate grants, on behalf of the very account it grants to?
+///
+/// Both credential arms need exactly this, and needed it identically — written
+/// out twice, the two could come to disagree about which of `device`, `device_key`
+/// and `account` must match, and the weaker copy would be the one an attacker
+/// used. Without it, anyone who observed a certificate could replay it and act on
+/// the real device's behalf; requiring possession makes the op an act OF the
+/// device rather than an assertion about it.
+fn check_op_is_the_certified_device(
+    op: &Op,
+    verified: &VerifiedDeviceCert,
+) -> Result<(), Rejected> {
+    if op.authorship.device_key != verified.sign_pk || op.authorship.device != verified.device {
+        return Err(Rejected::DeviceKeyStale {
+            device: verified.device,
+        });
+    }
+    // And that the account it acts as is the one the certificate grants to,
+    // rather than any account the payload cared to name.
+    if op.author() != verified.account {
+        return Err(Rejected::DeviceAccountMismatch {
+            device: verified.device,
+            bound: verified.account,
+            claimed: op.author(),
+        });
+    }
+    Ok(())
 }
 
 /// Authorize `op` against `acl_at_cut` — the [`AclView`] resolved at
@@ -52,18 +121,7 @@ fn check_data(
 /// Returns the plane-specific [`Rejected`] reason when the author lacks the
 /// authority the op's payload requires.
 pub fn authorize(op: &Op, acl_at_cut: &AclView) -> Result<(), Rejected> {
-    // Stage one: does the key that signed this op currently speak for the
-    // account the op claims? `Op::verify` already proved the signature genuine;
-    // that is integrity, not authority. Only the cut knows which links and
-    // revocations are in force, which is why the binding is resolved here and
-    // never from live store — a verdict that depended on receiver state would
-    // let two nodes disagree about the same op and diverge on `scope_root`.
-    //
-    // `DeviceLinked` is exempt because it is the op that *establishes* a
-    // binding; its own admission rules stand in for this check.
-    // A join carries its own credential for the same reason, and carries it at
-    // the one cut where the binding provably cannot have folded yet — the op
-    // establishing it is this one.
+    // Stage one — see the module docs for why these two payloads are exempt.
     if !matches!(
         op.payload,
         OpPayload::DeviceLinked { .. } | OpPayload::MemberJoinedWithDevice { .. }
@@ -73,10 +131,6 @@ pub fn authorize(op: &Op, acl_at_cut: &AclView) -> Result<(), Rejected> {
 
     // Stage two: does that account hold the authority this payload needs?
     match &op.payload {
-        // Split per data op so each carries its literal required mask — no
-        // `Option` to unwrap, so there is no unreachable fallback that could
-        // silently deny (or panic) if the arms ever drift. `required_mask_for`
-        // remains the public helper for external callers.
         OpPayload::Put { entity, .. } => {
             check_data(acl_at_cut, &op.author(), *entity, OpMask::WRITE)
         }
@@ -97,24 +151,8 @@ pub fn authorize(op: &Op, acl_at_cut: &AclView) -> Result<(), Rejected> {
                 Err(Rejected::NotGroupAdmin)
             }
         }
-        // **This arm FAILS CLOSED for an ordinary self-service join, on purpose.**
-        //
-        // A join's real warrant is the admin-signed invitation, and `OpPayload`
-        // has nowhere to put one — so this gate cannot decide a join in the
-        // affirmative, and a gate that cannot decide must refuse rather than
-        // guess. A genuine non-admin joiner is therefore rejected here. That is
-        // survivable only because the live governance apply is what actually
-        // gates a join today; `authorize` has no caller on the join path.
-        //
-        // **Do not wire `authorize` into the join path until the invitation is
-        // carried in the payload** — doing so would refuse every self-service
-        // join. Giving it a home, and with it a rule that can succeed for a
-        // non-admin joiner, belongs with moving the principal fields to
-        // `AccountId`.
-        //
-        // The credential half IS decidable from the op alone, so it is decided
-        // here rather than deferred: without it this arm would accept whatever
-        // bytes the payload carried, which is a worse trap than refusing.
+        // FAILS CLOSED for an ordinary self-service join — see the module docs
+        // before giving this arm a caller.
         OpPayload::MemberJoinedWithDevice {
             group,
             genesis,
@@ -122,37 +160,12 @@ pub fn authorize(op: &Op, acl_at_cut: &AclView) -> Result<(), Rejected> {
             cert,
             ..
         } => {
-            let verified = admit_device_link(
-                &acl_at_cut.accounts,
-                &acl_at_cut.devices,
-                &acl_at_cut.revoked_devices,
-                genesis,
-                chain,
-                cert,
-            )?;
-            // The same possession check the `DeviceLinked` arm makes, which a
-            // join could not carry while its authorship was derived from the
-            // signing key: the device it names was fiction, so comparing against
-            // it refused every honest join. The op now names the device its
-            // certificate grants, so requiring the join to be signed BY that
-            // device is decidable — and without it, anyone who observed a
-            // certificate could replay it and join on the real device's behalf.
-            if op.authorship.device_key != verified.sign_pk
-                || op.authorship.device != verified.device
-            {
-                return Err(Rejected::DeviceKeyStale {
-                    device: verified.device,
-                });
-            }
-            // And that the account it joins as is the one the certificate
-            // grants to, rather than any account the payload cared to name.
-            if op.author() != verified.account {
-                return Err(Rejected::DeviceAccountMismatch {
-                    device: verified.device,
-                    bound: verified.account,
-                    claimed: op.author(),
-                });
-            }
+            let verified = acl_at_cut.admit_device_link(genesis, chain, cert)?;
+            // A join could not make this check while its authorship was derived
+            // from the signing key: the device it named was fiction, so comparing
+            // against it refused every honest join. The op now names the device its
+            // certificate grants, which makes the question decidable here.
+            check_op_is_the_certified_device(op, &verified)?;
             // `is_scope_member(verified.account)` still cannot be required — the
             // whole point of a join is that the account is not a member yet.
             if acl_at_cut.is_group_admin(&op.author(), *group) {
@@ -198,32 +211,8 @@ pub fn authorize(op: &Op, acl_at_cut: &AclView) -> Result<(), Rejected> {
             chain,
             cert,
         } => {
-            let verified = admit_device_link(
-                &acl_at_cut.accounts,
-                &acl_at_cut.devices,
-                &acl_at_cut.revoked_devices,
-                genesis,
-                chain,
-                cert,
-            )?;
-            // The op must be signed by the very key it enrolls. Without this,
-            // anyone who observed a certificate could replay it and mint a
-            // binding on the real device's behalf; requiring possession makes a
-            // link an act of the device rather than an assertion about it.
-            if op.authorship.device_key != verified.sign_pk
-                || op.authorship.device != verified.device
-            {
-                return Err(Rejected::DeviceKeyStale {
-                    device: verified.device,
-                });
-            }
-            if op.author() != verified.account {
-                return Err(Rejected::DeviceAccountMismatch {
-                    device: verified.device,
-                    bound: verified.account,
-                    claimed: op.author(),
-                });
-            }
+            let verified = acl_at_cut.admit_device_link(genesis, chain, cert)?;
+            check_op_is_the_certified_device(op, &verified)?;
             // The one policy gate: a device may only link itself into a scope
             // its account already belongs to. This is what makes linking cheap
             // and safe at once — the account already holds every right the
@@ -291,7 +280,7 @@ pub fn authorize(op: &Op, acl_at_cut: &AclView) -> Result<(), Rejected> {
                     author: op.author(),
                 });
             }
-            admit_key_rotation(&acl_at_cut.accounts, handoff)
+            acl_at_cut.admit_key_rotation(handoff)
         }
     }
 }

--- a/crates/authz/src/error.rs
+++ b/crates/authz/src/error.rs
@@ -7,6 +7,7 @@
 use thiserror::Error as ThisError;
 
 use calimero_account::{AccountId, DeviceId};
+use calimero_storage::address::Id;
 use calimero_storage::entities::OpMask;
 
 /// Why an op was refused. One rejection type for every plane — the caller
@@ -14,8 +15,18 @@ use calimero_storage::entities::OpMask;
 #[derive(Clone, Debug, PartialEq, Eq, ThisError)]
 pub enum Rejected {
     /// Author lacks the required capability on a data entity.
-    #[error("author not permitted to write entity (needs {required:?})")]
-    NotPermitted { required: OpMask },
+    ///
+    /// Names the entity, not only the mask: a scope holds many entities and only
+    /// some carry an explicit ACL, so "needs WRITE" alone does not say whether the
+    /// author was refused by a per-object writer set or by not being a member at
+    /// all — which are different problems with different fixes.
+    #[error("author not permitted on entity {entity:?} (needs {required:?})")]
+    NotPermitted {
+        /// The entity the author was refused on.
+        entity: Id,
+        /// The capability the op required.
+        required: OpMask,
+    },
     /// Author is not the owner of the object whose writers are being set.
     #[error("author is not the owner of the object")]
     NotOwner,
@@ -98,10 +109,26 @@ pub enum Rejected {
     /// themselves in.
     #[error("account is not a member of this scope at the cut")]
     AccountNotMember,
-    /// A key rotation for an account this scope has never seen, or one that
-    /// does not continue the established chain.
-    #[error("key rotation does not continue this account's chain at the cut")]
-    RotationNotContinuous,
+    /// A key rotation for an account this scope has never seen.
+    ///
+    /// Distinct from [`Self::RotationNotContinuous`], which the two used to share:
+    /// they send whoever reads one somewhere different. This means the scope
+    /// learned no genesis for the account — nothing has linked a device of it here
+    /// — whereas a non-contiguous rotation means the account IS known and the
+    /// handoff simply starts at the wrong epoch.
+    #[error("no key chain known for account {account} at this cut")]
+    RotationAccountUnknown {
+        /// The account the handoff would roll.
+        account: AccountId,
+    },
+    /// A key rotation that does not continue the chain in force at the cut.
+    #[error("key rotation starts at epoch {found}, but epoch {expected} is in force")]
+    RotationNotContinuous {
+        /// The epoch currently established at the cut.
+        expected: u32,
+        /// The epoch the handoff declares it rolls from.
+        found: u32,
+    },
     /// A key rotation not signed by the outgoing root key.
     #[error("key rotation is not signed by the outgoing root key")]
     RotationSignatureInvalid,

--- a/crates/authz/src/inheritance.rs
+++ b/crates/authz/src/inheritance.rs
@@ -1,11 +1,41 @@
 //! The subgroup-tree walk, and the three questions that share it.
 //!
-//! `is_member_at_cut`, `is_authorized_admin` and `member_path_at_cut` all climb
-//! the same `subgroups` parent chain and stop at the same restricted wall; they
-//! differ only in what counts as success and what they report. Keeping them in
-//! one file is what makes the differences (documented on each) legible as
-//! deliberate rather than accidental drift — they answer three different
-//! questions and their walk order is *not* interchangeable.
+//! # Why it is shaped this way
+//!
+//! **One climb, three success conditions.** `is_member_at_cut`,
+//! `is_authorized_admin` and `member_path_at_cut` all follow the same
+//! `subgroups` parent chain and stop at the same restricted wall. That shape is
+//! now [`AclView::open_ancestors`], written once, so the three questions differ
+//! only in what they treat as success — which is the part that is genuinely
+//! load-bearing. Three hand-written copies of the climb meant three places a
+//! bound, a wall check, or a parent lookup could drift, and a drift there is not
+//! a bug in one question: it is one question granting what another refuses,
+//! about the same author and the same group.
+//!
+//! **`is_member_at_cut` is `member_path_at_cut` with the role discarded.** The
+//! two walks differed in one respect — the path checks the direct row before the
+//! admin carve-out so a stored role wins over the genesis admin's implied one,
+//! matching live's `list` semantics. That ordering decides which *role* is
+//! reported and cannot change *whether* the author is a member, so the predicate
+//! is now defined in terms of the path. `is_member_defined_by_the_path_walk`
+//! pins the equivalence exhaustively over every small tree rather than leaving it
+//! asserted.
+//!
+//! This matters beyond tidiness: `calimero-context` filters its candidate set
+//! with `is_member_at_cut` and then resolves each survivor's role with
+//! `member_path_at_cut`. If the two ever disagreed, the projection would emit a
+//! member with no role or a role for a non-member. That agreement used to rest on
+//! two implementations being kept in step by comment; it is now the same code.
+//!
+//! **A restricted edge is a hard wall.** Hitting one stops the climb
+//! immediately, even when an admin sits further up past it — visibility is not
+//! something an ancestor's authority reaches through.
+//!
+//! **`root` is the one un-folded fact.** The namespace's genesis admin has no
+//! governance op (it is set at backfill), so it arrives as an explicit parameter
+//! rather than from the view. Every *mutable* input — memberships, caps,
+//! visibility, the subgroup tree, the subgroup-creator admin — comes from the
+//! view, which is what makes the result honor the cut.
 
 use calimero_account::AccountId;
 use calimero_context_config::types::ContextGroupId;
@@ -43,17 +73,85 @@ pub enum MemberPathAtCut {
 }
 
 impl AclView {
-    /// Is `author` a member of `group` **at this cut** — direct, group admin, or
-    /// inherited through an open-subgroup chain — resolved entirely from the
-    /// folded view (no live-store reads). Faithful port of the live
-    /// `MembershipRepository::check_path` + the `acl_view_at` admin carve-out,
-    /// but over the at-cut state, so a membership the cut revoked is not granted.
+    /// The ancestors of `group` reachable while every edge crossed is **Open**,
+    /// nearest first — the climb all three inheritance questions share.
     ///
-    /// `root` is the immutable `(namespace_root_group, genesis_admin)` — the one
-    /// admin fact with no governance op (it lives in `GroupMeta` at namespace
-    /// genesis); pass `None` if unknown. Every *mutable* input (memberships,
-    /// caps, visibility, subgroup tree, subgroup-creator admin) comes from the
-    /// view, so the result honors the cut.
+    /// Ends at the first group with no subgroup edge (the namespace root) or at
+    /// the first `restricted` edge, and is bounded by `MAX_NAMESPACE_DEPTH` so a
+    /// cyclic or adversarial tree cannot spin. Yields parents only; `group`
+    /// itself is the caller's to check, because each question treats it
+    /// differently.
+    fn open_ancestors(&self, group: ContextGroupId) -> impl Iterator<Item = ContextGroupId> + '_ {
+        let mut current = Some(group);
+        core::iter::from_fn(move || {
+            let edge = self.subgroups.get(&ScopeId::from(current?.to_bytes()))?;
+            if edge.restricted {
+                current = None;
+                return None;
+            }
+            let parent = ContextGroupId::from(*edge.parent.as_bytes());
+            current = Some(parent);
+            Some(parent)
+        })
+        // One more than the depth limit, matching the bound the three
+        // hand-written climbs used.
+        .take(MAX_NAMESPACE_DEPTH + 1)
+    }
+
+    /// Does `author` hold a direct membership row in `group`?
+    fn has_direct_row(&self, group: ContextGroupId, author: &AccountId) -> bool {
+        self.groups
+            .get(&group)
+            .is_some_and(|members| members.contains_key(author))
+    }
+
+    /// Admin of `g` for **membership** purposes: a folded group admin (subgroup
+    /// creator / `Admin`-role holder) or the immutable namespace-root genesis
+    /// admin.
+    ///
+    /// Deliberately **not** the global [`AclView::is_root_admin`]: the root admin
+    /// is a member of a *subgroup* only over the open chain, never of a Restricted
+    /// one. Using the global predicate here would make the root admin a direct
+    /// member of every group, diverging from the membership set these walks must
+    /// mirror. [`AclView::is_authorized_admin`] does include it, because admin
+    /// *authority* is global in a way membership is not.
+    fn is_membership_admin(
+        &self,
+        group: ContextGroupId,
+        author: &AccountId,
+        root: Option<(ContextGroupId, AccountId)>,
+    ) -> bool {
+        self.is_group_admin(author, group)
+            || root.is_some_and(|(root_g, root_admin)| group == root_g && *author == root_admin)
+    }
+
+    /// `author`'s effective capability at `group`, falling back to
+    /// `default_cap_base`.
+    ///
+    /// The projection folds explicit `DefaultCapabilitiesSet` / `MemberCapabilitySet`
+    /// ops, but a group's CREATION default cap is a store write rather than an op —
+    /// so when nothing is folded we fall back to the materialized default the
+    /// caller passes. Mirrors live's `member_capability` = override.or(default).
+    fn effective_cap(
+        &self,
+        group: ContextGroupId,
+        author: &AccountId,
+        default_cap_base: u32,
+    ) -> u32 {
+        let folded = self.capability(&group, author);
+        if folded == 0 {
+            default_cap_base
+        } else {
+            folded
+        }
+    }
+
+    /// Is `author` a member of `group` **at this cut** — direct, group admin, or
+    /// inherited through an open-subgroup chain?
+    ///
+    /// Exactly [`AclView::member_path_at_cut`] with the role discarded; see the
+    /// module docs for why that is safe despite the two walks having once
+    /// differed in order.
     #[must_use]
     pub fn is_member_at_cut(
         &self,
@@ -62,86 +160,24 @@ impl AclView {
         root: Option<(ContextGroupId, AccountId)>,
         default_cap_base: u32,
     ) -> bool {
-        // Admin of `g` at the cut: a folded group admin (subgroup creator / an
-        // `Admin`-role holder) OR the immutable namespace-root genesis admin.
-        let is_admin = |g: ContextGroupId| -> bool {
-            self.is_group_admin(author, g)
-                || root.is_some_and(|(root_g, root_admin)| g == root_g && *author == root_admin)
-        };
-
-        // Direct member or admin of the target group. NOTE: an open-subgroup
-        // inheritance self-join (`MemberJoinedOpen`) is deliberately NOT folded as
-        // a direct membership (it carries no persistent direct row in the live
-        // model — its apply requires `check_path == Inherited` and creates no
-        // row); such membership is re-derived by the inheritance walk below, so it
-        // is correctly revoked when the anchor is removed.
-        if is_admin(group)
-            || self
-                .groups
-                .get(&group)
-                .is_some_and(|m| m.contains_key(author))
-        {
-            return true;
-        }
-
-        // Inherited: walk parents while the chain stays Open, mirroring
-        // `check_path`. The first direct-membership ancestor decides via its
-        // `CAN_JOIN_OPEN_SUBGROUPS` cap (recorded, not returned); an admin
-        // ancestor reached over the open chain grants immediately.
-        //
-        // `effective_cap`: the projection folds explicit `DefaultCapabilitiesSet`
-        // / `MemberCapabilitySet` ops, but a group's CREATION default cap is a
-        // store write, not an op — so when nothing is folded for the anchor we
-        // fall back to `default_cap_base` (the materialized default, immutable
-        // base state, passed by the caller). This mirrors live's
-        // `member_capability` = override.or(default).
-        let effective_cap = |g: &ContextGroupId| -> u32 {
-            let folded = self.capability(g, author);
-            if folded != 0 {
-                folded
-            } else {
-                default_cap_base
-            }
-        };
-
-        let mut anchor_is_member: Option<bool> = None;
-        let mut current = group;
-        for _ in 0..=MAX_NAMESPACE_DEPTH {
-            // `current` must be Open for inheritance to pass up through it.
-            let Some(edge) = self.subgroups.get(&ScopeId::from(current.to_bytes())) else {
-                return anchor_is_member.unwrap_or(false);
-            };
-            if edge.restricted {
-                return anchor_is_member.unwrap_or(false);
-            }
-            let parent = ContextGroupId::from(*edge.parent.as_bytes());
-            if is_admin(parent) {
-                return true;
-            }
-            if anchor_is_member.is_none()
-                && self
-                    .groups
-                    .get(&parent)
-                    .is_some_and(|m| m.contains_key(author))
-            {
-                anchor_is_member = Some(effective_cap(&parent) & CAN_JOIN_OPEN_SUBGROUPS != 0);
-            }
-            current = parent;
-        }
-        anchor_is_member.unwrap_or(false)
+        !matches!(
+            self.member_path_at_cut(group, author, root, default_cap_base),
+            MemberPathAtCut::None
+        )
     }
 
     /// Is `author` authorized as an ADMIN of `group` at the cut — the apply-gate
-    /// admin authority. Mirrors live's `is_authorized_with_capability` admin path:
-    /// a direct group admin (subgroup creator / `Admin`-role holder), the
-    /// namespace ROOT admin (who administers every group — folded, so it tracks
-    /// `AdminChanged`, with the genesis `root` carve-out as the un-folded base), OR
-    /// an admin of an ANCESTOR reached over the open-subgroup chain (an admin of an
-    /// Open parent administers its children). Restricted edges stop the walk.
+    /// admin authority?
     ///
-    /// Admin-only — unlike [`is_member_at_cut`](Self::is_member_at_cut), a plain
-    /// inherited MEMBER is not authorized. Capability holders are checked
-    /// separately by the caller.
+    /// A direct group admin (subgroup creator / `Admin`-role holder), the
+    /// namespace ROOT admin (who administers every group — folded, so it tracks
+    /// `AdminChanged`, with the genesis `root` carve-out as the un-folded base),
+    /// or an admin of an ANCESTOR reached over the open chain (an admin of an Open
+    /// parent administers its children).
+    ///
+    /// Admin-only — unlike [`AclView::is_member_at_cut`], a plain inherited MEMBER
+    /// is not authorized, and no capability bit grants admin authority. Capability
+    /// holders are checked separately by the caller.
     #[must_use]
     pub fn is_authorized_admin(
         &self,
@@ -149,39 +185,27 @@ impl AclView {
         author: &AccountId,
         root: Option<(ContextGroupId, AccountId)>,
     ) -> bool {
-        let is_admin = |g: ContextGroupId| -> bool {
-            self.is_group_admin(author, g)
-                || self.is_root_admin(author)
-                || root.is_some_and(|(root_g, root_admin)| g == root_g && *author == root_admin)
+        // The one place the GLOBAL root admin counts: admin authority reaches
+        // every group, where membership does not.
+        let is_admin = |g: ContextGroupId| {
+            self.is_membership_admin(g, author, root) || self.is_root_admin(author)
         };
-        if is_admin(group) {
-            return true;
-        }
-        let mut current = group;
-        for _ in 0..=MAX_NAMESPACE_DEPTH {
-            let Some(edge) = self.subgroups.get(&ScopeId::from(current.to_bytes())) else {
-                return false;
-            };
-            if edge.restricted {
-                return false;
-            }
-            let parent = ContextGroupId::from(*edge.parent.as_bytes());
-            if is_admin(parent) {
-                return true;
-            }
-            current = parent;
-        }
-        false
+        is_admin(group) || self.open_ancestors(group).any(is_admin)
     }
 
-    /// `author`'s membership PATH to `group` at the cut — the at-cut analogue of
-    /// live `check_path`, returning the role-bearing [`MemberPathAtCut`] for the
-    /// enumeration consumers. Mirrors the `is_member_at_cut` walk: direct row first
-    /// (with its folded role), then an admin of the group with no row (genesis root
-    /// admin), then up the open chain — an admin ancestor yields
-    /// `Inherited{via_admin:true}`, the first direct-member ancestor yields
-    /// `Inherited{via_admin:false}` iff it holds `CAN_JOIN_OPEN_SUBGROUPS` (else the
-    /// recorded decision is `None`, but the walk continues for an admin higher up).
+    /// `author`'s membership PATH to `group` at the cut — the role-bearing
+    /// verdict the enumeration consumers need.
+    ///
+    /// The direct row is checked **first**, before the admin carve-out: when an
+    /// identity is both a stored member and the genesis admin, live's `list`
+    /// returns the stored row's role, so the row is authoritative. The carve-out
+    /// only supplies a role (`Admin`) when there is no row to read.
+    ///
+    /// Then up the open chain: an admin ancestor yields
+    /// `Inherited { via_admin: true }` immediately; the **first** direct-member
+    /// ancestor yields `Inherited { via_admin: false }` iff it holds
+    /// `CAN_JOIN_OPEN_SUBGROUPS`. If it does not, that records a `None` verdict but
+    /// does **not** stop the climb — an admin further up still grants.
     #[must_use]
     pub fn member_path_at_cut(
         &self,
@@ -190,69 +214,38 @@ impl AclView {
         root: Option<(ContextGroupId, AccountId)>,
         default_cap_base: u32,
     ) -> MemberPathAtCut {
-        // Narrow admin, IDENTICAL to `is_member_at_cut`'s: a folded group admin or
-        // the genesis root admin OF THIS GROUP ONLY. Deliberately NOT the global
-        // `is_root_admin` — the root admin is a member of a *subgroup* only over
-        // the open-subgroup chain (the walk below), never of a Restricted subgroup.
-        // Using the global predicate here would mark the root admin a direct member
-        // of every group, diverging from the membership set this path must mirror.
-        let is_admin = |g: ContextGroupId| -> bool {
-            self.is_group_admin(author, g)
-                || root.is_some_and(|(root_g, root_admin)| g == root_g && *author == root_admin)
-        };
-        // Direct row FIRST (the reverse of `is_member_at_cut`, which only needs a
-        // bool so its order is immaterial): when an identity is BOTH a stored
-        // member and the genesis admin, live's `list` returns the stored row's
-        // role, so the row is authoritative. The `is_admin` carve-out below only
-        // supplies a role (`Admin`) when there is NO row to read.
         if let Some(role) = self.groups.get(&group).and_then(|m| m.get(author)) {
             return MemberPathAtCut::Direct { role: role.clone() };
         }
-        if is_admin(group) {
+        if self.is_membership_admin(group, author, root) {
             return MemberPathAtCut::Direct {
                 role: GroupMemberRole::Admin,
             };
         }
-        let effective_cap = |g: &ContextGroupId| -> u32 {
-            let folded = self.capability(g, author);
-            if folded != 0 {
-                folded
-            } else {
-                default_cap_base
-            }
-        };
+
         let mut anchor_decision: Option<MemberPathAtCut> = None;
-        let mut current = group;
-        for _ in 0..=MAX_NAMESPACE_DEPTH {
-            let Some(edge) = self.subgroups.get(&ScopeId::from(current.to_bytes())) else {
-                return anchor_decision.unwrap_or(MemberPathAtCut::None);
-            };
-            if edge.restricted {
-                return anchor_decision.unwrap_or(MemberPathAtCut::None);
-            }
-            let parent = ContextGroupId::from(*edge.parent.as_bytes());
-            if is_admin(parent) {
+        for parent in self.open_ancestors(group) {
+            if self.is_membership_admin(parent, author, root) {
                 return MemberPathAtCut::Inherited {
                     anchor: parent,
                     via_admin: true,
                 };
             }
-            if anchor_decision.is_none()
-                && self
-                    .groups
-                    .get(&parent)
-                    .is_some_and(|m| m.contains_key(author))
-            {
-                anchor_decision = Some(if effective_cap(&parent) & CAN_JOIN_OPEN_SUBGROUPS != 0 {
-                    MemberPathAtCut::Inherited {
-                        anchor: parent,
-                        via_admin: false,
-                    }
-                } else {
-                    MemberPathAtCut::None
-                });
+            if anchor_decision.is_none() && self.has_direct_row(parent, author) {
+                anchor_decision = Some(
+                    if self.effective_cap(parent, author, default_cap_base)
+                        & CAN_JOIN_OPEN_SUBGROUPS
+                        != 0
+                    {
+                        MemberPathAtCut::Inherited {
+                            anchor: parent,
+                            via_admin: false,
+                        }
+                    } else {
+                        MemberPathAtCut::None
+                    },
+                );
             }
-            current = parent;
         }
         anchor_decision.unwrap_or(MemberPathAtCut::None)
     }

--- a/crates/authz/src/lib.rs
+++ b/crates/authz/src/lib.rs
@@ -19,7 +19,7 @@
 //! | `authorize` | The decision itself: [`authorize`], [`required_mask_for`], and the device-binding precondition every op but a link must pass |
 //! | `view` | [`AclView`] — the at-cut state the decision reads — plus [`AccountBinding`], [`DeviceBinding`], [`SubgroupEdge`] and the flat predicates |
 //! | `inheritance` | The subgroup-tree walk shared by three questions, and [`MemberPathAtCut`] |
-//! | `admission` | Credential admission: [`admit_device_link`], [`fold_device_link`], [`admit_key_rotation`] — the rules `authorize` and the projection's fold must agree on |
+//! | `admission` | Credential admission: [`AclView::admit_device_link`], [`AclView::admit_key_rotation`], and [`fold_device_link`] — the rules `authorize` and the projection's fold must agree on |
 //! | `error` | [`Rejected`] — one rejection type for every plane |
 //!
 //! Every public item is re-exported here, so `calimero_authz::AclView` keeps
@@ -34,7 +34,7 @@ mod view;
 #[cfg(test)]
 mod tests;
 
-pub use crate::admission::{admit_device_link, admit_key_rotation, fold_device_link};
+pub use crate::admission::fold_device_link;
 pub use crate::authorize::{authorize, required_mask_for};
 pub use crate::error::Rejected;
 pub use crate::inheritance::MemberPathAtCut;

--- a/crates/authz/src/tests.rs
+++ b/crates/authz/src/tests.rs
@@ -13,3 +13,4 @@ mod support;
 
 mod authorize;
 mod inheritance;
+mod inheritance_climb;

--- a/crates/authz/src/tests/authorize.rs
+++ b/crates/authz/src/tests/authorize.rs
@@ -14,9 +14,9 @@ use calimero_storage::entities::OpMask;
 use super::support::{
     bind_account, bind_test_devices, hlc0, membership_view, op_with, view_with_writer,
 };
-use crate::authorize::authorize;
+use crate::authorize::{authorize, required_mask_for};
 use crate::error::Rejected;
-use crate::view::AclView;
+use crate::view::{AccountBinding, AclView};
 
 #[test]
 fn put_requires_write_capability() {
@@ -36,6 +36,7 @@ fn put_requires_write_capability() {
     assert_eq!(
         authorize(&op, &bind_account(AclView::default(), author)),
         Err(Rejected::NotPermitted {
+            entity,
             required: OpMask::WRITE
         })
     );
@@ -210,6 +211,7 @@ fn default_write_lets_a_member_write_a_non_restricted_entity() {
             &view
         ),
         Err(Rejected::NotPermitted {
+            entity: x,
             required: OpMask::WRITE
         })
     );
@@ -284,6 +286,7 @@ fn explicit_acl_overrides_default_write_for_restricted_objects() {
             &view
         ),
         Err(Rejected::NotPermitted {
+            entity: secret,
             required: OpMask::WRITE
         })
     );
@@ -364,5 +367,137 @@ fn a_join_replayed_by_another_device_is_refused() {
     assert!(
         authorize(&honest, &view).is_ok(),
         "the honest join must still pass, or the check above proves nothing"
+    );
+}
+
+// ---- the mask mapping, and the rotation refusals ----
+
+/// **`required_mask_for` must name the mask `authorize` actually enforces.**
+///
+/// `authorize` deliberately does *not* call this helper — each data arm inlines
+/// its literal mask so there is no `Option` to unwrap and no fallback arm that
+/// could silently deny. The cost of that choice is that the payload→mask mapping
+/// exists twice, and a comment explaining why cannot stop the two drifting. This
+/// is what stops it: the helper's answer is compared against the mask the
+/// decision reports refusing on, which is the mask it truly enforced.
+#[test]
+fn required_mask_for_agrees_with_the_mask_authorize_enforces() {
+    let author = AccountId::from([0x41; 32]);
+    let entity = Id::root();
+    // An author with no ACL entry and no membership holds nothing, so every data
+    // op is refused and the refusal carries the mask that was required.
+    let view = bind_account(AclView::default(), author);
+
+    for payload in [
+        OpPayload::Put {
+            entity,
+            value: vec![1],
+        },
+        OpPayload::Delete { entity },
+    ] {
+        let expected = required_mask_for(&payload)
+            .expect("every data payload maps to a mask, or the helper is lying");
+        assert_eq!(
+            authorize(&op_with(author, payload.clone()), &view),
+            Err(Rejected::NotPermitted {
+                entity,
+                required: expected,
+            }),
+            "authorize enforces a different mask than required_mask_for reports for {payload:?}"
+        );
+    }
+}
+
+/// A non-data payload has no mask, because the empty mask is contained by every
+/// mask — a `NONE` requirement fed to `may` would authorize anyone.
+#[test]
+fn required_mask_for_declines_to_answer_for_non_data_payloads() {
+    for payload in [
+        OpPayload::Noop,
+        OpPayload::SetWriters {
+            object: Id::root(),
+            writers: BTreeMap::new(),
+        },
+    ] {
+        assert_eq!(
+            required_mask_for(&payload),
+            None,
+            "a non-data payload must have no mask: {payload:?}"
+        );
+    }
+}
+
+/// **"This scope has never seen the account" and "the handoff starts at the wrong
+/// epoch" are different refusals.**
+///
+/// They used to share `RotationNotContinuous`, which sent whoever read it to the
+/// wrong question: the first means nothing has linked a device of this account
+/// here, the second means the account is known and only the epoch is off.
+#[test]
+fn the_two_rotation_refusals_are_told_apart() {
+    let owner = AccountId::from([0x51; 32]);
+    let new_key = calimero_primitives::identity::PrivateKey::from([0x52; 32]);
+    let root_sk = calimero_primitives::identity::PrivateKey::from([0x53; 32]);
+
+    let handoff_from_epoch = |from_epoch: u32| RootKeyHandoff {
+        account: owner,
+        from_epoch,
+        new_root_sign_pk: new_key.public_key(),
+        signature: [0u8; 64],
+    };
+
+    // Nothing known about the account at this cut.
+    let unknown = bind_account(bind_test_devices(AclView::default()), owner);
+    assert_eq!(
+        authorize(
+            &op_with(
+                owner,
+                OpPayload::AccountKeysRotated {
+                    handoff: handoff_from_epoch(0)
+                }
+            ),
+            &unknown
+        ),
+        Err(Rejected::RotationAccountUnknown { account: owner }),
+    );
+
+    // Account known at epoch 1; a handoff rolling from epoch 0 is stale.
+    let mut known = unknown;
+    let _ = known.accounts.insert(
+        owner,
+        AccountBinding {
+            epoch: 1,
+            root_pk: root_sk.public_key(),
+        },
+    );
+    assert_eq!(
+        authorize(
+            &op_with(
+                owner,
+                OpPayload::AccountKeysRotated {
+                    handoff: handoff_from_epoch(0)
+                }
+            ),
+            &known
+        ),
+        Err(Rejected::RotationNotContinuous {
+            expected: 1,
+            found: 0
+        }),
+    );
+
+    // At the right epoch the refusal moves on to the signature, which is filler
+    // here — proving the epoch check passed rather than short-circuiting.
+    assert_eq!(
+        authorize(
+            &op_with(
+                owner,
+                OpPayload::AccountKeysRotated {
+                    handoff: handoff_from_epoch(1)
+                }
+            ),
+            &known
+        ),
+        Err(Rejected::RotationSignatureInvalid),
     );
 }

--- a/crates/authz/src/tests/inheritance_climb.rs
+++ b/crates/authz/src/tests/inheritance_climb.rs
@@ -1,0 +1,334 @@
+//! The shared climb, pinned against the three hand-written walks it replaced.
+//!
+//! `reference_is_member_at_cut` below is the **pre-refactor** `is_member_at_cut`
+//! body, transcribed verbatim: its own loop, its own bound, its own wall check,
+//! its own admin carve-out. Asserting the crate against it over every small tree
+//! is what makes the refactor a behaviour-preserving one rather than a claim —
+//! and it keeps a second, independent implementation of the rule in the tree, so
+//! a future change to `open_ancestors` that alters membership cannot pass
+//! silently.
+//!
+//! Kept deliberately as a duplicate: the value of an oracle is that it does NOT
+//! share code with the thing it checks.
+
+use std::collections::BTreeMap;
+
+use calimero_account::AccountId;
+use calimero_context_config::types::ContextGroupId;
+use calimero_op::ScopeId;
+use calimero_primitives::context::GroupMemberRole;
+
+use crate::inheritance::{MemberPathAtCut, CAN_JOIN_OPEN_SUBGROUPS};
+use crate::view::{AclView, SubgroupEdge};
+
+const MAX_NAMESPACE_DEPTH: usize = calimero_context_config::MAX_NAMESPACE_DEPTH;
+
+/// The pre-refactor `is_member_at_cut`, transcribed. Do not refactor to share
+/// code with the crate — that would defeat its purpose.
+fn reference_is_member_at_cut(
+    view: &AclView,
+    group: ContextGroupId,
+    author: &AccountId,
+    root: Option<(ContextGroupId, AccountId)>,
+    default_cap_base: u32,
+) -> bool {
+    let is_admin = |g: ContextGroupId| -> bool {
+        view.is_group_admin(author, g)
+            || root.is_some_and(|(root_g, root_admin)| g == root_g && *author == root_admin)
+    };
+
+    if is_admin(group)
+        || view
+            .groups
+            .get(&group)
+            .is_some_and(|m| m.contains_key(author))
+    {
+        return true;
+    }
+
+    let effective_cap = |g: &ContextGroupId| -> u32 {
+        let folded = view.capability(g, author);
+        if folded != 0 {
+            folded
+        } else {
+            default_cap_base
+        }
+    };
+
+    let mut anchor_is_member: Option<bool> = None;
+    let mut current = group;
+    for _ in 0..=MAX_NAMESPACE_DEPTH {
+        let Some(edge) = view.subgroups.get(&ScopeId::from(current.to_bytes())) else {
+            return anchor_is_member.unwrap_or(false);
+        };
+        if edge.restricted {
+            return anchor_is_member.unwrap_or(false);
+        }
+        let parent = ContextGroupId::from(*edge.parent.as_bytes());
+        if is_admin(parent) {
+            return true;
+        }
+        if anchor_is_member.is_none()
+            && view
+                .groups
+                .get(&parent)
+                .is_some_and(|m| m.contains_key(author))
+        {
+            anchor_is_member = Some(effective_cap(&parent) & CAN_JOIN_OPEN_SUBGROUPS != 0);
+        }
+        current = parent;
+    }
+    anchor_is_member.unwrap_or(false)
+}
+
+/// The pre-refactor `is_authorized_admin`, transcribed, for the same reason.
+fn reference_is_authorized_admin(
+    view: &AclView,
+    group: ContextGroupId,
+    author: &AccountId,
+    root: Option<(ContextGroupId, AccountId)>,
+) -> bool {
+    let is_admin = |g: ContextGroupId| -> bool {
+        view.is_group_admin(author, g)
+            || view.is_root_admin(author)
+            || root.is_some_and(|(root_g, root_admin)| g == root_g && *author == root_admin)
+    };
+    if is_admin(group) {
+        return true;
+    }
+    let mut current = group;
+    for _ in 0..=MAX_NAMESPACE_DEPTH {
+        let Some(edge) = view.subgroups.get(&ScopeId::from(current.to_bytes())) else {
+            return false;
+        };
+        if edge.restricted {
+            return false;
+        }
+        let parent = ContextGroupId::from(*edge.parent.as_bytes());
+        if is_admin(parent) {
+            return true;
+        }
+        current = parent;
+    }
+    false
+}
+
+fn g(n: u8) -> ContextGroupId {
+    ContextGroupId::from([n; 32])
+}
+
+/// One point in the sweep: a chain `g(0) → g(1) → … → g(depth)` plus the flags
+/// that vary across it.
+///
+/// A struct rather than eight parameters, for the same reason the crate under
+/// test stopped passing its view a field at a time — and because a sweep whose
+/// axes are positional `u32`s is one transposed argument away from silently
+/// testing something else.
+#[derive(Clone, Copy)]
+struct TreeSpec {
+    depth: usize,
+    /// Bit `i` set = `g(i)` holds a direct membership row for the author.
+    rows: u32,
+    /// Bit `i` set = the edge from `g(i)` to its parent is Restricted.
+    restricted: u32,
+    /// Bit `i` set = the author is the folded group admin of `g(i)`.
+    admins: u32,
+    /// The author's folded per-member capability at every group.
+    cap: u32,
+    /// Whether the view's global `root_admin` is the author.
+    root_admin_is_author: bool,
+}
+
+impl TreeSpec {
+    fn groups(self) -> usize {
+        self.depth + 1
+    }
+}
+
+/// Build the synthetic view `spec` describes.
+fn chain_view(spec: TreeSpec, author: AccountId, other: AccountId) -> AclView {
+    let TreeSpec {
+        rows,
+        restricted,
+        admins,
+        cap,
+        root_admin_is_author,
+        ..
+    } = spec;
+    let n = spec.groups();
+    let mut groups: BTreeMap<ContextGroupId, BTreeMap<AccountId, GroupMemberRole>> =
+        BTreeMap::new();
+    let mut subgroups = BTreeMap::new();
+    let mut group_admin = BTreeMap::new();
+    let mut member_caps = BTreeMap::new();
+
+    for i in 0..n {
+        let gi = g(u8::try_from(i).expect("small"));
+        let holder = if rows & (1 << i) == 0 { other } else { author };
+        let _ = groups.insert(
+            gi,
+            [(holder, GroupMemberRole::Member)].into_iter().collect(),
+        );
+        if admins & (1 << i) != 0 {
+            let _ = group_admin.insert(gi, author);
+        }
+        let _ = member_caps.insert((gi, author), cap);
+        if i + 1 < n {
+            let _ = subgroups.insert(
+                ScopeId::from(gi.to_bytes()),
+                SubgroupEdge {
+                    parent: ScopeId::from(g(u8::try_from(i + 1).expect("small")).to_bytes()),
+                    restricted: restricted & (1 << i) != 0,
+                },
+            );
+        }
+    }
+
+    AclView {
+        groups,
+        subgroups,
+        group_admin,
+        member_caps,
+        root_admin: root_admin_is_author.then_some(author),
+        ..Default::default()
+    }
+}
+
+/// What one swept tree hands to a check: the view, who is asking, the un-folded
+/// `root` carve-out, and the materialized default capability.
+struct Case {
+    view: AclView,
+    author: AccountId,
+    root: Option<(ContextGroupId, AccountId)>,
+    base_cap: u32,
+}
+
+/// Sweep every small tree and hand each one to `check`.
+fn for_every_small_tree(mut check: impl FnMut(&Case)) {
+    let author = AccountId::from([0xAA; 32]);
+    let other = AccountId::from([0xBB; 32]);
+    for depth in 0usize..=3 {
+        let n = depth + 1;
+        for rows in 0u32..(1 << n) {
+            for restricted in 0u32..(1 << n) {
+                for admins in 0u32..(1 << n) {
+                    for cap in [0, CAN_JOIN_OPEN_SUBGROUPS] {
+                        for root_carve in [false, true] {
+                            for root_admin_is_author in [false, true] {
+                                for base_cap in [0, CAN_JOIN_OPEN_SUBGROUPS] {
+                                    let spec = TreeSpec {
+                                        depth,
+                                        rows,
+                                        restricted,
+                                        admins,
+                                        cap,
+                                        root_admin_is_author,
+                                    };
+                                    check(&Case {
+                                        view: chain_view(spec, author, other),
+                                        author,
+                                        root: root_carve.then_some((
+                                            g(u8::try_from(n - 1).expect("small")),
+                                            author,
+                                        )),
+                                        base_cap,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn is_member_matches_the_walk_it_replaced() {
+    let mut checked = 0usize;
+    for_every_small_tree(|case| {
+        let Case {
+            view,
+            author,
+            root,
+            base_cap,
+        } = case;
+        assert_eq!(
+            view.is_member_at_cut(g(0), author, *root, *base_cap),
+            reference_is_member_at_cut(view, g(0), author, *root, *base_cap),
+            "membership diverged from the pre-refactor walk on {view:?} (root={root:?}, \
+             base_cap={base_cap})"
+        );
+        checked += 1;
+    });
+    assert!(
+        checked > 10_000,
+        "the sweep must actually be wide: {checked}"
+    );
+}
+
+#[test]
+fn is_member_is_the_path_walk_with_the_role_discarded() {
+    // The equivalence `calimero-context` depends on: it filters candidates with
+    // `is_member_at_cut` and resolves each survivor's role with
+    // `member_path_at_cut`. A disagreement would emit a member with no role, or a
+    // role for a non-member.
+    for_every_small_tree(|case| {
+        assert_eq!(
+            case.view
+                .is_member_at_cut(g(0), &case.author, case.root, case.base_cap),
+            !matches!(
+                case.view
+                    .member_path_at_cut(g(0), &case.author, case.root, case.base_cap),
+                MemberPathAtCut::None
+            ),
+        );
+    });
+}
+
+#[test]
+fn admin_authority_matches_the_walk_it_replaced() {
+    for_every_small_tree(|case| {
+        let Case {
+            view, author, root, ..
+        } = case;
+        assert_eq!(
+            view.is_authorized_admin(g(0), author, *root),
+            reference_is_authorized_admin(view, g(0), author, *root),
+            "admin authority diverged from the pre-refactor walk on {view:?} (root={root:?})"
+        );
+    });
+}
+
+#[test]
+fn a_restricted_edge_walls_off_an_admin_further_up() {
+    // Pinned separately from the sweep because it is the rule most likely to be
+    // "fixed" by someone who reads the climb and assumes authority should reach
+    // through: it must not.
+    let author = AccountId::from([0xAA; 32]);
+    let mut view = chain_view(
+        TreeSpec {
+            depth: 2,
+            rows: 0,
+            restricted: 0b010,
+            admins: 0b100,
+            cap: 0,
+            root_admin_is_author: false,
+        },
+        author,
+        AccountId::from([0xBB; 32]),
+    );
+    assert!(
+        !view.is_authorized_admin(g(0), &author, None),
+        "an admin above a restricted edge must not administer through it"
+    );
+    // Open the wall and the same admin now reaches down.
+    let _ = view.subgroups.insert(
+        ScopeId::from(g(1).to_bytes()),
+        SubgroupEdge {
+            parent: ScopeId::from(g(2).to_bytes()),
+            restricted: false,
+        },
+    );
+    assert!(view.is_authorized_admin(g(0), &author, None));
+}

--- a/crates/authz/src/view.rs
+++ b/crates/authz/src/view.rs
@@ -4,6 +4,33 @@
 //! The three questions that walk the subgroup tree live in
 //! [`crate::inheritance`] instead; everything here answers from a single map
 //! lookup.
+//!
+//! # Why it is shaped this way
+//!
+//! **Two-tier data authorization.** A *restricted* entity — one with an explicit
+//! per-object ACL entry — is authoritative: only listed writers with a sufficient
+//! mask pass, even scope members. A *non-restricted* entity has no explicit ACL,
+//! so `default-write = membership`. That gives "members can write" for ordinary
+//! contexts, such as a key-value store, without enumerating a per-entity writer
+//! set for every key, while still letting an app narrow specific objects behind an
+//! explicit grant.
+//!
+//! **`DEFAULT_MEMBER_MASK` excludes `ADMIN` deliberately.** Any scope member can
+//! write **and delete** any non-restricted entity — so a single compromised member
+//! can wipe default data, which is the accepted cost of membership being the write
+//! boundary. What they cannot do is rotate an object's writer set: that always
+//! needs an explicit ownership grant, so a member can't lock everyone else out of
+//! default data.
+//!
+//! **Ownership is holding `ADMIN`.** [`AclView::is_owner`] is literally
+//! [`AclView::may`] with `OpMask::ADMIN`. If owner ever needs to diverge from
+//! admin/writer capability, that method is the one place to change.
+//!
+//! **`revoked_devices` is separate from `devices`, and grow-only.** That is what
+//! makes revocation order-independent: a revocation that folds *before* the link
+//! it withdraws still wins, because every link consults the set. Were revocation
+//! merely a flag on the binding, a revoke-then-link arrival order would silently
+//! resurrect the device.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -56,11 +83,8 @@ pub struct AclView {
     /// Devices whose binding has been withdrawn, and the account they were
     /// withdrawn from.
     ///
-    /// Separate from [`devices`](Self::devices) and **grow-only**, which is
-    /// what makes revocation order-independent: a revocation that folds
-    /// *before* the link it withdraws still wins, because every link consults
-    /// this set. Were revocation merely a flag on the binding, a
-    /// revoke-then-link arrival order would silently resurrect the device.
+    /// Separate from [`devices`](Self::devices) and **grow-only** — see the
+    /// module docs.
     pub revoked_devices: BTreeSet<DeviceId>,
 }
 
@@ -104,17 +128,9 @@ pub struct SubgroupEdge {
     pub restricted: bool,
 }
 
-/// Capabilities a scope **member** implicitly holds on a non-restricted
-/// entity (`default-write = membership`): `WRITE` + `DELETE`, but **not**
-/// `ADMIN` — rotating an object's writer set still requires an explicit ACL
-/// grant (ownership), so a plain member can't lock others out of a default
-/// entity.
-///
-/// Implication, by design: any member can write **and delete** any
-/// non-restricted entity in the scope (a single compromised member can wipe
-/// default data) — this matches a shared key-value store, where membership is
-/// the write boundary. Data that needs a narrower writer/deleter set must be a
-/// restricted object with an explicit ACL.
+/// Capabilities a scope **member** implicitly holds on a non-restricted entity
+/// (`default-write = membership`): `WRITE` + `DELETE`, but **not** `ADMIN`. See
+/// the module docs for why `ADMIN` is excluded.
 const DEFAULT_MEMBER_MASK: OpMask = OpMask::WRITE.union(OpMask::DELETE);
 
 impl AclView {
@@ -166,9 +182,7 @@ impl AclView {
 
     /// Is `author` the owner of `object` — permitted to rotate its writer set?
     ///
-    /// The `ADMIN` bit on the object confers ownership (owner = capability
-    /// holder). Refine here if `owner` ever becomes distinct from
-    /// `writer`/`admin`.
+    /// The `ADMIN` bit on the object confers ownership; see the module docs.
     #[must_use]
     pub fn is_owner(&self, author: &AccountId, object: Id) -> bool {
         self.may(author, object, OpMask::ADMIN)


### PR DESCRIPTION
Same treatment as #3566, applied to `calimero-authz`. The crate wrote the subgroup-tree walk three times, the credential possession check twice, and passed slices of the view it already held as loose arguments.

## One climb, three success conditions

`is_member_at_cut`, `is_authorized_admin` and `member_path_at_cut` each hand-rolled the same loop — same bound, same restricted-wall check, same parent lookup. Three copies are three places a bound or a wall check can drift, and a drift there is not a bug in one question: it is one question granting what another refuses, about the same author and the same group.

`AclView::open_ancestors` is now the loop, written once. The three questions differ only in what they treat as success, which is the part that is genuinely load-bearing.

## `is_member_at_cut` is `member_path_at_cut` with the role discarded

The two walks differed in one respect: the path checks the direct row before the admin carve-out, so a stored role wins over the genesis admin's implied one (matching live's `list` semantics). That ordering decides which **role** is reported and cannot change **whether** the author is a member — so the predicate is now defined in terms of the path.

This matters beyond tidiness. `crates/context` filters its candidate set with `is_member_at_cut`, then resolves each survivor's role with `member_path_at_cut`. A disagreement emits a member with no role, or a role for a non-member. `scope_projection.rs`'s own comments assert the two agree; they now agree by construction.

**`AGENTS.md` said not to unify these "without re-checking both call sites", so here is the re-check.** `src/tests/inheritance_climb.rs` keeps **both** pre-refactor walks transcribed verbatim as independent oracles and sweeps every small tree — 37,440 of them, every combination of depth, direct rows, restricted edges, group admins, the capability bit, the root carve-out and the default-cap base — asserting the crate matches. The oracles deliberately share no code with the crate; that is the point of an oracle, and the file says so, so nobody "cleans it up" later.

The call-site audit is the other half: every external caller takes the `bool`, and the predicate is unchanged, so none are affected.

## One possession check

The `DeviceLinked` and `MemberJoinedWithDevice` arms carried the same fourteen lines verbatim. Written twice, the two could come to disagree about which of `device`, `device_key` and `account` must match — and the weaker copy is the one an attacker would use. Now `check_op_is_the_certified_device`.

## Admission takes the view, not three slices of it

`admit_device_link` took six arguments, three of which were `AclView` fields its only caller already held; `admit_key_rotation` took two, one likewise. Both are methods on `AclView` now.

`fold_device_link` deliberately **stays** a free function taking the maps loose: its caller is the projection's fold, which is *building* the state a view is later read from and has none to pass. That asymmetry is now the stated reason one is a method and the other is not, rather than an accident of who was written first.

## Refusals that name their cause

- `RotationNotContinuous` answered two different questions — "this scope has never seen the account" and "the handoff starts at the wrong epoch". Split into `RotationAccountUnknown { account }` and `RotationNotContinuous { expected, found }`; they send whoever reads one somewhere different.
- `NotPermitted` now names the entity as well as the mask. A scope holds many entities and only some carry an explicit ACL, so "needs WRITE" alone did not say whether the author was refused by a per-object writer set or by not being a member at all.

## A guard where a comment used to be

`authorize` deliberately does not call `required_mask_for` — each data arm inlines its literal mask so there is no `Option` to unwrap and no fallback that could silently deny. The cost is the payload→mask mapping existing twice, which a comment cannot hold together. `required_mask_for_agrees_with_the_mask_authorize_enforces` compares the helper's answer against the mask the decision reports refusing on.

Worth flagging: **the helper has no callers outside this crate at all**, so `AGENTS.md`'s claim that it "stays as the public helper for external callers" was stale. It is kept (removing public API buys nothing here) and the drift test is what earns its keep. That correction is in `AGENTS.md`.

## Docs and AGENTS.md

Same split as #3566 — item docs are contract and errors, module headers carry the design argument (module doc lines 95 → 187). `AGENTS.md` is updated to the new signatures, its ASCII diagrams corrected, and its two stale claims fixed (the walk-order caution and `required_mask_for`'s rationale).

## Numbers

**Net −50 code lines in `src`**, the walk unification alone going 166 → 127 in `inheritance.rs`. Unlike #3566, which grew by 46, this crate genuinely shrank — the duplication here was duplicated *logic*, not accessor boilerplate. Tests 13 → 19.

## Blast radius

**Nothing outside `crates/authz` changed.** The two relocated functions had no external callers, and both altered `Rejected` variants were crate-internal (the `governance-store` hits on that name are a different enum, `BindingRejected`). The workspace build confirms it.

Marked `!` because `admit_device_link` / `admit_key_rotation` moved onto `AclView` and two `Rejected` variants changed shape. No behaviour change — that is what the oracle sweep is for.

## Noted, not fixed

`calimero-governance-store`'s `apply_rotation` conflates the same two rotation causes into `BindingRejected::RotationNotContinuous`. It is the legacy governance path, outside the unified-log flow this crate guards, so it is left for a follow-up and recorded in `AGENTS.md`.

## Verification

- `cargo test --workspace --features calimero-storage/testing` — **4946 passed, 0 failed**
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo doc -p calimero-authz` — no broken intra-doc links
- The consumer suites that would catch a walk divergence pass: `calimero-authz` 19, `calimero-projection` 10, `projection_membership_equivalence` 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)