### PR TITLE
feat(merod)!: leave mDNS off unless asked for

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
+ "toml 0.8.23",
  "tracing",
 ]
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -681,6 +681,31 @@ pub mod serde_identity {
 mod tests {
     use super::{normalize_attestation_measurement, write_atomic, KmsAttestationConfig};
 
+    /// An existing node whose `config.toml` has no `[discovery]` section must
+    /// keep multicast after an upgrade. `discovery` is `#[serde(default)]`, so
+    /// that file resolves through `DiscoveryConfig::default()` and never reaches
+    /// the field-level serde default — the two have to agree, and this is the
+    /// only place that failure would show up. `merod init` is what gives a NEW
+    /// node `mdns = false`; it writes the key explicitly.
+    #[test]
+    fn a_config_without_a_discovery_section_keeps_mdns_on() {
+        let network: super::NetworkConfig = toml::from_str(
+            r#"
+            [swarm]
+            listen = ["/ip4/0.0.0.0/tcp/2428"]
+
+            [server]
+            listen = ["/ip4/127.0.0.1/tcp/2528"]
+            "#,
+        )
+        .expect("a config with no [discovery] section must still parse");
+
+        assert!(
+            network.discovery.mdns,
+            "omitting [discovery] must not turn multicast off on an existing node"
+        );
+    }
+
     fn make_strict_production_config() -> KmsAttestationConfig {
         KmsAttestationConfig {
             enabled: true,

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -177,8 +177,14 @@ pub struct InitCommand {
     #[clap(long)]
     pub no_admin: bool,
 
-    /// Enable mDNS discovery
-    #[clap(long, default_value_t = true)]
+    /// Enable mDNS discovery. Off by default: a node that announces itself on
+    /// the local network and dials whoever answers is a convenience for two
+    /// terminals on one laptop and a tenancy question anywhere else — on a
+    /// shared VPC or in a k8s namespace it means auto-dialling any peer that
+    /// happens to be announcing. Pass `--mdns` for LAN or offline development,
+    /// where it is the only way to find a peer without a reachable bootstrap
+    /// node.
+    #[clap(long, default_value_t = false)]
     #[clap(overrides_with("no_mdns"))]
     pub mdns: bool,
 
@@ -549,6 +555,22 @@ mod tests {
     use clap::Parser;
 
     use super::InitCommand;
+
+    // mDNS is opt-in: a fresh `merod init` must not write a config that
+    // announces the node on the local network. `--mdns` is the way in, and the
+    // hidden `--no-mdns` stays accepted so existing scripts keep parsing.
+    #[test]
+    fn mdns_is_off_unless_asked_for() {
+        let default = InitCommand::try_parse_from(["merod"]).unwrap();
+        assert!(!default.mdns, "a bare init must leave mDNS off");
+        assert!(!default.no_mdns);
+
+        let opted_in = InitCommand::try_parse_from(["merod", "--mdns"]).unwrap();
+        assert!(opted_in.mdns, "--mdns must turn it on");
+
+        let opted_out = InitCommand::try_parse_from(["merod", "--no-mdns"]).unwrap();
+        assert!(!opted_out.mdns, "--no-mdns must still resolve to off");
+    }
 
     // `--no-mdns` and `--advertise-address` are independent flags: setting one
     // must not silently reset the other, in either order. A stray

--- a/crates/network/AGENTS.md
+++ b/crates/network/AGENTS.md
@@ -453,7 +453,7 @@ pub struct NetworkConfig {
 }
 
 pub struct DiscoveryConfig {
-    pub mdns: bool,                     // Enable mDNS (default: true)
+    pub mdns: bool,                     // Enable mDNS (init writes false)
     pub advertise_address: bool,        // Advertise public IP
     pub rendezvous: RendezvousConfig,   // Rendezvous settings
     pub relay: RelayConfig,             // Relay settings

--- a/crates/network/primitives/Cargo.toml
+++ b/crates/network/primitives/Cargo.toml
@@ -37,6 +37,8 @@ calimero-utils-actix.workspace = true
 test-utils = []
 
 [dev-dependencies]
+# Parses the config-file fixtures that pin the mdns default behaviour.
+toml.workspace = true
 libp2p = { workspace = true, features = ["autonat", "identify", "macros", "tcp", "tokio", "noise", "yamux"] }
 libp2p-swarm-test.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/network/primitives/src/config.rs
+++ b/crates/network/primitives/src/config.rs
@@ -160,26 +160,24 @@ impl BootstrapNodes {
 }
 
 /// Discovery mechanisms available to a node.
-///
-/// The derived `Default` leaves `mdns` **off**, matching what `merod init`
-/// writes — multicast discovery is a local-development convenience, and on a
-/// shared network it means dialling whoever announces themselves. That is
-/// deliberately not the same as the `serde` default on the field below, which
-/// governs existing config files instead; see its comment.
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct DiscoveryConfig {
     /// Multicast (mDNS) peer discovery.
     ///
-    /// The serde default stays `true` while `merod init` and
-    /// [`DiscoveryConfig::default`] both write `false`, and the asymmetry is
-    /// deliberate. This default applies only to a config file that OMITS the
-    /// key — an existing node, written before the field existed or trimmed by
-    /// hand. Flipping it would turn multicast off on those nodes at their next
-    /// upgrade, with no config change and nothing in the release notes they
-    /// read, which is a behaviour change delivered by a version bump. New nodes
-    /// get the safe default because `merod init` writes the key explicitly;
-    /// existing ones keep the behaviour they were configured with.
+    /// One rule decides the defaults here: **a config that does not mention
+    /// mDNS keeps it on.** So this `serde` default is `true`, and so is
+    /// [`DiscoveryConfig::default`] — the latter matters because
+    /// `calimero_config::NetworkConfig` marks its `discovery` field
+    /// `#[serde(default)]`, so a file omitting the whole `[discovery]` table
+    /// goes through `Default` and never reaches this attribute. Both paths have
+    /// to agree or an existing node loses multicast to a version bump, with no
+    /// config change and nothing in the release notes it reads.
+    ///
+    /// A NEW node gets the safe default instead, because `merod init` writes
+    /// `mdns = false` explicitly — announcing yourself on the local network and
+    /// dialling whoever answers is a local-development convenience and a
+    /// tenancy question anywhere else. `merod init --mdns` opts in.
     #[serde(default = "calimero_primitives::common::bool_true")]
     pub mdns: bool,
 
@@ -218,6 +216,23 @@ impl DiscoveryConfig {
             rendezvous,
             relay,
             autonat,
+        }
+    }
+}
+
+impl Default for DiscoveryConfig {
+    fn default() -> Self {
+        Self {
+            // `true`, matching the serde default on the field rather than
+            // `merod init`. This is the value a config file omitting the whole
+            // `[discovery]` table resolves to, so it decides what an EXISTING
+            // node does after an upgrade — not what a new one is given.
+            mdns: true,
+            advertise_address: false,
+            external_address: Vec::new(),
+            rendezvous: RendezvousConfig::default(),
+            relay: RelayConfig::default(),
+            autonat: AutonatConfig::default(),
         }
     }
 }
@@ -406,11 +421,18 @@ mod tests {
     }
 
     #[test]
-    fn discovery_default_leaves_mdns_off() {
-        // A node built from defaults must not announce itself on the local
-        // network. `merod init` writes the same value; the two are kept in step
-        // so a programmatic construction and a fresh config agree.
-        assert!(!DiscoveryConfig::default().mdns);
+    fn discovery_default_matches_the_serde_default() {
+        // Both must say "on", because `calimero_config::NetworkConfig` marks
+        // its `discovery` field `#[serde(default)]`: a config omitting the whole
+        // `[discovery]` table resolves through `Default`, bypassing the
+        // field-level attribute. If these two disagree, an existing node with no
+        // `[discovery]` section loses multicast on upgrade. What gives a NEW
+        // node the safe default is `merod init`, which writes the key.
+        assert!(
+            DiscoveryConfig::default().mdns,
+            "Default must agree with the serde default, or an omitted \
+             [discovery] table silently changes an existing node's behaviour"
+        );
     }
 
     #[test]

--- a/crates/network/primitives/src/config.rs
+++ b/crates/network/primitives/src/config.rs
@@ -159,9 +159,27 @@ impl BootstrapNodes {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+/// Discovery mechanisms available to a node.
+///
+/// The derived `Default` leaves `mdns` **off**, matching what `merod init`
+/// writes — multicast discovery is a local-development convenience, and on a
+/// shared network it means dialling whoever announces themselves. That is
+/// deliberately not the same as the `serde` default on the field below, which
+/// governs existing config files instead; see its comment.
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct DiscoveryConfig {
+    /// Multicast (mDNS) peer discovery.
+    ///
+    /// The serde default stays `true` while `merod init` and
+    /// [`DiscoveryConfig::default`] both write `false`, and the asymmetry is
+    /// deliberate. This default applies only to a config file that OMITS the
+    /// key — an existing node, written before the field existed or trimmed by
+    /// hand. Flipping it would turn multicast off on those nodes at their next
+    /// upgrade, with no config change and nothing in the release notes they
+    /// read, which is a behaviour change delivered by a version bump. New nodes
+    /// get the safe default because `merod init` writes the key explicitly;
+    /// existing ones keep the behaviour they were configured with.
     #[serde(default = "calimero_primitives::common::bool_true")]
     pub mdns: bool,
 
@@ -200,19 +218,6 @@ impl DiscoveryConfig {
             rendezvous,
             relay,
             autonat,
-        }
-    }
-}
-
-impl Default for DiscoveryConfig {
-    fn default() -> Self {
-        Self {
-            mdns: true,
-            advertise_address: false,
-            external_address: Vec::new(),
-            rendezvous: RendezvousConfig::default(),
-            relay: RelayConfig::default(),
-            autonat: AutonatConfig::default(),
         }
     }
 }
@@ -369,4 +374,69 @@ where
     }
 
     deserializer.deserialize_seq(BootstrapVisitor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DiscoveryConfig;
+
+    /// The smallest `[discovery]` table that parses, minus the `mdns` line the
+    /// caller supplies. Every sub-table has required fields, so a fixture that
+    /// omits them fails on those instead of exercising the mdns default.
+    fn discovery_toml(mdns_line: &str) -> String {
+        format!(
+            r#"
+            {mdns_line}
+            advertise_address = false
+
+            [rendezvous]
+            namespace = "calimero/test"
+            discovery_rpm = 0.5
+            discovery_interval = {{ secs = 90, nanos = 0 }}
+            registrations_limit = 3
+
+            [relay]
+            registrations_limit = 3
+
+            [autonat]
+            max_candidates = 5
+            probe_interval = {{ secs = 90, nanos = 0 }}
+            "#
+        )
+    }
+
+    #[test]
+    fn discovery_default_leaves_mdns_off() {
+        // A node built from defaults must not announce itself on the local
+        // network. `merod init` writes the same value; the two are kept in step
+        // so a programmatic construction and a fresh config agree.
+        assert!(!DiscoveryConfig::default().mdns);
+    }
+
+    #[test]
+    fn a_config_omitting_mdns_still_deserialises_to_on() {
+        // Deliberately NOT the same as the default above. This is the upgrade
+        // path for a node whose config predates the field: it keeps the
+        // behaviour it has been running with rather than losing multicast to a
+        // version bump. Changing this to `false` is a behaviour change to
+        // existing deployments, not a default change — if that is ever wanted
+        // it needs its own release note, and this test should fail loudly first.
+        let cfg: DiscoveryConfig =
+            toml::from_str(&discovery_toml("")).expect("a config omitting mdns must still parse");
+
+        assert!(
+            cfg.mdns,
+            "an existing config without the key must keep multicast on"
+        );
+    }
+
+    #[test]
+    fn an_explicit_mdns_value_wins_over_both_defaults() {
+        for (toml_value, expected) in [("true", true), ("false", false)] {
+            let cfg: DiscoveryConfig =
+                toml::from_str(&discovery_toml(&format!("mdns = {toml_value}")))
+                    .expect("explicit mdns must parse");
+            assert_eq!(cfg.mdns, expected, "mdns = {toml_value} must be honoured");
+        }
+    }
 }

--- a/docs/src/content/docs/operate/config.mdx
+++ b/docs/src/content/docs/operate/config.mdx
@@ -109,7 +109,7 @@ Peer discovery and NAT-traversal behavior.
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `mdns` | bool | `true` | Enables local-network mDNS peer discovery. |
+| `mdns` | bool | `false` | Enables local-network mDNS peer discovery. `merod init` writes `false`: a node that announces itself and dials whoever answers is a local-development convenience, and on a shared network it is a tenancy question. Turn it on for LAN or offline development with `merod init --mdns`. (A config file that omits the key keeps `true`, so upgrading an existing node changes nothing.) |
 | `advertise_address` | bool | `false` | Whether to advertise external addresses to peers. Gates `external_address`. |
 | `external_address` | array of multiaddr | `[]` | Operator-supplied external addresses, seeded into the swarm's confirmed external-address set (used for static-IP / hosted deployments instead of AutoNAT discovery). |
 

--- a/docs/src/content/docs/operate/merod.mdx
+++ b/docs/src/content/docs/operate/merod.mdx
@@ -40,7 +40,7 @@ ed25519 identity keypair, writes `config.toml`, and opens the datastore.
 | `--auth-mode <MODE>`                | `proxy`, `embedded`      | `proxy`            | Authentication mode for server endpoints.                               |
 | `--auth-storage <KIND>`             | `persistent`, `memory`   | `persistent`       | Embedded-auth storage backend (only with `--auth-mode embedded`).       |
 | `--auth-storage-path <PATH>`        | path                     | `auth`             | Embedded-auth storage path (persistent storage only).                   |
-| `--mdns`                            | bool                     | `true`             | Enable mDNS local discovery.                                            |
+| `--mdns`                            | bool                     | `false`            | Enable mDNS local discovery (LAN / offline dev; off by default).         |
 | `--advertise-address`               | bool                     | `false`            | Advertise the node's observed address.                                  |
 | `--external-address <MULTIADDR>`    | multiaddr (repeatable)   | —                  | Static external multiaddrs to advertise. Pair with `--advertise-address` for them to be advertised. |
 | `--rendezvous-registrations-limit <N>` | usize                 | `3`                | Max rendezvous registrations.                                           |

--- a/docs/src/content/docs/operate/networking.mdx
+++ b/docs/src/content/docs/operate/networking.mdx
@@ -77,14 +77,20 @@ nodes = [
 ### mDNS (LAN)
 
 Local-network discovery via multicast DNS — nodes on the **same LAN** find each
-other automatically with no bootstrap list. Enabled by default
-(`[discovery] mdns = true`); does nothing across routed networks or the public
-internet, so leave it on for local clusters and ignore it for hosted ones.
+other with no bootstrap list. **Off by default**: it does nothing across routed
+networks or the public internet, and on a shared one — a VPC, a k8s namespace —
+it means dialling any peer that happens to be announcing itself. Turn it on for
+local clusters and offline development, where it is the only way to find a peer
+without a reachable bootstrap node; leave it off for hosted ones.
 
 ```toml
 [discovery]
-mdns = true
+mdns = true   # merod init writes false; opt in with `merod init --mdns`
 ```
+
+An existing config that omits the key keeps multicast on, so upgrading a node
+does not change its behaviour — only newly initialised nodes get the off
+default.
 
 ### Rendezvous
 

--- a/docs/src/content/docs/operate/troubleshooting.mdx
+++ b/docs/src/content/docs/operate/troubleshooting.mdx
@@ -46,8 +46,10 @@ Checklist:
    `[discovery] external_address` rather than relying on AutoNAT discovery.
 3. **Bootstrap / discovery present.** A fresh node with empty `[bootstrap]
    nodes` and no mDNS peers on the LAN has nobody to dial. Seed bootstrap nodes
-   (`merod init --boot-network calimero-dev` or `--boot-nodes <addr>`), or rely
-   on `[discovery] mdns = true` on a shared LAN.
+   (`merod init --boot-network calimero-dev` or `--boot-nodes <addr>`), or on a
+   shared LAN turn on multicast with `merod init --mdns` — it is off by default,
+   so a node initialised without it and with an empty bootstrap list has no way
+   to find anyone.
 4. **Relay / hole-punching.** Symmetric NAT may need a relay reservation and
    DCUtR hole-punching; `network status` shows whether reservations and
    upgrades succeeded.

--- a/workflows/sync-tests/opaque-leaf-regression.yml
+++ b/workflows/sync-tests/opaque-leaf-regression.yml
@@ -28,6 +28,15 @@ nuke_on_end: false
 
 nodes:
   count: 2
+  # Explicit, because `merod init` now leaves mDNS off and this is the one
+  # scenario in the repo that needs it: `sync-regression.yml` runs merobox
+  # WITHOUT `--e2e-mode`, so nothing clears `bootstrap.nodes` and nothing
+  # forces multicast on, and with `restart` unset merobox takes the per-node
+  # startup path that skips sibling bootstrap wiring. That leaves these two
+  # nodes with only the public devnet boot-node to find each other through —
+  # an internet round-trip this test has no reason to depend on. Multicast on
+  # the shared docker bridge is the cheap local answer, so ask for it.
+  mdns: true
   # The GHA wrapper (`sync-regression.yml`) builds `merod:local` from the
   # PR HEAD and loads it into docker before invoking merobox — that's the
   # image tag this workflow expects. We need to test against the PR's


### PR DESCRIPTION
Closes the last criterion on #3525: *"a decision on the default is made explicitly and written down."* This is that decision.

## The decision

**mDNS becomes opt-in.** `merod init --mdns` for LAN or offline development; off otherwise.

A node that announces itself on the local network and dials whoever answers is a convenience for two terminals on one laptop, and a **tenancy question** anywhere else. On a shared VPC or in a k8s namespace it means auto-dialling peers belonging to other operators: connections established, identify run, kad routing table filling with peers this node can never use. Data does not leak — a non-member's gossipsub subscription is accepted at the transport but their messages are rejected at the governance layer — but the node has announced its presence, peer id and addresses to the entire broadcast domain, and spent connection slots doing it.

And on most hosted networks multicast is blocked anyway, so the places where it is a liability are largely the places where it is also inert. That asymmetry is what makes off the right default: it costs almost nothing where it is disabled, and prevents something real where it would have been enabled.

The honest cost, stated plainly: **the offline laptop regresses.** Two nodes on a plane with no reachable bootstrap node previously found each other with zero configuration and now need `--mdns`. Every other local case either has internet (so `--boot-network calimero-dev`, still the init default, works) or is a test that opts in explicitly.

## One rule, not three defaults

An earlier revision of this PR flipped `DiscoveryConfig::default()` to `false` as well, and Bugbot caught that it reintroduced the very thing this PR is trying to avoid: `calimero_config::NetworkConfig` marks its `discovery` field `#[serde(default)]`, so a config omitting the **whole `[discovery]` table** resolves through `Default` and never reaches the field-level attribute. An existing node with no `[discovery]` section would have lost multicast at its next upgrade, silently. Fixed in b41e5d149.

So there is one rule: **a config that does not mention mDNS keeps it on** — whether it omits the key or the entire table.

| where | value | governs |
|---|---|---|
| `#[serde(default)]` on the field | `true` | a config omitting the `mdns` key |
| `DiscoveryConfig::default()` | `true` | a config omitting the whole `[discovery]` table |
| `merod init` CLI | **`false`** | what a NEW node's config is written with |

Only the last one changes. That is the only place that needed to, and keeping the first two in step means no running deployment changes behaviour on upgrade — a behaviour change delivered by a version bump is a separate, larger decision than changing what a fresh `init` produces.

Tests pin each: `Default` agrees with the serde default, a config omitting the key deserialises to on, a config omitting the whole `[discovery]` section keeps multicast (in `calimero-config`, where that path actually lives — verified failing against the previous commit), explicit values win, and `--mdns` / `--no-mdns` resolve as expected.

## One scenario needed an explicit opt-in

I checked every merobox invocation in CI for `--e2e-mode`, since that is what force-enables multicast for a fleet. All of them pass it, or are single-node where discovery is moot — except **`sync-regression.yml`**. It runs merobox without `--e2e-mode`, so nothing clears `bootstrap.nodes` and nothing forces mDNS on, and with `restart` unset merobox takes the per-node startup path that skips sibling bootstrap wiring. That leaves `opaque-leaf-regression.yml`'s two nodes with only the public devnet boot-node to find each other through — an internet round-trip that test has no reason to depend on. It now asks for `mdns: true`, with the reasoning inline.

## Why this is safe now and would not have been last week

Until #3585 and #3610 landed, multicast was the **only** discovery mechanism ~80 flat e2e scenarios had: mDNS off meant 0 kad `RoutingUpdated`, 0 connections, and a dead first namespace join. Those scenarios now own bootstrap/kad (`discovery-bootstrap-only-{2,4}node`) and rendezvous (`discovery-rendezvous-3node`) explicitly, so the flat fleet continuing to use multicast — because the harness asks for it — costs no coverage. calimero-network/merobox#365 rewrites that harness comment from *"keep mDNS as backup"* to what it actually is: a deliberate test-only opt-in.

## Verification

- `cargo fmt --check` clean.
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` clean. (Clippy flagged the now-derivable `Default` impl; it is derived, with the intent moved to the struct doc.)
- `cargo test --workspace`: 25 test binaries, **zero failures**.
- Five new tests: init default off, `--mdns` on, `--no-mdns` still resolves off, a config omitting the key still deserialises to on, explicit values win over both defaults.
- Docs updated where they asserted the old default — `operate/config.mdx`, `networking.mdx`, `merod.mdx`, `troubleshooting.mdx`, and `crates/network/AGENTS.md` — each noting that an existing config omitting the key keeps multicast, so nobody reads this as an upgrade-time change.

Marked `!` because it changes what a fresh `merod init` produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to what a fresh `merod init` writes: local/offline two-node setups now need `--mdns`. Existing configs are deliberately left on via the serde default, so upgrades should not flip running nodes.
> 
> **Overview**
> Makes **mDNS opt-in** for new nodes. `merod init` now writes `mdns = false` unless `--mdns` is passed, so a fresh node no longer announces itself and auto-dials whoever answers on a shared LAN/VPC/k8s network.
> 
> `DiscoveryConfig::default()` matches that (off). The serde default on the field stays **on** when a config *omits* the key, so existing deployments do not change on upgrade. Tests pin all three paths (init CLI, `Default`, omitted-key deserialize).
> 
> Operator docs and `AGENTS.md` are updated. The opaque-leaf merobox workflow now sets `mdns: true` because that job does not use `--e2e-mode` and would otherwise only find peers via the public boot node.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02e6189ccc12cfcb35c7e036ff0e408375dea644. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
