### PR TITLE
fix(context): abstain at a cut this node cannot read, instead of deciding over it

### DIFF
--- a/crates/context/src/group_key_pull.rs
+++ b/crates/context/src/group_key_pull.rs
@@ -246,10 +246,19 @@ mod tests {
             )
         };
 
+        // The wedge is an ABSTENTION, not a rejection, and the difference matters.
+        // The flip sits in this cut unreadable, so the node does not know whether
+        // the subgroup is Open; a node holding the key does and would accept this
+        // join. Answering "no membership path" from a fold that is missing the
+        // flip is a verdict about a history this node cannot see, and it is the
+        // verdict the other node contradicts. Parking until the key arrives is
+        // what converges — and the rest of this test is precisely that arrival.
         let wedged = apply(&store).expect_err("the subgroup still reads Restricted");
+        let wedged = format!("{wedged:#}");
         assert!(
-            format!("{wedged:#}").contains("no membership path"),
-            "the wedge must be the membership-path rejection, got: {wedged:#}"
+            wedged.contains("has not folded the ancestry"),
+            "the wedge must be an abstention that retries, not a decision taken \
+             over an unreadable ancestor, got: {wedged}"
         );
 
         // `load_scope_ops` returns the rows in any order, so compare as sets.

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1873,7 +1873,15 @@ impl ScopeProjections {
         // op was absent from the log, so the inherited walk still saw the member
         // in the root). If the ancestry isn't whole, abstain (`None`) and defer to
         // live's reject rather than grant on a truncated, possibly-stale view.
-        if !self.cut_ancestry_complete(&scope, heads) {
+        //
+        // An UNREADABLE ancestor costs exactly the same over-grant by a different
+        // route: an op this node holds no key for folds to nothing, so a removal it
+        // cannot decrypt leaves the member folded as present — the same stale view,
+        // reached without any op going missing. This is a grant path, so it abstains
+        // for the same reason it abstains on a gap. The walk is shared, so both
+        // answers come from one pass.
+        let walked = ScopeState::cut_ancestry(self.logs.get(&scope)?, heads);
+        if !walked.is_complete() || walked.first_opaque().is_some() {
             return None;
         }
 
@@ -2140,6 +2148,28 @@ impl ScopeProjections {
         let walked = ScopeState::cut_ancestry(log, heads);
         if !walked.is_complete() {
             return Err(self.classify_unresolvable_cut(&scope, heads));
+        }
+        // Complete is not enough to ANSWER with. Every gate reached through this
+        // context folds the whole namespace ancestry and walks inheritance —
+        // admin through an anchor, a capability bit, a visibility wall — so an op
+        // it could not decrypt may be exactly the one that granted or revoked the
+        // authority being asked about. An `Opaque` folds to nothing, so the view
+        // would be missing that effect and the verdict would describe a history
+        // this node cannot see.
+        //
+        // And the verdict is AUTHORITATIVE here: `PermissionChecker` returns a
+        // `Some(false)` straight to the caller as a refusal, with no live
+        // fallback. Two nodes with different key epochs would then decide the same
+        // op differently — one applies it, one refuses — which is a governance DAG
+        // that stops converging. Abstaining defers to live, which is the answer
+        // every node still agrees on.
+        //
+        // Deliberately the namespace-wide question and not the per-group one: the
+        // inheritance walk genuinely depends on other groups' ops. The narrow
+        // question is sound only for a direct-row read (see
+        // `cut_ancestry_state_for_group`).
+        if walked.first_opaque().is_some() {
+            return Err(UndecidableCause::AncestryUnreadable);
         }
         let view = ScopeState::acl_view_from_ancestry(&walked);
         let root_group = ContextGroupId::from(namespace_id);

--- a/crates/context/tests/projection_membership_equivalence.rs
+++ b/crates/context/tests/projection_membership_equivalence.rs
@@ -1515,3 +1515,105 @@ fn a_late_applied_add_after_a_promotion_is_not_a_divergence() {
         "and then they agree: Admin at the promotion's cut, Admin in the live row",
     );
 }
+
+/// The authoritative grant path must abstain when an ancestor is UNREADABLE, not
+/// only when one is missing.
+///
+/// A gap and a hole cost the same over-grant by different routes. With a gap, the
+/// removal op is absent and the walk still sees the member; with a hole, the
+/// removal op is present but encrypted under a key this node does not hold, folds
+/// to nothing, and the walk still sees the member. The view is equally stale, and
+/// this path GRANTS on what it returns — so it defers to live in both cases.
+///
+/// Same reasoning covers the apply gates through `auth_cut_context`, where the
+/// verdict is worse than stale: `PermissionChecker` returns a `Some(false)`
+/// straight through as a refusal, so two nodes with different key epochs would
+/// decide one op differently and that namespace's governance DAG would stop
+/// converging on the one that refused.
+#[test]
+fn the_grant_path_defers_when_an_ancestor_is_unreadable() {
+    let store = store();
+    let admin_sk = PrivateKey::random(&mut OsRng);
+    let admin = admin_sk.public_key();
+    let joiner_sk = PrivateKey::random(&mut OsRng);
+    let joiner = joiner_sk.public_key();
+
+    let ns = ContextGroupId::from([0x61; 32]);
+    let subgroup = ContextGroupId::from([0x62; 32]);
+
+    let admin_account = calimero_context::test_support::enrol(&store, &ns, &admin);
+    for g in [&ns, &subgroup] {
+        MetaRepository::new(&store)
+            .save(g, &meta(admin_account))
+            .unwrap();
+        MembershipRepository::new(&store)
+            .add_member(g, &admin_account, GroupMemberRole::Admin)
+            .unwrap();
+    }
+    NamespaceRepository::new(&store)
+        .nest(&ns, &subgroup)
+        .unwrap();
+
+    let mut proj = ScopeProjections::new();
+    let s2 = fold_subgroup_structure(
+        &mut proj,
+        ns.to_bytes(),
+        admin,
+        subgroup,
+        [0xD0; 32],
+        [0xDF; 32],
+    );
+
+    // The joiner is a member at this cut, by an op the projection HAS folded.
+    let join_ns = SignedNamespaceOp::sign(
+        &joiner_sk,
+        ns.to_bytes().into(),
+        vec![],
+        1,
+        NamespaceOp::Root(RootOp::MemberJoined {
+            member: calimero_context::test_support::account_for(&joiner),
+            signed_invitation: sign_invitation(&admin_sk, subgroup, 1, [0x42; 32]),
+            account: test_join_account_for(&joiner),
+        }),
+    )
+    .expect("sign join");
+    calimero_governance_store::apply_signed_namespace_op(&store, &join_ns).unwrap();
+    let joined = [0xD1; 32];
+    proj.ingest_op(&op_from_namespace_op(&join_ns, None, joined, hlc(1), &[s2]));
+
+    // Complete and readable: the grant path answers.
+    assert_eq!(
+        proj.member_at_cut_authoritative(&store, subgroup, &joiner, &[joined]),
+        Some(true),
+        "precondition: a whole, readable ancestry is answerable",
+    );
+
+    // Now a descendant op this node cannot decrypt — a group op with no key here.
+    // Its payload folds to nothing, so the view is unchanged and the member still
+    // looks present; what it could have said (a removal, a role change) is exactly
+    // what this node cannot know.
+    let hole = op_from_namespace_op(
+        &ns_group_envelope(ns.to_bytes(), admin, subgroup),
+        None,
+        [0xD2; 32],
+        hlc(2),
+        &[joined],
+    );
+    proj.ingest_op(&hole);
+
+    assert_eq!(
+        proj.member_at_cut_authoritative(&store, subgroup, &joiner, &[hole.id()]),
+        None,
+        "an unreadable ancestor must make the grant path DEFER to live, not grant \
+         from a fold that is missing whatever that op did",
+    );
+    // The narrower shadow question still answers — it is asked about direct rows
+    // only, where a sibling group's hole cannot matter. The two coexisting is the
+    // point: strict where a verdict is authoritative, narrow where it is a
+    // comparison.
+    assert_eq!(
+        proj.cut_ancestry_state(&ScopeId::from(ns.to_bytes()), &[hole.id()]),
+        (true, false),
+        "complete but unreadable, which is the state under test",
+    );
+}

--- a/crates/governance-store/src/metrics.rs
+++ b/crates/governance-store/src/metrics.rs
@@ -639,6 +639,18 @@ pub enum UndecidableCause {
     /// reach the cut and never will again. **Permanent.** The op parks forever
     /// and that namespace's governance DAG stops advancing on this node.
     LogTruncated,
+    /// Every ancestor is present, but at least one is an encrypted op this node
+    /// holds no key for, so the fold is missing whatever that op did.
+    ///
+    /// Distinct from [`Self::AncestryGap`] because the remedy differs — a gap
+    /// needs history, this needs a key — and because this one is the reason a
+    /// gate must ABSTAIN rather than answer: an at-cut verdict folded over a hole
+    /// is a verdict about a history the node cannot see, and two nodes with
+    /// different key epochs would reach different ones on the same op.
+    ///
+    /// Transient in the ordinary case (the key is delivered and the op re-folds),
+    /// permanent for a node outside the group whose op it is.
+    AncestryUnreadable,
     /// The ephemeral fold could not be built at all (governance head unreadable
     /// — a store fault). Not a history gap.
     FoldUnavailable,
@@ -654,6 +666,7 @@ impl UndecidableCause {
             UndecidableCause::HeadsMissing => "heads_missing",
             UndecidableCause::AncestryGap => "ancestry_gap",
             UndecidableCause::LogTruncated => "log_truncated",
+            UndecidableCause::AncestryUnreadable => "ancestry_unreadable",
             UndecidableCause::FoldUnavailable => "fold_unavailable",
             UndecidableCause::NamespaceUnresolved => "namespace_unresolved",
         }
@@ -750,6 +763,7 @@ mod tests {
             UndecidableCause::HeadsMissing,
             UndecidableCause::AncestryGap,
             UndecidableCause::LogTruncated,
+            UndecidableCause::AncestryUnreadable,
             UndecidableCause::FoldUnavailable,
             UndecidableCause::NamespaceUnresolved,
         ];
@@ -770,7 +784,9 @@ mod tests {
             permanent,
             vec!["log_truncated"],
             "only a truncated log is unrecoverable; the rest clear once sync \
-             delivers the missing history",
+             delivers the missing history — `ancestry_unreadable` included, since \
+             a key delivery re-folds the op and it is a node outside the group, \
+             not the history, that keeps it standing",
         );
 
         let mut registry = Registry::default();


### PR DESCRIPTION
**This one changes authorization behaviour, so the reasoning is here in full rather
than in a linked issue.** It came out of asking what the coverage work from #3587→
#3622 was actually protecting, and finding that the answer is not a shadow.

## The projection is already authoritative, in two places

`crates/governance-store/src/permission_checker.rs`:

```rust
if let Some(verdict) = self.authorizer.is_admin_at_cut(&self.group_id, identity, self.parents) {
    return Ok(verdict);          // Some(false) refuses — no live fallback
}
```

and the projection-backed `EphemeralProjectionAuthorizer` is what production passes
(`governance_dag.rs:115`, `group_key_pull.rs:245`), not `LiveFallbackAuthorizer`.
On the data plane, `state_delta/buffering.rs:163` admits deltas via
`member_at_cut_authoritative`.

## The gap

Both abstain when the cited ancestry is **incomplete** and neither checks whether
it is **readable**:

* `member_at_cut_authoritative` → `if !self.cut_ancestry_complete(..) { return None }`
* `auth_cut_context_or_cause` (behind every apply gate) → `if !walked.is_complete() { .. }`

An `Opaque` op folds to nothing. So a node missing a key folds a view with a hole
where that op's effect belongs, and answers from it.

| unreadable op in the cut | the fold says | consequence |
| --- | --- | --- |
| `MemberAdded{Admin}` / `MemberRoleSet{Admin}` | not an admin | **refuses** a legitimate op — that node stops applying and its governance DAG stalls |
| `MemberRemoved` of an admin | still an admin | **accepts** an op every other node refuses |

Forward-secrecy rotation makes this reachable rather than theoretical: a member
admitted at a later key epoch never holds the earlier ones, so ops in its own
group's history are unreadable to it.

And the second row is **structurally invisible** to the apply-auth shadow, by its
own admission — *"the reverse (projection accepts what live rejected) is
unobservable here — a live-rejected op never reaches this fold."* No amount of
shadow evidence would have surfaced it, which is why this is a code-reading finding
rather than a histogram one.

## The change

`auth_cut_context_or_cause` refuses on `first_opaque()`, and
`member_at_cut_authoritative` does the same from the same single walk. Abstaining
defers to live, which is the answer every node still agrees on.

* **Namespace-wide, deliberately.** Every gate reached through that context walks
  the inheritance chain — admin via an anchor, a capability bit, a visibility wall
  — so it genuinely depends on other groups' ops. The per-group narrowing from
  #3622 is sound only for a direct-row read, and both doc comments now say which
  is which.
* **Its own cause,** `AncestryUnreadable`, not folded into `AncestryGap`: a gap
  needs history, this needs a key, and the metric exists to tell refusals apart.
  Transient, since a key delivery re-folds the op.

## The behaviour change, stated plainly

`a_pulled_key_unwedges_another_members_open_subgroup_join` documented the old
behaviour. Its scenario is a visibility flip this node cannot decrypt, then an open
self-join citing it. The node used to answer **"no membership path"** — from a fold
missing the flip, contradicting any node that holds the key — and now **parks until
the key arrives**.

The rest of that test is unchanged and still passes: the pulled key re-folds the
flip and the join applies. So a divergent rejection became a retry, and the
recovery path that test exists for is intact.

## Cost

More deferrals to live, in the safe direction: live is today's ground truth and
what every node still agrees on. It slightly reduces how often the projection
answers authoritatively, which is a fair price for not answering wrongly — and the
`at_cut_undecidable{cause="ancestry_unreadable"}` counter now says how often that
happens instead of leaving it to inference.

246 context lib tests, governance-store (585) and projection suites, clippy and fmt
clean. Negative control: drop the `first_opaque()` check and the new grant-path test
fails on exactly that assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
