### PR TITLE
test(e2e): cover peer discovery without mDNS on a flat bridge

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -502,6 +502,27 @@ jobs:
           - workflow: mesh-soak-8node
             file: workflows/mesh-soak-8node.yml
             app: scaffolding-e2e
+          # The only scenarios on a flat bridge that discover peers the way a
+          # real deployment must. Every other entry here runs with `mdns: true`
+          # and an empty `bootstrap.nodes` (`--e2e-mode` clears the list, then
+          # forces mDNS on), so multicast is not their fallback — it is their
+          # only discovery mechanism, and it exists only because one Docker
+          # bridge is one multicast domain. Nodes on separate hosts have no such
+          # path. Measured on `mesh-soak-8node` when these landed: mDNS off and
+          # nothing else changed gave 0 kad `RoutingUpdated`, 0 connections, 0
+          # identify, and a dead first join; mDNS on gave 112 dials and 112
+          # routing updates. So a total regression in bootstrap/kad discovery
+          # keeps ~80 of these entries green, and only these two go red.
+          #
+          # They are cheap (2 and 4 nodes, no soak tail) and they must stay in
+          # the matrix: a skip here reads as "discovery is fine" while removing
+          # the only evidence for it.
+          - workflow: discovery-bootstrap-only-2node
+            file: workflows/discovery-bootstrap-only-2node.yml
+            app: scaffolding-e2e
+          - workflow: discovery-bootstrap-only-4node
+            file: workflows/discovery-bootstrap-only-4node.yml
+            app: scaffolding-e2e
           # #2422 auto-follow regression workflows.
           - workflow: auto-follow-on-context-registered
             file: workflows/auto-follow/auto-follow-on-context-registered.yml

--- a/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-2node.yml
+++ b/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-2node.yml
@@ -1,0 +1,183 @@
+description: >
+  Two nodes find each other with mDNS switched off, using nothing but the
+  bootstrap addresses in their config.
+
+  Why this exists
+  ---------------
+
+  Every other flat-bridge scenario in the suite runs with `mdns: true` and an
+  EMPTY `bootstrap.nodes` — `--e2e-mode` clears the list to isolate the fleet
+  and then forces mDNS on. Those two settings together mean multicast is not a
+  fallback in those scenarios, it is the only discovery mechanism they have.
+  Measured on `mesh-soak-8node` at the time this landed: with mDNS disabled and
+  nothing else changed, the 8-node fleet recorded 0 kad `RoutingUpdated`, 0
+  connections and 0 identify exchanges, and the first namespace join died on
+  `KeyDelivery timed out ... no group key arrived within 5s`. With mDNS on, the
+  same run made 112 mDNS dials and 112 `RoutingUpdated` — one routing entry per
+  multicast-initiated connection.
+
+  The consequence is that a total regression in bootstrap/kad discovery — the
+  only path a real deployment has, since nodes on separate hosts share no
+  multicast domain — keeps every one of those scenarios green. This scenario is
+  the one that goes red instead.
+
+  How it forces the issue
+  -----------------------
+
+  `mdns: false` removes multicast. `restart: true` routes node startup through
+  merobox's `run_multiple_nodes`, the only path that calls
+  `_wire_cluster_bootstrap_peers`, which writes each node's siblings into its
+  `bootstrap.nodes` and restarts the container so merod re-reads it. So the
+  peers begin knowing each other's addresses and nothing else: no shouting, no
+  rendezvous server to ask.
+
+  There are deliberately no log-pattern assertions here. Convergence IS the
+  assertion — with multicast gone, the writes below can only cross if dialing a
+  bootstrap address, identify, and the kad routing table all work. A discovery
+  regression surfaces as a failed join or a failed read, not as a missing grep.
+
+  What it does NOT cover
+  ----------------------
+
+  The wiring hands every node a complete roster of its siblings. A real node is
+  told about one or two bootstrap peers and has to ASK one of them who else
+  exists — that is rendezvous register/discover, and it stays uncovered on a
+  flat bridge because there is no rendezvous server here to ask (merod builds
+  `rendezvous::client::Behaviour` only). The NAT `sync-resilience-*` scenarios
+  are the ones that exercise it, bundled together with relay reservations and
+  hole-punching.
+
+  Requires merobox >= 0.6.57: below it the cluster-connectivity gate that
+  `restart: true` runs into polls `/admin-api/peers` unauthenticated, reads the
+  401 as "0 peers", and fails node management on every embedded-auth fleet
+  before a single step executes.
+name: E2E Discovery - Bootstrap Only, No mDNS (2 nodes)
+
+force_pull_image: false
+near_devnet: false
+
+# Routes startup through the wiring path described above. Without it merobox
+# takes the per-node path, `bootstrap.nodes` stays empty, and with mDNS off the
+# two nodes never meet.
+restart: true
+
+auth_mode: embedded
+
+nodes:
+  count: 2
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+  mdns: false
+
+steps:
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev-password
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev-password
+
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      ns: namespaceId
+
+  - name: Create context on node-1
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{ns}}'
+    outputs:
+      ctx: contextId
+
+  # The join is the first thing that needs a peer: group-key delivery has to
+  # reach node-1 over the network. Pre-#3525 with mDNS off this is exactly
+  # where the run died, 5s after the request, with no mesh peer to ask.
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{ns}}'
+    outputs:
+      invitation: invitation
+
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{ns}}'
+    invitation: '{{invitation}}'
+
+  - name: Node-2 joins context
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+
+  # Writes in both directions: a one-way check passes on a half-open mesh where
+  # only the dialer's side of the gossipsub graph formed.
+  - name: Node-1 writes a key
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: set
+    args:
+      key: "from_node_1"
+      value: "dialed_over_bootstrap"
+
+  - name: Node-2 writes a key
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: set
+    args:
+      key: "from_node_2"
+      value: "dialed_over_bootstrap"
+
+  - name: Converge both peers
+    type: wait_for_sync
+    context_id: '{{ctx}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-2 reads node-1's key
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: get
+    args:
+      key: "from_node_1"
+    outputs:
+      n2_reads_n1: result
+
+  - name: Node-1 reads node-2's key
+    type: call
+    node: e2e-node-1
+    context_id: '{{ctx}}'
+    method: get
+    args:
+      key: "from_node_2"
+    outputs:
+      n1_reads_n2: result
+
+  - name: Assert both directions crossed without multicast
+    type: json_assert
+    statements:
+      - 'json_equal({{n2_reads_n1}}, {"output": "dialed_over_bootstrap"})'
+      - 'json_equal({{n1_reads_n2}}, {"output": "dialed_over_bootstrap"})'

--- a/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-2node.yml
+++ b/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-2node.yml
@@ -125,6 +125,23 @@ steps:
     node: e2e-node-2
     context_id: '{{ctx}}'
 
+  # Barrier before the writes, not decoration. `join_context` returns as soon as
+  # the join is accepted; node-2's context state materialises a moment later.
+  # Writing immediately raced that and node-2 answered `Uninitialized` ("context
+  # state not initialized, awaiting state sync"), which merobox papered over by
+  # retrying 3s later — so the scenario passed while logging two ERRORs that
+  # have nothing to do with discovery, and would have failed outright had the
+  # retry budget been shorter.
+  - name: Settle the join before either peer writes
+    type: wait_for_sync
+    context_id: '{{ctx}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
   # Writes in both directions: a one-way check passes on a half-open mesh where
   # only the dialer's side of the gossipsub graph formed.
   - name: Node-1 writes a key

--- a/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-2node.yml
+++ b/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-2node.yml
@@ -54,7 +54,6 @@ description: >
 name: E2E Discovery - Bootstrap Only, No mDNS (2 nodes)
 
 force_pull_image: false
-near_devnet: false
 
 # Routes startup through the wiring path described above. Without it merobox
 # takes the per-node path, `bootstrap.nodes` stays empty, and with mDNS off the

--- a/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-4node.yml
+++ b/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-4node.yml
@@ -138,6 +138,24 @@ steps:
     node: e2e-node-4
     context_id: '{{ctx}}'
 
+  # Barrier before the write, not decoration. `join_context` returns when the
+  # join is accepted, while the joiner's context state materialises a moment
+  # later; writing into that gap gets `Uninitialized` ("context state not
+  # initialized, awaiting state sync"), which merobox hides behind a retry. The
+  # 2-node companion hit exactly that and passed anyway, logging two ERRORs
+  # unrelated to discovery.
+  - name: Settle the joins before the write
+    type: wait_for_sync
+    context_id: '{{ctx}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+      - e2e-node-4
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
   # The point of the scenario: a joiner-to-joiner write. Node-1 created the
   # namespace and invited everyone, so every peer has a reason to talk to it.
   # Nothing gave node-3 and node-4 a reason to know each other beyond the

--- a/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-4node.yml
+++ b/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-4node.yml
@@ -1,0 +1,191 @@
+description: >
+  Four nodes discover each other with mDNS switched off, and a write travels
+  between two peers that are both joiners — neither of them the node that
+  created the namespace.
+
+  Why a second, larger case
+  -------------------------
+
+  The 2-node companion
+  (`discovery-bootstrap-only-2node.yml`) proves a bootstrap address can be
+  dialled at all. It cannot distinguish that from a fleet where only the one
+  connection it needs happens to form: with two peers there is exactly one edge,
+  and the writer is always either the namespace creator or its only peer.
+
+  Four nodes make the gossipsub mesh a real graph and put a write on an edge
+  that no invitation flow established: node-3 writes, node-4 reads. Both are
+  joiners, so the payload has to cross a link between two peers that only know
+  of each other through the bootstrap roster and kad — the namespace creator is
+  not on the path. A partially-populated routing table, or a mesh that forms
+  only towards the node everyone was invited by, converges in the 2-node case
+  and fails here.
+
+  Four rather than eight: `mesh-soak-8node` already owns the upper end of the
+  mesh-size range, and it is a soak with a 70s idle tail. This scenario is meant
+  to be cheap enough to run on every PR.
+
+  See the 2-node file for the full background on why mDNS is load-bearing in
+  the flat-bridge suite, how `restart: true` + `mdns: false` forces bootstrap
+  discovery, why there are no log-pattern assertions, and what this shape still
+  does not cover (rendezvous). Same merobox >= 0.6.57 requirement.
+name: E2E Discovery - Bootstrap Only, No mDNS (4 nodes)
+
+force_pull_image: false
+near_devnet: false
+
+restart: true
+
+auth_mode: embedded
+
+nodes:
+  count: 4
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+  mdns: false
+
+steps:
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev-password
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev-password
+
+  - name: Login on e2e-node-3
+    type: login
+    node: e2e-node-3
+    username: dev
+    password: dev-password
+
+  - name: Login on e2e-node-4
+    type: login
+    node: e2e-node-4
+    username: dev
+    password: dev-password
+
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      ns: namespaceId
+
+  - name: Create context on node-1
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{ns}}'
+    outputs:
+      ctx: contextId
+
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{ns}}'
+    outputs:
+      invite_n2: invitation
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{ns}}'
+    invitation: '{{invite_n2}}'
+  - name: Node-2 joins context
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+
+  - name: Invite node-3 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{ns}}'
+    outputs:
+      invite_n3: invitation
+  - name: Node-3 joins namespace
+    type: join_namespace
+    node: e2e-node-3
+    namespace_id: '{{ns}}'
+    invitation: '{{invite_n3}}'
+  - name: Node-3 joins context
+    type: join_context
+    node: e2e-node-3
+    context_id: '{{ctx}}'
+
+  - name: Invite node-4 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{ns}}'
+    outputs:
+      invite_n4: invitation
+  - name: Node-4 joins namespace
+    type: join_namespace
+    node: e2e-node-4
+    namespace_id: '{{ns}}'
+    invitation: '{{invite_n4}}'
+  - name: Node-4 joins context
+    type: join_context
+    node: e2e-node-4
+    context_id: '{{ctx}}'
+
+  # The point of the scenario: a joiner-to-joiner write. Node-1 created the
+  # namespace and invited everyone, so every peer has a reason to talk to it.
+  # Nothing gave node-3 and node-4 a reason to know each other beyond the
+  # bootstrap roster they started with.
+  - name: Node-3 writes a key
+    type: call
+    node: e2e-node-3
+    context_id: '{{ctx}}'
+    method: set
+    args:
+      key: "from_node_3"
+      value: "joiner_to_joiner"
+
+  - name: Converge all four peers
+    type: wait_for_sync
+    context_id: '{{ctx}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+      - e2e-node-4
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-4 reads node-3's key
+    type: call
+    node: e2e-node-4
+    context_id: '{{ctx}}'
+    method: get
+    args:
+      key: "from_node_3"
+    outputs:
+      n4_reads_n3: result
+
+  - name: Node-2 reads node-3's key
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: get
+    args:
+      key: "from_node_3"
+    outputs:
+      n2_reads_n3: result
+
+  - name: Assert the joiner-to-joiner write reached the other joiners
+    type: json_assert
+    statements:
+      - 'json_equal({{n4_reads_n3}}, {"output": "joiner_to_joiner"})'
+      - 'json_equal({{n2_reads_n3}}, {"output": "joiner_to_joiner"})'

--- a/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-4node.yml
+++ b/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-4node.yml
@@ -31,7 +31,6 @@ description: >
 name: E2E Discovery - Bootstrap Only, No mDNS (4 nodes)
 
 force_pull_image: false
-near_devnet: false
 
 restart: true
 


### PR DESCRIPTION
Part of #3525 — the "if mDNS is load-bearing in e2e, the fleet disables it so scenarios exercise the discovery path a real deployment uses" criterion. It is load-bearing; this adds the coverage rather than flipping the default under the other 80 scenarios.

## The gap

Every flat-bridge scenario runs with `mdns: true` and an **empty** `bootstrap.nodes` — `--e2e-mode` clears the list to isolate the fleet, then forces mDNS on in the same dict, commented *"keep mDNS as backup"*. It is not a backup; it is the only discovery mechanism those scenarios have, and it works only because one Docker bridge is one multicast domain. Nodes on separate hosts have no such path.

Measured on `mesh-soak-8node`, mDNS disabled and nothing else changed:

| | mDNS on | mDNS off |
|---|---:|---:|
| mDNS dials | 112 | 0 |
| kad `RoutingUpdated` | 112 | **0** |
| connections established | 440 | **0** |
| identify exchanges | 220 | **0** |
| result | pass | **fail** — first namespace join, `KeyDelivery timed out … no group key arrived within 5s` |

The 112/112 correspondence is causal: the kad routing table those scenarios depend on is populated as a side effect of multicast-initiated connections. So a total regression in bootstrap/kad discovery keeps ~80 matrix entries green.

## What this adds

- **`discovery-bootstrap-only-2node`** — a pair converges in both directions with multicast gone. Both directions because a one-way check passes on a half-open mesh.
- **`discovery-bootstrap-only-4node`** — a joiner-to-joiner write: node-3 writes, node-4 and node-2 read. With two peers there is one edge and the writer is always the namespace creator or its only peer; a routing table populated only towards the inviting node converges in the 2-node case and fails here.

`mdns: false` removes multicast; `restart: true` routes startup through merobox's `run_multiple_nodes`, the only path that calls `_wire_cluster_bootstrap_peers` to write each node's siblings into its `bootstrap.nodes`. Four nodes rather than eight because `mesh-soak-8node` already owns the top of the mesh-size range and carries a 70s soak tail — these are meant to be cheap enough for every PR.

No log-pattern assertions. Convergence **is** the assertion: with multicast gone, these writes cross only if bootstrap dialling, identify and kad all work, so a regression shows up as a failed join or read rather than a missing grep.

`restart: true` ends in a connectivity gate that needs merobox >= 0.6.57 to read a peer count rather than scoring the 401 every embedded-auth node returns from `/admin-api/peers` as "0 connected peers" — below that it fails node management after a full 60s timeout with all nodes reported at 0 peers while their logs show the fleet fully meshed (calimero-network/merobox#342, fixed in 0.6.57). The suite floor moved to 0.6.58 on master while this branch was open, which already satisfies it, so the floor bump this PR originally carried has been dropped — the diff is now only the two scenarios and their matrix entries.

## What this does NOT cover

The wiring hands every node a complete roster of its siblings. A real node is told about one or two bootstrap peers and has to **ask** one of them who else exists — rendezvous register/discover — which has no server on a flat bridge, since merod builds `rendezvous::client::Behaviour` only. The NAT `sync-resilience-*` scenarios stay its only coverage, bundled together with relay reservations and hole-punching, which is exactly what makes a discovery regression there hard to attribute. A plain-bridge boot-node topology would de-confound it; that needs a new merobox topology variant and is filed separately.

## Verification

Static checks pass locally: `scripts/lint-e2e-convergence.py` clean (132 scenarios scanned, no new convergence races), and both files pass merobox's own workflow-schema validation.

The mechanism these scenarios exercise is proven on real nodes: `mesh-soak-8node` run with `mdns: false` + `restart: true` went green end to end on 8 nodes — `✓ Cluster fully connected`, `mdns = false` in the live config, **zero** mDNS dials across all 8 node logs, and 15–26 kad `RoutingUpdated` each. A local 2-node run of *this* scenario got as far as `✓ Cluster fully connected` with 0 mDNS dials before dying on a missing wasm in my worktree (a build artifact CI supplies via the `e2e-apps` artifact).

**These two files themselves have not been run end to end** — local Docker on my machine wedged repeatedly under disk pressure, so the two new matrix entries are the verification. If they are wrong they say so directly.
