### PR TITLE
chore: gate unused dependencies in CI, and split the rotation refusal

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -139,6 +139,22 @@ jobs:
           cargo install cargo-deny --version 0.19.9 --locked
           cargo deny check advisories bans licenses sources
 
+      - name: Cargo machete (unused dependencies)
+        if: ${{ !cancelled() }}
+        run: |
+          # Catches dependencies nothing references any more. 35 had accumulated
+          # before this gate existed, three of them listed as "key deps" in their
+          # own crate's AGENTS.md — nobody had a reason to look.
+          #
+          # It works from source references, so a dependency linked only through a
+          # feature reads as unused. There is exactly one of those
+          # (`wasmer-compiler-cranelift` in calimero-runtime); it is declared in
+          # that crate's `[package.metadata.cargo-machete] ignored`, with the
+          # reason beside it. Add to that list only after confirming removal
+          # actually breaks the build — otherwise the entry hides a real dead dep.
+          cargo install cargo-machete --version 0.9.2 --locked
+          cargo machete
+
   cargo-mero-e2e:
     name: cargo-mero e2e
     runs-on: big-machine

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,9 +752,6 @@ version = "0.0.0"
 dependencies = [
  "calimero-sdk",
  "calimero-storage",
- "hex",
- "sha2",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1256,7 +1253,6 @@ dependencies = [
  "calimero-primitives",
  "calimero-store",
  "calimero-utils-actix",
- "either",
  "eyre",
  "futures-util",
  "hex",
@@ -1268,7 +1264,6 @@ dependencies = [
  "multiaddr",
  "owo-colors 3.5.0",
  "prometheus-client",
- "rand 0.8.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2016,7 +2011,6 @@ dependencies = [
  "bs58",
  "calimero-sdk",
  "calimero-storage",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2538,7 +2532,6 @@ version = "0.0.0"
 dependencies = [
  "calimero-sdk",
  "calimero-storage",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5833,7 +5826,6 @@ dependencies = [
  "hex",
  "jaq-interpret",
  "jaq-parse",
- "jaq-syn",
  "once_cell",
  "rocksdb",
  "serde",
@@ -8126,7 +8118,6 @@ dependencies = [
  "bs58",
  "calimero-sdk",
  "calimero-storage",
- "calimero-storage-macros",
  "hex",
  "sha2",
  "thiserror 1.0.69",
@@ -9119,7 +9110,6 @@ version = "0.0.0"
 dependencies = [
  "calimero-sdk",
  "calimero-storage",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -9150,8 +9140,6 @@ version = "0.0.0"
 dependencies = [
  "calimero-sdk",
  "calimero-storage",
- "calimero-storage-macros",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -11472,7 +11460,6 @@ version = "0.0.0"
 dependencies = [
  "calimero-sdk",
  "calimero-storage",
- "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/apps/blobs/Cargo.toml
+++ b/apps/blobs/Cargo.toml
@@ -11,11 +11,8 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-thiserror.workspace = true
 calimero-sdk.workspace = true
 calimero-storage.workspace = true
-sha2 = "0.10"
-hex = "0.4"
 
 [package.metadata.workspaces]
 independent = true

--- a/apps/collaborative-editor/Cargo.toml
+++ b/apps/collaborative-editor/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-thiserror.workspace = true
 calimero-sdk.workspace = true
 calimero-storage.workspace = true
 bs58 = "0.5"

--- a/apps/custom-key-store/Cargo.toml
+++ b/apps/custom-key-store/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-thiserror.workspace = true
 calimero-sdk.workspace = true
 calimero-storage.workspace = true
 

--- a/apps/scaffolding-e2e/Cargo.toml
+++ b/apps/scaffolding-e2e/Cargo.toml
@@ -17,7 +17,6 @@ thiserror.workspace = true
 # `tracing_logs` integration test.
 calimero-sdk = { workspace = true, features = ["tracing"] }
 calimero-storage.workspace = true
-calimero-storage-macros.workspace = true
 sha2.workspace = true
 hex.workspace = true
 bs58.workspace = true

--- a/apps/sorted-set-store/Cargo.toml
+++ b/apps/sorted-set-store/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-thiserror.workspace = true
 calimero-sdk.workspace = true
 calimero-storage.workspace = true
 

--- a/apps/state-schema-conformance/Cargo.toml
+++ b/apps/state-schema-conformance/Cargo.toml
@@ -14,8 +14,6 @@ crate-type = ["cdylib"]
 [dependencies]
 calimero-sdk.workspace = true
 calimero-storage.workspace = true
-calimero-storage-macros.workspace = true
-thiserror.workspace = true
 
 [package.metadata.workspaces]
 independent = true

--- a/apps/xcall-example/Cargo.toml
+++ b/apps/xcall-example/Cargo.toml
@@ -13,7 +13,6 @@ crate-type = ["cdylib"]
 [dependencies]
 calimero-sdk.workspace = true
 calimero-storage.workspace = true
-thiserror.workspace = true
 
 [package.metadata.workspaces]
 independent = true

--- a/crates/governance-store/src/account_bindings.rs
+++ b/crates/governance-store/src/account_bindings.rs
@@ -66,10 +66,28 @@ pub enum BindingRejected {
         /// Epoch already recorded.
         stored: u32,
     },
-    /// A rotation for an account this group has never seen, or one that does
-    /// not continue the established chain.
-    #[error("key rotation does not continue this account's chain")]
-    RotationNotContinuous,
+    /// A rotation for an account this group has never learned.
+    ///
+    /// Distinct from [`Self::RotationNotContinuous`], which the two used to
+    /// share: they send whoever reads one somewhere different. This means the
+    /// group holds no key chain for the account at all — nothing has linked a
+    /// device of it here — whereas a non-contiguous rotation means the account
+    /// IS known and the handoff merely starts at the wrong epoch. The first is a
+    /// relay of a stranger's rotation and is expected; the second is a stale or
+    /// forked handoff and is worth looking at.
+    #[error("no key chain known for account {account} in this group")]
+    RotationAccountUnknown {
+        /// The account the handoff would roll.
+        account: AccountId,
+    },
+    /// A rotation that does not continue the chain in force for this account.
+    #[error("key rotation starts at epoch {found}, but epoch {expected} is in force")]
+    RotationNotContinuous {
+        /// The epoch currently established for the account.
+        expected: u32,
+        /// The epoch the handoff declares it rolls from.
+        found: u32,
+    },
     /// A rotation not signed by the outgoing root key.
     #[error("key rotation is not signed by the outgoing root key")]
     RotationSignatureInvalid,
@@ -625,11 +643,16 @@ impl<'a> AccountBindingRepository<'a> {
     ) -> EyreResult<Result<(), BindingRejected>> {
         let key = GroupAccountKey::new(group.to_bytes(), *handoff.account.as_bytes());
         let Some(current): Option<GroupAccountKeyValue> = self.store.handle().get(&key)? else {
-            return Ok(Err(BindingRejected::RotationNotContinuous));
+            return Ok(Err(BindingRejected::RotationAccountUnknown {
+                account: handoff.account,
+            }));
         };
         let (epoch, root_pk) = (current.epoch, PublicKey::from(current.root_pk));
         if handoff.from_epoch != epoch {
-            return Ok(Err(BindingRejected::RotationNotContinuous));
+            return Ok(Err(BindingRejected::RotationNotContinuous {
+                expected: epoch,
+                found: handoff.from_epoch,
+            }));
         }
         if root_pk
             .verify_raw_signature(&handoff.payload(), &handoff.signature)
@@ -1302,7 +1325,56 @@ mod tests {
             RootKeyHandoff::sign(&key(1), g.account_id(), 0, &key(2).public_key()).expect("sign");
         assert_eq!(
             repo.apply_rotation(&gid, &handoff).expect("store"),
-            Err(BindingRejected::RotationNotContinuous)
+            Err(BindingRejected::RotationAccountUnknown {
+                account: g.account_id()
+            }),
+            "an account this group never learned must not be reported as a \
+             non-contiguous chain — there is no chain to be discontinuous with"
+        );
+    }
+
+    /// The other half of the split: a KNOWN account whose handoff starts at the
+    /// wrong epoch. Previously untested — the branch existed, but nothing pinned
+    /// which epochs it reports, and the fields are the whole point of separating
+    /// it from `RotationAccountUnknown`.
+    #[test]
+    fn a_rotation_from_the_wrong_epoch_names_both_epochs() {
+        let store = test_store();
+        let gid = test_group_id();
+        let repo = AccountBindingRepository::new(&store);
+        let g = genesis_for(1);
+        let account = g.account_id();
+
+        // Learn the account and roll it to epoch 1.
+        let _ = repo
+            .apply_link(&gid, &g, &[], &cert_for(&g, &key(1), 5, 0, 0))
+            .expect("store")
+            .expect("admitted");
+        let first = RootKeyHandoff::sign(&key(1), account, 0, &key(2).public_key()).expect("sign");
+        repo.apply_rotation(&gid, &first)
+            .expect("store")
+            .expect("rotated");
+
+        // Replaying the epoch-0 handoff is stale, not unknown.
+        assert_eq!(
+            repo.apply_rotation(&gid, &first).expect("store"),
+            Err(BindingRejected::RotationNotContinuous {
+                expected: 1,
+                found: 0
+            }),
+            "a replayed handoff must name the epoch in force and the one it \
+             offers, so a stale relay is distinguishable from a forked chain"
+        );
+
+        // ...and so is a handoff that skips ahead.
+        let skipped =
+            RootKeyHandoff::sign(&key(2), account, 3, &key(4).public_key()).expect("sign");
+        assert_eq!(
+            repo.apply_rotation(&gid, &skipped).expect("store"),
+            Err(BindingRejected::RotationNotContinuous {
+                expected: 1,
+                found: 3
+            }),
         );
     }
 

--- a/crates/governance-store/src/ops/group/account_ops.rs
+++ b/crates/governance-store/src/ops/group/account_ops.rs
@@ -363,7 +363,7 @@ fn endorser_is_member(
 /// Deliberately ungated, unlike its two siblings, and for a reason rather than by
 /// omission: the handoff is self-certifying against state the group already holds.
 /// A rotation for an account this group has never learned is refused outright
-/// (`RotationNotContinuous`, since there is no root key to continue from), and the
+/// (`RotationAccountUnknown` — there is no chain to be discontinuous with), and the
 /// only way the group learns an account is through a link that already passed the
 /// membership gate. So relaying someone else's rotation writes nothing an
 /// attacker chose, and gating it on the relayer would only break legitimate

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -11,7 +11,6 @@ publish = true
 [dependencies]
 actix.workspace = true
 borsh = { workspace = true, features = ["derive"] }
-either.workspace = true
 eyre.workspace = true
 futures-util.workspace = true
 hex.workspace = true
@@ -41,7 +40,6 @@ libp2p-stream.workspace = true
 multiaddr.workspace = true
 owo-colors.workspace = true
 prometheus-client.workspace = true
-rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["io-util", "macros"] }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -8,6 +8,13 @@ license.workspace = true
 description.workspace = true
 publish = true
 
+# `wasmer-compiler-cranelift` is the compiler backend wasmer links through a
+# feature, so no `use` of it ever appears in `src` — but removing it fails the
+# build. cargo-machete works from source references, so it cannot see that edge;
+# this is the one entry the CI gate has to be told about rather than a dead dep.
+[package.metadata.cargo-machete]
+ignored = ["wasmer-compiler-cranelift"]
+
 [dependencies]
 borsh = { workspace = true, features = ["derive"] }
 bytes.workspace = true

--- a/tools/merodb/Cargo.toml
+++ b/tools/merodb/Cargo.toml
@@ -31,7 +31,6 @@ sha2 = "0.10"
 once_cell = "1.19"
 jaq-interpret = "1.2"
 jaq-parse = "1.0"
-jaq-syn = "1.1"
 
 # GUI dependencies (optional)
 axum = { version = "0.7", optional = true, features = ["multipart"] }


### PR DESCRIPTION
Two independent cleanups from the maintainability audit — the CI gate that stops #3580's cleanup from silently undoing itself, and the rotation-refusal split that #3571 flagged as still live on the legacy path.

## A CI gate for unused dependencies

35 had accumulated across the workspace, three listed as "key deps" in their own crate's AGENTS.md — nobody had a reason to look. `cargo machete` now runs beside `cargo deny`, pinned to **0.9.2** (the version I tested against).

**Wiring it needed a curation pass first**, and that's the part worth reviewing. cargo-machete works from source references, so a dependency linked only through a *feature* reads as unused. There is exactly one in this workspace:

```
calimero-runtime :: wasmer-compiler-cranelift   -> FALSE POSITIVE
```

Never named in `src`, but removing it fails the build — it's the compiler backend wasmer links by feature. It's declared in that crate's `[package.metadata.cargo-machete] ignored` with the reason inline, and the workflow comment says to add to that list **only after confirming removal actually breaks the build**, since an entry there otherwise hides a real dead dep.

The other 13 findings were genuine, each verified by deleting the entry and recompiling:

| Crate | Removed |
| --- | --- |
| `merodb` | jaq-syn |
| `calimero-network` | either, rand |
| `scaffolding-e2e`, `state-schema-conformance` | calimero-storage-macros |
| `blobs` | hex, sha2, thiserror |
| six apps | thiserror |

`cargo machete` now reports clean on the whole tree.

## `BindingRejected::RotationNotContinuous` answered two questions

"This group has never learned the account" and "the handoff starts at the wrong epoch" shared one variant. They send whoever reads one somewhere different: the first is an ordinary relay of a stranger's rotation and expected, the second is a stale or forked handoff and worth looking at.

```rust
RotationAccountUnknown { account }              // no chain to be discontinuous with
RotationNotContinuous  { expected, found }      // known account, wrong starting epoch
```

Same defect split in **#3571** on the unified path, noted there as still live here.

Two things the split surfaced:

- The existing test `a_rotation_for_an_unknown_account_is_refused` asserted the *conflated* variant. Its name already described a case the enum couldn't express — a decent tell that the conflation was accidental rather than intended. It now asserts the precise one.
- **The epoch-mismatch branch had no test at all.** It existed, untested, and now carries fields worth pinning, so there's a new test covering both a replayed handoff (`expected: 1, found: 0`) and one that skips ahead (`expected: 1, found: 3`).

## Verification

- `cargo test --workspace --features calimero-storage/testing` — **4964 passed, 0 failed**
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` — clean
- `cargo machete` — clean
- `cargo fmt --check` — clean

No behaviour change beyond the two error variants, which are internal to `calimero-governance-store` (the `Rejected::RotationNotContinuous` hits elsewhere are `calimero-authz`'s separate enum, split in #3571).

🤖 Generated with [Claude Code](https://claude.com/claude-code)