### PR TITLE
test(e2e): assert the migration finished, in the scenarios that never did

### DIFF
--- a/workflows/app-migration/03-scenario-remove-field.yml
+++ b/workflows/app-migration/03-scenario-remove-field.yml
@@ -195,6 +195,15 @@ steps:
     outputs:
       v3_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-remove-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   # Both nodes self-migrated via the lazy path — assert the migration
   # logs on EACH after its triggering read above.
   - name: Assert lazy migration ran on node 1

--- a/workflows/app-migration/04-scenario-rename-field.yml
+++ b/workflows/app-migration/04-scenario-rename-field.yml
@@ -183,6 +183,15 @@ steps:
     outputs:
       v4_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-rename-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   # Both nodes self-migrated via the lazy path — assert the migration
   # logs on EACH after its triggering read above.
   - name: Assert lazy migration ran on node 1

--- a/workflows/app-migration/05-scenario-change-type.yml
+++ b/workflows/app-migration/05-scenario-change-type.yml
@@ -197,6 +197,15 @@ steps:
     outputs:
       v5_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-typechange-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   # Both nodes self-migrated via the lazy path — assert the migration
   # logs on EACH after its triggering read above.
   - name: Assert lazy migration ran on node 1

--- a/workflows/app-migration/06-scenario-new-method.yml
+++ b/workflows/app-migration/06-scenario-new-method.yml
@@ -208,6 +208,15 @@ steps:
     outputs:
       v2_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-newmethod-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   - name: Assert v2 schema on node 1 (version bumped, v1 data preserved byte-identical)
     type: json_assert
     statements:

--- a/workflows/app-migration/07-scenario-new-enum-variant.yml
+++ b/workflows/app-migration/07-scenario-new-enum-variant.yml
@@ -192,6 +192,15 @@ steps:
     outputs:
       v2_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-newenum-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   - name: Assert v2 schema on node 1 (schema_version bump + v1 status preserved)
     type: json_assert
     statements:

--- a/workflows/app-migration/08-scenario-pure-bugfix.yml
+++ b/workflows/app-migration/08-scenario-pure-bugfix.yml
@@ -213,6 +213,15 @@ steps:
     outputs:
       v2_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-bugfix-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   - name: Assert v2 schema on node 1 (version bumped, last_sum preserved from v1)
     type: json_assert
     statements:

--- a/workflows/app-migration/10-scenario-struct-to-enum.yml
+++ b/workflows/app-migration/10-scenario-struct-to-enum.yml
@@ -191,6 +191,15 @@ steps:
     outputs:
       v2_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-struct2enum-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   # Both nodes self-migrated via the lazy path — assert the migration
   # logs on EACH after its triggering read above.
   - name: Assert lazy migration ran on node 1

--- a/workflows/app-migration/13-scenario-invariant-reshuffle.yml
+++ b/workflows/app-migration/13-scenario-invariant-reshuffle.yml
@@ -230,6 +230,15 @@ steps:
     outputs:
       v2_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-reshuffle-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   # Both nodes self-migrated via the lazy path — assert the migration
   # logs on EACH after its triggering read above.
   - name: Assert lazy migration ran on node 1

--- a/workflows/app-migration/15-scenario-authored-map.yml
+++ b/workflows/app-migration/15-scenario-authored-map.yml
@@ -203,6 +203,15 @@ steps:
     outputs:
       v2_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-authmap-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   - name: Assert lazy migration ran on node 1
     type: assert_log_present
     nodes:

--- a/workflows/app-migration/16-scenario-user-storage.yml
+++ b/workflows/app-migration/16-scenario-user-storage.yml
@@ -193,6 +193,15 @@ steps:
     outputs:
       v2_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-userstore-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   - name: Assert lazy migration ran on node 1
     type: assert_log_present
     nodes:

--- a/workflows/app-migration/17-scenario-frozen-storage.yml
+++ b/workflows/app-migration/17-scenario-frozen-storage.yml
@@ -191,6 +191,15 @@ steps:
     outputs:
       v2_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-frozen-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   - name: Assert lazy migration ran on node 1
     type: assert_log_present
     nodes:

--- a/workflows/app-migration/18-scenario-shared-storage.yml
+++ b/workflows/app-migration/18-scenario-shared-storage.yml
@@ -189,6 +189,15 @@ steps:
     outputs:
       v2_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-shared-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   - name: Assert lazy migration ran on node 1
     type: assert_log_present
     nodes:

--- a/workflows/app-migration/19-scenario-authored-vector.yml
+++ b/workflows/app-migration/19-scenario-authored-vector.yml
@@ -194,6 +194,15 @@ steps:
     outputs:
       v2_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-authvec-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   - name: Assert lazy migration ran on node 1
     type: assert_log_present
     nodes:

--- a/workflows/app-migration/20-scenario-unordered-set.yml
+++ b/workflows/app-migration/20-scenario-unordered-set.yml
@@ -187,6 +187,15 @@ steps:
     outputs:
       v2_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-uset-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   - name: Assert lazy migration ran on node 1
     type: assert_log_present
     nodes:

--- a/workflows/app-migration/26-owner-driven-authored.yml
+++ b/workflows/app-migration/26-owner-driven-authored.yml
@@ -204,6 +204,15 @@ steps:
     outputs:
       v2_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-owner-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   # The migration EXECUTED (not just which WASM is loaded): the migrate body
   # ran and rewrote the root. These two logs fire whenever a migration is
   # applied, on whatever trigger path — under a cascade upgrade (migration_v2,

--- a/workflows/app-migration/28-get-migration-status.yml
+++ b/workflows/app-migration/28-get-migration-status.yml
@@ -175,6 +175,15 @@ steps:
     outputs:
       v2_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-mstatus-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   - name: Assert both nodes reached v2 (cohort is converged → rollup can go green)
     type: json_assert
     statements:

--- a/workflows/app-migration/29-migration-check-pass.yml
+++ b/workflows/app-migration/29-migration-check-pass.yml
@@ -146,6 +146,15 @@ steps:
     outputs:
       v2_schema: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-check-pass-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   - name: Assert node reached v2 with every v1 item preserved
     type: json_assert
     statements:

--- a/workflows/app-migration/32-authored-migrate-ux.yml
+++ b/workflows/app-migration/32-authored-migrate-ux.yml
@@ -195,6 +195,15 @@ steps:
     outputs:
       v2_schema_node2: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-ux-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   - name: Assert the migration executed on node 1
     type: assert_log_present
     nodes:

--- a/workflows/app-migration/33-authored-remaining-count.yml
+++ b/workflows/app-migration/33-authored-remaining-count.yml
@@ -147,6 +147,15 @@ steps:
     outputs:
       v2_schema: result
 
+  # The reads above trigger each node's lazy migration, so this is the
+  # first point at which "did the cohort finish" has an answer.
+  - name: Assert every member finished migrating
+    type: assert_migration_complete
+    node: app-migration-authored-count-1
+    namespace_id: "{{namespace_id}}"
+    timeout_seconds: 90
+    poll_interval: 5
+
   - name: Assert state migrated to v2 (both notes carried)
     type: json_assert
     statements:


### PR DESCRIPTION
Nineteen migration scenarios upgrade, read from each node, and assert on what the reads returned. Nothing among those steps establishes that the migration itself completed, so a cohort stalled part-way returns the same answers as a converged one and the scenario passes either way.

`assert_migration_complete` already polls `get_migration_status` until every member reports a converged schema with zero residue, and aborts early on a member that entered `failed`. Six scenarios call it today; these nineteen gain it.

## Placement

After the reads, because the migration is lazy. Each scenario says so:

> These reads TRIGGER each node's lazy migration: `schema_info` is not a state op, so `maybe_lazy_upgrade` fires on each node, migrating its own v1 state to v2 before serving the read.

Before the reads there is nothing to wait for, and the poll would sit at `0/N migrated, 0 failed` until it timed out. The six scenarios that already call it place it after the reads, which is what this follows.

## Purely additive

**19 files, 171 insertions, 0 deletions.** No sleep removed, no step reordered, no existing comment moved. A scenario that passes today can only fail here by revealing a migration that never finished, which is the point.

## Deliberately excluded

| scenario | why |
| --- | --- |
| `22-scenario-identity-downgrade`, `39-missing-abi-refused` | `expected_failure` on the upgrade |
| `30-migration-check-fail-abort`, `31-admin-abort-logical` | the migration is meant to abort |
| `21-reads-available-during-upgrade` | its subject is the in-progress window |
| `14-cascade-status-rpc` | asserts cascade completion instead, and has no reads to order after |
| `35-two-namespaces-coexist` | captures no namespace id to poll on |

Named individually rather than pattern-matched: a keyword filter over the descriptions produced two false positives, catching "refuses" in `03-scenario-remove-field` and flagging `29-migration-check-pass`, whose migration commits.

## Test plan

- All 134 workflows validate against merobox master: 0 failures
- Every inserted barrier verified to sit after the reads it orders
- The migration suite is the test. Any failure here is a migration that was not finishing, previously invisible because only the reads were checked.