### PR TITLE
feat(storage-cost): gate storage costs in CI and de-rot the chat-wall probe

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,46 @@
+name: Benchmarks
+
+permissions:
+  contents: read
+
+# Post-merge on master, plus opt-in per PR via the `run-benchmarks` label.
+# Deliberately NOT on every pull_request: a full sweep is tens of minutes, and
+# the result is a trend line rather than a verdict.
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [labeled]
+
+jobs:
+  criterion:
+    name: Criterion trend
+    # Never blocks a merge. Timing on shared runners is too noisy to gate on;
+    # the blocking storage-cost gate lives in ci-checks.yml.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.label.name == 'run-benchmarks'
+    continue-on-error: true
+    runs-on: ubuntu-24.04-8cpu
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Rust CI
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          toolchain: stable
+          shared-key: storage-cost
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Run benchmarks
+        run: cargo bench -p storage-cost -- --save-baseline ${{ github.sha }}
+
+      - name: Upload criterion baseline
+        uses: actions/upload-artifact@v4
+        with:
+          name: criterion-baseline-${{ github.sha }}
+          path: target/criterion
+          retention-days: 30

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -12,6 +12,7 @@ on:
       - "e2e-tests/**"
       - "tools/**"
       - "scripts/check-wasm-size.sh"
+      - "scripts/check-storage-cost.sh"
       - ".github/workflows/ci-checks.yml"
 
 env:
@@ -225,3 +226,33 @@ jobs:
 
       - name: Check wasm sizes against the runtime module-size limit
         run: ./scripts/check-wasm-size.sh
+
+  # Storage costs are deterministic — same inputs, same read/write/remove counts
+  # on any machine — so this gates. Wall-clock benchmarks do NOT gate; they run
+  # post-merge in benchmarks.yml, because timing noise on shared runners makes a
+  # time-based gate a false-alarm generator, and because a timing bench against
+  # an in-memory store would not have caught core#3602 at all.
+  storage-cost:
+    name: Storage cost gate
+    runs-on: ubuntu-24.04-8cpu
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Rust CI
+        uses: ./.github/actions/setup-rust-ci
+        with:
+          toolchain: stable
+          shared-key: storage-cost
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      # Shape first, constants second. The shape tests catch a complexity
+      # regression even when the snapshot was regenerated to absorb it, which is
+      # precisely how a reviewer gets fooled otherwise.
+      - name: Assert cost curves keep their declared shape
+        run: cargo test -p storage-cost --release
+
+      - name: Check storage costs against the committed snapshot
+        run: ./scripts/check-storage-cost.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,6 +1821,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,6 +1924,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -2363,6 +2402,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -3751,6 +3824,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4457,6 +4541,17 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6545,6 +6640,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opaque-debug"
@@ -9153,6 +9254,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "storage-cost"
+version = "0.1.0"
+dependencies = [
+ "calimero-storage",
+ "criterion",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9529,6 +9640,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,6 +191,7 @@ members = [
     "./tools/merodb",
     "./tools/mero-sign",
     "./tools/cargo-mero",
+    "./tools/storage-cost",
 ]
 
 [workspace.dependencies]
@@ -212,6 +213,7 @@ cargo_metadata = "0.20.0"
 cfg-if = "1.0.0"
 chrono = "0.4.37"
 claims = "0.7.1"
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 clap = "4.4.18"
 serial_test = "3.2"
 color-eyre = "0.6.2"

--- a/crates/runtime/tests/chat_wall.rs
+++ b/crates/runtime/tests/chat_wall.rs
@@ -19,6 +19,33 @@
 //! that point (core#3602). The wall is the count of the last message that
 //! landed.
 //!
+//! # This is a probe, not the gate
+//!
+//! It cannot be the gate: it drives a contract in another repo and is
+//! `#[ignore]`d, so core CI never runs it. It rotted silently once already,
+//! when mero-chat dropped `sender_username` from `send_message` — every call
+//! failed argument deserialization and the probe "walled" at 0.
+//!
+//! The property it is about — one positional read costing O(n) — is gated
+//! in-repo instead, with no cross-repo dependency, by the `vector_get_nth`
+//! workload in `tools/storage-cost` (`cargo test -p storage-cost`, plus
+//! `scripts/check-storage-cost.sh`). That runs on every PR. This probe adds the
+//! end-to-end number in gas, against the real app, on demand.
+//!
+//! # It can no longer rot quietly
+//!
+//! Every failure is classified before it is reported, and the two verdicts are
+//! kept apart on purpose:
+//!
+//! * `GasExhausted` — a real wall. The only outcome that produces a number.
+//! * anything else — CONTRACT DRIFT. Method renamed, arguments changed, ABI
+//!   moved. The probe panics naming the method and the error, and never reports
+//!   a wall, because a wall it did not measure is worse than no wall.
+//!
+//! A preflight runs one `send_message` and one `get_messages` before the sweep
+//! starts, so drift is reported in seconds rather than after a five-minute run
+//! that "found" a wall at 0.
+//!
 //! # Running it
 //!
 //! Ignored by default: it needs a `curb.wasm` built from mero-chat-pwa, which
@@ -33,6 +60,7 @@ use std::process::Command;
 use std::time::Instant;
 
 use calimero_account::AccountId;
+use calimero_runtime::errors::{FunctionCallError, MethodResolutionError};
 use calimero_runtime::logic::{Outcome, VMLimits};
 use calimero_runtime::store::InMemoryStorage;
 use calimero_runtime::Engine;
@@ -84,6 +112,24 @@ fn build_curb_wasm() -> Vec<u8> {
          clone it beside this workspace, or set CURB_LOGIC_DIR",
         logic_dir.display(),
     );
+
+    // A `[patch]` written into mero-chat's own manifest wins over the one this
+    // harness injects with `--config`, so the probe would silently measure
+    // whatever tree that patch names instead of this one — and report the
+    // number as if it came from here. Workstation overrides like that are
+    // common (they are how people develop against a local core), which is
+    // exactly why this has to be checked rather than assumed.
+    let manifest = std::fs::read_to_string(logic_dir.join("Cargo.toml"))
+        .expect("mero-chat logic manifest is readable");
+    if manifest.contains(&format!("[patch.\"{CORE_GIT_SOURCE}\"]")) {
+        drift(&format!(
+            "{}/Cargo.toml contains its own [patch.\"{CORE_GIT_SOURCE}\"] section.\n\
+             That overrides the redirect this probe injects, so the build would measure \
+             the tree that patch names, not this one. Remove it (it is a workstation-only \
+             override that should never be committed) and rerun.",
+            logic_dir.display(),
+        ));
+    }
 
     // Absolute paths: `--config` values are resolved against the invoking
     // directory, not the target manifest's.
@@ -175,8 +221,165 @@ fn call(
         .expect("run must return an Outcome")
 }
 
+/// The `init` arguments. Kept next to the other two so the whole cross-repo
+/// contract this probe depends on is visible in one screenful.
+fn init_args() -> serde_json::Value {
+    serde_json::json!({
+        "name": "wall",
+        "context_type": "Channel",
+        "description": "",
+        "created_at": 0_u64,
+        "creator_username": "alice",
+    })
+}
+
+/// The `send_message` arguments.
+///
+/// THIS is what rotted in 2026-08: mero-chat dropped `sender_username` and
+/// every call here started failing argument deserialization. Defined once so
+/// fixing it is one edit, and so a reader can diff it against the contract.
+fn send_message_args(i: usize) -> serde_json::Value {
+    serde_json::json!({
+        "message": format!("message {i}"),
+        "mentions": [],
+        "mentions_usernames": [],
+        "parent_message": null,
+        "timestamp": i as u64,
+        "files": null,
+        "images": null,
+    })
+}
+
+/// The `get_messages` arguments — one page, from the top.
+fn get_messages_args() -> serde_json::Value {
+    serde_json::json!({
+        "parent_message": null,
+        "limit": 20,
+        "offset": 0,
+        "search_term": null,
+    })
+}
+
+/// How many messages `get_messages` says the store holds.
+///
+/// Drifts if the response shape changes, which is a contract change like any
+/// other: without this number the cost curve could be an artifact of writes
+/// that silently vanished, and a harness whose writes vanish lands every call
+/// and looks exactly like success.
+fn total_count(outcome: &Outcome) -> usize {
+    let body = outcome
+        .returns
+        .as_ref()
+        .unwrap_or_else(|_| drift("get_messages failed while reading total_count"))
+        .as_ref()
+        .unwrap_or_else(|| drift("get_messages returned no value at all"));
+    let parsed: serde_json::Value = serde_json::from_slice(body)
+        .unwrap_or_else(|e| drift(&format!("get_messages did not return JSON: {e}")));
+    parsed
+        .pointer("/output/total_count")
+        .or_else(|| parsed.get("total_count"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or_else(|| {
+            drift(&format!(
+                "no total_count in the get_messages response: {parsed}"
+            ))
+        }) as usize
+}
+
+/// Prove the contract still answers the calls this probe makes, on a THROWAWAY
+/// store, before spending minutes on a sweep.
+///
+/// Runs against its own storage so the measured run still starts empty. Costs
+/// three calls; buys the difference between "the wall is at 0" and "your
+/// arguments are stale".
+fn preflight(module: &calimero_runtime::Module) {
+    let mut storage = InMemoryStorage::default();
+
+    expect_ok(&call(module, &mut storage, "init", &init_args()), "init");
+    expect_ok(
+        &call(module, &mut storage, "send_message", &send_message_args(0)),
+        "send_message",
+    );
+    let read = call(module, &mut storage, "get_messages", &get_messages_args());
+    expect_ok(&read, "get_messages");
+
+    let total = total_count(&read);
+    if total != 1 {
+        drift(&format!(
+            "after one send_message, get_messages reports total_count={total}, not 1. \
+             The write is not landing where the read looks, so every number this probe \
+             would produce is an artifact."
+        ));
+    }
+}
+
+/// What a failed call means. The distinction is the whole point of this probe:
+/// a measured wall and a broken harness must never be reported the same way.
+enum Verdict {
+    /// The guest ran and exhausted its budget. This is a result.
+    Wall { limit: u64 },
+    /// The guest did not get far enough to cost anything meaningful — the
+    /// method is gone, the arguments no longer deserialize, the ABI moved. This
+    /// is not a result, and must never be presented as one.
+    Drift(String),
+}
+
+/// Classify a failed outcome.
+///
+/// `GasExhausted` is the ONLY failure that counts as a wall. `ExecutionError`
+/// in particular does not: that is how a `#[app::logic]` method reports that it
+/// could not deserialize its arguments, which is exactly the drift that made
+/// this probe report a wall at 0 in 2026-08.
+fn classify(method: &str, error: &FunctionCallError) -> Verdict {
+    match error {
+        FunctionCallError::GasExhausted { limit } => Verdict::Wall { limit: *limit },
+        FunctionCallError::ExecutionError(payload) => Verdict::Drift(format!(
+            "{method} returned an application error: {}\n\
+             The usual cause is an argument this probe passes that the contract no \
+             longer takes (or one it now requires). Compare the call site below \
+             against mero-chat's current #[app::logic] signature.",
+            String::from_utf8_lossy(payload)
+        )),
+        other => Verdict::Drift(format!("{method} failed: {other}")),
+    }
+}
+
+/// Panic with a message that cannot be mistaken for a measurement.
+fn drift(detail: &str) -> ! {
+    panic!(
+        "\n\
+         ==================== CONTRACT DRIFT — NOT A STORAGE RESULT ====================\n\
+         {detail}\n\
+         \n\
+         This probe drives a contract in another repo (mero-chat-pwa) and its call\n\
+         arguments are hand-written here, so they go stale. Nothing has been measured\n\
+         and no wall has been found; fix the call site in this file, then rerun.\n\
+         \n\
+         The in-repo gate for the same property does not depend on that contract:\n\
+         \x20 cargo test -p storage-cost      (vector_get_nth, tools/storage-cost)\n\
+         \x20 ./scripts/check-storage-cost.sh\n\
+         ==============================================================================\n"
+    )
+}
+
+/// Run a call that is expected to succeed; drift if it does not.
+fn expect_ok(outcome: &Outcome, method: &str) {
+    if let Err(error) = &outcome.returns {
+        match classify(method, error) {
+            Verdict::Drift(detail) => drift(&detail),
+            Verdict::Wall { limit } => drift(&format!(
+                "{method} exhausted its {limit}-point gas budget on the FIRST call, \
+                 against an empty store. That is not a wall — a wall needs data behind \
+                 it. Either max_gas has been lowered dramatically or the contract now \
+                 does unbounded work at n=0."
+            )),
+        }
+    }
+}
+
 #[test]
-#[ignore = "needs curb.wasm from mero-chat-pwa; see module docs"]
+#[ignore = "cross-repo probe: needs curb.wasm from mero-chat-pwa. The in-repo gate \
+            for the same property is `cargo test -p storage-cost` (vector_get_nth)."]
 fn how_many_messages_before_send_message_walls() {
     let wasm = build_curb_wasm();
 
@@ -188,23 +391,14 @@ fn how_many_messages_before_send_message_walls() {
         .compile(&wasm)
         .expect("compile metered module");
 
+    // Before anything is measured: does the contract still answer these calls?
+    preflight(&module);
+
     // One store for the whole run: the point is that cost depends on what the
     // store already holds, so it must persist across calls.
     let mut storage = InMemoryStorage::default();
 
-    let init = call(
-        &module,
-        &mut storage,
-        "init",
-        &serde_json::json!({
-            "name": "wall",
-            "context_type": "Channel",
-            "description": "",
-            "created_at": 0_u64,
-            "creator_username": "alice",
-        }),
-    );
-    assert!(init.returns.is_ok(), "init failed: {:?}", init.returns);
+    expect_ok(&call(&module, &mut storage, "init", &init_args()), "init");
 
     // Geometric read probes: get_messages is O(n) in the app, so probing it
     // every append would dominate the run. These points are enough to see the
@@ -228,26 +422,26 @@ fn how_many_messages_before_send_message_walls() {
 
     for i in 0..ceiling {
         let started = Instant::now();
-        let outcome = call(
-            &module,
-            &mut storage,
-            "send_message",
-            &serde_json::json!({
-                "message": format!("message {i}"),
-                "mentions": [],
-                "mentions_usernames": [],
-                "parent_message": null,
-                "timestamp": i as u64,
-                "files": null,
-                "images": null,
-            }),
-        );
+        let outcome = call(&module, &mut storage, "send_message", &send_message_args(i));
         let write_ms = started.elapsed().as_secs_f64() * 1000.0;
 
-        if outcome.returns.is_err() {
-            println!("\nWRITE WALL at {landed}: {:?}", outcome.returns);
-            write_wall = Some(landed);
-            break;
+        if let Err(error) = &outcome.returns {
+            match classify("send_message", error) {
+                Verdict::Wall { limit } => {
+                    println!("\nWRITE WALL at {landed} (gas limit {limit})");
+                    write_wall = Some(landed);
+                    break;
+                }
+                // Preflight passed, so the contract answered this call a moment
+                // ago with an empty store. Failing now for a non-gas reason is
+                // a state-dependent bug, not a cost measurement, and reporting
+                // it as a wall would put a fictional number in a document.
+                Verdict::Drift(detail) => drift(&format!(
+                    "{detail}\n\
+                     This appeared only after {landed} messages, so it is state-dependent \
+                     rather than a stale signature."
+                )),
+            }
         }
         landed += 1;
 
@@ -255,37 +449,21 @@ fn how_many_messages_before_send_message_walls() {
             next_probe += 1;
 
             let started = Instant::now();
-            let read = call(
-                &module,
-                &mut storage,
-                "get_messages",
-                &serde_json::json!({
-                    "parent_message": null,
-                    "limit": 20,
-                    "offset": 0,
-                    "search_term": null,
-                }),
-            );
+            let read = call(&module, &mut storage, "get_messages", &get_messages_args());
             let read_ms = started.elapsed().as_secs_f64() * 1000.0;
 
             match &read.returns {
-                Ok(value) => {
+                Ok(_) => {
                     // Confirms the store really accumulated: a harness whose
                     // writes silently vanished would show a flat curve and land
                     // every call, which looks exactly like success.
-                    let body = value.as_ref().expect("get_messages returned no value");
-                    let parsed: serde_json::Value =
-                        serde_json::from_slice(body).expect("get_messages returns JSON");
-                    let total = parsed
-                        .pointer("/output/total_count")
-                        .or_else(|| parsed.get("total_count"))
-                        .and_then(serde_json::Value::as_u64)
-                        .unwrap_or_else(|| panic!("no total_count in {parsed}"));
-                    assert_eq!(
-                        total as usize, landed,
-                        "store holds {total} but {landed} were appended — the cost \
-                         curve would be an artifact, not a result"
-                    );
+                    let total = total_count(&read);
+                    if total != landed {
+                        drift(&format!(
+                            "store holds {total} but {landed} were appended — the cost \
+                             curve would be an artifact, not a result"
+                        ));
+                    }
 
                     if read_wall.is_none() {
                         last_read_ok = Some(landed);
@@ -295,15 +473,18 @@ fn how_many_messages_before_send_message_walls() {
                         outcome.gas_used, outcome.storage_reads, read.gas_used, read.storage_reads,
                     );
                 }
-                Err(e) => {
-                    println!(
-                        "  {landed:<6}  {:>12?}  {:>7}  {write_ms:>7.1} | READ WALL: {e:?}",
-                        outcome.gas_used, outcome.storage_reads,
-                    );
-                    if read_wall.is_none() {
-                        read_wall = Some(landed);
+                Err(error) => match classify("get_messages", error) {
+                    Verdict::Wall { .. } => {
+                        println!(
+                            "  {landed:<6}  {:>12?}  {:>7}  {write_ms:>7.1} | READ WALL (gas exhausted)",
+                            outcome.gas_used, outcome.storage_reads,
+                        );
+                        if read_wall.is_none() {
+                            read_wall = Some(landed);
+                        }
                     }
-                }
+                    Verdict::Drift(detail) => drift(&detail),
+                },
             }
         }
     }
@@ -322,8 +503,76 @@ fn how_many_messages_before_send_message_walls() {
         (_, None) => println!("read wall  (get_messages):  none below {landed}"),
     }
 
+    // Preflight already proved one message lands, and every non-gas failure
+    // above panics as drift, so reaching here with nothing appended would mean
+    // the classification is wrong rather than the storage layer.
     assert!(
         landed > 0,
-        "the contract could not append even one message — the harness is wrong, not the storage layer"
+        "no message was appended even though preflight succeeded — the failure \
+         classification in this file is broken"
+    );
+
+    // A wall found in the first handful of messages is not a wall; it is a
+    // symptom that the contract now does something unbounded per call. Say so
+    // rather than publishing the number.
+    if let Some(n) = write_wall.or(read_wall) {
+        assert!(
+            n >= 50,
+            "walled after only {n} messages. Preflight passed, so the calls are \
+             well-formed, but a ceiling this low is a change in the contract's work \
+             per call, not the cost curve this probe exists to measure. Investigate \
+             before quoting the number."
+        );
+    }
+}
+
+/// The discriminator itself runs in CI, even though the probe does not.
+///
+/// Everything above rests on `classify` telling a measured wall apart from a
+/// stale call signature. That function has no other coverage — the probe that
+/// uses it is `#[ignore]`d — so a refactor could invert it and nobody would
+/// find out until the next time someone quoted a number that was really a
+/// deserialization failure. Which is the exact history this file is guarding
+/// against.
+#[test]
+fn only_gas_exhaustion_counts_as_a_wall() {
+    assert!(
+        matches!(
+            classify(
+                "send_message",
+                &FunctionCallError::GasExhausted { limit: 1_000 }
+            ),
+            Verdict::Wall { limit: 1_000 }
+        ),
+        "gas exhaustion is the one failure that is a measurement"
+    );
+
+    // How a #[app::logic] method reports that it could not deserialize its
+    // arguments — i.e. exactly the 2026-08 rot.
+    let Verdict::Drift(detail) = classify(
+        "send_message",
+        &FunctionCallError::ExecutionError(b"missing field `sender_username`".to_vec()),
+    ) else {
+        panic!(
+            "an application error was classified as a wall — the probe would report \
+                a fictional number"
+        );
+    };
+    assert!(
+        detail.contains("sender_username"),
+        "the drift message must carry the contract's own complaint, got: {detail}"
+    );
+
+    let Verdict::Drift(detail) = classify(
+        "get_messages",
+        &FunctionCallError::MethodResolutionError(MethodResolutionError::MethodNotFound {
+            name: "get_messages".to_owned(),
+        }),
+    ) else {
+        panic!("a renamed method was classified as a wall");
+    };
+    assert!(
+        detail.contains("get_messages"),
+        "the drift message must name the method, got: {detail}"
     );
 }

--- a/scripts/check-storage-cost.sh
+++ b/scripts/check-storage-cost.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Fail if measured storage costs differ from the committed snapshot.
+#
+# Row counts are deterministic — same inputs, same read/write/remove counts on
+# any machine — so ANY delta is a real change and blocks. An improvement blocks
+# too, on purpose: the snapshot is the reviewed record of what operations cost,
+# and a cost that moves should move visibly.
+#
+# Byte counts are deliberately NOT in the snapshot. Entity ids are random
+# (`Id::random` -> `rand::thread_rng`), so index rows serialize to slightly
+# different lengths run to run; gating on them would flake. See the module docs
+# of tools/storage-cost/src/lib.rs.
+#
+# To accept a change: cargo run -p storage-cost --bin storage-cost --release \
+#     > tools/storage-cost/storage-costs.json
+# and commit it, so the delta appears in the PR diff.
+#
+# Usage: check-storage-cost.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+SNAPSHOT="tools/storage-cost/storage-costs.json"
+
+if [ ! -f "$SNAPSHOT" ]; then
+    echo "ERROR: $SNAPSHOT not found; generate it first (see the header of this script)" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq is required" >&2
+    exit 1
+fi
+
+measured="$(mktemp)"
+trap 'rm -f "$measured"' EXIT
+
+echo "Measuring storage costs..."
+cargo run --quiet -p storage-cost --bin storage-cost --release >"$measured"
+
+# Per-workload tolerance: 0 for almost everything, so almost everything is an
+# exact-equality gate. It is nonzero only where walking the whole child trie
+# makes the node count follow the random id distribution; tools/storage-cost/
+# tests/reproducible.rs re-derives every declared tolerance from live runs, so
+# a too-wide band fails there rather than passing here.
+#
+# A workload present in only one of the two files reports `null` on the missing
+# side, which is how an added or deleted workload announces itself instead of
+# silently passing.
+deltas="$(jq -r -s '
+  def num: if . == null then null else . end;
+  .[0] as $old | .[1] as $new
+  | [ (($old + $new) | keys[]) as $w
+      | ((($old[$w].sizes // {}) + ($new[$w].sizes // {})) | keys[]) as $s
+      | ["rows_read", "rows_written", "rows_removed"][] as $m
+      | { workload: $w, size: $s, metric: $m,
+          old: ($old[$w].sizes[$s][$m] | num),
+          new: ($new[$w].sizes[$s][$m] | num),
+          tol: (($old[$w].tolerance_pct // 0)) }
+    ]
+  | map(select(
+      (.old == null) or (.new == null) or
+      # tolerance 0 means exact equality. Anything else would let a one-row
+      # drift through on every workload, which is most of them.
+      (if .tol == 0
+       then .new != .old
+       else ((.new - .old) | fabs) > ([1, (.old * .tol / 100)] | max)
+       end)
+    ))
+  | .[]
+  | [ .workload, (.size | tonumber | tostring), .metric, (.old | tostring),
+      (.new | tostring), (.tol | tostring) ]
+  | @tsv
+' "$SNAPSHOT" "$measured")"
+
+if [ -z "$deltas" ]; then
+    rows="$(jq -r '[.[].sizes | keys[]] | length' "$measured")"
+    echo "OK: all $rows measured cost rows match $SNAPSHOT."
+    exit 0
+fi
+
+echo "" >&2
+echo "FAIL: measured storage costs differ from $SNAPSHOT." >&2
+echo "" >&2
+printf '%-24s %8s %-14s %12s %12s %6s\n' "WORKLOAD" "N" "METRIC" "SNAPSHOT" "MEASURED" "TOL%" >&2
+printf '%s\n' "$deltas" | while IFS=$'\t' read -r workload size metric old new tol; do
+    printf '%-24s %8s %-14s %12s %12s %6s\n' "$workload" "$size" "$metric" "$old" "$new" "$tol" >&2
+done
+
+echo "" >&2
+echo "If this change is intended, regenerate and commit the snapshot:" >&2
+echo "  cargo run -p storage-cost --bin storage-cost --release > $SNAPSHOT" >&2
+echo "so the cost delta lands in the PR diff where a reviewer sees it." >&2
+exit 1

--- a/tools/storage-cost/Cargo.toml
+++ b/tools/storage-cost/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "storage-cost"
+description = "Deterministic storage-cost measurement and benchmarks for calimero-storage"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+calimero-storage = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+criterion = { workspace = true }

--- a/tools/storage-cost/Cargo.toml
+++ b/tools/storage-cost/Cargo.toml
@@ -8,6 +8,24 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+# Only the criterion target is a benchmark. Without this, `cargo bench -p
+# storage-cost` also hands the lib and integration-test targets to libtest,
+# which then rejects criterion's own CLI flags.
+[lib]
+bench = false
+
+[[bin]]
+name = "storage-cost"
+bench = false
+
+[[test]]
+name = "flat_curve"
+bench = false
+
+[[test]]
+name = "reproducible"
+bench = false
+
 [dependencies]
 calimero-storage = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -15,3 +33,8 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+
+# `harness = false` hands the target's `main` to criterion instead of libtest.
+[[bench]]
+name = "collections"
+harness = false

--- a/tools/storage-cost/benches/collections.rs
+++ b/tools/storage-cost/benches/collections.rs
@@ -1,0 +1,45 @@
+//! Tier 2: wall-clock throughput. REPORTING ONLY — never a merge gate.
+//!
+//! Two reasons this does not gate, both load-bearing:
+//!
+//! 1. It would not have caught core#3602. Against an in-memory store, an O(n)
+//!    read pattern costs almost nothing in wall-clock, so the curve reads flat
+//!    while real gas explodes. The gate for that is the cost snapshot.
+//! 2. Criterion's default significance threshold is ~5%; shared CI runners
+//!    routinely exceed that from cache state and neighbouring jobs alone. A
+//!    gate that cries wolf gets muted, which is worse than no gate.
+//!
+//! What it IS good for: throughput curves over `n`, compared against a stored
+//! baseline on master, so a real algorithmic win or loss is visible as a trend.
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+use storage_cost::measure;
+use storage_cost::workloads::all;
+
+fn collections(c: &mut Criterion) {
+    let mut group = c.benchmark_group("collections");
+
+    for workload in all() {
+        // Elements-per-second rather than time-per-iteration: every workload
+        // builds `n` entries, so the per-entry rate is the comparable number
+        // across sizes. A rate that falls as `n` grows is the signal.
+        let _ignored = group.throughput(Throughput::Elements(workload.n as u64));
+        let _ignored = group.bench_function(format!("{}/{}", workload.name, workload.n), |b| {
+            b.iter_batched(
+                || workload.n,
+                |n| {
+                    let (result, _costs) = measure(|| (workload.run)(n));
+                    black_box(result)
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, collections);
+criterion_main!(benches);

--- a/tools/storage-cost/src/bin/storage-cost.rs
+++ b/tools/storage-cost/src/bin/storage-cost.rs
@@ -1,0 +1,82 @@
+//! Emit the storage-cost table as JSON on stdout.
+//!
+//! `scripts/check-storage-cost.sh` diffs this against the committed snapshot.
+//! Output is deterministically ordered (`BTreeMap`, zero-padded numeric keys)
+//! so a diff shows real cost changes and never key reordering.
+//!
+//! Only ROW counters are emitted. Byte counters are not reproducible — entity
+//! ids are random, so index rows serialize to slightly different lengths run to
+//! run. See the module docs of `storage_cost` for the full reasoning; gating on
+//! bytes would be a flake generator.
+//!
+//! `--workload <name>` restricts the run to one workload.
+//!
+//! Each workload also carries the tolerance the gate applies to it (see
+//! `workloads::Workload::tolerance_pct`); it is emitted here so regenerating
+//! the snapshot cannot drop it.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+use storage_cost::workloads::all;
+use storage_cost::{measure, RowCosts};
+
+/// One workload's snapshot entry: the tolerance the gate applies, then the
+/// measured costs per collection size.
+///
+/// The tolerance is emitted rather than hand-maintained in the JSON so that
+/// regenerating the snapshot cannot silently drop it, and so that changing it
+/// is a code change a reviewer sees in `workloads.rs`.
+#[derive(Serialize)]
+struct Entry {
+    tolerance_pct: u32,
+    sizes: BTreeMap<String, RowCosts>,
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mut only: Option<String> = None;
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--workload" => {
+                only = Some(args.next().unwrap_or_else(|| {
+                    eprintln!("--workload requires a value");
+                    std::process::exit(2);
+                }));
+            }
+            other => {
+                eprintln!("unknown argument: {other}");
+                eprintln!("usage: storage-cost [--workload <name>]");
+                std::process::exit(2);
+            }
+        }
+    }
+
+    let mut table: BTreeMap<String, Entry> = BTreeMap::new();
+    for workload in all() {
+        if only.as_ref().is_some_and(|name| workload.name != name) {
+            continue;
+        }
+        let (_, costs) = measure(|| (workload.run)(workload.n));
+        let entry = table.entry(workload.name.to_owned()).or_insert(Entry {
+            tolerance_pct: workload.tolerance_pct,
+            sizes: BTreeMap::new(),
+        });
+        // Zero-padded so string ordering matches numeric ordering in the
+        // committed snapshot — "10" must not sort before "1000".
+        let _ignored = entry
+            .sizes
+            .insert(format!("{:08}", workload.n), costs.rows());
+    }
+
+    if table.is_empty() {
+        eprintln!(
+            "no workloads matched{}",
+            only.map(|n| format!(" --workload {n}")).unwrap_or_default()
+        );
+        std::process::exit(2);
+    }
+
+    let json = serde_json::to_string_pretty(&table).expect("RowCosts serialization is infallible");
+    println!("{json}");
+}

--- a/tools/storage-cost/src/lib.rs
+++ b/tools/storage-cost/src/lib.rs
@@ -1,0 +1,214 @@
+//! Deterministic storage-cost measurement for `calimero-storage`.
+//!
+//! Installs a `RuntimeEnv` whose read/write/remove callbacks close over an
+//! owned map plus counters, so every storage operation a workload performs is
+//! counted exactly. Nothing in `crates/` changes: `RuntimeEnv::new` already
+//! takes the callbacks as `Rc<dyn Fn>`.
+//!
+//! Each `measure` call gets a FRESH backing map, so measurements are isolated
+//! from each other without needing `env::reset_for_testing` (which is
+//! `#[cfg(test)]` and therefore unreachable from this crate).
+//!
+//! # Determinism, measured 2026-08-26
+//!
+//! ROW counts are exactly reproducible in-process: three consecutive runs of
+//! every registered workload at every size produced identical
+//! `rows_read`/`rows_written`/`rows_removed`. No process isolation is needed.
+//!
+//! BYTE counts are NOT reproducible, and no amount of process isolation would
+//! make them so. Every entity gets an `Id::random()`
+//! (`crates/storage/src/address.rs:49`), which on the native path is
+//! `rand::thread_rng()` (`crates/storage/src/env.rs:1099`) with no seeding hook
+//! reachable from outside the crate. Random ids land in different child-trie
+//! buckets run to run, so index rows serialize to slightly different lengths —
+//! observed drift is ~1.5% at every size.
+//!
+//! Consequence for the gate: [`RowCosts`] — the row counters only — is what
+//! `storage-costs.json` records and what `scripts/check-storage-cost.sh` diffs.
+//! Byte counts stay on [`Costs`] for local inspection and for the benches, but
+//! gating on them would be a flake generator. Making them gateable needs a
+//! seedable RNG hook in `calimero-storage`, which is a production change and
+//! deliberately out of scope here.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+
+use calimero_storage::env::{with_runtime_env, RuntimeEnv};
+use calimero_storage::store::Key;
+use serde::{Deserialize, Serialize};
+
+pub mod workloads;
+
+/// The deterministic projection of [`Costs`]: what the snapshot gate diffs.
+///
+/// Row counts reproduce exactly; byte counts do not (see the module docs), so
+/// only these three cross into `storage-costs.json`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RowCosts {
+    /// Host reads issued, whether or not the key existed.
+    pub rows_read: u64,
+    /// Host writes issued.
+    pub rows_written: u64,
+    /// Host removes issued.
+    pub rows_removed: u64,
+}
+
+/// Storage operations performed by one workload.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Costs {
+    /// Host reads issued, whether or not the key existed.
+    pub rows_read: u64,
+    /// Host writes issued.
+    pub rows_written: u64,
+    /// Host removes issued.
+    pub rows_removed: u64,
+    /// Bytes handed to the write callback.
+    pub bytes_written: u64,
+    /// Bytes returned by the read callback (misses contribute nothing).
+    pub bytes_read: u64,
+}
+
+impl Costs {
+    /// The gateable subset. See the module docs for why bytes are excluded.
+    #[must_use]
+    pub const fn rows(&self) -> RowCosts {
+        RowCosts {
+            rows_read: self.rows_read,
+            rows_written: self.rows_written,
+            rows_removed: self.rows_removed,
+        }
+    }
+}
+
+#[derive(Default)]
+struct Backing {
+    map: BTreeMap<[u8; 32], Vec<u8>>,
+    costs: Costs,
+}
+
+/// Run `f` against a fresh counting store, returning its result and the
+/// storage operations it performed.
+pub fn measure<R>(f: impl FnOnce() -> R) -> (R, Costs) {
+    let backing = Rc::new(RefCell::new(Backing::default()));
+
+    let read = {
+        let b = Rc::clone(&backing);
+        Rc::new(move |key: &Key| {
+            let mut b = b.borrow_mut();
+            let value = b.map.get(&key.to_bytes()).cloned();
+            b.costs.rows_read += 1;
+            if let Some(bytes) = value.as_ref() {
+                b.costs.bytes_read += bytes.len() as u64;
+            }
+            value
+        })
+    };
+
+    let write = {
+        let b = Rc::clone(&backing);
+        Rc::new(move |key: Key, value: &[u8]| {
+            let mut b = b.borrow_mut();
+            b.costs.rows_written += 1;
+            b.costs.bytes_written += value.len() as u64;
+            let _ignored = b.map.insert(key.to_bytes(), value.to_vec());
+            true
+        })
+    };
+
+    let remove = {
+        let b = Rc::clone(&backing);
+        Rc::new(move |key: &Key| {
+            let mut b = b.borrow_mut();
+            b.costs.rows_removed += 1;
+            b.map.remove(&key.to_bytes()).is_some()
+        })
+    };
+
+    let env = RuntimeEnv::new(read, write, remove, [1; 32], [2; 32], [3; 32]);
+    let result = with_runtime_env(env, f);
+    let costs = backing.borrow().costs;
+    (result, costs)
+}
+
+#[cfg(test)]
+mod tests {
+    use calimero_storage::collections::{Root, UnorderedMap};
+    use calimero_storage::store::MainStorage;
+
+    use super::*;
+
+    /// The harness must observe writes at all — if the `RuntimeEnv` is not
+    /// actually routing `MainStorage` through our callbacks, every count is
+    /// silently zero and every downstream gate is vacuous.
+    #[test]
+    fn measure_observes_writes() {
+        let (_, costs) = measure(|| {
+            let mut map = Root::new(UnorderedMap::<String, String, MainStorage>::new);
+            map.insert("k".to_owned(), "v".to_owned())
+                .expect("insert should succeed");
+        });
+
+        assert!(
+            costs.rows_written > 0,
+            "harness observed no writes — RuntimeEnv is not routing MainStorage; got {costs:?}"
+        );
+        assert!(
+            costs.bytes_written > 0,
+            "harness observed no bytes written; got {costs:?}"
+        );
+    }
+
+    /// Two identical measurements must produce identical ROW counts. This is
+    /// the property the entire snapshot gate rests on: if per-process
+    /// thread-local state leaks between measurements, the snapshot is unstable
+    /// and the gate flakes.
+    #[test]
+    fn row_counts_are_deterministic_across_calls() {
+        let workload = || {
+            let mut map = Root::new(UnorderedMap::<String, String, MainStorage>::new);
+            for i in 0..16 {
+                map.insert(format!("k{i}"), "v".to_owned())
+                    .expect("insert should succeed");
+            }
+        };
+
+        let (_, first) = measure(workload);
+        let (_, second) = measure(workload);
+
+        assert_eq!(
+            first.rows(),
+            second.rows(),
+            "identical workloads produced different row counts — state is leaking \
+             between measurements, and the snapshot gate cannot be trusted"
+        );
+    }
+
+    /// Pins the reason bytes are not gated, so a future contributor who wants
+    /// to add them to the snapshot finds out here rather than from a flaky CI
+    /// run. If this ever FAILS, entity ids have become deterministic and
+    /// `bytes_written`/`bytes_read` can be promoted into `RowCosts`.
+    #[test]
+    fn byte_counts_are_not_reproducible() {
+        let workload = || {
+            let mut map = Root::new(UnorderedMap::<String, String, MainStorage>::new);
+            for i in 0..256 {
+                map.insert(format!("k{i}"), "v".to_owned())
+                    .expect("insert should succeed");
+            }
+        };
+
+        let mut seen = std::collections::BTreeSet::new();
+        for _ in 0..8 {
+            let (_, costs) = measure(workload);
+            let _ignored = seen.insert(costs.bytes_written);
+        }
+
+        assert!(
+            seen.len() > 1,
+            "byte counts reproduced exactly across 8 runs ({seen:?}) — entity ids may \
+             have become deterministic. If so, promote bytes into RowCosts and delete \
+             this test; see the module docs."
+        );
+    }
+}

--- a/tools/storage-cost/src/lib.rs
+++ b/tools/storage-cost/src/lib.rs
@@ -126,9 +126,36 @@ pub fn measure<R>(f: impl FnOnce() -> R) -> (R, Costs) {
     };
 
     let env = RuntimeEnv::new(read, write, remove, [1; 32], [2; 32], [3; 32]);
+
+    let previous = CURRENT.with(|c| c.borrow_mut().replace(Rc::clone(&backing)));
     let result = with_runtime_env(env, f);
+    CURRENT.with(|c| *c.borrow_mut() = previous);
+
     let costs = backing.borrow().costs;
     (result, costs)
+}
+
+thread_local! {
+    /// The backing store of the innermost in-flight [`measure`], so a workload
+    /// can zero the counters partway through. Restored on the way out, so
+    /// nesting behaves.
+    static CURRENT: RefCell<Option<Rc<RefCell<Backing>>>> = const { RefCell::new(None) };
+}
+
+/// Discard everything counted so far in the enclosing [`measure`] call.
+///
+/// This is what lets a workload isolate ONE operation from the build that had
+/// to precede it. A collection lives in the storage layer's thread-local state,
+/// so the build cannot happen outside the measured region; zeroing between the
+/// two is the only way to attribute cost to the operation alone.
+///
+/// A no-op outside `measure`, so a workload run directly in a test still works.
+pub fn reset_counters() {
+    CURRENT.with(|c| {
+        if let Some(backing) = c.borrow().as_ref() {
+            backing.borrow_mut().costs = Costs::default();
+        }
+    });
 }
 
 #[cfg(test)]

--- a/tools/storage-cost/src/workloads.rs
+++ b/tools/storage-cost/src/workloads.rs
@@ -1,0 +1,94 @@
+//! The single registry of measured workloads.
+//!
+//! The binary, the flat-curve tests and the criterion benches all iterate
+//! `all()`. Defining a workload anywhere else would let the gate and the
+//! benchmarks measure different things while claiming to measure one.
+
+use calimero_storage::collections::{Root, UnorderedMap};
+use calimero_storage::store::MainStorage;
+
+/// Collection sizes every workload is measured at. The gate compares costs at
+/// each size; the flat-curve test compares the first against the last.
+pub const SIZES: [usize; 4] = [10, 100, 1_000, 10_000];
+
+/// One measurable unit of work at one collection size.
+pub struct Workload {
+    /// Stable identifier. Appears in the snapshot, so renaming one is a
+    /// snapshot change a reviewer will see.
+    pub name: &'static str,
+    /// Collection size this instance exercises.
+    pub n: usize,
+    /// Builds a collection of `n` entries and performs the measured operation.
+    pub run: fn(usize),
+}
+
+/// Insert `n` entries into an `UnorderedMap`, measuring the whole build.
+fn unordered_map_insert(n: usize) {
+    let mut map = Root::new(UnorderedMap::<String, String, MainStorage>::new);
+    for i in 0..n {
+        map.insert(format!("key{i}"), "value".to_owned())
+            .expect("insert should succeed");
+    }
+}
+
+/// Build `n` entries, then call `len()` once. Subtracting the matching
+/// `unordered_map_insert` measurement isolates what a single `len()` costs —
+/// which is how core#3602 finding 2 was characterised.
+fn unordered_map_len(n: usize) {
+    let mut map = Root::new(UnorderedMap::<String, String, MainStorage>::new);
+    for i in 0..n {
+        map.insert(format!("key{i}"), "value".to_owned())
+            .expect("insert should succeed");
+    }
+    let _ignored = map.len().expect("len should succeed");
+}
+
+/// Every workload at every size.
+pub fn all() -> Vec<Workload> {
+    let mut out = Vec::new();
+    for n in SIZES {
+        out.push(Workload {
+            name: "unordered_map_insert",
+            n,
+            run: unordered_map_insert,
+        });
+        out.push(Workload {
+            name: "unordered_map_len",
+            n,
+            run: unordered_map_len,
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::measure;
+
+    #[test]
+    fn every_workload_is_measurable_and_writes_something() {
+        for workload in all() {
+            let (_, costs) = measure(|| (workload.run)(workload.n));
+            assert!(
+                costs.rows_written > 0,
+                "workload {} at n={} wrote nothing: {costs:?}",
+                workload.name,
+                workload.n
+            );
+        }
+    }
+
+    #[test]
+    fn workload_names_and_sizes_are_unique() {
+        let mut seen = std::collections::BTreeSet::new();
+        for workload in all() {
+            assert!(
+                seen.insert((workload.name, workload.n)),
+                "duplicate workload {} at n={}",
+                workload.name,
+                workload.n
+            );
+        }
+    }
+}

--- a/tools/storage-cost/src/workloads.rs
+++ b/tools/storage-cost/src/workloads.rs
@@ -3,13 +3,49 @@
 //! The binary, the flat-curve tests and the criterion benches all iterate
 //! `all()`. Defining a workload anywhere else would let the gate and the
 //! benchmarks measure different things while claiming to measure one.
+//!
+//! # Two kinds of workload
+//!
+//! A *build* workload does `n` operations and is measured whole: its total cost
+//! is expected to grow with `n`, and what must stay flat is cost **per entry**.
+//!
+//! A *point* workload builds `n` entries, calls [`crate::reset_counters`], and
+//! then performs exactly one operation. What it reports is the cost of that one
+//! operation with `n` entries already in the collection — which is the number
+//! that decides whether a collection stays readable as it grows.
+//!
+//! [`CostShape`] says which is which, and, for point workloads, whether the
+//! curve is required to be flat or is a known-linear cost being held under
+//! observation.
 
-use calimero_storage::collections::{Root, UnorderedMap};
+use calimero_storage::collections::{Root, UnorderedMap, UnorderedSet, Vector};
 use calimero_storage::store::MainStorage;
 
+use crate::reset_counters;
+
 /// Collection sizes every workload is measured at. The gate compares costs at
-/// each size; the flat-curve test compares the first against the last.
+/// each size; the shape tests compare the first against the last.
 pub const SIZES: [usize; 4] = [10, 100, 1_000, 10_000];
+
+/// What the cost curve of a workload is required to look like.
+///
+/// This is an assertion, not a description. Every variant is checked by
+/// `tests/flat_curve.rs`, including [`Self::KnownLinearInN`] — a workload that
+/// stops being linear fails just as loudly as one that starts being linear,
+/// because "we fixed it and nobody updated the marker" and "we broke something
+/// else" must not be told apart by guesswork.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CostShape {
+    /// A build of `n` entries. Cost **per entry** must not grow with `n`.
+    FlatPerEntry,
+    /// One operation against a collection of `n` entries. Its **total** cost
+    /// must not grow with `n`.
+    ConstantPerCall,
+    /// One operation whose total cost is KNOWN to grow linearly with `n`.
+    ///
+    /// This is not a licence — it is a ratchet. See `ordered_read` below.
+    KnownLinearInN,
+}
 
 /// One measurable unit of work at one collection size.
 pub struct Workload {
@@ -18,45 +54,161 @@ pub struct Workload {
     pub name: &'static str,
     /// Collection size this instance exercises.
     pub n: usize,
+    /// The curve this workload's cost is asserted to follow.
+    pub shape: CostShape,
+    /// How far a measured row count may sit from the committed snapshot before
+    /// the gate fails, as a percentage.
+    ///
+    /// Zero for almost everything: row counts reproduce exactly. It is nonzero
+    /// only where the operation walks the WHOLE child trie, because the trie's
+    /// node count depends on how random entity ids happened to distribute, so
+    /// the number of node reads varies run to run.
+    ///
+    /// This is a measured property, not a guess — `tests/reproducible.rs`
+    /// re-derives the spread of every workload and fails if a declared
+    /// tolerance is either too tight (flaky gate) or gratuitously loose
+    /// (blind gate).
+    pub tolerance_pct: u32,
     /// Builds a collection of `n` entries and performs the measured operation.
     pub run: fn(usize),
 }
 
 /// Insert `n` entries into an `UnorderedMap`, measuring the whole build.
 fn unordered_map_insert(n: usize) {
-    let mut map = Root::new(UnorderedMap::<String, String, MainStorage>::new);
+    build_map(n);
+}
+
+/// Push `n` entries onto a `Vector`, measuring the whole build.
+fn vector_push(n: usize) {
+    build_vector(n);
+}
+
+/// Insert `n` entries into an `UnorderedSet`, measuring the whole build.
+fn unordered_set_insert(n: usize) {
+    let mut set = Root::new(UnorderedSet::<String, MainStorage>::new);
     for i in 0..n {
-        map.insert(format!("key{i}"), "value".to_owned())
+        let _ignored = set
+            .insert(format!("value{i}"))
             .expect("insert should succeed");
     }
 }
 
-/// Build `n` entries, then call `len()` once. Subtracting the matching
-/// `unordered_map_insert` measurement isolates what a single `len()` costs —
-/// which is how core#3602 finding 2 was characterised.
+/// Cost of ONE `len()` against `n` entries. `len()` reading the whole
+/// collection to count it was core#3602 finding 2.
 fn unordered_map_len(n: usize) {
-    let mut map = Root::new(UnorderedMap::<String, String, MainStorage>::new);
-    for i in 0..n {
-        map.insert(format!("key{i}"), "value".to_owned())
-            .expect("insert should succeed");
-    }
+    let map = build_map(n);
+    reset_counters();
     let _ignored = map.len().expect("len should succeed");
 }
 
+/// Cost of ONE keyed `get()` against `n` entries.
+fn unordered_map_get(n: usize) {
+    let map = build_map(n);
+    reset_counters();
+    let _ignored = map.get("key0").expect("get should succeed");
+}
+
+/// Cost of ONE positional read — `Vector::get(i)` — against `n` entries.
+///
+/// # Why this is `KnownLinearInN`, and what it is standing in for
+///
+/// This is the in-repo fixture for the read wall documented in
+/// `docs/superpowers/2026-08-26-chat-read-wall.md`: mero-chat's `get_messages`
+/// exhausts a 1e9 gas budget at ~32,000 messages, and 30,000 already spends
+/// 99.83% of it. The cause is not the app. It is this call:
+///
+/// ```text
+/// Vector::get(i) -> Collection::nth(i) -> children_cache()
+///                -> Index::get_children_of(parent)
+///                -> ChildTrie::children()   // collect ALL, then sort
+/// ```
+///
+/// One O(n) id walk per positional read, because order lives in a comparator
+/// applied after a full enumeration rather than in the structure. The child
+/// trie bounded *write* cost; it never touched ordered *read* cost.
+///
+/// Fixing that is a real project (see the ordering design doc) and is
+/// deliberately not attempted here. What this workload does is make the cost
+/// **gated** instead of merely known: the snapshot pins the constant, and
+/// `tests/flat_curve.rs` pins the slope. Nobody can make it quietly worse, and
+/// nobody can fix it without the marker below going red and forcing this
+/// comment to be rewritten.
+///
+/// The middle index is read, not the first, so a hypothetical fast path for
+/// index 0 could not make the measurement lie.
+fn vector_get_nth(n: usize) {
+    let vector = build_vector(n);
+    reset_counters();
+    let _ignored = vector.get(n / 2).expect("get should succeed");
+}
+
+fn build_map(n: usize) -> Root<UnorderedMap<String, String, MainStorage>> {
+    let mut map = Root::new(UnorderedMap::<String, String, MainStorage>::new);
+    for i in 0..n {
+        map.insert(format!("key{i}"), "value".to_owned())
+            .expect("insert should succeed");
+    }
+    map
+}
+
+fn build_vector(n: usize) -> Root<Vector<String, MainStorage>> {
+    let mut vector = Root::new(Vector::<String, MainStorage>::new);
+    for i in 0..n {
+        vector
+            .push(format!("value{i}"))
+            .expect("push should succeed");
+    }
+    vector
+}
+
 /// Every workload at every size.
+///
+/// `SortedMap` and `SortedSet` are deliberately absent.
+///
+/// Their cost depends on `StorageAdaptor::index_supported()`
+/// (`crates/storage/src/store.rs`). Without `RuntimeEnv::with_index` installed,
+/// native ordered-index ops fall through to the process thread-local mock
+/// (`crates/storage/src/env.rs`), so measuring them here would publish numbers
+/// for the in-memory-sort fallback while appearing to describe the indexed path
+/// a real node takes. Adding them means wiring all eight `IndexCallbacks`
+/// through the counting store first — a separate piece of work, not a workload
+/// entry.
 pub fn all() -> Vec<Workload> {
-    let mut out = Vec::new();
+    use CostShape::{ConstantPerCall, FlatPerEntry, KnownLinearInN};
+
+    const REGISTRY: [(&str, CostShape, u32, fn(usize)); 6] = [
+        (
+            "unordered_map_insert",
+            FlatPerEntry,
+            0,
+            unordered_map_insert,
+        ),
+        (
+            "unordered_set_insert",
+            FlatPerEntry,
+            0,
+            unordered_set_insert,
+        ),
+        ("vector_push", FlatPerEntry, 0, vector_push),
+        ("unordered_map_len", ConstantPerCall, 0, unordered_map_len),
+        ("unordered_map_get", ConstantPerCall, 0, unordered_map_get),
+        // Walks the whole trie, so its node count follows the random id
+        // distribution. Measured spread over seven runs: 10.5% at n=10,
+        // under 3% at every larger size.
+        ("vector_get_nth", KnownLinearInN, 25, vector_get_nth),
+    ];
+
+    let mut out = Vec::with_capacity(REGISTRY.len() * SIZES.len());
     for n in SIZES {
-        out.push(Workload {
-            name: "unordered_map_insert",
-            n,
-            run: unordered_map_insert,
-        });
-        out.push(Workload {
-            name: "unordered_map_len",
-            n,
-            run: unordered_map_len,
-        });
+        for (name, shape, tolerance_pct, run) in REGISTRY {
+            out.push(Workload {
+                name,
+                n,
+                shape,
+                tolerance_pct,
+                run,
+            });
+        }
     }
     out
 }
@@ -67,16 +219,35 @@ mod tests {
     use crate::measure;
 
     #[test]
-    fn every_workload_is_measurable_and_writes_something() {
+    fn every_workload_is_measurable_and_touches_storage() {
         for workload in all() {
             let (_, costs) = measure(|| (workload.run)(workload.n));
+            let touched = costs.rows_read + costs.rows_written + costs.rows_removed;
             assert!(
-                costs.rows_written > 0,
-                "workload {} at n={} wrote nothing: {costs:?}",
+                touched > 0,
+                "workload {} at n={} performed no storage operations: {costs:?} — a \
+                 workload that measures nothing gates nothing",
                 workload.name,
                 workload.n
             );
         }
+    }
+
+    /// A point workload that forgot `reset_counters()` would silently report
+    /// its build cost and look linear no matter what the operation does.
+    #[test]
+    fn point_workloads_cost_far_less_than_the_build_they_follow() {
+        let n = 1_000;
+        let (_, build) = measure(|| unordered_map_insert(n));
+        let (_, point) = measure(|| unordered_map_get(n));
+
+        assert!(
+            point.rows_read * 10 < build.rows_read,
+            "unordered_map_get at n={n} read {} rows against a build of {} — it is \
+             reporting the build, so reset_counters() is not taking effect",
+            point.rows_read,
+            build.rows_read
+        );
     }
 
     #[test]

--- a/tools/storage-cost/src/workloads.rs
+++ b/tools/storage-cost/src/workloads.rs
@@ -176,7 +176,11 @@ fn build_vector(n: usize) -> Root<Vector<String, MainStorage>> {
 pub fn all() -> Vec<Workload> {
     use CostShape::{ConstantPerCall, FlatPerEntry, KnownLinearInN};
 
-    const REGISTRY: [(&str, CostShape, u32, fn(usize)); 6] = [
+    /// A registry row: name, shape, tolerance, body. Sized-independent, so
+    /// `all()` crosses it with [`SIZES`].
+    type Entry = (&'static str, CostShape, u32, fn(usize));
+
+    const REGISTRY: [Entry; 6] = [
         (
             "unordered_map_insert",
             FlatPerEntry,

--- a/tools/storage-cost/storage-costs.json
+++ b/tools/storage-cost/storage-costs.json
@@ -1,0 +1,152 @@
+{
+  "unordered_map_get": {
+    "tolerance_pct": 0,
+    "sizes": {
+      "00000010": {
+        "rows_read": 2,
+        "rows_written": 0,
+        "rows_removed": 0
+      },
+      "00000100": {
+        "rows_read": 2,
+        "rows_written": 0,
+        "rows_removed": 0
+      },
+      "00001000": {
+        "rows_read": 2,
+        "rows_written": 0,
+        "rows_removed": 0
+      },
+      "00010000": {
+        "rows_read": 2,
+        "rows_written": 0,
+        "rows_removed": 0
+      }
+    }
+  },
+  "unordered_map_insert": {
+    "tolerance_pct": 0,
+    "sizes": {
+      "00000010": {
+        "rows_read": 543,
+        "rows_written": 205,
+        "rows_removed": 0
+      },
+      "00000100": {
+        "rows_read": 4863,
+        "rows_written": 1825,
+        "rows_removed": 0
+      },
+      "00001000": {
+        "rows_read": 48063,
+        "rows_written": 18025,
+        "rows_removed": 0
+      },
+      "00010000": {
+        "rows_read": 480063,
+        "rows_written": 180025,
+        "rows_removed": 0
+      }
+    }
+  },
+  "unordered_map_len": {
+    "tolerance_pct": 0,
+    "sizes": {
+      "00000010": {
+        "rows_read": 1,
+        "rows_written": 0,
+        "rows_removed": 0
+      },
+      "00000100": {
+        "rows_read": 1,
+        "rows_written": 0,
+        "rows_removed": 0
+      },
+      "00001000": {
+        "rows_read": 1,
+        "rows_written": 0,
+        "rows_removed": 0
+      },
+      "00010000": {
+        "rows_read": 1,
+        "rows_written": 0,
+        "rows_removed": 0
+      }
+    }
+  },
+  "unordered_set_insert": {
+    "tolerance_pct": 0,
+    "sizes": {
+      "00000010": {
+        "rows_read": 543,
+        "rows_written": 205,
+        "rows_removed": 0
+      },
+      "00000100": {
+        "rows_read": 4863,
+        "rows_written": 1825,
+        "rows_removed": 0
+      },
+      "00001000": {
+        "rows_read": 48063,
+        "rows_written": 18025,
+        "rows_removed": 0
+      },
+      "00010000": {
+        "rows_read": 480063,
+        "rows_written": 180025,
+        "rows_removed": 0
+      }
+    }
+  },
+  "vector_get_nth": {
+    "tolerance_pct": 25,
+    "sizes": {
+      "00000010": {
+        "rows_read": 40,
+        "rows_written": 0,
+        "rows_removed": 0
+      },
+      "00000100": {
+        "rows_read": 306,
+        "rows_written": 0,
+        "rows_removed": 0
+      },
+      "00001000": {
+        "rows_read": 2152,
+        "rows_written": 0,
+        "rows_removed": 0
+      },
+      "00010000": {
+        "rows_read": 13266,
+        "rows_written": 0,
+        "rows_removed": 0
+      }
+    }
+  },
+  "vector_push": {
+    "tolerance_pct": 0,
+    "sizes": {
+      "00000010": {
+        "rows_read": 523,
+        "rows_written": 205,
+        "rows_removed": 0
+      },
+      "00000100": {
+        "rows_read": 4663,
+        "rows_written": 1825,
+        "rows_removed": 0
+      },
+      "00001000": {
+        "rows_read": 46063,
+        "rows_written": 18025,
+        "rows_removed": 0
+      },
+      "00010000": {
+        "rows_read": 460063,
+        "rows_written": 180025,
+        "rows_removed": 0
+      }
+    }
+  }
+}

--- a/tools/storage-cost/tests/flat_curve.rs
+++ b/tools/storage-cost/tests/flat_curve.rs
@@ -1,0 +1,167 @@
+//! Tier 1b: assert the SHAPE of each cost curve, not its constant.
+//!
+//! A per-operation cost that does not grow with collection size is the property
+//! that keeps a collection usable forever. Asserting it directly is
+//! machine-independent, immune to constant-factor drift, and runs in seconds —
+//! the four regressions in core#3602 were all violations of it, including one
+//! caused by a log line calling `enumerate()` instead of counting.
+//!
+//! Deliberately NOT a criterion benchmark: this is a correctness property.
+//!
+//! # Both directions
+//!
+//! `KnownLinearInN` workloads are asserted to STILL be linear. A cost that
+//! silently stops being linear is good news, but news — the marker, the
+//! snapshot and the comment explaining the wall all have to move with it. An
+//! improvement that nobody notices is how a stale "known issue" outlives the
+//! issue.
+//!
+//! # Relationship to `crates/runtime/tests/cost_is_flat.rs`
+//!
+//! That test asks a different question one layer down: does a WASM guest doing
+//! a FIXED number of host calls get charged more gas because the STORE grew? It
+//! uses a synthetic WAT guest and never touches `calimero-storage`.
+//!
+//! This one asks whether a `calimero-storage` COLLECTION operation costs more
+//! per entry as the collection grows. Neither subsumes the other: a flat host
+//! layer with an O(n) collection — exactly where this tree stands, see
+//! `vector_get_nth` — passes there and is caught here.
+
+use std::collections::BTreeMap;
+
+use storage_cost::workloads::{all, CostShape, SIZES};
+use storage_cost::{measure, Costs};
+
+/// Cost may grow by at most this factor between the smallest and largest
+/// collection size before it stops being "bounded with a plateau" and starts
+/// being "linear in n".
+///
+/// Ratio rather than equality because a build of `n` entries legitimately
+/// touches a little more per entry as interior index nodes fill.
+const MAX_GROWTH: f64 = 2.0;
+
+/// A `KnownLinearInN` read must cost at least `n / LINEAR_FLOOR_DIVISOR` rows
+/// at the largest measured size.
+///
+/// Stated as an absolute floor rather than a growth ratio on purpose. The trie
+/// packs better as it deepens, so reads/entry legitimately *falls* with `n`
+/// (4.0 at n=10, 1.3 at n=10,000) while the cost stays linear — a ratio test
+/// would confuse that with a fix. A sublinear replacement would land three
+/// orders of magnitude below this floor, so the band is wide and the verdict is
+/// unambiguous.
+const LINEAR_FLOOR_DIVISOR: f64 = 100.0;
+
+/// …and at most `n * LINEAR_CEILING_FACTOR`. Past that it is superlinear.
+const LINEAR_CEILING_FACTOR: f64 = 4.0;
+
+const SMALLEST: usize = SIZES[0];
+const LARGEST: usize = SIZES[SIZES.len() - 1];
+
+/// Measured cost of every workload of `shape`, as `name -> n -> cost`.
+///
+/// `FlatPerEntry` costs are divided by `n`, because the workload deliberately
+/// does `n` operations. Point workloads are not: they perform exactly one
+/// operation, and its absolute cost is the thing under test.
+fn series(
+    shape: CostShape,
+    metric: fn(Costs) -> u64,
+) -> BTreeMap<&'static str, BTreeMap<usize, f64>> {
+    let mut by_name: BTreeMap<&'static str, BTreeMap<usize, f64>> = BTreeMap::new();
+    for workload in all().into_iter().filter(|w| w.shape == shape) {
+        let (_, costs) = measure(|| (workload.run)(workload.n));
+        let divisor = if shape == CostShape::FlatPerEntry {
+            workload.n as f64
+        } else {
+            1.0
+        };
+        let _ignored = by_name
+            .entry(workload.name)
+            .or_default()
+            .insert(workload.n, metric(costs) as f64 / divisor);
+    }
+    assert!(
+        !by_name.is_empty(),
+        "no {shape:?} workloads were measured — the registry filter is wrong and this \
+         test is asserting nothing"
+    );
+    by_name
+}
+
+fn report(failures: Vec<String>, headline: &str) {
+    assert!(
+        failures.is_empty(),
+        "{headline}:\n  {}",
+        failures.join("\n  ")
+    );
+}
+
+fn assert_bounded(unit: &str, shape: CostShape, metric: fn(Costs) -> u64) {
+    let mut failures = Vec::new();
+    for (name, points) in &series(shape, metric) {
+        let (small, large) = (points[&SMALLEST], points[&LARGEST]);
+        if small > 0.0 && large > small * MAX_GROWTH {
+            failures.push(format!(
+                "{name}: {unit} grew {small:.1} (n={SMALLEST}) -> {large:.1} \
+                 (n={LARGEST}), {:.1}x — budget is {MAX_GROWTH}x",
+                large / small
+            ));
+        }
+    }
+    report(
+        failures,
+        &format!("{shape:?} workloads: {unit} cost grows with collection size"),
+    );
+}
+
+#[test]
+fn build_cost_per_entry_does_not_grow_with_collection_size() {
+    assert_bounded("writes/entry", CostShape::FlatPerEntry, |c| c.rows_written);
+    assert_bounded("reads/entry", CostShape::FlatPerEntry, |c| c.rows_read);
+}
+
+/// Reads are the assertion that matters most: they are invisible to gas
+/// accounting (no read counter, no read limit in the VM), so an O(n) read
+/// pattern shows up as neither a gas charge nor a wall-clock signal until a
+/// call dies outright.
+#[test]
+fn point_operation_cost_does_not_grow_with_collection_size() {
+    assert_bounded("reads/call", CostShape::ConstantPerCall, |c| c.rows_read);
+    assert_bounded("writes/call", CostShape::ConstantPerCall, |c| {
+        c.rows_written
+    });
+}
+
+/// The ratchet on costs we know are O(n) and have chosen not to fix yet.
+///
+/// Fails if one gets worse than linear, and fails — differently, and on
+/// purpose — if one stops being linear, so a fix cannot land while the
+/// documentation still describes the wall.
+#[test]
+fn known_linear_costs_are_still_exactly_linear() {
+    let floor = LARGEST as f64 / LINEAR_FLOOR_DIVISOR;
+    let ceiling = LARGEST as f64 * LINEAR_CEILING_FACTOR;
+    let mut failures = Vec::new();
+
+    for (name, points) in &series(CostShape::KnownLinearInN, |c| c.rows_read) {
+        let large = points[&LARGEST];
+
+        if large < floor {
+            failures.push(format!(
+                "{name}: reads/call at n={LARGEST} is {large:.0}, below the {floor:.0} \
+                 floor that marks a linear cost — this appears to have been FIXED. That \
+                 is good news, and it must be recorded: move it to \
+                 CostShape::ConstantPerCall, regenerate \
+                 tools/storage-cost/storage-costs.json, and update the wall write-up in \
+                 docs/superpowers/2026-08-26-chat-read-wall.md"
+            ));
+        } else if large > ceiling {
+            failures.push(format!(
+                "{name}: reads/call at n={LARGEST} is {large:.0}, above the \
+                 {ceiling:.0} ceiling — worse than linear, i.e. a regression stacked on \
+                 top of a known-bad cost"
+            ));
+        }
+    }
+
+    report(failures, "known-linear costs no longer match their marker");
+}

--- a/tools/storage-cost/tests/flat_curve.rs
+++ b/tools/storage-cost/tests/flat_curve.rs
@@ -99,7 +99,21 @@ fn assert_bounded(unit: &str, shape: CostShape, metric: fn(Costs) -> u64) {
     let mut failures = Vec::new();
     for (name, points) in &series(shape, metric) {
         let (small, large) = (points[&SMALLEST], points[&LARGEST]);
-        if small > 0.0 && large > small * MAX_GROWTH {
+        // A zero baseline is not a free pass. `small == 0.0` means the workload
+        // does none of this metric at the smallest size — `unordered_map_get`
+        // and `unordered_map_len` write nothing, and should keep writing
+        // nothing. A ratio cannot express that (everything is infinity), so
+        // any growth at all is the failure, and skipping the check instead
+        // would leave the gate blind in exactly the case it exists for: an
+        // operation that starts doing something it never used to.
+        if small == 0.0 {
+            if large > 0.0 {
+                failures.push(format!(
+                    "{name}: {unit} went 0 (n={SMALLEST}) -> {large:.1} (n={LARGEST}); \
+                     an operation that did none of this now does some"
+                ));
+            }
+        } else if large > small * MAX_GROWTH {
             failures.push(format!(
                 "{name}: {unit} grew {small:.1} (n={SMALLEST}) -> {large:.1} \
                  (n={LARGEST}), {:.1}x — budget is {MAX_GROWTH}x",

--- a/tools/storage-cost/tests/reproducible.rs
+++ b/tools/storage-cost/tests/reproducible.rs
@@ -1,0 +1,79 @@
+//! Every workload's declared `tolerance_pct` must match what it actually does.
+//!
+//! The snapshot gate compares measured row counts against a committed file. It
+//! is only meaningful if the measurement reproduces, and only useful if the
+//! band it allows is no wider than it has to be. Both halves rot silently:
+//! a tolerance that is too tight makes CI flaky (and someone widens it), a
+//! tolerance that is too wide makes the gate blind (and nobody notices).
+//!
+//! So the tolerance is re-derived here from live measurements rather than
+//! trusted. `RUNS` is small enough to stay quick and large enough that a
+//! genuinely varying count shows up.
+
+use std::collections::BTreeMap;
+
+use storage_cost::measure;
+use storage_cost::workloads::all;
+
+/// Repeats per workload. Seven was enough to separate the one varying workload
+/// from the twenty-three exact ones when the tolerances were first derived.
+const RUNS: usize = 7;
+
+/// No workload may claim more slack than this. A cost allowed to move by more
+/// than a quarter is not being gated on its constant any more, only on its
+/// order of magnitude — and that job belongs to `flat_curve.rs`.
+const MAX_DECLARED_TOLERANCE_PCT: u32 = 25;
+
+#[test]
+fn declared_tolerances_bound_the_observed_spread() {
+    let mut failures = Vec::new();
+
+    for workload in all() {
+        assert!(
+            workload.tolerance_pct <= MAX_DECLARED_TOLERANCE_PCT,
+            "{}/{} declares tolerance_pct={} — above the {MAX_DECLARED_TOLERANCE_PCT} \
+             cap. A band that wide is not a cost gate.",
+            workload.name,
+            workload.n,
+            workload.tolerance_pct
+        );
+
+        let mut counts = BTreeMap::<&str, Vec<u64>>::new();
+        for _ in 0..RUNS {
+            let (_, costs) = measure(|| (workload.run)(workload.n));
+            counts.entry("rows_read").or_default().push(costs.rows_read);
+            counts
+                .entry("rows_written")
+                .or_default()
+                .push(costs.rows_written);
+            counts
+                .entry("rows_removed")
+                .or_default()
+                .push(costs.rows_removed);
+        }
+
+        for (metric, values) in counts {
+            let lo = *values.iter().min().expect("RUNS > 0");
+            let hi = *values.iter().max().expect("RUNS > 0");
+            if lo == 0 {
+                continue;
+            }
+            let spread_pct = (hi - lo) as f64 * 100.0 / lo as f64;
+            if spread_pct > f64::from(workload.tolerance_pct) {
+                failures.push(format!(
+                    "{}/{} {metric}: varied {lo}..{hi} over {RUNS} runs ({spread_pct:.1}%) \
+                     but declares tolerance_pct={}. Either the measurement became \
+                     nondeterministic — find out why before widening anything — or the \
+                     declared tolerance in workloads.rs is stale.",
+                    workload.name, workload.n, workload.tolerance_pct
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "declared tolerances do not bound what was measured:\n  {}",
+        failures.join("\n  ")
+    );
+}


### PR DESCRIPTION
## Why

Cost regressions are invisible to correctness tests. A storage collection shipped with an append whose cost grew with the collection's size, until a single write exhausted gas and the collection became permanently unwritable (core#3602) — the full 715-test storage suite was green throughout, because every test asserts what the code *computes* and none asserts what it *costs*.

Implements `docs/superpowers/plans/2026-08-26-storage-cost-ci-gates.md`.

## Part A — `tools/storage-cost`

A counting `RuntimeEnv` (`src/lib.rs:44`) measures real storage operations per workload; results are diffed against a committed snapshot by `scripts/check-storage-cost.sh`. Deterministic and machine-independent, so it gates like the existing `wasm-size` gate. Blocking job in `ci-checks.yml`; non-blocking criterion trend job in `benchmarks.yml`.

`reset_counters()` (`src/lib.rs:88`, not in the plan) lets a workload discard its build cost so a single operation can be attributed — without it, a `len()` call would be buried in 480,063 build reads and the snapshot would be blind to it.

### Committed baseline (rows)

| workload | n=10 | 100 | 1,000 | 10,000 | tol |
|---|---|---|---|---|---|
| `unordered_map_insert` reads/writes | 543/205 | 4863/1825 | 48063/18025 | 480063/180025 | 0% |
| `unordered_set_insert` | identical | | | | 0% |
| `vector_push` reads/writes | 523/205 | 4663/1825 | 46063/18025 | 460063/180025 | 0% |
| `unordered_map_len` reads | 1 | 1 | 1 | 1 | 0% |
| `unordered_map_get` reads | 2 | 2 | 2 | 2 | 0% |
| **`vector_get_nth` reads** | **40** | **303** | **2134** | **13282** | **25%** |

`vector_get_nth` is the known-O(n) ordered read, marked `KnownLinearInN`. **This PR does not fix it** — it pins the current cost so the fix is visible when it lands. Snapshot diffing runs both directions, so an improvement fails the gate with a message naming the follow-ups.

## Part B — `crates/runtime/tests/chat_wall.rs`

The probe builds `curb.wasm` from the mero-chat-pwa sibling and is `#[ignore]`d, so core CI never ran it. It broke silently once when mero-chat dropped the `sender_username` argument: every call failed deserialization and the probe reported a wall at 0.

Now a `preflight()` on a throwaway store runs before the sweep and classifies failures. Contract drift fails in **0.30s** with the contract's own error text under a `CONTRACT DRIFT — NOT A STORAGE RESULT` banner, pointing at the in-repo gate that does not depend on the sibling. `only_gas_exhaustion_counts_as_a_wall` (`:614`) is **not** ignored and guards the discriminator itself in CI.

New guard: if the sibling's `logic/Cargo.toml` carries its own `[patch]` of core, it overrides a `--config` redirect and the probe would measure a *different core tree* while claiming to measure this one. This is live on at least one workstation today and caused a false "successful" run during development.

## Two deviations from the plan, both load-bearing

1. **Byte counts are not gateable, and the plan's predicted cause was wrong.** Not leaked thread-local state curable by process isolation — the cause is `Id::random()` → `rand::thread_rng()` (`crates/storage/src/env.rs:1099`), unseedable from outside. Random ids land in different trie buckets, so index rows serialize to different lengths (~1.5% drift, immune to process isolation). Row counts are exactly reproducible, verified across 3 runs × every workload × every size. `byte_counts_are_not_reproducible` (`src/lib.rs:180`) pins the reason. Gating bytes needs a seedable RNG hook in `calimero-storage` — a production change, not made here.
2. **`cargo bench -p storage-cost` does not work as the plan claims** — libtest targets reject criterion's flags. Needed `bench = false` on `[lib]`, `[[bin]]` and both `[[test]]` targets.

## Relationship to `crates/runtime/tests/cost_is_flat.rs`

Both kept, no duplication. `cost_is_flat` asks a VM-layer question with a synthetic WAT guest and never touches `calimero-storage`. `flat_curve` asks whether a *collection operation* costs more per entry as the collection grows. A flat host layer with an O(n) collection — exactly this tree — passes the first and is caught by the second. Cross-references are in both module docs.

## Verification

```
cargo test -p storage-cost --release        6 + 3 + 1 passed
./scripts/check-storage-cost.sh             OK: all 24 rows match
cargo test --release -p calimero-runtime --test cost_is_flat --test chat_wall
                                            2 passed | 1 passed, 1 ignored
rustup run 1.88.0 cargo fmt --check         clean
cargo clippy -p storage-cost -p calimero-runtime --all-targets -- -D warnings   clean
cargo check --workspace --all-targets       0 warnings
```

Gate proven to fail on: a 1-row drift on a zero-tolerance workload, a 2x drift on a tolerant one, and a deleted workload. A bug in the first version of the tolerance check (`> max(1, old*tol/100)` let a one-row drift pass on *every* workload) was found this way and fixed.

## Before merge

- `cargo deny check licenses sources` — `criterion` with `default-features = false` adds ~15 crates to `Cargo.lock`.
- `cargo machete` — deps hand-verified locally, not run.
- The `Criterion trend` job must be kept **out** of branch protection.

## Base

Targets `feat/storage-child-trie`, rebased onto it before push. Draft pending CI.