### PR TITLE
ci(release): stop reddening master when two commits share a release window

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,11 +99,30 @@ jobs:
               binary_release=true
               crate_release=true
               docker_release=true
-            elif [ "$(gh release view "$version" --repo ${{ github.repository }} --json assets --jq '.assets | length')" = "0" ]; then
-              # The release shell exists (created at trigger time by a
-              # previous attempt, or manually after a race) but no binaries
-              # were ever attached — a re-run must still upload them.
+            elif [ "${{ github.run_attempt }}" != "1" ] \
+              && [ "$(gh release view "$version" --repo ${{ github.repository }} --json assets --jq '.assets | length')" = "0" ]; then
+              # The release shell exists (this run created it on an earlier
+              # attempt, or someone created it by hand after a race) but no
+              # binaries were ever attached, so re-arm the upload.
+              #
+              # Only on a re-run. The shell is created seconds into the
+              # release commit's own run, while the binaries land ~40min
+              # later, so on a first attempt "shell with no assets" is the
+              # normal state of a release that is still building — not a
+              # release that needs rescuing. Re-arming there made every
+              # ordinary commit pushed inside that window believe it owned
+              # the release too, and the second one to reach the upload
+              # died on "an asset called ... already exists".
               binary_release=true
+            elif [ "$(gh release view "$version" --repo ${{ github.repository }} --json assets --jq '.assets | length')" = "0" ]; then
+              # Same shape, but on a first attempt, so this push is not the
+              # one that owns the release. Either the release is still
+              # building (fine, say nothing useful about it) or its build
+              # failed and nobody noticed. Say so rather than skipping in
+              # silence: the fix is to re-run the release commit's own run,
+              # because the tag points at that commit and the assets have
+              # to be built from it -- not from whatever landed since.
+              echo "::warning::Release $version exists with no assets. If its build failed, re-run that run; this push will not upload binaries."
             fi
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
             docker_release=true
@@ -285,7 +304,17 @@ jobs:
     runs-on: big-machine
     needs: [prepare, build-binaries]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}-${{ needs.prepare.outputs.version }}
+      # Keyed on the commit (or the PR), never on the release version. A
+      # version key puts every master push inside one release window into
+      # a single group, and GitHub resolves that contention by cancelling
+      # the older run -- so a commit that built perfectly still shows up
+      # red on master. A per-commit key leaves only the contention dedup
+      # is actually for: a re-run racing the attempt it replaces.
+      #
+      # `github.job` is deliberately absent: it is null everywhere except
+      # inside step execution, so using it here silently collapsed the
+      # binaries and app-bundle jobs into one shared group.
+      group: ${{ github.workflow }}-release-binaries-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: true
     permissions:
       contents: write
@@ -343,7 +372,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prepare]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}-${{ needs.prepare.outputs.version }}
+      # Per-commit, not per-version: a version key makes two master pushes
+      # in one release window contend, and the older run is cancelled --
+      # red master for a commit that was never broken.
+      group: ${{ github.workflow }}-release-app-bundle-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: true
     permissions:
       contents: write
@@ -448,7 +480,10 @@ jobs:
     name: Release Merod container
     needs: [prepare, build-binaries]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}-merod-${{ needs.prepare.outputs.version }}
+      # Per-commit, not per-version: a version key makes two master pushes
+      # in one release window contend, and the older run is cancelled --
+      # red master for a commit that was never broken.
+      group: ${{ github.workflow }}-merod-container-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: true
     permissions:
       contents: read
@@ -479,7 +514,10 @@ jobs:
     name: Release Mero Auth container
     needs: [prepare, build-binaries]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}-mero-auth-${{ needs.prepare.outputs.version }}
+      # Per-commit, not per-version: a version key makes two master pushes
+      # in one release window contend, and the older run is cancelled --
+      # red master for a commit that was never broken.
+      group: ${{ github.workflow }}-mero-auth-container-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: true
     permissions:
       contents: read
@@ -517,7 +555,10 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || needs.prepare.outputs.profiling_paths_changed == 'true' }}
     needs: [prepare, build-binaries]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}-merod-profiling-${{ needs.prepare.outputs.version }}
+      # Per-commit, not per-version: a version key makes two master pushes
+      # in one release window contend, and the older run is cancelled --
+      # red master for a commit that was never broken.
+      group: ${{ github.workflow }}-merod-profiling-container-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: true
     permissions:
       contents: read


### PR DESCRIPTION
38 of the last 100 `Release` runs on master were red. Only three of them broke anything.

| red runs | cause |
|---|---|
| 35 | `cancelled` — container jobs superseded by a later commit |
| 2 | `failure` — `An asset called ... already exists` |
| 1 | `failure` — GitHub 5xx inside `docker/build-push` (transient, not addressed) |

## The cancellations

The per-job concurrency groups were keyed on `needs.prepare.outputs.version`. That version is constant for every commit between two release cuts, so a burst of merges puts all of them in one group and GitHub resolves the contention by cancelling the older run:

```
Canceling since a higher priority waiting request for
Release--refs/heads/master-0.11.0-rc.24 exists
```

`Release Merod Profiling container` alone accounts for 23 of the 35 — it is the slowest of the three container jobs (~13 min), so it is in flight longest and gets superseded most.

Keying on the commit (or on the PR number, for `pull_request`) removes the collision between independent commits while keeping the dedup that actually matters: a re-run racing the attempt it replaces, and a new PR push superseding the old one.

That same annotation shows the second bug — `Release--refs/...`, with nothing between the dashes. The group interpolated `github.job`, which is null outside step execution, so `Release Binaries` and `Release App Bundle` had been sharing a single group. Each job now carries its own literal key.

## The upload collisions

`prepare` re-armed `binary_release` whenever the release existed with zero assets. But the release shell is created seconds into the release commit's own run and the binaries land ~40 minutes later, so "shell with no assets" is the normal state of a release that is *still building*. Every ordinary commit pushed inside that window therefore believed it owned the release, and the second one to reach the upload died.

The re-arm is now restricted to re-runs (`github.run_attempt != 1`), which is the case its own comment describes.

A first attempt seeing the same state emits a warning instead of skipping silently. If that build genuinely failed, the fix is to re-run the release commit's run — the tag points at that commit, so the assets have to be built from it, not from whatever landed since.

## Verification

- Both files parse, and `actionlint` reports exactly the same findings as `master` (pre-existing shellcheck nits, no new ones).
- The `version_info` script was extracted and run against a `gh` stub across all five branches:

| event | release state | attempt | binary | crate | docker |
|---|---|---|---|---|---|
| push master | none | 1 | ✅ | ✅ | ✅ |
| push master | shell, 0 assets | 1 | — | — | — | (warns) |
| push master | shell, 0 assets | 2 | ✅ | — | — |
| push master | complete | 1 | — | — | — |
| pull_request | — | 1 | — | — | ✅ |

## Cost

Master container builds are no longer skipped when superseded: ~17 min of runner time per superseded commit, against the ~70 min the same run already spends building binaries for that commit unconditionally.

One consequence worth naming: the `edge` tag is no longer guaranteed newest-wins, since overlapping runs both publish it. In practice the pipelines are near-identical in length so the later commit still finishes later. If it ever inverts, the fix is to gate the `edge` tag on the commit still being branch head rather than to reintroduce cancellation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)