### PR TITLE
feat(admin-api)!: an add may name a member by account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`POST admin-api/groups/:group_id/members` accepts an account.** The
+  `identity` field now takes either an account (64 hex characters, exactly what
+  `GET .../members` returns) or a signing key (base58) — the encoding says
+  which, and no string is valid as both, so a mix-up is still a parse error
+  rather than a different principal. Key-named adds are unchanged on the wire.
+
+  Adding an existing namespace member to a Restricted subgroup was previously
+  not expressible: the caller knows that person from a member listing, which
+  renders accounts and never discloses the keys behind one, while the endpoint
+  demanded a key and then refused any key not already bound here. The field's
+  own documentation claimed the key existed to serve subjects with no account
+  yet, which the handler had made unreachable.
+
+  Naming an account also delivers the group key to **every live device** that
+  person holds, sealed to each device's certified X25519 key, under the same
+  revocation rules the rotation fan-out enforces. A key names one device, so a
+  key-named add still delivers to that one and leaves any others to pull.
+
 ### Removed
 
 - **`upgradePolicy`** from the namespace and group-info responses (`GET
@@ -41,6 +61,18 @@
   bundles that client — so `MIN_MEROBOX` moves to 0.6.56 here, the floor at
   which a join against a node without the field still decodes ([#3485],
   [#3528])
+
+### Fixed
+
+- **`meroctl group members set-role` / `set-caps` and `meroctl group metadata
+  member get` / `set` took a signing key where the route names an account.**
+  Each hex-encoded the key's raw bytes into the `:account` path segment, which
+  parses cleanly and names a principal that exists nowhere, so the commands
+  addressed no member and reported success or a confusing miss. They now take
+  the account, as the routes and the member listing do. **Breaking** for anyone
+  scripting those four commands: pass the 64-hex account rather than the base58
+  key. There is no input that worked before and stops working — the previous one
+  could not reach a real member.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@
   Naming an account also delivers the group key to **every live device** that
   person holds, sealed to each device's certified X25519 key, under the same
   revocation rules the rotation fan-out enforces. A key names one device, so a
-  key-named add still delivers to that one and leaves any others to pull.
+  key-named add still delivers to that one and leaves any others to pull
+  ([#3574])
 
 ### Removed
 
@@ -72,7 +73,7 @@
   the account, as the routes and the member listing do. **Breaking** for anyone
   scripting those four commands: pass the 64-hex account rather than the base58
   key. There is no input that worked before and stops working — the previous one
-  could not reach a real member.
+  could not reach a real member ([#3574])
 
 ### Changed
 
@@ -850,3 +851,4 @@ Integrations:
 [#3485]: https://github.com/calimero-network/core/issues/3485
 [#3528]: https://github.com/calimero-network/core/pull/3528
 [#3530]: https://github.com/calimero-network/core/pull/3530
+[#3574]: https://github.com/calimero-network/core/pull/3574

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ### Added
 
+- **`GET admin-api/groups/:group_id/devices`** — the device bindings of the
+  namespace owning the group: `device`, `account`, `signingKey`, `deviceEpoch`.
+  `?member=` narrows to one principal in either encoding: an **account** lists
+  the devices that speak for it, a **signing key** lists the device presenting
+  it, which is how a caller holding only a key learns the account behind it.
+
+  That resolution had no home in the API before, and its absence is the only
+  reason `POST .../members` still accepts a key: the endpoint was doing double
+  duty as the sole key-to-account converter. With this, the key form is a
+  back-compat shim rather than load-bearing, and can be removed once
+  `calimero-client-py` and the merobox scenarios name accounts.
+
+  No KEM key is exposed. Scope-key deliveries are sealed to it, it is read from
+  the folded binding at the moment of wrapping, and it has never been on the
+  wire. Reading requires the node to be a member of the group (403 otherwise),
+  the same gate the member listing uses ([#3574])
+
 - **`POST admin-api/groups/:group_id/members` accepts an account.** The
   `identity` field now takes either an account (64 hex characters, exactly what
   `GET .../members` returns) or a signing key (base58) — the encoding says

--- a/crates/client/src/client/group.rs
+++ b/crates/client/src/client/group.rs
@@ -2,6 +2,7 @@
 
 use eyre::Result;
 
+use calimero_primitives::identity::MemberPrincipal;
 use calimero_server_primitives::admin::AbortMigrationApiResponse;
 use calimero_server_primitives::admin::AddGroupMembersApiRequest;
 use calimero_server_primitives::admin::AddGroupMembersApiResponse;
@@ -22,6 +23,7 @@ use calimero_server_primitives::admin::LeaveContextApiResponse;
 use calimero_server_primitives::admin::LeaveGroupApiResponse;
 use calimero_server_primitives::admin::LeaveNamespaceApiResponse;
 use calimero_server_primitives::admin::ListGroupContextsApiResponse;
+use calimero_server_primitives::admin::ListGroupDevicesApiResponse;
 use calimero_server_primitives::admin::ListGroupMembersApiResponse;
 use calimero_server_primitives::admin::ListSubgroupsApiResponse;
 use calimero_server_primitives::admin::RemoveGroupMembersApiRequest;
@@ -81,6 +83,25 @@ where
             .connection
             .get(&format!("admin-api/groups/{group_id}/members"))
             .await?;
+        Ok(response)
+    }
+
+    /// The device bindings of the namespace owning `group_id`.
+    ///
+    /// `member` narrows to one principal, in either encoding: an account lists
+    /// its devices, a signing key lists the device presenting it — which is how
+    /// a caller holding only a key learns the account to name in
+    /// [`add_group_members`](Self::add_group_members).
+    pub async fn list_group_devices(
+        &self,
+        group_id: &str,
+        member: Option<&MemberPrincipal>,
+    ) -> Result<ListGroupDevicesApiResponse> {
+        let path = match member {
+            Some(member) => format!("admin-api/groups/{group_id}/devices?member={member}"),
+            None => format!("admin-api/groups/{group_id}/devices"),
+        };
+        let response = self.connection.get(&path).await?;
         Ok(response)
     }
 

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -23,7 +23,7 @@ use calimero_context_config::types::SignedGroupOpenInvitation;
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::ContextId;
 use calimero_primitives::context::GroupMemberRole;
-use calimero_primitives::identity::PublicKey;
+use calimero_primitives::identity::{MemberPrincipal, PublicKey};
 use calimero_server_primitives::admin::AddGroupMembersApiRequest;
 use calimero_server_primitives::admin::CreateGroupInvitationApiRequest;
 use calimero_server_primitives::admin::CreateNamespaceApiRequest;
@@ -231,6 +231,12 @@ async fn add_group_members() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path(format!("/admin-api/groups/{GID}/members")))
+        // Asserted on the wire, not just in the type: the account has to reach
+        // the node as the hex a member listing prints, since that encoding is
+        // what tells it apart from a signing key.
+        .and(body_json(serde_json::json!({
+            "members": [{ "identity": ZERO_HEX_ACCOUNT, "role": "Member" }],
+        })))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
         .expect(1)
         .mount(&server)
@@ -242,7 +248,7 @@ async fn add_group_members() {
             GID,
             AddGroupMembersApiRequest {
                 members: vec![GroupMemberApiInput {
-                    identity: PublicKey::from([0u8; 32]),
+                    identity: MemberPrincipal::Account(ZERO_HEX_ACCOUNT.parse().unwrap()),
                     role: GroupMemberRole::Member,
                 }],
             },

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -10,7 +10,7 @@
 use async_trait::async_trait;
 use eyre::Result;
 use url::Url;
-use wiremock::matchers::{body_json, header, method, path};
+use wiremock::matchers::{body_json, header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::client::Client;
@@ -224,6 +224,51 @@ async fn a_caller_finds_itself_by_matching_its_account() {
             .any(|m| m.identity.to_string() == me.data.account_id),
         "a node's own account must be findable among the members it is returned",
     );
+}
+
+#[tokio::test]
+async fn list_group_devices_resolves_a_key_to_its_account() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/admin-api/groups/{GID}/devices")))
+        // The whole point of the `member` filter: hand it the key you hold and
+        // read back the account to name in an add.
+        .and(query_param("member", ZERO_BS58))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "devices": [{
+                "device": ZERO_HEX_ACCOUNT,
+                "account": ZERO_HEX_ACCOUNT,
+                "signingKey": ZERO_BS58,
+                "deviceEpoch": 0,
+            }],
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = make_client(&Url::parse(&server.uri()).unwrap());
+    let key = MemberPrincipal::Key(ZERO_BS58.parse().unwrap());
+    let response = client.list_group_devices(GID, Some(&key)).await.unwrap();
+
+    assert_eq!(response.devices[0].account.to_string(), ZERO_HEX_ACCOUNT);
+}
+
+#[tokio::test]
+async fn list_group_devices_without_a_filter_sends_no_query() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/admin-api/groups/{GID}/devices")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "devices": [],
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = make_client(&Url::parse(&server.uri()).unwrap());
+    let response = client.list_group_devices(GID, None).await.unwrap();
+
+    assert!(response.devices.is_empty());
 }
 
 #[tokio::test]
@@ -1033,8 +1078,6 @@ async fn create_namespace_returns_err_on_server_error() {
 // and authenticator, using `node_name = Some(..)` so the auth path runs.
 
 use std::sync::{Arc, Mutex as StdMutex};
-
-use wiremock::matchers::query_param;
 
 use crate::connection::ConnectionInfo as Conn;
 

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -37,17 +37,18 @@ use crate::group::{
     JoinSubgroupInheritanceRequest, JoinSubgroupInheritanceResponse, LeaveContextRequest,
     LeaveContextResponse, LeaveGroupRequest, LeaveGroupResponse, LeaveNamespaceRequest,
     LeaveNamespaceResponse, ListAllGroupsRequest, ListGroupContextsRequest,
-    ListGroupMembersRequest, ListGroupMembersResponse, ListNamespacesForApplicationRequest,
-    ListNamespacesRequest, MigrationStatus, NamespaceParticipation, NamespaceSummary,
-    PairDeviceCompleteRequest, PairDeviceInitRequest, RemoveGroupMembersRequest,
-    ResyncContextRequest, ResyncContextResponse, RetryGroupUpgradeRequest, RevokeDeviceRequest,
-    RotateGroupKeyRequest, SetContextMetadataRequest, SetDefaultCapabilitiesRequest,
-    SetGroupMetadataRequest, SetMemberAutoFollowRequest, SetMemberCapabilitiesRequest,
-    SetMemberMetadataRequest, SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest,
-    StoreContextMetadataRequest, StoreDefaultCapabilitiesRequest, StoreGroupContextRequest,
-    StoreGroupMetaRequest, StoreGroupMetadataRequest, StoreMemberCapabilityRequest,
-    StoreMemberMetadataRequest, StoreSubgroupVisibilityRequest, SyncGroupRequest,
-    SyncGroupResponse, UpdateMemberRoleRequest, UpgradeGroupRequest, UpgradeGroupResponse,
+    ListGroupDevicesRequest, ListGroupDevicesResponse, ListGroupMembersRequest,
+    ListGroupMembersResponse, ListNamespacesForApplicationRequest, ListNamespacesRequest,
+    MigrationStatus, NamespaceParticipation, NamespaceSummary, PairDeviceCompleteRequest,
+    PairDeviceInitRequest, RemoveGroupMembersRequest, ResyncContextRequest, ResyncContextResponse,
+    RetryGroupUpgradeRequest, RevokeDeviceRequest, RotateGroupKeyRequest,
+    SetContextMetadataRequest, SetDefaultCapabilitiesRequest, SetGroupMetadataRequest,
+    SetMemberAutoFollowRequest, SetMemberCapabilitiesRequest, SetMemberMetadataRequest,
+    SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest, StoreContextMetadataRequest,
+    StoreDefaultCapabilitiesRequest, StoreGroupContextRequest, StoreGroupMetaRequest,
+    StoreGroupMetadataRequest, StoreMemberCapabilityRequest, StoreMemberMetadataRequest,
+    StoreSubgroupVisibilityRequest, SyncGroupRequest, SyncGroupResponse, UpdateMemberRoleRequest,
+    UpgradeGroupRequest, UpgradeGroupResponse,
 };
 use crate::local_governance::AckRouter;
 use crate::messages::{
@@ -1911,6 +1912,12 @@ impl ContextClient {
         ListGroupMembers,
         ListGroupMembersRequest,
         eyre::Result<ListGroupMembersResponse>
+    );
+    forward_to_actor!(
+        list_group_devices,
+        ListGroupDevices,
+        ListGroupDevicesRequest,
+        eyre::Result<ListGroupDevicesResponse>
     );
     forward_to_actor!(
         list_group_contexts,

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -6,7 +6,7 @@ use calimero_context_config::types::{AppKey, ContextGroupId, SignedGroupOpenInvi
 use calimero_context_config::VisibilityMode;
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::{ContextId, GroupMemberRole};
-use calimero_primitives::identity::PublicKey;
+use calimero_primitives::identity::{MemberPrincipal, PublicKey};
 use calimero_primitives::metadata::MetadataRecord;
 use calimero_storage::logical_clock::HybridTimestamp;
 use thiserror::Error as ThisError;
@@ -97,7 +97,9 @@ pub struct DeleteNamespaceResponse {
 #[derive(Debug)]
 pub struct AddGroupMembersRequest {
     pub group_id: ContextGroupId,
-    pub members: Vec<(PublicKey, GroupMemberRole)>,
+    /// Each member named either way round: by account, or by one key they sign
+    /// with. See [`MemberPrincipal`] for which the handler prefers and why.
+    pub members: Vec<(MemberPrincipal, GroupMemberRole)>,
 }
 
 impl Message for AddGroupMembersRequest {

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -161,6 +161,57 @@ pub struct ListGroupMembersResponse {
     pub members: Vec<GroupMemberEntry>,
 }
 
+/// List the device bindings a namespace holds, optionally narrowed to one
+/// principal.
+///
+/// Bindings are what let the governance planes speak in accounts while nodes
+/// sign with keys, and until this existed they were readable only from inside
+/// the node. A caller holding a key had no way to learn the account it speaks
+/// for, which is the whole reason `add_group_members` still accepts a key at
+/// all: the endpoint was doing double duty as the only resolution service in
+/// the API.
+#[derive(Debug)]
+pub struct ListGroupDevicesRequest {
+    pub group_id: ContextGroupId,
+    /// Narrow to one principal, in either spelling:
+    ///
+    /// * an **account** lists the devices that speak for it;
+    /// * a **key** lists the device that presents it — which is how a caller
+    ///   holding only a key learns the account behind it.
+    ///
+    /// `None` lists every live binding in the namespace.
+    pub member: Option<MemberPrincipal>,
+    pub offset: usize,
+    pub limit: usize,
+}
+
+impl Message for ListGroupDevicesRequest {
+    type Result = eyre::Result<ListGroupDevicesResponse>;
+}
+
+#[derive(Clone, Debug)]
+pub struct ListGroupDevicesResponse {
+    pub devices: Vec<GroupDeviceEntry>,
+}
+
+/// One device binding that is currently in force.
+///
+/// Deliberately carries no KEM key. That key is what scope-key deliveries are
+/// sealed to, it is read from the folded binding at the moment of wrapping, and
+/// it has never been on the wire — publishing it here would put a delivery
+/// target in reach of anything that can read a listing, for no caller's benefit.
+#[derive(Clone, Debug)]
+pub struct GroupDeviceEntry {
+    /// The device — also its CRDT replica id.
+    pub device: DeviceId,
+    /// The account it speaks for.
+    pub account: AccountId,
+    /// The key whose signature counts as this device's.
+    pub signing_key: PublicKey,
+    /// Key-rotation epoch, so a caller can tell a re-keyed device from a new one.
+    pub device_epoch: u32,
+}
+
 #[derive(Clone, Debug)]
 pub struct GroupMemberEntry {
     /// The member's ACCOUNT — the principal every governance row is keyed by.

--- a/crates/context/primitives/src/messages.rs
+++ b/crates/context/primitives/src/messages.rs
@@ -18,15 +18,16 @@ use crate::group::{
     GetNamespaceIdentityRequest, IssueNamespaceOwnershipProofRequest, IssueOwnershipProofRequest,
     JoinContextRequest, JoinGroupRequest, JoinSubgroupInheritanceRequest, LeaveContextRequest,
     LeaveGroupRequest, LeaveNamespaceRequest, ListAllGroupsRequest, ListGroupContextsRequest,
-    ListGroupMembersRequest, ListNamespacesForApplicationRequest, ListNamespacesRequest,
-    PairDeviceCompleteRequest, PairDeviceInitRequest, RemoveGroupMembersRequest,
-    ResyncContextRequest, RetryGroupUpgradeRequest, RevokeDeviceRequest, RotateGroupKeyRequest,
-    SetContextMetadataRequest, SetDefaultCapabilitiesRequest, SetGroupMetadataRequest,
-    SetMemberAutoFollowRequest, SetMemberCapabilitiesRequest, SetMemberMetadataRequest,
-    SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest, StoreContextMetadataRequest,
-    StoreDefaultCapabilitiesRequest, StoreGroupContextRequest, StoreGroupMetaRequest,
-    StoreGroupMetadataRequest, StoreMemberCapabilityRequest, StoreMemberMetadataRequest,
-    StoreSubgroupVisibilityRequest, SyncGroupRequest, UpdateMemberRoleRequest, UpgradeGroupRequest,
+    ListGroupDevicesRequest, ListGroupMembersRequest, ListNamespacesForApplicationRequest,
+    ListNamespacesRequest, PairDeviceCompleteRequest, PairDeviceInitRequest,
+    RemoveGroupMembersRequest, ResyncContextRequest, RetryGroupUpgradeRequest, RevokeDeviceRequest,
+    RotateGroupKeyRequest, SetContextMetadataRequest, SetDefaultCapabilitiesRequest,
+    SetGroupMetadataRequest, SetMemberAutoFollowRequest, SetMemberCapabilitiesRequest,
+    SetMemberMetadataRequest, SetSubgroupVisibilityRequest, SetTeeAdmissionPolicyRequest,
+    StoreContextMetadataRequest, StoreDefaultCapabilitiesRequest, StoreGroupContextRequest,
+    StoreGroupMetaRequest, StoreGroupMetadataRequest, StoreMemberCapabilityRequest,
+    StoreMemberMetadataRequest, StoreSubgroupVisibilityRequest, SyncGroupRequest,
+    UpdateMemberRoleRequest, UpgradeGroupRequest,
 };
 use crate::{ContextAtomic, ContextAtomicKey};
 
@@ -397,6 +398,10 @@ pub enum ContextMessage {
     ListGroupMembers {
         request: ListGroupMembersRequest,
         outcome: oneshot::Sender<<ListGroupMembersRequest as Message>::Result>,
+    },
+    ListGroupDevices {
+        request: ListGroupDevicesRequest,
+        outcome: oneshot::Sender<<ListGroupDevicesRequest as Message>::Result>,
     },
     ListGroupContexts {
         request: ListGroupContextsRequest,

--- a/crates/context/src/handlers.rs
+++ b/crates/context/src/handlers.rs
@@ -38,6 +38,7 @@ pub mod leave_group;
 pub mod leave_namespace;
 pub mod list_all_groups;
 pub mod list_group_contexts;
+pub mod list_group_devices;
 pub mod list_group_members;
 pub mod list_namespaces;
 pub mod list_namespaces_for_application;
@@ -122,6 +123,9 @@ impl Handler<ContextMessage> for ContextManager {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::ListGroupMembers { request, outcome } => {
+                self.forward_handler(ctx, request, outcome)
+            }
+            ContextMessage::ListGroupDevices { request, outcome } => {
                 self.forward_handler(ctx, request, outcome)
             }
             ContextMessage::ListGroupContexts { request, outcome } => {

--- a/crates/context/src/handlers/add_group_members.rs
+++ b/crates/context/src/handlers/add_group_members.rs
@@ -1,14 +1,78 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use actix::{ActorResponse, Handler, Message, WrapFuture};
+use calimero_account::AccountId;
 use calimero_context_client::group::AddGroupMembersRequest;
 use calimero_context_client::local_governance::{GroupOp, NamespaceOp, RootOp};
+use calimero_crypto::X25519PublicKey;
+use calimero_primitives::identity::{MemberPrincipal, PublicKey};
 use tracing::{info, warn};
 
 use crate::ContextManager;
 use calimero_governance_store;
 use calimero_governance_store::governance_broadcast::ObserveDelivery;
-use calimero_governance_store::{GroupKeyring, NamespaceRepository};
+use calimero_governance_store::{
+    AccountBindingRepository, DeviceBinding, GroupKeyring, KeyRecipient, NamespaceRepository,
+};
+
+/// One planned delivery of the group key to a just-added member.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Delivery {
+    /// Where the key goes, and therefore which key it is sealed under.
+    recipient: KeyRecipient,
+    /// The identity whose ack proves this delivery arrived — passed as the
+    /// publish's `required_signers` so the report speaks about the recipient
+    /// rather than about the group.
+    acked_by: PublicKey,
+}
+
+/// Who the group key goes to for one member of an add.
+///
+/// This is the whole behavioural difference between the two ways of naming a
+/// member, so it is a function of its inputs and nothing else:
+///
+/// * A **key** names one device's worth of a person — the caller knows that key
+///   and possibly nothing else about them — so it is addressed as-is, under the
+///   Ed25519-identity agreement.
+/// * An **account** names the person, and a person is reached through their
+///   live devices. Every one of them gets an envelope sealed to the X25519 key
+///   its certificate published.
+///
+/// An account with no live device yields **nothing**, and deliberately does not
+/// fall back to addressing an identity. A member whose devices are all revoked
+/// or superseded must receive nothing, or the key is handed straight back to the
+/// revoked device — the same rule `current_key_recipients` enforces for the
+/// rotation fan-out. The member row still lands; the key follows by pull once a
+/// live device exists.
+fn plan_deliveries(
+    who: &MemberPrincipal,
+    devices_by_account: &BTreeMap<AccountId, Vec<DeviceBinding>>,
+) -> Vec<Delivery> {
+    match *who {
+        MemberPrincipal::Key(key) => vec![Delivery {
+            recipient: KeyRecipient::Member(key),
+            acked_by: key,
+        }],
+        MemberPrincipal::Account(account) => devices_by_account
+            .get(&account)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .map(|binding| Delivery {
+                // The KEM key comes from the folded binding, never from the
+                // wire: the row that supplies it is the row that says the
+                // device is still authorized, so a revoked device's key is
+                // simply not available to wrap with.
+                recipient: KeyRecipient::Device {
+                    device: binding.device,
+                    kem_pk: X25519PublicKey::from(binding.kem_pk),
+                },
+                acked_by: binding.sign_pk,
+            })
+            .collect(),
+    }
+}
 
 impl Handler<AddGroupMembersRequest> for ContextManager {
     type Result = ActorResponse<Self, <AddGroupMembersRequest as Message>::Result>;
@@ -32,15 +96,42 @@ impl Handler<AddGroupMembersRequest> for ContextManager {
 
         ActorResponse::r#async(
             async move {
-                for (identity, role) in &members {
-                    // The caller names the invitee by KEY — that is what an
-                    // operator holds and shares — but the op names the account
-                    // it acts as. Resolution runs at the NAMESPACE: every direct
-                    // add in practice targets a subgroup and names somebody who
-                    // joined the namespace earlier, so asking the subgroup would
-                    // refuse every legitimate add.
-                    let member_account =
-                        crate::member_account::require(&datastore, &group_id, identity)?;
+                // Both the device lookup below and the resolution a key needs
+                // are NAMESPACE-scoped. Bindings are written where the
+                // credential arrived, which is the namespace a member joined,
+                // and a subgroup holds none of its own — so since every direct
+                // add in practice targets a subgroup, asking the subgroup would
+                // find nothing for anybody.
+                let ns_id = NamespaceRepository::new(&datastore).resolve(&group_id)?;
+
+                // Read once for the whole call, and only when something needs
+                // it. Resolving one account at a time filters a fresh scan
+                // each time, so an add of *m* members would read the binding
+                // column *m* times to answer one question.
+                let devices_by_account = if members.iter().any(|(who, _)| who.account().is_some()) {
+                    AccountBindingRepository::new(&datastore).live_devices_by_account(&ns_id)?
+                } else {
+                    BTreeMap::new()
+                };
+
+                for (who, role) in &members {
+                    // The op names an ACCOUNT, so a caller naming a key has to
+                    // be resolved to one first.
+                    let member_account = match *who {
+                        // Already the principal the row is keyed by: nothing to
+                        // resolve, and so nothing that can refuse. An account
+                        // this node has not learned yet still names the same
+                        // person everywhere, which is what a key cannot do.
+                        MemberPrincipal::Account(account) => account,
+                        // What an operator can be handed for somebody this node
+                        // never listed. Resolution requires the key to be bound
+                        // here already, so this form cannot in fact serve a
+                        // subject with no account — see `MemberPrincipal` for
+                        // why an account is the better thing to name.
+                        MemberPrincipal::Key(ref key) => {
+                            crate::member_account::require(&datastore, &group_id, key)?
+                        }
+                    };
                     let report = calimero_governance_store::sign_apply_and_publish(
                         &datastore,
                         &node_client,
@@ -55,48 +146,69 @@ impl Handler<AddGroupMembersRequest> for ContextManager {
                     .await?;
                     report.observe("add_group_members", "MemberAdded");
 
-                    // Admin-initiated key delivery: proactively push the
-                    // group key to the just-added member, ECDH-wrapped, so
-                    // it can decrypt its `MemberAdded` and the group's ops
-                    // promptly. This is a ONE-SHOT publish per add (not the
-                    // removed receiver-side re-publish that caused #2319).
-                    // The joiner-side pull (`recover_missing_group_keys`) is
-                    // the durable fallback if this delivery is missed.
+                    // Admin-initiated key delivery: proactively push the group
+                    // key to the just-added member, ECDH-wrapped, so it can
+                    // decrypt its `MemberAdded` and the group's ops promptly.
+                    // This is a ONE-SHOT publish per addressee (not the removed
+                    // receiver-side re-publish that caused #2319). The
+                    // joiner-side pull (`recover_missing_group_keys`) is the
+                    // durable fallback if a delivery is missed.
                     if let Some((_key_id, group_key)) =
                         GroupKeyring::new(&datastore, group_id).load_current_key()?
                     {
-                        let ns_id = NamespaceRepository::new(&datastore).resolve(&group_id)?;
-                        match GroupKeyring::wrap_for_member(
-                            &sk,
-                            identity,
-                            &group_id.to_bytes(),
-                            &group_key,
-                        ) {
-                            Ok(envelope) => {
-                                let delivery_op = NamespaceOp::Root(RootOp::KeyDelivery {
-                                    group_id: group_id.to_bytes().into(),
-                                    envelope,
-                                });
-                                // Recipient-specific: pass
-                                // `required_signers = Some([identity])` so
-                                // the report's `acked_by` cleanly reflects
-                                // whether the recipient applied and acked.
-                                if let Err(e) = calimero_governance_store::sign_and_publish_namespace_op(
+                        let deliveries = plan_deliveries(who, &devices_by_account);
+                        if deliveries.is_empty() {
+                            warn!(
+                                %member_account, ?group_id,
+                                "added member holds no live device here, so the group \
+                                 key was not delivered; it will be pulled once one is \
+                                 enrolled"
+                            );
+                        }
+                        for Delivery {
+                            recipient,
+                            acked_by,
+                        } in deliveries
+                        {
+                            let envelope = match GroupKeyring::wrap_for_recipient(
+                                &sk,
+                                &recipient,
+                                &group_id.to_bytes(),
+                                &group_key,
+                            ) {
+                                Ok(envelope) => envelope,
+                                Err(e) => {
+                                    warn!(
+                                        ?e, %acked_by,
+                                        "failed to wrap group key for added member"
+                                    );
+                                    continue;
+                                }
+                            };
+                            let delivery_op = NamespaceOp::Root(RootOp::KeyDelivery {
+                                group_id: group_id.to_bytes().into(),
+                                envelope,
+                            });
+                            // Recipient-specific: `required_signers` is the one
+                            // identity that can ack this envelope, so the
+                            // report's `acked_by` reflects whether the
+                            // recipient applied it.
+                            if let Err(e) =
+                                calimero_governance_store::sign_and_publish_namespace_op(
                                     &datastore,
                                     &node_client,
                                     &ack_router,
                                     ns_id.to_bytes().into(),
                                     &sk,
                                     delivery_op,
-                                    Some(vec![*identity]),
+                                    Some(vec![acked_by]),
                                 )
                                 .await
-                                {
-                                    warn!(?e, %identity, "failed to publish KeyDelivery for added member");
-                                }
-                            }
-                            Err(e) => {
-                                warn!(?e, %identity, "failed to wrap group key for added member");
+                            {
+                                warn!(
+                                    ?e, %acked_by,
+                                    "failed to publish KeyDelivery for added member"
+                                );
                             }
                         }
                     }
@@ -111,5 +223,125 @@ impl Handler<AddGroupMembersRequest> for ContextManager {
             }
             .into_actor(self),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use calimero_account::{DeviceId, KemPublicKey};
+    use calimero_primitives::identity::PrivateKey;
+
+    use super::*;
+
+    fn key(seed: u8) -> PublicKey {
+        PrivateKey::from([seed; 32]).public_key()
+    }
+
+    /// A binding as the fold writes one: one device of one account, with the
+    /// signing key its certificate published and the KEM key deliveries are
+    /// sealed to.
+    fn binding(account: AccountId, device: u8, sign: u8, kem: u8) -> DeviceBinding {
+        DeviceBinding {
+            device: DeviceId::from([device; 32]),
+            account,
+            sign_pk: key(sign),
+            kem_pk: *KemPublicKey::from([kem; 32]).as_bytes(),
+            device_epoch: 0,
+        }
+    }
+
+    #[test]
+    fn a_key_named_member_is_addressed_as_the_key_the_caller_gave() {
+        // The caller knows a key and possibly nothing else about this person, so
+        // there is nothing to expand it to.
+        let who = MemberPrincipal::Key(key(7));
+
+        let deliveries = plan_deliveries(&who, &BTreeMap::new());
+
+        assert_eq!(
+            deliveries,
+            vec![Delivery {
+                recipient: KeyRecipient::Member(key(7)),
+                acked_by: key(7),
+            }],
+            "a key names exactly one addressee: itself"
+        );
+    }
+
+    #[test]
+    fn an_account_named_member_reaches_every_device_that_person_holds() {
+        // The point of naming an account. A key would have reached whichever
+        // single device the caller happened to know about, leaving this person's
+        // other devices to discover the key by pull.
+        let account = AccountId::from([0xA1; 32]);
+        let devices = BTreeMap::from([(
+            account,
+            vec![
+                binding(account, 0x01, 0x11, 0x21),
+                binding(account, 0x02, 0x12, 0x22),
+            ],
+        )]);
+
+        let deliveries = plan_deliveries(&MemberPrincipal::Account(account), &devices);
+
+        assert_eq!(
+            deliveries,
+            vec![
+                Delivery {
+                    recipient: KeyRecipient::Device {
+                        device: DeviceId::from([0x01; 32]),
+                        kem_pk: X25519PublicKey::from([0x21; 32]),
+                    },
+                    acked_by: key(0x11),
+                },
+                Delivery {
+                    recipient: KeyRecipient::Device {
+                        device: DeviceId::from([0x02; 32]),
+                        kem_pk: X25519PublicKey::from([0x22; 32]),
+                    },
+                    acked_by: key(0x12),
+                },
+            ],
+            "each device gets its own envelope, sealed to its own certified key"
+        );
+    }
+
+    #[test]
+    fn only_the_named_persons_devices_are_addressed() {
+        // The map is one scan of the whole namespace, so the filtering has to
+        // happen here rather than being assumed of the caller.
+        let account = AccountId::from([0xA1; 32]);
+        let other = AccountId::from([0xB2; 32]);
+        let devices = BTreeMap::from([
+            (account, vec![binding(account, 0x01, 0x11, 0x21)]),
+            (other, vec![binding(other, 0x03, 0x13, 0x23)]),
+        ]);
+
+        let deliveries = plan_deliveries(&MemberPrincipal::Account(account), &devices);
+
+        assert_eq!(deliveries.len(), 1);
+        assert_eq!(deliveries[0].acked_by, key(0x11));
+    }
+
+    #[test]
+    fn an_account_with_no_live_device_is_delivered_nothing() {
+        // NOT a fallback to identity addressing. Every device of this person is
+        // revoked or superseded, and identity-addressing the delivery would hand
+        // the group key straight back to the revoked device — the exclusion the
+        // device rows exist to enforce. The member row still lands, and the key
+        // follows by pull once a live device exists.
+        let account = AccountId::from([0xA1; 32]);
+
+        let empty_entry = BTreeMap::from([(account, Vec::new())]);
+        let absent = BTreeMap::new();
+
+        for devices in [empty_entry, absent] {
+            let deliveries = plan_deliveries(&MemberPrincipal::Account(account), &devices);
+
+            assert!(
+                deliveries.is_empty(),
+                "no live device must mean no delivery, never an identity-addressed one"
+            );
+        }
     }
 }

--- a/crates/context/src/handlers/list_group_devices.rs
+++ b/crates/context/src/handlers/list_group_devices.rs
@@ -1,0 +1,172 @@
+use actix::{ActorResponse, Handler, Message};
+use calimero_context_client::group::{
+    GroupDeviceEntry, ListGroupDevicesRequest, ListGroupDevicesResponse,
+};
+use calimero_governance_store::{
+    AccountBindingRepository, DeviceBinding, MembershipRepository, MetaRepository,
+    NamespaceRepository,
+};
+use calimero_primitives::identity::MemberPrincipal;
+use eyre::bail;
+
+use crate::ContextManager;
+use calimero_governance_store;
+
+/// Does `binding` belong to the principal a caller asked about?
+///
+/// The two spellings ask genuinely different questions of the same row — "which
+/// devices does this person have" versus "whose device is this key" — and both
+/// are answered by matching one field, so neither needs its own lookup.
+///
+/// A key match is not narrowed to one row on purpose. Nothing constrains two
+/// devices to distinct signing keys, and a caller resolving a key needs to see a
+/// collision if there is one rather than be handed whichever row a point lookup
+/// reached first.
+fn matches(binding: &DeviceBinding, member: &MemberPrincipal) -> bool {
+    match *member {
+        MemberPrincipal::Account(account) => binding.account == account,
+        MemberPrincipal::Key(key) => binding.sign_pk == key,
+    }
+}
+
+impl Handler<ListGroupDevicesRequest> for ContextManager {
+    type Result = ActorResponse<Self, <ListGroupDevicesRequest as Message>::Result>;
+
+    fn handle(
+        &mut self,
+        ListGroupDevicesRequest {
+            group_id,
+            member,
+            offset,
+            limit,
+        }: ListGroupDevicesRequest,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        let result = (|| -> eyre::Result<ListGroupDevicesResponse> {
+            if MetaRepository::new(&self.datastore)
+                .load(&group_id)?
+                .is_none()
+            {
+                bail!("group '{group_id:?}' not found");
+            }
+
+            // Same gate as the member listing, for the same reason: these rows
+            // say who may act in this namespace, so they are readable by a node
+            // that belongs to it and not by one that merely knows its id.
+            let Some((node_identity, _)) = self.node_signing_key(&group_id) else {
+                bail!("node has no group identity configured");
+            };
+            let node_account =
+                crate::member_account::require(&self.datastore, &group_id, &node_identity)?;
+            if MembershipRepository::new(&self.datastore).check_path(&group_id, &node_account)?
+                == calimero_governance_store::MembershipPath::None
+            {
+                // Typed so the admin API surfaces this precondition as a 403,
+                // not a generic 500 (see `parse_api_error`).
+                return Err(crate::error::ContextError::NotAGroupMember {
+                    group_id: format!("{group_id:?}"),
+                }
+                .into());
+            }
+
+            // Bindings live at the NAMESPACE: they are written where the
+            // credential arrived, which is the namespace a member joined, and a
+            // subgroup holds none of its own. A caller asking a subgroup means
+            // "the devices behind this subgroup's members", so resolving up is
+            // the answer rather than an empty list.
+            let namespace = NamespaceRepository::new(&self.datastore).resolve(&group_id)?;
+
+            let mut bindings =
+                AccountBindingRepository::new(&self.datastore).live_bindings(&namespace)?;
+            if let Some(ref member) = member {
+                bindings.retain(|binding| matches(binding, member));
+            }
+            // Stable, path-independent pagination: store order is not a
+            // contract, so two pages of one listing could otherwise skip or
+            // repeat a device. Device id is unique per row, which account and
+            // signing key are not.
+            bindings.sort_by_key(|binding| binding.device);
+
+            let devices = bindings
+                .into_iter()
+                .skip(offset)
+                .take(limit)
+                .map(|binding| GroupDeviceEntry {
+                    device: binding.device,
+                    account: binding.account,
+                    signing_key: binding.sign_pk,
+                    device_epoch: binding.device_epoch,
+                })
+                .collect();
+
+            Ok(ListGroupDevicesResponse { devices })
+        })();
+
+        ActorResponse::reply(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use calimero_account::{AccountId, DeviceId, KemPublicKey};
+    use calimero_primitives::identity::{PrivateKey, PublicKey};
+
+    use super::*;
+
+    fn key(seed: u8) -> PublicKey {
+        PrivateKey::from([seed; 32]).public_key()
+    }
+
+    fn binding(account: u8, device: u8, sign: u8) -> DeviceBinding {
+        DeviceBinding {
+            device: DeviceId::from([device; 32]),
+            account: AccountId::from([account; 32]),
+            sign_pk: key(sign),
+            kem_pk: *KemPublicKey::from([0x2B; 32]).as_bytes(),
+            device_epoch: 0,
+        }
+    }
+
+    #[test]
+    fn an_account_selects_every_device_that_speaks_for_it() {
+        let mine = binding(0xA1, 0x01, 0x11);
+        let also_mine = binding(0xA1, 0x02, 0x12);
+        let theirs = binding(0xB2, 0x03, 0x13);
+        let member = MemberPrincipal::Account(AccountId::from([0xA1; 32]));
+
+        assert!(matches(&mine, &member));
+        assert!(matches(&also_mine, &member));
+        assert!(!matches(&theirs, &member));
+    }
+
+    /// The resolution the `add_group_members` key form was standing in for: a
+    /// caller holds a key, and the row it selects names the account.
+    #[test]
+    fn a_key_selects_the_device_that_presents_it() {
+        let mine = binding(0xA1, 0x01, 0x11);
+        let sibling_device = binding(0xA1, 0x02, 0x12);
+
+        assert!(matches(&mine, &MemberPrincipal::Key(key(0x11))));
+        assert!(
+            !matches(&sibling_device, &MemberPrincipal::Key(key(0x11))),
+            "a key names one device, not the person's whole set"
+        );
+    }
+
+    /// An account is not a signing key and must not select as one, even though
+    /// both are 32 bytes. The encodings make this unreachable through the API;
+    /// the match arms make it unreachable here too.
+    #[test]
+    fn a_principal_never_matches_the_other_kinds_field() {
+        let row = binding(0xA1, 0x01, 0x11);
+
+        assert!(!matches(
+            &row,
+            &MemberPrincipal::Key(PublicKey::from([0xA1; 32]))
+        ));
+        assert!(!matches(
+            &row,
+            &MemberPrincipal::Account(AccountId::from(*key(0x11)))
+        ));
+    }
+}

--- a/crates/meroctl/src/cli/group/members.rs
+++ b/crates/meroctl/src/cli/group/members.rs
@@ -1,6 +1,7 @@
+use calimero_account::AccountId;
 use calimero_context_config::MemberCapabilities;
 use calimero_primitives::context::GroupMemberRole;
-use calimero_primitives::identity::PublicKey;
+use calimero_primitives::identity::MemberPrincipal;
 use calimero_server_primitives::admin::{
     AddGroupMembersApiRequest, GroupMemberApiInput, RemoveGroupMembersApiRequest,
     SetMemberCapabilitiesApiRequest, UpdateMemberRoleApiRequest,
@@ -105,8 +106,11 @@ pub struct AddMembersCommand {
     )]
     pub group_id: String,
 
-    #[clap(name = "IDENTITY", help = "Public key of the identity to add")]
-    pub identity: PublicKey,
+    #[clap(
+        name = "MEMBER",
+        help = "Account (64 hex chars, as `list-members` prints) or signing key (base58) to add"
+    )]
+    pub identity: MemberPrincipal,
 
     #[clap(
         name = "ROLE",
@@ -195,10 +199,10 @@ pub struct SetRoleCommand {
     pub group_id: String,
 
     #[clap(
-        name = "IDENTITY",
-        help = "Public key of the member whose role to update"
+        name = "MEMBER",
+        help = "Account of the member whose role to update (64 hex chars)"
     )]
-    pub identity: PublicKey,
+    pub identity: AccountId,
 
     #[clap(name = "ROLE", value_enum, help = "New role to assign")]
     pub role: MemberRoleArg,
@@ -206,7 +210,7 @@ pub struct SetRoleCommand {
 
 impl SetRoleCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
-        let identity_hex = hex::encode(self.identity.digest());
+        let account = self.identity.to_string();
 
         let request = UpdateMemberRoleApiRequest {
             role: self.role.into(),
@@ -214,7 +218,7 @@ impl SetRoleCommand {
 
         let client = environment.client()?;
         let response = client
-            .update_member_role(&self.group_id, &identity_hex, request)
+            .update_member_role(&self.group_id, &account, request)
             .await?;
 
         environment.output.write(&response);
@@ -233,8 +237,8 @@ pub struct SetCapabilitiesCommand {
     )]
     pub group_id: String,
 
-    #[clap(name = "IDENTITY", help = "Public key of the member")]
-    pub identity: PublicKey,
+    #[clap(name = "MEMBER", help = "Account of the member (64 hex chars)")]
+    pub identity: AccountId,
 
     #[clap(long, help = "Allow member to create contexts in the group")]
     pub can_create_context: bool,
@@ -282,13 +286,13 @@ impl SetCapabilitiesCommand {
             self.can_manage_metadata,
         );
 
-        let identity_hex = hex::encode(self.identity.digest());
+        let account = self.identity.to_string();
 
         let request = SetMemberCapabilitiesApiRequest { capabilities };
 
         let client = environment.client()?;
         let response = client
-            .set_member_capabilities(&self.group_id, &identity_hex, request)
+            .set_member_capabilities(&self.group_id, &account, request)
             .await?;
 
         environment.output.write(&response);
@@ -313,11 +317,11 @@ pub struct GetCapabilitiesCommand {
 
 impl GetCapabilitiesCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
-        let identity_hex = self.identity.to_string();
+        let account = self.identity.to_string();
 
         let client = environment.client()?;
         let response = client
-            .get_member_capabilities(&self.group_id, &identity_hex)
+            .get_member_capabilities(&self.group_id, &account)
             .await?;
 
         environment.output.write(&response);
@@ -342,12 +346,12 @@ pub struct CheckAccessCommand {
 
 impl CheckAccessCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
-        let identity_hex = self.identity.to_string();
+        let account = self.identity.to_string();
 
         let client = environment.client()?;
 
         let caps_response = client
-            .get_member_capabilities(&self.group_id, &identity_hex)
+            .get_member_capabilities(&self.group_id, &account)
             .await?;
         let members_response = client.list_group_members(&self.group_id).await?;
 

--- a/crates/meroctl/src/cli/group/members.rs
+++ b/crates/meroctl/src/cli/group/members.rs
@@ -56,6 +56,8 @@ pub enum MembersSubCommands {
     GetCapabilities(GetCapabilitiesCommand),
     #[command(about = "Check if an identity can join a context in this group")]
     CheckAccess(CheckAccessCommand),
+    #[command(about = "List the devices behind this group's members, or resolve one principal")]
+    Devices(DevicesCommand),
 }
 
 impl MembersCommand {
@@ -70,6 +72,7 @@ impl MembersCommand {
             MembersSubCommands::SetCapabilities,
             MembersSubCommands::GetCapabilities,
             MembersSubCommands::CheckAccess,
+            MembersSubCommands::Devices,
         )
     }
 }
@@ -89,6 +92,37 @@ impl ListMembersCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
         let client = environment.client()?;
         let response = client.list_group_members(&self.group_id).await?;
+
+        environment.output.write(&response);
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Parser)]
+#[command(about = "List the devices behind this group's members, or resolve one principal")]
+pub struct DevicesCommand {
+    #[clap(
+        name = "GROUP_ID",
+        value_parser = crate::cli::validation::group_id,
+        help = "The hex-encoded group ID"
+    )]
+    pub group_id: String,
+
+    #[clap(
+        name = "MEMBER",
+        help = "Optional: an account (64 hex chars) to list the devices of, or a \
+                signing key (base58) to learn the account it speaks for"
+    )]
+    pub member: Option<MemberPrincipal>,
+}
+
+impl DevicesCommand {
+    pub async fn run(self, environment: &mut Environment) -> Result<()> {
+        let client = environment.client()?;
+        let response = client
+            .list_group_devices(&self.group_id, self.member.as_ref())
+            .await?;
 
         environment.output.write(&response);
 

--- a/crates/meroctl/src/cli/group/metadata.rs
+++ b/crates/meroctl/src/cli/group/metadata.rs
@@ -1,8 +1,8 @@
 //! `meroctl group metadata ...` — manage generic [`MetadataRecord`]s on a
 //! group, a group member, or a group-registered context.
 
+use calimero_account::AccountId;
 use calimero_primitives::context::ContextId;
-use calimero_primitives::identity::PublicKey;
 use calimero_server_primitives::admin::SetMetadataApiRequest;
 use clap::{Args, Parser, Subcommand};
 use eyre::{bail, Result};
@@ -166,8 +166,8 @@ pub enum MemberMetadataSubCommands {
             help = "Hex-encoded group ID"
         )]
         group_id: String,
-        #[clap(name = "MEMBER", help = "Member public key")]
-        member: PublicKey,
+        #[clap(name = "MEMBER", help = "Member account (64 hex characters)")]
+        member: AccountId,
     },
     #[command(about = "Update a member's metadata record (read-modify-write)")]
     Set {
@@ -177,8 +177,8 @@ pub enum MemberMetadataSubCommands {
             help = "Hex-encoded group ID"
         )]
         group_id: String,
-        #[clap(name = "MEMBER", help = "Member public key")]
-        member: PublicKey,
+        #[clap(name = "MEMBER", help = "Member account (64 hex characters)")]
+        member: AccountId,
         #[command(flatten)]
         opts: SetOpts,
     },
@@ -189,8 +189,8 @@ impl MemberMetadataCommand {
         let client = environment.client()?;
         match self.subcommand {
             MemberMetadataSubCommands::Get { group_id, member } => {
-                let identity_hex = hex::encode(member.digest());
-                let response = client.get_member_metadata(&group_id, &identity_hex).await?;
+                let account = member.to_string();
+                let response = client.get_member_metadata(&group_id, &account).await?;
                 environment.output.write(&response);
             }
             MemberMetadataSubCommands::Set {
@@ -198,13 +198,10 @@ impl MemberMetadataCommand {
                 member,
                 opts,
             } => {
-                let identity_hex = hex::encode(member.digest());
-                let current = client
-                    .get_member_metadata(&group_id, &identity_hex)
-                    .await?
-                    .data;
+                let account = member.to_string();
+                let current = client.get_member_metadata(&group_id, &account).await?.data;
                 let response = client
-                    .set_member_metadata(&group_id, &identity_hex, opts.into_request(current))
+                    .set_member_metadata(&group_id, &account, opts.into_request(current))
                     .await?;
                 environment.output.write(&response);
             }

--- a/crates/meroctl/src/output/groups.rs
+++ b/crates/meroctl/src/output/groups.rs
@@ -5,13 +5,13 @@ use calimero_server_primitives::admin::{
     DetachContextFromGroupApiResponse, GetGroupUpgradeStatusApiResponse,
     GetMemberCapabilitiesApiResponse, GetMetadataApiResponse, GroupInfoApiResponse,
     JoinContextApiResponse, JoinGroupApiResponse, LeaveContextApiResponse, LeaveGroupApiResponse,
-    LeaveNamespaceApiResponse, ListGroupContextsApiResponse, ListGroupMembersApiResponse,
-    ListNamespaceGroupsApiResponse, ListNamespacesApiResponse, ListSubgroupsApiResponse,
-    NamespaceApiResponse, NodeIdentityApiResponse, PairDeviceCompleteApiResponse,
-    PairDeviceInitApiResponse, RemoveGroupMembersApiResponse, ReparentGroupApiResponse,
-    RevokeDeviceApiResponse, SetDefaultCapabilitiesApiResponse, SetMemberCapabilitiesApiResponse,
-    SetMetadataApiResponse, SetSubgroupVisibilityApiResponse, SyncGroupApiResponse,
-    UpdateMemberRoleApiResponse, UpgradeGroupApiResponse,
+    LeaveNamespaceApiResponse, ListGroupContextsApiResponse, ListGroupDevicesApiResponse,
+    ListGroupMembersApiResponse, ListNamespaceGroupsApiResponse, ListNamespacesApiResponse,
+    ListSubgroupsApiResponse, NamespaceApiResponse, NodeIdentityApiResponse,
+    PairDeviceCompleteApiResponse, PairDeviceInitApiResponse, RemoveGroupMembersApiResponse,
+    ReparentGroupApiResponse, RevokeDeviceApiResponse, SetDefaultCapabilitiesApiResponse,
+    SetMemberCapabilitiesApiResponse, SetMetadataApiResponse, SetSubgroupVisibilityApiResponse,
+    SyncGroupApiResponse, UpdateMemberRoleApiResponse, UpgradeGroupApiResponse,
 };
 use color_eyre::owo_colors::OwoColorize;
 use comfy_table::{Cell, Color, Table};
@@ -321,6 +321,34 @@ impl Report for ListGroupMembersApiResponse {
                     member.identity.to_string(),
                     format!("{:?}", member.role),
                     member.name.clone().unwrap_or_else(|| "-".to_owned()),
+                ]);
+            }
+            println!("{table}");
+        }
+    }
+}
+
+impl Report for ListGroupDevicesApiResponse {
+    fn report(&self) {
+        if self.devices.is_empty() {
+            println!("No devices found");
+        } else {
+            let mut table = Table::new();
+            // Account first: it is the answer a caller is usually here for —
+            // either "which devices does this person have" or, coming in with a
+            // signing key, "who is this".
+            let _ = table.set_header(vec![
+                Cell::new("Account").fg(Color::Blue),
+                Cell::new("Device").fg(Color::Blue),
+                Cell::new("Signing key").fg(Color::Blue),
+                Cell::new("Epoch").fg(Color::Blue),
+            ]);
+            for device in &self.devices {
+                let _ = table.add_row(vec![
+                    device.account.to_string(),
+                    device.device.to_string(),
+                    device.signing_key.to_string(),
+                    device.device_epoch.to_string(),
                 ]);
             }
             println!("{table}");

--- a/crates/primitives/src/identity.rs
+++ b/crates/primitives/src/identity.rs
@@ -354,11 +354,200 @@ impl DeviceId {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Naming a member
+// ---------------------------------------------------------------------------
+
+/// Who a membership call names: a **person**, or one **key** that person signs
+/// with.
+///
+/// Membership rows are keyed by [`AccountId`], and every verb that reads or
+/// changes one takes an account. An *add* is the exception, because the caller
+/// may hold nothing but a key — an operator adding an outsider knows the key
+/// that person signs with long before this node has learned their account. So
+/// both are accepted, in the same JSON string field, and the encoding alone
+/// decides which was meant.
+///
+/// That is unambiguous by construction rather than by luck. An account renders
+/// as exactly 64 hex characters; [`crate::hash::Hash`] — the parser behind every
+/// key — refuses any string longer than the widest base58 a 32-byte key can
+/// produce, which is 45 characters. No account string can therefore be read as
+/// a key, and no key string is 64 characters long. A caller who confuses the two
+/// gets a parse error rather than a different principal.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MemberPrincipal {
+    /// The person, named directly — the principal the row is keyed by. Prefer
+    /// this: it is what a member listing hands back, and it is what the key
+    /// resolves to anyway.
+    Account(AccountId),
+    /// One signing key the person holds.
+    ///
+    /// A person may hold several, so this names strictly less than an account
+    /// does. It is here for the one caller that has no choice: the subject is
+    /// not known here as an account yet.
+    Key(PublicKey),
+}
+
+impl MemberPrincipal {
+    /// The account, when that is what was named.
+    #[must_use]
+    pub const fn account(&self) -> Option<AccountId> {
+        match *self {
+            Self::Account(account) => Some(account),
+            Self::Key(_) => None,
+        }
+    }
+
+    /// The key, when that is what was named.
+    #[must_use]
+    pub const fn key(&self) -> Option<PublicKey> {
+        match *self {
+            Self::Key(key) => Some(key),
+            Self::Account(_) => None,
+        }
+    }
+}
+
+impl From<AccountId> for MemberPrincipal {
+    fn from(account: AccountId) -> Self {
+        Self::Account(account)
+    }
+}
+
+impl From<PublicKey> for MemberPrincipal {
+    fn from(key: PublicKey) -> Self {
+        Self::Key(key)
+    }
+}
+
+impl fmt::Display for MemberPrincipal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Account(account) => fmt::Display::fmt(account, f),
+            Self::Key(key) => fmt::Display::fmt(key, f),
+        }
+    }
+}
+
+/// A string was neither encoding, so it names no member.
+#[derive(Clone, Copy, Debug, Error)]
+#[error(
+    "expected an account (64 hex characters, as a member listing renders one) \
+     or a signing key (base58)"
+)]
+pub struct InvalidMemberPrincipal;
+
+impl FromStr for MemberPrincipal {
+    type Err = InvalidMemberPrincipal;
+
+    /// Accounts are tried first, so the wider parser never gets to claim one.
+    /// The orderings agree here — a 64-character string is too long for the key
+    /// parser — but relying on that would make the disambiguation a property of
+    /// two parsers instead of a property of this function.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(account) = s.parse::<AccountId>() {
+            return Ok(Self::Account(account));
+        }
+        s.parse::<PublicKey>()
+            .map(Self::Key)
+            .map_err(|_| InvalidMemberPrincipal)
+    }
+}
+
+/// Serializes as the string form of whichever principal it holds, so a value
+/// read back from a listing round-trips unchanged.
+impl Serialize for MemberPrincipal {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for MemberPrincipal {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = <std::borrow::Cow<'de, str> as Deserialize>::deserialize(d)?;
+        raw.parse().map_err(serde::de::Error::custom)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use core::mem::ManuallyDrop;
 
     use super::*;
+
+    /// The disambiguation the whole two-in-one-field design rests on.
+    #[test]
+    fn an_account_and_a_key_each_parse_back_to_what_they_are() {
+        let account = AccountId::from([0xA1; 32]);
+        let key = PublicKey::from([0xB2; 32]);
+
+        assert_eq!(
+            account.to_string().parse::<MemberPrincipal>().unwrap(),
+            MemberPrincipal::Account(account),
+            "64 hex characters is an account"
+        );
+        assert_eq!(
+            key.to_string().parse::<MemberPrincipal>().unwrap(),
+            MemberPrincipal::Key(key),
+            "base58 is a key"
+        );
+    }
+
+    /// Neither encoding may be read as the other principal.
+    ///
+    /// Both are 32 bytes, so a shared encoding would let one be pasted where the
+    /// other belongs and silently name somebody who exists nowhere. What rules
+    /// that out is a length: a key parses through `Hash`, which refuses anything
+    /// longer than the widest base58 32 bytes can produce, and an account is
+    /// always longer than that.
+    #[test]
+    fn neither_encoding_can_be_mistaken_for_the_other() {
+        let account = AccountId::from([0xA1; 32]).to_string();
+        let key = PublicKey::from([0xB2; 32]).to_string();
+
+        assert_eq!(account.len(), 64, "an account is always 64 characters");
+        assert!(
+            key.len() < 64,
+            "and base58 of 32 bytes is always shorter than that"
+        );
+        assert!(
+            account.parse::<PublicKey>().is_err(),
+            "an account string must not parse as a key"
+        );
+        assert!(
+            key.parse::<AccountId>().is_err(),
+            "a key string must not parse as an account"
+        );
+    }
+
+    #[test]
+    fn a_string_that_is_neither_names_no_member() {
+        for bad in ["", "not-an-id", "0xdeadbeef"] {
+            assert!(
+                bad.parse::<MemberPrincipal>().is_err(),
+                "{bad:?} names no member"
+            );
+        }
+    }
+
+    /// A value read out of a listing and handed straight back must survive the
+    /// round trip, or a caller could not use one endpoint's output as another's
+    /// input.
+    #[test]
+    fn a_principal_serializes_as_the_string_it_parses_from() {
+        for principal in [
+            MemberPrincipal::Account(AccountId::from([0xA1; 32])),
+            MemberPrincipal::Key(PublicKey::from([0xB2; 32])),
+        ] {
+            let json = serde_json::to_value(principal).unwrap();
+
+            assert_eq!(json, serde_json::json!(principal.to_string()));
+            assert_eq!(
+                serde_json::from_value::<MemberPrincipal>(json).unwrap(),
+                principal
+            );
+        }
+    }
 
     #[test]
     fn test_private_key_zeroize_on_drop() {

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -5,7 +5,7 @@ use calimero_primitives::alias::Alias;
 use calimero_primitives::application::{Application, ApplicationId};
 use calimero_primitives::context::{Context, ContextId, GroupMemberRole};
 use calimero_primitives::hash::Hash;
-use calimero_primitives::identity::{AccountId, MemberPrincipal, PublicKey};
+use calimero_primitives::identity::{AccountId, DeviceId, MemberPrincipal, PublicKey};
 use calimero_primitives::metadata::MetadataRecord;
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
@@ -1383,6 +1383,49 @@ pub struct GroupMemberApiEntry {
     pub role: GroupMemberRole,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+}
+
+/// Query for `GET .../groups/:group_id/devices`.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListGroupDevicesQuery {
+    /// Narrow to one principal, in either encoding — an account lists its
+    /// devices, a key lists the device that presents it. Omit to list every live
+    /// binding the namespace holds.
+    ///
+    /// A key here is how a caller holding nothing but a key learns the account it
+    /// speaks for. That resolution had no home in the API, which is the only
+    /// reason `POST .../members` still accepts a key at all.
+    pub member: Option<MemberPrincipal>,
+    pub offset: Option<usize>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListGroupDevicesApiResponse {
+    pub devices: Vec<GroupDeviceApiEntry>,
+}
+
+/// One device binding currently in force in the namespace owning the group.
+///
+/// No KEM key: scope-key deliveries are sealed to it, it is read from the folded
+/// binding at the moment of wrapping, and it has never travelled on the wire.
+/// Publishing it here would put a delivery target within reach of anything that
+/// can read a listing, and no caller needs it.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupDeviceApiEntry {
+    /// The device, 64 hex characters — also its CRDT replica id.
+    pub device: DeviceId,
+    /// The ACCOUNT this device speaks for, 64 hex characters. The principal
+    /// every membership row is keyed by, and what `POST .../members` should be
+    /// given.
+    pub account: AccountId,
+    /// The base58 signing key whose signature counts as this device's.
+    pub signing_key: PublicKey,
+    /// Key-rotation epoch, so a re-keyed device is distinguishable from a new one.
+    pub device_epoch: u32,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -5,7 +5,7 @@ use calimero_primitives::alias::Alias;
 use calimero_primitives::application::{Application, ApplicationId};
 use calimero_primitives::context::{Context, ContextId, GroupMemberRole};
 use calimero_primitives::hash::Hash;
-use calimero_primitives::identity::{AccountId, PublicKey};
+use calimero_primitives::identity::{AccountId, MemberPrincipal, PublicKey};
 use calimero_primitives::metadata::MetadataRecord;
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
@@ -1326,25 +1326,27 @@ impl Validate for AddGroupMembersApiRequest {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupMemberApiInput {
-    /// The only KEY-typed principal left on `/groups/:id/members`: every other
-    /// verb on this resource — the GET listing, remove, and the role /
-    /// capabilities / metadata / auto-follow updates — names members by
-    /// [`AccountId`]. A caller therefore has to know which encoding each
-    /// endpoint wants, and the two are rendered differently (bs58 vs 64-hex)
-    /// specifically so a mix-up fails loudly instead of resolving to the wrong
-    /// principal.
+    /// Who to add, named either way round — by ACCOUNT, as a member listing
+    /// renders one, or by one signing KEY that person holds. The encoding says
+    /// which, and the two cannot be confused: see [`MemberPrincipal`].
     ///
-    /// It is a key because an add is the one call whose subject may not have an
-    /// account here yet. An operator adding someone holds the key that person
-    /// signs with; the account is a hash of a genesis this node learns only once
-    /// they have joined, so requiring one would make the endpoint uncallable in
-    /// exactly the case it exists for. The apply resolves this key to the
-    /// account the row is keyed by, and the listing is where the caller reads
-    /// that account back.
+    /// **Prefer the account.** It is the principal the membership row is keyed
+    /// by, it is what `GET .../members` hands back, and it is what a key is
+    /// resolved to before anything is written — so naming it directly skips a
+    /// lookup that can only fail. It is also the only form that can name
+    /// somebody whose key this caller has never seen, which is the ordinary case
+    /// for adding an existing namespace member to a subgroup: a listing shows
+    /// accounts, and no endpoint discloses the keys behind one.
     ///
-    /// This converges on accounts once an add can name an account that does not
-    /// exist locally yet.
-    pub identity: PublicKey,
+    /// Naming an account additionally makes the group key reach every device
+    /// that person currently holds, under the same revocation rules the rest of
+    /// the key plane enforces. A key names one device's worth of that person, so
+    /// a key-named add delivers to that one and leaves any others to recover the
+    /// key by pull.
+    ///
+    /// The key form stays for the case it exists for — a subject with no account
+    /// here yet — and for callers written before the account form existed.
+    pub identity: MemberPrincipal,
     pub role: GroupMemberRole,
 }
 
@@ -2608,6 +2610,56 @@ pub struct SetSubgroupVisibilityApiResponse {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The request an add of an existing member has to be able to express.
+    ///
+    /// A caller adding somebody to a subgroup knows them from a member listing,
+    /// which renders accounts and never discloses the keys behind one. Before
+    /// this field took a principal there was nothing they could put here: the
+    /// account parsed as no key, and the key it wanted was not theirs to know.
+    #[test]
+    fn an_add_may_name_the_account_a_member_listing_prints() {
+        let account = AccountId::from([0xA1; 32]);
+        let json = serde_json::json!({
+            "members": [{ "identity": account.to_string(), "role": "Member" }],
+        });
+
+        let req: AddGroupMembersApiRequest = serde_json::from_value(json).unwrap();
+
+        assert_eq!(req.members[0].identity, MemberPrincipal::Account(account));
+        assert!(req.validate().is_empty());
+    }
+
+    /// The form that predates the account one, still on the wire.
+    #[test]
+    fn an_add_may_still_name_a_signing_key() {
+        let key = PublicKey::from([0xB2; 32]);
+        let json = serde_json::json!({
+            "members": [{ "identity": key.to_string(), "role": "Member" }],
+        });
+
+        let req: AddGroupMembersApiRequest = serde_json::from_value(json).unwrap();
+
+        assert_eq!(req.members[0].identity, MemberPrincipal::Key(key));
+    }
+
+    /// A principal that is neither encoding is refused at the boundary, so a
+    /// typo cannot travel inward as a member nobody is.
+    #[test]
+    fn an_add_refuses_a_principal_in_no_recognized_encoding() {
+        let json = serde_json::json!({
+            "members": [{ "identity": "definitely-not-an-id", "role": "Member" }],
+        });
+
+        let err = serde_json::from_value::<AddGroupMembersApiRequest>(json)
+            .expect_err("neither an account nor a key");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("account") && message.contains("key"),
+            "the refusal must name both encodings, got: {message}"
+        );
+    }
 
     #[test]
     fn join_response_ignores_a_governance_op_from_an_older_node() {

--- a/crates/server/src/admin/handlers/groups.rs
+++ b/crates/server/src/admin/handlers/groups.rs
@@ -16,6 +16,7 @@ pub mod join_group;
 pub mod join_subgroup_inheritance;
 pub mod leave_group;
 pub mod list_group_contexts;
+pub mod list_group_devices;
 pub mod list_group_members;
 pub mod list_subgroups;
 pub mod remove_group_members;

--- a/crates/server/src/admin/handlers/groups/list_group_devices.rs
+++ b/crates/server/src/admin/handlers/groups/list_group_devices.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+
+use axum::extract::{Path, Query};
+use axum::response::IntoResponse;
+use axum::Extension;
+use calimero_context_client::group::ListGroupDevicesRequest;
+use calimero_server_primitives::admin::{
+    GroupDeviceApiEntry, ListGroupDevicesApiResponse, ListGroupDevicesQuery,
+};
+use tracing::{error, info};
+
+use super::{parse_group_id, DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT};
+use crate::admin::service::{parse_api_error, ApiResponse};
+use crate::AdminState;
+
+pub async fn handler(
+    Path(group_id_str): Path<String>,
+    Query(query): Query<ListGroupDevicesQuery>,
+    Extension(state): Extension<Arc<AdminState>>,
+) -> impl IntoResponse {
+    let group_id = match parse_group_id(&group_id_str) {
+        Ok(id) => id,
+        Err(err) => return err.into_response(),
+    };
+
+    let offset = query.offset.unwrap_or(0);
+    let limit = query
+        .limit
+        .unwrap_or(DEFAULT_LIST_LIMIT)
+        .min(MAX_LIST_LIMIT);
+
+    info!(group_id=%group_id_str, %offset, %limit, "Listing group devices");
+
+    let result = state
+        .ctx_client
+        .list_group_devices(ListGroupDevicesRequest {
+            group_id,
+            member: query.member,
+            offset,
+            limit,
+        })
+        .await
+        .map_err(parse_api_error);
+
+    match result {
+        Ok(resp) => {
+            info!(group_id=%group_id_str, count=%resp.devices.len(), "Group devices retrieved successfully");
+            let devices = resp
+                .devices
+                .into_iter()
+                .map(|d| GroupDeviceApiEntry {
+                    device: d.device,
+                    account: d.account,
+                    signing_key: d.signing_key,
+                    device_epoch: d.device_epoch,
+                })
+                .collect();
+            ApiResponse {
+                payload: ListGroupDevicesApiResponse { devices },
+            }
+            .into_response()
+        }
+        Err(err) => {
+            error!(group_id=%group_id_str, error=?err, "Failed to list group devices");
+            err.into_response()
+        }
+    }
+}

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -202,6 +202,10 @@ pub(crate) fn setup(
             get(groups::list_group_members::handler).post(groups::add_group_members::handler),
         )
         .route(
+            "/groups/:group_id/devices",
+            get(groups::list_group_devices::handler),
+        )
+        .route(
             "/groups/:group_id/members/remove",
             post(groups::remove_group_members::handler),
         )

--- a/docs/src/content/docs/operate/admin-api.mdx
+++ b/docs/src/content/docs/operate/admin-api.mdx
@@ -265,6 +265,7 @@ the path parameter — these are reproduced exactly as routed below.
 | GET | `/admin-api/groups/:group_id/subgroups` | List subgroups. |
 | GET | `/admin-api/groups/:group_id/members` | List group members. |
 | POST | `/admin-api/groups/:group_id/members` | Add group members, each named by account (64 hex, as the listing above returns) or by signing key (base58). |
+| GET | `/admin-api/groups/:group_id/devices` | List the device bindings behind this group's members. `?member=` narrows to one principal: an account lists its devices, a signing key lists the device presenting it — which is how a caller holding only a key learns the account to add. |
 | POST | `/admin-api/groups/:group_id/members/remove` | Remove group members. |
 | POST | `/admin-api/groups/:group_id/leave` | Leave a group. |
 | PUT | `/admin-api/groups/:group_id/members/:identity/role` | Update a member's role. |

--- a/docs/src/content/docs/operate/admin-api.mdx
+++ b/docs/src/content/docs/operate/admin-api.mdx
@@ -264,7 +264,7 @@ the path parameter — these are reproduced exactly as routed below.
 | POST | `/admin-api/groups/:group_id/reparent` | Re-parent a group. |
 | GET | `/admin-api/groups/:group_id/subgroups` | List subgroups. |
 | GET | `/admin-api/groups/:group_id/members` | List group members. |
-| POST | `/admin-api/groups/:group_id/members` | Add group members. |
+| POST | `/admin-api/groups/:group_id/members` | Add group members, each named by account (64 hex, as the listing above returns) or by signing key (base58). |
 | POST | `/admin-api/groups/:group_id/members/remove` | Remove group members. |
 | POST | `/admin-api/groups/:group_id/leave` | Leave a group. |
 | PUT | `/admin-api/groups/:group_id/members/:identity/role` | Update a member's role. |


### PR DESCRIPTION
Reported by a user building mero-chat DMs on `0.11.0-rc.24`. A DM is a Restricted
subgroup, and adding the other person to it was not expressible. Their read of
the code was correct.

## Explain it like I'm five

A group is a clubhouse. There are two ways to name a person:

- **their name** (`AccountId`) — who they are
- **their door key** (`PublicKey`) — one key they happen to carry, and they may carry several

**Before.** The add door asked for **the key**. Its sign said: *"maybe this person
is a stranger with no name here yet — but you're holding their key, so use the
key."* Then, one step inside, the code looked the key up in the name book and
**refused if the name wasn't already written there**. So the stranger the sign
promised to help could never actually get in. Everyone who got in already had a
name.

Meanwhile the person doing the adding only ever gets shown **names** — the member
listing returns accounts, and nothing anywhere hands out the keys behind one. So
the door demanded the one thing it never gives you, in order to serve a case it
rejects. Passing the name got a 500.

And when the door did let someone in, it mailed them the group's secret **to the
one key that was typed** — no check that the key still belonged to them, and
nothing sent to their other devices.

**After.** The door takes **either** the name or a key. They can't be mixed up,
because a name is always 64 characters long and a key is always shorter, so
neither can be read as the other. Give it a name and the secret is mailed to
**every device that person currently has**, to the address each device published
itself, and to none that were taken away from them. If they have no devices right
now, nothing is mailed — rather than mailing it to a device that was taken away.

## What was actually wrong

Two comments in `rc.24` pulled opposite ways, and the handler won:

- `GroupMemberApiInput` said the field is a key *"because an add is the one call
  whose subject may not have an account here yet."*
- `add_group_members.rs` called `member_account::require`, which errors unless the
  key is already bound to an account (`account_bindings.rs`).

Both cannot be true. The doc's rationale described a path the handler had closed,
and `member_account::require`'s own docs say as much: *"an unresolvable key is a
genuine anomaly here."* So the key was protecting nothing that the account does
not protect better — while making the ordinary case (add a known namespace member
to a subgroup) impossible, since `GET .../members` renders accounts and no
endpoint discloses the keys behind one.

The key had one job left, and it was the wrong one. After resolving the account,
the add called `wrap_for_member` — the last identity-addressed key delivery in
the tree. `group_keys.rs` documents that exact thing as the hazard the device rows
exist to prevent:

> A member whose every device has been revoked or superseded receives **nothing**
> … any fallback to identity addressing would hand the fresh key straight back to
> it.

So the add wrapped to whatever Ed25519 key the caller typed, under no revocation
check, and only to that one — meaning a multi-device member got delivery to one
device and the rest waited on the joiner-side pull.

## What this changes

**`identity` takes a `MemberPrincipal`** — `Account(AccountId)` (64 hex) or
`Key(PublicKey)` (base58). Disambiguation is by construction, not by luck:
`Hash::from_str` refuses anything longer than the widest base58 32 bytes can
produce (45 chars), and an account is always 64, so neither encoding parses as the
other principal. Key-named adds are unchanged on the wire.

**Account-named adds fan out over devices.** `live_devices_by_account` +
`wrap_for_device`, sealed to each device's certified X25519 key read from the
folded binding — the row that supplies the key is the row that says the device is
still authorized, so a revoked device's key is not available to wrap with. An
account with no live device is delivered nothing rather than falling back to
identity addressing; the member row still lands and the key follows by pull. One
binding scan per call, not per member (`devices_of`'s docs warn about exactly
that loop).

The addressee decision is a pure function (`plan_deliveries`) so it is testable
without standing up an actor.

**Deleted the stale paragraph** that cost the reporter an afternoon.

### Also fixed

Four `meroctl` commands hex-encoded a *signing key* into an `:account` path
segment — `group members set-role`, `set-caps`, `group metadata member get` /
`set`. Valid hex, so `parse_account` accepted it, naming a principal that exists
nowhere. `crates/server/src/admin/handlers/groups.rs` has a test asserting a bs58
key must **not** parse as an account, for precisely this reason; the CLI defeated
it by re-encoding the bytes. **Breaking** for anyone scripting those four: pass
the account. No previously-working input regresses — the old one could not reach a
real member.

## Testing

12 new tests. The four that carry the argument:

- a key-named member is addressed as the key the caller gave
- an account-named member reaches every device that person holds
- only the named person's devices are addressed
- an account with no live device is delivered **nothing** — not an
  identity-addressed fallback

Plus principal parse / round-trip / mutual-exclusion, API-level acceptance of the
exact body the reporter sends, refusal of an unrecognized encoding naming both
encodings, and a client transport test asserting the account reaches the wire as
hex.

Full suites for the five affected crates pass, `cargo check --workspace
--all-targets`, `cargo fmt --check` and clippy are clean.

## What is NOT proven yet

There is no end-to-end run behind this, and the blocker is worth stating plainly:
merobox needs no change (its `add_group_members` step passes `members_json`
through verbatim), but `calimero-client-py` (`src/client.rs:2289`) does

```rust
let identity = identity_str.parse::<identity::PublicKey>().expect("invalid identity");
```

An account string does not 500 there — it **panics across the FFI boundary**. So
the account path cannot be exercised from a scenario until client-py is rebuilt
against this, via the usual core → client-py → merobox chain. That `expect` is a
defect in its own right (any caller typo panics instead of raising `ValueError`)
and belongs in its own client-py PR rather than folded in here.

Separately, and untouched: the same reporter says invitation + `POST /groups/join`
against a subgroup also 500s. That needs its own issue and repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
