### PR TITLE
fix(client): let a 403 keep the server's own message

### DIFF
--- a/crates/client/src/connection.rs
+++ b/crates/client/src/connection.rs
@@ -461,9 +461,17 @@ where
                 continue;
             }
 
-            if response.status() == 403 {
-                bail!("Access denied — your token may not have sufficient permissions.");
-            }
+            // 403 deliberately falls through to the generic handler below.
+            //
+            // It used to short-circuit here with a fixed "your token may not
+            // have sufficient permissions", which discarded the server's own
+            // message. That is wrong whenever a 403 is a business rule rather
+            // than an auth problem, and several now are: the delegated-intent
+            // endpoint answers "an admin must grant CAN_AUTHOR_ON_BEHALF to
+            // <account>" with a 403, and every caller — meroctl, client-py,
+            // merobox — was told to go and check its token instead. The hint is
+            // still appended below when the body carries no detail of its own,
+            // which is the only case it was ever right about.
 
             if !response.status().is_success() {
                 let status = response.status();
@@ -481,9 +489,17 @@ where
                 // variant rather than parsing the message string. The rendered
                 // message is still status-prefixed via `extract_error_message`,
                 // so the `Display` output stays "HTTP {code}[: detail]".
+                let mut message = extract_error_message(&body, status);
+                // A bare 403 with nothing to say is the one case the old fixed
+                // string suited, so keep it there and only there.
+                if status == 403 && message == format!("HTTP {}", status.as_u16()) {
+                    message.push_str(
+                        " — access denied; your token may not have sufficient permissions",
+                    );
+                }
                 return Err(ClientError::Http {
                     status: status.as_u16(),
-                    message: extract_error_message(&body, status),
+                    message,
                 }
                 .into());
             }
@@ -770,6 +786,33 @@ fn extract_error_message(body: &str, status: reqwest::StatusCode) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A 403 that carries a reason must keep it.
+    ///
+    /// The delegated-intent endpoint answers "an admin must grant
+    /// CAN_AUTHOR_ON_BEHALF to <account>" with a 403, serialized as
+    /// `{"error": "..."}`. That is the whole value of having typed the refusal,
+    /// and a client that replaced it with a fixed hint about tokens sent every
+    /// caller — meroctl, client-py, merobox — to check the wrong thing.
+    #[test]
+    fn a_403_keeps_the_servers_own_message() {
+        let body = r#"{"error":"this node holds no authorship grant on the group owning this context, so it cannot act for a member here — an admin must grant CAN_AUTHOR_ON_BEHALF to abc"}"#;
+        let message = extract_error_message(body, reqwest::StatusCode::FORBIDDEN);
+
+        assert!(message.contains("CAN_AUTHOR_ON_BEHALF"), "{message}");
+        assert!(message.starts_with("HTTP 403"), "{message}");
+    }
+
+    /// A 403 with nothing to say keeps the token hint, which is the only case
+    /// the old fixed string was ever right about.
+    #[test]
+    fn a_bare_403_says_only_what_it_knows() {
+        let message = extract_error_message("", reqwest::StatusCode::FORBIDDEN);
+        assert_eq!(message, "HTTP 403");
+        // The hint is appended by the caller, not here, so that a 403 which DOES
+        // carry a reason never has this tacked onto it.
+        assert!(!message.contains("token"), "{message}");
+    }
 
     #[test]
     fn resolve_path_builds_normal_path() {


### PR DESCRIPTION
`Connection::request` short-circuited **every** 403 with a fixed string and discarded the response body:

```rust
if response.status() == 403 {
    bail!("Access denied — your token may not have sufficient permissions.");
}
```

That is wrong whenever a 403 is a business rule rather than an auth problem, and #3636 made several. The delegated-intent endpoint answers *"this node holds no authorship grant on the group owning this context … an admin must grant CAN_AUTHOR_ON_BEHALF to `<account>`"* with a typed 403 — and every caller (`meroctl`, `calimero-client-py`, merobox) was told to go and check its token instead.

Typing those refusals is pointless if the shared client throws the message away.

## The fix

403 now falls through to the generic error handler, which already reads the body under a size cap (`MAX_ERROR_BODY_BYTES`) and extracts only known-safe fields. `ApiError` serializes `{"error": "..."}` and `extract_error_message` has an arm for exactly that, so the detail arrives intact and still status-prefixed (`HTTP 403: …`).

The hint survives where it was ever right: a 403 whose body says nothing gets it appended, and only then.

## How it was found, and why it is separate

CI, not reading. core#3642's e2e asserts that the pre-grant refusal mentions `CAN_AUTHOR_ON_BEHALF`, and merobox's `expected_error` correctly refused to accept the token message in its place — the guard working on its author.

It cannot be validated by core's own e2e in the same PR, though, and that is the reason this is split out. The e2e's HTTP client is `calimero-client` **compiled into the published client-py wheel**: `0.6.32`'s lock pins core `5cc9668ae`, which predates this commit. Observing this fix from core's merobox suite takes five hops — core → client-py → PyPI → merobox floor → merobox release → core pin.

So it lands here on its own merits, where `meroctl` benefits immediately (it uses `calimero-client` directly), and travels the chain from there. core#3642 meanwhile asserts what the *current* client makes observable.

## Tests

- `a_403_keeps_the_servers_own_message` — a 403 carrying the `CAN_AUTHOR_ON_BEHALF` reason keeps it.
- `a_bare_403_says_only_what_it_knows` — an empty body yields `HTTP 403` and the hint is appended by the caller, never tacked onto a 403 that does have a reason.