### PR TITLE
fix(projection): tell "could not read it" apart from "models nothing"

### DIFF
--- a/crates/authz/src/authorize.rs
+++ b/crates/authz/src/authorize.rs
@@ -204,6 +204,13 @@ pub fn authorize(op: &Op, acl_at_cut: &AclView) -> Result<(), Rejected> {
         }
         // A graph-only node mutates nothing, so there is nothing to authorize.
         OpPayload::Noop => Ok(()),
+        // Neither does a hole. An op this node could not decrypt writes no state
+        // here, so there is no rule to apply — and inventing a refusal would be
+        // wrong in the other direction: the op may well be authorized, this node
+        // simply cannot see what it says. Authorization of its real payload
+        // happens on the nodes that can read it, and on this one once a key
+        // arrives and the op re-folds.
+        OpPayload::Opaque { .. } => Ok(()),
 
         // ---- account plane ----
         OpPayload::DeviceLinked {

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -321,12 +321,16 @@ pub struct ScopeProjections {
     /// Op ids already retained per scope — gives `ingest_op` O(1) dedup of a
     /// replayed delta instead of an O(n) scan of the log.
     seen: HashMap<ScopeId, HashSet<[u8; 32]>>,
-    /// Index in `logs` of each op id currently folded as `Noop`, per scope. The
-    /// late-decrypt upgrade (a non-`Noop` payload re-ingested for a `Noop`-folded id)
-    /// uses it to replace the entry in O(1) instead of scanning the whole log, and the
-    /// common no-upgrade re-ingest skips the scan entirely (id not present here).
-    /// Entries are removed once upgraded, so it only ever holds still-undecrypted ops.
-    noop_log_pos: HashMap<ScopeId, HashMap<[u8; 32], usize>>,
+    /// Index in `logs` of each op id currently folded as `Opaque`, per scope — an
+    /// op this node could not decrypt. The late-decrypt upgrade (a readable payload
+    /// re-ingested for an id folded as a hole) uses it to replace the entry in O(1)
+    /// instead of scanning the whole log, and the common no-upgrade re-ingest skips
+    /// the scan entirely (id not present here). Entries are removed once upgraded, so
+    /// it only ever holds ops still waiting for a key.
+    ///
+    /// `Noop` is deliberately NOT tracked: an op the projection models nothing about
+    /// was read correctly and has nothing to upgrade to.
+    opaque_log_pos: HashMap<ScopeId, HashMap<[u8; 32], usize>>,
     /// Namespaces already replayed from persisted state, so `backfill_namespace`
     /// walks each governance DAG at most once (the live feed maintains it after).
     backfilled: HashSet<[u8; 32]>,
@@ -361,17 +365,17 @@ impl ScopeProjections {
         // O(1) dedup: `insert` is true only for a not-yet-seen id.
         if self.seen.entry(op.scope).or_default().insert(op.id()) {
             let log = self.logs.entry(op.scope).or_default();
-            if matches!(op.payload, OpPayload::Noop) {
+            if matches!(op.payload, OpPayload::Opaque { .. }) {
                 // Remember where this still-undecrypted op sits so a later decrypted
                 // re-ingest can upgrade it in O(1) (see below).
                 let _ = self
-                    .noop_log_pos
+                    .opaque_log_pos
                     .entry(op.scope)
                     .or_default()
                     .insert(op.id(), log.len());
             }
             log.push(op.clone());
-        } else if !matches!(op.payload, OpPayload::Noop) {
+        } else if !matches!(op.payload, OpPayload::Opaque { .. }) {
             // Already seen, but `op.id()` is the SIGNED op's content hash, not the decoded
             // payload's — so an encrypted op first folded as `Noop` (applied before its
             // group key arrived) shares an id with its later, decrypted form. The op-log
@@ -383,7 +387,7 @@ impl ScopeProjections {
             // common re-ingest (already a real payload) is an O(1) miss, and an actual
             // upgrade is an O(1) indexed replace — no log scan either way.
             if let Some(idx) = self
-                .noop_log_pos
+                .opaque_log_pos
                 .get_mut(&op.scope)
                 .and_then(|m| m.remove(&op.id()))
             {
@@ -398,7 +402,7 @@ impl ScopeProjections {
     /// Cap the retained op-log for `scope` so the live feed can't grow memory
     /// without bound. When the log crosses [`MAX_LIVE_LOG_OPS`] it is trimmed to
     /// [`LIVE_LOG_LOW_WATER`] (batched, so eviction is amortized), dropping the
-    /// oldest ops. `seen` and `noop_log_pos` are kept consistent with the
+    /// oldest ops. `seen` and `opaque_log_pos` are kept consistent with the
     /// trimmed log. The retained window matches the backfill walk's cap, so
     /// `acl_view_at` for a cut older than the window degrades exactly as it
     /// already does for a context whose history exceeded the backfill cap.
@@ -421,13 +425,13 @@ impl ScopeProjections {
                 let _ = seen.remove(id);
             }
         }
-        // `noop_log_pos` values are indices into `log`, which just shifted by
+        // `opaque_log_pos` values are indices into `log`, which just shifted by
         // `drain`; rebuild from the retained log (only runs on eviction).
-        if let Some(noop) = self.noop_log_pos.get_mut(&scope) {
-            noop.clear();
+        if let Some(opaque) = self.opaque_log_pos.get_mut(&scope) {
+            opaque.clear();
             for (idx, op) in log.iter().enumerate() {
-                if matches!(op.payload, OpPayload::Noop) {
-                    let _ = noop.insert(op.id(), idx);
+                if matches!(op.payload, OpPayload::Opaque { .. }) {
+                    let _ = opaque.insert(op.id(), idx);
                 }
             }
         }
@@ -2468,12 +2472,92 @@ mod tests {
         );
     }
 
+    /// The regression this variant exists for, on the production path: a
+    /// `KeyDelivery` is a root op the projection models nothing about, so it folds
+    /// `Noop` — and a cut behind it must still be READABLE. It is not an op anyone
+    /// failed to decrypt; it simply says nothing about membership.
+    ///
+    /// While both cases shared `Noop`, this made a cut provisional on every node,
+    /// including the admin that minted the key, and every scenario publishes one
+    /// of these on its first add. A measured 68% of the divergence gate's
+    /// comparisons abstained on the strength of it.
     #[test]
-    fn undecryptable_group_op_folds_as_a_noop_graph_node() {
+    fn a_readable_op_the_projection_models_nothing_about_leaves_the_cut_readable() {
+        let ns = [0x21; 32];
+        let signer = PublicKey::from([2u8; 32]);
+        let scope = ScopeId::from(ns);
+        let group = ContextGroupId::from([0x22; 32]);
+
+        // Key transport: readable by construction — nothing about it is encrypted
+        // to a group — and modelled by nothing.
+        let key_delivery = SignedNamespaceOp {
+            version: 1,
+            namespace_id: ns.into(),
+            parent_op_hashes: Vec::new(),
+            signer,
+            nonce: 0,
+            op: NamespaceOp::Root(calimero_governance_types::RootOp::KeyDelivery {
+                group_id: group.to_bytes().into(),
+                envelope: calimero_governance_types::KeyEnvelope {
+                    recipient: calimero_governance_types::EnvelopeRecipient::Member {
+                        identity: signer,
+                        ephemeral_pk: signer,
+                    },
+                    sender: signer,
+                    nonce: [0u8; 12],
+                    ciphertext: Vec::new(),
+                    signature: [0u8; 64],
+                },
+            }),
+            signature: [0u8; 64],
+        };
+        let delivery_op = op_from_namespace_op(&key_delivery, None, [0xA1; 32], hlc(1), &[]);
+        assert_eq!(
+            delivery_op.payload,
+            OpPayload::Noop,
+            "key transport folds to Noop — read fine, models nothing"
+        );
+
+        let mut proj = ScopeProjections::new();
+        proj.ingest_op(&delivery_op);
+
+        let (complete, decoded) = proj.cut_ancestry_state(&scope, &[delivery_op.id()]);
+        assert!(complete, "the op is right there in the log");
+        assert!(
+            decoded,
+            "a cut through an op this node READ must not be provisional"
+        );
+
+        // Contrast: the same cut behind an op that truly could not be decrypted.
+        let opaque_op = op_from_namespace_op(
+            &signed_group(ns, signer, group),
+            None,
+            [0xA2; 32],
+            hlc(2),
+            &[delivery_op.id()],
+        );
+        proj.ingest_op(&opaque_op);
+        let (complete, decoded) = proj.cut_ancestry_state(&scope, &[opaque_op.id()]);
+        assert!(complete, "still no gaps");
+        assert!(
+            !decoded,
+            "a cut through an op this node could not read IS provisional"
+        );
+    }
+
+    #[test]
+    fn undecryptable_group_op_folds_as_an_opaque_graph_node() {
         // A group op we can't decrypt (no `decrypted` supplied) carries no
         // membership change we can read, but it MUST still become a node so an
         // ancestry walk can pass through it to the ops behind it (dropping it
         // would orphan them — the bug this guards against).
+        //
+        // It folds `Opaque`, NOT `Noop`, and the distinction is the point: `Noop`
+        // is what a readable op the projection models nothing about folds to, and
+        // sharing one variant made every cut behind such an op — a `KeyDelivery`,
+        // a metadata set — look unreadable to a node holding every key. `Opaque`
+        // also carries the group whose key is missing, which the envelope states
+        // in cleartext even when the body cannot be read.
         let ns = [0x11; 32];
         let signer = PublicKey::from([1u8; 32]);
         let group = ContextGroupId::from([0x33; 32]);
@@ -2486,8 +2570,8 @@ mod tests {
         );
         assert_eq!(
             op.payload,
-            OpPayload::Noop,
-            "undecryptable group op is a Noop node"
+            OpPayload::Opaque { group },
+            "an undecryptable group op is a hole that names its group, not a Noop"
         );
         assert_eq!(op.id(), [0x99; 32], "but it still occupies its DAG node");
         assert_eq!(op.parents, vec![[0x88; 32]], "with its real parents");

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -564,7 +564,10 @@ impl ScopeProjections {
     pub fn ops_for_namespace(store: &Store, namespace_id: [u8; 32]) -> Option<Vec<Op>> {
         let scope = ScopeId::from(namespace_id);
         match crate::unified_op_store::load_scope_ops(store, &scope) {
-            Ok(ops) if !ops.is_empty() => Some(ops),
+            Ok(mut ops) if !ops.is_empty() => {
+                Self::reclassify_stored_holes(store, namespace_id, &mut ops);
+                Some(ops)
+            }
             Ok(_) => Self::collect_namespace_ops(store, namespace_id),
             Err(err) => {
                 tracing::warn!(
@@ -573,6 +576,83 @@ impl ScopeProjections {
                     "op-store load failed; falling back to the governance-DAG fold"
                 );
                 Self::collect_namespace_ops(store, namespace_id)
+            }
+        }
+    }
+
+    /// Re-derive the payload of every stored `Noop`, so a row written before
+    /// `Opaque` existed cannot pass as readable.
+    ///
+    /// The op-store persists the FOLDED op, and an older build wrote `Noop` for
+    /// both of the reasons a fold produces nothing — including an encrypted group
+    /// op it could not decrypt. Reading such a row now would say "readable" about
+    /// a hole, which is the one direction that must never happen: a provisional
+    /// fold presented as conclusive turns into a divergence marker for an op
+    /// nobody could see. `repersist_namespace_ops` rewrites rows when a key
+    /// ARRIVES, so it does not cover an op this node will never decrypt.
+    ///
+    /// Only stored `Noop`s are touched, and each is decided the way the walk would
+    /// decide it: consult the signed op, re-attempt the decrypt, and take whatever
+    /// payload that yields — a real one if the key is here now, `Noop` if the op is
+    /// readable and models nothing, `Opaque` if it cannot be read. A row already
+    /// carrying a real payload or an `Opaque` is left alone, so steady state costs
+    /// nothing and the work shrinks as rows are rewritten.
+    fn reclassify_stored_holes(store: &Store, namespace_id: [u8; 32], ops: &mut [Op]) {
+        let stale: Vec<usize> = ops
+            .iter()
+            .enumerate()
+            .filter(|(_, op)| matches!(op.payload, OpPayload::Noop))
+            .map(|(i, _)| i)
+            .collect();
+        if stale.is_empty() {
+            return;
+        }
+        let op_log = NamespaceOpLogService::new(store, namespace_id.into());
+        for i in stale {
+            let Ok(Some(signed)) = op_log.get_signed_op(ops[i].id()) else {
+                // No signed op behind it: nothing to re-derive from. Left as it
+                // is — a `Noop` that cannot be checked is not evidence of a hole.
+                continue;
+            };
+            let calimero_governance_types::NamespaceOp::Group {
+                group_id,
+                key_id,
+                encrypted,
+                ..
+            } = &signed.op
+            else {
+                // A root op that models nothing is a genuine `Noop`, then and now.
+                continue;
+            };
+            let decrypted = calimero_governance_store::decrypt_group_op(
+                store,
+                namespace_id.into(),
+                *group_id,
+                key_id.as_bytes(),
+                encrypted,
+            )
+            .ok()
+            .flatten();
+            let signer_binding = calimero_governance_store::signer_binding_for(
+                store,
+                &ContextGroupId::from(namespace_id),
+                &signed.signer,
+            );
+            let rebuilt = calimero_governance_store::op_from_namespace_op_with_binding(
+                &signed,
+                decrypted.as_ref(),
+                signer_binding,
+                ops[i].id(),
+                ops[i].hlc,
+                &ops[i].parents,
+            );
+            if rebuilt.payload != ops[i].payload {
+                tracing::debug!(
+                    namespace = ?namespace_id,
+                    op = ?ops[i].id(),
+                    "op-store: re-derived a stored placeholder written before holes were distinguishable"
+                );
+                ops[i] = rebuilt;
             }
         }
     }

--- a/crates/context/tests/op_store_reconstruction.rs
+++ b/crates/context/tests/op_store_reconstruction.rs
@@ -317,3 +317,110 @@ fn locally_authored_op_lands_in_the_op_store_atomically() {
         "the persisted op must decode to the real MemberAdded — the op-store fold sees the member"
     );
 }
+
+/// A row written before holes were distinguishable must not pass as readable.
+///
+/// The op-store persists the FOLDED op, and an older build wrote `Noop` for an
+/// encrypted group op it could not decrypt. Once `cut_ancestry` marks only
+/// `Opaque` as unreadable, such a row would say "fully readable" about a fold
+/// that is missing whatever the op did — a provisional answer presented as
+/// conclusive, which is how a divergence marker gets raised for an op nobody
+/// could see. `repersist_namespace_ops` rewrites rows when a key ARRIVES and so
+/// cannot cover an op this node will never decrypt.
+#[test]
+fn a_legacy_noop_row_for_an_unreadable_op_is_re_derived_as_a_hole() {
+    let store = store();
+    let admin = PrivateKey::random(&mut OsRng).public_key();
+    let member = PrivateKey::random(&mut OsRng).public_key();
+
+    let ns = ContextGroupId::from([0x71; 32]);
+    let ns_bytes = ns.to_bytes();
+    let admin_account = calimero_context::test_support::enrol(&store, &ns, &admin);
+    MetaRepository::new(&store)
+        .save(&ns, &meta(admin_account))
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&ns, &admin_account, GroupMemberRole::Admin)
+        .unwrap();
+
+    // Encrypted under a key this node does NOT hold: the keyring never learns
+    // `group_key`, so no re-decrypt can ever recover this op here. That is the
+    // case `repersist` cannot fix and the load path therefore must.
+    let group_key = [0x6B; 32];
+    let inner = GroupOp::MemberAdded {
+        member: calimero_context::test_support::enrol(&store, &ns, &member),
+        role: GroupMemberRole::Member,
+    };
+    let encrypted = GroupKeyring::encrypt_op(&group_key, &inner).unwrap();
+    let signed = SignedNamespaceOp {
+        version: 1,
+        namespace_id: ns_bytes.into(),
+        parent_op_hashes: Vec::new(),
+        signer: admin,
+        nonce: 1,
+        op: NamespaceOp::Group {
+            group_id: ns_bytes.into(),
+            key_id: [0x9E; 32].into(),
+            encrypted,
+            key_rotation: None,
+        },
+        signature: [0u8; 64],
+    };
+    let delta_id = signed.content_hash().unwrap();
+
+    NamespaceOpLogService::new(&store, ns_bytes.into())
+        .store_signed_operation(&signed)
+        .unwrap();
+    NamespaceDagService::new(&store, ns_bytes.into())
+        .advance_dag_head(delta_id, &[], 0)
+        .unwrap();
+
+    // The legacy row: `Noop`, as an older build persisted it. Written directly
+    // rather than through the current fold, which is the whole point — today's
+    // fold would write `Opaque`.
+    // `from_parts`, not `new`: a bridge op keeps the governance delta's own id
+    // instead of recomputing one from the payload, which is exactly what lets the
+    // decrypted form later replace the placeholder under the same id.
+    let legacy = calimero_op::Op::from_parts(
+        delta_id,
+        ScopeId::from(ns_bytes),
+        Vec::new(),
+        calimero_op::Authorship::unattributed(admin),
+        hlc(1),
+        calimero_op::OpPayload::Noop,
+        [0u8; 32],
+        [0u8; 64],
+    );
+    persist_op(&store, &legacy).unwrap();
+    assert_eq!(
+        load_scope_ops(&store, &ScopeId::from(ns_bytes))
+            .unwrap()
+            .iter()
+            .find(|op| op.id() == delta_id)
+            .expect("the legacy row is there")
+            .payload,
+        calimero_op::OpPayload::Noop,
+        "precondition: the stored row really is a bare Noop",
+    );
+
+    // The projection feed re-derives it, and finds a hole that names its group.
+    let ops = ScopeProjections::ops_for_namespace(&store, ns_bytes).expect("ops");
+    let rebuilt = ops
+        .iter()
+        .find(|op| op.id() == delta_id)
+        .expect("the op is in the feed");
+    assert_eq!(
+        rebuilt.payload,
+        calimero_op::OpPayload::Opaque { group: ns },
+        "a stored Noop for an op this node cannot decrypt must come back a hole",
+    );
+
+    // And the fold over the feed knows the cut is provisional, which is the
+    // property the re-derivation exists to preserve.
+    let mut proj = ScopeProjections::new();
+    proj.apply_backfill(ns_bytes, ops);
+    assert!(
+        !proj.cut_ancestry_decoded(&ScopeId::from(ns_bytes), &[delta_id]),
+        "a cut through the re-derived hole must not read as decoded",
+    );
+}

--- a/crates/governance-store/src/unified_op_decode.rs
+++ b/crates/governance-store/src/unified_op_decode.rs
@@ -209,9 +209,18 @@ pub fn op_from_namespace_op_with_binding(
         // let the apply path write a binding the projection never saw, which
         // re-keys the joiner's writer principal on one plane only.
         NamespaceOp::Root(root) => payload_from_root_op(root).unwrap_or(OpPayload::Noop),
-        NamespaceOp::Group { group_id, .. } => decrypted_group_op
-            .and_then(|g| payload_from_group_op(*group_id, g))
-            .unwrap_or(OpPayload::Noop),
+        // Two different nothings. A group op this node COULD read but the
+        // projection models nothing about (app config, metadata) folds to `Noop`;
+        // one it could not decrypt folds to `Opaque`, which records that
+        // something was dropped here so a reader can abstain deliberately rather
+        // than answer from a fold with an invisible hole. Collapsing both into
+        // `Noop` made every cut behind any unmodelled op look unreadable.
+        NamespaceOp::Group { group_id, .. } => match decrypted_group_op {
+            Some(group_op) => payload_from_group_op(*group_id, group_op).unwrap_or(OpPayload::Noop),
+            None => OpPayload::Opaque {
+                group: calimero_context_config::types::ContextGroupId::from(group_id.to_bytes()),
+            },
+        },
         // `NamespaceOp` is `#[non_exhaustive]`; an unknown future op folds as a
         // `Noop` graph node (same as an undecryptable/unfoldable op above),
         // preserving causal structure without inventing a payload.

--- a/crates/op/src/payload.rs
+++ b/crates/op/src/payload.rs
@@ -202,4 +202,31 @@ pub enum OpPayload {
         /// The root-signed grant binding the joining device.
         cert: DeviceCert,
     },
+
+    // ---- unreadable ----
+    /// An encrypted group op this node holds no key for: a hole in the fold, at
+    /// its right place in the causal graph.
+    ///
+    /// Distinct from [`Self::Noop`], which is the OTHER reason a fold produces
+    /// nothing — the op was read perfectly well and the projection models nothing
+    /// about it (key transport, metadata, a context registration). Those two
+    /// answers used to share `Noop`, and every reader that asked "is this cut's
+    /// ancestry readable" therefore said no whenever a namespace contained a
+    /// `KeyDelivery`, which is every namespace: an at-cut answer was treated as
+    /// provisional on nodes holding every key, and a measured 68% of the
+    /// divergence gate's comparisons abstained for want of nothing at all.
+    ///
+    /// Folding it changes no state — the state it would have written is
+    /// unknowable here, and that is the point. What it records is that something
+    /// WAS dropped, so a reader can abstain deliberately instead of answering from
+    /// a fold with an invisible hole in it.
+    ///
+    /// `group` is the envelope's cleartext group id, which survives the failed
+    /// decrypt. It is what lets a reader ask the narrower question — an
+    /// unreadable op in a sibling subgroup cannot change who is a member of
+    /// THIS one — rather than treating every hole as fatal to every question.
+    Opaque {
+        /// The group whose key would decrypt this op.
+        group: ContextGroupId,
+    },
 }

--- a/crates/op/src/tests/payload.rs
+++ b/crates/op/src/tests/payload.rs
@@ -107,6 +107,7 @@ fn op_payload_discriminants_are_pinned() {
             chain: vec![],
             cert,
         },
+        OpPayload::Opaque { group },
     ];
 
     // Exhaustive: a new variant forces a new arm here.
@@ -130,10 +131,11 @@ fn op_payload_discriminants_are_pinned() {
             OpPayload::DeviceRevoked { .. } => 15,
             OpPayload::AccountKeysRotated { .. } => 16,
             OpPayload::MemberJoinedWithDevice { .. } => 17,
+            OpPayload::Opaque { .. } => 18,
         }
     }
 
-    assert_eq!(all.len(), 18, "every OpPayload variant must be listed");
+    assert_eq!(all.len(), 19, "every OpPayload variant must be listed");
     for payload in &all {
         let bytes = borsh::to_vec(payload).expect("serialize");
         assert_eq!(

--- a/crates/projection/src/lib.rs
+++ b/crates/projection/src/lib.rs
@@ -442,6 +442,10 @@ impl ScopeState {
             // A graph-only node: present in the log so an ancestry walk can
             // traverse through it, but it folds to nothing.
             OpPayload::Noop => {}
+            // A hole folds to nothing, exactly like `Noop` — the difference is
+            // not what it does to the state, it is what it tells a reader about
+            // the state's completeness. `cut_ancestry` is where that lands.
+            OpPayload::Opaque { .. } => {}
 
             // ---- account plane (monotone; no LWW stamp) ----
             OpPayload::DeviceLinked {
@@ -819,7 +823,12 @@ impl ScopeState {
             }
             match by_id.get(&id) {
                 Some(op) => {
-                    if opaque.is_none() && matches!(op.payload, OpPayload::Noop) {
+                    // `Opaque` only. A `Noop` is an op this node READ and the
+                    // projection models nothing about — key transport, metadata, a
+                    // context registration — and counting it as unreadable made
+                    // every cut behind the first `KeyDelivery` in a namespace
+                    // provisional, on every node, however many keys it held.
+                    if opaque.is_none() && matches!(op.payload, OpPayload::Opaque { .. }) {
                         opaque = Some(id);
                     }
                     ops.push(op);
@@ -1219,7 +1228,10 @@ mod ancestry_oracle {
                 continue;
             }
             match by_id.get(&id) {
-                Some(op) if matches!(op.payload, OpPayload::Noop) => return false,
+                // `Opaque`, not `Noop`: the oracle tracks the corrected meaning of
+                // "readable" — an op this node could not DECRYPT, rather than any
+                // op the projection happens to model nothing about.
+                Some(op) if matches!(op.payload, OpPayload::Opaque { .. }) => return false,
                 Some(op) => queue.extend(op.parents.iter().copied()),
                 None => return false,
             }
@@ -1251,17 +1263,23 @@ mod ancestry_oracle {
     /// A chain `op[0] -> op[1] -> ... -> op[n-1]`, where bit `i` of `noop_mask`
     /// makes `op[i]` an undecrypted placeholder and bit `i` of `drop_mask` removes
     /// it from the log entirely.
-    fn chain(len: usize, noop_mask: u32, drop_mask: u32) -> (Vec<Op>, [u8; 32]) {
+    /// `kinds` is base-3, one digit per position: 0 = a modelled op, 1 = `Noop`
+    /// (read fine, models nothing), 2 = `Opaque` (unreadable here). Three kinds
+    /// rather than two because the two ways a fold produces nothing are exactly
+    /// what the walk has to tell apart.
+    fn chain(len: usize, kinds: u32, drop_mask: u32) -> (Vec<Op>, [u8; 32]) {
         let mut built: Vec<Op> = Vec::new();
         let mut prev: Vec<[u8; 32]> = Vec::new();
         for i in 0..len {
-            let payload = if noop_mask & (1 << i) != 0 {
-                OpPayload::Noop
-            } else {
-                OpPayload::Put {
+            let payload = match (kinds / 3u32.pow(u32::try_from(i).expect("small"))) % 3 {
+                1 => OpPayload::Noop,
+                2 => OpPayload::Opaque {
+                    group: calimero_context_config::types::ContextGroupId::from([0xC0; 32]),
+                },
+                _ => OpPayload::Put {
                     entity: calimero_storage::address::Id::root(),
                     value: vec![u8::try_from(i).expect("small")],
-                }
+                },
             };
             let op = op_with_parents(u64::try_from(i).expect("small") + 1, payload, prev.clone());
             prev = vec![op.id()];
@@ -1279,9 +1297,9 @@ mod ancestry_oracle {
 
     fn for_every_small_chain(mut check: impl FnMut(&[Op], &[[u8; 32]])) {
         for len in 1usize..=4 {
-            for noop_mask in 0u32..(1 << len) {
+            for kinds in 0u32..3u32.pow(u32::try_from(len).expect("small")) {
                 for drop_mask in 0u32..(1 << len) {
-                    let (log, head) = chain(len, noop_mask, drop_mask);
+                    let (log, head) = chain(len, kinds, drop_mask);
                     check(&log, &[head]);
                 }
             }
@@ -1336,8 +1354,10 @@ mod ancestry_oracle {
     /// the missing ancestor behind the placeholder.
     #[test]
     fn an_opaque_op_in_front_of_a_gap_is_both_undecoded_and_incomplete() {
-        // op0 <- op1(noop) <- op2, with op0 dropped from the log.
-        let (log, head) = chain(3, 0b010, 0b001);
+        // op0 <- op1(opaque) <- op2, with op0 dropped from the log. `kinds` is
+        // base-3 least-significant-digit-first, so 6 = (0, 2, 0): an `Opaque` in
+        // the middle position and modelled ops either side.
+        let (log, head) = chain(3, 6, 0b001);
         let walked = ScopeState::cut_ancestry(&log, &[head]);
 
         assert!(!walked.is_decoded(), "the placeholder must be reported");
@@ -1774,11 +1794,19 @@ mod tests {
     }
 
     #[test]
-    fn cut_ancestry_decoded_rejects_a_noop_in_the_ancestry() {
-        // add → re-add chain where the re-add is still an undecrypted `Noop`
-        // (its group key hasn't arrived). The ancestry is structurally COMPLETE —
-        // every id is present — but not fully DECODED, so a membership answer
-        // read over it is provisional and must not be flagged as a divergence.
+    fn cut_ancestry_decoded_rejects_an_unreadable_op_but_not_an_unmodelled_one() {
+        // add → re-add chain where the re-add is still undecrypted (its group key
+        // hasn't arrived), folded as `Opaque`. The ancestry is structurally
+        // COMPLETE — every id is present — but not fully DECODED, so a membership
+        // answer read over it is provisional and must not be flagged as a
+        // divergence.
+        //
+        // The second half is the distinction this used to miss: a `Noop` in the
+        // same position does NOT make the cut undecoded. `Noop` is what a
+        // perfectly readable op folds to when the projection models nothing about
+        // it — key transport, metadata, a context registration — and treating that
+        // as unreadable made every cut behind the first such op provisional, on
+        // every node, however many keys it held.
         let group = ContextGroupId::from([3u8; 32]);
         let member = AccountId::from([0x55; 32]);
         let scope = ScopeId::from([0u8; 32]);
@@ -1803,17 +1831,31 @@ mod tests {
                 role: GroupMemberRole::Member,
             },
         );
-        // The re-add op, still encrypted → retained as a `Noop` placeholder. Its
-        // content-id is stable across decrypt, so we model that by giving the
-        // Noop the same parents a decrypted re-add would carry.
-        let readd_noop = mk(vec![add.id()], OpPayload::Noop);
+        // The re-add op, still encrypted → retained as an `Opaque` placeholder.
+        // Its content-id is stable across decrypt, so we model that by giving the
+        // placeholder the same parents a decrypted re-add would carry.
+        let readd_noop = mk(vec![add.id()], OpPayload::Opaque { group });
 
         let log = vec![add.clone(), readd_noop.clone()];
 
         // Structurally complete — both ids reachable.
         assert!(ScopeState::cut_ancestry_complete(&log, &[readd_noop.id()]));
-        // But NOT fully decoded — the re-add is a Noop.
+        // But NOT fully decoded — the re-add is unreadable here.
         assert!(!ScopeState::cut_ancestry_decoded(&log, &[readd_noop.id()]));
+
+        // A readable op that models nothing, in the same position, leaves the cut
+        // DECODED. This is the case that used to abstain for nothing.
+        let unmodelled = mk(vec![add.id()], OpPayload::Noop);
+        let readable_log = vec![add.clone(), unmodelled.clone()];
+        assert!(ScopeState::cut_ancestry_complete(
+            &readable_log,
+            &[unmodelled.id()]
+        ));
+        assert!(
+            ScopeState::cut_ancestry_decoded(&readable_log, &[unmodelled.id()]),
+            "an op the projection models nothing about was still READ; a cut \
+             through it is not provisional",
+        );
 
         // Once the re-add decrypts (same id, real payload), it is decoded.
         let readd = mk(


### PR DESCRIPTION
Fixes #3615.

`OpPayload::Noop` meant two unrelated things:

1. **read fine, models nothing** — a `KeyDelivery`, a `GroupMetadataSet`, a
   `ContextRegistered`. `payload_from_*_op` returns `None` and the caller folds
   `Noop`.
2. **could not decrypt** — an encrypted group op whose key this node lacks.

Only (2) makes a fold provisional, but `cut_ancestry` marked either as opaque. So
every cut behind the first unmodelled op in a namespace was treated as unreadable
— on every node, including one holding every key. Every scenario publishes a
`KeyDelivery` on its first add, so that is nearly every cut, and the coverage
histogram from #3604 measured it: **267 of 394 comparisons abstained** for want of
nothing at all, with `skipped_incomplete` at zero (so it was never sync lag
either).

## The change

`Opaque { group }`, appended, for the case that actually warrants abstention.
`cut_ancestry` marks only that.

* **No state or hash change.** Folding `Opaque` is a no-op, and `governance_hash`
  is over folded state — an op that writes nothing contributes nothing either way.
* **No id change.** A governance op's id is its signed content hash, supplied at
  construction, not derived from the payload. That is also what keeps the
  late-decrypt upgrade replacing the right log entry when the key arrives.
* **Appended, never inserted.** The enum is Borsh-pinned because a data-plane op's
  id *is* a hash over its payload; `Opaque` takes tag 18 and every existing
  variant keeps its byte. The pinned-tag test enforces it.
* **An authz arm, deliberately.** The enum is exhaustively matched there on
  purpose so a new variant cannot be swept into a catch-all. A hole authorizes
  nothing — and inventing a *refusal* would be wrong in the other direction: the
  op may well be authorized, this node simply cannot see what it says.
* **The group id comes free** from the envelope, which states it in cleartext even
  when the body cannot be read. Nothing consumes it yet; it is what a later
  narrowing needs, since an unreadable op in a sibling subgroup cannot change who
  is a member of this one.

## Why not a side table

Recorded because it is the obvious cheaper design and it does not work.
Readability would have to be recoverable from **both** sources of ops: the
governance-DAG walk (`collect_namespace_ops`, which re-decrypts) and the persisted
unified op-store (`load_scope_ops`). The op-store keeps the folded `Op`, so a
stored `Noop` is ambiguous there — and the op-store is the *preferred* source. A
side table covers the walk and silently misses the common path.

## Tests

* `a_readable_op_the_projection_models_nothing_about_leaves_the_cut_readable` —
  the production path: a real `KeyDelivery` folds `Noop` and leaves the cut
  readable; the same cut behind a genuinely undecryptable group op does not.
  Negative control: restore the old `Noop`-means-opaque behaviour and this fails
  on exactly that assertion.
* `cut_ancestry_decoded_rejects_an_unreadable_op_but_not_an_unmodelled_one` —
  both directions at the predicate.
* `undecryptable_group_op_folds_as_an_opaque_graph_node` — the producer, and that
  the placeholder still occupies its DAG node with its real parents.
* The ancestry oracle now generates **three** payload kinds instead of two
  (modelled / `Noop` / `Opaque`) across every small chain and drop mask, and its
  transcribed reference tracks the corrected meaning — so the exhaustive walk
  covers the distinction rather than assuming it.
* `op_payload_discriminants_are_pinned` gains `Opaque` at 18.

Workspace `cargo check --all-targets`, clippy and fmt clean; op / projection /
authz / op-adapter / governance-store / context suites pass.

## Expected effect

`skipped_undecoded` should collapse and the conclusive count rise
correspondingly. #3613's `projection-coverage` job prints the histogram, so this
verifies itself against the recorded 121 conclusive / 267 undecoded baseline —
whichever of the two lands second gets the comparison for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payload encoding, ancestry-decoded checks, and op-store load reclassification that feed at-cut completeness and divergence abstention. Folding still writes no state and Borsh tags are append-only, but a misclassified hole vs Noop would change whether a cut is treated as conclusive.
> 
> **Overview**
> Stops treating every fold-to-nothing op as unreadable. `Noop` now means the op was read and the projection models nothing about it; a new appended `OpPayload::Opaque { group }` is the hole for an encrypted group op this node cannot decrypt.
> 
> `cut_ancestry` marks only `Opaque` as undecoded, so a cut behind a `KeyDelivery` (or similar) is conclusive even on nodes that hold every key. Folding `Opaque` is still a no-op; authz allows it without inventing a refusal. Late-decrypt log upgrades track `opaque_log_pos` instead of `Noop`.
> 
> On op-store load, stored `Noop`s from older builds are re-derived from the signed op so a never-decryptable row cannot pass as readable. Borsh discriminant 18 is pinned; existing tags are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de7ae673f181fa2953dde031228d9037d54d642a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->