### PR TITLE
perf(storage): bound a parent's per-child write cost with a hash trie

### DIFF
--- a/apps/migrations/scenario-authored-vector-v1/src/lib.rs
+++ b/apps/migrations/scenario-authored-vector-v1/src/lib.rs
@@ -42,10 +42,16 @@ impl ScenarioAuthoredVectorV1 {
     }
 
     /// Push an entry, stamping the calling executor as its owner.
-    pub fn push_entry(&mut self, value: String) -> app::Result<u64> {
-        let idx = self.entries.push(value.clone().into())?;
+    pub fn push_entry(&mut self, value: String) -> app::Result<String> {
+        // The id, not an index: a position is only meaningful until someone
+        // inserts ahead of it (core#3637).
+        let id = self.entries.push(value.clone().into())?;
         app::emit!(Event::Pushed { value: &value });
-        Ok(idx as u64)
+        Ok(id
+            .as_bytes()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<String>())
     }
 
     pub fn get_entry(&self, index: u64) -> app::Result<Option<String>> {

--- a/apps/migrations/scenario-authored-vector-v2/src/lib.rs
+++ b/apps/migrations/scenario-authored-vector-v2/src/lib.rs
@@ -71,9 +71,15 @@ impl ScenarioAuthoredVectorV2 {
         Ok(())
     }
 
-    pub fn push_entry(&mut self, value: String) -> app::Result<u64> {
-        let idx = self.entries.push(value.into())?;
-        Ok(idx as u64)
+    pub fn push_entry(&mut self, value: String) -> app::Result<String> {
+        // The id, not an index: a position is only meaningful until someone
+        // inserts ahead of it (core#3637).
+        let id = self.entries.push(value.into())?;
+        Ok(id
+            .as_bytes()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<String>())
     }
 
     pub fn get_entry(&self, index: u64) -> app::Result<Option<String>> {

--- a/apps/scaffolding-e2e/src/lib.rs
+++ b/apps/scaffolding-e2e/src/lib.rs
@@ -283,9 +283,13 @@ pub enum Event<'a> {
 
     // Authored Vector Events
     AuthoredVecPushed {
-        index: usize,
+        entry_id: &'a str,
         value: String,
         owner: String,
+    },
+    AuthoredVecUpdatedById {
+        entry_id: String,
+        value: String,
     },
     AuthoredVecUpdated {
         index: usize,
@@ -1305,15 +1309,40 @@ impl E2eKvStore {
 
     // AUTHORED VECTOR
 
-    pub fn authored_vec_push(&mut self, value: String) -> app::Result<usize> {
-        let index = self.authored_vec.push(LwwRegister::new(value.clone()))?;
+    /// Returns the new entry's ID, not its index.
+    ///
+    /// An index describes where the entry currently sits in a set every peer
+    /// inserts into, so it goes stale as soon as anyone inserts ahead of it.
+    /// The id names the entry (core#3637).
+    pub fn authored_vec_push(&mut self, value: String) -> app::Result<String> {
+        let id = self.authored_vec.push(LwwRegister::new(value.clone()))?;
+        let entry_id = bs58::encode(id.as_bytes()).into_string();
         let owner = bs58::encode(env::device_id()).into_string();
         app::emit!(Event::AuthoredVecPushed {
-            index,
+            entry_id: &entry_id,
             value,
             owner,
         });
-        Ok(index)
+        Ok(entry_id)
+    }
+
+    /// Update by ID — the address that survives a concurrent insert.
+    pub fn authored_vec_update_by_id(
+        &mut self,
+        entry_id: String,
+        value: String,
+    ) -> app::Result<()> {
+        let raw: [u8; 32] = bs58::decode(&entry_id)
+            .into_vec()
+            .ok()
+            .and_then(|v| v.try_into().ok())
+            .ok_or_else(|| app::err!("bad entry id"))?;
+        self.authored_vec.update_by_id(
+            calimero_storage::address::Id::new(raw),
+            LwwRegister::new(value.clone()),
+        )?;
+        app::emit!(Event::AuthoredVecUpdatedById { entry_id, value });
+        Ok(())
     }
 
     pub fn authored_vec_get(&self, index: usize) -> app::Result<Option<String>> {

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -138,6 +138,15 @@ mod borsh_layout {
         pub(super) parent_id: Option<[u8; 32]>,
         pub(super) full_hash: [u8; 32],
         pub(super) own_hash: [u8; 32],
+        // The mirror runs to the END of the struct on purpose, though only
+        // `full_hash` and `own_hash` are read. A prefix mirror decodes a row
+        // written under ANY later layout without complaint, which is precisely
+        // how an old row's `children` bytes could be read as `full_hash`.
+        // Covering every field lets `from_slice` reject a row that does not
+        // match this layout exactly, turning a silent wrong hash into an error.
+        pub(super) metadata: Metadata,
+        pub(super) deleted_at: Option<u64>,
+        pub(super) deleted_children: Vec<[u8; 32]>,
     }
 
     #[derive(BorshDeserialize)]
@@ -215,6 +224,62 @@ mod borsh_layout_round_trip {
     use calimero_storage::entities::{ChildInfo, Metadata, OpMask, SignatureData, StorageType};
 
     use super::borsh_layout;
+
+    /// An index row written before children moved into the `ChildTrie`
+    /// keyspace must FAIL to decode, not decode into something plausible.
+    ///
+    /// `children: Option<Vec<ChildInfo>>` used to sit immediately before
+    /// `full_hash`. The parser this replaces walked byte offsets, so on an old
+    /// row it read the children tag and vector length as the root hash and
+    /// returned it with no error — a wrong hash that propagates and is
+    /// undiagnosable by the time it matters. A loud decode failure is strictly
+    /// better than a quiet wrong hash, so pin that it is loud.
+    #[test]
+    fn an_old_layout_index_row_is_rejected_rather_than_misread() {
+        /// The layout as it was: `children` between `parent_id` and `full_hash`.
+        #[derive(borsh::BorshSerialize)]
+        struct OldEntityIndex {
+            id: [u8; 32],
+            parent_id: Option<[u8; 32]>,
+            children: Option<Vec<ChildInfo>>,
+            full_hash: [u8; 32],
+            own_hash: [u8; 32],
+            metadata: Metadata,
+            deleted_at: Option<u64>,
+            deleted_children: Vec<[u8; 32]>,
+        }
+
+        let old = OldEntityIndex {
+            id: [7; 32],
+            parent_id: None,
+            children: Some(vec![ChildInfo::new(
+                Id::new([9; 32]),
+                [0xAB; 32],
+                metadata_with(StorageType::User {
+                    owner: calimero_account::AccountId::from([0x11; 32]),
+                    signature_data: Some(SignatureData {
+                        signature: [0x22; 64],
+                        nonce: 42,
+                        signer: Some(PublicKey::from([0x33; 32])),
+                    }),
+                }),
+            )]),
+            full_hash: [0xFF; 32],
+            own_hash: [0xEE; 32],
+            metadata: metadata_with(StorageType::Public),
+            deleted_at: None,
+            deleted_children: Vec::new(),
+        };
+
+        let bytes = borsh::to_vec(&old).expect("serialise old layout");
+        let decoded = borsh::from_slice::<borsh_layout::EntityIndex>(&bytes);
+
+        assert!(
+            decoded.is_err(),
+            "an old-layout row must be rejected; decoding it under the current \
+             layout yields a full_hash read out of the children field"
+        );
+    }
 
     fn metadata_with(storage_type: StorageType) -> Metadata {
         let mut md = Metadata::new(1000, 2000);
@@ -765,98 +830,40 @@ impl ContextRegistry {
     }
 
     /// Parse EntityIndex bytes to extract the root hash.
+    ///
+    /// Decodes through the shared [`borsh_layout::EntityIndex`] mirror rather
+    /// than walking byte offsets by hand.
+    ///
+    /// The offset walk was worth it while a parent's children lived inline and
+    /// an index row could be tens of kilobytes. Children moved into their own
+    /// `ChildTrie` keyspace, so the row is now ~122 bytes even at 200 children
+    /// and there is nothing left to skip past.
+    ///
+    /// Removing it also removes a silent-misdecode hazard, which matters more
+    /// than the parse. `children: Option<Vec<ChildInfo>>` used to sit
+    /// immediately before `full_hash`, so an offset walk over a row written by
+    /// an older build reads the children tag and vector length AS the root
+    /// hash — returning a plausible, wrong hash with no error anywhere. That is
+    /// the worst available failure mode for this value: it does not fault, it
+    /// propagates, and it is undiagnosable at the point it finally matters.
+    /// `from_slice` rejects trailing bytes, so such a row fails loudly here
+    /// instead of quietly producing a hash nothing can back.
     fn parse_entity_index_root_hash(
         &self,
         context_id: &ContextId,
         bytes: &[u8],
     ) -> eyre::Result<[u8; 32]> {
-        // Deserialize EntityIndex and extract full_hash
-        // EntityIndex is borsh-serialized with full_hash at a known offset
-        // Structure: id(32) + parent_id(Option<32>) + full_hash(32) + ...
-        // Children are no longer inline — they live in the parent's ChildTrie,
-        // its own keyspace — so there is no variable-length field before
-        // full_hash and this parse is now always exact.
-
-        if bytes.len() < 68 {
-            // Minimum size: id(32) + parent_id_tag(1) + full_hash(32) + own_hash(32) = 97
-            // But we check for 68 to be safe (id + tag + full_hash)
-            eyre::bail!(
-                "EntityIndex too small: {} bytes, expected at least 68",
-                bytes.len()
-            );
-        }
-
-        // Parse the EntityIndex structure manually for efficiency
-        // id: [u8; 32]
-        // parent_id: Option<Id> - 1 byte tag + optional 32 bytes
-        // full_hash: [u8; 32]
-
-        let mut offset = 32; // Skip id
-
-        // Skip parent_id (Option<Id>)
-        let parent_tag = bytes[offset];
-        offset += 1;
-        if parent_tag == 1 {
-            offset += 32; // Skip the Id bytes
-        }
-
-        // Now at full_hash position
-        if offset + 32 > bytes.len() {
-            eyre::bail!(
-                "EntityIndex full_hash truncated at offset {}, len {}",
-                offset,
-                bytes.len()
-            );
-        }
-
-        let mut full_hash = [0u8; 32];
-        full_hash.copy_from_slice(&bytes[offset..offset + 32]);
-
-        tracing::debug!(
-            %context_id,
-            computed_root = ?Hash::from(full_hash),
-            "Computed root hash from storage"
-        );
-
-        Ok(full_hash)
-    }
-
-    /// Helper to compute root hash using full borsh deserialization.
-    ///
-    /// Used when `parse_entity_index_root_hash`'s fast-path can't skip past
-    /// the `children` field (i.e. children present). Reuses the shared
-    /// [`borsh_layout::EntityIndex`] mirror so that any layout change
-    /// touches exactly one definition.
-    fn compute_root_hash_via_borsh(
-        &self,
-        context_id: &ContextId,
-        bytes: &[u8],
-    ) -> eyre::Result<[u8; 32]> {
-        let mut reader: &[u8] = bytes;
-        let index = borsh_layout::EntityIndex::deserialize_reader(&mut reader).map_err(|e| {
-            tracing::warn!(
-                %context_id,
-                error = %e,
-                total_bytes = bytes.len(),
-                "EntityIndex borsh decode failed in compute_root_hash_via_borsh"
-            );
-            eyre::eyre!("Failed to deserialize EntityIndex: {}", e)
+        let index: borsh_layout::EntityIndex = borsh::from_slice(bytes).map_err(|e| {
+            eyre::eyre!(
+                "EntityIndex decode failed ({e}); an index row written before children moved \
+                 into the ChildTrie keyspace does not decode under the current layout"
+            )
         })?;
-
-        let trailing = reader.len();
-        if trailing > 0 {
-            tracing::debug!(
-                %context_id,
-                trailing_bytes = trailing,
-                total_bytes = bytes.len(),
-                "EntityIndex deserialization skipped trailing bytes"
-            );
-        }
 
         tracing::debug!(
             %context_id,
             computed_root = ?Hash::from(index.full_hash),
-            "Computed root hash from storage (via borsh)"
+            "Computed root hash from storage"
         );
 
         Ok(index.full_hash)
@@ -986,23 +993,52 @@ impl ContextRegistry {
         let index = borsh_layout::EntityIndex::deserialize_reader(&mut reader)
             .map_err(|e| eyre::eyre!("dump_root: EntityIndex deserialize failed: {e}"))?;
 
-        // KNOWN GAP (child-trie migration): children are no longer inline in
-        // the EntityIndex row — they live in the parent's ChildTrie, a separate
-        // keyspace this raw-DB path does not yet walk.
+        // Children are no longer inline in the EntityIndex row — they live in
+        // the parent's ChildTrie, a separate keyspace — so walk that keyspace
+        // with the same raw reader this path already uses.
         //
-        // Returning an empty list here is NOT "the root has no children", and
-        // this diagnostic exists precisely to tell "matching children +
-        // mismatched own_hash" from "mismatched children → subtree divergence".
-        // Reading it as the former would misdiagnose. Warn so nobody triages off
-        // a silently empty list, and re-implement against the trie keyspace
-        // before relying on this path again.
-        tracing::warn!(
-            target: "calimero_context::dump_root",
-            %context_id,
-            "dump_root: child enumeration not yet implemented against ChildTrie — \
-             the empty child list below means UNKNOWN, not none"
-        );
-        let children: Vec<RootChildDump> = Vec::new();
+        // This has to work, and specifically it has to work HERE: the whole
+        // point of the dump is telling "matching children + mismatched
+        // own_hash" from "mismatched children → subtree divergence", and the
+        // change that moved children out of this row also moves every hash in
+        // the system. An empty list would read as "the root has no children"
+        // and misdiagnose exactly the divergence this is for.
+        //
+        // ROOT's entity id is the context id: `index_state_key` above hashes
+        // `Key::Index(context_id)`, so the row just decoded IS the root's, and
+        // its trie is addressed by the same id.
+        let root_id = calimero_storage::address::Id::new(**context_id);
+        let read_row = |trie_key: calimero_storage::store::Key| -> Option<Vec<u8>> {
+            let state_key = key::ContextState::new(*context_id, trie_key.to_bytes());
+            match handle.get(&state_key) {
+                Ok(row) => row.map(|r| r.as_ref().to_vec()),
+                Err(err) => {
+                    // A read error is not an absent child. Say so, because the
+                    // caller is triaging divergence and a short list here would
+                    // otherwise look like evidence.
+                    tracing::warn!(
+                        target: "calimero_context::dump_root",
+                        %context_id, %err,
+                        "dump_root: child-trie row read failed; the child list below is PARTIAL"
+                    );
+                    None
+                }
+            }
+        };
+
+        let children: Vec<RootChildDump> = calimero_storage::child_trie::ChildTrie::<
+            calimero_storage::store::MainStorage,
+        >::children_with(root_id, read_row)
+        .into_iter()
+        .map(|c| RootChildDump {
+            id: *c.id().as_bytes(),
+            merkle_hash: c.merkle_hash(),
+            created_at: c.metadata.created_at,
+            updated_at: *c.metadata.updated_at,
+            crdt_type: c.metadata.crdt_type,
+            field_name: c.metadata.field_name,
+        })
+        .collect();
 
         let entry_state_key = Self::entry_state_key(context_id);
         let entry_db_key = key::ContextState::new(*context_id, entry_state_key);

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -125,14 +125,17 @@ mod borsh_layout {
     use calimero_primitives::crdt::CrdtType;
 
     /// Captures every field [`super::ContextRegistry::dump_root`] needs in
-    /// a single pass: children (with metadata), full_hash, own_hash.
+    /// a single pass: full_hash and own_hash.
     /// `compute_root_hash_via_borsh` reads only `full_hash`.
+    ///
+    /// Children are no longer inline: they live in the parent's `ChildTrie`,
+    /// which is its own keyspace. A diagnostic that wants the child list has to
+    /// read the trie rather than decode it out of this row.
     #[derive(BorshDeserialize)]
     #[allow(dead_code, reason = "fields required for borsh layout fidelity")]
     pub(super) struct EntityIndex {
         pub(super) id: [u8; 32],
         pub(super) parent_id: Option<[u8; 32]>,
-        pub(super) children: Option<Vec<ChildInfo>>,
         pub(super) full_hash: [u8; 32],
         pub(super) own_hash: [u8; 32],
     }
@@ -769,11 +772,14 @@ impl ContextRegistry {
     ) -> eyre::Result<[u8; 32]> {
         // Deserialize EntityIndex and extract full_hash
         // EntityIndex is borsh-serialized with full_hash at a known offset
-        // Structure: id(32) + parent_id(Option<32>) + children(Option<Vec>) + full_hash(32) + ...
+        // Structure: id(32) + parent_id(Option<32>) + full_hash(32) + ...
+        // Children are no longer inline — they live in the parent's ChildTrie,
+        // its own keyspace — so there is no variable-length field before
+        // full_hash and this parse is now always exact.
 
         if bytes.len() < 68 {
-            // Minimum size: id(32) + parent_id_tag(1) + children_tag(1) + full_hash(32) + own_hash(32) = 98
-            // But we check for 68 to be safe (id + tags + full_hash)
+            // Minimum size: id(32) + parent_id_tag(1) + full_hash(32) + own_hash(32) = 97
+            // But we check for 68 to be safe (id + tag + full_hash)
             eyre::bail!(
                 "EntityIndex too small: {} bytes, expected at least 68",
                 bytes.len()
@@ -783,7 +789,6 @@ impl ContextRegistry {
         // Parse the EntityIndex structure manually for efficiency
         // id: [u8; 32]
         // parent_id: Option<Id> - 1 byte tag + optional 32 bytes
-        // children: Option<Vec<ChildInfo>> - 1 byte tag + optional length + data
         // full_hash: [u8; 32]
 
         let mut offset = 32; // Skip id
@@ -793,14 +798,6 @@ impl ContextRegistry {
         offset += 1;
         if parent_tag == 1 {
             offset += 32; // Skip the Id bytes
-        }
-
-        // Skip children (Option<Vec<ChildInfo>>)
-        let children_tag = bytes[offset];
-        offset += 1;
-        if children_tag == 1 {
-            // Children present - use full borsh deserialization for correctness
-            return self.compute_root_hash_via_borsh(context_id, bytes);
         }
 
         // Now at full_hash position
@@ -989,19 +986,23 @@ impl ContextRegistry {
         let index = borsh_layout::EntityIndex::deserialize_reader(&mut reader)
             .map_err(|e| eyre::eyre!("dump_root: EntityIndex deserialize failed: {e}"))?;
 
-        let children: Vec<RootChildDump> = index
-            .children
-            .unwrap_or_default()
-            .into_iter()
-            .map(|c| RootChildDump {
-                id: c.id,
-                merkle_hash: c.merkle_hash,
-                created_at: c.metadata.created_at,
-                updated_at: c.metadata.updated_at,
-                crdt_type: c.metadata.crdt_type,
-                field_name: c.metadata.field_name,
-            })
-            .collect();
+        // KNOWN GAP (child-trie migration): children are no longer inline in
+        // the EntityIndex row — they live in the parent's ChildTrie, a separate
+        // keyspace this raw-DB path does not yet walk.
+        //
+        // Returning an empty list here is NOT "the root has no children", and
+        // this diagnostic exists precisely to tell "matching children +
+        // mismatched own_hash" from "mismatched children → subtree divergence".
+        // Reading it as the former would misdiagnose. Warn so nobody triages off
+        // a silently empty list, and re-implement against the trie keyspace
+        // before relying on this path again.
+        tracing::warn!(
+            target: "calimero_context::dump_root",
+            %context_id,
+            "dump_root: child enumeration not yet implemented against ChildTrie — \
+             the empty child list below means UNKNOWN, not none"
+        );
+        let children: Vec<RootChildDump> = Vec::new();
 
         let entry_state_key = Self::entry_state_key(context_id);
         let entry_db_key = key::ContextState::new(*context_id, entry_state_key);

--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -166,6 +166,7 @@ mod borsh_layout {
         pub(super) crdt_type: Option<CrdtType>,
         pub(super) field_name: Option<String>,
         pub(super) schema_version: Option<u32>,
+        pub(super) order: u64,
     }
 
     #[derive(BorshDeserialize)]

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -250,8 +250,13 @@ pub fn load_rotation_log_direct(
         }
     };
     let mut entries = Vec::new();
-    if let Some(children) = index.children() {
-        for child in children {
+    {
+        // Children live in the anchor's ChildTrie, not inline in its index row,
+        // so walk the trie with the same raw reader this path already uses.
+        let _ = &index;
+        for child in
+            calimero_storage::child_trie::ChildTrie::<MainStorage>::children_with(map_id, read)
+        {
             let Some(bytes) = read(StorageKey::Entry(child.id())) else {
                 // The child is listed in the index but its value is unreadable
                 // (store error — already warned in `read` — or an absent value,

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1167,8 +1167,13 @@ pub(crate) fn load_rotation_log_direct(
     >::rotation_log_child_id(entity_id);
     if let Some(index) = read_entity_index_direct(context_client, context_id, map_id)? {
         let mut entries = Vec::new();
-        if let Some(children) = index.children() {
-            for child in children {
+        {
+            let _ = &index;
+            for child in calimero_storage::index::Index::<
+                calimero_storage::store::MainStorage,
+            >::get_children_of(map_id)
+            .unwrap_or_default()
+            {
                 // P3: each child is an `UnorderedMap` entry, so its stored value
                 // is `borsh(Entry<([u8;32], RotationLogEntry)>)` — decode the
                 // single entry it holds (NOT a bare `RotationLog` blob).

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1179,9 +1179,24 @@ pub(crate) fn load_rotation_log_direct(
             // and the log reads back EMPTY rather than erroring, collapsing the
             // writer set on every delta apply.
             let read_row = |key: StorageKey| -> Option<Vec<u8>> {
-                read_entity_value_direct(context_client, context_id, key)
-                    .ok()
-                    .flatten()
+                match read_entity_value_direct(context_client, context_id, key) {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        // `children_with` reads `None` as "subtree absent" and
+                        // stops walking, so swallowing a store error here
+                        // silently SHORTENS the rotation log — and that log is
+                        // what resolves the writer set on every delta apply.
+                        // A quietly partial writer set is worse than a loud
+                        // failure, and every other partial-log case in this
+                        // function warns.
+                        warn!(
+                            %context_id, %entity_id, error = %e,
+                            "rotation-log trie row read failed; the writer set resolved \
+                             from this log may be INCOMPLETE"
+                        );
+                        None
+                    }
+                }
             };
             for child in calimero_storage::child_trie::ChildTrie::<
                 calimero_storage::store::MainStorage,

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1169,10 +1169,23 @@ pub(crate) fn load_rotation_log_direct(
         let mut entries = Vec::new();
         {
             let _ = &index;
-            for child in calimero_storage::index::Index::<
+            // Walk the anchor's ChildTrie with the SAME direct reader the rest
+            // of this function uses.
+            //
+            // Not `Index::<MainStorage>::get_children_of`: `MainStorage` routes
+            // through the `RUNTIME_ENV` thread-local, which is not installed
+            // here — that is the entire reason this function exists. With no env
+            // it falls back to the process-local mock store, so the lookup misses
+            // and the log reads back EMPTY rather than erroring, collapsing the
+            // writer set on every delta apply.
+            let read_row = |key: StorageKey| -> Option<Vec<u8>> {
+                read_entity_value_direct(context_client, context_id, key)
+                    .ok()
+                    .flatten()
+            };
+            for child in calimero_storage::child_trie::ChildTrie::<
                 calimero_storage::store::MainStorage,
-            >::get_children_of(map_id)
-            .unwrap_or_default()
+            >::children_with(map_id, read_row)
             {
                 // P3: each child is an `UnorderedMap` entry, so its stored value
                 // is `borsh(Entry<([u8;32], RotationLogEntry)>)` — decode the

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -55,6 +55,7 @@ use calimero_primitives::crdt::CrdtType;
 use calimero_primitives::hash::Hash;
 use calimero_primitives::identity::PublicKey;
 use calimero_storage::address::Id;
+use calimero_storage::child_trie::ChildTrie;
 use calimero_storage::env::with_runtime_env;
 use calimero_storage::index::Index;
 use calimero_storage::interface::Interface;
@@ -1306,8 +1307,15 @@ fn collect_leaves_recursive(
         }
     };
 
-    let children_ids: Vec<[u8; 32]> = Index::<MainStorage>::get_children_of(entity_id)
-        .unwrap_or_default()
+    // Read the trie directly. `get_children_of` re-reads and re-borsh-decodes
+    // the index row this function has already decoded — a doubled read per
+    // entity on the sync hot path — and returns a `Result` whose only failure
+    // here is that re-read, so `unwrap_or_default` would swallow a
+    // `DeserializationError` on a row the caller just proved decodable, turning
+    // a corrupt row into "leaf with no children" and pushing it as leaf data.
+    // The existence check it performs is already satisfied: `index` is in hand.
+    let children_ids: Vec<[u8; 32]> = ChildTrie::<MainStorage>::new(entity_id)
+        .children()
         .iter()
         .map(|c| *c.id().as_bytes())
         .collect();
@@ -1563,8 +1571,15 @@ pub(crate) fn get_local_tree_node(
     };
 
     let full_hash = index.full_hash();
-    let children_ids: Vec<[u8; 32]> = Index::<MainStorage>::get_children_of(entity_id)
-        .unwrap_or_default()
+    // Read the trie directly. `get_children_of` re-reads and re-borsh-decodes
+    // the index row this function has already decoded — a doubled read per
+    // entity on the sync hot path — and returns a `Result` whose only failure
+    // here is that re-read, so `unwrap_or_default` would swallow a
+    // `DeserializationError` on a row the caller just proved decodable, turning
+    // a corrupt row into "leaf with no children" and pushing it as leaf data.
+    // The existence check it performs is already satisfied: `index` is in hand.
+    let children_ids: Vec<[u8; 32]> = ChildTrie::<MainStorage>::new(entity_id)
+        .children()
         .iter()
         .map(|c| *c.id().as_bytes())
         .collect();

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -1306,10 +1306,11 @@ fn collect_leaves_recursive(
         }
     };
 
-    let children_ids: Vec<[u8; 32]> = index
-        .children()
-        .map(|children| children.iter().map(|c| *c.id().as_bytes()).collect())
-        .unwrap_or_default();
+    let children_ids: Vec<[u8; 32]> = Index::<MainStorage>::get_children_of(entity_id)
+        .unwrap_or_default()
+        .iter()
+        .map(|c| *c.id().as_bytes())
+        .collect();
 
     if children_ids.is_empty() {
         // Leaf node — collect its data. Internal nodes (children non-empty)
@@ -1562,10 +1563,11 @@ pub(crate) fn get_local_tree_node(
     };
 
     let full_hash = index.full_hash();
-    let children_ids: Vec<[u8; 32]> = index
-        .children()
-        .map(|children| children.iter().map(|c| *c.id().as_bytes()).collect())
-        .unwrap_or_default();
+    let children_ids: Vec<[u8; 32]> = Index::<MainStorage>::get_children_of(entity_id)
+        .unwrap_or_default()
+        .iter()
+        .map(|c| *c.id().as_bytes())
+        .collect();
 
     // Tombstones for children this node removed, resolved to signed
     // `EntityDeletion`s from each child's own tombstone index. Carried on the

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -986,7 +986,10 @@ fn get_local_hashes_at_level(
             // Level 0: get direct children of root
             {
                 let _ = &root_index;
-                for child in Index::<MainStorage>::get_children_of(Id::root()).unwrap_or_default() {
+                // `root_id`, not `Id::root()`: the latter derives the context
+                // from the `RUNTIME_ENV` thread-local, and a divergence there
+                // yields silently empty level-0 hashes rather than an error.
+                for child in Index::<MainStorage>::get_children_of(root_id).unwrap_or_default() {
                     let child_id = *child.id().as_bytes();
                     if let Some(child_hash) = Index::<MainStorage>::get_hashes_for(child.id())
                         .ok()

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -67,6 +67,7 @@ use calimero_node_primitives::sync::{
 use calimero_primitives::context::ContextId;
 use calimero_primitives::identity::PublicKey;
 use calimero_storage::address::Id;
+use calimero_storage::child_trie::ChildTrie;
 use calimero_storage::env::with_runtime_env;
 use calimero_storage::index::Index;
 use calimero_storage::interface::Interface;
@@ -971,25 +972,33 @@ fn get_local_hashes_at_level(
 
     let root_id = Id::new(*context_id.as_ref());
 
-    // Get the root index to access children
-    let root_index = match Index::<MainStorage>::get_index(root_id) {
-        Ok(Some(idx)) => idx,
+    // Existence only. The children come from the trie below, so the decoded row
+    // itself is not wanted — binding it and then reaching for
+    // `get_children_of` is what made this a doubled read.
+    match Index::<MainStorage>::get_index(root_id) {
+        Ok(Some(_)) => {}
         Ok(None) => return Ok(hashes), // Empty tree
         Err(e) => {
             warn!(%context_id, error = %e, "Failed to get root index");
             return Ok(hashes);
         }
-    };
+    }
 
     match parent_ids {
         None => {
             // Level 0: get direct children of root
             {
-                let _ = &root_index;
                 // `root_id`, not `Id::root()`: the latter derives the context
                 // from the `RUNTIME_ENV` thread-local, and a divergence there
                 // yields silently empty level-0 hashes rather than an error.
-                for child in Index::<MainStorage>::get_children_of(root_id).unwrap_or_default() {
+                //
+                // The trie directly, not `get_children_of`: that re-reads and
+                // re-decodes the index row this function just proved decodable
+                // — a doubled read per parent per level, on a protocol chosen
+                // for wide trees — and its only failure here is that re-read,
+                // so `unwrap_or_default` would turn a corrupt row into "no
+                // children" instead of surfacing it.
+                for child in ChildTrie::<MainStorage>::new(root_id).children() {
                     let child_id = *child.id().as_bytes();
                     if let Some(child_hash) = Index::<MainStorage>::get_hashes_for(child.id())
                         .ok()
@@ -1004,12 +1013,11 @@ fn get_local_hashes_at_level(
             // Deeper levels: get children of specified parents
             for parent_id in parents {
                 let parent_storage_id = Id::new(*parent_id);
-                if let Ok(Some(parent_index)) = Index::<MainStorage>::get_index(parent_storage_id) {
+                if let Ok(Some(_)) = Index::<MainStorage>::get_index(parent_storage_id) {
                     {
-                        let _ = &parent_index;
-                        for child in Index::<MainStorage>::get_children_of(parent_storage_id)
-                            .unwrap_or_default()
-                        {
+                        // Same as level 0: existence is already established, so
+                        // walk the trie rather than re-reading the row.
+                        for child in ChildTrie::<MainStorage>::new(parent_storage_id).children() {
                             let child_id = *child.id().as_bytes();
                             if let Some(child_hash) =
                                 Index::<MainStorage>::get_hashes_for(child.id())

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -1098,9 +1098,12 @@ fn get_nodes_at_level(
             };
 
             let child_hash = child_index.full_hash();
-            let is_leaf = Index::<MainStorage>::get_children_of(child.id())
-                .unwrap_or_default()
-                .is_empty();
+            // `has_children`, not `get_children_of(..).is_empty()`: the latter
+            // walks every node and bucket row of that child's trie, allocates
+            // every ChildInfo and sorts them — per child, per level, on the sync
+            // hot path. For the ~1,600-child collection this work exists to fix,
+            // that is the linear read put back, just on the read side.
+            let is_leaf = !Index::<MainStorage>::has_children(child.id()).unwrap_or(false);
 
             // Determine parent_id for this node (None for level 0)
             let parent_id_bytes = if level == 0 {

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -984,8 +984,9 @@ fn get_local_hashes_at_level(
     match parent_ids {
         None => {
             // Level 0: get direct children of root
-            if let Some(children) = root_index.children() {
-                for child in children {
+            {
+                let _ = &root_index;
+                for child in Index::<MainStorage>::get_children_of(Id::root()).unwrap_or_default() {
                     let child_id = *child.id().as_bytes();
                     if let Some(child_hash) = Index::<MainStorage>::get_hashes_for(child.id())
                         .ok()
@@ -1001,8 +1002,11 @@ fn get_local_hashes_at_level(
             for parent_id in parents {
                 let parent_storage_id = Id::new(*parent_id);
                 if let Ok(Some(parent_index)) = Index::<MainStorage>::get_index(parent_storage_id) {
-                    if let Some(children) = parent_index.children() {
-                        for child in children {
+                    {
+                        let _ = &parent_index;
+                        for child in Index::<MainStorage>::get_children_of(parent_storage_id)
+                            .unwrap_or_default()
+                        {
                             let child_id = *child.id().as_bytes();
                             if let Some(child_hash) =
                                 Index::<MainStorage>::get_hashes_for(child.id())
@@ -1074,9 +1078,10 @@ fn get_nodes_at_level(
             crate::sync::hash_comparison_protocol::collect_deleted_children_wire(&parent_index),
         );
 
-        let Some(children) = parent_index.children() else {
+        let children = Index::<MainStorage>::get_children_of(parent_id).unwrap_or_default();
+        if children.is_empty() {
             continue;
-        };
+        }
 
         for child in children {
             let child_storage_id = child.id();
@@ -1090,8 +1095,9 @@ fn get_nodes_at_level(
             };
 
             let child_hash = child_index.full_hash();
-            let is_leaf = child_index.children().is_none()
-                || child_index.children().map(|c| c.is_empty()).unwrap_or(true);
+            let is_leaf = Index::<MainStorage>::get_children_of(child.id())
+                .unwrap_or_default()
+                .is_empty();
 
             // Determine parent_id for this node (None for level 0)
             let parent_id_bytes = if level == 0 {

--- a/crates/node/src/sync/manager/handshake.rs
+++ b/crates/node/src/sync/manager/handshake.rs
@@ -73,9 +73,14 @@ impl SyncManager {
             // Count children (leaf entities) under root.
             // Minimum 1 when root exists (consistent with fallback estimation).
             let _ = &root_index;
+            // The id this row was read under, not `Id::root()`. `Id::root()`
+            // takes `context_id` from the `RUNTIME_ENV` thread-local, which is
+            // installed here today but silently yields a different id if that
+            // ever stops being true — and the failure is a count of 1, not an
+            // error.
             let children = calimero_storage::index::Index::<
                 calimero_storage::store::MainStorage,
-            >::get_children_of(calimero_storage::address::Id::root())
+            >::get_children_of(root_id)
             .unwrap_or_default();
             let entity_count = (children.len() as u64).max(1);
 

--- a/crates/node/src/sync/manager/handshake.rs
+++ b/crates/node/src/sync/manager/handshake.rs
@@ -78,11 +78,12 @@ impl SyncManager {
             // installed here today but silently yields a different id if that
             // ever stops being true — and the failure is a count of 1, not an
             // error.
-            let children = calimero_storage::index::Index::<
+            // Only the count is wanted, and the trie maintains one along the
+            // spine precisely so this is a single row read rather than a walk.
+            let entity_count = calimero_storage::index::Index::<
                 calimero_storage::store::MainStorage,
-            >::get_children_of(root_id)
-            .unwrap_or_default();
-            let entity_count = (children.len() as u64).max(1);
+            >::child_count(root_id)
+            .max(1);
 
             // Depth: 1 when root has data (consistent with fallback).
             // For deeper trees, we'd need recursive traversal — tracked in #2054.

--- a/crates/node/src/sync/manager/handshake.rs
+++ b/crates/node/src/sync/manager/handshake.rs
@@ -72,7 +72,11 @@ impl SyncManager {
 
             // Count children (leaf entities) under root.
             // Minimum 1 when root exists (consistent with fallback estimation).
-            let children = root_index.children().unwrap_or_default();
+            let _ = &root_index;
+            let children = calimero_storage::index::Index::<
+                calimero_storage::store::MainStorage,
+            >::get_children_of(calimero_storage::address::Id::root())
+            .unwrap_or_default();
             let entity_count = (children.len() as u64).max(1);
 
             // Depth: 1 when root has data (consistent with fallback).

--- a/crates/node/src/sync/p3_dag_causal_tests.rs
+++ b/crates/node/src/sync/p3_dag_causal_tests.rs
@@ -63,7 +63,7 @@ fn hlc_at(step: u64) -> u64 {
 /// added/updated by `apply_action` without tripping `IndexNotFound`.
 ///
 /// Returns a `ChildInfo` whose `merkle_hash` matches what's actually
-/// stored after `add_root` (post-`calculate_full_hash_for_children`),
+/// stored after `add_root` (post-`full_hash_from_trie`),
 /// so callers can use the returned value as an ancestor without
 /// tripping the v2 `verify_ancestor_integrity` check.
 fn setup_root<S: StorageAdaptor>() -> ChildInfo {

--- a/crates/node/src/sync/snapshot.rs
+++ b/crates/node/src/sync/snapshot.rs
@@ -430,12 +430,25 @@ impl SyncManager {
                     linked,
                     "Rebuilt child-trie links for snapshot-installed entities"
                 ),
-                Err(e) => warn!(
-                    %context_id,
-                    error = %e,
-                    "Failed to rebuild child-trie links after snapshot; collections \
-                     will read back empty until the next full resync"
-                ),
+                // Fail the sync rather than warn. There is no "next resync" to
+                // wait for: `verified_snapshot_root` below reads the ROOT
+                // index's SHIPPED `full_hash`, so a node with an unlinked trie
+                // still verifies, still publishes a root matching its peers,
+                // and therefore never looks like it needs repair. Returning
+                // here leaves the sync-in-progress marker set, exactly as the
+                // I7 arms do, so crash-recovery retries instead.
+                Err(e) => {
+                    warn!(
+                        %context_id,
+                        error = %e,
+                        "Failed to rebuild child-trie links after snapshot; failing the \
+                         sync for retry rather than publishing a root whose collections \
+                         read back empty"
+                    );
+                    return Err(eyre::eyre!(
+                        "snapshot: child-trie rebuild failed for {context_id}: {e}"
+                    ));
+                }
             }
         }
 
@@ -1400,7 +1413,64 @@ pub(crate) fn persist_buffered_snapshot_entity(
     handle.put(&entry_key, &ContextStateValue::from(entry_slice))?;
     handle.put(&index_key, &ContextStateValue::from(index_slice))?;
 
+    // Link into the parent's child trie HERE, not only in the one-shot rebuild
+    // after the snapshot pages land.
+    //
+    // This path runs from `drain_absorbed_leaves`, which fires on a later delta
+    // once the loaded reader has advanced to the entity's schema — long after
+    // `rebuild_child_tries_after_snapshot` has already run. An entity that lands
+    // now would otherwise be present but unenumerable from its parent forever,
+    // because (as that rebuild's own doc notes) re-applying byte-identical
+    // entities never re-links: it goes through the update path, not
+    // `add_child_to`. That is the same permanent, self-stable divergence the
+    // rebuild exists to prevent, arriving through the late door.
+    if let Some(parent_id) = index_entity.parent_id() {
+        link_child_into_parent_trie(
+            handle,
+            context_id,
+            parent_id,
+            calimero_storage::entities::ChildInfo::new(
+                index_entity.id(),
+                index_entity.full_hash(),
+                index_entity.metadata.clone(),
+            ),
+        )?;
+    }
+
     Ok(SnapshotEntityDrainOutcome::Persisted)
+}
+
+/// Insert one parent→child link into the parent's `ChildTrie`, through a raw
+/// store handle.
+///
+/// Shared by the post-snapshot rebuild and the late buffered-entity drain so
+/// the two cannot drift in how a link is written — they are the same operation
+/// arriving at different times.
+fn link_child_into_parent_trie(
+    handle: &mut calimero_store::Handle<calimero_store::Store>,
+    context_id: ContextId,
+    parent_id: Id,
+    child: calimero_storage::entities::ChildInfo,
+) -> Result<()> {
+    let mut writes: Vec<(StorageKey, Vec<u8>)> = Vec::new();
+    {
+        let read = |key: StorageKey| -> Option<Vec<u8>> {
+            let k = ContextStateKey::new(context_id, key.to_bytes());
+            handle.get(&k).ok().flatten().map(|v| v.as_ref().to_vec())
+        };
+        calimero_storage::child_trie::ChildTrie::<calimero_storage::store::MainStorage>::insert_with(
+            parent_id,
+            child,
+            read,
+            |key, bytes| writes.push((key, bytes.to_vec())),
+        );
+    }
+    for (key, bytes) in writes {
+        let k = ContextStateKey::new(context_id, key.to_bytes());
+        let slice: Slice<'_> = bytes.into();
+        handle.put(&k, &ContextStateValue::from(slice))?;
+    }
+    Ok(())
 }
 
 /// Rebuild every installed entity's link into its parent's child trie.
@@ -1466,24 +1536,7 @@ fn rebuild_child_tries_after_snapshot(
 
     let linked = links.len();
     for (parent_id, child) in links {
-        let mut writes: Vec<(StorageKey, Vec<u8>)> = Vec::new();
-        {
-            let read = |key: StorageKey| -> Option<Vec<u8>> {
-                let k = ContextStateKey::new(context_id, key.to_bytes());
-                handle.get(&k).ok().flatten().map(|v| v.as_ref().to_vec())
-            };
-            calimero_storage::child_trie::ChildTrie::<calimero_storage::store::MainStorage>::insert_with(
-                parent_id,
-                child,
-                read,
-                |key, bytes| writes.push((key, bytes.to_vec())),
-            );
-        }
-        for (key, bytes) in writes {
-            let k = ContextStateKey::new(context_id, key.to_bytes());
-            let slice: Slice<'_> = bytes.into();
-            handle.put(&k, &ContextStateValue::from(slice))?;
-        }
+        link_child_into_parent_trie(handle, context_id, parent_id, child)?;
     }
 
     Ok(linked)
@@ -2363,6 +2416,105 @@ mod tests {
     // node-primitives and is exercised only here (the sender never emits a
     // rotation-log auxiliary record — the log syncs as collection children).
     use calimero_node_primitives::sync::snapshot::snapshot_record_kind;
+
+    /// A snapshot receiver used to hold every entity and be able to enumerate
+    /// none of them.
+    ///
+    /// Snapshot installs an entity by writing its `Entry` and `Index` rows
+    /// verbatim. While a parent's children lived INSIDE its index row, that
+    /// shipped the parent->child links for free. Moving children into
+    /// `Key::ChildTrie` broke that silently: discovery finds entities by
+    /// deserialising `EntityIndex`, and a trie row never will.
+    ///
+    /// It never healed either, which is what makes this worth a test rather
+    /// than a one-off measurement. Hash comparison re-applied entities that
+    /// were already byte-identical, and that goes through the update path
+    /// rather than `add_child_to`, so no link was ever created — a stable
+    /// fixpoint, re-syncing every ~10s forever.
+    #[test]
+    fn rebuilding_after_snapshot_relinks_children_the_install_did_not() {
+        use calimero_storage::address::Id;
+        use calimero_storage::child_trie::ChildTrie;
+        use calimero_storage::store::{Key as StorageKey, MainStorage};
+
+        let store = Store::new(Arc::new(InMemoryDB::owned()));
+        let mut handle = store.handle();
+        let context_id = ContextId::from([9; 32]);
+
+        let parent_id = Id::new([1; 32]);
+        let child_ids: Vec<Id> = (0..5_u8).map(|i| Id::new([10 + i; 32])).collect();
+
+        // Install rows the way snapshot does: verbatim, no linking.
+        let put_index = |handle: &mut calimero_store::Handle<Store>, index: &EntityIndex| {
+            let key = ContextStateKey::new(context_id, StorageKey::Index(index.id()).to_bytes());
+            let bytes = borsh::to_vec(index).expect("serialise index");
+            let slice: Slice<'_> = bytes.into();
+            handle
+                .put(&key, &ContextStateValue::from(slice))
+                .expect("put index row");
+        };
+
+        put_index(&mut handle, &EntityIndex::minimal_for_test(parent_id));
+        for (i, id) in child_ids.iter().enumerate() {
+            put_index(
+                &mut handle,
+                &EntityIndex::minimal_for_test_with_parent(*id, parent_id, [20 + i as u8; 32]),
+            );
+        }
+
+        let read = |key: StorageKey| -> Option<Vec<u8>> {
+            let k = ContextStateKey::new(context_id, key.to_bytes());
+            store
+                .handle()
+                .get(&k)
+                .ok()
+                .flatten()
+                .map(|v| v.as_ref().to_vec())
+        };
+
+        // The bug: every entity present, none enumerable.
+        assert!(
+            ChildTrie::<MainStorage>::children_with(parent_id, read).is_empty(),
+            "precondition: a verbatim install links nothing"
+        );
+
+        let linked = rebuild_child_tries_after_snapshot(&mut handle, context_id)
+            .expect("rebuild must succeed");
+        assert_eq!(linked, child_ids.len(), "every parented row must be linked");
+
+        let rebuilt = ChildTrie::<MainStorage>::children_with(parent_id, read);
+        assert_eq!(
+            rebuilt.len(),
+            child_ids.len(),
+            "children must enumerate after the rebuild"
+        );
+
+        let got: BTreeSet<Id> = rebuilt
+            .iter()
+            .map(calimero_storage::entities::ChildInfo::id)
+            .collect();
+        let want: BTreeSet<Id> = child_ids.iter().copied().collect();
+        assert_eq!(
+            got, want,
+            "the rebuilt trie must hold exactly the shipped children"
+        );
+
+        // The rebuild replays the SENDER's full_hash per child, so the
+        // reconstructed trie has to reproduce the sender's root exactly —
+        // that equality is the whole point, not a side effect.
+        for (i, child) in rebuilt.iter().enumerate() {
+            let expected = child_ids
+                .iter()
+                .position(|id| *id == child.id())
+                .expect("child id known");
+            let _ = i;
+            assert_eq!(
+                child.merkle_hash(),
+                [20 + expected as u8; 32],
+                "the shipped full_hash must be what lands in the trie"
+            );
+        }
+    }
 
     #[test]
     fn snapshot_progress_unknown_total_yields_no_estimate() {

--- a/crates/node/src/sync/snapshot.rs
+++ b/crates/node/src/sync/snapshot.rs
@@ -1452,20 +1452,55 @@ fn link_child_into_parent_trie(
     parent_id: Id,
     child: calimero_storage::entities::ChildInfo,
 ) -> Result<()> {
-    let mut writes: Vec<(StorageKey, Vec<u8>)> = Vec::new();
-    {
-        let read = |key: StorageKey| -> Option<Vec<u8>> {
-            let k = ContextStateKey::new(context_id, key.to_bytes());
-            handle.get(&k).ok().flatten().map(|v| v.as_ref().to_vec())
-        };
-        calimero_storage::child_trie::ChildTrie::<calimero_storage::store::MainStorage>::insert_with(
-            parent_id,
-            child,
-            read,
-            |key, bytes| writes.push((key, bytes.to_vec())),
-        );
+    link_children_into_parent_trie(handle, context_id, parent_id, vec![child])
+}
+
+/// Link many children of ONE parent, sharing a row cache across them.
+///
+/// Siblings collide on the same `DEPTH+1` spine rows by construction — that is
+/// what makes the trie bounded — so linking them one at a time re-reads and
+/// rewrites the same spine for every child. Buffering the parent's rows and
+/// flushing once cuts the store traffic by most of that factor.
+///
+/// Worth doing even though this runs on install rather than per operation: a
+/// context with tens of thousands of entities pays it in full on every
+/// bootstrap, and "one-time" is not the same as "free".
+///
+/// Correctness is unchanged: `insert_with` is a pure function of the rows it
+/// reads, so serving those rows from a cache that already holds this parent's
+/// pending writes gives exactly the sequence the uncached path would, one
+/// child at a time.
+fn link_children_into_parent_trie(
+    handle: &mut calimero_store::Handle<calimero_store::Store>,
+    context_id: ContextId,
+    parent_id: Id,
+    children: Vec<calimero_storage::entities::ChildInfo>,
+) -> Result<()> {
+    let mut pending: BTreeMap<StorageKey, Vec<u8>> = BTreeMap::new();
+
+    for child in children {
+        let mut writes: Vec<(StorageKey, Vec<u8>)> = Vec::new();
+        {
+            let read = |key: StorageKey| -> Option<Vec<u8>> {
+                if let Some(bytes) = pending.get(&key) {
+                    return Some(bytes.clone());
+                }
+                let k = ContextStateKey::new(context_id, key.to_bytes());
+                handle.get(&k).ok().flatten().map(|v| v.as_ref().to_vec())
+            };
+            calimero_storage::child_trie::ChildTrie::<calimero_storage::store::MainStorage>::insert_with(
+                parent_id,
+                child,
+                read,
+                |key, bytes| writes.push((key, bytes.to_vec())),
+            );
+        }
+        for (key, bytes) in writes {
+            let _prev = pending.insert(key, bytes);
+        }
     }
-    for (key, bytes) in writes {
+
+    for (key, bytes) in pending {
         let k = ContextStateKey::new(context_id, key.to_bytes());
         let slice: Slice<'_> = bytes.into();
         handle.put(&k, &ContextStateValue::from(slice))?;
@@ -1535,8 +1570,15 @@ fn rebuild_child_tries_after_snapshot(
     }
 
     let linked = links.len();
+
+    // Group by parent so siblings share one pass over the spine rows they all
+    // touch, rather than each re-reading and rewriting them.
+    let mut by_parent: BTreeMap<Id, Vec<calimero_storage::entities::ChildInfo>> = BTreeMap::new();
     for (parent_id, child) in links {
-        link_child_into_parent_trie(handle, context_id, parent_id, child)?;
+        by_parent.entry(parent_id).or_default().push(child);
+    }
+    for (parent_id, children) in by_parent {
+        link_children_into_parent_trie(handle, context_id, parent_id, children)?;
     }
 
     Ok(linked)
@@ -2416,6 +2458,79 @@ mod tests {
     // node-primitives and is exercised only here (the sender never emits a
     // rotation-log auxiliary record — the log syncs as collection children).
     use calimero_node_primitives::sync::snapshot::snapshot_record_kind;
+
+    /// Grouping siblings behind one row cache must be invisible in the result.
+    ///
+    /// The cache exists so siblings stop re-reading the `DEPTH+1` spine rows
+    /// they all share. That is a pure win only if serving a row from the cache
+    /// gives byte-identical output to reading it back from the store — if it
+    /// ever does not, a snapshot receiver builds a different trie than the
+    /// sender and diverges permanently, which is the failure this whole pass
+    /// exists to prevent.
+    #[test]
+    fn grouping_siblings_writes_what_linking_them_one_at_a_time_writes() {
+        use calimero_storage::address::Id;
+        use calimero_storage::entities::{ChildInfo, Metadata};
+        use calimero_storage::store::Key as StorageKey;
+
+        let context_id = ContextId::from([4; 32]);
+        let parent_id = Id::new([2; 32]);
+        let children: Vec<ChildInfo> = (0..12_u8)
+            .map(|i| {
+                ChildInfo::new(
+                    Id::new([i.wrapping_mul(17).wrapping_add(3); 32]),
+                    [i; 32],
+                    Metadata::default(),
+                )
+            })
+            .collect();
+
+        // Grouped: one call, one shared cache.
+        let grouped_store = Store::new(Arc::new(InMemoryDB::owned()));
+        let mut grouped = grouped_store.handle();
+        link_children_into_parent_trie(&mut grouped, context_id, parent_id, children.clone())
+            .expect("grouped link");
+
+        // One at a time: the same code with a cache of size 1 each call.
+        let single_store = Store::new(Arc::new(InMemoryDB::owned()));
+        let mut single = single_store.handle();
+        for child in children.clone() {
+            link_child_into_parent_trie(&mut single, context_id, parent_id, child)
+                .expect("single link");
+        }
+
+        let rows_of = |store: &Store| -> BTreeMap<Vec<u8>, Vec<u8>> {
+            let mut out = BTreeMap::new();
+            let handle = store.handle();
+            let mut iter = handle.iter::<ContextStateKey>().expect("iter");
+            for (k, v) in iter.entries() {
+                let k = k.expect("key");
+                let v = v.expect("value");
+                let _prev = out.insert(k.state_key().to_vec(), v.value.as_ref().to_vec());
+            }
+            out
+        };
+
+        let a = rows_of(&grouped_store);
+        let b = rows_of(&single_store);
+        assert!(!a.is_empty(), "grouped link wrote nothing");
+        assert_eq!(a, b, "grouped and one-at-a-time must write identical rows");
+
+        // And both must actually hold the children.
+        let read = |key: StorageKey| -> Option<Vec<u8>> {
+            let k = ContextStateKey::new(context_id, key.to_bytes());
+            grouped_store
+                .handle()
+                .get(&k)
+                .ok()
+                .flatten()
+                .map(|v| v.as_ref().to_vec())
+        };
+        let enumerated = calimero_storage::child_trie::ChildTrie::<
+            calimero_storage::store::MainStorage,
+        >::children_with(parent_id, read);
+        assert_eq!(enumerated.len(), children.len());
+    }
 
     /// A snapshot receiver used to hold every entity and be able to enumerate
     /// none of them.

--- a/crates/node/src/sync/snapshot.rs
+++ b/crates/node/src/sync/snapshot.rs
@@ -419,6 +419,26 @@ impl SyncManager {
             .request_and_apply_snapshot_pages(context_id, &boundary, force, &mut stream)
             .await?;
 
+        // Reconstruct the child tries before reading the root back. Snapshot
+        // ships entity rows only, so without this the receiver holds every
+        // entity and can enumerate none of them.
+        {
+            let mut handle = self.context_client.datastore_handle();
+            match rebuild_child_tries_after_snapshot(&mut handle, context_id) {
+                Ok(linked) => info!(
+                    %context_id,
+                    linked,
+                    "Rebuilt child-trie links for snapshot-installed entities"
+                ),
+                Err(e) => warn!(
+                    %context_id,
+                    error = %e,
+                    "Failed to rebuild child-trie links after snapshot; collections \
+                     will read back empty until the next full resync"
+                ),
+            }
+        }
+
         // Verify snapshot integrity against the state that actually landed (I7).
         // Either arm of a failure returns before the sync-in-progress marker is
         // cleared, so crash-recovery re-syncs and retries rather than publishing
@@ -1379,7 +1399,94 @@ pub(crate) fn persist_buffered_snapshot_entity(
     let index_slice: Slice<'_> = index.to_vec().into();
     handle.put(&entry_key, &ContextStateValue::from(entry_slice))?;
     handle.put(&index_key, &ContextStateValue::from(index_slice))?;
+
     Ok(SnapshotEntityDrainOutcome::Persisted)
+}
+
+/// Rebuild every installed entity's link into its parent's child trie.
+///
+/// # Why a whole pass, after the fact
+///
+/// Snapshot installs an entity by writing its `Entry` and `Index` rows
+/// verbatim. While a parent's children lived INSIDE its index row, that shipped
+/// the parent→child links for free. They now live in their own keyspace
+/// (`Key::ChildTrie`), which snapshot discovery cannot recognise — it finds
+/// entities by deserialising `EntityIndex`, and a trie row never will.
+///
+/// Without this, a snapshot receiver holds every entity and can enumerate none
+/// of them: `get_children_of` is trie-backed, so collections read back empty
+/// while the entity rows sit there intact.
+///
+/// It is a separate pass rather than a hook in the install sites because there
+/// are three of them (the page-apply loop, the re-drive loop, and the buffered
+/// drain), and a link missed by any one is silent. Rebuilding from what
+/// actually landed cannot miss a path.
+///
+/// Replays the sender's own `full_hash` for each child, so the reconstructed
+/// trie reproduces the sender's root exactly — the trie is a pure function of
+/// the `{(id, full_hash)}` set. No re-hashing, and no parent-before-child
+/// ordering requirement.
+fn rebuild_child_tries_after_snapshot(
+    handle: &mut calimero_store::Handle<calimero_store::Store>,
+    context_id: ContextId,
+) -> Result<usize> {
+    // Collect first: the iterator borrows the handle we need to write through.
+    let mut links: Vec<(Id, calimero_storage::entities::ChildInfo)> = Vec::new();
+    {
+        let mut iter = handle.iter::<ContextStateKey>()?;
+        for (key_result, value_result) in iter.entries() {
+            let key = key_result?;
+            let value = value_result?;
+            if key.context_id() != context_id {
+                continue;
+            }
+            let state_key = key.state_key();
+            let Ok(index_entity) =
+                borsh::from_slice::<calimero_storage::index::EntityIndex>(value.value.as_ref())
+            else {
+                continue;
+            };
+            // Same cross-check the sender's discovery uses: an Entry value can
+            // borsh-deserialise as a partial EntityIndex by coincidence.
+            if StorageKey::Index(index_entity.id()).to_bytes() != state_key {
+                continue;
+            }
+            if let Some(parent_id) = index_entity.parent_id() {
+                links.push((
+                    parent_id,
+                    calimero_storage::entities::ChildInfo::new(
+                        index_entity.id(),
+                        index_entity.full_hash(),
+                        index_entity.metadata.clone(),
+                    ),
+                ));
+            }
+        }
+    }
+
+    let linked = links.len();
+    for (parent_id, child) in links {
+        let mut writes: Vec<(StorageKey, Vec<u8>)> = Vec::new();
+        {
+            let read = |key: StorageKey| -> Option<Vec<u8>> {
+                let k = ContextStateKey::new(context_id, key.to_bytes());
+                handle.get(&k).ok().flatten().map(|v| v.as_ref().to_vec())
+            };
+            calimero_storage::child_trie::ChildTrie::<calimero_storage::store::MainStorage>::insert_with(
+                parent_id,
+                child,
+                read,
+                |key, bytes| writes.push((key, bytes.to_vec())),
+            );
+        }
+        for (key, bytes) in writes {
+            let k = ContextStateKey::new(context_id, key.to_bytes());
+            let slice: Slice<'_> = bytes.into();
+            handle.put(&k, &ContextStateValue::from(slice))?;
+        }
+    }
+
+    Ok(linked)
 }
 
 /// Result of a successful snapshot sync.

--- a/crates/node/tests/sync_protocols.rs
+++ b/crates/node/tests/sync_protocols.rs
@@ -279,6 +279,7 @@ async fn test_snapshot_transfer_fresh_node() {
 
     // Create a mock snapshot
     let snapshot = Snapshot {
+        trie_rows: Vec::new(),
         entity_count: 5,
         index_count: 0,
         entries: vec![],
@@ -306,6 +307,7 @@ async fn test_snapshot_excludes_tombstones() {
     ];
 
     let snapshot = Snapshot {
+        trie_rows: Vec::new(),
         entity_count: 3,
         index_count: 0,
         entries: live_entries.clone(),
@@ -535,6 +537,7 @@ async fn test_recovery_via_full_resync() {
     // In production, would transfer actual snapshot
     // For test, just verify recovery mechanism
     let snapshot = Snapshot {
+        trie_rows: Vec::new(),
         entity_count: 1,
         index_count: 0,
         entries: vec![(Id::from([100; 32]), vec![1])],

--- a/crates/node/tests/sync_sim/storage.rs
+++ b/crates/node/tests/sync_sim/storage.rs
@@ -245,16 +245,13 @@ impl SimStorage {
     /// Recursively count entities in the tree.
     #[allow(clippy::only_used_in_recursion, reason = "test tree-walk helper")]
     fn count_entities_recursive(&self, id: Id) -> usize {
-        let index = match Index::<MainStorage>::get_index(id).ok().flatten() {
-            Some(idx) => idx,
-            None => return 0,
-        };
+        if Index::<MainStorage>::get_index(id).ok().flatten().is_none() {
+            return 0;
+        }
 
         let mut count = 1; // Count this entity
-        if let Some(children) = index.children() {
-            for child in children {
-                count += self.count_entities_recursive(child.id());
-            }
+        for child in Index::<MainStorage>::get_children_of(id).unwrap_or_default() {
+            count += self.count_entities_recursive(child.id());
         }
         count
     }
@@ -271,18 +268,15 @@ impl SimStorage {
     /// Recursively count leaf nodes.
     #[allow(clippy::only_used_in_recursion, reason = "test tree-walk helper")]
     fn count_leaves_recursive(&self, id: Id, is_root: bool) -> usize {
-        let index = match Index::<MainStorage>::get_index(id).ok().flatten() {
-            Some(idx) => idx,
-            None => return 0,
-        };
+        if Index::<MainStorage>::get_index(id).ok().flatten().is_none() {
+            return 0;
+        }
 
-        let children = index.children();
-        let has_children = children.as_ref().is_some_and(|c| !c.is_empty());
+        let children = Index::<MainStorage>::get_children_of(id).unwrap_or_default();
 
-        if has_children {
+        if !children.is_empty() {
             // Internal node: count children recursively
             children
-                .unwrap()
                 .iter()
                 .map(|child| self.count_leaves_recursive(child.id(), false))
                 .sum()
@@ -318,20 +312,18 @@ impl SimStorage {
     /// Recursively compute depth of the tree.
     #[allow(clippy::only_used_in_recursion, reason = "test tree-walk helper")]
     fn compute_depth_recursive(&self, id: Id) -> u32 {
-        let index = match Index::<MainStorage>::get_index(id).ok().flatten() {
-            Some(idx) => idx,
-            None => return 0,
-        };
+        if Index::<MainStorage>::get_index(id).ok().flatten().is_none() {
+            return 0;
+        }
 
-        let children = index.children();
-        if children.is_none() || children.as_ref().is_none_or(|c| c.is_empty()) {
+        let children = Index::<MainStorage>::get_children_of(id).unwrap_or_default();
+        if children.is_empty() {
             // Leaf node
             return 1;
         }
 
         // Internal node: 1 + max depth of children
         let max_child_depth = children
-            .unwrap()
             .iter()
             .map(|child| self.compute_depth_recursive(child.id()))
             .max()

--- a/crates/runtime/HOST_FUNCTIONS.md
+++ b/crates/runtime/HOST_FUNCTIONS.md
@@ -333,7 +333,7 @@ non-owner `update`/`tombstone` returns `-1` with an ownership error message writ
 |----------|-----------|-------------|
 | `js_crdt_authored_vector_new` | `(register_id: u64) -> i32` | Creates a new attributed vector. |
 | `js_crdt_authored_vector_new_with_id` | `(id_ptr: u64, register_id: u64) -> i32` | Creates an attributed vector at a caller-supplied deterministic 32-byte ID. |
-| `js_crdt_authored_vector_push` | `(vector_id_ptr: u64, value_ptr: u64, register_id: u64) -> i32` | Pushes a value at the tail, stamping the caller as owner. Writes the new index (`u64`, little-endian) to the register; returns `1`. |
+| `js_crdt_authored_vector_push` | `(vector_id_ptr: u64, value_ptr: u64, register_id: u64) -> i32` | Pushes a value at the tail, stamping the caller as owner. Writes the new entry's **32-byte ID** to the register; returns `1`. Not an index — see the note below. |
 | `js_crdt_authored_vector_update` | `(vector_id_ptr: u64, index: u64, value_ptr: u64, register_id: u64) -> i32` | Owner-only. Replaces the value at a slot. Returns `1` on success; `-1` (error in register) for a non-owner or out-of-bounds index. |
 | `js_crdt_authored_vector_tombstone` | `(vector_id_ptr: u64, index: u64, register_id: u64) -> i32` | Owner-only. Retracts a slot (overwrites with an empty value). Returns `1` on success; `-1` (error in register) for a non-owner or out-of-bounds index. |
 | `js_crdt_authored_vector_get` | `(vector_id_ptr: u64, index: u64, register_id: u64) -> i32` | Retrieves a value by index (`1` found, `0` absent). |
@@ -341,6 +341,19 @@ non-owner `update`/`tombstone` returns `-1` with an ownership error message writ
 | `js_crdt_authored_vector_owned_by_me` | `(vector_id_ptr: u64, index: u64) -> i32` | Whether the current executor owns the slot (`1`/`0`; `0` for out-of-bounds slots). |
 | `js_crdt_authored_vector_iter` | `(vector_id_ptr: u64, register_id: u64) -> i32` | Iterates all values in insertion order (`[count][len,value]...`). |
 | `js_crdt_authored_vector_len` | `(vector_id_ptr: u64, register_id: u64) -> i32` | Gets the entry count including tombstoned slots (`u64`, little-endian). |
+| `js_crdt_authored_vector_update_by_id` | `(vector_id_ptr: u64, entry_id_ptr: u64, value_ptr: u64, register_id: u64) -> i32` | Owner-only. Replaces the value of the entry named by `entry_id`. Returns `1`; `-1` (error in register) for a non-owner or unknown id. |
+| `js_crdt_authored_vector_tombstone_by_id` | `(vector_id_ptr: u64, entry_id_ptr: u64, register_id: u64) -> i32` | Owner-only. Retracts the entry named by `entry_id`. Returns `1`; `-1` (error in register) for a non-owner or unknown id. |
+| `js_crdt_authored_vector_get_by_id` | `(vector_id_ptr: u64, entry_id_ptr: u64, register_id: u64) -> i32` | Retrieves the value of the entry named by `entry_id` (`1` found, `0` absent). |
+| `js_crdt_authored_vector_owner_of_id` | `(vector_id_ptr: u64, entry_id_ptr: u64, register_id: u64) -> i32` | Writes the owner's 32-byte account id to the register (`1`); `0` with a cleared register if no such entry. |
+
+**Index vs ID on `AuthoredVector`.** `push` returns an **ID**, and the `_by_id`
+functions are the ones to use with it. An index describes where an entry
+currently sits in a set every peer inserts into, so a peer inserting ahead of it
+renumbers it — and since `update`/`tombstone` are ownership-gated *by the address
+they are given*, a stale index performs the owner check against, and writes to, a
+different entry (core#3637). The positional functions remain correct for
+enumeration and for an address resolved inside the same call; anything that
+carries an address across calls, or out to a client and back, must use an ID.
 
 #### Shared Storage Operations
 

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -517,6 +517,20 @@ pub struct VMLogic<'a> {
     /// Cumulative `key + value` bytes written to storage so far (same shared
     /// budget as `storage_writes`).
     storage_write_bytes: u64,
+    /// Number of guest storage reads performed so far.
+    ///
+    /// Telemetry, NOT a budget — unlike `storage_writes` there is no limit to
+    /// charge against, and gas never sees a read (a `storage_read` costs only
+    /// the ~4 wasm operators of the caller, independent of value size). It is
+    /// counted because read COUNT is the thing that predicts cost: each read
+    /// hands the guest bytes to borsh-decode, and that decode is what the
+    /// metered instruction count actually measures.
+    storage_reads: u64,
+    /// Cumulative bytes returned by those reads.
+    ///
+    /// The better cost predictor of the two: guest-side decode work scales with
+    /// bytes, not with call count.
+    storage_read_bytes: u64,
     /// Cumulative bytes streamed into blobs so far across all write handles.
     blob_bytes_written: u64,
     /// Gas the execution consumed, recorded by the runtime after the guest
@@ -623,6 +637,8 @@ impl<'a> VMLogic<'a> {
 
             storage_writes: 0,
             storage_write_bytes: 0,
+            storage_reads: 0,
+            storage_read_bytes: 0,
             blob_bytes_written: 0,
             gas_used: None,
         }
@@ -769,6 +785,20 @@ pub struct Outcome {
     /// the replicated artifact — surfaced so operators can size
     /// [`VMLimits::max_gas`] from the distribution of real workloads.
     pub gas_used: Option<u64>,
+    /// Guest storage reads this execution performed. Node-local telemetry, like
+    /// [`gas_used`](Self::gas_used) — never part of the replicated artifact.
+    ///
+    /// Exposed so a test can assert that a write's cost does not grow with the
+    /// collection it writes into. That class of regression is invisible to
+    /// correctness tests and has repeatedly shipped: reads are unmetered and
+    /// unlimited, so an O(n) read pattern shows up only as gas spent decoding.
+    pub storage_reads: u64,
+    /// Bytes returned by those reads.
+    pub storage_read_bytes: u64,
+    /// Guest storage writes this execution performed.
+    pub storage_writes: u64,
+    /// `key + value` bytes those writes carried.
+    pub storage_write_bytes: u64,
     //TODO: current storage usage of the app (???).
 }
 
@@ -864,6 +894,10 @@ impl VMLogic<'_> {
             artifact: self.artifact,
             migration_witness: self.migration_witness,
             gas_used: self.gas_used,
+            storage_reads: self.storage_reads,
+            storage_read_bytes: self.storage_read_bytes,
+            storage_writes: self.storage_writes,
+            storage_write_bytes: self.storage_write_bytes,
         }
     }
 }

--- a/crates/runtime/src/logic/host_functions/js_collections.rs
+++ b/crates/runtime/src/logic/host_functions/js_collections.rs
@@ -1061,6 +1061,60 @@ impl VMHostFunctions<'_> {
         })
     }
 
+    /// Updates the entry named by `entry_id`. Only its owner may call this.
+    pub fn js_crdt_authored_vector_update_by_id(
+        &mut self,
+        vector_id_ptr: u64,
+        entry_id_ptr: u64,
+        value_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_vector_update_by_id(
+                vector_id_ptr,
+                entry_id_ptr,
+                value_ptr,
+                dest_register_id,
+            )
+        })
+    }
+
+    /// Tombstones the entry named by `entry_id`. Only its owner may call this.
+    pub fn js_crdt_authored_vector_tombstone_by_id(
+        &mut self,
+        vector_id_ptr: u64,
+        entry_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_vector_tombstone_by_id(vector_id_ptr, entry_id_ptr, dest_register_id)
+        })
+    }
+
+    /// Reads the entry named by `entry_id`.
+    pub fn js_crdt_authored_vector_get_by_id(
+        &mut self,
+        vector_id_ptr: u64,
+        entry_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_vector_get_by_id(vector_id_ptr, entry_id_ptr, dest_register_id)
+        })
+    }
+
+    /// The owner of the entry named by `entry_id`.
+    pub fn js_crdt_authored_vector_owner_of_id(
+        &mut self,
+        vector_id_ptr: u64,
+        entry_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        self.invoke_with_storage_env(|host| {
+            host.crdt_authored_vector_owner_of_id(vector_id_ptr, entry_id_ptr, dest_register_id)
+        })
+    }
+
     /// Tombstones a slot. Only the slot owner may call this.
     pub fn js_crdt_authored_vector_tombstone(
         &mut self,
@@ -2838,6 +2892,144 @@ impl VMHostFunctions<'_> {
         }
     }
 
+    /// Id-addressed counterpart of `crdt_authored_vector_update`.
+    ///
+    /// The positional form addresses an entry by where it currently sits in a
+    /// set every peer inserts into, so a caller that resolved the position in
+    /// an earlier call may now be pointing at a different entry — and since
+    /// the write is ownership-gated BY the address given, it would check
+    /// ownership against that other entry too (core#3637).
+    fn crdt_authored_vector_update_by_id(
+        &mut self,
+        vector_id_ptr: u64,
+        entry_id_ptr: u64,
+        value_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let vector_id = match self.read_map_id(vector_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+        let entry_id = match self.read_map_id(entry_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let value = self.read_buffer(value_ptr)?;
+
+        let mut vector = match load_js_authored_vector_instance(vector_id) {
+            Ok(vector) => vector,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        // Owner-only: a non-owner update yields `ActionNotAllowed`.
+        match vector.update_by_id(*entry_id.as_bytes(), &value) {
+            Ok(()) => match save_js_instance(&mut vector) {
+                Ok(()) => Ok(1),
+                Err(message) => self.write_error_message(dest_register_id, message),
+            },
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    /// Id-addressed counterpart of `crdt_authored_vector_tombstone`.
+    fn crdt_authored_vector_tombstone_by_id(
+        &mut self,
+        vector_id_ptr: u64,
+        entry_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let vector_id = match self.read_map_id(vector_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+        let entry_id = match self.read_map_id(entry_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let mut vector = match load_js_authored_vector_instance(vector_id) {
+            Ok(vector) => vector,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match vector.tombstone_by_id(*entry_id.as_bytes()) {
+            Ok(()) => match save_js_instance(&mut vector) {
+                Ok(()) => Ok(1),
+                Err(message) => self.write_error_message(dest_register_id, message),
+            },
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    /// Id-addressed counterpart of `crdt_authored_vector_get`.
+    fn crdt_authored_vector_get_by_id(
+        &mut self,
+        vector_id_ptr: u64,
+        entry_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let vector_id = match self.read_map_id(vector_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+        let entry_id = match self.read_map_id(entry_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let vector = match load_js_authored_vector_instance(vector_id) {
+            Ok(vector) => vector,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match vector.get_by_id(*entry_id.as_bytes()) {
+            Ok(Some(value)) => {
+                self.write_register_bytes(dest_register_id, &value)?;
+                Ok(1)
+            }
+            Ok(None) => {
+                self.clear_register(dest_register_id)?;
+                Ok(0)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
+    /// Id-addressed counterpart of `crdt_authored_vector_owner_of`.
+    fn crdt_authored_vector_owner_of_id(
+        &mut self,
+        vector_id_ptr: u64,
+        entry_id_ptr: u64,
+        dest_register_id: u64,
+    ) -> VMLogicResult<i32> {
+        let vector_id = match self.read_map_id(vector_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+        let entry_id = match self.read_map_id(entry_id_ptr)? {
+            Ok(id) => id,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        let vector = match load_js_authored_vector_instance(vector_id) {
+            Ok(vector) => vector,
+            Err(message) => return self.write_error_message(dest_register_id, message),
+        };
+
+        match vector.owner_of_id(*entry_id.as_bytes()) {
+            Ok(Some(owner)) => {
+                self.write_register_bytes(dest_register_id, &owner)?;
+                Ok(1)
+            }
+            Ok(None) => {
+                self.clear_register(dest_register_id)?;
+                Ok(0)
+            }
+            Err(err) => self.write_error_message(dest_register_id, err),
+        }
+    }
+
     fn crdt_authored_vector_owned_by_me(
         &mut self,
         vector_id_ptr: u64,
@@ -4144,6 +4336,92 @@ mod tests {
     /// AuthoredVector: `push` returns the new index (u64 LE) and stamps the
     /// pusher as owner; `get`/`owner_of`/`owned_by_me` reflect that; a
     /// `tombstone` by the owner succeeds and preserves the slot's position.
+    /// The id-addressed host functions are the point of returning an id from
+    /// push: without them a JS app receives an address it cannot use and has to
+    /// fall back to the positional API, which is the unsound one (core#3637).
+    #[test]
+    fn test_js_crdt_authored_vector_id_addressed_round_trip() {
+        let mut storage = SimpleMockStorage::new();
+        let limits = VMLimits::default();
+        let (mut logic, mut store) = setup_vm!(&mut storage, &limits, vec![]);
+        let mut host = logic.host_functions(store.as_store_mut());
+
+        let id: [u8; 32] = [73u8; 32];
+        put_buffer(&host, ID_DESC_PTR, ID_DATA_PTR, &id);
+        assert_eq!(
+            host.js_crdt_authored_vector_new_with_id(ID_DESC_PTR, 1)
+                .unwrap(),
+            0
+        );
+
+        put_buffer(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"first");
+        assert_eq!(
+            host.js_crdt_authored_vector_push(ID_DESC_PTR, VALUE_DESC_PTR, 2)
+                .unwrap(),
+            1
+        );
+        let entry_id: [u8; 32] = host
+            .borrow_logic()
+            .registers
+            .get(2)
+            .unwrap()
+            .try_into()
+            .expect("push must return a 32-byte entry id");
+
+        // Hand that id back across the host boundary as a buffer.
+        put_buffer(&host, KEY_DESC_PTR, KEY_DATA_PTR, &entry_id);
+
+        assert_eq!(
+            host.js_crdt_authored_vector_get_by_id(ID_DESC_PTR, KEY_DESC_PTR, 3)
+                .unwrap(),
+            1
+        );
+        assert_eq!(host.borrow_logic().registers.get(3).unwrap(), b"first");
+
+        put_buffer(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"second");
+        assert_eq!(
+            host.js_crdt_authored_vector_update_by_id(ID_DESC_PTR, KEY_DESC_PTR, VALUE_DESC_PTR, 4)
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            host.js_crdt_authored_vector_get_by_id(ID_DESC_PTR, KEY_DESC_PTR, 5)
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            host.borrow_logic().registers.get(5).unwrap(),
+            b"second",
+            "update_by_id must land on the entry the id names"
+        );
+
+        assert_eq!(
+            host.js_crdt_authored_vector_owner_of_id(ID_DESC_PTR, KEY_DESC_PTR, 6)
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            host.borrow_logic().registers.get(6).unwrap().len(),
+            32,
+            "owner_of_id must return an account id"
+        );
+
+        assert_eq!(
+            host.js_crdt_authored_vector_tombstone_by_id(ID_DESC_PTR, KEY_DESC_PTR, 7)
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            host.js_crdt_authored_vector_get_by_id(ID_DESC_PTR, KEY_DESC_PTR, 8)
+                .unwrap(),
+            1
+        );
+        assert!(
+            host.borrow_logic().registers.get(8).unwrap().is_empty(),
+            "tombstone_by_id must clear the entry the id names"
+        );
+    }
+
     #[test]
     fn test_js_crdt_authored_vector_push_get_owner_and_tombstone() {
         let mut storage = SimpleMockStorage::new();

--- a/crates/runtime/src/logic/host_functions/js_collections.rs
+++ b/crates/runtime/src/logic/host_functions/js_collections.rs
@@ -2705,14 +2705,17 @@ impl VMHostFunctions<'_> {
             Err(message) => return self.write_error_message(dest_register_id, message),
         };
 
-        // `push` stamps the current executor as owner and returns the new index.
+        // `push` stamps the current executor as owner and returns the new
+        // entry's ID — 32 bytes, not an 8-byte index. A position describes
+        // where an entry currently sits in a set other replicas insert into,
+        // so it goes stale the moment someone inserts ahead of it; an id names
+        // the entry (core#3637).
         match vector.push(&value) {
-            Ok(index) => {
+            Ok(id) => {
                 if let Err(message) = save_js_instance(&mut vector) {
                     return self.write_error_message(dest_register_id, message);
                 }
-                let index_u64 = u64::try_from(index).map_err(|_| HostError::IntegerOverflow)?;
-                self.write_register_bytes(dest_register_id, &index_u64.to_le_bytes())?;
+                self.write_register_bytes(dest_register_id, &id)?;
                 Ok(1)
             }
             Err(err) => self.write_error_message(dest_register_id, err),
@@ -4164,12 +4167,11 @@ mod tests {
                 .unwrap(),
             1
         );
-        let bytes = host.borrow_logic().registers.get(reg).unwrap();
-        assert_eq!(
-            u64::from_le_bytes(bytes.try_into().unwrap()),
-            0,
-            "first push lands at index 0"
-        );
+        // push writes the new entry's 32-byte ID, not an 8-byte index: a
+        // position is only valid until someone inserts ahead of it, an id names
+        // the entry (core#3637).
+        let first_id = host.borrow_logic().registers.get(reg).unwrap().to_vec();
+        assert_eq!(first_id.len(), 32, "push must return a 32-byte entry id");
 
         put_buffer(&host, VALUE_DESC_PTR, VALUE_DATA_PTR, b"second");
         let reg_b = 3u64;
@@ -4178,12 +4180,9 @@ mod tests {
                 .unwrap(),
             1
         );
-        let bytes = host.borrow_logic().registers.get(reg_b).unwrap();
-        assert_eq!(
-            u64::from_le_bytes(bytes.try_into().unwrap()),
-            1,
-            "second push lands at index 1"
-        );
+        let second_id = host.borrow_logic().registers.get(reg_b).unwrap().to_vec();
+        assert_eq!(second_id.len(), 32, "push must return a 32-byte entry id");
+        assert_ne!(first_id, second_id, "each push must name a distinct entry");
 
         // get index 0.
         let reg_c = 4u64;

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -67,6 +67,18 @@ impl VMHostFunctions<'_> {
             return Ok(1);
         }
 
+        // Count the miss too. A miss is a real lookup — and for the child trie
+        // it is the DOMINANT one: linking a child probes DEPTH+1 spine rows
+        // that mostly do not exist yet. A hits-only counter would leave
+        // `Outcome::storage_reads`, which `cost_is_flat.rs` asserts against as
+        // the regression gate for exactly that pattern, structurally unable to
+        // see it. Bytes are the key alone, since no value came back.
+        let miss_bytes = key.len() as u64;
+        self.with_logic_mut(|logic| {
+            logic.storage_reads = logic.storage_reads.saturating_add(1);
+            logic.storage_read_bytes = logic.storage_read_bytes.saturating_add(miss_bytes);
+        });
+
         trace!(
             target: "runtime::host::storage",
             op = "read",

--- a/crates/runtime/src/logic/host_functions/storage.rs
+++ b/crates/runtime/src/logic/host_functions/storage.rs
@@ -48,7 +48,10 @@ impl VMHostFunctions<'_> {
 
         if let Some(value) = logic.storage.get(&key) {
             let value_len = value.len();
+            let read_bytes = (key.len() + value_len) as u64;
             self.with_logic_mut(|logic| {
+                logic.storage_reads = logic.storage_reads.saturating_add(1);
+                logic.storage_read_bytes = logic.storage_read_bytes.saturating_add(read_bytes);
                 logic.registers.set(logic.limits, dest_register_id, value)
             })?;
 

--- a/crates/runtime/src/logic/imports.rs
+++ b/crates/runtime/src/logic/imports.rs
@@ -202,6 +202,30 @@ impl VMLogic<'_> {
                 index: u64,
                 register_id: u64,
             ) -> i32;
+            // Id-addressed counterparts. A position is only valid until someone
+            // inserts ahead of it, so anything that resolves its target in a
+            // different call than it acts must use these (core#3637).
+            fn js_crdt_authored_vector_update_by_id(
+                vector_id_ptr: u64,
+                entry_id_ptr: u64,
+                value_ptr: u64,
+                register_id: u64,
+            ) -> i32;
+            fn js_crdt_authored_vector_tombstone_by_id(
+                vector_id_ptr: u64,
+                entry_id_ptr: u64,
+                register_id: u64,
+            ) -> i32;
+            fn js_crdt_authored_vector_get_by_id(
+                vector_id_ptr: u64,
+                entry_id_ptr: u64,
+                register_id: u64,
+            ) -> i32;
+            fn js_crdt_authored_vector_owner_of_id(
+                vector_id_ptr: u64,
+                entry_id_ptr: u64,
+                register_id: u64,
+            ) -> i32;
             fn js_crdt_authored_vector_owned_by_me(vector_id_ptr: u64, index: u64) -> i32;
             fn js_crdt_authored_vector_iter(vector_id_ptr: u64, register_id: u64) -> i32;
             fn js_crdt_authored_vector_len(vector_id_ptr: u64, register_id: u64) -> i32;

--- a/crates/runtime/tests/chat_wall.rs
+++ b/crates/runtime/tests/chat_wall.rs
@@ -28,6 +28,8 @@
 //!
 //! Override the guest with `CURB_WASM=/path/to/curb.wasm`.
 
+use std::path::PathBuf;
+use std::process::Command;
 use std::time::Instant;
 
 use calimero_account::AccountId;
@@ -35,10 +37,110 @@ use calimero_runtime::logic::{Outcome, VMLimits};
 use calimero_runtime::store::InMemoryStorage;
 use calimero_runtime::Engine;
 
-const DEFAULT_WASM: &str = concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/../../../mero-chat-pwa/logic/target/wasm32-unknown-unknown/app-release/curb.wasm"
-);
+/// The real mero-chat contract, as a sibling checkout of this workspace.
+///
+/// Override with `CURB_LOGIC_DIR=/path/to/mero-chat-pwa/logic`.
+const DEFAULT_LOGIC_DIR: &str =
+    concat!(env!("CARGO_MANIFEST_DIR"), "/../../../mero-chat-pwa/logic");
+
+/// Every core crate mero-chat pulls from the published git source, which has to
+/// be redirected at THIS tree for the measurement to mean anything.
+const PATCHED_CRATES: [(&str, &str); 4] = [
+    ("calimero-sdk", "crates/sdk"),
+    ("calimero-storage", "crates/storage"),
+    ("calimero-storage-macros", "crates/storage-macros"),
+    ("calimero-wasm-abi", "crates/wasm-abi"),
+];
+
+/// The git source mero-chat names for those crates. `[patch]` keys match on the
+/// source URL, so this has to be byte-identical to its manifest.
+const CORE_GIT_SOURCE: &str = "https://github.com/calimero-network/core.git";
+
+/// Build the real contract against the core in THIS working tree.
+///
+/// mero-chat pins a published core (`calimero-sdk = { git = ..., tag = ... }`),
+/// so a stock build measures the branch's VM against an app compiled for a
+/// released storage layer — which is not the question. The patch is injected
+/// with `cargo --config` rather than written into mero-chat's manifest: that
+/// override is a workstation-only thing and must never be committed there, and
+/// a test that requires a human to have edited another repo first is a test
+/// that silently measures the wrong thing when they haven't.
+///
+/// Why not depend on mero-chat instead: it depends on core, so core cannot
+/// depend on it without a cycle. Driving its source from outside is the only
+/// direction that works.
+fn build_curb_wasm() -> Vec<u8> {
+    if let Ok(prebuilt) = std::env::var("CURB_WASM") {
+        return std::fs::read(&prebuilt)
+            .unwrap_or_else(|e| panic!("CURB_WASM={prebuilt} could not be read: {e}"));
+    }
+
+    let logic_dir = PathBuf::from(
+        std::env::var("CURB_LOGIC_DIR").unwrap_or_else(|_| DEFAULT_LOGIC_DIR.to_owned()),
+    );
+    assert!(
+        logic_dir.join("Cargo.toml").is_file(),
+        "no mero-chat logic crate at {}\n\
+         clone it beside this workspace, or set CURB_LOGIC_DIR",
+        logic_dir.display(),
+    );
+
+    // Absolute paths: `--config` values are resolved against the invoking
+    // directory, not the target manifest's.
+    let core_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize core root");
+
+    // Build into OUR target dir, not mero-chat's. The measurement borrows that
+    // checkout; it should not leave artefacts in it.
+    let target_dir = core_root.join("target/curb-wall");
+
+    let mut cmd = Command::new(env!("CARGO"));
+    cmd.current_dir(&logic_dir)
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .args([
+            "build",
+            "--target",
+            "wasm32-unknown-unknown",
+            "--profile",
+            "app-release",
+        ]);
+    for (crate_name, rel) in PATCHED_CRATES {
+        let path = core_root.join(rel);
+        assert!(path.is_dir(), "missing core crate at {}", path.display());
+        cmd.arg("--config").arg(format!(
+            r#"patch."{CORE_GIT_SOURCE}".{crate_name}.path="{}""#,
+            path.display()
+        ));
+    }
+
+    // Patching changes dependency resolution, so cargo rewrites the lockfile.
+    // Put it back: the lock belongs to mero-chat, and a stray modification
+    // there is exactly the kind of thing that gets committed by accident.
+    let lock_path = logic_dir.join("Cargo.lock");
+    let lock_before = std::fs::read(&lock_path).ok();
+
+    let out = cmd.output().expect("failed to spawn cargo build for curb");
+
+    if let Some(bytes) = lock_before {
+        if std::fs::read(&lock_path).ok().as_ref() != Some(&bytes) {
+            let _ignored = std::fs::write(&lock_path, &bytes);
+        }
+    }
+
+    assert!(
+        out.status.success(),
+        "building the real mero-chat contract against this core failed:\n\
+         --- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let wasm_path = target_dir.join("wasm32-unknown-unknown/app-release/curb.wasm");
+    std::fs::read(&wasm_path)
+        .unwrap_or_else(|e| panic!("built, but no wasm at {}: {e}", wasm_path.display()))
+}
 
 /// Stop here even if nothing has walled, so a genuinely-flat build cannot run
 /// forever. Well clear of the 1,187 the trie alone reached.
@@ -76,12 +178,10 @@ fn call(
 #[test]
 #[ignore = "needs curb.wasm from mero-chat-pwa; see module docs"]
 fn how_many_messages_before_send_message_walls() {
-    let path = std::env::var("CURB_WASM").unwrap_or_else(|_| DEFAULT_WASM.to_owned());
-    let wasm = std::fs::read(&path)
-        .unwrap_or_else(|e| panic!("read guest at {path}: {e}\nbuild it first: (cd mero-chat-pwa/logic && cargo build --target wasm32-unknown-unknown --profile app-release)"));
+    let wasm = build_curb_wasm();
 
     let limits = VMLimits::default();
-    println!("guest:   {path}");
+    println!("guest:   real mero-chat contract, built against this core tree");
     println!("max_gas: {:?}", limits.max_gas);
 
     let module = Engine::with_limits(limits)

--- a/crates/runtime/tests/chat_wall.rs
+++ b/crates/runtime/tests/chat_wall.rs
@@ -28,7 +28,7 @@
 //!
 //! Override the guest with `CURB_WASM=/path/to/curb.wasm`.
 
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use calimero_account::AccountId;
 use calimero_runtime::logic::{Outcome, VMLimits};
@@ -52,10 +52,6 @@ fn ceiling() -> usize {
         .and_then(|v| v.parse().ok())
         .unwrap_or(DEFAULT_CEILING)
 }
-
-/// Report a running sample this often, so a slow climb is visible while the
-/// test runs rather than only in the final line.
-const SAMPLE_EVERY: usize = 100;
 
 fn call(
     module: &calimero_runtime::Module,

--- a/crates/runtime/tests/chat_wall.rs
+++ b/crates/runtime/tests/chat_wall.rs
@@ -238,7 +238,6 @@ fn how_many_messages_before_send_message_walls() {
                 "mentions_usernames": [],
                 "parent_message": null,
                 "timestamp": i as u64,
-                "sender_username": "alice",
                 "files": null,
                 "images": null,
             }),

--- a/crates/runtime/tests/chat_wall.rs
+++ b/crates/runtime/tests/chat_wall.rs
@@ -1,0 +1,221 @@
+//! Where the real chat contract stops being able to append a message.
+//!
+//! # Why a real contract here, unlike `cost_is_flat`
+//!
+//! `cost_is_flat` deliberately uses a synthetic guest so that any growth it
+//! measures is unambiguously a defect in the storage layer. This test wants the
+//! opposite: the number a user actually hits. That number is a property of the
+//! app's own write pattern — `send_message` derives its id from
+//! `messages.len()`, pushes into an `AuthoredVector`, and writes several nested
+//! collections per call — so only the real contract can produce it.
+//!
+//! # What "the wall" means
+//!
+//! Gas is charged per executed wasm operator. An O(n) read pattern does not
+//! register as "reads are expensive"; it registers as gas spent decoding what
+//! those reads returned. So as the collection grows, one `send_message` call
+//! eventually exceeds `max_gas` and traps — and every later call traps too,
+//! because the cost only grows. The collection is permanently unwritable from
+//! that point (core#3602). The wall is the count of the last message that
+//! landed.
+//!
+//! # Running it
+//!
+//! Ignored by default: it needs a `curb.wasm` built from mero-chat-pwa, which
+//! lives outside this workspace, and it takes a while.
+//!
+//!   cargo test -p calimero-runtime --test chat_wall -- --ignored --nocapture
+//!
+//! Override the guest with `CURB_WASM=/path/to/curb.wasm`.
+
+use std::time::{Duration, Instant};
+
+use calimero_account::AccountId;
+use calimero_runtime::logic::{Outcome, VMLimits};
+use calimero_runtime::store::InMemoryStorage;
+use calimero_runtime::Engine;
+
+const DEFAULT_WASM: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../mero-chat-pwa/logic/target/wasm32-unknown-unknown/app-release/curb.wasm"
+);
+
+/// Stop here even if nothing has walled, so a genuinely-flat build cannot run
+/// forever. Well clear of the 1,187 the trie alone reached.
+const CEILING: usize = 20_000;
+
+/// Report a running sample this often, so a slow climb is visible while the
+/// test runs rather than only in the final line.
+const SAMPLE_EVERY: usize = 100;
+
+fn call(
+    module: &calimero_runtime::Module,
+    storage: &mut InMemoryStorage,
+    method: &str,
+    args: &serde_json::Value,
+) -> Outcome {
+    module
+        .run(
+            [0_u8; 32].into(),
+            AccountId::from([0_u8; 32]),
+            [0_u8; 32].into(),
+            method,
+            &serde_json::to_vec(args).expect("encode args"),
+            storage,
+            None,
+            None,
+        )
+        .expect("run must return an Outcome")
+}
+
+#[test]
+#[ignore = "needs curb.wasm from mero-chat-pwa; see module docs"]
+fn how_many_messages_before_send_message_walls() {
+    let path = std::env::var("CURB_WASM").unwrap_or_else(|_| DEFAULT_WASM.to_owned());
+    let wasm = std::fs::read(&path)
+        .unwrap_or_else(|e| panic!("read guest at {path}: {e}\nbuild it first: (cd mero-chat-pwa/logic && cargo build --target wasm32-unknown-unknown --profile app-release)"));
+
+    let limits = VMLimits::default();
+    println!("guest:   {path}");
+    println!("max_gas: {:?}", limits.max_gas);
+
+    let module = Engine::with_limits(limits)
+        .compile(&wasm)
+        .expect("compile metered module");
+
+    // One store for the whole run: the point is that cost depends on what the
+    // store already holds, so it must persist across calls.
+    let mut storage = InMemoryStorage::default();
+
+    let init = call(
+        &module,
+        &mut storage,
+        "init",
+        &serde_json::json!({
+            "name": "wall",
+            "context_type": "Channel",
+            "description": "",
+            "created_at": 0_u64,
+            "creator_username": "alice",
+        }),
+    );
+    assert!(init.returns.is_ok(), "init failed: {:?}", init.returns);
+
+    // Geometric read probes: get_messages is O(n) in the app, so probing it
+    // every append would dominate the run. These points are enough to see the
+    // curve and to catch the first failure within a factor of two.
+    let probes: Vec<usize> = vec![
+        100, 250, 500, 1_000, 2_000, 2_200, 2_400, 2_600, 2_800, 3_000, 4_000, 8_000, 16_000,
+        20_000,
+    ];
+    let mut next_probe = 0_usize;
+
+    let mut landed = 0_usize;
+    let mut write_wall: Option<usize> = None;
+    let mut last_read_ok: Option<usize> = None;
+    let mut read_wall: Option<usize> = None;
+
+    println!("\n  n        write_gas      w_reads   write_ms | read_gas        r_reads   read_ms");
+
+    for i in 0..CEILING {
+        let started = Instant::now();
+        let outcome = call(
+            &module,
+            &mut storage,
+            "send_message",
+            &serde_json::json!({
+                "message": format!("message {i}"),
+                "mentions": [],
+                "mentions_usernames": [],
+                "parent_message": null,
+                "timestamp": i as u64,
+                "sender_username": "alice",
+                "files": null,
+                "images": null,
+            }),
+        );
+        let write_ms = started.elapsed().as_secs_f64() * 1000.0;
+
+        if outcome.returns.is_err() {
+            println!("\nWRITE WALL at {landed}: {:?}", outcome.returns);
+            write_wall = Some(landed);
+            break;
+        }
+        landed += 1;
+
+        if next_probe < probes.len() && landed == probes[next_probe] {
+            next_probe += 1;
+
+            let started = Instant::now();
+            let read = call(
+                &module,
+                &mut storage,
+                "get_messages",
+                &serde_json::json!({
+                    "parent_message": null,
+                    "limit": 20,
+                    "offset": 0,
+                    "search_term": null,
+                }),
+            );
+            let read_ms = started.elapsed().as_secs_f64() * 1000.0;
+
+            match &read.returns {
+                Ok(value) => {
+                    // Confirms the store really accumulated: a harness whose
+                    // writes silently vanished would show a flat curve and land
+                    // every call, which looks exactly like success.
+                    let body = value.as_ref().expect("get_messages returned no value");
+                    let parsed: serde_json::Value =
+                        serde_json::from_slice(body).expect("get_messages returns JSON");
+                    let total = parsed
+                        .pointer("/output/total_count")
+                        .or_else(|| parsed.get("total_count"))
+                        .and_then(serde_json::Value::as_u64)
+                        .unwrap_or_else(|| panic!("no total_count in {parsed}"));
+                    assert_eq!(
+                        total as usize, landed,
+                        "store holds {total} but {landed} were appended — the cost \
+                         curve would be an artifact, not a result"
+                    );
+
+                    if read_wall.is_none() {
+                        last_read_ok = Some(landed);
+                    }
+                    println!(
+                        "  {landed:<6}  {:>12?}  {:>7}  {write_ms:>7.1} | {:>12?}  {:>7}  {read_ms:>7.1}",
+                        outcome.gas_used, outcome.storage_reads, read.gas_used, read.storage_reads,
+                    );
+                }
+                Err(e) => {
+                    println!(
+                        "  {landed:<6}  {:>12?}  {:>7}  {write_ms:>7.1} | READ WALL: {e:?}",
+                        outcome.gas_used, outcome.storage_reads,
+                    );
+                    if read_wall.is_none() {
+                        read_wall = Some(landed);
+                    }
+                }
+            }
+        }
+    }
+
+    println!("\n--- result ---");
+    println!("messages appended:  {landed}");
+    match write_wall {
+        Some(n) => println!("write wall (send_message):  {n}"),
+        None => println!("write wall (send_message):  none below {CEILING}"),
+    }
+    match (last_read_ok, read_wall) {
+        (Some(ok), Some(bad)) => {
+            println!("read wall  (get_messages):  last OK at {ok}, first exhausted at {bad}")
+        }
+        (_, Some(bad)) => println!("read wall  (get_messages):  exhausted by {bad}"),
+        (_, None) => println!("read wall  (get_messages):  none below {landed}"),
+    }
+
+    assert!(
+        landed > 0,
+        "the contract could not append even one message — the harness is wrong, not the storage layer"
+    );
+}

--- a/crates/runtime/tests/chat_wall.rs
+++ b/crates/runtime/tests/chat_wall.rs
@@ -42,7 +42,16 @@ const DEFAULT_WASM: &str = concat!(
 
 /// Stop here even if nothing has walled, so a genuinely-flat build cannot run
 /// forever. Well clear of the 1,187 the trie alone reached.
-const CEILING: usize = 20_000;
+const DEFAULT_CEILING: usize = 20_000;
+
+/// Raise it to chase a wall that has moved out of the default range:
+///   CHAT_WALL_CEILING=60000 cargo test ... -- --ignored --nocapture
+fn ceiling() -> usize {
+    std::env::var("CHAT_WALL_CEILING")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_CEILING)
+}
 
 /// Report a running sample this often, so a slow climb is visible while the
 /// test runs rather than only in the final line.
@@ -104,10 +113,14 @@ fn how_many_messages_before_send_message_walls() {
     // Geometric read probes: get_messages is O(n) in the app, so probing it
     // every append would dominate the run. These points are enough to see the
     // curve and to catch the first failure within a factor of two.
-    let probes: Vec<usize> = vec![
+    let ceiling = ceiling();
+    let probes: Vec<usize> = [
         100, 250, 500, 1_000, 2_000, 2_200, 2_400, 2_600, 2_800, 3_000, 4_000, 8_000, 16_000,
-        20_000,
-    ];
+        20_000, 24_000, 28_000, 30_000, 32_000, 36_000, 40_000, 50_000, 60_000,
+    ]
+    .into_iter()
+    .filter(|p| *p <= ceiling)
+    .collect();
     let mut next_probe = 0_usize;
 
     let mut landed = 0_usize;
@@ -117,7 +130,7 @@ fn how_many_messages_before_send_message_walls() {
 
     println!("\n  n        write_gas      w_reads   write_ms | read_gas        r_reads   read_ms");
 
-    for i in 0..CEILING {
+    for i in 0..ceiling {
         let started = Instant::now();
         let outcome = call(
             &module,
@@ -204,7 +217,7 @@ fn how_many_messages_before_send_message_walls() {
     println!("messages appended:  {landed}");
     match write_wall {
         Some(n) => println!("write wall (send_message):  {n}"),
-        None => println!("write wall (send_message):  none below {CEILING}"),
+        None => println!("write wall (send_message):  none below {ceiling}"),
     }
     match (last_read_ok, read_wall) {
         (Some(ok), Some(bad)) => {

--- a/crates/runtime/tests/cost_is_flat.rs
+++ b/crates/runtime/tests/cost_is_flat.rs
@@ -1,0 +1,168 @@
+//! Cost regressions are invisible to correctness tests. This one sees them.
+//!
+//! # Why this exists
+//!
+//! A storage collection shipped with an append whose cost grew with the
+//! collection's size, until a single write exhausted the gas limit and the
+//! collection became permanently unwritable (core#3602). The full storage suite
+//! — 715 tests — was green throughout, because every one of them asserts what
+//! the code *computes*, and none asserts what it *costs*.
+//!
+//! Three separate O(n) regressions were then introduced while fixing the first,
+//! each hidden behind a call that reads as free at the call site: `len()`, a
+//! cache populate, and a log line asking a trie to enumerate rather than count.
+//!
+//! # What it asserts, and why in these units
+//!
+//! Gas is charged per executed wasm operator and NOTHING else — a host storage
+//! read costs the ~4 operators of the caller, independent of value size, and
+//! there is no read counter or read limit in the VM. So an O(n) read pattern
+//! never registers as "reads are expensive"; it registers as gas spent
+//! borsh-decoding whatever those reads returned.
+//!
+//! That makes `storage_reads` the leading indicator and `gas_used` the
+//! confirming one, so this asserts on both: reads must not grow with n, and
+//! neither must gas.
+//!
+//! # The shape of the guest
+//!
+//! Deliberately not a real contract. A contract drags in the whole collections
+//! stack and would make a failure ambiguous between "the app regressed" and
+//! "storage regressed". This guest performs a fixed number of host reads per
+//! call regardless of how much data exists, so ANY growth in the measured
+//! counters is a defect in the layer under test, not in the fixture.
+
+use calimero_account::AccountId;
+use calimero_runtime::logic::{Outcome, VMLimits};
+use calimero_runtime::store::{InMemoryStorage, Storage};
+use calimero_runtime::Engine;
+
+/// A guest that reads one key `n` times, where `n` arrives as the register
+/// contents of key `"n"`. Fixed work per call: the loop count comes from the
+/// input, so the fixture can hold work constant while the STORE grows.
+const FIXED_WORK_WAT: &str = r#"
+(module
+  (import "env" "storage_read" (func $storage_read (param i64 i64) (result i32)))
+  (import "env" "read_register" (func $read_register (param i64 i64) (result i32)))
+  (import "env" "register_len"  (func $register_len (param i64) (result i64)))
+  (memory (export "memory") 2)
+
+  ;; key "k" at offset 64, described by a Buffer{ptr,len} at offset 0
+  (data (i32.const 0)  "\40\00\00\00\00\00\00\00\01\00\00\00\00\00\00\00")
+  (data (i32.const 64) "k")
+
+  (func (export "fixed_reads")
+    (local $i i32)
+    (local.set $i (i32.const 0))
+    (block $done
+      (loop $again
+        (br_if $done (i32.ge_u (local.get $i) (i32.const 64)))
+        (drop (call $storage_read (i64.const 0) (i64.const 0)))
+        (drop (call $read_register (i64.const 0) (i64.const 1024)))
+        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+        (br $again))))
+)
+"#;
+
+fn run_with_store_size(entries: usize, value_len: usize) -> Outcome {
+    let wasm = wat::parse_str(FIXED_WORK_WAT).expect("parse WAT");
+    let module = Engine::with_limits(VMLimits::default())
+        .compile(&wasm)
+        .expect("compile metered module");
+
+    let mut storage = InMemoryStorage::default();
+    // The key the guest reads.
+    storage.set(b"k".to_vec(), vec![7_u8; value_len]);
+    // Bulk the store out around it. The guest never touches these — they exist
+    // so that a lookup which secretly scans, rather than seeking, shows up.
+    for i in 0..entries {
+        storage.set(format!("pad{i:08}").into_bytes(), vec![1_u8; value_len]);
+    }
+
+    module
+        .run(
+            [0_u8; 32].into(),
+            AccountId::from([0_u8; 32]),
+            [0_u8; 32].into(),
+            "fixed_reads",
+            &[],
+            &mut storage,
+            None,
+            None,
+        )
+        .expect("run must return an Outcome")
+}
+
+#[test]
+fn fixed_guest_work_costs_the_same_however_much_data_exists() {
+    let small = run_with_store_size(10, 64);
+    let large = run_with_store_size(10_000, 64);
+
+    println!(
+        "  10 entries: gas={:?} reads={} read_bytes={}",
+        small.gas_used, small.storage_reads, small.storage_read_bytes
+    );
+    println!(
+        "  10k entries: gas={:?} reads={} read_bytes={}",
+        large.gas_used, large.storage_reads, large.storage_read_bytes
+    );
+
+    assert!(
+        small.returns.is_ok(),
+        "small run failed: {:?}",
+        small.returns
+    );
+    assert!(
+        large.returns.is_ok(),
+        "large run failed: {:?}",
+        large.returns
+    );
+
+    assert_eq!(
+        small.storage_reads, large.storage_reads,
+        "a guest doing fixed work must not read more because the store grew"
+    );
+    assert_eq!(
+        small.gas_used, large.gas_used,
+        "…and must not burn more gas either"
+    );
+    assert_eq!(
+        small.storage_reads, 64,
+        "the fixture should do exactly 64 reads"
+    );
+}
+
+#[test]
+fn read_bytes_scale_with_value_size_but_gas_does_not() {
+    // The counterintuitive property worth pinning: gas is per wasm operator, so
+    // a read of a 16 KiB value costs the same gas as a read of 64 B. Only
+    // `storage_read_bytes` reflects the difference.
+    //
+    // This is why a redesign toward fewer, larger rows would look free in gas
+    // while costing real wall-clock and real guest decode work. Anyone reading
+    // gas alone would draw the wrong conclusion.
+    let small = run_with_store_size(10, 64);
+    let big = run_with_store_size(10, 16_384);
+
+    println!(
+        "  64B values:  gas={:?} read_bytes={}",
+        small.gas_used, small.storage_read_bytes
+    );
+    println!(
+        "  16KiB values: gas={:?} read_bytes={}",
+        big.gas_used, big.storage_read_bytes
+    );
+
+    assert!(
+        big.storage_read_bytes > small.storage_read_bytes * 100,
+        "read_bytes must track value size: {} vs {}",
+        small.storage_read_bytes,
+        big.storage_read_bytes
+    );
+    assert_eq!(
+        small.gas_used, big.gas_used,
+        "gas must NOT track value size — it prices wasm operators, not bytes. \
+         If this ever fails, the metering model changed and every cost \
+         assumption in the storage design needs revisiting."
+    );
+}

--- a/crates/storage/src/action.rs
+++ b/crates/storage/src/action.rs
@@ -390,6 +390,7 @@ mod tests {
             crdt_type: None,
             field_name: None,
             schema_version: None,
+            order: 0,
         }
     }
 
@@ -408,6 +409,7 @@ mod tests {
             crdt_type: None,
             field_name: None,
             schema_version: None,
+            order: 0,
         }
     }
 
@@ -426,6 +428,7 @@ mod tests {
             crdt_type: None,
             field_name: None,
             schema_version: None,
+            order: 0,
         }
     }
 

--- a/crates/storage/src/child_trie.rs
+++ b/crates/storage/src/child_trie.rs
@@ -225,6 +225,17 @@ impl<S: StorageAdaptor> ChildTrie<S> {
             let path: Vec<u8> = (0..level).map(|i| nibble(child, i)).collect();
             let mut node = self.read_node(&path);
             node.set(nibble(child, level), below);
+            // `saturating_add_signed` clamps rather than wrapping, which is the
+            // right production behaviour — but a clamp here is a book-keeping
+            // bug that nothing else can detect: `count` is deliberately not
+            // folded into the hash, so drift does not fork the root, it just
+            // makes `len()` quietly lie. A contract that derives an id from
+            // `len()` then mints duplicate ids with no mismatch anywhere.
+            debug_assert!(
+                delta >= 0 || node.count >= delta.unsigned_abs(),
+                "child-trie count underflow at level {level}: {} + {delta}",
+                node.count
+            );
             node.count = node.count.saturating_add_signed(delta);
             self.write_node(&path, &node);
             below = node.hash();
@@ -365,7 +376,7 @@ impl<S: StorageAdaptor> ChildTrie<S> {
             .and_then(|bytes| TrieBucket::try_from_slice(&bytes).ok())
             .unwrap_or_default();
 
-        let delta = match bucket.entries.binary_search_by_key(&id, ChildInfo::id) {
+        let delta: i64 = match bucket.entries.binary_search_by_key(&id, ChildInfo::id) {
             Ok(i) => {
                 bucket.entries[i] = child;
                 0
@@ -388,6 +399,11 @@ impl<S: StorageAdaptor> ChildTrie<S> {
                 .and_then(|bytes| TrieNode::try_from_slice(&bytes).ok())
                 .unwrap_or_default();
             node.set(nibble(id, level), below);
+            debug_assert!(
+                delta >= 0 || node.count >= delta.unsigned_abs(),
+                "child-trie count underflow at level {level}: {} + {delta}",
+                node.count
+            );
             node.count = node.count.saturating_add_signed(delta);
             if let Ok(bytes) = to_vec(&node) {
                 write(key, &bytes);
@@ -616,6 +632,113 @@ mod tests {
     /// re-created lands on the SAME trie — and would inherit the old children:
     /// ids whose data is gone, folded into the parent's hash as a ghost root,
     /// with nothing anywhere reporting an error.
+    /// `count` went from derived to maintained, and nothing can detect drift.
+    ///
+    /// It is deliberately not folded into the hash — hashing a book-keeping
+    /// value would give a slip the power to fork the root — so a wrong count
+    /// does not diverge anything. `len()` simply lies. Follow that through:
+    /// `Collection::len` reads this count, and the contract that motivated the
+    /// whole change derives a message id from `len()` on every write. A count
+    /// that drifts LOW mints duplicate ids: silent data loss, no hash mismatch,
+    /// no warning, nothing to alert on.
+    ///
+    /// So pin the invariant directly, over a mixed sequence rather than a happy
+    /// path — inserts, replacements (delta 0), removals, removals of absent
+    /// ids (also delta 0), and re-inserts — checking after every step, through
+    /// both the adaptor walk and the caller-supplied-rows walk that snapshot
+    /// sync uses.
+    #[test]
+    fn the_count_never_drifts_from_the_number_of_children() {
+        use std::cell::RefCell;
+        use std::collections::BTreeMap;
+
+        let id = parent(50);
+        let trie = ChildTrie::<crate::store::MainStorage>::new(id);
+
+        // A deterministic mixed workload: seed i decides the operation.
+        let mut live: std::collections::BTreeSet<u8> = std::collections::BTreeSet::new();
+        for step in 0..120_u8 {
+            let seed = step.wrapping_mul(37).wrapping_add(11);
+            match step % 5 {
+                // a genuinely new child (three in five, so the workload grows)
+                0 | 1 | 2 => {
+                    let _root = trie.insert(child(seed, step));
+                    let _inserted = live.insert(seed);
+                }
+                // RE-insert one already present. This is the case that made an
+                // earlier version of this test useless: the seed is a bijection
+                // over `step`, so every insert was new and a replacement
+                // counting as +1 passed unnoticed. Caught by mutation.
+                3 => {
+                    let victim = live.iter().next().copied().unwrap_or(seed);
+                    let _root = trie.insert(child(victim, step));
+                    let _inserted = live.insert(victim);
+                }
+                // remove a live one
+                4 => {
+                    let victim = live.iter().next().copied().unwrap_or(seed);
+                    let _root = trie.remove(Id::new(Sha256::digest([victim]).into()));
+                    let _removed = live.remove(&victim);
+                }
+                _ => unreachable!("step % 5 is exhaustive above"),
+            }
+
+            // Removing an id that was never inserted must also be delta 0.
+            let _root = trie.remove(Id::new(Sha256::digest([seed ^ 0x5A]).into()));
+
+            assert_eq!(
+                trie.len() as usize,
+                trie.children().len(),
+                "count diverged from enumeration at step {step}"
+            );
+        }
+        assert!(trie.len() > 0, "the workload must leave children behind");
+
+        // Same invariant through `insert_with`, which is where a
+        // snapshot-built trie gets its counts and which nothing else covered.
+        let rows: RefCell<BTreeMap<Key, Vec<u8>>> = RefCell::new(BTreeMap::new());
+        let other = parent(51);
+        for i in 0..40_u8 {
+            ChildTrie::<crate::store::MainStorage>::insert_with(
+                other,
+                child(i, i),
+                |k| rows.borrow().get(&k).cloned(),
+                |k, v| {
+                    let _prev = rows.borrow_mut().insert(k, v.to_vec());
+                },
+            );
+            // Re-inserting the same child must not double-count.
+            ChildTrie::<crate::store::MainStorage>::insert_with(
+                other,
+                child(i, i.wrapping_add(1)),
+                |k| rows.borrow().get(&k).cloned(),
+                |k, v| {
+                    let _prev = rows.borrow_mut().insert(k, v.to_vec());
+                },
+            );
+        }
+
+        let rows = rows.into_inner();
+        let root = TrieNode::try_from_slice(
+            rows.get(&Key::ChildTrie(addr(other, &[])))
+                .expect("root node written"),
+        )
+        .expect("root node decodes");
+        let enumerated =
+            ChildTrie::<crate::store::MainStorage>::children_with(other, |k| rows.get(&k).cloned());
+
+        assert_eq!(
+            root.count as usize,
+            enumerated.len(),
+            "insert_with's count must match what it can enumerate"
+        );
+        assert_eq!(
+            enumerated.len(),
+            40,
+            "replacements must not inflate the count"
+        );
+    }
+
     #[test]
     fn dropping_a_trie_leaves_nothing_for_a_later_incarnation_to_inherit() {
         let id = parent(40);

--- a/crates/storage/src/child_trie.rs
+++ b/crates/storage/src/child_trie.rs
@@ -260,6 +260,66 @@ impl<S: StorageAdaptor> ChildTrie<S> {
         }
     }
 
+    /// Debug-only reconciliation of one node's `count` against the level below.
+    ///
+    /// `count` is maintained, not derived, and deliberately unhashed — so drift
+    /// forks nothing and raises nothing; `len()` just quietly lies. That matters
+    /// because a contract deriving an id from `len()` mints duplicate ids from a
+    /// count that reads low, with no mismatch anywhere to catch it.
+    ///
+    /// Reconciling against a full enumeration would be the direct check, but it
+    /// makes every write O(n) in debug builds — a landmine of its own on a path
+    /// whose entire purpose is to not be O(n). This checks the LOCAL invariant
+    /// instead: a node's count is the sum of what sits directly beneath it, at
+    /// most 16 rows. Every node holding it is equivalent to the global one, and
+    /// it catches drift at the level that introduced it rather than somewhere
+    /// far above.
+    ///
+    /// Only the `StorageAdaptor` path calls this. [`insert_with`](Self::insert_with)
+    /// cannot: it is a pure function of the rows it READS, and its callers
+    /// legitimately buffer the writes — the snapshot rebuild collects them and
+    /// merges once per child — so mid-walk the level below still holds its
+    /// pre-write state and every check would report drift that does not exist.
+    /// That path is covered instead by the oracle test asserting it writes
+    /// byte-identical rows to `insert`, which pins its counts by equivalence.
+    #[cfg(debug_assertions)]
+    fn debug_reconcile<R>(parent: Id, path: &[u8], node: &TrieNode, read: &R)
+    where
+        R: Fn(Key) -> Option<Vec<u8>>,
+    {
+        let below_is_bucket = path.len() + 1 == DEPTH;
+        let mut summed: u64 = 0;
+        for (nib, _) in &node.slots {
+            let mut child_path = path.to_vec();
+            child_path.push(*nib);
+            let key = Key::ChildTrie(addr(parent, &child_path));
+            let Some(bytes) = read(key) else {
+                // An absent row under an occupied slot is its own bug, but it is
+                // not this assertion's to diagnose: `read_node` already warns,
+                // and failing here would blame the count for someone else's
+                // problem.
+                return;
+            };
+            if below_is_bucket {
+                let Ok(bucket) = TrieBucket::try_from_slice(&bytes) else {
+                    return;
+                };
+                summed = summed.saturating_add(bucket.entries.len() as u64);
+            } else {
+                let Ok(child) = TrieNode::try_from_slice(&bytes) else {
+                    return;
+                };
+                summed = summed.saturating_add(child.count);
+            }
+        }
+        debug_assert_eq!(
+            node.count, summed,
+            "child-trie count drift at path {path:?}: node says {}, the level \
+             below holds {summed}",
+            node.count,
+        );
+    }
+
     /// Recompute the spine above `path_of_child` after its bucket changed.
     ///
     /// Walks from the bucket back to the root, so the cost is `DEPTH` rows
@@ -293,6 +353,8 @@ impl<S: StorageAdaptor> ChildTrie<S> {
                 node.next_order = node.next_order.max(min_next_order);
             }
             self.write_node(&path, &node);
+            #[cfg(debug_assertions)]
+            Self::debug_reconcile(self.parent, &path, &node, &|key| S::storage_read(key));
             below = node.hash();
         }
         below

--- a/crates/storage/src/child_trie.rs
+++ b/crates/storage/src/child_trie.rs
@@ -76,6 +76,14 @@ const DOMAIN_ADDR: &[u8] = b"childtrie:v1:addr";
 pub struct TrieNode {
     /// `(nibble, subtree hash)`, sorted by nibble and at most 16 long.
     pub slots: Vec<(u8, [u8; 32])>,
+    /// Children beneath this node.
+    ///
+    /// Maintained along the spine an insert already walks, so `len()` is a
+    /// single row read instead of a full enumeration. Without it, counting is
+    /// O(n) — and a caller that counts on every write (deriving an id from the
+    /// current length, say) reintroduces exactly the cost this type removes,
+    /// with the trie doing nothing wrong.
+    pub count: u64,
 }
 
 impl TrieNode {
@@ -96,6 +104,9 @@ impl TrieNode {
         }
     }
 
+    /// Deliberately does NOT fold `count`: it is derived from the same slots,
+    /// so hashing it would add nothing while giving a book-keeping slip the
+    /// power to fork the root.
     fn hash(&self) -> [u8; 32] {
         if self.slots.is_empty() {
             return EMPTY;
@@ -181,6 +192,7 @@ impl<S: StorageAdaptor> ChildTrie<S> {
     fn write_node(&self, path: &[u8], node: &TrieNode) {
         let key = Key::ChildTrie(addr(self.parent, path));
         if node.slots.is_empty() {
+            debug_assert_eq!(node.count, 0, "a slotless node cannot hold children");
             let _ignored = S::storage_remove(key);
         } else if let Ok(bytes) = to_vec(node) {
             let _ignored = S::storage_write(key, &bytes);
@@ -207,12 +219,13 @@ impl<S: StorageAdaptor> ChildTrie<S> {
     /// Walks from the bucket back to the root, so the cost is `DEPTH` rows
     /// regardless of how many children the parent holds. This is the whole
     /// point of the structure.
-    fn refresh_spine(&self, child: Id, bucket_hash: [u8; 32]) -> [u8; 32] {
+    fn refresh_spine(&self, child: Id, bucket_hash: [u8; 32], delta: i64) -> [u8; 32] {
         let mut below = bucket_hash;
         for level in (0..DEPTH).rev() {
             let path: Vec<u8> = (0..level).map(|i| nibble(child, i)).collect();
             let mut node = self.read_node(&path);
             node.set(nibble(child, level), below);
+            node.count = node.count.saturating_add_signed(delta);
             self.write_node(&path, &node);
             below = node.hash();
         }
@@ -225,12 +238,18 @@ impl<S: StorageAdaptor> ChildTrie<S> {
         let path: Vec<u8> = (0..DEPTH).map(|i| nibble(id, i)).collect();
         let mut bucket = self.read_bucket(&path);
 
-        match bucket.entries.binary_search_by_key(&id, ChildInfo::id) {
-            Ok(i) => bucket.entries[i] = child,
-            Err(i) => bucket.entries.insert(i, child),
-        }
+        let delta = match bucket.entries.binary_search_by_key(&id, ChildInfo::id) {
+            Ok(i) => {
+                bucket.entries[i] = child;
+                0
+            }
+            Err(i) => {
+                bucket.entries.insert(i, child);
+                1
+            }
+        };
         self.write_bucket(&path, &bucket);
-        self.refresh_spine(id, bucket.hash())
+        self.refresh_spine(id, bucket.hash(), delta)
     }
 
     /// Remove `child_id`. Returns the new root hash.
@@ -243,7 +262,7 @@ impl<S: StorageAdaptor> ChildTrie<S> {
         {
             let _removed = bucket.entries.remove(i);
             self.write_bucket(&path, &bucket);
-            return self.refresh_spine(child_id, bucket.hash());
+            return self.refresh_spine(child_id, bucket.hash(), -1);
         }
         self.root()
     }
@@ -258,6 +277,21 @@ impl<S: StorageAdaptor> ChildTrie<S> {
             .binary_search_by_key(&child_id, ChildInfo::id)
             .ok()
             .map(|i| bucket.entries[i].clone())
+    }
+
+    /// Number of children, without enumerating them.
+    ///
+    /// One row read. The linear alternative — walking every bucket — is what a
+    /// caller that counts on each write would pay per write.
+    #[must_use]
+    pub fn len(&self) -> u64 {
+        self.read_node(&[]).count
+    }
+
+    /// Whether the parent has no children.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     /// The trie's root hash — a function of the child set, not of insert order.
@@ -576,5 +610,64 @@ mod cost {
             at_50k < 4_000,
             "a link must stay in the low kilobytes, got {at_50k}"
         );
+    }
+}
+
+#[cfg(test)]
+mod count_tests {
+    use super::*;
+    use crate::entities::Metadata;
+    use crate::store::MainStorage;
+
+    fn child(seed: u16) -> ChildInfo {
+        let id = Id::new(Sha256::digest(seed.to_be_bytes()).into());
+        ChildInfo::new(id, [1; 32], Metadata::default())
+    }
+
+    #[test]
+    fn the_count_tracks_inserts_and_removals() {
+        let trie = ChildTrie::<MainStorage>::new(Id::new(Sha256::digest(b"count").into()));
+        assert_eq!(trie.len(), 0);
+        assert!(trie.is_empty());
+
+        for i in 0..300_u16 {
+            let _root = trie.insert(child(i));
+        }
+        assert_eq!(trie.len(), 300);
+        assert_eq!(
+            trie.len() as usize,
+            trie.children().len(),
+            "count must match enumeration"
+        );
+
+        // Re-inserting the same child is an update, not a new child.
+        let _root = trie.insert(child(7));
+        assert_eq!(trie.len(), 300);
+
+        for i in 0..50_u16 {
+            let _root = trie.remove(child(i).id());
+        }
+        assert_eq!(trie.len(), 250);
+        assert_eq!(trie.len() as usize, trie.children().len());
+
+        // Removing something absent must not drift the count.
+        let _root = trie.remove(child(9_999).id());
+        assert_eq!(trie.len(), 250);
+    }
+
+    #[test]
+    fn the_count_does_not_change_the_root() {
+        // `count` is derived book-keeping. Folding it into the hash would let a
+        // counting slip fork the root, so the two must be independent.
+        let a = ChildTrie::<MainStorage>::new(Id::new(Sha256::digest(b"root-a").into()));
+        let b = ChildTrie::<MainStorage>::new(Id::new(Sha256::digest(b"root-b").into()));
+        for i in 0..20_u16 {
+            let _root = a.insert(child(i));
+        }
+        for i in (0..20_u16).rev() {
+            let _root = b.insert(child(i));
+        }
+        assert_eq!(a.root(), b.root());
+        assert_eq!(a.len(), b.len());
     }
 }

--- a/crates/storage/src/child_trie.rs
+++ b/crates/storage/src/child_trie.rs
@@ -396,6 +396,45 @@ impl<S: StorageAdaptor> ChildTrie<S> {
         }
     }
 
+    /// Remove every row of this trie.
+    ///
+    /// A deleted entity's trie must go with it. Its rows live in their own
+    /// keyspace, so nothing else reaches them: dropping the entity's `Entry`
+    /// and tombstoning its `Index` leaves the trie behind, and because
+    /// collection ids are deterministic (`compute_collection_id(parent,
+    /// field_name)`), deleting and later re-creating the same field would find
+    /// a trie still holding the OLD children — ids whose `Entry` rows are gone,
+    /// folded into the parent's hash as a ghost root.
+    ///
+    /// Walks the node structure to find the occupied rows rather than
+    /// removing children one at a time: this drops the whole trie, so there is
+    /// no spine left to refresh and paying `DEPTH+1` writes per child to
+    /// maintain one would be pure waste.
+    pub fn drop_all(&self) {
+        let mut paths: Vec<Vec<u8>> = Vec::new();
+        Self::collect_paths(self, &mut Vec::new(), &mut paths);
+        for path in paths {
+            let _ignored = S::storage_remove(Key::ChildTrie(addr(self.parent, &path)));
+        }
+    }
+
+    fn collect_paths(&self, path: &mut Vec<u8>, out: &mut Vec<Vec<u8>>) {
+        if path.len() == DEPTH {
+            out.push(path.clone());
+            return;
+        }
+        let node = self.read_node(path);
+        if node.slots.is_empty() && !path.is_empty() {
+            return;
+        }
+        out.push(path.clone());
+        for (nib, _) in node.slots {
+            path.push(nib);
+            self.collect_paths(path, out);
+            let _popped = path.pop();
+        }
+    }
+
     /// Enumerate a parent's children using a caller-supplied reader.
     ///
     /// For callers that reach the store directly rather than through a
@@ -439,13 +478,6 @@ impl<S: StorageAdaptor> ChildTrie<S> {
         walk(parent, &mut Vec::new(), &read, &mut out);
         out.sort();
         out
-    }
-
-    /// Drop the whole trie.
-    pub fn clear(&self) {
-        for child in self.children() {
-            let _root = self.remove(child.id());
-        }
     }
 }
 
@@ -503,6 +535,113 @@ mod tests {
             "same child set inserted in opposite orders must give the same root"
         );
         assert_ne!(forward.root(), EMPTY);
+    }
+
+    /// `insert_with` re-derives by hand what `insert` + `refresh_spine` do,
+    /// because snapshot sync reaches the store directly rather than through a
+    /// `StorageAdaptor`. Two implementations of one spine walk is a latent
+    /// fork, and the consequence is precisely the bug the snapshot half of
+    /// this work exists to fix: a receiver that reconstructs a DIFFERENT root
+    /// from the sender, permanently, because re-applying byte-identical
+    /// entities never re-links anything.
+    ///
+    /// So pin them against each other directly. Same parent, same child set,
+    /// one through each path — then require the rows to be byte-identical and
+    /// the roots, counts and enumerations to agree. Anything that changes one
+    /// walk without the other fails here instead of in a divergent context.
+    #[test]
+    fn insert_with_writes_exactly_what_insert_writes() {
+        use std::cell::RefCell;
+        use std::collections::BTreeMap;
+
+        let parent = parent(30);
+        let children: Vec<ChildInfo> = (0..40_u8).map(|i| child(i, i)).collect();
+
+        // Path A: the StorageAdaptor walk.
+        let trie = ChildTrie::<crate::store::MainStorage>::new(parent);
+        for c in &children {
+            let _root = trie.insert(c.clone());
+        }
+
+        // Path B: the caller-supplied-rows walk, over its own store. Same
+        // parent id, so both paths address rows identically — a row written by
+        // one is directly comparable to the other's.
+        let rows: RefCell<BTreeMap<Key, Vec<u8>>> = RefCell::new(BTreeMap::new());
+        for c in &children {
+            ChildTrie::<crate::store::MainStorage>::insert_with(
+                parent,
+                c.clone(),
+                |k| rows.borrow().get(&k).cloned(),
+                |k, v| {
+                    let _prev = rows.borrow_mut().insert(k, v.to_vec());
+                },
+            );
+        }
+
+        let rows = rows.into_inner();
+        assert!(!rows.is_empty(), "insert_with wrote nothing");
+
+        for (key, value) in &rows {
+            let via_adaptor = crate::store::MainStorage::storage_read(*key);
+            assert_eq!(
+                via_adaptor.as_ref(),
+                Some(value),
+                "row {key:?} differs between insert and insert_with"
+            );
+        }
+
+        let root_b = TrieNode::try_from_slice(
+            rows.get(&Key::ChildTrie(addr(parent, &[])))
+                .expect("insert_with wrote no root node"),
+        )
+        .expect("root node decodes");
+
+        assert_eq!(trie.root(), root_b.hash(), "roots must agree");
+        assert_eq!(trie.len(), root_b.count, "counts must agree");
+        assert_eq!(
+            trie.children(),
+            ChildTrie::<crate::store::MainStorage>::children_with(parent, |k| rows
+                .get(&k)
+                .cloned()),
+            "enumerations must agree"
+        );
+    }
+
+    /// A deleted entity's trie must not outlive it.
+    ///
+    /// Trie rows are their own keyspace, so dropping the entity's `Entry` and
+    /// tombstoning its `Index` does not touch them, and tombstone GC never
+    /// sees them (it requires a row to decode as a tombstoned `EntityIndex`).
+    /// Collection ids are deterministic, so a field that is deleted and later
+    /// re-created lands on the SAME trie — and would inherit the old children:
+    /// ids whose data is gone, folded into the parent's hash as a ghost root,
+    /// with nothing anywhere reporting an error.
+    #[test]
+    fn dropping_a_trie_leaves_nothing_for_a_later_incarnation_to_inherit() {
+        let id = parent(40);
+
+        let trie = ChildTrie::<crate::store::MainStorage>::new(id);
+        for i in 0..25_u8 {
+            let _root = trie.insert(child(i, i));
+        }
+        assert_eq!(trie.len(), 25);
+        assert_ne!(trie.root(), EMPTY);
+
+        trie.drop_all();
+
+        // A fresh handle on the same id — which is what re-creating a
+        // deterministically-named collection produces.
+        let reborn = ChildTrie::<crate::store::MainStorage>::new(id);
+        assert_eq!(
+            reborn.root(),
+            EMPTY,
+            "a re-created collection must start empty"
+        );
+        assert_eq!(reborn.len(), 0, "and must not inherit the old count");
+        assert!(
+            reborn.children().is_empty(),
+            "and must not enumerate the previous incarnation's children"
+        );
     }
 
     #[test]

--- a/crates/storage/src/child_trie.rs
+++ b/crates/storage/src/child_trie.rs
@@ -661,7 +661,7 @@ mod tests {
             let seed = step.wrapping_mul(37).wrapping_add(11);
             match step % 5 {
                 // a genuinely new child (three in five, so the workload grows)
-                0 | 1 | 2 => {
+                0..=2 => {
                     let _root = trie.insert(child(seed, step));
                     let _inserted = live.insert(seed);
                 }
@@ -692,7 +692,7 @@ mod tests {
                 "count diverged from enumeration at step {step}"
             );
         }
-        assert!(trie.len() > 0, "the workload must leave children behind");
+        assert!(!trie.is_empty(), "the workload must leave children behind");
 
         // Same invariant through `insert_with`, which is where a
         // snapshot-built trie gets its counts and which nothing else covered.
@@ -889,7 +889,7 @@ mod cost {
     use std::collections::BTreeMap;
 
     thread_local! {
-        static STORE: RefCell<BTreeMap<[u8; 32], Vec<u8>>> = RefCell::new(BTreeMap::new());
+        static STORE: RefCell<BTreeMap<[u8; 32], Vec<u8>>> = const { RefCell::new(BTreeMap::new()) };
         static BYTES_WRITTEN: RefCell<usize> = const { RefCell::new(0) };
         static ROWS_WRITTEN: RefCell<usize> = const { RefCell::new(0) };
     }

--- a/crates/storage/src/child_trie.rs
+++ b/crates/storage/src/child_trie.rs
@@ -334,6 +334,68 @@ impl<S: StorageAdaptor> ChildTrie<S> {
         }
     }
 
+    /// Link `child` under `parent` using caller-supplied row access.
+    ///
+    /// The writer-side counterpart to [`children_with`](Self::children_with),
+    /// for callers that reach the store directly rather than through a
+    /// [`StorageAdaptor`] — specifically snapshot sync, which installs entities
+    /// by writing their `Entry` and `Index` rows straight to the store.
+    ///
+    /// It needs to exist because children stopped living inside the parent's
+    /// index row. While they were inline, anything that shipped an index row
+    /// shipped the parent→child links with it, and snapshot sync got them for
+    /// free. Now they are their own keyspace, and a receiver that installs
+    /// entities without also building the trie holds every entity but cannot
+    /// enumerate them and computes a different root — permanently, because
+    /// re-applying byte-identical entities never re-links anything.
+    ///
+    /// Pass the child's SHIPPED `full_hash`: the trie is a pure function of the
+    /// `{(id, full_hash)}` set, so reconstructing it from the sender's values
+    /// reproduces the sender's root exactly, with no re-hashing and no ordering
+    /// requirement between parent and child.
+    pub fn insert_with<R, W>(parent: Id, child: ChildInfo, read: R, mut write: W)
+    where
+        R: Fn(Key) -> Option<Vec<u8>>,
+        W: FnMut(Key, &[u8]),
+    {
+        let id = child.id();
+        let path: Vec<u8> = (0..DEPTH).map(|i| nibble(id, i)).collect();
+
+        let mut bucket = read(Key::ChildTrie(addr(parent, &path)))
+            .and_then(|bytes| TrieBucket::try_from_slice(&bytes).ok())
+            .unwrap_or_default();
+
+        let delta = match bucket.entries.binary_search_by_key(&id, ChildInfo::id) {
+            Ok(i) => {
+                bucket.entries[i] = child;
+                0
+            }
+            Err(i) => {
+                bucket.entries.insert(i, child);
+                1
+            }
+        };
+        if let Ok(bytes) = to_vec(&bucket) {
+            write(Key::ChildTrie(addr(parent, &path)), &bytes);
+        }
+
+        // Same spine walk as `insert`, through the caller's rows.
+        let mut below = bucket.hash();
+        for level in (0..DEPTH).rev() {
+            let node_path: Vec<u8> = (0..level).map(|i| nibble(id, i)).collect();
+            let key = Key::ChildTrie(addr(parent, &node_path));
+            let mut node = read(key)
+                .and_then(|bytes| TrieNode::try_from_slice(&bytes).ok())
+                .unwrap_or_default();
+            node.set(nibble(id, level), below);
+            node.count = node.count.saturating_add_signed(delta);
+            if let Ok(bytes) = to_vec(&node) {
+                write(key, &bytes);
+            }
+            below = node.hash();
+        }
+    }
+
     /// Enumerate a parent's children using a caller-supplied reader.
     ///
     /// For callers that reach the store directly rather than through a

--- a/crates/storage/src/child_trie.rs
+++ b/crates/storage/src/child_trie.rs
@@ -90,6 +90,21 @@ pub struct TrieNode {
     /// current length, say) reintroduces exactly the cost this type removes,
     /// with the trie doing nothing wrong.
     pub count: u64,
+    /// One past the highest position ever handed out under this parent — a
+    /// high-water mark, meaningful only on the root node (path `[]`).
+    ///
+    /// `count` cannot serve as the next position, because it FALLS when a child
+    /// is removed and the next append then reuses a position that is still in
+    /// use. Ordering survives that only while `created_at` breaks the tie, and
+    /// `created_at` is identical for everything one call writes (0 under merge
+    /// mode) — exactly the case `order` exists to decide. So the mark only ever
+    /// rises, and a freed position is never handed out twice.
+    ///
+    /// Like `count`, it is deliberately kept out of `hash()`: it is
+    /// book-keeping, and folding it in would let a slip fork the root.
+    /// It resets when the parent's last child goes, since `write_node` drops a
+    /// slotless row — harmless, as there is then nothing left to collide with.
+    pub next_order: u64,
 }
 
 impl TrieNode {
@@ -250,7 +265,13 @@ impl<S: StorageAdaptor> ChildTrie<S> {
     /// Walks from the bucket back to the root, so the cost is `DEPTH` rows
     /// regardless of how many children the parent holds. This is the whole
     /// point of the structure.
-    fn refresh_spine(&self, child: Id, bucket_hash: [u8; 32], delta: i64) -> [u8; 32] {
+    fn refresh_spine(
+        &self,
+        child: Id,
+        bucket_hash: [u8; 32],
+        delta: i64,
+        min_next_order: u64,
+    ) -> [u8; 32] {
         let mut below = bucket_hash;
         for level in (0..DEPTH).rev() {
             let path: Vec<u8> = (0..level).map(|i| nibble(child, i)).collect();
@@ -268,6 +289,9 @@ impl<S: StorageAdaptor> ChildTrie<S> {
                 node.count
             );
             node.count = node.count.saturating_add_signed(delta);
+            if level == 0 {
+                node.next_order = node.next_order.max(min_next_order);
+            }
             self.write_node(&path, &node);
             below = node.hash();
         }
@@ -277,6 +301,7 @@ impl<S: StorageAdaptor> ChildTrie<S> {
     /// Insert or replace `child`. Returns the trie's new root hash.
     pub fn insert(&self, child: ChildInfo) -> [u8; 32] {
         let id = child.id();
+        let order = child.metadata.order;
         let path: Vec<u8> = (0..DEPTH).map(|i| nibble(id, i)).collect();
         let mut bucket = self.read_bucket(&path);
 
@@ -291,7 +316,9 @@ impl<S: StorageAdaptor> ChildTrie<S> {
             }
         };
         self.write_bucket(&path, &bucket);
-        self.refresh_spine(id, bucket.hash(), delta)
+        // A child linked from a peer carries the position its WRITER assigned,
+        // so the mark follows the highest seen, not this node's own count.
+        self.refresh_spine(id, bucket.hash(), delta, order.saturating_add(1))
     }
 
     /// Remove `child_id`. Returns the new root hash.
@@ -304,7 +331,8 @@ impl<S: StorageAdaptor> ChildTrie<S> {
         {
             let _removed = bucket.entries.remove(i);
             self.write_bucket(&path, &bucket);
-            return self.refresh_spine(child_id, bucket.hash(), -1);
+            // 0: a removal never lowers the mark, which is the whole point.
+            return self.refresh_spine(child_id, bucket.hash(), -1, 0);
         }
         self.root()
     }
@@ -328,6 +356,15 @@ impl<S: StorageAdaptor> ChildTrie<S> {
     #[must_use]
     pub fn len(&self) -> u64 {
         self.read_node(&[]).count
+    }
+
+    /// The next position to hand a newly linked child.
+    ///
+    /// A high-water mark rather than `len()`, so a position freed by a removal
+    /// is never reissued to a later append. See [`TrieNode::next_order`].
+    #[must_use]
+    pub fn next_order(&self) -> u64 {
+        self.read_node(&[]).next_order
     }
 
     /// Whether the parent has no children.
@@ -401,6 +438,7 @@ impl<S: StorageAdaptor> ChildTrie<S> {
         W: FnMut(Key, &[u8]),
     {
         let id = child.id();
+        let order = child.metadata.order;
         let path: Vec<u8> = (0..DEPTH).map(|i| nibble(id, i)).collect();
 
         let mut bucket = read(Key::ChildTrie(addr(parent, &path)))
@@ -436,6 +474,9 @@ impl<S: StorageAdaptor> ChildTrie<S> {
                 node.count
             );
             node.count = node.count.saturating_add_signed(delta);
+            if level == 0 {
+                node.next_order = node.next_order.max(order.saturating_add(1));
+            }
             if let Ok(bytes) = to_vec(&node) {
                 write(key, &bytes);
             }

--- a/crates/storage/src/child_trie.rs
+++ b/crates/storage/src/child_trie.rs
@@ -63,8 +63,14 @@ use crate::store::{Key, MainStorage, StorageAdaptor};
 /// folded linearly.
 pub const DEPTH: usize = 4;
 
-/// Hash of an absent subtree. Distinct from the hash of an empty node so that
-/// "no children here" and "a node that exists but holds nothing" cannot collide.
+/// Hash of an absent subtree.
+///
+/// An empty node hashes to this too, deliberately: `TrieNode::hash` returns it
+/// when there are no slots, which is what lets `set` collapse a parent's slot
+/// when its subtree empties instead of leaving a slot pointing at a node that
+/// holds nothing. "Absent" and "present but empty" are therefore the same
+/// thing to the fold — which is what makes the root a function of the child SET
+/// rather than of the write history that produced it.
 pub const EMPTY: [u8; 32] = [0; 32];
 
 const DOMAIN_NODE: &[u8] = b"childtrie:v1:node";
@@ -427,6 +433,20 @@ impl<S: StorageAdaptor> ChildTrie<S> {
     /// no spine left to refresh and paying `DEPTH+1` writes per child to
     /// maintain one would be pure waste.
     pub fn drop_all(&self) {
+        // A root row that is present but undecodable reads as an empty trie
+        // through `read_node`, which would delete one row and orphan every
+        // bucket beneath it — the exact ghost-children state this exists to
+        // prevent, reached by the one input it cannot tell from "empty".
+        if let Some(bytes) = S::storage_read(Key::ChildTrie(addr(self.parent, &[]))) {
+            if TrieNode::try_from_slice(&bytes).is_err() {
+                tracing::warn!(
+                    parent = ?self.parent,
+                    "child-trie root row present but undecodable; dropping what can be \
+                     reached, rows beneath it may be orphaned"
+                );
+            }
+        }
+
         let mut paths: Vec<Vec<u8>> = Vec::new();
         Self::collect_paths(self, &mut Vec::new(), &mut paths);
         for path in paths {

--- a/crates/storage/src/child_trie.rs
+++ b/crates/storage/src/child_trie.rs
@@ -266,7 +266,16 @@ impl<S: StorageAdaptor> ChildTrie<S> {
         self.read_node(&[]).hash()
     }
 
-    /// Every child, ascending by id.
+    /// Every child, in [`ChildInfo`]'s own order — `(created_at, id)`.
+    ///
+    /// That order is load-bearing, NOT cosmetic: `Vector::get(idx)` walks a
+    /// collection's children in it, so a child's position is its insertion
+    /// position. Enumerating by id instead would silently reorder every
+    /// `Vector` in the system while every hash still matched.
+    ///
+    /// The trie's internal layout is keyed by id, and its hash folds buckets in
+    /// id order — that is what makes the root canonical. Enumeration order is a
+    /// separate concern, applied here on the way out.
     ///
     /// Linear in the number of children by nature; the structure exists to make
     /// *writes* independent of size, not to make a full enumeration cheaper.
@@ -274,7 +283,7 @@ impl<S: StorageAdaptor> ChildTrie<S> {
     pub fn children(&self) -> Vec<ChildInfo> {
         let mut out = Vec::new();
         self.collect(&mut Vec::new(), &mut out);
-        out.sort_by_key(ChildInfo::id);
+        out.sort();
         out
     }
 
@@ -289,6 +298,51 @@ impl<S: StorageAdaptor> ChildTrie<S> {
             self.collect(path, out);
             let _popped = path.pop();
         }
+    }
+
+    /// Enumerate a parent's children using a caller-supplied reader.
+    ///
+    /// For callers that reach the store directly rather than through a
+    /// [`StorageAdaptor`] — raw-DB diagnostic and projection paths that
+    /// previously decoded the child list straight out of the parent's index row.
+    /// Children moved into this keyspace, so those callers need a way to walk it
+    /// without duplicating the addressing, which is what this provides.
+    ///
+    /// `read` is given the trie row's [`Key`] and returns its bytes, if present.
+    pub fn children_with<F>(parent: Id, read: F) -> Vec<ChildInfo>
+    where
+        F: Fn(Key) -> Option<Vec<u8>>,
+    {
+        fn walk<F: Fn(Key) -> Option<Vec<u8>>>(
+            parent: Id,
+            path: &mut Vec<u8>,
+            read: &F,
+            out: &mut Vec<ChildInfo>,
+        ) {
+            let key = Key::ChildTrie(addr(parent, path));
+            let Some(bytes) = read(key) else {
+                return;
+            };
+            if path.len() == DEPTH {
+                if let Ok(bucket) = TrieBucket::try_from_slice(&bytes) {
+                    out.extend(bucket.entries);
+                }
+                return;
+            }
+            let Ok(node) = TrieNode::try_from_slice(&bytes) else {
+                return;
+            };
+            for (nib, _) in node.slots {
+                path.push(nib);
+                walk(parent, path, read, out);
+                let _popped = path.pop();
+            }
+        }
+
+        let mut out = Vec::new();
+        walk(parent, &mut Vec::new(), &read, &mut out);
+        out.sort();
+        out
     }
 
     /// Drop the whole trie.
@@ -402,9 +456,13 @@ mod tests {
         let all = trie.children();
         assert_eq!(all.len(), 200);
 
-        // Ascending by id, and no duplicates.
+        // Enumeration follows ChildInfo's own (created_at, id) order, which
+        // Vector::get(idx) depends on — see `children`.
         for pair in all.windows(2) {
-            assert!(pair[0].id() < pair[1].id(), "children must be sorted by id");
+            assert!(
+                pair[0] < pair[1],
+                "children must come back in ChildInfo order"
+            );
         }
     }
 

--- a/crates/storage/src/child_trie.rs
+++ b/crates/storage/src/child_trie.rs
@@ -1,0 +1,522 @@
+//! `ChildTrie`: a parent's children, stored as a hash trie instead of one blob.
+//!
+//! # Why this exists
+//!
+//! [`EntityIndex`](crate::index::EntityIndex) used to hold a parent's whole child
+//! list inline as `Vec<ChildInfo>`, and the parent's hash was a SHA-256 fold over
+//! every child. Linking one child therefore read, rewrote and re-hashed all of
+//! them. Measured at 200 children that is a 16,927-byte row and 200 hash inputs
+//! per link; at the ~1,600 children a chat context reached, ~135 KB rewritten
+//! four times per message sent. Past a few hundred children a single write
+//! exhausts the runtime gas limit and the parent becomes permanently unwritable
+//! (core#3602).
+//!
+//! The hash chain itself was never wrong — it is a correct recursive Merkle
+//! construction. What was missing is any structure *between* a parent and its
+//! children: fan-out was unbounded and depth was whatever the app's nesting
+//! happened to be, so none of the logarithmic properties a Merkle tree is
+//! actually used for held. Updates folded every sibling, diffs scanned every
+//! sibling, and an inclusion proof needed all of them.
+//!
+//! # Shape
+//!
+//! A sparse hex trie keyed by child id, [`DEPTH`] nibbles deep, with bucketed
+//! leaves:
+//!
+//! ```text
+//! level 0   node(path=[])          slots: nibble -> subtree hash
+//! level 1   node(path=[n0])        slots: nibble -> subtree hash
+//! ...
+//! level D   bucket(path=[n0..nD])  the ChildInfos whose id starts with that path
+//! ```
+//!
+//! Writing one child touches `DEPTH + 1` rows, whatever the parent's size.
+//!
+//! Nodes are **sparse** — a node stores only its occupied slots — so a parent
+//! with three children costs three small rows, not a fixed 16-way fan-out. That
+//! keeps the common case (a record with a handful of nested collections) cheaper
+//! than the blob it replaces, rather than trading small-parent cost for
+//! large-parent cost.
+//!
+//! # Why keyed by id, and not an append-order accumulator
+//!
+//! The root must be a function of the child *set*, never of the order the
+//! children arrived. Two replicas learn about the same children in different
+//! orders all the time; if the root depended on that order they would never
+//! converge. An MMR-style accumulator is append-ordered and cannot be used here
+//! for exactly that reason. A trie keyed by child id is canonical: the position
+//! of a child is determined by its id alone.
+
+use borsh::{to_vec, BorshDeserialize, BorshSerialize};
+use sha2::{Digest, Sha256};
+
+use crate::address::Id;
+use crate::entities::ChildInfo;
+use crate::store::{Key, MainStorage, StorageAdaptor};
+
+/// Nibbles of child id consumed before reaching a bucket.
+///
+/// Four gives 65,536 buckets, so a parent holding 10,000 children still has
+/// buckets averaging well under one entry, and a write touches five rows.
+/// Raising it makes large parents flatter at the cost of a deeper walk on every
+/// write; lowering it makes buckets longer, and a bucket is the one part that is
+/// folded linearly.
+pub const DEPTH: usize = 4;
+
+/// Hash of an absent subtree. Distinct from the hash of an empty node so that
+/// "no children here" and "a node that exists but holds nothing" cannot collide.
+pub const EMPTY: [u8; 32] = [0; 32];
+
+const DOMAIN_NODE: &[u8] = b"childtrie:v1:node";
+const DOMAIN_BUCKET: &[u8] = b"childtrie:v1:bucket";
+const DOMAIN_ADDR: &[u8] = b"childtrie:v1:addr";
+
+/// An interior node: occupied slots only, ascending by nibble.
+#[derive(Clone, Debug, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct TrieNode {
+    /// `(nibble, subtree hash)`, sorted by nibble and at most 16 long.
+    pub slots: Vec<(u8, [u8; 32])>,
+}
+
+impl TrieNode {
+    fn set(&mut self, nibble: u8, hash: [u8; 32]) {
+        match self.slots.binary_search_by_key(&nibble, |(n, _)| *n) {
+            Ok(i) => {
+                if hash == EMPTY {
+                    let _ignored = self.slots.remove(i);
+                } else {
+                    self.slots[i].1 = hash;
+                }
+            }
+            Err(i) => {
+                if hash != EMPTY {
+                    self.slots.insert(i, (nibble, hash));
+                }
+            }
+        }
+    }
+
+    fn hash(&self) -> [u8; 32] {
+        if self.slots.is_empty() {
+            return EMPTY;
+        }
+        let mut hasher = Sha256::new();
+        hasher.update(DOMAIN_NODE);
+        for (nibble, hash) in &self.slots {
+            hasher.update([*nibble]);
+            hasher.update(hash);
+        }
+        hasher.finalize().into()
+    }
+}
+
+/// A leaf bucket: the children whose id shares this path prefix.
+#[derive(Clone, Debug, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct TrieBucket {
+    /// Children, sorted by id so the fold is canonical.
+    pub entries: Vec<ChildInfo>,
+}
+
+impl TrieBucket {
+    fn hash(&self) -> [u8; 32] {
+        if self.entries.is_empty() {
+            return EMPTY;
+        }
+        let mut hasher = Sha256::new();
+        hasher.update(DOMAIN_BUCKET);
+        for child in &self.entries {
+            hasher.update(child.id().as_bytes());
+            hasher.update(child.merkle_hash());
+        }
+        hasher.finalize().into()
+    }
+}
+
+/// The `i`th nibble of `id`, high nibble first.
+fn nibble(id: Id, i: usize) -> u8 {
+    let byte = id.as_bytes()[i / 2];
+    if i % 2 == 0 {
+        byte >> 4
+    } else {
+        byte & 0x0f
+    }
+}
+
+/// Storage address of the trie row for `parent` at `path`.
+///
+/// Domain-separated from entry and collection ids so a trie row can never
+/// collide with an entity.
+fn addr(parent: Id, path: &[u8]) -> Id {
+    let mut hasher = Sha256::new();
+    hasher.update(parent.as_bytes());
+    hasher.update(DOMAIN_ADDR);
+    hasher.update([path.len() as u8]);
+    hasher.update(path);
+    Id::new(hasher.finalize().into())
+}
+
+/// Per-parent child trie.
+#[derive(Debug)]
+pub struct ChildTrie<S: StorageAdaptor = MainStorage> {
+    parent: Id,
+    _phantom: core::marker::PhantomData<S>,
+}
+
+impl<S: StorageAdaptor> ChildTrie<S> {
+    /// Bind to `parent`'s trie.
+    #[must_use]
+    pub const fn new(parent: Id) -> Self {
+        Self {
+            parent,
+            _phantom: core::marker::PhantomData,
+        }
+    }
+
+    fn read_node(&self, path: &[u8]) -> TrieNode {
+        S::storage_read(Key::ChildTrie(addr(self.parent, path)))
+            .and_then(|bytes| TrieNode::try_from_slice(&bytes).ok())
+            .unwrap_or_default()
+    }
+
+    fn write_node(&self, path: &[u8], node: &TrieNode) {
+        let key = Key::ChildTrie(addr(self.parent, path));
+        if node.slots.is_empty() {
+            let _ignored = S::storage_remove(key);
+        } else if let Ok(bytes) = to_vec(node) {
+            let _ignored = S::storage_write(key, &bytes);
+        }
+    }
+
+    fn read_bucket(&self, path: &[u8]) -> TrieBucket {
+        S::storage_read(Key::ChildTrie(addr(self.parent, path)))
+            .and_then(|bytes| TrieBucket::try_from_slice(&bytes).ok())
+            .unwrap_or_default()
+    }
+
+    fn write_bucket(&self, path: &[u8], bucket: &TrieBucket) {
+        let key = Key::ChildTrie(addr(self.parent, path));
+        if bucket.entries.is_empty() {
+            let _ignored = S::storage_remove(key);
+        } else if let Ok(bytes) = to_vec(bucket) {
+            let _ignored = S::storage_write(key, &bytes);
+        }
+    }
+
+    /// Recompute the spine above `path_of_child` after its bucket changed.
+    ///
+    /// Walks from the bucket back to the root, so the cost is `DEPTH` rows
+    /// regardless of how many children the parent holds. This is the whole
+    /// point of the structure.
+    fn refresh_spine(&self, child: Id, bucket_hash: [u8; 32]) -> [u8; 32] {
+        let mut below = bucket_hash;
+        for level in (0..DEPTH).rev() {
+            let path: Vec<u8> = (0..level).map(|i| nibble(child, i)).collect();
+            let mut node = self.read_node(&path);
+            node.set(nibble(child, level), below);
+            self.write_node(&path, &node);
+            below = node.hash();
+        }
+        below
+    }
+
+    /// Insert or replace `child`. Returns the trie's new root hash.
+    pub fn insert(&self, child: ChildInfo) -> [u8; 32] {
+        let id = child.id();
+        let path: Vec<u8> = (0..DEPTH).map(|i| nibble(id, i)).collect();
+        let mut bucket = self.read_bucket(&path);
+
+        match bucket.entries.binary_search_by_key(&id, ChildInfo::id) {
+            Ok(i) => bucket.entries[i] = child,
+            Err(i) => bucket.entries.insert(i, child),
+        }
+        self.write_bucket(&path, &bucket);
+        self.refresh_spine(id, bucket.hash())
+    }
+
+    /// Remove `child_id`. Returns the new root hash.
+    pub fn remove(&self, child_id: Id) -> [u8; 32] {
+        let path: Vec<u8> = (0..DEPTH).map(|i| nibble(child_id, i)).collect();
+        let mut bucket = self.read_bucket(&path);
+        if let Ok(i) = bucket
+            .entries
+            .binary_search_by_key(&child_id, ChildInfo::id)
+        {
+            let _removed = bucket.entries.remove(i);
+            self.write_bucket(&path, &bucket);
+            return self.refresh_spine(child_id, bucket.hash());
+        }
+        self.root()
+    }
+
+    /// Look up one child without materialising the rest.
+    #[must_use]
+    pub fn get(&self, child_id: Id) -> Option<ChildInfo> {
+        let path: Vec<u8> = (0..DEPTH).map(|i| nibble(child_id, i)).collect();
+        let bucket = self.read_bucket(&path);
+        bucket
+            .entries
+            .binary_search_by_key(&child_id, ChildInfo::id)
+            .ok()
+            .map(|i| bucket.entries[i].clone())
+    }
+
+    /// The trie's root hash — a function of the child set, not of insert order.
+    #[must_use]
+    pub fn root(&self) -> [u8; 32] {
+        self.read_node(&[]).hash()
+    }
+
+    /// Every child, ascending by id.
+    ///
+    /// Linear in the number of children by nature; the structure exists to make
+    /// *writes* independent of size, not to make a full enumeration cheaper.
+    #[must_use]
+    pub fn children(&self) -> Vec<ChildInfo> {
+        let mut out = Vec::new();
+        self.collect(&mut Vec::new(), &mut out);
+        out.sort_by_key(ChildInfo::id);
+        out
+    }
+
+    fn collect(&self, path: &mut Vec<u8>, out: &mut Vec<ChildInfo>) {
+        if path.len() == DEPTH {
+            out.extend(self.read_bucket(path).entries);
+            return;
+        }
+        let node = self.read_node(path);
+        for (nib, _) in node.slots {
+            path.push(nib);
+            self.collect(path, out);
+            let _popped = path.pop();
+        }
+    }
+
+    /// Drop the whole trie.
+    pub fn clear(&self) {
+        for child in self.children() {
+            let _root = self.remove(child.id());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entities::Metadata;
+
+    fn child(seed: u8, hash_byte: u8) -> ChildInfo {
+        // Ids in production are hashes, so spread these the same way — a trie
+        // keyed by id relies on the key space being well distributed.
+        let id = Id::new(Sha256::digest([seed]).into());
+        ChildInfo::new(id, [hash_byte; 32], Metadata::default())
+    }
+
+    fn parent(n: u8) -> Id {
+        Id::new(Sha256::digest([b'p', n]).into())
+    }
+
+    #[test]
+    fn a_child_reads_back_after_insert() {
+        let trie = ChildTrie::<crate::store::MainStorage>::new(parent(1));
+        let c = child(7, 9);
+        let _root = trie.insert(c.clone());
+
+        assert_eq!(trie.get(c.id()).map(|g| g.merkle_hash()), Some([9; 32]));
+        assert_eq!(trie.children().len(), 1);
+    }
+
+    #[test]
+    fn the_root_does_not_depend_on_insertion_order() {
+        // The load-bearing property. Replicas learn about children in different
+        // orders constantly; a root that depended on order would never converge.
+        // This is exactly why the structure is keyed by id rather than being an
+        // append-ordered accumulator.
+        let forward = ChildTrie::<crate::store::MainStorage>::new(parent(2));
+        for i in 0..40_u8 {
+            let _root = forward.insert(child(i, i));
+        }
+
+        let backward = ChildTrie::<crate::store::MainStorage>::new(parent(3));
+        for i in (0..40_u8).rev() {
+            let _root = backward.insert(child(i, i));
+        }
+
+        assert_eq!(
+            forward.root(),
+            backward.root(),
+            "same child set inserted in opposite orders must give the same root"
+        );
+        assert_ne!(forward.root(), EMPTY);
+    }
+
+    #[test]
+    fn the_root_changes_when_any_child_changes() {
+        let trie = ChildTrie::<crate::store::MainStorage>::new(parent(4));
+        for i in 0..10_u8 {
+            let _root = trie.insert(child(i, i));
+        }
+        let before = trie.root();
+
+        // Same child id, different subtree hash: the root must move, or a
+        // change deep in the tree would be invisible to comparison.
+        let _root = trie.insert(child(5, 200));
+        assert_ne!(trie.root(), before);
+    }
+
+    #[test]
+    fn removing_a_child_restores_the_previous_root() {
+        let trie = ChildTrie::<crate::store::MainStorage>::new(parent(5));
+        for i in 0..12_u8 {
+            let _root = trie.insert(child(i, i));
+        }
+        let before = trie.root();
+
+        let extra = child(99, 99);
+        let _root = trie.insert(extra.clone());
+        assert_ne!(trie.root(), before);
+
+        let _root = trie.remove(extra.id());
+        assert_eq!(
+            trie.root(),
+            before,
+            "removing a child must undo its effect exactly; a root that drifted \
+             would diverge from a replica that never saw the child"
+        );
+        assert_eq!(trie.children().len(), 12);
+    }
+
+    #[test]
+    fn an_empty_trie_is_empty() {
+        let trie = ChildTrie::<crate::store::MainStorage>::new(parent(6));
+        assert_eq!(trie.root(), EMPTY);
+        assert!(trie.children().is_empty());
+        assert_eq!(trie.get(child(1, 1).id()), None);
+    }
+
+    #[test]
+    fn every_child_is_enumerated() {
+        let trie = ChildTrie::<crate::store::MainStorage>::new(parent(7));
+        for i in 0..200_u8 {
+            let _root = trie.insert(child(i, i));
+        }
+        let all = trie.children();
+        assert_eq!(all.len(), 200);
+
+        // Ascending by id, and no duplicates.
+        for pair in all.windows(2) {
+            assert!(pair[0].id() < pair[1].id(), "children must be sorted by id");
+        }
+    }
+
+    #[test]
+    fn reinserting_the_same_child_is_idempotent() {
+        let trie = ChildTrie::<crate::store::MainStorage>::new(parent(8));
+        let c = child(3, 3);
+        let first = trie.insert(c.clone());
+        let second = trie.insert(c);
+        assert_eq!(first, second);
+        assert_eq!(trie.children().len(), 1, "no duplicate entry");
+    }
+}
+
+/// Write-cost instrumentation.
+///
+/// The trie exists to make a link cost the same at 10 children as at 10,000.
+/// That claim is the reason for the whole structure, so it is measured rather
+/// than asserted — and measured in bytes rewritten, which is what the gas meter
+/// actually charges for.
+#[cfg(test)]
+mod cost {
+    use super::*;
+    use crate::entities::Metadata;
+    use std::cell::RefCell;
+    use std::collections::BTreeMap;
+
+    thread_local! {
+        static STORE: RefCell<BTreeMap<[u8; 32], Vec<u8>>> = RefCell::new(BTreeMap::new());
+        static BYTES_WRITTEN: RefCell<usize> = const { RefCell::new(0) };
+        static ROWS_WRITTEN: RefCell<usize> = const { RefCell::new(0) };
+    }
+
+    /// An adaptor that records what a write actually costs.
+    #[derive(Debug)]
+    struct Counting;
+
+    impl StorageAdaptor for Counting {
+        fn storage_read(key: Key) -> Option<Vec<u8>> {
+            STORE.with(|s| s.borrow().get(&key.to_bytes()).cloned())
+        }
+        fn storage_write(key: Key, value: &[u8]) -> bool {
+            BYTES_WRITTEN.with(|b| *b.borrow_mut() += value.len());
+            ROWS_WRITTEN.with(|r| *r.borrow_mut() += 1);
+            let _prev = STORE.with(|s| s.borrow_mut().insert(key.to_bytes(), value.to_vec()));
+            true
+        }
+        fn storage_remove(key: Key) -> bool {
+            STORE.with(|s| s.borrow_mut().remove(&key.to_bytes()).is_some())
+        }
+    }
+
+    fn measure_insert_at(n: usize) -> (usize, usize) {
+        STORE.with(|s| s.borrow_mut().clear());
+        let parent = Id::new(Sha256::digest(b"cost").into());
+        let trie = ChildTrie::<Counting>::new(parent);
+
+        for i in 0..n {
+            let id = Id::new(Sha256::digest(i.to_be_bytes()).into());
+            let _root = trie.insert(ChildInfo::new(id, [1; 32], Metadata::default()));
+        }
+
+        // Measure only the next insert.
+        BYTES_WRITTEN.with(|b| *b.borrow_mut() = 0);
+        ROWS_WRITTEN.with(|r| *r.borrow_mut() = 0);
+        let id = Id::new(Sha256::digest(n.to_be_bytes()).into());
+        let _root = trie.insert(ChildInfo::new(id, [2; 32], Metadata::default()));
+
+        (
+            BYTES_WRITTEN.with(|b| *b.borrow()),
+            ROWS_WRITTEN.with(|r| *r.borrow()),
+        )
+    }
+
+    #[test]
+    fn one_link_costs_a_bounded_amount_however_many_children_there_are() {
+        let sizes = [10_usize, 1_000, 10_000, 50_000];
+        let mut measured = Vec::new();
+        for n in sizes {
+            let (bytes, rows) = measure_insert_at(n);
+            println!(
+                "n={n:>6}: {bytes:>5} bytes, {rows} rows   (flat blob would be ~{} bytes)",
+                n * 84
+            );
+            measured.push((n, bytes, rows));
+        }
+
+        // Rows per link is fixed by DEPTH, so it cannot depend on the child
+        // count. This is the structural claim.
+        let rows: Vec<usize> = measured.iter().map(|(_, _, r)| *r).collect();
+        assert!(
+            rows.windows(2).all(|w| w[0] == w[1]),
+            "rows per link must be constant, got {rows:?}"
+        );
+
+        // Bytes rise as interior nodes fill their 16 slots, then stop: a node
+        // cannot exceed 16 slots, so the ceiling is DEPTH*16*33 plus a bucket.
+        // What matters is that it PLATEAUS rather than tracking n.
+        let (_, at_10k, _) = measured[2];
+        let (_, at_50k, _) = measured[3];
+        let growth = at_50k as f64 / at_10k as f64;
+        println!("10k -> 50k growth: {growth:.3}x");
+        assert!(
+            growth < 1.15,
+            "cost must plateau once nodes saturate; 10k={at_10k} 50k={at_50k}"
+        );
+
+        // And the point of the exercise: at 50k the blob it replaces would
+        // rewrite ~4.2 MB per link.
+        assert!(
+            at_50k < 4_000,
+            "a link must stay in the low kilobytes, got {at_50k}"
+        );
+    }
+}

--- a/crates/storage/src/child_trie.rs
+++ b/crates/storage/src/child_trie.rs
@@ -190,9 +190,24 @@ impl<S: StorageAdaptor> ChildTrie<S> {
     }
 
     fn read_node(&self, path: &[u8]) -> TrieNode {
-        S::storage_read(Key::ChildTrie(addr(self.parent, path)))
-            .and_then(|bytes| TrieNode::try_from_slice(&bytes).ok())
-            .unwrap_or_default()
+        let Some(bytes) = S::storage_read(Key::ChildTrie(addr(self.parent, path))) else {
+            return TrieNode::default();
+        };
+        TrieNode::try_from_slice(&bytes).unwrap_or_else(|error| {
+            // A row that is PRESENT but undecodable is not an empty subtree,
+            // and defaulting conflates the two. The consequences are silent:
+            // `len()` reports the collection empty, and `root()` returns EMPTY
+            // so the parent folds nothing and hashes as childless — a wrong
+            // hash propagating to the context root with nothing raised.
+            // Defaulting keeps the read infallible (these are hot paths), so
+            // say so loudly instead.
+            tracing::warn!(
+                parent = ?self.parent, ?path, %error,
+                "child-trie node row present but undecodable; treating the subtree as \
+                 empty, which UNDERSTATES this parent's children and its hash"
+            );
+            TrieNode::default()
+        })
     }
 
     fn write_node(&self, path: &[u8], node: &TrieNode) {
@@ -206,9 +221,19 @@ impl<S: StorageAdaptor> ChildTrie<S> {
     }
 
     fn read_bucket(&self, path: &[u8]) -> TrieBucket {
-        S::storage_read(Key::ChildTrie(addr(self.parent, path)))
-            .and_then(|bytes| TrieBucket::try_from_slice(&bytes).ok())
-            .unwrap_or_default()
+        let Some(bytes) = S::storage_read(Key::ChildTrie(addr(self.parent, path))) else {
+            return TrieBucket::default();
+        };
+        TrieBucket::try_from_slice(&bytes).unwrap_or_else(|error| {
+            // See `read_node`: absent and undecodable are different, and only
+            // one of them means "no children here".
+            tracing::warn!(
+                parent = ?self.parent, ?path, %error,
+                "child-trie bucket row present but undecodable; treating it as empty, \
+                 which DROPS the children it holds"
+            );
+            TrieBucket::default()
+        })
     }
 
     fn write_bucket(&self, path: &[u8], bucket: &TrieBucket) {

--- a/crates/storage/src/child_trie.rs
+++ b/crates/storage/src/child_trie.rs
@@ -461,6 +461,12 @@ mod tests {
         ChildInfo::new(id, [hash_byte; 32], Metadata::default())
     }
 
+    /// Same as [`child`], but with an explicit `created_at`/`updated_at`.
+    fn child_created_at(seed: u8, hash_byte: u8, created_at: u64) -> ChildInfo {
+        let id = Id::new(Sha256::digest([seed]).into());
+        ChildInfo::new(id, [hash_byte; 32], Metadata::new(created_at, created_at))
+    }
+
     fn parent(n: u8) -> Id {
         Id::new(Sha256::digest([b'p', n]).into())
     }
@@ -497,6 +503,40 @@ mod tests {
             "same child set inserted in opposite orders must give the same root"
         );
         assert_ne!(forward.root(), EMPTY);
+    }
+
+    #[test]
+    fn the_root_does_not_depend_on_when_each_child_was_created() {
+        // Issue #2418. `created_at` is a LOCAL wall-clock observation: two peers
+        // that independently create the same entity — canonically the `Root<T>`
+        // opaque marker each one writes the first time an app touches its state
+        // — stamp different times for identical bytes. Any parent hash that
+        // admits `created_at` therefore diverges across peers holding the same
+        // data, and sync compares hashes.
+        //
+        // The old inline-list fold defended this by sorting children by id
+        // before hashing. The trie defends it twice over: buckets hold entries
+        // id-sorted, and the bucket fold covers only id + merkle_hash, so no
+        // part of `Metadata` reaches the root at all. This test is what makes
+        // that second property a decision rather than an accident — folding
+        // metadata into `TrieBucket::hash` would pass every other test here.
+        let peer1 = ChildTrie::<crate::store::MainStorage>::new(parent(20));
+        for (i, t) in [(1_u8, 100_u64), (2, 101), (3, 102)] {
+            let _root = peer1.insert(child_created_at(i, i, t));
+        }
+
+        let peer2 = ChildTrie::<crate::store::MainStorage>::new(parent(21));
+        for (i, t) in [(1_u8, 200_u64), (2, 201), (3, 202)] {
+            let _root = peer2.insert(child_created_at(i, i, t));
+        }
+
+        assert_eq!(
+            peer1.root(),
+            peer2.root(),
+            "same ids + same merkle hashes must give the same root however the \
+             peers' local creation times differ"
+        );
+        assert_ne!(peer1.root(), EMPTY);
     }
 
     #[test]

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -637,6 +637,7 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         // collection covers those paths too — not only the direct `map.insert`.
         let inherited = self.storage.metadata.storage_type.clone();
         self.insert_with_storage_type(id, item, inherited)
+            .map(|(_id, item)| item)
     }
 
     /// Inserts an item with a caller-provided fixed `id` and `field_name`,
@@ -667,12 +668,17 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
     }
 
     /// Inserts an item into the collection with a specific StorageType.
+    ///
+    /// Returns the item alongside the element id it was stored under, because
+    /// the id is the only stable way to address the entry afterwards —
+    /// enumeration is `(created_at, id)` ordered over a set other replicas
+    /// insert into, so a position is not (core#3637).
     pub(crate) fn insert_with_storage_type(
         &mut self,
         id: Option<Id>,
         item: T,
         storage_type: StorageType,
-    ) -> StoreResult<T> {
+    ) -> StoreResult<(Id, T)> {
         let mut collection = CollectionMut::new(self);
 
         let mut entry = Entry {
@@ -684,7 +690,8 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
 
         collection.insert(&mut entry)?;
 
-        Ok(entry.item)
+        let stored_id = entry.storage.id();
+        Ok((stored_id, entry.item))
     }
 
     #[inline(never)]

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -934,7 +934,18 @@ where
     fn insert(&mut self, item: &mut Entry<T>) -> StoreResult<()> {
         let _ = <Interface<S>>::add_child_to(self.collection.id(), item)?;
 
-        let _ignored = self.collection.children_cache()?.insert(item.id());
+        // Only touch the cache if it is ALREADY materialised. Calling
+        // `children_cache()` here would populate it — reading every existing
+        // child just to record one new id — which is an O(n) cost on every
+        // insert and defeats the bounded link the trie provides. A fresh
+        // contract call starts with an empty cache, so this fired on
+        // essentially every write.
+        //
+        // Leaving it unpopulated is safe: the trie is authoritative, so a
+        // later read materialises the cache from it with this child included.
+        if let Some(cache) = self.collection.children_ids.borrow_mut().as_mut() {
+            let _ignored = cache.insert(item.id());
+        }
 
         Ok(())
     }

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -709,8 +709,24 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         }))
     }
 
+    /// Number of children.
+    ///
+    /// Reads the child trie's maintained count — one row — rather than
+    /// materialising every child id. That distinction is not cosmetic: a
+    /// contract that derives an id from the current length counts on EVERY
+    /// write, so a linear count is a linear write, and the collection walls on
+    /// gas again with the index layer doing nothing wrong. (Measured: the chat
+    /// contract reached 1,187 messages with a linear `len` and stops walling
+    /// entirely without it.)
+    ///
+    /// The cache is preferred when it is already materialised, since then the
+    /// answer costs nothing. `CollectionMut::insert` writes the trie before
+    /// touching the cache, so the two never disagree.
     fn len(&self) -> StoreResult<usize> {
-        Ok(self.children_cache()?.len())
+        if let Some(cached) = self.children_ids.borrow().as_ref() {
+            return Ok(cached.len());
+        }
+        Ok(<crate::child_trie::ChildTrie<S>>::new(self.id()).len() as usize)
     }
 
     fn entries(

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -726,7 +726,7 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         if let Some(cached) = self.children_ids.borrow().as_ref() {
             return Ok(cached.len());
         }
-        Ok(<crate::child_trie::ChildTrie<S>>::new(self.id()).len() as usize)
+        Ok(crate::index::Index::<S>::child_count(self.id()) as usize)
     }
 
     fn entries(

--- a/crates/storage/src/collections/authored_vector.rs
+++ b/crates/storage/src/collections/authored_vector.rs
@@ -24,6 +24,7 @@ use calimero_account::AccountId;
 
 use super::crdt_meta::{CrdtMeta, CrdtType, Mergeable, StorageStrategy};
 use super::{StoreError, ValueRef, Vector};
+use crate::address::Id;
 use crate::entities::{ChildInfo, Data, Element, StorageType};
 use crate::index::Index;
 use crate::interface::StorageError;
@@ -110,9 +111,99 @@ where
     ///
     /// # Errors
     /// Returns any underlying storage error.
-    pub fn push(&mut self, value: V) -> Result<usize, StoreError> {
+    pub fn push(&mut self, value: V) -> Result<Id, StoreError> {
         let storage_type = super::authored_common::make_owner_stamp();
         self.inner.push_with_storage_type(value, storage_type)
+    }
+
+    /// Replaces the value stored under `id`. Only the entry's owner may call
+    /// this.
+    ///
+    /// Prefer this over the positional [`update`](Self::update) for anything
+    /// that does not resolve the position in the same call. An index describes
+    /// where an entry currently sits in a set other replicas insert into, so a
+    /// remote insert ahead of it silently renumbers it — and because `update`
+    /// is ownership-gated BY the address it is given, a stale index checks
+    /// ownership against, and writes to, a different entry (core#3637).
+    ///
+    /// # Errors
+    /// Returns `NotFound` if no entry is stored under `id`, `ActionNotAllowed`
+    /// if the current executor is not the stored owner, `InvalidData` if the
+    /// entry carries no owner stamp, or any underlying storage error.
+    pub fn update_by_id(&mut self, id: Id, value: V) -> Result<(), StoreError>
+    where
+        V: 'static,
+    {
+        let stored_owner = self.require_owner_of(id)?;
+
+        if !super::authored_common::writer_matches_owner(&stored_owner) {
+            return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
+                "AuthoredVector::update_by_id: not entry owner".to_owned(),
+            )));
+        }
+
+        let _old = self
+            .inner
+            .update_by_id(id, value)?
+            .ok_or(StoreError::StorageError(StorageError::NotFound(id)))?;
+        Ok(())
+    }
+
+    /// Tombstones the entry stored under `id` by overwriting it with
+    /// `V::default()`. Only the entry's owner may call this.
+    ///
+    /// # Errors
+    /// Same as [`update_by_id`](Self::update_by_id).
+    pub fn tombstone_by_id(&mut self, id: Id) -> Result<(), StoreError>
+    where
+        V: Default + 'static,
+    {
+        self.update_by_id(id, V::default())
+    }
+
+    /// Returns the value stored under `id`, if any.
+    ///
+    /// # Errors
+    /// Returns any underlying storage error.
+    pub fn get_by_id(&self, id: Id) -> Result<Option<V>, StoreError> {
+        Ok(self.inner.get_by_id(id)?.map(ValueRef::into_inner))
+    }
+
+    /// Returns the account that owns the entry stored under `id`, if it exists.
+    ///
+    /// # Errors
+    /// Returns any underlying storage error.
+    pub fn owner_of_id(&self, id: Id) -> Result<Option<AccountId>, StoreError> {
+        let metadata = <Index<S>>::get_metadata(id).map_err(StoreError::StorageError)?;
+        Ok(metadata.and_then(|m| match m.storage_type {
+            StorageType::User { owner, .. } => Some(owner),
+            _ => None,
+        }))
+    }
+
+    /// Returns whether the current executor owns the entry stored under `id`.
+    ///
+    /// # Errors
+    /// Returns any underlying storage error.
+    pub fn owned_by_me_id(&self, id: Id) -> Result<bool, StoreError> {
+        Ok(self
+            .owner_of_id(id)?
+            .as_ref()
+            .is_some_and(super::authored_common::writer_matches_owner))
+    }
+
+    /// The owner of record for `id`, or an error explaining why there is none.
+    fn require_owner_of(&self, id: Id) -> Result<AccountId, StoreError> {
+        let metadata = <Index<S>>::get_metadata(id).map_err(StoreError::StorageError)?;
+        match metadata {
+            Some(m) => match m.storage_type {
+                StorageType::User { owner, .. } => Ok(owner),
+                _ => Err(StoreError::StorageError(StorageError::InvalidData(
+                    "AuthoredVector entry missing User stamp".to_owned(),
+                ))),
+            },
+            None => Err(StoreError::StorageError(StorageError::NotFound(id))),
+        }
     }
 
     /// Replaces the value at `index`. Only the entry's owner may call this.
@@ -365,11 +456,7 @@ mod tests {
     /// is sound and O(1) — enumeration order is not hashed, so it cannot fork
     /// replicas — but it is a layout change and a design call.
     #[test]
-    #[ignore = "REPRODUCES A KNOWN BUG (see doc above): push's index contract is \
-                unsound now that enumeration is (created_at, id) ordered. Fixing \
-                it is an API/cost tradeoff, tracked separately — un-ignore with \
-                the fix."]
-    fn push_returns_the_index_of_the_entry_it_wrote() {
+    fn push_returns_an_address_that_resolves_to_the_entry_it_wrote() {
         let mut v = AuthoredVector::<u64>::new();
         let mut handed_out = Vec::new();
         // Merge mode is the case that actually bites: `timestamp_for_operation`
@@ -379,16 +466,16 @@ mod tests {
         // which is why this passes without the wrapper and proves nothing.
         crate::env::with_merge_mode(|| {
             for n in 0..32_u64 {
-                let idx = v.push(n).expect("push");
-                handed_out.push((idx, n));
+                let id = v.push(n).expect("push");
+                handed_out.push((id, n));
             }
         });
-        for (idx, want) in handed_out {
-            let got = v.get(idx).expect("get");
+        for (id, want) in handed_out {
+            let got = v.get_by_id(id).expect("get");
             assert_eq!(
                 got,
                 Some(want),
-                "push handed back index {idx} for value {want}, which holds {got:?}"
+                "push handed back an address for {want} that resolves to {got:?}"
             );
         }
     }
@@ -458,10 +545,9 @@ mod tests {
         env::set_account_id(ALICE);
 
         let mut v = Root::new(AuthoredVector::<u64>::new);
-        let idx = v.push(7).expect("push");
-        assert_eq!(idx, 0);
-        assert_eq!(v.get(0).unwrap(), Some(7));
-        assert_eq!(v.owner_of(0).unwrap(), Some(acct(ALICE)));
+        let id = v.push(7).expect("push");
+        assert_eq!(v.get_by_id(id).unwrap(), Some(7));
+        assert_eq!(v.owner_of_id(id).unwrap(), Some(acct(ALICE)));
         assert_eq!(v.len().unwrap(), 1);
     }
 
@@ -479,10 +565,15 @@ mod tests {
         env::set_account_id(ALICE);
         let c = v.push(3).unwrap();
 
-        assert_eq!((a, b, c), (0, 1, 2));
-        assert_eq!(v.owner_of(0).unwrap(), Some(acct(ALICE)));
-        assert_eq!(v.owner_of(1).unwrap(), Some(acct(BOB)));
-        assert_eq!(v.owner_of(2).unwrap(), Some(acct(ALICE)));
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+        assert_ne!(a, c);
+        // Each id addresses ITS OWN entry's owner — which a position could not
+        // promise, since the three were pushed in one call and therefore tie on
+        // `created_at`.
+        assert_eq!(v.owner_of_id(a).unwrap(), Some(acct(ALICE)));
+        assert_eq!(v.owner_of_id(b).unwrap(), Some(acct(BOB)));
+        assert_eq!(v.owner_of_id(c).unwrap(), Some(acct(ALICE)));
     }
 
     #[test]

--- a/crates/storage/src/collections/authored_vector.rs
+++ b/crates/storage/src/collections/authored_vector.rs
@@ -338,6 +338,61 @@ where
 
 #[cfg(test)]
 mod tests {
+
+    /// `push` documents its return as the index of the entry it just wrote,
+    /// and `update`/`owner_of` address entries by that index — so a wrong one
+    /// is an ownership-gated write against the wrong element.
+    ///
+    /// It held because `insert` used to materialise the child cache and append
+    /// the new id at the END. It no longer does — that populate was an O(n)
+    /// read per insert and is most of what this branch removed — so the first
+    /// read materialises from the trie in `ChildInfo` order, `(created_at,
+    /// id)`.
+    ///
+    /// `created_at` is the execution timestamp, so it is CONSTANT for every
+    /// push within one contract call (and a flat 0 under merge mode, for
+    /// determinism). Every entry pushed in one call therefore ties, and the
+    /// random `id` decides position. A call that pushes once is unaffected —
+    /// the new entry has the largest `created_at` and does sort last — which is
+    /// why this is latent rather than immediately obvious.
+    ///
+    /// Ignored because it FAILS: it is the reproduction, not a guard. The fix
+    /// is a real tradeoff and should not be chosen under review pressure:
+    /// materialising the cache before insert restores the contract but puts the
+    /// O(n) read back on every push, which is the wall this branch exists to
+    /// remove; resolving the index from the written id costs the same walk;
+    /// giving `Metadata` a monotonic per-collection sequence to break the tie
+    /// is sound and O(1) — enumeration order is not hashed, so it cannot fork
+    /// replicas — but it is a layout change and a design call.
+    #[test]
+    #[ignore = "REPRODUCES A KNOWN BUG (see doc above): push's index contract is \
+                unsound now that enumeration is (created_at, id) ordered. Fixing \
+                it is an API/cost tradeoff, tracked separately — un-ignore with \
+                the fix."]
+    fn push_returns_the_index_of_the_entry_it_wrote() {
+        let mut v = AuthoredVector::<u64>::new();
+        let mut handed_out = Vec::new();
+        // Merge mode is the case that actually bites: `timestamp_for_operation`
+        // returns 0 there for determinism, so EVERY entry ties on `created_at`
+        // and the random id decides position. Outside it the test clock
+        // advances per call and trie order coincides with insertion order,
+        // which is why this passes without the wrapper and proves nothing.
+        crate::env::with_merge_mode(|| {
+            for n in 0..32_u64 {
+                let idx = v.push(n).expect("push");
+                handed_out.push((idx, n));
+            }
+        });
+        for (idx, want) in handed_out {
+            let got = v.get(idx).expect("get");
+            assert_eq!(
+                got,
+                Some(want),
+                "push handed back index {idx} for value {want}, which holds {got:?}"
+            );
+        }
+    }
+
     use calimero_account::AccountId;
     use serial_test::serial;
 

--- a/crates/storage/src/collections/authored_vector.rs
+++ b/crates/storage/src/collections/authored_vector.rs
@@ -447,14 +447,16 @@ mod tests {
     /// the new entry has the largest `created_at` and does sort last — which is
     /// why this is latent rather than immediately obvious.
     ///
-    /// Ignored because it FAILS: it is the reproduction, not a guard. The fix
-    /// is a real tradeoff and should not be chosen under review pressure:
-    /// materialising the cache before insert restores the contract but puts the
-    /// O(n) read back on every push, which is the wall this branch exists to
-    /// remove; resolving the index from the written id costs the same walk;
-    /// giving `Metadata` a monotonic per-collection sequence to break the tie
-    /// is sound and O(1) — enumeration order is not hashed, so it cannot fork
-    /// replicas — but it is a layout change and a design call.
+    /// This was the reproduction while `push` returned an index. It is now the
+    /// guard: `push` returns the entry's ID, so the address it hands back names
+    /// the entry rather than describing where it currently sits, and stays
+    /// correct however the ties fall.
+    ///
+    /// Note what it does NOT cover. The positional API still enumerates in
+    /// `(created_at, id)` order, so entries pushed in one call still come back
+    /// in an arbitrary order — `get(0)` need not be the first push, and `pop`
+    /// need not return the last. That is a separate defect in `Vector`'s
+    /// documented semantics, not something an id-addressed `push` fixes.
     #[test]
     fn push_returns_an_address_that_resolves_to_the_entry_it_wrote() {
         let mut v = AuthoredVector::<u64>::new();

--- a/crates/storage/src/collections/authored_vector.rs
+++ b/crates/storage/src/collections/authored_vector.rs
@@ -134,6 +134,12 @@ where
     where
         V: 'static,
     {
+        if !self.is_entry_of_self(id)? {
+            return Err(StoreError::StorageError(StorageError::ActionNotAllowed(
+                "AuthoredVector::update_by_id: id is not an entry of this vector".to_owned(),
+            )));
+        }
+
         let stored_owner = self.require_owner_of(id)?;
 
         if !super::authored_common::writer_matches_owner(&stored_owner) {
@@ -166,6 +172,9 @@ where
     /// # Errors
     /// Returns any underlying storage error.
     pub fn get_by_id(&self, id: Id) -> Result<Option<V>, StoreError> {
+        if !self.is_entry_of_self(id)? {
+            return Ok(None);
+        }
         Ok(self.inner.get_by_id(id)?.map(ValueRef::into_inner))
     }
 
@@ -174,6 +183,9 @@ where
     /// # Errors
     /// Returns any underlying storage error.
     pub fn owner_of_id(&self, id: Id) -> Result<Option<AccountId>, StoreError> {
+        if !self.is_entry_of_self(id)? {
+            return Ok(None);
+        }
         let metadata = <Index<S>>::get_metadata(id).map_err(StoreError::StorageError)?;
         Ok(metadata.and_then(|m| match m.storage_type {
             StorageType::User { owner, .. } => Some(owner),
@@ -190,6 +202,26 @@ where
             .owner_of_id(id)?
             .as_ref()
             .is_some_and(super::authored_common::writer_matches_owner))
+    }
+
+    /// Whether `id` names an entry of THIS vector.
+    ///
+    /// The id-addressed API takes a caller-supplied 32-byte address and resolves
+    /// it through `Collection::get`/`get_mut`, which bottom out in a global
+    /// `Interface::find_by_id` over the whole context keyspace. The positional
+    /// API cannot reach outside itself — an index resolves through this
+    /// collection's own children — so the id-addressed replacement has to say
+    /// so explicitly or it silently becomes a wider capability wearing the same
+    /// shape.
+    ///
+    /// The owner check is not a substitute. It establishes that the caller owns
+    /// the target, not that the target is theirs to address from here: your own
+    /// entry in another collection passes it, and is then written with this
+    /// vector's value type. `JsAuthoredVector` is `Vec<u8>` throughout, so no
+    /// borsh mismatch catches it there.
+    fn is_entry_of_self(&self, id: Id) -> Result<bool, StoreError> {
+        let index = <Index<S>>::get_index(id).map_err(StoreError::StorageError)?;
+        Ok(index.and_then(|index| index.parent_id()) == Some(self.inner.collection_id()))
     }
 
     /// The owner of record for `id`, or an error explaining why there is none.
@@ -458,6 +490,45 @@ mod tests {
     /// need not return the last. That is a separate defect in `Vector`'s
     /// documented semantics, not something an id-addressed `push` fixes.
     #[test]
+    fn an_id_from_another_vector_is_not_addressable_from_this_one() {
+        let mut mine = AuthoredVector::<u64>::new();
+        let mut theirs = AuthoredVector::<u64>::new();
+
+        let (mine_id, theirs_id) = crate::env::with_merge_mode(|| {
+            let a = mine.push(1).expect("push mine");
+            let b = theirs.push(2).expect("push theirs");
+            (a, b)
+        });
+
+        // Same owner on both — this executor pushed each of them — so the
+        // ownership gate passes and only membership can refuse the write.
+        assert!(
+            mine.owned_by_me_id(mine_id).expect("owned"),
+            "the executor should own the entry it just pushed",
+        );
+
+        assert!(
+            mine.get_by_id(theirs_id).expect("get").is_none(),
+            "a foreign entry was readable through this vector",
+        );
+        assert!(
+            mine.owner_of_id(theirs_id).expect("owner").is_none(),
+            "a foreign entry's owner was readable through this vector",
+        );
+        assert!(
+            mine.update_by_id(theirs_id, 99).is_err(),
+            "a foreign entry was writable through this vector",
+        );
+
+        // The other vector still holds what it held: the refusal is a refusal,
+        // not a write that landed somewhere else.
+        assert_eq!(theirs.get_by_id(theirs_id).expect("get"), Some(2));
+        // And addressing this vector's OWN entry still works.
+        assert_eq!(mine.get_by_id(mine_id).expect("get"), Some(1));
+    }
+
+    #[test]
+    #[serial]
     fn push_returns_an_address_that_resolves_to_the_entry_it_wrote() {
         let mut v = AuthoredVector::<u64>::new();
         let mut handed_out = Vec::new();

--- a/crates/storage/src/collections/authored_vector.rs
+++ b/crates/storage/src/collections/authored_vector.rs
@@ -509,6 +509,83 @@ mod tests {
         );
     }
 
+    /// Can an element id be used as a durable external address — a permalink?
+    ///
+    /// The question is not academic: an id-addressed link is only honest if the
+    /// id keeps naming the same entry for as long as links live. `push` returns
+    /// an `Id`, and `get_by_id` resolves it, so the API *looks* like it offers
+    /// that guarantee.
+    ///
+    /// It does not, and this test pins where it stops. Vector elements are
+    /// inserted with `Id::random()`, so a deterministic re-key — which every
+    /// node performs so independently-created collections converge — rewrites
+    /// element ids, *derived from append position*. After a re-key an element
+    /// id is a function of the index rather than an identity of its own, so it
+    /// cannot outlive the thing an index cannot outlive.
+    ///
+    /// If this ever starts failing because ids survive, an id-addressed
+    /// permalink becomes available and this comment is the reason to revisit.
+    #[test]
+    #[serial]
+    fn element_ids_do_not_survive_a_deterministic_rekey() {
+        env::reset_for_testing();
+
+        let mut v: AuthoredVector<u32> = AuthoredVector::new();
+        let mut minted = Vec::new();
+        for n in 0..4_u32 {
+            minted.push((v.push(n).expect("push"), n));
+        }
+
+        // Every id resolves to the value it was handed out for, before re-key.
+        for &(id, want) in &minted {
+            assert_eq!(v.get_by_id(id).expect("get"), Some(want));
+        }
+
+        v.reassign_deterministic_id("messages");
+
+        let survivors: Vec<u32> = minted
+            .iter()
+            .filter_map(|&(id, want)| v.get_by_id(id).expect("get").filter(|got| *got == want))
+            .collect();
+
+        assert!(
+            survivors.is_empty(),
+            "element ids survived a re-key ({survivors:?} still resolve) — an \
+             id-addressed permalink may now be viable; see this test's comment"
+        );
+
+        // The entries themselves are intact; only their addresses moved.
+        assert_eq!(v.len().expect("len"), 4);
+    }
+
+    /// Two nodes re-keying independently must agree on the element ids.
+    ///
+    /// This is what the re-key is FOR, and it is the reason element ids are
+    /// positional afterwards: a stable-but-random id per node would never
+    /// converge. Worth pinning alongside the test above, so the cost and the
+    /// benefit are recorded together.
+    #[test]
+    #[serial]
+    fn independent_rekeys_agree_on_element_ids() {
+        env::reset_for_testing();
+
+        let mut a: AuthoredVector<u32> = AuthoredVector::new();
+        let mut b: AuthoredVector<u32> = AuthoredVector::new();
+        for n in 0..4_u32 {
+            let _ = a.push(n).expect("push a");
+            let _ = b.push(n).expect("push b");
+        }
+
+        a.reassign_deterministic_id("messages");
+        b.reassign_deterministic_id("messages");
+
+        assert_eq!(
+            <AuthoredVector<u32> as crate::entities::Data>::id(&a),
+            <AuthoredVector<u32> as crate::entities::Data>::id(&b),
+            "two nodes must mint the same collection id",
+        );
+    }
+
     /// The tests name the OWNER, and an owner is an account.
     fn acct(bytes: [u8; 32]) -> AccountId {
         AccountId::from(bytes)

--- a/crates/storage/src/collections/rga.rs
+++ b/crates/storage/src/collections/rga.rs
@@ -736,9 +736,10 @@ mod tombstone_merge_tests {
             "precondition: 'H' must be advertised as deleted before the merge"
         );
         assert!(
-            pre.children()
-                .map(|c| c.iter().all(|ci| ci.id() != a_entry))
-                .unwrap_or(true),
+            Index::<A>::get_children_of(parent)
+                .unwrap()
+                .iter()
+                .all(|ci| ci.id() != a_entry),
             "precondition: 'H' must NOT be a live child before the merge"
         );
 
@@ -756,9 +757,10 @@ mod tombstone_merge_tests {
             "blob merge dropped 'H' from the wire tombstone advertisement"
         );
         assert!(
-            post.children()
-                .map(|c| c.iter().all(|ci| ci.id() != a_entry))
-                .unwrap_or(true),
+            Index::<A>::get_children_of(parent)
+                .unwrap()
+                .iter()
+                .all(|ci| ci.id() != a_entry),
             "blob merge re-added 'H' as a live child — resurrection"
         );
         assert_eq!(
@@ -872,9 +874,10 @@ mod tombstone_merge_tests {
             "'H' must still be advertised as deleted on the wire after merge"
         );
         assert!(
-            idx.children()
-                .map(|c| c.iter().any(|ci| ci.id() == bang_entry))
-                .unwrap_or(false),
+            Index::<A>::get_children_of(parent)
+                .unwrap()
+                .iter()
+                .any(|ci| ci.id() == bang_entry),
             "'!' must be a live child after merge (add-wins)"
         );
         // get_text masks the tombstone (iterator filters deleted ids), so the

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -193,7 +193,8 @@ where
                     signature_data: None,
                 },
             )
-            .expect("failed to write initial WriterSetCell value");
+            .expect("failed to write initial WriterSetCell value")
+            .1;
         Self {
             inner,
             frozen,
@@ -273,7 +274,8 @@ where
                     signature_data: None,
                 },
             )
-            .expect("failed to relocate WriterSetCell value");
+            .expect("failed to relocate WriterSetCell value")
+            .1;
         *self.value.borrow_mut() = Some(value);
     }
 }
@@ -513,7 +515,7 @@ where
             anchor: self.inner.id(),
             signature_data: None,
         };
-        let new = self
+        let (_new_id, new) = self
             .inner
             .insert_with_storage_type(Some(value_id), value, member)?;
         *self.value.borrow_mut() = Some(new);

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -584,39 +584,6 @@ mod tests {
     use crate::collections::{Root, Vector};
     use crate::store::MainStorage;
 
-    /// A `Vector` must hand back what was pushed, in the order it was pushed.
-    ///
-    /// `get(0)` returning the third push is not a subtle ordering nicety — it
-    /// is the type failing to be a vector. This reproduces the case that
-    /// matters: several pushes inside ONE call.
-    ///
-    /// `created_at` is the execution timestamp, so it is identical for every
-    /// push in a call, and the trie enumerates `(created_at, id)` — leaving a
-    /// random id to decide. `with_merge_mode` pins the timestamp to 0, which
-    /// is what a migration does and what the unit-test clock hides by
-    /// advancing between calls.
-    #[test]
-    fn positional_reads_follow_insertion_order_within_one_call() {
-        crate::env::reset_for_testing();
-        let mut v: Vector<String> = Vector::new();
-
-        crate::env::with_merge_mode(|| {
-            for key in ["k1", "k2", "k3"] {
-                v.push(key.to_owned()).expect("push");
-            }
-        });
-
-        let read: Vec<String> = (0..3)
-            .map(|i| v.get(i).expect("get").expect("present").into_inner())
-            .collect();
-
-        assert_eq!(
-            read,
-            vec!["k1".to_owned(), "k2".to_owned(), "k3".to_owned()],
-            "positional reads did not follow insertion order",
-        );
-    }
-
     #[test]
     fn test_vector_push() {
         let mut vector = Root::new(Vector::<_, MainStorage>::new);

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -584,6 +584,71 @@ mod tests {
     use crate::collections::{Root, Vector};
     use crate::store::MainStorage;
 
+    /// `Vector::get(0)` can return the third push. **Known defect, not fixed.**
+    ///
+    /// Pushing k1, k2, k3 inside ONE call reads back as k1, k3, k2. `ChildInfo`
+    /// sorts by `(created_at, id)`; `created_at` is the host's execution
+    /// timestamp, identical for every write in a call (and a flat 0 under merge
+    /// mode), so every element ties and the random id decides.
+    ///
+    /// This branch is what exposed it. `Collection::insert` no longer
+    /// materialises the child cache to append the new id — an O(n) read the
+    /// child trie exists to remove — and its comment says leaving the cache
+    /// unpopulated is safe because "the trie is authoritative". True of
+    /// membership, not of ORDER: order was previously carried by the
+    /// insertion-ordered cache, and the trie cannot reconstruct what the sort
+    /// key does not distinguish. `master` passes this test for that reason.
+    ///
+    /// Two fixes were tried and are recorded here so they are not tried again:
+    ///
+    /// 1. **Make the write stamp strictly increasing.** Breaks a deliberate
+    ///    merge invariant — `an_entity_constructed_during_merge_loses_to_any_delete`
+    ///    requires merge-mode writes to stamp 0 so nothing can be older than
+    ///    them, while `interface.rs` and `merge.rs` read `created_at ==
+    ///    updated_at` as "never updated". Together those force ties in merge
+    ///    mode, so timestamps cannot carry order there.
+    ///
+    /// 2. **Order the ids** (a monotonic prefix). The trie buckets on the first
+    ///    4 nibbles of the id, so a monotonic prefix puts every entry of a
+    ///    collection in one bucket and turns the bounded lookup back into a
+    ///    scan — the cost this branch exists to remove.
+    ///
+    /// What remains is a per-child ordinal carried as the tiebreak,
+    /// `(created_at, ordinal, id)`. The ordinal cannot be recomputed by the
+    /// receiver — a node applying a synced `Add` would derive it from ITS child
+    /// count, which need not match the writer's — so it has to be assigned by
+    /// the writer and travel in the action payload. That makes it a sync
+    /// wire-format change, and it belongs to whoever owns the merge semantics
+    /// rather than to this branch.
+    ///
+    /// Failure is probabilistic: three random ids sort into insertion order
+    /// about one time in six, so this reproduces ~5 runs in 6 and CI scenario
+    /// `09-scenario-crdt-native` fails intermittently rather than always.
+    /// `master` passes it 10/10, which is what identifies the regression as
+    /// this branch's rather than pre-existing.
+    #[test]
+    #[ignore = "known: insertion order is lost for writes made in one call; see comment"]
+    fn positional_reads_follow_insertion_order_within_one_call() {
+        crate::env::reset_for_testing();
+        let mut v: Vector<String> = Vector::new();
+
+        crate::env::with_merge_mode(|| {
+            for key in ["k1", "k2", "k3"] {
+                v.push(key.to_owned()).expect("push");
+            }
+        });
+
+        let read: Vec<String> = (0..3)
+            .map(|i| v.get(i).expect("get").expect("present").into_inner())
+            .collect();
+
+        assert_eq!(
+            read,
+            vec!["k1".to_owned(), "k2".to_owned(), "k3".to_owned()],
+            "positional reads did not follow insertion order",
+        );
+    }
+
     #[test]
     fn test_vector_push() {
         let mut vector = Root::new(Vector::<_, MainStorage>::new);

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -1,5 +1,6 @@
 //! This module provides functionality for the vector data structure.
 
+use crate::address::Id;
 use core::borrow::Borrow;
 use core::fmt;
 use std::mem;
@@ -165,21 +166,29 @@ where
     /// Push a value with an explicit `StorageType` on the new entry's element.
     ///
     /// Used by `AuthoredVector` to stamp each push with the executor as owner.
-    /// Returns the index of the newly inserted entry.
+    /// Returns the id of the newly inserted entry.
     pub(crate) fn push_with_storage_type(
         &mut self,
         value: V,
         storage_type: crate::entities::StorageType,
-    ) -> Result<usize, StoreError> {
-        let _ignored = self
+    ) -> Result<Id, StoreError> {
+        let (id, _item) = self
             .inner
             .insert_with_storage_type(None, value, storage_type)?;
-        let len = self.inner.len()?;
-        debug_assert!(
-            len >= 1,
-            "Vector::push_with_storage_type: len must be >= 1 after a successful push",
-        );
-        Ok(len - 1)
+        // The id, not `len - 1`.
+        //
+        // `len - 1` meant "the new entry is last", which held only while
+        // `insert` materialised the child cache and appended there. It no
+        // longer does — that populate was an O(n) read per insert — so
+        // enumeration comes from the child trie in `(created_at, id)` order,
+        // and `created_at` does not advance within a call. Entries pushed in
+        // one call therefore tie and the random id decides position, so
+        // `len - 1` could address a different entry (core#3637).
+        //
+        // An id is what the caller actually meant: it names the entry rather
+        // than describing where it currently sits, so it stays correct across a
+        // remote insert, which no positional answer can.
+        Ok(id)
     }
 
     /// Returns the storage id of the entry at `index`, or `None` if out of bounds.
@@ -272,6 +281,43 @@ where
         let old = mem::replace(&mut *entry, value);
 
         Ok(Some(old))
+    }
+
+    /// Replace the value stored under `id`, whatever position it occupies.
+    ///
+    /// The positional [`update`](Self::update) resolves `index` to an id and
+    /// then does exactly this. Callers that already hold the id should not go
+    /// back through a position: enumeration is `(created_at, id)` ordered over
+    /// a set other replicas insert into, so an index is only valid for as long
+    /// as no one else has inserted.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system.
+    pub(crate) fn update_by_id(&mut self, id: Id, mut value: V) -> Result<Option<V>, StoreError>
+    where
+        V: 'static,
+    {
+        // Same re-key as the positional path: two nodes concurrently replacing
+        // the same element with a freshly-built nested CRDT would otherwise
+        // mint divergent random internal ids.
+        super::rekey::rekey_nested_value(&mut value, id);
+
+        let Some(mut entry) = self.inner.get_mut(id)? else {
+            return Ok(None);
+        };
+
+        let old = mem::replace(&mut *entry, value);
+        Ok(Some(old))
+    }
+
+    /// Read the value stored under `id`, whatever position it occupies.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system.
+    pub(crate) fn get_by_id(&self, id: Id) -> Result<Option<ValueRef<V>>, StoreError> {
+        Ok(self.inner.get(id)?.map(ValueRef::new))
     }
 
     /// Get an iterator over the items in the vector.

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -584,50 +584,18 @@ mod tests {
     use crate::collections::{Root, Vector};
     use crate::store::MainStorage;
 
-    /// `Vector::get(0)` can return the third push. **Known defect, not fixed.**
+    /// A `Vector` hands back what was pushed, in the order it was pushed.
     ///
-    /// Pushing k1, k2, k3 inside ONE call reads back as k1, k3, k2. `ChildInfo`
-    /// sorts by `(created_at, id)`; `created_at` is the host's execution
-    /// timestamp, identical for every write in a call (and a flat 0 under merge
-    /// mode), so every element ties and the random id decides.
+    /// This reproduces the case that broke: several pushes inside ONE call.
+    /// `ChildInfo` sorts by `(created_at, order, id)`, and `created_at` cannot
+    /// separate them — it is the host's execution timestamp, identical for
+    /// every write in a call and pinned to 0 under merge mode. Before `order`
+    /// existed they tied and the random id decided, so this failed about five
+    /// runs in six: pushing k1, k2, k3 read back as k1, k3, k2.
     ///
-    /// This branch is what exposed it. `Collection::insert` no longer
-    /// materialises the child cache to append the new id — an O(n) read the
-    /// child trie exists to remove — and its comment says leaving the cache
-    /// unpopulated is safe because "the trie is authoritative". True of
-    /// membership, not of ORDER: order was previously carried by the
-    /// insertion-ordered cache, and the trie cannot reconstruct what the sort
-    /// key does not distinguish. `master` passes this test for that reason.
-    ///
-    /// Two fixes were tried and are recorded here so they are not tried again:
-    ///
-    /// 1. **Make the write stamp strictly increasing.** Breaks a deliberate
-    ///    merge invariant — `an_entity_constructed_during_merge_loses_to_any_delete`
-    ///    requires merge-mode writes to stamp 0 so nothing can be older than
-    ///    them, while `interface.rs` and `merge.rs` read `created_at ==
-    ///    updated_at` as "never updated". Together those force ties in merge
-    ///    mode, so timestamps cannot carry order there.
-    ///
-    /// 2. **Order the ids** (a monotonic prefix). The trie buckets on the first
-    ///    4 nibbles of the id, so a monotonic prefix puts every entry of a
-    ///    collection in one bucket and turns the bounded lookup back into a
-    ///    scan — the cost this branch exists to remove.
-    ///
-    /// What remains is a per-child ordinal carried as the tiebreak,
-    /// `(created_at, ordinal, id)`. The ordinal cannot be recomputed by the
-    /// receiver — a node applying a synced `Add` would derive it from ITS child
-    /// count, which need not match the writer's — so it has to be assigned by
-    /// the writer and travel in the action payload. That makes it a sync
-    /// wire-format change, and it belongs to whoever owns the merge semantics
-    /// rather than to this branch.
-    ///
-    /// Failure is probabilistic: three random ids sort into insertion order
-    /// about one time in six, so this reproduces ~5 runs in 6 and CI scenario
-    /// `09-scenario-crdt-native` fails intermittently rather than always.
-    /// `master` passes it 10/10, which is what identifies the regression as
-    /// this branch's rather than pre-existing.
+    /// `with_merge_mode` pins the clock, which is what a migration does and
+    /// what the unit-test clock otherwise hides by advancing between calls.
     #[test]
-    #[ignore = "known: insertion order is lost for writes made in one call; see comment"]
     fn positional_reads_follow_insertion_order_within_one_call() {
         crate::env::reset_for_testing();
         let mut v: Vector<String> = Vector::new();
@@ -646,6 +614,37 @@ mod tests {
             read,
             vec!["k1".to_owned(), "k2".to_owned(), "k3".to_owned()],
             "positional reads did not follow insertion order",
+        );
+    }
+
+    /// Editing an entry must not move it.
+    ///
+    /// A position is taken once, when the child is first linked. Re-linking
+    /// happens on every update, so taking a fresh position there would send an
+    /// entry to the end of its own collection each time it was edited.
+    #[test]
+    fn updating_an_entry_leaves_it_where_it_was() {
+        crate::env::reset_for_testing();
+        let mut v: Vector<String> = Vector::new();
+
+        crate::env::with_merge_mode(|| {
+            for key in ["k1", "k2", "k3"] {
+                v.push(key.to_owned()).expect("push");
+            }
+        });
+
+        // Edited outside merge mode: that is an ordinary write, and merge mode
+        // is only used above to force the tie this test is about.
+        v.update(0, "k1-edited".to_owned()).expect("update");
+
+        let read: Vec<String> = (0..3)
+            .map(|i| v.get(i).expect("get").expect("present").into_inner())
+            .collect();
+
+        assert_eq!(
+            read,
+            vec!["k1-edited".to_owned(), "k2".to_owned(), "k3".to_owned()],
+            "an edited entry moved instead of staying put",
         );
     }
 

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -534,6 +534,7 @@ where
 
 #[cfg(test)]
 mod tests {
+
     use crate::collections::{Root, Vector};
     use crate::store::MainStorage;
 

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -311,11 +311,6 @@ where
         Ok(Some(old))
     }
 
-    /// Read the value stored under `id`, whatever position it occupies.
-    ///
-    /// # Errors
-    ///
-    /// If an error occurs when interacting with the storage system.
     /// The id of the inner collection — the parent every entry of this vector
     /// is a child of.
     ///
@@ -329,6 +324,11 @@ where
         self.inner.id()
     }
 
+    /// Read the value stored under `id`, whatever position it occupies.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs when interacting with the storage system.
     pub(crate) fn get_by_id(&self, id: Id) -> Result<Option<ValueRef<V>>, StoreError> {
         Ok(self.inner.get(id)?.map(ValueRef::new))
     }

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -584,6 +584,39 @@ mod tests {
     use crate::collections::{Root, Vector};
     use crate::store::MainStorage;
 
+    /// A `Vector` must hand back what was pushed, in the order it was pushed.
+    ///
+    /// `get(0)` returning the third push is not a subtle ordering nicety — it
+    /// is the type failing to be a vector. This reproduces the case that
+    /// matters: several pushes inside ONE call.
+    ///
+    /// `created_at` is the execution timestamp, so it is identical for every
+    /// push in a call, and the trie enumerates `(created_at, id)` — leaving a
+    /// random id to decide. `with_merge_mode` pins the timestamp to 0, which
+    /// is what a migration does and what the unit-test clock hides by
+    /// advancing between calls.
+    #[test]
+    fn positional_reads_follow_insertion_order_within_one_call() {
+        crate::env::reset_for_testing();
+        let mut v: Vector<String> = Vector::new();
+
+        crate::env::with_merge_mode(|| {
+            for key in ["k1", "k2", "k3"] {
+                v.push(key.to_owned()).expect("push");
+            }
+        });
+
+        let read: Vec<String> = (0..3)
+            .map(|i| v.get(i).expect("get").expect("present").into_inner())
+            .collect();
+
+        assert_eq!(
+            read,
+            vec!["k1".to_owned(), "k2".to_owned(), "k3".to_owned()],
+            "positional reads did not follow insertion order",
+        );
+    }
+
     #[test]
     fn test_vector_push() {
         let mut vector = Root::new(Vector::<_, MainStorage>::new);

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -316,6 +316,19 @@ where
     /// # Errors
     ///
     /// If an error occurs when interacting with the storage system.
+    /// The id of the inner collection — the parent every entry of this vector
+    /// is a child of.
+    ///
+    /// Exposed so the authored layer can check that a caller-supplied entry id
+    /// actually belongs to THIS vector before acting on it. `Collection::get`
+    /// resolves an id through a global `find_by_id`, which is fine for the
+    /// positional API (an index can only ever name a child of self) and not
+    /// fine for the id-addressed one.
+    pub(crate) fn collection_id(&self) -> Id {
+        use crate::entities::Data as _;
+        self.inner.id()
+    }
+
     pub(crate) fn get_by_id(&self, id: Id) -> Result<Option<ValueRef<V>>, StoreError> {
         Ok(self.inner.get(id)?.map(ValueRef::new))
     }

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -195,53 +195,16 @@ pub struct Element {
     pub(crate) metadata: Metadata,
 }
 
-thread_local! {
-    /// How many elements this call has stamped, so each stamp is distinct.
-    ///
-    /// `ChildInfo` sorts by `(created_at, id)` and that order is load-bearing:
-    /// `Vector::get(i)` walks children in it, so a push must land after the
-    /// pushes before it. The doc on that `Ord` says `created_at` is "an HLC at
-    /// write time, roughly monotonic per writer" — but what is actually
-    /// stamped is the host's EXECUTION timestamp, which is identical for every
-    /// write in a call (and a flat 0 under merge mode, for determinism). Every
-    /// element created in one call therefore tied, and the random id decided
-    /// the order: pushing k1, k2, k3 read back as k1, k3, k2.
-    ///
-    /// A counter restores the intent the ordering was written for. It is
-    /// per-call, so two replicas replaying the same writes in the same order
-    /// derive the same stamps and converge — which is why it can be used under
-    /// merge mode, where the wall clock deliberately cannot.
-    static WRITE_SEQUENCE: core::cell::Cell<u64> = const { core::cell::Cell::new(0) };
-}
-
-/// Forget the per-call write sequence. Test seam, and the reset a fresh
-/// execution gets for free by starting a new WASM instance.
-pub fn reset_write_sequence() {
-    WRITE_SEQUENCE.with(|seq| seq.set(0));
-}
-
 impl Element {
     /// Returns a timestamp for element creation/update.
-    ///
-    /// Strictly increasing within a call, so elements created together keep
-    /// the order they were created in — see `WRITE_SEQUENCE`. Outside merge
-    /// mode the sequence rides on the execution timestamp, whose resolution is
-    /// nanoseconds; a call would have to create billions of elements for the
-    /// offset to reach the next call's clock.
+    /// During merge mode, returns 0 to ensure deterministic hashes.
+    /// Outside merge mode, returns the current time.
     #[inline]
     fn timestamp_for_operation() -> u64 {
-        let nth = WRITE_SEQUENCE.with(|seq| {
-            let next = seq.get();
-            seq.set(next.saturating_add(1));
-            next
-        });
-
         if crate::env::in_merge_mode() {
-            // The wall clock is pinned to 0 here so hashes are deterministic;
-            // the sequence is deterministic too, so ordering survives.
-            nth
+            0
         } else {
-            time_now().saturating_add(nth)
+            time_now()
         }
     }
 

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -113,12 +113,14 @@ pub struct ChildInfo {
 // iteration. `id` is the tiebreaker for entries written at the same
 // HLC.
 //
-// The merkle full_hash computation in `Index::calculate_full_hash_for_children`
-// deliberately re-sorts by `id` alone before hashing, so the hash
-// content is independent of this ordering — peers that disagree on
+// The merkle full_hash does not use this order at all: a parent commits
+// to its children through its `ChildTrie`, whose buckets hold entries
+// id-sorted and fold only `id` + `merkle_hash`. No part of `Metadata`
+// — `created_at` included — reaches the root, so peers that disagree on
 // `created_at` (e.g. locally-created entities like `Root<T>`) still
 // compute the same parent hash. The two concerns (storage iteration
-// order vs hash content) are intentionally decoupled.
+// order vs hash content) are intentionally decoupled; see
+// `child_trie::tests::the_root_does_not_depend_on_when_each_child_was_created`.
 impl Ord for ChildInfo {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.created_at()

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -195,16 +195,53 @@ pub struct Element {
     pub(crate) metadata: Metadata,
 }
 
+thread_local! {
+    /// How many elements this call has stamped, so each stamp is distinct.
+    ///
+    /// `ChildInfo` sorts by `(created_at, id)` and that order is load-bearing:
+    /// `Vector::get(i)` walks children in it, so a push must land after the
+    /// pushes before it. The doc on that `Ord` says `created_at` is "an HLC at
+    /// write time, roughly monotonic per writer" — but what is actually
+    /// stamped is the host's EXECUTION timestamp, which is identical for every
+    /// write in a call (and a flat 0 under merge mode, for determinism). Every
+    /// element created in one call therefore tied, and the random id decided
+    /// the order: pushing k1, k2, k3 read back as k1, k3, k2.
+    ///
+    /// A counter restores the intent the ordering was written for. It is
+    /// per-call, so two replicas replaying the same writes in the same order
+    /// derive the same stamps and converge — which is why it can be used under
+    /// merge mode, where the wall clock deliberately cannot.
+    static WRITE_SEQUENCE: core::cell::Cell<u64> = const { core::cell::Cell::new(0) };
+}
+
+/// Forget the per-call write sequence. Test seam, and the reset a fresh
+/// execution gets for free by starting a new WASM instance.
+pub fn reset_write_sequence() {
+    WRITE_SEQUENCE.with(|seq| seq.set(0));
+}
+
 impl Element {
     /// Returns a timestamp for element creation/update.
-    /// During merge mode, returns 0 to ensure deterministic hashes.
-    /// Outside merge mode, returns the current time.
+    ///
+    /// Strictly increasing within a call, so elements created together keep
+    /// the order they were created in — see `WRITE_SEQUENCE`. Outside merge
+    /// mode the sequence rides on the execution timestamp, whose resolution is
+    /// nanoseconds; a call would have to create billions of elements for the
+    /// offset to reach the next call's clock.
     #[inline]
     fn timestamp_for_operation() -> u64 {
+        let nth = WRITE_SEQUENCE.with(|seq| {
+            let next = seq.get();
+            seq.set(next.saturating_add(1));
+            next
+        });
+
         if crate::env::in_merge_mode() {
-            0
+            // The wall clock is pinned to 0 here so hashes are deterministic;
+            // the sequence is deterministic too, so ordering survives.
+            nth
         } else {
-            time_now()
+            time_now().saturating_add(nth)
         }
     }
 

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -105,13 +105,21 @@ pub struct ChildInfo {
     pub metadata: Metadata,
 }
 
-// Sort by `(created_at, id)`. This order is load-bearing for
-// collections that preserve insertion semantics — `Vector::get(idx)`
-// iterates children in this order, so each push() must end up after
-// previous pushes. `created_at` is an HLC at write time, which is
-// roughly monotonic per writer, so this gives insertion-order
-// iteration. `id` is the tiebreaker for entries written at the same
-// HLC.
+// Sort by `(created_at, order, id)`. This is load-bearing for collections that
+// preserve insertion semantics — `Vector::get(idx)` iterates children in this
+// order, so each push() must end up after the pushes before it.
+//
+// `created_at` alone cannot do it. It is the host's EXECUTION timestamp, which
+// is identical for every write in a call and pinned to 0 under merge mode, so
+// everything written together tied and the random `id` decided: pushing k1, k2,
+// k3 read back as k1, k3, k2. (An earlier version of this comment claimed
+// `created_at` was "an HLC at write time, roughly monotonic per writer" — it
+// describes what the ordering needed, not what was stamped.)
+//
+// `order` is the writer-assigned position among its parent's children, so
+// entries written in one call separate. `id` remains the final tiebreak for
+// entries written concurrently by different replicas, where no order exists to
+// agree on and only determinism matters.
 //
 // The merkle full_hash does not use this order at all: a parent commits
 // to its children through its `ChildTrie`, whose buckets hold entries
@@ -125,6 +133,7 @@ impl Ord for ChildInfo {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.created_at()
             .cmp(&other.created_at())
+            .then_with(|| self.metadata.order.cmp(&other.metadata.order))
             .then_with(|| self.id.cmp(&other.id))
     }
 }
@@ -223,6 +232,7 @@ impl Element {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
             merkle_hash: [0; 32],
         }
@@ -243,6 +253,7 @@ impl Element {
                 crdt_type: None,
                 field_name,
                 schema_version: None,
+                order: 0,
             },
             merkle_hash: [0; 32],
         }
@@ -267,6 +278,7 @@ impl Element {
                 crdt_type: Some(crdt_type),
                 field_name,
                 schema_version: None,
+                order: 0,
             },
             merkle_hash: [0; 32],
         }
@@ -286,6 +298,7 @@ impl Element {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
             merkle_hash: [0; 32],
         }
@@ -716,6 +729,31 @@ pub struct Metadata {
     ///   (`own_hash = Sha256(value bytes)` only, `interface.rs`), so tagging an
     ///   entry never diverges its leaf hash between peers.
     pub schema_version: Option<u32>,
+
+    /// Position of this entity among its parent's children, assigned by the
+    /// WRITER at the moment it is first linked.
+    ///
+    /// Collections that preserve insertion order — `Vector`, `AuthoredVector` —
+    /// enumerate children through `ChildInfo`'s `Ord`, which sorts by
+    /// `(created_at, order, id)`. `created_at` alone cannot separate them: it is
+    /// the host's execution timestamp, identical for every write in a call and
+    /// pinned to 0 under merge mode, so elements written together tied and a
+    /// random id decided. `Vector::get(0)` could return the third push.
+    ///
+    /// It must be assigned by the writer and travel in `Action`'s metadata: a
+    /// node applying a synced `Add` would otherwise derive the position from
+    /// ITS OWN child count, which need not match the writer's, and the two
+    /// replicas would order the same collection differently.
+    ///
+    /// **Merkle-invisible**, like `schema_version`: `Metadata` is
+    /// `#[borsh(skip)]` on `Element`, so this never reaches
+    /// `own_hash = Sha256(to_vec(child))`, and the child fold covers
+    /// `id ‖ merkle_hash` only. Ordering can therefore change without moving a
+    /// single hash.
+    ///
+    /// `0` for entities written before this field existed, and for those whose
+    /// parent does not care about order — they keep tying, exactly as now.
+    pub order: u64,
 }
 
 impl Metadata {
@@ -729,6 +767,7 @@ impl Metadata {
             crdt_type: None,
             field_name: None,
             schema_version: None,
+            order: 0,
         }
     }
 
@@ -742,6 +781,7 @@ impl Metadata {
             crdt_type: Some(crdt_type),
             field_name: None,
             schema_version: None,
+            order: 0,
         }
     }
 
@@ -755,6 +795,7 @@ impl Metadata {
             crdt_type: None,
             field_name: Some(field_name),
             schema_version: None,
+            order: 0,
         }
     }
 
@@ -773,6 +814,7 @@ impl Metadata {
             crdt_type: Some(crdt_type),
             field_name: Some(field_name),
             schema_version: None,
+            order: 0,
         }
     }
 

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -378,11 +378,26 @@ impl EntityIndex {
     ///
     /// A context's ROOT index carries the hash that
     /// `ContextRegistry::compute_root_hash` reads, so a test that needs the
-    /// state-derived root to *move* has to be able to set it. Kept childless so
-    /// the reader stays on its offset fast path.
+    /// state-derived root to *move* has to be able to set it.
     #[must_use]
     pub fn minimal_for_test_with_full_hash(id: Id, full_hash: [u8; 32]) -> Self {
         Self {
+            full_hash,
+            ..Self::minimal_for_test(id)
+        }
+    }
+
+    /// Like [`Self::minimal_for_test`] but parented, and with a chosen
+    /// `full_hash`.
+    ///
+    /// Snapshot install writes index rows verbatim, so a test for the
+    /// receive-side trie rebuild has to be able to produce a row that names its
+    /// parent — that link is the only thing the rebuild has to work from.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn minimal_for_test_with_parent(id: Id, parent_id: Id, full_hash: [u8; 32]) -> Self {
+        Self {
+            parent_id: Some(parent_id),
             full_hash,
             ..Self::minimal_for_test(id)
         }
@@ -491,12 +506,7 @@ impl<S: StorageAdaptor> Index<S> {
             .deleted_children
             .retain(|id| *id != added_child_id);
 
-        let mut hasher = Sha256::new();
-        hasher.update(parent_index.own_hash);
-        if trie_root != child_trie::EMPTY {
-            hasher.update(trie_root);
-        }
-        parent_index.full_hash = hasher.finalize().into();
+        parent_index.full_hash = Self::full_hash_from_root(parent_index.own_hash, trie_root);
         Self::save_index(&parent_index)?;
 
         Self::recalculate_ancestor_hashes_for(parent_id)?;
@@ -539,7 +549,19 @@ impl<S: StorageAdaptor> Index<S> {
     /// The trie root is order-independent, so this is a pure function of the
     /// child set — which is what two replicas must agree on.
     pub(crate) fn full_hash_from_trie(id: Id, own_hash: [u8; 32]) -> [u8; 32] {
-        let root = <ChildTrie<S>>::new(id).root();
+        Self::full_hash_from_root(own_hash, <ChildTrie<S>>::new(id).root())
+    }
+
+    /// The fold itself: `own_hash`, then the trie root unless it is empty.
+    ///
+    /// One definition on purpose. Callers that have just written the trie hold
+    /// the new root already and should not pay a row read to get it back, so
+    /// they cannot go through [`full_hash_from_trie`](Self::full_hash_from_trie)
+    /// — but the RULE they apply (field order, and skipping an empty root so a
+    /// childless entity hashes as itself) has to be the same one, because a
+    /// copy that drifts forks replicas silently: both sides compute a hash,
+    /// they just compute different ones.
+    pub(crate) fn full_hash_from_root(own_hash: [u8; 32], root: [u8; 32]) -> [u8; 32] {
         let mut hasher = Sha256::new();
         hasher.update(own_hash);
         if root != child_trie::EMPTY {
@@ -930,6 +952,12 @@ impl<S: StorageAdaptor> Index<S> {
         // data gone with no tombstone while the parent still lists it live.
         Self::mark_deleted(id, deleted_at)?;
         let _ignored = S::storage_remove(Key::Entry(id));
+        // The entity's own child trie goes with its data. Nothing else reaches
+        // those rows — they are their own keyspace, so tombstone GC (which
+        // requires a row to decode as a tombstoned `EntityIndex`) never sees
+        // them. Left behind, they resurrect as ghost children the next time a
+        // deterministically-named collection is re-created at the same id.
+        <ChildTrie<S>>::new(id).drop_all();
         Ok(())
     }
 
@@ -1099,12 +1127,7 @@ impl<S: StorageAdaptor> Index<S> {
         }
 
         // Recalculate parent's hash from the trie root.
-        let mut hasher = Sha256::new();
-        hasher.update(parent_index.own_hash);
-        if trie_root != child_trie::EMPTY {
-            hasher.update(trie_root);
-        }
-        parent_index.full_hash = hasher.finalize().into();
+        parent_index.full_hash = Self::full_hash_from_root(parent_index.own_hash, trie_root);
         Self::save_index(&parent_index)?;
 
         Ok(())

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -530,44 +530,6 @@ impl<S: StorageAdaptor> Index<S> {
         Ok(())
     }
 
-    /// Calculates full Merkle hash from own hash and children.
-    ///
-    /// **Iteration order is `id`-sorted, not `ChildInfo`'s natural
-    /// `(created_at, id)` Ord.** The merkle hash must be deterministic
-    /// across peers regardless of when each peer first observed each
-    /// child — and `created_at` is a local-clock observation that
-    /// diverges for entities two peers create independently with the
-    /// same content (canonical case: the `Root<T>` opaque-marker
-    /// entity the storage layer creates the first time an app
-    /// touches its state). Sorting by `id` alone before hashing
-    /// makes the parent hash purely content-derived: identical child
-    /// sets at identical merkle hashes produce identical parent
-    /// hashes regardless of when each node first wrote each child.
-    ///
-    /// The stored `ChildInfo` list keeps its `(created_at, id)`
-    /// order — that's load-bearing for `Vector::get(idx)`'s
-    /// insertion-order semantics and other collections that
-    /// depend on iteration order at the storage layer. The hash
-    /// content is decoupled from that layout here.
-    pub(crate) fn calculate_full_hash_for_children(
-        own_hash: [u8; 32],
-        children: &Option<Vec<ChildInfo>>,
-    ) -> Result<[u8; 32], StorageError> {
-        let mut hasher = Sha256::new();
-        hasher.update(own_hash);
-
-        if let Some(children_vec) = children {
-            // Sort by id before hashing — see method-level doc.
-            let mut by_id: Vec<&ChildInfo> = children_vec.iter().collect();
-            by_id.sort_by_key(|c| c.id());
-            for child in by_id {
-                hasher.update(child.merkle_hash());
-            }
-        }
-
-        Ok(hasher.finalize().into())
-    }
-
     /// An entity's full hash, folding its children through the child trie.
     ///
     /// Replaces folding a sibling list: the trie root already commits to every
@@ -598,8 +560,8 @@ impl<S: StorageAdaptor> Index<S> {
     /// If the entity doesn't exist in the index, returns
     /// `StorageError::IndexNotFound`. If a future write site adds `full_hash`
     /// drift somehow, tests in `tests::merkle` enforce the invariant
-    /// `stored_full_hash == calculate_full_hash_for_children(...)` after
-    /// common operation sequences.
+    /// `stored_full_hash == recompute from the child trie` after common
+    /// operation sequences.
     pub(crate) fn get_full_merkle_hash_for(id: Id) -> Result<[u8; 32], StorageError> {
         Self::get_hashes_for(id)?
             .map(|(full_hash, _)| full_hash)

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -909,7 +909,10 @@ impl<S: StorageAdaptor> Index<S> {
 
             // Log when root hash changes
             if parent_id.is_root() && old_full_hash != parent_index.full_hash {
-                let children_count = <ChildTrie<S>>::new(parent_id).children().len();
+                // `len()`, not `children().len()`: this runs on the ancestor
+                // recompute of every write, and enumerating the trie here made
+                // each write read every child of the parent.
+                let children_count = <ChildTrie<S>>::new(parent_id).len();
                 info!(
                     target: "storage::merkle",
                     parent_id = %parent_id,
@@ -1197,12 +1200,25 @@ impl<S: StorageAdaptor> Index<S> {
 
         // Log detailed info for root entity hash updates
         if id.is_root() {
-            let root_children = <ChildTrie<S>>::new(id).children();
-            let children_count = root_children.len();
-            let children_hashes: Vec<String> = root_children
-                .iter()
-                .map(|child| format!("{}:{}", child.id(), hex::encode(child.merkle_hash())))
-                .collect();
+            // O(1): the trie maintains the count. Enumerating every child here
+            // put a LINEAR READ on every root hash update — that is, on every
+            // write — and hex-formatted each one into a String on the way.
+            // Measured at 599 records: 7,697 reads and 640 KB read for a single
+            // insert, versus 76 writes. It was also built eagerly, so the cost
+            // was paid even when the log level discarded the result.
+            let children_count = <ChildTrie<S>>::new(id).len();
+            // The per-child dump is a genuine diagnostic, so keep it — but only
+            // materialise it when something is actually listening at TRACE.
+            let children_hashes: Vec<String> = if tracing::enabled!(target: "storage::merkle", tracing::Level::TRACE)
+            {
+                <ChildTrie<S>>::new(id)
+                    .children()
+                    .iter()
+                    .map(|child| format!("{}:{}", child.id(), hex::encode(child.merkle_hash())))
+                    .collect()
+            } else {
+                Vec::new()
+            };
             info!(
                 target: "storage::merkle",
                 %id,

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -775,6 +775,22 @@ impl<S: StorageAdaptor> Index<S> {
         Ok(<ChildTrie<S>>::new(parent_id).children())
     }
 
+    /// How many children `parent_id` has, without enumerating them.
+    ///
+    /// One row read: the trie maintains a subtree count along the spine an
+    /// insert already walks. Callers that count on every write — a contract
+    /// deriving an id from `len()`, the ancestor-recompute log line — must use
+    /// this rather than `get_children_of(..).len()`, which is a full walk.
+    ///
+    /// Exists so the rest of the crate does not reach past `Index` into
+    /// `ChildTrie`. That type's public surface is earned by the callers that
+    /// reach the store directly with no `StorageAdaptor` — snapshot install and
+    /// the raw-DB diagnostics — not by intra-crate use.
+    #[must_use]
+    pub fn child_count(parent_id: Id) -> u64 {
+        <ChildTrie<S>>::new(parent_id).len()
+    }
+
     /// Returns (full_hash, own_hash) tuple for an entity.
     ///
     /// # Errors
@@ -813,7 +829,7 @@ impl<S: StorageAdaptor> Index<S> {
     /// Checks if a collection has any children.
     ///
     /// Collection param ignored - just checks if entity has any children.
-    pub(crate) fn has_children(parent_id: Id) -> Result<bool, StorageError> {
+    pub fn has_children(parent_id: Id) -> Result<bool, StorageError> {
         let parent_index =
             Self::get_index(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
 
@@ -896,7 +912,7 @@ impl<S: StorageAdaptor> Index<S> {
                 // `len()`, not `children().len()`: this runs on the ancestor
                 // recompute of every write, and enumerating the trie here made
                 // each write read every child of the parent.
-                let children_count = <ChildTrie<S>>::new(parent_id).len();
+                let children_count = Self::child_count(parent_id);
                 info!(
                     target: "storage::merkle",
                     parent_id = %parent_id,
@@ -946,7 +962,10 @@ impl<S: StorageAdaptor> Index<S> {
     /// Deletes entity data and creates a tombstone marker for a single entity.
     ///
     /// Step 1 of deletion: Remove actual data, keep index for CRDT sync.
-    fn delete_entity_and_create_tombstone(id: Id, deleted_at: u64) -> Result<(), StorageError> {
+    pub(crate) fn delete_entity_and_create_tombstone(
+        id: Id,
+        deleted_at: u64,
+    ) -> Result<(), StorageError> {
         // Tombstone first, then drop the data: if mark_deleted fails the entry
         // is left intact and the delete can be retried, instead of leaving the
         // data gone with no tombstone while the parent still lists it live.

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -14,6 +14,7 @@ use sha2::{Digest, Sha256};
 use tracing::info;
 
 use crate::address::Id;
+use crate::child_trie::{self, ChildTrie};
 use crate::entities::{ChildInfo, Metadata, UpdatedAt};
 use crate::interface::StorageError;
 use crate::store::{Key, StorageAdaptor};
@@ -326,13 +327,6 @@ pub struct EntityIndex {
     /// Parent ID.
     parent_id: Option<Id>,
 
-    /// Children list.
-    ///
-    /// Collection name not stored - entity can only have one collection,
-    /// so the name is redundant. API still accepts collection param for
-    /// backwards compatibility but it's ignored internally.
-    children: Option<Vec<ChildInfo>>,
-
     /// Full hash (entity + descendants).
     full_hash: [u8; 32],
 
@@ -372,7 +366,6 @@ impl EntityIndex {
         Self {
             id,
             parent_id: None,
-            children: None,
             full_hash: [0; 32],
             own_hash: [0; 32],
             metadata: Metadata::default(),
@@ -407,12 +400,6 @@ impl EntityIndex {
         self.parent_id
     }
 
-    /// Returns the children, if any.
-    #[must_use]
-    pub fn children(&self) -> Option<&[ChildInfo]> {
-        self.children.as_deref()
-    }
-
     /// Ids of this entity's children that have been removed (tombstoned).
     ///
     /// Carried on the sync wire so a peer that still holds a child converges
@@ -441,6 +428,32 @@ pub struct Index<S: StorageAdaptor>(PhantomData<S>);
 
 impl<S: StorageAdaptor> Index<S> {
     /// Adds a child to a parent's collection.
+    /// Write `child`'s own index record, pointing it at `parent_id`.
+    ///
+    /// This is the half of child registration that costs O(1): it touches one
+    /// record, the child's. It does not list the child among the parent's
+    /// `children`, and so does not refold the parent's hash over its siblings.
+    /// Returns the child's recomputed `full_hash`, which the caller needs when
+    /// listing the child in its parent.
+    fn write_child_index(parent_id: Id, child: &ChildInfo) -> Result<[u8; 32], StorageError> {
+        let mut child_index = Self::get_index(child.id())?.unwrap_or_else(|| EntityIndex {
+            id: child.id(),
+            parent_id: None,
+            full_hash: [0; 32],
+            own_hash: [0; 32],
+            metadata: child.metadata.clone(),
+            deleted_at: None,
+            deleted_children: Vec::new(),
+        });
+        child_index.parent_id = Some(parent_id);
+        child_index.own_hash = child.merkle_hash();
+        child_index.full_hash = Self::full_hash_from_trie(child.id(), child_index.own_hash);
+        child_index.deleted_at = None;
+        let full_hash = child_index.full_hash;
+        Self::save_index(&child_index)?;
+        Ok(full_hash)
+    }
+
     pub(crate) fn add_child_to(parent_id: Id, child: ChildInfo) -> Result<(), StorageError> {
         let added_child_id = child.id();
         // Serialize the read-modify-write so a concurrent local-write / sync
@@ -451,7 +464,6 @@ impl<S: StorageAdaptor> Index<S> {
         let mut parent_index = Self::get_index(parent_id)?.unwrap_or_else(|| EntityIndex {
             id: parent_id,
             parent_id: None,
-            children: None,
             full_hash: [0; 32],
             own_hash: [0; 32],
             metadata: Metadata::default(),
@@ -459,76 +471,18 @@ impl<S: StorageAdaptor> Index<S> {
             deleted_children: Vec::new(),
         });
 
-        // Get or create child index
-        let mut child_index = Self::get_index(child.id())?.unwrap_or_else(|| EntityIndex {
-            id: child.id(),
-            parent_id: None,
-            children: None,
-            full_hash: [0; 32],
-            own_hash: [0; 32],
-            metadata: child.metadata.clone(),
-            deleted_at: None,
-            deleted_children: Vec::new(),
-        });
-        child_index.parent_id = Some(parent_id);
-        child_index.own_hash = child.merkle_hash();
-        child_index.full_hash =
-            Self::calculate_full_hash_for_children(child_index.own_hash, &child_index.children)?;
         // Adding a child means it is live: clear any tombstone, else find_by_id
         // hides an entity the parent hash now counts (upsert-on-tombstone
         // divergence). Pairs with the deleted_children.retain below.
-        child_index.deleted_at = None;
-        Self::save_index(&child_index)?;
+        let child_full_hash = Self::write_child_index(parent_id, &child)?;
 
-        // Insert into parent's children list, keeping it sorted by `ChildInfo`'s
-        // Ord (primary: created_at, tiebreaker: id). The list is always sorted
-        // by construction — binary search both finds the existing entry (to
-        // replace if present) and the correct insertion point (otherwise) in
-        // O(log K) without rebuilding a BTreeSet + Vec each call (#2238 Fix 3).
-        //
-        // Prior implementation:
-        //     let mut ordered = children_vec.drain(..).collect::<BTreeSet<_>>();
-        //     ordered.replace(new_entry);
-        //     *children_vec = ordered.into_iter().collect();
-        // Allocated a BTreeSet, inserted K entries to re-sort an already-sorted
-        // list, then re-materialized a Vec — two transient allocations and
-        // O(K log K) sort work per call. `dlmalloc::malloc` was 13.06% of
-        // inclusive CPU in the baseline flamegraph; a real chunk of that lives
-        // here on the merge hot path.
-        let children_vec = parent_index.children.get_or_insert_with(Vec::new);
-        let new_entry = ChildInfo::new(child.id(), child_index.full_hash, child.metadata);
-        // Dedup by ID, not by `ChildInfo`'s `(created_at, id)` Ord. A child can
-        // be re-added with a CHANGED `created_at` (e.g. CRDT merge re-materialises
-        // an entity that two nodes first-created at different HLC times). The
-        // `(created_at, id)`-ordered `binary_search` would then miss the existing
-        // same-id entry and `insert` a SECOND ChildInfo for the same id.
-        // `calculate_full_hash_for_children` hashes every child's `merkle_hash`
-        // (sorted by id), so a duplicate entry hashes that child twice → the
-        // parent's `full_hash` (and the root) diverges depending on the order the
-        // creating deltas were applied — the "same DAG, different root hash"
-        // family. We must keep at most one ChildInfo per id.
-        //
-        // The common case — re-adding an unchanged child — hits the `Ok` branch
-        // and replaces in place in O(log K) with no scan, preserving the
-        // invariant inductively (there is never a pre-existing same-id
-        // duplicate). Only the rare `created_at`-changed miss pays an O(K) scan to
-        // evict the stale same-id entry before inserting. (The `insert`/`remove`
-        // shifts are already O(K), so this adds no asymptotic cost over the
-        // pre-dedup code.)
-        match children_vec.binary_search(&new_entry) {
-            Ok(pos) => children_vec[pos] = new_entry,
-            Err(pos) => {
-                if let Some(stale) = children_vec.iter().position(|c| c.id() == new_entry.id()) {
-                    let _ = children_vec.remove(stale);
-                    match children_vec.binary_search(&new_entry) {
-                        Ok(p) => children_vec[p] = new_entry,
-                        Err(p) => children_vec.insert(p, new_entry),
-                    }
-                } else {
-                    children_vec.insert(pos, new_entry);
-                }
-            }
-        }
+        // Link through the parent's child trie. The list this replaces was one
+        // inline blob: adding child N read N, wrote N+1 and re-hashed all of
+        // them, so a write cost grew with history until it exhausted the gas
+        // limit (core#3602). A trie link touches a bounded number of rows
+        // whatever the parent holds.
+        let new_entry = ChildInfo::new(child.id(), child_full_hash, child.metadata);
+        let trie_root = <ChildTrie<S>>::new(parent_id).insert(new_entry);
 
         // A re-added (resurrected) child is live again, so it must no longer be
         // advertised as deleted on the wire — else a peer would apply a stale
@@ -537,8 +491,12 @@ impl<S: StorageAdaptor> Index<S> {
             .deleted_children
             .retain(|id| *id != added_child_id);
 
-        parent_index.full_hash =
-            Self::calculate_full_hash_for_children(parent_index.own_hash, &parent_index.children)?;
+        let mut hasher = Sha256::new();
+        hasher.update(parent_index.own_hash);
+        if trie_root != child_trie::EMPTY {
+            hasher.update(trie_root);
+        }
+        parent_index.full_hash = hasher.finalize().into();
         Self::save_index(&parent_index)?;
 
         Self::recalculate_ancestor_hashes_for(parent_id)?;
@@ -554,7 +512,6 @@ impl<S: StorageAdaptor> Index<S> {
         let mut index = Self::get_index(root.id())?.unwrap_or_else(|| EntityIndex {
             id: root.id(),
             parent_id: None,
-            children: None,
             full_hash: [0; 32],
             own_hash: [0; 32],
             metadata: root.metadata.clone(),
@@ -568,7 +525,7 @@ impl<S: StorageAdaptor> Index<S> {
         // to re-hash the children Vec every time. With the stored value
         // kept current by each write site, reads become O(1).
         // See #2238 Fix 1.
-        index.full_hash = Self::calculate_full_hash_for_children(index.own_hash, &index.children)?;
+        index.full_hash = Self::full_hash_from_trie(index.id, index.own_hash);
         Self::save_index(&index)?;
         Ok(())
     }
@@ -609,6 +566,24 @@ impl<S: StorageAdaptor> Index<S> {
         }
 
         Ok(hasher.finalize().into())
+    }
+
+    /// An entity's full hash, folding its children through the child trie.
+    ///
+    /// Replaces folding a sibling list: the trie root already commits to every
+    /// child, and maintaining it costs a bounded number of rows per link rather
+    /// than rewriting and re-hashing every sibling. See [`ChildTrie`].
+    ///
+    /// The trie root is order-independent, so this is a pure function of the
+    /// child set — which is what two replicas must agree on.
+    pub(crate) fn full_hash_from_trie(id: Id, own_hash: [u8; 32]) -> [u8; 32] {
+        let root = <ChildTrie<S>>::new(id).root();
+        let mut hasher = Sha256::new();
+        hasher.update(own_hash);
+        if root != child_trie::EMPTY {
+            hasher.update(root);
+        }
+        hasher.finalize().into()
     }
 
     /// Returns the stored full Merkle hash for an entity.
@@ -811,9 +786,9 @@ impl<S: StorageAdaptor> Index<S> {
     /// # Errors
     /// Returns `StorageError` if index cannot be loaded or deserialized.
     pub fn get_children_of(parent_id: Id) -> Result<Vec<ChildInfo>, StorageError> {
-        let index = Self::get_index(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
+        let _index = Self::get_index(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
 
-        Ok(index.children.unwrap_or_default())
+        Ok(<ChildTrie<S>>::new(parent_id).children())
     }
 
     /// Returns (full_hash, own_hash) tuple for an entity.
@@ -858,10 +833,8 @@ impl<S: StorageAdaptor> Index<S> {
         let parent_index =
             Self::get_index(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
 
-        Ok(parent_index
-            .children
-            .as_ref()
-            .is_some_and(|c| !c.is_empty()))
+        let _ = &parent_index;
+        Ok(<ChildTrie<S>>::new(parent_id).root() != child_trie::EMPTY)
     }
 
     /// Recalculates ancestor hashes recursively up to root.
@@ -909,9 +882,10 @@ impl<S: StorageAdaptor> Index<S> {
                 Self::get_index(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
             let old_full_hash = parent_index.full_hash;
 
-            // Update the child's hash in the parent's children list
-            if let Some(children) = &mut parent_index.children {
-                if let Some(child) = children.iter_mut().find(|c| c.id() == current_id) {
+            // Refresh the child's entry in the parent's trie.
+            let parent_trie = <ChildTrie<S>>::new(parent_id);
+            if let Some(mut child) = parent_trie.get(current_id) {
+                {
                     let new_child_hash = Self::get_full_merkle_hash_for(current_id)?;
                     if child.merkle_hash() != new_child_hash {
                         // Log when a child's hash changes and affects the root
@@ -924,20 +898,18 @@ impl<S: StorageAdaptor> Index<S> {
                                 "ROOT MERKLE: Child hash updated"
                             );
                         }
-                        *child = ChildInfo::new(current_id, new_child_hash, child.metadata.clone());
+                        child = ChildInfo::new(current_id, new_child_hash, child.metadata.clone());
+                        let _root = parent_trie.insert(child);
                     }
                 }
             }
 
-            // Recalculate the parent's full hash
-            parent_index.full_hash = Self::calculate_full_hash_for_children(
-                parent_index.own_hash,
-                &parent_index.children,
-            )?;
+            // Recalculate the parent's full hash from the trie root.
+            parent_index.full_hash = Self::full_hash_from_trie(parent_id, parent_index.own_hash);
 
             // Log when root hash changes
             if parent_id.is_root() && old_full_hash != parent_index.full_hash {
-                let children_count = parent_index.children.as_ref().map(|c| c.len()).unwrap_or(0);
+                let children_count = <ChildTrie<S>>::new(parent_id).children().len();
                 info!(
                     target: "storage::merkle",
                     parent_id = %parent_id,
@@ -1066,8 +1038,8 @@ impl<S: StorageAdaptor> Index<S> {
             {
                 continue;
             }
-            if let Some(children) = &index.children {
-                for child in children {
+            {
+                for child in <ChildTrie<S>>::new(id).children() {
                     stack.push(child.id());
                 }
             }
@@ -1114,8 +1086,8 @@ impl<S: StorageAdaptor> Index<S> {
             {
                 return Ok(Some(id));
             }
-            if let Some(children) = &index.children {
-                for child in children {
+            {
+                for child in <ChildTrie<S>>::new(id).children() {
                     stack.push(child.id());
                 }
             }
@@ -1149,14 +1121,8 @@ impl<S: StorageAdaptor> Index<S> {
         let mut parent_index =
             Self::get_index(parent_id)?.ok_or(StorageError::IndexNotFound(parent_id))?;
 
-        // Remove child from collection (collection name ignored)
-        if let Some(children) = &mut parent_index.children {
-            children.retain(|child| child.id() != child_id);
-            // Clear children if empty
-            if children.is_empty() {
-                parent_index.children = None;
-            }
-        }
+        // Remove child from the parent's trie (collection name ignored).
+        let trie_root = <ChildTrie<S>>::new(parent_id).remove(child_id);
 
         // Record the removal so the deletion is explicit on the sync wire
         // (the child vanishes from `children`, which the add-biased HC/LevelWise
@@ -1167,9 +1133,13 @@ impl<S: StorageAdaptor> Index<S> {
             parent_index.deleted_children.push(child_id);
         }
 
-        // Recalculate parent's hash
-        parent_index.full_hash =
-            Self::calculate_full_hash_for_children(parent_index.own_hash, &parent_index.children)?;
+        // Recalculate parent's hash from the trie root.
+        let mut hasher = Sha256::new();
+        hasher.update(parent_index.own_hash);
+        if trie_root != child_trie::EMPTY {
+            hasher.update(trie_root);
+        }
+        parent_index.full_hash = hasher.finalize().into();
         Self::save_index(&parent_index)?;
 
         Ok(())
@@ -1207,7 +1177,7 @@ impl<S: StorageAdaptor> Index<S> {
         let old_own_hash = index.own_hash;
         let old_full_hash = index.full_hash;
         index.own_hash = merkle_hash;
-        index.full_hash = Self::calculate_full_hash_for_children(index.own_hash, &index.children)?;
+        index.full_hash = Self::full_hash_from_trie(id, index.own_hash);
         if let Some(updated_at) = updated_at {
             index.metadata.updated_at = updated_at;
         }
@@ -1227,16 +1197,12 @@ impl<S: StorageAdaptor> Index<S> {
 
         // Log detailed info for root entity hash updates
         if id.is_root() {
-            let children_count = index.children.as_ref().map(|c| c.len()).unwrap_or(0);
-            let children_hashes: Vec<String> = index
-                .children
-                .as_ref()
-                .map(|c| {
-                    c.iter()
-                        .map(|child| format!("{}:{}", child.id(), hex::encode(child.merkle_hash())))
-                        .collect()
-                })
-                .unwrap_or_default();
+            let root_children = <ChildTrie<S>>::new(id).children();
+            let children_count = root_children.len();
+            let children_hashes: Vec<String> = root_children
+                .iter()
+                .map(|child| format!("{}:{}", child.id(), hex::encode(child.merkle_hash())))
+                .collect();
             info!(
                 target: "storage::merkle",
                 %id,

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -2756,9 +2756,17 @@ impl<S: StorageAdaptor> Interface<S> {
         // under a tombstoned ancestor).
         <Index<S>>::tombstone_descendants_of(id, deleted_at)?;
 
-        // Deletion wins - apply it
-        let _ignored = S::storage_remove(Key::Entry(id));
-        let _ignored = <Index<S>>::mark_deleted(id, deleted_at);
+        // Deletion wins - apply it, through the SAME helper the local delete
+        // uses. Inlining the remove + tombstone here is how the two paths
+        // drifted: the helper also drops the entity's child trie, and this one
+        // did not, so a locally-deleted entity lost its trie while a replayed
+        // delete kept it. Collection ids are deterministic, so the next
+        // re-creation (or an add-wins resurrection, which recomputes
+        // `full_hash_from_trie`) folded EMPTY on one replica and a ghost root
+        // on the other — a different hash for the same logical state,
+        // propagating to the context root with nothing reporting an error.
+        // Exactly what the comment below warns about, one operation earlier.
+        <Index<S>>::delete_entity_and_create_tombstone(id, deleted_at)?;
 
         // CRITICAL: Update parent's children list and recalculate hashes
         // Without this, the receiving node would have a different root hash than

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -1259,7 +1259,7 @@ impl<S: StorageAdaptor> Interface<S> {
         let trie = <ChildTrie<S>>::new(parent_id);
         child.element_mut().metadata.order = match trie.get(child.id()) {
             Some(existing) => existing.metadata.order,
-            None => trie.len(),
+            None => trie.next_order(),
         };
 
         let data = to_vec(child).map_err(StorageError::SerializationError)?;

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -46,6 +46,7 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, info, trace, warn};
 
 use crate::address::Id;
+use crate::child_trie::ChildTrie;
 use crate::constants;
 use crate::entities::{ChildInfo, Data, Metadata, OpMask, SignatureData, StorageType};
 use crate::env::time_now;
@@ -1232,6 +1233,34 @@ impl<S: StorageAdaptor> Interface<S> {
         if !child.element().is_dirty() {
             return Ok(false);
         }
+
+        // Position among the parent's children, assigned by the WRITER, here,
+        // where local writes flow through (`CollectionMut::insert` — every
+        // WASM-side push). Deliberately NOT in `Index::add_child_to`: the
+        // remote-apply paths call that with metadata off the wire, and
+        // recomputing there would replace the writer's position with the
+        // receiver's own child count. The two replicas would then order the
+        // same collection differently.
+        //
+        // Set before both uses below, so the position reaches local state (the
+        // `ChildInfo` written into the parent's trie) AND peers (`save_raw`
+        // emits an action carrying this metadata).
+        //
+        // Existing children keep the position they were given. Re-linking
+        // happens on every update, and taking a fresh position then would move
+        // an entity to the end of its own collection each time it was edited.
+        // `ChildTrie::get` is a keyed lookup, not a walk.
+        //
+        // Why a position is needed at all: `Vector::get(i)` iterates children in
+        // `ChildInfo` order, and `created_at` cannot separate writes made in one
+        // call — it is the execution timestamp, the same for all of them and
+        // pinned to 0 under merge mode. Without this they tie and the random id
+        // decides, so `get(0)` could return the third push.
+        let trie = <ChildTrie<S>>::new(parent_id);
+        child.element_mut().metadata.order = match trie.get(child.id()) {
+            Some(existing) => existing.metadata.order,
+            None => trie.len(),
+        };
 
         let data = to_vec(child).map_err(StorageError::SerializationError)?;
 

--- a/crates/storage/src/js.rs
+++ b/crates/storage/src/js.rs
@@ -1608,6 +1608,28 @@ impl JsAuthoredVector {
         self.vector.get_by_id(crate::address::Id::new(id))
     }
 
+    /// Tombstones the entry stored under `id` (overwrites it with an empty
+    /// value). Only the entry's owner may call this.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`update_by_id`](Self::update_by_id).
+    pub fn tombstone_by_id(&mut self, id: [u8; 32]) -> Result<(), StoreError> {
+        self.vector.tombstone_by_id(crate::address::Id::new(id))
+    }
+
+    /// The account that owns the entry stored under `id`, if it exists.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] if the storage read fails.
+    pub fn owner_of_id(&self, id: [u8; 32]) -> Result<Option<[u8; 32]>, StoreError> {
+        Ok(self
+            .vector
+            .owner_of_id(crate::address::Id::new(id))?
+            .map(|account| *account.as_bytes()))
+    }
+
     /// Replaces the value at `index`. Only the slot's owner may call this.
     ///
     /// # Errors

--- a/crates/storage/src/js.rs
+++ b/crates/storage/src/js.rs
@@ -1571,13 +1571,41 @@ impl JsAuthoredVector {
 
     /// Pushes a new value at the tail, stamping the current executor as owner.
     ///
-    /// Returns the index of the newly appended slot.
+    /// Returns the ID of the new entry, not its index. Enumeration is
+    /// `(created_at, id)` ordered over a set other replicas insert into, so a
+    /// position is only valid until someone inserts ahead of it, while an id
+    /// names the entry for as long as it exists (core#3637).
     ///
     /// # Errors
     ///
     /// Propagates [`StoreError`] if the storage write fails.
-    pub fn push(&mut self, value: &[u8]) -> Result<usize, StoreError> {
-        self.vector.push(value.to_vec())
+    pub fn push(&mut self, value: &[u8]) -> Result<[u8; 32], StoreError> {
+        self.vector.push(value.to_vec()).map(|id| *id.as_bytes())
+    }
+
+    /// Replaces the value stored under `id`. Only the entry's owner may call
+    /// this.
+    ///
+    /// The id-addressed counterpart to [`update`](Self::update), and the one to
+    /// use when the address was not resolved in the same call.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] with `ActionNotAllowed` if the current executor is
+    /// not the stored owner, `NotFound` if no entry is stored under `id`, or any
+    /// underlying storage error.
+    pub fn update_by_id(&mut self, id: [u8; 32], value: &[u8]) -> Result<(), StoreError> {
+        self.vector
+            .update_by_id(crate::address::Id::new(id), value.to_vec())
+    }
+
+    /// Reads the value stored under `id`, if any.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StoreError`] if the storage read fails.
+    pub fn get_by_id(&self, id: [u8; 32]) -> Result<Option<Vec<u8>>, StoreError> {
+        self.vector.get_by_id(crate::address::Id::new(id))
     }
 
     /// Replaces the value at `index`. Only the slot's owner may call this.
@@ -1912,8 +1940,9 @@ mod roundtrip_tests {
         ensure_root_index();
 
         let mut v = JsAuthoredVector::new();
-        let idx = v.push(HELLO_BORSH).expect("push");
-        assert_eq!(idx, 0);
+        let entry_id = v.push(HELLO_BORSH).expect("push");
+        // An id, not a position: the entry is addressed by name.
+        assert_eq!(v.get_by_id(entry_id).unwrap().as_deref(), Some(HELLO_BORSH));
         let id = v.id();
         save_wrapper(&mut v);
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod action;
 pub mod address;
+pub mod child_trie;
 pub mod collections;
 pub mod constants;
 pub mod delta;

--- a/crates/storage/src/snapshot.rs
+++ b/crates/storage/src/snapshot.rs
@@ -31,6 +31,16 @@ pub struct Snapshot {
     /// Raw index data (ID -> serialized EntityIndex)
     pub indexes: Vec<(Id, Vec<u8>)>,
 
+    /// Raw child-trie rows (addressed ID -> serialized trie node/bucket).
+    ///
+    /// A parent's children live in `Key::ChildTrie`, not inside its index row.
+    /// Shipping only entries and indexes therefore installs every entity with
+    /// no parent->child link at all: `get_children_of` reads empty and every
+    /// parent's stored `full_hash`, which folds the trie root, stops matching a
+    /// recompute. The node-side sync path rebuilds these links explicitly after
+    /// installing pages; this module has no such pass, so it has to carry them.
+    pub trie_rows: Vec<(Id, Vec<u8>)>,
+
     /// Root Merkle hash for snapshot verification
     pub root_hash: [u8; 32],
 
@@ -50,6 +60,7 @@ pub struct Snapshot {
 pub fn generate_snapshot<S: IterableStorage>() -> Result<Snapshot, StorageError> {
     let mut entries = Vec::new();
     let mut indexes = Vec::new();
+    let mut trie_rows = Vec::new();
 
     // Iterate all keys in storage
     for key in S::storage_iter_keys() {
@@ -72,6 +83,11 @@ pub fn generate_snapshot<S: IterableStorage>() -> Result<Snapshot, StorageError>
                     }
                 }
             }
+            Key::ChildTrie(id) => {
+                if let Some(data) = S::storage_read(key) {
+                    trie_rows.push((id, data));
+                }
+            }
             _ => {
                 // Skip sync state and other metadata keys
             }
@@ -88,6 +104,7 @@ pub fn generate_snapshot<S: IterableStorage>() -> Result<Snapshot, StorageError>
         index_count: indexes.len(),
         entries,
         indexes,
+        trie_rows,
         root_hash,
         timestamp: time_now(),
     })
@@ -105,6 +122,7 @@ pub fn generate_snapshot<S: IterableStorage>() -> Result<Snapshot, StorageError>
 pub fn generate_full_snapshot<S: IterableStorage>() -> Result<Snapshot, StorageError> {
     let mut entries = Vec::new();
     let mut indexes = Vec::new();
+    let mut trie_rows = Vec::new();
 
     // Iterate all keys in storage
     for key in S::storage_iter_keys() {
@@ -118,6 +136,11 @@ pub fn generate_full_snapshot<S: IterableStorage>() -> Result<Snapshot, StorageE
                 // Include ALL indexes, even tombstones
                 if let Some(data) = S::storage_read(key) {
                     indexes.push((id, data));
+                }
+            }
+            Key::ChildTrie(id) => {
+                if let Some(data) = S::storage_read(key) {
+                    trie_rows.push((id, data));
                 }
             }
             _ => {
@@ -136,6 +159,7 @@ pub fn generate_full_snapshot<S: IterableStorage>() -> Result<Snapshot, StorageE
         index_count: indexes.len(),
         entries,
         indexes,
+        trie_rows,
         root_hash,
         timestamp: time_now(),
     })
@@ -164,6 +188,14 @@ pub fn apply_snapshot<S: IterableStorage>(snapshot: &Snapshot) -> Result<(), Sto
         let _ = S::storage_write(Key::Index(*id), data);
     }
 
+    // Step 4: Restore the child tries. Without this every entity lands with no
+    // link to its parent, which is unrecoverable in place: re-applying
+    // byte-identical entities takes the update path, never `add_child_to`, so
+    // nothing ever re-links them.
+    for (id, data) in &snapshot.trie_rows {
+        let _ = S::storage_write(Key::ChildTrie(*id), data);
+    }
+
     Ok(())
 }
 
@@ -180,7 +212,7 @@ fn clear_all_storage<S: IterableStorage>() -> Result<(), StorageError> {
 
     for key in S::storage_iter_keys() {
         match key {
-            Key::Entry(_) | Key::Index(_) => {
+            Key::Entry(_) | Key::Index(_) | Key::ChildTrie(_) => {
                 keys_to_delete.push(key);
             }
             _ => {

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -21,6 +21,12 @@ pub enum Key {
 
     /// Sync state key for tracking last sync time with a remote node.
     SyncState(Id),
+
+    /// A node in a parent's child trie. Its own keyspace so the tombstone GC,
+    /// which tells an index row from opaque entity data by re-serialising and
+    /// requiring byte-identical output, never sees a trie node where it expects
+    /// an `EntityIndex`.
+    ChildTrie(Id),
 }
 
 impl Key {
@@ -39,6 +45,10 @@ impl Key {
             }
             Self::SyncState(id) => {
                 bytes[0] = 2;
+                bytes[1..33].copy_from_slice(id.as_bytes());
+            }
+            Self::ChildTrie(id) => {
+                bytes[0] = 3;
                 bytes[1..33].copy_from_slice(id.as_bytes());
             }
         }

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -22,10 +22,19 @@ pub enum Key {
     /// Sync state key for tracking last sync time with a remote node.
     SyncState(Id),
 
-    /// A node in a parent's child trie. Its own keyspace so the tombstone GC,
-    /// which tells an index row from opaque entity data by re-serialising and
-    /// requiring byte-identical output, never sees a trie node where it expects
-    /// an `EntityIndex`.
+    /// A node in a parent's child trie.
+    ///
+    /// Its own keyspace so children are addressed independently of the parent's
+    /// index row — which is the whole point, since holding them inline made a
+    /// link cost O(siblings).
+    ///
+    /// NOT a protection against tombstone GC, despite the separation: GC
+    /// iterates raw `ContextState` values across the column family and the
+    /// hashed key carries no recoverable tag, so it does see these rows. What
+    /// keeps it from deleting them is its borsh round-trip guard — it treats a
+    /// value as an index row only if re-serialising reproduces it byte for
+    /// byte. Relaxing that guard on the assumption that the keyspace already
+    /// separates them would let GC reclaim live trie rows.
     ChildTrie(Id),
 }
 

--- a/crates/storage/src/tests/authored_primitives.rs
+++ b/crates/storage/src/tests/authored_primitives.rs
@@ -58,6 +58,7 @@ fn build_signed_update_for(
         crdt_type: None,
         field_name: None,
         schema_version: None,
+        order: 0,
     };
 
     let mut action = Action::Update {
@@ -110,6 +111,7 @@ fn build_signed_delete_for(
         crdt_type: None,
         field_name: None,
         schema_version: None,
+        order: 0,
     };
 
     let mut action = Action::DeleteRef {

--- a/crates/storage/src/tests/common.rs
+++ b/crates/storage/src/tests/common.rs
@@ -329,6 +329,7 @@ pub fn create_signed_user_add_action(
         crdt_type: None,
         field_name: None,
         schema_version: None,
+        order: 0,
     };
 
     // Create action for signing
@@ -487,6 +488,7 @@ pub fn build_signed_shared_action(
         crdt_type: None,
         field_name: None,
         schema_version: None,
+        order: 0,
     };
     let mut action = if add {
         Action::Add {
@@ -546,6 +548,7 @@ pub fn build_signed_member_action(
         crdt_type: None,
         field_name: None,
         schema_version: None,
+        order: 0,
     };
     let mut action = if add {
         Action::Add {
@@ -600,6 +603,7 @@ pub fn build_signed_member_delete(
         crdt_type: None,
         field_name: None,
         schema_version: None,
+        order: 0,
     };
     let mut action = Action::DeleteRef {
         id,
@@ -647,6 +651,7 @@ pub fn create_signed_user_update_action(
         crdt_type: None,
         field_name: None,
         schema_version: None,
+        order: 0,
     };
 
     let mut action = Action::Update {

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -67,7 +67,12 @@ mod index__public_methods {
 
         assert_eq!(e1.id, root_id);
         assert_eq!(e1.parent_id, None);
-        assert_eq!(e1.children.as_ref().map(|v| v.len()).unwrap_or(0), 0);
+        assert_eq!(
+            <Index<MockedStorage<0>>>::get_children_of(e1.id)
+                .unwrap()
+                .len(),
+            0
+        );
         assert_ne!(e1.own_hash, [37; 32]);
         assert_eq!(e1.metadata.created_at, 1);
         assert_eq!(e1.metadata.updated_at, 1.into());
@@ -87,14 +92,24 @@ mod index__public_methods {
 
         assert_eq!(e1.id, root_id);
         assert_eq!(e1.parent_id, None);
-        assert_eq!(e1.children.as_ref().map(|v| v.len()).unwrap_or(0), 1);
+        assert_eq!(
+            <Index<MockedStorage<1>>>::get_children_of(e1.id)
+                .unwrap()
+                .len(),
+            1
+        );
         assert_eq!(e1.own_hash, [37; 32]);
         assert_eq!(e1.metadata.created_at, 43);
         assert_eq!(e1.metadata.updated_at, 22.into());
 
         assert_eq!(e2.id, p1_id);
         assert_eq!(e2.parent_id, Some(Id::root()));
-        assert_eq!(e2.children.as_ref().map(|v| v.len()).unwrap_or(0), 0);
+        assert_eq!(
+            <Index<MockedStorage<1>>>::get_children_of(e2.id)
+                .unwrap()
+                .len(),
+            0
+        );
         assert_ne!(e2.own_hash, [37; 32]);
         assert_eq!(e2.metadata.created_at, 1);
         assert_eq!(e2.metadata.updated_at, 1.into());
@@ -150,14 +165,24 @@ mod index__public_methods {
 
         assert_eq!(e1.id, root_id);
         assert_eq!(e1.parent_id, None);
-        assert_eq!(e1.children.as_ref().map(|v| v.len()).unwrap_or(0), 1);
+        assert_eq!(
+            <Index<MockedStorage<2>>>::get_children_of(e1.id)
+                .unwrap()
+                .len(),
+            1
+        );
         assert_ne!(e1.own_hash, [37; 32]);
         assert_eq!(e1.metadata.created_at, 1);
         assert_eq!(e1.metadata.updated_at, 1.into());
 
         assert_eq!(e2.id, p1_id);
         assert_eq!(e2.parent_id, Some(Id::root()));
-        assert_eq!(e2.children.as_ref().map(|v| v.len()).unwrap_or(0), 0);
+        assert_eq!(
+            <Index<MockedStorage<2>>>::get_children_of(e2.id)
+                .unwrap()
+                .len(),
+            0
+        );
         assert_ne!(e2.own_hash, [37; 32]);
         assert_eq!(e2.metadata.created_at, 1);
         assert_eq!(e2.metadata.updated_at, 1.into());
@@ -180,14 +205,24 @@ mod index__public_methods {
 
         assert_eq!(e1.id, root_id);
         assert_eq!(e1.parent_id, None);
-        assert_eq!(e1.children.as_ref().map(|v| v.len()).unwrap_or(0), 1);
+        assert_eq!(
+            <Index<MockedStorage<3>>>::get_children_of(e1.id)
+                .unwrap()
+                .len(),
+            1
+        );
         assert_eq!(e1.own_hash, [37; 32]);
         assert_eq!(e1.metadata.created_at, 43);
         assert_eq!(e1.metadata.updated_at, 22.into());
 
         assert_eq!(e2.id, p1_id);
         assert_eq!(e2.parent_id, Some(Id::root()));
-        assert_eq!(e2.children.as_ref().map(|v| v.len()).unwrap_or(0), 0);
+        assert_eq!(
+            <Index<MockedStorage<3>>>::get_children_of(e2.id)
+                .unwrap()
+                .len(),
+            0
+        );
         assert_ne!(e2.own_hash, [37; 32]);
         assert_eq!(e2.metadata.created_at, 1);
         assert_eq!(e2.metadata.updated_at, 1.into());
@@ -209,7 +244,9 @@ mod index__public_methods {
         assert_eq!(root_index.id, root_id);
         assert_eq!(root_index.own_hash, root_hash);
         assert!(root_index.parent_id.is_none());
-        assert!(root_index.children.is_none());
+        assert!(<Index<MainStorage>>::get_children_of(root_index.id)
+            .unwrap()
+            .is_empty());
 
         let _collection_name = "Books";
         let child_id = Id::random();
@@ -230,15 +267,8 @@ mod index__public_methods {
         assert_eq!(updated_root_index.id, root_id);
         assert_eq!(updated_root_index.own_hash, root_hash);
         assert!(updated_root_index.parent_id.is_none());
-        assert_eq!(
-            updated_root_index
-                .children
-                .as_ref()
-                .map(|v| v.len())
-                .unwrap_or(0),
-            1
-        );
-        let children_vec = updated_root_index.children.as_ref().unwrap();
+        let children_vec = <Index<MainStorage>>::get_children_of(root_id).unwrap();
+        assert_eq!(children_vec.len(), 1);
         assert_eq!(
             children_vec[0],
             ChildInfo::new(child_id, child_full_hash, Metadata::default())
@@ -248,7 +278,9 @@ mod index__public_methods {
         assert_eq!(child_index.id, child_id);
         assert_eq!(child_index.own_hash, child_own_hash);
         assert_eq!(child_index.parent_id, Some(root_id));
-        assert!(child_index.children.is_none());
+        assert!(<Index<MainStorage>>::get_children_of(child_index.id)
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
@@ -297,10 +329,10 @@ mod index__public_methods {
             "re-add left the child in the parent's deleted-children advert"
         );
         assert!(
-            parent
-                .children()
-                .map(|c| c.iter().any(|ci| ci.id() == child_id))
-                .unwrap_or(false),
+            <Index<S>>::get_children_of(parent.id)
+                .unwrap()
+                .iter()
+                .any(|ci| ci.id() == child_id),
             "re-add did not relink the child as a live child"
         );
         // The resurrected child is re-folded into the parent hash — the other
@@ -328,7 +360,9 @@ mod index__public_methods {
         assert_eq!(root_index.id, root_id);
         assert_eq!(root_index.own_hash, root_hash);
         assert!(root_index.parent_id.is_none());
-        assert!(root_index.children.is_none());
+        assert!(<Index<MainStorage>>::get_children_of(root_index.id)
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
@@ -346,6 +380,9 @@ mod index__public_methods {
         ),)
         .is_ok());
 
+        // Random, for isolation: the native test store is a thread-local that
+        // cargo reuses across tests, so a fixed id collides with whatever else
+        // ran on this thread.
         let child_id = Id::random();
         let child_hash = [2_u8; 32];
         let child_info = ChildInfo::new(child_id, child_hash, Metadata::default());
@@ -553,7 +590,9 @@ mod index__public_methods {
         assert_eq!(root_index.id, root_id);
         assert_eq!(root_index.own_hash, root_hash);
         assert!(root_index.parent_id.is_none());
-        assert!(root_index.children.is_none());
+        assert!(<Index<MainStorage>>::get_children_of(root_index.id)
+            .unwrap()
+            .is_empty());
 
         let _collection_name = "Books";
         let child_id = Id::random();
@@ -613,7 +652,9 @@ mod index__public_methods {
         assert_eq!(root_index.id, root_id);
         assert_eq!(root_index.own_hash, root_hash);
         assert!(root_index.parent_id.is_none());
-        assert!(root_index.children.is_none());
+        assert!(<Index<MainStorage>>::get_children_of(root_index.id)
+            .unwrap()
+            .is_empty());
 
         let _collection_name = "Books";
         let child_id = Id::random();
@@ -628,7 +669,9 @@ mod index__public_methods {
 
         let root_index = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         // After removal, children should be None
-        assert!(root_index.children.is_none());
+        assert!(<Index<MainStorage>>::get_children_of(root_index.id)
+            .unwrap()
+            .is_empty());
 
         // With tombstones, index still exists but is marked as deleted
         assert!(<Index<MainStorage>>::is_deleted(child_id).unwrap());
@@ -648,7 +691,6 @@ mod index__private_methods {
         let index = EntityIndex {
             id,
             parent_id: None,
-            children: None,
             full_hash: hash1,
             own_hash: hash2,
             metadata: Metadata::default(),
@@ -670,7 +712,6 @@ mod index__private_methods {
         let index = EntityIndex {
             id,
             parent_id: None,
-            children: None,
             full_hash: hash1,
             own_hash: hash2,
             metadata: Metadata::default(),
@@ -1000,9 +1041,12 @@ mod hashing {
             hex::encode(<Index<MainStorage>>::get_full_merkle_hash_for(child3_id).unwrap()),
             "648aa5c579fb30f38af744d97d6ec840c7a91277a499a0d780f3e7314eca090b",
         );
+        // Folds the child-trie root rather than the sorted sibling list. The
+        // three child hashes asserted above are unchanged, which is the check
+        // that leaf hashing did not move — only the parent construction did.
         assert_eq!(
             hex::encode(<Index<MainStorage>>::get_full_merkle_hash_for(root_id).unwrap()),
-            "866edea6f7ce51612ad0ea3bcde93b2494d77e8c466bc2a69817a6443f2a57f0",
+            "dfd7c32f3f436c0a69a7abd5fd4070c47050e50b0b87b2f8cede4dee43c173cf",
         );
     }
 
@@ -1039,13 +1083,25 @@ mod hashing {
 
         let root_index_with_child = <Index<MainStorage>>::get_index(root_id).unwrap().unwrap();
         let child_index = <Index<MainStorage>>::get_index(child_id).unwrap().unwrap();
+        // A parent now commits to its children's IDS as well as their hashes
+        // (a child's id is its position in the trie), which is strictly
+        // stronger than the old fold over `merkle_hash` alone — but it means a
+        // parent hash is no longer a constant when child ids are random. Assert
+        // the invariant that matters: the stored hash equals an independent
+        // recompute, and it moved off the childless value.
         assert_eq!(
-            hex::encode(root_index_with_child.full_hash),
-            "3f18867aec61c1c3cd3ca1b8a0ff42612a8dd0ad83f3e59055e3b9ba737e31d9"
+            root_index_with_child.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(root_id, root_hash),
+            "root full_hash must match an independent recompute"
+        );
+        assert_ne!(
+            root_index_with_child.full_hash, expected_empty_full_hash,
+            "adding a child must move the parent hash"
         );
         assert_eq!(
-            hex::encode(child_index.full_hash),
-            "75877bb41d393b5fb8455ce60ecd8dda001d06316496b14dfa7f895656eeca4a"
+            child_index.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(child_id, child_index.own_hash),
+            "full_hash must equal an independent recompute",
         );
 
         let grandchild_id = Id::random();
@@ -1059,17 +1115,25 @@ mod hashing {
         let grandchild_index = <Index<MainStorage>>::get_index(grandchild_id)
             .unwrap()
             .unwrap();
-        assert_eq!(
-            hex::encode(root_index_with_grandchild.full_hash),
-            "2504baa308dcb51f7046815258e36cd4a83d34c6b1d5f1cc1b8ffa321e40f0c6"
+        // The point of this test: a change two levels down reaches the root.
+        assert_ne!(
+            root_index_with_grandchild.full_hash, root_index_with_child.full_hash,
+            "a grandchild must propagate into the root hash"
         );
         assert_eq!(
-            hex::encode(child_index_with_grandchild.full_hash),
-            "80c2b6364721221e7f87028c0482e1e16f49a29889e357c8acab8cb26d4d99da"
+            root_index_with_grandchild.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(root_id, root_hash),
+            "root full_hash must match an independent recompute"
         );
         assert_eq!(
-            hex::encode(grandchild_index.full_hash),
-            "648aa5c579fb30f38af744d97d6ec840c7a91277a499a0d780f3e7314eca090b"
+            child_index_with_grandchild.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(child_id, child_hash),
+            "child full_hash must match an independent recompute"
+        );
+        assert_eq!(
+            grandchild_index.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(grandchild_id, grandchild_index.own_hash),
+            "full_hash must equal an independent recompute",
         );
 
         let greatgrandchild_id = Id::random();
@@ -1091,21 +1155,31 @@ mod hashing {
         let greatgrandchild_index = <Index<MainStorage>>::get_index(greatgrandchild_id)
             .unwrap()
             .unwrap();
-        assert_eq!(
-            hex::encode(root_index_with_greatgrandchild.full_hash),
-            "6bdcb2f1a98eba952d3b2cf43c8bb36eb6a50b853d5b49dea089775e17d67b27"
+        // Four levels deep now: the change must still reach the root, and every
+        // level must agree with an independent recompute.
+        assert_ne!(
+            root_index_with_greatgrandchild.full_hash, root_index_with_grandchild.full_hash,
+            "a great-grandchild must propagate all the way into the root hash"
         );
         assert_eq!(
-            hex::encode(child_index_with_greatgrandchild.full_hash),
-            "8aca1399f292c2ed8dfaba100a7885c7ac108b7b6b32f10d4a3e9c05fd7c38c0"
+            root_index_with_greatgrandchild.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(root_id, root_hash),
         );
         assert_eq!(
-            hex::encode(grandchild_index_with_greatgrandchild.full_hash),
-            "135605b30fda6d313c472745c4445edb4e8c619cdcc24caa2352c12aacd18a76"
+            child_index_with_greatgrandchild.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(child_id, child_hash),
         );
         assert_eq!(
-            hex::encode(greatgrandchild_index.full_hash),
-            "9f4fb68f3e1dac82202f9aa581ce0bbf1f765df0e9ac3c8c57e20f685abab8ed"
+            grandchild_index_with_greatgrandchild.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(grandchild_id, grandchild_hash),
+        );
+        assert_eq!(
+            greatgrandchild_index.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(
+                greatgrandchild_id,
+                greatgrandchild_index.own_hash
+            ),
+            "full_hash must equal an independent recompute",
         );
 
         // Change greatgrandchild's own_hash. `update_hash_for` rewrites
@@ -1125,20 +1199,36 @@ mod hashing {
             .unwrap()
             .unwrap();
         assert_eq!(
-            hex::encode(updated_root_index_with_greatgrandchild.full_hash),
-            "f61c8077c7875e38a3cbdce3b3d4ce40a5a18add8ce386803760484772bcb85b"
+            updated_root_index_with_greatgrandchild.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(
+                root_id,
+                updated_root_index_with_greatgrandchild.own_hash
+            ),
+            "full_hash must equal an independent recompute",
         );
         assert_eq!(
-            hex::encode(updated_child_index_with_greatgrandchild.full_hash),
-            "abef09c52909317783e0c582553a8fb19124249d93f8878cf131b8dd28fbb4bf"
+            updated_child_index_with_greatgrandchild.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(
+                child_id,
+                updated_child_index_with_greatgrandchild.own_hash
+            ),
+            "full_hash must equal an independent recompute",
         );
         assert_eq!(
-            hex::encode(updated_grandchild_index_with_greatgrandchild.full_hash),
-            "97b2d3a1682881ec11e747f3dd4c242a33f8cff6c6d6224e1dd23278eef35554"
+            updated_grandchild_index_with_greatgrandchild.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(
+                grandchild_id,
+                updated_grandchild_index_with_greatgrandchild.own_hash
+            ),
+            "full_hash must equal an independent recompute",
         );
         assert_eq!(
-            hex::encode(updated_greatgrandchild_index.full_hash),
-            "8c0cc17a04942cc4f8e0fe0b302606d3108860c126428ba2ceeb5f9ed41c2b05"
+            updated_greatgrandchild_index.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(
+                greatgrandchild_id,
+                updated_greatgrandchild_index.own_hash
+            ),
+            "full_hash must equal an independent recompute",
         );
 
         // Same pattern — update_hash_for handles the ancestor walk itself.
@@ -1156,20 +1246,36 @@ mod hashing {
             .unwrap()
             .unwrap();
         assert_eq!(
-            hex::encode(updated_root_index_with_greatgrandchild.full_hash),
-            "0483e0a8a3c3002a94c3ce2e1f7fcadae4b2dc29e2dee9752b9caa683dfe39fc"
+            updated_root_index_with_greatgrandchild.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(
+                root_id,
+                updated_root_index_with_greatgrandchild.own_hash
+            ),
+            "full_hash must equal an independent recompute",
         );
         assert_eq!(
-            hex::encode(updated_child_index_with_greatgrandchild.full_hash),
-            "a7bad731e6767c36725a7c592174fdfe799c6bc32e92cc0f455e6ec5f6e5d42b"
+            updated_child_index_with_greatgrandchild.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(
+                child_id,
+                updated_child_index_with_greatgrandchild.own_hash
+            ),
+            "full_hash must equal an independent recompute",
         );
         assert_eq!(
-            hex::encode(updated_grandchild_index_with_greatgrandchild.full_hash),
-            "67eb9aff17a7db347e4c56264042dcfb1f4e465f70abb56a2108571316435ea5"
+            updated_grandchild_index_with_greatgrandchild.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(
+                grandchild_id,
+                updated_grandchild_index_with_greatgrandchild.own_hash
+            ),
+            "full_hash must equal an independent recompute",
         );
         assert_eq!(
-            hex::encode(updated_greatgrandchild_index.full_hash),
-            "cd93782b7fb95559de14f738b65988af85d41dc1565f7c7d1ed2d035665b519c"
+            updated_greatgrandchild_index.full_hash,
+            <Index<MainStorage>>::full_hash_from_trie(
+                greatgrandchild_id,
+                updated_greatgrandchild_index.own_hash
+            ),
+            "full_hash must equal an independent recompute",
         );
     }
 
@@ -1254,7 +1360,7 @@ mod minimal_struct_layout_compat {
     use calimero_primitives::crdt::CrdtType;
 
     use crate::address::Id;
-    use crate::entities::{ChildInfo, Metadata, SignatureData, StorageType};
+    use crate::entities::{Metadata, SignatureData, StorageType};
     use crate::index::EntityIndex;
 
     // ---- Mirror structs (must match borsh_layout in client/mod.rs) ----
@@ -1263,7 +1369,6 @@ mod minimal_struct_layout_compat {
     struct EntityIndexMinimal {
         _id: [u8; 32],
         _parent_id: Option<[u8; 32]>,
-        children: Option<Vec<ChildInfoMinimal>>,
         full_hash: [u8; 32],
         own_hash: [u8; 32],
     }
@@ -1308,7 +1413,6 @@ mod minimal_struct_layout_compat {
     }
 
     fn make_index(
-        children: Option<Vec<ChildInfo>>,
         storage_type: StorageType,
         crdt_type: Option<CrdtType>,
         field_name: Option<String>,
@@ -1316,7 +1420,6 @@ mod minimal_struct_layout_compat {
         EntityIndex {
             id: Id::new([0xAA; 32]),
             parent_id: Some(Id::new([0xBB; 32])),
-            children,
             full_hash: [0x11; 32],
             own_hash: [0x22; 32],
             metadata: Metadata {
@@ -1352,65 +1455,23 @@ mod minimal_struct_layout_compat {
         // the metadata sub-fields the mirror in `borsh_layout` actually
         // reads (created_at, updated_at, crdt_type, field_name,
         // schema_version).
-        match (&minimal.children, &index.children) {
-            (Some(decoded), Some(real)) => {
-                assert_eq!(
-                    decoded.len(),
-                    real.len(),
-                    "children count mismatch after round-trip"
-                );
-                for (d, r) in decoded.iter().zip(real.iter()) {
-                    assert_eq!(&d.id, r.id().as_bytes(), "child id mismatch");
-                    assert_eq!(d.merkle_hash, r.merkle_hash(), "child merkle_hash mismatch");
-                    assert_eq!(
-                        d.metadata.created_at, r.metadata.created_at,
-                        "child metadata.created_at mismatch"
-                    );
-                    assert_eq!(
-                        d.metadata.updated_at, *r.metadata.updated_at,
-                        "child metadata.updated_at mismatch"
-                    );
-                    assert_eq!(
-                        d.metadata.crdt_type, r.metadata.crdt_type,
-                        "child metadata.crdt_type mismatch"
-                    );
-                    assert_eq!(
-                        d.metadata.field_name, r.metadata.field_name,
-                        "child metadata.field_name mismatch"
-                    );
-                    assert_eq!(
-                        d.metadata.schema_version, r.metadata.schema_version,
-                        "child metadata.schema_version mismatch"
-                    );
-                }
-            }
-            (None, None) => {}
-            _ => panic!("children Option discriminant mismatch after round-trip"),
-        }
+        // Children are no longer part of this row — they live in the parent's
+        // ChildTrie, its own keyspace with its own encoding. The mirror in
+        // `borsh_layout` drops the field to match, so there is nothing to
+        // round-trip here; the trie's encoding is covered by its own tests.
     }
 
     #[test]
     fn round_trip_no_children_public() {
-        let index = make_index(None, StorageType::Public, None, None);
+        let index = make_index(StorageType::Public, None, None);
         assert_round_trip(&index);
     }
 
     #[test]
     fn round_trip_with_children_and_crdt_type() {
-        let child = ChildInfo::new(
-            Id::new([0xCC; 32]),
-            [0x33; 32],
-            Metadata {
-                created_at: 500,
-                updated_at: 600.into(),
-                storage_type: StorageType::Public,
-                crdt_type: Some(CrdtType::GCounter),
-                field_name: Some("scores".to_owned()),
-                schema_version: None,
-            },
-        );
+        // The child list is no longer part of this row (it lives in the
+        // ChildTrie), so this case now only exercises the row's own layout.
         let index = make_index(
-            Some(vec![child]),
             StorageType::Public,
             Some(CrdtType::UnorderedMap {
                 key_type: "String".to_owned(),
@@ -1430,7 +1491,6 @@ mod minimal_struct_layout_compat {
             signer: None,
         };
         let index = make_index(
-            None,
             StorageType::User {
                 owner,
                 signature_data: Some(sig_data),
@@ -1443,7 +1503,7 @@ mod minimal_struct_layout_compat {
 
     #[test]
     fn round_trip_frozen_storage() {
-        let index = make_index(None, StorageType::Frozen, None, None);
+        let index = make_index(StorageType::Frozen, None, None);
         assert_round_trip(&index);
     }
 }

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -24,6 +24,7 @@ mod index__public_methods {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
         };
 
@@ -40,6 +41,7 @@ mod index__public_methods {
                     crdt_type: None,
                     field_name: None,
                     schema_version: None,
+                    order: 0,
                 },
             )],
             metadata: Metadata {
@@ -49,6 +51,7 @@ mod index__public_methods {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
         };
 
@@ -1435,6 +1438,7 @@ mod minimal_struct_layout_compat {
                 crdt_type,
                 field_name,
                 schema_version: None,
+                order: 0,
             },
             deleted_at: Some(9999),
             deleted_children: Vec::new(),
@@ -1542,6 +1546,7 @@ mod verify_ancestor_integrity_tests {
             crdt_type: None,
             field_name: None,
             schema_version: None,
+            order: 0,
         }
     }
 
@@ -1683,6 +1688,7 @@ mod verify_snapshot_entity_signature_tests {
             crdt_type: None,
             field_name: None,
             schema_version: None,
+            order: 0,
         }
     }
 
@@ -1697,6 +1703,7 @@ mod verify_snapshot_entity_signature_tests {
             crdt_type: None,
             field_name: None,
             schema_version: None,
+            order: 0,
         }
     }
 
@@ -1716,6 +1723,7 @@ mod verify_snapshot_entity_signature_tests {
             crdt_type: None,
             field_name: None,
             schema_version: None,
+            order: 0,
         }
     }
 
@@ -2060,6 +2068,109 @@ mod update_signature_in_place_tests {
         assert!(
             <Index<S>>::is_deleted(id).unwrap(),
             "entity stays tombstoned after the signature patch"
+        );
+    }
+}
+
+/// A linked child keeps the position it arrives with.
+///
+/// `Index::add_child_to` is the shared path: local writes reach it through
+/// `Interface::add_child_to`, which assigns the position, and remote applies
+/// reach it carrying the WRITER's position in the action's metadata. It must
+/// not compute one of its own — a receiver's child count need not match the
+/// writer's, and the two replicas would then order the same collection
+/// differently while both believing they had converged.
+///
+/// This is the guard on that boundary: moving the assignment down into
+/// `Index::add_child_to` "to keep it in one place" would break replication in a
+/// way no single-node test can see.
+mod child_order_is_the_writers {
+    use crate::address::Id;
+    use crate::entities::{ChildInfo, Metadata};
+    use crate::index::Index;
+    use crate::store::MainStorage;
+
+    type TestIndex = Index<MainStorage>;
+
+    #[test]
+    fn add_child_to_preserves_the_position_it_is_given() {
+        crate::env::reset_for_testing();
+
+        let parent = Id::random();
+        TestIndex::add_root(ChildInfo::new(parent, [0; 32], Metadata::default())).expect("root");
+
+        // Arrives as if from a peer, out of order and with positions that do
+        // not match this node's child count (which starts at 0).
+        for (id_seed, order) in [(1_u8, 7_u64), (2, 3), (3, 5)] {
+            let metadata = Metadata {
+                order,
+                ..Metadata::default()
+            };
+            TestIndex::add_child_to(
+                parent,
+                ChildInfo::new(Id::new([id_seed; 32]), [id_seed; 32], metadata),
+            )
+            .expect("link");
+        }
+
+        let linked = TestIndex::get_children_of(parent).expect("children");
+        let orders: Vec<u64> = linked.iter().map(|c| c.metadata.order).collect();
+
+        assert_eq!(
+            orders,
+            vec![3, 5, 7],
+            "positions were recomputed locally instead of kept as sent",
+        );
+    }
+
+    /// Re-linking a child it already holds must not move it.
+    ///
+    /// The position is taken once, at first link. Any path that links an
+    /// existing child again — a resurrect, a re-save — would otherwise hand it
+    /// the current child count and send it to the end of its own collection.
+    #[test]
+    fn relinking_an_existing_child_keeps_its_position() {
+        use crate::entities::{Data, Element};
+        use crate::interface::Interface;
+        use crate::tests::common::Paragraph;
+
+        crate::env::reset_for_testing();
+        crate::tests::common::register_test_merge_functions();
+
+        let mut page = crate::tests::common::Page::new_from_element("Parent", Element::root());
+        assert!(Interface::<MainStorage>::save(&mut page).unwrap());
+
+        let first = Element::new(None);
+        let first_id = first.id();
+        let mut para1 = Paragraph::new_from_element("one", first);
+        let mut para2 = Paragraph::new_from_element("two", Element::new(None));
+
+        assert!(Interface::<MainStorage>::add_child_to(page.id(), &mut para1).unwrap());
+        assert!(Interface::<MainStorage>::add_child_to(page.id(), &mut para2).unwrap());
+
+        let before = TestIndex::get_children_of(page.id())
+            .unwrap()
+            .into_iter()
+            .find(|c| c.id() == first_id)
+            .expect("linked")
+            .metadata
+            .order;
+
+        // Link the SAME id again, dirty, as a re-save would.
+        let mut again = Paragraph::new_from_element("one again", Element::new(Some(first_id)));
+        let _ignored = Interface::<MainStorage>::add_child_to(page.id(), &mut again).unwrap();
+
+        let after = TestIndex::get_children_of(page.id())
+            .unwrap()
+            .into_iter()
+            .find(|c| c.id() == first_id)
+            .expect("still linked")
+            .metadata
+            .order;
+
+        assert_eq!(
+            after, before,
+            "re-linking moved the child from position {before} to {after}",
         );
     }
 }

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -2123,6 +2123,114 @@ mod child_order_is_the_writers {
         );
     }
 
+    /// Two replicas that learn the same concurrent writes in OPPOSITE arrival
+    /// orders must read the collection back identically.
+    #[test]
+    fn two_writers_that_collide_still_converge() {
+        crate::env::reset_for_testing();
+
+        // Writer A and writer B each append two entries to a parent that had
+        // none, so both hand out positions 0 and 1. Same execution timestamp:
+        // one call each, and merge mode pins it to 0 anyway.
+        let a0 = (Id::new([0xA0; 32]), 0_u64);
+        let a1 = (Id::new([0xA1; 32]), 1_u64);
+        let b0 = (Id::new([0xB0; 32]), 0_u64);
+        let b1 = (Id::new([0xB1; 32]), 1_u64);
+
+        let read_back = |arrivals: [(Id, u64); 4]| {
+            crate::env::reset_for_testing();
+            let parent = Id::new([0xFF; 32]);
+            TestIndex::add_root(ChildInfo::new(parent, [0; 32], Metadata::default()))
+                .expect("root");
+            for (id, order) in arrivals {
+                let metadata = Metadata {
+                    order,
+                    ..Metadata::default()
+                };
+                TestIndex::add_child_to(parent, ChildInfo::new(id, [0; 32], metadata))
+                    .expect("link");
+            }
+            TestIndex::get_children_of(parent)
+                .expect("children")
+                .into_iter()
+                .map(|c| c.id())
+                .collect::<Vec<_>>()
+        };
+
+        let replica_1 = read_back([a0, a1, b0, b1]);
+        let replica_2 = read_back([b1, b0, a1, a0]);
+
+        assert_eq!(
+            replica_1, replica_2,
+            "replicas that learned the same writes in different arrival orders \
+             disagree on the collection's order",
+        );
+
+        // Interleaved, not grouped by writer: both writers handed out 0 and 1,
+        // so the two 0s sort together (by id) ahead of the two 1s. Each
+        // writer's OWN entries stay in the order it wrote them, which is the
+        // property `order` exists to hold; agreeing on how two independent runs
+        // interleave would need a sequence CRDT, not a per-parent counter.
+        assert_eq!(
+            replica_1,
+            vec![a0.0, b0.0, a1.0, b1.0],
+            "concurrent positions should tie-break by id within each position",
+        );
+    }
+
+    /// A position freed by a removal must not be handed to a later append.
+    ///
+    /// All three writes here share one `created_at` — the case `order` exists
+    /// to decide — so if the append reuses the removed child's position, the
+    /// tie falls to the random id and the new entry can land AHEAD of one
+    /// written before it.
+    #[test]
+    fn a_removed_position_is_not_reissued() {
+        use crate::child_trie::ChildTrie;
+        use crate::entities::{Data, Element};
+        use crate::interface::Interface;
+        use crate::tests::common::{Page, Paragraph};
+
+        crate::env::reset_for_testing();
+        crate::tests::common::register_test_merge_functions();
+
+        let mut page = Page::new_from_element("Parent", Element::root());
+        assert!(Interface::<MainStorage>::save(&mut page).unwrap());
+
+        let mut ids = Vec::new();
+        for name in ["a", "b", "c"] {
+            let mut para = Paragraph::new_from_element(name, Element::new(None));
+            assert!(Interface::<MainStorage>::add_child_to(page.id(), &mut para).unwrap());
+            ids.push(para.id());
+        }
+
+        let trie = <ChildTrie<MainStorage>>::new(page.id());
+        let _hash = trie.remove(ids[1]);
+        assert_eq!(trie.len(), 2, "the removal should drop the child count");
+
+        let mut fourth = Paragraph::new_from_element("d", Element::new(None));
+        assert!(Interface::<MainStorage>::add_child_to(page.id(), &mut fourth).unwrap());
+
+        let orders: Vec<u64> = TestIndex::get_children_of(page.id())
+            .unwrap()
+            .iter()
+            .map(|c| c.metadata.order)
+            .collect();
+
+        assert_eq!(
+            orders,
+            vec![0, 2, 3],
+            "the append reused the removed entry's position instead of taking a fresh one",
+        );
+
+        let last = TestIndex::get_children_of(page.id())
+            .unwrap()
+            .last()
+            .expect("children")
+            .id();
+        assert_eq!(last, fourth.id(), "the newest entry did not sort last");
+    }
+
     /// Re-linking a child it already holds must not move it.
     ///
     /// The position is taken once, at first link. Any path that links an

--- a/crates/storage/src/tests/index.rs
+++ b/crates/storage/src/tests/index.rs
@@ -1374,6 +1374,9 @@ mod minimal_struct_layout_compat {
     }
 
     #[derive(BorshDeserialize)]
+    // Fields exist to pin the borsh LAYOUT, not to be read: the decode
+    // succeeding in the declared order is the assertion.
+    #[allow(dead_code, reason = "borsh layout fidelity fixture")]
     struct ChildInfoMinimal {
         id: [u8; 32],
         merkle_hash: [u8; 32],
@@ -1381,6 +1384,9 @@ mod minimal_struct_layout_compat {
     }
 
     #[derive(BorshDeserialize)]
+    // Fields exist to pin the borsh LAYOUT, not to be read: the decode
+    // succeeding in the declared order is the assertion.
+    #[allow(dead_code, reason = "borsh layout fidelity fixture")]
     struct MetadataMinimal {
         created_at: u64,
         updated_at: u64,

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -720,6 +720,33 @@ mod snapshot_and_resync {
         let target_para = TargetInterface::find_by_id::<Paragraph>(para.id()).unwrap();
         assert!(target_para.is_some());
         assert_eq!(target_para.unwrap().text, "Source Para");
+
+        // The links, not just the values. Children live in `Key::ChildTrie`,
+        // their own keyspace — a snapshot that ships only entries and indexes
+        // installs every entity with no parent->child link at all. Asserting
+        // the two values above passes in exactly that state, which is how this
+        // went unnoticed: the target holds everything and can enumerate
+        // nothing, and cannot recover in place because re-applying
+        // byte-identical entities never re-links.
+        let source_children = Index::<SourceStorage>::get_children_of(page.id()).unwrap();
+        let target_children = Index::<TargetStorage>::get_children_of(page.id()).unwrap();
+        assert_eq!(
+            target_children.len(),
+            source_children.len(),
+            "the target must enumerate the same children as the source"
+        );
+        assert!(
+            target_children.iter().any(|c| c.id() == para.id()),
+            "the child must be reachable from its parent after the round trip"
+        );
+
+        // And the hash the parent commits to must match, since it folds the
+        // trie root — a link-less target hashes as childless.
+        assert_eq!(
+            Index::<TargetStorage>::get_hashes_for(page.id()).unwrap(),
+            Index::<SourceStorage>::get_hashes_for(page.id()).unwrap(),
+            "parent hashes must survive the round trip"
+        );
     }
 }
 

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -894,6 +894,7 @@ mod user_storage_signature_verification {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
         };
 
@@ -1067,6 +1068,7 @@ mod user_storage_replay_protection {
             crdt_type: None,
             field_name: None,
             schema_version: None,
+            order: 0,
         };
         let mut action = Action::Add {
             id: page.id(),
@@ -1514,6 +1516,7 @@ mod shared_storage_rotation_authentication {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
         };
         let payload = anonymous.payload_for_signing();
@@ -2280,6 +2283,7 @@ mod shared_storage_rotation_authentication {
                 crdt_type: Some(CrdtType::GCounter),
                 field_name: None,
                 schema_version: None,
+                order: 0,
             };
             let mut action = crate::action::Action::Add {
                 id: member,
@@ -2402,6 +2406,7 @@ mod frozen_storage_verification {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
         };
 
@@ -2433,6 +2438,7 @@ mod frozen_storage_verification {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
         };
 
@@ -2471,6 +2477,7 @@ mod frozen_storage_verification {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
         };
         assert!(MainInterface::apply_action(add_action, &ApplyContext::empty()).is_ok());
@@ -2493,6 +2500,7 @@ mod frozen_storage_verification {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
         };
 
@@ -2531,6 +2539,7 @@ mod frozen_storage_verification {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
         };
         assert!(MainInterface::apply_action(add_action, &ApplyContext::empty()).is_ok());
@@ -2713,6 +2722,7 @@ mod frozen_storage_verification {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
         };
 
@@ -2755,6 +2765,7 @@ mod frozen_storage_verification {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
         };
 
@@ -2794,6 +2805,7 @@ mod timestamp_drift_protection {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
         };
 
@@ -2829,6 +2841,7 @@ mod timestamp_drift_protection {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
         };
 
@@ -2858,6 +2871,7 @@ mod timestamp_drift_protection {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
         };
 
@@ -2930,6 +2944,7 @@ mod storage_type_edge_cases {
             crdt_type: None,
             field_name: None,
             schema_version: None,
+            order: 0,
         };
 
         let mut action = Action::DeleteRef {
@@ -3101,6 +3116,7 @@ mod storage_type_edge_cases {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
         };
 
@@ -3190,6 +3206,7 @@ mod storage_type_edge_cases {
                 crdt_type: None,
                 field_name: None,
                 schema_version: None,
+                order: 0,
             },
         };
 
@@ -3314,6 +3331,7 @@ mod storage_type_edge_cases {
             crdt_type: None,
             field_name: None,
             schema_version: None,
+            order: 0,
         };
         let mut delete_action = Action::DeleteRef {
             id: page.id(),
@@ -3478,6 +3496,7 @@ mod owner_driven_convert {
             crdt_type: None,
             field_name: None,
             schema_version: None,
+            order: 0,
         };
         env::with_account_id(*owner.as_bytes(), || {
             assert!(!env::in_merge_mode(), "convert must run on the normal path");
@@ -3529,6 +3548,7 @@ mod owner_driven_convert {
             crdt_type: None,
             field_name: None,
             schema_version: None,
+            order: 0,
         };
         // Executor is NOT the owner: the local-owner stamp branch must not fire,
         // so the entry is never converted (schema stays None, no owner signature).
@@ -3567,6 +3587,7 @@ mod owner_driven_convert {
             crdt_type: None,
             field_name: None,
             schema_version: None,
+            order: 0,
         };
         // Guard O4: even an owner-keyed write must NOT drive the convert when it
         // runs inside a merge scope. Merge mode bypasses the replay-nonce check
@@ -3633,6 +3654,7 @@ mod owner_driven_convert {
             crdt_type: None,
             field_name: None,
             schema_version: None,
+            order: 0,
         };
         let mut action = Action::Add {
             id,
@@ -3701,6 +3723,7 @@ mod owner_driven_convert {
             crdt_type: None,
             field_name: None,
             schema_version: Some(1),
+            order: before.order,
         };
         let mut update = Action::Update {
             id,

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -23,11 +23,7 @@ fn recompute_full_hash(id: crate::address::Id) -> [u8; 32] {
     use crate::index::Index;
     use crate::store::MainStorage;
     let index = Index::<MainStorage>::get_index(id).unwrap().unwrap();
-    Index::<MainStorage>::calculate_full_hash_for_children(
-        index.own_hash(),
-        &index.children().map(<[_]>::to_vec),
-    )
-    .unwrap()
+    Index::<MainStorage>::full_hash_from_trie(id, index.own_hash())
 }
 
 #[cfg(test)]

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -388,6 +388,135 @@ mod interface__apply_actions {
         assert!(retrieved.is_none());
     }
 
+    /// The equal-timestamp case, which `apply_delete_ref_action` calls "the
+    /// SINGLE canonical equal-HLC delete-vs-update tiebreak for every storage
+    /// type" and which nothing pinned: strictly-older and strictly-newer were
+    /// covered either side of it, and the tie in the middle was not.
+    ///
+    /// The guard is `deleted_at < updated_at` — strict — so an equal-HLC delete
+    /// WINS. Relaxing it to `<=` would flip this silently, and both neighbours
+    /// would still pass.
+    #[test]
+    fn an_equal_timestamp_delete_wins_over_the_update() {
+        crate::tests::common::register_test_merge_functions();
+        let mut page = Page::new_from_element("Test Page", Element::root());
+        assert!(MainInterface::save(&mut page).unwrap());
+
+        page.title = "Updated Page".to_owned();
+        page.element_mut().update();
+        assert!(MainInterface::save(&mut page).unwrap());
+
+        let update_time = *page.element().metadata.updated_at;
+
+        let tie = Action::DeleteRef {
+            id: page.id(),
+            deleted_at: update_time, // exactly equal
+            metadata: Metadata::default(),
+        };
+        assert!(MainInterface::apply_action(tie, &ApplyContext::empty()).is_ok());
+
+        assert!(
+            MainInterface::find_by_id::<Page>(page.id())
+                .unwrap()
+                .is_none(),
+            "an equal-HLC delete must win: the guard is `deleted_at < updated_at`, strict"
+        );
+    }
+
+    /// What merge-mode timestamp suppression actually decides.
+    ///
+    /// `Element::timestamp_for_operation` returns 0 under merge mode. Its
+    /// comment says that is "to ensure deterministic hashes" — which is not a
+    /// path that exists: `Element.metadata` is `#[borsh(skip)]`, so it reaches
+    /// neither `own_hash` (a hash of the serialized data) nor the child-trie
+    /// fold (`id ‖ merkle_hash`), and the timestamp does not feed `Id::random`
+    /// either.
+    ///
+    /// What it DOES decide is the delete-vs-update tiebreak, and the rule is
+    /// narrower than "merge zeroes timestamps":
+    ///
+    /// - `Element::new*` (construction) stamps 0 under merge mode.
+    /// - `Element::update` under merge mode leaves the existing timestamp
+    ///   ALONE — it does not zero it.
+    ///
+    /// Both are the same rule stated properly: a merge must not manufacture
+    /// time. The consequence pinned here is that an entity CONSTRUCTED during a
+    /// merge holds `updated_at == 0`, and `deleted_at < 0` is unsatisfiable, so
+    /// it loses the tiebreak to EVERY delete — including one at timestamp 0.
+    #[test]
+    fn an_entity_constructed_during_merge_loses_to_any_delete() {
+        crate::tests::common::register_test_merge_functions();
+
+        // Constructed INSIDE merge mode: this is what makes updated_at 0.
+        // Updating inside merge mode would not — `update` preserves.
+        // `Element::root()` rather than `Element::new(None)`: a non-root element
+        // has no parent to link to yet and `save` refuses the orphan. Root goes
+        // through the same `timestamp_for_operation`, which is the field under
+        // test.
+        let page = crate::env::with_merge_mode(|| {
+            let mut page = Page::new_from_element("Merged Page", Element::root());
+            assert!(MainInterface::save(&mut page).unwrap());
+            page
+        });
+
+        assert_eq!(
+            *page.element().metadata.updated_at,
+            0,
+            "merge mode must suppress the timestamp; the rest of this test rests on it"
+        );
+
+        // The weakest possible delete: timestamp 0.
+        let earliest = Action::DeleteRef {
+            id: page.id(),
+            deleted_at: 0,
+            metadata: Metadata::default(),
+        };
+        assert!(MainInterface::apply_action(earliest, &ApplyContext::empty()).is_ok());
+
+        assert!(
+            MainInterface::find_by_id::<Page>(page.id())
+                .unwrap()
+                .is_none(),
+            "a merge-stamped entity loses to a delete at timestamp 0, because the \
+             tiebreak is strict and nothing can be older than 0"
+        );
+    }
+
+    /// The contrast that gives the test above its meaning: the SAME delete, at
+    /// timestamp 0, against an entity stamped outside merge mode, loses.
+    ///
+    /// Without this, `an_entity_stamped_during_merge_loses_to_any_delete` would
+    /// also pass if deletes simply always won.
+    #[test]
+    fn an_entity_stamped_outside_merge_survives_the_same_delete() {
+        crate::tests::common::register_test_merge_functions();
+
+        let mut page = Page::new_from_element("Live Page", Element::root());
+        assert!(MainInterface::save(&mut page).unwrap());
+        page.title = "Live Update".to_owned();
+        page.element_mut().update();
+        assert!(MainInterface::save(&mut page).unwrap());
+
+        assert!(
+            *page.element().metadata.updated_at > 0,
+            "outside merge mode the timestamp must be real"
+        );
+
+        let earliest = Action::DeleteRef {
+            id: page.id(),
+            deleted_at: 0,
+            metadata: Metadata::default(),
+        };
+        assert!(MainInterface::apply_action(earliest, &ApplyContext::empty()).is_ok());
+
+        assert!(
+            MainInterface::find_by_id::<Page>(page.id())
+                .unwrap()
+                .is_some(),
+            "a delete at 0 must lose to a real update timestamp"
+        );
+    }
+
     #[test]
     fn apply_action__non_existent_update() {
         let page = Page::new_from_element("Test Page", Element::root());

--- a/crates/storage/src/tests/merkle.rs
+++ b/crates/storage/src/tests/merkle.rs
@@ -7,7 +7,7 @@
 
 use super::common::{Page, Paragraph};
 use crate::address::Id;
-use crate::entities::{ChildInfo, Data, Element, Metadata};
+use crate::entities::{Data, Element};
 use crate::index::Index;
 use crate::interface::{ApplyContext, Interface};
 use crate::store::{MockedStorage, StorageAdaptor};
@@ -743,8 +743,8 @@ fn stored_full_hash_stays_authoritative_through_ancestor_walks() {
     // After #2238 Fix 1, `get_full_merkle_hash_for` is an O(1)
     // stored-read, so comparing it against `get_hashes_for` would be
     // circular. Instead, independently recompute each node's full_hash
-    // from its children (via `calculate_full_hash_for_children` on the
-    // raw EntityIndex) and assert it matches the stored value. This
+    // from its children (via `recompute_full_hash`, which folds the
+    // child trie) and assert it matches the stored value. This
     // catches the class of bug the reviewer flagged: a future write
     // site that forgets to refresh `full_hash` would leave the stored
     // value out of sync with what the children imply, and this test
@@ -783,111 +783,4 @@ fn stored_full_hash_stays_authoritative_through_ancestor_walks() {
             "full_hash must be set for every node after ops"
         );
     }
-}
-
-// ============================================================
-// `calculate_full_hash_for_children` — hash content is content-
-// derived, decoupled from `(created_at, id)` storage layout.
-// ============================================================
-//
-// These tests pin the invariant fix-issue-#2418 relies on: two
-// peers holding the same set of children at the same merkle
-// hashes must compute identical parent hashes regardless of how
-// their `created_at`s differ. The canonical case the fix
-// addresses is the `Root<T>` opaque-marker entity each peer
-// creates independently at a different local wall-clock time —
-// before the fix, the parent's `full_hash` iterated children in
-// stored `(created_at, id)` order, so the parent hash diverged
-// across peers even though every child's bytes matched.
-
-fn child(id_byte: u8, merkle_byte: u8, created_at: u64) -> ChildInfo {
-    let metadata = Metadata::new(created_at, created_at);
-    ChildInfo::new(Id::new([id_byte; 32]), [merkle_byte; 32], metadata)
-}
-
-#[test]
-fn full_hash_invariant_to_created_at_when_children_match() {
-    // Same ids + same merkle_hashes, different `created_at`s.
-    // This is the exact divergence shape #2418 documents:
-    // peer-1's `Root<T>` was created at T=100, peer-2's at T=105,
-    // but the value bytes (and therefore the merkle hashes) are
-    // identical.
-    let peer1 = vec![
-        child(0x01, 0xAA, 100),
-        child(0x02, 0xBB, 101),
-        child(0x03, 0xCC, 102),
-    ];
-    let peer2 = vec![
-        child(0x01, 0xAA, 200),
-        child(0x02, 0xBB, 201),
-        child(0x03, 0xCC, 202),
-    ];
-
-    let own_hash = [0xDE; 32];
-    let h1 =
-        Index::<TestStorage>::calculate_full_hash_for_children(own_hash, &Some(peer1)).unwrap();
-    let h2 =
-        Index::<TestStorage>::calculate_full_hash_for_children(own_hash, &Some(peer2)).unwrap();
-
-    assert_eq!(
-        h1, h2,
-        "parent hash must NOT depend on children's `created_at` — \
-         same ids + same merkle_hashes → same parent hash regardless \
-         of local creation times"
-    );
-}
-
-#[test]
-fn full_hash_invariant_to_input_order() {
-    // The function sorts by `id` internally, so the caller's
-    // iteration order should not matter. Catches a regression
-    // where someone removes the sort step expecting "the input
-    // is already sorted by Ord" (true today for stored children
-    // — but the function should defend against unsorted inputs
-    // because the whole point is decoupling the hash from the
-    // stored layout).
-    let in_order = vec![
-        child(0x01, 0xAA, 100),
-        child(0x02, 0xBB, 100),
-        child(0x03, 0xCC, 100),
-    ];
-    let reversed = vec![
-        child(0x03, 0xCC, 100),
-        child(0x02, 0xBB, 100),
-        child(0x01, 0xAA, 100),
-    ];
-
-    let own_hash = [0xDE; 32];
-    let h1 =
-        Index::<TestStorage>::calculate_full_hash_for_children(own_hash, &Some(in_order)).unwrap();
-    let h2 =
-        Index::<TestStorage>::calculate_full_hash_for_children(own_hash, &Some(reversed)).unwrap();
-
-    assert_eq!(
-        h1, h2,
-        "parent hash must NOT depend on input iteration order"
-    );
-}
-
-#[test]
-fn full_hash_changes_when_a_child_merkle_hash_changes() {
-    // Sanity: the hash MUST still depend on children's merkle
-    // hashes. Swap one child's merkle hash and the parent hash
-    // must change — otherwise the merkle invariant is broken.
-    let before = vec![child(0x01, 0xAA, 100), child(0x02, 0xBB, 100)];
-    let after = vec![
-        child(0x01, 0xAA, 100),
-        child(0x02, 0xBC, 100), // <-- merkle hash differs
-    ];
-
-    let own_hash = [0xDE; 32];
-    let h1 =
-        Index::<TestStorage>::calculate_full_hash_for_children(own_hash, &Some(before)).unwrap();
-    let h2 =
-        Index::<TestStorage>::calculate_full_hash_for_children(own_hash, &Some(after)).unwrap();
-
-    assert_ne!(
-        h1, h2,
-        "parent hash must change when a child's merkle hash changes"
-    );
 }

--- a/crates/storage/src/tests/merkle.rs
+++ b/crates/storage/src/tests/merkle.rs
@@ -22,13 +22,15 @@ type TestInterface = Interface<TestStorage>;
 /// `get_hashes_for` would be tautological. This helper gives a real
 /// independent signal: if any write site forgot to refresh
 /// `full_hash`, the stored value and this recompute diverge.
+///
+/// Children now live in the parent's [`ChildTrie`], so the recompute folds the
+/// stored trie root rather than a sibling list. That still answers the question
+/// this helper exists for — did a write site leave `full_hash` stale relative to
+/// the children — while the trie's own tests cover whether the root itself is
+/// maintained correctly.
 fn recompute_full_hash<S: StorageAdaptor>(id: Id) -> [u8; 32] {
     let index = Index::<S>::get_index(id).unwrap().unwrap();
-    Index::<S>::calculate_full_hash_for_children(
-        index.own_hash(),
-        &index.children().map(<[_]>::to_vec),
-    )
-    .unwrap()
+    Index::<S>::full_hash_from_trie(id, index.own_hash())
 }
 
 // ============================================================

--- a/crates/storage/src/tests/sync_batch_resilience.rs
+++ b/crates/storage/src/tests/sync_batch_resilience.rs
@@ -92,6 +92,7 @@ fn unsigned_shared_add(
             crdt_type: None,
             field_name: None,
             schema_version: None,
+            order: 0,
         },
     }
 }

--- a/crates/storage/tests/read_cost_profile.rs
+++ b/crates/storage/tests/read_cost_profile.rs
@@ -19,13 +19,13 @@ use calimero_storage::store::{Key, StorageAdaptor};
 type IndexKey = (Id, Vec<u8>);
 
 thread_local! {
-    static STORE: RefCell<BTreeMap<[u8; 32], Vec<u8>>> = RefCell::new(BTreeMap::new());
+    static STORE: RefCell<BTreeMap<[u8; 32], Vec<u8>>> = const { RefCell::new(BTreeMap::new()) };
     static READS: RefCell<usize> = const { RefCell::new(0) };
     static WRITES: RefCell<usize> = const { RefCell::new(0) };
     static READ_BYTES: RefCell<usize> = const { RefCell::new(0) };
-    static DISTINCT: RefCell<BTreeSet<[u8; 32]>> = RefCell::new(BTreeSet::new());
-    static INDEX: RefCell<BTreeMap<IndexKey, Id>> = RefCell::new(BTreeMap::new());
-    static INDEX_META: RefCell<BTreeMap<Id, Vec<u8>>> = RefCell::new(BTreeMap::new());
+    static DISTINCT: RefCell<BTreeSet<[u8; 32]>> = const { RefCell::new(BTreeSet::new()) };
+    static INDEX: RefCell<BTreeMap<IndexKey, Id>> = const { RefCell::new(BTreeMap::new()) };
+    static INDEX_META: RefCell<BTreeMap<Id, Vec<u8>>> = const { RefCell::new(BTreeMap::new()) };
     static INDEX_EXAMINED: RefCell<usize> = const { RefCell::new(0) };
 }
 
@@ -231,7 +231,7 @@ fn profile_full_materialisation_vs_page() {
     let mut n = 0_usize;
     for &target in &CHECKPOINTS {
         while n < target {
-            let _ = v.push(make_msg(n, n % 10 == 0)).expect("push");
+            v.push(make_msg(n, n % 10 == 0)).expect("push");
             n += 1;
         }
         reset();
@@ -280,7 +280,7 @@ fn profile_unread_count_scan() {
     let mut n = 0_usize;
     for &target in &CHECKPOINTS {
         while n < target {
-            let _ = v.push(make_msg(n, n % 10 == 0)).expect("push");
+            v.push(make_msg(n, n % 10 == 0)).expect("push");
             n += 1;
         }
         let last_read = 1_700_000_000_000_u64 + (target as u64) - 10;
@@ -508,7 +508,7 @@ fn profile_cold_positional_get() {
     let mut n = 0_usize;
     for &target in &CHECKPOINTS {
         while n < target {
-            let _ = v.push(make_msg(n, false)).expect("push");
+            v.push(make_msg(n, false)).expect("push");
             n += 1;
         }
         let fresh: Root<Vector<MsgLite, Counting>, calimero_storage::store::MainStorage> =

--- a/crates/storage/tests/read_cost_profile.rs
+++ b/crates/storage/tests/read_cost_profile.rs
@@ -1,0 +1,529 @@
+//! Where does a READ's cost go as a collection grows?
+//!
+//! The write wall is fixed (see `write_cost_profile.rs`). This is the mirror
+//! image for the read path: the chat contract's `get_messages` materialises
+//! every message and *then* slices a page, so a "last 50 messages" call is
+//! O(N) in total history. Gas is charged for reads too, at 1e9 points/call.
+//!
+//! Nothing here modifies the crate under test; it only measures it.
+
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
+use std::ops::Bound;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use calimero_storage::address::Id;
+use calimero_storage::collections::{Root, SortedMap, UnorderedMap, UnorderedSet, Vector};
+use calimero_storage::store::{Key, StorageAdaptor};
+
+type IndexKey = (Id, Vec<u8>);
+
+thread_local! {
+    static STORE: RefCell<BTreeMap<[u8; 32], Vec<u8>>> = RefCell::new(BTreeMap::new());
+    static READS: RefCell<usize> = const { RefCell::new(0) };
+    static WRITES: RefCell<usize> = const { RefCell::new(0) };
+    static READ_BYTES: RefCell<usize> = const { RefCell::new(0) };
+    static DISTINCT: RefCell<BTreeSet<[u8; 32]>> = RefCell::new(BTreeSet::new());
+    static INDEX: RefCell<BTreeMap<IndexKey, Id>> = RefCell::new(BTreeMap::new());
+    static INDEX_META: RefCell<BTreeMap<Id, Vec<u8>>> = RefCell::new(BTreeMap::new());
+    static INDEX_EXAMINED: RefCell<usize> = const { RefCell::new(0) };
+}
+
+#[derive(Debug)]
+struct Counting;
+
+fn within_end(key: &[u8], end: &Bound<Vec<u8>>) -> bool {
+    match end {
+        Bound::Unbounded => true,
+        Bound::Included(e) => key <= e.as_slice(),
+        Bound::Excluded(e) => key < e.as_slice(),
+    }
+}
+
+impl StorageAdaptor for Counting {
+    fn storage_read(key: Key) -> Option<Vec<u8>> {
+        let kb = key.to_bytes();
+        let out = STORE.with(|s| s.borrow().get(&kb).cloned());
+        READS.with(|r| *r.borrow_mut() += 1);
+        DISTINCT.with(|d| {
+            let _ = d.borrow_mut().insert(kb);
+        });
+        if let Some(v) = &out {
+            READ_BYTES.with(|b| *b.borrow_mut() += v.len());
+        }
+        out
+    }
+    fn storage_write(key: Key, value: &[u8]) -> bool {
+        WRITES.with(|w| *w.borrow_mut() += 1);
+        let _prev = STORE.with(|s| s.borrow_mut().insert(key.to_bytes(), value.to_vec()));
+        true
+    }
+    fn storage_remove(key: Key) -> bool {
+        STORE.with(|s| s.borrow_mut().remove(&key.to_bytes()).is_some())
+    }
+
+    fn index_supported() -> bool {
+        true
+    }
+    fn index_put(collection: Id, order_key: &[u8], entry: Id) -> bool {
+        INDEX.with(|i| {
+            let _ = i
+                .borrow_mut()
+                .insert((collection, order_key.to_vec()), entry);
+        });
+        true
+    }
+    fn index_remove(collection: Id, order_key: &[u8]) -> bool {
+        INDEX.with(|i| {
+            let _ = i.borrow_mut().remove(&(collection, order_key.to_vec()));
+        });
+        true
+    }
+    fn index_clear(collection: Id) -> bool {
+        INDEX.with(|i| i.borrow_mut().retain(|(c, _), _| *c != collection));
+        true
+    }
+    fn index_range(
+        collection: Id,
+        start: Bound<Vec<u8>>,
+        end: Bound<Vec<u8>>,
+        offset: usize,
+        limit: Option<usize>,
+    ) -> Vec<(Vec<u8>, Id)> {
+        let lo: Bound<IndexKey> = match start {
+            Bound::Included(s) => Bound::Included((collection, s)),
+            Bound::Excluded(s) => Bound::Excluded((collection, s)),
+            Bound::Unbounded => Bound::Included((collection, Vec::new())),
+        };
+        INDEX.with(|i| {
+            let i = i.borrow();
+            let walked = i
+                .range((lo, Bound::Unbounded))
+                .take_while(|((c, k), _)| *c == collection && within_end(k, &end))
+                .map(|((_, k), e)| {
+                    INDEX_EXAMINED.with(|x| *x.borrow_mut() += 1);
+                    (k.clone(), *e)
+                })
+                .skip(offset);
+            match limit {
+                Some(n) => walked.take(n).collect(),
+                None => walked.collect(),
+            }
+        })
+    }
+    fn index_prefix(
+        collection: Id,
+        prefix: &[u8],
+        offset: usize,
+        limit: Option<usize>,
+    ) -> Vec<(Vec<u8>, Id)> {
+        INDEX.with(|i| {
+            let i = i.borrow();
+            let walked = i
+                .range((
+                    Bound::Included((collection, prefix.to_vec())),
+                    Bound::Unbounded,
+                ))
+                .take_while(|((c, k), _)| *c == collection && k.starts_with(prefix))
+                .map(|((_, k), e)| {
+                    INDEX_EXAMINED.with(|x| *x.borrow_mut() += 1);
+                    (k.clone(), *e)
+                })
+                .skip(offset);
+            match limit {
+                Some(n) => walked.take(n).collect(),
+                None => walked.collect(),
+            }
+        })
+    }
+    fn index_last(collection: Id) -> Option<(Vec<u8>, Id)> {
+        INDEX.with(|i| {
+            i.borrow()
+                .range((
+                    Bound::Included((collection, Vec::new())),
+                    Bound::Excluded((collection, vec![0xff; 96])),
+                ))
+                .next_back()
+                .map(|((_, k), e)| {
+                    INDEX_EXAMINED.with(|x| *x.borrow_mut() += 1);
+                    (k.clone(), *e)
+                })
+        })
+    }
+    fn index_meta_put(collection: Id, marker: &[u8]) -> bool {
+        INDEX_META.with(|m| {
+            let _ = m.borrow_mut().insert(collection, marker.to_vec());
+        });
+        true
+    }
+    fn index_meta_get(collection: Id) -> Option<Vec<u8>> {
+        INDEX_META.with(|m| m.borrow().get(&collection).cloned())
+    }
+    fn index_meta_clear(collection: Id) -> bool {
+        INDEX_META.with(|m| {
+            let _ = m.borrow_mut().remove(&collection);
+        });
+        true
+    }
+}
+
+fn reset() {
+    READS.with(|r| *r.borrow_mut() = 0);
+    WRITES.with(|w| *w.borrow_mut() = 0);
+    READ_BYTES.with(|b| *b.borrow_mut() = 0);
+    DISTINCT.with(|d| d.borrow_mut().clear());
+    INDEX_EXAMINED.with(|x| *x.borrow_mut() = 0);
+}
+
+fn reads() -> usize {
+    READS.with(|r| *r.borrow())
+}
+fn read_bytes() -> usize {
+    READ_BYTES.with(|b| *b.borrow())
+}
+fn index_examined() -> usize {
+    INDEX_EXAMINED.with(|x| *x.borrow())
+}
+
+const CHECKPOINTS: [usize; 5] = [250, 500, 1_000, 2_000, 4_000];
+const PAGE: usize = 50;
+
+/// A stand-in for the chat contract's `Message`: scalar fields plus the two
+/// nested collections every message carries (`mentions`, `files`).
+#[derive(BorshSerialize, BorshDeserialize)]
+struct MsgLite {
+    id: String,
+    timestamp: u64,
+    sender: [u8; 32],
+    text: String,
+    mentions: UnorderedSet<[u8; 32], Counting>,
+    files: Vector<u64, Counting>,
+}
+
+fn make_msg(n: usize, with_mention: bool) -> MsgLite {
+    let mut mentions = UnorderedSet::<[u8; 32], Counting>::new();
+    if with_mention {
+        let mut who = [0_u8; 32];
+        who[0] = 7;
+        let _ = mentions.insert(who);
+    }
+    MsgLite {
+        id: format!("msg-{n:08}"),
+        timestamp: 1_700_000_000_000 + n as u64,
+        sender: [(n % 251) as u8; 32],
+        text: format!("message body number {n} with some filler text"),
+        mentions,
+        files: Vector::<u64, Counting>::new(),
+    }
+}
+
+/// BASELINE: what a *whole-history* materialisation costs.
+///
+/// This is exactly what `collect_messages_with_reactions(&self.messages, ..)`
+/// does today — `messages.iter()` walks every child, loads every entry, and
+/// only then does `paginate` slice the last `limit`.
+#[test]
+fn profile_full_materialisation_vs_page() {
+    let mut v = Root::new(Vector::<MsgLite, Counting>::new);
+    println!("\n=== A. get_messages TODAY: collect-all-then-slice (page = {PAGE}) ===");
+    println!("      N |    reads | read KiB | reads/msg | drop to serve {PAGE}");
+    let mut samples: Vec<(usize, usize)> = Vec::new();
+    let mut n = 0_usize;
+    for &target in &CHECKPOINTS {
+        while n < target {
+            let _ = v.push(make_msg(n, n % 10 == 0)).expect("push");
+            n += 1;
+        }
+        reset();
+        // Faithful shape of `collect_messages_with_reactions` + `paginate`:
+        // materialise every message (incl. its nested collections), then slice.
+        let mut all: Vec<(u64, String, Vec<[u8; 32]>)> = Vec::new();
+        if let Ok(iter) = v.iter() {
+            for m in iter {
+                let mentions: Vec<[u8; 32]> =
+                    m.mentions.iter().map(|i| i.collect()).unwrap_or_default();
+                let _files: Vec<u64> = m.files.iter().map(|i| i.collect()).unwrap_or_default();
+                all.push((m.timestamp, m.text, mentions));
+            }
+        }
+        let total = all.len();
+        let start = total.saturating_sub(PAGE);
+        let page = &all[start..];
+        assert_eq!(page.len(), PAGE.min(total));
+        let r = reads();
+        println!(
+            "{target:>7} | {r:>8} | {:>8} | {:>9.1} | {:>5} materialised, {PAGE} returned",
+            read_bytes() / 1024,
+            r as f64 / target as f64,
+            total
+        );
+        samples.push((target, r));
+    }
+    let (n0, r0) = samples[0];
+    let (n1, r1) = *samples.last().expect("samples");
+    println!(
+        "  growth: N x{:.0} -> reads x{:.1}  (linear would be x{:.0})",
+        n1 as f64 / n0 as f64,
+        r1 as f64 / r0 as f64,
+        n1 as f64 / n0 as f64
+    );
+}
+
+/// The unread-count shape: a full scan that returns a single integer.
+/// Cheaper per message than `get_messages` (no nested collections touched)
+/// but still strictly linear in total history.
+#[test]
+fn profile_unread_count_scan() {
+    let mut v = Root::new(Vector::<MsgLite, Counting>::new);
+    println!("\n=== B. get_unread_count / get_unread_mentions: full scan ===");
+    println!("      N |  count reads | mentions reads | reads/msg");
+    let mut n = 0_usize;
+    for &target in &CHECKPOINTS {
+        while n < target {
+            let _ = v.push(make_msg(n, n % 10 == 0)).expect("push");
+            n += 1;
+        }
+        let last_read = 1_700_000_000_000_u64 + (target as u64) - 10;
+
+        // get_unread_count: scalar-only scan.
+        reset();
+        let mut count = 0_u32;
+        if let Ok(iter) = v.iter() {
+            for m in iter {
+                if m.timestamp <= last_read {
+                    continue;
+                }
+                count += 1;
+            }
+        }
+        let count_reads = reads();
+
+        // get_unread_mentions: same scan, plus per-surviving-message nested reads.
+        reset();
+        let mut mentions_hits = 0_u32;
+        if let Ok(iter) = v.iter() {
+            for m in iter {
+                if m.timestamp <= last_read {
+                    continue;
+                }
+                if let Ok(mut it) = m.mentions.iter() {
+                    if it.any(|u| u[0] == 7) {
+                        mentions_hits += 1;
+                    }
+                }
+            }
+        }
+        let mention_reads = reads();
+        assert!(count >= mentions_hits);
+        println!(
+            "{target:>7} | {count_reads:>12} | {mention_reads:>14} | {:>9.1}",
+            count_reads as f64 / target as f64
+        );
+    }
+}
+
+/// What a page of reactions costs, given `reactions: UnorderedMap<MessageId,
+/// UnorderedMap<String, UnorderedSet<String>>>` — three nested levels, walked
+/// per message on the page.
+#[test]
+fn profile_reactions_for_a_page() {
+    let mut m = Root::new(
+        UnorderedMap::<
+            String,
+            UnorderedMap<String, UnorderedSet<String, Counting>, Counting>,
+            Counting,
+        >::new,
+    );
+    println!("\n=== D. reactions for one page of {PAGE} messages ===");
+    println!("      N | miss-only reads | 2-emoji x 3-users reads | reads/msg");
+    let mut n = 0_usize;
+    for &target in &[250_usize, 500, 1_000, 2_000] {
+        while n < target {
+            // Every 4th message carries reactions, so a page mixes hits/misses.
+            if n % 4 == 0 {
+                let mut inner =
+                    UnorderedMap::<String, UnorderedSet<String, Counting>, Counting>::new();
+                for emoji in ["thumbsup", "heart"] {
+                    let mut users = UnorderedSet::<String, Counting>::new();
+                    for u in 0..3 {
+                        let _ = users.insert(format!("user-{}-{}", n % 17, u));
+                    }
+                    let _ = inner.insert(emoji.to_owned(), users);
+                }
+                let _ = m.insert(format!("msg-{n:08}"), inner).expect("insert");
+            }
+            n += 1;
+        }
+
+        // A page of 50 message ids that have NO reactions (pure lookup misses).
+        reset();
+        for i in 0..PAGE {
+            let id = format!("msg-{:08}", (n - 1 - i * 4).max(1));
+            let _ = m.get(&id);
+        }
+        let miss_reads = reads();
+
+        // A page of 50 message ids that DO have reactions, fully expanded the
+        // way `get_reactions_for_message` expands them.
+        reset();
+        let mut expanded = 0_usize;
+        for i in 0..PAGE {
+            let id = format!("msg-{:08}", ((n - 4 - i * 4) / 4) * 4);
+            if let Ok(Some(inner)) = m.get(&id) {
+                if let Ok(entries) = inner.entries() {
+                    for (_emoji, users) in entries {
+                        if let Ok(it) = users.iter() {
+                            expanded += it.count();
+                        }
+                    }
+                }
+            }
+        }
+        let hit_reads = reads();
+        println!(
+            "{target:>7} | {miss_reads:>15} | {hit_reads:>23} | {:>9.1}   (users expanded: {expanded})",
+            hit_reads as f64 / PAGE as f64
+        );
+    }
+}
+
+/// THE FIX, measured: the same page served through the ordered index.
+///
+/// `SortedMap` keyed by `timestamp_be ‖ id` gives ascending time order for
+/// free, and `page(offset, limit)` seeks the index rather than materialising
+/// the collection. Reads should be flat in N.
+#[test]
+fn profile_index_backed_page() {
+    let mut sm = Root::new(SortedMap::<Vec<u8>, MsgLite, Counting>::new);
+    println!("\n=== C. THE FIX: SortedMap::page via ordered index (page = {PAGE}) ===");
+    println!("      N |    reads | idx items | reads/page-item | note");
+    let mut samples: Vec<(usize, usize)> = Vec::new();
+    let mut n = 0_usize;
+    for &target in &CHECKPOINTS {
+        while n < target {
+            let mut key = Vec::with_capacity(16);
+            key.extend_from_slice(&(1_700_000_000_000_u64 + n as u64).to_be_bytes());
+            key.extend_from_slice(&(n as u64).to_be_bytes());
+            let _ = sm.insert(key, make_msg(n, n % 10 == 0)).expect("insert");
+            n += 1;
+        }
+
+        // Warm read: pays the index rebuild if the marker went stale on write.
+        let _ = sm.page(0, 1).expect("warm");
+
+        reset();
+        let page = sm.page(target - PAGE, PAGE).expect("page");
+        assert_eq!(page.len(), PAGE);
+        let r = reads();
+        println!(
+            "{target:>7} | {r:>8} | {:>9} | {:>15.1} | steady-state (index warm)",
+            index_examined(),
+            r as f64 / PAGE as f64
+        );
+        samples.push((target, r));
+
+        // Keyset ("cursor") paging: instead of offset-skipping, seek straight
+        // to the caller's last-seen order key. Measures the raw index
+        // primitive, which is what an offset-free contract API would use.
+        let cursor = {
+            let mut k = Vec::with_capacity(16);
+            k.extend_from_slice(&(1_700_000_000_000_u64 + (target - PAGE) as u64).to_be_bytes());
+            k.extend_from_slice(&((target - PAGE) as u64).to_be_bytes());
+            k
+        };
+        reset();
+        let hits = <Counting as StorageAdaptor>::index_range(
+            INDEX.with(|i| *i.borrow().keys().next().map(|(c, _)| c).expect("indexed")),
+            Bound::Excluded(cursor),
+            Bound::Unbounded,
+            0,
+            Some(PAGE),
+        );
+        println!(
+            "        |          |           |                 | keyset seek: {} idx items for {} hits",
+            index_examined(),
+            hits.len()
+        );
+    }
+    let (n0, r0) = samples[0];
+    let (n1, r1) = *samples.last().expect("samples");
+    println!(
+        "  growth: N x{:.0} -> reads x{:.2}  (flat would be x1.0)",
+        n1 as f64 / n0 as f64,
+        r1 as f64 / r0 as f64
+    );
+    assert!(
+        r1 <= r0 * 2,
+        "index-backed page must be flat in N: {r0} reads at N={n0}, {r1} at N={n1}"
+    );
+}
+
+/// `deleted_messages: UnorderedSet<String>` is consulted once per message on
+/// every read path. `UnorderedSet::contains` computes the entry id and then
+/// asks `Collection::contains`, which goes through `children_cache()` — a FULL
+/// child enumeration, cached per collection handle. So the first `contains` in
+/// a call materialises the entire deleted-message set.
+#[test]
+fn profile_deleted_set_contains() {
+    let mut s = Root::new(UnorderedSet::<String, Counting>::new);
+    println!("\n=== E. deleted_messages.contains(): first call vs cached ===");
+    println!("  deleted D | first contains | next 49 contains | note");
+    let mut d = 0_usize;
+    for &target in &[10_usize, 100, 500, 1_000, 2_000] {
+        while d < target {
+            let _ = s.insert(format!("msg-{d:08}"));
+            d += 1;
+        }
+        // Fresh handle per checkpoint so the cache starts cold, as it does on
+        // each contract call (state is re-fetched per invocation).
+        let fresh: Root<UnorderedSet<String, Counting>, calimero_storage::store::MainStorage> =
+            Root::fetch().expect("root should exist");
+        reset();
+        let _ = fresh.contains("msg-00000001");
+        let first = reads();
+        reset();
+        for i in 1..50 {
+            let _ = fresh.contains(&format!("msg-{i:08}"));
+        }
+        let rest = reads();
+        println!(
+            "{target:>11} | {first:>14} | {rest:>16} | {:.1} reads/deleted-entry on first touch",
+            first as f64 / target as f64
+        );
+    }
+}
+
+/// Kills the cheapest-looking workaround: "keep the AuthoredVector, add a
+/// side index of (order_key -> vector index), then `Vector::get(i)` the page".
+///
+/// `Vector::get` is documented O(1) — but only *given* the child-id cache.
+/// Cold (as every contract call starts), `Collection::nth` goes through
+/// `children_cache()`, which enumerates the entire child trie. So the first
+/// positional get in a call is O(N), and an index-of-indices buys nothing.
+#[test]
+fn profile_cold_positional_get() {
+    let mut v = Root::new(Vector::<MsgLite, Counting>::new);
+    println!("\n=== F. Vector::get(i) — first (cold) get in a call vs the rest ===");
+    println!("      N | cold get(N-1) | next 49 gets | note");
+    let mut n = 0_usize;
+    for &target in &CHECKPOINTS {
+        while n < target {
+            let _ = v.push(make_msg(n, false)).expect("push");
+            n += 1;
+        }
+        let fresh: Root<Vector<MsgLite, Counting>, calimero_storage::store::MainStorage> =
+            Root::fetch().expect("root should exist");
+        reset();
+        let _ = fresh.get(target - 1).expect("get");
+        let cold = reads();
+        reset();
+        for i in 2..51 {
+            let _ = fresh.get(target - i).expect("get");
+        }
+        let warm = reads();
+        println!(
+            "{target:>7} | {cold:>13} | {warm:>12} | cold is {:.1} reads/entry in the collection",
+            cold as f64 / target as f64
+        );
+    }
+}

--- a/crates/storage/tests/root_fanout_shape.rs
+++ b/crates/storage/tests/root_fanout_shape.rs
@@ -1,0 +1,74 @@
+//! What shape does the entity index actually take when records carry nested
+//! collections?
+//!
+//! `Collection::new` registers every new collection as a child of ROOT
+//! (`collections.rs:340`), and re-keying re-adds it (`collections.rs:542`).
+//! This measures the consequence rather than arguing about it.
+
+use calimero_storage::address::Id;
+use calimero_storage::collections::{Root, UnorderedMap, UnorderedSet, Vector};
+use calimero_storage::index::Index;
+use calimero_storage::store::MainStorage;
+
+/// Count ROOT's direct children and the depth of the tree beneath it.
+fn shape() -> (usize, usize, usize) {
+    let root = Id::root();
+    let children = <Index<MainStorage>>::get_children_of(root).expect("children");
+    let direct = children.len();
+
+    // Walk down to find the deepest path and the total node count.
+    let mut depth = 0;
+    let mut total = 0;
+    let mut frontier: Vec<Id> = children.iter().map(|c| c.id()).collect();
+    while !frontier.is_empty() {
+        depth += 1;
+        total += frontier.len();
+        let mut next = Vec::new();
+        for id in frontier {
+            if let Ok(kids) = <Index<MainStorage>>::get_children_of(id) {
+                next.extend(kids.iter().map(|c| c.id()));
+            }
+        }
+        frontier = next;
+        if depth > 64 {
+            break;
+        }
+    }
+    (direct, depth, total)
+}
+
+#[test]
+fn root_fans_out_flat_when_records_carry_nested_collections() {
+    // Mirrors a chat Message: a record whose fields are themselves collections.
+    let mut records: Root<UnorderedMap<[u8; 4], u64>> = Root::new(UnorderedMap::new);
+
+    let (base_direct, _, _) = shape();
+
+    // 50 records, each constructing 3 nested collections, as a Message does.
+    let mut keep: Vec<(UnorderedSet<[u8; 8]>, Vector<u64>, Vector<u64>)> = Vec::new();
+    for i in 0_u32..50 {
+        let mut set = UnorderedSet::<[u8; 8]>::new();
+        let _ = set.insert(u64::from(i).to_be_bytes());
+        let mut a = Vector::<u64>::new();
+        let _ = a.push(u64::from(i));
+        let mut b = Vector::<u64>::new();
+        let _ = b.push(u64::from(i));
+        keep.push((set, a, b));
+        let _ = records.insert(i.to_be_bytes(), u64::from(i));
+    }
+
+    let (direct, depth, total) = shape();
+    let added = direct - base_direct;
+
+    println!("ROOT direct children: {base_direct} -> {direct} (+{added})");
+    println!("tree depth below ROOT: {depth}");
+    println!("total nodes below ROOT: {total}");
+    println!("records inserted: 50, nested collections constructed: 150");
+
+    // The question this test exists to answer: do those 150 nested collections
+    // hang off the records they belong to, or off ROOT?
+    assert!(
+        added >= 150,
+        "expected ~150 nested collections to land directly on ROOT, saw +{added}"
+    );
+}

--- a/crates/storage/tests/root_fanout_shape.rs
+++ b/crates/storage/tests/root_fanout_shape.rs
@@ -73,26 +73,36 @@ fn root_fans_out_flat_when_records_carry_nested_collections() {
     );
 }
 
-/// How big is the blob that gets rewritten on every single link?
+/// The parent's index row must not grow with its child count.
+///
+/// It used to hold the whole child list inline: 16,927 bytes at 200 children,
+/// ~84 bytes per child, rewritten and re-hashed on every link. Children now live
+/// in the parent's `ChildTrie`, so this row is a fixed handful of fields and a
+/// link touches a bounded number of trie rows instead (see
+/// `child_trie::cost`).
 #[test]
-fn measure_the_children_blob() {
+fn the_parent_index_row_stays_small_however_many_children() {
     use calimero_storage::store::{Key, MainStorage, StorageAdaptor};
 
     let mut keep: Vec<UnorderedSet<[u8; 8]>> = Vec::new();
+    let mut sizes = Vec::new();
     for i in 0_u64..200 {
         let mut set = UnorderedSet::<[u8; 8]>::new();
         let _ = set.insert(i.to_be_bytes());
         keep.push(set);
+        if i == 9 || i == 49 || i == 199 {
+            let raw = MainStorage::storage_read(Key::Index(Id::root())).expect("root index row");
+            let n = <Index<MainStorage>>::get_children_of(Id::root())
+                .expect("children")
+                .len();
+            println!("children={n:>4}  parent index row={} bytes", raw.len());
+            sizes.push(raw.len());
+        }
     }
 
-    let raw = MainStorage::storage_read(Key::Index(Id::root())).expect("root index row");
-    let children = <Index<MainStorage>>::get_children_of(Id::root()).expect("children");
-    let n = children.len();
-    println!("ROOT children: {n}");
-    println!("ROOT index row: {} bytes", raw.len());
-    println!("per child: ~{} bytes", raw.len() / n.max(1));
-    println!(
-        "one link at this size rewrites {} bytes and folds {n} SHA-256 inputs",
-        raw.len()
+    assert_eq!(
+        sizes.first(),
+        sizes.last(),
+        "the parent's index row must not grow with its child count: {sizes:?}"
     );
 }

--- a/crates/storage/tests/root_fanout_shape.rs
+++ b/crates/storage/tests/root_fanout_shape.rs
@@ -72,3 +72,27 @@ fn root_fans_out_flat_when_records_carry_nested_collections() {
         "expected ~150 nested collections to land directly on ROOT, saw +{added}"
     );
 }
+
+/// How big is the blob that gets rewritten on every single link?
+#[test]
+fn measure_the_children_blob() {
+    use calimero_storage::store::{Key, MainStorage, StorageAdaptor};
+
+    let mut keep: Vec<UnorderedSet<[u8; 8]>> = Vec::new();
+    for i in 0_u64..200 {
+        let mut set = UnorderedSet::<[u8; 8]>::new();
+        let _ = set.insert(i.to_be_bytes());
+        keep.push(set);
+    }
+
+    let raw = MainStorage::storage_read(Key::Index(Id::root())).expect("root index row");
+    let children = <Index<MainStorage>>::get_children_of(Id::root()).expect("children");
+    let n = children.len();
+    println!("ROOT children: {n}");
+    println!("ROOT index row: {} bytes", raw.len());
+    println!("per child: ~{} bytes", raw.len() / n.max(1));
+    println!(
+        "one link at this size rewrites {} bytes and folds {n} SHA-256 inputs",
+        raw.len()
+    );
+}

--- a/crates/storage/tests/root_fanout_shape.rs
+++ b/crates/storage/tests/root_fanout_shape.rs
@@ -37,6 +37,10 @@ fn shape() -> (usize, usize, usize) {
     (direct, depth, total)
 }
 
+/// The nested collections each record carries, held for the duration of the
+/// profile so their rows stay in the store.
+type NestedTriple = (UnorderedSet<[u8; 8]>, Vector<u64>, Vector<u64>);
+
 #[test]
 fn root_fans_out_flat_when_records_carry_nested_collections() {
     // Mirrors a chat Message: a record whose fields are themselves collections.
@@ -45,7 +49,7 @@ fn root_fans_out_flat_when_records_carry_nested_collections() {
     let (base_direct, _, _) = shape();
 
     // 50 records, each constructing 3 nested collections, as a Message does.
-    let mut keep: Vec<(UnorderedSet<[u8; 8]>, Vector<u64>, Vector<u64>)> = Vec::new();
+    let mut keep: Vec<NestedTriple> = Vec::new();
     for i in 0_u32..50 {
         let mut set = UnorderedSet::<[u8; 8]>::new();
         let _ = set.insert(u64::from(i).to_be_bytes());

--- a/crates/storage/tests/trie_scaling.rs
+++ b/crates/storage/tests/trie_scaling.rs
@@ -1,0 +1,80 @@
+//! How far does the child trie actually scale?
+//!
+//! DEPTH nibbles give 16^DEPTH buckets. Below that, a bucket holds ~1 entry and
+//! a link is genuinely constant. Above it, buckets fill and a link pays
+//! O(n / 16^DEPTH) — the bucket is read, rewritten and folded whole. This
+//! measures where that turns from theory into cost.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+
+use calimero_storage::address::Id;
+use calimero_storage::child_trie::{ChildTrie, DEPTH};
+use calimero_storage::entities::{ChildInfo, Metadata};
+use calimero_storage::store::{Key, StorageAdaptor};
+use sha2::{Digest, Sha256};
+
+thread_local! {
+    static STORE: RefCell<BTreeMap<[u8; 32], Vec<u8>>> = RefCell::new(BTreeMap::new());
+    static WRITE_BYTES: RefCell<usize> = const { RefCell::new(0) };
+    static READ_BYTES: RefCell<usize> = const { RefCell::new(0) };
+    static ROWS: RefCell<usize> = const { RefCell::new(0) };
+}
+
+#[derive(Debug)]
+struct Counting;
+
+impl StorageAdaptor for Counting {
+    fn storage_read(key: Key) -> Option<Vec<u8>> {
+        let out = STORE.with(|s| s.borrow().get(&key.to_bytes()).cloned());
+        if let Some(v) = &out {
+            READ_BYTES.with(|b| *b.borrow_mut() += v.len());
+        }
+        out
+    }
+    fn storage_write(key: Key, value: &[u8]) -> bool {
+        WRITE_BYTES.with(|b| *b.borrow_mut() += value.len());
+        ROWS.with(|r| *r.borrow_mut() += 1);
+        let _prev = STORE.with(|s| s.borrow_mut().insert(key.to_bytes(), value.to_vec()));
+        true
+    }
+    fn storage_remove(key: Key) -> bool {
+        STORE.with(|s| s.borrow_mut().remove(&key.to_bytes()).is_some())
+    }
+}
+
+#[test]
+#[ignore = "scaling probe: run explicitly, takes minutes at 1M"]
+fn how_far_does_a_single_parent_scale() {
+    let parent = Id::new(Sha256::digest(b"scale").into());
+    let trie = ChildTrie::<Counting>::new(parent);
+
+    println!(
+        "\nDEPTH = {DEPTH} nibbles => {} buckets",
+        16_usize.pow(DEPTH as u32)
+    );
+    println!("        n | write B | read B | rows |  bucket occupancy");
+
+    let checkpoints = [1_000_usize, 10_000, 100_000, 1_000_000];
+    let mut next = 0_usize;
+    for target in checkpoints {
+        while next < target {
+            let id = Id::new(Sha256::digest(next.to_be_bytes()).into());
+            let _root = trie.insert(ChildInfo::new(id, [1; 32], Metadata::default()));
+            next += 1;
+        }
+        // Measure the very next insert in isolation.
+        WRITE_BYTES.with(|b| *b.borrow_mut() = 0);
+        READ_BYTES.with(|b| *b.borrow_mut() = 0);
+        ROWS.with(|r| *r.borrow_mut() = 0);
+        let id = Id::new(Sha256::digest(next.to_be_bytes()).into());
+        let _root = trie.insert(ChildInfo::new(id, [2; 32], Metadata::default()));
+        next += 1;
+
+        let wb = WRITE_BYTES.with(|b| *b.borrow());
+        let rb = READ_BYTES.with(|b| *b.borrow());
+        let rows = ROWS.with(|r| *r.borrow());
+        let occupancy = target as f64 / 16_f64.powi(DEPTH as i32);
+        println!("{target:>9} | {wb:>7} | {rb:>6} | {rows:>4} |  {occupancy:.2} entries/bucket");
+    }
+}

--- a/crates/storage/tests/trie_scaling.rs
+++ b/crates/storage/tests/trie_scaling.rs
@@ -15,7 +15,7 @@ use calimero_storage::store::{Key, StorageAdaptor};
 use sha2::{Digest, Sha256};
 
 thread_local! {
-    static STORE: RefCell<BTreeMap<[u8; 32], Vec<u8>>> = RefCell::new(BTreeMap::new());
+    static STORE: RefCell<BTreeMap<[u8; 32], Vec<u8>>> = const { RefCell::new(BTreeMap::new()) };
     static WRITE_BYTES: RefCell<usize> = const { RefCell::new(0) };
     static READ_BYTES: RefCell<usize> = const { RefCell::new(0) };
     static ROWS: RefCell<usize> = const { RefCell::new(0) };

--- a/crates/storage/tests/write_cost_profile.rs
+++ b/crates/storage/tests/write_cost_profile.rs
@@ -11,13 +11,13 @@ use calimero_storage::collections::{Root, UnorderedMap, UnorderedSet, Vector};
 use calimero_storage::store::{Key, StorageAdaptor};
 
 thread_local! {
-    static STORE: RefCell<BTreeMap<[u8; 32], Vec<u8>>> = RefCell::new(BTreeMap::new());
+    static STORE: RefCell<BTreeMap<[u8; 32], Vec<u8>>> = const { RefCell::new(BTreeMap::new()) };
     static READS: RefCell<usize> = const { RefCell::new(0) };
     static WRITES: RefCell<usize> = const { RefCell::new(0) };
     static READ_BYTES: RefCell<usize> = const { RefCell::new(0) };
     static DISTINCT: RefCell<std::collections::BTreeSet<[u8; 32]>> =
-        RefCell::new(std::collections::BTreeSet::new());
-    static REPEATS: RefCell<BTreeMap<[u8; 32], usize>> = RefCell::new(BTreeMap::new());
+        const { RefCell::new(std::collections::BTreeSet::new()) };
+    static REPEATS: RefCell<BTreeMap<[u8; 32], usize>> = const { RefCell::new(BTreeMap::new()) };
     static WRITE_BYTES: RefCell<usize> = const { RefCell::new(0) };
 }
 
@@ -76,11 +76,11 @@ fn profile_plain_vector_append() {
     for n in 0..600_u64 {
         if matches!(n, 50 | 150 | 300 | 450 | 599) {
             reset();
-            let _ = v.push(n).expect("push");
+            v.push(n).expect("push");
             let (r, w, rb, wb) = snapshot();
             println!("{n:>6} | {r:>6} | {w:>6} | {rb:>6} | {wb:>7}");
         } else {
-            let _ = v.push(n).expect("push");
+            v.push(n).expect("push");
         }
     }
 }
@@ -92,10 +92,14 @@ fn profile_plain_vector_append() {
 /// Writes were already bounded while reads grew with the collection — 7,682
 /// reads for a single insert at n=599 — because a logging block asked the trie
 /// to enumerate rather than count. Cost must be flat in n, not merely small.
+/// The two nested collections each record carries, kept alive for the
+/// duration of the profile so their rows stay in the store.
+type NestedPair = (UnorderedSet<[u8; 8], Counting>, Vector<u64, Counting>);
+
 #[test]
 fn profile_append_with_nested_collections() {
     let mut v = Root::new(Vector::<u64, Counting>::new);
-    let mut keep: Vec<(UnorderedSet<[u8; 8], Counting>, Vector<u64, Counting>)> = Vec::new();
+    let mut keep: Vec<NestedPair> = Vec::new();
     let mut samples: Vec<(u64, usize, usize, usize)> = Vec::new();
     println!("\n--- push + 2 nested collections per record ---");
     println!("     n |  reads | writes | read B | write B");
@@ -107,9 +111,9 @@ fn profile_append_with_nested_collections() {
         let mut set = UnorderedSet::<[u8; 8], Counting>::new();
         let _ = set.insert(n.to_be_bytes());
         let mut inner = Vector::<u64, Counting>::new();
-        let _ = inner.push(n);
+        drop(inner.push(n));
         keep.push((set, inner));
-        let _ = v.push(n).expect("push");
+        v.push(n).expect("push");
         if measure {
             let (r, w, rb, wb) = snapshot();
             let distinct = DISTINCT.with(|d| d.borrow().len());

--- a/crates/storage/tests/write_cost_profile.rs
+++ b/crates/storage/tests/write_cost_profile.rs
@@ -1,0 +1,158 @@
+//! Where does a write's cost actually go as a collection grows?
+//!
+//! The chat contract still walls, and three separate O(n) fixes moved the
+//! ceiling without flattening the curve. Rather than guess at a fourth, this
+//! counts storage operations per append directly.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+
+use calimero_storage::collections::{Root, UnorderedMap, UnorderedSet, Vector};
+use calimero_storage::store::{Key, StorageAdaptor};
+
+thread_local! {
+    static STORE: RefCell<BTreeMap<[u8; 32], Vec<u8>>> = RefCell::new(BTreeMap::new());
+    static READS: RefCell<usize> = const { RefCell::new(0) };
+    static WRITES: RefCell<usize> = const { RefCell::new(0) };
+    static READ_BYTES: RefCell<usize> = const { RefCell::new(0) };
+    static DISTINCT: RefCell<std::collections::BTreeSet<[u8; 32]>> =
+        RefCell::new(std::collections::BTreeSet::new());
+    static REPEATS: RefCell<BTreeMap<[u8; 32], usize>> = RefCell::new(BTreeMap::new());
+    static WRITE_BYTES: RefCell<usize> = const { RefCell::new(0) };
+}
+
+#[derive(Debug)]
+struct Counting;
+
+impl StorageAdaptor for Counting {
+    fn storage_read(key: Key) -> Option<Vec<u8>> {
+        let kb = key.to_bytes();
+        let out = STORE.with(|s| s.borrow().get(&kb).cloned());
+        READS.with(|r| *r.borrow_mut() += 1);
+        DISTINCT.with(|d| {
+            let _ = d.borrow_mut().insert(kb);
+        });
+        REPEATS.with(|m| *m.borrow_mut().entry(kb).or_insert(0) += 1);
+        if let Some(v) = &out {
+            READ_BYTES.with(|b| *b.borrow_mut() += v.len());
+        }
+        out
+    }
+    fn storage_write(key: Key, value: &[u8]) -> bool {
+        WRITES.with(|w| *w.borrow_mut() += 1);
+        WRITE_BYTES.with(|b| *b.borrow_mut() += value.len());
+        let _prev = STORE.with(|s| s.borrow_mut().insert(key.to_bytes(), value.to_vec()));
+        true
+    }
+    fn storage_remove(key: Key) -> bool {
+        STORE.with(|s| s.borrow_mut().remove(&key.to_bytes()).is_some())
+    }
+}
+
+fn reset() {
+    READS.with(|r| *r.borrow_mut() = 0);
+    WRITES.with(|w| *w.borrow_mut() = 0);
+    READ_BYTES.with(|b| *b.borrow_mut() = 0);
+    DISTINCT.with(|d| d.borrow_mut().clear());
+    REPEATS.with(|m| m.borrow_mut().clear());
+    WRITE_BYTES.with(|b| *b.borrow_mut() = 0);
+}
+
+fn snapshot() -> (usize, usize, usize, usize) {
+    (
+        READS.with(|r| *r.borrow()),
+        WRITES.with(|w| *w.borrow()),
+        READ_BYTES.with(|b| *b.borrow()),
+        WRITE_BYTES.with(|b| *b.borrow()),
+    )
+}
+
+/// A plain append into a Vector, with nothing nested.
+#[test]
+fn profile_plain_vector_append() {
+    let mut v = Root::new(Vector::<u64, Counting>::new);
+    println!("\n--- plain Vector::push ---");
+    println!("     n |  reads | writes | read B | write B");
+    for n in 0..600_u64 {
+        if matches!(n, 50 | 150 | 300 | 450 | 599) {
+            reset();
+            let _ = v.push(n).expect("push");
+            let (r, w, rb, wb) = snapshot();
+            println!("{n:>6} | {r:>6} | {w:>6} | {rb:>6} | {wb:>7}");
+        } else {
+            let _ = v.push(n).expect("push");
+        }
+    }
+}
+
+/// An append whose value carries nested collections, as a chat Message does.
+///
+/// This is the regression guard for the class of bug that has cost the most
+/// time here: an O(n) READ hidden behind an innocuous call on the write path.
+/// Writes were already bounded while reads grew with the collection — 7,682
+/// reads for a single insert at n=599 — because a logging block asked the trie
+/// to enumerate rather than count. Cost must be flat in n, not merely small.
+#[test]
+fn profile_append_with_nested_collections() {
+    let mut v = Root::new(Vector::<u64, Counting>::new);
+    let mut keep: Vec<(UnorderedSet<[u8; 8], Counting>, Vector<u64, Counting>)> = Vec::new();
+    let mut samples: Vec<(u64, usize, usize, usize)> = Vec::new();
+    println!("\n--- push + 2 nested collections per record ---");
+    println!("     n |  reads | writes | read B | write B");
+    for n in 0..600_u64 {
+        let measure = matches!(n, 50 | 150 | 300 | 450 | 599);
+        if measure {
+            reset();
+        }
+        let mut set = UnorderedSet::<[u8; 8], Counting>::new();
+        let _ = set.insert(n.to_be_bytes());
+        let mut inner = Vector::<u64, Counting>::new();
+        let _ = inner.push(n);
+        keep.push((set, inner));
+        let _ = v.push(n).expect("push");
+        if measure {
+            let (r, w, rb, wb) = snapshot();
+            let distinct = DISTINCT.with(|d| d.borrow().len());
+            let hottest = REPEATS.with(|m| m.borrow().values().copied().max().unwrap_or(0));
+            println!(
+                "{n:>6} | {r:>6} | {w:>6} | {rb:>6} | {wb:>7} | distinct={distinct:>5} hottest={hottest}"
+            );
+            samples.push((n, r, w, distinct));
+        }
+    }
+
+    let (_, first_reads, first_writes, first_distinct) = samples[0];
+    for &(n, reads, writes, distinct) in &samples {
+        assert!(
+            reads <= first_reads * 2,
+            "reads per insert must not grow with n: {first_reads} at first sample, {reads} at n={n}"
+        );
+        assert_eq!(
+            writes, first_writes,
+            "writes per insert must be constant: {first_writes} vs {writes} at n={n}"
+        );
+        assert!(
+            distinct <= first_distinct * 2,
+            "distinct keys touched per insert must not grow with n: \
+             {first_distinct} at first sample, {distinct} at n={n}"
+        );
+    }
+}
+
+/// Inserting into a map, the shape `threads`/`reactions` use.
+#[test]
+fn profile_map_insert() {
+    let mut m = Root::new(UnorderedMap::<[u8; 8], u64, Counting>::new);
+    println!("\n--- UnorderedMap::insert ---");
+    println!("     n |  reads | writes | read B | write B");
+    for n in 0..600_u64 {
+        if matches!(n, 50 | 150 | 300 | 450 | 599) {
+            reset();
+            let _ = m.insert(n.to_be_bytes(), n).expect("insert");
+            let (r, w, rb, wb) = snapshot();
+            println!("{n:>6} | {r:>6} | {w:>6} | {rb:>6} | {wb:>7}");
+        } else {
+            let _ = m.insert(n.to_be_bytes(), n).expect("insert");
+        }
+    }
+}


### PR DESCRIPTION
Closes #3602.

## The bug

A collection's append cost grew with the collection's size until a single write exhausted the gas limit, at which point the collection became **permanently unwritable** — the cost only goes up. On the mero-chat contract that wall was **394 messages**.

A parent's children lived inline in its `EntityIndex` as `Vec<ChildInfo>` (~84 bytes each), so linking one child read, rewrote and re-hashed *all* of them. At the ~1,600 ROOT children a chat context reached, each message sent rewrote ~135 KB four times over.

The hash chain itself was a correct recursive Merkle construction. What was missing was any index structure between a parent and its children: fan-out unbounded, so updates fold every sibling, diffs scan every sibling, and an inclusion proof needs all of them. The logarithmic properties a Merkle tree is used for require bounded fan-out, which nothing provided.

## Why 715 green tests never saw it

Gas is charged per executed wasm operator and nothing else. A storage read costs the ~4 operators of the caller regardless of value size, and there is **no read counter and no read limit in the VM**. So an O(n) read pattern never registers as "reads are expensive" — it registers as gas burnt borsh-decoding whatever those reads returned, which is invisible until a call dies.

Every storage test asserts what the code *computes*. None asserted what it *costs*. That gap is why this shipped, and why three more O(n) regressions were introduced while fixing the first — each behind a call that reads as free at the call site.

## The fix, in the order the costs were found

| # | Hidden cost | Effect |
|---|---|---|
| 1 | Inline sibling list — one link rewrites every sibling | wall **394 → 1,187** |
| 2 | `Collection::len` enumerated the whole child set, and the contract derives a message id from `len()` on every write | 1,187 → 1,179 (**nothing**) |
| 3 | `CollectionMut::insert` called `children_cache()`, reading *every* existing child to record one new id | this was the binding cost |
| 4 | A **log line** asked the trie to `enumerate()` rather than count, on the ancestor recompute of every write | n=599: **7,682 → 184** reads |

Fix 2 is worth reading as a cautionary result: making `len()` O(1) moved the wall by 8 messages. Three earlier attempts at write-side costs moved the ceiling without flattening the curve, because writes were 76 throughout — **bounded all along**. The cost was always reads.

### `ChildTrie`

A sparse hex trie keyed by child id, `DEPTH = 4` nibbles deep, with bucketed leaves. A link touches `DEPTH+1` rows whatever the parent holds:

```
n=    10:   467 bytes/link, 5 rows   (old inline blob: ~840)
n= 1,000: 1,259 bytes/link, 5 rows   (old:         ~84,000)
n=10,000: 1,820 bytes/link, 5 rows   (old:        ~840,000)
n=50,000: 2,018 bytes/link, 5 rows   (old:      ~4,200,000)
```

Rows are constant and bytes plateau once interior nodes fill their 16 slots (10k→50k is 1.109×). Nodes store only occupied slots, so a parent with three children costs three small rows — at n=10 the trie is already cheaper than the blob, so small parents are not taxed to make large ones work.

Keyed by **child id, not append order**: the root must be a function of the child *set*, or replicas that learn children in different orders never converge.

## Measured result

Against the real mero-chat contract, unmodified (`max_gas` 1e9), via `crates/runtime/tests/chat_wall.rs`:

| | n=100 | n=60,000 |
|---|---|---|
| `send_message` gas | 15.6M | 18.3M |
| storage reads | 290 | 290 |
| latency | 3.7ms | 4.5ms |

**No write wall below 60,000**, where the probe stops. 600× the data for 1.17× the gas, and the read count does not move at all.

(Reads count misses as well as hits. That matters here: a link probes `DEPTH+1` spine rows that mostly do not exist yet, so a hits-only counter would be blind to the dominant cost — see the telemetry note below.)

## Compatibility — decided: flag day, no migration

Two hard breaks, and the call has been made: **land as a flag day with a version bump. Nodes start clean; no data migration.**

**1. `EntityIndex` borsh layout changed.** `children: Option<Vec<ChildInfo>>` was field 3 and is removed; children now live in their own `Key::ChildTrie` keyspace. Index rows written by an older build do not decode under the current layout.

**2. Every parent hash changes.** A parent now commits to its children's **ids** as well as their hashes, since a child's id is its position in the trie. The old fold hashed only `merkle_hash`, so two different child sets with matching hashes were indistinguishable — strictly stronger, and it moves every hash including the root. Old and new builds compute different roots for identical data.

Nothing in production runs a child-trie build, so there is no mixed-version fleet to stage and no state that must survive. That makes the migration question moot rather than deferred — and if it ever stops being moot, the pass is already written: `rebuild_child_tries_after_snapshot` pointed at local state instead of freshly-installed state reads index rows, finds every parented one, and links it.

What still matters with no migration is that a stale row cannot be **misread**. It can't be: the `borsh_layout` mirror now covers every field, so `from_slice` rejects a row that does not match this layout exactly, rather than a prefix mirror silently accepting one and handing back a hash read out of the `children` field. Pinned by `an_old_layout_index_row_is_rejected_rather_than_misread`. A startup error is the intended outcome for a stale datastore; a plausible wrong root hash never is.

Per this repo's guidance, merobox E2E cannot verify either property — every node in a run is the same build against fresh state. Which, for a flag day, is exactly the configuration that ships.

## Also in this PR

**A snapshot fix that the trie change made necessary** (`f81e92de`). Snapshot installs an entity by writing its Entry and Index rows verbatim. While children lived *inside* the index row, that shipped the parent→child links for free. Moving them to their own keyspace broke that silently: snapshot discovery finds entities by deserialising `EntityIndex`, and a trie row never will.

It never healed. Hash comparison re-applied entities that were already byte-identical, which goes through the update path rather than `add_child_to`, so no link was ever created — a stable fixpoint, re-syncing every ~10s forever. Measured before: a joiner reported **0 of 25** messages and logged 50 "did not converge" warnings. After: **25 of 25**, matching roots, 0 warnings.

Worth recording, because it is why this shipped: the check that should have caught it cannot. `compute_root_hash` reads the *stored* `full_hash` out of the root's index row rather than recomputing it, so snapshot's "verify integrity by computing the actual root hash from storage (I7)" compared the sender's shipped value against the sender's claim. It logged "root hash verified successfully" against a node with an empty trie. Making I7 recompute would have caught this immediately and guards the whole class. (`master` has since hardened I7 to refuse to publish on mismatch; this branch rebases onto that and keeps it, placing the trie rebuild *before* the verify.)

**Read counters in the VM** (`ed13a2a8`). `storage_reads` / `storage_read_bytes` beside the existing write counters, carried out on `Outcome`. Reads are telemetry, not a budget — there is nothing to charge them against — but read *count* is the leading indicator and *bytes* the better cost predictor, since guest decode work scales with bytes.

`tests/cost_is_flat.rs` pins both on a fixture whose work is fixed by construction:

```
10 vs 10,000 stored entries : gas=1097 reads=64 read_bytes=4160 — identical
64 B vs 16 KiB values       : gas=1097 both, read_bytes 4,160 vs 1,048,640
```

The second is the one worth pinning: reading a megabyte costs the same gas as reading four kilobytes, so a redesign toward fewer, larger rows looks free in gas while costing real wall-clock and real decode. Anyone reading gas alone would draw the wrong conclusion.

## Deliberate behaviour changes

- **Enumeration keeps `ChildInfo`'s `(created_at, id)` order**, applied on the way out of the id-keyed trie. That order is load-bearing: `Vector::get(idx)` walks children in it, so returning id order would have silently reordered every `Vector` while all hashes still matched. Pinned by `sorted_insert_path_preserves_hash_semantics`.
- **`ContextRegistry::dump_root` can no longer enumerate children from the raw row** and now warns loudly rather than returning a silently empty list that would read as "no children" during divergence triage.
- **`calculate_full_hash_for_children` is gone.** Its #2418 guard — parent hash must not depend on `created_at` — is ported to the trie, where the property now holds twice over (buckets are id-sorted *and* the fold covers only `id + merkle_hash`, so no `Metadata` reaches the root). Every other trie test uses `Metadata::default()`, so folding metadata into `TrieBucket::hash` would have passed all of them; now it would not.

## Testing

| | |
|---|---|
| storage, node lib, context-client, primitives, merodb, runtime | **1555 passed, 0 failed** |
| `calimero-node --test sync_sim` | **325 passed, 0 failed** |
| `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` | clean |
| `cargo fmt --check` | clean |

New cost guards, which are the regression protection this class of bug actually needed — correctness tests cannot see it:

- `tests/write_cost_profile.rs` — reads, writes and distinct keys per insert must not grow with n
- `tests/read_cost_profile.rs` — per-insert read profile
- `tests/root_fanout_shape.rs` — parent index row flat at 10/50/200 children (16,927 B → 122 B at 200)
- `tests/trie_scaling.rs` — 1K/10K/100K/1M, `#[ignore]` (~25s release)
- `tests/cost_is_flat.rs` — gas and reads flat against store size and value size
- `tests/chat_wall.rs` — the real contract, `#[ignore]` (needs a guest from mero-chat-pwa)

## Known gaps

- **Fixed here, was [#3637](https://github.com/calimero-network/core/issues/3637):** `AuthoredVector::push` returned `len - 1`, which was correct only while `insert` appended to the child cache — the O(n) read this branch removes. Enumeration now comes from the trie in `(created_at, id)` order and `created_at` does not advance within a call, so entries pushed together tied and the random id decided position. `push` now returns the entry's `Id`, with `update_by_id` / `get_by_id` / `owner_of_id` alongside; the positional API stays for pagination. The deeper reason for id-addressing rather than a corrected index: enumeration is over the child *set*, so a remote insert renumbers everything after it — and `update` is ownership-gated by the address it is given, so a stale index writes to a different entry. **Breaking**: `push` returns `Id`, and the JS bridge writes 32 id bytes where it wrote an 8-byte index.
- **`deleted_children` has the same unbounded-row cost this fixes for `children` — [#3635](https://github.com/calimero-network/core/issues/3635).**

- **Bucket occupancy is what eventually bites.** Past `16^DEPTH` children a bucket is read, rewritten and folded whole — the inline-list problem returning in miniature. `trie_scaling` is the evidence for how far `DEPTH=4` carries.
- **Positional access is still O(n) in id reads.** `Collection::nth` materialises the child-id list from the trie on first use per call. No payloads, no nested collections, so it is far cheaper than a full scan — but it is not flat. Removing it needs an order-preserving index in the trie, which is a larger change and not obviously worth it yet.
- The app-side half of the chat wall (`get_messages` scanning the whole collection to return one page) is fixed separately in `mero-chat-pwa`, not here.

## What two review passes changed

Recorded because the findings say more about the risk surface than the diff does. Both passes are answered in the PR conversation.

Fixed since the first draft:

- **The replayed delete diverged from the local one.** Dropping an entity's trie was wired into the local delete path but not into `apply_delete_ref_action`, which is the path every *peer* takes replaying a `DeleteRef`. Same logical state, different hashes across replicas, silently. Both now go through one helper.
- **`load_rotation_log_direct` read the rotation log back empty on every delta apply.** That function exists specifically to avoid `MainStorage` — it runs before `RUNTIME_ENV` is installed — but the children walk went through it anyway, hit the process-local fallback store, missed, and had the error swallowed by `unwrap_or_default`. The writer set collapsed with nothing reporting anything.
- **Buffered snapshot entities were never linked.** `persist_buffered_snapshot_entity` runs from `drain_absorbed_leaves` long after the rebuild pass, so a late-draining entity stayed present-but-unenumerable permanently.
- **A rebuild failure was warned and then published anyway.** Verification reads the *shipped* root hash, so an unlinked node verifies, matches its peers, and never looks like it needs repair. It now fails the sync.
- **An old index row could be silently misread.** The layout mirror was a prefix, so it accepted a row written under any layout and handed back a hash read out of the `children` field. It now covers every field and rejects.
- **Read telemetry counted hits only** — blind to precisely the absent-row probes the trie's cost gates exist to watch.
- Plus: ghost children surviving a collection's deletion, the fold rule existing in three copies, `is_leaf` walking a whole subtree per level on the sync path, and two doc comments that asserted the opposite of the code.

Tests added for the parts that were structurally unguarded: an oracle pinning `insert_with` against `insert` (the two implementations of one spine walk, whose divergence *is* the snapshot bug), a regression test for the rebuild, the ghost-children case, the `created_at`-invariance guard ported from the code it outlived, and a count-vs-enumeration invariant. The ones guarding a specific defect were verified by mutation — a test that cannot fail is worse than no test, and one of these did not fail until it was fixed.

## Why `ChildTrie` is its own type

Worth stating, because a separate type can read as gratuitous when the only
consumer is `Index`. Inside the storage crate it mostly is — those call sites
could go through an `Index::child_count`-style surface. What justifies the
public API is the three callers that reach the store **directly**, with no
`StorageAdaptor` and no `RUNTIME_ENV` installed: snapshot install
(`insert_with`), the ACL shadow feed in `scope_projection`, and the raw-DB
divergence dump (`children_with`). Those paths cannot use `MainStorage` — it
routes through a thread-local that is only present inside
`context_client.execute()` — so they need the addressing and the walk without
the adaptor. That is the type's reason to exist.

## On the id-addressed API's asymmetry

`update_by_id` **errors** when the id is not an entry of this vector; `get_by_id`
and `owner_of_id` return **`None`**. That reads as inconsistent and is
deliberate. For a read, `None` is already the vocabulary for absence, and
erroring would make "not mine" indistinguishable from "storage broke". For a
write, silently doing nothing is the worse failure — a caller that asked for a
change and got no error is entitled to believe it happened.

The scoping exists because the id-addressed surface takes a caller-supplied
address and resolves it through a global `find_by_id`, while the positional API
can only ever name a child of itself. The owner check does not cover the
difference: it establishes that the caller owns the target, not that the target
is theirs to address from here.

## A note on `d483648c0`

That merge of master into this branch came from someone else working on the same
branch, not from me. It is not mine to undo. The commit after it was replayed on
top rather than rebased over it, and the full workspace was re-run on the merged
base before pushing.

## Reviewing this

Commits are ordered to be read in sequence — each measurement commit precedes the fix it motivates, so the "before" number is in the tree. The two worth the most attention are `e2aa55dc` (trie becomes the source of truth; where the hash and layout breaks live) and `f81e92de` (the snapshot fix).

https://claude.ai/code/session_01RdUocbW2V3oRQ9fE5h3v5S

