### PR TITLE
test(sdk-e2e): cover the intents route, and drop it from the ratchet

### DIFF
--- a/.github/workflows/sdk-e2e.yml
+++ b/.github/workflows/sdk-e2e.yml
@@ -164,6 +164,12 @@ jobs:
           NODE_BASE_URL: "http://localhost:${{ env.SERVER_PORT }}"
           # The e2e coverage recorder writes the endpoints it hit here.
           MERO_COVERAGE_OUT: "${{ github.workspace }}/_mero-js/covered-endpoints.json"
+          # The delegated-authorship suite mints a warrant with the merod built
+          # above. It has to be real: this SDK cannot sign one (that would need
+          # ed25519 and a borsh encoding kept byte-identical with the node's), and
+          # a fabricated warrant would register the route as covered while being
+          # refused every time. Without this the suite skips rather than fails.
+          MEROD_BINARY: "${{ github.workspace }}/target/debug/merod"
           # MERO_E2E_USER / MERO_E2E_PASS are inherited from the workflow-level
           # env (dev / dev-password) so the suite logs in with the exact
           # credentials the "Bootstrap root key" step provisioned. Do not

--- a/crates/server/coverage-baseline.json
+++ b/crates/server/coverage-baseline.json
@@ -3,7 +3,6 @@
   "GET /admin-api/groups/:group_id/members/:account/metadata",
   "GET /admin-api/identity",
   "GET /admin-api/ready",
-  "POST /admin-api/contexts/:context_id/intents",
   "POST /admin-api/groups/:group_id/members",
   "POST /admin-api/groups/:group_id/members/remove",
   "POST /admin-api/namespaces/:namespace_id/account/pair-complete",


### PR DESCRIPTION
sdk-ref: feat/perform-intent

Closes #3640.

`POST /admin-api/contexts/:context_id/intents` has sat in `crates/server/coverage-baseline.json` since it shipped, for a structural reason: the ratchet is fed by the **SDK e2e**, and nothing there could reach the route because mero-js had no client method. Merobox coverage — of which there is plenty — cannot move it.

calimero-network/mero-js#113 adds `performIntent` and a suite that spends a **real** warrant through it.

## Why the warrant has to be real

A test calling the endpoint with a fabricated warrant would register the route as covered while being refused on every run. **The ratchet cannot tell the difference** — it records endpoints the client hit, not whether anything worked. That would have closed #3640 on a test that proved nothing, which is the same hollowness we just spent four PRs removing from the merobox side.

So the suite mints with the `merod` this workflow already builds, which is why the e2e step now exports `MEROD_BINARY`. Without that line the suite **skips** rather than fails — so the env change is what makes the coverage actually happen, and its absence would be silent.

## What the suite asserts

One warrant, three answers:

| | |
|---|---|
| before the authorship grant | refused, naming `CAN_AUTHOR_ON_BEHALF` |
| after it | accepted, and `rootHash` non-empty |
| presented again | refused, naming the nonce |

Minted once and reused deliberately: the same bytes getting a different answer is what makes the **grant** the variable. A fresh warrant per step would prove much less.

It also restores a property core's own e2e gave up when it moved to live minting (#3653): here the author's account holds **no node at all**, which is the case delegated authorship exists for. `sign-cert --from <phrase>` is what allows it — the node under test is serving the suite, and without `--from` `sign-cert` opens the datastore, whose lock is exclusive.

## Verification

The two CLI invocations were run against the real binary with the exact argument shapes the test builds, and all three parsed fields confirmed present in the output.

Worth flagging for reviewers: mero-js does **not** typecheck its tests (`tsconfig.json` includes only `src/**/*` and excludes `**/*.test.ts`), so a clean `tsc` there says nothing about the new file. I verified the risky parts — the shell-outs and the output parsing — directly instead.

Paired via `sdk-ref` above; the ref goes to master once mero-js#113 merges.