### PR TITLE
fix(sync): serve the group the invitation names, not the namespace

### DIFF
--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -89,6 +89,29 @@ impl KeyFetchRound {
     }
 }
 
+/// The group a join request is actually for.
+///
+/// The stream is keyed by NAMESPACE, but the invitation names the group being
+/// joined, which is a subgroup whenever the invite was issued on one. The two
+/// coincide only for a namespace invitation, so reading the request's id
+/// instead serves the wrong group's key bound to the wrong scope, and the
+/// joiner's unwrap refuses the envelope it is sent.
+///
+/// A signed invitation is authority over the group it names and nothing else,
+/// so that group has to resolve back to the namespace being served.
+fn join_target_group(
+    store: &calimero_store::Store,
+    namespace: calimero_context_config::types::ContextGroupId,
+    invitation: &calimero_context_config::types::SignedGroupOpenInvitation,
+) -> Result<calimero_context_config::types::ContextGroupId, String> {
+    let group_id = invitation.invitation.group_id;
+    match calimero_governance_store::NamespaceRepository::new(store).resolve(&group_id) {
+        Ok(owner) if owner == namespace => Ok(group_id),
+        Ok(_) => Err("invitation names a group outside this namespace".to_owned()),
+        Err(err) => Err(format!("could not resolve the invited group: {err}")),
+    }
+}
+
 impl SyncManager {
     /// Actively request governance catch-up from a specific peer whose
     /// identity we don't yet recognize as a context member.
@@ -564,8 +587,21 @@ impl SyncManager {
             }
         };
 
-        let group_id = ContextGroupId::from(namespace_id);
+        let namespace = ContextGroupId::from(namespace_id);
         let store = self.context_client.datastore_handle().into_inner();
+
+        let group_id = match join_target_group(&store, namespace, &invitation) {
+            Ok(target) => target,
+            Err(reason) => {
+                let msg = StreamMessage::Message {
+                    sequence_id: 0,
+                    payload: MessagePayload::NamespaceJoinRejected { reason },
+                    next_nonce: nonce,
+                };
+                crate::sync::stream::send(stream, &msg, None).await?;
+                return Ok(());
+            }
+        };
 
         let meta = match MetaRepository::new(&store).load(&group_id)? {
             Some(m) => m,
@@ -687,7 +723,7 @@ impl SyncManager {
         let key_envelope_bytes = match GroupKeyring::new(&store, group_id).load_current_key()? {
             Some((_key_id, group_key)) => {
                 let ns_identity =
-                    NamespaceRepository::new(&store).resolve_identity_record(&group_id)?;
+                    NamespaceRepository::new(&store).resolve_identity_record(&namespace)?;
                 match ns_identity {
                     Some(record) => {
                         let sender_sk =
@@ -761,7 +797,7 @@ impl SyncManager {
         // updated as those ops apply). `unwrap_or(0)` matches the
         // pre-existing semantics for "default key absent."
         let default_capabilities = CapabilitiesRepository::new(&store)
-            .default_capabilities(&group_id)?
+            .default_capabilities(&namespace)?
             .unwrap_or(0);
 
         debug!(
@@ -2630,5 +2666,88 @@ mod namespace_pull_peer_tests {
             "callers that supply no fallback keep the old behaviour exactly — \
              this must not start guessing at a peer on its own",
         );
+    }
+}
+
+#[cfg(test)]
+mod join_target_tests {
+    use std::sync::Arc;
+
+    use calimero_context_config::types::{
+        ContextGroupId, GroupInvitationFromAdmin, SignedGroupOpenInvitation, SignerId,
+    };
+    use calimero_governance_store::NamespaceRepository;
+    use calimero_primitives::identity::PrivateKey;
+    use calimero_store::db::InMemoryDB;
+    use calimero_store::Store;
+    use rand::rngs::OsRng;
+    use sha2::{Digest, Sha256};
+
+    use super::join_target_group;
+
+    fn invitation_to(admin_sk: &PrivateKey, group_id: ContextGroupId) -> SignedGroupOpenInvitation {
+        let invitation = GroupInvitationFromAdmin {
+            inviter_identity: SignerId::from(*admin_sk.public_key().digest()),
+            group_id,
+            expiration_timestamp: 0,
+            invitation_nonce: [0x11; 32],
+            invited_role: 1,
+        };
+        let signature = admin_sk
+            .sign(&Sha256::digest(borsh::to_vec(&invitation).unwrap()))
+            .unwrap();
+        SignedGroupOpenInvitation {
+            inviter_account: None,
+            invitation,
+            inviter_signature: hex::encode(signature.to_bytes()),
+            application_id: None,
+            app_key: None,
+        }
+    }
+
+    #[test]
+    fn a_subgroup_invitation_resolves_to_the_subgroup() {
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let namespace = ContextGroupId::from([0x01; 32]);
+        let subgroup = ContextGroupId::from([0x02; 32]);
+        NamespaceRepository::new(&store)
+            .nest(&namespace, &subgroup)
+            .expect("nest the subgroup");
+        let admin_sk = PrivateKey::random(&mut OsRng);
+
+        // The request names the namespace; only the invitation knows it is for
+        // the subgroup, and serving the namespace instead is the whole bug.
+        assert_eq!(
+            join_target_group(&store, namespace, &invitation_to(&admin_sk, subgroup)).unwrap(),
+            subgroup
+        );
+    }
+
+    #[test]
+    fn a_namespace_invitation_resolves_to_the_namespace() {
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let namespace = ContextGroupId::from([0x01; 32]);
+        let admin_sk = PrivateKey::random(&mut OsRng);
+
+        assert_eq!(
+            join_target_group(&store, namespace, &invitation_to(&admin_sk, namespace)).unwrap(),
+            namespace
+        );
+    }
+
+    #[test]
+    fn an_invitation_from_another_namespace_is_refused() {
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let namespace = ContextGroupId::from([0x01; 32]);
+        let elsewhere = ContextGroupId::from([0x03; 32]);
+        let stranger = ContextGroupId::from([0x04; 32]);
+        NamespaceRepository::new(&store)
+            .nest(&elsewhere, &stranger)
+            .expect("nest the foreign subgroup");
+        let admin_sk = PrivateKey::random(&mut OsRng);
+
+        // Pairing a valid invitation with someone else's namespace must not
+        // release that namespace's key material.
+        assert!(join_target_group(&store, namespace, &invitation_to(&admin_sk, stranger)).is_err());
     }
 }


### PR DESCRIPTION
## Summary

`POST /admin-api/groups/join` returns `500` for **any** subgroup invitation. Closes #3577.

The two sides of the key handover bind the envelope to different groups:

- the responder wraps for the namespace the stream is keyed by - `namespace_sync.rs` set `group_id = ContextGroupId::from(namespace_id)` and used it for everything;
- the joiner unwraps against the invitation's group, which for a subgroup invitation is the subgroup (`join_group.rs:273`).

`KeyEnvelope::signing_payload` folds `group_id` into the signed bytes, so the payloads differ and the Ed25519 check fails:

```
key envelope sender authentication failed: verify: signature error: Verification equation was not satisfied
```

The namespace case only ever worked because there the invitation's group id *equals* the namespace id, so wrap and unwrap coincidentally agree. It is not a separate code path.

This bit hardest on Restricted subgroups, which had **no working entry at all**: `join-via-inheritance` correctly refuses there with a 403, so an invited node could not get in by any route.

### The change

The responder takes the target group from the invitation, which is the only thing that knows what is being joined, and refuses one that does not resolve back to the namespace being served - a signed invitation is authority over the group it names, never over whatever namespace the requester paired it with.

Everything downstream of that decision follows the same id: the key it loads and wraps, the re-entry check, the pre-registered membership row, and the contexts enumerated into the bundle. The namespace's own signing identity and `default_capabilities` stay namespace-scoped, and are now spelled with a separate `namespace` binding so the two scopes cannot be confused again.

**For a namespace invitation the target group *is* the namespace**, so none of this alters the path that works today. It only changes subgroup joins, which are broken outright.

## Test plan

Two real `merod` nodes, same flow on each binary. Node-2 joins the namespace, node-1 creates a Restricted subgroup, node-1 invites node-2 to *the subgroup*, node-2 calls `POST /groups/join`:

| | result |
| --- | --- |
| before | `500 {"error":"Internal server error"}`, joiner log: `key envelope sender authentication failed: verify: signature error: Verification equation was not satisfied` |
| after | `200`, response names the subgroup |

Proven functionally, not just by status code. After the fix node-2 logged `received group key via direct join response`, appeared in `GET /groups/<subgroup>/members`, joined a context inside that subgroup, and read back a value node-1 had written (`{"output":"works"}`).

Automated: `join_target_group` is extracted so the decision can be pinned, with three cases - a subgroup invitation resolves to the subgroup, a namespace invitation to the namespace, and an invitation from another namespace is refused. Each was observed failing under mutation: reverting the id to the namespace fails the first and third, and dropping the containment guard fails the third alone.

`cargo fmt --check`, `clippy -D warnings` on the crate, and the full `calimero-node` lib suite (555 tests) pass.

## Not covered

No merobox scenario: neither `calimero-client-py` nor merobox exposes `POST /groups/:id/invite` or `POST /groups/join`, so this flow cannot be expressed in a workflow yet. Same blocker class as the account-addressed add, different endpoints.