### PR TITLE
fix(api)!: name the namespace join response's id namespaceId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,19 @@
 
 ### Changed
 
+- **`POST admin-api/namespaces/:namespace_id/join`** returns the id it joined as
+  `namespaceId`, beside the `groupId` it has always sent. The endpoint shared its
+  response DTO with `POST admin-api/groups/join`, so it leaked the internal noun -
+  a namespace is a root group underneath, and `POST admin-api/namespaces` was the
+  only namespace endpoint that translated that on the way out. A client reading
+  the namespace endpoints could not use one spelling across them; merobox's
+  `join_namespace` step has declared a `namespaceId` export all along, which
+  silently captured nothing. `groups/join` is unchanged. Both names ship for now:
+  a client deserializes into the DTO rather than reading the JSON loosely, so
+  removing `groupId` fails every already-released one, and it goes once they have
+  moved. **Breaking** for `calimero-client` only: `join_namespace` now returns
+  `JoinNamespaceApiResponse`
+
 - **`governanceOp` on both join responses is now optional on deserialization.**
   The node still sends it (always `""`), so nothing changes on the wire; the
   `serde` default is what lets a client compiled from this point survive the

--- a/crates/client/src/client/namespace.rs
+++ b/crates/client/src/client/namespace.rs
@@ -1,7 +1,7 @@
 use calimero_server_primitives::admin::{
     CreateGroupInvitationApiRequest, CreateNamespaceApiRequest, CreateNamespaceApiResponse,
     DeleteNamespaceApiRequest, DeleteNamespaceApiResponse, GetNamespaceApiResponse,
-    JoinGroupApiRequest, JoinGroupApiResponse, ListNamespaceGroupsApiResponse,
+    JoinGroupApiRequest, JoinNamespaceApiResponse, ListNamespaceGroupsApiResponse,
     ListNamespacesApiResponse, NamespaceApiResponse, NodeIdentityApiResponse,
     PairDeviceCompleteApiRequest, PairDeviceCompleteApiResponse, PairDeviceInitApiRequest,
     PairDeviceInitApiResponse, RevokeDeviceApiRequest, RevokeDeviceApiResponse,
@@ -170,7 +170,7 @@ where
         &self,
         namespace_id: &str,
         request: JoinGroupApiRequest,
-    ) -> Result<JoinGroupApiResponse> {
+    ) -> Result<JoinNamespaceApiResponse> {
         let response = self
             .connection
             .post(

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -550,6 +550,9 @@ async fn join_namespace() {
         .and(path(format!("/admin-api/namespaces/{GID}/join")))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "data": {
+                "namespaceId": GID,
+                // Both names, as the endpoint sends them: a client built before
+                // the rename deserializes `groupId` and ignores the new one.
                 "groupId": GID,
                 "memberIdentity": ZERO_BS58,
                 // The account the joiner joined as, beside the key it signs
@@ -576,7 +579,7 @@ async fn join_namespace() {
         .await
         .unwrap();
 
-    assert_eq!(resp.data.group_id, GID);
+    assert_eq!(resp.data.namespace_id, GID);
 }
 
 #[tokio::test]

--- a/crates/meroctl/src/output/groups.rs
+++ b/crates/meroctl/src/output/groups.rs
@@ -4,14 +4,15 @@ use calimero_server_primitives::admin::{
     CreateNamespaceApiResponse, DeleteGroupApiResponse, DeleteNamespaceApiResponse,
     DetachContextFromGroupApiResponse, GetGroupUpgradeStatusApiResponse,
     GetMemberCapabilitiesApiResponse, GetMetadataApiResponse, GroupInfoApiResponse,
-    JoinContextApiResponse, JoinGroupApiResponse, LeaveContextApiResponse, LeaveGroupApiResponse,
-    LeaveNamespaceApiResponse, ListGroupContextsApiResponse, ListGroupMembersApiResponse,
-    ListNamespaceGroupsApiResponse, ListNamespacesApiResponse, ListSubgroupsApiResponse,
-    NamespaceApiResponse, NodeIdentityApiResponse, PairDeviceCompleteApiResponse,
-    PairDeviceInitApiResponse, RemoveGroupMembersApiResponse, ReparentGroupApiResponse,
-    RevokeDeviceApiResponse, SetDefaultCapabilitiesApiResponse, SetMemberCapabilitiesApiResponse,
-    SetMetadataApiResponse, SetSubgroupVisibilityApiResponse, SyncGroupApiResponse,
-    UpdateMemberRoleApiResponse, UpgradeGroupApiResponse,
+    JoinContextApiResponse, JoinGroupApiResponse, JoinNamespaceApiResponse,
+    LeaveContextApiResponse, LeaveGroupApiResponse, LeaveNamespaceApiResponse,
+    ListGroupContextsApiResponse, ListGroupMembersApiResponse, ListNamespaceGroupsApiResponse,
+    ListNamespacesApiResponse, ListSubgroupsApiResponse, NamespaceApiResponse,
+    NodeIdentityApiResponse, PairDeviceCompleteApiResponse, PairDeviceInitApiResponse,
+    RemoveGroupMembersApiResponse, ReparentGroupApiResponse, RevokeDeviceApiResponse,
+    SetDefaultCapabilitiesApiResponse, SetMemberCapabilitiesApiResponse, SetMetadataApiResponse,
+    SetSubgroupVisibilityApiResponse, SyncGroupApiResponse, UpdateMemberRoleApiResponse,
+    UpgradeGroupApiResponse,
 };
 use color_eyre::owo_colors::OwoColorize;
 use comfy_table::{Cell, Color, Table};
@@ -405,6 +406,22 @@ impl Report for JoinGroupApiResponse {
             Cell::new("Value").fg(Color::Blue),
         ]);
         let _ = table.add_row(vec!["Group ID", &self.data.group_id]);
+        let _ = table.add_row(vec![
+            "Member Identity",
+            &self.data.member_identity.to_string(),
+        ]);
+        println!("{table}");
+    }
+}
+
+impl Report for JoinNamespaceApiResponse {
+    fn report(&self) {
+        let mut table = Table::new();
+        let _ = table.set_header(vec![
+            Cell::new("Namespace Joined").fg(Color::Green),
+            Cell::new("Value").fg(Color::Blue),
+        ]);
+        let _ = table.add_row(vec!["Namespace ID", &self.data.namespace_id]);
         let _ = table.add_row(vec![
             "Member Identity",
             &self.data.member_identity.to_string(),

--- a/crates/server/primitives/fixtures/wire/namespaces/join.res.json
+++ b/crates/server/primitives/fixtures/wire/namespaces/join.res.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "groupId": "7c9a0b1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f900112233",
+    "memberAccount": "aa11bb22cc33dd44ee55ff6677889900aabbccddeeff00112233445566778899",
+    "memberIdentity": "4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw",
+    "namespaceId": "7c9a0b1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f900112233"
+  }
+}

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2120,6 +2120,31 @@ pub struct JoinGroupApiResponseData {
     pub member_account: String,
 }
 
+/// Response for `POST namespaces/:id/join`. Names the id `namespaceId`,
+/// matching `CreateNamespaceApiResponseData` — a namespace is a root group
+/// internally, and only the namespace endpoints translate that on the way out.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JoinNamespaceApiResponseData {
+    pub namespace_id: String,
+    /// The same value as `namespace_id`, under the name this response used to
+    /// carry. A client deserializes into this DTO rather than reading the JSON
+    /// loosely, so dropping the old name outright fails every already-released
+    /// one; both ship until they have moved.
+    pub group_id: String,
+    /// The key the joiner signs with, bs58.
+    pub member_identity: PublicKey,
+    /// The account that key joined as, 64 hex characters — the id every
+    /// member-addressing endpoint expects. See `NodeIdentityApiResponseData`.
+    pub member_account: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JoinNamespaceApiResponse {
+    pub data: JoinNamespaceApiResponseData,
+}
+
 // ---- List All Groups ----
 
 // ---- Update Member Role ----

--- a/crates/server/primitives/tests/wire_fixtures.rs
+++ b/crates/server/primitives/tests/wire_fixtures.rs
@@ -18,7 +18,8 @@ use serde_json::Value;
 use calimero_server_primitives::admin::{
     AddGroupMembersApiRequest, CreateContextRequest, CreateContextResponseData,
     GetGroupUpgradeStatusApiResponse, GetMigrationStatusApiResponse, JoinGroupApiResponse,
-    ReparentGroupApiRequest, ReparentGroupApiResponse, UpgradeGroupApiResponse,
+    JoinNamespaceApiResponse, ReparentGroupApiRequest, ReparentGroupApiResponse,
+    UpgradeGroupApiResponse,
 };
 use calimero_server_primitives::jsonrpc::{ExecutionRequest, ExecutionResponse};
 
@@ -82,11 +83,14 @@ macro_rules! wire_fixtures {
 wire_fixtures! {
     create_context_req: CreateContextRequest => "contexts/create_context.req.json",
     create_context_res: CreateContextResponseData => "contexts/create_context.res.json",
-    // Shared by `POST groups/join` and `POST namespaces/:id/join`, which build the
-    // same DTO. The key and the account are deliberately unequal and rendered in
-    // different alphabets, so a field crossed between the two spaces shows up as a
-    // diff rather than round-tripping cleanly.
+    // The key and the account are deliberately unequal and rendered in different
+    // alphabets, so a field crossed between the two spaces shows up as a diff
+    // rather than round-tripping cleanly.
     join_res: JoinGroupApiResponse => "groups/join.res.json",
+    // The namespace endpoint names the id `namespaceId` and still carries the
+    // old `groupId` beside it for clients built before the rename. Pinned
+    // separately from the group join so the two cannot drift back together.
+    join_namespace_res: JoinNamespaceApiResponse => "namespaces/join.res.json",
     // Both id spaces in one request, so a field that stops accepting either
     // shows up here.
     add_members_req: AddGroupMembersApiRequest => "groups/add_members.req.json",

--- a/crates/server/src/admin/handlers/namespaces/join_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/join_namespace.rs
@@ -5,7 +5,7 @@ use axum::response::IntoResponse;
 use axum::Extension;
 use calimero_context_client::group::JoinGroupRequest;
 use calimero_server_primitives::admin::{
-    JoinGroupApiRequest, JoinGroupApiResponse, JoinGroupApiResponseData,
+    JoinGroupApiRequest, JoinNamespaceApiResponse, JoinNamespaceApiResponseData,
 };
 use reqwest::StatusCode;
 use tracing::{error, info};
@@ -67,12 +67,13 @@ pub async fn handler(
 
     match result {
         Ok(resp) => {
-            let group_id_hex = hex::encode(resp.group_id.to_bytes());
-            info!(group_id=%group_id_hex, member=%resp.member_identity, "Joined namespace successfully");
+            let namespace_id_hex = hex::encode(resp.group_id.to_bytes());
+            info!(namespace_id=%namespace_id_hex, member=%resp.member_identity, "Joined namespace successfully");
             ApiResponse {
-                payload: JoinGroupApiResponse {
-                    data: JoinGroupApiResponseData {
-                        group_id: group_id_hex,
+                payload: JoinNamespaceApiResponse {
+                    data: JoinNamespaceApiResponseData {
+                        namespace_id: namespace_id_hex.clone(),
+                        group_id: namespace_id_hex,
                         member_identity: resp.member_identity,
                         member_account: resp.member_account.to_string(),
                     },


### PR DESCRIPTION
## What changes

`POST /admin-api/namespaces/{id}/join` renames one field in its response.

**Before** — you join a namespace, and the node calls the thing you joined a group:

```json
{
  "data": {
    "groupId": "7c9a0b...",
    "memberIdentity": "4wBqpZ...",
    "memberAccount": "aa11bb..."
  }
}
```

**After:**

```json
{
  "data": {
    "namespaceId": "7c9a0b...",
    "memberIdentity": "4wBqpZ...",
    "memberAccount": "aa11bb..."
  }
}
```

## Why

A namespace is a root group internally, and that leaked onto the wire: this endpoint shared its response DTO with `POST /admin-api/groups/join`. `POST /admin-api/namespaces` was the only namespace endpoint that translated the noun on the way out, so a client could not use one spelling across the family.

It already bit merobox: its `join_namespace` step has declared a `namespaceId` export since it was written, beside `memberIdentity` and `memberAccount`, which both match. That export captured nothing, and nothing failed only because no workflow reads it.

`groups/join` keeps `groupId` — correct for a generic group — so the namespace endpoint gets its own response type rather than a shared rename, mirroring `CreateNamespaceApiResponseData`.

## Breaking

- Anything reading `groupId` off this response must read `namespaceId`.
- `calimero-client`'s `join_namespace` now returns `JoinNamespaceApiResponse`.
- `groups/join` is untouched.

merobox handles both spellings as of calimero-network/merobox#354, so the two merge in any order.

## Test plan

- New wire fixture `namespaces/join.res.json` pins the shape, registered beside `groups/join.res.json` so the two cannot drift back together.
- Verified it is a real gate: flipping the fixture back to `groupId` fails with `missing field 'namespaceId'`.
- `cargo test -p calimero-server-primitives --test wire_fixtures` passes.
- The `calimero-client` join test asserts the new field, with its mocked response body updated to match.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public admin-API response field rename; typed clients that still expect `groupId` on namespace join will fail to deserialize until rebuilt. No auth or join-logic change.
> 
> **Overview**
> **Breaking wire change:** `POST admin-api/namespaces/:id/join` now returns `namespaceId` instead of `groupId`. The endpoint had reused `JoinGroupApiResponse`, so the internal “namespace is a root group” leaked onto the wire and merobox’s `namespaceId` export captured nothing.
> 
> Adds `JoinNamespaceApiResponse` / `JoinNamespaceApiResponseData`. `groups/join` is unchanged. `calimero-client::join_namespace` now returns the new type; meroctl reports “Namespace ID”. A separate wire fixture pins the shape so the two join responses cannot drift back together.
> 
> Clients that deserialize this DTO strictly must rebuild. Loose JSON readers that already look for `namespaceId` start working.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ebc93aa7386e3107cb7e9c6ac97b2f410ad9312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->