### PR TITLE
fix(projection): ask about one group's rows, not the whole namespace's readability

### DIFF
--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -470,8 +470,20 @@ fn shadow_fold_and_compare(
                 // conditions with different remedies — a gap needs a fetch, an
                 // opaque op needs a key — and reporting them as one refusal is
                 // what made 52 abstentions in a suite unattributable.
-                let (complete, decoded) = membership.map_or((false, false), |_| {
-                    projections.cut_ancestry_state(&shadow_op.scope, &[shadow_op.id()])
+                // Asked about THIS group, not the whole namespace. The compared
+                // value is a direct member row, which only this group's own ops
+                // write — so an unreadable op belonging to a sibling subgroup
+                // cannot have changed it, and treating it as fatal is what left a
+                // node blind to one subgroup unable to conclude anything about any
+                // group in the namespace. The apply-auth compare below keeps the
+                // namespace-wide question, because it walks the inheritance chain
+                // and so genuinely depends on other groups' ops.
+                let (complete, decoded) = membership.map_or((false, false), |(group, _, _)| {
+                    projections.cut_ancestry_state_for_group(
+                        &shadow_op.scope,
+                        &[shadow_op.id()],
+                        group,
+                    )
                 });
                 (true, role, complete, decoded, at_frontier)
             }

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -717,6 +717,38 @@ impl ScopeProjections {
         })
     }
 
+    /// [`cut_ancestry_state`](Self::cut_ancestry_state), asked about ONE group's
+    /// direct member rows rather than the whole namespace.
+    ///
+    /// An unreadable ancestor only blocks if it belongs to `group`. Everything
+    /// else about the cut is judged identically — a gap is still a gap, since a
+    /// missing ancestor could be anything at all, including an op of this group.
+    ///
+    /// This is the narrowing the namespace-wide question was costing us: a node
+    /// outside one subgroup cannot read that subgroup's ops and so could never
+    /// conclude anything about ANY group in the namespace, including groups it
+    /// reads perfectly. Sound because an `Opaque` op is an encrypted op of one
+    /// group, and only ops naming `g` write `groups[g][member]` — see
+    /// [`ScopeState::first_opaque_in`], which also spells out why an
+    /// inheritance-walking answer must NOT use this.
+    #[must_use]
+    pub fn cut_ancestry_state_for_group(
+        &self,
+        scope: &ScopeId,
+        parents: &[[u8; 32]],
+        group: ContextGroupId,
+    ) -> (bool, bool) {
+        let Some(log) = self.logs.get(scope) else {
+            return (false, false);
+        };
+        let ancestry = ScopeState::cut_ancestry(log, parents);
+        let complete = ancestry.is_complete();
+        (
+            complete,
+            complete && ancestry.first_opaque_in(group).is_none(),
+        )
+    }
+
     /// Whether the cut's ancestry is both present AND fully decoded (no `Noop`
     /// placeholders for ops this node can't yet decrypt). See
     /// [`ScopeState::cut_ancestry_decoded`]. `false` for an unknown scope.
@@ -2549,6 +2581,64 @@ mod tests {
             OpPayload::AdminChanged {
                 new_admin: test_account(&signer),
             }
+        );
+    }
+
+    /// The group-scoped question through the projection: a node blind to one
+    /// subgroup can still answer about another. Same log, two groups, two
+    /// different verdicts — which is the whole point, since the namespace-wide
+    /// question gave one verdict for both and it was the pessimistic one.
+    #[test]
+    fn a_hole_in_one_subgroup_does_not_blind_the_projection_to_another() {
+        let ns = [0x31; 32];
+        let scope = ScopeId::from(ns);
+        let signer = PublicKey::from([3u8; 32]);
+        let mine = ContextGroupId::from([0x41; 32]);
+        let sibling = ContextGroupId::from([0x42; 32]);
+
+        let mut proj = ScopeProjections::new();
+        // A readable op of `mine`, then a hole belonging to `sibling`.
+        let readable = op_from_namespace_op(
+            &signed_group(ns, signer, mine),
+            Some(
+                &calimero_context_client::local_governance::GroupOp::MemberAdded {
+                    member: calimero_account::AccountId::from([0x77; 32]),
+                    role: calimero_primitives::context::GroupMemberRole::Member,
+                },
+            ),
+            [0xE1; 32],
+            hlc(1),
+            &[],
+        );
+        let hole = op_from_namespace_op(
+            &signed_group(ns, signer, sibling),
+            None,
+            [0xE2; 32],
+            hlc(2),
+            &[[0xE1; 32]],
+        );
+        assert_eq!(
+            hole.payload,
+            OpPayload::Opaque { group: sibling },
+            "precondition: the hole names the sibling",
+        );
+        proj.ingest_op(&readable);
+        proj.ingest_op(&hole);
+
+        let cut = [hole.id()];
+        // Namespace-wide: blocked, as it must stay for inheritance-walking reads.
+        assert_eq!(proj.cut_ancestry_state(&scope, &cut), (true, false));
+        // Asked about `mine`: nothing unreadable belongs to it, so answerable.
+        assert_eq!(
+            proj.cut_ancestry_state_for_group(&scope, &cut, mine),
+            (true, true),
+            "a hole in a sibling subgroup cannot have moved this group's rows",
+        );
+        // Asked about `sibling`: still blocked, and rightly.
+        assert_eq!(
+            proj.cut_ancestry_state_for_group(&scope, &cut, sibling),
+            (true, false),
+            "the group whose op is unreadable stays unanswerable",
         );
     }
 

--- a/crates/projection/src/lib.rs
+++ b/crates/projection/src/lib.rs
@@ -193,6 +193,29 @@ impl<'a> CutAncestry<'a> {
         self.missing.is_none() && self.opaque.is_none()
     }
 
+    /// Is any ancestor unreadable AND capable of writing `group`'s direct member
+    /// rows — i.e. is it an unreadable op belonging to `group` itself?
+    ///
+    /// The narrower question behind [`Self::first_opaque`], and the one a
+    /// direct-row read should ask. An `Opaque` op is always an encrypted op of
+    /// ONE group (its envelope names that group in cleartext), and the only
+    /// payloads that write `groups[g][member]` name `g`. So an unreadable op
+    /// belonging to a sibling subgroup cannot have changed who is a direct
+    /// member of this one, and refusing to answer about `group` on its account
+    /// discards a conclusion this node can soundly reach.
+    ///
+    /// **Sound for the direct-row question only.** An answer that walks the
+    /// inheritance chain — membership via an anchor, a capability bit, a
+    /// visibility wall — depends on other groups' ops, so it must keep asking
+    /// [`Self::first_opaque`] about the whole ancestry.
+    #[must_use]
+    pub fn first_opaque_in(&self, group: ContextGroupId) -> Option<[u8; 32]> {
+        self.ops
+            .iter()
+            .find(|op| matches!(&op.payload, OpPayload::Opaque { group: g } if *g == group))
+            .map(|op| op.id())
+    }
+
     /// The first ancestor found absent from the log, if any.
     ///
     /// Distinct from [`Self::first_opaque`] because the two call for different
@@ -204,7 +227,8 @@ impl<'a> CutAncestry<'a> {
         self.missing
     }
 
-    /// The first ancestor found present but still an undecrypted `Noop`.
+    /// The first ancestor found present but unreadable — an `Opaque` placeholder
+    /// for a group op whose key this node does not hold.
     #[must_use]
     pub fn first_opaque(&self) -> Option<[u8; 32]> {
         self.opaque
@@ -1791,6 +1815,73 @@ mod tests {
 
         // A cited head absent from the log → also incomplete.
         assert!(!ScopeState::cut_ancestry_complete(&[], &[remove.id()]));
+    }
+
+    /// An unreadable op belonging to a SIBLING group must not block a direct-row
+    /// answer about this one, and an unreadable op of this group must.
+    ///
+    /// This is what the namespace-wide question was costing: a node outside one
+    /// subgroup cannot read that subgroup's ops, so it could never conclude
+    /// anything about ANY group in the namespace — including groups whose every
+    /// op it reads. An `Opaque` op is an encrypted op of one group, and only ops
+    /// naming `g` write `groups[g][member]`, so the narrower question is sound.
+    #[test]
+    fn an_unreadable_sibling_group_does_not_block_this_group() {
+        let scope = ScopeId::from([0u8; 32]);
+        let mine = ContextGroupId::from([0xA1; 32]);
+        let sibling = ContextGroupId::from([0xB2; 32]);
+        let member = AccountId::from([0x55; 32]);
+        let author = AccountId::from([1u8; 32]);
+        let mk = |parents: Vec<[u8; 32]>, payload: OpPayload| -> Op {
+            Op::new(
+                scope,
+                parents,
+                authorship(author),
+                hlc(0),
+                payload,
+                [0u8; 32],
+                [0u8; 64],
+            )
+        };
+
+        let add = mk(
+            vec![],
+            OpPayload::MemberAdded {
+                group: mine,
+                member,
+                role: GroupMemberRole::Member,
+            },
+        );
+        // A hole in the sibling subgroup, sitting in this cut's ancestry.
+        let sibling_hole = mk(vec![add.id()], OpPayload::Opaque { group: sibling });
+        let later = mk(
+            vec![sibling_hole.id()],
+            OpPayload::MemberAdded {
+                group: mine,
+                member,
+                role: GroupMemberRole::Admin,
+            },
+        );
+        let log = vec![add.clone(), sibling_hole.clone(), later.clone()];
+        let walked = ScopeState::cut_ancestry(&log, &[later.id()]);
+
+        assert!(walked.is_complete(), "no gaps either way");
+        assert!(
+            !walked.is_decoded(),
+            "the namespace-wide question still reports the hole — the inheritance \
+             walk depends on other groups' ops and must keep asking it",
+        );
+        assert_eq!(
+            walked.first_opaque_in(mine),
+            None,
+            "no unreadable op of THIS group, so its direct rows are fully known",
+        );
+        assert_eq!(
+            walked.first_opaque_in(sibling),
+            Some(sibling_hole.id()),
+            "and the sibling's own direct rows are not — asked about it, the same \
+             walk says so",
+        );
     }
 
     #[test]


### PR DESCRIPTION
The last of the measured abstentions. After #3616 and #3621, the histogram reports
**362 conclusive of 399**, and the remaining 27 are all `skipped_undecoded` — a
direct-row answer refused because *some* op in the cut's ancestry is unreadable,
wherever it belongs.

That is stricter than the question needs. A node outside one subgroup cannot
decrypt that subgroup's ops by construction, so it could never conclude anything
about **any** group in the namespace — including groups whose every op it reads
perfectly.

## Why narrowing is sound

An `Opaque` op is an encrypted op of exactly ONE group. Its envelope names that
group in cleartext, which is how the placeholder came to carry it (#3616). And the
only payloads that write `groups[g][member]` — `MemberAdded`,
`MemberJoinedWithDevice`, `MemberRemoved` — name `g`.

So an unreadable op belonging to a sibling subgroup **cannot** have moved this
group's direct rows. Refusing on its account discards a conclusion the node can
soundly reach.

`first_opaque_in(group)` and `cut_ancestry_state_for_group(...)` ask the narrower
question, and the membership compare uses them.

## What deliberately does NOT change

The apply-auth compare keeps the namespace-wide question. It walks the inheritance
chain — anchor membership, the `CAN_JOIN_OPEN_SUBGROUPS` bit, a visibility wall —
so it genuinely depends on other groups' ops, and narrowing it would be unsound.
Both doc comments state which question they ask and why, so the next reader does
not "simplify" them into one.

## Tests

* `an_unreadable_sibling_group_does_not_block_this_group` (projection) — same walk,
  same log: `first_opaque_in(mine)` is `None` while `first_opaque_in(sibling)` names
  the hole, and `is_decoded()` still reports it for the inheritance-walking callers.
* `a_hole_in_one_subgroup_does_not_blind_the_projection_to_another` (context) — the
  same thing through `ScopeProjections`, built from real `op_from_namespace_op`
  folds: namespace-wide `(true, false)`, asked about `mine` `(true, true)`, asked
  about `sibling` `(true, false)`.

**Coverage caveat, stated rather than glossed:** these pin the API in both
directions, but nothing unit-tests the *handler's choice* of which question to ask
— I checked, and reverting that one line leaves every unit test green. The
`projection-coverage` histogram is what catches it, which is exactly the coverage
instrument this series built, so the wiring is verified by the e2e run below rather
than by a Rust test.

246 context lib tests, projection suites, clippy and fmt clean.

## Expected effect

`skipped_undecoded` should fall from 27 toward zero, and conclusive should rise to
match. If it does not move, the remaining abstentions are same-group holes — a node
genuinely blind to the group it is being asked about, which is the one case that
*should* abstain, and the histogram will have told us that too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
