### PR TITLE
feat(wire-descriptor): gate the replicated borsh surface on a structural fingerprint

### DIFF
--- a/.github/workflows/wire-format-borsh.yml
+++ b/.github/workflows/wire-format-borsh.yml
@@ -1,0 +1,91 @@
+name: Wire Format (borsh)
+
+# The gate on the REPLICATED wire surface: the borsh types that travel between
+# nodes (governance ops, the unified `Op` envelope). Separate from
+# `wire-contract.yml`, which guards HTTP request/response DTOs — different
+# blast radius (a DTO break is a client 400; a borsh break is a fleet that
+# reports "joined" and replicates nothing, as in the rc.7/rc.8
+# NamespaceGovOpValue incident), different reviewers, and a path filter that
+# would otherwise make each job run on the other's changes.
+#
+# Two independent statements of the layout have to agree:
+#   * frozen-byte goldens, decoded (never re-encoded) — catch a renumbered
+#     discriminant, which a same-binary round-trip provably cannot;
+#   * a hand-maintained structural descriptor pinned to a committed snapshot —
+#     catches what a golden cannot, e.g. a field retyped or two same-width
+#     fields swapped.
+# Regenerate a snapshot after an intended change with
+# `UPDATE_WIRE_FINGERPRINT=1 cargo test -p <crate> wire_fingerprint`.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - "crates/governance-types/**"
+      - "crates/op/**"
+      - "crates/wire-descriptor/**"
+      # Leaf types embedded in the wire surface: their layout is pinned by the
+      # snapshots above, so a change here can move a fingerprint.
+      - "crates/account/**"
+      - "crates/context/config/**"
+      - "crates/primitives/**"
+      - "crates/storage/**"
+      - ".github/workflows/wire-format-borsh.yml"
+  push:
+    branches:
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  wire-format-borsh:
+    name: Wire Format (borsh)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Rust toolchain
+        # Pinned to a commit SHA (supply-chain hygiene); comment tracks the tag.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      # The descriptor framework itself: its diff/fingerprint behaviour is what
+      # the two gates below report failures through, so it is tested first.
+      - name: Descriptor framework
+        run: cargo test -p calimero-wire-descriptor
+
+      # Governance ops: goldens (exhaustive over every variant) + snapshot.
+      - name: Governance wire surface
+        run: cargo test -p calimero-governance-types
+
+      # The unified op envelope: pinned tags + snapshot.
+      - name: Op envelope wire surface
+        run: cargo test -p calimero-op
+
+      # The snapshots are derived files, so regenerating them must be a no-op.
+      # This proves the documented regeneration command still works and that
+      # nobody hand-edited a snapshot into a shape the descriptor cannot
+      # produce — the same guarantee `wire-contract.yml` gets from
+      # `UPDATE_FIXTURES=1`.
+      - name: Snapshots regenerate clean
+        run: |
+          UPDATE_WIRE_FINGERPRINT=1 cargo test -p calimero-governance-types wire_fingerprint
+          UPDATE_WIRE_FINGERPRINT=1 cargo test -p calimero-op wire_fingerprint
+          git diff --exit-code
+          test -z "$(git status --porcelain)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,6 +1236,7 @@ dependencies = [
  "calimero-context-config",
  "calimero-primitives",
  "calimero-storage",
+ "calimero-wire-descriptor",
  "ed25519-dalek",
  "rand 0.8.5",
  "serde",
@@ -1408,6 +1409,7 @@ dependencies = [
  "calimero-context-config",
  "calimero-primitives",
  "calimero-storage",
+ "calimero-wire-descriptor",
  "sha2",
 ]
 
@@ -1734,6 +1736,13 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "wasmparser 0.118.2",
+]
+
+[[package]]
+name = "calimero-wire-descriptor"
+version = "0.0.0"
+dependencies = [
+ "blake3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ members = [
     "./crates/storage",
     "./crates/storage-macros",
     "./crates/tee-attestation",
+    "./crates/wire-descriptor",
 
     "./crates/store",
     "./crates/store/blobs",
@@ -341,6 +342,7 @@ calimero-server = { path = "./crates/server" }
 calimero-server-primitives = { path = "./crates/server/primitives" }
 calimero-storage = { path = "./crates/storage" }
 calimero-storage-macros = { path = "./crates/storage-macros" }
+calimero-wire-descriptor = { path = "./crates/wire-descriptor" }
 calimero-store = { path = "./crates/store" }
 calimero-store-encryption = { path = "./crates/store/encryption" }
 calimero-store-rocksdb = { path = "./crates/store/impl/rocksdb" }

--- a/crates/governance-types/Cargo.toml
+++ b/crates/governance-types/Cargo.toml
@@ -31,3 +31,4 @@ calimero-storage.workspace = true
 calimero-account.workspace = true
 calimero-primitives = { workspace = true, features = ["borsh", "rand"] }
 rand.workspace = true
+calimero-wire-descriptor.workspace = true

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+// The structural-fingerprint gate. Lives beside these goldens because it reads
+// them: the descriptor there and the frozen bytes here check each other.
+mod wire_fingerprint;
+
 use calimero_primitives::identity::{PrivateKey, PublicKey};
 use rand::rngs::OsRng;
 
@@ -299,6 +303,17 @@ const GOLDEN_GROUP_OP_ACCOUNT_KEYS_ROTATED: &[u8] = &[
     0, // handoff.signature
 ];
 
+/// GroupOp ordinal 27 - GroupKeyRotatedForDevice { device: [0;32] }
+///
+/// `DeviceId` is a transparent 32-byte newtype, so the payload is the bare id.
+/// Frozen here because the variant is the tail of the enum today: the next
+/// append lands at 28, and this vector is what proves 27 did not move under it.
+const GOLDEN_GROUP_OP_GROUP_KEY_ROTATED_FOR_DEVICE: &[u8] = &[
+    27, // discriminant
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, // device
+];
+
 /// GroupOp ordinal 23 - GroupKeyRotated { departed: [0;32] }
 const GOLDEN_GROUP_OP_GROUP_KEY_ROTATED: &[u8] = &[
     23, // discriminant
@@ -482,6 +497,11 @@ fn group_op_discriminants_are_golden() {
         GOLDEN_GROUP_OP_ACCOUNT_KEYS_ROTATED,
         GroupOp::AccountKeysRotated { .. },
         26
+    );
+    check_group_op!(
+        GOLDEN_GROUP_OP_GROUP_KEY_ROTATED_FOR_DEVICE,
+        GroupOp::GroupKeyRotatedForDevice { .. },
+        27
     );
 
     assert!(
@@ -735,6 +755,26 @@ const GOLDEN_ROOT_OP_MEMBER_JOINED_VIA_TEE: &[u8] = &[
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+];
+
+/// NamespaceOp ordinal 1 — `Group` (the encrypted arm).
+///
+/// The `Root` arm is covered by every `GOLDEN_ROOT_OP_*` vector above; this is
+/// the only vector that pins tag 1. Without it a swap of the two arms would
+/// leave every RootOp golden still decoding "correctly" as tag 0 while every
+/// group-scoped op on the wire became unreadable.
+///
+/// Layout: tag, group_id[32], key_id[32], encrypted.nonce[12],
+/// encrypted.ciphertext (vec len 0), key_rotation = None.
+const GOLDEN_NAMESPACE_OP_GROUP: &[u8] = &[
+    1, // NamespaceOp::Group discriminant
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, // group_id
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, // key_id
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // encrypted.nonce [0u8; 12]
+    0, 0, 0, 0, // encrypted.ciphertext vec len = 0
+    0, // key_rotation = None
 ];
 
 #[test]

--- a/crates/governance-types/src/tests/wire_fingerprint.rs
+++ b/crates/governance-types/src/tests/wire_fingerprint.rs
@@ -1,0 +1,1964 @@
+//! The structural fingerprint of this crate's replicated wire surface.
+//!
+//! # What this adds over the frozen-byte goldens in `super`
+//!
+//! The goldens in `tests.rs` decode a hand-written byte vector per variant, so
+//! they catch a renumbered discriminant. They cannot catch a change that keeps
+//! every discriminant and every length: a `u32` retyped to `[u8; 4]`, two
+//! same-width fields swapped, a field renamed. They also only cover the
+//! variants somebody remembered to write a vector for.
+//!
+//! This module closes both gaps:
+//!
+//! 1. A hand-maintained **descriptor** states the layout a second time, in
+//!    prose the reviewer reads, and a committed snapshot pins it. The
+//!    descriptor is never derived from the type — a derive would move with the
+//!    type and be exactly as blind as a same-binary round-trip.
+//! 2. The descriptor is **anchored to reality** three ways, so the second
+//!    statement cannot quietly drift from the first:
+//!    * an exhaustive `match` per enum that destructures every field, so
+//!      adding a variant *or a field* does not compile until the descriptor is
+//!      updated (`GroupOp` is `#[non_exhaustive]`, which is why this lives
+//!      in-crate rather than in a shared gate crate);
+//!    * an exhaustive destructuring per struct, same reason;
+//!    * `every_described_ordinal_is_the_real_one` decodes the golden corpus and
+//!      checks the descriptor's ordinal/name against what borsh actually
+//!      produced, and `no_variant_exists_past_the_described_end` proves there
+//!      is no undescribed variant hiding after the last one.
+//!
+//! Regenerate the snapshot after an intended change:
+//!
+//! ```text
+//! UPDATE_WIRE_FINGERPRINT=1 cargo test -p calimero-governance-types wire_fingerprint
+//! ```
+
+use std::collections::BTreeMap;
+use std::io::ErrorKind;
+use std::path::PathBuf;
+
+use calimero_account::{
+    AccountGenesis, AccountId, AccountMemberEndorsement, AccountProof, DeviceCert, DeviceId,
+    DeviceRevocation, KemPublicKey, RootKeyHandoff, SignedDeviceRevocation,
+};
+use calimero_context_config::types::{
+    BytecodeId, ContextGroupId, GroupInvitationFromAdmin, SignedGroupOpenInvitation,
+};
+use calimero_context_config::{MemberCapabilities, VisibilityMode};
+use calimero_primitives::application::ApplicationId;
+use calimero_primitives::blobs::BlobId;
+use calimero_primitives::context::{ContextId, GroupMemberRole};
+use calimero_primitives::identity::PublicKey;
+use calimero_storage::logical_clock::HybridTimestamp;
+use calimero_wire_descriptor::{assert_snapshot, Field, Leaf, Shape, Surface, TypeDesc, Variant};
+
+use crate::{
+    ContextCapabilityBits, EncryptedGroupOp, EnvelopeRecipient, GroupOp, JoinAccountCredential,
+    KeyEnvelope, KeyId, KeyRotation, NamespaceId, NamespaceOp, OpaqueSkeleton, RootOp,
+    SignableGroupOp, SignableNamespaceOp, SignedGroupOp, SignedNamespaceOp, StoredNamespaceEntry,
+};
+
+// ---------------------------------------------------------------------------
+// The descriptor: a second, independent statement of the wire layout.
+// ---------------------------------------------------------------------------
+
+const GROUP_OP: TypeDesc = TypeDesc {
+    name: "GroupOp",
+    shape: Shape::Enum(&[
+        Variant {
+            ordinal: 0,
+            name: "Noop",
+            fields: &[],
+        },
+        Variant {
+            ordinal: 1,
+            name: "MemberAdded",
+            fields: &[
+                Field {
+                    name: "member",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "role",
+                    ty: "GroupMemberRole",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 2,
+            name: "MemberRemoved",
+            fields: &[
+                Field {
+                    name: "member",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "expected_group_state_hash",
+                    ty: "[u8; 32]",
+                },
+                Field {
+                    name: "expected_context_state_hashes",
+                    ty: "Vec<(ContextId, [u8; 32])>",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 3,
+            name: "MemberLeft",
+            fields: &[
+                Field {
+                    name: "member",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "expected_group_state_hash",
+                    ty: "[u8; 32]",
+                },
+                Field {
+                    name: "expected_context_state_hashes",
+                    ty: "Vec<(ContextId, [u8; 32])>",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 4,
+            name: "MemberRoleSet",
+            fields: &[
+                Field {
+                    name: "member",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "role",
+                    ty: "GroupMemberRole",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 5,
+            name: "MemberCapabilitySet",
+            fields: &[
+                Field {
+                    name: "member",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "capabilities",
+                    ty: "MemberCapabilities",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 6,
+            name: "DefaultCapabilitiesSet",
+            fields: &[Field {
+                name: "capabilities",
+                ty: "MemberCapabilities",
+            }],
+        },
+        Variant {
+            ordinal: 7,
+            name: "TargetApplicationSet",
+            fields: &[
+                Field {
+                    name: "bytecode_id",
+                    ty: "BytecodeId",
+                },
+                Field {
+                    name: "target_application_id",
+                    ty: "ApplicationId",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 8,
+            name: "ContextRegistered",
+            fields: &[
+                Field {
+                    name: "context_id",
+                    ty: "ContextId",
+                },
+                Field {
+                    name: "application_id",
+                    ty: "ApplicationId",
+                },
+                Field {
+                    name: "blob_id",
+                    ty: "BlobId",
+                },
+                Field {
+                    name: "source",
+                    ty: "String",
+                },
+                Field {
+                    name: "service_name",
+                    ty: "Option<String>",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 9,
+            name: "ContextDetached",
+            fields: &[Field {
+                name: "context_id",
+                ty: "ContextId",
+            }],
+        },
+        Variant {
+            ordinal: 10,
+            name: "SubgroupVisibilitySet",
+            fields: &[Field {
+                name: "mode",
+                ty: "VisibilityMode",
+            }],
+        },
+        Variant {
+            ordinal: 11,
+            name: "GroupMetadataSet",
+            fields: &[
+                Field {
+                    name: "name",
+                    ty: "Option<String>",
+                },
+                Field {
+                    name: "data",
+                    ty: "BTreeMap<String, String>",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 12,
+            name: "MemberMetadataSet",
+            fields: &[
+                Field {
+                    name: "member",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "name",
+                    ty: "Option<String>",
+                },
+                Field {
+                    name: "data",
+                    ty: "BTreeMap<String, String>",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 13,
+            name: "ContextMetadataSet",
+            fields: &[
+                Field {
+                    name: "context_id",
+                    ty: "ContextId",
+                },
+                Field {
+                    name: "name",
+                    ty: "Option<String>",
+                },
+                Field {
+                    name: "data",
+                    ty: "BTreeMap<String, String>",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 14,
+            name: "GroupDelete",
+            fields: &[],
+        },
+        Variant {
+            ordinal: 15,
+            name: "GroupMigrationSet",
+            fields: &[Field {
+                name: "migration",
+                ty: "Option<Vec<u8>>",
+            }],
+        },
+        Variant {
+            ordinal: 16,
+            name: "ContextCapabilityGranted",
+            fields: &[
+                Field {
+                    name: "context_id",
+                    ty: "ContextId",
+                },
+                Field {
+                    name: "member",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "capability",
+                    ty: "ContextCapabilityBits",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 17,
+            name: "ContextCapabilityRevoked",
+            fields: &[
+                Field {
+                    name: "context_id",
+                    ty: "ContextId",
+                },
+                Field {
+                    name: "member",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "capability",
+                    ty: "ContextCapabilityBits",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 18,
+            name: "TeeAdmissionPolicySet",
+            fields: &[
+                Field {
+                    name: "allowed_mrtd",
+                    ty: "Vec<String>",
+                },
+                Field {
+                    name: "allowed_rtmr0",
+                    ty: "Vec<String>",
+                },
+                Field {
+                    name: "allowed_rtmr1",
+                    ty: "Vec<String>",
+                },
+                Field {
+                    name: "allowed_rtmr2",
+                    ty: "Vec<String>",
+                },
+                Field {
+                    name: "allowed_rtmr3",
+                    ty: "Vec<String>",
+                },
+                Field {
+                    name: "allowed_tcb_statuses",
+                    ty: "Vec<String>",
+                },
+                Field {
+                    name: "accept_mock",
+                    ty: "bool",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 19,
+            name: "MemberJoinedViaTeeAttestation",
+            fields: &[
+                Field {
+                    name: "member",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "quote_hash",
+                    ty: "[u8; 32]",
+                },
+                Field {
+                    name: "mrtd",
+                    ty: "String",
+                },
+                Field {
+                    name: "rtmr0",
+                    ty: "String",
+                },
+                Field {
+                    name: "rtmr1",
+                    ty: "String",
+                },
+                Field {
+                    name: "rtmr2",
+                    ty: "String",
+                },
+                Field {
+                    name: "rtmr3",
+                    ty: "String",
+                },
+                Field {
+                    name: "tcb_status",
+                    ty: "String",
+                },
+                Field {
+                    name: "role",
+                    ty: "GroupMemberRole",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 20,
+            name: "MemberSetAutoFollow",
+            fields: &[
+                Field {
+                    name: "target",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "auto_follow_contexts",
+                    ty: "bool",
+                },
+                Field {
+                    name: "auto_follow_subgroups",
+                    ty: "bool",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 21,
+            name: "TransferOwnership",
+            fields: &[Field {
+                name: "new_owner",
+                ty: "AccountId",
+            }],
+        },
+        Variant {
+            ordinal: 22,
+            name: "CascadeUpgrade",
+            fields: &[
+                Field {
+                    name: "from_bytecode_id",
+                    ty: "BytecodeId",
+                },
+                Field {
+                    name: "bytecode_id",
+                    ty: "BytecodeId",
+                },
+                Field {
+                    name: "target_application_id",
+                    ty: "ApplicationId",
+                },
+                Field {
+                    name: "to_state_version",
+                    ty: "u32",
+                },
+                Field {
+                    name: "migration",
+                    ty: "Option<Vec<u8>>",
+                },
+                Field {
+                    name: "cascade_hlc",
+                    ty: "HybridTimestamp",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 23,
+            name: "GroupKeyRotated",
+            fields: &[Field {
+                name: "departed",
+                ty: "AccountId",
+            }],
+        },
+        Variant {
+            ordinal: 24,
+            name: "AccountDeviceLinked",
+            fields: &[
+                Field {
+                    name: "genesis",
+                    ty: "AccountGenesis",
+                },
+                Field {
+                    name: "chain",
+                    ty: "Vec<RootKeyHandoff>",
+                },
+                Field {
+                    name: "cert",
+                    ty: "DeviceCert",
+                },
+                Field {
+                    name: "endorsement",
+                    ty: "AccountMemberEndorsement",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 25,
+            name: "AccountDeviceUnlinked",
+            fields: &[
+                Field {
+                    name: "account",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "device",
+                    ty: "DeviceId",
+                },
+                Field {
+                    name: "proof",
+                    ty: "Option<SignedDeviceRevocation>",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 26,
+            name: "AccountKeysRotated",
+            fields: &[Field {
+                name: "handoff",
+                ty: "RootKeyHandoff",
+            }],
+        },
+        Variant {
+            ordinal: 27,
+            name: "GroupKeyRotatedForDevice",
+            fields: &[Field {
+                name: "device",
+                ty: "DeviceId",
+            }],
+        },
+    ]),
+};
+
+const NAMESPACE_OP: TypeDesc = TypeDesc {
+    name: "NamespaceOp",
+    shape: Shape::Enum(&[
+        Variant {
+            ordinal: 0,
+            name: "Root",
+            fields: &[Field {
+                name: "0",
+                ty: "RootOp",
+            }],
+        },
+        Variant {
+            ordinal: 1,
+            name: "Group",
+            fields: &[
+                Field {
+                    name: "group_id",
+                    ty: "ContextGroupId",
+                },
+                Field {
+                    name: "key_id",
+                    ty: "KeyId",
+                },
+                Field {
+                    name: "encrypted",
+                    ty: "EncryptedGroupOp",
+                },
+                Field {
+                    name: "key_rotation",
+                    ty: "Option<KeyRotation>",
+                },
+            ],
+        },
+    ]),
+};
+
+const ROOT_OP: TypeDesc = TypeDesc {
+    name: "RootOp",
+    shape: Shape::Enum(&[
+        Variant {
+            ordinal: 0,
+            name: "GroupCreated",
+            fields: &[
+                Field {
+                    name: "group_id",
+                    ty: "ContextGroupId",
+                },
+                Field {
+                    name: "parent_id",
+                    ty: "ContextGroupId",
+                },
+                Field {
+                    name: "restricted",
+                    ty: "bool",
+                },
+                Field {
+                    name: "admin",
+                    ty: "AccountId",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 1,
+            name: "GroupReparented",
+            fields: &[
+                Field {
+                    name: "child_group_id",
+                    ty: "ContextGroupId",
+                },
+                Field {
+                    name: "new_parent_id",
+                    ty: "ContextGroupId",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 2,
+            name: "GroupDeleted",
+            fields: &[
+                Field {
+                    name: "root_group_id",
+                    ty: "ContextGroupId",
+                },
+                Field {
+                    name: "cascade_group_ids",
+                    ty: "Vec<ContextGroupId>",
+                },
+                Field {
+                    name: "cascade_context_ids",
+                    ty: "Vec<ContextId>",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 3,
+            name: "AdminChanged",
+            fields: &[Field {
+                name: "new_admin",
+                ty: "AccountId",
+            }],
+        },
+        Variant {
+            ordinal: 4,
+            name: "PolicyUpdated",
+            fields: &[Field {
+                name: "policy_bytes",
+                ty: "Vec<u8>",
+            }],
+        },
+        Variant {
+            ordinal: 5,
+            name: "MemberJoined",
+            fields: &[
+                Field {
+                    name: "member",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "signed_invitation",
+                    ty: "SignedGroupOpenInvitation",
+                },
+                Field {
+                    name: "account",
+                    ty: "Box<JoinAccountCredential>",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 6,
+            name: "KeyDelivery",
+            fields: &[
+                Field {
+                    name: "group_id",
+                    ty: "ContextGroupId",
+                },
+                Field {
+                    name: "envelope",
+                    ty: "KeyEnvelope",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 7,
+            name: "MemberJoinedOpen",
+            fields: &[
+                Field {
+                    name: "member",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "group_id",
+                    ty: "ContextGroupId",
+                },
+                Field {
+                    name: "account",
+                    ty: "Box<JoinAccountCredential>",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 8,
+            name: "MemberJoinedAt",
+            fields: &[
+                Field {
+                    name: "member",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "signed_invitation",
+                    ty: "SignedGroupOpenInvitation",
+                },
+                Field {
+                    name: "joined_at",
+                    ty: "u64",
+                },
+                Field {
+                    name: "account",
+                    ty: "Box<JoinAccountCredential>",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 9,
+            name: "NamespaceCreated",
+            fields: &[
+                Field {
+                    name: "founder",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "account",
+                    ty: "Box<JoinAccountCredential>",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 10,
+            name: "MemberJoinedViaTeeAttestation",
+            fields: &[
+                Field {
+                    name: "group_id",
+                    ty: "ContextGroupId",
+                },
+                Field {
+                    name: "member",
+                    ty: "PublicKey",
+                },
+                Field {
+                    name: "quote_hash",
+                    ty: "[u8; 32]",
+                },
+                Field {
+                    name: "mrtd",
+                    ty: "String",
+                },
+                Field {
+                    name: "rtmr0",
+                    ty: "String",
+                },
+                Field {
+                    name: "rtmr1",
+                    ty: "String",
+                },
+                Field {
+                    name: "rtmr2",
+                    ty: "String",
+                },
+                Field {
+                    name: "rtmr3",
+                    ty: "String",
+                },
+                Field {
+                    name: "tcb_status",
+                    ty: "String",
+                },
+                Field {
+                    name: "role",
+                    ty: "GroupMemberRole",
+                },
+                Field {
+                    name: "account",
+                    ty: "Box<JoinAccountCredential>",
+                },
+            ],
+        },
+    ]),
+};
+
+const ENVELOPE_RECIPIENT: TypeDesc = TypeDesc {
+    name: "EnvelopeRecipient",
+    shape: Shape::Enum(&[
+        Variant {
+            ordinal: 0,
+            name: "Member",
+            fields: &[
+                Field {
+                    name: "identity",
+                    ty: "PublicKey",
+                },
+                Field {
+                    name: "ephemeral_pk",
+                    ty: "PublicKey",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 1,
+            name: "Device",
+            fields: &[
+                Field {
+                    name: "device",
+                    ty: "DeviceId",
+                },
+                Field {
+                    name: "ephemeral_pk",
+                    ty: "KemPublicKey",
+                },
+            ],
+        },
+    ]),
+};
+
+const STORED_NAMESPACE_ENTRY: TypeDesc = TypeDesc {
+    name: "StoredNamespaceEntry",
+    shape: Shape::Enum(&[
+        Variant {
+            ordinal: 0,
+            name: "Signed",
+            fields: &[Field {
+                name: "0",
+                ty: "SignedNamespaceOp",
+            }],
+        },
+        Variant {
+            ordinal: 1,
+            name: "Opaque",
+            fields: &[Field {
+                name: "0",
+                ty: "OpaqueSkeleton",
+            }],
+        },
+    ]),
+};
+
+// ---- structs -------------------------------------------------------------
+//
+// Field ORDER is the encoding. A struct has no tag, so inserting a field in
+// the middle silently reinterprets every byte after it — strictly worse than
+// an enum renumber, because there is no discriminant to fail on.
+
+const SIGNABLE_GROUP_OP: TypeDesc = TypeDesc {
+    name: "SignableGroupOp",
+    shape: Shape::Struct(&[
+        Field {
+            name: "version",
+            ty: "u8",
+        },
+        Field {
+            name: "group_id",
+            ty: "ContextGroupId",
+        },
+        Field {
+            name: "parent_op_hashes",
+            ty: "Vec<[u8; 32]>",
+        },
+        Field {
+            name: "signer",
+            ty: "PublicKey",
+        },
+        Field {
+            name: "nonce",
+            ty: "u64",
+        },
+        Field {
+            name: "op",
+            ty: "GroupOp",
+        },
+    ]),
+};
+
+const SIGNED_GROUP_OP: TypeDesc = TypeDesc {
+    name: "SignedGroupOp",
+    shape: Shape::Struct(&[
+        Field {
+            name: "version",
+            ty: "u8",
+        },
+        Field {
+            name: "group_id",
+            ty: "ContextGroupId",
+        },
+        Field {
+            name: "parent_op_hashes",
+            ty: "Vec<[u8; 32]>",
+        },
+        Field {
+            name: "signer",
+            ty: "PublicKey",
+        },
+        Field {
+            name: "nonce",
+            ty: "u64",
+        },
+        Field {
+            name: "op",
+            ty: "GroupOp",
+        },
+        Field {
+            name: "signature",
+            ty: "[u8; 64]",
+        },
+    ]),
+};
+
+const SIGNABLE_NAMESPACE_OP: TypeDesc = TypeDesc {
+    name: "SignableNamespaceOp",
+    shape: Shape::Struct(&[
+        Field {
+            name: "version",
+            ty: "u8",
+        },
+        Field {
+            name: "namespace_id",
+            ty: "NamespaceId",
+        },
+        Field {
+            name: "parent_op_hashes",
+            ty: "Vec<[u8; 32]>",
+        },
+        Field {
+            name: "signer",
+            ty: "PublicKey",
+        },
+        Field {
+            name: "nonce",
+            ty: "u64",
+        },
+        Field {
+            name: "op",
+            ty: "NamespaceOp",
+        },
+    ]),
+};
+
+const SIGNED_NAMESPACE_OP: TypeDesc = TypeDesc {
+    name: "SignedNamespaceOp",
+    shape: Shape::Struct(&[
+        Field {
+            name: "version",
+            ty: "u8",
+        },
+        Field {
+            name: "namespace_id",
+            ty: "NamespaceId",
+        },
+        Field {
+            name: "parent_op_hashes",
+            ty: "Vec<[u8; 32]>",
+        },
+        Field {
+            name: "signer",
+            ty: "PublicKey",
+        },
+        Field {
+            name: "nonce",
+            ty: "u64",
+        },
+        Field {
+            name: "op",
+            ty: "NamespaceOp",
+        },
+        Field {
+            name: "signature",
+            ty: "[u8; 64]",
+        },
+    ]),
+};
+
+const ENCRYPTED_GROUP_OP: TypeDesc = TypeDesc {
+    name: "EncryptedGroupOp",
+    shape: Shape::Struct(&[
+        Field {
+            name: "nonce",
+            ty: "[u8; 12]",
+        },
+        Field {
+            name: "ciphertext",
+            ty: "Vec<u8>",
+        },
+    ]),
+};
+
+const KEY_ENVELOPE: TypeDesc = TypeDesc {
+    name: "KeyEnvelope",
+    shape: Shape::Struct(&[
+        Field {
+            name: "recipient",
+            ty: "EnvelopeRecipient",
+        },
+        Field {
+            name: "sender",
+            ty: "PublicKey",
+        },
+        Field {
+            name: "nonce",
+            ty: "[u8; 12]",
+        },
+        Field {
+            name: "ciphertext",
+            ty: "Vec<u8>",
+        },
+        Field {
+            name: "signature",
+            ty: "[u8; 64]",
+        },
+    ]),
+};
+
+const KEY_ROTATION: TypeDesc = TypeDesc {
+    name: "KeyRotation",
+    shape: Shape::Struct(&[
+        Field {
+            name: "new_key_id",
+            ty: "KeyId",
+        },
+        Field {
+            name: "envelopes",
+            ty: "Vec<KeyEnvelope>",
+        },
+    ]),
+};
+
+const OPAQUE_SKELETON: TypeDesc = TypeDesc {
+    name: "OpaqueSkeleton",
+    shape: Shape::Struct(&[
+        Field {
+            name: "delta_id",
+            ty: "[u8; 32]",
+        },
+        Field {
+            name: "parent_op_hashes",
+            ty: "Vec<[u8; 32]>",
+        },
+        Field {
+            name: "group_id",
+            ty: "ContextGroupId",
+        },
+        Field {
+            name: "signer",
+            ty: "PublicKey",
+        },
+    ]),
+};
+
+/// Every described type, in the order they appear in the snapshot.
+fn described_types() -> Vec<TypeDesc> {
+    vec![
+        NAMESPACE_OP,
+        ROOT_OP,
+        GROUP_OP,
+        ENVELOPE_RECIPIENT,
+        STORED_NAMESPACE_ENTRY,
+        SIGNABLE_GROUP_OP,
+        SIGNED_GROUP_OP,
+        SIGNABLE_NAMESPACE_OP,
+        SIGNED_NAMESPACE_OP,
+        ENCRYPTED_GROUP_OP,
+        KEY_ENVELOPE,
+        KEY_ROTATION,
+        OPAQUE_SKELETON,
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Compile-time anchors.
+//
+// None of these functions is ever called. They exist so that `cargo test`
+// FAILS TO BUILD when a variant or a field is added, which is the moment the
+// author has to decide whether their change is an append (compatible) or a
+// reshuffle (a break). A test that merely asserts at runtime would be silent
+// until someone thought to run it against an old peer.
+// ---------------------------------------------------------------------------
+
+fn group_op_variant_name(op: &GroupOp) -> &'static str {
+    match op {
+        GroupOp::Noop => "Noop",
+        GroupOp::MemberAdded { member, role } => {
+            let _: &AccountId = member;
+            let _: &GroupMemberRole = role;
+            "MemberAdded"
+        }
+        GroupOp::MemberRemoved {
+            member,
+            expected_group_state_hash,
+            expected_context_state_hashes,
+        } => {
+            let _: &AccountId = member;
+            let _: &[u8; 32] = expected_group_state_hash;
+            let _: &Vec<(ContextId, [u8; 32])> = expected_context_state_hashes;
+            "MemberRemoved"
+        }
+        GroupOp::MemberLeft {
+            member,
+            expected_group_state_hash,
+            expected_context_state_hashes,
+        } => {
+            let _: &AccountId = member;
+            let _: &[u8; 32] = expected_group_state_hash;
+            let _: &Vec<(ContextId, [u8; 32])> = expected_context_state_hashes;
+            "MemberLeft"
+        }
+        GroupOp::MemberRoleSet { member, role } => {
+            let _: &AccountId = member;
+            let _: &GroupMemberRole = role;
+            "MemberRoleSet"
+        }
+        GroupOp::MemberCapabilitySet {
+            member,
+            capabilities,
+        } => {
+            let _: &AccountId = member;
+            let _: &MemberCapabilities = capabilities;
+            "MemberCapabilitySet"
+        }
+        GroupOp::DefaultCapabilitiesSet { capabilities } => {
+            let _: &MemberCapabilities = capabilities;
+            "DefaultCapabilitiesSet"
+        }
+        GroupOp::TargetApplicationSet {
+            bytecode_id,
+            target_application_id,
+        } => {
+            let _: &BytecodeId = bytecode_id;
+            let _: &ApplicationId = target_application_id;
+            "TargetApplicationSet"
+        }
+        GroupOp::ContextRegistered {
+            context_id,
+            application_id,
+            blob_id,
+            source,
+            service_name,
+        } => {
+            let _: &ContextId = context_id;
+            let _: &ApplicationId = application_id;
+            let _: &BlobId = blob_id;
+            let _: &String = source;
+            let _: &Option<String> = service_name;
+            "ContextRegistered"
+        }
+        GroupOp::ContextDetached { context_id } => {
+            let _: &ContextId = context_id;
+            "ContextDetached"
+        }
+        GroupOp::SubgroupVisibilitySet { mode } => {
+            let _: &VisibilityMode = mode;
+            "SubgroupVisibilitySet"
+        }
+        GroupOp::GroupMetadataSet { name, data } => {
+            let _: &Option<String> = name;
+            let _: &BTreeMap<String, String> = data;
+            "GroupMetadataSet"
+        }
+        GroupOp::MemberMetadataSet { member, name, data } => {
+            let _: &AccountId = member;
+            let _: &Option<String> = name;
+            let _: &BTreeMap<String, String> = data;
+            "MemberMetadataSet"
+        }
+        GroupOp::ContextMetadataSet {
+            context_id,
+            name,
+            data,
+        } => {
+            let _: &ContextId = context_id;
+            let _: &Option<String> = name;
+            let _: &BTreeMap<String, String> = data;
+            "ContextMetadataSet"
+        }
+        GroupOp::GroupDelete => "GroupDelete",
+        GroupOp::GroupMigrationSet { migration } => {
+            let _: &Option<Vec<u8>> = migration;
+            "GroupMigrationSet"
+        }
+        GroupOp::ContextCapabilityGranted {
+            context_id,
+            member,
+            capability,
+        } => {
+            let _: &ContextId = context_id;
+            let _: &AccountId = member;
+            let _: &ContextCapabilityBits = capability;
+            "ContextCapabilityGranted"
+        }
+        GroupOp::ContextCapabilityRevoked {
+            context_id,
+            member,
+            capability,
+        } => {
+            let _: &ContextId = context_id;
+            let _: &AccountId = member;
+            let _: &ContextCapabilityBits = capability;
+            "ContextCapabilityRevoked"
+        }
+        GroupOp::TeeAdmissionPolicySet {
+            allowed_mrtd,
+            allowed_rtmr0,
+            allowed_rtmr1,
+            allowed_rtmr2,
+            allowed_rtmr3,
+            allowed_tcb_statuses,
+            accept_mock,
+        } => {
+            let _: &Vec<String> = allowed_mrtd;
+            let _: &Vec<String> = allowed_rtmr0;
+            let _: &Vec<String> = allowed_rtmr1;
+            let _: &Vec<String> = allowed_rtmr2;
+            let _: &Vec<String> = allowed_rtmr3;
+            let _: &Vec<String> = allowed_tcb_statuses;
+            let _: &bool = accept_mock;
+            "TeeAdmissionPolicySet"
+        }
+        GroupOp::MemberJoinedViaTeeAttestation {
+            member,
+            quote_hash,
+            mrtd,
+            rtmr0,
+            rtmr1,
+            rtmr2,
+            rtmr3,
+            tcb_status,
+            role,
+        } => {
+            let _: &AccountId = member;
+            let _: &[u8; 32] = quote_hash;
+            let _: &String = mrtd;
+            let _: &String = rtmr0;
+            let _: &String = rtmr1;
+            let _: &String = rtmr2;
+            let _: &String = rtmr3;
+            let _: &String = tcb_status;
+            let _: &GroupMemberRole = role;
+            "MemberJoinedViaTeeAttestation"
+        }
+        GroupOp::MemberSetAutoFollow {
+            target,
+            auto_follow_contexts,
+            auto_follow_subgroups,
+        } => {
+            let _: &AccountId = target;
+            let _: &bool = auto_follow_contexts;
+            let _: &bool = auto_follow_subgroups;
+            "MemberSetAutoFollow"
+        }
+        GroupOp::TransferOwnership { new_owner } => {
+            let _: &AccountId = new_owner;
+            "TransferOwnership"
+        }
+        GroupOp::CascadeUpgrade {
+            from_bytecode_id,
+            bytecode_id,
+            target_application_id,
+            to_state_version,
+            migration,
+            cascade_hlc,
+        } => {
+            let _: &BytecodeId = from_bytecode_id;
+            let _: &BytecodeId = bytecode_id;
+            let _: &ApplicationId = target_application_id;
+            let _: &u32 = to_state_version;
+            let _: &Option<Vec<u8>> = migration;
+            let _: &HybridTimestamp = cascade_hlc;
+            "CascadeUpgrade"
+        }
+        GroupOp::GroupKeyRotated { departed } => {
+            let _: &AccountId = departed;
+            "GroupKeyRotated"
+        }
+        GroupOp::AccountDeviceLinked {
+            genesis,
+            chain,
+            cert,
+            endorsement,
+        } => {
+            let _: &AccountGenesis = genesis;
+            let _: &Vec<RootKeyHandoff> = chain;
+            let _: &DeviceCert = cert;
+            let _: &AccountMemberEndorsement = endorsement;
+            "AccountDeviceLinked"
+        }
+        GroupOp::AccountDeviceUnlinked {
+            account,
+            device,
+            proof,
+        } => {
+            let _: &AccountId = account;
+            let _: &DeviceId = device;
+            let _: &Option<SignedDeviceRevocation> = proof;
+            "AccountDeviceUnlinked"
+        }
+        GroupOp::AccountKeysRotated { handoff } => {
+            let _: &RootKeyHandoff = handoff;
+            "AccountKeysRotated"
+        }
+        GroupOp::GroupKeyRotatedForDevice { device } => {
+            let _: &DeviceId = device;
+            "GroupKeyRotatedForDevice"
+        }
+    }
+}
+
+fn root_op_variant_name(op: &RootOp) -> &'static str {
+    match op {
+        RootOp::GroupCreated {
+            group_id,
+            parent_id,
+            restricted,
+            admin,
+        } => {
+            let _: &ContextGroupId = group_id;
+            let _: &ContextGroupId = parent_id;
+            let _: &bool = restricted;
+            let _: &AccountId = admin;
+            "GroupCreated"
+        }
+        RootOp::GroupReparented {
+            child_group_id,
+            new_parent_id,
+        } => {
+            let _: &ContextGroupId = child_group_id;
+            let _: &ContextGroupId = new_parent_id;
+            "GroupReparented"
+        }
+        RootOp::GroupDeleted {
+            root_group_id,
+            cascade_group_ids,
+            cascade_context_ids,
+        } => {
+            let _: &ContextGroupId = root_group_id;
+            let _: &Vec<ContextGroupId> = cascade_group_ids;
+            let _: &Vec<ContextId> = cascade_context_ids;
+            "GroupDeleted"
+        }
+        RootOp::AdminChanged { new_admin } => {
+            let _: &AccountId = new_admin;
+            "AdminChanged"
+        }
+        RootOp::PolicyUpdated { policy_bytes } => {
+            let _: &Vec<u8> = policy_bytes;
+            "PolicyUpdated"
+        }
+        RootOp::MemberJoined {
+            member,
+            signed_invitation,
+            account,
+        } => {
+            let _: &AccountId = member;
+            let _: &SignedGroupOpenInvitation = signed_invitation;
+            let _: &Box<JoinAccountCredential> = account;
+            "MemberJoined"
+        }
+        RootOp::KeyDelivery { group_id, envelope } => {
+            let _: &ContextGroupId = group_id;
+            let _: &KeyEnvelope = envelope;
+            "KeyDelivery"
+        }
+        RootOp::MemberJoinedOpen {
+            member,
+            group_id,
+            account,
+        } => {
+            let _: &AccountId = member;
+            let _: &ContextGroupId = group_id;
+            let _: &Box<JoinAccountCredential> = account;
+            "MemberJoinedOpen"
+        }
+        RootOp::MemberJoinedAt {
+            member,
+            signed_invitation,
+            joined_at,
+            account,
+        } => {
+            let _: &AccountId = member;
+            let _: &SignedGroupOpenInvitation = signed_invitation;
+            let _: &u64 = joined_at;
+            let _: &Box<JoinAccountCredential> = account;
+            "MemberJoinedAt"
+        }
+        RootOp::NamespaceCreated { founder, account } => {
+            let _: &AccountId = founder;
+            let _: &Box<JoinAccountCredential> = account;
+            "NamespaceCreated"
+        }
+        RootOp::MemberJoinedViaTeeAttestation {
+            group_id,
+            member,
+            quote_hash,
+            mrtd,
+            rtmr0,
+            rtmr1,
+            rtmr2,
+            rtmr3,
+            tcb_status,
+            role,
+            account,
+        } => {
+            let _: &ContextGroupId = group_id;
+            let _: &PublicKey = member;
+            let _: &[u8; 32] = quote_hash;
+            let _: &String = mrtd;
+            let _: &String = rtmr0;
+            let _: &String = rtmr1;
+            let _: &String = rtmr2;
+            let _: &String = rtmr3;
+            let _: &String = tcb_status;
+            let _: &GroupMemberRole = role;
+            let _: &Box<JoinAccountCredential> = account;
+            "MemberJoinedViaTeeAttestation"
+        }
+    }
+}
+
+fn namespace_op_variant_name(op: &NamespaceOp) -> &'static str {
+    match op {
+        NamespaceOp::Root(f0) => {
+            let _: &RootOp = f0;
+            "Root"
+        }
+        NamespaceOp::Group {
+            group_id,
+            key_id,
+            encrypted,
+            key_rotation,
+        } => {
+            let _: &ContextGroupId = group_id;
+            let _: &KeyId = key_id;
+            let _: &EncryptedGroupOp = encrypted;
+            let _: &Option<KeyRotation> = key_rotation;
+            "Group"
+        }
+    }
+}
+
+fn envelope_recipient_variant_name(op: &EnvelopeRecipient) -> &'static str {
+    match op {
+        EnvelopeRecipient::Member {
+            identity,
+            ephemeral_pk,
+        } => {
+            let _: &PublicKey = identity;
+            let _: &PublicKey = ephemeral_pk;
+            "Member"
+        }
+        EnvelopeRecipient::Device {
+            device,
+            ephemeral_pk,
+        } => {
+            let _: &DeviceId = device;
+            let _: &KemPublicKey = ephemeral_pk;
+            "Device"
+        }
+    }
+}
+
+#[expect(
+    dead_code,
+    reason = "compile-time anchor: StoredNamespaceEntry is storage-side and has \
+              no golden corpus to call this from, but the exhaustive match must \
+              still fail to compile when a variant is added"
+)]
+fn stored_entry_variant_name(op: &StoredNamespaceEntry) -> &'static str {
+    match op {
+        StoredNamespaceEntry::Signed(f0) => {
+            let _: &SignedNamespaceOp = f0;
+            "Signed"
+        }
+        StoredNamespaceEntry::Opaque(f0) => {
+            let _: &OpaqueSkeleton = f0;
+            "Opaque"
+        }
+    }
+}
+
+/// Struct field lists, destructured WITHOUT `..` so a new field is a compile
+/// error rather than a silently undescribed trailing field.
+#[expect(
+    dead_code,
+    reason = "compile-time anchor: exists to be type-checked, never called"
+)]
+fn struct_fields_are_described(
+    signable_group: &SignableGroupOp,
+    signed_group: &SignedGroupOp,
+    signable_ns: &SignableNamespaceOp,
+    signed_ns: &SignedNamespaceOp,
+    encrypted: &EncryptedGroupOp,
+    envelope: &KeyEnvelope,
+    rotation: &KeyRotation,
+    skeleton: &OpaqueSkeleton,
+) {
+    let SignableGroupOp {
+        version,
+        group_id,
+        parent_op_hashes,
+        signer,
+        nonce,
+        op,
+    } = signable_group;
+    let _: &u8 = version;
+    let _: &ContextGroupId = group_id;
+    let _: &Vec<[u8; 32]> = parent_op_hashes;
+    let _: &PublicKey = signer;
+    let _: &u64 = nonce;
+    let _: &GroupOp = op;
+    let SignedGroupOp {
+        version,
+        group_id,
+        parent_op_hashes,
+        signer,
+        nonce,
+        op,
+        signature,
+    } = signed_group;
+    let _: &u8 = version;
+    let _: &ContextGroupId = group_id;
+    let _: &Vec<[u8; 32]> = parent_op_hashes;
+    let _: &PublicKey = signer;
+    let _: &u64 = nonce;
+    let _: &GroupOp = op;
+    let _: &[u8; 64] = signature;
+    let SignableNamespaceOp {
+        version,
+        namespace_id,
+        parent_op_hashes,
+        signer,
+        nonce,
+        op,
+    } = signable_ns;
+    let _: &u8 = version;
+    let _: &NamespaceId = namespace_id;
+    let _: &Vec<[u8; 32]> = parent_op_hashes;
+    let _: &PublicKey = signer;
+    let _: &u64 = nonce;
+    let _: &NamespaceOp = op;
+    let SignedNamespaceOp {
+        version,
+        namespace_id,
+        parent_op_hashes,
+        signer,
+        nonce,
+        op,
+        signature,
+    } = signed_ns;
+    let _: &u8 = version;
+    let _: &NamespaceId = namespace_id;
+    let _: &Vec<[u8; 32]> = parent_op_hashes;
+    let _: &PublicKey = signer;
+    let _: &u64 = nonce;
+    let _: &NamespaceOp = op;
+    let _: &[u8; 64] = signature;
+    let EncryptedGroupOp { nonce, ciphertext } = encrypted;
+    let _: &[u8; 12] = nonce;
+    let _: &Vec<u8> = ciphertext;
+    let KeyEnvelope {
+        recipient,
+        sender,
+        nonce,
+        ciphertext,
+        signature,
+    } = envelope;
+    let _: &EnvelopeRecipient = recipient;
+    let _: &PublicKey = sender;
+    let _: &[u8; 12] = nonce;
+    let _: &Vec<u8> = ciphertext;
+    let _: &[u8; 64] = signature;
+    let KeyRotation {
+        new_key_id,
+        envelopes,
+    } = rotation;
+    let _: &KeyId = new_key_id;
+    let _: &Vec<KeyEnvelope> = envelopes;
+    let OpaqueSkeleton {
+        delta_id,
+        parent_op_hashes,
+        group_id,
+        signer,
+    } = skeleton;
+    let _: &[u8; 32] = delta_id;
+    let _: &Vec<[u8; 32]> = parent_op_hashes;
+    let _: &ContextGroupId = group_id;
+    let _: &PublicKey = signer;
+}
+
+// ---------------------------------------------------------------------------
+// Leaves: types this crate embeds but does not own.
+//
+// The descriptor stops at this crate's boundary on purpose (covering the whole
+// crate graph would make every unrelated refactor a wire review). Instead each
+// foreign type is held still by the bytes a canonical all-zero instance
+// encodes to — a field added to `DeviceCert` moves its leaf line without this
+// file knowing anything about `DeviceCert`.
+// ---------------------------------------------------------------------------
+
+fn zero_pk() -> PublicKey {
+    PublicKey::from([0u8; 32])
+}
+const ZERO_ACCOUNT: AccountId = AccountId::from_raw([0u8; 32]);
+const ZERO_DEVICE: DeviceId = DeviceId::from_raw([0u8; 32]);
+
+fn zero_genesis() -> AccountGenesis {
+    AccountGenesis::new(zero_pk())
+}
+
+fn zero_cert() -> DeviceCert {
+    DeviceCert {
+        account: ZERO_ACCOUNT,
+        device: ZERO_DEVICE,
+        sign_pk: zero_pk(),
+        kem_pk: KemPublicKey::from([0u8; 32]),
+        key_epoch: 0,
+        device_epoch: 0,
+        signature: [0u8; 64],
+    }
+}
+
+fn zero_handoff() -> RootKeyHandoff {
+    RootKeyHandoff {
+        account: ZERO_ACCOUNT,
+        from_epoch: 0,
+        new_root_sign_pk: zero_pk(),
+        signature: [0u8; 64],
+    }
+}
+
+fn zero_revocation() -> DeviceRevocation {
+    DeviceRevocation {
+        account: ZERO_ACCOUNT,
+        device: ZERO_DEVICE,
+        key_epoch: 0,
+        signature: [0u8; 64],
+    }
+}
+
+fn zero_invitation() -> SignedGroupOpenInvitation {
+    SignedGroupOpenInvitation {
+        invitation: GroupInvitationFromAdmin {
+            inviter_identity: (*zero_pk()).into(),
+            group_id: ContextGroupId::from([0u8; 32]),
+            expiration_timestamp: 0_u64.into(),
+            invitation_nonce: [0u8; 32],
+            invited_role: 1,
+        },
+        inviter_signature: String::new(),
+        inviter_account: None,
+        application_id: None,
+        bytecode_id: None,
+    }
+}
+
+fn leaf<T: borsh::BorshSerialize>(name: &'static str, value: &T) -> Leaf {
+    Leaf {
+        name,
+        bytes: borsh::to_vec(value).expect("borsh-encode a canonical leaf instance"),
+    }
+}
+
+fn described_leaves() -> Vec<Leaf> {
+    vec![
+        leaf("AccountGenesis", &zero_genesis()),
+        leaf(
+            "AccountMemberEndorsement",
+            &AccountMemberEndorsement {
+                account: ZERO_ACCOUNT,
+                member: zero_pk(),
+                signature: [0u8; 64],
+            },
+        ),
+        leaf("DeviceCert", &zero_cert()),
+        leaf("RootKeyHandoff", &zero_handoff()),
+        leaf("DeviceRevocation", &zero_revocation()),
+        leaf(
+            "JoinAccountCredential",
+            &AccountProof {
+                genesis: zero_genesis(),
+                chain: vec![],
+                statement: zero_cert(),
+            },
+        ),
+        leaf(
+            "SignedDeviceRevocation",
+            &AccountProof {
+                genesis: zero_genesis(),
+                chain: vec![],
+                statement: zero_revocation(),
+            },
+        ),
+        leaf("SignedGroupOpenInvitation", &zero_invitation()),
+        leaf("HybridTimestamp::zero", &HybridTimestamp::zero()),
+        leaf("MemberCapabilities::empty", &MemberCapabilities::empty()),
+        // Role and visibility are enums whose tags decide AUTHORITY, so every
+        // variant is pinned individually rather than by one representative.
+        leaf("GroupMemberRole::Admin", &GroupMemberRole::Admin),
+        leaf("GroupMemberRole::Member", &GroupMemberRole::Member),
+        leaf("GroupMemberRole::ReadOnly", &GroupMemberRole::ReadOnly),
+        leaf(
+            "GroupMemberRole::ReadOnlyTee",
+            &GroupMemberRole::ReadOnlyTee,
+        ),
+        leaf("VisibilityMode::Open", &VisibilityMode::Open),
+        leaf("VisibilityMode::Restricted", &VisibilityMode::Restricted),
+        // The 32-byte id newtypes: transparent today, and this is what says so.
+        leaf("AccountId", &ZERO_ACCOUNT),
+        leaf("DeviceId", &ZERO_DEVICE),
+        leaf("PublicKey", &zero_pk()),
+        leaf("KemPublicKey", &KemPublicKey::from([0u8; 32])),
+        leaf("ContextId", &ContextId::from([0u8; 32])),
+        leaf("ContextGroupId", &ContextGroupId::from([0u8; 32])),
+        leaf("BytecodeId", &BytecodeId::from([0u8; 32])),
+        leaf("ApplicationId", &ApplicationId::from([0u8; 32])),
+        leaf("BlobId", &BlobId::from([0u8; 32])),
+        leaf("NamespaceId", &NamespaceId::new([0u8; 32])),
+        leaf("KeyId", &KeyId::new([0u8; 32])),
+    ]
+}
+
+fn surface() -> Surface {
+    Surface {
+        label: "calimero-governance-types",
+        types: described_types(),
+        leaves: described_leaves(),
+    }
+}
+
+fn snapshot_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("wire-fingerprint.txt")
+}
+
+#[test]
+fn wire_fingerprint_matches_snapshot() {
+    assert_snapshot(&surface(), &snapshot_path());
+}
+
+// ---------------------------------------------------------------------------
+// Descriptor <-> reality.
+// ---------------------------------------------------------------------------
+
+/// The golden corpus, keyed by the ordinal each vector claims.
+///
+/// This is the registry the exhaustiveness test iterates: a variant with no
+/// entry here has no frozen bytes, and the test says so by name.
+const GROUP_OP_GOLDENS: &[(u8, &[u8])] = &[
+    (0, super::GOLDEN_GROUP_OP_NOOP),
+    (1, super::GOLDEN_GROUP_OP_MEMBER_ADDED),
+    (2, super::GOLDEN_GROUP_OP_MEMBER_REMOVED),
+    (3, super::GOLDEN_GROUP_OP_MEMBER_LEFT),
+    (4, super::GOLDEN_GROUP_OP_MEMBER_ROLE_SET),
+    (5, super::GOLDEN_GROUP_OP_MEMBER_CAPABILITY_SET),
+    (6, super::GOLDEN_GROUP_OP_DEFAULT_CAPABILITIES_SET),
+    (7, super::GOLDEN_GROUP_OP_TARGET_APPLICATION_SET),
+    (8, super::GOLDEN_GROUP_OP_CONTEXT_REGISTERED),
+    (9, super::GOLDEN_GROUP_OP_CONTEXT_DETACHED),
+    (10, super::GOLDEN_GROUP_OP_SUBGROUP_VISIBILITY_SET),
+    (11, super::GOLDEN_GROUP_OP_GROUP_METADATA_SET),
+    (12, super::GOLDEN_GROUP_OP_MEMBER_METADATA_SET),
+    (13, super::GOLDEN_GROUP_OP_CONTEXT_METADATA_SET),
+    (14, super::GOLDEN_GROUP_OP_GROUP_DELETE),
+    (15, super::GOLDEN_GROUP_OP_GROUP_MIGRATION_SET),
+    (16, super::GOLDEN_GROUP_OP_CONTEXT_CAPABILITY_GRANTED),
+    (17, super::GOLDEN_GROUP_OP_CONTEXT_CAPABILITY_REVOKED),
+    (18, super::GOLDEN_GROUP_OP_TEE_ADMISSION_POLICY_SET),
+    (19, super::GOLDEN_GROUP_OP_MEMBER_JOINED_VIA_TEE),
+    (20, super::GOLDEN_GROUP_OP_MEMBER_SET_AUTO_FOLLOW),
+    (21, super::GOLDEN_GROUP_OP_TRANSFER_OWNERSHIP),
+    (22, super::GOLDEN_GROUP_OP_CASCADE_UPGRADE),
+    (23, super::GOLDEN_GROUP_OP_GROUP_KEY_ROTATED),
+    (24, super::GOLDEN_GROUP_OP_ACCOUNT_DEVICE_LINKED),
+    (25, super::GOLDEN_GROUP_OP_ACCOUNT_DEVICE_UNLINKED),
+    (26, super::GOLDEN_GROUP_OP_ACCOUNT_KEYS_ROTATED),
+    (27, super::GOLDEN_GROUP_OP_GROUP_KEY_ROTATED_FOR_DEVICE),
+];
+
+/// `RootOp` goldens are `NamespaceOp`-wrapped (byte 0 is the `NamespaceOp`
+/// tag, byte 1 the `RootOp` tag) — see the header of `tests.rs`.
+const ROOT_OP_GOLDENS: &[(u8, &[u8])] = &[
+    (0, super::GOLDEN_ROOT_OP_GROUP_CREATED),
+    (1, super::GOLDEN_ROOT_OP_GROUP_REPARENTED),
+    (2, super::GOLDEN_ROOT_OP_GROUP_DELETED),
+    (3, super::GOLDEN_ROOT_OP_ADMIN_CHANGED),
+    (4, super::GOLDEN_ROOT_OP_POLICY_UPDATED),
+    (5, super::GOLDEN_ROOT_OP_MEMBER_JOINED),
+    (6, super::GOLDEN_ROOT_OP_KEY_DELIVERY),
+    (7, super::GOLDEN_ROOT_OP_MEMBER_JOINED_OPEN),
+    (8, super::GOLDEN_ROOT_OP_MEMBER_JOINED_AT),
+    (9, super::GOLDEN_ROOT_OP_NAMESPACE_CREATED),
+    (10, super::GOLDEN_ROOT_OP_MEMBER_JOINED_VIA_TEE),
+];
+
+const NAMESPACE_OP_GOLDENS: &[(u8, &[u8])] = &[
+    (0, super::GOLDEN_ROOT_OP_GROUP_CREATED),
+    (1, super::GOLDEN_NAMESPACE_OP_GROUP),
+];
+
+fn variants_of(ty: &TypeDesc) -> &'static [Variant] {
+    match ty.shape {
+        Shape::Enum(v) => v,
+        Shape::Struct(_) => panic!("{} is not an enum", ty.name),
+    }
+}
+
+/// Every described variant must have frozen bytes that decode to exactly that
+/// variant, at exactly that ordinal.
+///
+/// This is the join between the two halves of the gate: the descriptor says
+/// "ordinal 7 is TargetApplicationSet", the golden says "these bytes start
+/// with 7", and the enum says "these bytes are a TargetApplicationSet". Break
+/// any one of the three and this test names it.
+#[test]
+fn every_described_variant_has_a_golden_that_decodes_to_it() {
+    let mut failures: Vec<String> = Vec::new();
+
+    for v in variants_of(&GROUP_OP) {
+        let Some((_, bytes)) = GROUP_OP_GOLDENS.iter().find(|(o, _)| *o == v.ordinal) else {
+            failures.push(format!(
+                "GroupOp::{} (ordinal {}) has no frozen bytes — add a \
+                 GOLDEN_GROUP_OP_* vector and register it in GROUP_OP_GOLDENS",
+                v.name, v.ordinal
+            ));
+            continue;
+        };
+        match borsh::from_slice::<GroupOp>(bytes) {
+            Err(e) => failures.push(format!("GroupOp ordinal {}: decode failed: {e}", v.ordinal)),
+            Ok(op) => {
+                let got = group_op_variant_name(&op);
+                if got != v.name {
+                    failures.push(format!(
+                        "GroupOp ordinal {}: descriptor says {}, bytes decoded as {got}",
+                        v.ordinal, v.name
+                    ));
+                }
+                if bytes[0] != v.ordinal {
+                    failures.push(format!(
+                        "GroupOp::{}: descriptor ordinal {} but golden's tag byte is {}",
+                        v.name, v.ordinal, bytes[0]
+                    ));
+                }
+            }
+        }
+    }
+
+    for v in variants_of(&ROOT_OP) {
+        let Some((_, bytes)) = ROOT_OP_GOLDENS.iter().find(|(o, _)| *o == v.ordinal) else {
+            failures.push(format!(
+                "RootOp::{} (ordinal {}) has no frozen bytes — add a \
+                 GOLDEN_ROOT_OP_* vector and register it in ROOT_OP_GOLDENS",
+                v.name, v.ordinal
+            ));
+            continue;
+        };
+        match borsh::from_slice::<NamespaceOp>(bytes) {
+            Err(e) => failures.push(format!("RootOp ordinal {}: decode failed: {e}", v.ordinal)),
+            Ok(NamespaceOp::Group { .. }) => failures.push(format!(
+                "RootOp ordinal {}: golden is not NamespaceOp::Root-wrapped",
+                v.ordinal
+            )),
+            Ok(NamespaceOp::Root(root)) => {
+                let got = root_op_variant_name(&root);
+                if got != v.name {
+                    failures.push(format!(
+                        "RootOp ordinal {}: descriptor says {}, bytes decoded as {got}",
+                        v.ordinal, v.name
+                    ));
+                }
+                if bytes[1] != v.ordinal {
+                    failures.push(format!(
+                        "RootOp::{}: descriptor ordinal {} but golden's tag byte is {}",
+                        v.name, v.ordinal, bytes[1]
+                    ));
+                }
+            }
+        }
+    }
+
+    for v in variants_of(&NAMESPACE_OP) {
+        let Some((_, bytes)) = NAMESPACE_OP_GOLDENS.iter().find(|(o, _)| *o == v.ordinal) else {
+            failures.push(format!(
+                "NamespaceOp::{} (ordinal {}) has no frozen bytes",
+                v.name, v.ordinal
+            ));
+            continue;
+        };
+        match borsh::from_slice::<NamespaceOp>(bytes) {
+            Err(e) => failures.push(format!(
+                "NamespaceOp ordinal {}: decode failed: {e}",
+                v.ordinal
+            )),
+            Ok(op) => {
+                let got = namespace_op_variant_name(&op);
+                if got != v.name {
+                    failures.push(format!(
+                        "NamespaceOp ordinal {}: descriptor says {}, bytes decoded as {got}",
+                        v.ordinal, v.name
+                    ));
+                }
+            }
+        }
+    }
+
+    // `EnvelopeRecipient` rides inside a `KeyDelivery`, so its two goldens are
+    // the two KeyDelivery vectors that differ only in the addressing tag.
+    for (bytes, expected) in [
+        (super::GOLDEN_ROOT_OP_KEY_DELIVERY, "Member"),
+        (super::GOLDEN_ROOT_OP_KEY_DELIVERY_TO_DEVICE, "Device"),
+    ] {
+        match borsh::from_slice::<NamespaceOp>(bytes) {
+            Ok(NamespaceOp::Root(RootOp::KeyDelivery { envelope, .. })) => {
+                let got = envelope_recipient_variant_name(&envelope.recipient);
+                if got != expected {
+                    failures.push(format!(
+                        "EnvelopeRecipient: expected {expected}, decoded {got}"
+                    ));
+                }
+            }
+            other => failures.push(format!(
+                "EnvelopeRecipient golden is not a KeyDelivery: {other:?}"
+            )),
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "descriptor/golden mismatches ({}):\n{}\n\n\
+         Every variant on the replicated wire needs frozen bytes: a same-binary \
+         round-trip cannot catch a renumbered discriminant, because encoder and \
+         decoder shift together.",
+        failures.len(),
+        failures.join("\n")
+    );
+}
+
+/// There must be no variant AFTER the last described one.
+///
+/// Without this, appending a variant and forgetting the descriptor would be
+/// invisible: every described ordinal still checks out, and the new one is
+/// simply never looked at. Decoding a one-byte buffer whose only content is
+/// the tag distinguishes the three cases cleanly:
+///
+/// * unknown tag        -> `InvalidData` ("Unexpected variant tag") — correct;
+/// * known tag, fields  -> `UnexpectedEof` (it wanted more bytes) — undescribed;
+/// * known tag, unit    -> `Ok` — undescribed.
+#[test]
+fn no_variant_exists_past_the_described_end() {
+    fn assert_absent(what: &str, prefix: &[u8], next_ordinal: u8, decode: fn(&[u8]) -> ErrorKind) {
+        let mut buf = prefix.to_vec();
+        buf.push(next_ordinal);
+        assert_eq!(
+            decode(&buf),
+            ErrorKind::InvalidData,
+            "{what} ordinal {next_ordinal} decodes to something — a variant was \
+             appended without adding it to the descriptor in this file (and \
+             without frozen bytes). Append it to the descriptor, add a golden, \
+             then regenerate the snapshot."
+        );
+    }
+
+    fn group_kind(b: &[u8]) -> ErrorKind {
+        borsh::from_slice::<GroupOp>(b).map_or_else(|e| e.kind(), |_| ErrorKind::Other)
+    }
+    fn ns_kind(b: &[u8]) -> ErrorKind {
+        borsh::from_slice::<NamespaceOp>(b).map_or_else(|e| e.kind(), |_| ErrorKind::Other)
+    }
+
+    let group_variants = variants_of(&GROUP_OP);
+    let next = u8::try_from(group_variants.len()).expect("fewer than 256 variants");
+    assert_absent("GroupOp", &[], next, group_kind);
+
+    let root_variants = variants_of(&ROOT_OP);
+    let next = u8::try_from(root_variants.len()).expect("fewer than 256 variants");
+    assert_absent("RootOp", &[0], next, ns_kind);
+
+    let ns_variants = variants_of(&NAMESPACE_OP);
+    let next = u8::try_from(ns_variants.len()).expect("fewer than 256 variants");
+    assert_absent("NamespaceOp", &[], next, ns_kind);
+}
+
+/// `StoredNamespaceEntry` is storage-side rather than gossip-side, so it has
+/// no golden corpus; the descriptor is still anchored by its exhaustive match
+/// above and by this ordinal-boundary check.
+#[test]
+fn stored_namespace_entry_has_no_variant_past_the_described_end() {
+    let variants = variants_of(&STORED_NAMESPACE_ENTRY);
+    let next = u8::try_from(variants.len()).expect("fewer than 256 variants");
+    let err = borsh::from_slice::<StoredNamespaceEntry>(&[next]).expect_err("no such variant");
+    assert_eq!(err.kind(), ErrorKind::InvalidData);
+}

--- a/crates/governance-types/wire-fingerprint.txt
+++ b/crates/governance-types/wire-fingerprint.txt
@@ -1,0 +1,156 @@
+# Calimero replicated wire surface — GENERATED, DO NOT EDIT BY HAND.
+#
+# Regenerate with UPDATE_WIRE_FINGERPRINT=1 and the crate's test command; the
+# failing assertion prints the exact one.
+#
+# APPENDING a variant at the END of an enum is wire-COMPATIBLE: an old node
+# fails to decode the new tag and rejects the op, but every op it already
+# understands still decodes identically.
+#
+# INSERTING, REMOVING, REORDERING or RETYPING anything below is a HARD BREAK:
+# borsh discriminants are bare positional u8s, so every later variant silently
+# renumbers and an old peer decodes the WRONG variant rather than erroring.
+# That is the rc.7/rc.8 NamespaceGovOpValue incident — a fleet that reported
+# 'joined' while replicating nothing. If you must do it, bump the schema
+# version constant in the same commit and plan a coordinated rollout.
+fingerprint blake3=c1d66b7a7bcece0f
+
+surface calimero-governance-types
+
+enum NamespaceOp
+  0 Root(0: RootOp)
+  1 Group(group_id: ContextGroupId, key_id: KeyId, encrypted: EncryptedGroupOp, key_rotation: Option<KeyRotation>)
+
+enum RootOp
+  0 GroupCreated(group_id: ContextGroupId, parent_id: ContextGroupId, restricted: bool, admin: AccountId)
+  1 GroupReparented(child_group_id: ContextGroupId, new_parent_id: ContextGroupId)
+  2 GroupDeleted(root_group_id: ContextGroupId, cascade_group_ids: Vec<ContextGroupId>, cascade_context_ids: Vec<ContextId>)
+  3 AdminChanged(new_admin: AccountId)
+  4 PolicyUpdated(policy_bytes: Vec<u8>)
+  5 MemberJoined(member: AccountId, signed_invitation: SignedGroupOpenInvitation, account: Box<JoinAccountCredential>)
+  6 KeyDelivery(group_id: ContextGroupId, envelope: KeyEnvelope)
+  7 MemberJoinedOpen(member: AccountId, group_id: ContextGroupId, account: Box<JoinAccountCredential>)
+  8 MemberJoinedAt(member: AccountId, signed_invitation: SignedGroupOpenInvitation, joined_at: u64, account: Box<JoinAccountCredential>)
+  9 NamespaceCreated(founder: AccountId, account: Box<JoinAccountCredential>)
+  10 MemberJoinedViaTeeAttestation(group_id: ContextGroupId, member: PublicKey, quote_hash: [u8; 32], mrtd: String, rtmr0: String, rtmr1: String, rtmr2: String, rtmr3: String, tcb_status: String, role: GroupMemberRole, account: Box<JoinAccountCredential>)
+
+enum GroupOp
+  0 Noop
+  1 MemberAdded(member: AccountId, role: GroupMemberRole)
+  2 MemberRemoved(member: AccountId, expected_group_state_hash: [u8; 32], expected_context_state_hashes: Vec<(ContextId, [u8; 32])>)
+  3 MemberLeft(member: AccountId, expected_group_state_hash: [u8; 32], expected_context_state_hashes: Vec<(ContextId, [u8; 32])>)
+  4 MemberRoleSet(member: AccountId, role: GroupMemberRole)
+  5 MemberCapabilitySet(member: AccountId, capabilities: MemberCapabilities)
+  6 DefaultCapabilitiesSet(capabilities: MemberCapabilities)
+  7 TargetApplicationSet(bytecode_id: BytecodeId, target_application_id: ApplicationId)
+  8 ContextRegistered(context_id: ContextId, application_id: ApplicationId, blob_id: BlobId, source: String, service_name: Option<String>)
+  9 ContextDetached(context_id: ContextId)
+  10 SubgroupVisibilitySet(mode: VisibilityMode)
+  11 GroupMetadataSet(name: Option<String>, data: BTreeMap<String, String>)
+  12 MemberMetadataSet(member: AccountId, name: Option<String>, data: BTreeMap<String, String>)
+  13 ContextMetadataSet(context_id: ContextId, name: Option<String>, data: BTreeMap<String, String>)
+  14 GroupDelete
+  15 GroupMigrationSet(migration: Option<Vec<u8>>)
+  16 ContextCapabilityGranted(context_id: ContextId, member: AccountId, capability: ContextCapabilityBits)
+  17 ContextCapabilityRevoked(context_id: ContextId, member: AccountId, capability: ContextCapabilityBits)
+  18 TeeAdmissionPolicySet(allowed_mrtd: Vec<String>, allowed_rtmr0: Vec<String>, allowed_rtmr1: Vec<String>, allowed_rtmr2: Vec<String>, allowed_rtmr3: Vec<String>, allowed_tcb_statuses: Vec<String>, accept_mock: bool)
+  19 MemberJoinedViaTeeAttestation(member: AccountId, quote_hash: [u8; 32], mrtd: String, rtmr0: String, rtmr1: String, rtmr2: String, rtmr3: String, tcb_status: String, role: GroupMemberRole)
+  20 MemberSetAutoFollow(target: AccountId, auto_follow_contexts: bool, auto_follow_subgroups: bool)
+  21 TransferOwnership(new_owner: AccountId)
+  22 CascadeUpgrade(from_bytecode_id: BytecodeId, bytecode_id: BytecodeId, target_application_id: ApplicationId, to_state_version: u32, migration: Option<Vec<u8>>, cascade_hlc: HybridTimestamp)
+  23 GroupKeyRotated(departed: AccountId)
+  24 AccountDeviceLinked(genesis: AccountGenesis, chain: Vec<RootKeyHandoff>, cert: DeviceCert, endorsement: AccountMemberEndorsement)
+  25 AccountDeviceUnlinked(account: AccountId, device: DeviceId, proof: Option<SignedDeviceRevocation>)
+  26 AccountKeysRotated(handoff: RootKeyHandoff)
+  27 GroupKeyRotatedForDevice(device: DeviceId)
+
+enum EnvelopeRecipient
+  0 Member(identity: PublicKey, ephemeral_pk: PublicKey)
+  1 Device(device: DeviceId, ephemeral_pk: KemPublicKey)
+
+enum StoredNamespaceEntry
+  0 Signed(0: SignedNamespaceOp)
+  1 Opaque(0: OpaqueSkeleton)
+
+struct SignableGroupOp
+  0 version: u8
+  1 group_id: ContextGroupId
+  2 parent_op_hashes: Vec<[u8; 32]>
+  3 signer: PublicKey
+  4 nonce: u64
+  5 op: GroupOp
+
+struct SignedGroupOp
+  0 version: u8
+  1 group_id: ContextGroupId
+  2 parent_op_hashes: Vec<[u8; 32]>
+  3 signer: PublicKey
+  4 nonce: u64
+  5 op: GroupOp
+  6 signature: [u8; 64]
+
+struct SignableNamespaceOp
+  0 version: u8
+  1 namespace_id: NamespaceId
+  2 parent_op_hashes: Vec<[u8; 32]>
+  3 signer: PublicKey
+  4 nonce: u64
+  5 op: NamespaceOp
+
+struct SignedNamespaceOp
+  0 version: u8
+  1 namespace_id: NamespaceId
+  2 parent_op_hashes: Vec<[u8; 32]>
+  3 signer: PublicKey
+  4 nonce: u64
+  5 op: NamespaceOp
+  6 signature: [u8; 64]
+
+struct EncryptedGroupOp
+  0 nonce: [u8; 12]
+  1 ciphertext: Vec<u8>
+
+struct KeyEnvelope
+  0 recipient: EnvelopeRecipient
+  1 sender: PublicKey
+  2 nonce: [u8; 12]
+  3 ciphertext: Vec<u8>
+  4 signature: [u8; 64]
+
+struct KeyRotation
+  0 new_key_id: KeyId
+  1 envelopes: Vec<KeyEnvelope>
+
+struct OpaqueSkeleton
+  0 delta_id: [u8; 32]
+  1 parent_op_hashes: Vec<[u8; 32]>
+  2 group_id: ContextGroupId
+  3 signer: PublicKey
+
+leaf AccountGenesis len=33 blake3=79efc4eb5e34fb06
+leaf AccountMemberEndorsement len=128 blake3=272fc82430c30a4f
+leaf DeviceCert len=200 blake3=bb7c84c0d6cc4368
+leaf RootKeyHandoff len=132 blake3=ff46c07437cfbd6e
+leaf DeviceRevocation len=132 blake3=ff46c07437cfbd6e
+leaf JoinAccountCredential len=237 blake3=039d086a90863034
+leaf SignedDeviceRevocation len=169 blake3=7f5fcb6788d30126
+leaf SignedGroupOpenInvitation len=112 blake3=5318e0796f6dd682
+leaf HybridTimestamp::zero len=24 blake3=ffc587cc36ab1393
+leaf MemberCapabilities::empty len=4 blake3=ec2bd03bf86b935f
+leaf GroupMemberRole::Admin len=1 blake3=2d3adedff11b61f1
+leaf GroupMemberRole::Member len=1 blake3=48fc721fbbc172e0
+leaf GroupMemberRole::ReadOnly len=1 blake3=ab13bedf42e84bae
+leaf GroupMemberRole::ReadOnlyTee len=1 blake3=e1e0e81d6ea39b0c
+leaf VisibilityMode::Open len=1 blake3=2d3adedff11b61f1
+leaf VisibilityMode::Restricted len=1 blake3=48fc721fbbc172e0
+leaf AccountId len=32 blake3=2ada83c1819a5372
+leaf DeviceId len=32 blake3=2ada83c1819a5372
+leaf PublicKey len=32 blake3=2ada83c1819a5372
+leaf KemPublicKey len=32 blake3=2ada83c1819a5372
+leaf ContextId len=32 blake3=2ada83c1819a5372
+leaf ContextGroupId len=32 blake3=2ada83c1819a5372
+leaf BytecodeId len=32 blake3=2ada83c1819a5372
+leaf ApplicationId len=32 blake3=2ada83c1819a5372
+leaf BlobId len=32 blake3=2ada83c1819a5372
+leaf NamespaceId len=32 blake3=2ada83c1819a5372
+leaf KeyId len=32 blake3=2ada83c1819a5372

--- a/crates/op/Cargo.toml
+++ b/crates/op/Cargo.toml
@@ -16,3 +16,6 @@ calimero-account.workspace = true
 calimero-context-config.workspace = true
 calimero-primitives.workspace = true
 calimero-storage.workspace = true
+
+[dev-dependencies]
+calimero-wire-descriptor.workspace = true

--- a/crates/op/src/op.rs
+++ b/crates/op/src/op.rs
@@ -230,3 +230,37 @@ impl Op {
         hasher.finalize().into()
     }
 }
+
+/// Compile-time anchor for the [`Op`] entry in `tests::wire_fingerprint`'s
+/// structural descriptor.
+///
+/// It lives in this module, not beside the descriptor, because [`Op::id`] is
+/// private *here* — a sibling test module cannot destructure it, and neither
+/// could a central gate crate. The destructuring carries no `..` and annotates
+/// every binding, so adding, removing, reordering or retyping a field fails to
+/// compile until the descriptor and its snapshot are updated to match.
+#[cfg(test)]
+#[expect(
+    dead_code,
+    reason = "compile-time anchor: exists to be type-checked, never called"
+)]
+pub(crate) fn op_fields_are_described(op: &Op) {
+    let Op {
+        id,
+        scope,
+        parents,
+        authorship,
+        hlc,
+        payload,
+        expected_scope_root,
+        signature,
+    } = op;
+    let _: &[u8; 32] = id;
+    let _: &ScopeId = scope;
+    let _: &Vec<[u8; 32]> = parents;
+    let _: &Authorship = authorship;
+    let _: &HybridTimestamp = hlc;
+    let _: &OpPayload = payload;
+    let _: &[u8; 32] = expected_scope_root;
+    let _: &[u8; 64] = signature;
+}

--- a/crates/op/src/tests.rs
+++ b/crates/op/src/tests.rs
@@ -17,3 +17,4 @@ mod op;
 mod payload;
 mod scope;
 mod wire;
+mod wire_fingerprint;

--- a/crates/op/src/tests/payload.rs
+++ b/crates/op/src/tests/payload.rs
@@ -6,109 +6,16 @@
 //! the point at which they find out that inserting it in the middle would have
 //! invalidated the signature of every stored op after it.
 
-use std::collections::BTreeMap;
-
-use calimero_account::{AccountGenesis, AccountId, DeviceCert, DeviceId, RootKeyHandoff};
-use calimero_context_config::types::ContextGroupId;
-use calimero_context_config::MemberCapabilities;
-use calimero_primitives::context::GroupMemberRole;
-use calimero_storage::address::Id;
-
-use crate::tests::support::key;
-use crate::{OpPayload, ScopeId};
+use crate::tests::support::every_op_payload;
+use crate::OpPayload;
 
 #[test]
 fn op_payload_discriminants_are_pinned() {
-    let id = Id::new([1u8; 32]);
-    let pk = AccountId::from([2u8; 32]);
-    let scope = ScopeId::from([3u8; 32]);
-    let group = ContextGroupId::from([4u8; 32]);
-    let caps = MemberCapabilities::empty();
-    let genesis = AccountGenesis::new(key(1).public_key());
-    let account = genesis.account_id();
-    let device = DeviceId::mint(account, [1u8; 16]);
-    let handoff = RootKeyHandoff {
-        account,
-        from_epoch: 0,
-        new_root_sign_pk: key(2).public_key(),
-        signature: [0u8; 64],
-    };
-    let cert = DeviceCert {
-        account,
-        device,
-        sign_pk: key(3).public_key(),
-        kem_pk: calimero_account::KemPublicKey::from([4u8; 32]),
-        key_epoch: 0,
-        device_epoch: 0,
-        signature: [0u8; 64],
-    };
-
     // Every variant, paired with the borsh discriminant it MUST keep forever
     // (see the append-only note on `OpPayload`). The exhaustive `match` below
     // means adding a variant fails to compile until it is appended here with
     // its own pinned tag — never inserted in the middle.
-    let all = [
-        OpPayload::Put {
-            entity: id,
-            value: vec![1],
-        },
-        OpPayload::Delete { entity: id },
-        OpPayload::SetWriters {
-            object: id,
-            writers: BTreeMap::new(),
-        },
-        OpPayload::MemberAdded {
-            group,
-            member: pk,
-            role: GroupMemberRole::Member,
-        },
-        OpPayload::MemberRemoved { group, member: pk },
-        OpPayload::AdminChanged { new_admin: pk },
-        OpPayload::PolicyUpdated {
-            policy_bytes: vec![],
-        },
-        OpPayload::SubgroupCreated {
-            child: scope,
-            parent: scope,
-            restricted: false,
-            admin: pk,
-        },
-        OpPayload::SubgroupReparented {
-            child: scope,
-            new_parent: scope,
-        },
-        OpPayload::SubgroupDeleted { scope },
-        OpPayload::SubgroupVisibilitySet {
-            scope,
-            restricted: true,
-        },
-        OpPayload::DefaultCapabilitiesSet {
-            group,
-            capabilities: caps,
-        },
-        OpPayload::MemberCapabilitySet {
-            group,
-            member: pk,
-            capabilities: caps,
-        },
-        OpPayload::Noop,
-        OpPayload::DeviceLinked {
-            genesis,
-            chain: vec![],
-            cert,
-        },
-        OpPayload::DeviceRevoked { account, device },
-        OpPayload::AccountKeysRotated { handoff },
-        OpPayload::MemberJoinedWithDevice {
-            group,
-            member: account,
-            role: GroupMemberRole::Member,
-            genesis,
-            chain: vec![],
-            cert,
-        },
-        OpPayload::Opaque { group },
-    ];
+    let all = every_op_payload();
 
     // Exhaustive: a new variant forces a new arm here.
     fn pinned_tag(p: &OpPayload) -> u8 {

--- a/crates/op/src/tests/support.rs
+++ b/crates/op/src/tests/support.rs
@@ -4,11 +4,17 @@
 //! same seed always yields the same keypair, hence the same account, device and
 //! op id.
 
-use calimero_account::{AccountGenesis, DeviceId};
+use std::collections::BTreeMap;
+
+use calimero_account::{AccountGenesis, AccountId, DeviceCert, DeviceId, RootKeyHandoff};
+use calimero_context_config::types::ContextGroupId;
+use calimero_context_config::MemberCapabilities;
+use calimero_primitives::context::GroupMemberRole;
 use calimero_primitives::identity::PrivateKey;
+use calimero_storage::address::Id;
 use calimero_storage::logical_clock::HybridTimestamp;
 
-use crate::Authorship;
+use crate::{Authorship, OpPayload, ScopeId};
 
 /// Deterministic keypair, so failures reproduce exactly.
 pub(crate) fn key(seed: u8) -> PrivateKey {
@@ -33,4 +39,99 @@ pub(crate) fn hlc0() -> HybridTimestamp {
         NTP64(0),
         ID::from(NonZeroU128::new(1).unwrap()),
     ))
+}
+
+/// Every `OpPayload` variant, in declaration order, with placeholder contents.
+///
+/// Shared by `payload::op_payload_discriminants_are_pinned` (which checks the
+/// tag each one encodes to) and `wire_fingerprint` (which checks the same
+/// samples against the committed structural descriptor). One list, so the two
+/// gates can never disagree about which variants exist.
+pub(crate) fn every_op_payload() -> Vec<OpPayload> {
+    let id = Id::new([1u8; 32]);
+    let pk = AccountId::from([2u8; 32]);
+    let scope = ScopeId::from([3u8; 32]);
+    let group = ContextGroupId::from([4u8; 32]);
+    let caps = MemberCapabilities::empty();
+    let genesis = AccountGenesis::new(key(1).public_key());
+    let account = genesis.account_id();
+    let device = DeviceId::mint(account, [1u8; 16]);
+    let handoff = RootKeyHandoff {
+        account,
+        from_epoch: 0,
+        new_root_sign_pk: key(2).public_key(),
+        signature: [0u8; 64],
+    };
+    let cert = DeviceCert {
+        account,
+        device,
+        sign_pk: key(3).public_key(),
+        kem_pk: calimero_account::KemPublicKey::from([4u8; 32]),
+        key_epoch: 0,
+        device_epoch: 0,
+        signature: [0u8; 64],
+    };
+
+    vec![
+        OpPayload::Put {
+            entity: id,
+            value: vec![1],
+        },
+        OpPayload::Delete { entity: id },
+        OpPayload::SetWriters {
+            object: id,
+            writers: BTreeMap::new(),
+        },
+        OpPayload::MemberAdded {
+            group,
+            member: pk,
+            role: GroupMemberRole::Member,
+        },
+        OpPayload::MemberRemoved { group, member: pk },
+        OpPayload::AdminChanged { new_admin: pk },
+        OpPayload::PolicyUpdated {
+            policy_bytes: vec![],
+        },
+        OpPayload::SubgroupCreated {
+            child: scope,
+            parent: scope,
+            restricted: false,
+            admin: pk,
+        },
+        OpPayload::SubgroupReparented {
+            child: scope,
+            new_parent: scope,
+        },
+        OpPayload::SubgroupDeleted { scope },
+        OpPayload::SubgroupVisibilitySet {
+            scope,
+            restricted: true,
+        },
+        OpPayload::DefaultCapabilitiesSet {
+            group,
+            capabilities: caps,
+        },
+        OpPayload::MemberCapabilitySet {
+            group,
+            member: pk,
+            capabilities: caps,
+        },
+        OpPayload::Noop,
+        OpPayload::DeviceLinked {
+            genesis,
+            chain: vec![],
+            cert,
+        },
+        OpPayload::DeviceRevoked { account, device },
+        OpPayload::AccountKeysRotated { handoff },
+        OpPayload::MemberJoinedWithDevice {
+            group,
+            member: account,
+            role: GroupMemberRole::Member,
+            genesis,
+            chain: vec![],
+            cert,
+        },
+        OpPayload::Opaque { group },
+    ]
 }

--- a/crates/op/src/tests/wire_fingerprint.rs
+++ b/crates/op/src/tests/wire_fingerprint.rs
@@ -1,0 +1,655 @@
+//! The structural fingerprint of the unified op envelope.
+//!
+//! `payload.rs` already pins every [`OpPayload`] tag by *encoding* a sample of
+//! each variant. That is exhaustive over variants, but encode-side: it cannot
+//! see a field retyped underneath a tag, and it says nothing about [`Op`]
+//! itself, whose field ORDER is the whole preimage of `compute_id` and thus of
+//! every signature.
+//!
+//! This module states the layout a second time as a descriptor, pins it to a
+//! committed snapshot, and anchors the descriptor to the real types with
+//! exhaustive, *typed* destructuring — so adding, removing, reordering or
+//! retyping a field fails to compile here before it can reach a peer.
+//!
+//! See `calimero-wire-descriptor` for why the descriptor is hand-maintained
+//! rather than derived.
+//!
+//! Regenerate after an intended change:
+//!
+//! ```text
+//! UPDATE_WIRE_FINGERPRINT=1 cargo test -p calimero-op wire_fingerprint
+//! ```
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use calimero_account::{AccountGenesis, AccountId, DeviceCert, DeviceId, RootKeyHandoff};
+use calimero_context_config::types::ContextGroupId;
+use calimero_context_config::MemberCapabilities;
+use calimero_primitives::context::GroupMemberRole;
+use calimero_primitives::identity::PublicKey;
+use calimero_storage::address::Id;
+use calimero_storage::entities::OpMask;
+use calimero_storage::logical_clock::HybridTimestamp;
+use calimero_wire_descriptor::{assert_snapshot, Field, Leaf, Shape, Surface, TypeDesc, Variant};
+
+use crate::authorship::Authorship;
+use crate::payload::OpPayload;
+use crate::scope::ScopeId;
+
+const OP_PAYLOAD: TypeDesc = TypeDesc {
+    name: "OpPayload",
+    shape: Shape::Enum(&[
+        Variant {
+            ordinal: 0,
+            name: "Put",
+            fields: &[
+                Field {
+                    name: "entity",
+                    ty: "Id",
+                },
+                Field {
+                    name: "value",
+                    ty: "Vec<u8>",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 1,
+            name: "Delete",
+            fields: &[Field {
+                name: "entity",
+                ty: "Id",
+            }],
+        },
+        Variant {
+            ordinal: 2,
+            name: "SetWriters",
+            fields: &[
+                Field {
+                    name: "object",
+                    ty: "Id",
+                },
+                Field {
+                    name: "writers",
+                    ty: "BTreeMap<AccountId, OpMask>",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 3,
+            name: "MemberAdded",
+            fields: &[
+                Field {
+                    name: "group",
+                    ty: "ContextGroupId",
+                },
+                Field {
+                    name: "member",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "role",
+                    ty: "GroupMemberRole",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 4,
+            name: "MemberRemoved",
+            fields: &[
+                Field {
+                    name: "group",
+                    ty: "ContextGroupId",
+                },
+                Field {
+                    name: "member",
+                    ty: "AccountId",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 5,
+            name: "AdminChanged",
+            fields: &[Field {
+                name: "new_admin",
+                ty: "AccountId",
+            }],
+        },
+        Variant {
+            ordinal: 6,
+            name: "PolicyUpdated",
+            fields: &[Field {
+                name: "policy_bytes",
+                ty: "Vec<u8>",
+            }],
+        },
+        Variant {
+            ordinal: 7,
+            name: "SubgroupCreated",
+            fields: &[
+                Field {
+                    name: "child",
+                    ty: "ScopeId",
+                },
+                Field {
+                    name: "parent",
+                    ty: "ScopeId",
+                },
+                Field {
+                    name: "restricted",
+                    ty: "bool",
+                },
+                Field {
+                    name: "admin",
+                    ty: "AccountId",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 8,
+            name: "SubgroupReparented",
+            fields: &[
+                Field {
+                    name: "child",
+                    ty: "ScopeId",
+                },
+                Field {
+                    name: "new_parent",
+                    ty: "ScopeId",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 9,
+            name: "SubgroupDeleted",
+            fields: &[Field {
+                name: "scope",
+                ty: "ScopeId",
+            }],
+        },
+        Variant {
+            ordinal: 10,
+            name: "SubgroupVisibilitySet",
+            fields: &[
+                Field {
+                    name: "scope",
+                    ty: "ScopeId",
+                },
+                Field {
+                    name: "restricted",
+                    ty: "bool",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 11,
+            name: "DefaultCapabilitiesSet",
+            fields: &[
+                Field {
+                    name: "group",
+                    ty: "ContextGroupId",
+                },
+                Field {
+                    name: "capabilities",
+                    ty: "MemberCapabilities",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 12,
+            name: "MemberCapabilitySet",
+            fields: &[
+                Field {
+                    name: "group",
+                    ty: "ContextGroupId",
+                },
+                Field {
+                    name: "member",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "capabilities",
+                    ty: "MemberCapabilities",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 13,
+            name: "Noop",
+            fields: &[],
+        },
+        Variant {
+            ordinal: 14,
+            name: "DeviceLinked",
+            fields: &[
+                Field {
+                    name: "genesis",
+                    ty: "AccountGenesis",
+                },
+                Field {
+                    name: "chain",
+                    ty: "Vec<RootKeyHandoff>",
+                },
+                Field {
+                    name: "cert",
+                    ty: "DeviceCert",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 15,
+            name: "DeviceRevoked",
+            fields: &[
+                Field {
+                    name: "account",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "device",
+                    ty: "DeviceId",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 16,
+            name: "AccountKeysRotated",
+            fields: &[Field {
+                name: "handoff",
+                ty: "RootKeyHandoff",
+            }],
+        },
+        Variant {
+            ordinal: 17,
+            name: "MemberJoinedWithDevice",
+            fields: &[
+                Field {
+                    name: "group",
+                    ty: "ContextGroupId",
+                },
+                Field {
+                    name: "member",
+                    ty: "AccountId",
+                },
+                Field {
+                    name: "role",
+                    ty: "GroupMemberRole",
+                },
+                Field {
+                    name: "genesis",
+                    ty: "AccountGenesis",
+                },
+                Field {
+                    name: "chain",
+                    ty: "Vec<RootKeyHandoff>",
+                },
+                Field {
+                    name: "cert",
+                    ty: "DeviceCert",
+                },
+            ],
+        },
+        Variant {
+            ordinal: 18,
+            name: "Opaque",
+            fields: &[Field {
+                name: "group",
+                ty: "ContextGroupId",
+            }],
+        },
+    ]),
+};
+
+fn op_payload_variant_name(p: &OpPayload) -> &'static str {
+    match p {
+        OpPayload::Put { entity, value } => {
+            let _: &Id = entity;
+            let _: &Vec<u8> = value;
+            "Put"
+        }
+        OpPayload::Delete { entity } => {
+            let _: &Id = entity;
+            "Delete"
+        }
+        OpPayload::SetWriters { object, writers } => {
+            let _: &Id = object;
+            let _: &BTreeMap<AccountId, OpMask> = writers;
+            "SetWriters"
+        }
+        OpPayload::MemberAdded {
+            group,
+            member,
+            role,
+        } => {
+            let _: &ContextGroupId = group;
+            let _: &AccountId = member;
+            let _: &GroupMemberRole = role;
+            "MemberAdded"
+        }
+        OpPayload::MemberRemoved { group, member } => {
+            let _: &ContextGroupId = group;
+            let _: &AccountId = member;
+            "MemberRemoved"
+        }
+        OpPayload::AdminChanged { new_admin } => {
+            let _: &AccountId = new_admin;
+            "AdminChanged"
+        }
+        OpPayload::PolicyUpdated { policy_bytes } => {
+            let _: &Vec<u8> = policy_bytes;
+            "PolicyUpdated"
+        }
+        OpPayload::SubgroupCreated {
+            child,
+            parent,
+            restricted,
+            admin,
+        } => {
+            let _: &ScopeId = child;
+            let _: &ScopeId = parent;
+            let _: &bool = restricted;
+            let _: &AccountId = admin;
+            "SubgroupCreated"
+        }
+        OpPayload::SubgroupReparented { child, new_parent } => {
+            let _: &ScopeId = child;
+            let _: &ScopeId = new_parent;
+            "SubgroupReparented"
+        }
+        OpPayload::SubgroupDeleted { scope } => {
+            let _: &ScopeId = scope;
+            "SubgroupDeleted"
+        }
+        OpPayload::SubgroupVisibilitySet { scope, restricted } => {
+            let _: &ScopeId = scope;
+            let _: &bool = restricted;
+            "SubgroupVisibilitySet"
+        }
+        OpPayload::DefaultCapabilitiesSet {
+            group,
+            capabilities,
+        } => {
+            let _: &ContextGroupId = group;
+            let _: &MemberCapabilities = capabilities;
+            "DefaultCapabilitiesSet"
+        }
+        OpPayload::MemberCapabilitySet {
+            group,
+            member,
+            capabilities,
+        } => {
+            let _: &ContextGroupId = group;
+            let _: &AccountId = member;
+            let _: &MemberCapabilities = capabilities;
+            "MemberCapabilitySet"
+        }
+        OpPayload::Noop => "Noop",
+        OpPayload::DeviceLinked {
+            genesis,
+            chain,
+            cert,
+        } => {
+            let _: &AccountGenesis = genesis;
+            let _: &Vec<RootKeyHandoff> = chain;
+            let _: &DeviceCert = cert;
+            "DeviceLinked"
+        }
+        OpPayload::DeviceRevoked { account, device } => {
+            let _: &AccountId = account;
+            let _: &DeviceId = device;
+            "DeviceRevoked"
+        }
+        OpPayload::AccountKeysRotated { handoff } => {
+            let _: &RootKeyHandoff = handoff;
+            "AccountKeysRotated"
+        }
+        OpPayload::MemberJoinedWithDevice {
+            group,
+            member,
+            role,
+            genesis,
+            chain,
+            cert,
+        } => {
+            let _: &ContextGroupId = group;
+            let _: &AccountId = member;
+            let _: &GroupMemberRole = role;
+            let _: &AccountGenesis = genesis;
+            let _: &Vec<RootKeyHandoff> = chain;
+            let _: &DeviceCert = cert;
+            "MemberJoinedWithDevice"
+        }
+        OpPayload::Opaque { group } => {
+            let _: &ContextGroupId = group;
+            "Opaque"
+        }
+    }
+}
+
+/// The envelope.
+///
+/// `id` is first and it is PRIVATE — it is still on the wire, and a struct has
+/// no tag to fail on, so a field inserted before it would be read as the id by
+/// an old peer. Described here precisely because no `pub` API reveals it.
+const OP: TypeDesc = TypeDesc {
+    name: "Op",
+    shape: Shape::Struct(&[
+        Field {
+            name: "id",
+            ty: "[u8; 32]",
+        },
+        Field {
+            name: "scope",
+            ty: "ScopeId",
+        },
+        Field {
+            name: "parents",
+            ty: "Vec<[u8; 32]>",
+        },
+        Field {
+            name: "authorship",
+            ty: "Authorship",
+        },
+        Field {
+            name: "hlc",
+            ty: "HybridTimestamp",
+        },
+        Field {
+            name: "payload",
+            ty: "OpPayload",
+        },
+        Field {
+            name: "expected_scope_root",
+            ty: "[u8; 32]",
+        },
+        Field {
+            name: "signature",
+            ty: "[u8; 64]",
+        },
+    ]),
+};
+
+const AUTHORSHIP: TypeDesc = TypeDesc {
+    name: "Authorship",
+    shape: Shape::Struct(&[
+        Field {
+            name: "account",
+            ty: "AccountId",
+        },
+        Field {
+            name: "device",
+            ty: "DeviceId",
+        },
+        Field {
+            name: "device_key",
+            ty: "PublicKey",
+        },
+    ]),
+};
+
+const SCOPE_ID: TypeDesc = TypeDesc {
+    name: "ScopeId",
+    shape: Shape::Struct(&[Field {
+        name: "0",
+        ty: "[u8; 32]",
+    }]),
+};
+
+/// Compile-time anchor: no `..`, and every binding carries its declared type,
+/// so a field added, removed, reordered or retyped stops the build here.
+///
+/// [`Op`] itself is anchored by `op::op_fields_are_described` instead: its
+/// leading `id` field is private to the `op` module, so not even a sibling
+/// test module can destructure it. That privacy is the reason this gate cannot
+/// live in a central crate.
+#[expect(
+    dead_code,
+    reason = "compile-time anchor: exists to be type-checked, never called"
+)]
+fn struct_fields_are_described(authorship: &Authorship, scope: &ScopeId) {
+    let Authorship {
+        account,
+        device,
+        device_key,
+    } = authorship;
+    let _: &AccountId = account;
+    let _: &DeviceId = device;
+    let _: &PublicKey = device_key;
+
+    let _: &[u8; 32] = scope.as_bytes();
+}
+
+fn leaf<T: borsh::BorshSerialize>(name: &'static str, value: &T) -> Leaf {
+    Leaf {
+        name,
+        bytes: borsh::to_vec(value).expect("borsh-encode a canonical leaf instance"),
+    }
+}
+
+const ZERO_ACCOUNT: AccountId = AccountId::from_raw([0u8; 32]);
+const ZERO_DEVICE: DeviceId = DeviceId::from_raw([0u8; 32]);
+
+fn zero_genesis() -> AccountGenesis {
+    AccountGenesis::new(PublicKey::from([0u8; 32]))
+}
+
+/// Types embedded in the payload but owned elsewhere: pinned by the bytes a
+/// canonical all-zero instance encodes to rather than described field by
+/// field. See `calimero-wire-descriptor::Leaf`.
+fn described_leaves() -> Vec<Leaf> {
+    vec![
+        leaf("AccountGenesis", &zero_genesis()),
+        leaf(
+            "DeviceCert",
+            &DeviceCert {
+                account: ZERO_ACCOUNT,
+                device: ZERO_DEVICE,
+                sign_pk: PublicKey::from([0u8; 32]),
+                kem_pk: calimero_account::KemPublicKey::from([0u8; 32]),
+                key_epoch: 0,
+                device_epoch: 0,
+                signature: [0u8; 64],
+            },
+        ),
+        leaf(
+            "RootKeyHandoff",
+            &RootKeyHandoff {
+                account: ZERO_ACCOUNT,
+                from_epoch: 0,
+                new_root_sign_pk: PublicKey::from([0u8; 32]),
+                signature: [0u8; 64],
+            },
+        ),
+        leaf("HybridTimestamp::zero", &HybridTimestamp::zero()),
+        leaf("MemberCapabilities::empty", &MemberCapabilities::empty()),
+        leaf("OpMask::default", &OpMask::default()),
+        leaf("Id", &Id::new([0u8; 32])),
+        leaf("GroupMemberRole::Admin", &GroupMemberRole::Admin),
+        leaf("GroupMemberRole::Member", &GroupMemberRole::Member),
+        leaf("GroupMemberRole::ReadOnly", &GroupMemberRole::ReadOnly),
+        leaf(
+            "GroupMemberRole::ReadOnlyTee",
+            &GroupMemberRole::ReadOnlyTee,
+        ),
+        leaf("AccountId", &ZERO_ACCOUNT),
+        leaf("DeviceId", &ZERO_DEVICE),
+        leaf("PublicKey", &PublicKey::from([0u8; 32])),
+        leaf("ContextGroupId", &ContextGroupId::from([0u8; 32])),
+        leaf("ScopeId", &ScopeId::from([0u8; 32])),
+    ]
+}
+
+fn surface() -> Surface {
+    Surface {
+        label: "calimero-op",
+        types: vec![OP, AUTHORSHIP, SCOPE_ID, OP_PAYLOAD],
+        leaves: described_leaves(),
+    }
+}
+
+#[test]
+fn wire_fingerprint_matches_snapshot() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("wire-fingerprint.txt");
+    assert_snapshot(&surface(), &path);
+}
+
+/// The descriptor's ordinals are what borsh actually emits.
+///
+/// `op_payload_discriminants_are_pinned` in `payload.rs` checks the same tags
+/// against a hand-written table; this checks them against the DESCRIPTOR, so
+/// the snapshot can never claim an ordinal the encoder disagrees with.
+#[test]
+fn described_ordinals_are_the_real_borsh_tags() {
+    let Shape::Enum(variants) = OP_PAYLOAD.shape else {
+        panic!("OpPayload is an enum");
+    };
+
+    let mut failures: Vec<String> = Vec::new();
+    for (payload, v) in super::support::every_op_payload().iter().zip(variants) {
+        let name = op_payload_variant_name(payload);
+        if name != v.name {
+            failures.push(format!(
+                "ordinal {}: descriptor says {}, sample is {name}",
+                v.ordinal, v.name
+            ));
+            continue;
+        }
+        let bytes = borsh::to_vec(payload).expect("serialize");
+        if bytes[0] != v.ordinal {
+            failures.push(format!(
+                "OpPayload::{}: descriptor ordinal {} but borsh emitted {}",
+                v.name, v.ordinal, bytes[0]
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "descriptor/encoder mismatches ({}):\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}
+
+/// No variant may exist past the last described one.
+///
+/// A one-byte buffer separates the cases: an unknown tag is `InvalidData`
+/// ("Unexpected variant tag"), whereas a *known* tag either wants more bytes
+/// (`UnexpectedEof`) or decodes outright. Either of the latter two means a
+/// variant was appended without being described.
+#[test]
+fn no_variant_exists_past_the_described_end() {
+    let Shape::Enum(variants) = OP_PAYLOAD.shape else {
+        panic!("OpPayload is an enum");
+    };
+    let next = u8::try_from(variants.len()).expect("fewer than 256 variants");
+    let kind = borsh::from_slice::<OpPayload>(&[next])
+        .map_or_else(|e| e.kind(), |_| std::io::ErrorKind::Other);
+    assert_eq!(
+        kind,
+        std::io::ErrorKind::InvalidData,
+        "OpPayload ordinal {next} decodes to something — a variant was appended \
+         without adding it to the descriptor in this file. Append it, then \
+         regenerate the snapshot."
+    );
+}

--- a/crates/op/wire-fingerprint.txt
+++ b/crates/op/wire-fingerprint.txt
@@ -1,0 +1,74 @@
+# Calimero replicated wire surface — GENERATED, DO NOT EDIT BY HAND.
+#
+# Regenerate with UPDATE_WIRE_FINGERPRINT=1 and the crate's test command; the
+# failing assertion prints the exact one.
+#
+# APPENDING a variant at the END of an enum is wire-COMPATIBLE: an old node
+# fails to decode the new tag and rejects the op, but every op it already
+# understands still decodes identically.
+#
+# INSERTING, REMOVING, REORDERING or RETYPING anything below is a HARD BREAK:
+# borsh discriminants are bare positional u8s, so every later variant silently
+# renumbers and an old peer decodes the WRONG variant rather than erroring.
+# That is the rc.7/rc.8 NamespaceGovOpValue incident — a fleet that reported
+# 'joined' while replicating nothing. If you must do it, bump the schema
+# version constant in the same commit and plan a coordinated rollout.
+fingerprint blake3=f51f2a1a7bc51b2a
+
+surface calimero-op
+
+struct Op
+  0 id: [u8; 32]
+  1 scope: ScopeId
+  2 parents: Vec<[u8; 32]>
+  3 authorship: Authorship
+  4 hlc: HybridTimestamp
+  5 payload: OpPayload
+  6 expected_scope_root: [u8; 32]
+  7 signature: [u8; 64]
+
+struct Authorship
+  0 account: AccountId
+  1 device: DeviceId
+  2 device_key: PublicKey
+
+struct ScopeId
+  0 0: [u8; 32]
+
+enum OpPayload
+  0 Put(entity: Id, value: Vec<u8>)
+  1 Delete(entity: Id)
+  2 SetWriters(object: Id, writers: BTreeMap<AccountId, OpMask>)
+  3 MemberAdded(group: ContextGroupId, member: AccountId, role: GroupMemberRole)
+  4 MemberRemoved(group: ContextGroupId, member: AccountId)
+  5 AdminChanged(new_admin: AccountId)
+  6 PolicyUpdated(policy_bytes: Vec<u8>)
+  7 SubgroupCreated(child: ScopeId, parent: ScopeId, restricted: bool, admin: AccountId)
+  8 SubgroupReparented(child: ScopeId, new_parent: ScopeId)
+  9 SubgroupDeleted(scope: ScopeId)
+  10 SubgroupVisibilitySet(scope: ScopeId, restricted: bool)
+  11 DefaultCapabilitiesSet(group: ContextGroupId, capabilities: MemberCapabilities)
+  12 MemberCapabilitySet(group: ContextGroupId, member: AccountId, capabilities: MemberCapabilities)
+  13 Noop
+  14 DeviceLinked(genesis: AccountGenesis, chain: Vec<RootKeyHandoff>, cert: DeviceCert)
+  15 DeviceRevoked(account: AccountId, device: DeviceId)
+  16 AccountKeysRotated(handoff: RootKeyHandoff)
+  17 MemberJoinedWithDevice(group: ContextGroupId, member: AccountId, role: GroupMemberRole, genesis: AccountGenesis, chain: Vec<RootKeyHandoff>, cert: DeviceCert)
+  18 Opaque(group: ContextGroupId)
+
+leaf AccountGenesis len=33 blake3=79efc4eb5e34fb06
+leaf DeviceCert len=200 blake3=bb7c84c0d6cc4368
+leaf RootKeyHandoff len=132 blake3=ff46c07437cfbd6e
+leaf HybridTimestamp::zero len=24 blake3=ffc587cc36ab1393
+leaf MemberCapabilities::empty len=4 blake3=ec2bd03bf86b935f
+leaf OpMask::default len=1 blake3=448bd8dd9624154a
+leaf Id len=32 blake3=2ada83c1819a5372
+leaf GroupMemberRole::Admin len=1 blake3=2d3adedff11b61f1
+leaf GroupMemberRole::Member len=1 blake3=48fc721fbbc172e0
+leaf GroupMemberRole::ReadOnly len=1 blake3=ab13bedf42e84bae
+leaf GroupMemberRole::ReadOnlyTee len=1 blake3=e1e0e81d6ea39b0c
+leaf AccountId len=32 blake3=2ada83c1819a5372
+leaf DeviceId len=32 blake3=2ada83c1819a5372
+leaf PublicKey len=32 blake3=2ada83c1819a5372
+leaf ContextGroupId len=32 blake3=2ada83c1819a5372
+leaf ScopeId len=32 blake3=2ada83c1819a5372

--- a/crates/wire-descriptor/Cargo.toml
+++ b/crates/wire-descriptor/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "calimero-wire-descriptor"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+description.workspace = true
+# Test-support only: this crate is a dev-dependency of the crates that own a
+# replicated wire type. It is never linked into a shipped binary, which is why
+# it may carry filesystem/snapshot machinery a `publish = true` data crate
+# should not.
+publish = false
+
+[dependencies]
+blake3.workspace = true

--- a/crates/wire-descriptor/src/lib.rs
+++ b/crates/wire-descriptor/src/lib.rs
@@ -1,0 +1,425 @@
+//! A structural fingerprint for borsh types that travel between nodes.
+//!
+//! # The failure this exists to catch
+//!
+//! Borsh encodes an enum variant as a bare `u8` *ordinal* derived from
+//! declaration order. Inserting a variant anywhere but the end silently
+//! renumbers every later variant, and a struct field added in the middle
+//! silently reinterprets every byte after it. Neither shows up in an
+//! encode → decode round-trip inside one binary: the encoder and the decoder
+//! shift together and agree on the wrong answer. It only shows up when an old
+//! node meets a new one — in production, as "joined, replicating 0 contexts".
+//!
+//! Frozen-byte goldens (decode-only) catch this for the *specific* variants
+//! somebody remembered to freeze. This module catches it for the *shape of the
+//! whole surface*, including the case nobody freezes: a field retyped from
+//! `u32` to `u64`, or renamed in a way that swaps two same-width fields.
+//!
+//! # Why a hand-maintained descriptor
+//!
+//! There is no derive here on purpose. A macro that reflected the real type
+//! would make the snapshot a function of the type, so a change to the type
+//! would change both sides at once — exactly the same blindness as a
+//! round-trip test, one level up. The descriptor is a **second, independent
+//! statement** of the wire layout, written by a human, and the gate is that
+//! the two statements agree. The crates that own a wire type pair each
+//! descriptor with an exhaustive `match` (for enums) or an exhaustive
+//! destructuring (for structs), so adding a variant or a field does not
+//! compile until the descriptor is updated too, and updating the descriptor
+//! moves the snapshot, which is the review signal.
+//!
+//! # Usage
+//!
+//! Build a [`Surface`] in a `#[cfg(test)]` module of the crate that owns the
+//! types, then call [`assert_snapshot`] against a committed `.txt` file.
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::Path;
+
+/// Environment variable that turns the snapshot assertion into a regeneration.
+///
+/// Mirrors `UPDATE_FIXTURES` on the HTTP-DTO wire-contract gate.
+pub const UPDATE_ENV: &str = "UPDATE_WIRE_FINGERPRINT";
+
+/// One named field of a struct, or of a struct-like enum variant.
+#[derive(Clone, Copy, Debug)]
+pub struct Field {
+    /// Field name exactly as declared (a rename is a review-worthy event even
+    /// though borsh does not encode it — it usually accompanies a retype).
+    pub name: &'static str,
+    /// Rendered type, as declared. Foreign leaf types are named, not expanded;
+    /// pin those with [`Leaf`] instead of growing this into a whole-graph
+    /// reflection.
+    pub ty: &'static str,
+}
+
+/// One enum variant and the borsh ordinal it must keep forever.
+#[derive(Clone, Copy, Debug)]
+pub struct Variant {
+    /// The `u8` borsh discriminant. Declaration order, permanently.
+    pub ordinal: u8,
+    /// Variant name as declared.
+    pub name: &'static str,
+    /// Fields in declaration (= encoding) order. Empty for a unit variant.
+    pub fields: &'static [Field],
+}
+
+/// Whether a described type encodes as a tagged union or as a flat record.
+#[derive(Clone, Copy, Debug)]
+pub enum Shape {
+    /// Tagged union: one leading ordinal byte, then the variant's fields.
+    Enum(&'static [Variant]),
+    /// Flat record: fields concatenated in declaration order, no tag.
+    Struct(&'static [Field]),
+}
+
+/// A described wire type.
+#[derive(Clone, Copy, Debug)]
+pub struct TypeDesc {
+    /// Type name as declared.
+    pub name: &'static str,
+    /// Its encoding shape.
+    pub shape: Shape,
+}
+
+/// A type whose layout is owned by *another* crate and is not described
+/// field-by-field here, pinned instead by the bytes a canonical instance
+/// encodes to.
+///
+/// This is the deliberate boundary of the gate: the descriptor stops at the
+/// crate that owns the wire surface, and everything below it is held still by
+/// a hash rather than by a second graph of hand-written descriptors. A field
+/// added to `DeviceCert` reddens the leaf line without this crate knowing
+/// anything about `DeviceCert`.
+pub struct Leaf {
+    /// Type name as referenced from the descriptor above.
+    pub name: &'static str,
+    /// `borsh::to_vec` of a canonical (conventionally all-zero) instance.
+    pub bytes: Vec<u8>,
+}
+
+/// Everything one crate contributes to the replicated wire surface.
+pub struct Surface {
+    /// Snapshot label — conventionally the crate name.
+    pub label: &'static str,
+    /// Described types, in a stable order chosen by the author.
+    pub types: Vec<TypeDesc>,
+    /// Foreign leaf types pinned by encoded bytes.
+    pub leaves: Vec<Leaf>,
+}
+
+impl Surface {
+    /// The snapshot body: everything except the header comment.
+    ///
+    /// Deliberately a line-per-variant text rather than a single hash, so the
+    /// `git diff` on an intentional change *is* the review artifact — you see
+    /// "variant 7 became variant 8", not "a hash changed".
+    #[must_use]
+    pub fn body(&self) -> String {
+        let mut out = String::new();
+        let _ = writeln!(out, "surface {}", self.label);
+        out.push('\n');
+        for ty in &self.types {
+            match ty.shape {
+                Shape::Enum(variants) => {
+                    let _ = writeln!(out, "enum {}", ty.name);
+                    for v in variants {
+                        let _ = writeln!(out, "  {} {}{}", v.ordinal, v.name, render(v.fields));
+                    }
+                }
+                Shape::Struct(fields) => {
+                    let _ = writeln!(out, "struct {}", ty.name);
+                    for (i, f) in fields.iter().enumerate() {
+                        let _ = writeln!(out, "  {} {}: {}", i, f.name, f.ty);
+                    }
+                }
+            }
+            out.push('\n');
+        }
+        for leaf in &self.leaves {
+            let _ = writeln!(
+                out,
+                "leaf {} len={} blake3={}",
+                leaf.name,
+                leaf.bytes.len(),
+                short_hash(&leaf.bytes)
+            );
+        }
+        out
+    }
+
+    /// A single value naming this whole surface — handy to quote in a release
+    /// note or a compatibility catalog entry.
+    #[must_use]
+    pub fn fingerprint(&self) -> String {
+        short_hash(self.body().as_bytes())
+    }
+
+    /// The full committed file: header, fingerprint, body.
+    #[must_use]
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        out.push_str(HEADER);
+        let _ = writeln!(out, "fingerprint blake3={}", self.fingerprint());
+        out.push('\n');
+        out.push_str(&self.body());
+        out
+    }
+}
+
+fn render(fields: &[Field]) -> String {
+    if fields.is_empty() {
+        return String::new();
+    }
+    let inner: Vec<String> = fields
+        .iter()
+        .map(|f| format!("{}: {}", f.name, f.ty))
+        .collect();
+    format!("({})", inner.join(", "))
+}
+
+fn short_hash(bytes: &[u8]) -> String {
+    // 16 hex chars is plenty to make an accidental collision impossible while
+    // keeping the snapshot readable; this is a change detector, not a MAC.
+    blake3::hash(bytes).to_hex()[..16].to_owned()
+}
+
+const HEADER: &str = "\
+# Calimero replicated wire surface — GENERATED, DO NOT EDIT BY HAND.
+#
+# Regenerate with UPDATE_WIRE_FINGERPRINT=1 and the crate's test command; the
+# failing assertion prints the exact one.
+#
+# APPENDING a variant at the END of an enum is wire-COMPATIBLE: an old node
+# fails to decode the new tag and rejects the op, but every op it already
+# understands still decodes identically.
+#
+# INSERTING, REMOVING, REORDERING or RETYPING anything below is a HARD BREAK:
+# borsh discriminants are bare positional u8s, so every later variant silently
+# renumbers and an old peer decodes the WRONG variant rather than erroring.
+# That is the rc.7/rc.8 NamespaceGovOpValue incident — a fleet that reported
+# 'joined' while replicating nothing. If you must do it, bump the schema
+# version constant in the same commit and plan a coordinated rollout.
+";
+
+/// Compare a computed surface against a committed snapshot, returning a
+/// human-readable report on mismatch.
+///
+/// # Errors
+///
+/// Returns the rendered diff plus remediation guidance when the two differ.
+pub fn check(surface: &Surface, committed: &str) -> Result<(), String> {
+    let computed = surface.render();
+    if computed == committed {
+        return Ok(());
+    }
+    Err(format!(
+        "{}\n{}",
+        diff(committed, &computed),
+        GUIDANCE.trim_end()
+    ))
+}
+
+/// A line-oriented diff of committed (`-`) versus computed (`+`).
+///
+/// Not a real LCS diff: wire snapshots change in small, localized ways, and a
+/// positional comparison points at the moved variant just as well while
+/// staying dependency-free.
+#[must_use]
+pub fn diff(committed: &str, computed: &str) -> String {
+    let old: Vec<&str> = committed.lines().collect();
+    let new: Vec<&str> = computed.lines().collect();
+    let mut out = String::from("wire surface changed:\n");
+    let mut shown = 0_usize;
+    for i in 0..old.len().max(new.len()) {
+        let o = old.get(i).copied();
+        let n = new.get(i).copied();
+        if o == n {
+            continue;
+        }
+        if shown == MAX_DIFF_LINES {
+            let _ = writeln!(out, "  ... (further differences suppressed)");
+            break;
+        }
+        shown += 1;
+        let _ = writeln!(out, "  line {}:", i + 1);
+        if let Some(o) = o {
+            let _ = writeln!(out, "    - committed: {o}");
+        }
+        if let Some(n) = n {
+            let _ = writeln!(out, "    + computed:  {n}");
+        }
+    }
+    out
+}
+
+const MAX_DIFF_LINES: usize = 40;
+
+const GUIDANCE: &str = "\
+What to do about it:
+
+  * You APPENDED a variant at the end of an enum (ordinals of existing
+    variants unchanged, only new lines at the bottom of a block):
+    wire-compatible. Regenerate the snapshot and mention it in the PR.
+
+  * Anything else is a HARD BREAK — a variant inserted or removed, two
+    variants swapped, a field added/removed/reordered/retyped, a leaf hash
+    moved. Old peers will decode the wrong variant or the wrong field bytes,
+    silently. Bump the schema-version constant for that surface in the same
+    commit, and treat the rollout as coordinated (owner nodes and TEE fleet
+    nodes must not straddle the change).
+
+Regenerate (only after deciding which of the two cases you are in):
+
+  UPDATE_WIRE_FINGERPRINT=1 cargo test -p <crate> wire_fingerprint
+";
+
+/// Assert a surface against a snapshot file, or rewrite it when
+/// [`UPDATE_ENV`] is set.
+///
+/// # Panics
+///
+/// Panics with the diff and guidance when the surface has drifted, and when
+/// the snapshot cannot be read or written.
+pub fn assert_snapshot(surface: &Surface, path: &Path) {
+    let computed = surface.render();
+
+    if std::env::var_os(UPDATE_ENV).is_some() {
+        fs::write(path, &computed)
+            .unwrap_or_else(|e| panic!("write wire snapshot {}: {e}", path.display()));
+        return;
+    }
+
+    let committed = fs::read_to_string(path).unwrap_or_else(|e| {
+        panic!(
+            "read wire snapshot {}: {e}\n\
+             If this is a new surface, create it with \
+             {UPDATE_ENV}=1 cargo test -p <crate> wire_fingerprint",
+            path.display()
+        )
+    });
+
+    if let Err(report) = check(surface, &committed) {
+        panic!("{}\n\nsnapshot: {}", report, path.display());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const A: TypeDesc = TypeDesc {
+        name: "E",
+        shape: Shape::Enum(&[
+            Variant {
+                ordinal: 0,
+                name: "One",
+                fields: &[],
+            },
+            Variant {
+                ordinal: 1,
+                name: "Two",
+                fields: &[Field {
+                    name: "x",
+                    ty: "u32",
+                }],
+            },
+        ]),
+    };
+
+    fn surface(types: Vec<TypeDesc>) -> Surface {
+        Surface {
+            label: "test",
+            types,
+            leaves: vec![],
+        }
+    }
+
+    #[test]
+    fn identical_surface_passes() {
+        let s = surface(vec![A]);
+        let rendered = s.render();
+        assert!(check(&s, &rendered).is_ok());
+    }
+
+    #[test]
+    fn a_reordered_variant_is_reported_with_its_line() {
+        let committed = surface(vec![A]).render();
+
+        const SWAPPED: TypeDesc = TypeDesc {
+            name: "E",
+            shape: Shape::Enum(&[
+                Variant {
+                    ordinal: 0,
+                    name: "Two",
+                    fields: &[Field {
+                        name: "x",
+                        ty: "u32",
+                    }],
+                },
+                Variant {
+                    ordinal: 1,
+                    name: "One",
+                    fields: &[],
+                },
+            ]),
+        };
+
+        let report = check(&surface(vec![SWAPPED]), &committed).expect_err("must fail");
+        assert!(report.contains("- committed:   0 One"), "{report}");
+        assert!(report.contains("+ computed:    0 Two(x: u32)"), "{report}");
+        assert!(report.contains("HARD BREAK"), "{report}");
+    }
+
+    #[test]
+    fn a_retyped_field_moves_the_fingerprint() {
+        const RETYPED: TypeDesc = TypeDesc {
+            name: "E",
+            shape: Shape::Enum(&[
+                Variant {
+                    ordinal: 0,
+                    name: "One",
+                    fields: &[],
+                },
+                Variant {
+                    ordinal: 1,
+                    name: "Two",
+                    fields: &[Field {
+                        name: "x",
+                        ty: "u64",
+                    }],
+                },
+            ]),
+        };
+
+        assert_ne!(
+            surface(vec![A]).fingerprint(),
+            surface(vec![RETYPED]).fingerprint(),
+            "u32 -> u64 must not be invisible"
+        );
+    }
+
+    #[test]
+    fn a_leaf_whose_bytes_change_is_reported() {
+        let base = Surface {
+            label: "test",
+            types: vec![],
+            leaves: vec![Leaf {
+                name: "L",
+                bytes: vec![0; 4],
+            }],
+        };
+        let grown = Surface {
+            label: "test",
+            types: vec![],
+            leaves: vec![Leaf {
+                name: "L",
+                bytes: vec![0; 8],
+            }],
+        };
+        let report = check(&grown, &base.render()).expect_err("must fail");
+        assert!(report.contains("leaf L len=4"), "{report}");
+        assert!(report.contains("leaf L len=8"), "{report}");
+    }
+}


### PR DESCRIPTION
## Why

Borsh enum discriminants are bare u8 ordinals, so inserting a variant anywhere but the end silently renumbers every later variant. An encode→decode round-trip in one binary **cannot** catch this: encoder and decoder shift together.

This is not hypothetical. merod rc.7 ↔ rc.8 were wire-incompatible at the `NamespaceGovOpValue` enum, and a production TEE fleet silently stopped replicating — nodes reported "joined" while replicating 0/6 contexts, and it was debugged as a NAT problem for days. rc.13 → rc.17 turned out compatible, but only by hand-verification after the fact, per incident.

## What this adds

- **`crates/wire-descriptor`** (new, `publish = false`) — render/diff/fingerprint machinery for a structural description of the replicated wire surface, with a readable diff and append-vs-break guidance on failure. Regenerate with `UPDATE_WIRE_FINGERPRINT=1`.
- **Governance surface pinned** — `crates/governance-types/wire-fingerprint.txt` covers `NamespaceOp`, `RootOp`, `GroupOp`, `EnvelopeRecipient`, `StoredNamespaceEntry`, 8 structs and 27 pinned leaves.
- **`Op` envelope pinned** — `crates/op/wire-fingerprint.txt`. `Op`'s field order is the entire `compute_id` preimage and previously had no gate at all.
- **Golden corpus made exhaustive** — a variant without frozen bytes now fails.
- **`.github/workflows/wire-format-borsh.yml`** — kept separate from `wire-contract.yml` because `on.paths` is per-workflow; folding them would run the HTTP-DTO job on every governance change and vice versa.

## Two real holes it found on this branch

- `GroupOp::GroupKeyRotatedForDevice` (ordinal 27) had no frozen bytes.
- `NamespaceOp` tag 1 (`Group`) had none — every existing golden pins tag 0 only. Swapping the two arms would have left all of them decoding "correctly" while every group-scoped op became unreadable.

## Design note: hand-maintained descriptors, no derive

A derive reads the real type, so the snapshot moves *with* the type — the same blindness as a round-trip test, one level up. The descriptor is a second, independent statement; the gate is that the two agree.

Descriptors must live in the owning crate: `GroupOp`/`NamespaceOp` are `#[non_exhaustive]` (exhaustive match impossible from outside) and `Op::id` is private to its module.

## Break classes, verified by mutation

| Mutation | Caught by |
|---|---|
| Insert a variant mid-enum | `error[E0004]: non-exhaustive patterns` |
| Retype a field | `error[E0308]: expected &u32, found &u64` |
| Append a variant, forget the descriptor | test failure naming the ordinal |
| Corrupt a snapshot line | diff: `- committed: 2 parentz` / `+ computed: 2 parents` |

## What it does not catch

Semantic change under unchanged layout; a same-width retype where the author also updates the descriptor (deliberate, not accidental); the encrypted inner `GroupOp` inside `NamespaceOp::Group`; and anything at runtime — two skewed nodes still meet, handshake, and drop ops.

## Out of scope

Version negotiation at handshake and reporting `Degraded` instead of `joined` is deliberately not in this PR. Notes: `crates/network/src/behaviour.rs:20,181` already advertises a version via identify, and `handlers/stream/swarm/identify.rs:52-64` destructures it into `..` and discards it. `node/src/handlers/network_event/namespace.rs:36-42` is the rc.7/rc.8 line itself — an undecodable gossip op is a `warn!` and a `return`, with no counter and no peer attribution.

## Verification

```
cargo test -p calimero-governance-types   50 passed
cargo test -p calimero-op                 16 passed
cargo test -p calimero-wire-descriptor     4 passed
rustup run 1.88.0 cargo fmt --check       clean
cargo check --workspace                   clean
UPDATE_WIRE_FINGERPRINT=1 … ; git status  regeneration is a no-op
```

`cargo machete` and `cargo deny` were not run locally — CI is the first check.

## Base

Targets `feat/storage-child-trie`, rebased onto it after push. Draft pending CI.