### PR TITLE
fix(context): abstain at a cut whose relevant history this node cannot read

### DIFF
--- a/crates/authz/src/inheritance.rs
+++ b/crates/authz/src/inheritance.rs
@@ -98,6 +98,35 @@ impl AclView {
         .take(MAX_NAMESPACE_DEPTH + 1)
     }
 
+    /// `group` and every ancestor above it, nearest first — the set of groups
+    /// whose ops can move an authority question asked about `group`.
+    ///
+    /// Deliberately climbs THROUGH a `restricted` edge, unlike
+    /// [`Self::open_ancestors`]. That walk stops there because inheritance stops
+    /// there; this one cannot, because whether an edge is restricted is itself
+    /// decided by a `SubgroupVisibilitySet` op of that subgroup — which may be
+    /// exactly the op a reader cannot decrypt. Stopping at an edge whose state is
+    /// unknown would silently shorten the set and let an unreadable ancestor pass
+    /// as irrelevant.
+    ///
+    /// Same `MAX_NAMESPACE_DEPTH` bound as the inheritance climb, so a cyclic or
+    /// adversarial tree cannot spin.
+    pub fn group_and_ancestors(
+        &self,
+        group: ContextGroupId,
+    ) -> impl Iterator<Item = ContextGroupId> + '_ {
+        let mut current = Some(group);
+        core::iter::once(group).chain(
+            core::iter::from_fn(move || {
+                let edge = self.subgroups.get(&ScopeId::from(current?.to_bytes()))?;
+                let parent = ContextGroupId::from(*edge.parent.as_bytes());
+                current = Some(parent);
+                Some(parent)
+            })
+            .take(MAX_NAMESPACE_DEPTH + 1),
+        )
+    }
+
     /// Does `author` hold a direct membership row in `group`?
     fn has_direct_row(&self, group: ContextGroupId, author: &AccountId) -> bool {
         self.groups

--- a/crates/context/src/group_key_pull.rs
+++ b/crates/context/src/group_key_pull.rs
@@ -246,10 +246,19 @@ mod tests {
             )
         };
 
+        // The wedge is an ABSTENTION, not a rejection, and the difference matters.
+        // The flip sits in this cut unreadable, so the node does not know whether
+        // the subgroup is Open; a node holding the key does and would accept this
+        // join. Answering "no membership path" from a fold that is missing the
+        // flip is a verdict about a history this node cannot see, and it is the
+        // verdict the other node contradicts. Parking until the key arrives is
+        // what converges — and the rest of this test is precisely that arrival.
         let wedged = apply(&store).expect_err("the subgroup still reads Restricted");
+        let wedged = format!("{wedged:#}");
         assert!(
-            format!("{wedged:#}").contains("no membership path"),
-            "the wedge must be the membership-path rejection, got: {wedged:#}"
+            wedged.contains("has not folded the ancestry"),
+            "the wedge must be an abstention that retries, not a decision taken \
+             over an unreadable ancestor, got: {wedged}"
         );
 
         // `load_scope_ops` returns the rows in any order, so compare as sets.

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -591,17 +591,25 @@ impl ScopeProjections {
     /// nobody could see. `repersist_namespace_ops` rewrites rows when a key
     /// ARRIVES, so it does not cover an op this node will never decrypt.
     ///
-    /// Only stored `Noop`s are touched, and each is decided the way the walk would
-    /// decide it: consult the signed op, re-attempt the decrypt, and take whatever
-    /// payload that yields — a real one if the key is here now, `Noop` if the op is
-    /// readable and models nothing, `Opaque` if it cannot be read. A row already
-    /// carrying a real payload or an `Opaque` is left alone, so steady state costs
-    /// nothing and the work shrinks as rows are rewritten.
+    /// Both kinds of placeholder are re-attempted — a stored `Noop` AND a stored
+    /// `Opaque` — and each is decided the way the walk would decide it: consult the
+    /// signed op, re-attempt the decrypt, and take whatever payload that yields.
+    ///
+    /// Re-attempting `Opaque` is the point, not an extra. That row means "I could
+    /// not read this WHEN I FOLDED IT", which is a cache of a past failure, and the
+    /// whole design has the key arriving later: a member pulls the epoch by
+    /// `key_id` and the op becomes readable. Treating the row as settled left the
+    /// apply gates authorizing against a hole that no longer existed — the retry
+    /// that ran the moment the key landed asked this fold, was told "unreadable",
+    /// and abstained, so the op that the key was pulled FOR could never apply.
+    ///
+    /// Rows already carrying a real payload are untouched, so steady state costs
+    /// nothing and the work shrinks as holes are filled.
     fn reclassify_stored_holes(store: &Store, namespace_id: [u8; 32], ops: &mut [Op]) {
         let stale: Vec<usize> = ops
             .iter()
             .enumerate()
-            .filter(|(_, op)| matches!(op.payload, OpPayload::Noop))
+            .filter(|(_, op)| matches!(op.payload, OpPayload::Noop | OpPayload::Opaque { .. }))
             .map(|(i, _)| i)
             .collect();
         if stale.is_empty() {

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -1873,7 +1873,27 @@ impl ScopeProjections {
         // op was absent from the log, so the inherited walk still saw the member
         // in the root). If the ancestry isn't whole, abstain (`None`) and defer to
         // live's reject rather than grant on a truncated, possibly-stale view.
-        if !self.cut_ancestry_complete(&scope, heads) {
+        //
+        // An UNREADABLE ancestor costs exactly the same over-grant by a different
+        // route: an op this node holds no key for folds to nothing, so a removal it
+        // cannot decrypt leaves the member folded as present — the same stale view,
+        // reached without any op going missing. This is a grant path, so it abstains
+        // for the same reason it abstains on a gap. The walk is shared, so both
+        // answers come from one pass.
+        //
+        // Scoped to the groups that can move THIS membership — the target and its
+        // ancestors, since inheritance climbs — and not to the namespace. A hole in
+        // a sibling subgroup is one this node may never be able to fill, so
+        // abstaining on it would park the question permanently rather than
+        // conservatively.
+        let walked = ScopeState::cut_ancestry(self.logs.get(&scope)?, heads);
+        if !walked.is_complete() {
+            return None;
+        }
+        let view = ScopeState::acl_view_from_ancestry(&walked);
+        let relevant: std::collections::BTreeSet<ContextGroupId> =
+            view.group_and_ancestors(group).collect();
+        if walked.first_opaque_in_any(&relevant).is_some() {
             return None;
         }
 
@@ -2142,6 +2162,33 @@ impl ScopeProjections {
             return Err(self.classify_unresolvable_cut(&scope, heads));
         }
         let view = ScopeState::acl_view_from_ancestry(&walked);
+
+        // Complete is not enough to ANSWER with. An `Opaque` op folds to nothing,
+        // so a verdict taken over one describes a history this node cannot see —
+        // and the verdict here is AUTHORITATIVE: `PermissionChecker` hands a
+        // `Some(false)` straight back as a refusal. Two nodes with different keys
+        // would decide the same op differently.
+        //
+        // Scoped to the groups whose ops can MOVE this question — the target and
+        // its ancestors — not to the namespace. Every input to an
+        // admin-or-capability answer at `group` is an op naming `group` or an
+        // ancestor of it: roles and caps name their group, a visibility wall names
+        // its subgroup, and the root admin arrives on readable root ops. A sibling
+        // subgroup's hole cannot change any of them.
+        //
+        // The namespace-wide version of this check is what an earlier attempt
+        // shipped, and e2e refused it within the hour: a node legitimately not a
+        // member of one subgroup can never obtain that key, so it parked EVERY
+        // authority question in that namespace forever — including questions about
+        // its own group, whose every op it reads. `dm-subgroup-privacy` is that
+        // exact shape and its legitimate join failed. A refusal that cannot clear
+        // is not the conservative choice.
+        let relevant: std::collections::BTreeSet<ContextGroupId> =
+            view.group_and_ancestors(group).collect();
+        if walked.first_opaque_in_any(&relevant).is_some() {
+            return Err(UndecidableCause::AncestryUnreadable);
+        }
+
         let root_group = ContextGroupId::from(namespace_id);
         let root = MetaRepository::new(store)
             .load(&root_group)

--- a/crates/context/tests/projection_membership_equivalence.rs
+++ b/crates/context/tests/projection_membership_equivalence.rs
@@ -1515,3 +1515,144 @@ fn a_late_applied_add_after_a_promotion_is_not_a_divergence() {
         "and then they agree: Admin at the promotion's cut, Admin in the live row",
     );
 }
+
+/// The authoritative grant path must abstain when an ancestor is UNREADABLE, not
+/// only when one is missing.
+///
+/// A gap and a hole cost the same over-grant by different routes. With a gap, the
+/// removal op is absent and the walk still sees the member; with a hole, the
+/// removal op is present but encrypted under a key this node does not hold, folds
+/// to nothing, and the walk still sees the member. The view is equally stale, and
+/// this path GRANTS on what it returns — so it defers to live in both cases.
+///
+/// Same reasoning covers the apply gates through `auth_cut_context`, where the
+/// verdict is worse than stale: `PermissionChecker` returns a `Some(false)`
+/// straight through as a refusal, so two nodes with different key epochs would
+/// decide one op differently and that namespace's governance DAG would stop
+/// converging on the one that refused.
+#[test]
+fn the_grant_path_defers_when_an_ancestor_is_unreadable() {
+    let store = store();
+    let admin_sk = PrivateKey::random(&mut OsRng);
+    let admin = admin_sk.public_key();
+    let joiner_sk = PrivateKey::random(&mut OsRng);
+    let joiner = joiner_sk.public_key();
+
+    let ns = ContextGroupId::from([0x61; 32]);
+    let subgroup = ContextGroupId::from([0x62; 32]);
+
+    let admin_account = calimero_context::test_support::enrol(&store, &ns, &admin);
+    for g in [&ns, &subgroup] {
+        MetaRepository::new(&store)
+            .save(g, &meta(admin_account))
+            .unwrap();
+        MembershipRepository::new(&store)
+            .add_member(g, &admin_account, GroupMemberRole::Admin)
+            .unwrap();
+    }
+    NamespaceRepository::new(&store)
+        .nest(&ns, &subgroup)
+        .unwrap();
+
+    let mut proj = ScopeProjections::new();
+    let s2 = fold_subgroup_structure(
+        &mut proj,
+        ns.to_bytes(),
+        admin,
+        subgroup,
+        [0xD0; 32],
+        [0xDF; 32],
+    );
+
+    // The joiner is a member at this cut, by an op the projection HAS folded.
+    let join_ns = SignedNamespaceOp::sign(
+        &joiner_sk,
+        ns.to_bytes().into(),
+        vec![],
+        1,
+        NamespaceOp::Root(RootOp::MemberJoined {
+            member: calimero_context::test_support::account_for(&joiner),
+            signed_invitation: sign_invitation(&admin_sk, subgroup, 1, [0x42; 32]),
+            account: test_join_account_for(&joiner),
+        }),
+    )
+    .expect("sign join");
+    calimero_governance_store::apply_signed_namespace_op(&store, &join_ns).unwrap();
+    let joined = [0xD1; 32];
+    proj.ingest_op(&op_from_namespace_op(&join_ns, None, joined, hlc(1), &[s2]));
+
+    // Complete and readable: the grant path answers.
+    assert_eq!(
+        proj.member_at_cut_authoritative(&store, subgroup, &joiner, &[joined]),
+        Some(true),
+        "precondition: a whole, readable ancestry is answerable",
+    );
+
+    // Now a descendant op this node cannot decrypt — a group op with no key here.
+    // Its payload folds to nothing, so the view is unchanged and the member still
+    // looks present; what it could have said (a removal, a role change) is exactly
+    // what this node cannot know.
+    let hole = op_from_namespace_op(
+        &ns_group_envelope(ns.to_bytes(), admin, subgroup),
+        None,
+        [0xD2; 32],
+        hlc(2),
+        &[joined],
+    );
+    proj.ingest_op(&hole);
+
+    assert_eq!(
+        proj.member_at_cut_authoritative(&store, subgroup, &joiner, &[hole.id()]),
+        None,
+        "an unreadable op OF THIS GROUP must make the grant path abstain, not grant \
+         from a fold that is missing whatever that op did",
+    );
+
+    // And the distinction e2e taught the hard way: a hole in a group that cannot
+    // move this answer must NOT abstain. `dm-subgroup-privacy` has exactly this
+    // shape — a node not in the other DM subgroup can never obtain that key, so a
+    // namespace-wide check parked its own legitimate join forever.
+    let sibling = ContextGroupId::from([0x63; 32]);
+    NamespaceRepository::new(&store)
+        .nest(&ns, &sibling)
+        .unwrap();
+    let sibling_hole = op_from_namespace_op(
+        &ns_group_envelope(ns.to_bytes(), admin, sibling),
+        None,
+        [0xD3; 32],
+        hlc(3),
+        &[joined],
+    );
+    let mut proj_sibling = ScopeProjections::new();
+    let s2b = fold_subgroup_structure(
+        &mut proj_sibling,
+        ns.to_bytes(),
+        admin,
+        subgroup,
+        [0xE0; 32],
+        [0xEF; 32],
+    );
+    proj_sibling.ingest_op(&op_from_namespace_op(
+        &join_ns,
+        None,
+        joined,
+        hlc(1),
+        &[s2b],
+    ));
+    proj_sibling.ingest_op(&sibling_hole);
+    assert_eq!(
+        proj_sibling.member_at_cut_authoritative(&store, subgroup, &joiner, &[sibling_hole.id()]),
+        Some(true),
+        "a hole in a group that cannot move this membership must not park the \
+         question — that node may never be able to fill it",
+    );
+    // The narrower shadow question still answers — it is asked about direct rows
+    // only, where a sibling group's hole cannot matter. The two coexisting is the
+    // point: strict where a verdict is authoritative, narrow where it is a
+    // comparison.
+    assert_eq!(
+        proj.cut_ancestry_state(&ScopeId::from(ns.to_bytes()), &[hole.id()]),
+        (true, false),
+        "complete but unreadable, which is the state under test",
+    );
+}

--- a/crates/governance-store/src/metrics.rs
+++ b/crates/governance-store/src/metrics.rs
@@ -639,6 +639,18 @@ pub enum UndecidableCause {
     /// reach the cut and never will again. **Permanent.** The op parks forever
     /// and that namespace's governance DAG stops advancing on this node.
     LogTruncated,
+    /// Every ancestor is present, but at least one is an encrypted op this node
+    /// holds no key for, so the fold is missing whatever that op did.
+    ///
+    /// Distinct from [`Self::AncestryGap`] because the remedy differs — a gap
+    /// needs history, this needs a key — and because this one is the reason a
+    /// gate must ABSTAIN rather than answer: an at-cut verdict folded over a hole
+    /// is a verdict about a history the node cannot see, and two nodes with
+    /// different key epochs would reach different ones on the same op.
+    ///
+    /// Transient in the ordinary case (the key is delivered and the op re-folds),
+    /// permanent for a node outside the group whose op it is.
+    AncestryUnreadable,
     /// The ephemeral fold could not be built at all (governance head unreadable
     /// — a store fault). Not a history gap.
     FoldUnavailable,
@@ -654,6 +666,7 @@ impl UndecidableCause {
             UndecidableCause::HeadsMissing => "heads_missing",
             UndecidableCause::AncestryGap => "ancestry_gap",
             UndecidableCause::LogTruncated => "log_truncated",
+            UndecidableCause::AncestryUnreadable => "ancestry_unreadable",
             UndecidableCause::FoldUnavailable => "fold_unavailable",
             UndecidableCause::NamespaceUnresolved => "namespace_unresolved",
         }
@@ -750,6 +763,7 @@ mod tests {
             UndecidableCause::HeadsMissing,
             UndecidableCause::AncestryGap,
             UndecidableCause::LogTruncated,
+            UndecidableCause::AncestryUnreadable,
             UndecidableCause::FoldUnavailable,
             UndecidableCause::NamespaceUnresolved,
         ];
@@ -770,7 +784,9 @@ mod tests {
             permanent,
             vec!["log_truncated"],
             "only a truncated log is unrecoverable; the rest clear once sync \
-             delivers the missing history",
+             delivers the missing history — `ancestry_unreadable` included, since \
+             a key delivery re-folds the op and it is a node outside the group, \
+             not the history, that keeps it standing",
         );
 
         let mut registry = Registry::default();

--- a/crates/projection/src/lib.rs
+++ b/crates/projection/src/lib.rs
@@ -208,6 +208,27 @@ impl<'a> CutAncestry<'a> {
     /// inheritance chain — membership via an anchor, a capability bit, a
     /// visibility wall — depends on other groups' ops, so it must keep asking
     /// [`Self::first_opaque`] about the whole ancestry.
+    /// [`first_opaque_in`](Self::first_opaque_in) over a SET of groups — the ops
+    /// that can move an authority question, i.e. the target group and its
+    /// ancestors.
+    ///
+    /// A hole outside that set is not an abstention: a sibling subgroup's
+    /// encrypted op cannot change who is an admin of this one, and treating it as
+    /// fatal makes a node that is legitimately not a member of that sibling
+    /// unable to answer about its OWN group — permanently, since it can never be
+    /// given that key. That is not a conservative refusal, it is a node parked
+    /// forever.
+    #[must_use]
+    pub fn first_opaque_in_any(
+        &self,
+        groups: &std::collections::BTreeSet<ContextGroupId>,
+    ) -> Option<[u8; 32]> {
+        self.ops
+            .iter()
+            .find(|op| matches!(&op.payload, OpPayload::Opaque { group } if groups.contains(group)))
+            .map(|op| op.id())
+    }
+
     #[must_use]
     pub fn first_opaque_in(&self, group: ContextGroupId) -> Option<[u8; 32]> {
         self.ops


### PR DESCRIPTION
Replaces #3626, which I closed after e2e rejected it. Same finding, correct scope,
and the scoping is the whole design — so the story of how it was learned is below,
because it is the reviewable part.

## The finding

The at-cut authority paths abstain on an **incomplete** ancestry and never on an
**unreadable** one:

* `member_at_cut_authoritative` → `if !cut_ancestry_complete(..) { return None }`
* `auth_cut_context_or_cause` (behind every apply gate) → `if !walked.is_complete() { .. }`

An `Opaque` op folds to nothing, so a node missing a key folds a view with a hole
where that op's effect belongs — and answers from it. Authoritatively:
`PermissionChecker` hands the projection's `Some(false)` straight back as a refusal
with no live fallback.

| unreadable op in the cut | the fold says | consequence |
| --- | --- | --- |
| `MemberAdded{Admin}` / `MemberRoleSet{Admin}` | not an admin | refuses a legitimate op |
| `MemberRemoved` of an admin | still an admin | **accepts one every other node refuses** |

The second is unobservable to the apply-auth shadow by its own admission — *"a
live-rejected op never reaches this fold"* — so no amount of shadow evidence would
have surfaced it. This came from reading the authoritative paths.

## The fix, and why it is scoped rather than namespace-wide

Both paths now refuse when an unreadable ancestor belongs to a group whose ops can
**move the question** — the target group or an ancestor of it. Every input to an
admin-or-capability answer at `group` is an op naming `group` or an ancestor:
roles and caps name their group, a visibility wall names its subgroup, the root
admin arrives on readable root ops. A sibling subgroup's hole cannot change any of
them.

**#3626 asked the namespace-wide question and e2e refused it inside the hour**, in
three scenarios. `dm-subgroup-privacy` is the shape: node-3 is legitimately not a
member of the other DM subgroup, can therefore *never* obtain that key, and so
parked **every** authority question in the namespace forever — including questions
about its own group, whose every op it reads. Its legitimate `join_context` failed
with `cause=AncestryUnreadable`. A refusal that can never clear is not the
conservative choice; it is a stall.

I had reasoned my way to that risk and then talked myself out of it, on the
assumption that the hole was in the target group. It was not. The logs settled it:
the abstaining group was node-3's own (`4bada981…`, whose key it had received via
direct delivery), so the hole was the sibling's.

## One subtlety worth reviewing closely

`AclView::group_and_ancestors` climbs **through** a `restricted` edge, unlike
`open_ancestors`, which stops there because inheritance stops there. This walk
cannot: whether an edge is restricted is itself decided by a
`SubgroupVisibilitySet` op **of that subgroup**, which may be precisely the op that
cannot be read. Stopping at an edge whose state is unknown would shorten the set
and let a relevant hole pass as irrelevant. The tree's *shape*, unlike its
visibility, comes from root ops and is always readable.

## Tests

`the_grant_path_defers_when_an_ancestor_is_unreadable` pins the scoping **from both
sides**, which is what #3626 lacked:

* an unreadable op **of the target group** → abstain (`None`);
* an unreadable op of a **sibling** → still answers `Some(true)`.

Negative controls both ways: remove the check and the first assertion fails; widen
it back to namespace-wide and the second fails. The second is the one that would
have caught #3626 before CI did.

`a_pulled_key_unwedges_another_members_open_subgroup_join` keeps its updated
assertion from #3626: with a hole in the target group the node parks instead of
answering "no membership path" over a fold missing the visibility flip, and the
rest of that test is unchanged — the pulled key re-folds the flip and the join
applies.

## Cause label

`AncestryUnreadable`, its own cause rather than folded into `AncestryGap`: a gap
needs history, this needs a key, and the metric exists to tell refusals apart.
Transient for a member — the pull responder serves any epoch by `key_id` to a
current member, and `repersist_namespace_ops` re-folds the op after.

246 context lib tests, 585 governance-store, projection and authz suites, clippy
and fmt clean. e2e is the check that matters and it is running here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
