### PR TITLE
test(e2e): assert which refusal fired, now that the client says

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -36,7 +36,7 @@ runs:
         #
         # Both are the deliberate bump the note above describes, and the PR
         # carrying it runs the full suite against the new version.
-        MEROBOX_VERSION="0.6.64"
+        MEROBOX_VERSION="0.6.65"
         TAG="v${MEROBOX_VERSION}"
 
         case "$(uname -m)" in

--- a/apps/scaffolding-e2e/workflows/delegated-authorship.yml
+++ b/apps/scaffolding-e2e/workflows/delegated-authorship.yml
@@ -176,18 +176,13 @@ steps:
   # DAR-11: refused at the API, never published as a delta peers would drop.
   #
   # `expected_error` is not decoration — without it a node that never started
-  # satisfies this assertion too. But it can only match what the client makes
-  # observable, and today that is the generic 403 text: `calimero-client`
-  # replaced every 403 body with a fixed token hint, so the endpoint's actual
-  # answer ("an admin must grant CAN_AUTHOR_ON_BEHALF to <account>") never
-  # reaches a caller. #3647 fixes that; it cannot be observed from here until it
-  # travels core → client-py → merobox → this pin.
+  # satisfies this assertion too. It names the endpoint's own reason, which is
+  # what makes this step distinguish "the relay holds no grant" from every other
+  # way a request can fail, including the replay refusal below.
   #
-  # The cost of the weaker string is worth naming: both refusals below are 403s,
-  # so until #3647 lands this scenario cannot tell "no authorship grant" from
-  # "nonce already spent". It still distinguishes either from a 500, a connection
-  # error, or an acceptance — which is what the guard is mainly for. Tighten both
-  # to their specific reasons once the fix is in the pinned client.
+  # That specificity needed #3647: `calimero-client` used to replace every 403
+  # body with a fixed token hint, so both refusals here read identically and the
+  # assertion could only say "some 403 happened".
   - name: Refused before the relay is granted authorship
     type: perform_intent
     node: delegated-node-1
@@ -199,7 +194,7 @@ steps:
     warrant: '{{warrant}}'
     author_proof: '02b2a942ff4c98718bed76e255987f6d59b1a72d3b2cd2510003e6170ac63a9ffb000000000e2cd2d3dc84e1db5088e32510ca45bc491e4033bbb0f6bbb733bc0c7b7f5e304d0774b93e8028899a745dbe03d7727fa31fc2f060945b5789cb36c23cba380366245580f7aa816a35d1ff324a714355995ef44a72bcd2341e21d9587d16efce973135e50bc7280f06bb32a53a566983cf0f0c8428be4b461df54264f07319540000000000000000e0c3743677508f5cfbe245f043f2d7bc3ba6c88c001464cae581e2e9ec8cb63780f1f5c2a393521a0038b357fffe63092403fa6e0e2ec12da5e96d50692d400f'
     expected_failure: true
-    expected_error: Access denied
+    expected_error: CAN_AUTHOR_ON_BEHALF
 
   # Bit 9, so 512 on its own — authorship and nothing else, which is the posture
   # the capability exists to make possible. Implied by neither membership nor
@@ -237,8 +232,6 @@ steps:
   # forgery, which is why the nonce ledger has to exist and why the envelope check
   # cannot be what stops it.
   #
-  # Same generic 403 text as above, for the same reason — see #3647. What this
-  # still proves is that presenting a valid warrant twice does not write twice.
   - name: The spent warrant is refused a second time
     type: perform_intent
     node: delegated-node-1
@@ -250,7 +243,7 @@ steps:
     warrant: '{{warrant}}'
     author_proof: '02b2a942ff4c98718bed76e255987f6d59b1a72d3b2cd2510003e6170ac63a9ffb000000000e2cd2d3dc84e1db5088e32510ca45bc491e4033bbb0f6bbb733bc0c7b7f5e304d0774b93e8028899a745dbe03d7727fa31fc2f060945b5789cb36c23cba380366245580f7aa816a35d1ff324a714355995ef44a72bcd2341e21d9587d16efce973135e50bc7280f06bb32a53a566983cf0f0c8428be4b461df54264f07319540000000000000000e0c3743677508f5cfbe245f043f2d7bc3ba6c88c001464cae581e2e9ec8cb63780f1f5c2a393521a0038b357fffe63092403fa6e0e2ec12da5e96d50692d400f'
     expected_failure: true
-    expected_error: Access denied
+    expected_error: nonce
 
   # --- The half a relay cannot fake ---
   #


### PR DESCRIPTION
Restores the two `expected_error` values #3642 had to weaken, and bumps the merobox pin to `0.6.65` that makes them assertable.

## What was lost, and why

The assertions named the endpoint's own reasons — `CAN_AUTHOR_ON_BEHALF` and `nonce` — which **no caller could see**: `calimero-client` replaced every 403 body with a fixed *"your token may not have sufficient permissions"*. Both refusals therefore read identically, and the scenario could only assert *"some 403 happened"*.

Since every `WarrantRefusal` is a 403, that meant it could not distinguish:

- *"the relay holds no authorship grant"* from
- *"this warrant's nonce is already spent"*

It could still separate either from a 500, a connection error, or an unexpected acceptance — which is why weakening beat dropping `expected_error` — but the specificity was gone.

## Four hops to undo it, and this is the last

```
core#3647            fixed the client
calimero-client-py   0.6.33 shipped it
merobox              0.6.65 raised its floor to that
core (this PR)       pins 0.6.65
```

A `crates/client` fix is not observable from core's own merobox e2e until it comes back around — the e2e's HTTP client is `calimero-client` compiled into the published client-py wheel. That is why it could not be done in #3642, and why re-running that PR would never have turned these green.

## Verified before pushing

`0.6.65`'s **GitHub release asset** is downloadable — checked with `curl -fsI` against the exact URL `setup-merobox` fetches, not PyPI. The two publish on separate schedules: this release reported success at `12:12:34Z` and the linux binary only became fetchable at `12:20:35Z`, and core's pin needs the binary.

`merobox bootstrap validate` passes.

## What to watch on this run

That both tightened steps pass, rather than the workflow merely going green — they are the only assertions in the suite that depend on the client having kept a 403's message, so they are the proof the four hops arrived intact.