### PR TITLE
chore(e2e): drop the create_mesh path every step already resolves

### DIFF
--- a/apps/abi_conformance/workflows/abi-conformance.yml
+++ b/apps/abi_conformance/workflows/abi-conformance.yml
@@ -21,7 +21,6 @@ steps:
     type: create_mesh
     context_node: abi-conformance-node-1
     application_id: "{{app_id}}"
-    path: res/abi_conformance.wasm
     nodes:
       - abi-conformance-node-2
     outputs:

--- a/apps/blobs/workflows/blob-announce-namespace-membership.yml
+++ b/apps/blobs/workflows/blob-announce-namespace-membership.yml
@@ -65,7 +65,6 @@ steps:
     type: create_mesh
     context_node: rust-blob-announce-1
     application_id: "{{app_id}}"
-    path: "res/blobs.wasm"
     nodes:
       - rust-blob-announce-2
     outputs:

--- a/apps/blobs/workflows/blob-cross-node-sizes.yml
+++ b/apps/blobs/workflows/blob-cross-node-sizes.yml
@@ -80,7 +80,6 @@ steps:
     type: create_mesh
     context_node: rust-blob-size-1
     application_id: "{{app_id}}"
-    path: "res/blobs.wasm"
     nodes:
       - rust-blob-size-2
     outputs:

--- a/apps/blobs/workflows/blob-cross-node-transfer.yml
+++ b/apps/blobs/workflows/blob-cross-node-transfer.yml
@@ -63,7 +63,6 @@ steps:
     type: create_mesh
     context_node: rust-blob-xfer-1
     application_id: "{{app_id}}"
-    path: "res/blobs.wasm"
     nodes:
       - rust-blob-xfer-2
     outputs:

--- a/apps/blobs/workflows/blobs-example.yml
+++ b/apps/blobs/workflows/blobs-example.yml
@@ -47,7 +47,6 @@ steps:
     type: create_mesh
     context_node: node-blob-1
     application_id: "{{app_id}}"
-    path: "res/blobs.wasm"
     nodes:
       - node-blob-2
     outputs:

--- a/apps/blobs/workflows/blobs.yml
+++ b/apps/blobs/workflows/blobs.yml
@@ -37,7 +37,6 @@ steps:
     type: create_mesh
     context_node: rust-blob-1
     application_id: "{{app_id}}"
-    path: "res/blobs.wasm"
     nodes:
       - rust-blob-2
     outputs:

--- a/apps/collaborative-editor/workflows/collaborative-editor.yml
+++ b/apps/collaborative-editor/workflows/collaborative-editor.yml
@@ -28,7 +28,6 @@ steps:
     type: create_mesh
     context_node: calimero-node-1
     application_id: "{{app_id}}"
-    path: res/collaborative_editor.wasm
     nodes:
       - calimero-node-2
     outputs:

--- a/apps/components-demo/workflows/components-demo.yml
+++ b/apps/components-demo/workflows/components-demo.yml
@@ -45,7 +45,6 @@ steps:
     type: create_mesh
     context_node: new-calimero-node-1
     application_id: '{{app_id}}'
-    path: "./res/components_demo.wasm"
     nodes:
       - new-calimero-node-2
     outputs:

--- a/apps/kv-store-init/workflows/kv-store-init.yml
+++ b/apps/kv-store-init/workflows/kv-store-init.yml
@@ -21,7 +21,6 @@ steps:
     type: create_mesh
     context_node: kv-store-init-node-1
     application_id: "{{app_id}}"
-    path: res/kv_store_init.wasm
     nodes:
       - kv-store-init-node-2
     outputs:

--- a/apps/kv-store-with-handlers/workflows/kv-store-with-handlers.yml
+++ b/apps/kv-store-with-handlers/workflows/kv-store-with-handlers.yml
@@ -21,7 +21,6 @@ steps:
     type: create_mesh
     context_node: kvh-node-1
     application_id: "{{app_id}}"
-    path: res/kv_store_with_handlers.wasm
     nodes:
       - kvh-node-2
     outputs:

--- a/apps/kv-store-with-shared-storage/workflows/test_shared_storage.yml
+++ b/apps/kv-store-with-shared-storage/workflows/test_shared_storage.yml
@@ -42,7 +42,6 @@ steps:
     type: create_mesh
     context_node: new-calimero-node-1
     application_id: '{{app_id}}'
-    path: "./res/kv_store_with_shared_storage.wasm"
     nodes:
       - new-calimero-node-2
     outputs:

--- a/apps/kv-store-with-user-and-frozen-storage/workflows/test_frozen_storage.yml
+++ b/apps/kv-store-with-user-and-frozen-storage/workflows/test_frozen_storage.yml
@@ -26,7 +26,6 @@ steps:
     type: create_mesh
     context_node: new-calimero-node-1
     application_id: '{{app_id}}'
-    path: "./res/kv_store_with_user_and_frozen_storage.wasm"
     nodes:
       - new-calimero-node-2
     outputs:

--- a/apps/kv-store-with-user-and-frozen-storage/workflows/test_user_storage.yml
+++ b/apps/kv-store-with-user-and-frozen-storage/workflows/test_user_storage.yml
@@ -26,7 +26,6 @@ steps:
     type: create_mesh
     context_node: new-calimero-node-1
     application_id: '{{app_id}}'
-    path: "./res/kv_store_with_user_and_frozen_storage.wasm"
     nodes:
       - new-calimero-node-2
     outputs:

--- a/apps/kv-store/workflows/bundle-invitation-test.yml
+++ b/apps/kv-store/workflows/bundle-invitation-test.yml
@@ -43,7 +43,6 @@ steps:
     type: create_mesh
     context_node: calimero-node-1
     application_id: "{{bundle_app_id}}"
-    path: dist/com.calimero.kv-store-0.0.0.mpk
     nodes:
       - calimero-node-2
     outputs:

--- a/apps/nested-crdt-test/workflows/nested-crdt-test.yml
+++ b/apps/nested-crdt-test/workflows/nested-crdt-test.yml
@@ -21,7 +21,6 @@ steps:
     type: create_mesh
     context_node: nested-node-1
     application_id: "{{app_id}}"
-    path: res/nested_crdt_test.wasm
     nodes:
       - nested-node-2
     outputs:

--- a/apps/private_data/workflows/example.yml
+++ b/apps/private_data/workflows/example.yml
@@ -25,7 +25,6 @@ steps:
     type: create_mesh
     context_node: calimero-node-1
     application_id: "{{app_id}}"
-    path: res/private_data.wasm
     nodes:
       - calimero-node-2
     outputs:

--- a/apps/private_data/workflows/private-data.yml
+++ b/apps/private_data/workflows/private-data.yml
@@ -21,7 +21,6 @@ steps:
     type: create_mesh
     context_node: rust-private-data-1
     application_id: "{{app_id}}"
-    path: res/private_data.wasm
     nodes:
       - rust-private-data-2
     outputs:

--- a/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-2node.yml
+++ b/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-2node.yml
@@ -93,7 +93,6 @@ steps:
     type: create_mesh
     context_node: e2e-node-1
     application_id: '{{app_id}}'
-    path: res/scaffolding_e2e.wasm
     nodes:
       - e2e-node-2
     outputs:

--- a/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-4node.yml
+++ b/apps/scaffolding-e2e/workflows/discovery-bootstrap-only-4node.yml
@@ -79,7 +79,6 @@ steps:
     type: create_mesh
     context_node: e2e-node-1
     application_id: '{{app_id}}'
-    path: res/scaffolding_e2e.wasm
     nodes:
       - e2e-node-2
       - e2e-node-3

--- a/apps/scaffolding-e2e/workflows/e2e.yml
+++ b/apps/scaffolding-e2e/workflows/e2e.yml
@@ -50,7 +50,6 @@ steps:
     type: create_mesh
     context_node: e2e-node-1
     application_id: "{{app_id}}"
-    path: res/scaffolding_e2e.wasm
     nodes:
       - e2e-node-2
     outputs:

--- a/apps/scaffolding-e2e/workflows/frozen-rga-convergence.yml
+++ b/apps/scaffolding-e2e/workflows/frozen-rga-convergence.yml
@@ -53,7 +53,6 @@ steps:
     type: create_mesh
     context_node: e2e-node-1
     application_id: "{{app_id}}"
-    path: res/scaffolding_e2e.wasm
     nodes:
       - e2e-node-2
     outputs:

--- a/apps/scaffolding-e2e/workflows/group-3node.yml
+++ b/apps/scaffolding-e2e/workflows/group-3node.yml
@@ -53,7 +53,6 @@ steps:
     type: create_mesh
     context_node: e2e-node-1
     application_id: '{{app_id}}'
-    path: res/scaffolding_e2e.wasm
     nodes:
       - e2e-node-2
       - e2e-node-3

--- a/apps/scaffolding-e2e/workflows/kad-routing-from-identify.yml
+++ b/apps/scaffolding-e2e/workflows/kad-routing-from-identify.yml
@@ -74,7 +74,6 @@ steps:
     type: create_mesh
     context_node: kad-identify-node-1
     application_id: "{{app_id}}"
-    path: res/scaffolding_e2e.wasm
     nodes:
       - kad-identify-node-2
     outputs:

--- a/apps/scaffolding-e2e/workflows/mesh-soak-8node.yml
+++ b/apps/scaffolding-e2e/workflows/mesh-soak-8node.yml
@@ -82,7 +82,6 @@ steps:
     type: create_mesh
     context_node: e2e-node-1
     application_id: '{{app_id}}'
-    path: res/scaffolding_e2e.wasm
     nodes:
       - e2e-node-2
       - e2e-node-3

--- a/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
+++ b/apps/scaffolding-e2e/workflows/shared-storage-concurrent-rotation-converge.yml
@@ -125,7 +125,6 @@ steps:
     type: create_mesh
     context_node: e2e-node-1
     application_id: '{{app_id}}'
-    path: res/scaffolding_e2e.wasm
     nodes:
       - e2e-node-2
       - e2e-node-3

--- a/apps/scaffolding-e2e/workflows/simple-sync.yml
+++ b/apps/scaffolding-e2e/workflows/simple-sync.yml
@@ -21,7 +21,6 @@ steps:
     type: create_mesh
     context_node: e2e-node-1
     application_id: "{{app_id}}"
-    path: res/scaffolding_e2e.wasm
     nodes:
       - e2e-node-2
     outputs:

--- a/apps/scaffolding-e2e/workflows/sorted-set-concurrent-convergence.yml
+++ b/apps/scaffolding-e2e/workflows/sorted-set-concurrent-convergence.yml
@@ -74,7 +74,6 @@ steps:
     type: create_mesh
     context_node: sortedset-node-1
     application_id: "{{app_id}}"
-    path: res/scaffolding_e2e.wasm
     nodes:
       - sortedset-node-2
     outputs:

--- a/apps/scaffolding-e2e/workflows/sync-resilience-network-partition-symmetric.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-network-partition-symmetric.yml
@@ -78,7 +78,6 @@ steps:
     type: create_mesh
     context_node: sync-resil-node-1
     application_id: '{{app_id}}'
-    path: res/scaffolding_e2e.wasm
     nodes:
       - sync-resil-node-2
     outputs:

--- a/apps/scaffolding-e2e/workflows/sync-resilience-network-partition.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-network-partition.yml
@@ -113,7 +113,6 @@ steps:
     type: create_mesh
     context_node: sync-resil-node-1
     application_id: '{{app_id}}'
-    path: res/scaffolding_e2e.wasm
     nodes:
       - sync-resil-node-2
     outputs:

--- a/apps/scaffolding-e2e/workflows/sync-resilience-peer-pause-symmetric.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-peer-pause-symmetric.yml
@@ -73,7 +73,6 @@ steps:
     type: create_mesh
     context_node: sync-resil-node-1
     application_id: '{{app_id}}'
-    path: res/scaffolding_e2e.wasm
     nodes:
       - sync-resil-node-2
     outputs:

--- a/apps/scaffolding-e2e/workflows/sync-resilience-peer-pause.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-peer-pause.yml
@@ -71,7 +71,6 @@ steps:
     type: create_mesh
     context_node: sync-resil-node-1
     application_id: '{{app_id}}'
-    path: res/scaffolding_e2e.wasm
     nodes:
       - sync-resil-node-2
     outputs:

--- a/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart-autoresync.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart-autoresync.yml
@@ -84,7 +84,6 @@ steps:
     type: create_mesh
     context_node: sync-autoresync-node-1
     application_id: '{{app_id}}'
-    path: res/scaffolding_e2e.wasm
     nodes:
       - sync-autoresync-node-2
     outputs:

--- a/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart-symmetric.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart-symmetric.yml
@@ -79,7 +79,6 @@ steps:
     type: create_mesh
     context_node: sync-resil-node-1
     application_id: '{{app_id}}'
-    path: res/scaffolding_e2e.wasm
     nodes:
       - sync-resil-node-2
     outputs:

--- a/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart.yml
+++ b/apps/scaffolding-e2e/workflows/sync-resilience-peer-restart.yml
@@ -79,7 +79,6 @@ steps:
     type: create_mesh
     context_node: sync-resil-node-1
     application_id: '{{app_id}}'
-    path: res/scaffolding_e2e.wasm
     nodes:
       - sync-resil-node-2
     outputs:

--- a/apps/team-metrics-custom/workflows/team-metrics-custom.yml
+++ b/apps/team-metrics-custom/workflows/team-metrics-custom.yml
@@ -21,7 +21,6 @@ steps:
     type: create_mesh
     context_node: team-custom-node-1
     application_id: "{{app_id}}"
-    path: res/team_metrics_custom.wasm
     nodes:
       - team-custom-node-2
     outputs:

--- a/apps/team-metrics-macro/workflows/team-metrics-macro.yml
+++ b/apps/team-metrics-macro/workflows/team-metrics-macro.yml
@@ -21,7 +21,6 @@ steps:
     type: create_mesh
     context_node: team-macro-node-1
     application_id: "{{app_id}}"
-    path: res/team_metrics_macro.wasm
     nodes:
       - team-macro-node-2
     outputs:

--- a/workflows/fuzzy-tests/kv-store-with-handlers/fuzzy-test.yml
+++ b/workflows/fuzzy-tests/kv-store-with-handlers/fuzzy-test.yml
@@ -25,7 +25,6 @@ steps:
     type: create_mesh
     context_node: fuzzy-handlers-node-1
     application_id: "{{handlers_app_id}}"
-    path: apps/kv-store-with-handlers/res/kv_store_with_handlers.wasm
     nodes:
       - fuzzy-handlers-node-2
       - fuzzy-handlers-node-3

--- a/workflows/fuzzy-tests/kv-store/fuzzy-test.yml
+++ b/workflows/fuzzy-tests/kv-store/fuzzy-test.yml
@@ -25,7 +25,6 @@ steps:
     type: create_mesh
     context_node: fuzzy-kv-node-1
     application_id: "{{kv_app_id}}"
-    path: apps/kv-store/res/kv_store.wasm
     nodes:
       - fuzzy-kv-node-2
       - fuzzy-kv-node-3

--- a/workflows/fuzzy-tests/scaffolding-e2e/fuzzy-test.yml
+++ b/workflows/fuzzy-tests/scaffolding-e2e/fuzzy-test.yml
@@ -25,7 +25,6 @@ steps:
     type: create_mesh
     context_node: fuzzy-e2e-node-1
     application_id: "{{e2e_app_id}}"
-    path: apps/scaffolding-e2e/res/scaffolding_e2e.wasm
     nodes:
       - fuzzy-e2e-node-2
       - fuzzy-e2e-node-3


### PR DESCRIPTION
## Summary

`create_mesh` resolves the application itself when no `path` is given:

```python
# merobox/commands/bootstrap/steps/mesh.py:372-374
raw_application_path = self.config.get("path")
if not raw_application_path:
    raw_application_path = dynamic_values.get(f"app_path_{context_node}")
```

All 39 uses in this repo passed a `path` the step was going to derive anyway, so the key is redundant at every call site. This removes it from all 39.

The change is behaviour-preserving on its own: the fallback resolves to the same file, keyed on the node that owns the context.

## Why now

It unblocks a merobox change. `create_mesh` pre-installs the application on joining nodes, which pre-empts the delivery path core already implements: sync fetches the context's blob from a peer and installs it when the application is not found (`crates/node/src/sync/manager/blob_fetch.rs:81`).

merobox recently removed the equivalent pre-install from `join_namespace` (merobox#369) and its CI stayed green, with 25 of its 26 join steps having relied on it. That is direct evidence core delivers the application over the wire.

Retiring the `create_mesh` half means removing its `path` key too, and merobox cannot drop a field while scenarios still set it: `extra="forbid"` rejects unknown keys, and a key nothing reads is exactly what that validator exists to catch. So the scenarios have to stop passing it first.

## Test plan

- All 133 workflows parse and validate against merobox master's `validate_workflow_step`: **0 failures**.
- `install_application` step count unchanged at 198, so no install path was touched. Every removed line is a `path:` belonging to a `create_mesh` step.
- The e2e suite is the real check, since these are the scenarios themselves.