### PR TITLE
chore(e2e): drop the retired chain_id key from every scenario

### DIFF
--- a/apps/abi_conformance/workflows/abi-conformance.yml
+++ b/apps/abi_conformance/workflows/abi-conformance.yml
@@ -4,7 +4,6 @@ name: ABI Conformance Test
 force_pull_image: true
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: abi-conformance-node

--- a/apps/blobs/workflows/blob-announce-namespace-membership.yml
+++ b/apps/blobs/workflows/blob-announce-namespace-membership.yml
@@ -31,7 +31,6 @@ force_pull_image: true
 auth_mode: embedded
 
 nodes:
-  chain_id: calimero-testnet
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: rust-blob-announce

--- a/apps/blobs/workflows/blob-cross-node-sizes.yml
+++ b/apps/blobs/workflows/blob-cross-node-sizes.yml
@@ -51,7 +51,6 @@ force_pull_image: true
 auth_mode: embedded
 
 nodes:
-  chain_id: calimero-testnet
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: rust-blob-size

--- a/apps/blobs/workflows/blob-cross-node-transfer.yml
+++ b/apps/blobs/workflows/blob-cross-node-transfer.yml
@@ -34,7 +34,6 @@ force_pull_image: true
 auth_mode: embedded
 
 nodes:
-  chain_id: calimero-testnet
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: rust-blob-xfer

--- a/apps/blobs/workflows/blobs-example.yml
+++ b/apps/blobs/workflows/blobs-example.yml
@@ -8,7 +8,6 @@ force_pull_image: true
 auth_mode: embedded
 
 nodes:
-  chain_id: calimero-testnet
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: node-blob

--- a/apps/blobs/workflows/blobs.yml
+++ b/apps/blobs/workflows/blobs.yml
@@ -6,7 +6,6 @@ force_pull_image: true
 auth_mode: embedded
 
 nodes:
-  chain_id: calimero-testnet
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: rust-blob

--- a/apps/collaborative-editor/workflows/collaborative-editor.yml
+++ b/apps/collaborative-editor/workflows/collaborative-editor.yml
@@ -5,7 +5,6 @@ name: Collaborative Editor Workflow
 force_pull_image: true
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: calimero-node

--- a/apps/components-demo/workflows/components-demo.yml
+++ b/apps/components-demo/workflows/components-demo.yml
@@ -13,7 +13,6 @@ wait_timeout: 120
 auth_mode: embedded
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: new-calimero-node

--- a/apps/kv-store-init/workflows/kv-store-init.yml
+++ b/apps/kv-store-init/workflows/kv-store-init.yml
@@ -4,7 +4,6 @@ name: KV Store Init Test
 force_pull_image: true
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: kv-store-init-node

--- a/apps/kv-store-with-handlers/workflows/kv-store-with-handlers.yml
+++ b/apps/kv-store-with-handlers/workflows/kv-store-with-handlers.yml
@@ -4,7 +4,6 @@ description: Test KV Store with handlers functionality, including insert, update
 force_pull_image: true
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: kvh-node

--- a/apps/kv-store-with-shared-storage/workflows/test_shared_storage.yml
+++ b/apps/kv-store-with-shared-storage/workflows/test_shared_storage.yml
@@ -9,7 +9,6 @@ wait_timeout: 120
 auth_mode: embedded
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: new-calimero-node

--- a/apps/kv-store-with-user-and-frozen-storage/workflows/test_frozen_storage.yml
+++ b/apps/kv-store-with-user-and-frozen-storage/workflows/test_frozen_storage.yml
@@ -7,7 +7,6 @@ restart: false
 wait_timeout: 120
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: new-calimero-node

--- a/apps/kv-store-with-user-and-frozen-storage/workflows/test_user_storage.yml
+++ b/apps/kv-store-with-user-and-frozen-storage/workflows/test_user_storage.yml
@@ -7,7 +7,6 @@ restart: false
 wait_timeout: 120
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: new-calimero-node

--- a/apps/kv-store/workflows/bundle-invitation-test.yml
+++ b/apps/kv-store/workflows/bundle-invitation-test.yml
@@ -5,7 +5,6 @@ name: Bundle Invitation Flow Test
 force_pull_image: false
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: calimero-node

--- a/apps/kv-store/workflows/simple-store.yml
+++ b/apps/kv-store/workflows/simple-store.yml
@@ -4,7 +4,6 @@ name: Simple Store App Test
 force_pull_image: true
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: simple-store-node

--- a/apps/kv-store/workflows/workflow-example.yml
+++ b/apps/kv-store/workflows/workflow-example.yml
@@ -5,7 +5,6 @@ name: Sample Calimero Workflow
 force_pull_image: true
 
 nodes:
-  chain_id: testnet-1
   count: 3
   image: ghcr.io/calimero-network/merod:edge
   prefix: calimero-node

--- a/apps/nested-crdt-test/workflows/nested-crdt-test.yml
+++ b/apps/nested-crdt-test/workflows/nested-crdt-test.yml
@@ -4,7 +4,6 @@ description: Nested CRDT test - verifies Map<String, Counter>, Map<String, LWW>,
 force_pull_image: true
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: nested-node

--- a/apps/private_data/workflows/example.yml
+++ b/apps/private_data/workflows/example.yml
@@ -5,7 +5,6 @@ name: Sample Calimero Workflow
 force_pull_image: true
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: calimero-node

--- a/apps/private_data/workflows/private-data.yml
+++ b/apps/private_data/workflows/private-data.yml
@@ -4,7 +4,6 @@ description: Private data storage example using the Rust SDK.
 force_pull_image: true
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: rust-private-data

--- a/apps/scaffolding-e2e/workflows/simple-sync.yml
+++ b/apps/scaffolding-e2e/workflows/simple-sync.yml
@@ -4,7 +4,6 @@ description: Basic set/get sync test without event handlers
 force_pull_image: false
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: e2e-node

--- a/apps/team-metrics-custom/workflows/team-metrics-custom.yml
+++ b/apps/team-metrics-custom/workflows/team-metrics-custom.yml
@@ -4,7 +4,6 @@ description: Test team metrics with custom Mergeable implementation
 force_pull_image: true
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: team-custom-node

--- a/apps/team-metrics-macro/workflows/team-metrics-macro.yml
+++ b/apps/team-metrics-macro/workflows/team-metrics-macro.yml
@@ -4,7 +4,6 @@ description: Test team metrics with derive(Mergeable) macro implementation
 force_pull_image: true
 
 nodes:
-  chain_id: testnet-1
   count: 2
   image: ghcr.io/calimero-network/merod:edge
   prefix: team-macro-node

--- a/workflows/fuzzy-tests/group-governance/fuzzy-test.yml
+++ b/workflows/fuzzy-tests/group-governance/fuzzy-test.yml
@@ -21,7 +21,6 @@ nuke_on_start: true
 nuke_on_end: false
 
 nodes:
-  chain_id: calimero-testnet
   count: 4
   image: ghcr.io/calimero-network/merod:edge-profiling
   prefix: fuzzy-gov-node

--- a/workflows/fuzzy-tests/kv-store-with-handlers/fuzzy-test.yml
+++ b/workflows/fuzzy-tests/kv-store-with-handlers/fuzzy-test.yml
@@ -7,7 +7,6 @@ nuke_on_start: true
 nuke_on_end: false
 
 nodes:
-  chain_id: calimero-testnet
   count: 4
   image: ghcr.io/calimero-network/merod:edge-profiling
   prefix: fuzzy-handlers-node

--- a/workflows/fuzzy-tests/kv-store/fuzzy-test.yml
+++ b/workflows/fuzzy-tests/kv-store/fuzzy-test.yml
@@ -7,7 +7,6 @@ nuke_on_start: true
 nuke_on_end: false
 
 nodes:
-  chain_id: calimero-testnet
   count: 4
   image: ghcr.io/calimero-network/merod:edge-profiling
   prefix: fuzzy-kv-node

--- a/workflows/fuzzy-tests/scaffolding-e2e/fuzzy-test.yml
+++ b/workflows/fuzzy-tests/scaffolding-e2e/fuzzy-test.yml
@@ -7,7 +7,6 @@ nuke_on_start: true
 nuke_on_end: false
 
 nodes:
-  chain_id: calimero-testnet
   count: 4
   image: ghcr.io/calimero-network/merod:edge-profiling
   prefix: fuzzy-e2e-node

--- a/workflows/sync-tests/opaque-leaf-regression.yml
+++ b/workflows/sync-tests/opaque-leaf-regression.yml
@@ -36,12 +36,16 @@ nodes:
   # but specify it here so a local `merobox bootstrap run` works without
   # the override.
   #
-  # NB: no `use_image_entrypoint` / `chain_id` here, on purpose — those
-  # are the *profiling* fuzzy-workflow shape, used with the
+  # NB: no `use_image_entrypoint` here, on purpose — that is the
+  # *profiling* fuzzy-workflow shape, used with the
   # `merod:edge-profiling` image that wraps the binary in `perf record`.
   # For the plain `merod:edge`/`merod:local` images (no profiling
   # wrapper), merobox invokes the merod CLI directly — same shape as
   # every working e2e workflow under `apps/*/workflows/*.yml`.
+  #
+  # This note used to name `chain_id` alongside it. merobox no longer
+  # reads that key anywhere, so its presence or absence decides nothing
+  # and it has been dropped from every scenario.
   image: merod:local
   prefix: sync-regression-node
 


### PR DESCRIPTION
Companion to #3592, which removed `near_devnet` and deliberately left this for its own change.

## Why it needed a separate PR

merobox reads `chain_id` nowhere — zero references in its source, schema included — and its changelog records the parameter's removal from `testing.cluster()` / `testing.workflow()`. All 26 occurrences sit under `nodes:`, where `NodesConfig` does not declare the key and tolerates unknown ones. So every value here is inert.

But unlike `near_devnet: false`, these carry values that read as decisions: `testnet-1` on 17 scenarios, `calimero-testnet` on 9. That is worse than a bare dead flag. A reader who finds `chain_id: calimero-testnet` on a blobs scenario has to go and establish which chain it is pinned to before discovering the answer is neither — and someone writing a new scenario copies it forward, because it looks load-bearing.

## The one judgement call

`workflows/sync-tests/opaque-leaf-regression.yml` carried a note saying its *absence* of `use_image_entrypoint` / `chain_id` was deliberate — the profiling-workflow shape, for the `merod:edge-profiling` image that wraps the binary in `perf record`.

That comment conflates a live key with a dead one. `use_image_entrypoint` **is** still read by merobox and still matters, so the note keeps that half; the `chain_id` half now records that the key decides nothing. Deleting the note wholesale would have thrown away a real piece of knowledge about the profiling image.

## Verification

Same method as #3592, adapted for a nested key: each file parsed before and after, with the edit kept only where the two parsed documents differed by nothing but a **recursively** removed `chain_id`. Any file where removal would have changed anything else was skipped and reported — none were.

- 26 files, 26 deletions, plus the comment correction.
- `scripts/lint-e2e-convergence.py`: clean (132 scenarios scanned, no new races).
- All 27 touched files still pass merobox's workflow-schema validation.

No behaviour change is possible: merobox never reads the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only cleanup of a key merobox never reads; no product, auth, or test-step logic changes.
> 
> **Overview**
> Removes the unused `chain_id` key from every merobox workflow `nodes:` block. merobox no longer reads it, so values like `testnet-1` / `calimero-testnet` were inert but looked like a real chain pin.
> 
> Touches 26 scenario files plus a comment in `opaque-leaf-regression.yml` that still documents `use_image_entrypoint` (still live) and now notes that `chain_id` decides nothing. No runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8454fb3b1a9e1c9bc5bfc2301642fffd5542b0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->