### PR TITLE
test(e2e): install the app on nodes that CREATE a context, and pin merobox 0.6.64

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -36,7 +36,7 @@ runs:
         #
         # Both are the deliberate bump the note above describes, and the PR
         # carrying it runs the full suite against the new version.
-        MEROBOX_VERSION="0.6.62"
+        MEROBOX_VERSION="0.6.64"
         TAG="v${MEROBOX_VERSION}"
 
         case "$(uname -m)" in

--- a/apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml
+++ b/apps/scaffolding-e2e/workflows/dm-subgroup-privacy.yml
@@ -178,6 +178,16 @@ steps:
       - identity: '{{identity_node3}}'
         role: Member
 
+  # Explicit, because merobox no longer installs it during the join (merobox
+  # #369). Joining without the app is core's job — sync fetches the context's
+  # blob from a peer and installs it. CREATING a context is not: it names an
+  # application the node must already hold, so node-2 needs its own copy.
+  - name: Install the application on node-2, which is about to create a context
+    type: install_application
+    node: e2e-node-2
+    path: res/scaffolding_e2e.wasm
+    dev: true
+
   - name: Node-2 creates a context in the private subgroup
     type: create_context
     node: e2e-node-2

--- a/apps/scaffolding-e2e/workflows/group-member-channel-lifecycle.yml
+++ b/apps/scaffolding-e2e/workflows/group-member-channel-lifecycle.yml
@@ -179,6 +179,16 @@ steps:
   # node-2 is the subgroup's admin (it created it), so no extra
   # CAN_CREATE_CONTEXT grant is needed here.
 
+  # Explicit, because merobox no longer installs it during the join (merobox
+  # #369). Joining without the app is core's job — sync fetches the context's
+  # blob from a peer and installs it. CREATING a context is not: it names an
+  # application the node must already hold.
+  - name: Install the application on node-2, which is about to create a context
+    type: install_application
+    node: e2e-node-2
+    path: res/scaffolding_e2e.wasm
+    dev: true
+
   - name: Node-2 creates a context in the subgroup
     type: create_context
     node: e2e-node-2


### PR DESCRIPTION
Migrates core's e2e suite onto merobox `0.6.64`, and fixes the two scenarios that the pin bump breaks.

## What changed upstream

merobox#369 stopped pre-installing the application during a join, and that is the right call — a node joining a namespace it has no application for is a path **core implements**: sync fetches the context's blob from a peer, recognises a bundle, installs it, and points the context at the installed id. Of 104 join steps in core's suite, 76 never reached that path because merobox had taken the job over.

**Creating** a context is a different matter: it names an application the node must already hold. Two scenarios relied on the join's pre-install to satisfy that, and fail against `0.6.64` with:

```
create context error=ApiError { status_code: 500 } application_id=CUuQVzKTEgS3yr5RpCpKeBfbSbhQTxwMRi2mDiHPMgad
```

Both now install it explicitly on the node about to create, which is what a real operator would do.

## Swept, not spot-fixed

Rather than fix the two CI happened to surface, I checked every workflow in the repo for the same shape — a node running `create_context` with no `install_application` of its own. **Three sites across those two files; no others.**

The check is non-vacuous: run against `origin/master` it finds all three (`dm-subgroup-privacy` ×2, `group-member-channel-lifecycle` ×1), and against this branch it finds none. In `dm-subgroup-privacy` one install covers both of node-2's create sites, and it is ordered before the first.

## The pin

`0.6.62 → 0.6.64`. Besides #369 that range carries the delegated-authorship steps (#373), `expected_failure` on them (#376), and a change that fails a workflow whose node panicked (#377) — which this suite already satisfies, since no scenario here trips it.

## Why this is separate

calimero-network/core#3642 needs `0.6.64` for its own reasons (it drives delegated authorship through the new steps). Bundling this migration into it would have mixed a suite-wide merobox upgrade into a feature PR, making both harder to review and to revert. #3642 rebases onto this.