### PR TITLE
fix(context): fold every delta an apply applied, not just the one handed in

### DIFF
--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -40,7 +40,6 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
         let delta_hlc = delta.hlc;
         let delta_parents = delta.parents.clone();
         let signed_op = op;
-        let feed_store = self.datastore.clone();
         let scope_projections = Arc::clone(&self.scope_projections);
 
         ActorResponse::r#async(
@@ -52,280 +51,19 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                 // the divergence-outbox gating below. A poisoned lock is ignored:
                 // the projection is not yet authoritative, so it must never break
                 // the governance apply path.
-                if matches!(outcome, Ok(AddDeltaOutcome::Applied)) {
-                    // For an encrypted `NamespaceOp::Group` that just applied,
-                    // decrypt its cleartext membership op (the key is present —
-                    // the live apply already used it). Read-only decrypt; never
-                    // re-runs the mutation. A `Root` op or an undecryptable group
-                    // op yields `None` → the node folds as `Noop` (still recorded
-                    // so the ancestry walk can pass through it).
-                    let decrypted = match &signed_op.op {
-                        calimero_governance_types::NamespaceOp::Group {
-                            group_id,
-                            key_id,
-                            encrypted,
-                            ..
-                        } => calimero_governance_store::decrypt_group_op(
-                            &feed_store,
-                            namespace_id,
-                            *group_id,
-                            key_id.as_bytes(),
-                            encrypted,
-                        )
-                        .map_err(|err| {
-                            tracing::warn!(%err, "unified-op shadow: group-op decrypt failed; folded as Noop");
-                        })
-                        .ok()
-                        .flatten(),
-                        calimero_governance_types::NamespaceOp::Root(_) => None,
-                        // `NamespaceOp` is `#[non_exhaustive]`; an unknown future
-                        // op has nothing to decrypt and folds as `Noop`.
-                        _ => None,
-                    };
-                    // Resolved from the store, not derived from the key: the op
-                    // has just applied, and it could not have unless the signer's
-                    // binding was present — so every node agrees on this value.
-                    let signer_binding = calimero_governance_store::signer_binding_for(
+                if let Ok(applied) = &outcome {
+                    shadow_fold_applied(
                         &compare_store,
-                        &ContextGroupId::from(namespace_id.to_bytes()),
-                        &signed_op.signer,
+                        &scope_projections,
+                        &dag,
+                        AppliedOp {
+                            signed: &signed_op,
+                            id: delta_id,
+                            hlc: delta_hlc,
+                            parents: &delta_parents,
+                        },
+                        applied,
                     );
-                    let shadow_op = calimero_governance_store::op_from_namespace_op_with_binding(
-                        &signed_op,
-                        decrypted.as_ref(),
-                        signer_binding,
-                        delta_id,
-                        delta_hlc,
-                        &delta_parents,
-                    );
-
-                    // Live's governance frontier for this namespace, read AFTER
-                    // the apply above advanced it. The shadow compares an at-cut
-                    // projection answer against a live row, and those describe the
-                    // same history only while the cut reaches this frontier — see
-                    // the `at_frontier` gate below. `None` (head unreadable) leaves
-                    // that unestablished, so the compare is skipped rather than run
-                    // on an unknown premise.
-                    let live_frontier = calimero_governance_store::NamespaceDagService::new(
-                        &compare_store,
-                        namespace_id,
-                    )
-                    .read_head_record()
-                    .map(|head| head.parent_hashes)
-                    .map_err(|err| {
-                        tracing::debug!(%err, "unified-op shadow: governance head unreadable; skipping compare");
-                    })
-                    .ok();
-
-                    {
-                        // The member this op touches (for the per-member
-                        // shadow-compare), if it's a membership op.
-                        let membership = match &shadow_op.payload {
-                            calimero_op::OpPayload::MemberAdded { group, member, .. }
-                            | calimero_op::OpPayload::MemberRemoved { group, member } => {
-                                Some((*group, *member))
-                            }
-                            _ => None,
-                        };
-
-                        // ONE lock acquisition: ingest, then read the just-applied
-                        // member's projected role so the compare reflects exactly
-                        // this op (no TOCTOU window between ingest and read). A
-                        // poisoned lock skips feed+compare with a warning rather
-                        // than affecting the governance apply path.
-                        let (fed, projected, decoded, at_frontier) = match scope_projections.write() {
-                            Ok(mut projections) => {
-                                projections.ingest_op(&shadow_op);
-                                // Does THIS op's cut — the one `role` is resolved
-                                // at, just below — reach everything live has
-                                // applied? Asked after the ingest, so the ordinary
-                                // in-order apply (the op IS live's head) covers the
-                                // frontier and the compare is meaningful.
-                                let at_frontier = live_frontier.as_ref().is_some_and(|heads| {
-                                    projections.cut_covers_frontier(
-                                        &shadow_op.scope,
-                                        &[shadow_op.id()],
-                                        heads,
-                                    )
-                                });
-                                // Resolve at THIS op's own causal cut (its id),
-                                // so a re-add after a remove reflects the
-                                // causally-latest state rather than the non-causal
-                                // `states` snapshot (governance ops share hlc=0).
-                                let role = membership.and_then(|(g, m)| {
-                                    projections.role_at_cut(
-                                        &shadow_op.scope,
-                                        &g,
-                                        &m,
-                                        &[shadow_op.id()],
-                                    )
-                                });
-                                // Is this cut's whole history present AND decoded?
-                                // If an ancestor is still an undecrypted `Noop`,
-                                // the folded membership is provisional and a
-                                // mismatch against live is a decrypt-feed lag, not
-                                // a fold-logic bug — same causal cut as `role`.
-                                let decoded = membership.is_some_and(|_| {
-                                    projections.cut_ancestry_decoded(
-                                        &shadow_op.scope,
-                                        &[shadow_op.id()],
-                                    )
-                                });
-                                (true, role, decoded, at_frontier)
-                            }
-                            Err(err) => {
-                                tracing::warn!(%err, "scope-projections lock poisoned; skipping unified-op shadow feed/compare");
-                                (false, None, false, false)
-                            }
-                        };
-
-                        // Shadow-compare (additive, log-only). Per-member (not
-                        // full-set) so a partially-fed projection — e.g. right
-                        // after restart — can't false-positive. Conservative gate:
-                        // only flag when the live resolver has a DIRECT row the
-                        // projection disagrees with; skip inherited / open-join
-                        // members the live system doesn't store directly but the
-                        // projection models as direct (an expected model
-                        // difference, not a feed bug). The projection's first
-                        // reader — the precursor to authorizing against it.
-                        //
-                        // Also require the cut's ancestry to be fully DECODED. When
-                        // an ancestor is still an undecrypted `Noop` — the window
-                        // between a member re-join and the `KeyDelivery` that lets
-                        // this node decrypt the encrypted `MemberAdded` (forward
-                        // secrecy rotates the group key on departure, so a re-add
-                        // rides a key epoch the rejoiner briefly lacks) — live
-                        // already has the materialized row while the projection is
-                        // still holding the add encrypted. That is a decrypt-feed
-                        // lag that the late-decrypt log upgrade heals on its own,
-                        // not a fold-logic divergence. Skipping it keeps the shadow
-                        // sharp for real disagreements, which surface only once the
-                        // history is fully readable.
-                        //
-                        // And require this op's CUT to cover live's governance
-                        // frontier. The role is resolved at the op's own cut while
-                        // `live` answers about now, so an op applied out of causal
-                        // order — the author's own op returning through the feed
-                        // after it published a newer one, a partition heal replaying
-                        // old history — makes the two answer different questions.
-                        // That is what fired here: the projection said `Member` at
-                        // the cut of an add while live said `Admin`, because the
-                        // promotion that followed the add had already applied. Both
-                        // correct, a divergence for neither. Folding more ops does
-                        // not fix it — the cut is what excludes the promotion — so
-                        // this is a real precondition, not a lag to wait out.
-                        if fed && decoded {
-                            if let Some((group, member)) = membership {
-                                // Both sides now name the same principal: `member`
-                                // comes off the op payload as an account, and the
-                                // live rows are keyed by account. This used to
-                                // invert the account back into a member key by
-                                // scanning the live rows, because the two planes
-                                // disagreed about what a member IS.
-                                let live = calimero_governance_store::MembershipRepository::new(
-                                    &compare_store,
-                                )
-                                .role_of(&group, &member)
-                                .ok()
-                                .flatten();
-                                if live.is_some() && projected != live {
-                                    // Disagreement is only a DIVERGENCE if both
-                                    // planes were answering the same question.
-                                    // Off the frontier they were not, and saying
-                                    // so — rather than dropping the observation —
-                                    // keeps the suppression visible, so a gate
-                                    // that stops firing can be told apart from a
-                                    // gate that has nothing to fire about.
-                                    if at_frontier {
-                                        tracing::warn!(
-                                            marker = "unified_projection_divergence",
-                                            plane = "membership",
-                                            ?group,
-                                            %member,
-                                            ?projected,
-                                            ?live,
-                                            "unified-op projection disagrees with live membership resolver"
-                                        );
-                                    } else {
-                                        tracing::debug!(
-                                            plane = "membership",
-                                            ?group,
-                                            %member,
-                                            ?projected,
-                                            ?live,
-                                            "projection behind live's governance frontier; \
-                                             at-cut answer is not comparable to the live row"
-                                        );
-                                    }
-                                }
-                            }
-                        }
-
-                        // APPLY-AUTH shadow (F5 #28, log-only): the op just APPLIED,
-                        // so the LIVE resolver authorized its signer. Would the
-                        // projection authorize the signer too — at the op's PARENT
-                        // cut (state EXCLUDING this op, the correct cut to authorize
-                        // against)? `Some(false)` = the projection would REJECT what
-                        // live accepted (under-auth — safe, but a real divergence to
-                        // investigate); `None` = ancestry not fully folded → skip.
-                        // The reverse (projection accepts what live rejected) is
-                        // unobservable here — a live-rejected op never reaches this
-                        // fold. Resolved at the parent cut (independent of the
-                        // just-ingested op), so it runs OUTSIDE the write lock under
-                        // a brief read lock — no store I/O while the apply path's
-                        // ingest is blocked.
-                        //
-                        // Same frontier premise as the membership compare above: a
-                        // projection that holds less than live under-authorizes for
-                        // that reason alone, so `Some(false)` would name the lag
-                        // rather than a real disagreement.
-                        if fed {
-                            if let Some((auth_group, req)) =
-                                apply_auth_requirement(&signed_op, decrypted.as_ref())
-                            {
-                                let verdict = match scope_projections.read() {
-                                    Ok(projections) => match req {
-                                        ApplyAuthReq::Admin => projections.is_admin_at_cut(
-                                            &feed_store,
-                                            auth_group,
-                                            &signed_op.signer,
-                                            &delta_parents,
-                                        ),
-                                        ApplyAuthReq::AdminOrCap(bits) => projections
-                                            .is_admin_or_capability_at_cut(
-                                                &feed_store,
-                                                auth_group,
-                                                &signed_op.signer,
-                                                bits,
-                                                &delta_parents,
-                                            ),
-                                    },
-                                    Err(_) => None,
-                                };
-                                if verdict == Some(false) {
-                                    // Same frontier premise, same reporting split
-                                    // as the membership compare above.
-                                    if at_frontier {
-                                        tracing::warn!(
-                                            marker = "unified_projection_divergence",
-                                            plane = "governance-auth",
-                                            group_id = ?auth_group,
-                                            signer = %signed_op.signer,
-                                            "projection would reject a governance op the live resolver authorized"
-                                        );
-                                    } else {
-                                        tracing::debug!(
-                                            plane = "governance-auth",
-                                            group_id = ?auth_group,
-                                            signer = %signed_op.signer,
-                                            "projection behind live's governance frontier; \
-                                             under-auth at the parent cut is the lag, not a disagreement"
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
                 }
 
                 // Bound this namespace's in-memory governance-DAG history. A hot
@@ -347,7 +85,7 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                 // Lossless for peers: applied ops are durably persisted and the
                 // backfill responder serves from RocksDB, not this DAG — so the
                 // pruned ids are discarded, NOT deleted from disk.
-                if matches!(outcome, Ok(AddDeltaOutcome::Applied))
+                if matches!(outcome, Ok(AddDeltaOutcome::Applied { .. }))
                     && dag.stats().applied_deltas > NAMESPACE_DAG_PRUNE_THRESHOLD
                 {
                     let pruned = dag.prune_to_recent(NAMESPACE_DAG_PRUNE_RETAIN);
@@ -369,7 +107,7 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                 // don't run the apply path.
                 let divergence = applier.take_divergence();
                 match outcome {
-                    Ok(AddDeltaOutcome::Applied) => {
+                    Ok(AddDeltaOutcome::Applied { .. }) => {
                         Ok(NamespaceApplyOutcome::Applied { divergence })
                     }
                     Ok(AddDeltaOutcome::Pending) => Ok(NamespaceApplyOutcome::Pending),
@@ -447,5 +185,468 @@ fn apply_auth_requirement(
         // `NamespaceOp` is `#[non_exhaustive]`; an unknown future op authorizes
         // nothing here (secure default — no admin/cap requirement is granted).
         _ => None,
+    }
+}
+
+/// One delta the DAG just applied, as the shadow fold needs to see it: the
+/// signed op plus the delta coordinates the fold keys and orders it by.
+///
+/// A struct rather than four positional parameters because two of the four are
+/// `[u8; 32]`-shaped and one is a slice of the same, and the ordering mistake
+/// that makes possible is silent — an op folded under a neighbour's id.
+struct AppliedOp<'a> {
+    signed: &'a calimero_governance_types::SignedNamespaceOp,
+    id: [u8; 32],
+    hlc: calimero_storage::logical_clock::HybridTimestamp,
+    parents: &'a [[u8; 32]],
+}
+
+/// Fold everything an apply just applied into the shadow projection.
+///
+/// The DAG applies the delta it was handed AND every pending delta that one
+/// unblocked, so this folds all of them: the primary op first, then the drained
+/// cascade in the order it applied. Folding only the primary is what let the
+/// projection trail the live store — a drained child reached the live store and
+/// never the projection, leaving every later at-cut read of that scope answered
+/// from a log missing an op the store had.
+///
+/// A no-op unless the apply actually applied something. The live governance
+/// frontier is read once here and shared by every op folded, since they all
+/// landed before it was read.
+fn shadow_fold_applied(
+    store: &calimero_store::Store,
+    scope_projections: &std::sync::RwLock<crate::scope_projection::ScopeProjections>,
+    dag: &calimero_dag::DagStore<calimero_governance_types::SignedNamespaceOp>,
+    primary: AppliedOp<'_>,
+    outcome: &AddDeltaOutcome,
+) {
+    if !outcome.is_applied() {
+        return;
+    }
+    // Read AFTER the apply advanced it. The shadow compares an at-cut projection
+    // answer against a live row, and those describe the same history only while
+    // the cut reaches this frontier — see the `at_frontier` gate in
+    // `shadow_fold_and_compare`. `None` (head unreadable) leaves that
+    // unestablished, so the compare is skipped rather than run on an unknown
+    // premise.
+    let live_frontier = calimero_governance_store::NamespaceDagService::new(
+        store,
+        primary.signed.namespace_id,
+    )
+    .read_head_record()
+    .map(|head| head.parent_hashes)
+    .map_err(|err| {
+        tracing::debug!(%err, "unified-op shadow: governance head unreadable; skipping compare");
+    })
+    .ok();
+    let frontier = live_frontier.as_deref();
+
+    shadow_fold_and_compare(store, scope_projections, primary, frontier);
+
+    for cascaded_id in outcome.cascaded() {
+        let Some(cascaded) = dag.get_delta(cascaded_id) else {
+            // Applied-then-gone inside one call is not a state the DAG produces;
+            // say so rather than fold a guess.
+            tracing::warn!(
+                delta_id = %hex::encode(cascaded_id),
+                "unified-op shadow: drained delta absent from the DAG; not folded"
+            );
+            continue;
+        };
+        shadow_fold_and_compare(
+            store,
+            scope_projections,
+            AppliedOp {
+                signed: &cascaded.payload,
+                id: cascaded.id,
+                hlc: cascaded.hlc,
+                parents: &cascaded.parents,
+            },
+            frontier,
+        );
+    }
+}
+
+/// Fold one just-applied governance op into the shadow projection, then compare
+/// what the projection says against the live resolver.
+///
+/// Called once per delta the DAG actually applied — see
+/// [`shadow_fold_applied`], which enumerates them.
+///
+/// `live_frontier` is live's governance head set, read once by
+/// [`shadow_fold_applied`] and shared by every op folded in that call. `None`
+/// means it could not be read, which leaves the comparison premise
+/// unestablished — see the `at_frontier` gate below.
+fn shadow_fold_and_compare(
+    store: &calimero_store::Store,
+    scope_projections: &std::sync::RwLock<crate::scope_projection::ScopeProjections>,
+    op: AppliedOp<'_>,
+    live_frontier: Option<&[[u8; 32]]>,
+) {
+    let AppliedOp {
+        signed: signed_op,
+        id: delta_id,
+        hlc: delta_hlc,
+        parents: delta_parents,
+    } = op;
+    let ns_id = signed_op.namespace_id;
+    // For an encrypted `NamespaceOp::Group` that just applied,
+    // decrypt its cleartext membership op (the key is present —
+    // the live apply already used it). Read-only decrypt; never
+    // re-runs the mutation. A `Root` op or an undecryptable group
+    // op yields `None` → the node folds as `Noop` (still recorded
+    // so the ancestry walk can pass through it).
+    let decrypted = match &signed_op.op {
+        calimero_governance_types::NamespaceOp::Group {
+            group_id,
+            key_id,
+            encrypted,
+            ..
+        } => calimero_governance_store::decrypt_group_op(
+            store,
+            ns_id,
+            *group_id,
+            key_id.as_bytes(),
+            encrypted,
+        )
+        .map_err(|err| {
+            tracing::warn!(%err, "unified-op shadow: group-op decrypt failed; folded as Noop");
+        })
+        .ok()
+        .flatten(),
+        calimero_governance_types::NamespaceOp::Root(_) => None,
+        // `NamespaceOp` is `#[non_exhaustive]`; an unknown future
+        // op has nothing to decrypt and folds as `Noop`.
+        _ => None,
+    };
+    // Resolved from the store, not derived from the key: the op
+    // has just applied, and it could not have unless the signer's
+    // binding was present — so every node agrees on this value.
+    let signer_binding = calimero_governance_store::signer_binding_for(
+        store,
+        &ContextGroupId::from(ns_id.to_bytes()),
+        &signed_op.signer,
+    );
+    let shadow_op = calimero_governance_store::op_from_namespace_op_with_binding(
+        signed_op,
+        decrypted.as_ref(),
+        signer_binding,
+        delta_id,
+        delta_hlc,
+        delta_parents,
+    );
+
+    {
+        // The member this op touches (for the per-member
+        // shadow-compare), if it's a membership op.
+        let membership = match &shadow_op.payload {
+            calimero_op::OpPayload::MemberAdded { group, member, .. }
+            | calimero_op::OpPayload::MemberRemoved { group, member } => Some((*group, *member)),
+            _ => None,
+        };
+
+        // ONE lock acquisition: ingest, then read the just-applied
+        // member's projected role so the compare reflects exactly
+        // this op (no TOCTOU window between ingest and read). A
+        // poisoned lock skips feed+compare with a warning rather
+        // than affecting the governance apply path.
+        let (fed, projected, decoded, at_frontier) = match scope_projections.write() {
+            Ok(mut projections) => {
+                projections.ingest_op(&shadow_op);
+                // Does THIS op's cut — the one `role` is resolved
+                // at, just below — reach everything live has
+                // applied? Asked after the ingest, so the ordinary
+                // in-order apply (the op IS live's head) covers the
+                // frontier and the compare is meaningful.
+                let at_frontier = live_frontier.is_some_and(|heads| {
+                    projections.cut_covers_frontier(&shadow_op.scope, &[shadow_op.id()], heads)
+                });
+                // Resolve at THIS op's own causal cut (its id),
+                // so a re-add after a remove reflects the
+                // causally-latest state rather than the non-causal
+                // `states` snapshot (governance ops share hlc=0).
+                let role = membership.and_then(|(g, m)| {
+                    projections.role_at_cut(&shadow_op.scope, &g, &m, &[shadow_op.id()])
+                });
+                // Is this cut's whole history present AND decoded?
+                // If an ancestor is still an undecrypted `Noop`,
+                // the folded membership is provisional and a
+                // mismatch against live is a decrypt-feed lag, not
+                // a fold-logic bug — same causal cut as `role`.
+                let decoded = membership.is_some_and(|_| {
+                    projections.cut_ancestry_decoded(&shadow_op.scope, &[shadow_op.id()])
+                });
+                (true, role, decoded, at_frontier)
+            }
+            Err(err) => {
+                tracing::warn!(%err, "scope-projections lock poisoned; skipping unified-op shadow feed/compare");
+                (false, None, false, false)
+            }
+        };
+
+        // Shadow-compare (additive, log-only). Per-member (not
+        // full-set) so a partially-fed projection — e.g. right
+        // after restart — can't false-positive. Conservative gate:
+        // only flag when the live resolver has a DIRECT row the
+        // projection disagrees with; skip inherited / open-join
+        // members the live system doesn't store directly but the
+        // projection models as direct (an expected model
+        // difference, not a feed bug). The projection's first
+        // reader — the precursor to authorizing against it.
+        //
+        // Also require the cut's ancestry to be fully DECODED. When
+        // an ancestor is still an undecrypted `Noop` — the window
+        // between a member re-join and the `KeyDelivery` that lets
+        // this node decrypt the encrypted `MemberAdded` (forward
+        // secrecy rotates the group key on departure, so a re-add
+        // rides a key epoch the rejoiner briefly lacks) — live
+        // already has the materialized row while the projection is
+        // still holding the add encrypted. That is a decrypt-feed
+        // lag that the late-decrypt log upgrade heals on its own,
+        // not a fold-logic divergence. Skipping it keeps the shadow
+        // sharp for real disagreements, which surface only once the
+        // history is fully readable.
+        //
+        // And require this op's CUT to cover live's governance
+        // frontier. The role is resolved at the op's own cut while
+        // `live` answers about now, so an op applied out of causal
+        // order — the author's own op returning through the feed
+        // after it published a newer one, a partition heal replaying
+        // old history — makes the two answer different questions.
+        // That is what fired here: the projection said `Member` at
+        // the cut of an add while live said `Admin`, because the
+        // promotion that followed the add had already applied. Both
+        // correct, a divergence for neither. Folding more ops does
+        // not fix it — the cut is what excludes the promotion — so
+        // this is a real precondition, not a lag to wait out.
+        if fed && decoded {
+            if let Some((group, member)) = membership {
+                // Both sides now name the same principal: `member`
+                // comes off the op payload as an account, and the
+                // live rows are keyed by account. This used to
+                // invert the account back into a member key by
+                // scanning the live rows, because the two planes
+                // disagreed about what a member IS.
+                let live = calimero_governance_store::MembershipRepository::new(store)
+                    .role_of(&group, &member)
+                    .ok()
+                    .flatten();
+                if live.is_some() && projected != live {
+                    // Disagreement is only a DIVERGENCE if both
+                    // planes were answering the same question.
+                    // Off the frontier they were not, and saying
+                    // so — rather than dropping the observation —
+                    // keeps the suppression visible, so a gate
+                    // that stops firing can be told apart from a
+                    // gate that has nothing to fire about.
+                    if at_frontier {
+                        tracing::warn!(
+                            marker = "unified_projection_divergence",
+                            plane = "membership",
+                            ?group,
+                            %member,
+                            ?projected,
+                            ?live,
+                            "unified-op projection disagrees with live membership resolver"
+                        );
+                    } else {
+                        tracing::debug!(
+                            plane = "membership",
+                            ?group,
+                            %member,
+                            ?projected,
+                            ?live,
+                            "projection behind live's governance frontier; \
+                             at-cut answer is not comparable to the live row"
+                        );
+                    }
+                }
+            }
+        }
+
+        // APPLY-AUTH shadow (F5 #28, log-only): the op just APPLIED,
+        // so the LIVE resolver authorized its signer. Would the
+        // projection authorize the signer too — at the op's PARENT
+        // cut (state EXCLUDING this op, the correct cut to authorize
+        // against)? `Some(false)` = the projection would REJECT what
+        // live accepted (under-auth — safe, but a real divergence to
+        // investigate); `None` = ancestry not fully folded → skip.
+        // The reverse (projection accepts what live rejected) is
+        // unobservable here — a live-rejected op never reaches this
+        // fold. Resolved at the parent cut (independent of the
+        // just-ingested op), so it runs OUTSIDE the write lock under
+        // a brief read lock — no store I/O while the apply path's
+        // ingest is blocked.
+        //
+        // Same frontier premise as the membership compare above: a
+        // projection that holds less than live under-authorizes for
+        // that reason alone, so `Some(false)` would name the lag
+        // rather than a real disagreement.
+        if fed {
+            if let Some((auth_group, req)) = apply_auth_requirement(signed_op, decrypted.as_ref()) {
+                let verdict = match scope_projections.read() {
+                    Ok(projections) => match req {
+                        ApplyAuthReq::Admin => projections.is_admin_at_cut(
+                            store,
+                            auth_group,
+                            &signed_op.signer,
+                            delta_parents,
+                        ),
+                        ApplyAuthReq::AdminOrCap(bits) => projections
+                            .is_admin_or_capability_at_cut(
+                                store,
+                                auth_group,
+                                &signed_op.signer,
+                                bits,
+                                delta_parents,
+                            ),
+                    },
+                    Err(_) => None,
+                };
+                if verdict == Some(false) {
+                    // Same frontier premise, same reporting split
+                    // as the membership compare above.
+                    if at_frontier {
+                        tracing::warn!(
+                            marker = "unified_projection_divergence",
+                            plane = "governance-auth",
+                            group_id = ?auth_group,
+                            signer = %signed_op.signer,
+                            "projection would reject a governance op the live resolver authorized"
+                        );
+                    } else {
+                        tracing::debug!(
+                            plane = "governance-auth",
+                            group_id = ?auth_group,
+                            signer = %signed_op.signer,
+                            "projection behind live's governance frontier; \
+                             under-auth at the parent cut is the lag, not a disagreement"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, RwLock};
+
+    use calimero_dag::{ApplyError, CausalDelta, DagStore, DeltaApplier};
+    use calimero_governance_types::{NamespaceOp, RootOp, SignedNamespaceOp};
+    use calimero_op::ScopeId;
+    use calimero_primitives::identity::PublicKey;
+    use calimero_storage::logical_clock::{HybridTimestamp, Timestamp, ID, NTP64};
+    use calimero_store::db::InMemoryDB;
+    use calimero_store::Store;
+    use core::num::NonZeroU128;
+
+    use super::{shadow_fold_applied, AppliedOp};
+    use crate::scope_projection::ScopeProjections;
+
+    /// Drives the DAG's ordering machinery without a governance apply: this test
+    /// is about which deltas the fold SEES, and a real applier would make the
+    /// setup about signature and membership validity instead.
+    struct NoopApplier;
+
+    #[async_trait::async_trait]
+    impl DeltaApplier<SignedNamespaceOp> for NoopApplier {
+        async fn apply(&self, _delta: &CausalDelta<SignedNamespaceOp>) -> Result<(), ApplyError> {
+            Ok(())
+        }
+    }
+
+    fn hlc(ns: u64) -> HybridTimestamp {
+        HybridTimestamp::new(Timestamp::new(
+            NTP64(ns),
+            ID::from(NonZeroU128::new(1).unwrap()),
+        ))
+    }
+
+    /// A minimal well-formed envelope. The payload folds as a graph node; what
+    /// matters here is that the op carries the namespace the fold scopes by.
+    fn envelope(namespace: [u8; 32], parents: Vec<[u8; 32]>) -> SignedNamespaceOp {
+        SignedNamespaceOp {
+            version: 1,
+            namespace_id: namespace.into(),
+            parent_op_hashes: parents,
+            signer: PublicKey::from([7u8; 32]),
+            nonce: 0,
+            op: NamespaceOp::Root(RootOp::PolicyUpdated {
+                policy_bytes: Vec::new(),
+            }),
+            signature: [0u8; 64],
+        }
+    }
+
+    /// The apply path must fold every delta the DAG applied, not just the one it
+    /// was handed. Two children arrive before their parent and sit pending; the
+    /// parent's apply drains both, and all three have to reach the projection —
+    /// otherwise an at-cut read of this scope answers from a log missing ops the
+    /// live store holds.
+    #[tokio::test]
+    async fn folds_the_deltas_the_apply_drained_not_just_the_one_handed_in() {
+        let ns = [0x44u8; 32];
+        let scope = ScopeId::from(ns);
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let projections = RwLock::new(ScopeProjections::new());
+        let mut dag = DagStore::new([0u8; 32]);
+        let applier = NoopApplier;
+
+        let (id1, id2, id3) = ([0xD1u8; 32], [0xD2u8; 32], [0xD3u8; 32]);
+        let op1 = envelope(ns, vec![]);
+        let op2 = envelope(ns, vec![id1]);
+        let op3 = envelope(ns, vec![id2]);
+
+        // Children first: both park in the pending buffer.
+        let out3 = dag
+            .add_delta_with_outcome(CausalDelta::new(id3, vec![id2], op3, hlc(3)), &applier)
+            .await
+            .expect("add id3");
+        let out2 = dag
+            .add_delta_with_outcome(CausalDelta::new(id2, vec![id1], op2, hlc(2)), &applier)
+            .await
+            .expect("add id2");
+        assert!(out3.is_pending() && out2.is_pending());
+
+        // The parent arrives and takes the chain with it.
+        let outcome = dag
+            .add_delta_with_outcome(
+                CausalDelta::new(id1, vec![], op1.clone(), hlc(1)).into_genesis(),
+                &applier,
+            )
+            .await
+            .expect("add id1");
+        assert_eq!(
+            outcome.cascaded(),
+            &[id2, id3],
+            "the apply drained both children",
+        );
+
+        shadow_fold_applied(
+            &store,
+            &projections,
+            &dag,
+            AppliedOp {
+                signed: &op1,
+                id: id1,
+                hlc: hlc(1),
+                parents: &[],
+            },
+            &outcome,
+        );
+
+        let folded = projections.read().expect("projection lock");
+        // Asserted per id, NOT through the coverage walk: that walk counts an id
+        // cited by a folded op as reached whether or not the op itself is
+        // present, so it would pass with the drained deltas still missing.
+        for id in [id1, id2, id3] {
+            assert!(
+                folded.has_folded(&scope, &id),
+                "delta {} applied but was never folded",
+                hex::encode(id),
+            );
+        }
     }
 }

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -625,6 +625,17 @@ impl ScopeProjections {
             .is_some_and(|log| ScopeState::cut_ancestry_decoded(log, parents))
     }
 
+    /// Has `scope`'s projection folded `id`?
+    ///
+    /// The direct question behind [`Self::cut_covers_frontier`]'s walk, exposed
+    /// for callers that need to check one op rather than a cut's reach — and for
+    /// tests that have to distinguish "folded" from "merely cited by something
+    /// folded", which the coverage walk deliberately conflates.
+    #[must_use]
+    pub fn has_folded(&self, scope: &ScopeId, id: &[u8; 32]) -> bool {
+        self.seen.get(scope).is_some_and(|seen| seen.contains(id))
+    }
+
     /// Does the cut at `parents` cover `frontier` in `scope` — the precondition
     /// for comparing an at-cut projection answer against a live row?
     ///

--- a/crates/dag/src/lib.rs
+++ b/crates/dag/src/lib.rs
@@ -281,10 +281,23 @@ pub struct PendingStats {
 /// `Duplicate` into `Ok(false)`. Callers that need to distinguish the two —
 /// e.g. to avoid triggering a network backfill on a duplicate gossip op —
 /// should use the `_with_outcome` variant.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AddDeltaOutcome {
     /// The delta was applied immediately (all parents present).
-    Applied,
+    ///
+    /// `cascaded` names the deltas that were **unblocked by this one** and
+    /// applied in the same call, in the order they were applied — the delta's
+    /// own id is not among them. It is empty in the common case (nothing was
+    /// waiting).
+    ///
+    /// A caller that maintains a view alongside the applier — a projection, an
+    /// index, a metric — has to fold these too, or its view silently lags the
+    /// applier's by however much was buffered. That is not hypothetical: the
+    /// unified-op projection folded only the delta passed in, so a drained
+    /// child reached the live store and never the projection, and every later
+    /// at-cut read of that scope was answered from a log missing an op the
+    /// store had.
+    Applied { cascaded: Vec<[u8; 32]> },
     /// The delta was stored as pending (at least one parent missing).
     Pending,
     /// The delta was already present in the DAG; no work performed.
@@ -294,7 +307,17 @@ pub enum AddDeltaOutcome {
 impl AddDeltaOutcome {
     /// `true` when the outcome is [`AddDeltaOutcome::Applied`].
     pub fn is_applied(&self) -> bool {
-        matches!(self, Self::Applied)
+        matches!(self, Self::Applied { .. })
+    }
+
+    /// The deltas this apply unblocked and applied, in apply order — see
+    /// [`AddDeltaOutcome::Applied`]. Empty for every other outcome.
+    #[must_use]
+    pub fn cascaded(&self) -> &[[u8; 32]] {
+        match self {
+            Self::Applied { cascaded } => cascaded,
+            Self::Pending | Self::Duplicate => &[],
+        }
     }
 
     /// `true` when the outcome is [`AddDeltaOutcome::Pending`] — i.e. the
@@ -478,7 +501,7 @@ impl<T: Clone> DagStore<T> {
         T: Send + Sync,
     {
         let seed: Vec<[u8; 32]> = self.pending.keys().copied().collect();
-        self.cascade_ready(seed, applier).await
+        Ok(self.cascade_ready(seed, applier).await?.len())
     }
 
     /// Add a delta to the DAG.
@@ -499,10 +522,10 @@ impl<T: Clone> DagStore<T> {
     where
         T: Send + Sync,
     {
-        Ok(matches!(
-            self.add_delta_with_outcome(delta, applier).await?,
-            AddDeltaOutcome::Applied
-        ))
+        Ok(self
+            .add_delta_with_outcome(delta, applier)
+            .await?
+            .is_applied())
     }
 
     /// Add a delta to the DAG and return the detailed outcome.
@@ -564,8 +587,8 @@ impl<T: Clone> DagStore<T> {
             // by this index. Removing (vs. cloning) also keeps the bucket
             // from lingering until its children drain.
             let seed = self.pending_children.remove(&delta_id).unwrap_or_default();
-            let _ = self.cascade_ready(seed, applier).await?;
-            Ok(AddDeltaOutcome::Applied)
+            let cascaded = self.cascade_ready(seed, applier).await?;
+            Ok(AddDeltaOutcome::Applied { cascaded })
         } else {
             // Missing parents - store as pending. Cap the pending map so a
             // flood of out-of-order deltas arriving faster than the time-based
@@ -759,14 +782,16 @@ impl<T: Clone> DagStore<T> {
         &mut self,
         seed: Vec<[u8; 32]>,
         applier: &A,
-    ) -> Result<usize, DagError>
+    ) -> Result<Vec<[u8; 32]>, DagError>
     where
         T: Send + Sync,
     {
         use std::collections::VecDeque;
         let mut queue: VecDeque<[u8; 32]> = seed.into_iter().collect();
         let mut queued: std::collections::HashSet<[u8; 32]> = queue.iter().copied().collect();
-        let mut applied = 0usize;
+        // The ids, not just how many: a caller folding these into a view of its
+        // own needs to know WHICH deltas applied, and in what order.
+        let mut applied: Vec<[u8; 32]> = Vec::new();
 
         while let Some(id) = queue.pop_front() {
             let _ = queued.remove(&id);
@@ -782,7 +807,7 @@ impl<T: Clone> DagStore<T> {
                 continue;
             };
             self.apply_delta(pending.delta, applier).await?;
-            applied += 1;
+            applied.push(id);
 
             // Enqueue the deltas that were waiting on `id`.
             if let Some(children) = self.pending_children.get(&id) {
@@ -1623,7 +1648,7 @@ mod basic_tests {
             .add_delta_with_outcome(delta, &working)
             .await
             .expect("retry should evict the zombie and succeed");
-        assert!(matches!(outcome, AddDeltaOutcome::Applied));
+        assert!(outcome.is_applied());
         assert!(dag.applied.contains(&delta_id));
     }
 
@@ -1657,7 +1682,7 @@ mod basic_tests {
             .add_delta_with_outcome(delta, &working)
             .await
             .expect("retry should succeed after rollback");
-        assert!(matches!(outcome, AddDeltaOutcome::Applied));
+        assert!(outcome.is_applied());
         assert!(dag.applied.contains(&delta_id));
     }
 

--- a/crates/dag/src/tests.rs
+++ b/crates/dag/src/tests.rs
@@ -154,8 +154,8 @@ async fn test_dag_add_delta_with_outcome_tri_state() {
         dag.add_delta_with_outcome(delta1.clone(), &applier)
             .await
             .unwrap(),
-        AddDeltaOutcome::Applied,
-        "fresh delta with present parent applies immediately",
+        AddDeltaOutcome::Applied { cascaded: vec![] },
+        "fresh delta with present parent applies immediately, unblocking nothing",
     );
 
     assert_eq!(
@@ -166,7 +166,7 @@ async fn test_dag_add_delta_with_outcome_tri_state() {
 
     assert_eq!(
         dag.add_delta_with_outcome(delta2, &applier).await.unwrap(),
-        AddDeltaOutcome::Applied,
+        AddDeltaOutcome::Applied { cascaded: vec![] },
         "chained delta with applied parent also applies immediately",
     );
 
@@ -253,6 +253,54 @@ async fn test_dag_multiple_pending_sequential() {
     assert_eq!(applied, vec![[1; 32], [2; 32], [3; 32]]);
     assert_eq!(dag.pending_stats().count, 0);
     assert_eq!(dag.get_heads(), vec![[3; 32]]);
+}
+
+/// The outcome must name the deltas the apply DRAINED, not just report that
+/// something applied. A caller keeping a view alongside the applier folds the
+/// delta it passed in; without this list the drained children are invisible to
+/// it, so its view lags the applier's by however much was buffered — which is
+/// how the unified-op projection ended up answering at-cut reads from a log
+/// missing ops the live store held.
+#[tokio::test]
+async fn test_dag_outcome_reports_the_drained_cascade() {
+    use crate::AddDeltaOutcome;
+
+    let applier = TestApplier::new();
+    let mut dag = DagStore::new([0; 32]);
+
+    // root -> d1 -> d2 -> d3, delivered so that d2 and d3 wait on d1.
+    let delta1 = CausalDelta::new_test([1; 32], vec![[0; 32]], TestPayload { value: 1 });
+    let delta2 = CausalDelta::new_test([2; 32], vec![[1; 32]], TestPayload { value: 2 });
+    let delta3 = CausalDelta::new_test([3; 32], vec![[2; 32]], TestPayload { value: 3 });
+
+    assert_eq!(
+        dag.add_delta_with_outcome(delta3, &applier).await.unwrap(),
+        AddDeltaOutcome::Pending,
+    );
+    assert_eq!(
+        dag.add_delta_with_outcome(delta2, &applier).await.unwrap(),
+        AddDeltaOutcome::Pending,
+    );
+
+    // d1 arrives and takes the whole chain with it. The cascade is reported in
+    // apply order, and excludes d1 itself — the caller already has that one.
+    assert_eq!(
+        dag.add_delta_with_outcome(delta1, &applier).await.unwrap(),
+        AddDeltaOutcome::Applied {
+            cascaded: vec![[2; 32], [3; 32]]
+        },
+        "the outcome must name what the apply drained, in the order it applied",
+    );
+
+    // The applier saw exactly the ids the outcome accounts for: d1 (passed in)
+    // followed by the reported cascade. Asserting against the applier is the
+    // point — it is the view the caller has to stay level with.
+    assert_eq!(
+        applier.get_applied().await,
+        vec![[1; 32], [2; 32], [3; 32]],
+        "cascade + the delta itself must be exactly what the applier applied",
+    );
+    assert_eq!(dag.pending_stats().count, 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Follow-up to #3587, which closed the false-positive half of the divergence gate
and named this as the residual.

## The gap

The governance apply handler folded the delta it was handed into the shadow
projection and nothing else. But `add_delta_with_outcome` applies more than that:
when the delta unblocks pending children, the DAG applies them through the same
applier on the same call. Those children reached the live store and never the
projection.

So the projection trailed live by whatever had been buffered, and every later
at-cut read of that scope answered from a log missing ops the store held. With
#3587's frontier gate in place the symptom is not a false marker but silence: a
drained op leaves the projection short of live's frontier, the comparison is
correctly suppressed — and stays suppressed. The gate's reach quietly depended on
how much a scenario buffered, which is not a property a HARD gate should have.

## The fix

**`feat(dag)`** — `AddDeltaOutcome::Applied` now carries `cascaded`: the drained
delta ids, in the order they applied, excluding the delta itself. `cascade_ready`
returns the ids rather than a count. `try_process_pending` keeps its count by
taking the length — its only caller is the state-delta store, which drives its
own applier and needs no list. `is_applied()` and the `add_delta` bool wrapper
are unchanged, so no caller outside this PR moves.

**`fix(context)`** — the handler folds the primary op, then the reported cascade
in apply order, sharing one read of the live governance frontier (every op folded
landed before it was read). The per-op work moved into `shadow_fold_and_compare`
and the enumeration into `shadow_fold_applied`, so the test drives the same
function the handler calls instead of re-implementing the loop.

## Tests

| Test | Proves |
| --- | --- |
| `test_dag_outcome_reports_the_drained_cascade` | the outcome names what the apply drained, in apply order — asserted against the applier's own record, so delta-passed-in + cascade must equal exactly what the applier saw |
| `folds_the_deltas_the_apply_drained_not_just_the_one_handed_in` | two children arrive before their parent; the parent's apply drains both; all three reach the projection |

Two deliberate choices in the second test:

* it asserts with the new `ScopeProjections::has_folded`, **not** with
  `cut_covers_frontier` — the coverage walk counts an id *cited* by a folded op as
  reached whether or not that op is present, so it would pass with the drained
  deltas still missing;
* it drives the DAG with a no-op applier. The subject is which deltas the fold
  sees; a real governance applier would make the setup about signature and
  membership validity instead.

`AppliedOp` bundles the delta coordinates. That began as a clippy arg-count fix,
but two of the four fields are `[u8; 32]` and a third is a slice of the same — a
positional mix-up there would silently fold an op under a neighbour's id.

## Verification

* Negative control: stub out the cascade loop and the context test fails on the
  first drained delta.
* Refactor oracle: a normalised before/after of the moved logic differs only by
  the cascade loop, the early return, and the frontier read changing position —
  nothing was smuggled into the extraction. Most of the handler diff is that
  extraction (a shallower indent, rustfmt re-wrapping).
* 67 DAG tests, 242 context lib tests, `cargo check --workspace --all-targets`,
  clippy clean on both crates, fmt clean. E2E runs here for the first time.

## Still open

`try_process_pending` has the same shape of gap in principle. Its only caller is
the state-delta store, whose DAG does not feed this projection, so there is
nothing to fix there today — worth remembering if that changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
