### PR TITLE
fix(node): gate the snapshot boundary on the state root, not a lagging ContextMeta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,21 @@
   which a join against a node without the field still decodes ([#3485],
   [#3528])
 
+### Fixed
+
+- **Snapshot sync no longer serves state its announced boundary does not
+  describe.** Both boundary checks on the serve path — before page generation
+  and the recheck after it — compared `ContextMeta.root_hash`, but a local
+  execution commits context state well before it persists the new root hash
+  into `ContextMeta`. For that window the metadata still reported the pre-write
+  hash while every entity the snapshot reads had already moved, so both checks
+  passed and the receiver was handed post-boundary state under a pre-boundary
+  hash. It then adopted the mismatching hash and advertised a root whose state
+  it did not hold, which satisfies every root-hash equality check — including
+  the one that selects a repair protocol — so nothing ever corrected it. Both
+  checks now read the root through the context's ROOT `Index` entry, which is
+  written in the same batch as the entities it covers ([#3595])
+
 ### Changed
 
 - **`governanceOp` on both join responses is now optional on deserialization.**
@@ -818,3 +833,4 @@ Integrations:
 [#3485]: https://github.com/calimero-network/core/issues/3485
 [#3528]: https://github.com/calimero-network/core/pull/3528
 [#3530]: https://github.com/calimero-network/core/pull/3530
+[#3595]: https://github.com/calimero-network/core/pull/3595

--- a/crates/node/src/sync/snapshot.rs
+++ b/crates/node/src/sync/snapshot.rs
@@ -4,6 +4,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::Instant;
 
 use borsh::BorshDeserialize;
+use calimero_context_client::client::ContextRegistry;
 use calimero_crypto::Nonce;
 use calimero_network_primitives::stream::Stream;
 use calimero_node_primitives::sync::snapshot::{SnapshotRecord, MAX_SNAPSHOT_PAGE_SIZE};
@@ -24,6 +25,7 @@ use calimero_store::key::ContextState as ContextStateKey;
 use calimero_store::key::{Generic as GenericKey, SCOPE_SIZE};
 use calimero_store::slice::Slice;
 use calimero_store::types::ContextState as ContextStateValue;
+use calimero_store::Store;
 use eyre::Result;
 use hex;
 use tracing::{debug, info, warn};
@@ -151,19 +153,44 @@ impl SyncManager {
         let page_limit = page_limit.clamp(1, MAX_PAGE_LIMIT);
         let byte_limit = byte_limit.clamp(1, MAX_SNAPSHOT_PAGE_SIZE);
 
-        // Verify boundary is still valid
-        let context = match self.context_client.get_context(&context_id)? {
-            Some(ctx) => ctx,
-            None => {
-                warn!(%context_id, "Context not found for snapshot stream");
-                return self
-                    .send_snapshot_error(stream, SnapshotError::InvalidBoundary)
-                    .await;
-            }
-        };
+        // The context must exist before its state means anything.
+        if self.context_client.get_context(&context_id)?.is_none() {
+            warn!(%context_id, "Context not found for snapshot stream");
+            return self
+                .send_snapshot_error(stream, SnapshotError::InvalidBoundary)
+                .await;
+        }
 
-        if context.root_hash != boundary_root_hash {
-            warn!(%context_id, "Boundary mismatch - state changed during sync");
+        // Compare the *state* root, not `ContextMeta.root_hash`.
+        //
+        // `ContextMeta.root_hash` is not a safe stand-in for the state this
+        // snapshot is about to read. A local execution commits context state
+        // (`storage.commit()`) well before it persists the new root hash into
+        // `ContextMeta` — see `crates/context/src/handlers/execute/mod.rs` —
+        // so for the duration of that window the metadata still reports the
+        // pre-write hash while every entity `generate_snapshot_pages` will
+        // read has already moved. Gating on the metadata there accepts the
+        // boundary as intact and streams post-boundary state under a
+        // pre-boundary hash.
+        //
+        // The receiver cannot recover from that on its own: it recomputes the
+        // root from the state it received, finds it disagrees with the hash it
+        // was promised, and adopts the mismatching hash anyway (see
+        // `request_snapshot_sync`). It then advertises a root whose state it
+        // does not hold, which satisfies every root-hash equality check —
+        // including the one in `protocol_selector` — so no repair is ever
+        // triggered.
+        //
+        // The ROOT `Index` entry moves in the same write batch as the entities,
+        // so reading through it observes exactly the state that will be served.
+        let state_root = served_state_root(self.context_client.datastore(), context_id)?;
+        if state_root != boundary_root_hash {
+            warn!(
+                %context_id,
+                expected = %boundary_root_hash,
+                actual = %state_root,
+                "Boundary mismatch - state changed during sync"
+            );
             return self
                 .send_snapshot_error(stream, SnapshotError::InvalidBoundary)
                 .await;
@@ -224,21 +251,23 @@ impl SyncManager {
             schema_app_key,
         )?;
 
-        // Post-iteration recheck: verify root hash hasn't changed during page generation.
-        // This is a safety guardrail in addition to the RocksDB snapshot iterator.
-        let current_context = self.context_client.get_context(&context_id)?;
-        if let Some(ctx) = current_context {
-            if ctx.root_hash != boundary_root_hash {
-                warn!(
-                    %context_id,
-                    expected = %boundary_root_hash,
-                    actual = %ctx.root_hash,
-                    "Root hash changed during snapshot generation"
-                );
-                return self
-                    .send_snapshot_error(stream, SnapshotError::InvalidBoundary)
-                    .await;
-            }
+        // Post-iteration recheck: verify the state hasn't moved during page
+        // generation. A safety guardrail in addition to the point-in-time
+        // iterator above. Reads the state root for the same reason the
+        // pre-generation check does: `ContextMeta.root_hash` lags a committed
+        // state write, so it cannot see the very change this recheck exists to
+        // catch.
+        let state_root = served_state_root(self.context_client.datastore(), context_id)?;
+        if state_root != boundary_root_hash {
+            warn!(
+                %context_id,
+                expected = %boundary_root_hash,
+                actual = %state_root,
+                "Root hash changed during snapshot generation"
+            );
+            return self
+                .send_snapshot_error(stream, SnapshotError::InvalidBoundary)
+                .await;
         }
 
         info!(%context_id, pages = pages.len(), total_entries, "Streaming snapshot");
@@ -1397,6 +1426,35 @@ struct SnapshotBoundary {
     dag_heads: Vec<[u8; 32]>,
 }
 
+/// The hash a snapshot boundary is validated against: the root of the state
+/// [`generate_snapshot_pages`] will actually read.
+///
+/// Reads the context's ROOT `Index` entry, **not** `ContextMeta.root_hash`.
+/// The two agree whenever no write is in flight, but they are not
+/// interchangeable: a local execution commits context state
+/// (`storage.commit()`) well before it persists the new root hash into
+/// `ContextMeta` — see `crates/context/src/handlers/execute/mod.rs` — so for
+/// the duration of that window the metadata still reports the pre-write hash
+/// while every entity a snapshot would read has already moved. A boundary
+/// check reading the metadata there sees nothing wrong and streams
+/// post-boundary state under a pre-boundary hash.
+///
+/// The receiver cannot recover from that on its own. It recomputes the root
+/// from the state it received, finds it disagrees with the hash it was
+/// promised, and adopts the mismatching hash anyway (see
+/// [`SyncManager::request_snapshot_sync`]). It then advertises a root whose
+/// state it does not hold, which satisfies every root-hash equality check —
+/// including the one in `protocol_selector` — so no repair is ever triggered.
+///
+/// The ROOT `Index` entry is rewritten in the same batch as the entities it
+/// covers, so reading through it observes exactly the state that will be
+/// served.
+fn served_state_root(store: &Store, context_id: ContextId) -> Result<Hash> {
+    Ok(Hash::from(
+        ContextRegistry::new(store.clone()).compute_root_hash(&context_id)?,
+    ))
+}
+
 /// Generate snapshot pages. Returns `(pages, next_cursor, total_entries)`,
 /// where `total_entries` is the grand total of shippable `Entity` records at
 /// this boundary — every entity with both an `Index` and an `Entry`, counted
@@ -1439,10 +1497,13 @@ struct SnapshotBoundary {
 ///
 /// **Read consistency:** the discovery scan uses a snapshot
 /// iterator, but the per-bundle value lookups in step 3 hit the
-/// live store. That is safe because `stream_snapshot_pages`
-/// re-reads `root_hash` after generation and rejects the snapshot
-/// with `InvalidBoundary` if the context mutated in the meantime, so
-/// a torn read can never be shipped to a peer.
+/// live store. What makes that safe is that `stream_snapshot_pages`
+/// re-checks the boundary after generation via [`served_state_root`]
+/// and rejects the snapshot with `InvalidBoundary` if the state moved
+/// in the meantime. The re-check has to read the *state* root: it used
+/// to compare `ContextMeta.root_hash`, which lags a committed state
+/// write, so it could not see the very mutation it existed to catch
+/// and a torn read did reach peers.
 fn generate_snapshot_pages<L: calimero_store::layer::ReadLayer>(
     handle: &calimero_store::Handle<L>,
     context_id: ContextId,
@@ -2151,9 +2212,13 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use calimero_primitives::application::ApplicationId;
     use calimero_primitives::context::ContextId;
     use calimero_storage::index::EntityIndex;
     use calimero_store::db::InMemoryDB;
+    use calimero_store::key::ApplicationMeta as ApplicationMetaKey;
+    use calimero_store::key::ContextMeta as ContextMetaKey;
+    use calimero_store::types::ContextMeta as ContextMetaValue;
     use calimero_store::Store;
 
     use super::*;
@@ -2452,6 +2517,114 @@ mod tests {
         assert!(
             totals.iter().all(|&t| t == 4),
             "total_entries drifted: {totals:?}"
+        );
+    }
+
+    /// Seed the `ContextMeta` row, whose `root_hash` the serve path used to
+    /// gate on.
+    fn put_context_meta(store: &Store, ctx: ContextId, root_hash: [u8; 32]) {
+        let mut handle = store.handle();
+        handle
+            .put(
+                &ContextMetaKey::new(ctx),
+                &ContextMetaValue::new(
+                    ApplicationMetaKey::new(ApplicationId::from([9u8; 32])),
+                    root_hash,
+                    vec![],
+                    None,
+                ),
+            )
+            .unwrap();
+    }
+
+    /// Write the context's ROOT `Index` entry carrying `full_hash`.
+    ///
+    /// This is the entry `compute_root_hash` reads, and in production it is
+    /// rewritten in the same batch as the entities it covers — which is why
+    /// reading through it sees the state a snapshot will actually serve.
+    fn put_root_index(store: &Store, ctx: ContextId, full_hash: [u8; 32]) {
+        let root = Id::new(*ctx);
+        let index_bytes = borsh::to_vec(&EntityIndex::minimal_for_test_with_full_hash(
+            root, full_hash,
+        ))
+        .unwrap();
+        store
+            .handle()
+            .put(
+                &ContextStateKey::new(ctx, StorageKey::Index(root).to_bytes()),
+                &ContextStateValue::from(Slice::from(index_bytes)),
+            )
+            .unwrap();
+    }
+
+    /// The hash the serve path validates a requested boundary against — the
+    /// same function both guard sites call, so a regression that points them
+    /// back at `ContextMeta.root_hash` fails this test.
+    fn boundary_guard_hash(store: &Store, ctx: ContextId) -> Hash {
+        served_state_root(store, ctx).unwrap()
+    }
+
+    /// Two snapshots generated under the same boundary hash must carry the
+    /// same state. If the payload can move while the boundary hash sits
+    /// still, the sender streams state its announced boundary does not
+    /// describe — and the receiver has no way to tell.
+    ///
+    /// Two checks on the serve path exist to prevent exactly that:
+    /// `handle_snapshot_stream_request` before page generation, and the
+    /// recheck in `stream_snapshot_pages` after it. Both used to compare
+    /// `ContextMeta.root_hash`, and neither could see a write that had
+    /// committed its *state* but not yet its *metadata* — a window a local
+    /// execution leaves open on every call, because
+    /// `crates/context/src/handlers/execute/mod.rs` commits context state
+    /// roughly 250us before it persists the new root hash into `ContextMeta`.
+    /// A snapshot generated inside it read post-write state and validated
+    /// against a pre-write hash.
+    #[test]
+    fn same_boundary_hash_must_mean_same_snapshot_payload() {
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let ctx = ContextId::from([7u8; 32]);
+
+        // State as of the announced boundary. The ROOT index and the metadata
+        // agree on the hash that describes it, as they do whenever no write is
+        // in flight.
+        let boundary = [0xB1_u8; 32];
+        for id in [[1u8; 32], [2u8; 32], [3u8; 32]] {
+            put_entity(&store, ctx, id, 64);
+        }
+        put_root_index(&store, ctx, boundary);
+        put_context_meta(&store, ctx, boundary);
+
+        let guard_before = boundary_guard_hash(&store, ctx);
+        let (payload_before, _) =
+            drain_all_pages(&store, ctx, DEFAULT_PAGE_LIMIT, DEFAULT_PAGE_BYTE_LIMIT);
+        assert_eq!(
+            guard_before,
+            Hash::from(boundary),
+            "precondition: with no write in flight the guard must agree with \
+             the announced boundary, or the sender could never serve at all"
+        );
+
+        // The concurrent local write, caught mid-execution: the entity and the
+        // ROOT index it updates are committed together, while the `ContextMeta`
+        // root-hash write has not landed yet.
+        put_entity(&store, ctx, [4u8; 32], 64);
+        put_root_index(&store, ctx, [0xB2_u8; 32]);
+
+        let guard_after = boundary_guard_hash(&store, ctx);
+        let (payload_after, _) =
+            drain_all_pages(&store, ctx, DEFAULT_PAGE_LIMIT, DEFAULT_PAGE_BYTE_LIMIT);
+
+        assert_ne!(
+            payload_before, payload_after,
+            "sanity check: a committed state write must be visible to the \
+             snapshot reader, otherwise this test proves nothing"
+        );
+        assert_ne!(
+            guard_before, guard_after,
+            "the snapshot payload moved while the hash the serve path \
+             validates the boundary against did not: the guards accept the \
+             boundary as intact and stream post-boundary state under a \
+             pre-boundary hash"
         );
     }
 

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -381,6 +381,20 @@ impl EntityIndex {
         }
     }
 
+    /// Like [`Self::minimal_for_test`] but with a chosen `full_hash`.
+    ///
+    /// A context's ROOT index carries the hash that
+    /// `ContextRegistry::compute_root_hash` reads, so a test that needs the
+    /// state-derived root to *move* has to be able to set it. Kept childless so
+    /// the reader stays on its offset fast path.
+    #[must_use]
+    pub fn minimal_for_test_with_full_hash(id: Id, full_hash: [u8; 32]) -> Self {
+        Self {
+            full_hash,
+            ..Self::minimal_for_test(id)
+        }
+    }
+
     /// Returns the entity ID.
     #[must_use]
     pub fn id(&self) -> Id {


### PR DESCRIPTION
## The bug

A snapshot could be served across a concurrent local write, handing the receiver post-boundary state under a pre-boundary hash.

The serve path checks the announced boundary twice — before page generation in `handle_snapshot_stream_request`, and again after it in `stream_snapshot_pages` — and both compared `ContextMeta.root_hash`. But a local execution commits context state (`storage.commit()`) well before it persists the new root hash into `ContextMeta`, so for the duration of that window the metadata still reports the pre-write hash while every entity `generate_snapshot_pages` reads has already moved. Both checks see nothing wrong and stream.

The point-in-time iterator does not help here: it is internally consistent, it just captures a state the boundary does not describe.

## Observed

From a `group-subgroup` E2E run ([run 32463110645](https://github.com/calimero-network/core/actions/runs/32463110645/job/96716789916)), sender timeline:

```
.925479  boundary announced, root_hash = 4Nah…   (pre-write)
.926451  `set` begins
.929460  root 4Nah… → B66s… (in memory)
.929670  snapshot payload read + streamed         ← 210us AFTER the state commit
.929697  ContextMeta root_hash persisted
.929952  context cache updated
```

Neither guard fired — zero `Boundary mismatch`, zero `Root hash changed during snapshot generation`.

The receiver then computed `B66s…` from the state it received, found it disagreed with the promised `4Nah…`, and **adopted the mismatching hash anyway**. It was left advertising a root whose state it did not hold, which satisfies every root-hash equality check — including `protocol_selector`'s "root hashes match, already in sync" — so no repair could ever trigger. Proof the hash was a lie: applying the delta that set the key left the root **unchanged** (`old_root_hash=B66s… new_root_hash=B66s…`) — the state changed, the hash did not.

Downstream, the scenario's `wait_for_sync` reported convergence in `0.00s` (it compares root hashes across nodes) and the following read returned `null`, losing to the real apply by 4ms.

## The fix

Both checks now read the root through the context's ROOT `Index` entry (`served_state_root()`), which is rewritten in the same batch as the entities it covers — so the comparison observes exactly the state that will be served.

## Why this is safe

`execute` sets `ContextMeta.root_hash` from the WASM-reported root *even when `storage.is_empty()`*, so if the two sources could diverge in quiescence this change would break snapshot serving outright. Checked against a fully passing master run at this PR's base commit:

| across 30 passing scenarios (132 node logs) | count |
| --- | --- |
| snapshot syncs | 51 |
| `Snapshot root hash verified successfully` | **51** |
| `Snapshot root hash mismatch` | **0** |
| `Boundary mismatch - state changed during sync` | 6 |

51/51 agreement means the two sources are interchangeable outside the window. The 6 legitimate firings confirm the guard is load-bearing rather than a no-op — this narrows a hole in a check that already works. A boundary rejected inside the window is self-healing: the receiver retries once the metadata catches up.

## Test

`same_boundary_hash_must_mean_same_snapshot_payload` — hermetic, no timing. Seeds state plus an agreeing ROOT index and `ContextMeta`, drains pages, commits one more entity together with the updated ROOT index (leaving `ContextMeta` stale, exactly the window), drains again, and asserts the guard hash moved because the payload did. It asserts payload-moved first, so it cannot pass vacuously.

Both guard sites and the test call the same `served_state_root()`, and I verified the test **fails** when that function is reverted to reading `ContextMeta` — a regression cannot pass silently. `EntityIndex::minimal_for_test_with_full_hash` was added because the ROOT index hash has to actually move.

## Deliberately not in scope

- **The boundary announcement** in `handle_snapshot_boundary_request` is still metadata-derived. Making it state-derived too would be more coherent and would cut retry churn, but it is wire-visible; the guards alone close this bug.
- **The receiver still adopts a mismatching hash** instead of failing for retry. With the sender fixed that path should stop being reachable from this cause, but it remains the wrong response to a detected torn transfer — it is what turned a caught error into a node advertising state it did not have. Filed as #3596.

## Checks

`cargo fmt --check` clean; clippy `--all-features --tests` clean on both crates; no new rustdoc warnings. Tests: 558 node lib + 325 sync integration + 692 storage, all passing.

⚠️ This is a sync-protocol behaviour change — it wants a full E2E run before merge, not just the unit gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

