### PR TITLE
fix(sync): stop asserting a pre-staged blob is exactly the stream ceiling

### DIFF
--- a/.github/workflows/app-migration-e2e.yml
+++ b/.github/workflows/app-migration-e2e.yml
@@ -212,6 +212,7 @@ jobs:
           - 37-stranded-resync
           - 38-namespace-invite-join-regression
           - 39-missing-abi-refused
+          - 40-peer-prestages-target-blob
     env:
       WORKFLOW: ${{ matrix.workflow }}
     steps:

--- a/crates/node/primitives/src/client/application/install.rs
+++ b/crates/node/primitives/src/client/application/install.rs
@@ -246,6 +246,7 @@ impl NodeClient {
                     Cursor::new(&artifact.bytes[..]),
                     Some(artifact.bytes.len() as u64),
                     None,
+                    None,
                 )
                 .await?;
             services.push(types::ServiceMeta {
@@ -320,7 +321,7 @@ impl NodeClient {
         );
 
         let (blob_id, size) = self
-            .add_blob(file.compat(), Some(expected_size), None)
+            .add_blob(file.compat(), Some(expected_size), None, None)
             .await?;
         debug!(
             %blob_id,
@@ -403,7 +404,7 @@ impl NodeClient {
 
             let cursor = Cursor::new(&bundle_data[..]);
             let (bundle_blob_id, stored_size) = self
-                .add_blob(cursor, Some(bundle_data.len() as u64), expected_hash)
+                .add_blob(cursor, Some(bundle_data.len() as u64), None, expected_hash)
                 .await?;
 
             debug!(
@@ -430,6 +431,7 @@ impl NodeClient {
                     .map_err(io::Error::other)
                     .into_async_read(),
                 expected_size,
+                None,
                 expected_hash,
             )
             .await?;
@@ -450,7 +452,7 @@ impl NodeClient {
 
         let cursor = Cursor::new(&bundle_data[..]);
         let (bundle_blob_id, stored_size) = self
-            .add_blob(cursor, Some(bundle_data.len() as u64), None)
+            .add_blob(cursor, Some(bundle_data.len() as u64), None, None)
             .await?;
 
         debug!(

--- a/crates/node/primitives/src/client/blob.rs
+++ b/crates/node/primitives/src/client/blob.rs
@@ -37,21 +37,30 @@ impl BlobManager {
         Self { blobstore }
     }
 
+    /// `expected_size` is a length the caller was told and is asserted exactly.
+    /// `max_size` only bounds the stream, for a caller that must cap an
+    /// untrusted sender without knowing how many bytes to expect - passing a
+    /// ceiling as `expected_size` would demand the transfer be exactly that big.
     pub async fn add_blob<S: AsyncRead>(
         &self,
         stream: S,
         expected_size: Option<u64>,
+        max_size: Option<u64>,
         expected_hash: Option<&Hash>,
     ) -> eyre::Result<(BlobId, u64)> {
         debug!(
             expected_size,
+            max_size,
             has_expected_hash = expected_hash.is_some(),
             "add_blob invoked"
         );
 
+        // Either bound caps the write; only `expected_size` is asserted below.
+        let bound = expected_size.or(max_size);
+
         let (blob_id, hash, size) = match self
             .blobstore
-            .put_sized(expected_size.map(Size::Exact), stream)
+            .put_sized(bound.map(Size::Exact), stream)
             .await
         {
             Ok(result) => {
@@ -113,10 +122,11 @@ impl NodeClient {
         &self,
         stream: S,
         expected_size: Option<u64>,
+        max_size: Option<u64>,
         expected_hash: Option<&Hash>,
     ) -> eyre::Result<(BlobId, u64)> {
         self.blob_manager
-            .add_blob(stream, expected_size, expected_hash)
+            .add_blob(stream, expected_size, max_size, expected_hash)
             .await
     }
 
@@ -244,7 +254,7 @@ impl NodeClient {
 
                             // Store the blob locally for future use
                             let (blob_id_stored, _size) = self
-                                .add_blob(data.as_slice(), Some(data.len() as u64), None)
+                                .add_blob(data.as_slice(), Some(data.len() as u64), None, None)
                                 .await?;
 
                             // Verify we stored the correct blob

--- a/crates/node/src/cascade_dispatch_e2e.rs
+++ b/crates/node/src/cascade_dispatch_e2e.rs
@@ -79,7 +79,7 @@ pub(crate) async fn seed_app_blobs(node: &TestNode) -> AppBlobs {
     async fn add(node: &TestNode, bytes: Vec<u8>) -> [u8; 32] {
         let (blob_id, _) = node
             .node_client
-            .add_blob(&bytes[..], None, None)
+            .add_blob(&bytes[..], None, None, None)
             .await
             .expect("seed blob");
         *blob_id.as_ref()
@@ -1059,7 +1059,7 @@ async fn seed_ladder_bundles(node: &TestNode) -> LadderBlobs {
     async fn add(node: &TestNode, bytes: Vec<u8>) -> [u8; 32] {
         let (blob_id, _) = node
             .node_client
-            .add_blob(&bytes[..], None, None)
+            .add_blob(&bytes[..], None, None, None)
             .await
             .expect("seed bundle blob");
         *blob_id.as_ref()

--- a/crates/node/src/sync/blobs.rs
+++ b/crates/node/src/sync/blobs.rs
@@ -97,13 +97,13 @@ impl SyncManager {
         } else {
             MAX_BLOB_STREAM_SIZE_BYTES
         };
-        // The cap is a ceiling, not a length: `add_blob` compares `expected_size`
-        // for EQUALITY, so handing it the ceiling asserts every transfer is
-        // exactly MAX_BLOB_STREAM_SIZE_BYTES. Only assert a size we were told.
-        let expected_size = (size > 0).then_some(size_limit);
+        // Assert only a size the peer advertised; the ceiling still bounds the
+        // stream. Passing the ceiling as the expected size demanded every
+        // transfer be exactly MAX_BLOB_STREAM_SIZE_BYTES.
         let add_task = self.node_client.add_blob(
             poll_fn(|cx| rx.poll_recv(cx)).into_async_read(),
-            expected_size,
+            (size > 0).then_some(size),
+            Some(size_limit),
             None,
         );
 

--- a/crates/node/src/sync/blobs.rs
+++ b/crates/node/src/sync/blobs.rs
@@ -97,9 +97,13 @@ impl SyncManager {
         } else {
             MAX_BLOB_STREAM_SIZE_BYTES
         };
+        // The cap is a ceiling, not a length: `add_blob` compares `expected_size`
+        // for EQUALITY, so handing it the ceiling asserts every transfer is
+        // exactly MAX_BLOB_STREAM_SIZE_BYTES. Only assert a size we were told.
+        let expected_size = (size > 0).then_some(size_limit);
         let add_task = self.node_client.add_blob(
             poll_fn(|cx| rx.poll_recv(cx)).into_async_read(),
-            Some(size_limit),
+            expected_size,
             None,
         );
 

--- a/crates/runtime/src/logic/host_functions/blobs.rs
+++ b/crates/runtime/src/logic/host_functions/blobs.rs
@@ -130,7 +130,7 @@ impl VMHostFunctions<'_> {
                     stream.map(|data: Vec<u8>| Ok::<bytes::Bytes, Error>(data.into()));
                 let reader = byte_stream.into_async_read();
 
-                node_client.add_blob(reader, None, None).await
+                node_client.add_blob(reader, None, None, None).await
             });
 
             //TODO: add assert that no bytes were written during the creation of an empty blob.

--- a/crates/server/src/admin/handlers/blob.rs
+++ b/crates/server/src/admin/handlers/blob.rs
@@ -131,7 +131,7 @@ pub async fn upload_handler(
 
     match state
         .node_client
-        .add_blob(reader, None, expected_hash.as_ref())
+        .add_blob(reader, None, None, expected_hash.as_ref())
         .await
     {
         Ok((blob_id, size)) => {

--- a/workflows/app-migration/40-peer-prestages-target-blob.yml
+++ b/workflows/app-migration/40-peer-prestages-target-blob.yml
@@ -1,0 +1,362 @@
+name: 40 - The peer pre-stages the target blob (v1 → v2, 2-node)
+description: >
+  2-node end-to-end baseline migration. Node 1 (admin) installs
+  migration-suite-v1, creates a namespace + one Open subgroup + one
+  context in the subgroup, invites node 2 via namespace invitation,
+  node 2 materialises subgroup membership via inheritance + joins the
+  context. Node 1 writes v1 state, waits for node 2 to catch up, then
+  runs upgrade_group on the subgroup (per-context, cascade=false)
+  and the node resolves migrate_v1_to_v2 from the target bundle's
+  embedded ABI. Asserts the Migrated event + v2 schema shape
+  on node 1 AND mirrors the post-migration schema_info on node 2 to
+  prove cross-node convergence via context-sync gossip.
+
+  Acts as the regression guard for Root<T> merge semantics: a change
+  there once broke write_migration_state's save_raw call with
+  MergeFailure(NoMergeFunctionRegistered), which this workflow catches
+  at the upgrade_group step.
+
+no_docker: false
+nuke_on_start: true
+nuke_on_end: false
+
+nodes:
+  count: 2
+  image: merod:local
+  prefix: app-migration-baseline
+  base_port: 9220
+  base_rpc_port: 9320
+
+steps:
+  # Phase 1: Install both binaries on the ADMIN node (node 1) only.
+  #
+  # Realistic distribution: node 2 never runs install_application. It
+  # auto-fetches the from-version when it joins the context and the
+  # to-version when the upgrade announces the target blob (pulled over
+  # BlobShare during its lazy migration; the sync-gate leaves BlobShare
+  # open for exactly this). App ids are content-addressed, so node 1's
+  # captured app ids are the same ids node 2 resolves. Proven by the
+  # 01/02 admin-only canary.
+  - name: Install migration-suite-v1 on node 1
+    type: install_application
+    node: app-migration-baseline-1
+    path: dist/com.calimero.migration-suite-1.0.0.mpk
+    dev: true
+    outputs:
+      app_v1: applicationId
+
+  # Node 2 installs v1 ITSELF. Every member who downloads an update from the
+  # registry lands here, and it is the state the baseline never reaches: the
+  # peer meets the upgrade already holding the version-stable ApplicationId,
+  # so the new bytecode arrives by pre-stage rather than a first fetch.
+  - name: Install migration-suite-v1 on node 2 as well
+    type: install_application
+    node: app-migration-baseline-2
+    path: dist/com.calimero.migration-suite-1.0.0.mpk
+    dev: true
+
+  # Phase 2: Node 1 builds namespace + Open subgroup + context.
+  - name: Create namespace on node 1
+    type: create_namespace
+    node: app-migration-baseline-1
+    application_id: "{{app_v1}}"
+    outputs:
+      namespace_id: namespaceId
+
+  - name: Create Open subgroup on node 1
+    # Open visibility lets node 2 materialise its inherited membership
+    # via `join_subgroup_inheritance`.
+    type: create_group_in_namespace
+    node: app-migration-baseline-1
+    namespace_id: "{{namespace_id}}"
+    group_name: "baseline-migration"
+    outputs:
+      group_id: groupId
+
+  - name: Mark subgroup as Open
+    type: set_subgroup_visibility
+    node: app-migration-baseline-1
+    group_id: "{{group_id}}"
+    visibility: open
+
+  - name: Create context in subgroup on node 1 (v1)
+    type: create_context
+    node: app-migration-baseline-1
+    application_id: "{{app_v1}}"
+    group_id: "{{group_id}}"
+    outputs:
+      ctx_id: contextId
+
+  # Phase 3: Invite node 2 to the namespace, then have it materialise
+  # the inherited Open-subgroup + context.
+  - name: Create namespace invitation for node 2
+    type: create_namespace_invitation
+    node: app-migration-baseline-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      namespace_invitation: invitation
+
+  - name: Wait for subgroup visibility + context-registered ops to gossip
+    type: wait
+    seconds: 10
+
+  - name: Node 2 joins namespace
+    type: join_namespace
+    node: app-migration-baseline-2
+    namespace_id: "{{namespace_id}}"
+    invitation: "{{namespace_invitation}}"
+
+  - name: Node 2 materialises subgroup membership via inheritance
+    type: join_subgroup_inheritance
+    node: app-migration-baseline-2
+    group_id: "{{group_id}}"
+
+  - name: Node 2 joins the context
+    type: join_context
+    node: app-migration-baseline-2
+    context_id: "{{ctx_id}}"
+
+  # Phase 4: Write v1 state on node 1, wait for node 2 to catch up.
+  - name: Set description (v1)
+    type: call
+    node: app-migration-baseline-1
+    context_id: "{{ctx_id}}"
+    method: set_description
+    args:
+      description: "set-before-migration"
+
+  - name: Increment counter (v1)
+    type: call
+    node: app-migration-baseline-1
+    context_id: "{{ctx_id}}"
+    method: increment_counter
+
+  - name: Wait for v1 state to sync to node 2
+    type: wait_for_sync
+    context_id: "{{ctx_id}}"
+    nodes:
+      - app-migration-baseline-1
+      - app-migration-baseline-2
+    timeout: 90
+    trigger_sync: true
+
+  - name: Read v1 schema_info on node 1 (sanity)
+    type: call
+    node: app-migration-baseline-1
+    context_id: "{{ctx_id}}"
+    method: schema_info
+    outputs:
+      v1_schema: result
+
+  - name: Assert v1 schema before migration
+    type: json_assert
+    statements:
+      - 'json_subset({{v1_schema}}, {"output": {"schema_version": "1.0.0", "description": "set-before-migration", "counter": "1"}})'
+
+  # Phase 5: Per-context upgrade on the subgroup (cascade=false default).
+  - name: Install migration-suite-v2-add-field on node 1
+    type: install_application
+    node: app-migration-baseline-1
+    path: dist/com.calimero.migration-suite-2.0.0.mpk
+    dev: true
+    outputs:
+      app_v2: applicationId
+
+
+  - name: Assert both versions share one application id (bundle same-id)
+    # Same-package bundles derive ApplicationId = hash(package, signer),
+    # so the second install MUST dedup onto the first id - the upgrade
+    # below then exercises the same-id (blob-only) propagation path.
+    type: json_assert
+    statements:
+      - 'equal("{{app_v1}}", "{{app_v2}}")'
+
+  - name: Upgrade with migrate_v1_to_v2
+    type: upgrade_group
+    node: app-migration-baseline-1
+    group_id: "{{group_id}}"
+    target_application_id: "{{app_v2}}"
+    # The node resolves the migration from the target bundle's embedded
+    # ABI (declared by #[derive(app::Migrate)]). This workflow is the
+    # regression guard for that resolution path.
+
+  # Fixed wait, NOT wait_for_sync: per-context migration apply is
+  # asynchronous and a root_hash-based wait_for_sync polled here exits
+  # vacuously synced because both nodes still hold the identical v1
+  # root at the first poll. The fixed wait covers (a) per-context
+  # migration apply on node 1, (b) context-sync gossip of the new
+  # post-migration state to node 2, (c) docker stdout flush so
+  # assert_log_present can see the "Executing migration" log line.
+  - name: Wait for upgrade + migration to apply + log flush
+    type: wait
+    seconds: 15
+
+  - name: Read the subgroup's upgrade record
+    type: get_group_upgrade_status
+    node: app-migration-baseline-1
+    group_id: "{{group_id}}"
+    outputs:
+      up_status: status
+      up_to_version: toVersion
+
+  - name: Assert the record names the v2 target
+    # Only these two fields carry a value on a per-context upgrade: contexts
+    # swap on demand, so `completedAt` and the counters stay null. Whether the
+    # state actually migrated is the rollup's question, asserted below.
+    type: json_assert
+    statements:
+      - 'equal("{{up_status}}", "completed")'
+      - 'equal("{{up_to_version}}", "2.0.0")'
+
+  # These reads TRIGGER each node's lazy migration: schema_info is not
+  # a state op, so `maybe_lazy_upgrade` fires on each node, migrating
+  # its own v1 state to v2 before serving the read.
+  - name: Read post-migration schema_info on node 1 (triggers lazy migration)
+    type: call
+    node: app-migration-baseline-1
+    context_id: "{{ctx_id}}"
+    method: schema_info
+    outputs:
+      v2_schema_node1: result
+
+  - name: Read post-migration schema_info on node 2 (triggers lazy migration)
+    type: call
+    node: app-migration-baseline-2
+    context_id: "{{ctx_id}}"
+    method: schema_info
+    outputs:
+      v2_schema_node2: result
+
+  # schema_info cannot prove a migration ran: the version string it returns is a
+  # constant compiled into the v2 binary, so it reads "2.0.0" over un-migrated
+  # v1 bytes too. The rollup carries each member's ABI STATE version instead.
+  - name: Wait for both members to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-baseline-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
+  - name: Read the migration-status rollup on node 1 (admin)
+    type: get_migration_status
+    node: app-migration-baseline-1
+    namespace_id: "{{namespace_id}}"
+    outputs:
+      mig_target: target_version
+      mig_expected: expected_members
+      mig_total: total
+      mig_migrated: migrated
+      mig_failed: failed
+      mig_below_target: reported_below_target
+      mig_missing: reported_missing
+      mig_residue: residue_total
+
+  - name: Assert each member migrated its own state, with no residue left
+    type: json_assert
+    statements:
+      # The inherited Open-subgroup member is pinned into the cohort, so a
+      # cohort of 1 would mean node 2's state was never being waited on.
+      - "equal({{mig_expected}}, 2)"
+      - "equal({{mig_total}}, 2)"
+      - "equal({{mig_migrated}}, 2)"
+      - "equal({{mig_failed}}, 0)"
+      # A u32 ABI state version, not the "2.0.0" bundle semver the schema_info
+      # reads compare against.
+      - "equal({{mig_target}}, 2)"
+      # Recomputed from each member's raw report, not read back from core's own
+      # all_migrated, so a rollup with the wrong comparison still fails here.
+      - "equal({{mig_below_target}}, 0)"
+      - "equal({{mig_missing}}, 0)"
+      - "equal({{mig_residue}}, 0)"
+
+  - name: Assert v2 schema on node 1 (v1 data preserved + notes seeded)
+    type: json_assert
+    statements:
+      - 'json_subset({{v2_schema_node1}}, {"output": {"schema_version": "2.0.0"}})'
+      - 'json_subset({{v2_schema_node1}}, {"output": {"description": "set-before-migration", "counter": "1"}})'
+      - 'json_subset({{v2_schema_node1}}, {"output": {"notes": "added in v2"}})'
+
+  - name: Assert v2 schema on node 2 (same shape, proves migration reached node 2)
+    type: json_assert
+    statements:
+      - 'json_subset({{v2_schema_node2}}, {"output": {"schema_version": "2.0.0"}})'
+      - 'json_subset({{v2_schema_node2}}, {"output": {"description": "set-before-migration", "counter": "1"}})'
+      - 'json_subset({{v2_schema_node2}}, {"output": {"notes": "added in v2"}})'
+
+  # Phase 6: v2-only setter on node 1 round-trips to node 2.
+  - name: Node 1 calls v2-only setter set_notes
+    type: call
+    node: app-migration-baseline-1
+    context_id: "{{ctx_id}}"
+    method: set_notes
+    args:
+      notes: "written-post-migration"
+
+  - name: Wait for v2 write to sync to node 2
+    type: wait_for_sync
+    context_id: "{{ctx_id}}"
+    nodes:
+      - app-migration-baseline-1
+      - app-migration-baseline-2
+    timeout: 60
+    trigger_sync: true
+
+  - name: Node 2 reads notes via v2 getter
+    type: call
+    node: app-migration-baseline-2
+    context_id: "{{ctx_id}}"
+    method: get_notes
+    outputs:
+      notes_after_node2: result
+
+  - name: Assert v2-only write reached node 2
+    type: json_assert
+    statements:
+      - 'json_equal({{notes_after_node2}}, {"output": "written-post-migration"})'
+
+  # Phase 7: Teardown (node 1 holds admin authority).
+  - name: Delete context
+    type: delete_context
+    node: app-migration-baseline-1
+    context_id: "{{ctx_id}}"
+
+  - name: Delete subgroup
+    type: delete_group
+    node: app-migration-baseline-1
+    group_id: "{{group_id}}"
+
+
+  # Pre-staging is a prefetch: when it fails the lazy path still completes the
+  # migration, so every outcome assertion in this suite stays green while the
+  # peer silently falls back. Only the node log distinguishes the two, which is
+  # why this scenario asserts on it.
+  #
+  # Regression pinned: passing the stream ceiling as `expected_size` made
+  # add_blob assert every transfer was exactly MAX_BLOB_STREAM_SIZE_BYTES,
+  # so any real bundle failed with "fatal: blob size mismatch".
+  - name: Assert the peer pre-staged the target bytecode rather than failing over
+    type: assert_log_absent
+    nodes:
+      - app-migration-baseline-2
+    patterns:
+      - "failed to pre-stage target app blob"
+      - "blob size mismatch"
+
+  - name: Assert the pre-stage actually ran and succeeded on the peer
+    type: assert_log_present
+    nodes:
+      - app-migration-baseline-2
+    patterns:
+      - "pre-staged target app bytecode for pending upgrade"
+
+  - name: Delete namespace
+    type: delete_namespace
+    node: app-migration-baseline-1
+    namespace_id: "{{namespace_id}}"
+
+  - name: Uninstall v1 on node 1
+    type: uninstall_application
+    node: app-migration-baseline-1
+    application_id: "{{app_v1}}"
+
+stop_all_nodes: false


### PR DESCRIPTION
## Summary

A peer pre-staging the target bytecode for a same-ApplicationId bundle upgrade fails every time:

```
WARN calimero_node::sync::manager: failed to pre-stage target app blob; will retry after backoff
  stage_blob=odTnGdHM6ooRQ4tukG8ofwQ47TRAxQzgx7itASf4RgX  err=fatal: blob size mismatch
```

`initiate_blob_share_process` caps the inbound stream so a rogue sender cannot stream unbounded data, then passes that cap to `add_blob` as `expected_size`. `add_blob` compares it for **equality**, so the transfer is asserted to be exactly `MAX_BLOB_STREAM_SIZE_BYTES` = 500 MB. A ~590 KB bundle is well under the ceiling and fails the assertion.

The only caller that passes `size = 0` is `stage_target_blob`, which cannot know the size ahead of the transfer. Its comment still reads *"0 disables the expected-size check"* - true until #2970 replaced the `if size > 0 { Some(size) } else { None }` it relied on with the ceiling. So pre-staging has been broken since 2026-06-27, and the neighbouring *"Failures are benign - every sync attempt retries"* does not hold for an error that is deterministic and `fatal:`.

The fix keeps both intentions: cap the stream, and only assert a size the peer actually advertised.

## Why nothing caught it

Pre-staging is a prefetch. When it fails the lazy path still completes the migration:

```
lazy upgrade triggered -> replaying upgrade ladder hop -> resolves migration edge
-> AppKey continuity check passed -> Executing migration -> Running WASM migrate_v1_to_v2
```

Every scenario in the suite asserts on final state, which the fallback reaches, so a dead prefetch is invisible to all 35 of them. Nothing was under-asserting migration correctness - the prefetch simply had no assertion.

The baseline also never reaches the state that exercises it: node 2 there never installs anything, while any member who downloads an update from the registry meets the upgrade already holding the version-stable ApplicationId.

## Test plan

New scenario `workflows/app-migration/40-peer-prestages-target-blob.yml` adds that one variable (node 2 installs v1 itself) and asserts on the node log, which is the only place the two paths differ. Registered in the CI matrix, which is an explicit list rather than a glob.

Run locally with merobox in binary mode against the same fixtures, changing only the binary:

| | pre-fix merod | with this fix |
|---|---|---|
| exit code | **1** | **0** |
| `failed to pre-stage target app blob` | 1 | 0 |
| `blob size mismatch` | 1 | 0 |
| `pre-staged target app bytecode for pending upgrade` | 0 | 1 |

Red output on the unfixed binary:

```
✗ assert_log_absent failed on node 'app-migration-baseline-2' line 5908:
  matched pattern 'failed to pre-stage target app blob'
❌ Step 'Assert the peer pre-staged the target bytecode rather than failing over'
```

`00-single-group-migration-baseline` still passes unchanged, and `cargo fmt --check` / `cargo clippy -p calimero-node --all-targets` are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches blob ingest and the blob-share sync path, which is security-relevant for untrusted streams, but the change is a small API split plus an e2e that pins the previously silent prefetch failure.
> 
> **Overview**
> Fixes peer pre-staging of target bytecode on same-`ApplicationId` upgrades. Blob share was passing the inbound size ceiling as `expected_size`, so `add_blob` required every transfer to be exactly `MAX_BLOB_STREAM_SIZE_BYTES` and real bundles failed with `fatal: blob size mismatch`. Lazy migration still succeeded, so existing e2e never saw it.
> 
> `add_blob` now takes a separate `max_size` cap. Only an advertised size is equality-checked; unknown-size shares (pre-stage) stay bounded without that assertion. Call sites are updated accordingly.
> 
> Adds merobox scenario `40-peer-prestages-target-blob`: node 2 installs v1 itself, then asserts logs that pre-stage succeeded rather than falling back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af16cd1ee6c65bde9e6e5865c920dc167eb6459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->