### PR TITLE
test(e2e): drop the sleep before every namespace join

### DIFF
--- a/apps/kv-store/workflows/ephemeral-presence-e2e.yml
+++ b/apps/kv-store/workflows/ephemeral-presence-e2e.yml
@@ -100,11 +100,6 @@ steps:
     outputs:
       ns_invite: invitation
 
-  - name: Wait for namespace governance to gossip to node 2
-    # Namespace governance DAG needs to propagate before the join.
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: ephemeral-node-2

--- a/apps/scaffolding-e2e/workflows/auto-follow/asymmetric-context-membership.yml
+++ b/apps/scaffolding-e2e/workflows/auto-follow/asymmetric-context-membership.yml
@@ -118,10 +118,6 @@ steps:
     outputs:
       ns_invite: invitation
 
-  - name: Wait for namespace governance to gossip
-    type: wait
-    seconds: 10
-
   - name: Node-2 joins namespace
     type: join_namespace
     node: af-asym-node-2

--- a/apps/scaffolding-e2e/workflows/auto-follow/auto-follow-backfill-on-join.yml
+++ b/apps/scaffolding-e2e/workflows/auto-follow/auto-follow-backfill-on-join.yml
@@ -180,10 +180,6 @@ steps:
     outputs:
       ns_invite: invitation
 
-  - name: Wait for namespace + contexts governance to gossip
-    type: wait
-    seconds: 10
-
   - name: Node-2 joins namespace
     type: join_namespace
     node: af-backfill-node-2

--- a/apps/scaffolding-e2e/workflows/auto-follow/auto-follow-flag-flipped-late.yml
+++ b/apps/scaffolding-e2e/workflows/auto-follow/auto-follow-flag-flipped-late.yml
@@ -174,10 +174,6 @@ steps:
     outputs:
       ns_invite: invitation
 
-  - name: Wait for governance to gossip
-    type: wait
-    seconds: 10
-
   - name: Node-2 joins namespace
     type: join_namespace
     node: af-late-flip-node-2

--- a/apps/scaffolding-e2e/workflows/auto-follow/auto-follow-on-context-registered.yml
+++ b/apps/scaffolding-e2e/workflows/auto-follow/auto-follow-on-context-registered.yml
@@ -82,12 +82,6 @@ steps:
     outputs:
       ns_invite: invitation
 
-  - name: Wait for namespace governance to gossip
-    # Same 10s budget as sync-tests/opaque-leaf-regression.yml — enough
-    # for the invitation to become visible to node-2 in a 2-node mesh.
-    type: wait
-    seconds: 10
-
   - name: Node-2 joins namespace
     type: join_namespace
     node: af-baseline-node-2

--- a/apps/scaffolding-e2e/workflows/auto-follow/no-unknown-context-rejection-spam.yml
+++ b/apps/scaffolding-e2e/workflows/auto-follow/no-unknown-context-rejection-spam.yml
@@ -151,10 +151,6 @@ steps:
     outputs:
       ns_invite: invitation
 
-  - name: Wait for governance to gossip
-    type: wait
-    seconds: 10
-
   - name: Node-2 joins namespace
     type: join_namespace
     node: af-no-spam-node-2

--- a/apps/scaffolding-e2e/workflows/group-governance-cold-context-push-converge.yml
+++ b/apps/scaffolding-e2e/workflows/group-governance-cold-context-push-converge.yml
@@ -121,10 +121,6 @@ steps:
     outputs:
       invitation_node2: invitation
 
-  - name: Wait for namespace gossip
-    type: wait
-    seconds: 5
-
   - name: Node-2 joins namespace
     type: join_namespace
     node: cold-ctx-node-2

--- a/apps/scaffolding-e2e/workflows/group-join-then-list-from-joiner.yml
+++ b/apps/scaffolding-e2e/workflows/group-join-then-list-from-joiner.yml
@@ -95,15 +95,6 @@ steps:
     outputs:
       invitation: invitation
 
-  - name: Wait for the group governance + invitation to gossip
-    # Lets node-2 form the namespace mesh and see the invitation before it
-    # joins. Kept modest (not generous) so a genuine join/mesh-timing
-    # regression still surfaces rather than being masked by a long sleep.
-    type: wait
-    seconds: 8
-
-  # ── The reported flow: node-2 joins the group via the invitation ──────
-
   - name: Node-2 joins the group (join_group / JoinGroupRequest path)
     type: join_namespace
     node: joinlist-node-2

--- a/apps/scaffolding-e2e/workflows/group-join-via-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-join-via-inheritance.yml
@@ -87,10 +87,6 @@ steps:
     outputs:
       ns_invite: invitation
 
-  - name: Wait for namespace governance to gossip
-    type: wait
-    seconds: 10
-
   - name: Node-2 joins namespace
     type: join_namespace
     node: join-inherit-node-2

--- a/apps/scaffolding-e2e/workflows/group-kick-and-readd-deny-list.yml
+++ b/apps/scaffolding-e2e/workflows/group-kick-and-readd-deny-list.yml
@@ -113,10 +113,6 @@ steps:
     outputs:
       invite_node3: invitation
 
-  - name: Wait for namespace governance to gossip
-    type: wait
-    seconds: 10
-
   - name: Node-2 joins namespace
     type: join_namespace
     node: kick-readd-node-2

--- a/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
+++ b/apps/scaffolding-e2e/workflows/group-kick-and-rejoin-keyshare.yml
@@ -126,10 +126,6 @@ steps:
     outputs:
       invite_node3: invitation
 
-  - name: Wait for namespace governance to gossip
-    type: wait
-    seconds: 10
-
   - name: Node-2 joins namespace
     # Default member capabilities include CAN_JOIN_OPEN_SUBGROUPS, so
     # node-2 inherits eligibility for any Open subgroup beneath this

--- a/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
+++ b/apps/scaffolding-e2e/workflows/group-leave-then-rejoin-via-inheritance.yml
@@ -133,10 +133,6 @@ steps:
     outputs:
       invite_node3: invitation
 
-  - name: Wait for namespace governance to gossip
-    type: wait
-    seconds: 10
-
   - name: Node-2 joins namespace
     type: join_namespace
     node: leave-rejoin-node-2

--- a/apps/scaffolding-e2e/workflows/group-metadata.yml
+++ b/apps/scaffolding-e2e/workflows/group-metadata.yml
@@ -143,10 +143,6 @@ steps:
     outputs:
       invitation: invitation
 
-  - name: Wait for namespace gossip
-    type: wait
-    seconds: 5
-
   - name: Node-2 joins namespace
     type: join_namespace
     node: e2e-node-2

--- a/apps/scaffolding-e2e/workflows/group-open-self-join-key-delivery.yml
+++ b/apps/scaffolding-e2e/workflows/group-open-self-join-key-delivery.yml
@@ -89,12 +89,6 @@ steps:
     outputs:
       ns_invite: invitation
 
-  - name: Wait for namespace governance to gossip
-    # 10s matches the post-#2344 opaque-leaf-regression timing; covers
-    # invitation visibility so `join_namespace` doesn't 404.
-    type: wait
-    seconds: 10
-
   - name: Node-2 joins namespace
     # Default member capabilities include CAN_JOIN_OPEN_SUBGROUPS, so
     # node-2 inherits the right to join any Open subgroup beneath

--- a/apps/scaffolding-e2e/workflows/group-private-add-then-write.yml
+++ b/apps/scaffolding-e2e/workflows/group-private-add-then-write.yml
@@ -104,10 +104,6 @@ steps:
     outputs:
       invite_node3: invitation
 
-  - name: Wait for namespace governance to gossip
-    type: wait
-    seconds: 10
-
   - name: Node-2 joins namespace
     type: join_namespace
     node: private-add-node-2

--- a/apps/scaffolding-e2e/workflows/group-remove-from-root-revokes-inherited.yml
+++ b/apps/scaffolding-e2e/workflows/group-remove-from-root-revokes-inherited.yml
@@ -127,10 +127,6 @@ steps:
     outputs:
       invite_node3: invitation
 
-  - name: Wait for namespace governance to gossip
-    type: wait
-    seconds: 10
-
   - name: Node-2 joins namespace
     type: join_namespace
     node: revoke-inherit-node-2

--- a/workflows/app-migration/00-single-group-migration-baseline.yml
+++ b/workflows/app-migration/00-single-group-migration-baseline.yml
@@ -86,10 +86,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-baseline-2

--- a/workflows/app-migration/01-namespace-cascade-migration.yml
+++ b/workflows/app-migration/01-namespace-cascade-migration.yml
@@ -106,13 +106,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    # Same rationale as group-join-via-inheritance.yml - node 2 needs
-    # to see the Open-visibility row and the context-registered op
-    # before its inheritance materialisation can succeed.
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-cascade-2

--- a/workflows/app-migration/02-scenario-additive-field.yml
+++ b/workflows/app-migration/02-scenario-additive-field.yml
@@ -85,10 +85,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-additive-2

--- a/workflows/app-migration/03-scenario-remove-field.yml
+++ b/workflows/app-migration/03-scenario-remove-field.yml
@@ -85,10 +85,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-remove-2

--- a/workflows/app-migration/04-scenario-rename-field.yml
+++ b/workflows/app-migration/04-scenario-rename-field.yml
@@ -81,10 +81,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-rename-2

--- a/workflows/app-migration/05-scenario-change-type.yml
+++ b/workflows/app-migration/05-scenario-change-type.yml
@@ -81,10 +81,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-typechange-2

--- a/workflows/app-migration/06-scenario-new-method.yml
+++ b/workflows/app-migration/06-scenario-new-method.yml
@@ -83,10 +83,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-newmethod-2

--- a/workflows/app-migration/07-scenario-new-enum-variant.yml
+++ b/workflows/app-migration/07-scenario-new-enum-variant.yml
@@ -82,10 +82,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-newenum-2

--- a/workflows/app-migration/08-scenario-pure-bugfix.yml
+++ b/workflows/app-migration/08-scenario-pure-bugfix.yml
@@ -84,10 +84,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-bugfix-2

--- a/workflows/app-migration/09-scenario-crdt-native.yml
+++ b/workflows/app-migration/09-scenario-crdt-native.yml
@@ -94,10 +94,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-crdt-2

--- a/workflows/app-migration/10-scenario-struct-to-enum.yml
+++ b/workflows/app-migration/10-scenario-struct-to-enum.yml
@@ -83,10 +83,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-struct2enum-2

--- a/workflows/app-migration/11-scenario-field-split.yml
+++ b/workflows/app-migration/11-scenario-field-split.yml
@@ -83,10 +83,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-split-2

--- a/workflows/app-migration/12-scenario-field-remove-archive.yml
+++ b/workflows/app-migration/12-scenario-field-remove-archive.yml
@@ -88,10 +88,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-archive-2

--- a/workflows/app-migration/13-scenario-invariant-reshuffle.yml
+++ b/workflows/app-migration/13-scenario-invariant-reshuffle.yml
@@ -90,10 +90,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-reshuffle-2

--- a/workflows/app-migration/14-cascade-status-rpc.yml
+++ b/workflows/app-migration/14-cascade-status-rpc.yml
@@ -86,10 +86,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-status-2

--- a/workflows/app-migration/15-scenario-authored-map.yml
+++ b/workflows/app-migration/15-scenario-authored-map.yml
@@ -75,10 +75,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-authmap-2

--- a/workflows/app-migration/16-scenario-user-storage.yml
+++ b/workflows/app-migration/16-scenario-user-storage.yml
@@ -71,10 +71,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-userstore-2

--- a/workflows/app-migration/17-scenario-frozen-storage.yml
+++ b/workflows/app-migration/17-scenario-frozen-storage.yml
@@ -73,10 +73,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-frozen-2

--- a/workflows/app-migration/18-scenario-shared-storage.yml
+++ b/workflows/app-migration/18-scenario-shared-storage.yml
@@ -71,10 +71,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-shared-2

--- a/workflows/app-migration/19-scenario-authored-vector.yml
+++ b/workflows/app-migration/19-scenario-authored-vector.yml
@@ -71,10 +71,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-authvec-2

--- a/workflows/app-migration/20-scenario-unordered-set.yml
+++ b/workflows/app-migration/20-scenario-unordered-set.yml
@@ -74,10 +74,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-uset-2

--- a/workflows/app-migration/26-owner-driven-authored.yml
+++ b/workflows/app-migration/26-owner-driven-authored.yml
@@ -100,10 +100,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-owner-2

--- a/workflows/app-migration/28-get-migration-status.yml
+++ b/workflows/app-migration/28-get-migration-status.yml
@@ -93,10 +93,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-mstatus-2

--- a/workflows/app-migration/32-authored-migrate-ux.yml
+++ b/workflows/app-migration/32-authored-migrate-ux.yml
@@ -81,10 +81,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-ux-2

--- a/workflows/app-migration/36-chained-catchup.yml
+++ b/workflows/app-migration/36-chained-catchup.yml
@@ -72,10 +72,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-chained-2

--- a/workflows/app-migration/37-stranded-resync.yml
+++ b/workflows/app-migration/37-stranded-resync.yml
@@ -87,10 +87,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace
     type: join_namespace
     node: app-migration-strand-2

--- a/workflows/app-migration/38-namespace-invite-join-regression.yml
+++ b/workflows/app-migration/38-namespace-invite-join-regression.yml
@@ -78,10 +78,6 @@ steps:
     outputs:
       namespace_invitation: invitation
 
-  - name: Wait for subgroup visibility + context-registered ops to gossip
-    type: wait
-    seconds: 10
-
   - name: Node 2 joins namespace (publishes MemberJoinedAt)
     type: join_namespace
     node: invite-join-regression-2

--- a/workflows/sync-tests/opaque-leaf-regression.yml
+++ b/workflows/sync-tests/opaque-leaf-regression.yml
@@ -99,19 +99,6 @@ steps:
     outputs:
       ns_invite: invitation
 
-  - name: Wait for namespace governance to gossip
-    # Namespace governance DAG needs to propagate to node-2 before the
-    # join op (otherwise `join_namespace` 404s on the invitation). 10s
-    # matches mero-drive's e2e and is enough for *invitation visibility*
-    # specifically. The longer membership-state-propagation race that
-    # bit `bdc61af` (node-2 rejecting node-1's sync streams as
-    # "inbound stream for unknown context") is now handled inside the
-    # responder via a bounded materialisation wait in
-    # `sync::manager::internal_handle_opened_stream` — no workflow-level
-    # guard needed.
-    type: wait
-    seconds: 10
-
   - name: Node-2 joins namespace
     type: join_namespace
     node: sync-regression-node-2


### PR DESCRIPTION
Every `join_namespace` in the suite was preceded by an unconditional sleep, 44 of them totalling 428s, named things like "Wait for namespace governance to gossip to node 2". This removes all 44.

## Why they are safe to remove

`join_group` already waits for the conditions these sleeps were guarding: `NAMESPACE_MESH_GRACE` (2s) and the operator-tunable `key_delivery_fallback_wait` (5s, `ContextManagerConfig`). Both predate the sleeps. `NAMESPACE_MESH_GRACE` landed 2026-04-06 and `key_delivery_fallback_wait` 2026-05-10; the sleeps were added 2026-05-14 through 05-17, three of them within four days, which is the signature of a copy-paste rather than a measurement.

The value confirms it. `workflows/sync-tests/opaque-leaf-regression.yml` recorded where 10s came from: "10s matches mero-drive's e2e". It was carried over from another repository, not derived from this one.

A fixed sleep is also the wrong instrument regardless of the number: if governance is slower than 10s the join fails anyway, and if it is faster the run pays the remainder. Nothing here asserts that the sleep was sufficient, so it can only mask.

## Changes

44 files, 198 deletions. Exactly 44 `type: wait` steps and nothing else, confirmed by diffing on `type:` lines.

## Test plan

The suite is the test, and every scenario whose sleep was removed ran:

- 144 checks pass, 0 fail
- `Sync regression` passes, which runs `opaque-leaf-regression.yml`, the scenario whose own comment predicted a 404 on the invitation without the sleep. That failure did not occur.
- The auto-follow scenarios that carried the pattern all pass: `auto-follow-asymmetric-context-membership`, `auto-follow-backfill-on-join`, `auto-follow-flag-flipped-late`, `auto-follow-on-context-registered`, `auto-follow-no-rejection-spam`
- `ephemeral-presence-e2e`, `group-governance-cold-context-push-converge`, `group-join-then-list-from-joiner` pass
- All 133 workflows validate against merobox master

Roughly 16 of the removed sleeps sit in CI-matrix scenarios, so this run is that many independent chances to hit the race the sleeps were guarding against, and none did.