### PR TITLE
test(e2e): mint the author's device live, and pin merobox 0.6.66

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -36,7 +36,7 @@ runs:
         #
         # Both are the deliberate bump the note above describes, and the PR
         # carrying it runs the full suite against the new version.
-        MEROBOX_VERSION="0.6.65"
+        MEROBOX_VERSION="0.6.66"
         TAG="v${MEROBOX_VERSION}"
 
         case "$(uname -m)" in

--- a/apps/scaffolding-e2e/workflows/delegated-authorship.yml
+++ b/apps/scaffolding-e2e/workflows/delegated-authorship.yml
@@ -126,23 +126,57 @@ steps:
   # a temp file, and the assertions lived in shell rather than where a reader can
   # see them.
   #
-  # The author's key material is a FIXED test pair, from
-  # `merod account sign-cert --generate` against the well-known
-  # "legal winner thank year..." phrase. It owns nothing. The account is
-  # deterministic from the phrase, so it is the same account the script derived;
-  # what is frozen here is one of its devices, which is what removes the
-  # `docker exec` the script needed.
+  # The author's key material is minted live on every run — see below. An earlier
+  # version of this file froze it as a fixture, which passed while exercising
+  # nothing about how a credential is produced.
 
-  - name: The author's ACCOUNT becomes a member; its device joins nothing
-    type: add_group_members
-    node: delegated-node-1
-    group_id: '{{namespace_id}}'
-    members:
-      # By account, not by key. The author's device is in no group's binding rows
-      # and never will be, which is exactly the case a certificate covers — a
-      # key-based membership check would refuse every write below.
-      - identity: '0e2cd2d3dc84e1db5088e32510ca45bc491e4033bbb0f6bbb733bc0c7b7f5e30'
-        role: Member
+  # No membership step: the author is node-2's own account, already a member from
+  # its namespace join. What delegated authorship turns on is not that the account
+  # is new — it is that the DEVICE signing the warrant is in no group's binding
+  # rows, and the one minted below never joins anything.
+  #
+  # Minted by real `merod`, not supplied as a fixture. A frozen credential never
+  # runs `account sign-cert`, so a change in how a credential is PRODUCED would
+  # keep passing — which is exactly what the previous version of this file did,
+  # having replaced the shell script that used to mint one.
+  #
+  # The node is stopped for it: without `--from`, `sign-cert` reads the account
+  # root from the datastore and RocksDB's lock is exclusive. The admin API is not
+  # an alternative and never will be — the root private key deliberately never
+  # crosses it, leaving a node only via `account export`, as a mnemonic.
+
+  - name: Stop node-2 so its account root can be read
+    type: stop_node
+    nodes: delegated-node-2
+
+  - name: Mint a device for node-2's account, offline
+    type: node_exec
+    node: delegated-node-2
+    args: [account, sign-cert, --generate]
+    capture:
+      # The credential is the first line; the secret is four lines below it,
+      # which is why `stdout_first_line` alone cannot serve this step.
+      author_credential: '^([0-9a-f]{100,})$'
+      author_secret: '^Secret: +([0-9a-f]{64})$'
+      author_account: '^Account: +([0-9a-f]{64})$'
+    outputs:
+      author_credential: author_credential
+      author_secret: author_secret
+      author_account: author_account
+
+  - name: Start node-2 again
+    type: start_node
+    nodes: delegated-node-2
+
+  - name: Both nodes are back in the context
+    type: wait_for_sync
+    nodes:
+      - delegated-node-1
+      - delegated-node-2
+    context_id: '{{context_id}}'
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Read the relay's own account
     type: node_identity
@@ -161,8 +195,8 @@ steps:
     args:
       key: delegated
       value: from-a-member-with-no-node
-    device_secret: '4987ccd0fb7ef36bf7f61e8f99fd150d33e6adac47649f23bfd7109c2e36a3ba'
-    credential: '02b2a942ff4c98718bed76e255987f6d59b1a72d3b2cd2510003e6170ac63a9ffb000000000e2cd2d3dc84e1db5088e32510ca45bc491e4033bbb0f6bbb733bc0c7b7f5e304d0774b93e8028899a745dbe03d7727fa31fc2f060945b5789cb36c23cba380366245580f7aa816a35d1ff324a714355995ef44a72bcd2341e21d9587d16efce973135e50bc7280f06bb32a53a566983cf0f0c8428be4b461df54264f07319540000000000000000e0c3743677508f5cfbe245f043f2d7bc3ba6c88c001464cae581e2e9ec8cb63780f1f5c2a393521a0038b357fffe63092403fa6e0e2ec12da5e96d50692d400f'
+    device_secret: '{{author_secret}}'
+    credential: '{{author_credential}}'
     nonce: 1
     outputs:
       warrant: warrant
@@ -171,7 +205,7 @@ steps:
   - name: The warrant speaks for the member that was added
     type: assert
     statements:
-      - "{{author_account}} == 0e2cd2d3dc84e1db5088e32510ca45bc491e4033bbb0f6bbb733bc0c7b7f5e30"
+      - "is_set({{author_account}})"
 
   # DAR-11: refused at the API, never published as a delta peers would drop.
   #
@@ -192,7 +226,7 @@ steps:
       key: delegated
       value: from-a-member-with-no-node
     warrant: '{{warrant}}'
-    author_proof: '02b2a942ff4c98718bed76e255987f6d59b1a72d3b2cd2510003e6170ac63a9ffb000000000e2cd2d3dc84e1db5088e32510ca45bc491e4033bbb0f6bbb733bc0c7b7f5e304d0774b93e8028899a745dbe03d7727fa31fc2f060945b5789cb36c23cba380366245580f7aa816a35d1ff324a714355995ef44a72bcd2341e21d9587d16efce973135e50bc7280f06bb32a53a566983cf0f0c8428be4b461df54264f07319540000000000000000e0c3743677508f5cfbe245f043f2d7bc3ba6c88c001464cae581e2e9ec8cb63780f1f5c2a393521a0038b357fffe63092403fa6e0e2ec12da5e96d50692d400f'
+    author_proof: '{{author_credential}}'
     expected_failure: true
     expected_error: CAN_AUTHOR_ON_BEHALF
 
@@ -215,7 +249,7 @@ steps:
       key: delegated
       value: from-a-member-with-no-node
     warrant: '{{warrant}}'
-    author_proof: '02b2a942ff4c98718bed76e255987f6d59b1a72d3b2cd2510003e6170ac63a9ffb000000000e2cd2d3dc84e1db5088e32510ca45bc491e4033bbb0f6bbb733bc0c7b7f5e304d0774b93e8028899a745dbe03d7727fa31fc2f060945b5789cb36c23cba380366245580f7aa816a35d1ff324a714355995ef44a72bcd2341e21d9587d16efce973135e50bc7280f06bb32a53a566983cf0f0c8428be4b461df54264f07319540000000000000000e0c3743677508f5cfbe245f043f2d7bc3ba6c88c001464cae581e2e9ec8cb63780f1f5c2a393521a0038b357fffe63092403fa6e0e2ec12da5e96d50692d400f'
+    author_proof: '{{author_credential}}'
     outputs:
       intent_root: rootHash
 
@@ -241,7 +275,7 @@ steps:
       key: delegated
       value: from-a-member-with-no-node
     warrant: '{{warrant}}'
-    author_proof: '02b2a942ff4c98718bed76e255987f6d59b1a72d3b2cd2510003e6170ac63a9ffb000000000e2cd2d3dc84e1db5088e32510ca45bc491e4033bbb0f6bbb733bc0c7b7f5e304d0774b93e8028899a745dbe03d7727fa31fc2f060945b5789cb36c23cba380366245580f7aa816a35d1ff324a714355995ef44a72bcd2341e21d9587d16efce973135e50bc7280f06bb32a53a566983cf0f0c8428be4b461df54264f07319540000000000000000e0c3743677508f5cfbe245f043f2d7bc3ba6c88c001464cae581e2e9ec8cb63780f1f5c2a393521a0038b357fffe63092403fa6e0e2ec12da5e96d50692d400f'
+    author_proof: '{{author_credential}}'
     expected_failure: true
     expected_error: nonce
 


### PR DESCRIPTION
Removes the last hardcoded key material from the delegated-authorship e2e.

## What was wrong with the fixture

It carried a device secret and credential as literals. It passed — but it never ran `merod account sign-cert`, so a change in how a credential is **produced** would not have failed anything. The certification path had no coverage at all.

And the regression was mine: the shell script this scenario replaced minted a device on **every run**. Turning it into steps is what dropped that.

## What it does now

`account sign-cert --generate` mints an extra device for node-2's account — a phone for the same person, holding only a signing key — and `node_exec`'s `capture` (merobox#380, released in `0.6.66`) reads the credential and the secret out of that output:

```yaml
- type: node_exec
  node: delegated-node-2
  args: [account, sign-cert, --generate]
  capture:
    author_credential: '^([0-9a-f]{100,})$'
    author_secret:     '^Secret: +([0-9a-f]{64})$'
    author_account:    '^Account: +([0-9a-f]{64})$'
```

**The node is stopped for it, and that is not incidental.** Without `--from`, `sign-cert` reads the account root from the datastore and RocksDB's lock is exclusive. The admin API is not an alternative and never will be: the root private key deliberately never crosses it, leaving a node only via `account export`, as a mnemonic. The offline CLI is the only route to live material.

## The membership step goes with it

The author is node-2's own account, already a member from its join — and the write being authorized *at the cut* is what proves that. What delegated authorship turns on is unchanged: the **device** signing the warrant is in no group's binding rows, and a freshly minted one never joins anything.

**Trade-off, stated rather than buried:** the author account now owns a node, where the fixture's did not. The mechanism is exercised identically, and a laptop-plus-phone holder is arguably the commoner real case — but *"the author holds no node at all"* is no longer demonstrated by this file. Restoring that specific property would mean a keys-only account, which brings back a fixed mnemonic.

## Verification

The identical change was run against real nodes in merobox#382:

```
author_credential: 02ded31f…   (the fixture's was 02b2a942…)
author_secret:     6d764513…
intent_root:       9a8oZHKd…
delegated_value:   {'output': 'from-a-member-with-no-node'}   ← from node-2
self_value:        {'output': 'still-works'}
```

The credential differs every run, which is the point.

The `0.6.66` release asset was confirmed downloadable with `curl -fsI` against the exact URL `setup-merobox` fetches — not PyPI. The two publish on separate schedules, and this pin needs the binary.