### PR TITLE
refactor(runtime): generate the JS collection constructors instead of copying them

### DIFF
--- a/crates/runtime/src/logic/host_functions/js_collections.rs
+++ b/crates/runtime/src/logic/host_functions/js_collections.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use calimero_storage::{
     address::Id,
-    entities::{ChildInfo, Metadata},
+    entities::{ChildInfo, Data, Metadata},
     env::{time_now, with_runtime_env, RuntimeEnv},
     index::Index,
     interface::{Interface, StorageError},
@@ -28,6 +28,77 @@ use super::system::build_runtime_env;
 const COLLECTION_ID_LEN: usize = 32;
 /// Byte length of an Ed25519 public key, the unit of a serialized writer set.
 const PUBLIC_KEY_LEN: usize = 32;
+
+/// Generate the `*_new_with_id` host function for one JS-facing collection type.
+///
+/// Thirteen copies of this existed, byte-identical apart from the type and which
+/// saver they called. Each is the same four steps — read a caller-supplied id, mint
+/// the collection at it, persist it, hand the id back — and the only interesting
+/// thing about them is what they must do when the guest panics mid-construction.
+///
+/// **Why the `catch_unwind`.** Minting and persisting runs guest-reachable storage
+/// code, and a panic crossing the host boundary aborts the whole call with no
+/// diagnostic the app can see. Catching it here turns it into an error message in
+/// the destination register, which is the same channel every other failure in this
+/// file uses. Thirteen copies of that reasoning is thirteen chances for one of them
+/// to lose it.
+/// Generate the `*_new` host function for one JS-facing collection type.
+///
+/// The sibling of [`js_new_with_id_op`], for the case where the host mints the id
+/// instead of the caller supplying it. Thirteen copies, one shape; the same
+/// `catch_unwind` reasoning applies, and applies for the same reason.
+macro_rules! js_new_op {
+    ($op:ident, $ty:ty, save: $save:ident $(,)?) => {
+        fn $op(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
+            let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<$ty, String> {
+                let mut value = <$ty>::new();
+                $save(&mut value)?;
+                Ok(value)
+            }));
+
+            match outcome {
+                Ok(Ok(value)) => {
+                    self.write_register_bytes(dest_register_id, value.id().as_bytes())?;
+                    Ok(0)
+                }
+                Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+                Err(payload) => self.write_error_message(
+                    dest_register_id,
+                    panic_payload_to_string(payload.as_ref(), "unknown panic"),
+                ),
+            }
+        }
+    };
+}
+
+macro_rules! js_new_with_id_op {
+    ($op:ident, $ty:ty, save: $save:ident $(,)?) => {
+        fn $op(&mut self, id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
+            let id = match self.read_map_id(id_ptr)? {
+                Ok(id) => id,
+                Err(message) => return self.write_error_message(dest_register_id, message),
+            };
+
+            let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<$ty, String> {
+                let mut value = <$ty>::new_with_id(id);
+                $save(&mut value)?;
+                Ok(value)
+            }));
+
+            match outcome {
+                Ok(Ok(value)) => {
+                    self.write_register_bytes(dest_register_id, value.id().as_bytes())?;
+                    Ok(0)
+                }
+                Ok(Err(err)) => self.write_error_message(dest_register_id, err),
+                Err(payload) => self.write_error_message(
+                    dest_register_id,
+                    panic_payload_to_string(payload.as_ref(), "unknown panic"),
+                ),
+            }
+        }
+    };
+}
 
 impl VMHostFunctions<'_> {
     fn make_runtime_env(&mut self) -> VMLogicResult<RuntimeEnv> {
@@ -948,53 +1019,6 @@ impl VMHostFunctions<'_> {
         self.invoke_with_storage_env(|host| host.crdt_delete_collection(id_ptr, register_id))
     }
 
-    fn crdt_map_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
-        let outcome =
-            panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsUnorderedMap, String> {
-                let mut map = JsUnorderedMap::new();
-                save_js_map_instance(&mut map)?;
-                Ok(map)
-            }));
-
-        match outcome {
-            Ok(Ok(map)) => {
-                self.write_register_bytes(dest_register_id, map.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
-    fn crdt_map_new_with_id(&mut self, id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
-        let id = match self.read_map_id(id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let outcome =
-            panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsUnorderedMap, String> {
-                let mut map = JsUnorderedMap::new_with_id(id);
-                save_js_map_instance(&mut map)?;
-                Ok(map)
-            }));
-
-        match outcome {
-            Ok(Ok(map)) => {
-                self.write_register_bytes(dest_register_id, map.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
     fn crdt_map_get(
         &mut self,
         map_id_ptr: u64,
@@ -1048,7 +1072,7 @@ impl VMHostFunctions<'_> {
 
         match map.insert(&key, &value) {
             Ok(previous) => {
-                if let Err(message) = save_js_map_instance(&mut map) {
+                if let Err(message) = save_js_instance(&mut map) {
                     return self.write_error_message(dest_register_id, message);
                 }
 
@@ -1084,7 +1108,7 @@ impl VMHostFunctions<'_> {
 
         match map.remove(&key) {
             Ok(Some(previous)) => {
-                if let Err(message) = save_js_map_instance(&mut map) {
+                if let Err(message) = save_js_instance(&mut map) {
                     return self.write_error_message(dest_register_id, message);
                 }
                 self.write_register_bytes(dest_register_id, &previous)?;
@@ -1164,55 +1188,6 @@ impl VMHostFunctions<'_> {
         Ok(1)
     }
 
-    fn crdt_vector_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsVector, String> {
-            let mut vector = JsVector::new();
-            save_js_vector_instance(&mut vector)?;
-            Ok(vector)
-        }));
-
-        match outcome {
-            Ok(Ok(vector)) => {
-                self.write_register_bytes(dest_register_id, vector.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
-    fn crdt_vector_new_with_id(
-        &mut self,
-        id_ptr: u64,
-        dest_register_id: u64,
-    ) -> VMLogicResult<i32> {
-        let id = match self.read_map_id(id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsVector, String> {
-            let mut vector = JsVector::new_with_id(id);
-            save_js_vector_instance(&mut vector)?;
-            Ok(vector)
-        }));
-
-        match outcome {
-            Ok(Ok(vector)) => {
-                self.write_register_bytes(dest_register_id, vector.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
     fn crdt_vector_len(&mut self, vector_id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
         let vector_id = match self.read_map_id(vector_id_ptr)? {
             Ok(id) => id,
@@ -1248,7 +1223,7 @@ impl VMHostFunctions<'_> {
         };
 
         match vector.push(&value) {
-            Ok(()) => match save_js_vector_instance(&mut vector) {
+            Ok(()) => match save_js_instance(&mut vector) {
                 Ok(()) => Ok(1),
                 Err(message) => self.write_error_message(0, message),
             },
@@ -1308,7 +1283,7 @@ impl VMHostFunctions<'_> {
 
         match vector.pop() {
             Ok(Some(value)) => {
-                if let Err(message) = save_js_vector_instance(&mut vector) {
+                if let Err(message) = save_js_instance(&mut vector) {
                     return self.write_error_message(dest_register_id, message);
                 }
                 self.write_register_bytes(dest_register_id, &value)?;
@@ -1319,53 +1294,6 @@ impl VMHostFunctions<'_> {
                 Ok(0)
             }
             Err(err) => self.write_error_message(dest_register_id, err),
-        }
-    }
-
-    fn crdt_set_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
-        let outcome =
-            panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsUnorderedSet, String> {
-                let mut set = JsUnorderedSet::new();
-                save_js_set_instance(&mut set)?;
-                Ok(set)
-            }));
-
-        match outcome {
-            Ok(Ok(set)) => {
-                self.write_register_bytes(dest_register_id, set.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
-    fn crdt_set_new_with_id(&mut self, id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
-        let id = match self.read_map_id(id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let outcome =
-            panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsUnorderedSet, String> {
-                let mut set = JsUnorderedSet::new_with_id(id);
-                save_js_set_instance(&mut set)?;
-                Ok(set)
-            }));
-
-        match outcome {
-            Ok(Ok(set)) => {
-                self.write_register_bytes(dest_register_id, set.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
         }
     }
 
@@ -1387,7 +1315,7 @@ impl VMHostFunctions<'_> {
                 if !inserted {
                     return Ok(0);
                 }
-                if let Err(message) = save_js_set_instance(&mut set) {
+                if let Err(message) = save_js_instance(&mut set) {
                     return self.write_error_message(0, message);
                 }
                 Ok(1)
@@ -1433,7 +1361,7 @@ impl VMHostFunctions<'_> {
                 if !removed {
                     return Ok(0);
                 }
-                if let Err(message) = save_js_set_instance(&mut set) {
+                if let Err(message) = save_js_instance(&mut set) {
                     return self.write_error_message(0, message);
                 }
                 Ok(1)
@@ -1524,57 +1452,12 @@ impl VMHostFunctions<'_> {
                 if len_before == 0 {
                     return Ok(0);
                 }
-                if let Err(message) = save_js_set_instance(&mut set) {
+                if let Err(message) = save_js_instance(&mut set) {
                     return self.write_error_message(0, message);
                 }
                 Ok(1)
             }
             Err(err) => self.write_error_message(0, err),
-        }
-    }
-
-    fn crdt_lww_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsLwwRegister, String> {
-            let mut register = JsLwwRegister::new();
-            save_js_lww_instance(&mut register)?;
-            Ok(register)
-        }));
-
-        match outcome {
-            Ok(Ok(register)) => {
-                self.write_register_bytes(dest_register_id, register.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
-    fn crdt_lww_new_with_id(&mut self, id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
-        let id = match self.read_map_id(id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsLwwRegister, String> {
-            let mut register = JsLwwRegister::new_with_id(id);
-            save_js_lww_instance(&mut register)?;
-            Ok(register)
-        }));
-
-        match outcome {
-            Ok(Ok(register)) => {
-                self.write_register_bytes(dest_register_id, register.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
         }
     }
 
@@ -1664,55 +1547,6 @@ impl VMHostFunctions<'_> {
         Ok(1)
     }
 
-    fn crdt_counter_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsCounter, String> {
-            let mut counter = JsCounter::new();
-            save_js_counter_instance(&mut counter)?;
-            Ok(counter)
-        }));
-
-        match outcome {
-            Ok(Ok(counter)) => {
-                self.write_register_bytes(dest_register_id, counter.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
-    fn crdt_counter_new_with_id(
-        &mut self,
-        id_ptr: u64,
-        dest_register_id: u64,
-    ) -> VMLogicResult<i32> {
-        let id = match self.read_map_id(id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsCounter, String> {
-            let mut counter = JsCounter::new_with_id(id);
-            save_js_counter_instance(&mut counter)?;
-            Ok(counter)
-        }));
-
-        match outcome {
-            Ok(Ok(counter)) => {
-                self.write_register_bytes(dest_register_id, counter.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
     fn crdt_counter_increment(&mut self, counter_id_ptr: u64) -> VMLogicResult<i32> {
         let counter_id = match self.read_map_id(counter_id_ptr)? {
             Ok(id) => id,
@@ -1798,55 +1632,6 @@ impl VMHostFunctions<'_> {
         }
     }
 
-    fn user_storage_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsUserStorage, String> {
-            let mut storage = JsUserStorage::new();
-            save_js_user_storage_instance(&mut storage)?;
-            Ok(storage)
-        }));
-
-        match outcome {
-            Ok(Ok(storage)) => {
-                self.write_register_bytes(dest_register_id, storage.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
-    fn user_storage_new_with_id(
-        &mut self,
-        id_ptr: u64,
-        dest_register_id: u64,
-    ) -> VMLogicResult<i32> {
-        let id = match self.read_map_id(id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsUserStorage, String> {
-            let mut storage = JsUserStorage::new_with_id(id);
-            save_js_user_storage_instance(&mut storage)?;
-            Ok(storage)
-        }));
-
-        match outcome {
-            Ok(Ok(storage)) => {
-                self.write_register_bytes(dest_register_id, storage.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
     fn user_storage_insert(
         &mut self,
         storage_id_ptr: u64,
@@ -1867,7 +1652,7 @@ impl VMHostFunctions<'_> {
 
         match storage.insert(&value) {
             Ok(previous) => {
-                if let Err(message) = save_js_user_storage_instance(&mut storage) {
+                if let Err(message) = save_js_instance(&mut storage) {
                     return self.write_error_message(dest_register_id, message);
                 }
 
@@ -1966,7 +1751,7 @@ impl VMHostFunctions<'_> {
 
         match storage.remove() {
             Ok(Some(previous)) => {
-                if let Err(message) = save_js_user_storage_instance(&mut storage) {
+                if let Err(message) = save_js_instance(&mut storage) {
                     return self.write_error_message(dest_register_id, message);
                 }
                 self.write_register_bytes(dest_register_id, &previous)?;
@@ -2024,57 +1809,6 @@ impl VMHostFunctions<'_> {
         }
     }
 
-    fn frozen_storage_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
-        let outcome =
-            panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsFrozenStorage, String> {
-                let mut storage = JsFrozenStorage::new();
-                save_js_frozen_storage_instance(&mut storage)?;
-                Ok(storage)
-            }));
-
-        match outcome {
-            Ok(Ok(storage)) => {
-                self.write_register_bytes(dest_register_id, storage.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
-    fn frozen_storage_new_with_id(
-        &mut self,
-        id_ptr: u64,
-        dest_register_id: u64,
-    ) -> VMLogicResult<i32> {
-        let id = match self.read_map_id(id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let outcome =
-            panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsFrozenStorage, String> {
-                let mut storage = JsFrozenStorage::new_with_id(id);
-                save_js_frozen_storage_instance(&mut storage)?;
-                Ok(storage)
-            }));
-
-        match outcome {
-            Ok(Ok(storage)) => {
-                self.write_register_bytes(dest_register_id, storage.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
     fn frozen_storage_add(
         &mut self,
         storage_id_ptr: u64,
@@ -2095,7 +1829,7 @@ impl VMHostFunctions<'_> {
 
         match storage.insert(&value) {
             Ok(hash) => {
-                if let Err(message) = save_js_frozen_storage_instance(&mut storage) {
+                if let Err(message) = save_js_instance(&mut storage) {
                     return self.write_error_message(dest_register_id, message);
                 }
                 self.write_register_bytes(dest_register_id, &hash)?;
@@ -2169,55 +1903,6 @@ impl VMHostFunctions<'_> {
         }
     }
 
-    fn crdt_pncounter_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsPnCounter, String> {
-            let mut counter = JsPnCounter::new();
-            save_js_pncounter_instance(&mut counter)?;
-            Ok(counter)
-        }));
-
-        match outcome {
-            Ok(Ok(counter)) => {
-                self.write_register_bytes(dest_register_id, counter.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
-    fn crdt_pncounter_new_with_id(
-        &mut self,
-        id_ptr: u64,
-        dest_register_id: u64,
-    ) -> VMLogicResult<i32> {
-        let id = match self.read_map_id(id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsPnCounter, String> {
-            let mut counter = JsPnCounter::new_with_id(id);
-            save_js_pncounter_instance(&mut counter)?;
-            Ok(counter)
-        }));
-
-        match outcome {
-            Ok(Ok(counter)) => {
-                self.write_register_bytes(dest_register_id, counter.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
     fn crdt_pncounter_increment(&mut self, counter_id_ptr: u64) -> VMLogicResult<i32> {
         let counter_id = match self.read_map_id(counter_id_ptr)? {
             Ok(id) => id,
@@ -2230,7 +1915,7 @@ impl VMHostFunctions<'_> {
         };
 
         match counter.increment() {
-            Ok(()) => match save_js_pncounter_instance(&mut counter) {
+            Ok(()) => match save_js_instance(&mut counter) {
                 Ok(()) => Ok(1),
                 Err(message) => self.write_error_message(0, message),
             },
@@ -2250,7 +1935,7 @@ impl VMHostFunctions<'_> {
         };
 
         match counter.decrement() {
-            Ok(()) => match save_js_pncounter_instance(&mut counter) {
+            Ok(()) => match save_js_instance(&mut counter) {
                 Ok(()) => Ok(1),
                 Err(message) => self.write_error_message(0, message),
             },
@@ -2323,51 +2008,6 @@ impl VMHostFunctions<'_> {
         }
     }
 
-    fn crdt_rga_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsRga, String> {
-            let mut rga = JsRga::new();
-            save_js_rga_instance(&mut rga)?;
-            Ok(rga)
-        }));
-
-        match outcome {
-            Ok(Ok(rga)) => {
-                self.write_register_bytes(dest_register_id, rga.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
-    fn crdt_rga_new_with_id(&mut self, id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
-        let id = match self.read_map_id(id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsRga, String> {
-            let mut rga = JsRga::new_with_id(id);
-            save_js_rga_instance(&mut rga)?;
-            Ok(rga)
-        }));
-
-        match outcome {
-            Ok(Ok(rga)) => {
-                self.write_register_bytes(dest_register_id, rga.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
     fn crdt_rga_insert(
         &mut self,
         rga_id_ptr: u64,
@@ -2395,7 +2035,7 @@ impl VMHostFunctions<'_> {
         };
 
         match rga.insert(idx, &value) {
-            Ok(()) => match save_js_rga_instance(&mut rga) {
+            Ok(()) => match save_js_instance(&mut rga) {
                 Ok(()) => Ok(1),
                 Err(message) => self.write_error_message(0, message),
             },
@@ -2423,7 +2063,7 @@ impl VMHostFunctions<'_> {
         };
 
         match rga.delete(idx) {
-            Ok(()) => match save_js_rga_instance(&mut rga) {
+            Ok(()) => match save_js_instance(&mut rga) {
                 Ok(()) => Ok(1),
                 Err(message) => self.write_error_message(0, message),
             },
@@ -2469,55 +2109,6 @@ impl VMHostFunctions<'_> {
                 Ok(1)
             }
             Err(err) => self.write_error_message(dest_register_id, err.to_string()),
-        }
-    }
-
-    fn crdt_sortedmap_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsSortedMap, String> {
-            let mut map = JsSortedMap::new();
-            save_js_sortedmap_instance(&mut map)?;
-            Ok(map)
-        }));
-
-        match outcome {
-            Ok(Ok(map)) => {
-                self.write_register_bytes(dest_register_id, map.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
-    fn crdt_sortedmap_new_with_id(
-        &mut self,
-        id_ptr: u64,
-        dest_register_id: u64,
-    ) -> VMLogicResult<i32> {
-        let id = match self.read_map_id(id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsSortedMap, String> {
-            let mut map = JsSortedMap::new_with_id(id);
-            save_js_sortedmap_instance(&mut map)?;
-            Ok(map)
-        }));
-
-        match outcome {
-            Ok(Ok(map)) => {
-                self.write_register_bytes(dest_register_id, map.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
         }
     }
 
@@ -2574,7 +2165,7 @@ impl VMHostFunctions<'_> {
 
         match map.insert(&key, &value) {
             Ok(previous) => {
-                if let Err(message) = save_js_sortedmap_instance(&mut map) {
+                if let Err(message) = save_js_instance(&mut map) {
                     return self.write_error_message(dest_register_id, message);
                 }
 
@@ -2610,7 +2201,7 @@ impl VMHostFunctions<'_> {
 
         match map.remove(&key) {
             Ok(Some(previous)) => {
-                if let Err(message) = save_js_sortedmap_instance(&mut map) {
+                if let Err(message) = save_js_instance(&mut map) {
                     return self.write_error_message(dest_register_id, message);
                 }
                 self.write_register_bytes(dest_register_id, &previous)?;
@@ -2694,55 +2285,6 @@ impl VMHostFunctions<'_> {
         Ok(1)
     }
 
-    fn crdt_sortedset_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsSortedSet, String> {
-            let mut set = JsSortedSet::new();
-            save_js_sortedset_instance(&mut set)?;
-            Ok(set)
-        }));
-
-        match outcome {
-            Ok(Ok(set)) => {
-                self.write_register_bytes(dest_register_id, set.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
-    fn crdt_sortedset_new_with_id(
-        &mut self,
-        id_ptr: u64,
-        dest_register_id: u64,
-    ) -> VMLogicResult<i32> {
-        let id = match self.read_map_id(id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsSortedSet, String> {
-            let mut set = JsSortedSet::new_with_id(id);
-            save_js_sortedset_instance(&mut set)?;
-            Ok(set)
-        }));
-
-        match outcome {
-            Ok(Ok(set)) => {
-                self.write_register_bytes(dest_register_id, set.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
     fn crdt_sortedset_insert(&mut self, set_id_ptr: u64, value_ptr: u64) -> VMLogicResult<i32> {
         let set_id = match self.read_map_id(set_id_ptr)? {
             Ok(id) => id,
@@ -2761,7 +2303,7 @@ impl VMHostFunctions<'_> {
                 if !inserted {
                     return Ok(0);
                 }
-                if let Err(message) = save_js_sortedset_instance(&mut set) {
+                if let Err(message) = save_js_instance(&mut set) {
                     return self.write_error_message(0, message);
                 }
                 Ok(1)
@@ -2807,7 +2349,7 @@ impl VMHostFunctions<'_> {
                 if !removed {
                     return Ok(0);
                 }
-                if let Err(message) = save_js_sortedset_instance(&mut set) {
+                if let Err(message) = save_js_instance(&mut set) {
                     return self.write_error_message(0, message);
                 }
                 Ok(1)
@@ -2902,61 +2444,12 @@ impl VMHostFunctions<'_> {
                 if len_before == 0 {
                     return Ok(0);
                 }
-                if let Err(message) = save_js_sortedset_instance(&mut set) {
+                if let Err(message) = save_js_instance(&mut set) {
                     return self.write_error_message(0, message);
                 }
                 Ok(1)
             }
             Err(err) => self.write_error_message(0, err),
-        }
-    }
-
-    fn crdt_authored_map_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsAuthoredMap, String> {
-            let mut map = JsAuthoredMap::new();
-            save_js_authored_map_instance(&mut map)?;
-            Ok(map)
-        }));
-
-        match outcome {
-            Ok(Ok(map)) => {
-                self.write_register_bytes(dest_register_id, map.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
-    fn crdt_authored_map_new_with_id(
-        &mut self,
-        id_ptr: u64,
-        dest_register_id: u64,
-    ) -> VMLogicResult<i32> {
-        let id = match self.read_map_id(id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let outcome = panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsAuthoredMap, String> {
-            let mut map = JsAuthoredMap::new_with_id(id);
-            save_js_authored_map_instance(&mut map)?;
-            Ok(map)
-        }));
-
-        match outcome {
-            Ok(Ok(map)) => {
-                self.write_register_bytes(dest_register_id, map.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
         }
     }
 
@@ -2984,7 +2477,7 @@ impl VMHostFunctions<'_> {
         // the entry owner and rejects an already-present key.
         match map.insert(&key, &value) {
             Ok(()) => {
-                if let Err(message) = save_js_authored_map_instance(&mut map) {
+                if let Err(message) = save_js_instance(&mut map) {
                     return self.write_error_message(dest_register_id, message);
                 }
                 self.clear_register(dest_register_id)?;
@@ -3017,7 +2510,7 @@ impl VMHostFunctions<'_> {
         // Owner-only: the collection returns `ActionNotAllowed` when the current
         // executor is not the stored owner; surface it verbatim.
         match map.update(&key, &value) {
-            Ok(()) => match save_js_authored_map_instance(&mut map) {
+            Ok(()) => match save_js_instance(&mut map) {
                 Ok(()) => Ok(1),
                 Err(message) => self.write_error_message(dest_register_id, message),
             },
@@ -3047,7 +2540,7 @@ impl VMHostFunctions<'_> {
         // yields `Ok(None)`.
         match map.remove(&key) {
             Ok(Some(previous)) => {
-                if let Err(message) = save_js_authored_map_instance(&mut map) {
+                if let Err(message) = save_js_instance(&mut map) {
                     return self.write_error_message(dest_register_id, message);
                 }
                 self.write_register_bytes(dest_register_id, &previous)?;
@@ -3243,57 +2736,6 @@ impl VMHostFunctions<'_> {
         }
     }
 
-    fn crdt_authored_vector_new(&mut self, dest_register_id: u64) -> VMLogicResult<i32> {
-        let outcome =
-            panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsAuthoredVector, String> {
-                let mut vector = JsAuthoredVector::new();
-                save_js_authored_vector_instance(&mut vector)?;
-                Ok(vector)
-            }));
-
-        match outcome {
-            Ok(Ok(vector)) => {
-                self.write_register_bytes(dest_register_id, vector.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
-    fn crdt_authored_vector_new_with_id(
-        &mut self,
-        id_ptr: u64,
-        dest_register_id: u64,
-    ) -> VMLogicResult<i32> {
-        let id = match self.read_map_id(id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let outcome =
-            panic::catch_unwind(AssertUnwindSafe(|| -> Result<JsAuthoredVector, String> {
-                let mut vector = JsAuthoredVector::new_with_id(id);
-                save_js_authored_vector_instance(&mut vector)?;
-                Ok(vector)
-            }));
-
-        match outcome {
-            Ok(Ok(vector)) => {
-                self.write_register_bytes(dest_register_id, vector.id().as_bytes())?;
-                Ok(0)
-            }
-            Ok(Err(err)) => self.write_error_message(dest_register_id, err),
-            Err(payload) => self.write_error_message(
-                dest_register_id,
-                panic_payload_to_string(payload.as_ref(), "unknown panic"),
-            ),
-        }
-    }
-
     fn crdt_authored_vector_push(
         &mut self,
         vector_id_ptr: u64,
@@ -3315,7 +2757,7 @@ impl VMHostFunctions<'_> {
         // `push` stamps the current executor as owner and returns the new index.
         match vector.push(&value) {
             Ok(index) => {
-                if let Err(message) = save_js_authored_vector_instance(&mut vector) {
+                if let Err(message) = save_js_instance(&mut vector) {
                     return self.write_error_message(dest_register_id, message);
                 }
                 let index_u64 = u64::try_from(index).map_err(|_| HostError::IntegerOverflow)?;
@@ -3357,7 +2799,7 @@ impl VMHostFunctions<'_> {
 
         // Owner-only: a non-owner update yields `ActionNotAllowed`.
         match vector.update(idx, &value) {
-            Ok(()) => match save_js_authored_vector_instance(&mut vector) {
+            Ok(()) => match save_js_instance(&mut vector) {
                 Ok(()) => Ok(1),
                 Err(message) => self.write_error_message(dest_register_id, message),
             },
@@ -3393,7 +2835,7 @@ impl VMHostFunctions<'_> {
 
         // Owner-only: a non-owner tombstone yields `ActionNotAllowed`.
         match vector.tombstone(idx) {
-            Ok(()) => match save_js_authored_vector_instance(&mut vector) {
+            Ok(()) => match save_js_instance(&mut vector) {
                 Ok(()) => Ok(1),
                 Err(message) => self.write_error_message(dest_register_id, message),
             },
@@ -3594,7 +3036,7 @@ impl VMHostFunctions<'_> {
         let outcome = panic::catch_unwind(AssertUnwindSafe(
             move || -> Result<JsSharedStorage, String> {
                 let mut cell = JsSharedStorage::new(writers, frozen);
-                save_js_shared_instance(&mut cell)?;
+                save_js_instance(&mut cell)?;
                 Ok(cell)
             },
         ));
@@ -3633,7 +3075,7 @@ impl VMHostFunctions<'_> {
         let outcome = panic::catch_unwind(AssertUnwindSafe(
             move || -> Result<JsSharedStorage, String> {
                 let mut cell = JsSharedStorage::new_with_id(id, writers, frozen);
-                save_js_shared_instance(&mut cell)?;
+                save_js_instance(&mut cell)?;
                 Ok(cell)
             },
         ));
@@ -3667,7 +3109,7 @@ impl VMHostFunctions<'_> {
         // Writer-gated: `set` returns `ActionNotAllowed` when the current
         // executor is not in the writer set; surface it verbatim in register 0.
         match cell.set(&value) {
-            Ok(()) => match save_js_shared_instance(&mut cell) {
+            Ok(()) => match save_js_instance(&mut cell) {
                 Ok(()) => Ok(1),
                 Err(message) => self.write_error_message(0, message),
             },
@@ -3776,7 +3218,7 @@ impl VMHostFunctions<'_> {
         // Writer-gated: a non-writer rotation (or a frozen/empty target) yields
         // `ActionNotAllowed`; surface it verbatim in register 0.
         match cell.rotate_writers(writers) {
-            Ok(()) => match save_js_shared_instance(&mut cell) {
+            Ok(()) => match save_js_instance(&mut cell) {
                 Ok(()) => Ok(1),
                 Err(message) => self.write_error_message(0, message),
             },
@@ -3897,210 +3339,36 @@ impl VMHostFunctions<'_> {
     fn clear_register(&mut self, register_id: u64) -> VMLogicResult<()> {
         self.write_register_bytes(register_id, &[])
     }
-}
 
-fn load_js_map_instance(id: Id) -> Result<JsUnorderedMap, String> {
-    match JsUnorderedMap::load(id) {
-        Ok(Some(map)) => {
-            debug!(
-                target: "runtime::map",
-                map_id = %id.to_string(),
-                "loaded JsUnorderedMap from storage"
-            );
-            Ok(map)
-        }
-        Ok(None) => {
-            let missing_id = id.to_string();
-            warn!(
-                target: "runtime::map",
-                map_id = %missing_id,
-                "JsUnorderedMap not found in storage"
-            );
-            // This can happen if the contract serialised only the collection id
-            // (e.g. via state snapshot) but the underlying CRDT was never
-            // persisted.  Recreate the host object with the same id and attach
-            // it to the root so the very next read/write works as expected.
-            let mut map = JsUnorderedMap::new_with_id(id);
-            match save_js_map_instance(&mut map) {
-                Ok(()) => {
-                    debug!(
-                        target: "runtime::map",
-                        map_id = %missing_id,
-                        "recreated missing JsUnorderedMap"
-                    );
-                    Ok(map)
-                }
-                Err(err) => Err(err),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
+    // ---- host-minted-id constructors, one per collection type ----
+    js_new_op!(crdt_map_new, JsUnorderedMap, save: save_js_instance);
+    js_new_op!(crdt_vector_new, JsVector, save: save_js_instance);
+    js_new_op!(crdt_set_new, JsUnorderedSet, save: save_js_instance);
+    js_new_op!(crdt_lww_new, JsLwwRegister, save: save_js_lww_instance);
+    js_new_op!(crdt_counter_new, JsCounter, save: save_js_counter_instance);
+    js_new_op!(user_storage_new, JsUserStorage, save: save_js_instance);
+    js_new_op!(frozen_storage_new, JsFrozenStorage, save: save_js_instance);
+    js_new_op!(crdt_pncounter_new, JsPnCounter, save: save_js_instance);
+    js_new_op!(crdt_rga_new, JsRga, save: save_js_instance);
+    js_new_op!(crdt_sortedmap_new, JsSortedMap, save: save_js_instance);
+    js_new_op!(crdt_sortedset_new, JsSortedSet, save: save_js_instance);
+    js_new_op!(crdt_authored_map_new, JsAuthoredMap, save: save_js_instance);
+    js_new_op!(crdt_authored_vector_new, JsAuthoredVector, save: save_js_instance);
 
-fn save_js_map_instance(map: &mut JsUnorderedMap) -> Result<(), String> {
-    match map.save() {
-        Ok(_) => Ok(()),
-        Err(StorageError::CannotCreateOrphan(_)) => {
-            ensure_root_index_internal().map_err(|err| err.to_string())?;
-            match Interface::<MainStorage>::add_child_to(Id::root(), map) {
-                Ok(_) => Ok(()),
-                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
-                Err(err) => Err(err.to_string()),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn load_js_vector_instance(id: Id) -> Result<JsVector, String> {
-    match JsVector::load(id) {
-        Ok(Some(vector)) => {
-            debug!(
-                target: "runtime::vector",
-                vector_id = %id.to_string(),
-                "loaded JsVector from storage"
-            );
-            Ok(vector)
-        }
-        Ok(None) => {
-            let missing_id = id.to_string();
-            warn!(
-                target: "runtime::vector",
-                vector_id = %missing_id,
-                "JsVector not found in storage"
-            );
-            // The vector was referenced by id but not stored. Recreate and
-            // persist it so subsequent operations proceed without errors.
-            let mut vector = JsVector::new_with_id(id);
-            match save_js_vector_instance(&mut vector) {
-                Ok(()) => {
-                    debug!(
-                        target: "runtime::vector",
-                        vector_id = %missing_id,
-                        "recreated missing JsVector"
-                    );
-                    Ok(vector)
-                }
-                Err(err) => Err(err),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn save_js_vector_instance(vector: &mut JsVector) -> Result<(), String> {
-    match vector.save() {
-        Ok(_) => Ok(()),
-        Err(StorageError::CannotCreateOrphan(_)) => {
-            ensure_root_index_internal().map_err(|err| err.to_string())?;
-            match Interface::<MainStorage>::add_child_to(Id::root(), vector) {
-                Ok(_) => Ok(()),
-                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
-                Err(err) => Err(err.to_string()),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn load_js_set_instance(id: Id) -> Result<JsUnorderedSet, String> {
-    match JsUnorderedSet::load(id) {
-        Ok(Some(set)) => {
-            debug!(
-                target: "runtime::set",
-                set_id = %id.to_string(),
-                "loaded JsUnorderedSet from storage"
-            );
-            Ok(set)
-        }
-        Ok(None) => {
-            let missing_id = id.to_string();
-            warn!(
-                target: "runtime::set",
-                set_id = %missing_id,
-                "JsUnorderedSet not found in storage"
-            );
-            // See comment above: recreate the CRDT so the deserialised state
-            // has a concrete backing object before we try to mutate it.
-            let mut set = JsUnorderedSet::new_with_id(id);
-            match save_js_set_instance(&mut set) {
-                Ok(()) => {
-                    debug!(
-                        target: "runtime::set",
-                        set_id = %missing_id,
-                        "recreated missing JsUnorderedSet"
-                    );
-                    Ok(set)
-                }
-                Err(err) => Err(err),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn save_js_set_instance(set: &mut JsUnorderedSet) -> Result<(), String> {
-    match set.save() {
-        Ok(_) => Ok(()),
-        Err(StorageError::CannotCreateOrphan(_)) => {
-            ensure_root_index_internal().map_err(|err| err.to_string())?;
-            match Interface::<MainStorage>::add_child_to(Id::root(), set) {
-                Ok(_) => Ok(()),
-                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
-                Err(err) => Err(err.to_string()),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn load_js_lww_register_instance(id: Id) -> Result<JsLwwRegister, String> {
-    match JsLwwRegister::load(id) {
-        Ok(Some(register)) => {
-            debug!(
-                target: "runtime::lww_register",
-                register_id = %id.to_string(),
-                "loaded JsLwwRegister from storage"
-            );
-            Ok(register)
-        }
-        Ok(None) => {
-            let missing_id = id.to_string();
-            warn!(
-                target: "runtime::lww_register",
-                register_id = %missing_id,
-                "JsLwwRegister not found in storage"
-            );
-            let mut register = JsLwwRegister::new_with_id(id);
-            match save_js_lww_register_instance(&mut register) {
-                Ok(()) => {
-                    debug!(
-                        target: "runtime::lww_register",
-                        register_id = %missing_id,
-                        "recreated missing JsLwwRegister"
-                    );
-                    Ok(register)
-                }
-                Err(err) => Err(err),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn save_js_lww_register_instance(register: &mut JsLwwRegister) -> Result<(), String> {
-    match register.save() {
-        Ok(_) => Ok(()),
-        Err(StorageError::CannotCreateOrphan(_)) => {
-            ensure_root_index_internal().map_err(|err| err.to_string())?;
-            match Interface::<MainStorage>::add_child_to(Id::root(), register) {
-                Ok(_) => Ok(()),
-                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
-                Err(err) => Err(err.to_string()),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
+    // ---- deterministic-id constructors, one per collection type ----
+    js_new_with_id_op!(crdt_map_new_with_id, JsUnorderedMap, save: save_js_instance);
+    js_new_with_id_op!(crdt_vector_new_with_id, JsVector, save: save_js_instance);
+    js_new_with_id_op!(crdt_set_new_with_id, JsUnorderedSet, save: save_js_instance);
+    js_new_with_id_op!(crdt_lww_new_with_id, JsLwwRegister, save: save_js_lww_instance);
+    js_new_with_id_op!(crdt_counter_new_with_id, JsCounter, save: save_js_counter_instance);
+    js_new_with_id_op!(user_storage_new_with_id, JsUserStorage, save: save_js_instance);
+    js_new_with_id_op!(frozen_storage_new_with_id, JsFrozenStorage, save: save_js_instance);
+    js_new_with_id_op!(crdt_pncounter_new_with_id, JsPnCounter, save: save_js_instance);
+    js_new_with_id_op!(crdt_rga_new_with_id, JsRga, save: save_js_instance);
+    js_new_with_id_op!(crdt_sortedmap_new_with_id, JsSortedMap, save: save_js_instance);
+    js_new_with_id_op!(crdt_sortedset_new_with_id, JsSortedSet, save: save_js_instance);
+    js_new_with_id_op!(crdt_authored_map_new_with_id, JsAuthoredMap, save: save_js_instance);
+    js_new_with_id_op!(crdt_authored_vector_new_with_id, JsAuthoredVector, save: save_js_instance);
 }
 
 fn load_js_lww_instance(id: Id) -> Result<JsLwwRegister, String> {
@@ -4108,42 +3376,7 @@ fn load_js_lww_instance(id: Id) -> Result<JsLwwRegister, String> {
 }
 
 fn save_js_lww_instance(register: &mut JsLwwRegister) -> Result<(), String> {
-    save_js_lww_register_instance(register)
-}
-
-fn load_js_counter_instance(id: Id) -> Result<JsCounter, String> {
-    match JsCounter::load(id) {
-        Ok(Some(counter)) => {
-            let counter_id_str = counter.id().to_string();
-            debug!(
-                target: "runtime::counter",
-                counter_id = %counter_id_str,
-                "loaded JsCounter from storage"
-            );
-            Ok(counter)
-        }
-        Ok(None) => {
-            let missing_id = id.to_string();
-            warn!(
-                target: "runtime::counter",
-                counter_id = %missing_id,
-                "JsCounter not found in storage"
-            );
-            let mut counter = JsCounter::new_with_id(id);
-            match save_js_counter_instance(&mut counter) {
-                Ok(()) => {
-                    debug!(
-                        target: "runtime::counter",
-                        counter_id = %missing_id,
-                        "recreated missing JsCounter"
-                    );
-                    Ok(counter)
-                }
-                Err(err) => Err(err),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
+    save_js_instance(register)
 }
 
 fn save_js_counter_instance(counter: &mut JsCounter) -> Result<(), String> {
@@ -4176,6 +3409,177 @@ fn save_js_counter_instance(counter: &mut JsCounter) -> Result<(), String> {
     }
 }
 
+/// Persist a JS-facing collection, attaching it to the root index if it has no
+/// parent yet.
+///
+/// One function for every collection type. There were thirteen of these — one per
+/// `Js*` type, byte-identical apart from the binding name — because each type's
+/// `save()` is an inherent method, so nothing about them looked shared. It is:
+/// `save()` is a one-line wrapper over `Interface::<MainStorage>::save`, which is
+/// already generic over `Data`, and `add_child_to` takes the same bound. Thirteen
+/// copies of an orphan-recovery path is thirteen places it can be fixed in twelve.
+///
+/// `CannotCreateOrphan` is not a failure here: it means the collection was minted
+/// without a parent, which is exactly what a JS app does when it constructs one
+/// standalone. Attaching it to the root and retrying is the recovery, and a second
+/// `CannotCreateOrphan` after that is a genuine refusal.
+fn save_js_instance<D: Data>(value: &mut D) -> Result<(), String> {
+    match Interface::<MainStorage>::save(value) {
+        Ok(_) => Ok(()),
+        Err(StorageError::CannotCreateOrphan(_)) => {
+            ensure_root_index_internal().map_err(|err| err.to_string())?;
+            match Interface::<MainStorage>::add_child_to(Id::root(), value) {
+                Ok(_) => Ok(()),
+                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
+                Err(err) => Err(err.to_string()),
+            }
+        }
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+/// Generate the load-or-recreate wrapper for one JS-facing collection type.
+///
+/// Thirteen of these were written out by hand, differing only in the type, the
+/// tracing target, and the name of the id field in the log line — the three things
+/// a macro can carry and a generic cannot, because a `target:` and a field name
+/// must both be literals at the call site. What the copies could not keep straight
+/// was the recovery path: seven of them logged the recreation and six silently did
+/// it, which is the kind of divergence that makes a log trail unreadable exactly
+/// when it is needed. Generated, they cannot disagree.
+///
+/// **The `Ok(None)` arm recreates rather than failing.** A JS app can serialise
+/// just the collection id — via a state snapshot, say — while the underlying CRDT
+/// was never persisted. Rebuilding the host object at the same id and attaching it
+/// to the root makes the very next read or write behave as the app expects, instead
+/// of failing on a collection the app believes it holds.
+///
+/// `JsSharedStorage` is deliberately **not** generated from this: a shared cell
+/// cannot be recreated on the fly, because its writer set is only known at
+/// construction and inventing an empty one would silently make the cell
+/// unwritable. It stays hand-written below, with that reasoning beside it.
+macro_rules! js_load_or_recreate {
+    (
+        $load:ident, $ty:ty,
+        target: $target:literal,
+        id_field: $id_field:ident,
+        save: $save:ident $(,)?
+    ) => {
+        fn $load(id: Id) -> Result<$ty, String> {
+            match <$ty>::load(id) {
+                Ok(Some(value)) => {
+                    debug!(
+                        target: $target,
+                        $id_field = %id.to_string(),
+                        concat!("loaded ", stringify!($ty), " from storage")
+                    );
+                    Ok(value)
+                }
+                Ok(None) => {
+                    let missing_id = id.to_string();
+                    warn!(
+                        target: $target,
+                        $id_field = %missing_id,
+                        concat!(stringify!($ty), " not found in storage")
+                    );
+                    let mut value = <$ty>::new_with_id(id);
+                    match $save(&mut value) {
+                        Ok(()) => {
+                            debug!(
+                                target: $target,
+                                $id_field = %missing_id,
+                                concat!("recreated missing ", stringify!($ty))
+                            );
+                            Ok(value)
+                        }
+                        Err(err) => Err(err),
+                    }
+                }
+                Err(err) => Err(err.to_string()),
+            }
+        }
+    };
+}
+
+js_load_or_recreate!(
+    load_js_map_instance, JsUnorderedMap,
+    target: "runtime::map",
+    id_field: map_id,
+    save: save_js_instance,
+);
+js_load_or_recreate!(
+    load_js_vector_instance, JsVector,
+    target: "runtime::vector",
+    id_field: vector_id,
+    save: save_js_instance,
+);
+js_load_or_recreate!(
+    load_js_set_instance, JsUnorderedSet,
+    target: "runtime::set",
+    id_field: set_id,
+    save: save_js_instance,
+);
+js_load_or_recreate!(
+    load_js_lww_register_instance, JsLwwRegister,
+    target: "runtime::lww_register",
+    id_field: register_id,
+    save: save_js_instance,
+);
+js_load_or_recreate!(
+    load_js_counter_instance, JsCounter,
+    target: "runtime::counter",
+    id_field: counter_id,
+    save: save_js_counter_instance,
+);
+js_load_or_recreate!(
+    load_js_user_storage_instance, JsUserStorage,
+    target: "runtime::user_storage",
+    id_field: storage_id,
+    save: save_js_instance,
+);
+js_load_or_recreate!(
+    load_js_frozen_storage_instance, JsFrozenStorage,
+    target: "runtime::frozen_storage",
+    id_field: storage_id,
+    save: save_js_instance,
+);
+js_load_or_recreate!(
+    load_js_pncounter_instance, JsPnCounter,
+    target: "runtime::pncounter",
+    id_field: counter_id,
+    save: save_js_instance,
+);
+js_load_or_recreate!(
+    load_js_rga_instance, JsRga,
+    target: "runtime::rga",
+    id_field: rga_id,
+    save: save_js_instance,
+);
+js_load_or_recreate!(
+    load_js_sortedmap_instance, JsSortedMap,
+    target: "runtime::sortedmap",
+    id_field: map_id,
+    save: save_js_instance,
+);
+js_load_or_recreate!(
+    load_js_sortedset_instance, JsSortedSet,
+    target: "runtime::sortedset",
+    id_field: set_id,
+    save: save_js_instance,
+);
+js_load_or_recreate!(
+    load_js_authored_map_instance, JsAuthoredMap,
+    target: "runtime::authored_map",
+    id_field: map_id,
+    save: save_js_instance,
+);
+js_load_or_recreate!(
+    load_js_authored_vector_instance, JsAuthoredVector,
+    target: "runtime::authored_vector",
+    id_field: vector_id,
+    save: save_js_instance,
+);
+
 fn ensure_root_index_internal() -> Result<(), StorageError> {
     match Index::<MainStorage>::get_hashes_for(Id::root()) {
         Ok(Some(_)) => Ok(()),
@@ -4185,356 +3589,6 @@ fn ensure_root_index_internal() -> Result<(), StorageError> {
             Index::<MainStorage>::add_root(ChildInfo::new(Id::root(), [0; 32], metadata))
         }
         Err(err) => Err(err),
-    }
-}
-
-fn load_js_user_storage_instance(id: Id) -> Result<JsUserStorage, String> {
-    match JsUserStorage::load(id) {
-        Ok(Some(storage)) => {
-            debug!(
-                target: "runtime::user_storage",
-                storage_id = %id.to_string(),
-                "loaded JsUserStorage from storage"
-            );
-            Ok(storage)
-        }
-        Ok(None) => {
-            let missing_id = id.to_string();
-            warn!(
-                target: "runtime::user_storage",
-                storage_id = %missing_id,
-                "JsUserStorage not found in storage"
-            );
-            let mut storage = JsUserStorage::new_with_id(id);
-            match save_js_user_storage_instance(&mut storage) {
-                Ok(()) => {
-                    debug!(
-                        target: "runtime::user_storage",
-                        storage_id = %missing_id,
-                        "recreated missing JsUserStorage"
-                    );
-                    Ok(storage)
-                }
-                Err(err) => Err(err),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn save_js_user_storage_instance(storage: &mut JsUserStorage) -> Result<(), String> {
-    match storage.save() {
-        Ok(_) => Ok(()),
-        Err(StorageError::CannotCreateOrphan(_)) => {
-            ensure_root_index_internal().map_err(|err| err.to_string())?;
-            match Interface::<MainStorage>::add_child_to(Id::root(), storage) {
-                Ok(_) => Ok(()),
-                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
-                Err(err) => Err(err.to_string()),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn load_js_frozen_storage_instance(id: Id) -> Result<JsFrozenStorage, String> {
-    match JsFrozenStorage::load(id) {
-        Ok(Some(storage)) => {
-            debug!(
-                target: "runtime::frozen_storage",
-                storage_id = %id.to_string(),
-                "loaded JsFrozenStorage from storage"
-            );
-            Ok(storage)
-        }
-        Ok(None) => {
-            let missing_id = id.to_string();
-            warn!(
-                target: "runtime::frozen_storage",
-                storage_id = %missing_id,
-                "JsFrozenStorage not found in storage"
-            );
-            let mut storage = JsFrozenStorage::new_with_id(id);
-            match save_js_frozen_storage_instance(&mut storage) {
-                Ok(()) => {
-                    debug!(
-                        target: "runtime::frozen_storage",
-                        storage_id = %missing_id,
-                        "recreated missing JsFrozenStorage"
-                    );
-                    Ok(storage)
-                }
-                Err(err) => Err(err),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn save_js_frozen_storage_instance(storage: &mut JsFrozenStorage) -> Result<(), String> {
-    match storage.save() {
-        Ok(_) => Ok(()),
-        Err(StorageError::CannotCreateOrphan(_)) => {
-            ensure_root_index_internal().map_err(|err| err.to_string())?;
-            match Interface::<MainStorage>::add_child_to(Id::root(), storage) {
-                Ok(_) => Ok(()),
-                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
-                Err(err) => Err(err.to_string()),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn load_js_pncounter_instance(id: Id) -> Result<JsPnCounter, String> {
-    match JsPnCounter::load(id) {
-        Ok(Some(counter)) => {
-            debug!(
-                target: "runtime::pncounter",
-                counter_id = %id.to_string(),
-                "loaded JsPnCounter from storage"
-            );
-            Ok(counter)
-        }
-        Ok(None) => {
-            let missing_id = id.to_string();
-            warn!(
-                target: "runtime::pncounter",
-                counter_id = %missing_id,
-                "JsPnCounter not found in storage"
-            );
-            let mut counter = JsPnCounter::new_with_id(id);
-            match save_js_pncounter_instance(&mut counter) {
-                Ok(()) => Ok(counter),
-                Err(err) => Err(err),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn save_js_pncounter_instance(counter: &mut JsPnCounter) -> Result<(), String> {
-    match counter.save() {
-        Ok(_) => Ok(()),
-        Err(StorageError::CannotCreateOrphan(_)) => {
-            ensure_root_index_internal().map_err(|err| err.to_string())?;
-            match Interface::<MainStorage>::add_child_to(Id::root(), counter) {
-                Ok(_) => Ok(()),
-                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
-                Err(err) => Err(err.to_string()),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn load_js_rga_instance(id: Id) -> Result<JsRga, String> {
-    match JsRga::load(id) {
-        Ok(Some(rga)) => {
-            debug!(
-                target: "runtime::rga",
-                rga_id = %id.to_string(),
-                "loaded JsRga from storage"
-            );
-            Ok(rga)
-        }
-        Ok(None) => {
-            let missing_id = id.to_string();
-            warn!(
-                target: "runtime::rga",
-                rga_id = %missing_id,
-                "JsRga not found in storage"
-            );
-            let mut rga = JsRga::new_with_id(id);
-            match save_js_rga_instance(&mut rga) {
-                Ok(()) => Ok(rga),
-                Err(err) => Err(err),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn save_js_rga_instance(rga: &mut JsRga) -> Result<(), String> {
-    match rga.save() {
-        Ok(_) => Ok(()),
-        Err(StorageError::CannotCreateOrphan(_)) => {
-            ensure_root_index_internal().map_err(|err| err.to_string())?;
-            match Interface::<MainStorage>::add_child_to(Id::root(), rga) {
-                Ok(_) => Ok(()),
-                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
-                Err(err) => Err(err.to_string()),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn load_js_sortedmap_instance(id: Id) -> Result<JsSortedMap, String> {
-    match JsSortedMap::load(id) {
-        Ok(Some(map)) => {
-            debug!(
-                target: "runtime::sortedmap",
-                map_id = %id.to_string(),
-                "loaded JsSortedMap from storage"
-            );
-            Ok(map)
-        }
-        Ok(None) => {
-            let missing_id = id.to_string();
-            warn!(
-                target: "runtime::sortedmap",
-                map_id = %missing_id,
-                "JsSortedMap not found in storage"
-            );
-            let mut map = JsSortedMap::new_with_id(id);
-            match save_js_sortedmap_instance(&mut map) {
-                Ok(()) => Ok(map),
-                Err(err) => Err(err),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn save_js_sortedmap_instance(map: &mut JsSortedMap) -> Result<(), String> {
-    match map.save() {
-        Ok(_) => Ok(()),
-        Err(StorageError::CannotCreateOrphan(_)) => {
-            ensure_root_index_internal().map_err(|err| err.to_string())?;
-            match Interface::<MainStorage>::add_child_to(Id::root(), map) {
-                Ok(_) => Ok(()),
-                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
-                Err(err) => Err(err.to_string()),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn load_js_sortedset_instance(id: Id) -> Result<JsSortedSet, String> {
-    match JsSortedSet::load(id) {
-        Ok(Some(set)) => {
-            debug!(
-                target: "runtime::sortedset",
-                set_id = %id.to_string(),
-                "loaded JsSortedSet from storage"
-            );
-            Ok(set)
-        }
-        Ok(None) => {
-            let missing_id = id.to_string();
-            warn!(
-                target: "runtime::sortedset",
-                set_id = %missing_id,
-                "JsSortedSet not found in storage"
-            );
-            let mut set = JsSortedSet::new_with_id(id);
-            match save_js_sortedset_instance(&mut set) {
-                Ok(()) => Ok(set),
-                Err(err) => Err(err),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn save_js_sortedset_instance(set: &mut JsSortedSet) -> Result<(), String> {
-    match set.save() {
-        Ok(_) => Ok(()),
-        Err(StorageError::CannotCreateOrphan(_)) => {
-            ensure_root_index_internal().map_err(|err| err.to_string())?;
-            match Interface::<MainStorage>::add_child_to(Id::root(), set) {
-                Ok(_) => Ok(()),
-                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
-                Err(err) => Err(err.to_string()),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn load_js_authored_map_instance(id: Id) -> Result<JsAuthoredMap, String> {
-    match JsAuthoredMap::load(id) {
-        Ok(Some(map)) => {
-            debug!(
-                target: "runtime::authored_map",
-                map_id = %id.to_string(),
-                "loaded JsAuthoredMap from storage"
-            );
-            Ok(map)
-        }
-        Ok(None) => {
-            let missing_id = id.to_string();
-            warn!(
-                target: "runtime::authored_map",
-                map_id = %missing_id,
-                "JsAuthoredMap not found in storage"
-            );
-            let mut map = JsAuthoredMap::new_with_id(id);
-            match save_js_authored_map_instance(&mut map) {
-                Ok(()) => Ok(map),
-                Err(err) => Err(err),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn save_js_authored_map_instance(map: &mut JsAuthoredMap) -> Result<(), String> {
-    match map.save() {
-        Ok(_) => Ok(()),
-        Err(StorageError::CannotCreateOrphan(_)) => {
-            ensure_root_index_internal().map_err(|err| err.to_string())?;
-            match Interface::<MainStorage>::add_child_to(Id::root(), map) {
-                Ok(_) => Ok(()),
-                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
-                Err(err) => Err(err.to_string()),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn load_js_authored_vector_instance(id: Id) -> Result<JsAuthoredVector, String> {
-    match JsAuthoredVector::load(id) {
-        Ok(Some(vector)) => {
-            debug!(
-                target: "runtime::authored_vector",
-                vector_id = %id.to_string(),
-                "loaded JsAuthoredVector from storage"
-            );
-            Ok(vector)
-        }
-        Ok(None) => {
-            let missing_id = id.to_string();
-            warn!(
-                target: "runtime::authored_vector",
-                vector_id = %missing_id,
-                "JsAuthoredVector not found in storage"
-            );
-            let mut vector = JsAuthoredVector::new_with_id(id);
-            match save_js_authored_vector_instance(&mut vector) {
-                Ok(()) => Ok(vector),
-                Err(err) => Err(err),
-            }
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn save_js_authored_vector_instance(vector: &mut JsAuthoredVector) -> Result<(), String> {
-    match vector.save() {
-        Ok(_) => Ok(()),
-        Err(StorageError::CannotCreateOrphan(_)) => {
-            ensure_root_index_internal().map_err(|err| err.to_string())?;
-            match Interface::<MainStorage>::add_child_to(Id::root(), vector) {
-                Ok(_) => Ok(()),
-                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
-                Err(err) => Err(err.to_string()),
-            }
-        }
-        Err(err) => Err(err.to_string()),
     }
 }
 
@@ -4561,21 +3615,6 @@ fn load_js_shared_instance(id: Id) -> Result<JsSharedStorage, String> {
             // means the id was referenced before `new`/`new_with_id` persisted it,
             // which is a caller error — surface it rather than paper over it.
             Err(format!("JsSharedStorage {missing_id} not found in storage"))
-        }
-        Err(err) => Err(err.to_string()),
-    }
-}
-
-fn save_js_shared_instance(cell: &mut JsSharedStorage) -> Result<(), String> {
-    match cell.save() {
-        Ok(_) => Ok(()),
-        Err(StorageError::CannotCreateOrphan(_)) => {
-            ensure_root_index_internal().map_err(|err| err.to_string())?;
-            match Interface::<MainStorage>::add_child_to(Id::root(), cell) {
-                Ok(_) => Ok(()),
-                Err(StorageError::CannotCreateOrphan(_)) => Err("cannot create orphan".to_owned()),
-                Err(err) => Err(err.to_string()),
-            }
         }
         Err(err) => Err(err.to_string()),
     }


### PR DESCRIPTION
First half of **F1** from the maintainability audit — the largest single duplication in the codebase.

`js_collections.rs` carried the same four functions thirteen times over, once per JS-facing collection type, because each `Js*` type exposes `new`, `new_with_id`, `save` and `load` as *inherent* methods. Nothing about them looked shared, so each new collection type got added by copying the last one.

They are shared: `save()` is a one-line wrapper over `Interface::<MainStorage>::save`, which is **already generic over `Data`**, and `add_child_to` takes the same bound.

## What replaced what

| Generator | Replaces | Why this form |
| --- | --- | --- |
| `save_js_instance<D: Data>` | 13 byte-identical savers | A plain **generic function, not a macro** — stays greppable; 64 call sites resolve by inference |
| `js_load_or_recreate!` | 13 load-or-recreate wrappers | Macro, because the differences are a `target:` and a log field name — both must be literals at the call site, which a generic cannot carry |
| `js_new_with_id_op!` | 13 caller-supplied-id constructors | Macro; needs the inherent `new_with_id` |
| `js_new_op!` | 13 host-minted-id constructors | Macro; needs the inherent `new` |

52 functions → 1 generic + 3 generators. **Net −908 lines** (5,817 → 4,909).

## The copies had already drifted — that's the point

Seven of the thirteen load wrappers logged the recreation of a missing collection; **six silently did it**. That's the divergence that makes a log trail useless exactly when someone is reading it to explain a missing collection.

Generated, they can't disagree — so the six now log it too. **That is the only behaviour change in this PR**, and it's measured below rather than asserted.

## One deliberate exception, now visible as one

`JsSharedStorage` is **not** generated. A shared cell cannot be recreated on the fly: its writer set is only known at construction, and inventing an empty one would silently make the cell unwritable. It stays hand-written with that reasoning beside it — which is now legible as an exception, instead of being buried among thirteen near-identical neighbours where nobody would notice it differs.

## The host ABI is compiler-enforced, not merely asserted

`imports.rs` expands to `data.host_functions(store).$func(...)` for every name it declares, so a renamed or dropped host method **fails the build**. `imports.rs` is untouched here, and the expansion confirms the surface:

```
js_* ABI functions   before: 101   after: 101   removed: 0
```

## Verified against the pre-refactor expansion

For a mechanical substitution, `cargo expand` is a stronger oracle than tests — it compares what the compiler actually sees. Baseline captured **before** the first edit:

```
log callsites, attributed by target:
  runtime::authored_map      DEBUG  +1
  runtime::authored_vector   DEBUG  +1
  runtime::pncounter         DEBUG  +1
  runtime::rga               DEBUG  +1
  runtime::sortedmap         DEBUG  +1
  runtime::sortedset         DEBUG  +1
                             net    +6      ← exactly the six that lacked it
  every other target                 0
  WARN (all targets)          42 → 42

functions removed: the 13 save_js_*_instance helpers, and nothing else
functions added:   save_js_instance<D: Data>
```

Worth noting how I nearly got this wrong: a first pass counting `grep -c "::tracing::Level::DEBUG"` reported +18, because that string appears more than once per callsite. Attributing callsites by their embedded `Metadata::new(_, target, level)` is the measurement that actually answers the question.

## What is left, and why

**897 lines across 18 families remain** in this file — all read-path ops (`get` / `iter` / `insert` / `remove` / `contains` / `len`). Deliberately not attempted here, because their variance is real: the similarity detector groups `crdt_map_get` with `crdt_authored_map_owner_of`, and `crdt_map_contains` with `crdt_authored_map_owned_by_me`. Those are **different operations that merely look alike** — collapsing by similarity would merge things that should stay distinct. That half needs a per-operation read, not another sweep.

## Verification

- `cargo test --workspace --features calimero-storage/testing` — **4946 passed, 0 failed**, including the 26 `crdt_conformance` cases that drive real wasm
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo expand` diff — see above; +6 log callsites, 0 ABI changes

Not marked `!`: no public API, wire format or host ABI changes. The one observable difference is six additional DEBUG log lines on a recovery path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)