### PR TITLE
chore(e2e): drop the retired near_devnet flag from every scenario

### DIFF
--- a/apps/scaffolding-e2e/workflows/account-device-revoke-lockout.yml
+++ b/apps/scaffolding-e2e/workflows/account-device-revoke-lockout.yml
@@ -98,7 +98,6 @@ description: >
   it kept reading our messages."
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/account-facts-cross-namespace.yml
+++ b/apps/scaffolding-e2e/workflows/account-facts-cross-namespace.yml
@@ -46,7 +46,6 @@ description: >
   it kept writing to my other team's data."
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/account-revoke-lost-device.yml
+++ b/apps/scaffolding-e2e/workflows/account-revoke-lost-device.yml
@@ -87,7 +87,6 @@ description: >
   recovery phrase, and there is no way to stop that machine from writing."
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/account-root-backup-restore.yml
+++ b/apps/scaffolding-e2e/workflows/account-root-backup-restore.yml
@@ -81,7 +81,6 @@ description: >
   which is the value writes attribute to.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml
+++ b/apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml
@@ -30,7 +30,6 @@ description: >
   and `collect_visible_descendant_groups_walls_at_restricted_subgroups_inviter_not_in`.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/e2e.yml
+++ b/apps/scaffolding-e2e/workflows/e2e.yml
@@ -2,7 +2,6 @@ name: E2E KV Store - Consolidated Backend Tests
 description: Consolidated E2E backend tests covering KV operations, handlers, user storage, frozen storage, private storage, nested CRDTs, and RGA
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-3node.yml
+++ b/apps/scaffolding-e2e/workflows/group-3node.yml
@@ -5,7 +5,6 @@ description: >
   write — covering the multi-party sync path that the 2-node test misses.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-capabilities.yml
+++ b/apps/scaffolding-e2e/workflows/group-capabilities.yml
@@ -10,7 +10,6 @@ description: >
   capability enforcement (server rejecting unauthorized operations).
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-context-isolation.yml
+++ b/apps/scaffolding-e2e/workflows/group-context-isolation.yml
@@ -6,7 +6,6 @@ description: >
   state in each independently.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-default-capabilities-propagation.yml
+++ b/apps/scaffolding-e2e/workflows/group-default-capabilities-propagation.yml
@@ -39,7 +39,6 @@ description: >
        is sufficient regression coverage.)
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-governance-late-joiner.yml
+++ b/apps/scaffolding-e2e/workflows/group-governance-late-joiner.yml
@@ -6,7 +6,6 @@ description: >
   proving "applied locally + propagated via sync".
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-governance-peer-down.yml
+++ b/apps/scaffolding-e2e/workflows/group-governance-peer-down.yml
@@ -6,7 +6,6 @@ description: >
   governance op; both must converge on the new capability value via sync.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-join-mesh-not-ready.yml
+++ b/apps/scaffolding-e2e/workflows/group-join-mesh-not-ready.yml
@@ -34,7 +34,6 @@ description: >
   is the proof that the 500 reproduces on pre-fix code.)
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-join-then-list-from-joiner.yml
+++ b/apps/scaffolding-e2e/workflows/group-join-then-list-from-joiner.yml
@@ -38,7 +38,6 @@ description: >
   context.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-join-via-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-join-via-inheritance.yml
@@ -34,7 +34,6 @@ description: >
   workflow exercises the new top-level entry point instead.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-kick-and-readd-deny-list.yml
+++ b/apps/scaffolding-e2e/workflows/group-kick-and-readd-deny-list.yml
@@ -36,7 +36,6 @@ description: >
   symptom of a stale deny-list entry on the receiver side.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
+++ b/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
@@ -49,7 +49,6 @@ description: >
   someone from a public channel and they just walked straight back in."
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-late-joiner.yml
+++ b/apps/scaffolding-e2e/workflows/group-late-joiner.yml
@@ -6,7 +6,6 @@ description: >
   well as new writes after joining.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-leave-context.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-context.yml
@@ -5,7 +5,6 @@ description: >
   leaver can rejoin via `join_context` and resume syncing.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-leave-member.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-member.yml
@@ -5,7 +5,6 @@ description: >
   apply-side checks: direct-row required, last-admin protection.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-leave-namespace.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-namespace.yml
@@ -6,7 +6,6 @@ description: >
   subtree on every peer.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
@@ -56,7 +56,6 @@ description: >
   actually do anything."
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-list-subgroups-restricted-hidden.yml
+++ b/apps/scaffolding-e2e/workflows/group-list-subgroups-restricted-hidden.yml
@@ -32,7 +32,6 @@ description: >
   tests `subgroup_visible_to_*` in `group_store/tests.rs`.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-member-channel-lifecycle.yml
+++ b/apps/scaffolding-e2e/workflows/group-member-channel-lifecycle.yml
@@ -24,7 +24,6 @@ description: >
   covered by the `calimero-context` unit tests.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-membership.yml
+++ b/apps/scaffolding-e2e/workflows/group-membership.yml
@@ -6,7 +6,6 @@ description: >
   signing key hierarchy fix.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-metadata.yml
+++ b/apps/scaffolding-e2e/workflows/group-metadata.yml
@@ -25,7 +25,6 @@ description: >
   force_pull_image: false — CI builds merod:local locally).
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-multi-service.yml
+++ b/apps/scaffolding-e2e/workflows/group-multi-service.yml
@@ -10,7 +10,6 @@ description: >
     4. CRDT sync works correctly within each service's context.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-open-self-join-key-delivery.yml
+++ b/apps/scaffolding-e2e/workflows/group-open-self-join-key-delivery.yml
@@ -36,7 +36,6 @@ description: >
   succeed.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-private-add-then-write.yml
+++ b/apps/scaffolding-e2e/workflows/group-private-add-then-write.yml
@@ -38,7 +38,6 @@ description: >
   chain on the admin-add path.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-remove-from-root-revokes-inherited.yml
+++ b/apps/scaffolding-e2e/workflows/group-remove-from-root-revokes-inherited.yml
@@ -49,7 +49,6 @@ description: >
   namespace and the descendant access was purely inherited.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-reparent-and-cascade-delete.yml
+++ b/apps/scaffolding-e2e/workflows/group-reparent-and-cascade-delete.yml
@@ -11,7 +11,6 @@ description: >
   Spec: docs/superpowers/specs/2026-04-22-strict-group-tree-and-cascade-delete.md
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-reparent.yml
+++ b/apps/scaffolding-e2e/workflows/group-reparent.yml
@@ -14,7 +14,6 @@ description: >
   Spec: docs/superpowers/specs/2026-04-22-strict-group-tree-and-cascade-delete.md
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-subgroup-cold-sync.yml
+++ b/apps/scaffolding-e2e/workflows/group-subgroup-cold-sync.yml
@@ -28,7 +28,6 @@ description: >
   fallback for subgroup-owned contexts, this test will catch it.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-subgroup-queued-deltas.yml
+++ b/apps/scaffolding-e2e/workflows/group-subgroup-queued-deltas.yml
@@ -42,7 +42,6 @@ description: >
   can accumulate first.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-subgroup-visibility-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-subgroup-visibility-inheritance.yml
@@ -27,7 +27,6 @@ description: >
        subscriber.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/group-subgroup.yml
+++ b/apps/scaffolding-e2e/workflows/group-subgroup.yml
@@ -9,7 +9,6 @@ description: >
     5. Subgroup and root contexts are fully isolated
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/groups.yml
+++ b/apps/scaffolding-e2e/workflows/groups.yml
@@ -4,7 +4,6 @@ description: >
   multi-context groups, and context invitation within groups.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/handler-test.yml
+++ b/apps/scaffolding-e2e/workflows/handler-test.yml
@@ -8,7 +8,6 @@ description: >
     3. get_handler_execution_count reflects handler invocations.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/hashcomparison-shared-user-reconcile.yml
+++ b/apps/scaffolding-e2e/workflows/hashcomparison-shared-user-reconcile.yml
@@ -70,7 +70,6 @@ description: >
   and the assertions only depend on final convergence.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/kv-store-joiner-cold.yml
+++ b/apps/scaffolding-e2e/workflows/kv-store-joiner-cold.yml
@@ -11,7 +11,6 @@ description: >
   branch in `execute/mod.rs` ("group key not yet delivered") and fail.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/member-removed-late-joiner-catchup.yml
+++ b/apps/scaffolding-e2e/workflows/member-removed-late-joiner-catchup.yml
@@ -27,7 +27,6 @@ description: >
       hasn't materialized
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/member-removed-multi-context-convergence.yml
+++ b/apps/scaffolding-e2e/workflows/member-removed-multi-context-convergence.yml
@@ -25,7 +25,6 @@ description: >
   for the partition variant.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/member-removed-partition-window-reconcile.yml
+++ b/apps/scaffolding-e2e/workflows/member-removed-partition-window-reconcile.yml
@@ -51,7 +51,6 @@ description: >
   while partitioned is what makes the divergence deterministic.
 
 force_pull_image: false
-near_devnet: false
 
 nodes:
   count: 3

--- a/apps/scaffolding-e2e/workflows/mesh-soak-8node.yml
+++ b/apps/scaffolding-e2e/workflows/mesh-soak-8node.yml
@@ -9,7 +9,6 @@ description: >
   logs so the steady-state mesh size is captured in the artifact.
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/scaffolding-e2e/workflows/root-bootstrap-converge.yml
+++ b/apps/scaffolding-e2e/workflows/root-bootstrap-converge.yml
@@ -48,7 +48,6 @@ description: >
   updated_at).
 
 force_pull_image: false
-near_devnet: false
 
 # `nodes.image` below is the workflow's default — used when this YAML
 # is run locally without an explicit override (`merobox bootstrap run

--- a/apps/scaffolding-e2e/workflows/shared-storage-account-writers-two-devices.yml
+++ b/apps/scaffolding-e2e/workflows/shared-storage-account-writers-two-devices.yml
@@ -71,7 +71,6 @@ description: >
   and then my second device got permission denied."
 
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 

--- a/apps/xcall-example/workflows/xcall-example.yml
+++ b/apps/xcall-example/workflows/xcall-example.yml
@@ -10,7 +10,6 @@ description: >
   namespace so the calls are permitted.
 
 force_pull_image: false
-near_devnet: false
 
 nodes:
   count: 1

--- a/apps/xcall-example/workflows/xcall.yml
+++ b/apps/xcall-example/workflows/xcall.yml
@@ -39,7 +39,6 @@ description: >
 # imports the `xcall_origin` host function added by this change, so it requires
 # a merod built from this branch (or a release that includes it).
 force_pull_image: false
-near_devnet: false
 
 auth_mode: embedded
 


### PR DESCRIPTION
Follows review feedback on #3585, which caught this key in two brand-new scenario files.

## Why

merobox removed `near_devnet`. Nothing in it reads the key any more, and its changelog records it as *"No longer used"* — along with the `near_devnet` and `chain_id` parameters dropped from `testing.cluster()` / `testing.workflow()`. Every one of the **48** occurrences in this repo was `near_devnet: false`, so the flag is uniformly inert: it parses, it is silently ignored, and — because `validate_workflow_config` accepts unknown top-level keys — nothing anywhere flags it.

That silence is the actual problem. The key spreads by template: you write a new scenario from an existing one, the header block comes along, and the dead flag gets another copy. That is precisely how it reached 48 files, and how two new scenarios in #3585 picked it up before review caught it. Removing it stops the propagation at the source.

## How

Mechanical, but verified per file rather than trusted to `sed`: each file was parsed before and after, and the edit was kept only where the *sole* difference between the two parsed documents was the dropped key. Any file where removal would have changed anything else — or where the line was not an exact top-level `near_devnet: false` — was skipped and reported. None were.

- 48 files, 48 deletions, nothing else in the diff.
- `scripts/lint-e2e-convergence.py`: clean (130 scenarios scanned, no new convergence races).
- All 48 files still pass merobox's own workflow-schema validation.

No behaviour change is possible: merobox never reads the key.

## Deliberately not included

`chain_id`, which merobox has also stopped reading. It differs in one way that matters: it carries real-looking values — `testnet-1` (x17) and `calimero-testnet` (x9) — and one scenario has a comment stating that *not* setting it is deliberate. It is just as inert, but deleting values a reader may believe are load-bearing, and invalidating a comment that reasons about them, is a judgement call rather than a no-op. Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)