### PR TITLE
test(workflows): bootstrap through create_mesh where the preamble is inert

### DIFF
--- a/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-2node.yml
+++ b/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-2node.yml
@@ -89,41 +89,20 @@ steps:
     outputs:
       app_id: applicationId
 
-  - name: Create namespace on node-1
-    type: create_namespace
-    node: e2e-node-1
+  - name: Create the mesh - namespace, context and every joiner
+    type: create_mesh
+    context_node: e2e-node-1
     application_id: '{{app_id}}'
+    path: res/scaffolding_e2e.wasm
+    nodes:
+      - e2e-node-2
     outputs:
       ns: namespaceId
-
-  - name: Create context on node-1
-    type: create_context
-    node: e2e-node-1
-    application_id: '{{app_id}}'
-    group_id: '{{ns}}'
-    outputs:
       ctx: contextId
 
   # The join is the first thing that needs a peer: group-key delivery has to
   # reach node-1 over the network. Pre-#3525 with mDNS off this is exactly
   # where the run died, 5s after the request, with no mesh peer to ask.
-  - name: Invite node-2 to namespace
-    type: create_namespace_invitation
-    node: e2e-node-1
-    namespace_id: '{{ns}}'
-    outputs:
-      invitation: invitation
-
-  - name: Node-2 joins namespace
-    type: join_namespace
-    node: e2e-node-2
-    namespace_id: '{{ns}}'
-    invitation: '{{invitation}}'
-
-  - name: Node-2 joins context
-    type: join_context
-    node: e2e-node-2
-    context_id: '{{ctx}}'
 
   # Barrier before the writes, not decoration. `join_context` returns as soon as
   # the join is accepted; node-2's context state materialises a moment later.

--- a/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-4node.yml
+++ b/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-4node.yml
@@ -75,68 +75,18 @@ steps:
     outputs:
       app_id: applicationId
 
-  - name: Create namespace on node-1
-    type: create_namespace
-    node: e2e-node-1
+  - name: Create the mesh - namespace, context and every joiner
+    type: create_mesh
+    context_node: e2e-node-1
     application_id: '{{app_id}}'
+    path: res/scaffolding_e2e.wasm
+    nodes:
+      - e2e-node-2
+      - e2e-node-3
+      - e2e-node-4
     outputs:
       ns: namespaceId
-
-  - name: Create context on node-1
-    type: create_context
-    node: e2e-node-1
-    application_id: '{{app_id}}'
-    group_id: '{{ns}}'
-    outputs:
       ctx: contextId
-
-  - name: Invite node-2 to namespace
-    type: create_namespace_invitation
-    node: e2e-node-1
-    namespace_id: '{{ns}}'
-    outputs:
-      invite_n2: invitation
-  - name: Node-2 joins namespace
-    type: join_namespace
-    node: e2e-node-2
-    namespace_id: '{{ns}}'
-    invitation: '{{invite_n2}}'
-  - name: Node-2 joins context
-    type: join_context
-    node: e2e-node-2
-    context_id: '{{ctx}}'
-
-  - name: Invite node-3 to namespace
-    type: create_namespace_invitation
-    node: e2e-node-1
-    namespace_id: '{{ns}}'
-    outputs:
-      invite_n3: invitation
-  - name: Node-3 joins namespace
-    type: join_namespace
-    node: e2e-node-3
-    namespace_id: '{{ns}}'
-    invitation: '{{invite_n3}}'
-  - name: Node-3 joins context
-    type: join_context
-    node: e2e-node-3
-    context_id: '{{ctx}}'
-
-  - name: Invite node-4 to namespace
-    type: create_namespace_invitation
-    node: e2e-node-1
-    namespace_id: '{{ns}}'
-    outputs:
-      invite_n4: invitation
-  - name: Node-4 joins namespace
-    type: join_namespace
-    node: e2e-node-4
-    namespace_id: '{{ns}}'
-    invitation: '{{invite_n4}}'
-  - name: Node-4 joins context
-    type: join_context
-    node: e2e-node-4
-    context_id: '{{ctx}}'
 
   # Barrier before the write, not decoration. `join_context` returns when the
   # join is accepted, while the joiner's context state materialises a moment

--- a/apps/scaffolding-e2e/workflows/group-3node.yml
+++ b/apps/scaffolding-e2e/workflows/group-3node.yml
@@ -49,25 +49,22 @@ steps:
     statements:
       - "is_set({{app_id}})"
 
-  - name: Create namespace on node-1
-    type: create_namespace
-    node: e2e-node-1
+  - name: Create the mesh - namespace, context and every joiner
+    type: create_mesh
+    context_node: e2e-node-1
     application_id: '{{app_id}}'
+    path: res/scaffolding_e2e.wasm
+    nodes:
+      - e2e-node-2
+      - e2e-node-3
     outputs:
       namespace_id: namespaceId
+      ctx_id: contextId
 
   - name: Assert namespace created
     type: assert
     statements:
       - "is_set({{namespace_id}})"
-
-  - name: Create context in namespace on node-1
-    type: create_context
-    node: e2e-node-1
-    application_id: '{{app_id}}'
-    group_id: '{{namespace_id}}'
-    outputs:
-      ctx_id: contextId
 
   - name: Assert context created
     type: assert
@@ -76,43 +73,7 @@ steps:
 
   # --- Node-2 joins ---
 
-  - name: Create namespace invitation for node-2
-    type: create_namespace_invitation
-    node: e2e-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      invite_node2: invitation
-
-  - name: Node-2 joins namespace
-    type: join_namespace
-    node: e2e-node-2
-    namespace_id: '{{namespace_id}}'
-    invitation: '{{invite_node2}}'
-
-  - name: Node-2 joins context via group membership
-    type: join_context
-    node: e2e-node-2
-    context_id: '{{ctx_id}}'
-
   # --- Node-3 joins ---
-
-  - name: Create namespace invitation for node-3
-    type: create_namespace_invitation
-    node: e2e-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      invite_node3: invitation
-
-  - name: Node-3 joins namespace
-    type: join_namespace
-    node: e2e-node-3
-    namespace_id: '{{namespace_id}}'
-    invitation: '{{invite_node3}}'
-
-  - name: Node-3 joins context via group membership
-    type: join_context
-    node: e2e-node-3
-    context_id: '{{ctx_id}}'
 
   # --- SCENARIO 1: node-1 writes, all three converge ---
 

--- a/apps/scaffolding-e2e/workflows/mesh-soak-8node.yml
+++ b/apps/scaffolding-e2e/workflows/mesh-soak-8node.yml
@@ -78,134 +78,24 @@ steps:
     outputs:
       app_id: applicationId
 
-  - name: Create namespace on node-1
-    type: create_namespace
-    node: e2e-node-1
+  - name: Create the mesh - namespace, context and every joiner
+    type: create_mesh
+    context_node: e2e-node-1
     application_id: '{{app_id}}'
+    path: res/scaffolding_e2e.wasm
+    nodes:
+      - e2e-node-2
+      - e2e-node-3
+      - e2e-node-4
+      - e2e-node-5
+      - e2e-node-6
+      - e2e-node-7
+      - e2e-node-8
     outputs:
       namespace_id: namespaceId
-
-  - name: Create context in namespace on node-1
-    type: create_context
-    node: e2e-node-1
-    application_id: '{{app_id}}'
-    group_id: '{{namespace_id}}'
-    outputs:
       ctx_id: contextId
 
   # --- Nodes 2-8 join namespace + context ---
-
-  - name: Invite node-2 to namespace
-    type: create_namespace_invitation
-    node: e2e-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      invite_n2: invitation
-  - name: Node-2 joins namespace
-    type: join_namespace
-    node: e2e-node-2
-    namespace_id: '{{namespace_id}}'
-    invitation: '{{invite_n2}}'
-  - name: Node-2 joins context
-    type: join_context
-    node: e2e-node-2
-    context_id: '{{ctx_id}}'
-
-  - name: Invite node-3 to namespace
-    type: create_namespace_invitation
-    node: e2e-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      invite_n3: invitation
-  - name: Node-3 joins namespace
-    type: join_namespace
-    node: e2e-node-3
-    namespace_id: '{{namespace_id}}'
-    invitation: '{{invite_n3}}'
-  - name: Node-3 joins context
-    type: join_context
-    node: e2e-node-3
-    context_id: '{{ctx_id}}'
-
-  - name: Invite node-4 to namespace
-    type: create_namespace_invitation
-    node: e2e-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      invite_n4: invitation
-  - name: Node-4 joins namespace
-    type: join_namespace
-    node: e2e-node-4
-    namespace_id: '{{namespace_id}}'
-    invitation: '{{invite_n4}}'
-  - name: Node-4 joins context
-    type: join_context
-    node: e2e-node-4
-    context_id: '{{ctx_id}}'
-
-  - name: Invite node-5 to namespace
-    type: create_namespace_invitation
-    node: e2e-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      invite_n5: invitation
-  - name: Node-5 joins namespace
-    type: join_namespace
-    node: e2e-node-5
-    namespace_id: '{{namespace_id}}'
-    invitation: '{{invite_n5}}'
-  - name: Node-5 joins context
-    type: join_context
-    node: e2e-node-5
-    context_id: '{{ctx_id}}'
-
-  - name: Invite node-6 to namespace
-    type: create_namespace_invitation
-    node: e2e-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      invite_n6: invitation
-  - name: Node-6 joins namespace
-    type: join_namespace
-    node: e2e-node-6
-    namespace_id: '{{namespace_id}}'
-    invitation: '{{invite_n6}}'
-  - name: Node-6 joins context
-    type: join_context
-    node: e2e-node-6
-    context_id: '{{ctx_id}}'
-
-  - name: Invite node-7 to namespace
-    type: create_namespace_invitation
-    node: e2e-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      invite_n7: invitation
-  - name: Node-7 joins namespace
-    type: join_namespace
-    node: e2e-node-7
-    namespace_id: '{{namespace_id}}'
-    invitation: '{{invite_n7}}'
-  - name: Node-7 joins context
-    type: join_context
-    node: e2e-node-7
-    context_id: '{{ctx_id}}'
-
-  - name: Invite node-8 to namespace
-    type: create_namespace_invitation
-    node: e2e-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      invite_n8: invitation
-  - name: Node-8 joins namespace
-    type: join_namespace
-    node: e2e-node-8
-    namespace_id: '{{namespace_id}}'
-    invitation: '{{invite_n8}}'
-  - name: Node-8 joins context
-    type: join_context
-    node: e2e-node-8
-    context_id: '{{ctx_id}}'
 
   # --- Broadcast path: write on node-1, verify all 8 converge ---
 

--- a/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
+++ b/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
@@ -121,60 +121,21 @@ steps:
     outputs:
       app_id: applicationId
 
-  - name: Create namespace on node-1
-    type: create_namespace
-    node: e2e-node-1
+  - name: Create the mesh - namespace, context and every joiner
+    type: create_mesh
+    context_node: e2e-node-1
     application_id: '{{app_id}}'
+    path: res/scaffolding_e2e.wasm
+    nodes:
+      - e2e-node-2
+      - e2e-node-3
     outputs:
       ns: namespaceId
-
-  - name: Create context on node-1
-    type: create_context
-    node: e2e-node-1
-    application_id: '{{app_id}}'
-    group_id: '{{ns}}'
-    outputs:
       ctx: contextId
-
-  - name: Invite node-2 to namespace
-    type: create_namespace_invitation
-    node: e2e-node-1
-    namespace_id: '{{ns}}'
-    outputs:
-      invite_node2: invitation
-
-  - name: Invite node-3 to namespace
-    type: create_namespace_invitation
-    node: e2e-node-1
-    namespace_id: '{{ns}}'
-    outputs:
-      invite_node3: invitation
 
   - name: Wait for namespace gossip
     type: wait
     seconds: 5
-
-  - name: Node-2 joins namespace
-    type: join_namespace
-    node: e2e-node-2
-    namespace_id: '{{ns}}'
-    invitation: '{{invite_node2}}'
-
-  - name: Node-2 joins context
-    type: join_context
-    node: e2e-node-2
-    context_id: '{{ctx}}'
-
-  - name: Node-3 joins namespace
-    type: join_namespace
-    node: e2e-node-3
-    namespace_id: '{{ns}}'
-    invitation: '{{invite_node3}}'
-
-  - name: Node-3 joins context
-    type: join_context
-    node: e2e-node-3
-    context_id: '{{ctx}}'
 
   # Capture each node's ACCOUNT (A/B/C) — what a writer set names.
   #

--- a/apps/scaffolding-e2e/workflows/sync-resilience-network-partition-symmetric.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-network-partition-symmetric.yml
@@ -74,42 +74,20 @@ steps:
     outputs:
       app_id: applicationId
 
-  - name: Create namespace on node-1
-    type: create_namespace
-    node: sync-resil-node-1
+  - name: Create the mesh - namespace, context and every joiner
+    type: create_mesh
+    context_node: sync-resil-node-1
     application_id: '{{app_id}}'
+    path: res/scaffolding_e2e.wasm
+    nodes:
+      - sync-resil-node-2
     outputs:
       namespace_id: namespaceId
-
-  - name: Create context in namespace on node-1
-    type: create_context
-    node: sync-resil-node-1
-    application_id: '{{app_id}}'
-    group_id: '{{namespace_id}}'
-    outputs:
       ctx_id: contextId
-
-  - name: Create namespace invitation for node-2
-    type: create_namespace_invitation
-    node: sync-resil-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      invitation_node2: invitation
 
   - name: Wait for namespace gossip (via relay)
     type: wait
     seconds: 10
-
-  - name: Node-2 joins namespace
-    type: join_namespace
-    node: sync-resil-node-2
-    namespace_id: '{{namespace_id}}'
-    invitation: '{{invitation_node2}}'
-
-  - name: Node-2 joins context via group membership
-    type: join_context
-    node: sync-resil-node-2
-    context_id: '{{ctx_id}}'
 
   # ---------- Baseline ----------
 

--- a/apps/scaffolding-e2e/workflows/sync-resilience-network-partition.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-network-partition.yml
@@ -109,42 +109,20 @@ steps:
     outputs:
       app_id: applicationId
 
-  - name: Create namespace on node-1
-    type: create_namespace
-    node: sync-resil-node-1
+  - name: Create the mesh - namespace, context and every joiner
+    type: create_mesh
+    context_node: sync-resil-node-1
     application_id: '{{app_id}}'
+    path: res/scaffolding_e2e.wasm
+    nodes:
+      - sync-resil-node-2
     outputs:
       namespace_id: namespaceId
-
-  - name: Create context in namespace on node-1
-    type: create_context
-    node: sync-resil-node-1
-    application_id: '{{app_id}}'
-    group_id: '{{namespace_id}}'
-    outputs:
       ctx_id: contextId
-
-  - name: Create namespace invitation for node-2
-    type: create_namespace_invitation
-    node: sync-resil-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      invitation_node2: invitation
 
   - name: Wait for namespace gossip
     type: wait
     seconds: 5
-
-  - name: Node-2 joins namespace
-    type: join_namespace
-    node: sync-resil-node-2
-    namespace_id: '{{namespace_id}}'
-    invitation: '{{invitation_node2}}'
-
-  - name: Node-2 joins context via group membership
-    type: join_context
-    node: sync-resil-node-2
-    context_id: '{{ctx_id}}'
 
   # ---------- Baseline ----------
 

--- a/apps/scaffolding-e2e/workflows/sync-resilience-peer-pause-symmetric.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-peer-pause-symmetric.yml
@@ -69,42 +69,20 @@ steps:
     outputs:
       app_id: applicationId
 
-  - name: Create namespace on node-1
-    type: create_namespace
-    node: sync-resil-node-1
+  - name: Create the mesh - namespace, context and every joiner
+    type: create_mesh
+    context_node: sync-resil-node-1
     application_id: '{{app_id}}'
+    path: res/scaffolding_e2e.wasm
+    nodes:
+      - sync-resil-node-2
     outputs:
       namespace_id: namespaceId
-
-  - name: Create context in namespace on node-1
-    type: create_context
-    node: sync-resil-node-1
-    application_id: '{{app_id}}'
-    group_id: '{{namespace_id}}'
-    outputs:
       ctx_id: contextId
-
-  - name: Create namespace invitation for node-2
-    type: create_namespace_invitation
-    node: sync-resil-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      invitation_node2: invitation
 
   - name: Wait for namespace gossip (via relay)
     type: wait
     seconds: 10
-
-  - name: Node-2 joins namespace
-    type: join_namespace
-    node: sync-resil-node-2
-    namespace_id: '{{namespace_id}}'
-    invitation: '{{invitation_node2}}'
-
-  - name: Node-2 joins context via group membership
-    type: join_context
-    node: sync-resil-node-2
-    context_id: '{{ctx_id}}'
 
   # ---------- Baseline ----------
 

--- a/apps/scaffolding-e2e/workflows/sync-resilience-peer-pause.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-peer-pause.yml
@@ -67,42 +67,20 @@ steps:
     outputs:
       app_id: applicationId
 
-  - name: Create namespace on node-1
-    type: create_namespace
-    node: sync-resil-node-1
+  - name: Create the mesh - namespace, context and every joiner
+    type: create_mesh
+    context_node: sync-resil-node-1
     application_id: '{{app_id}}'
+    path: res/scaffolding_e2e.wasm
+    nodes:
+      - sync-resil-node-2
     outputs:
       namespace_id: namespaceId
-
-  - name: Create context in namespace on node-1
-    type: create_context
-    node: sync-resil-node-1
-    application_id: '{{app_id}}'
-    group_id: '{{namespace_id}}'
-    outputs:
       ctx_id: contextId
-
-  - name: Create namespace invitation for node-2
-    type: create_namespace_invitation
-    node: sync-resil-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      invitation_node2: invitation
 
   - name: Wait for namespace gossip
     type: wait
     seconds: 5
-
-  - name: Node-2 joins namespace
-    type: join_namespace
-    node: sync-resil-node-2
-    namespace_id: '{{namespace_id}}'
-    invitation: '{{invitation_node2}}'
-
-  - name: Node-2 joins context via group membership
-    type: join_context
-    node: sync-resil-node-2
-    context_id: '{{ctx_id}}'
 
   # ---------- Baseline ----------
 

--- a/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart-autoresync.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart-autoresync.yml
@@ -80,42 +80,20 @@ steps:
     outputs:
       app_id: applicationId
 
-  - name: Create namespace on node-1
-    type: create_namespace
-    node: sync-autoresync-node-1
+  - name: Create the mesh - namespace, context and every joiner
+    type: create_mesh
+    context_node: sync-autoresync-node-1
     application_id: '{{app_id}}'
+    path: res/scaffolding_e2e.wasm
+    nodes:
+      - sync-autoresync-node-2
     outputs:
       namespace_id: namespaceId
-
-  - name: Create context in namespace on node-1
-    type: create_context
-    node: sync-autoresync-node-1
-    application_id: '{{app_id}}'
-    group_id: '{{namespace_id}}'
-    outputs:
       ctx_id: contextId
-
-  - name: Create namespace invitation for node-2
-    type: create_namespace_invitation
-    node: sync-autoresync-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      invitation_node2: invitation
 
   - name: Wait for namespace gossip
     type: wait
     seconds: 5
-
-  - name: Node-2 joins namespace
-    type: join_namespace
-    node: sync-autoresync-node-2
-    namespace_id: '{{namespace_id}}'
-    invitation: '{{invitation_node2}}'
-
-  - name: Node-2 joins context via group membership
-    type: join_context
-    node: sync-autoresync-node-2
-    context_id: '{{ctx_id}}'
 
   # ---------- Baseline: confirm sync works before the fault ----------
 

--- a/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart-symmetric.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart-symmetric.yml
@@ -75,44 +75,22 @@ steps:
     outputs:
       app_id: applicationId
 
-  - name: Create namespace on node-1
-    type: create_namespace
-    node: sync-resil-node-1
+  - name: Create the mesh - namespace, context and every joiner
+    type: create_mesh
+    context_node: sync-resil-node-1
     application_id: '{{app_id}}'
+    path: res/scaffolding_e2e.wasm
+    nodes:
+      - sync-resil-node-2
     outputs:
       namespace_id: namespaceId
-
-  - name: Create context in namespace on node-1
-    type: create_context
-    node: sync-resil-node-1
-    application_id: '{{app_id}}'
-    group_id: '{{namespace_id}}'
-    outputs:
       ctx_id: contextId
-
-  - name: Create namespace invitation for node-2
-    type: create_namespace_invitation
-    node: sync-resil-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      invitation_node2: invitation
 
   # Bumped from 5s → 10s: symmetric mode is slower to converge
   # because there's no direct-dial shortcut.
   - name: Wait for namespace gossip (via relay)
     type: wait
     seconds: 10
-
-  - name: Node-2 joins namespace
-    type: join_namespace
-    node: sync-resil-node-2
-    namespace_id: '{{namespace_id}}'
-    invitation: '{{invitation_node2}}'
-
-  - name: Node-2 joins context via group membership
-    type: join_context
-    node: sync-resil-node-2
-    context_id: '{{ctx_id}}'
 
   # ---------- Baseline ----------
 

--- a/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart.yml
@@ -75,42 +75,20 @@ steps:
     outputs:
       app_id: applicationId
 
-  - name: Create namespace on node-1
-    type: create_namespace
-    node: sync-resil-node-1
+  - name: Create the mesh - namespace, context and every joiner
+    type: create_mesh
+    context_node: sync-resil-node-1
     application_id: '{{app_id}}'
+    path: res/scaffolding_e2e.wasm
+    nodes:
+      - sync-resil-node-2
     outputs:
       namespace_id: namespaceId
-
-  - name: Create context in namespace on node-1
-    type: create_context
-    node: sync-resil-node-1
-    application_id: '{{app_id}}'
-    group_id: '{{namespace_id}}'
-    outputs:
       ctx_id: contextId
-
-  - name: Create namespace invitation for node-2
-    type: create_namespace_invitation
-    node: sync-resil-node-1
-    namespace_id: '{{namespace_id}}'
-    outputs:
-      invitation_node2: invitation
 
   - name: Wait for namespace gossip
     type: wait
     seconds: 5
-
-  - name: Node-2 joins namespace
-    type: join_namespace
-    node: sync-resil-node-2
-    namespace_id: '{{namespace_id}}'
-    invitation: '{{invitation_node2}}'
-
-  - name: Node-2 joins context via group membership
-    type: join_context
-    node: sync-resil-node-2
-    context_id: '{{ctx_id}}'
 
   # ---------- Baseline: confirm sync works before the fault ----------
 


### PR DESCRIPTION
## Summary

`create_mesh` performs the whole bootstrap — namespace, context, then an invitation and a join per node — and merobox now exports the ids it produces (calimero-network/merobox#350). A scenario no longer has to spell the preamble out to reach them.

Twelve scenarios were repeating the same nine steps, plus a bare `join_context` that a namespace member gets by auto-join anyway:

```yaml
- type: create_mesh
  context_node: e2e-node-1
  application_id: '{{app_id}}'
  path: res/scaffolding_e2e.wasm
  nodes: [e2e-node-2, e2e-node-3]
  outputs:
    namespace_id: namespaceId
    ctx_id: contextId
```

**-496 lines.** What remains in each file is what that scenario is actually about.

## Where it is NOT applied, and why

`create_mesh` joins every peer **up front**. A scenario that writes, sets capabilities, or stops a node *between* creating the context and the last join is doing that deliberately — the cold-cache, HLC-inversion and late-joiner paths exist precisely because the joiner arrives after the state does. Collapsing those silently stops exercising the thing they test.

An earlier revision of this work converted seven such scenarios. CI failed three, and Cursor Bugbot independently flagged five, under the same heading: *deferred joins collapsed too early*. This revision excludes them by rule rather than by inspection:

| Rule | Why |
| --- | --- |
| nothing but asserts/waits between the context and the **last** join | a write or a `stop_node` in there is the scenario's point |
| no `outputs` on `join_namespace` / `join_context` | `create_mesh` does not export a per-node member id in that form |
| single context, created before any join | `create_mesh` puts the context on the namespace |
| no subgroup, no `node_identity`, no `expected_failure` in the bootstrap | `create_mesh` expresses none of them |

**75 scenarios keep their preamble** on those grounds. Verified that all seven previously-failing files are excluded.

## Verification

- All 12 parse, and pass merobox's own step validator with **0 errors**.
- Every `{{placeholder}}` still resolves to something produced — checked mechanically, **no dangling references**.
- Applied by script and reviewed as a diff: section comments and interleaved asserts/waits are preserved in place.

Depends on nothing; independent of #3603.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only e2e workflow refactor with no product or auth changes. Residual risk is that create_mesh joins everyone up front, which would hide late-joiner bugs if applied to the wrong files.
> 
> **Overview**
> Collapses the repeated namespace/context/invite/join preamble in **12** scaffolding e2e workflows into a single `create_mesh` step, now that merobox exports the ids it produces.
> 
> Scenarios that only wait or assert between context creation and the last join no longer spell out those steps. Workflows that write, rotate capabilities, or stop a node *before* every peer has joined are left unchanged so late-joiner and cold-cache paths stay explicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f69d507500c1a55eb0bb3c7183319373c94f1957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->