### PR TITLE
test(e2e): make group-subgroup's convergence barriers wait on the read

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -16,12 +16,22 @@ runs:
         # red at once and none of them had touched a scenario. Bumping is now a
         # deliberate edit here, and the PR that makes it runs the full e2e suite
         # against the new version before it becomes everyone's problem.
-        # 0.6.60 adds `topology: { type: bootstrap }`, which
+        # 0.6.60 added `topology: { type: bootstrap }`, which
         # workflows/discovery-rendezvous-3node.yml needs — on 0.6.59 that key
         # fails schema validation ("only 'nat' is implemented") before any node
-        # starts. This is the deliberate bump the note above describes, and the
-        # PR carrying it runs the full suite against the new version.
-        MEROBOX_VERSION="0.6.60"
+        # starts.
+        #
+        # 0.6.61 adds `wait_for_sync`'s `expect:` block
+        # (calimero-network/merobox#358 plus #359, which registers the key in the
+        # step schema — without it the block fails validation as unknown). The
+        # three convergence barriers in
+        # apps/scaffolding-e2e/workflows/group-subgroup.yml now use it, and since
+        # unknown scenario keys are fatal as of 0.6.59, that scenario does not
+        # merely lose its barrier on an older merobox — it fails to validate.
+        #
+        # Both are the deliberate bump the note above describes, and the PR
+        # carrying it runs the full suite against the new version.
+        MEROBOX_VERSION="0.6.61"
         TAG="v${MEROBOX_VERSION}"
 
         case "$(uname -m)" in

--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -21,17 +21,22 @@ runs:
         # fails schema validation ("only 'nat' is implemented") before any node
         # starts.
         #
-        # 0.6.61 adds `wait_for_sync`'s `expect:` block
-        # (calimero-network/merobox#358 plus #359, which registers the key in the
-        # step schema — without it the block fails validation as unknown). The
-        # three convergence barriers in
-        # apps/scaffolding-e2e/workflows/group-subgroup.yml now use it, and since
-        # unknown scenario keys are fatal as of 0.6.59, that scenario does not
-        # merely lose its barrier on an older merobox — it fails to validate.
+        # 0.6.62 is the first release with a working `wait_for_sync` `expect:`
+        # block, which the three convergence barriers in
+        # apps/scaffolding-e2e/workflows/group-subgroup.yml use. It took three
+        # merobox changes: #358 added it, #359 registered the key in the step
+        # schema (without which the block fails validation as unknown), and #361
+        # fixed it comparing the JSON-RPC envelope instead of the inner `result`
+        # — which no `equals` can match, so the gate timed out at 60s reporting
+        # a value as absent while every node had returned it. 0.6.61 carries the
+        # first two only, so `expect` is unusable there.
+        #
+        # Unknown scenario keys are fatal as of 0.6.59, so on anything older that
+        # scenario does not merely lose its barrier — it fails to validate.
         #
         # Both are the deliberate bump the note above describes, and the PR
         # carrying it runs the full suite against the new version.
-        MEROBOX_VERSION="0.6.61"
+        MEROBOX_VERSION="0.6.62"
         TAG="v${MEROBOX_VERSION}"
 
         case "$(uname -m)" in

--- a/apps/scaffolding-e2e/workflows/group-subgroup.yml
+++ b/apps/scaffolding-e2e/workflows/group-subgroup.yml
@@ -118,6 +118,23 @@ steps:
       - e2e-node-2
     timeout: 60
     trigger_sync: true
+    # `expect` is what makes this a barrier. Converging on a state hash only
+    # proves the nodes agree on a claim about state: a hash can be published
+    # ahead of the state behind it (calimero-network/core#3595, #3596), and
+    # even truthful hashes can agree a few milliseconds before a pending delta
+    # finishes applying — which is how this scenario failed, reading null 4ms
+    # before the apply committed while the wait had already reported
+    # convergence in 0.00s. Waiting on the read itself cannot pass early.
+    #
+    # The read + json_assert below are kept deliberately: they remain the
+    # scenario's statement of intent, and they now assert something that has
+    # already been observed rather than racing it.
+    expect:
+      method: get
+      args:
+        key: "ns_root_key"
+      equals:
+        output: "from_node1"
 
   - name: Node-2 reads root context value
     type: call
@@ -206,6 +223,12 @@ steps:
       - e2e-node-2
     timeout: 60
     trigger_sync: true
+    expect:
+      method: get
+      args:
+        key: "sub_key"
+      equals:
+        output: "from_subgroup"
 
   - name: Node-2 reads subgroup context value
     type: call
@@ -273,6 +296,12 @@ steps:
       - e2e-node-2
     timeout: 60
     trigger_sync: true
+    expect:
+      method: get
+      args:
+        key: "post_subgroup_key"
+      equals:
+        output: "still_works"
 
   - name: Node-1 reads post-subgroup key
     type: call


### PR DESCRIPTION
**Draft — blocked on a merobox release.** calimero-network/merobox#358 is merged, but it is not in a published release yet: `v0.6.60` was tagged from `31142e4`, the commit *before* that merge, and the release pipeline on the merge skipped `create-release` / `Publish to PyPI` because no version bump accompanied it. So this pins `0.6.61`, which needs a merobox release PR first (`chore(release): 0.6.61`).

**Do not un-draft until 0.6.61 is on the releases page** — the pin verifies the downloaded binary self-reports the pinned version, so CI fails loudly rather than silently running something else.

## Why

The three `wait_for_sync` steps in `group-subgroup` waited for the nodes to agree on a state hash. A hash is a claim about state, not proof of it, so the barrier could clear while the read after it still missed:

```
✓ All targets synced after 0.00s (1 attempts)!
  context=7wX23f…: B66sV3mV…
✗ JSON equality failed
  left={'output': None}
  right='{"output": "from_node1"}'
```

Two independent ways that happens, both seen: a node publishing a root hash whose state it does not hold (#3595, #3596 — both now fixed), and truthful hashes agreeing a few milliseconds before a pending delta finishes applying. In the run this came from, the read lost by **4ms**. The second cause is not a core bug at all — it is the gate answering a question nobody asked, and no core fix closes it.

## What changed

Each barrier now declares the read it is actually waiting for:

```yaml
  - name: Wait for root context sync
    type: wait_for_sync
    context_id: '{{root_ctx_id}}'
    nodes: [e2e-node-1, e2e-node-2]
    timeout: 60
    trigger_sync: true
    expect:
      method: get
      args:
        key: "ns_root_key"
      equals:
        output: "from_node1"
```

The reads and `json_assert`s below them are kept on purpose. They remain the scenario's statement of intent, they keep the captured `outputs:` intact, and they now assert something already observed rather than racing it. Nothing is deleted, so the change is additive to the scenario's coverage.

All three triples are converted: root context, subgroup context, and the post-subgroup root write (which reads on node-1 rather than node-2).

## Verification

- `merobox bootstrap validate` passes on the converted scenario, run against a local build of merobox#358.
- `scripts/lint-e2e-convergence.py` passes: 132 scenarios scanned, 5 baselined, no new findings.
- The pin is the only merobox version reference in the repo; five workflows share the composite action, so all of them move together.

## Follow-ups, deliberately not here

1. **The other scenarios.** This converts the one that flaked. The same `wait_for_sync → call → json_assert` shape appears across the suite, and each one is exposed to the same race.
2. **`scripts/lint-e2e-convergence.py` treats a bare `wait_for_sync` as a sufficient barrier**, which is exactly the assumption this PR undermines. Teaching it that a barrier without `expect` is a *weak* barrier is the right end state, but it would flag most of the suite at once and so needs its own ratchet baseline — a separate PR, after adoption is broader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Test-only, but the merobox pin is global for CI via the shared setup action, so a bad 0.6.62 binary or schema change can fail every e2e workflow at once.
> 
> **Overview**
> Stops `group-subgroup` from racing the follow-up reads: the three `wait_for_sync` steps now include an `expect:` `get` that must match the written value before the barrier clears. Hash-only convergence could pass while a pending apply (or a published hash ahead of state) still left the next read as `null`.
> 
> The existing `call` + `json_assert` steps stay; they now check a value the barrier already observed.
> 
> Pins merobox **0.6.60 → 0.6.62** in `setup-merobox` so `expect` is schema-valid and compares the inner RPC `result` (0.6.61 is not enough). That pin is shared by all workflows using the composite action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 868d7b708a028d82114621d6a47d636c2dee6729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->