### PR TITLE
ci(ai-review): stop the review workflow from running on every pr

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -1,18 +1,8 @@
 name: AI Code Review
 
 on:
-  # This workflow is core's ONLY automatic reviewer (the MeroReviewer App is
-  # removed from this repo - it double-reviewed every PR). `synchronize` is
-  # included: every push re-reviews, with delta tracking + convergence keeping
-  # repeat passes cheap and cancel-in-progress deduping rapid push trains.
-  pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
-    # Skipped only when ALL changed files are doc-site content - mixed PRs
-    # still trigger (standard paths-ignore semantics). Pure-doc PRs are owned
-    # by the Doc Auto-Update workflow.
-    paths-ignore:
-      - 'docs/**'
-      - 'docs-static/**'
+  # Manual only: trigger via workflow_dispatch or the /ai-review PR comment
+  # (see ai-review-trigger.yaml).
   workflow_dispatch:
     inputs:
       pr_number:
@@ -27,19 +17,12 @@ on:
         options: ["1", "2", "3", "4", "5"]
 
 concurrency:
-  group: ai-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  group: ai-review-${{ github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   review:
     runs-on: ubuntu-latest
-    # Skip drafts and fork PRs (forks don't get repo secrets, so the run
-    # would call Claude with no key and fail noisily). Review fork PRs via
-    # workflow_dispatch after auditing the diff.
-    if: >-
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.pull_request.draft == false &&
-       github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
       pull-requests: write
@@ -60,15 +43,8 @@ jobs:
       - name: Determine PR number and agent count
         id: pr
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
-            echo "agents=${{ github.event.inputs.agents }}"    >> $GITHUB_OUTPUT
-          else
-            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-            # 3 agents so the cross-review validation round runs (needs >=3);
-            # the agents block in .ai-reviewer.yaml selects security/logic/patterns.
-            echo "agents=3"                                        >> $GITHUB_OUTPUT
-          fi
+          echo "number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
+          echo "agents=${{ github.event.inputs.agents }}"    >> $GITHUB_OUTPUT
 
       - name: Run AI Code Review
         env:

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -19,7 +19,7 @@ on:
     branches: [main, master]
     # Doc-only merges — including this workflow's OWN auto-doc PRs — must not
     # trigger another run, else the bot generates docs for its own doc PRs in an
-    # infinite loop. Mirrors the paths-ignore in ai-review.yaml.
+    # infinite loop.
     paths-ignore:
       - 'docs/**'
       - 'docs-static/**'


### PR DESCRIPTION
## Summary

The AI Code Review workflow (`ai-review.yaml`) currently runs automatically on every pull request via a `pull_request` trigger.
Its Claude credits are exhausted, so every run fails and turns CI red.

This PR removes the `pull_request` trigger so the workflow only runs when explicitly requested:

- `.github/workflows/ai-review.yaml`: drop the `pull_request` trigger block, leaving only `workflow_dispatch`. Update the `on:` comment to state the manual-only behaviour. Simplify `concurrency.group` to use only `github.event.inputs.pr_number`. Remove the `review` job's `if:` condition and the dead `pull_request` branch in the "Determine PR number and agent count" step, since every run is now a deliberate dispatch.
- `.github/workflows/doc-update.yaml`: drop a comment that referenced the `paths-ignore` block removed from `ai-review.yaml`.

The two existing manual paths are unchanged:
- `workflow_dispatch` with `pr_number` and `agents` inputs
- `.github/workflows/ai-review-trigger.yaml`, which dispatches the workflow from a `/ai-review` PR comment by a write-access author

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ai-review.yaml'))"` parses without error
- Confirmed `on:` contains only `workflow_dispatch`, no `pull_request`
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/doc-update.yaml'))"` parses without error
