### PR TITLE
feat(sdk): expose the calling account to the guest as env::caller_account()

### DIFF
--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -1265,6 +1265,17 @@ impl E2eKvStore {
         Ok(AccountId::from(env::account_id()).to_string())
     }
 
+    /// The account that ASKED for this call, hex-encoded, or `None` when nobody
+    /// in particular did.
+    ///
+    /// Exists for the e2e: the distinction from `my_account` is invisible from
+    /// outside the guest, so a scenario needs both to prove the node stopped
+    /// answering "who asked" with its own identity. A direct node-owner call has
+    /// no separate caller, so `None` here is the expected result today.
+    pub fn my_caller(&self) -> app::Result<Option<String>> {
+        Ok(env::caller_account().map(|caller| AccountId::from(caller).to_string()))
+    }
+
     /// Add a writer, by ACCOUNT — the writer set grants people, so one grant
     /// covers every device they hold.
     pub fn shared_add_writer(&mut self, writer: AccountId) -> app::Result<()> {

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use async_stream::try_stream;
 use borsh::BorshDeserialize;
+use calimero_account::AccountId;
 use calimero_context_config::types::{ContextGroupId, InvitationFromMember, SignedOpenInvitation};
 use calimero_node_primitives::client::NodeClient;
 use calimero_primitives::application::ApplicationId;
@@ -1603,6 +1604,11 @@ impl ContextClient {
     /// # Returns
     ///
     /// A `Result` containing the `ExecuteResponse` on success, or an `ExecuteError` on failure.
+    ///
+    /// Attributes **no caller**: the guest reads `env::caller_account()` as absent. Every caller
+    /// here is system-initiated (delta apply, sync, cascade, event dispatch). A transport that
+    /// authorized a real principal must call [`execute_with_origin`](Self::execute_with_origin)
+    /// and pass it, or the account it checked is silently dropped.
     pub async fn execute(
         &self,
         context_id: &ContextId,
@@ -1611,14 +1617,18 @@ impl ContextClient {
         payload: Vec<u8>,
         atomic: Option<ContextAtomic>,
     ) -> Result<ExecuteResponse, ExecuteError> {
-        self.execute_with_origin(context_id, executor, method, payload, atomic, None, 0)
+        self.execute_with_origin(context_id, executor, method, payload, atomic, None, None, 0)
             .await
     }
 
-    /// Like [`execute`](Self::execute), but tags the run with the source
-    /// context that dispatched it via `xcall`, surfaced to the guest as
-    /// `env::xcall_origin()`. Pass `None`/`0` for a direct/RPC call; the xcall
-    /// dispatch loop passes `Some(source)` and `parent_depth + 1`.
+    /// Like [`execute`](Self::execute), but carries the two provenance values the
+    /// convenience form leaves absent: `caller_account`, the account the transport
+    /// authorized this call as, and `xcall_origin`, the context that dispatched it.
+    ///
+    /// The xcall dispatch loop passes `None` for `caller_account` deliberately — a
+    /// relayed hop has no direct caller to attribute, and propagating the outer one
+    /// would let any context in the namespace act under a principal that never
+    /// addressed it.
     #[allow(clippy::too_many_arguments, reason = "execution context is wide")]
     pub async fn execute_with_origin(
         &self,
@@ -1627,6 +1637,7 @@ impl ContextClient {
         method: String,
         payload: Vec<u8>,
         atomic: Option<ContextAtomic>,
+        caller_account: Option<AccountId>,
         xcall_origin: Option<ContextId>,
         xcall_depth: u32,
     ) -> Result<ExecuteResponse, ExecuteError> {
@@ -1640,6 +1651,7 @@ impl ContextClient {
                     method,
                     payload,
                     atomic,
+                    caller_account,
                     xcall_origin,
                     xcall_depth,
                 },

--- a/crates/context/primitives/src/messages.rs
+++ b/crates/context/primitives/src/messages.rs
@@ -1,4 +1,5 @@
 use actix::Message;
+use calimero_account::AccountId;
 use calimero_context_config::types::ContextGroupId;
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::ContextId;
@@ -76,6 +77,12 @@ pub struct ExecuteRequest {
     pub method: String,
     pub payload: Vec<u8>,
     pub atomic: Option<ContextAtomic>,
+    /// The account this call was authorized as, surfaced to the guest via
+    /// `env::caller_account()`. `None` means no direct caller to attribute (an
+    /// xcall hop, or a caller authorized by a route naming no account) and must
+    /// never fall back to the node's own account — that is the value the guest
+    /// already reads as `env::account_id()`.
+    pub caller_account: Option<AccountId>,
     /// Source context when this execution is dispatched via `xcall`; `None`
     /// for direct/RPC calls. Surfaced to the guest via `env::xcall_origin()`.
     pub xcall_origin: Option<ContextId>,

--- a/crates/context/src/handlers/create_context.rs
+++ b/crates/context/src/handlers/create_context.rs
@@ -373,6 +373,7 @@ async fn create_context(
         private_storage,
         node_client.clone(),
         false, // init always writes state
+        None,  // creation runs as the node, so `init` has no caller to attribute
         None,  // context init is never an xcall
     )
     .await?;

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -95,6 +95,7 @@ impl Handler<ExecuteRequest> for ContextManager {
             method,
             payload,
             atomic,
+            caller_account,
             xcall_origin,
             xcall_depth,
         }: ExecuteRequest,
@@ -873,6 +874,7 @@ impl Handler<ExecuteRequest> for ContextManager {
                         is_read_only_call,
                         block_writes_for_group,
                         &private_key,
+                        caller_account,
                         xcall_origin,
                     )
                     .await?;
@@ -1258,6 +1260,11 @@ impl Handler<ExecuteRequest> for ContextManager {
                                         &target_executor,
                                         function.clone(),
                                         params.clone(),
+                                        None,
+                                        // A relayed hop has no direct caller.
+                                        // Forwarding the outer one would let any
+                                        // context in the namespace act under a
+                                        // principal that never addressed it.
                                         None,
                                         Some(context_id),
                                         // Child runs one level deeper. The depth
@@ -1938,6 +1945,11 @@ async fn internal_execute(
     // post-exec gate then serves reads but refuses writes (see `handle()`).
     block_writes_for_group: Option<ContextGroupId>,
     identity_private_key: &PrivateKey,
+    // The account the transport authorized this call as, for the guest's
+    // `env::caller_account()`. `None` when no direct caller names one; it is
+    // never widened to this node's own account, which the guest already reads
+    // as `env::account_id()`.
+    caller_account: Option<AccountId>,
     // Source context when this run was dispatched via `xcall`; threaded to the
     // runtime so the guest can read `env::xcall_origin()`. `None` for direct
     // calls.
@@ -2009,6 +2021,7 @@ async fn internal_execute(
         private_storage,
         node_client.clone(),
         is_read_only_call,
+        caller_account,
         xcall_origin,
     )
     .await?;
@@ -2504,6 +2517,7 @@ pub async fn execute(
     mut private_storage: ContextPrivateStorage,
     node_client: NodeClient,
     is_read_only_call: bool,
+    caller_account: Option<AccountId>,
     xcall_origin: Option<ContextId>,
 ) -> eyre::Result<(Outcome, ContextStorage, ContextPrivateStorage)> {
     let context_id = **context;
@@ -2526,6 +2540,7 @@ pub async fn execute(
                     &mut ro_storage,
                     Some(&mut ro_private),
                     Some(node_client),
+                    caller_account,
                     xcall_origin,
                 )?
             } else {
@@ -2538,6 +2553,7 @@ pub async fn execute(
                     &mut storage,
                     Some(&mut private_storage),
                     Some(node_client),
+                    caller_account,
                     xcall_origin,
                 )?
             };

--- a/crates/governance-store/src/node_device.rs
+++ b/crates/governance-store/src/node_device.rs
@@ -2065,3 +2065,52 @@ mod tests {
         assert_eq!(listed, want);
     }
 }
+
+#[cfg(test)]
+mod caller_vs_node_account {
+    use super::*;
+    use crate::test_fixtures::{enrolled, test_group_id, test_store};
+    use crate::{member_account_in_namespace, register_context_in_group};
+    use calimero_primitives::context::ContextId;
+
+    /// The account a call is AUTHORIZED as and the account this node RUNS as are
+    /// different values, and both are real.
+    ///
+    /// Why the guest needs `env::caller_account()` as well as `env::account_id()`:
+    /// the second answers a question about this node and cannot stand in for the
+    /// first. Anything gating per-member permissions on `account_id` grants every
+    /// caller the node's own rights.
+    #[test]
+    fn the_authorized_account_is_not_the_account_this_node_runs_as() {
+        let store = test_store();
+        let ns = test_group_id();
+        let context = ContextId::from([0x77; 32]);
+        register_context_in_group(&store, &ns, &context).expect("register context");
+
+        // This node enrols in the namespace, so it speaks for an account of its own.
+        let own = NodeDeviceRepository::new(&store)
+            .ensure_enrolled(&ns)
+            .expect("enrol this node");
+
+        // A second member of the same group whose binding this node holds — the
+        // ordinary result of applying that member's join op.
+        let (caller_key, caller_account) = enrolled(&store, &ns, 0x42);
+
+        // What the server's membership gate resolves for a call by `caller_key`,
+        // and now carries through to the guest.
+        let authorized_as = member_account_in_namespace(&store, &ns, &caller_key)
+            .expect("read binding")
+            .expect("the caller's key is bound");
+        assert_eq!(authorized_as, caller_account);
+
+        // What the guest reads as `env::account_id()` — this node, positively,
+        // not merely something that happens to differ.
+        let runs_as = account_for_context(&store, &context).expect("node account");
+        assert_eq!(runs_as, own.account);
+
+        assert_ne!(
+            authorized_as, runs_as,
+            "the two identities must stay distinct, or the split buys nothing"
+        );
+    }
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -428,13 +428,18 @@ impl Module {
             private_storage,
             node_client,
             None,
+            None,
         )
     }
 
-    /// Run a method, optionally tagged with the source context that dispatched
-    /// it via `xcall`. `xcall_origin` is surfaced to the guest through
-    /// `env::xcall_origin()` so a target can authorize its caller; `None` for
-    /// direct/RPC calls.
+    /// Run a method, optionally tagged with who asked for it and what dispatched
+    /// it. `caller_account` reaches the guest as `env::caller_account()` and
+    /// `xcall_origin` as `env::xcall_origin()`; both are `None` for a run with no
+    /// direct caller and no dispatching context.
+    ///
+    /// `caller_account` is deliberately NOT defaulted to `account` — the guest
+    /// reads that one as `env::account_id()`, and collapsing the two would put an
+    /// app back to being unable to tell who asked from which node ran it.
     #[allow(clippy::too_many_arguments, reason = "execution context is wide")]
     pub fn run_with_origin<'a>(
         &'a self,
@@ -446,6 +451,7 @@ impl Module {
         storage: &'a mut dyn Storage,
         private_storage: Option<&'a mut dyn Storage>,
         node_client: Option<NodeClient>,
+        caller_account: Option<AccountId>,
         xcall_origin: Option<ContextId>,
     ) -> RuntimeResult<Outcome> {
         let context_id = context;
@@ -454,6 +460,7 @@ impl Module {
 
         let mut context = VMContext::new(input.into(), *context_id, *executor, account);
         context.xcall_origin = xcall_origin.map(|origin| *origin);
+        context.caller_account = caller_account.map(|caller| *caller.as_bytes());
 
         let mut logic = VMLogic::new(storage, private_storage, context, &self.limits, node_client);
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -739,6 +739,101 @@ mod wasm_integration_tests {
         );
     }
 
+    /// A real guest importing `caller_account` links, and reads the CALLER.
+    ///
+    /// The host-function unit tests drive `VMLogic` directly, so they cannot see
+    /// the import table. This one instantiates an actual module that declares
+    /// `(import "env" "caller_account" ...)`: if the name or the signature ever
+    /// disagrees with `calimero-sys`, instantiation fails here rather than at a
+    /// deployed app's first call.
+    ///
+    /// The guest traps on any mismatch, so `returns.is_ok()` is the assertion.
+    #[test]
+    fn a_guest_importing_caller_account_links_and_reads_the_caller() {
+        // Distinct from the node's account and device below, so reading the
+        // wrong one traps.
+        const CALLER_BYTE: u8 = 11;
+
+        let wat = format!(
+            r#"
+            (module
+                (import "env" "caller_account" (func $caller_account (param i64) (result i32)))
+                (import "env" "read_register" (func $read_register (param i64 i64) (result i32)))
+                (memory (export "memory") 1)
+                (func (export "probe")
+                    ;; A caller is present, so the host must report 1.
+                    (if (i32.eqz (call $caller_account (i64.const 0)))
+                        (then unreachable))
+                    ;; BufferMut descriptor at 16: dest ptr = 100, len = 32.
+                    (i64.store (i32.const 16) (i64.const 100))
+                    (i64.store (i32.const 24) (i64.const 32))
+                    (if (i32.eqz (call $read_register (i64.const 0) (i64.const 16)))
+                        (then unreachable))
+                    ;; First and last byte, so a short or zeroed register cannot pass.
+                    (if (i32.ne (i32.load8_u (i32.const 100)) (i32.const {CALLER_BYTE}))
+                        (then unreachable))
+                    (if (i32.ne (i32.load8_u (i32.const 131)) (i32.const {CALLER_BYTE}))
+                        (then unreachable))
+                )
+                (func (export "probe_absent")
+                    ;; No caller, so the host must report 0 and write nothing.
+                    (if (call $caller_account (i64.const 0))
+                        (then unreachable))
+                )
+            )
+        "#
+        );
+        let wasm = wat::parse_str(&wat).expect("Failed to parse WAT");
+        let module = Engine::default()
+            .compile(&wasm)
+            .expect("Failed to compile module");
+
+        let node_account = AccountId::from([7; 32]);
+        let caller = AccountId::from([CALLER_BYTE; 32]);
+
+        let mut storage = InMemoryStorage::default();
+        let present = module
+            .run_with_origin(
+                [0; 32].into(),
+                node_account,
+                [5; 32].into(),
+                "probe",
+                &[],
+                &mut storage,
+                None,
+                None,
+                Some(caller),
+                None,
+            )
+            .expect("Failed to run module");
+        assert!(
+            present.returns.is_ok(),
+            "the guest must see the caller, not the node: {:?}",
+            present.returns
+        );
+
+        let mut storage = InMemoryStorage::default();
+        let absent = module
+            .run_with_origin(
+                [0; 32].into(),
+                node_account,
+                [5; 32].into(),
+                "probe_absent",
+                &[],
+                &mut storage,
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("Failed to run module");
+        assert!(
+            absent.returns.is_ok(),
+            "with no caller the host must report absence, never the node: {:?}",
+            absent.returns
+        );
+    }
+
     /// Test that a simple WASM module runs successfully (baseline test)
     #[test]
     fn test_wasm_execution_success() {

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -89,6 +89,16 @@ pub struct VMContext<'a> {
     /// for direct/RPC calls. Set by the node, never from guest memory, so the
     /// target can trust it. Exposed to the guest via `env::xcall_origin()`.
     pub xcall_origin: Option<[u8; DIGEST_SIZE]>,
+    /// The account the transport authorized this call as; `None` when no direct
+    /// caller names one. Set by the node, never from guest memory. Exposed via
+    /// `env::caller_account()`.
+    ///
+    /// The only one of the three identities here that describes **who asked**;
+    /// [`Self::account_id`] and [`Self::executor_public_key`] both describe this
+    /// node. `None` must stay absent rather than widening to either of them — an
+    /// app testing per-member permissions has to be able to tell "nobody in
+    /// particular" from "the node owner".
+    pub caller_account: Option<[u8; DIGEST_SIZE]>,
 }
 
 impl<'a> VMContext<'a> {
@@ -119,6 +129,7 @@ impl<'a> VMContext<'a> {
             executor_public_key,
             governance_position: None,
             xcall_origin: None,
+            caller_account: None,
         }
     }
 }

--- a/crates/runtime/src/logic/host_functions/system.rs
+++ b/crates/runtime/src/logic/host_functions/system.rs
@@ -575,6 +575,39 @@ impl VMHostFunctions<'_> {
         Ok(())
     }
 
+    /// Writes the account this call was **authorized as** into `dest_register_id`
+    /// and returns `1`, or returns `0` and leaves the register untouched when no
+    /// direct caller names one.
+    ///
+    /// The only identity here that answers *who asked*. [`account_id`](Self::account_id)
+    /// and [`device_id`](Self::device_id) both describe the node that ran the
+    /// call, so an app gating per-member permissions wants this one.
+    ///
+    /// `0` means "nobody in particular" — an xcall hop, or a caller authorized by
+    /// a route naming no account — and is never the node standing in for a
+    /// caller. Treat it as "do not authorize", not as a reason to fall back.
+    ///
+    /// # Errors
+    ///
+    /// * `HostError::InvalidMemoryAccess` if the register operation fails.
+    pub fn caller_account(&mut self, dest_register_id: u64) -> VMLogicResult<u32> {
+        let caller = self.borrow_logic().context.caller_account;
+        let Some(caller) = caller else {
+            return Ok(0);
+        };
+        self.with_logic_mut(|logic| -> VMLogicResult<()> {
+            logic.registers.set(logic.limits, dest_register_id, caller)
+        })?;
+
+        trace!(
+            target: "runtime::host::system",
+            dest_register_id,
+            "caller_account written"
+        );
+
+        Ok(1)
+    }
+
     /// Copies the executing **device**'s public key into a register.
     ///
     /// The replica this node speaks as: unique per installation, and what signs
@@ -1718,6 +1751,85 @@ mod tests {
             host.borrow_logic().registers.get(2).unwrap(),
             &device,
             "device_id must still be the device"
+        );
+    }
+
+    /// `caller_account()` answers with the CALLER, not the node.
+    ///
+    /// The regression gate for the bug this import exists to close: the account
+    /// the transport authorized and the account the node runs as are different
+    /// values, and before this existed only the node's reached the guest. All
+    /// three identities are distinct here, so a host function returning the wrong
+    /// one cannot pass.
+    #[test]
+    fn caller_account_is_the_caller_not_the_node_or_the_device() {
+        let context_id = [3u8; DIGEST_SIZE];
+        let device = [5u8; DIGEST_SIZE];
+        let node_account = calimero_account::AccountId::from([7u8; DIGEST_SIZE]);
+        let caller = calimero_account::AccountId::from([11u8; DIGEST_SIZE]);
+        assert!(
+            [device, *node_account.as_bytes()]
+                .iter()
+                .all(|other| other != caller.as_bytes()),
+            "precondition: all three must differ, or this proves nothing"
+        );
+
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let mut context = VMContext::new(Cow::Owned(vec![]), context_id, device, node_account);
+        context.caller_account = Some(*caller.as_bytes());
+        let mut logic = VMLogic::new(&mut storage, None, context, &limits, None);
+        let mut store = Store::default();
+        let memory =
+            wasmer::Memory::new(&mut store, wasmer::MemoryType::new(1, None, false)).unwrap();
+        let _ = logic.with_memory(memory);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        assert_eq!(host.caller_account(1).unwrap(), 1, "a caller is present");
+        assert_eq!(
+            host.borrow_logic().registers.get(1).unwrap(),
+            caller.as_bytes(),
+            "the guest must be told who asked, not who ran it"
+        );
+
+        // The other two still answer about this node, so the split is intact
+        // rather than caller_account having displaced them.
+        host.account_id(2).unwrap();
+        assert_eq!(
+            host.borrow_logic().registers.get(2).unwrap(),
+            node_account.as_bytes()
+        );
+        host.device_id(3).unwrap();
+        assert_eq!(host.borrow_logic().registers.get(3).unwrap(), &device);
+    }
+
+    /// No direct caller ⇒ `0` and an untouched register, never the node standing
+    /// in. An app that falls back on absence would re-create the original bug,
+    /// so absence has to be distinguishable from any real account.
+    #[test]
+    fn caller_account_is_absent_rather_than_the_node_when_nobody_asked() {
+        let node_account = calimero_account::AccountId::from([7u8; DIGEST_SIZE]);
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        // Left as constructed: `VMContext::new` defaults `caller_account` to
+        // `None`, which is the xcall / no-binding case.
+        let context = VMContext::new(
+            Cow::Owned(vec![]),
+            [3u8; DIGEST_SIZE],
+            [5u8; DIGEST_SIZE],
+            node_account,
+        );
+        let mut logic = VMLogic::new(&mut storage, None, context, &limits, None);
+        let mut store = Store::default();
+        let memory =
+            wasmer::Memory::new(&mut store, wasmer::MemoryType::new(1, None, false)).unwrap();
+        let _ = logic.with_memory(memory);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        assert_eq!(host.caller_account(1).unwrap(), 0, "nobody asked");
+        assert!(
+            host.borrow_logic().registers.get(1).is_err(),
+            "the register must be untouched, not filled with the node's account"
         );
     }
 

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -22,6 +22,7 @@ impl VMLogic<'_> {
             // Not offered by `calimero-sys`, so no new app can reach it.
             fn executor_id(register_id: u64);
             fn xcall_origin(register_id: u64) -> u32;
+            fn caller_account(register_id: u64) -> u32;
 
             fn input(register_id: u64);
             fn value_return(value_ptr: u64);

--- a/crates/sdk/src/env.rs
+++ b/crates/sdk/src/env.rs
@@ -356,6 +356,32 @@ pub fn xcall_origin() -> Option<[u8; 32]> {
     host::xcall_origin()
 }
 
+/// The account this call was **authorized as** — who asked — or `None` when no
+/// direct caller names one.
+///
+/// This is the value to test for per-member permissions. [`account_id`] and
+/// [`device_id`] both describe the node that ran the call, not the requester, so
+/// gating on either grants everyone the node's own rights.
+///
+/// The node sets this from an authenticated key, through the same binding lookup
+/// it uses for itself; it cannot be asserted by the caller. `None` means an xcall
+/// hop or a caller authorized by a route naming no account — treat it as "do not
+/// authorize", never as a reason to fall back to [`account_id`].
+#[must_use]
+pub fn caller_account() -> Option<[u8; 32]> {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let present: bool = unsafe {
+            sys::caller_account(DATA_REGISTER)
+                .try_into()
+                .unwrap_or_else(expected_boolean)
+        };
+        present.then(|| read_register_sized(DATA_REGISTER).expect("caller account present"))
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    host::caller_account()
+}
+
 #[inline]
 #[must_use]
 pub fn input() -> Option<Vec<u8>> {

--- a/crates/sdk/src/env/host.rs
+++ b/crates/sdk/src/env/host.rs
@@ -226,6 +226,12 @@ pub(crate) fn xcall_origin() -> Option<[u8; 32]> {
     None
 }
 
+pub(crate) fn caller_account() -> Option<[u8; 32]> {
+    // `TestHost` drives methods directly rather than through a transport that
+    // authorizes anyone, so a hosted call has no caller to attribute.
+    None
+}
+
 pub(crate) fn input() -> Option<Vec<u8>> {
     // `TestHost` drives methods directly via closures rather than through the
     // JSON-input WASM entrypoint, so there is no input buffer to serve.

--- a/crates/server/src/execute.rs
+++ b/crates/server/src/execute.rs
@@ -8,6 +8,7 @@
 
 use std::pin::pin;
 
+use calimero_account::AccountId;
 use calimero_context_client::client::ContextClient;
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
@@ -32,7 +33,19 @@ pub(crate) enum CallerIdentity<'a> {
     NodeOwner,
 }
 
-/// Whether `caller` may act on `context_id`.
+/// The outcome of the membership gate: whether `caller` may act, and the account
+/// they were authorized as.
+///
+/// The account is carried out rather than dropped because the guest needs it
+/// (`env::caller_account()`). It is `None` whenever no account names this caller
+/// — a `NodeOwner`, or a key authorized by `has_member`'s key-keyed arm without a
+/// binding — and `None` must never be widened into the node's own account.
+pub(crate) struct Authorization {
+    pub authorized: bool,
+    pub account: Option<AccountId>,
+}
+
+/// Whether `caller` may act on `context_id`, and as which account.
 ///
 /// `CallerIdentity::Key` is checked against context membership (resolving the
 /// account the key acts as first, since membership rows are account-keyed).
@@ -47,13 +60,19 @@ pub(crate) fn caller_authorized_for_context(
     ctx_client: &ContextClient,
     context_id: &ContextId,
     caller: &CallerIdentity<'_>,
-) -> eyre::Result<bool> {
+) -> eyre::Result<Authorization> {
     match *caller {
         CallerIdentity::Key(key) => {
             let account = crate::caller_account::for_context(ctx_client, context_id, key);
-            ctx_client.has_member(context_id, key, account)
+            Ok(Authorization {
+                authorized: ctx_client.has_member(context_id, key, account)?,
+                account,
+            })
         }
-        CallerIdentity::NodeOwner => Ok(true),
+        CallerIdentity::NodeOwner => Ok(Authorization {
+            authorized: true,
+            account: None,
+        }),
     }
 }
 
@@ -68,16 +87,18 @@ pub(crate) fn caller_authorized_for_context(
 /// each node owns exactly one identity per context (the namespace identity),
 /// so callers never specify it.
 ///
-/// # Security note — caller vs executor identity
+/// # Security note — three identities, deliberately distinct
 ///
-/// When `CallerIdentity::Key` is used, the **caller's key** gates access (the
-/// membership check). However, the **executor identity** passed to the WASM
-/// runtime is the node's owned key for the context, not the caller's key.
-/// Applications that inspect `executor` inside WASM will see the node's owned
-/// identity, which may have different in-application permissions than the
-/// caller's identity. This is an intentional design: the node always executes
-/// on behalf of its own namespace identity; the caller's key is used only to
-/// authorise the call.
+/// The **executor** passed to the runtime is this node's owned key for the
+/// context, never the caller's: the node holds no private key but its own, and
+/// the executor doubles as the replica id seeding CRDT slots. The **account**
+/// the guest reads as `env::account_id()` is likewise this node's, since a delta
+/// is attributed by its signer. Neither may be substituted for the caller.
+///
+/// The caller is surfaced as a third value, `env::caller_account()`, carried
+/// here from the membership gate that already resolved it. It is what an app
+/// should test for per-member permissions; the other two answer questions about
+/// this node, not about who asked.
 pub(crate) async fn execute_request(
     ctx_client: &ContextClient,
     caller: CallerIdentity<'_>,
@@ -86,8 +107,8 @@ pub(crate) async fn execute_request(
     // Verify the caller is a member of the target context before doing
     // anything else. This prevents a valid token from being used to execute
     // against contexts the caller has no membership in.
-    if matches!(caller, CallerIdentity::Key(_)) {
-        let is_member = caller_authorized_for_context(ctx_client, &request.context_id, &caller)
+    let caller_account = if matches!(caller, CallerIdentity::Key(_)) {
+        let authorization = caller_authorized_for_context(ctx_client, &request.context_id, &caller)
             .map_err(|err| {
                 error!(%err, "Membership lookup failed during execute");
                 ExecutionError::FunctionCallError(
@@ -95,14 +116,16 @@ pub(crate) async fn execute_request(
                 )
             })?;
 
-        if !is_member {
+        if !authorization.authorized {
             return Err(ExecutionError::FunctionCallError(
                 "Caller is not a member of this context".to_owned(),
             ));
         }
+        authorization.account
     } else {
         debug!(context_id=%request.context_id, method=%request.method, "NodeOwner-privileged execute: membership check skipped");
-    }
+        None
+    };
 
     let args =
         serde_json::to_vec(&request.args_json).map_err(|err| ExecutionError::SerdeError {
@@ -111,12 +134,9 @@ pub(crate) async fn execute_request(
 
     // Always auto-resolve the executor identity. Each node has exactly one
     // owned identity per context (the namespace identity). The caller should
-    // not need to specify it.
-    // TODO: pass the caller's key as the executor identity so that WASM
-    // applications that enforce per-member permissions see the actual caller
-    // rather than the node's owned key. Until then, a context member whose
-    // in-WASM permissions are lower than the node-owner's can execute at
-    // the higher privilege level. Tracked as a known limitation.
+    // not need to specify it, and could not be substituted for it: executing as
+    // the caller's key would need that key's private half, which this node does
+    // not hold. Per-member permissions read `env::caller_account()` instead.
     let executor = {
         let members = ctx_client.get_context_members(&request.context_id, Some(true));
         let mut members = pin!(members);
@@ -139,7 +159,16 @@ pub(crate) async fn execute_request(
     };
 
     let outcome = ctx_client
-        .execute(&request.context_id, &executor, request.method, args, None)
+        .execute_with_origin(
+            &request.context_id,
+            &executor,
+            request.method,
+            args,
+            None,
+            caller_account,
+            None,
+            0,
+        )
         .await
         .map_err(ExecutionError::ExecuteError)?;
 

--- a/crates/server/src/execute.rs
+++ b/crates/server/src/execute.rs
@@ -190,3 +190,120 @@ pub(crate) async fn execute_request(
 
     Ok(ExecutionResponse::new(Some(returns)))
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use calimero_account::{AccountGenesis, DeviceCert, DeviceId, KemPublicKey};
+    use calimero_context_config::types::ContextGroupId;
+    use calimero_primitives::context::GroupMemberRole;
+    use calimero_primitives::events::NodeEvent;
+    use calimero_primitives::identity::PrivateKey;
+    use calimero_store::db::InMemoryDB;
+    use calimero_store::Store;
+    use calimero_utils_actix::LazyRecipient;
+    use tokio::sync::broadcast;
+
+    use super::*;
+
+    /// Bind `sign_pk` to a fresh account in `namespace`, the way an applied join
+    /// op does, and return that account.
+    ///
+    /// Mirrors governance-store's own enrolment fixture, which is crate-private
+    /// there. The KEM half is arbitrary because nothing here opens an envelope —
+    /// only the binding lookup matters.
+    fn enrol(store: &Store, namespace: &ContextGroupId, sign_pk: &PublicKey) -> AccountId {
+        let key_bytes: [u8; 32] = *(*sign_pk);
+        let root_sk = PrivateKey::from(key_bytes);
+        let genesis = AccountGenesis::new(root_sk.public_key());
+        let cert = DeviceCert::sign(
+            &root_sk,
+            genesis.account_id(),
+            DeviceId::from(key_bytes),
+            sign_pk,
+            &KemPublicKey::from([0; 32]),
+            0,
+            0,
+        )
+        .expect("the account root signs its own device cert");
+        let account = cert.account;
+        let bindings = calimero_governance_store::AccountBindingRepository::new(store);
+        let _ = bindings
+            .apply_link(namespace, &genesis, &[], &cert)
+            .expect("store the binding");
+        bindings
+            .record_endorser(namespace, account, &account)
+            .expect("record the endorser");
+        // The membership row the account-keyed arm of `has_member` reads. A join
+        // writes both; the binding alone resolves the key but admits nobody.
+        calimero_governance_store::MembershipRepository::new(store)
+            .add_member(namespace, &account, GroupMemberRole::Member)
+            .expect("add the member row");
+        account
+    }
+
+    /// A `ContextClient` over a fresh in-memory store, plus the store to seed.
+    ///
+    /// The returned `TempDir` backs the blob store and must outlive the client.
+    async fn client() -> (ContextClient, Store, tempfile::TempDir) {
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let (event_sender, _) = broadcast::channel::<NodeEvent>(16);
+        let (node_client, blob_dir) =
+            crate::test_support::test_node_client(&store, LazyRecipient::new(), event_sender).await;
+        let ctx_client = ContextClient::new(store.clone(), node_client, LazyRecipient::new());
+        (ctx_client, store, blob_dir)
+    }
+
+    /// The gate hands back the account it authorized, instead of dropping it.
+    ///
+    /// The regression guard for the defect `caller_account` exists to close: this
+    /// account was resolved to answer "may this caller act?" and then discarded,
+    /// leaving the guest to derive a different one from this node's own device
+    /// row. Carrying it out is what makes `env::caller_account()` answerable.
+    #[tokio::test]
+    async fn the_gate_returns_the_account_it_authorized() {
+        let (ctx_client, store, _blob_dir) = client().await;
+        let namespace = ContextGroupId::from([0xAA; 32]);
+        let context_id = ContextId::from([0x77; 32]);
+        calimero_governance_store::register_context_in_group(&store, &namespace, &context_id)
+            .expect("register context");
+
+        let caller_key = PublicKey::from([0x42; 32]);
+        let caller_account = enrol(&store, &namespace, &caller_key);
+
+        let authorization = caller_authorized_for_context(
+            &ctx_client,
+            &context_id,
+            &CallerIdentity::Key(&caller_key),
+        )
+        .expect("gate must not error");
+
+        assert!(authorization.authorized, "an enrolled member may act");
+        assert_eq!(
+            authorization.account,
+            Some(caller_account),
+            "the gate must surface who it authorized, not drop it"
+        );
+    }
+
+    /// A node owner names no separate account, and must not borrow one.
+    ///
+    /// Every call made today takes this branch, so `None` here is what keeps them
+    /// reading as "no direct caller to attribute" rather than silently presenting
+    /// this node as the requester.
+    #[tokio::test]
+    async fn a_node_owner_authorizes_with_no_account() {
+        let (ctx_client, _store, _blob_dir) = client().await;
+
+        let authorization = caller_authorized_for_context(
+            &ctx_client,
+            &ContextId::from([0x77; 32]),
+            &CallerIdentity::NodeOwner,
+        )
+        .expect("gate must not error");
+
+        assert!(authorization.authorized);
+        assert_eq!(authorization.account, None);
+    }
+}

--- a/crates/server/src/jsonrpc/set_ephemeral.rs
+++ b/crates/server/src/jsonrpc/set_ephemeral.rs
@@ -49,11 +49,13 @@ impl Request for SetEphemeralRequest {
 
         if !crate::execute::caller_authorized_for_context(&state.ctx_client, &context_id, &caller)
             .map_err(|err| {
-            error!(%err, %context_id, "Membership lookup failed during set_ephemeral");
-            RpcError::MethodCallError(SetEphemeralError::InternalError(
-                "internal error during membership verification".to_owned(),
-            ))
-        })? {
+                error!(%err, %context_id, "Membership lookup failed during set_ephemeral");
+                RpcError::MethodCallError(SetEphemeralError::InternalError(
+                    "internal error during membership verification".to_owned(),
+                ))
+            })?
+            .authorized
+        {
             return Err(RpcError::MethodCallError(SetEphemeralError::Unauthorized));
         }
 

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -20,6 +20,9 @@ wasm_imports! {
         // Source context of an xcall dispatch; writes the register and returns
         // true only when this execution was invoked via `xcall`.
         fn xcall_origin(register_id: RegisterId) -> Bool;
+        // Account this call was authorized as; writes the register and returns
+        // true only when a direct caller names one.
+        fn caller_account(register_id: RegisterId) -> Bool;
         // --
         fn input(register_id: RegisterId);
         fn value_return(value: Ref<ValueReturn<'_>>);


### PR DESCRIPTION
## Summary

An application's `env::account_id()` returns the account of the node that executed a call, never the account of whoever made it. The caller's account is already resolved server-side to run the membership gate, then discarded; the execute handler independently derives a different account from this node's own device binding.

An app gating per-member permissions therefore tests this node's identity rather than the requester's:

```rust
// Reads as "is this node the owner?", not "is this caller the owner?"
if AccountId::from(env::account_id()) != self.owner {
    app::bail!("only the owner may reset");
}
```

**This is latent, not live.** No shipped auth path produces a second principal — `user_password` is the only provider and stores a username where a public key would go, so every call today resolves to `NodeOwner`. The defect matters because multi-principal is planned: the moment a node serves more than one account, every already-deployed app with a check like the above starts granting the node owner's rights to everyone it serves, with no code change and no error.

## What changes

| Host function | Returns | Purpose |
| --- | --- | --- |
| `env::device_id()` | node's replica id | CRDT mechanics. Unchanged. |
| `env::account_id()` | account this write is attributed to | Storage stamps, owner gates. Unchanged. |
| `env::caller_account()` | account the caller is authorized as | Permission checks. New. |

The executor and the account stay as they were, and neither can stand in for the caller: the node holds no private key but its own (`get_identity` requires `private_key: Some(_)`), and a delta is attributed by its signer, so an op cannot be labelled with an account this node holds no binding for.

`caller_account()` returns `Option`, absent whenever nobody in particular asked — an xcall hop, or a caller authorized by a route that names no account. Propagating the outer caller across an xcall would let any context in the namespace act under a principal that never addressed it (`#[app::xcall]` defaults to `AnyInNamespace`); falling back to the node's account would reproduce the original defect. Absence is therefore distinguishable from every real account and means "do not authorize".

Every call today is `NodeOwner`, which resolves to `None`, so no deployed app changes behaviour.

Also removes the `TODO` in `execute.rs` proposing the caller's key be passed as the executor. That cannot work: the node would need that key's private half, so such a call fails with `Unauthorized` on first use.

## Rollout constraint

This adds a WASM host import. **Nodes must ship before any app built against the new SDK** — an app importing `caller_account` cannot instantiate on a node that does not offer it (`LinkError { UnknownImport }`). New nodes run old apps fine; the incompatibility is one-directional. Merobox cannot catch this, since every node in a run is the same build against fresh state.

## Test plan

Reproduction — the two resolutions disagree for the same call:

```
caller key             : 5TeWSsjg2gbxCyWVniXeCmwM7UtHTCK7svzJr5xYJzHf
authorized as          : a71c3dd073939d81f972525e9788c6b958818e33f30674ef43b4184eef40aa50   <- resolved, then dropped
node's own account     : ae8b82beb817b8bb8cf5beb2e41f04f5ac504e1d83c96258a64ec616fcef282f
guest env::account_id(): ae8b82beb817b8bb8cf5beb2e41f04f5ac504e1d83c96258a64ec616fcef282f
```

| Test | Covers |
| --- | --- |
| `server::execute::tests` (2) | The gate surfaces the account it authorized instead of dropping it; a node owner surfaces none rather than borrowing one. Driven over a real `ContextClient` and store. |
| `governance-store` | The authorized account and the account this node runs as are different values, and both are real. |
| `runtime` host functions (2) | A present caller is written and reports `1`; an absent one reports `0` and leaves the register untouched. |
| `runtime` integration (WAT) | A real guest declaring `(import "env" "caller_account" ...)` links and reads the caller. The only test that exercises the import table. |
| `apps/scaffolding-e2e` | `my_caller()` beside `my_account()`, so merobox runs the path through a genuinely SDK-built app. |

Every gate was confirmed failing before being believed:

| Sabotage | Result |
| --- | --- |
| gate drops the resolved account (**exactly what master does**) | server gate test failed |
| `NodeOwner` presents an account instead of abstaining | server owner test failed |
| host fn falls back to the node's account on absence | absence test failed |
| host fn returns the node's account (the original bug) | both host tests failed, WAT guest trapped |
| import removed from the host table | `LinkError { Import("env", "caller_account", UnknownImport) }` |

### What the tests do not cover

- **No end-to-end merobox scenario for the bypass.** One cannot be written: `ExecutionRequest` carries no caller field, so a scenario's identity comes entirely from its auth token, and `login` (username/password) is the only auth verb available. Every merobox call is `NodeOwner`. The `executor_public_key` field in scenario YAML selects which *node* to send to, not which principal — it never reaches the wire request.
- **The 4 hops between the gate and the runtime** (`ContextClient` → actor → `internal_execute` → `run_with_origin`) are straight parameter passing, type-checked but not directly asserted.

Verification, in a clean target directory: `calimero-runtime` 154, `calimero-governance-store` 586, `calimero-context` 240, `calimero-server` 105, plus `sys` / `sdk` / `context-client` — all passing. `cargo fmt --check` clean. `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` clean. `cargo mero build` on `apps/scaffolding-e2e` succeeds, with the import present in the emitted wasm and `my_caller` in the embedded ABI.