### PR TITLE
ci(e2e): pin merobox instead of installing whatever is newest

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -8,21 +8,22 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        MIN_MEROBOX="0.6.59"
+
+        # An exact pin, not a floor. This used to install whatever merobox had
+        # published most recently, so a merobox release reached every core CI run
+        # within minutes of being cut, with nothing gating it: when 0.6.59 turned
+        # unknown scenario-YAML keys from ignored into fatal, every open PR went
+        # red at once and none of them had touched a scenario. Bumping is now a
+        # deliberate edit here, and the PR that makes it runs the full e2e suite
+        # against the new version before it becomes everyone's problem.
+        MEROBOX_VERSION="0.6.59"
+        TAG="v${MEROBOX_VERSION}"
 
         case "$(uname -m)" in
           x86_64) MEROBOX_ARCH="linux-x86-64" ;;
           aarch64 | arm64) MEROBOX_ARCH="linux-aarch64" ;;
           *) echo "::error::no merobox release binary for $(uname -m)"; exit 1 ;;
         esac
-
-        TAG="$(timeout 60 curl -fsSLI -o /dev/null -w '%{url_effective}' \
-          --retry 3 --retry-all-errors \
-          https://github.com/calimero-network/merobox/releases/latest | sed 's#.*/tag/##')"
-        if [ -z "$TAG" ]; then
-          echo "::error::could not resolve the latest merobox release tag"
-          exit 1
-        fi
 
         ASSET="https://github.com/calimero-network/merobox/releases/download/${TAG}/merobox-${TAG}-${MEROBOX_ARCH}"
         timeout 180 curl -fsSL --retry 3 --retry-all-errors -o /tmp/merobox "$ASSET"
@@ -41,7 +42,7 @@ runs:
         export PATH="$HOME/.local/bin:$PATH"
         merobox --version
         HAVE_MEROBOX="$(merobox --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
-        if [ "$(printf '%s\n%s\n' "$MIN_MEROBOX" "$HAVE_MEROBOX" | sort -V | head -1)" != "$MIN_MEROBOX" ]; then
-          echo "::error::merobox ${HAVE_MEROBOX} is older than the required ${MIN_MEROBOX}"
+        if [ "$HAVE_MEROBOX" != "$MEROBOX_VERSION" ]; then
+          echo "::error::merobox reports ${HAVE_MEROBOX} but ${MEROBOX_VERSION} is pinned — the ${TAG} asset does not carry the version it is named for"
           exit 1
         fi

--- a/apps/blobs/workflows/blob-announce-namespace-membership.yml
+++ b/apps/blobs/workflows/blob-announce-namespace-membership.yml
@@ -22,9 +22,9 @@ description: >
 
   SCOPE: this covers defect 1 (announce skipped). Defect 2 (every outgoing blob
   request unsigned, so the serving node answers found:false) needs an assertion
-  on the received BYTES, which requires merobox's `download_blob` step —
-  unreleased at time of writing. blob-cross-node-transfer.yml is that test,
-  waiting on a MIN_MEROBOX bump to 0.6.44.
+  on the received BYTES, which requires merobox's `download_blob` step.
+  blob-cross-node-transfer.yml is that test, and it now runs — the step shipped
+  in merobox 0.6.44 and the version CI installs is well past it.
 
 force_pull_image: true
 

--- a/apps/blobs/workflows/blob-cross-node-transfer.yml
+++ b/apps/blobs/workflows/blob-cross-node-transfer.yml
@@ -12,9 +12,9 @@ description: >
   never even logged "Processing blob request stream" — it bailed at the auth
   gate before looking for a blob it was holding.
 
-  Needs merobox >= 0.6.44 for the `download_blob` step (floor enforced in
-  .github/actions/setup-merobox/action.yml) and a node build carrying #3326,
-  without which the kad preconditions below fail.
+  Needs merobox >= 0.6.44 for the `download_blob` step (the version CI installs
+  is pinned in .github/actions/setup-merobox/action.yml) and a node build
+  carrying #3326, without which the kad preconditions below fail.
 
   Run locally — --e2e-mode is REQUIRED, it clears the public devnet bootstrap
   list `merod init` writes; without it the provider lookup times out on


### PR DESCRIPTION
## The problem

`setup-merobox` resolved `releases/latest` at run time, then only checked the result cleared a floor:

```bash
MIN_MEROBOX="0.6.59"                                    # a floor
TAG="$(curl ... /releases/latest | sed 's#.*/tag/##')"   # whatever is newest
```

So every core CI run installed whatever merobox had published most recently. A merobox release reached every open PR within minutes of being cut, with nothing between the two — and the floor check is near-vacuous, since the newest release always clears it.

This is not hypothetical. merobox **0.6.59** turned unknown scenario-YAML keys from silently ignored into a fatal error:

```
Step 'Create mesh (node-2 joins node-1's namespace)' (index 3):
  unknown field 'capability' - the step would ignore it.
```

Within the hour, master and every open PR went red across the entire e2e suite — `blobs-lifecycle`, `xcall-example`, `sorted-set-concurrent-convergence`, `frozen-rga-convergence` — and **none had touched a scenario**. The jobs died in 15 seconds with "Setup Node" skipped, so nothing under test ever ran. Two rounds of scenario fixes (#3603, #3606) chased it, and every PR cut before those had to rebase just to recover its CI.

The failure mode is the expensive part: a governance-auth PR appears to break blob transfer. Distinguishing "my change is wrong" from "the tooling moved under me" costs a real debugging cycle, per engineer, per PR.

## The change

Pin the exact version:

```bash
MEROBOX_VERSION="0.6.59"
TAG="v${MEROBOX_VERSION}"
```

Bumping merobox becomes a deliberate one-line edit, and the PR making it runs the full e2e suite against the new version *before* it is mandatory for everyone. That is the gate that was missing — today's breakage would have been one bump PR going red instead of every open PR.

Two consequences worth calling out:

- **The `releases/latest` round-trip is gone.** The tag is known without asking, so a network call and its failure mode go with it.
- **The post-install check is now equality, not a floor.** Against a pin a floor can only ever pass, so it would wave through an asset that doesn't carry the version it's named for. Equality catches that.

## Not pinning, deliberately

The cost of a pin is that merobox regressions surface later, on the bump, rather than immediately. That is the trade being made on purpose: the same information arrives, attributed to a PR that changed merobox, instead of arriving as simultaneous red on unrelated PRs. Nothing stops a bump PR from being opened the day a release lands.

## Verification

Fetched the exact asset the action now constructs and confirmed the published checksum:

```
merobox-v0.6.59-linux-x86-64
expected: 1883af4aa3ffeaca2a04de20a6f2cc0f9ed6d83d84da38a1b9021b136c27a229
actual:   1883af4aa3ffeaca2a04de20a6f2cc0f9ed6d83d84da38a1b9021b136c27a229
```

- `bash -n` clean on the extracted run block
- all three touched YAML files parse
- no `MIN_MEROBOX` references remain outside CHANGELOG history
- this action is the **only** merobox install path (used by `e2e-rust-apps`, `e2e-rust-apps-release`, `app-migration-e2e`, `sync-regression`, `fuzzy-load-test`); there is no pip/pipx alternative, so pinning here pins everything

The real proof is this PR's own e2e run: it touches `apps/blobs/workflows/`, so the suite executes against the pinned version.

## Drive-by

Two scenario comments named the old floor as the mechanism, so both are updated. One was stale on its own terms — it described `blob-cross-node-transfer.yml` as still waiting on a `download_blob` step that shipped in 0.6.44, while that scenario has been running with the step (lines 117/125) for some time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared merobox install used by all e2e jobs. A bad pin or checksum mismatch would fail those suites, but it does not change product, auth, or data-handling code.
> 
> **Overview**
> Stops CI from installing whatever merobox `releases/latest` points at. `setup-merobox` now pins **0.6.59** and checks that the installed binary reports that exact version, so a merobox bump is a deliberate one-line change that runs e2e before it becomes mandatory.
> 
> Removes the GitHub latest-tag redirect and the old floor check (which always passed against newest). Scenario comments that still talked about waiting on `download_blob` / `MIN_MEROBOX` are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ecbee7451bfa50412247f7db90a35f1b39f5b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->