### PR TITLE
fix(server): answer "not yet" with 503 instead of a 500 that reads like "no"

### DIFF
--- a/crates/context/src/error.rs
+++ b/crates/context/src/error.rs
@@ -61,6 +61,26 @@ pub enum ContextError {
     /// A legitimate client-side precondition (the node hasn't joined the
     /// group, or isn't in it), not a server fault — callers map this to a
     /// `403`, never a generic `500`.
+    /// The node cannot yet decide whether the op's signer was authorized,
+    /// because the causal cut it must judge against cites history this node has
+    /// not folded — a missing ancestor, or one encrypted under a key it does not
+    /// hold yet.
+    ///
+    /// **Not a refusal, and the distinction is the whole point.** The apply path
+    /// burns nothing on this outcome — the DAG head does not advance and the
+    /// nonce is not consumed — so the identical call succeeds once sync or a key
+    /// pull delivers what is missing. Typed for the same reason as
+    /// [`Self::NotAGroupMember`], but mapping to a RETRYABLE status: a caller that
+    /// sees a generic `500` cannot tell "wait, and this will work" from "no, and
+    /// it never will", and those want opposite client behaviour.
+    #[error(
+        "authority for '{group_id}' cannot be resolved at this op's causal cut yet          — this node is missing history or a key it is entitled to; retry once it          has synced"
+    )]
+    AuthorityNotYetResolvable {
+        /// The group whose authority could not be resolved.
+        group_id: String,
+    },
+
     #[error("node is not a member of group '{group_id}'")]
     NotAGroupMember {
         /// Debug rendering of the target group id (for the message only).

--- a/crates/context/src/governance_dag.rs
+++ b/crates/context/src/governance_dag.rs
@@ -70,6 +70,10 @@ pub fn signed_op_to_delta(op: &SignedGroupOp) -> Result<CausalDelta<SignedGroupO
 pub struct NamespaceGovernanceApplier {
     store: Store,
     divergence_outbox: Arc<Mutex<Option<DivergenceReport>>>,
+    /// Set when the apply failed because authority was UNDECIDABLE at the cut,
+    /// rather than refused. Same single-slot, read-once shape as
+    /// `divergence_outbox`, and single-flight for the same reason.
+    undecidable_outbox: Arc<Mutex<Option<String>>>,
 }
 
 impl NamespaceGovernanceApplier {
@@ -77,6 +81,7 @@ impl NamespaceGovernanceApplier {
         Self {
             store,
             divergence_outbox: Arc::new(Mutex::new(None)),
+            undecidable_outbox: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -92,6 +97,25 @@ impl NamespaceGovernanceApplier {
     /// path never fires on the report a poison-inducing panic was
     /// concurrent with — exactly the operator-investigation signal
     /// we need to preserve.
+    /// The group whose authority the last apply could not resolve, if that is why
+    /// it failed — read once, like [`Self::take_divergence`].
+    ///
+    /// `ApplyError::Application` carries only a string, so the typed
+    /// `AuthorityUndecidable` the gate raised is gone by the time the DAG returns
+    /// it. It matters at the API edge, where "not yet" and "refused" want opposite
+    /// client behaviour, so it is carried out of band from the one place that
+    /// still has the type rather than recovered by matching on prose.
+    pub fn take_undecidable(&self) -> Option<String> {
+        let mut slot = self.undecidable_outbox.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!(
+                "undecidable_outbox mutex was poisoned by a prior panic; recovering the \
+                 inner value so the retryable outcome still reaches the caller"
+            );
+            poisoned.into_inner()
+        });
+        slot.take()
+    }
+
     pub fn take_divergence(&self) -> Option<DivergenceReport> {
         let mut slot = self.divergence_outbox.lock().unwrap_or_else(|poisoned| {
             tracing::warn!(
@@ -119,7 +143,27 @@ impl DeltaApplier<SignedNamespaceOp> for NamespaceGovernanceApplier {
             &delta.parents,
             &authorizer,
         )
-        .map_err(|e| ApplyError::Application(e.to_string()))?;
+        .map_err(|e| {
+            // The one place the typed gate error still exists. Downcast before the
+            // string conversion swallows it; a `None` here is any other apply
+            // failure and stays exactly as it was.
+            if let Some(calimero_governance_store::ApplyError::AuthorityUndecidable {
+                group_id,
+                ..
+            }) = e.downcast_ref::<calimero_governance_store::ApplyError>()
+            {
+                let mut slot = self.undecidable_outbox.lock().unwrap_or_else(|poisoned| {
+                    tracing::warn!(
+                        "undecidable_outbox mutex was poisoned by a prior panic; \
+                         recovering the inner slot so this retryable outcome still \
+                         reaches the caller"
+                    );
+                    poisoned.into_inner()
+                });
+                *slot = Some(group_id.clone());
+            }
+            ApplyError::Application(e.to_string())
+        })?;
         if let Some(report) = outcome.divergence {
             // Last-writer-wins on the outbox. The applier instance
             // is single-flight per actor message turn, so multiple

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -112,7 +112,18 @@ impl Handler<ApplySignedNamespaceOpRequest> for ContextManager {
                     }
                     Ok(AddDeltaOutcome::Pending) => Ok(NamespaceApplyOutcome::Pending),
                     Ok(AddDeltaOutcome::Duplicate) => Ok(NamespaceApplyOutcome::Duplicate),
-                    Err(e) => Err(eyre::eyre!("namespace DAG apply error: {e}")),
+                    Err(e) => Err(match applier.take_undecidable() {
+                        // Not a refusal: the gate could not judge this cut yet, the
+                        // head did not advance and the nonce was not burned, so the
+                        // identical call works once sync or a key pull delivers what
+                        // is missing. Typed so the API edge can say "retry" instead
+                        // of a `500` that reads the same as a permanent no.
+                        Some(group_id) => {
+                            crate::error::ContextError::AuthorityNotYetResolvable { group_id }
+                                .into()
+                        }
+                        None => eyre::eyre!("namespace DAG apply error: {e}"),
+                    }),
                 }
             }
             .into_actor(self),

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -640,6 +640,20 @@ pub fn parse_api_error(err: Report) -> ApiError {
             message: err.to_string(),
         };
     }
+    // The node cannot decide this op's authority YET — it is missing history or a
+    // key it is entitled to, and the apply burned nothing, so the identical call
+    // succeeds once it has caught up. `503` rather than the generic `500` because
+    // the two ask opposite things of a client: retry me, versus stop. `Retry-After`
+    // is deliberately omitted — how long depends on sync, which this layer cannot
+    // estimate, and a wrong number is worse than none.
+    if let Some(calimero_context::error::ContextError::AuthorityNotYetResolvable { .. }) =
+        err.downcast_ref::<calimero_context::error::ContextError>()
+    {
+        return ApiError {
+            status_code: StatusCode::SERVICE_UNAVAILABLE,
+            message: err.to_string(),
+        };
+    }
     // The application's own `init` refused the call — nearly always because the
     // `initializationParams` do not match its signature. That is the caller's
     // input, not a server fault, and the guest's message is the only thing that
@@ -869,6 +883,52 @@ mod parse_api_error_tests {
             "the guest's own diagnosis is the only useful part; got: {}",
             api.message
         );
+    }
+
+    /// "Wait" and "no" must not answer the same. A node that has not yet folded
+    /// the history (or received a key it is entitled to) cannot decide the op's
+    /// authority, and the apply burns nothing — so the identical call succeeds
+    /// after it catches up. A caller told `500` cannot tell that from the
+    /// permanent refusal next to it, and the two want opposite behaviour: retry
+    /// versus stop.
+    #[test]
+    fn authority_not_yet_resolvable_maps_to_503_not_500() {
+        let err = calimero_context::error::ContextError::AuthorityNotYetResolvable {
+            group_id: "test-group".to_owned(),
+        };
+        let api = parse_api_error(err.into());
+        assert_eq!(api.status_code, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(
+            api.message.contains("retry"),
+            "the client is being asked to come back, and the message should say so; \
+             got: {}",
+            api.message
+        );
+    }
+
+    /// The pair that must stay apart: same shape of failure to a caller, opposite
+    /// meanings. If these ever collapse to one status, retry logic built on the
+    /// first will spin forever on the second.
+    #[test]
+    fn a_retryable_wait_and_a_permanent_refusal_get_different_statuses() {
+        let waiting = parse_api_error(
+            calimero_context::error::ContextError::AuthorityNotYetResolvable {
+                group_id: "g".to_owned(),
+            }
+            .into(),
+        );
+        let refused = parse_api_error(
+            calimero_context::error::ContextError::NotAGroupMember {
+                group_id: "g".to_owned(),
+            }
+            .into(),
+        );
+        assert_ne!(
+            waiting.status_code, refused.status_code,
+            "'not yet' and 'never' must not be the same answer",
+        );
+        assert!(waiting.status_code.is_server_error());
+        assert!(refused.status_code.is_client_error());
     }
 
     #[test]


### PR DESCRIPTION
Option A from the discussion on #3627: make "retry me" distinguishable from "stop",
without touching any authorization logic.

## The problem

A node that cannot yet decide an op's authority burns nothing on the attempt — the
DAG head does not advance and the nonce is not consumed. The error type has always
said so:

> Treated like any other apply error by the DAG: the head is not advanced and the
> nonce is not burned, so the op is re-fetched and re-applied once the missing
> ancestry arrives.

So the identical call succeeds once the node syncs, or once a key pull delivers an
epoch it is entitled to. But a caller could not tell, because it arrived as
`500 Internal server error` — the same answer as the permanent refusal beside it,
a node that is genuinely not a member and never will be.

Retrying works today. It just isn't a contract; it's folklore, and a client cannot
implement it without parsing prose.

## Why it needed more than one line

The type is destroyed twice on the way out:

```
governance-store   ApplyError::AuthorityUndecidable{..}      ← typed
crates/dag         ApplyError::Application(String)           ← stringified
context handler    eyre!("namespace DAG apply error: {e}")   ← stringified again
server             parse_api_error → generic 500
```

Three options were on the table: widen the DAG's error type to carry a source
(clean, but it moves every applier and `map_err` site), match the message text
(five lines, and a prose contract between crates that don't know each other), or
carry the fact from the one place that still has the type. This is the third.

## What it does

* the applier downcasts to `AuthorityUndecidable` immediately before the string
  conversion swallows it, and records the group in a single-slot read-once outbox —
  the same shape, and the same rationale, as the `divergence_outbox` already beside
  it;
* the handler turns that into `ContextError::AuthorityNotYetResolvable` instead of
  an untyped `eyre!`;
* `parse_api_error` maps it to **503**, next to the existing `NotAGroupMember → 403`
  and `InitFailed → 400` arms, whose comments make exactly this argument ("a
  legitimate client-side precondition, not a server fault … instead of letting it
  fall through to the generic 500").

No `Retry-After`: how long depends on sync, which that layer cannot estimate, and a
wrong number is worse than none.

## Tests

* `authority_not_yet_resolvable_maps_to_503_not_500` — and that the message still
  tells the caller to come back.
* `a_retryable_wait_and_a_permanent_refusal_get_different_statuses` — the one that
  matters. Same shape of failure, opposite meanings; if they ever collapse to one
  status, retry logic built on the first spins forever on the second.

Negative control: remove the new arm and the first test fails on exactly that
assertion.

## Scope

No authorization logic is touched. Any other apply failure still stringifies to the
generic 500 exactly as before, so the only behaviour change a client can observe is
the status on a case that was already retryable.

246 context lib tests, 105 server, clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
