### PR TITLE
test(e2e): wait for the migration instead of sleeping past it

### DIFF
--- a/apps/scaffolding-e2e/workflows/account-device-revoke-lockout.yml
+++ b/apps/scaffolding-e2e/workflows/account-device-revoke-lockout.yml
@@ -480,9 +480,22 @@ steps:
   # device-addressed, everything above would pass and then the node would
   # quietly re-fetch the rotated key on its next sync round.
 
-  - name: Give the recovery loop several rounds to try
-    type: wait
-    seconds: 20
+  - name: Wait for the recovered write to reach the revoked device's replacement
+    type: wait_for_sync
+    context_id: '{{context_id}}'
+    nodes:
+      - account-revoke-node-1
+      - account-revoke-node-3
+    timeout: 60
+    trigger_sync: true
+    # Waiting on the read itself, not just a converged hash: agreeing
+    # hashes can precede the delta actually applying.
+    expect:
+      method: get
+      args:
+        key: "from-laptop"
+      equals:
+        output: "laptop-wrote-this"
 
   # Asserted as the PROPERTY, not as a log signal, because this shape cannot
   # trigger the pull path at all. A node asks for a key when it is a member of a

--- a/apps/scaffolding-e2e/workflows/hashcomparison-shared-user-reconcile.yml
+++ b/apps/scaffolding-e2e/workflows/hashcomparison-shared-user-reconcile.yml
@@ -299,10 +299,14 @@ steps:
     timeout: 90
     check_interval: 2
     trigger_sync: true
-
-  - name: Settle after reconciliation
-    type: wait
-    seconds: 5
+    # Waiting on the read itself, not just a converged hash: agreeing
+    # hashes can precede the delta actually applying.
+    expect:
+      method: get_user_simple_for
+      args:
+        user_key: "{{node1_account}}"
+      equals:
+        output: "node-1-profile-final"
 
   # --- Phase 5: read each entity back from node-2 and assert it
   #     reconciled to the final (post-update) value. Pre-redesign,

--- a/apps/scaffolding-e2e/workflows/root-bootstrap-converge.yml
+++ b/apps/scaffolding-e2e/workflows/root-bootstrap-converge.yml
@@ -182,10 +182,14 @@ steps:
     timeout: 60
     check_interval: 2
     trigger_sync: true
-
-  - name: Settle after convergence
-    type: wait
-    seconds: 3
+    # Waiting on the read itself, not just a converged hash: agreeing
+    # hashes can precede the delta actually applying.
+    expect:
+      method: get
+      args:
+        key: "alpha"
+      equals:
+        output: "from_node_1_first"
 
   # --- Phase 5: read back from both sides. Pre-fix, node-2 would
   # see only its own write (`delta_from_node2`) and none of

--- a/workflows/app-migration/00-single-group-migration-baseline.yml
+++ b/workflows/app-migration/00-single-group-migration-baseline.yml
@@ -170,16 +170,18 @@ steps:
     # ABI (declared by #[derive(app::Migrate)]). This workflow is the
     # regression guard for that resolution path.
 
-  # Fixed wait, NOT wait_for_sync: per-context migration apply is
   # asynchronous and a root_hash-based wait_for_sync polled here exits
   # vacuously synced because both nodes still hold the identical v1
   # root at the first poll. The fixed wait covers (a) per-context
   # migration apply on node 1, (b) context-sync gossip of the new
   # post-migration state to node 2, (c) docker stdout flush so
   # assert_log_present can see the "Executing migration" log line.
-  - name: Wait for upgrade + migration to apply + log flush
-    type: wait
-    seconds: 15
+  - name: Wait for both members to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-baseline-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   - name: Read the subgroup's upgrade record
     type: get_group_upgrade_status
@@ -220,12 +222,6 @@ steps:
   # schema_info cannot prove a migration ran: the version string it returns is a
   # constant compiled into the v2 binary, so it reads "2.0.0" over un-migrated
   # v1 bytes too. The rollup carries each member's ABI STATE version instead.
-  - name: Wait for both members to report the target ABI state version
-    type: assert_migration_complete
-    node: app-migration-baseline-1
-    namespace_id: "{{namespace_id}}"
-    timeout_seconds: 90
-    poll_interval: 5
 
   - name: Read the migration-status rollup on node 1 (admin)
     type: get_migration_status

--- a/workflows/app-migration/01-namespace-cascade-migration.yml
+++ b/workflows/app-migration/01-namespace-cascade-migration.yml
@@ -216,7 +216,6 @@ steps:
     # regression guard for that resolution path.
     cascade: true
 
-  # Fixed wait, NOT wait_for_sync: cascade is published async, and
   # the per-context migration propagator spawns after publish. A
   # root_hash-based wait_for_sync polled here exits in 0.00s
   # vacuously synced - both nodes still hold the identical v1 root
@@ -226,9 +225,12 @@ steps:
   # CascadeUpgrade op, (b) per-context migration apply on both nodes,
   # (c) docker stdout flush so assert_log_present can see the
   # "Executing migration" log line.
-  - name: Wait for cascade + migration to apply + log flush on both nodes
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-cascade-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # Phase 7a: Both nodes' local meta for BOTH layers must reflect v2.
   - name: Node 1 reads namespace root info

--- a/workflows/app-migration/02-scenario-additive-field.yml
+++ b/workflows/app-migration/02-scenario-additive-field.yml
@@ -194,11 +194,12 @@ steps:
     group_id: "{{group_id}}"
     target_application_id: "{{app_v2}}"
 
-  # Fixed wait, NOT wait_for_sync (see scenario 01 rationale): lets the
-  # target+migration meta gossip to node 2 before its lazy read.
-  - name: Wait for upgrade meta to gossip to node 2
-    type: wait
-    seconds: 15
+  - name: Wait for both members to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-additive-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # These reads TRIGGER each node's lazy migration: schema_info is not
   # a state op, so `maybe_lazy_upgrade` fires on each node, migrating
@@ -222,12 +223,6 @@ steps:
   # schema_info cannot prove a migration ran: the version string it returns is a
   # constant compiled into the v2 binary, so it reads "2.0.0" over un-migrated
   # v1 bytes too. The rollup carries each member's ABI STATE version instead.
-  - name: Wait for both members to report the target ABI state version
-    type: assert_migration_complete
-    node: app-migration-additive-1
-    namespace_id: "{{namespace_id}}"
-    timeout_seconds: 90
-    poll_interval: 5
 
   - name: Read the migration-status rollup on node 1 (admin)
     type: get_migration_status

--- a/workflows/app-migration/03-scenario-remove-field.yml
+++ b/workflows/app-migration/03-scenario-remove-field.yml
@@ -175,10 +175,12 @@ steps:
     target_application_id: "{{app_v3}}"
     # The node resolves the migration from the target bundle's embedded ABI.
 
-  # Fixed wait, NOT wait_for_sync (see scenario 01 rationale).
-  - name: Wait for upgrade + migration to apply + log flush
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-remove-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # These reads TRIGGER each node's lazy migration: schema_info is not
   # a state op, so `maybe_lazy_upgrade` fires on each node, migrating

--- a/workflows/app-migration/04-scenario-rename-field.yml
+++ b/workflows/app-migration/04-scenario-rename-field.yml
@@ -163,10 +163,12 @@ steps:
     target_application_id: "{{app_v4}}"
     # The node resolves the migration from the target bundle's embedded ABI.
 
-  # Fixed wait, NOT wait_for_sync (see scenario 01 rationale).
-  - name: Wait for upgrade + migration to apply + log flush
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-rename-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # These reads TRIGGER each node's lazy migration: schema_info is not
   # a state op, so `maybe_lazy_upgrade` fires on each node, migrating

--- a/workflows/app-migration/05-scenario-change-type.yml
+++ b/workflows/app-migration/05-scenario-change-type.yml
@@ -177,10 +177,12 @@ steps:
     target_application_id: "{{app_v5}}"
     # The node resolves the migration from the target bundle's embedded ABI.
 
-  # Fixed wait, NOT wait_for_sync (see scenario 01 rationale).
-  - name: Wait for upgrade + migration to apply + log flush
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-typechange-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # These reads TRIGGER each node's lazy migration: schema_info is not
   # a state op, so `maybe_lazy_upgrade` fires on each node, migrating

--- a/workflows/app-migration/06-scenario-new-method.yml
+++ b/workflows/app-migration/06-scenario-new-method.yml
@@ -188,10 +188,12 @@ steps:
     group_id: "{{group_id}}"
     target_application_id: "{{app_v2}}"
 
-  # Fixed wait, NOT wait_for_sync (see scenario 01 rationale).
-  - name: Wait for upgrade to apply + log flush
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-newmethod-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # These reads TRIGGER each node's lazy migration: schema_info is not
   # a state op, so `maybe_lazy_upgrade` fires on each node, migrating

--- a/workflows/app-migration/07-scenario-new-enum-variant.yml
+++ b/workflows/app-migration/07-scenario-new-enum-variant.yml
@@ -172,10 +172,12 @@ steps:
     group_id: "{{group_id}}"
     target_application_id: "{{app_v2}}"
 
-  # Fixed wait, NOT wait_for_sync (see scenario 01 rationale).
-  - name: Wait for upgrade to apply + log flush
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-newenum-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # These reads TRIGGER each node's lazy migration: schema_info is not
   # a state op, so `maybe_lazy_upgrade` fires on each node, migrating

--- a/workflows/app-migration/08-scenario-pure-bugfix.yml
+++ b/workflows/app-migration/08-scenario-pure-bugfix.yml
@@ -193,10 +193,12 @@ steps:
     group_id: "{{group_id}}"
     target_application_id: "{{app_v2}}"
 
-  # Fixed wait, NOT wait_for_sync (see scenario 01 rationale).
-  - name: Wait for upgrade to apply + log flush
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-bugfix-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # These reads TRIGGER each node's lazy migration: schema_info is not
   # a state op, so `maybe_lazy_upgrade` fires on each node, migrating

--- a/workflows/app-migration/09-scenario-crdt-native.yml
+++ b/workflows/app-migration/09-scenario-crdt-native.yml
@@ -207,10 +207,12 @@ steps:
     target_application_id: "{{app_v2}}"
     # The node resolves the migration from the target bundle's embedded ABI.
 
-  # Fixed wait, NOT wait_for_sync (see scenario 01 rationale).
-  - name: Wait for upgrade + migration to apply + log flush
-    type: wait
-    seconds: 15
+  - name: Wait for both members to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-crdt-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # These reads TRIGGER each node's lazy migration: schema_info is not
   # a state op, so `maybe_lazy_upgrade` fires on each node, migrating
@@ -234,12 +236,6 @@ steps:
   # schema_info cannot prove a migration ran: the version string it returns is a
   # constant compiled into the v2 binary, so it reads "2.0.0" over un-migrated
   # v1 bytes too. The rollup carries each member's ABI STATE version instead.
-  - name: Wait for both members to report the target ABI state version
-    type: assert_migration_complete
-    node: app-migration-crdt-1
-    namespace_id: "{{namespace_id}}"
-    timeout_seconds: 90
-    poll_interval: 5
 
   - name: Read the migration-status rollup on node 1 (admin)
     type: get_migration_status

--- a/workflows/app-migration/10-scenario-struct-to-enum.yml
+++ b/workflows/app-migration/10-scenario-struct-to-enum.yml
@@ -170,11 +170,12 @@ steps:
     target_application_id: "{{app_v2}}"
     # The node resolves the migration from the target bundle's embedded ABI.
 
-  # Fixed wait, NOT wait_for_sync (see scenario 01 rationale): lets the
-  # target+migration meta gossip to node 2 before its lazy read.
-  - name: Wait for upgrade meta to gossip to node 2
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-struct2enum-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # These reads TRIGGER each node's lazy migration: schema_info is not
   # a state op, so `maybe_lazy_upgrade` fires on each node, migrating

--- a/workflows/app-migration/11-scenario-field-split.yml
+++ b/workflows/app-migration/11-scenario-field-split.yml
@@ -180,11 +180,12 @@ steps:
     target_application_id: "{{app_v2}}"
     # The node resolves the migration from the target bundle's embedded ABI.
 
-  # Fixed wait, NOT wait_for_sync (see scenario 01 rationale): lets the
-  # target+migration meta gossip to node 2 before its lazy read.
-  - name: Wait for upgrade meta to gossip to node 2
-    type: wait
-    seconds: 15
+  - name: Wait for both members to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-split-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # These reads TRIGGER each node's lazy migration: schema_info is not
   # a state op, so `maybe_lazy_upgrade` fires on each node, migrating
@@ -208,12 +209,6 @@ steps:
   # schema_info cannot prove a migration ran: the version string it returns is a
   # constant compiled into the v2 binary, so it reads "2.0.0" over un-migrated
   # v1 bytes too. The rollup carries each member's ABI STATE version instead.
-  - name: Wait for both members to report the target ABI state version
-    type: assert_migration_complete
-    node: app-migration-split-1
-    namespace_id: "{{namespace_id}}"
-    timeout_seconds: 90
-    poll_interval: 5
 
   - name: Read the migration-status rollup on node 1 (admin)
     type: get_migration_status

--- a/workflows/app-migration/12-scenario-field-remove-archive.yml
+++ b/workflows/app-migration/12-scenario-field-remove-archive.yml
@@ -193,11 +193,12 @@ steps:
     target_application_id: "{{app_v2}}"
     # The node resolves the migration from the target bundle's embedded ABI.
 
-  # Fixed wait, NOT wait_for_sync (see scenario 01 rationale): lets the
-  # target+migration meta gossip to node 2 before its lazy read.
-  - name: Wait for upgrade meta to gossip to node 2
-    type: wait
-    seconds: 15
+  - name: Wait for both members to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-archive-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # These reads TRIGGER each node's lazy migration: schema_info is not
   # a state op, so `maybe_lazy_upgrade` fires on each node, migrating
@@ -221,12 +222,6 @@ steps:
   # schema_info cannot prove a migration ran: the version string it returns is a
   # constant compiled into the v2 binary, so it reads "2.0.0" over un-migrated
   # v1 bytes too. The rollup carries each member's ABI STATE version instead.
-  - name: Wait for both members to report the target ABI state version
-    type: assert_migration_complete
-    node: app-migration-archive-1
-    namespace_id: "{{namespace_id}}"
-    timeout_seconds: 90
-    poll_interval: 5
 
   - name: Read the migration-status rollup on node 1 (admin)
     type: get_migration_status

--- a/workflows/app-migration/13-scenario-invariant-reshuffle.yml
+++ b/workflows/app-migration/13-scenario-invariant-reshuffle.yml
@@ -209,11 +209,12 @@ steps:
     target_application_id: "{{app_v2}}"
     # The node resolves the migration from the target bundle's embedded ABI.
 
-  # Fixed wait, NOT wait_for_sync (see scenario 01 rationale): lets the
-  # target+migration meta gossip to node 2 before its lazy read.
-  - name: Wait for upgrade meta to gossip to node 2
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-reshuffle-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # These reads TRIGGER each node's lazy migration: schema_info is not
   # a state op, so `maybe_lazy_upgrade` fires on each node, migrating

--- a/workflows/app-migration/14-cascade-status-rpc.yml
+++ b/workflows/app-migration/14-cascade-status-rpc.yml
@@ -150,9 +150,12 @@ steps:
     # The node resolves the migration from the target bundle's embedded ABI.
     cascade: true
 
-  - name: Wait for cascade op to gossip + apply on both nodes
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-status-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # Phase 6a: the cascade actually landed (sanity — makes the status
   # assertions meaningful). Atomic CascadeUpgrade applies on the emitter

--- a/workflows/app-migration/15-scenario-authored-map.yml
+++ b/workflows/app-migration/15-scenario-authored-map.yml
@@ -186,9 +186,12 @@ steps:
     target_application_id: "{{app_v2}}"
     # The node resolves the migration from the target bundle's embedded ABI.
 
-  - name: Wait for upgrade + migration to apply + log flush
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-authmap-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # Phase 6: reads trigger each node's lazy migration.
   - name: Read post-migration schema_info on node 1 (triggers lazy migration)

--- a/workflows/app-migration/16-scenario-user-storage.yml
+++ b/workflows/app-migration/16-scenario-user-storage.yml
@@ -177,9 +177,12 @@ steps:
     target_application_id: "{{app_v2}}"
     # The node resolves the migration from the target bundle's embedded ABI.
 
-  - name: Wait for upgrade + migration to apply + log flush
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-userstore-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   - name: Read post-migration schema_info on node 1 (triggers lazy migration)
     type: call

--- a/workflows/app-migration/17-scenario-frozen-storage.yml
+++ b/workflows/app-migration/17-scenario-frozen-storage.yml
@@ -175,9 +175,12 @@ steps:
     target_application_id: "{{app_v2}}"
     # The node resolves the migration from the target bundle's embedded ABI.
 
-  - name: Wait for upgrade + migration to apply + log flush
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-frozen-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   - name: Read post-migration schema_info on node 1 (triggers lazy migration)
     type: call

--- a/workflows/app-migration/18-scenario-shared-storage.yml
+++ b/workflows/app-migration/18-scenario-shared-storage.yml
@@ -173,9 +173,12 @@ steps:
     target_application_id: "{{app_v2}}"
     # The node resolves the migration from the target bundle's embedded ABI.
 
-  - name: Wait for upgrade + migration to apply + log flush
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-shared-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   - name: Read post-migration schema_info on node 1 (triggers lazy migration)
     type: call

--- a/workflows/app-migration/19-scenario-authored-vector.yml
+++ b/workflows/app-migration/19-scenario-authored-vector.yml
@@ -178,9 +178,12 @@ steps:
     target_application_id: "{{app_v2}}"
     # The node resolves the migration from the target bundle's embedded ABI.
 
-  - name: Wait for upgrade + migration to apply + log flush
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-authvec-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   - name: Read post-migration schema_info on node 1 (triggers lazy migration)
     type: call

--- a/workflows/app-migration/20-scenario-unordered-set.yml
+++ b/workflows/app-migration/20-scenario-unordered-set.yml
@@ -171,9 +171,12 @@ steps:
     target_application_id: "{{app_v2}}"
     # The node resolves the migration from the target bundle's embedded ABI.
 
-  - name: Wait for upgrade + migration to apply + log flush
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-uset-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   - name: Read post-migration schema_info on node 1 (triggers lazy migration)
     type: call

--- a/workflows/app-migration/26-owner-driven-authored.yml
+++ b/workflows/app-migration/26-owner-driven-authored.yml
@@ -187,9 +187,12 @@ steps:
     # The node resolves the migration from the target bundle's embedded ABI.
     cascade: true
 
-  - name: Wait for cascade op to gossip + apply on both nodes
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-owner-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # Phase 6: reads trigger each node's lazy whole-root migration to v2.
   - name: Read post-migration schema_info on node 1 (triggers lazy migration)

--- a/workflows/app-migration/28-get-migration-status.yml
+++ b/workflows/app-migration/28-get-migration-status.yml
@@ -159,9 +159,12 @@ steps:
     # The node resolves the migration from the target bundle's embedded ABI.
     cascade: true
 
-  - name: Wait for cascade op to gossip + apply on both nodes
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-mstatus-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   - name: Read post-migration schema_info on node 1 (triggers lazy migration)
     type: call

--- a/workflows/app-migration/29-migration-check-pass.yml
+++ b/workflows/app-migration/29-migration-check-pass.yml
@@ -131,9 +131,12 @@ steps:
     # The node resolves the migration from the target bundle's embedded ABI.
     cascade: true
 
-  - name: Wait for cascade op to gossip
-    type: wait
-    seconds: 5
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-check-pass-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # Access the context → triggers the lazy migration: execute_migration produces
   # the v2 root, the pre-commit migration_check runs on it (and PASSES), then the

--- a/workflows/app-migration/30-migration-check-fail-abort.yml
+++ b/workflows/app-migration/30-migration-check-fail-abort.yml
@@ -145,9 +145,12 @@ steps:
     # The node resolves the migration from the target bundle's embedded ABI.
     cascade: true
 
-  - name: Wait for cascade op to gossip
-    type: wait
-    seconds: 5
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-check-fail-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # Access the context → triggers the lazy migration: execute_migration produces
   # the lossy v2 root, the pre-commit migration_check runs on it and REJECTS it,

--- a/workflows/app-migration/31-admin-abort-logical.yml
+++ b/workflows/app-migration/31-admin-abort-logical.yml
@@ -137,9 +137,12 @@ steps:
   # 15s to match the peer lazy scenarios (21/28): the cascade's migration commit
   # runs asynchronously after the upgrade_group RPC returns, so the abort below
   # must not race it — the context must be committed to v2 first.
-  - name: Wait for the migration to settle
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-admin-abort-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # ── ABORT: native merobox abort_migration step ──
   # Calls abort_migration(namespace_id) against the node's RPC. The abort handler

--- a/workflows/app-migration/32-authored-migrate-ux.yml
+++ b/workflows/app-migration/32-authored-migrate-ux.yml
@@ -178,9 +178,12 @@ steps:
     # The node resolves the migration from the target bundle's embedded ABI.
     cascade: true
 
-  - name: Wait for cascade op to gossip + apply on both nodes
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-ux-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # Phase 6: a read drives each node's whole-root migrate to v2 (notes carried).
   - name: Read post-migration schema_info on node 1

--- a/workflows/app-migration/33-authored-remaining-count.yml
+++ b/workflows/app-migration/33-authored-remaining-count.yml
@@ -135,9 +135,12 @@ steps:
     # The node resolves the migration from the target bundle's embedded ABI.
     cascade: true
 
-  - name: Wait for the cascade + migration to apply
-    type: wait
-    seconds: 8
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-authored-count-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   - name: Read post-migration schema_info (now v2, notes carried through)
     type: call

--- a/workflows/app-migration/36-chained-catchup.yml
+++ b/workflows/app-migration/36-chained-catchup.yml
@@ -148,9 +148,12 @@ steps:
     group_id: "{{group_id}}"
     target_application_id: "{{app_v2}}"
 
-  - name: Wait for v2 upgrade meta to gossip to node 2
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-chained-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   - name: Activate v2 on node 1
     type: call
@@ -190,9 +193,12 @@ steps:
     group_id: "{{group_id}}"
     target_application_id: "{{app_v3}}"
 
-  - name: Wait for v3 upgrade meta to gossip
-    type: wait
-    seconds: 10
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-chained-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   - name: Install migration-suite-v4 on node 1
     type: install_application
@@ -208,9 +214,12 @@ steps:
     group_id: "{{group_id}}"
     target_application_id: "{{app_v4}}"
 
-  - name: Wait for v4 upgrade meta to gossip to node 2
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-chained-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   # Phase 6: ONE read per node triggers the chained replay v2 -> v3 -> v4.
   - name: Single read on node 2 chains both hops

--- a/workflows/app-migration/37-stranded-resync.yml
+++ b/workflows/app-migration/37-stranded-resync.yml
@@ -185,9 +185,12 @@ steps:
     group_id: "{{group_id}}"
     target_application_id: "{{app_v2}}"
 
-  - name: Wait for v2 upgrade meta to gossip to node 2
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-strand-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   - name: Activate v2 on node 1 only (node 2 stays at v1 - never accessed)
     type: call
@@ -219,9 +222,12 @@ steps:
     group_id: "{{group_id}}"
     target_application_id: "{{app_v3}}"
 
-  - name: Wait for v3 upgrade meta to gossip to node 2
-    type: wait
-    seconds: 15
+  - name: Wait for the cohort to report the target ABI state version
+    type: assert_migration_complete
+    node: app-migration-strand-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
 
   - name: Activate v3 on node 1 only
     type: call


### PR DESCRIPTION
Thirty-three scenarios slept a fixed 15s after `upgrade_group` and then read, with nothing establishing that the migration had finished. A cohort stalled part-way through reads as successfully as a converged one, so the sleep supplied the only ordering and no assertion at all.

## Changes

**Migration suite — 30 scenarios.** `assert_migration_complete` already polls `get_migration_status` until every member reports a converged schema with zero residue, and aborts early if a member enters `failed`. Its own docstring says it exists to save authors from hand-rolling a `wait` loop, which is what these were.

- 5 scenarios already called it, but *after* the reads it should have ordered. Those now call it before, and the sleep goes.
- 25 had no barrier at all. They gain one in place of the sleep.

**3 scenarios outside the migration suite** slept before a cross-node read of a specific value. Those get `expect:` on the barrier that already precedes them, so the wait ends when the value arrives rather than when the hashes agree, which can happen a few milliseconds early:

```yaml
    expect:
      method: get
      args:
        key: "alpha"
      equals:
        output: "from_node_1_first"
```

**36 sleeps removed, 491 seconds.** Every barrier exits as soon as its condition holds, so the happy path gets faster, not slower.

## Deliberately left alone

- `22-scenario-identity-downgrade.yml` and `39-missing-abi-refused.yml` carry `expected_failure` on the upgrade. A completion barrier there would assert the opposite of the test.
- `35-two-namespaces-coexist.yml` captures no namespace id to poll on.
- The `sync-resilience` sleeps, which are measured against `with_idle_connection_timeout` rather than guessed.

## Test plan

The suite is the test, and this is a correctness change as much as a timing one: where no barrier existed, a stalled migration previously passed. If any scenario now fails, that is the barrier reporting something the sleep was hiding, and the failure names the member and its residue rather than surfacing as a confusing read.

- All 133 workflows validate against merobox master: 0 failures
- 36 `type: wait` steps removed, confirmed by diffing on `seconds:` at step indent; no other step type touched
- 2 incidental blank-line removals, no other whitespace churn