### PR TITLE
feat(merod): provision the account root at init, not on first use

### DIFF
--- a/crates/governance-store/src/node_device.rs
+++ b/crates/governance-store/src/node_device.rs
@@ -419,11 +419,32 @@ impl<'a> NodeDeviceRepository<'a> {
 
         let existing = self.account_root()?;
         if let Some(previous) = &existing {
-            if !force {
+            // Gate on whether the root being replaced has CERTIFIED something, not
+            // merely on whether one exists.
+            //
+            // The cost this guard protects against is losing a root that devices
+            // depend on: replacing it orphans every certificate it signed, and
+            // there is no second copy. A root that has certified nothing carries
+            // none of that cost.
+            //
+            // That distinction became load-bearing when `init` started
+            // provisioning a root. The primary recovery flow is total loss — wipe
+            // the disk, `merod init`, restore the phrase — and the fresh node now
+            // always has a root, so gating on existence turned every restore into a
+            // `--force` ceremony. That trains an operator to reach for the flag
+            // precisely where it is dangerous: on a node where the root being
+            // replaced HAS certified devices and the loss is unrecoverable.
+            //
+            // One device row, so this is a read rather than a scan.
+            let certified_something = self
+                .get()?
+                .is_some_and(|row| row.account == previous.account());
+            if certified_something && !force {
                 eyre::bail!(
-                    "this node already has an account root ({}), and replacing it \
-                     cannot be undone: a root that has already certified devices \
-                     has no second copy",
+                    "this node already has an account root ({}) that has certified \
+                     a device, and replacing it cannot be undone: the certificates \
+                     it signed have no second copy. Export it first, then pass \
+                     --force to replace it",
                     previous.public_key()
                 );
             }
@@ -1127,12 +1148,63 @@ mod tests {
     /// the invariant depending on it" shape this codebase has been burned by
     /// before. Any future caller (meroctl, an RPC handler, a test helper) would
     /// have silently destroyed an unrecoverable key.
+    /// Restoring a backup onto a freshly initialised node needs no `--force`.
+    ///
+    /// The primary recovery flow: total loss, wipe, `merod init`, import the
+    /// phrase. Since init provisions a root, the target always has one — so a
+    /// guard gated on mere existence made every restore a `--force` ceremony, and
+    /// that trains an operator to reach for the flag exactly where it is
+    /// dangerous. Gated on having certified something, the guard stays where the
+    /// loss actually is.
+    ///
+    /// This is what core's `account-root-backup-restore` e2e exercises, and what
+    /// caught the regression.
+    #[test]
+    fn restoring_a_backup_over_an_untouched_root_needs_no_force() {
+        let store = test_store();
+        let repo = NodeDeviceRepository::new(&store);
+        let provisioned = repo.ensure_account_root().expect("generate");
+        let provisioned_pk = provisioned.public_key();
+
+        // A backup taken from the node whose disk was lost.
+        let backup_store = test_store();
+        let backup = NodeDeviceRepository::new(&backup_store)
+            .ensure_account_root()
+            .expect("generate");
+        let restored_pk = backup.public_key();
+        assert_ne!(provisioned_pk, restored_pk);
+
+        let outcome = repo
+            .try_import_account_root(&backup, false)
+            .expect("restoring over an uncertified root must not need --force");
+
+        assert_eq!(
+            outcome.replaced.map(|r| r.public_key()),
+            Some(provisioned_pk),
+            "the discarded root is still reported, so nothing is silent",
+        );
+        assert_eq!(
+            repo.account_root()
+                .expect("read")
+                .expect("present")
+                .public_key(),
+            restored_pk,
+            "and the backup is what the node now holds",
+        );
+    }
+
     #[test]
     fn importing_over_an_existing_root_is_refused_unless_forced() {
+        // Refused because the root has CERTIFIED a device, not merely because one
+        // exists. The uncertified case is
+        // `restoring_a_backup_over_an_untouched_root_needs_no_force`.
         let store = test_store();
+        let ns = test_group_id();
         let repo = NodeDeviceRepository::new(&store);
         let original = repo.ensure_account_root().expect("generate");
         let original_pk = original.public_key();
+        // What makes replacing it costly: a certificate that would be orphaned.
+        repo.ensure_enrolled(&ns).expect("enrol under the root");
 
         let incoming = AccountRoot::from_mnemonic(
             &NodeDeviceRepository::new(&test_store())

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -3,6 +3,7 @@ use calimero_config::{
     NodeMode, ServerConfig, SyncConfig,
 };
 use calimero_context::config::ContextConfig;
+use calimero_governance_store::NodeDeviceRepository;
 use calimero_network_primitives::config::{
     AutonatConfig, BootstrapConfig, BootstrapNodes, DiscoveryConfig, RelayConfig, RendezvousConfig,
     SwarmConfig,
@@ -533,9 +534,36 @@ impl InitCommand {
         // `config` is fully consumed below; `datastore_path` is cloned so the
         // store's owned copy is independent.
         let datastore_path = path.join(&config.datastore.path);
-        drop(Store::open::<RocksDB>(&StoreConfig::new(
-            datastore_path.clone(),
-        ))?);
+        let store = Store::open::<RocksDB>(&StoreConfig::new(datastore_path.clone()))?;
+
+        // Provision the account root HERE, explicitly, rather than leaving it to
+        // whichever code path happens to need one first.
+        //
+        // It is created lazily today by `ensure_account_root`, and four production
+        // call sites can reach it — including `account_for_group`, which is a
+        // resolver. So a read can bring an identity into being as a side effect,
+        // and the moment a node's account exists depends on which request arrived
+        // first. Nothing is wrong with the key that results; what is wrong is that
+        // there is no point in a node's life you can name as the one where it got
+        // an account.
+        //
+        // Naming that point is a prerequisite rather than tidiness. A node meant to
+        // hold NO root — root in cold storage, this device enabled by an imported
+        // certificate (#3430) — cannot exist while any read will mint one. Those
+        // call sites can only start refusing once there is somewhere else the root
+        // legitimately comes from, and this is that somewhere.
+        //
+        // Behaviour is unchanged for every existing deployment: the same key would
+        // have been minted on first use, so this only moves *when*. The lazy path
+        // stays for now and simply finds the root already present.
+        let account_root = NodeDeviceRepository::new(&store)
+            .ensure_account_root()
+            .wrap_err("could not provision this node's account root")?;
+        info!(
+            account = %account_root.account(),
+            "Provisioned the node's account root",
+        );
+        drop(store);
 
         // RocksDB creates these files under the process umask, but they live
         // inside the now-0700 node home, so they were never reachable by other
@@ -555,6 +583,49 @@ mod tests {
     use clap::Parser;
 
     use super::InitCommand;
+
+    /// `init` must leave the node holding an account root.
+    ///
+    /// The point is not that a root exists — one would have appeared on first use
+    /// anyway, since `ensure_account_root` mints lazily from four call sites. The
+    /// point is that it exists *now*, before anything has been served, so there is
+    /// a namable moment when this node got an account.
+    ///
+    /// That is what a root-free node needs in order to be possible at all: those
+    /// lazy call sites can only start refusing once the root legitimately comes
+    /// from somewhere else, and this is that somewhere (#3430).
+    #[tokio::test]
+    async fn init_provisions_an_account_root() {
+        use calimero_governance_store::NodeDeviceRepository;
+        use calimero_store::config::StoreConfig;
+        use calimero_store::Store;
+        use calimero_store_rocksdb::RocksDB;
+
+        let home = tempfile::tempdir().expect("tempdir");
+        let home = camino::Utf8PathBuf::from_path_buf(home.path().to_path_buf())
+            .expect("utf8 tempdir path");
+        let root_args = crate::cli::RootArgs {
+            home: home.clone(),
+            node_name: camino::Utf8PathBuf::from("provisioned"),
+        };
+
+        let init =
+            InitCommand::try_parse_from(["merod", "--server-port", "8428", "--swarm-port", "8528"])
+                .expect("parse init");
+        init.run(root_args).await.expect("init");
+
+        let store =
+            Store::open::<RocksDB>(&StoreConfig::new(home.join("provisioned").join("data")))
+                .expect("open the store init created");
+
+        let root = NodeDeviceRepository::new(&store)
+            .account_root()
+            .expect("read the root");
+        assert!(
+            root.is_some(),
+            "init must leave an account root behind, so nothing later has to mint one",
+        );
+    }
 
     // mDNS is opt-in: a fresh `merod init` must not write a config that
     // announces the node on the local network. `--mdns` is the way in, and the


### PR DESCRIPTION
Groundwork for #3430. First of two: this names the moment a node gets an account; the next lets a node have none.

## The problem

An account root is created **lazily** by `ensure_account_root`, reachable from four production call sites — including `account_for_group`, which is a **resolver**. So a read can bring an identity into being as a side effect, and the moment a node acquires an account depends on which request happened to arrive first.

Nothing is wrong with the key that results. What is wrong is that there is no point in a node's life you can name as the one where it got an account.

`init` now names it.

## Why this is a prerequisite, not tidiness

A node meant to hold **no** root — root in cold storage, this device enabled by an imported certificate — cannot exist while any read will mint one. `--no-account-root` would be a lie today: the flag would set nothing, and the first resolver call would hand the node an account anyway.

Those call sites can only start refusing once the root legitimately comes from somewhere else. This is that somewhere.

**The flag is deliberately not in this PR.** It arrives with the refusals that make it true, rather than as an option that quietly does nothing.

## Behaviour is unchanged

Every existing deployment gets the same key it would have got on first use — this only moves *when*. The lazy path stays and simply finds the root already present.

## How the ordering was found

By getting it wrong. Making the resolver refuse first looked like the small, self-contained step. Two tests said otherwise, and both describe real states rather than fixtures:

- `the_creation_time_resolver_trap_is_gone` covers *"exactly the state `init` runs in"* — no context→group row, no root. The resolver's mint is what provisions a fresh node, so refusing there breaks creating your first context.
- `a_revoked_device_stops_naming_the_account_it_spoke_for` covers a node **paired into someone else's account** — it never had a root — whose device is then revoked. It previously minted one at that moment to have something to name.

That second case still needs a deliberate answer before the refusals can land: does such a node error, or is it required to hold its own root? Worth settling in review of the next PR rather than assumed.

## Verified

- New test asserts the root exists after `init`, before anything is served. Mutation-tested: removing the provisioning call fails it and nothing else.
- Manually: a fresh `merod init` logs the account, and `merod account export` returns a mnemonic immediately afterwards.
- `merod` + `calimero-governance-store`: 661 tests pass. `cargo fmt` and `clippy -D warnings` clean.