### PR TITLE
build(auth): pin the auth-frontend version and retry a transient fetch

### DIFF
--- a/crates/auth/AGENTS.md
+++ b/crates/auth/AGENTS.md
@@ -22,7 +22,7 @@ cargo test -p mero-auth
 cargo run -p mero-auth -- --config crates/auth/config/config.toml --bind 0.0.0.0:3001
 ```
 
-Building the binary requires `CALIMERO_AUTH_FRONTEND_PATH` to point at a built auth-frontend static bundle (`src/api/handlers/mod.rs` embeds it via `rust_embed`); `build.rs` fetches the `calimero-network/auth-frontend` release archive into `OUT_DIR` if the env var isn't already set to a local checkout.
+Building the binary requires `CALIMERO_AUTH_FRONTEND_PATH` to point at a built auth-frontend static bundle (`src/api/handlers/mod.rs` embeds it via `rust_embed`); `build.rs` fetches the `calimero-network/auth-frontend` release archive into `OUT_DIR` if the env var isn't already set to a local checkout. The fetched version is **pinned** in `build.rs` (`CALIMERO_AUTH_FRONTEND_VERSION`), so a given core commit always embeds the same frontend — bump that constant to take a new auth-frontend release, or set `CALIMERO_AUTH_FRONTEND_VERSION` (`latest` included) for a one-off build.
 
 ## What it does
 

--- a/crates/auth/build.rs
+++ b/crates/auth/build.rs
@@ -3,6 +3,8 @@ use std::env;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
 
 use cached_path::Cache;
 use cached_path::Options;
@@ -16,8 +18,15 @@ use reqwest_compat::header::AUTHORIZATION;
 
 const USER_AGENT: &str = "calimero-auth-build";
 const FRESHNESS_LIFETIME: u64 = 60 * 60 * 24 * 7; // 1 week
+const FETCH_RETRY_ATTEMPTS: u32 = 4;
+const FETCH_RETRY_INITIAL_DELAY_SECS: u64 = 2;
 const CALIMERO_AUTH_FRONTEND_REPO: &str = "calimero-network/auth-frontend";
-const CALIMERO_AUTH_FRONTEND_VERSION: &str = "latest";
+/// Pinned, not `"latest"`. Resolving `"latest"` at build time meant two builds of
+/// one core commit could embed different auth-frontend bundles, and the resolution
+/// itself was a live GitHub round-trip on every build — outside the download cache
+/// below, so a warm cache did not spare it. Bumping is a deliberate edit here.
+/// `CALIMERO_AUTH_FRONTEND_VERSION=latest` still opts back in per build.
+const CALIMERO_AUTH_FRONTEND_VERSION: &str = "v1.3.3";
 const CALIMERO_AUTH_FRONTEND_DEFAULT_REF: &str = "master";
 const CALIMERO_AUTH_FRONTEND_LATEST_RELEASE_URL: &str = "https://github.com/{repo}/releases/latest";
 
@@ -108,7 +117,7 @@ fn try_main() -> eyre::Result<()> {
             options = options.force();
         }
 
-        let workdir = cache.cached_path_with_options(&src, &options)?;
+        let workdir = cached_path_with_retry(&cache, &src, &options)?;
 
         let repo = fs::read_dir(workdir)?
             .filter_map(Result::ok)
@@ -125,6 +134,41 @@ fn try_main() -> eyre::Result<()> {
     );
 
     Ok(())
+}
+
+/// Fetch the frontend archive, retrying a failure that looks transient.
+///
+/// Mirrors `cached_path_with_retry` in `crates/server/build.rs`, which exists for
+/// the same reason: `cached_path` retries only 502/503/504 and timeouts, and
+/// classifies a 404 as fatal. That is the wrong call for this URL, because
+/// GitHub's codeload builds tag archives on demand and can answer 404 for a tag
+/// that certainly exists — which is how a release build once failed on a tag that
+/// resolved by hand minutes later. A genuinely bad tag still fails, just after a
+/// few seconds of patience instead of instantly.
+fn cached_path_with_retry(cache: &Cache, src: &str, options: &Options) -> eyre::Result<PathBuf> {
+    let mut delay_secs = FETCH_RETRY_INITIAL_DELAY_SECS;
+
+    for attempt in 1..=FETCH_RETRY_ATTEMPTS {
+        match cache.cached_path_with_options(src, options) {
+            Ok(path) => return Ok(path),
+            Err(err) => {
+                let report = eyre::Report::new(err).wrap_err(format!(
+                    "failed to fetch the auth-frontend archive from {src} (attempt {attempt}/{FETCH_RETRY_ATTEMPTS})"
+                ));
+
+                if attempt == FETCH_RETRY_ATTEMPTS {
+                    return Err(report);
+                }
+
+                eprintln!("cargo:warning={report:#}");
+                eprintln!("cargo:warning=retrying the auth-frontend fetch in {delay_secs}s");
+                thread::sleep(Duration::from_secs(delay_secs));
+                delay_secs = delay_secs.saturating_mul(2);
+            }
+        }
+    }
+
+    unreachable!("the auth-frontend fetch retry loop should have returned")
 }
 
 fn resolve_latest_release_tag(repo: &str, token: Option<&str>) -> eyre::Result<Option<String>> {


### PR DESCRIPTION
## Two defects, one build script

`crates/auth/build.rs` fetched the auth-frontend bundle with `CALIMERO_AUTH_FRONTEND_VERSION = "latest"`, resolved live on every build.

**Reproducibility.** Two builds of one core commit could embed different frontends. For a bundle compiled into a shipped binary via `rust_embed`, a released `mero-auth` had no fixed answer to "which frontend is in here".

**A network call before the cache.** Resolving `"latest"` goes through `resolve_latest_release_tag`, which sits *outside* the `cached_path` cache below it — so a warm cache did not spare it. Every build phoned GitHub before it could look in its own cache. Pinning removes that round-trip entirely on the default path.

## The pin alone would not have fixed the failure that prompted this

A release build once died on `HTTP 404` from codeload for tag **v1.3.3** — a tag that resolved by hand then and still does (`archive/refs/tags/v1.3.3.zip` → 200 today). So the natural next thought is "raise `max_retries`". That does nothing, and it's worth writing down why:

```rust
// cached-path-0.8.1/src/error.rs
fn is_retriable(&self) -> bool {
    match self {
        Error::HttpError(source) => if source.is_status() {
            matches!(source.status().map(|s| s.as_u16()),
                     Some(502) | Some(503) | Some(504))   // <- 404 absent
        } else { source.is_timeout() },
        _ => false,
    }
}
```

`cached_path` already retries 3 times by default, but **404 is classified fatal**, so the retry never engaged and raising the count would have changed nothing. codeload builds tag archives on demand and can 404 for a tag that certainly exists — so the fetch needs a retry that treats this URL's 404 as transient.

## Matching what the repo already does

The wrapper deliberately mirrors `cached_path_with_retry` in `crates/server/build.rs`: same name, 4 attempts, 2s doubling, and `cargo:warning=` so retries are visible in build output. That script had already hit this exact problem for the webui bundle and solved it this way; this brings auth in line rather than inventing a second shape.

(My first draft used `eprintln!("warning: …")`, which does *not* surface as a cargo warning. The existing pattern gets that right.)

## Verification

Forced a bad tag, which exercises the path an intermittent 404 takes:

```
cargo:warning=failed to fetch the auth-frontend archive from ...v0.0.0-nonexistent.zip
  (attempt 1/4): HTTP status client error (404 Not Found) for url
  (https://codeload.github.com/calimero-network/auth-frontend/zip/refs/tags/v0.0.0-nonexistent)
cargo:warning=retrying the auth-frontend fetch in 2s
... attempts 2/4, 3/4 ...
error: failed to fetch the auth-frontend archive ... (attempt 4/4)
```

Before this change that 404 was fatal on attempt 1. Note the host: `codeload.github.com`, exactly what failed before. A genuinely bad tag still fails, just after a few seconds of patience.

Confirmed the pinned path is what actually runs — the build cache records the fetched URL and extracted directory:

```
resource: https://github.com/calimero-network/auth-frontend/archive/refs/tags/v1.3.3.zip
extracted: .../auth-frontend-1.3.3
```

`cargo build -p mero-auth` succeeds, `cargo fmt --all --check` clean, `cargo clippy -p mero-auth --all-targets -D warnings` clean.

## Left out deliberately

`crates/server/build.rs` still carries `CALIMERO_WEBUI_VERSION = "latest"` for the admin-dashboard bundle. It has the retry but **not** the pin, so it retains the reproducibility half of this problem. That's a one-line change of the same kind — flagged rather than folded in, to keep this scoped. Happy to follow up.

## Trade-off, stated

Pinning means core stops picking up new auth-frontend releases automatically; taking one becomes a deliberate bump. That is the point — for a bundle embedded in a shipped binary, "which version shipped" should be a decision, not a timestamp. `CALIMERO_AUTH_FRONTEND_VERSION=latest` still opts back in for a one-off build, and `CALIMERO_AUTH_FRONTEND_SRC` still points at a local checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script only: version pin and fetch retries. No runtime, auth, or security-path changes.
> 
> **Overview**
> Pins the embedded auth-frontend to **v1.3.3** in `crates/auth/build.rs` so a given core commit always ships the same bundle, instead of resolving `"latest"` on every build (which also skipped the download cache). Override with `CALIMERO_AUTH_FRONTEND_VERSION` (including `latest`) for a one-off.
> 
> Adds `cached_path_with_retry` (same 4-attempt, doubling-delay pattern as `crates/server/build.rs`) so GitHub codeload 404s on a real tag are treated as transient rather than fatal. Docs in `AGENTS.md` note the pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1eb0f785468ff6b588c12cff971a2691953699d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->