### PR TITLE
chore: cut release 0.11.0-rc.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.24"
+version = "0.11.0-rc.25"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Bumps `[workspace.metadata.workspaces].version` to `0.11.0-rc.25`. One line, same shape as every previous cut (`5ae945b5`, `7a25641c`, `25b1967b`).

**31 commits since rc.24.**

> [!WARNING]
> **This is a hard-cutover release: rc.24 and rc.25 nodes cannot talk to each other, and rc.24 delta rows will not decode on rc.25.**
> `4f99416c` (#3557) closes the delta's remaining unauthenticated wire fields and pays three breaks at once, deliberately in one PR: the delta-id preimage changes (every delta id changes), the signed envelope's domain separator goes `calimero/delta/1` → `/2` (old and new nodes reject each other's deltas), and `expected_root_hash` is removed from the persisted delta row **with no migration**. Existing stores need to be recreated, and the fleet needs an atomic rollout — not a rolling one.

## The security fix behind the break

`metadata.updated_at` **is** the LWW comparison key, and for `Public`/`Frozen` entities nothing signed it. On the DAG-catchup and parent-fetch paths a delta arrives as plaintext, so a catchup responder could inflate `updated_at` on a `Public` action and win last-write-wins permanently — no signature to break, and no drift guard to bound it. Timestamps and `ancestors` are now inside the `compute_id` preimage, so the content-address gate already deployed on all five receive paths authenticates them. `Add` and `Update` are also domain-separated; they previously hashed identically, so the variant itself was malleable. The HLC is bound into the envelope payload in the same pass (#3552).

`8e476ed2` (#3565) closes the adjacent hole — parentless deltas that do not declare themselves the root are now rejected.

## Other breaking surfaces

- **`8522491a` (#3571) authz** — one subgroup climb instead of three hand-rolled copies, one possession check instead of two. `RotationNotContinuous` splits into `RotationAccountUnknown` / `RotationNotContinuous { expected, found }`, and `NotPermitted` now names the entity as well as the mask.
- **`b9b4da18` (#3566) account** — one credential shape (`AccountProof<T>`), one verifier (`RootSigned`), proof-carrying `Verified<T>` wrappers on all three statements. Old names survive as aliases.
- **`c50849e3` (#3554) api** — `upgradePolicy` is gone from `GET namespaces`, `namespaces/:id`, `namespaces/for-application/:id` and `groups/:id`. Requests are untouched: both create endpoints still declare the field required. mero-js#104 and swift-sdk#22 landed first; merobox needed nothing.

## Operational fix worth calling out

**`6612a49b` (#3563) store** — a node's store reached **19 GB while holding 109 MB of data** (99.3% write-ahead log, growing ~10.7 GB/day). WAL retention is now bounded and every column family is flushed. Any node running rc.24 or earlier for a sustained period is accumulating this.

## Correctness fixes

- `26b78b18` (#3584) — `POST admin-api/groups/join` returned **500 for any subgroup invitation**: the responder wrapped the key for the namespace while the joiner unwrapped against the subgroup, and `group_id` is folded into the signed bytes. Also `9fae4c15` (#3588), which fetches the inherited subgroup key directly on context join.
- `cd272fe0` (#3593) / `407f3e35` (#3587) — the divergence gate, both halves: the projection trailed live by whatever the DAG had buffered, because the apply handler folded only the delta it was handed and not the pending children the same call unblocked.
- `77b6be28` (#3548) — deltas park on a missing application instead of waiting for it.
- `1ecc0181` (#3582) / `808dbcdb` (#3573) — group add and meroctl now take an account where the endpoint is account-addressed.
- `37893ca3` (#3569) — a client token can read the node's own identity.

## New surface

`1fe0afa7` (#3579) adds `GET /admin-api/groups/:group_id/member-devices`, joining the two identity spaces the API already exposed separately — `groups/:id/members` names accounts, `contexts/:id/identities` names bare signing keys, and nothing mapped one to the other. Needed for naming a record's author, moderating by person rather than by key, and honest member counts.

## Downstream

The wire break is the whole story for consumers. Anything pinning `calimero-server-primitives` or speaking the delta wire format needs a coordinated bump, and every node in a deployment must move together. The `upgradePolicy` removal is already absorbed by mero-js, swift-sdk and merobox.

Verified on this branch: manifest parses (`cargo metadata --no-deps`).
