### PR TITLE
refactor: name the parameters a caller can silently transpose

### DIFF
--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -74,7 +74,6 @@ impl Handler<CreateContextRequest> for ContextManager {
             external_config,
             application,
             context,
-            context_secret,
             identity,
             identity_secret,
             group_id,
@@ -130,12 +129,10 @@ impl Handler<CreateContextRequest> for ContextManager {
                     create_context(
                         act.datastore.clone(),
                         act.node_client.clone(),
-                        act.context_client.clone(),
                         Arc::clone(&act.ack_router),
                         module,
                         external_config,
                         context_meta,
-                        context_secret,
                         application,
                         identity,
                         identity_secret,
@@ -181,7 +178,6 @@ struct Prepared<'a> {
     external_config: ContextConfigParams,
     application: Application,
     context: &'a ContextMeta,
-    context_secret: PrivateKey,
     identity: PublicKey,
     identity_secret: PrivateKey,
     group_id: ContextGroupId,
@@ -306,8 +302,14 @@ impl Prepared<'_> {
                 break;
             }
         }
-        let (entry, context_id, context_secret) = context
+        // `context_secret` is dropped with the loop: its only role is deriving
+        // `context_id` from its public key, and the seeded path is what makes that
+        // derivation reproducible. Nothing after this point needs the key — it used
+        // to be carried through `Prepared` to a `create_context` parameter that
+        // ignored it.
+        let (entry, context_id) = context
             .flatten()
+            .map(|(entry, id, _secret)| (entry, id))
             .ok_or_eyre("failed to derive a context id after 5 tries")?;
 
         let identity = identity_secret.public_key();
@@ -323,7 +325,6 @@ impl Prepared<'_> {
             external_config,
             application,
             context,
-            context_secret,
             identity,
             identity_secret,
             group_id,
@@ -339,12 +340,10 @@ impl Prepared<'_> {
 async fn create_context(
     datastore: Store,
     node_client: NodeClient,
-    _context_client: ContextClient,
     ack_router: Arc<calimero_context_client::local_governance::AckRouter>,
     module: calimero_runtime::Module,
     external_config: ContextConfigParams,
     mut context: Context,
-    _context_secret: PrivateKey,
     application: Application,
     identity: PublicKey,
     identity_secret: PrivateKey,

--- a/crates/context/src/handlers/issue_ownership_proof.rs
+++ b/crates/context/src/handlers/issue_ownership_proof.rs
@@ -16,6 +16,23 @@ use calimero_governance_store;
 use calimero_governance_store::MAX_NAMESPACE_DEPTH;
 use calimero_governance_store::{MembershipRepository, NamespaceRepository};
 
+/// The claim a proof asserts, named so its three strings cannot be transposed.
+///
+/// They were three adjacent `&str` parameters. Swapping `audience` and `subject`
+/// compiled, and — unlike a swapped epoch, which changes a signature preimage and
+/// is refused by the first verifier — it is **silent**: the payload is built from
+/// named fields and then signed, so the proof verifies perfectly and simply
+/// asserts the wrong thing. A valid signature over a false statement.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ProofClaim<'a> {
+    /// Who the proof is addressed to.
+    pub(crate) audience: &'a str,
+    /// What the proof is about.
+    pub(crate) subject: &'a str,
+    /// Caller-supplied replay guard.
+    pub(crate) nonce: &'a str,
+}
+
 /// Domain-separation tag prepended to the serialized payload before signing.
 /// Verifiers MUST reconstruct the signed bytes as `OWNERSHIP_PROOF_DOMAIN ||
 /// signed_payload_bytes`.
@@ -127,12 +144,15 @@ pub(crate) fn build_ownership_proof(
     node_identity: PublicKey,
     group_id: ContextGroupId,
     context_id: ContextId,
-    audience: &str,
-    subject: &str,
-    nonce: &str,
+    claim: ProofClaim<'_>,
     requested_expires_at_ms: u64,
     now_ms: u64,
 ) -> eyre::Result<OwnershipProofBuildOutput> {
+    let ProofClaim {
+        audience,
+        subject,
+        nonce,
+    } = claim;
     validate_proof_fields(audience, subject, nonce)?;
 
     let node_account = crate::member_account::require(store, &group_id, &node_identity)?;
@@ -235,12 +255,15 @@ pub(crate) fn build_namespace_ownership_proof(
     store: &Store,
     node_identity: PublicKey,
     group_id: ContextGroupId,
-    audience: &str,
-    subject: &str,
-    nonce: &str,
+    claim: ProofClaim<'_>,
     requested_expires_at_ms: u64,
     now_ms: u64,
 ) -> eyre::Result<OwnershipProofBuildOutput> {
+    let ProofClaim {
+        audience,
+        subject,
+        nonce,
+    } = claim;
     validate_proof_fields(audience, subject, nonce)?;
 
     let node_account = crate::member_account::require(store, &group_id, &node_identity)?;
@@ -337,9 +360,11 @@ impl Handler<IssueOwnershipProofRequest> for ContextManager {
                 node_identity,
                 req.group_id,
                 req.context_id,
-                &req.audience,
-                &req.subject,
-                &req.nonce,
+                ProofClaim {
+                    audience: &req.audience,
+                    subject: &req.subject,
+                    nonce: &req.nonce,
+                },
                 req.expires_at_ms,
                 now_ms,
             )?;
@@ -375,9 +400,11 @@ impl Handler<IssueNamespaceOwnershipProofRequest> for ContextManager {
                 &self.datastore,
                 node_identity,
                 req.group_id,
-                &req.audience,
-                &req.subject,
-                &req.nonce,
+                ProofClaim {
+                    audience: &req.audience,
+                    subject: &req.subject,
+                    nonce: &req.nonce,
+                },
                 req.expires_at_ms,
                 now_ms,
             )?;
@@ -404,7 +431,9 @@ mod tests {
     use calimero_store::Store;
     use serde_json::Value;
 
-    use super::{build_namespace_ownership_proof, build_ownership_proof, OWNERSHIP_PROOF_DOMAIN};
+    use super::{
+        build_namespace_ownership_proof, build_ownership_proof, ProofClaim, OWNERSHIP_PROOF_DOMAIN,
+    };
     use calimero_governance_store;
     use calimero_governance_store::{MembershipRepository, NamespaceRepository};
 
@@ -451,9 +480,11 @@ mod tests {
             signing_pub,
             group_id,
             context_id,
-            "mdma.cloud",
-            "subject-xyz",
-            "deadbeefcafebabe1122334455667788",
+            ProofClaim {
+                audience: "mdma.cloud",
+                subject: "subject-xyz",
+                nonce: "deadbeefcafebabe1122334455667788",
+            },
             requested_expires_at_ms,
             NOW_MS,
         )
@@ -501,9 +532,11 @@ mod tests {
             identity,
             group_id,
             context_id,
-            "aud",
-            "sub",
-            "deadbeefcafebabe1122334455667788",
+            ProofClaim {
+                audience: "aud",
+                subject: "sub",
+                nonce: "deadbeefcafebabe1122334455667788",
+            },
             NOW_MS + 1_000,
             NOW_MS,
         )
@@ -535,9 +568,11 @@ mod tests {
             identity,
             group_id,
             context_id,
-            "aud",
-            "sub",
-            "deadbeefcafebabe1122334455667788",
+            ProofClaim {
+                audience: "aud",
+                subject: "sub",
+                nonce: "deadbeefcafebabe1122334455667788",
+            },
             NOW_MS + 1_000,
             NOW_MS,
         )
@@ -555,9 +590,11 @@ mod tests {
             signing_pub,
             group_id,
             context_id,
-            "aud",
-            "sub",
-            "deadbeefcafebabe1122334455667788",
+            ProofClaim {
+                audience: "aud",
+                subject: "sub",
+                nonce: "deadbeefcafebabe1122334455667788",
+            },
             NOW_MS - 1,
             NOW_MS,
         )
@@ -575,9 +612,11 @@ mod tests {
             signing_pub,
             group_id,
             context_id,
-            "aud",
-            "sub",
-            "deadbeefcafebabe1122334455667788",
+            ProofClaim {
+                audience: "aud",
+                subject: "sub",
+                nonce: "deadbeefcafebabe1122334455667788",
+            },
             NOW_MS,
             NOW_MS,
         )
@@ -621,9 +660,11 @@ mod tests {
             signing_pub,
             root,
             context_id,
-            "mdma.cloud",
-            "subject-xyz",
-            "deadbeefcafebabe1122334455667788",
+            ProofClaim {
+                audience: "mdma.cloud",
+                subject: "subject-xyz",
+                nonce: "deadbeefcafebabe1122334455667788",
+            },
             NOW_MS + 1_000,
             NOW_MS,
         )
@@ -654,9 +695,11 @@ mod tests {
             signing_pub,
             group_id,
             foreign_ctx,
-            "aud",
-            "sub",
-            "deadbeefcafebabe1122334455667788",
+            ProofClaim {
+                audience: "aud",
+                subject: "sub",
+                nonce: "deadbeefcafebabe1122334455667788",
+            },
             NOW_MS + 1_000,
             NOW_MS,
         )
@@ -703,9 +746,11 @@ mod tests {
             other_identity,
             group_id,
             context_id,
-            "mdma.cloud",
-            "subject-xyz",
-            "deadbeefcafebabe1122334455667788",
+            ProofClaim {
+                audience: "mdma.cloud",
+                subject: "subject-xyz",
+                nonce: "deadbeefcafebabe1122334455667788",
+            },
             NOW_MS + 1_000,
             NOW_MS,
         )
@@ -742,9 +787,11 @@ mod tests {
             &store,
             signing_pub,
             group_id,
-            "mdma:enable-ha-namespace",
-            "subject-xyz",
-            "deadbeefcafebabe1122334455667788",
+            ProofClaim {
+                audience: "mdma:enable-ha-namespace",
+                subject: "subject-xyz",
+                nonce: "deadbeefcafebabe1122334455667788",
+            },
             NOW_MS + 1_000,
             NOW_MS,
         )
@@ -785,9 +832,11 @@ mod tests {
             &store,
             identity,
             group_id,
-            "mdma:enable-ha-namespace",
-            "sub",
-            "deadbeefcafebabe1122334455667788",
+            ProofClaim {
+                audience: "mdma:enable-ha-namespace",
+                subject: "sub",
+                nonce: "deadbeefcafebabe1122334455667788",
+            },
             NOW_MS + 1_000,
             NOW_MS,
         )
@@ -836,9 +885,11 @@ mod tests {
             &store,
             signing_pub,
             child,
-            "mdma:enable-ha-namespace",
-            "subject-xyz",
-            "deadbeefcafebabe1122334455667788",
+            ProofClaim {
+                audience: "mdma:enable-ha-namespace",
+                subject: "subject-xyz",
+                nonce: "deadbeefcafebabe1122334455667788",
+            },
             NOW_MS + 1_000,
             NOW_MS,
         )
@@ -861,9 +912,11 @@ mod tests {
                 signing_pub,
                 group_id,
                 context_id,
-                audience,
-                subject,
-                nonce,
+                ProofClaim {
+                    audience,
+                    subject,
+                    nonce,
+                },
                 NOW_MS + 1_000,
                 NOW_MS,
             )
@@ -920,9 +973,11 @@ mod tests {
             &store,
             identity,
             group_id,
-            "aud",
-            "sub",
-            "short",
+            ProofClaim {
+                audience: "aud",
+                subject: "sub",
+                nonce: "short",
+            },
             NOW_MS + 1_000,
             NOW_MS,
         )

--- a/crates/meroctl/src/cli/group/members.rs
+++ b/crates/meroctl/src/cli/group/members.rs
@@ -275,15 +275,7 @@ pub struct SetCapabilitiesCommand {
 
 impl SetCapabilitiesCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
-        let capabilities = encode_capabilities(
-            self.can_create_context,
-            self.can_invite_members,
-            self.can_join_open_subgroups,
-            self.can_create_subgroup,
-            self.can_delete_subgroup,
-            self.can_manage_visibility,
-            self.can_manage_metadata,
-        );
+        let capabilities = encode_capabilities(&self);
 
         let identity_hex = self.identity.to_string();
 
@@ -396,37 +388,36 @@ impl CheckAccessCommand {
     }
 }
 
-/// Encode the seven member-capability flags into the `MemberCapabilities`
-/// bitmask sent to the node.
-fn encode_capabilities(
-    can_create_context: bool,
-    can_invite_members: bool,
-    can_join_open_subgroups: bool,
-    can_create_subgroup: bool,
-    can_delete_subgroup: bool,
-    can_manage_visibility: bool,
-    can_manage_metadata: bool,
-) -> u32 {
+/// Encode the member-capability flags into the `MemberCapabilities` bitmask sent
+/// to the node.
+///
+/// Takes the command rather than seven `bool`s. Positionally, every one of those
+/// arguments had the same type and the call site passed them in declaration
+/// order — so transposing any two compiled, passed every test, and granted the
+/// wrong capability. Nothing in a bitmask of `u32` reveals afterwards which flag
+/// was meant. Reading each field by name at the point of use makes the mistake
+/// unrepresentable rather than merely unlikely.
+fn encode_capabilities(cmd: &SetCapabilitiesCommand) -> u32 {
     let mut capabilities: u32 = 0;
-    if can_create_context {
+    if cmd.can_create_context {
         capabilities |= MemberCapabilities::CAN_CREATE_CONTEXT.bits();
     }
-    if can_invite_members {
+    if cmd.can_invite_members {
         capabilities |= MemberCapabilities::CAN_INVITE_MEMBERS.bits();
     }
-    if can_join_open_subgroups {
+    if cmd.can_join_open_subgroups {
         capabilities |= MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS.bits();
     }
-    if can_create_subgroup {
+    if cmd.can_create_subgroup {
         capabilities |= MemberCapabilities::CAN_CREATE_SUBGROUP.bits();
     }
-    if can_delete_subgroup {
+    if cmd.can_delete_subgroup {
         capabilities |= MemberCapabilities::CAN_DELETE_SUBGROUP.bits();
     }
-    if can_manage_visibility {
+    if cmd.can_manage_visibility {
         capabilities |= MemberCapabilities::CAN_MANAGE_VISIBILITY.bits();
     }
-    if can_manage_metadata {
+    if cmd.can_manage_metadata {
         capabilities |= MemberCapabilities::CAN_MANAGE_METADATA.bits();
     }
     capabilities
@@ -434,36 +425,112 @@ fn encode_capabilities(
 
 #[cfg(test)]
 mod tests {
-    use super::encode_capabilities;
+    use super::{encode_capabilities, SetCapabilitiesCommand};
     use calimero_context_config::MemberCapabilities;
 
-    #[test]
-    fn no_flags_encodes_to_zero() {
-        assert_eq!(
-            encode_capabilities(false, false, false, false, false, false, false),
-            0
-        );
+    /// A command with every flag off, to be turned on by name.
+    ///
+    /// Built field-by-field on purpose. The previous tests called
+    /// `encode_capabilities(false, true, false, …)` positionally, which is the
+    /// same hazard the signature had — a test written that way cannot catch a
+    /// transposition, because it makes the identical mistake.
+    fn cmd() -> SetCapabilitiesCommand {
+        SetCapabilitiesCommand {
+            group_id: String::new(),
+            identity: calimero_account::AccountId::from([0u8; 32]),
+            can_create_context: false,
+            can_invite_members: false,
+            can_join_open_subgroups: false,
+            can_create_subgroup: false,
+            can_delete_subgroup: false,
+            can_manage_visibility: false,
+            can_manage_metadata: false,
+        }
     }
 
     #[test]
-    fn each_flag_maps_to_its_bit() {
-        assert_eq!(
-            encode_capabilities(true, false, false, false, false, false, false),
-            MemberCapabilities::CAN_CREATE_CONTEXT.bits()
-        );
-        assert_eq!(
-            encode_capabilities(false, true, false, false, false, false, false),
-            MemberCapabilities::CAN_INVITE_MEMBERS.bits()
-        );
-        assert_eq!(
-            encode_capabilities(false, false, false, false, false, false, true),
-            MemberCapabilities::CAN_MANAGE_METADATA.bits()
-        );
+    fn no_flags_encodes_to_zero() {
+        assert_eq!(encode_capabilities(&cmd()), 0);
+    }
+
+    /// **Every** flag, not a sample of three.
+    ///
+    /// The old test covered `can_create_context`, `can_invite_members` and
+    /// `can_manage_metadata`, so swapping the four untested flags with each other
+    /// passed. Each entry here sets exactly one field by name and asserts exactly
+    /// one bit, which is what makes a mis-wiring visible.
+    /// One row of [`each_flag_maps_to_its_own_bit`]: the field to switch on, the
+    /// single bit that must result, and the name to report.
+    struct FlagCase {
+        set: fn(&mut SetCapabilitiesCommand),
+        expected: MemberCapabilities,
+        name: &'static str,
+    }
+
+    #[test]
+    fn each_flag_maps_to_its_own_bit() {
+        let cases = [
+            FlagCase {
+                set: |c| c.can_create_context = true,
+                expected: MemberCapabilities::CAN_CREATE_CONTEXT,
+                name: "can_create_context",
+            },
+            FlagCase {
+                set: |c| c.can_invite_members = true,
+                expected: MemberCapabilities::CAN_INVITE_MEMBERS,
+                name: "can_invite_members",
+            },
+            FlagCase {
+                set: |c| c.can_join_open_subgroups = true,
+                expected: MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS,
+                name: "can_join_open_subgroups",
+            },
+            FlagCase {
+                set: |c| c.can_create_subgroup = true,
+                expected: MemberCapabilities::CAN_CREATE_SUBGROUP,
+                name: "can_create_subgroup",
+            },
+            FlagCase {
+                set: |c| c.can_delete_subgroup = true,
+                expected: MemberCapabilities::CAN_DELETE_SUBGROUP,
+                name: "can_delete_subgroup",
+            },
+            FlagCase {
+                set: |c| c.can_manage_visibility = true,
+                expected: MemberCapabilities::CAN_MANAGE_VISIBILITY,
+                name: "can_manage_visibility",
+            },
+            FlagCase {
+                set: |c| c.can_manage_metadata = true,
+                expected: MemberCapabilities::CAN_MANAGE_METADATA,
+                name: "can_manage_metadata",
+            },
+        ];
+
+        for case in cases {
+            let mut c = cmd();
+            (case.set)(&mut c);
+            assert_eq!(
+                encode_capabilities(&c),
+                case.expected.bits(),
+                "{} must set exactly its own bit and no other",
+                case.name
+            );
+        }
     }
 
     #[test]
     fn all_flags_or_together() {
-        let all = encode_capabilities(true, true, true, true, true, true, true);
+        let mut c = cmd();
+        c.can_create_context = true;
+        c.can_invite_members = true;
+        c.can_join_open_subgroups = true;
+        c.can_create_subgroup = true;
+        c.can_delete_subgroup = true;
+        c.can_manage_visibility = true;
+        c.can_manage_metadata = true;
+
+        let all = encode_capabilities(&c);
         let expected = (MemberCapabilities::CAN_CREATE_CONTEXT
             | MemberCapabilities::CAN_INVITE_MEMBERS
             | MemberCapabilities::CAN_JOIN_OPEN_SUBGROUPS

--- a/crates/node/src/sync/manager/mod.rs
+++ b/crates/node/src/sync/manager/mod.rs
@@ -1679,8 +1679,10 @@ impl SyncManager {
                     context_id,
                     chosen_peer,
                     our_identity,
-                    &context.root_hash,
-                    &peer_root_hash,
+                    crate::sync::protocol_selector::RootHashPair {
+                        local: &context.root_hash,
+                        peer: &peer_root_hash,
+                    },
                     session_peer,
                     stream,
                 )

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -95,6 +95,22 @@ pub(crate) struct ProtocolSelector {
     context_client: ContextClient,
 }
 
+/// The two root hashes a sync compares, named so they cannot be swapped.
+///
+/// They were adjacent `&Hash` parameters. Transposing them compiled, and the
+/// consequence was silent: the local hash would be forwarded as
+/// `remote_root_hash` into the HashComparison / LevelWise initiator config, so
+/// the protocol would reconcile against this node's own state and conclude there
+/// was nothing to fetch. Nothing downstream can tell the two apart afterwards —
+/// they are the same type and both are legitimate values.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RootHashPair<'a> {
+    /// This node's root hash for the context.
+    pub(crate) local: &'a Hash,
+    /// The peer's root hash, as it reported it.
+    pub(crate) peer: &'a Hash,
+}
+
 impl ProtocolSelector {
     pub(crate) fn new(context_client: ContextClient) -> Self {
         Self { context_client }
@@ -108,9 +124,9 @@ impl ProtocolSelector {
     /// selection was `SyncProtocol::None` (already converged), or
     /// `Err(_)` if every protocol in the chain failed.
     ///
-    /// `local_root_hash` is included in the `None` arm's debug log
+    /// `roots.local` is included in the `None` arm's debug log
     /// so operators can correlate "no sync needed" entries with the
-    /// state of the local context. `peer_root_hash` is the deref'd
+    /// state of the local context. `roots.peer` is the deref'd
     /// `[u8; 32]` of the peer's root — needed by `LevelWiseConfig`.
     ///
     /// ## Stream postconditions
@@ -148,8 +164,7 @@ impl ProtocolSelector {
         context_id: ContextId,
         chosen_peer: PeerId,
         our_identity: PublicKey,
-        local_root_hash: &Hash,
-        peer_root_hash: &Hash,
+        roots: RootHashPair<'_>,
         // Remote peer's attributable member identity, forwarded to the
         // HC / LevelWise initiator configs to gate authorless leaves.
         session_peer: Option<PublicKey>,
@@ -160,7 +175,7 @@ impl ProtocolSelector {
                 debug!(
                     %context_id,
                     %chosen_peer,
-                    root_hash = %local_root_hash,
+                    root_hash = %roots.local,
                     reason = %selection.reason,
                     "No sync needed: {}",
                     selection.reason
@@ -378,7 +393,7 @@ impl ProtocolSelector {
                 // Get store for protocol execution
                 let store = self.context_client.datastore_handle().into_inner();
                 let config = LevelWiseConfig {
-                    remote_root_hash: **peer_root_hash,
+                    remote_root_hash: **roots.peer,
                     max_depth,
                     context_client: Some(self.context_client.clone()),
                     session_peer,


### PR DESCRIPTION
F5 from the maintainability audit — but the entry had the wrong shape, so this is narrower and better targeted than it asked for.

## Width isn't the defect

The entry asked for a params struct on each of 38 functions taking ≥7 arguments. Measuring:

- **11 of 38 are trait impls** (`Handler<T>` for actix, `BroadcastTransport`). Their signatures aren't ours to change.
- Of the 27 left, only **9 have adjacent same-type parameters** — two arguments of one type, side by side, that the compiler accepts in either order.

And the real criterion isn't "transposable" but **"silently transposable"**. Where the value is covered by a signature, a swap is refused at the first verification and costs a puzzled minute. Three that are genuinely silent are fixed here.

## `encode_capabilities` — seven adjacent `bool`s

Swap any two and the wrong capability is granted, with nothing in a `u32` bitmask to reveal it afterwards. Now takes the command and reads each flag by name.

**Its tests were part of the hazard, not a guard against it.** They called it positionally too, and covered 3 of 7 flags — so transposing any of the four untested ones passed. Rewritten to build the command by name and assert all seven.

Mutation-verified twice:

| mutation | result |
| --- | --- |
| swap `can_create_subgroup` / `can_delete_subgroup` | `FAILED: can_create_subgroup must set exactly its own bit` |
| mis-wire `can_manage_visibility` → `CAN_MANAGE_METADATA` | `FAILED: can_manage_visibility must set exactly its own bit` |

`all_flags_or_together` passes under **both** mutations, because OR-ing all seven is invariant under a swap. That's precisely why the old sample-of-three was insufficient.

## `build_ownership_proof` ×2 — `audience`, `subject`, `nonce`

Three adjacent `&str`. The claim payload is built from *named* fields and then signed — so a caller that swaps audience and subject produces a proof that **verifies perfectly and asserts the wrong thing**. A valid signature over a false statement.

Now a `ProofClaim` struct; 15 call sites converted (2 production, 13 test).

Being precise about what this buys: it makes the mistake **visible at review**, not impossible. `audience: &req.subject` reads as obviously wrong, where two swapped lines in a nine-argument list did not. That's a weaker guarantee than a newtype and I'd rather say so than imply otherwise.

## `protocol_selector::execute` — `local_root_hash`, `peer_root_hash`

Adjacent `&Hash`, one call site passing `&context.root_hash, &peer_root_hash`. Transposed, the local hash is forwarded as `remote_root_hash` into the HashComparison initiator config — so the protocol reconciles against this node's own state and concludes there's nothing to fetch. Now `RootHashPair { local, peer }`.

## `DeviceCert::sign` — deliberately NOT changed

This one is mine, from #3566, and I had it on the list as a hazard. A probe settled it:

```
PROBE intended:   Ok("accepted")
PROBE transposed: Err(CertSignatureInvalid)
PROBE equal epochs identical: true
```

Both epochs sit inside the signed preimage, so a transposition produces a certificate no verifier accepts, and with equal epochs a swap is a no-op. **56 call sites of churn across the account plane to guard a self-detecting mistake** — declined, with evidence rather than a guess.

## Also: two dead parameters, and a dead field behind them

`create_context` drops `_context_client` and `_context_secret` (15 params → 13). Pulling that thread found `Prepared.context_secret` — a field carrying a *private key* whose only consumer was the `_context_secret` parameter that ignored it. The key's real job is deriving `context_id` from its public half, and the seeded path is what makes that reproducible; nothing after needs it. Removed.

Flagging it explicitly in case someone knows better: if that secret is *meant* to be persisted somewhere, this change removes the last trace of it and I'd want to know.

## Verification

- `cargo test --workspace --features calimero-storage/testing` — **4975 passed, 0 failed** (meroctl 45, calimero-context 241, calimero-node 557)
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` — clean
- `cargo fmt --check` — clean

No wire, API or behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)