### PR TITLE
refactor(runtime): generate the five reads whose authored half is the same code

### DIFF
--- a/crates/runtime/src/logic/host_functions/js_collections.rs
+++ b/crates/runtime/src/logic/host_functions/js_collections.rs
@@ -100,6 +100,200 @@ macro_rules! js_new_with_id_op {
     };
 }
 
+// The plain and authored halves of these five reads are the same code; only the
+// loader differs. Generating both from one body is what stops them drifting apart
+// unnoticed — before this they sat ~1500 lines apart in the same impl.
+//
+// `insert`, `push` and `remove` are deliberately NOT generated. Their halves only
+// look alike: authored `insert` rejects an already-present key where plain upserts
+// and returns the previous value, authored `push` returns the new index through an
+// extra register argument, and authored `remove` is owner-only. Those differences
+// are intentional and covered by tests in `calimero-storage`; folding them in would
+// assert an equivalence the design rejects.
+/// `map_get` for a plain and an authored collection: the same host-function body,
+/// differing only in which loader resolves the instance id.
+macro_rules! js_map_get {
+    ($name:ident, $loader:ident) => {
+        fn $name(
+            &mut self,
+            map_id_ptr: u64,
+            key_ptr: u64,
+            dest_register_id: u64,
+        ) -> VMLogicResult<i32> {
+            let map_id = match self.read_map_id(map_id_ptr)? {
+                Ok(id) => id,
+                Err(message) => return self.write_error_message(dest_register_id, message),
+            };
+
+            let key = self.read_buffer(key_ptr)?;
+
+            let map = match $loader(map_id) {
+                Ok(map) => map,
+                Err(message) => return self.write_error_message(dest_register_id, message),
+            };
+
+            match map.get(&key) {
+                Ok(Some(value)) => {
+                    self.write_register_bytes(dest_register_id, &value)?;
+                    Ok(1)
+                }
+                Ok(None) => {
+                    self.clear_register(dest_register_id)?;
+                    Ok(0)
+                }
+                Err(err) => self.write_error_message(dest_register_id, err),
+            }
+        }
+    };
+}
+/// `vector_get` for a plain and an authored collection: the same host-function body,
+/// differing only in which loader resolves the instance id.
+macro_rules! js_vector_get {
+    ($name:ident, $loader:ident) => {
+        fn $name(
+            &mut self,
+            vector_id_ptr: u64,
+            index: u64,
+            dest_register_id: u64,
+        ) -> VMLogicResult<i32> {
+            let vector_id = match self.read_map_id(vector_id_ptr)? {
+                Ok(id) => id,
+                Err(message) => return self.write_error_message(dest_register_id, message),
+            };
+
+            let idx = match usize::try_from(index) {
+                Ok(value) => value,
+                Err(_) => {
+                    return self.write_error_message(
+                        dest_register_id,
+                        format!("index {index} does not fit into usize"),
+                    )
+                }
+            };
+
+            let vector = match $loader(vector_id) {
+                Ok(vector) => vector,
+                Err(message) => return self.write_error_message(dest_register_id, message),
+            };
+
+            match vector.get(idx) {
+                Ok(Some(value)) => {
+                    self.write_register_bytes(dest_register_id, &value)?;
+                    Ok(1)
+                }
+                Ok(None) => {
+                    self.clear_register(dest_register_id)?;
+                    Ok(0)
+                }
+                Err(err) => self.write_error_message(dest_register_id, err),
+            }
+        }
+    };
+}
+/// `map_contains` for a plain and an authored collection: the same host-function body,
+/// differing only in which loader resolves the instance id.
+macro_rules! js_map_contains {
+    ($name:ident, $loader:ident) => {
+        fn $name(&mut self, map_id_ptr: u64, key_ptr: u64) -> VMLogicResult<i32> {
+            let map_id = match self.read_map_id(map_id_ptr)? {
+                Ok(id) => id,
+                Err(message) => return self.write_error_message(0, message),
+            };
+
+            let key = self.read_buffer(key_ptr)?;
+
+            let map = match $loader(map_id) {
+                Ok(map) => map,
+                Err(message) => return self.write_error_message(0, message),
+            };
+
+            match map.contains(&key) {
+                Ok(result) => Ok(i32::from(result)),
+                Err(err) => self.write_error_message(0, err),
+            }
+        }
+    };
+}
+/// `map_iter` for a plain and an authored collection: the same host-function body,
+/// differing only in which loader resolves the instance id.
+macro_rules! js_map_iter {
+    ($name:ident, $loader:ident) => {
+        fn $name(&mut self, map_id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
+            let map_id = match self.read_map_id(map_id_ptr)? {
+                Ok(id) => id,
+                Err(message) => return self.write_error_message(dest_register_id, message),
+            };
+
+            let map = match $loader(map_id) {
+                Ok(map) => map,
+                Err(message) => return self.write_error_message(dest_register_id, message),
+            };
+
+            let entries = match map.entries() {
+                Ok(entries) => entries,
+                Err(err) => return self.write_error_message(dest_register_id, err),
+            };
+
+            let count = u32::try_from(entries.len()).map_err(|_| HostError::IntegerOverflow)?;
+
+            let mut total_len: usize = 4;
+            for (key, value) in &entries {
+                let key_len = key.len();
+                let value_len = value.len();
+                u32::try_from(key_len).map_err(|_| HostError::IntegerOverflow)?;
+                u32::try_from(value_len).map_err(|_| HostError::IntegerOverflow)?;
+                total_len = total_len
+                    .checked_add(4)
+                    .and_then(|acc| acc.checked_add(key_len))
+                    .and_then(|acc| acc.checked_add(4))
+                    .and_then(|acc| acc.checked_add(value_len))
+                    .ok_or(HostError::IntegerOverflow)?;
+            }
+
+            let mut buffer = Vec::with_capacity(total_len);
+            buffer.extend_from_slice(&count.to_le_bytes());
+            for (key, value) in entries {
+                let key_len = u32::try_from(key.len()).map_err(|_| HostError::IntegerOverflow)?;
+                let value_len =
+                    u32::try_from(value.len()).map_err(|_| HostError::IntegerOverflow)?;
+                buffer.extend_from_slice(&key_len.to_le_bytes());
+                buffer.extend_from_slice(&key);
+                buffer.extend_from_slice(&value_len.to_le_bytes());
+                buffer.extend_from_slice(&value);
+            }
+
+            self.write_register_bytes(dest_register_id, &buffer)?;
+            Ok(1)
+        }
+    };
+}
+/// `vector_len` for a plain and an authored collection: the same host-function body,
+/// differing only in which loader resolves the instance id.
+macro_rules! js_vector_len {
+    ($name:ident, $loader:ident) => {
+        fn $name(&mut self, vector_id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
+            let vector_id = match self.read_map_id(vector_id_ptr)? {
+                Ok(id) => id,
+                Err(message) => return self.write_error_message(dest_register_id, message),
+            };
+
+            let vector = match $loader(vector_id) {
+                Ok(vector) => vector,
+                Err(message) => return self.write_error_message(dest_register_id, message),
+            };
+
+            match vector.len() {
+                Ok(len) => {
+                    let len_u64 = u64::try_from(len).map_err(|_| HostError::IntegerOverflow)?;
+                    self.write_register_bytes(dest_register_id, &len_u64.to_le_bytes())?;
+                    Ok(1)
+                }
+                Err(err) => self.write_error_message(dest_register_id, err),
+            }
+        }
+    };
+}
+
 impl VMHostFunctions<'_> {
     fn make_runtime_env(&mut self) -> VMLogicResult<RuntimeEnv> {
         self.with_logic_mut(|logic| {
@@ -1019,36 +1213,8 @@ impl VMHostFunctions<'_> {
         self.invoke_with_storage_env(|host| host.crdt_delete_collection(id_ptr, register_id))
     }
 
-    fn crdt_map_get(
-        &mut self,
-        map_id_ptr: u64,
-        key_ptr: u64,
-        dest_register_id: u64,
-    ) -> VMLogicResult<i32> {
-        let map_id = match self.read_map_id(map_id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let key = self.read_buffer(key_ptr)?;
-
-        let map = match load_js_map_instance(map_id) {
-            Ok(map) => map,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        match map.get(&key) {
-            Ok(Some(value)) => {
-                self.write_register_bytes(dest_register_id, &value)?;
-                Ok(1)
-            }
-            Ok(None) => {
-                self.clear_register(dest_register_id)?;
-                Ok(0)
-            }
-            Err(err) => self.write_error_message(dest_register_id, err),
-        }
-    }
+    js_map_get!(crdt_map_get, load_js_map_instance);
+    js_map_get!(crdt_authored_map_get, load_js_authored_map_instance);
 
     fn crdt_map_insert(
         &mut self,
@@ -1122,92 +1288,14 @@ impl VMHostFunctions<'_> {
         }
     }
 
-    fn crdt_map_contains(&mut self, map_id_ptr: u64, key_ptr: u64) -> VMLogicResult<i32> {
-        let map_id = match self.read_map_id(map_id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(0, message),
-        };
+    js_map_contains!(crdt_map_contains, load_js_map_instance);
+    js_map_contains!(crdt_authored_map_contains, load_js_authored_map_instance);
 
-        let key = self.read_buffer(key_ptr)?;
+    js_map_iter!(crdt_map_iter, load_js_map_instance);
+    js_map_iter!(crdt_authored_map_iter, load_js_authored_map_instance);
 
-        let map = match load_js_map_instance(map_id) {
-            Ok(map) => map,
-            Err(message) => return self.write_error_message(0, message),
-        };
-
-        match map.contains(&key) {
-            Ok(result) => Ok(i32::from(result)),
-            Err(err) => self.write_error_message(0, err),
-        }
-    }
-
-    fn crdt_map_iter(&mut self, map_id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
-        let map_id = match self.read_map_id(map_id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let map = match load_js_map_instance(map_id) {
-            Ok(map) => map,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let entries = match map.entries() {
-            Ok(entries) => entries,
-            Err(err) => return self.write_error_message(dest_register_id, err),
-        };
-
-        let count = u32::try_from(entries.len()).map_err(|_| HostError::IntegerOverflow)?;
-
-        let mut total_len: usize = 4;
-        for (key, value) in &entries {
-            let key_len = key.len();
-            let value_len = value.len();
-            u32::try_from(key_len).map_err(|_| HostError::IntegerOverflow)?;
-            u32::try_from(value_len).map_err(|_| HostError::IntegerOverflow)?;
-            total_len = total_len
-                .checked_add(4)
-                .and_then(|acc| acc.checked_add(key_len))
-                .and_then(|acc| acc.checked_add(4))
-                .and_then(|acc| acc.checked_add(value_len))
-                .ok_or(HostError::IntegerOverflow)?;
-        }
-
-        let mut buffer = Vec::with_capacity(total_len);
-        buffer.extend_from_slice(&count.to_le_bytes());
-        for (key, value) in entries {
-            let key_len = u32::try_from(key.len()).map_err(|_| HostError::IntegerOverflow)?;
-            let value_len = u32::try_from(value.len()).map_err(|_| HostError::IntegerOverflow)?;
-            buffer.extend_from_slice(&key_len.to_le_bytes());
-            buffer.extend_from_slice(&key);
-            buffer.extend_from_slice(&value_len.to_le_bytes());
-            buffer.extend_from_slice(&value);
-        }
-
-        self.write_register_bytes(dest_register_id, &buffer)?;
-        Ok(1)
-    }
-
-    fn crdt_vector_len(&mut self, vector_id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
-        let vector_id = match self.read_map_id(vector_id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let vector = match load_js_vector_instance(vector_id) {
-            Ok(vector) => vector,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        match vector.len() {
-            Ok(len) => {
-                let len_u64 = u64::try_from(len).map_err(|_| HostError::IntegerOverflow)?;
-                self.write_register_bytes(dest_register_id, &len_u64.to_le_bytes())?;
-                Ok(1)
-            }
-            Err(err) => self.write_error_message(dest_register_id, err),
-        }
-    }
+    js_vector_len!(crdt_vector_len, load_js_vector_instance);
+    js_vector_len!(crdt_authored_vector_len, load_js_authored_vector_instance);
 
     fn crdt_vector_push(&mut self, vector_id_ptr: u64, value_ptr: u64) -> VMLogicResult<i32> {
         let vector_id = match self.read_map_id(vector_id_ptr)? {
@@ -1231,44 +1319,8 @@ impl VMHostFunctions<'_> {
         }
     }
 
-    fn crdt_vector_get(
-        &mut self,
-        vector_id_ptr: u64,
-        index: u64,
-        dest_register_id: u64,
-    ) -> VMLogicResult<i32> {
-        let vector_id = match self.read_map_id(vector_id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let idx = match usize::try_from(index) {
-            Ok(value) => value,
-            Err(_) => {
-                return self.write_error_message(
-                    dest_register_id,
-                    format!("index {index} does not fit into usize"),
-                )
-            }
-        };
-
-        let vector = match load_js_vector_instance(vector_id) {
-            Ok(vector) => vector,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        match vector.get(idx) {
-            Ok(Some(value)) => {
-                self.write_register_bytes(dest_register_id, &value)?;
-                Ok(1)
-            }
-            Ok(None) => {
-                self.clear_register(dest_register_id)?;
-                Ok(0)
-            }
-            Err(err) => self.write_error_message(dest_register_id, err),
-        }
-    }
+    js_vector_get!(crdt_vector_get, load_js_vector_instance);
+    js_vector_get!(crdt_authored_vector_get, load_js_authored_vector_instance);
 
     fn crdt_vector_pop(&mut self, vector_id_ptr: u64, dest_register_id: u64) -> VMLogicResult<i32> {
         let vector_id = match self.read_map_id(vector_id_ptr)? {
@@ -2554,56 +2606,6 @@ impl VMHostFunctions<'_> {
         }
     }
 
-    fn crdt_authored_map_get(
-        &mut self,
-        map_id_ptr: u64,
-        key_ptr: u64,
-        dest_register_id: u64,
-    ) -> VMLogicResult<i32> {
-        let map_id = match self.read_map_id(map_id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let key = self.read_buffer(key_ptr)?;
-
-        let map = match load_js_authored_map_instance(map_id) {
-            Ok(map) => map,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        match map.get(&key) {
-            Ok(Some(value)) => {
-                self.write_register_bytes(dest_register_id, &value)?;
-                Ok(1)
-            }
-            Ok(None) => {
-                self.clear_register(dest_register_id)?;
-                Ok(0)
-            }
-            Err(err) => self.write_error_message(dest_register_id, err),
-        }
-    }
-
-    fn crdt_authored_map_contains(&mut self, map_id_ptr: u64, key_ptr: u64) -> VMLogicResult<i32> {
-        let map_id = match self.read_map_id(map_id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(0, message),
-        };
-
-        let key = self.read_buffer(key_ptr)?;
-
-        let map = match load_js_authored_map_instance(map_id) {
-            Ok(map) => map,
-            Err(message) => return self.write_error_message(0, message),
-        };
-
-        match map.contains(&key) {
-            Ok(result) => Ok(i32::from(result)),
-            Err(err) => self.write_error_message(0, err),
-        }
-    }
-
     fn crdt_authored_map_owner_of(
         &mut self,
         map_id_ptr: u64,
@@ -2658,57 +2660,6 @@ impl VMHostFunctions<'_> {
             Ok(result) => Ok(i32::from(result)),
             Err(err) => self.write_error_message(0, err),
         }
-    }
-
-    fn crdt_authored_map_iter(
-        &mut self,
-        map_id_ptr: u64,
-        dest_register_id: u64,
-    ) -> VMLogicResult<i32> {
-        let map_id = match self.read_map_id(map_id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let map = match load_js_authored_map_instance(map_id) {
-            Ok(map) => map,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let entries = match map.entries() {
-            Ok(entries) => entries,
-            Err(err) => return self.write_error_message(dest_register_id, err),
-        };
-
-        let count = u32::try_from(entries.len()).map_err(|_| HostError::IntegerOverflow)?;
-
-        let mut total_len: usize = 4;
-        for (key, value) in &entries {
-            let key_len = key.len();
-            let value_len = value.len();
-            u32::try_from(key_len).map_err(|_| HostError::IntegerOverflow)?;
-            u32::try_from(value_len).map_err(|_| HostError::IntegerOverflow)?;
-            total_len = total_len
-                .checked_add(4)
-                .and_then(|acc| acc.checked_add(key_len))
-                .and_then(|acc| acc.checked_add(4))
-                .and_then(|acc| acc.checked_add(value_len))
-                .ok_or(HostError::IntegerOverflow)?;
-        }
-
-        let mut buffer = Vec::with_capacity(total_len);
-        buffer.extend_from_slice(&count.to_le_bytes());
-        for (key, value) in entries {
-            let key_len = u32::try_from(key.len()).map_err(|_| HostError::IntegerOverflow)?;
-            let value_len = u32::try_from(value.len()).map_err(|_| HostError::IntegerOverflow)?;
-            buffer.extend_from_slice(&key_len.to_le_bytes());
-            buffer.extend_from_slice(&key);
-            buffer.extend_from_slice(&value_len.to_le_bytes());
-            buffer.extend_from_slice(&value);
-        }
-
-        self.write_register_bytes(dest_register_id, &buffer)?;
-        Ok(1)
     }
 
     fn crdt_authored_map_len(
@@ -2843,45 +2794,6 @@ impl VMHostFunctions<'_> {
         }
     }
 
-    fn crdt_authored_vector_get(
-        &mut self,
-        vector_id_ptr: u64,
-        index: u64,
-        dest_register_id: u64,
-    ) -> VMLogicResult<i32> {
-        let vector_id = match self.read_map_id(vector_id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let idx = match usize::try_from(index) {
-            Ok(value) => value,
-            Err(_) => {
-                return self.write_error_message(
-                    dest_register_id,
-                    format!("index {index} does not fit into usize"),
-                )
-            }
-        };
-
-        let vector = match load_js_authored_vector_instance(vector_id) {
-            Ok(vector) => vector,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        match vector.get(idx) {
-            Ok(Some(value)) => {
-                self.write_register_bytes(dest_register_id, &value)?;
-                Ok(1)
-            }
-            Ok(None) => {
-                self.clear_register(dest_register_id)?;
-                Ok(0)
-            }
-            Err(err) => self.write_error_message(dest_register_id, err),
-        }
-    }
-
     fn crdt_authored_vector_owner_of(
         &mut self,
         vector_id_ptr: u64,
@@ -2994,31 +2906,6 @@ impl VMHostFunctions<'_> {
 
         self.write_register_bytes(dest_register_id, &buffer)?;
         Ok(1)
-    }
-
-    fn crdt_authored_vector_len(
-        &mut self,
-        vector_id_ptr: u64,
-        dest_register_id: u64,
-    ) -> VMLogicResult<i32> {
-        let vector_id = match self.read_map_id(vector_id_ptr)? {
-            Ok(id) => id,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        let vector = match load_js_authored_vector_instance(vector_id) {
-            Ok(vector) => vector,
-            Err(message) => return self.write_error_message(dest_register_id, message),
-        };
-
-        match vector.len() {
-            Ok(len) => {
-                let len_u64 = u64::try_from(len).map_err(|_| HostError::IntegerOverflow)?;
-                self.write_register_bytes(dest_register_id, &len_u64.to_le_bytes())?;
-                Ok(1)
-            }
-            Err(err) => self.write_error_message(dest_register_id, err),
-        }
     }
 
     fn crdt_shared_new(


### PR DESCRIPTION
## What

Five `js_collections` host functions had a plain and an `authored` variant that were **the same body**, differing only in which loader resolved the instance id — `map_get`, `vector_get`, `map_contains`, `map_iter`, `vector_len`. Each pair is now generated from one body.

```rust
js_map_get!(crdt_map_get,          load_js_map_instance);
js_map_get!(crdt_authored_map_get, load_js_authored_map_instance);
```

**204 insertions, 317 deletions.**

They were also **~1500 lines apart inside the same `impl`** (`crdt_map_get` at L1022, `crdt_authored_map_get` at L2557), which is why the duplication went unnoticed. The invocations are adjacent now, so the relationship is two visible lines rather than invisible across half the file.

## What is deliberately NOT generated

`insert`, `push` and `remove`, and the module comment says why — otherwise the natural next move for a future reader is to "finish the job" and merge the three that must not be merged:

- **`insert`** — authored rejects an already-present key; plain upserts and returns the previous value. `authored_map.rs:112`: *"Fails with `ActionNotAllowed` if `k` is already present. Ownership transfer is not supported — use `remove` + `insert` from the new owner."* Test: `insert_rejects_existing_key`.
- **`push`** — authored returns the new index through an **extra register argument**, so its host ABI signature differs outright.
- **`remove`** — authored is owner-only.

Those are intended distinctions, documented and tested in `calimero-storage`. Folding them in would assert an equivalence the design rejects.

## Proven mechanical, not assumed

**Pre-flight, before editing.** Each pair's two halves were reduced to a single template and compared **token by token**, ignoring whitespace and the trailing comma rustfmt adds to a wrapped signature. All ten halves matched exactly; a mismatch was set to abort the transformation.

That check earned its keep. It initially flagged `map_iter` and `vector_len` as differing, contradicting an earlier eyeball read of "formatting only" — because blanket-replacing `authored_` had also renamed the loader and masked a real token. The genuine difference turned out to be one trailing comma.

**`cargo expand` oracle, after.** Stronger than tests for a substitution like this:

```
functions: before=622 after=622
names differing: none
bodies differing (line numbers normalized): NONE
```

Every one of the 622 expanded functions is byte-identical. The only residual is embedded `tracing` call-site line numbers shifting by exactly the 113 lines removed (`js_collections.rs:3504` → `:3391`) — which is what deleting lines above a callsite does.

## Verification

- `cargo test --workspace` — **4983 passed, 0 failed**
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` — clean
- `cargo fmt --all --check` — clean

## One caveat, stated plainly

I recommended against this change before making it, and the result doesn't fully change my view. The plain/authored family is **diverging by design** — three of eight operations already differ, with docs and tests asserting the difference. A shared macro encodes "plain and authored behave identically", so the next legitimate divergence will have to tear part of it back out. −113 lines is real; so is that cost. Reviewers may reasonably weigh it the other way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor of VM host functions with no intended behavior change; insert/push/remove stay handwritten because those authored variants differ by design.
> 
> **Overview**
> Deduplicates the five JS collection host reads whose **plain** and **authored** halves were the same body, differing only in the instance loader: `map_get`, `vector_get`, `map_contains`, `map_iter`, and `vector_len`.
> 
> Each pair is now generated from one macro, with both invocations next to each other instead of ~1500 lines apart. `insert`, `push`, and `remove` stay handwritten — authored insert rejects existing keys, authored push has a different ABI, and authored remove is owner-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eb435954909b77d5b1e6e105b5928cb4f76bcb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->