### PR TITLE
test(workflows): drop the keys no step reads

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -8,7 +8,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        MIN_MEROBOX="0.6.58"
+        MIN_MEROBOX="0.6.59"
 
         case "$(uname -m)" in
           x86_64) MEROBOX_ARCH="linux-x86-64" ;;

--- a/apps/abi_conformance/workflows/abi-conformance.yml
+++ b/apps/abi_conformance/workflows/abi-conformance.yml
@@ -25,7 +25,6 @@ steps:
     path: res/abi_conformance.wasm
     nodes:
       - abi-conformance-node-2
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/apps/blobs/workflows/blob-announce-namespace-membership.yml
+++ b/apps/blobs/workflows/blob-announce-namespace-membership.yml
@@ -69,7 +69,6 @@ steps:
     path: "res/blobs.wasm"
     nodes:
       - rust-blob-announce-2
-    capability: member
     outputs:
       context_id: contextId
       inviter_key: memberPublicKey

--- a/apps/blobs/workflows/blob-cross-node-sizes.yml
+++ b/apps/blobs/workflows/blob-cross-node-sizes.yml
@@ -84,7 +84,6 @@ steps:
     path: "res/blobs.wasm"
     nodes:
       - rust-blob-size-2
-    capability: member
     outputs:
       context_id: contextId
 

--- a/apps/blobs/workflows/blob-cross-node-transfer.yml
+++ b/apps/blobs/workflows/blob-cross-node-transfer.yml
@@ -67,7 +67,6 @@ steps:
     path: "res/blobs.wasm"
     nodes:
       - rust-blob-xfer-2
-    capability: member
     outputs:
       context_id: contextId
       inviter_key: memberPublicKey

--- a/apps/blobs/workflows/blobs-example.yml
+++ b/apps/blobs/workflows/blobs-example.yml
@@ -51,7 +51,6 @@ steps:
     path: "res/blobs.wasm"
     nodes:
       - node-blob-2
-    capability: member
     outputs:
       context_id: contextId
       inviter_key: memberPublicKey

--- a/apps/blobs/workflows/blobs.yml
+++ b/apps/blobs/workflows/blobs.yml
@@ -41,7 +41,6 @@ steps:
     path: "res/blobs.wasm"
     nodes:
       - rust-blob-2
-    capability: member
     outputs:
       context_id: contextId
       inviter_key: memberPublicKey

--- a/apps/collaborative-editor/workflows/collaborative-editor.yml
+++ b/apps/collaborative-editor/workflows/collaborative-editor.yml
@@ -32,7 +32,6 @@ steps:
     path: res/collaborative_editor.wasm
     nodes:
       - calimero-node-2
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/apps/components-demo/workflows/components-demo.yml
+++ b/apps/components-demo/workflows/components-demo.yml
@@ -49,7 +49,6 @@ steps:
     path: "./res/components_demo.wasm"
     nodes:
       - new-calimero-node-2
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/apps/kv-store-init/workflows/kv-store-init.yml
+++ b/apps/kv-store-init/workflows/kv-store-init.yml
@@ -25,7 +25,6 @@ steps:
     path: res/kv_store_init.wasm
     nodes:
       - kv-store-init-node-2
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/apps/kv-store-with-handlers/workflows/kv-store-with-handlers.yml
+++ b/apps/kv-store-with-handlers/workflows/kv-store-with-handlers.yml
@@ -25,7 +25,6 @@ steps:
     path: res/kv_store_with_handlers.wasm
     nodes:
       - kvh-node-2
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/apps/kv-store-with-shared-storage/workflows/test_shared_storage.yml
+++ b/apps/kv-store-with-shared-storage/workflows/test_shared_storage.yml
@@ -46,7 +46,6 @@ steps:
     path: "./res/kv_store_with_shared_storage.wasm"
     nodes:
       - new-calimero-node-2
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/apps/kv-store-with-user-and-frozen-storage/workflows/test_frozen_storage.yml
+++ b/apps/kv-store-with-user-and-frozen-storage/workflows/test_frozen_storage.yml
@@ -30,7 +30,6 @@ steps:
     path: "./res/kv_store_with_user_and_frozen_storage.wasm"
     nodes:
       - new-calimero-node-2
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/apps/kv-store-with-user-and-frozen-storage/workflows/test_user_storage.yml
+++ b/apps/kv-store-with-user-and-frozen-storage/workflows/test_user_storage.yml
@@ -30,7 +30,6 @@ steps:
     path: "./res/kv_store_with_user_and_frozen_storage.wasm"
     nodes:
       - new-calimero-node-2
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/apps/kv-store/workflows/bundle-invitation-test.yml
+++ b/apps/kv-store/workflows/bundle-invitation-test.yml
@@ -47,7 +47,6 @@ steps:
     path: dist/com.calimero.kv-store-0.0.0.mpk
     nodes:
       - calimero-node-2
-    capability: member
     outputs:
       context_id: contextId
       inviter_public_key: memberPublicKey

--- a/apps/nested-crdt-test/workflows/nested-crdt-test.yml
+++ b/apps/nested-crdt-test/workflows/nested-crdt-test.yml
@@ -25,7 +25,6 @@ steps:
     path: res/nested_crdt_test.wasm
     nodes:
       - nested-node-2
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/apps/private_data/workflows/example.yml
+++ b/apps/private_data/workflows/example.yml
@@ -29,7 +29,6 @@ steps:
     path: res/private_data.wasm
     nodes:
       - calimero-node-2
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/apps/private_data/workflows/private-data.yml
+++ b/apps/private_data/workflows/private-data.yml
@@ -25,7 +25,6 @@ steps:
     path: res/private_data.wasm
     nodes:
       - rust-private-data-2
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/apps/scaffolding-e2e/workflows/account-facts-cross-namespace.yml
+++ b/apps/scaffolding-e2e/workflows/account-facts-cross-namespace.yml
@@ -139,7 +139,7 @@ steps:
   # Two barriers, because a namespace is a DAG and `wait_for_sync` settles one.
   - name: Settle the join to namespace A
     type: wait_for_sync
-    comment: >-
+    description: >-
       lint-convergence: ok — node-3 is deliberately outside both barriers. It is
       a member of nothing at this point; its only mutation so far is a local
       application install, which no other node reads. Its whole right to act

--- a/apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml
+++ b/apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml
@@ -153,7 +153,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-2
     namespace_id: '{{namespace_id}}'
-    group_alias: private-dm
+    group_name: private-dm
     outputs:
       subgroup_priv: groupId
 
@@ -269,7 +269,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-2
     namespace_id: '{{namespace_id}}'
-    group_alias: open-channel
+    group_name: open-channel
     outputs:
       subgroup_open: groupId
 

--- a/apps/scaffolding-e2e/workflows/e2e.yml
+++ b/apps/scaffolding-e2e/workflows/e2e.yml
@@ -54,7 +54,6 @@ steps:
     path: res/scaffolding_e2e.wasm
     nodes:
       - e2e-node-2
-    capability: member
     outputs:
       context_id: contextId
       node1_key: memberPublicKey

--- a/apps/scaffolding-e2e/workflows/frozen-rga-convergence.yml
+++ b/apps/scaffolding-e2e/workflows/frozen-rga-convergence.yml
@@ -56,7 +56,6 @@ steps:
     path: res/scaffolding_e2e.wasm
     nodes:
       - e2e-node-2
-    capability: member
     outputs:
       context_id: contextId
       node1_key: memberPublicKey

--- a/apps/scaffolding-e2e/workflows/group-join-via-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-join-via-inheritance.yml
@@ -105,7 +105,7 @@ steps:
     type: create_group_in_namespace
     node: join-inherit-node-1
     namespace_id: '{{namespace_id}}'
-    group_alias: open-subgroup
+    group_name: open-subgroup
     outputs:
       subgroup_id: groupId
 

--- a/apps/scaffolding-e2e/workflows/group-kick-and-readd-deny-list.yml
+++ b/apps/scaffolding-e2e/workflows/group-kick-and-readd-deny-list.yml
@@ -142,7 +142,7 @@ steps:
     type: create_group_in_namespace
     node: kick-readd-node-1
     namespace_id: '{{namespace_id}}'
-    group_alias: private-channel
+    group_name: private-channel
     outputs:
       subgroup_id: groupId
 

--- a/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
+++ b/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
@@ -155,7 +155,7 @@ steps:
     type: create_group_in_namespace
     node: kick-rejoin-node-1
     namespace_id: '{{namespace_id}}'
-    group_alias: open-channel
+    group_name: open-channel
     outputs:
       subgroup_id: groupId
 

--- a/apps/scaffolding-e2e/workflows/group-leave-context.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-context.yml
@@ -63,7 +63,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-1
     namespace_id: '{{namespace_id}}'
-    group_alias: leave-context-subgroup
+    group_name: leave-context-subgroup
     outputs:
       subgroup_id: groupId
 

--- a/apps/scaffolding-e2e/workflows/group-leave-member.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-member.yml
@@ -92,7 +92,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-1
     namespace_id: '{{namespace_id}}'
-    group_alias: leave-group-subgroup
+    group_name: leave-group-subgroup
     outputs:
       subgroup_id: groupId
 

--- a/apps/scaffolding-e2e/workflows/group-leave-namespace.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-namespace.yml
@@ -71,7 +71,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-1
     namespace_id: '{{namespace_id}}'
-    group_alias: leave-namespace-subgroup-a
+    group_name: leave-namespace-subgroup-a
     outputs:
       subgroup_a_id: groupId
 
@@ -79,7 +79,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-1
     namespace_id: '{{namespace_id}}'
-    group_alias: leave-namespace-subgroup-b
+    group_name: leave-namespace-subgroup-b
     outputs:
       subgroup_b_id: groupId
 

--- a/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
@@ -160,7 +160,7 @@ steps:
     type: create_group_in_namespace
     node: leave-rejoin-node-1
     namespace_id: '{{namespace_id}}'
-    group_alias: open-channel
+    group_name: open-channel
     outputs:
       subgroup_id: groupId
 

--- a/apps/scaffolding-e2e/workflows/group-member-channel-lifecycle.yml
+++ b/apps/scaffolding-e2e/workflows/group-member-channel-lifecycle.yml
@@ -102,7 +102,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-2
     namespace_id: '{{namespace_id}}'
-    group_alias: should-not-exist
+    group_name: should-not-exist
     expected_failure: true
 
   # --- node-1 grants node-2 the subgroup-management capabilities ---
@@ -141,7 +141,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-2
     namespace_id: '{{namespace_id}}'
-    group_alias: member-channel
+    group_name: member-channel
     outputs:
       subgroup_id: groupId
 

--- a/apps/scaffolding-e2e/workflows/group-membership.yml
+++ b/apps/scaffolding-e2e/workflows/group-membership.yml
@@ -106,7 +106,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-1
     namespace_id: '{{namespace_id}}'
-    group_alias: test-subgroup
+    group_name: test-subgroup
     outputs:
       subgroup_id: groupId
 

--- a/apps/scaffolding-e2e/workflows/group-open-self-join-key-delivery.yml
+++ b/apps/scaffolding-e2e/workflows/group-open-self-join-key-delivery.yml
@@ -111,7 +111,7 @@ steps:
     type: create_group_in_namespace
     node: open-selfjoin-node-1
     namespace_id: '{{namespace_id}}'
-    group_alias: open-channel
+    group_name: open-channel
     outputs:
       subgroup_id: groupId
 

--- a/apps/scaffolding-e2e/workflows/group-remove-from-root-revokes-inherited.yml
+++ b/apps/scaffolding-e2e/workflows/group-remove-from-root-revokes-inherited.yml
@@ -152,7 +152,7 @@ steps:
     type: create_group_in_namespace
     node: revoke-inherit-node-1
     namespace_id: '{{namespace_id}}'
-    group_alias: open-channel
+    group_name: open-channel
     outputs:
       subgroup_id: groupId
 

--- a/apps/scaffolding-e2e/workflows/group-reparent-and-cascade-delete.yml
+++ b/apps/scaffolding-e2e/workflows/group-reparent-and-cascade-delete.yml
@@ -52,7 +52,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-1
     namespace_id: '{{ns_id}}'
-    group_alias: cascade-a
+    group_name: cascade-a
     outputs:
       group_a: groupId
 
@@ -60,7 +60,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-1
     namespace_id: '{{ns_id}}'
-    group_alias: cascade-b
+    group_name: cascade-b
     outputs:
       group_b: groupId
 
@@ -68,7 +68,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-1
     namespace_id: '{{ns_id}}'
-    group_alias: cascade-c-initial
+    group_name: cascade-c-initial
     outputs:
       group_c: groupId
 

--- a/apps/scaffolding-e2e/workflows/group-reparent.yml
+++ b/apps/scaffolding-e2e/workflows/group-reparent.yml
@@ -117,7 +117,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-1
     namespace_id: '{{ns_id}}'
-    group_alias: subgroup-a
+    group_name: subgroup-a
     outputs:
       group_a: groupId
 
@@ -125,7 +125,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-1
     namespace_id: '{{ns_id}}'
-    group_alias: subgroup-b
+    group_name: subgroup-b
     outputs:
       group_b: groupId
 

--- a/apps/scaffolding-e2e/workflows/group-subgroup-cold-sync.yml
+++ b/apps/scaffolding-e2e/workflows/group-subgroup-cold-sync.yml
@@ -102,7 +102,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-1
     namespace_id: '{{namespace_id}}'
-    group_alias: cold-sync-subgroup
+    group_name: cold-sync-subgroup
     outputs:
       subgroup_id: groupId
 

--- a/apps/scaffolding-e2e/workflows/group-subgroup-queued-deltas.yml
+++ b/apps/scaffolding-e2e/workflows/group-subgroup-queued-deltas.yml
@@ -122,7 +122,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-1
     namespace_id: '{{namespace_id}}'
-    group_alias: queued-deltas-subgroup
+    group_name: queued-deltas-subgroup
     outputs:
       subgroup_id: groupId
 

--- a/apps/scaffolding-e2e/workflows/group-subgroup-visibility-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-subgroup-visibility-inheritance.yml
@@ -102,7 +102,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-1
     namespace_id: '{{namespace_id}}'
-    group_alias: open-subgroup
+    group_name: open-subgroup
     outputs:
       subgroup_id: groupId
 

--- a/apps/scaffolding-e2e/workflows/group-subgroup.yml
+++ b/apps/scaffolding-e2e/workflows/group-subgroup.yml
@@ -141,7 +141,7 @@ steps:
     type: create_group_in_namespace
     node: e2e-node-1
     namespace_id: '{{namespace_id}}'
-    group_alias: match-subgroup
+    group_name: match-subgroup
     outputs:
       subgroup_id: groupId
 

--- a/apps/scaffolding-e2e/workflows/kad-routing-from-identify.yml
+++ b/apps/scaffolding-e2e/workflows/kad-routing-from-identify.yml
@@ -77,7 +77,6 @@ steps:
     path: res/scaffolding_e2e.wasm
     nodes:
       - kad-identify-node-2
-    capability: member
     outputs:
       context_id: contextId
 

--- a/apps/scaffolding-e2e/workflows/namespace-owner-writes-in-a-foreign-open-subgroup.yml
+++ b/apps/scaffolding-e2e/workflows/namespace-owner-writes-in-a-foreign-open-subgroup.yml
@@ -143,7 +143,7 @@ steps:
     type: create_group_in_namespace
     node: owner-foreign-sub-node-2
     namespace_id: '{{namespace_id}}'
-    group_alias: foreign-open-subgroup
+    group_name: foreign-open-subgroup
     outputs:
       subgroup_id: groupId
 

--- a/apps/scaffolding-e2e/workflows/simple-sync.yml
+++ b/apps/scaffolding-e2e/workflows/simple-sync.yml
@@ -25,7 +25,6 @@ steps:
     path: res/scaffolding_e2e.wasm
     nodes:
       - e2e-node-2
-    capability: member
     outputs:
       context_id: contextId
       node1_key: memberPublicKey

--- a/apps/scaffolding-e2e/workflows/sorted-set-concurrent-convergence.yml
+++ b/apps/scaffolding-e2e/workflows/sorted-set-concurrent-convergence.yml
@@ -77,7 +77,6 @@ steps:
     path: res/scaffolding_e2e.wasm
     nodes:
       - sortedset-node-2
-    capability: member
     outputs:
       context_id: contextId
       node1_key: memberPublicKey

--- a/apps/team-metrics-custom/workflows/team-metrics-custom.yml
+++ b/apps/team-metrics-custom/workflows/team-metrics-custom.yml
@@ -25,7 +25,6 @@ steps:
     path: res/team_metrics_custom.wasm
     nodes:
       - team-custom-node-2
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/apps/team-metrics-macro/workflows/team-metrics-macro.yml
+++ b/apps/team-metrics-macro/workflows/team-metrics-macro.yml
@@ -25,7 +25,6 @@ steps:
     path: res/team_metrics_macro.wasm
     nodes:
       - team-macro-node-2
-    capability: member
     outputs:
       context_id: contextId
       member_public_key: memberPublicKey

--- a/apps/xcall-example/workflows/xcall.yml
+++ b/apps/xcall-example/workflows/xcall.yml
@@ -346,7 +346,7 @@ steps:
     type: create_group_in_namespace
     node: xcall-authz-1
     namespace_id: "{{ns_n}}"
-    group_alias: subgroup-s
+    group_name: subgroup-s
     outputs:
       sub_s: groupId
 

--- a/workflows/fuzzy-tests/kv-store-with-handlers/fuzzy-test.yml
+++ b/workflows/fuzzy-tests/kv-store-with-handlers/fuzzy-test.yml
@@ -31,7 +31,6 @@ steps:
       - fuzzy-handlers-node-2
       - fuzzy-handlers-node-3
       - fuzzy-handlers-node-4
-    capability: member
     outputs:
       handlers_context_id: contextId
       handlers_node1_key: memberPublicKey

--- a/workflows/fuzzy-tests/kv-store/fuzzy-test.yml
+++ b/workflows/fuzzy-tests/kv-store/fuzzy-test.yml
@@ -31,7 +31,6 @@ steps:
       - fuzzy-kv-node-2
       - fuzzy-kv-node-3
       - fuzzy-kv-node-4
-    capability: member
     outputs:
       kv_context_id: contextId
       node1_key: memberPublicKey
@@ -60,15 +59,14 @@ steps:
   - name: Seed initial data
     type: repeat
     count: 10
-    variable: seed_idx
     steps:
       - type: call
         node: fuzzy-kv-node-1
         context_id: "{{kv_context_id}}"
         method: set
         args:
-          key: "initial_key_{{seed_idx}}"
-          value: "initial_value_{{seed_idx}}"
+          key: "initial_key_{{iteration}}"
+          value: "initial_value_{{iteration}}"
 
   - name: Wait for seed data sync
     type: wait_for_sync

--- a/workflows/fuzzy-tests/scaffolding-e2e/fuzzy-test.yml
+++ b/workflows/fuzzy-tests/scaffolding-e2e/fuzzy-test.yml
@@ -31,7 +31,6 @@ steps:
       - fuzzy-e2e-node-2
       - fuzzy-e2e-node-3
       - fuzzy-e2e-node-4
-    capability: member
     outputs:
       e2e_context_id: contextId
       node1_key: memberPublicKey
@@ -60,7 +59,6 @@ steps:
   - name: Seed initial KV data
     type: repeat
     count: 10
-    variable: seed_idx
     steps:
       - type: call
         node: fuzzy-e2e-node-1
@@ -68,14 +66,13 @@ steps:
         executor_public_key: "{{node1_key}}"
         method: set
         args:
-          key: "seed_key_{{seed_idx}}"
-          value: "seed_value_{{seed_idx}}"
+          key: "seed_key_{{iteration}}"
+          value: "seed_value_{{iteration}}"
 
   # Pre-populate CRDT counters so increment operations always have existing state
   - name: Seed initial CRDT counters
     type: repeat
     count: 5
-    variable: cnt_idx
     steps:
       - type: call
         node: fuzzy-e2e-node-1
@@ -83,13 +80,12 @@ steps:
         executor_public_key: "{{node1_key}}"
         method: increment_g_counter
         args:
-          key: "perf_counter_{{cnt_idx}}"
+          key: "perf_counter_{{iteration}}"
 
   # Pre-populate Vector so get_metric(0) always has an entry to read
   - name: Seed initial metrics vector
     type: repeat
     count: 3
-    variable: metric_idx
     steps:
       - type: call
         node: fuzzy-e2e-node-1


### PR DESCRIPTION
merobox **0.6.59 is released**, and core installs `releases/latest` with no pin — so this is live now. It rejects a key no step declares (calimero-network/merobox#351). Until now such keys were accepted and then ignored, so these scenarios stated an intent the harness never acted on, and went green regardless.

Without this, 46 scenarios fail at validation before a container starts.

| Key | Count | What actually happened |
| --- | --- | --- |
| `group_alias` on `create_group_in_namespace` | 26 | The step declares `group_name`. Every subgroup was born **unnamed** while the YAML read as though it were named. |
| `capability` on `create_mesh` | 27 | Read until March 2026, when calimero-network/merobox#184 moved every invite to `SignedOpenInvitation` and deleted the code behind it. Inert since. |
| `comment` on `wait_for_sync` | 1 | `description` is the field that exists. |
| `variable` on `repeat` | 4 | **A real bug — see below.** |

## `repeat`'s `variable` was doing nothing

`repeat` binds `{{iteration}}`. It has never bound a user-named variable:

```yaml
- type: repeat
  count: 10
  variable: seed_idx                     # never read
  steps:
    - args:
        key: "initial_key_{{seed_idx}}"  # resolved to nothing
```

Ten iterations wrote **the same key**, so the fuzzy tests seeded one row where they meant to seed ten, and the reads afterwards had almost nothing to find. They now use `{{iteration}}`.

## Verification

- merobox's own validator over every workflow in the repo: **132 scenarios, 0 errors**. The 6 remaining hits are `tools/merodb/examples/*.yaml`, which are `merodb migrate --plan` files, not merobox workflows.
- No undeclared keys left anywhere, re-scanned against merobox's `STEP_TYPE_MODELS`.
- The first three groups are no-op removals; the fourth is the fix described above.

## Not here

Collapsing hand-rolled bootstraps into `create_mesh` was in this branch and has been pulled out. CI showed three of the conversions were unsafe — scenarios that write or set capabilities *while solo* before a late joiner arrives, that stop a node between two joins, or that read a member identity captured from `join_namespace`. `create_mesh` expresses none of those. It will come back separately, with those cases excluded and verified on its own CI run, rather than delaying a fix core needs now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-workflow and CI merobox version pin only. Production runtime is unchanged; the fuzzy seed interpolation is a test-data correctness fix.
> 
> **Overview**
> Bumps the merobox floor to **0.6.59** and rewrites workflows so they pass the new “no undeclared keys” validator. Without this, ~46 scenarios fail at parse time.
> 
> **Schema alignment:** `create_mesh` drops the unused `capability: member` field (inert since SignedOpenInvitation). `create_group_in_namespace` uses `group_name` instead of `group_alias` (subgroups were actually created unnamed). One `wait_for_sync` `comment` becomes `description`.
> 
> **Real seed bug:** fuzzy `repeat` steps no longer set a dummy `variable`. They interpolate `{{iteration}}`, so seed loops write distinct keys instead of overwriting one row ten times.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17ee583e1a6ba0e29ab63d385ae243a5c9ba4759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->