### PR TITLE
feat(auth): a scoped permission for submitting delegated intents

### DIFF
--- a/crates/auth/src/auth/permissions/types.rs
+++ b/crates/auth/src/auth/permissions/types.rs
@@ -154,6 +154,19 @@ pub enum ContextPermission {
     Leave(ResourceScope, UserScope),
     Invite(ResourceScope, UserScope),
     Execute(ResourceScope, UserScope, Option<String>),
+    /// Submit a delegated intent: run one method under a warrant a MEMBER
+    /// signed, with the result attributed to them.
+    ///
+    /// Separate from `Execute` rather than folded into it, because the two are
+    /// not the same authority. `Execute` also covers join/leave/resync, so a
+    /// token minted for an author to submit intents would have carried
+    /// membership operations too — and the point of issuing one is that the
+    /// holder gets nothing else.
+    ///
+    /// It is an access grant, not the authority for the write. The warrant is
+    /// that: this token only decides who may *ask*, and a request without a
+    /// warrant the author signed is refused regardless.
+    PerformIntent(ResourceScope),
     Capabilities(CapabilityPermission),
     Application(ContextApplicationPermission),
     Alias(AliasPermission),
@@ -439,6 +452,7 @@ impl FromStr for Permission {
                     "execute" => Ok(Permission::Context(ContextPermission::Execute(
                         scope, user_scope, method,
                     ))),
+                    "intent" => Ok(Permission::Context(ContextPermission::PerformIntent(scope))),
                     "capabilities" => match *subaction {
                         "grant" => Ok(Permission::Context(ContextPermission::Capabilities(
                             CapabilityPermission::Grant(scope),
@@ -660,6 +674,10 @@ impl fmt::Display for Permission {
                     let params = format_params(scope, user, method);
                     write!(f, "context:execute{params}")
                 }
+                ContextPermission::PerformIntent(scope) => {
+                    let params = format_simple_params(scope);
+                    write!(f, "context:intent{params}")
+                }
                 ContextPermission::Alias(alias_perm) => match alias_perm {
                     AliasPermission::All(scope) => {
                         let params = format_simple_params(scope);
@@ -831,6 +849,10 @@ impl Permission {
                         && matches_user_scope(h_user, r_user)
                         && matches_method(h_method.as_deref(), r_method.as_deref())
                 }
+                (
+                    ContextPermission::PerformIntent(h_scope),
+                    ContextPermission::PerformIntent(r_scope),
+                ) => matches_scope(h_scope, r_scope),
                 (ContextPermission::Alias(held), ContextPermission::Alias(required)) => {
                     matches_alias(held, required)
                 }

--- a/crates/auth/src/auth/permissions/validator.rs
+++ b/crates/auth/src/auth/permissions/validator.rs
@@ -72,6 +72,9 @@ static CONTEXT_READ_SUBRESOURCE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 static CONTEXT_MEMBERSHIP_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^/admin-api/contexts/([^/]+)/(join|leave|resync)$").unwrap());
 
+static CONTEXT_INTENTS_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/admin-api/contexts/([^/]+)/intents$").unwrap());
+
 static CONTEXT_SYNC_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^/admin-api/contexts/sync/([^/]+)$").unwrap());
 
@@ -346,6 +349,32 @@ fn get_permissions_for_path_with_params(path: &str, method: &HttpMethod) -> Vec<
                     UserScope::Any,
                     None,
                 ))],
+                _ => vec![],
+            };
+        }
+    }
+
+    // Delegated intents: submit a write a MEMBER signed a warrant for.
+    //
+    // Mapped so an author can hold a token for this and nothing else. Unmapped,
+    // it fell to the default-deny below and needed `admin` — which meant the
+    // only way to let a member submit their own intent was handing them node
+    // credentials, the one thing the design exists to avoid.
+    //
+    // Scoped to the context, and deliberately NOT `Execute`: that also covers
+    // join/leave/resync, so reusing it would have handed an intent submitter
+    // membership operations as well.
+    //
+    // The token decides who may ASK. The warrant decides whether the write is
+    // authorised and whose it is, and a request carrying no warrant the author
+    // signed is refused whatever token presents it.
+    if let Some(captures) = CONTEXT_INTENTS_REGEX.captures(path) {
+        if let Some(ctx_id) = captures.get(1) {
+            let scope = ResourceScope::Specific(vec![ctx_id.as_str().to_string()]);
+            return match method {
+                HttpMethod::POST => {
+                    vec![Permission::Context(ContextPermission::PerformIntent(scope))]
+                }
                 _ => vec![],
             };
         }
@@ -1162,6 +1191,83 @@ mod tests {
     /// Updating a key's permissions must require `admin`, so a non-admin key
     /// holding a scoped `keys:update-permissions` cannot escalate itself (or
     /// any key) to `admin`. Reading permissions stays a scoped key permission.
+    /// An author must be able to hold a token for submitting intents and
+    /// nothing else — that is the whole reason this route is mapped.
+    ///
+    /// Before it was, `/intents` fell to the admin-api default-deny, so letting
+    /// a member submit their own delegated write meant handing them node
+    /// credentials: the exact thing delegated authorship exists to avoid.
+    #[test]
+    fn performing_an_intent_does_not_require_admin() {
+        let validator = PermissionValidator::new();
+
+        let post = Request::builder()
+            .method(Method::POST)
+            .uri("/admin-api/contexts/ctx-1/intents")
+            .body(Body::empty())
+            .unwrap();
+        let required = validator.determine_required_permissions(&post);
+
+        assert!(
+            matches!(
+                required.as_slice(),
+                [Permission::Context(ContextPermission::PerformIntent(_))]
+            ),
+            "expected a scoped intent permission, got {required:?}",
+        );
+
+        // The scoped token passes, and so does admin — but the point is the
+        // first one.
+        assert!(validator.validate_permissions(&["context:intent[ctx-1]".to_owned()], &required));
+        assert!(validator.validate_permissions(&["admin".to_owned()], &required));
+    }
+
+    /// The scope is load-bearing: a token for one context must not reach
+    /// another. Otherwise "a token for this author's context" would in fact be
+    /// "a token for every context on the node".
+    #[test]
+    fn an_intent_token_is_confined_to_its_context() {
+        let validator = PermissionValidator::new();
+
+        let post = Request::builder()
+            .method(Method::POST)
+            .uri("/admin-api/contexts/ctx-2/intents")
+            .body(Body::empty())
+            .unwrap();
+        let required = validator.determine_required_permissions(&post);
+
+        assert!(!validator.validate_permissions(&["context:intent[ctx-1]".to_owned()], &required));
+        assert!(validator.validate_permissions(&["context:intent[ctx-2]".to_owned()], &required));
+    }
+
+    /// And it reaches nothing else. `Execute` was the tempting variant to reuse,
+    /// and this is why it was not: it also covers join/leave/resync, so an
+    /// intent token minted from it would have carried membership operations.
+    #[test]
+    fn an_intent_token_grants_nothing_beyond_intents() {
+        let validator = PermissionValidator::new();
+        let token = vec!["context:intent[ctx-1]".to_owned()];
+
+        for (method, uri) in [
+            (Method::POST, "/admin-api/contexts/ctx-1/join"),
+            (Method::POST, "/admin-api/contexts/ctx-1/leave"),
+            (Method::POST, "/admin-api/contexts/ctx-1/resync"),
+            (Method::DELETE, "/admin-api/contexts/ctx-1"),
+            (Method::GET, "/admin-api/peers"),
+        ] {
+            let req = Request::builder()
+                .method(method.clone())
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap();
+            let required = validator.determine_required_permissions(&req);
+            assert!(
+                !validator.validate_permissions(&token, &required),
+                "an intent-only token must not reach {method} {uri}",
+            );
+        }
+    }
+
     #[test]
     fn updating_key_permissions_requires_admin() {
         let validator = PermissionValidator::new();


### PR DESCRIPTION
`POST /admin-api/contexts/:id/intents` was **unmapped** in the permission validator, so it fell to the admin-api default-deny and required `admin`. The only way to let a member submit their own delegated write was to hand them node credentials — the exact thing delegated authorship exists to avoid, and the reason the endpoint could not be offered to the holders it was built for.

The validator's own fallback comment names the fix: *"A scoped (non-admin) token that must reach one of these needs an explicit mapping added above."*

## What this adds

`context:intent[<context>]`, mapped to `POST` on that route. An admin can mint a token good for **one context's intents and nothing else**.

Not `ContextPermission::Execute`, which was the tempting reuse — it also covers `join`/`leave`/`resync`, so a token minted for an author would have carried membership operations too. The point of issuing one is that the holder gets nothing else, so it is its own variant.

## The token is an access grant, not the authority

It decides who may **ask**. The warrant still decides whether the write is authorised and whose it is — a request carrying no warrant the author signed is refused whatever token presents it.

That is what makes a bearer token a defensible shape here: leaking one lets someone submit warrants **they already hold**, which are the author's own intended writes, single-use and context-bound. It does not let them mint warrants. That is a far smaller blast radius than the status quo, which is sharing admin credentials.

## Tests

Three, and the middle one would be a privilege escalation if it broke:

- the permission is required, and admin is no longer necessary;
- a token for `ctx-1` does **not** reach `ctx-2`;
- an intent token reaches nothing else — `join`, `leave`, `resync`, context delete, `peers`.

Mutation-tested: swapping the mapping to `Execute` fails two of the three. (The third does not distinguish that mutation — an intent token satisfies neither — since it tests a different property.)

Full `mero-auth` suite: 175 + 6 pass. `cargo fmt` and `clippy -D warnings` clean.

## One consequence worth knowing

This deliberately does **not** join the client-token battery, so a standard SDK token does not gain intent submission — it has to be granted. Concretely: mero-js's `performIntent` needs a token carrying this permission, not merely an authenticated one. The SDK e2e passes today because it runs as admin.

If the intent is instead that every client token can submit intents, that is a different decision and the battery is where it would be made.

## Still open, deliberately

Per-request signature auth (§5) remains the better end state — no shared secret, no issuance step. This makes the endpoint offerable now, and the mapping stays useful either way. Rate limiting is **not** included here (agreed as out of scope for now), but it becomes more relevant once this is exposed to more parties than admins.