### PR TITLE
test(e2e): cover rendezvous discovery on a flat bridge

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -16,7 +16,12 @@ runs:
         # red at once and none of them had touched a scenario. Bumping is now a
         # deliberate edit here, and the PR that makes it runs the full e2e suite
         # against the new version before it becomes everyone's problem.
-        MEROBOX_VERSION="0.6.59"
+        # 0.6.60 adds `topology: { type: bootstrap }`, which
+        # workflows/discovery-rendezvous-3node.yml needs — on 0.6.59 that key
+        # fails schema validation ("only 'nat' is implemented") before any node
+        # starts. This is the deliberate bump the note above describes, and the
+        # PR carrying it runs the full suite against the new version.
+        MEROBOX_VERSION="0.6.60"
         TAG="v${MEROBOX_VERSION}"
 
         case "$(uname -m)" in

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -523,6 +523,17 @@ jobs:
           - workflow: discovery-bootstrap-only-4node
             file: workflows/discovery-bootstrap-only-4node.yml
             app: scaffolding-e2e
+          # The only scenario on any topology that exercises rendezvous
+          # register/discover WITHOUT also testing relay reservations and
+          # hole-punching. The two entries above are handed a full roster of
+          # sibling addresses, so they never ask anyone for one; the eight NAT
+          # `sync-resilience-*` scenarios do ask, but behind a gateway, which is
+          # why a discovery regression there reads as a NAT flake. A
+          # cookie-poisoning bug in exactly this path once shipped with CI green
+          # (see crates/network/src/manager_discovery_tests.rs).
+          - workflow: discovery-rendezvous-3node
+            file: workflows/discovery-rendezvous-3node.yml
+            app: scaffolding-e2e
           # #2422 auto-follow regression workflows.
           - workflow: auto-follow-on-context-registered
             file: workflows/auto-follow/auto-follow-on-context-registered.yml

--- a/apps/scaffolding-e2e/workflows/discovery-rendezvous-3node.yml
+++ b/apps/scaffolding-e2e/workflows/discovery-rendezvous-3node.yml
@@ -1,0 +1,196 @@
+description: >
+  Three nodes find each other by ASKING a boot-node who else exists, with
+  mDNS off and no sibling address in any config.
+
+  Why this exists
+  ---------------
+
+  `discovery-bootstrap-only-{2,4}node` already prove that a bootstrap
+  address can be dialled with multicast gone. But merobox hands those
+  fleets a complete roster: every node starts with all of its siblings in
+  `bootstrap.nodes`, so nobody ever has to ask a peer for an address it
+  does not already hold. That covers bootstrap dial, identify and kad, and
+  it stops there.
+
+  A deployed node is told about one or two bootstrap peers and has to
+  discover the rest — rendezvous register and discover. Until this
+  scenario, the only coverage of that path on any topology was the eight
+  NAT `sync-resilience-*` scenarios, which exercise it behind a gateway
+  alongside relay reservations and DCUtR hole-punching. That bundling is
+  the problem: when one of them fails, "discovery regressed" is nobody's
+  first guess, and those scenarios are the most environment-sensitive in
+  the suite.
+
+  The gap this closes is not hypothetical. `crates/network/src/
+  manager_discovery_tests.rs` exists because a cookie-poisoning bug — a
+  per-overlay discover response's cookie stored into the slot the global
+  discover replays, giving `InvalidCookie` forever and killing
+  namespace-invite joins until restart — shipped with CI fully green. Its
+  own comment names the reason: the merobox fleet runs every node on one
+  Docker network with direct bootstrap, so the rendezvous layer is dead
+  code in every CI scenario.
+
+  How it forces the issue
+  -----------------------
+
+  `topology: { type: bootstrap }` (merobox 0.6.60+) puts one boot-node on
+  a plain bridge with the clients and gives each client exactly one
+  `bootstrap.nodes` entry: the boot-node, TCP and QUIC. Sibling addresses
+  are withheld and `discovery.mdns` is forced false after any override, so
+  neither multicast nor a pre-seeded roster can carry the traffic. The
+  boot-node is the `calimero-network/boot-node` image, which serves the
+  rendezvous and relay protocols merod does not — merod builds
+  `rendezvous::client::Behaviour` only, which is exactly why a fleet of
+  plain merods records zero registers and zero discovers however long it
+  runs.
+
+  The write below travels between two joiners, neither of which created
+  the namespace or invited the other. For it to arrive, node-3 must have
+  learned node-2's address from the boot-node.
+
+  No log-pattern assertions: convergence is the assertion. A rendezvous
+  regression surfaces as a failed join or a failed read rather than as a
+  missing grep. Measured on a local run of this shape: 0 mDNS dials, kad
+  routing populated on every node, and rendezvous register AND discover on
+  all three clients.
+name: E2E Discovery - Rendezvous via Boot-Node (3 nodes)
+
+force_pull_image: false
+
+topology:
+  type: bootstrap
+
+auth_mode: embedded
+
+nodes:
+  count: 3
+  image: ghcr.io/calimero-network/merod:edge
+  prefix: e2e-node
+
+steps:
+  - name: Login on e2e-node-1
+    type: login
+    node: e2e-node-1
+    username: dev
+    password: dev-password
+
+  - name: Login on e2e-node-2
+    type: login
+    node: e2e-node-2
+    username: dev
+    password: dev-password
+
+  - name: Login on e2e-node-3
+    type: login
+    node: e2e-node-3
+    username: dev
+    password: dev-password
+
+  - name: Install application on node-1
+    type: install_application
+    node: e2e-node-1
+    path: res/scaffolding_e2e.wasm
+    dev: true
+    outputs:
+      app_id: applicationId
+
+  - name: Create namespace on node-1
+    type: create_namespace
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    outputs:
+      ns: namespaceId
+
+  - name: Create context on node-1
+    type: create_context
+    node: e2e-node-1
+    application_id: '{{app_id}}'
+    group_id: '{{ns}}'
+    outputs:
+      ctx: contextId
+
+  # The join is the first step that needs a peer at all: group-key delivery
+  # has to reach node-1 over the network, and node-2 holds no address for
+  # it. Reaching node-1 here already means the rendezvous lookup worked.
+  - name: Invite node-2 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{ns}}'
+    outputs:
+      invite_2: invitation
+  - name: Node-2 joins namespace
+    type: join_namespace
+    node: e2e-node-2
+    namespace_id: '{{ns}}'
+    invitation: '{{invite_2}}'
+  - name: Node-2 joins context
+    type: join_context
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+
+  - name: Invite node-3 to namespace
+    type: create_namespace_invitation
+    node: e2e-node-1
+    namespace_id: '{{ns}}'
+    outputs:
+      invite_3: invitation
+  - name: Node-3 joins namespace
+    type: join_namespace
+    node: e2e-node-3
+    namespace_id: '{{ns}}'
+    invitation: '{{invite_3}}'
+  - name: Node-3 joins context
+    type: join_context
+    node: e2e-node-3
+    context_id: '{{ctx}}'
+
+  # Barrier before the write: `join_context` returns when the join is
+  # accepted, while the joiner's context state materialises a moment later.
+  # Writing into that gap answers `Uninitialized`, which merobox hides
+  # behind a retry — a pass that depends on the retry budget rather than on
+  # the thing under test.
+  - name: Settle the joins before the write
+    type: wait_for_sync
+    context_id: '{{ctx}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 90
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-2 writes a key
+    type: call
+    node: e2e-node-2
+    context_id: '{{ctx}}'
+    method: set
+    args:
+      key: "asked_the_boot_node"
+      value: "found_you"
+
+  - name: Converge all three peers
+    type: wait_for_sync
+    context_id: '{{ctx}}'
+    nodes:
+      - e2e-node-1
+      - e2e-node-2
+      - e2e-node-3
+    timeout: 90
+    check_interval: 2
+    trigger_sync: true
+
+  - name: Node-3 reads node-2's key
+    type: call
+    node: e2e-node-3
+    context_id: '{{ctx}}'
+    method: get
+    args:
+      key: "asked_the_boot_node"
+    outputs:
+      n3_read: result
+
+  - name: Assert the joiner-to-joiner write crossed
+    type: json_assert
+    statements:
+      - 'json_equal({{n3_read}}, {"output": "found_you"})'


### PR DESCRIPTION
Closes the last coverage criterion on #3525. Depends on merobox 0.6.60 (released), which added the topology this uses.

## What was still uncovered

#3585 added `discovery-bootstrap-only-{2,4}node`, which converge with mDNS off. But merobox hands those fleets a **complete roster**: every node starts holding all of its siblings' addresses, so no node ever asks a peer for an address it does not already have. That covers bootstrap dial → identify → kad, and stops there.

A deployed node is told about one or two bootstrap peers and discovers the rest — rendezvous register and discover. Before this, the only coverage of that path on any topology was the eight NAT `sync-resilience-*` scenarios, which exercise it *behind a gateway, alongside relay reservations and DCUtR hole-punching*. When one of those fails, "discovery regressed" is nobody's first guess — and they are the most environment-sensitive scenarios in the suite.

The gap is not hypothetical. A cookie-poisoning bug in exactly this path — a per-overlay discover response's cookie stored into the slot the global discover replays, `InvalidCookie` forever, namespace-invite joins dead until restart — **shipped with CI fully green**. The comment on `crates/network/src/manager_discovery_tests.rs` names why: the merobox fleet runs every node on one Docker network with direct bootstrap, so *"the rendezvous discovery layer is dead code in every CI scenario"*. That stops being true with this scenario.

## How it forces the issue

`topology: { type: bootstrap }` puts one boot-node on a plain bridge with the clients and gives each client exactly one `bootstrap.nodes` entry — the boot-node, TCP and QUIC. Sibling addresses are withheld and `discovery.mdns` is forced false after any override, so neither multicast nor a pre-seeded roster can carry the traffic.

The boot-node is the `calimero-network/boot-node` image, which serves the rendezvous protocol merod does not: merod builds `rendezvous::client::Behaviour` only, which is precisely why a fleet of plain merods records zero registers and zero discovers however long it runs.

The write travels **joiner-to-joiner**: node-2 writes, node-3 reads, and neither created the namespace nor invited the other. For it to arrive, node-3 must have learned node-2's address by asking the boot-node.

No log-pattern assertions — convergence is the assertion, so a rendezvous regression surfaces as a failed join or a failed read rather than a missing grep. There is a barrier before the write, because `join_context` returns when the join is accepted while the joiner's context state materialises a moment later; writing into that gap answers `Uninitialized`, which merobox hides behind a retry (the same race #3585 fixed in its own scenarios).

## Verification

This shape was run against real containers while developing the merobox side (calimero-network/merobox#357), 3 clients joining a namespace and passing a joiner-to-joiner write:

| client | mDNS dials | kad `RoutingUpdated` | rendezvous Registered | rendezvous Discovered |
|---|---:|---:|---:|---:|
| client-1 | **0** | 6 | 9 | 2 |
| client-2 | **0** | 8 | 29 | 3 |
| client-3 | **0** | 10 | 7 | 4 |

Zero multicast, and every client both registered with and discovered through the boot-node. Locally here: `scripts/lint-e2e-convergence.py` clean (133 scenarios), and the file passes merobox's workflow-schema validation with the new topology accepted. The scenario itself has not run in CI yet — these two matrix entries are its first execution there.

The merobox pin moves to 0.6.60. Master has since replaced the version *floor* with an exact **pin** (#3609), on the reasoning that installing whatever merobox published most recently meant a release reached every open PR within minutes — which is how 0.6.59's unknown-key strictness turned every PR red at once, none of them having touched a scenario. So this is the deliberate bump that note describes, and this PR is where the full suite runs against 0.6.60 before it becomes everyone's default. Below 0.6.60, `topology: { type: bootstrap }` fails schema validation (*"only 'nat' is implemented"*) before any node starts.

## Coverage after this

| mechanism | owner |
|---|---|
| mDNS (local-dev convenience) | the ~80 flat scenarios, incidentally |
| bootstrap dial → identify → kad | `discovery-bootstrap-only-{2,4}node` |
| rendezvous register/discover | **this scenario** (previously: NAT only, confounded) |
| relay reservation / DCUtR | the 8 NAT `sync-resilience-*` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pins merobox for every CI job and adds a new discovery e2e; a bad 0.6.60 binary or a flaky scenario can fail the full suite, but this is test-only with no production code changes.
> 
> **Overview**
> Adds **unconfounded CI coverage** for rendezvous register/discover: three merods on a flat bridge with mDNS off and only the boot-node in `bootstrap.nodes`, so peers must ask who else exists instead of using a pre-seeded roster or NAT/relay paths.
> 
> The new `discovery-rendezvous-3node` scenario joins two clients through invitations, then asserts a **joiner-to-joiner** write (node-2 `set`, node-3 `get`) after `wait_for_sync` barriers. It is wired into the rust-apps e2e matrix.
> 
> Pins merobox from **0.6.59 → 0.6.60** so `topology: { type: bootstrap }` validates; that bump applies to all merobox-using CI, not just this workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10dd14cf47c1ded0c089e35d05ab60b6b744df3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
