### PR TITLE
refactor(context): drop the unreachable ViewUnavailable cause

### DIFF
--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1986,12 +1986,28 @@ impl ScopeProjections {
             .map_err(|_| UndecidableCause::NamespaceUnresolved)?
             .to_bytes();
         let scope = ScopeId::from(namespace_id);
-        if !self.cut_ancestry_complete(&scope, heads) {
+        // One lookup and one walk answer both questions: is the cited ancestry
+        // whole, and what does folding it yield. Asking `cut_ancestry_complete`
+        // and then `acl_view_at` walked the same ancestry twice and left the fold
+        // with a `None` arm no input could reach — completeness had already
+        // established the log exists, so there was nothing left for the fold to
+        // fail on. Holding the log here keeps that unreachable state out of the
+        // types rather than giving it a metric label it could never populate.
+        //
+        // An absent log goes through `classify_unresolvable_cut`, not a bare
+        // `ScopeUnfed`: that function checks truncation FIRST, so a truncated
+        // scope whose log is already evicted keeps reporting the permanent
+        // `LogTruncated` instead of a cause `is_transient` calls self-healing —
+        // which would park the op retrying forever and leave the one series
+        // worth alerting on silent.
+        let Some(log) = self.logs.get(&scope) else {
+            return Err(self.classify_unresolvable_cut(&scope, heads));
+        };
+        let walked = ScopeState::cut_ancestry(log, heads);
+        if !walked.is_complete() {
             return Err(self.classify_unresolvable_cut(&scope, heads));
         }
-        let view = self
-            .acl_view_at(&scope, heads)
-            .ok_or(UndecidableCause::ViewUnavailable)?;
+        let view = ScopeState::acl_view_from_ancestry(&walked);
         let root_group = ContextGroupId::from(namespace_id);
         let root = MetaRepository::new(store)
             .load(&root_group)
@@ -2531,11 +2547,13 @@ mod tests {
     /// SAME two-op ancestry (`add <- remove`) so only the projection's state
     /// differs between cases.
     ///
-    /// The last case is the load-bearing one: with the log shaped exactly as the
-    /// `AncestryGap` case, marking the scope truncated must change the verdict to
-    /// `LogTruncated`. Truncation is *why* the ancestor is missing, and it is
-    /// permanent, so classifying by log shape first would file a node that has
-    /// stalled forever under a cause that reads as "retrying, give it a moment".
+    /// The two truncation cases are the load-bearing ones. With the log shaped
+    /// exactly as the `AncestryGap` case, marking the scope truncated must change
+    /// the verdict to `LogTruncated`; and the same must hold once the log is
+    /// evicted outright, where the shape alone reads as an unfed scope. Truncation
+    /// is *why* the ancestry is missing, and it is permanent, so classifying by
+    /// log shape first would file a node that has stalled forever under a cause
+    /// that reads as "retrying, give it a moment".
     #[test]
     fn an_unresolvable_cut_is_classified_by_the_reason_it_cannot_resolve() {
         let scope = ScopeId::from([7u8; 32]);
@@ -2607,6 +2625,27 @@ mod tests {
             UndecidableCause::LogTruncated,
             "a truncated log presents as an ancestry gap; reporting it as one \
              would hide a permanent stall inside a transient-looking cause",
+        );
+
+        // Truncation that evicted the scope's log entirely. By shape this is
+        // indistinguishable from the never-fed case above, so log-shape-first
+        // ordering would call it `ScopeUnfed` — transient, self-healing, retry
+        // forever — for a scope whose history is permanently gone. Callers that
+        // short-circuit an absent log to `ScopeUnfed` themselves, instead of
+        // asking this function, reintroduce exactly that bug.
+        let mut truncated_and_evicted = ScopeProjections::new();
+        let _ = truncated_and_evicted.truncated.insert(scope);
+        let cause = truncated_and_evicted.classify_unresolvable_cut(&scope, &cut);
+        assert_eq!(
+            cause,
+            UndecidableCause::LogTruncated,
+            "an evicted log looks unfed; the truncation mark is the only thing \
+             that distinguishes permanent loss from history that never arrived",
+        );
+        assert!(
+            !cause.is_transient(),
+            "the point of the distinction: this cut can never resolve, so the \
+             op must stop being retried as though it could",
         );
 
         // Sanity: a complete ancestry is not classified at all — the walk

--- a/crates/governance-store/src/metrics.rs
+++ b/crates/governance-store/src/metrics.rs
@@ -349,8 +349,8 @@ impl Metrics {
         //   A sustained rate here is the signal that a namespace's governance
         //   history has outgrown the retained window and that node's governance
         //   DAG has stopped advancing. This is the series to alert on.
-        // - `fold_unavailable` / `namespace_unresolved` / `view_unavailable` —
-        //   a store or mapping fault, not a history gap.
+        // - `fold_unavailable` / `namespace_unresolved` — a store or mapping
+        //   fault, not a history gap.
         //
         // A rate that never decays for a given cause means ops are parked
         // indefinitely, not retrying successfully.
@@ -645,10 +645,6 @@ pub enum UndecidableCause {
     /// The group's namespace could not be resolved (a store or mapping fault).
     /// Not a history gap.
     NamespaceUnresolved,
-    /// The ancestry is complete, but folding it yielded no view. Should not
-    /// happen given a complete ancestry; recorded distinctly so it cannot hide
-    /// inside a history-gap series.
-    ViewUnavailable,
 }
 
 impl UndecidableCause {
@@ -660,7 +656,6 @@ impl UndecidableCause {
             UndecidableCause::LogTruncated => "log_truncated",
             UndecidableCause::FoldUnavailable => "fold_unavailable",
             UndecidableCause::NamespaceUnresolved => "namespace_unresolved",
-            UndecidableCause::ViewUnavailable => "view_unavailable",
         }
     }
 
@@ -757,7 +752,6 @@ mod tests {
             UndecidableCause::LogTruncated,
             UndecidableCause::FoldUnavailable,
             UndecidableCause::NamespaceUnresolved,
-            UndecidableCause::ViewUnavailable,
         ];
 
         let labels: std::collections::HashSet<&str> = all.iter().map(|c| c.as_label()).collect();


### PR DESCRIPTION
## Summary

`UndecidableCause::ViewUnavailable` was built at exactly one site and could not fire there, so its metric label could never be populated.

In `auth_cut_context_or_cause`:

```rust
if !self.cut_ancestry_complete(&scope, heads) {          // logs.get(scope).is_some_and(..)
    return Err(self.classify_unresolvable_cut(&scope, heads));
}
let view = self.acl_view_at(&scope, heads)              // logs.get(scope)?  ← same map, same key
    .ok_or(UndecidableCause::ViewUnavailable)?;         // unreachable
```

`acl_view_at` returns `None` only for a missing log. The completeness check three lines above had already established the log exists, on the same map under the same key with nothing mutating in between — so the only input that could reach the `ok_or` was already excluded.

The variant's doc acknowledged it "should not happen" and kept it as a distinct label so the case couldn't hide inside a history-gap series. That's a reasonable instinct, but the state it defends against is not merely unlikely, it is unrepresentable given the guard above it. A label for an impossible state costs a dead enum arm and an `ok_or` that reads at every future visit as though it could fire.

## What changed

Hold the log once and let the shape carry the guarantee: one `logs.get`, one `cut_ancestry` walk feeding both the completeness verdict and the fold.

```rust
let Some(log) = self.logs.get(&scope) else {
    return Err(self.classify_unresolvable_cut(&scope, heads));
};
let walked = ScopeState::cut_ancestry(log, heads);
if !walked.is_complete() {
    return Err(self.classify_unresolvable_cut(&scope, heads));
}
let view = ScopeState::acl_view_from_ancestry(&walked);
```

This also collapses the double ancestry walk this site was left with after #3589 — it was the one call site I couldn't fold there, precisely because doing so stranded `ViewUnavailable`.

## The precedence trap

An absent log routes through `classify_unresolvable_cut` rather than short-circuiting to `ScopeUnfed`. That ordering is load-bearing, and my first draft got it wrong: `classify_unresolvable_cut` checks truncation **first**, so a truncated scope whose log has already been evicted reports the permanent `LogTruncated`. Returning a bare `ScopeUnfed` would relabel it as a cause `is_transient()` calls self-healing — parking the op retrying forever for a scope whose history is permanently gone, and silencing the one series worth alerting on.

The existing classification test covered truncated-*with*-a-log but not truncated-with-*no*-log, which is why the shape alone reads as unfed there. This adds that case.

## Verification

- `cargo test --workspace` — **4978 passed, 0 failed**
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` — clean
- `cargo fmt --all --check` — clean

Mutation-checked the new test: reordering `classify_unresolvable_cut` to check log shape before truncation fails it —

```
assertion `left == right` failed: an evicted log looks unfed; the truncation
mark is the only thing that distinguishes permanent loss from history that
never arrived
  left: ScopeUnfed
 right: LogTruncated
```

The pre-existing truncated case (which has a log) survives that same mutation, confirming the gap was real rather than redundant coverage.

No behaviour change for any reachable input: every cause a real cut could previously produce, it still produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches apply-time at-cut refusal classification, which drives retry vs permanent park and the `log_truncated` alert series. Intended behavior is unchanged for reachable inputs, but a mis-order here would retry forever on permanently lost history.
> 
> **Overview**
> `auth_cut_context_or_cause` now holds the scope log once, walks ancestry once, and folds that walk into the ACL view. That drops the unreachable `UndecidableCause::ViewUnavailable` metric arm (completeness already proved the log existed) and the second ancestry walk.
> 
> A missing log is classified via `classify_unresolvable_cut` rather than a bare `ScopeUnfed`, so a truncated scope whose log has already been evicted still reports permanent `LogTruncated`. The classification test now covers that evicted-log case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 922fa3305340c506a566fa424380612d1096b881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->