### PR TITLE
ci(e2e): fail the run when a node panicked

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -1030,7 +1030,8 @@ jobs:
               # in node logs, so the raw pattern never matches.
               grep -rhE "Application panic occurred|thread '[^']*' panicked at" docker-logs/ \
                 | sed -E 's/\x1b\[[0-9;]*m//g' \
-                | grep -oE "panic\.message=[^ ]*|thread '[^']*' panicked at [^ ]*" \
+                | sed -E "s/.*(panic\.message=.*) panic\.thread=.*/\\1/; \
+                         s/.*(thread '[^']*' panicked at [^,]*).*/\\1/" \
                 | sort | uniq -c | head -10
               exit 1
           else

--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -1007,6 +1007,36 @@ jobs:
               echo "no gov_divergence_pull_triggered markers — no scope_root governance divergence pulled this run"
           fi
 
+      - name: Assert no node panicked (HARD gate)
+        if: always()
+        run: |
+          # merod installs a panic hook that logs `Application panic occurred`
+          # with the message, thread and location as fields, then chains to the
+          # default hook, so a panic leaves Rust's `thread '...' panicked at` too.
+          # Match either: the structured line is absent for a panic raised before
+          # the hook is installed, and the default line is what a non-merod
+          # process leaves.
+          #
+          # Nothing else fails on this. A node that panics and is restarted, or
+          # panics on a path the scenario does not assert against, leaves a green
+          # run today: exactly one scenario in the suite greps for panics.
+          if grep -rlE "Application panic occurred|thread '[^']*' panicked at" docker-logs/ 2>/dev/null | grep -q .; then
+              count=$(grep -rhoE "Application panic occurred|thread '[^']*' panicked at" docker-logs/ | wc -l | tr -d ' ')
+              echo "::error::node panic in ${{ matrix.workflow }} — $count occurrence(s); a panicking node is a bug even when the scenario still passes"
+              echo "where:"
+              grep -rlE "Application panic occurred|thread '[^']*' panicked at" docker-logs/ | head -10
+              echo "messages:"
+              # Strip ANSI first: escapes sit between the field name and its `=`
+              # in node logs, so the raw pattern never matches.
+              grep -rhE "Application panic occurred|thread '[^']*' panicked at" docker-logs/ \
+                | sed -E 's/\x1b\[[0-9;]*m//g' \
+                | grep -oE "panic\.message=[^ ]*|thread '[^']*' panicked at [^ ]*" \
+                | sort | uniq -c | head -10
+              exit 1
+          else
+              echo "no panic markers across docker-logs/ — no node panicked this run"
+          fi
+
       - name: List docker-logs/ before upload (debug)
         if: always()
         run: ls -la docker-logs/ 2>&1 || echo "docker-logs/ missing"


### PR DESCRIPTION
Exactly one scenario in the suite greps its node logs for a panic (`apps/kv-store/workflows/ephemeral-presence-e2e.yml`). The other 89 matrix jobs go green over a node that panicked and restarted, or that panicked on a path the scenario never asserts against, because nothing reads the logs for it.

## What it matches

`merod` installs a panic hook (`crates/merod/src/main.rs:181`) that logs the message, thread and location as structured fields under `Application panic occurred`, then chains to the previous hook at `:217` — so a panic also leaves Rust's default `thread '...' panicked at`.

The gate matches either. The structured line is absent for a panic raised before the hook is installed, and the default line is what a non-merod process leaves. Matching the two known formats rather than the bare word `panicked` keeps prose out of it.

It sits with the existing hard gates over `docker-logs/`, so it covers every matrix job rather than the single scenario that thought to ask.

## Test plan

The gate was run against synthetic log directories and observed failing before being believed:

| input | expected | result |
| --- | --- | --- |
| clean logs | pass | rc=0 |
| `Application panic occurred` with fields | **fail** | rc=1 |
| `thread 'tokio-runtime-worker' panicked at crates/node/src/x.rs:42:9` | **fail** | rc=1 |
| the same line carrying ANSI colour escapes | **fail** | rc=1 |
| prose containing the word `panicked` | pass, no false positive | rc=0 |

The ANSI case matters because escapes sit between a field name and its `=` in node logs; the existing op-store gate strips them for the same reason and this follows it.

## Expectation

If a scenario is currently panicking, this turns that from invisible into a red run naming the workflow, the file and the message. That is the intended outcome, not a regression — the suite has had no way to see it.