### PR TITLE
fix(context): a divergence marker only where both planes answer the same question

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -789,12 +789,26 @@ jobs:
           # decision_group_in_view) are printed on the offending lines to pinpoint
           # the failure mode. Runs `always()` so divergence is reported even when
           # the scenario itself failed for another reason.
+          #
+          # A marker means the two planes disagreed about the SAME question: the
+          # node only compares when the applied op's cut reaches everything live
+          # has applied. An op applied out of causal order is reported at debug
+          # ("projection behind live's governance frontier") and is not a
+          # divergence — the two answers describe different histories.
+          #
+          # Node logs carry ANSI escapes between a field name and its value, so
+          # every grep here strips them first; matching `plane="…"` on the raw
+          # line silently finds nothing, which is how "planes seen:" used to
+          # print an empty list under a failing gate.
           if grep -rl "unified_projection_divergence" docker-logs/ 2>/dev/null | grep -q .; then
               echo "::error::unified-op projection diverged from the live decision in ${{ matrix.workflow }} — cutover gate not met"
               echo "planes seen:"
-              grep -rho 'plane="[^"]*"' docker-logs/ | sort | uniq -c
+              grep -rh "unified_projection_divergence" docker-logs/ \
+                | sed -E 's/\x1b\[[0-9;]*m//g' \
+                | grep -o 'plane="[^"]*"' | sort | uniq -c
               echo "sample:"
-              grep -rn "unified_projection_divergence" docker-logs/ | head -30
+              grep -rn "unified_projection_divergence" docker-logs/ \
+                | sed -E 's/\x1b\[[0-9;]*m//g' | head -30
               exit 1
           fi
           echo "no unified_projection_divergence markers — projection agrees with the live decision"
@@ -818,7 +832,11 @@ jobs:
               echo "sample (missing_count per namespace):"
               # Match `missing_count=N` anywhere on an op_store_incomplete line — robust
               # to field ordering. Tolerates the line not carrying the field at all.
-              grep -rho 'op_store_incomplete.*' docker-logs/ | grep -oE 'missing_count=[0-9]+' | sort | uniq -c | head -10
+              # ANSI escapes are stripped first: they sit between the field name and
+              # the `=` in node logs, so the raw pattern never matches.
+              grep -rho 'op_store_incomplete.*' docker-logs/ \
+                | sed -E 's/\x1b\[[0-9;]*m//g' \
+                | grep -oE 'missing_count=[0-9]+' | sort | uniq -c | head -10
               grep -rn "op_store_incomplete" docker-logs/ | head -10
               exit 1
           elif grep -rl "op_store_gate_unavailable" docker-logs/ 2>/dev/null | grep -q .; then

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -99,6 +99,24 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                         &delta_parents,
                     );
 
+                    // Live's governance frontier for this namespace, read AFTER
+                    // the apply above advanced it. The shadow compares an at-cut
+                    // projection answer against a live row, and those describe the
+                    // same history only while the cut reaches this frontier — see
+                    // the `at_frontier` gate below. `None` (head unreadable) leaves
+                    // that unestablished, so the compare is skipped rather than run
+                    // on an unknown premise.
+                    let live_frontier = calimero_governance_store::NamespaceDagService::new(
+                        &compare_store,
+                        namespace_id,
+                    )
+                    .read_head_record()
+                    .map(|head| head.parent_hashes)
+                    .map_err(|err| {
+                        tracing::debug!(%err, "unified-op shadow: governance head unreadable; skipping compare");
+                    })
+                    .ok();
+
                     {
                         // The member this op touches (for the per-member
                         // shadow-compare), if it's a membership op.
@@ -115,9 +133,21 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                         // this op (no TOCTOU window between ingest and read). A
                         // poisoned lock skips feed+compare with a warning rather
                         // than affecting the governance apply path.
-                        let (fed, projected, decoded) = match scope_projections.write() {
+                        let (fed, projected, decoded, at_frontier) = match scope_projections.write() {
                             Ok(mut projections) => {
                                 projections.ingest_op(&shadow_op);
+                                // Does THIS op's cut — the one `role` is resolved
+                                // at, just below — reach everything live has
+                                // applied? Asked after the ingest, so the ordinary
+                                // in-order apply (the op IS live's head) covers the
+                                // frontier and the compare is meaningful.
+                                let at_frontier = live_frontier.as_ref().is_some_and(|heads| {
+                                    projections.cut_covers_frontier(
+                                        &shadow_op.scope,
+                                        &[shadow_op.id()],
+                                        heads,
+                                    )
+                                });
                                 // Resolve at THIS op's own causal cut (its id),
                                 // so a re-add after a remove reflects the
                                 // causally-latest state rather than the non-causal
@@ -141,11 +171,11 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                                         &[shadow_op.id()],
                                     )
                                 });
-                                (true, role, decoded)
+                                (true, role, decoded, at_frontier)
                             }
                             Err(err) => {
                                 tracing::warn!(%err, "scope-projections lock poisoned; skipping unified-op shadow feed/compare");
-                                (false, None, false)
+                                (false, None, false, false)
                             }
                         };
 
@@ -171,6 +201,19 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                         // not a fold-logic divergence. Skipping it keeps the shadow
                         // sharp for real disagreements, which surface only once the
                         // history is fully readable.
+                        //
+                        // And require this op's CUT to cover live's governance
+                        // frontier. The role is resolved at the op's own cut while
+                        // `live` answers about now, so an op applied out of causal
+                        // order — the author's own op returning through the feed
+                        // after it published a newer one, a partition heal replaying
+                        // old history — makes the two answer different questions.
+                        // That is what fired here: the projection said `Member` at
+                        // the cut of an add while live said `Admin`, because the
+                        // promotion that followed the add had already applied. Both
+                        // correct, a divergence for neither. Folding more ops does
+                        // not fix it — the cut is what excludes the promotion — so
+                        // this is a real precondition, not a lag to wait out.
                         if fed && decoded {
                             if let Some((group, member)) = membership {
                                 // Both sides now name the same principal: `member`
@@ -186,15 +229,34 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                                 .ok()
                                 .flatten();
                                 if live.is_some() && projected != live {
-                                    tracing::warn!(
-                                        marker = "unified_projection_divergence",
-                                        plane = "membership",
-                                        ?group,
-                                        %member,
-                                        ?projected,
-                                        ?live,
-                                        "unified-op projection disagrees with live membership resolver"
-                                    );
+                                    // Disagreement is only a DIVERGENCE if both
+                                    // planes were answering the same question.
+                                    // Off the frontier they were not, and saying
+                                    // so — rather than dropping the observation —
+                                    // keeps the suppression visible, so a gate
+                                    // that stops firing can be told apart from a
+                                    // gate that has nothing to fire about.
+                                    if at_frontier {
+                                        tracing::warn!(
+                                            marker = "unified_projection_divergence",
+                                            plane = "membership",
+                                            ?group,
+                                            %member,
+                                            ?projected,
+                                            ?live,
+                                            "unified-op projection disagrees with live membership resolver"
+                                        );
+                                    } else {
+                                        tracing::debug!(
+                                            plane = "membership",
+                                            ?group,
+                                            %member,
+                                            ?projected,
+                                            ?live,
+                                            "projection behind live's governance frontier; \
+                                             at-cut answer is not comparable to the live row"
+                                        );
+                                    }
                                 }
                             }
                         }
@@ -212,6 +274,11 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                         // just-ingested op), so it runs OUTSIDE the write lock under
                         // a brief read lock — no store I/O while the apply path's
                         // ingest is blocked.
+                        //
+                        // Same frontier premise as the membership compare above: a
+                        // projection that holds less than live under-authorizes for
+                        // that reason alone, so `Some(false)` would name the lag
+                        // rather than a real disagreement.
                         if fed {
                             if let Some((auth_group, req)) =
                                 apply_auth_requirement(&signed_op, decrypted.as_ref())
@@ -236,13 +303,25 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                                     Err(_) => None,
                                 };
                                 if verdict == Some(false) {
-                                    tracing::warn!(
-                                        marker = "unified_projection_divergence",
-                                        plane = "governance-auth",
-                                        group_id = ?auth_group,
-                                        signer = %signed_op.signer,
-                                        "projection would reject a governance op the live resolver authorized"
-                                    );
+                                    // Same frontier premise, same reporting split
+                                    // as the membership compare above.
+                                    if at_frontier {
+                                        tracing::warn!(
+                                            marker = "unified_projection_divergence",
+                                            plane = "governance-auth",
+                                            group_id = ?auth_group,
+                                            signer = %signed_op.signer,
+                                            "projection would reject a governance op the live resolver authorized"
+                                        );
+                                    } else {
+                                        tracing::debug!(
+                                            plane = "governance-auth",
+                                            group_id = ?auth_group,
+                                            signer = %signed_op.signer,
+                                            "projection behind live's governance frontier; \
+                                             under-auth at the parent cut is the lag, not a disagreement"
+                                        );
+                                    }
                                 }
                             }
                         }

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -594,6 +594,32 @@ impl ScopeProjections {
             .is_some_and(|log| ScopeState::cut_ancestry_decoded(log, parents))
     }
 
+    /// Does the cut at `parents` cover `frontier` in `scope` — the precondition
+    /// for comparing an at-cut projection answer against a live row?
+    ///
+    /// `frontier` is live's governance head set. When the cut reaches it, both
+    /// planes are describing the same history and a disagreement is a real one.
+    /// When it does not, the op being folded is behind live: an author's own op
+    /// arriving through the apply feed after it has already published a newer
+    /// one, or a partition heal replaying old history. The projection then
+    /// answers about the older cut, live answers about now, and the difference
+    /// is the ordering, not the fold. `false` for an unfed scope, and for a
+    /// frontier the walk cannot reach — including one sitting behind a gap in
+    /// the log, which errs toward suppressing the comparison.
+    ///
+    /// See [`ScopeState::cut_covers`].
+    #[must_use]
+    pub fn cut_covers_frontier(
+        &self,
+        scope: &ScopeId,
+        parents: &[[u8; 32]],
+        frontier: &[[u8; 32]],
+    ) -> bool {
+        self.logs
+            .get(scope)
+            .is_some_and(|log| ScopeState::cut_covers(log, parents, frontier))
+    }
+
     /// Rebuild this namespace's governance scopes from **persisted** source
     /// state — the startup/backfill path, so a just-restarted node's projection
     /// isn't empty (an empty projection can't be authoritative). The projection
@@ -2611,6 +2637,66 @@ mod tests {
             LIVE_LOG_LOW_WATER,
             "eviction trims to the low-water mark",
         );
+    }
+
+    /// The gate the shadow compare stands on: an at-cut answer is only
+    /// comparable to a live row while the cut reaches everything live has
+    /// applied. Live's governance head set is what "everything" means, and
+    /// folding more ops is no substitute — a cut that excludes a later op still
+    /// excludes it once that op is in the log.
+    #[test]
+    fn cut_covers_frontier_gates_on_the_cut_not_the_log() {
+        let scope = ScopeId::from([7u8; 32]);
+        let signer = PublicKey::from([2u8; 32]);
+        let build = |ns: u64, parents: Vec<[u8; 32]>| -> Op {
+            Op::new(
+                scope,
+                parents,
+                calimero_op::Authorship::unattributed(signer),
+                hlc(ns),
+                OpPayload::Noop,
+                [0u8; 32],
+                [0u8; 64],
+            )
+        };
+        let add = build(1, vec![]);
+        let promote = build(2, vec![add.id()]);
+
+        // Unfed scope: nothing to walk, so no coverage can be shown.
+        let empty = ScopeProjections::new();
+        assert!(!empty.cut_covers_frontier(&scope, &[add.id()], &[add.id()]));
+
+        let mut proj = ScopeProjections::new();
+        proj.ingest_op(&add);
+        proj.ingest_op(&promote);
+
+        // In-order apply: the op being folded IS live's head, so its cut covers
+        // the frontier and the compare must run.
+        assert!(proj.cut_covers_frontier(&scope, &[promote.id()], &[promote.id()]));
+
+        // The CI failure: the add applies after the promotion it precedes. Both
+        // ops are folded — the log is complete — and the cut still excludes the
+        // promotion live already applied, so the compare must stay quiet. This is
+        // the case a log-completeness check would wave through.
+        assert!(
+            !proj.cut_covers_frontier(&scope, &[add.id()], &[promote.id()]),
+            "a cut that predates live's newest op does not cover it, however much \
+             else has been folded",
+        );
+
+        // A forked live frontier needs every head reached, not either.
+        let sibling = build(3, vec![add.id()]);
+        proj.ingest_op(&sibling);
+        assert!(!proj.cut_covers_frontier(&scope, &[promote.id()], &[promote.id(), sibling.id()]));
+
+        // An empty frontier — a namespace with no governance head yet — is
+        // covered vacuously: there is nothing live holds to be behind on.
+        assert!(proj.cut_covers_frontier(&scope, &[add.id()], &[]));
+
+        // A cut whose ancestry the log cannot walk proves nothing.
+        let orphan = build(4, vec![[0xEE; 32]]);
+        proj.ingest_op(&orphan);
+        assert!(!proj.cut_covers_frontier(&scope, &[orphan.id()], &[promote.id()]));
     }
 
     #[test]

--- a/crates/context/tests/projection_membership_equivalence.rs
+++ b/crates/context/tests/projection_membership_equivalence.rs
@@ -1390,3 +1390,128 @@ fn a_rotation_by_an_enrolled_device_absorbs_through_the_real_converter() {
          real account against the converter's stand-in and dropped the rotation."
     );
 }
+
+/// The CI failure this gate produced, reduced: an author promotes a member, then
+/// its OWN earlier add lands in the DAG afterwards (the publisher path writes
+/// live directly, so an author's ops reach its DAG only through the apply feed).
+/// The projection answers about the add's cut — `Member`, correctly, the
+/// promotion is not an ancestor — while live answers about now — `Admin`, also
+/// correctly. Neither plane is wrong, so the shadow must not call it a
+/// divergence; the frontier gate (`has_folded_all` over live's governance head)
+/// is what tells the two situations apart.
+#[test]
+fn a_late_applied_add_after_a_promotion_is_not_a_divergence() {
+    let store = store();
+    let admin_sk = PrivateKey::random(&mut OsRng);
+    let admin = admin_sk.public_key();
+    let member_sk = PrivateKey::random(&mut OsRng);
+    let member = member_sk.public_key();
+
+    let ns = ContextGroupId::from([0x31; 32]);
+    let subgroup = ContextGroupId::from([0x32; 32]);
+    let scope = ScopeId::from(ns.to_bytes());
+
+    // Genesis seeds, as `create_group` writes them: both groups exist, the admin
+    // is Admin of both, the subgroup is nested under the root.
+    let admin_account = calimero_context::test_support::enrol(&store, &ns, &admin);
+    let member_account = calimero_context::test_support::enrol(&store, &ns, &member);
+    for g in [&ns, &subgroup] {
+        MetaRepository::new(&store)
+            .save(g, &meta(admin_account))
+            .unwrap();
+        MembershipRepository::new(&store)
+            .add_member(g, &admin_account, GroupMemberRole::Admin)
+            .unwrap();
+    }
+    NamespaceRepository::new(&store)
+        .nest(&ns, &subgroup)
+        .unwrap();
+
+    let add = GroupOp::MemberAdded {
+        member: member_account,
+        role: GroupMemberRole::Member,
+    };
+    let promote = GroupOp::MemberRoleSet {
+        member: member_account,
+        role: GroupMemberRole::Admin,
+    };
+    let add_id = [0xD1; 32];
+    let promote_id = [0xD2; 32];
+
+    // The publisher path, twice: each op mutates the live store and advances the
+    // persisted governance head, and neither touches the DAG or the projection.
+    // (`advance_dag_head` + the live write is exactly what `publish_post_gate`
+    // does; the encrypted group op cannot go through `apply_signed_namespace_op`
+    // here because that needs the group key.)
+    let gov = calimero_governance_store::NamespaceDagService::new(&store, ns.to_bytes().into());
+    MembershipRepository::new(&store)
+        .add_member(&subgroup, &member_account, GroupMemberRole::Member)
+        .unwrap();
+    gov.advance_dag_head(add_id, &[], 1).unwrap();
+    MembershipRepository::new(&store)
+        .set_role(&subgroup, &member_account, GroupMemberRole::Admin)
+        .unwrap();
+    gov.advance_dag_head(promote_id, &[add_id], 2).unwrap();
+
+    assert_eq!(
+        MembershipRepository::new(&store)
+            .role_of(&subgroup, &member_account)
+            .unwrap(),
+        Some(GroupMemberRole::Admin),
+        "live holds the promotion — it applied at publish time",
+    );
+
+    // Now the author's own ADD arrives through the apply feed, after the
+    // promotion has already published. This is the only op the projection has.
+    let mut proj = ScopeProjections::new();
+    let env = ns_group_envelope(ns.to_bytes(), admin, subgroup);
+    proj.ingest_op(&op_from_namespace_op(&env, Some(&add), add_id, hlc(1), &[]));
+
+    let live_heads = gov.read_head_record().unwrap().parent_hashes;
+    assert_eq!(
+        live_heads,
+        vec![promote_id],
+        "live's frontier is the promotion, the newest op it applied",
+    );
+    assert_eq!(
+        proj.role_at_cut(&scope, &subgroup, &member_account, &[add_id]),
+        Some(GroupMemberRole::Member),
+        "at the add's own cut the member IS a Member — the promotion comes after it",
+    );
+    assert!(
+        !proj.cut_covers_frontier(&scope, &[add_id], &live_heads),
+        "the add's cut does not reach the promotion live already applied, so its \
+         at-cut answer and live's row are answers to different questions and the \
+         shadow compare must stay quiet",
+    );
+
+    // The promotion then folds too — through the same feed, one op later — and
+    // the compare it triggers runs at a cut live has caught up with.
+    proj.ingest_op(&op_from_namespace_op(
+        &env,
+        Some(&promote),
+        promote_id,
+        hlc(2),
+        &[add_id],
+    ));
+    let live_heads = gov.read_head_record().unwrap().parent_hashes;
+    assert!(
+        proj.cut_covers_frontier(&scope, &[promote_id], &live_heads),
+        "the promotion's own cut reaches live's frontier — it IS live's frontier — \
+         so the compare its apply triggers is a real one",
+    );
+    // And the add's cut is STILL not comparable, now that the log holds both ops:
+    // the gate is the cut, not how much has been folded. A log-completeness check
+    // would have re-opened the false positive here.
+    assert!(
+        !proj.cut_covers_frontier(&scope, &[add_id], &live_heads),
+        "folding the promotion cannot put it inside a cut that precedes it",
+    );
+    assert_eq!(
+        proj.role_at_cut(&scope, &subgroup, &member_account, &[promote_id]),
+        MembershipRepository::new(&store)
+            .role_of(&subgroup, &member_account)
+            .unwrap(),
+        "and then they agree: Admin at the promotion's cut, Admin in the live row",
+    );
+}

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -590,6 +590,15 @@ impl<'a> NamespaceGovernance<'a> {
         // `notify_namespace_op_applied` for the cross-crate plumbing.
         node_client.notify_namespace_op_applied(self.namespace_id.to_bytes());
 
+        // And feed the op to our own apply feed, the same as the publish-only
+        // path does — `apply_signed_op` above wrote the live store, the
+        // persisted head and the op-log, none of which is the in-memory
+        // governance DAG or the unified-op projection. Before the publish, not
+        // after: the publish awaits acks, and the local DAG should not wait on
+        // the network to learn about an op this node just authored. See
+        // `NodeClient::feed_local_namespace_op`.
+        node_client.feed_local_namespace_op(signed_for_caller.clone());
+
         let mesh = node_client
             .mesh_peer_count_for_namespace(self.namespace_id.to_bytes())
             .await;
@@ -794,6 +803,14 @@ impl<'a> NamespaceGovernance<'a> {
         // to be told. Both paths converge at `Handler<NamespaceOpApplied>`
         // on `ReadinessManager`, mirroring the gossipsub-receive route.
         node_client.notify_namespace_op_applied(self.namespace_id.to_bytes());
+
+        // And hand the op to our OWN apply feed. The two writes above cover the
+        // live store — the persisted head and the op-log — and neither reaches
+        // the in-memory governance DAG or the unified-op projection, which only
+        // that feed maintains. Before the publish for the same reason as on the
+        // apply-and-publish path: it awaits acks. See
+        // `NodeClient::feed_local_namespace_op` for what the gap costs.
+        node_client.feed_local_namespace_op(signed.clone());
 
         if observe_mesh {
             record_governance_publish_mesh_peers(op_kind, mesh);

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -170,6 +170,30 @@ impl actix::Handler<calimero_network_primitives::messages::NetworkMessage> for S
     }
 }
 
+/// Captures every `NodeMessage` the publish path enqueues, so a test can assert
+/// on the signals it fires rather than on log output. Forwards on an unbounded
+/// channel: the test then AWAITS the message it expects instead of sleeping for
+/// the actor to run.
+struct CapturingNodeActor {
+    seen: tokio::sync::mpsc::UnboundedSender<calimero_node_primitives::messages::NodeMessage>,
+}
+
+impl actix::Actor for CapturingNodeActor {
+    type Context = actix::Context<Self>;
+}
+
+impl actix::Handler<calimero_node_primitives::messages::NodeMessage> for CapturingNodeActor {
+    type Result = ();
+
+    fn handle(
+        &mut self,
+        msg: calimero_node_primitives::messages::NodeMessage,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        let _ = self.seen.send(msg);
+    }
+}
+
 /// Build a real `NodeClient`/`AckRouter` pair for tests that call
 /// `NamespaceGovernance::sign_apply_and_publish[_returning_op]`: a namespace
 /// with a bootstrapped admin (returned as the signing key), and a
@@ -184,6 +208,7 @@ async fn namespace_publish_fixture() -> (
     NamespaceId,
     PrivateKey,
     tempfile::TempDir,
+    tokio::sync::mpsc::UnboundedReceiver<calimero_node_primitives::messages::NodeMessage>,
 ) {
     use actix::Actor;
     use calimero_network_primitives::client::NetworkClient;
@@ -218,11 +243,22 @@ async fn namespace_publish_fixture() -> (
     let (open_subgroup_join_tx, _open_rx) = tokio::sync::mpsc::channel(8);
     let sync_client = SyncClient::new(ctx_sync_tx, ns_sync_tx, ns_join_tx, open_subgroup_join_tx);
 
+    // The node-manager side is wired to a capturing actor rather than left
+    // uninitialized: the publish path now enqueues the local-apply feed there,
+    // and a test that wants to see it needs a live recipient.
+    let (seen_tx, seen_rx) = tokio::sync::mpsc::unbounded_channel();
+    let node_recipient = LazyRecipient::<calimero_node_primitives::messages::NodeMessage>::new();
+    let capture_recipient = node_recipient.clone();
+    let _node_addr = CapturingNodeActor::create(move |ctx| {
+        assert!(capture_recipient.init(ctx), "node recipient init");
+        CapturingNodeActor { seen: seen_tx }
+    });
+
     let node_client = NodeClient::new(
         store.clone(),
         blob_manager,
         network_client,
-        LazyRecipient::new(),
+        node_recipient,
         event_sender,
         sync_client,
         None,
@@ -230,14 +266,23 @@ async fn namespace_publish_fixture() -> (
 
     let ack_router = calimero_context_client::local_governance::AckRouter::default();
 
-    (store, node_client, ack_router, ns_id.into(), sk, tmp)
+    (
+        store,
+        node_client,
+        ack_router,
+        ns_id.into(),
+        sk,
+        tmp,
+        seen_rx,
+    )
 }
 
 #[actix::test]
 async fn sign_apply_and_publish_returns_the_signed_op() {
     use calimero_context_client::local_governance::{hash_scoped_namespace, NamespaceOp, RootOp};
 
-    let (store, node_client, ack_router, ns_id, sk, _tmp) = namespace_publish_fixture().await;
+    let (store, node_client, ack_router, ns_id, sk, _tmp, _node_msgs) =
+        namespace_publish_fixture().await;
     let op = NamespaceOp::Root(RootOp::MemberJoinedAt {
         // The member and the credential name the same account, which the apply
         // requires: the signer has to hold a credential for the member it names.
@@ -262,6 +307,109 @@ async fn sign_apply_and_publish_returns_the_signed_op() {
         )
         .unwrap(),
         "returned op must be the one the report describes"
+    );
+}
+
+/// The op an author publishes must reach its OWN governance DAG, not just the
+/// live store: the publish path writes the live rows, the persisted head and the
+/// op-log directly, and nothing else feeds the in-memory DAG or the unified-op
+/// projection. Before this signal existed, an author learned its own ops back
+/// only when a peer echoed them — which left every child op a peer sent parked
+/// as `Pending` behind parents this node had authored itself.
+#[actix::test]
+async fn a_published_op_is_fed_to_the_local_apply_path() {
+    use calimero_context_client::local_governance::{NamespaceOp, RootOp};
+    use calimero_node_primitives::messages::NodeMessage;
+
+    let (store, node_client, ack_router, ns_id, sk, _tmp, mut node_msgs) =
+        namespace_publish_fixture().await;
+    let op = NamespaceOp::Root(RootOp::MemberJoinedAt {
+        member: crate::test_fixtures::account_for(&sk.public_key()),
+        signed_invitation: test_signed_invitation(&sk, ContextGroupId::from(ns_id.to_bytes()), 0),
+        joined_at: 0,
+        account: crate::test_fixtures::real_join_account(&sk.public_key()),
+    });
+
+    let (_report, signed) = NamespaceGovernance::new(&store, ns_id)
+        .sign_apply_and_publish_returning_op(&node_client, &ack_router, &sk, op)
+        .await
+        .expect("publish");
+    let published = signed.content_hash().expect("content hash");
+
+    // Awaited, not slept on: the feed is fire-and-forget, so the test drains the
+    // capture channel until the signal shows up (or the timeout fails the test
+    // with the messages it did see).
+    let mut observed = Vec::new();
+    let found = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while let Some(msg) = node_msgs.recv().await {
+            match msg {
+                NodeMessage::ApplyLocalNamespaceOp { op } => {
+                    return op.content_hash().expect("content hash") == published;
+                }
+                other => observed.push(other),
+            }
+        }
+        false
+    })
+    .await
+    .expect("the local-apply feed must fire within the timeout");
+
+    assert!(
+        found,
+        "publishing must hand the signed op to the local apply feed; saw {} other \
+         node signal(s) instead",
+        observed.len(),
+    );
+}
+
+/// The publish-only choke point (`publish_post_gate`) feeds the local apply path
+/// too — that is the route every GROUP op takes, and group ops are where the
+/// stale-cut divergence showed up. Same assertion, different path, deliberately
+/// not folded into the test above: one covering the other is exactly how a
+/// second write path goes unfed.
+#[actix::test]
+async fn the_publish_only_path_also_feeds_the_local_apply_path() {
+    use calimero_context_client::local_governance::{NamespaceOp, RootOp};
+    use calimero_node_primitives::messages::NodeMessage;
+
+    let (store, node_client, ack_router, ns_id, sk, _tmp, mut node_msgs) =
+        namespace_publish_fixture().await;
+    // A `KeyDelivery` stands in for any publish-only op: it carries no local
+    // mutation, so this path signs and publishes without applying first.
+    let op = NamespaceOp::Root(RootOp::KeyDelivery {
+        group_id: ns_id.to_bytes().into(),
+        envelope: calimero_context_client::local_governance::KeyEnvelope {
+            recipient: calimero_governance_types::EnvelopeRecipient::Member {
+                identity: sk.public_key(),
+                ephemeral_pk: sk.public_key(),
+            },
+            sender: sk.public_key(),
+            nonce: [0u8; 12],
+            ciphertext: Vec::new(),
+            signature: [0u8; 64],
+        },
+    });
+
+    // The publish itself gathers no acks against the stub network; irrelevant
+    // here — the feed fires before the publish is awaited, which is the point
+    // (the local DAG must not wait on the network for an op authored here).
+    let _ = NamespaceGovernance::new(&store, ns_id)
+        .sign_and_publish_post_gate(&node_client, &ack_router, &sk, op, 0, 0, true)
+        .await;
+
+    let fed = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while let Some(msg) = node_msgs.recv().await {
+            if matches!(msg, NodeMessage::ApplyLocalNamespaceOp { .. }) {
+                return true;
+            }
+        }
+        false
+    })
+    .await
+    .expect("the local-apply feed must fire within the timeout");
+    assert!(
+        fed,
+        "the publish-only path must feed the local apply path too"
     );
 }
 

--- a/crates/node/primitives/src/client.rs
+++ b/crates/node/primitives/src/client.rs
@@ -356,6 +356,27 @@ impl NodeClient {
         }
     }
 
+    /// Feed a governance op this node just published into its own namespace
+    /// governance DAG and unified-op projection — the local half of the apply
+    /// feed, which the publisher path otherwise bypasses entirely. See
+    /// [`NodeMessage::ApplyLocalNamespaceOp`].
+    ///
+    /// Best-effort, like the two notifications above: on a full mailbox the op
+    /// still reaches the DAG the old way (a peer echoing it back), so the cost
+    /// of a drop is latency, not lost state.
+    pub fn feed_local_namespace_op(&self, op: SignedNamespaceOp) {
+        if let Err(err) = self
+            .node_manager
+            .try_send(NodeMessage::ApplyLocalNamespaceOp { op: Box::new(op) })
+        {
+            warn!(
+                ?err,
+                "failed to enqueue ApplyLocalNamespaceOp — the op stays out of the \
+                 local governance DAG until a peer echoes it back"
+            );
+        }
+    }
+
     /// Notify the readiness FSM that we just subscribed to a namespace
     /// topic, so it seeds `subscribed_at` at subscribe time (boot-grace
     /// anchor) instead of at the first applied op. Best-effort, mirroring

--- a/crates/node/primitives/src/messages.rs
+++ b/crates/node/primitives/src/messages.rs
@@ -45,6 +45,25 @@ pub enum NodeMessage {
         namespace_id: [u8; 32],
         op: Box<SignedNamespaceOp>,
     },
+    /// Hand a governance op this node just PUBLISHED to its own namespace
+    /// governance DAG, by the same route a peer's op takes.
+    ///
+    /// The publisher path commits the live mutation, advances the persisted
+    /// governance head and writes the op-log directly — it never touches the
+    /// in-memory `DagStore` or the unified-op projection that the apply feed
+    /// maintains. So without this signal an author's own ops reach its own DAG
+    /// only when some peer echoes them back: until then the DAG holds every
+    /// child op a peer sends as `Pending` (its parents are the author's own
+    /// unfed ops), which costs a backfill round-trip per op, and the projection
+    /// lags the live store it is supposed to mirror.
+    ///
+    /// Routed `NodeClient -> NodeManager -> ContextClient` because
+    /// `crates/governance-store` holds a `NodeClient` and cannot name the
+    /// context actor. Fire-and-forget by design: the apply must not be awaited
+    /// from inside the context handler that published (the actor is blocked on
+    /// that handler's future, so awaiting its own message would deadlock), and
+    /// a dropped signal only restores the old peer-echo behaviour.
+    ApplyLocalNamespaceOp { op: Box<SignedNamespaceOp> },
     /// Edge-trigger the migration-heartbeat emitter to recompute and re-publish
     /// this node's facts for a namespace, out of band of the periodic tick.
     /// Routed `NodeClient -> NodeManager` (the emitter address lives on

--- a/crates/node/src/handlers.rs
+++ b/crates/node/src/handlers.rs
@@ -3,7 +3,7 @@
 //! **Purpose**: Handles incoming events from network layer and processes node-level requests.
 //! **Structure**: Each event type has its own focused file (SRP).
 
-use actix::Handler;
+use actix::{AsyncContext, Handler, WrapFuture};
 use calimero_node_primitives::messages::NodeMessage;
 use calimero_utils_actix::adapters::ActorExt;
 use tracing::debug;
@@ -112,6 +112,30 @@ impl Handler<NodeMessage> for NodeManager {
                          dropping (namespace sync remains the fallback)"
                     );
                 }
+            }
+            NodeMessage::ApplyLocalNamespaceOp { op } => {
+                // The publisher path wrote this op to the live store and the
+                // persisted governance log but never to the in-memory DAG or the
+                // unified-op projection; hand it to the same actor entry a peer's
+                // op uses so both origins converge on one apply path. Applying it
+                // again is safe and deliberate: the live apply short-circuits on
+                // finding the op already in the local op-log, so what this call
+                // actually does is insert the DAG node and feed the projection,
+                // while the op is still live's head.
+                let context_client = self.clients.context.clone();
+                let work = async move {
+                    match context_client.apply_signed_namespace_op(*op).await {
+                        Ok(outcome) => {
+                            debug!(?outcome, "fed locally-published governance op to own DAG")
+                        }
+                        // Not fatal: peers still carry the op, and a peer echo
+                        // re-offers it to this same handler later.
+                        Err(err) => {
+                            debug!(%err, "failed to feed locally-published governance op to own DAG")
+                        }
+                    }
+                };
+                let _spawn_handle = ctx.spawn(work.into_actor(self));
             }
             NodeMessage::RefreshMigrationFacts { namespace_id } => {
                 // Edge-trigger a fact recompute + emit-on-change for this

--- a/crates/projection/src/lib.rs
+++ b/crates/projection/src/lib.rs
@@ -808,6 +808,48 @@ impl ScopeState {
         true
     }
 
+    /// Does the cut at `parents` **cover** `frontier` — is every id in
+    /// `frontier` the cut itself or one of its ancestors, as far as `log` can
+    /// show?
+    ///
+    /// The question a shadow comparison has to ask before trusting an at-cut
+    /// answer against a materialized one. An at-cut read answers about the
+    /// history behind that cut; a live row answers about everything applied so
+    /// far. They are the same question only while the cut reaches every op live
+    /// has, which is what `frontier` (live's governance head set) names.
+    ///
+    /// A cut that does NOT cover the frontier is not stale bookkeeping to be
+    /// repaired: no amount of extra folding changes what the cut excludes. An op
+    /// applied out of causal order — an author's own op returning after it
+    /// published a newer one, a partition heal replaying old history — is
+    /// permanently behind live, and comparing the two is comparing different
+    /// questions.
+    ///
+    /// The walk decides coverage on the CITATION graph, not on what the log
+    /// holds: an id cited as a parent is an ancestor whether or not its own
+    /// record is present, so it counts as reached. What a gap does cost is
+    /// reach BEYOND it — the walk cannot follow an absent op's parents — which
+    /// errs toward `false`, and a comparison suppressed for a gap is the safe
+    /// direction. An empty `frontier` (nothing applied) is covered vacuously.
+    #[must_use]
+    pub fn cut_covers(log: &[Op], parents: &[[u8; 32]], frontier: &[[u8; 32]]) -> bool {
+        if frontier.is_empty() {
+            return true;
+        }
+        let by_id: HashMap<[u8; 32], &Op> = log.iter().map(|op| (op.id(), op)).collect();
+        let mut visited: HashSet<[u8; 32]> = HashSet::new();
+        let mut queue: VecDeque<[u8; 32]> = parents.iter().copied().collect();
+        while let Some(id) = queue.pop_front() {
+            if !visited.insert(id) {
+                continue;
+            }
+            if let Some(op) = by_id.get(&id) {
+                queue.extend(op.parents.iter().copied());
+            }
+        }
+        frontier.iter().all(|id| visited.contains(id))
+    }
+
     /// Like [`Self::cut_ancestry_complete`], but ALSO requires every op in the
     /// cut's ancestry to be **decoded** — i.e. carry a real payload, not
     /// `OpPayload::Noop`.


### PR DESCRIPTION
`master` went red on `Test (group-private-add-then-write)` in run
[32405497601](https://github.com/calimero-network/core/actions/runs/32405497601/job/96550302056).
The scenario itself passed; the failing step was the projection-divergence HARD
gate, on one marker from the author node:

```
plane="membership" group=b06bc57f… member=f2ccbe48…
projected=Some(Member)  live=Some(Admin)
```

## What actually happened

The shadow resolves a member's role at the **applied op's own causal cut** and
compares it against the **live row**, which answers about now. Those are the same
question only while the cut reaches everything live has applied.

The author published `MemberAdded{node-2, Member}` at 19:15:23 and
`MemberRoleSet{node-2, Admin}` at 19:15:56.149 — and its own add reached its DAG
at 19:15:56.30, *after* the promotion had already moved live. So the projection
answered `Member` at the add's cut (correct — the promotion is not an ancestor of
the add) and live answered `Admin` (correct — it had applied). Both planes were
right, and the gate failed the job for neither.

Two things made that reachable:

* **The originator bypass.** `sign_apply_and_publish` / `publish_post_gate` write
  the live store, the persisted governance head and the op-log — never the
  in-memory DAG or the projection, which only the apply feed maintains. So an
  author learns its own ops back from a peer, seconds later or never. In this run
  node-1 backfilled its own add and promotion *from node-2*, which is also why
  node-2's child op sat `Pending` on node-1 first.
* **Phase 5 of #3581** is the first e2e where a later op supersedes a
  `(group, member)` row, so at-cut vs live-now could disagree at all. Timing
  dependent: green on the PR branch
  ([32405405962](https://github.com/calimero-network/core/actions/runs/32405405962)),
  and #3581's own master run was cancelled by concurrency — so the commit after
  it was the first master run to execute the scenario.

## The fix

**1. Compare only at a cut live has reached** (`fix(context)`).
`ScopeState::cut_covers` + `ScopeProjections::cut_covers_frontier`; both shadow
planes require the applied op's cut to cover live's governance head set.

The gate is on the **cut**, not on log completeness, and that distinction is the
whole point: folding the later op cannot put it inside a cut that precedes it, so
a "has the projection caught up" check fixes this run and re-opens the hole the
moment the promotion folds. Both tests assert that explicitly. When the premise
does not hold, the observation is logged at debug rather than dropped, so a gate
that stops firing stays distinguishable from a gate with nothing to fire about.

**2. Feed an author's own published op into its own DAG** (`fix(governance)`).
`NodeMessage::ApplyLocalNamespaceOp` + `NodeClient::feed_local_namespace_op`,
from both publish choke points — including `publish_post_gate`, the one group ops
take. The op goes to the same actor entry a peer's op uses; the live re-apply
short-circuits on the op-log idempotency guard, so what the call buys is the DAG
node and the projection fold, while the op is still live's head. Fire-and-forget
(awaiting from the publishing context handler would deadlock that actor), and
before the publish, since the publish awaits acks. This also retires the
pending-parent → proactive-backfill round-trip peers hit on every op an author
signs.

**3. The gate could not print its own diagnostics** (`ci(e2e)`). Node logs carry
ANSI escapes between a field name and its value, so `plane="[^"]*"` matched
nothing — the failing run printed `planes seen:` followed by an empty list, and
the C3 completeness gate's `missing_count=N` histogram had the same blindness.
Both strip escapes first; verified against the real failing log, which now yields
`1 plane="membership"`.

## Tests

| Test | Proves |
| --- | --- |
| `cut_covers_frontier_gates_on_the_cut_not_the_log` | in-order apply compares; a stale cut does not, *even with a complete log*; a forked frontier needs every head; a gap errs toward suppression |
| `a_late_applied_add_after_a_promotion_is_not_a_divergence` | the CI failure reduced to a unit test: live `Admin`, at-cut `Member`, compare suppressed — then the promotion folds and both planes agree |
| `a_published_op_is_fed_to_the_local_apply_path` | the apply-and-publish path enqueues the feed carrying the published op |
| `the_publish_only_path_also_feeds_the_local_apply_path` | so does the publish-only path (kept separate on purpose — one covering the other is how a second write path goes unfed) |

Negative control: with the two feed calls commented out, both governance-store
tests fail. `cargo fmt` clean, clippy clean on all five touched crates, 21 test
binaries green across `projection` / `context` / `governance-store` /
`node-primitives`. The e2e suite has not been run locally — this PR's CI is the
first run of it against these commits, and it is the check that matters for (2),
which touches the governance publish path.

## Known residual (follow-up, not fixed here)

A DAG pending-drain applies ops without feeding the projection, so a drained op
leaves the projection behind live and its later compares are suppressed by the
new gate. Coverage loss, not a correctness gap — worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
