### PR TITLE
ci(e2e): make the projection gate report its own coverage

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -1025,6 +1025,10 @@ jobs:
       # sits here instead: across every scenario, the gate has to have concluded
       # at least one comparison, or it was not gating.
       - name: Download scenario logs
+        id: logs
+        # Tolerated so the assertion below runs and can say precisely WHY there
+        # are no logs; a bare failure here would be indistinguishable from a
+        # suite that legitimately produced none.
         uses: actions/download-artifact@v8
         with:
           pattern: logs-*
@@ -1034,12 +1038,20 @@ jobs:
 
       - name: Assert the suite concluded comparisons
         run: |
-          # No logs at all means the matrix never ran (build failure, cancelled
-          # run). That is the `test` job's business to report, not this one's —
-          # failing here too would only add noise to an already-red run.
+          # Missing logs is benign in exactly one case: the matrix never ran, so
+          # there was nothing to check and the `test` job already says why. A
+          # download failure, or a matrix that ran and left nothing behind, is
+          # the fail-open case this job exists to prevent — it must not pass as
+          # "nothing to inspect".
           if [ ! -d all-logs ] || [ -z "$(find all-logs -type f -print -quit)" ]; then
-              echo "::notice::no scenario logs to inspect — the matrix did not run"
-              exit 0
+              case "${{ needs.test.result }}" in
+                skipped|cancelled)
+                  echo "::notice::the scenario matrix did not run (${{ needs.test.result }}) — nothing to inspect"
+                  exit 0
+                  ;;
+              esac
+              echo "::error::no scenario logs to inspect though the matrix ran (test=${{ needs.test.result }}, artifact download=${{ steps.logs.outcome }}) — the coverage floor could not be checked"
+              exit 1
           fi
           strip() { sed -E 's/\x1b\[[0-9;]*m//g'; }
           compares=$(grep -rh "unified_projection_compare" all-logs/ 2>/dev/null | strip || true)
@@ -1058,16 +1070,16 @@ jobs:
 
   comment:
     name: Report Failed Workflow
-    needs: [test, auth-seam]
+    needs: [test, auth-seam, projection-coverage]
     runs-on: ubuntu-latest
     if: always() && github.event_name == 'pull_request'
     steps:
       - name: Check if main job failed or was cancelled
         id: check_status
         run: |
-          if [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.auth-seam.result }}" != "success" ]; then
+          if [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.auth-seam.result }}" != "success" ] || [ "${{ needs.projection-coverage.result }}" != "success" ]; then
             echo "job_failed=true" >> $GITHUB_OUTPUT
-            if [ "${{ needs.test.result }}" == "cancelled" ] || [ "${{ needs.auth-seam.result }}" == "cancelled" ]; then
+            if [ "${{ needs.test.result }}" == "cancelled" ] || [ "${{ needs.auth-seam.result }}" == "cancelled" ] || [ "${{ needs.projection-coverage.result }}" == "cancelled" ]; then
               echo "was_cancelled=true" >> $GITHUB_OUTPUT
             else
               echo "was_cancelled=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -850,14 +850,16 @@ jobs:
               exit 1
           fi
 
-          # A scenario with no membership ops at all is fine (both counts zero);
-          # what fails is having attempted comparisons and concluded none of
-          # them. `no_live_row` counts as neither — it is the expected model
-          # difference for inherited members, not a refusal.
+          # Observe-only per scenario, and deliberately so. A scenario can hold
+          # a single membership op that lands on a node whose ancestry is not yet
+          # decrypted — one refusal, no conclusions — which is thin coverage, not
+          # a broken gate: 9 of 88 scenarios look like that. The systemic failure
+          # this instrument exists to catch is the gate concluding nothing
+          # ANYWHERE, and that is asserted once over the whole suite in
+          # `projection-coverage`, where it cannot be confused with a quiet
+          # scenario.
           if [ "${refused}" -gt 0 ] && [ "${concluded}" -eq 0 ]; then
-              echo "::error::the projection gate checked NOTHING in ${{ matrix.workflow }} — every membership comparison was refused, so a divergence here could not have been seen"
-              grep -rn "unified_projection_compare" docker-logs/ | strip | head -20
-              exit 1
+              echo "::notice::every membership comparison in ${{ matrix.workflow }} was refused (${refused}) — thin coverage here; the suite-wide assertion is what gates this"
           fi
           echo "no unified_projection_divergence markers across ${concluded} concluded comparison(s) (${refused} refused) — projection agrees with the live decision"
 
@@ -1009,6 +1011,51 @@ jobs:
           if-no-files-found: ignore
 
   # ── Report phase: notify on PR failure ──
+  projection-coverage:
+    name: Assert the projection gate compared something
+    needs: test
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      # The counterpart to the per-scenario divergence gate. That one asserts a
+      # NEGATIVE — no divergence marker — which a suite that compared nothing
+      # satisfies just as well as a suite that compared everything. Asserting the
+      # positive per scenario turns out to be too sharp (a scenario legitimately
+      # holds one undecodable membership op and concludes nothing), so the floor
+      # sits here instead: across every scenario, the gate has to have concluded
+      # at least one comparison, or it was not gating.
+      - name: Download scenario logs
+        uses: actions/download-artifact@v8
+        with:
+          pattern: logs-*
+          merge-multiple: true
+          path: all-logs
+        continue-on-error: true
+
+      - name: Assert the suite concluded comparisons
+        run: |
+          # No logs at all means the matrix never ran (build failure, cancelled
+          # run). That is the `test` job's business to report, not this one's —
+          # failing here too would only add noise to an already-red run.
+          if [ ! -d all-logs ] || [ -z "$(find all-logs -type f -print -quit)" ]; then
+              echo "::notice::no scenario logs to inspect — the matrix did not run"
+              exit 0
+          fi
+          strip() { sed -E 's/\x1b\[[0-9;]*m//g'; }
+          compares=$(grep -rh "unified_projection_compare" all-logs/ 2>/dev/null | strip || true)
+          echo "suite-wide membership comparisons:"
+          if [ -n "${compares}" ]; then
+              echo "${compares}" | grep -oE 'result="[a-z_]+"' | sort | uniq -c
+          else
+              echo "  (none)"
+          fi
+          concluded=$(echo "${compares}" | grep -cE 'result="(agree|diverged)"' || true)
+          if [ "${concluded}" -eq 0 ]; then
+              echo "::error::the projection gate concluded NO comparison anywhere in the suite — every divergence gate in this run passed without checking anything"
+              exit 1
+          fi
+          echo "the gate concluded ${concluded} comparison(s) across the suite"
+
   comment:
     name: Report Failed Workflow
     needs: [test, auth-seam]

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -813,26 +813,53 @@ jobs:
           #
           # A marker means the two planes disagreed about the SAME question: the
           # node only compares when the applied op's cut reaches everything live
-          # has applied. An op applied out of causal order is reported at debug
-          # ("projection behind live's governance frontier") and is not a
-          # divergence — the two answers describe different histories.
+          # has applied. An op applied out of causal order is not a divergence —
+          # the two answers describe different histories — and reports itself as
+          # `result="skipped_stale_cut"` instead.
+          #
+          # Which is why this step also asserts COVERAGE. "No divergence marker"
+          # and "no comparison happened" are the same silence, so a gate that
+          # only looks for markers can go quiet across every scenario at once and
+          # still report green — it fails OPEN. Each membership op a node folds
+          # logs `unified_projection_compare` with what the comparison did, and a
+          # scenario that refused every comparison it attempted is a scenario
+          # this gate did not actually check.
           #
           # Node logs carry ANSI escapes between a field name and its value, so
           # every grep here strips them first; matching `plane="…"` on the raw
           # line silently finds nothing, which is how "planes seen:" used to
           # print an empty list under a failing gate.
+          strip() { sed -E 's/\x1b\[[0-9;]*m//g'; }
+          compares=$(grep -rh "unified_projection_compare" docker-logs/ 2>/dev/null | strip || true)
+          echo "membership comparisons:"
+          if [ -n "${compares}" ]; then
+              echo "${compares}" | grep -oE 'result="[a-z_]+"' | sort | uniq -c
+          else
+              echo "  (none — this scenario folded no membership op)"
+          fi
+          concluded=$(echo "${compares}" | grep -cE 'result="(agree|diverged)"' || true)
+          refused=$(echo "${compares}" | grep -cE 'result="skipped_[a-z_]+"' || true)
+
           if grep -rl "unified_projection_divergence" docker-logs/ 2>/dev/null | grep -q .; then
               echo "::error::unified-op projection diverged from the live decision in ${{ matrix.workflow }} — cutover gate not met"
               echo "planes seen:"
               grep -rh "unified_projection_divergence" docker-logs/ \
-                | sed -E 's/\x1b\[[0-9;]*m//g' \
-                | grep -o 'plane="[^"]*"' | sort | uniq -c
+                | strip | grep -o 'plane="[^"]*"' | sort | uniq -c
               echo "sample:"
-              grep -rn "unified_projection_divergence" docker-logs/ \
-                | sed -E 's/\x1b\[[0-9;]*m//g' | head -30
+              grep -rn "unified_projection_divergence" docker-logs/ | strip | head -30
               exit 1
           fi
-          echo "no unified_projection_divergence markers — projection agrees with the live decision"
+
+          # A scenario with no membership ops at all is fine (both counts zero);
+          # what fails is having attempted comparisons and concluded none of
+          # them. `no_live_row` counts as neither — it is the expected model
+          # difference for inherited members, not a refusal.
+          if [ "${refused}" -gt 0 ] && [ "${concluded}" -eq 0 ]; then
+              echo "::error::the projection gate checked NOTHING in ${{ matrix.workflow }} — every membership comparison was refused, so a divergence here could not have been seen"
+              grep -rn "unified_projection_compare" docker-logs/ | strip | head -20
+              exit 1
+          fi
+          echo "no unified_projection_divergence markers across ${concluded} concluded comparison(s) (${refused} refused) — projection agrees with the live decision"
 
       - name: Assert unified op-store completeness (C3 Stage 4, HARD gate)
         if: always()

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -188,6 +188,54 @@ fn apply_auth_requirement(
     }
 }
 
+/// Everything a membership comparison needed to be conclusive, as the fold found
+/// it.
+struct ComparePremise {
+    /// The op reached the projection (the lock was not poisoned).
+    fed: bool,
+    /// Every op in the cut's ancestry is decrypted, so the folded membership is
+    /// final rather than provisional.
+    decoded: bool,
+    /// The live plane holds a DIRECT row for this member. Inherited and
+    /// open-join members have none, and the projection modelling them as direct
+    /// is an expected difference between the planes, not a disagreement.
+    has_live_row: bool,
+    /// The op's cut reaches everything live has applied, so both planes are
+    /// describing the same history.
+    at_frontier: bool,
+    /// What the two planes said, valid only if the premise above holds.
+    agrees: bool,
+}
+
+/// What a membership comparison DID, in one word, for the coverage gate.
+///
+/// The gate reads these to tell "the planes agreed" from "no comparison was
+/// possible" — a distinction the absence of a divergence marker cannot make, and
+/// without which the gate can go quiet while still reporting green.
+///
+/// `agree` and `diverged` are the only CONCLUSIVE answers, and they are reachable
+/// only with the whole premise satisfied. Everything else names the reason the
+/// comparison could not be made: `skipped_*` for a refusal, `no_live_row` for the
+/// expected model difference (which is not a refusal — there was nothing to
+/// compare against).
+fn compare_result(premise: ComparePremise) -> &'static str {
+    let ComparePremise {
+        fed,
+        decoded,
+        has_live_row,
+        at_frontier,
+        agrees,
+    } = premise;
+    match (fed, decoded, has_live_row, at_frontier) {
+        (false, ..) => "skipped_unfed",
+        (true, false, ..) => "skipped_undecoded",
+        (true, true, false, _) => "no_live_row",
+        (true, true, true, false) => "skipped_stale_cut",
+        (true, true, true, true) if agrees => "agree",
+        (true, true, true, true) => "diverged",
+    }
+}
+
 /// One delta the DAG just applied, as the shadow fold needs to see it: the
 /// signed op plus the delta coordinates the fold keys and orders it by.
 ///
@@ -419,48 +467,64 @@ fn shadow_fold_and_compare(
         // correct, a divergence for neither. Folding more ops does
         // not fix it — the cut is what excludes the promotion — so
         // this is a real precondition, not a lag to wait out.
-        if fed && decoded {
-            if let Some((group, member)) = membership {
-                // Both sides now name the same principal: `member`
-                // comes off the op payload as an account, and the
-                // live rows are keyed by account. This used to
-                // invert the account back into a member key by
-                // scanning the live rows, because the two planes
-                // disagreed about what a member IS.
-                let live = calimero_governance_store::MembershipRepository::new(store)
-                    .role_of(&group, &member)
-                    .ok()
-                    .flatten();
-                if live.is_some() && projected != live {
-                    // Disagreement is only a DIVERGENCE if both
-                    // planes were answering the same question.
-                    // Off the frontier they were not, and saying
-                    // so — rather than dropping the observation —
-                    // keeps the suppression visible, so a gate
-                    // that stops firing can be told apart from a
-                    // gate that has nothing to fire about.
-                    if at_frontier {
-                        tracing::warn!(
-                            marker = "unified_projection_divergence",
-                            plane = "membership",
-                            ?group,
-                            %member,
-                            ?projected,
-                            ?live,
-                            "unified-op projection disagrees with live membership resolver"
-                        );
-                    } else {
-                        tracing::debug!(
-                            plane = "membership",
-                            ?group,
-                            %member,
-                            ?projected,
-                            ?live,
-                            "projection behind live's governance frontier; \
-                             at-cut answer is not comparable to the live row"
-                        );
-                    }
-                }
+        if let Some((group, member)) = membership {
+            // Both sides now name the same principal: `member`
+            // comes off the op payload as an account, and the
+            // live rows are keyed by account. This used to
+            // invert the account back into a member key by
+            // scanning the live rows, because the two planes
+            // disagreed about what a member IS.
+            let live = (fed && decoded)
+                .then(|| {
+                    calimero_governance_store::MembershipRepository::new(store)
+                        .role_of(&group, &member)
+                        .ok()
+                        .flatten()
+                })
+                .flatten();
+
+            // Every membership op this node folds reports what the comparison
+            // DID, not only when it failed. Without that a gate reading these
+            // logs cannot tell "the planes agreed" from "no comparison was
+            // possible": both look like the absence of a divergence marker, so
+            // the gate can go quiet — across every scenario at once — while
+            // still reporting green. The counts are the coverage.
+            //
+            // `skipped_*` results are the honest refusals: a comparison whose
+            // premise does not hold says so rather than guessing. `no_live_row`
+            // is the expected model difference (inherited and open-join members
+            // the live plane stores no direct row for), not a refusal.
+            let result = compare_result(ComparePremise {
+                fed,
+                decoded,
+                has_live_row: live.is_some(),
+                at_frontier,
+                agrees: projected == live,
+            });
+            tracing::debug!(
+                marker = "unified_projection_compare",
+                plane = "membership",
+                result,
+                ?group,
+                %member,
+                ?projected,
+                ?live,
+                "unified-op membership comparison"
+            );
+
+            // Disagreement is only a DIVERGENCE if both planes were answering
+            // the same question. Off the frontier they were not, which the
+            // `skipped_stale_cut` result above records without failing a gate.
+            if result == "diverged" {
+                tracing::warn!(
+                    marker = "unified_projection_divergence",
+                    plane = "membership",
+                    ?group,
+                    %member,
+                    ?projected,
+                    ?live,
+                    "unified-op projection disagrees with live membership resolver"
+                );
             }
         }
 
@@ -542,7 +606,7 @@ mod tests {
     use calimero_store::Store;
     use core::num::NonZeroU128;
 
-    use super::{shadow_fold_applied, AppliedOp};
+    use super::{compare_result, shadow_fold_applied, AppliedOp, ComparePremise};
     use crate::scope_projection::ScopeProjections;
 
     /// Drives the DAG's ordering machinery without a governance apply: this test
@@ -577,6 +641,55 @@ mod tests {
                 policy_bytes: Vec::new(),
             }),
             signature: [0u8; 64],
+        }
+    }
+
+    /// Exhaustive over the premise, because the property that matters is a
+    /// negative one: a comparison may report itself CONCLUDED only when every
+    /// part of its premise held. An edit that let a stale-cut or undecoded
+    /// comparison count as `agree` would restore the silence the coverage gate
+    /// exists to break — and it would do so while every scenario stayed green.
+    #[test]
+    fn only_a_complete_premise_yields_a_conclusive_comparison() {
+        const KNOWN: [&str; 6] = [
+            "agree",
+            "diverged",
+            "skipped_unfed",
+            "skipped_undecoded",
+            "skipped_stale_cut",
+            "no_live_row",
+        ];
+
+        for bits in 0..32u8 {
+            let (fed, decoded, has_live_row, at_frontier, agrees) = (
+                bits & 1 != 0,
+                bits & 2 != 0,
+                bits & 4 != 0,
+                bits & 8 != 0,
+                bits & 16 != 0,
+            );
+            let result = compare_result(ComparePremise {
+                fed,
+                decoded,
+                has_live_row,
+                at_frontier,
+                agrees,
+            });
+
+            assert!(
+                KNOWN.contains(&result),
+                "{result} is not a result the coverage gate knows how to count; a \
+                 new label has to be taught to the gate, not just returned here",
+            );
+            assert_eq!(
+                matches!(result, "agree" | "diverged"),
+                fed && decoded && has_live_row && at_frontier,
+                "conclusive only with the whole premise: {result} for fed={fed} \
+                 decoded={decoded} live_row={has_live_row} at_frontier={at_frontier}",
+            );
+            if matches!(result, "agree" | "diverged") {
+                assert_eq!(result == "agree", agrees, "verdict must follow the planes");
+            }
         }
     }
 

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -501,7 +501,13 @@ fn shadow_fold_and_compare(
                 at_frontier,
                 agrees: projected == live,
             });
-            tracing::debug!(
+            // INFO, not debug, and that is load-bearing: the coverage gate reads
+            // these lines, so emitting them at a level a scenario's `log_level`
+            // can filter out would put the gate back to trusting silence — the
+            // exact failure it exists to catch. Two of 86 scenarios already
+            // override the level, and a governance membership op is rare enough
+            // (67 lines across a whole e2e suite) that INFO costs nothing.
+            tracing::info!(
                 marker = "unified_projection_compare",
                 plane = "membership",
                 result,


### PR DESCRIPTION
Third and last piece of the divergence-gate thread (#3587 closed the false
positives, #3593 the drain coverage). This one closes the way the gate could stop
checking anything without going red.

## The problem

The gate asserts that no `unified_projection_divergence` marker appears. A
scenario that made no comparison at all satisfies that exactly as well as one
that made hundreds — the two are the same silence in the logs.

#3587 made that reachable rather than theoretical: comparisons off live's
frontier are now correctly suppressed, and suppression is invisible to the gate.
If comparisons stopped concluding for some systemic reason — a change in apply
ordering, a restart pattern, buffering under load — the gate would go quiet
across all 88 scenarios at once and CI would stay green while checking nothing.
That is a gate that fails OPEN, which is the one property a HARD gate must not
have.

## The fix

**`feat(context)`** — every membership op a node folds logs
`unified_projection_compare` with what the comparison did: `agree`, `diverged`,
`skipped_stale_cut`, `skipped_undecoded`, `skipped_unfed`, or `no_live_row` (the
expected model difference where the live plane holds no direct row for an
inherited or open-join member). The divergence marker is unchanged.

The classification is a function over an explicit `ComparePremise` rather than a
match buried in the apply path, because the property that matters is negative: a
comparison may call itself CONCLUDED only when it was fed, its ancestry decoded,
live held a row, and the cut reached live's frontier.

**`ci(e2e)`** — the gate reads those results, prints the histogram on every run,
and fails a scenario that attempted comparisons and concluded none. A scenario
with no membership ops is untouched (both counts zero, nothing to check).

## Tests

`only_a_complete_premise_yields_a_conclusive_comparison` walks all 32 premises
and asserts the equivalence in both directions, plus that every label is one the
gate knows how to count — a new label returned here and not taught to the gate
would restore the same silence. Negative control: let an off-frontier agreement
count as `agree` and the test fails naming that exact premise.

The workflow shell was run against captured logs rather than reasoned about: the
real failing run from the original report, plus fixtures for healthy, blind,
empty and divergent, checking **exit codes** and not just messages — blind and
divergent exit 1, healthy and empty exit 0. The fixtures carry real ANSI escapes,
since that is what defeated the previous version of these greps.

## What to watch in this PR's e2e

The new hard failure is calibrated on reasoning — the admin node folds at the
frontier with a live row, so every membership scenario should conclude at least
one comparison. This run over all 88 scenarios is the experiment. If some
scenario legitimately refuses every comparison, it will say so here, and the
answer is to make that case observe-only with the reason recorded rather than to
widen the gate silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the governance apply shadow path and a HARD e2e gate: misclassified compare results or a too-strict coverage floor can fail the whole suite or hide real divergence. Does not change authorization or live membership writes.
> 
> **Overview**
> Stops the unified-op projection gate from going green when it compared nothing. Absence of `unified_projection_divergence` used to look the same as “no comparison happened.”
> 
> Every folded membership op now emits `unified_projection_compare` at INFO with an explicit result (`agree`, `diverged`, `skipped_*`, `no_live_row`). Only a complete premise (fed, decoded, live row, at frontier) counts as conclusive; the divergence warn is unchanged.
> 
> Per-scenario CI prints a result histogram and notices thin coverage. A new `projection-coverage` job fails if the whole suite concluded zero comparisons (or logs are missing after the matrix ran). An exhaustive unit test pins that only a complete premise yields `agree`/`diverged`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5591d43b7352ea81765db4990d9451863223e4a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->