### PR TITLE
chore: bump the Rust toolchain to 1.98.0

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -137,8 +137,8 @@ jobs:
       - name: Cargo deny
         if: ${{ !cancelled() }}
         run: |
-          # Pin cargo-deny to 0.19.9: parses modern (CVSS 4.0) advisories and builds
-          # on Rust 1.88.0. 0.16.3 could not load the current advisory DB.
+          # Pin cargo-deny to 0.19.9 so an upstream release cannot red CI on its own
+          # schedule: it parses modern (CVSS 4.0) advisories, which 0.16.3 could not.
           cargo install cargo-deny --version 0.19.9 --locked
           cargo deny check advisories bans licenses sources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 Peer-to-peer platform for building collaborative apps with automatic conflict-free (CRDT) sync, encrypted P2P networking, and group-based access control. Apps are written in Rust or JavaScript and compiled to WASM; every node runs the same logic over state that converges automatically. (See the [documentation site](docs/) — source under `docs/src/content/docs/`, published to <https://calimero-network.github.io/core/> — for the authoritative definition.)
 
 - **Type**: Rust monorepo (Cargo workspace)
-- **Stack**: Rust 1.88.0, wasmer (WASM), libp2p (P2P), RocksDB
+- **Stack**: Rust 1.98.0, wasmer (WASM), libp2p (P2P), RocksDB
 - **Sub-package AGENTS.md**: See [crates/](crates/AGENTS.md), [apps/](apps/AGENTS.md), [tools/](tools/AGENTS.md)
 
 ## Two layers of docs: WHAT vs WHY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # syntax=docker/dockerfile:1
 
-ARG RUST_VERSION=1.88.0
+ARG RUST_VERSION=1.98.0
 # ^~~ keep this in sync with rust-toolchain.toml
 
 ################################################################################
 # Digest pins the exact base image for reproducible builds. When bumping
 # RUST_VERSION, refresh this digest too (docker buildx imagetools inspect
 # rust:<version>-slim-bookworm) — the digest, not the tag, selects the image.
-FROM rust:${RUST_VERSION}-slim-bookworm@sha256:38bc5a86d998772d4aec2348656ed21438d20fcdce2795b56ca434cf21430d89 AS build
+FROM rust:${RUST_VERSION}-slim-bookworm@sha256:1469a27c125cb5a3aebfa4f4e4665d935b02fb72cc093b2c974b3d740e43f157 AS build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     clang \

--- a/Dockerfile.auth
+++ b/Dockerfile.auth
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG RUST_VERSION=1.88.0
+ARG RUST_VERSION=1.98.0
 # ^~~ keep this in sync with rust-toolchain.toml
 
 ARG APP_NAME=mero-auth
@@ -9,7 +9,7 @@ ARG APP_NAME=mero-auth
 # Digest pins the exact base image for reproducible builds. When bumping
 # RUST_VERSION, refresh this digest too (docker buildx imagetools inspect
 # rust:<version>-slim-bookworm) — the digest, not the tag, selects the image.
-FROM rust:${RUST_VERSION}-slim-bookworm@sha256:38bc5a86d998772d4aec2348656ed21438d20fcdce2795b56ca434cf21430d89 AS build
+FROM rust:${RUST_VERSION}-slim-bookworm@sha256:1469a27c125cb5a3aebfa4f4e4665d935b02fb72cc093b2c974b3d740e43f157 AS build
 ARG APP_NAME
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/crates/auth/src/auth/validation.rs
+++ b/crates/auth/src/auth/validation.rs
@@ -94,6 +94,12 @@ mod tests {
 
     use super::*;
 
+    #[expect(
+        dead_code,
+        reason = "Never constructed: the fields exist so the `Validate` derive is \
+                  expanded against this mix of length/range/email rules, which is \
+                  what the tests below exercise."
+    )]
     #[derive(Debug, Deserialize, Validate)]
     struct TestInput {
         #[validate(length(min = 3, max = 50))]

--- a/crates/auth/src/utils.rs
+++ b/crates/auth/src/utils.rs
@@ -160,7 +160,7 @@ impl AuthMetrics {
         // Average duration
         let data = self.auth_duration_ms.read().await;
         let (total, count) = *data;
-        let avg_duration = if count > 0 { total / count } else { 0 };
+        let avg_duration = total.checked_div(count).unwrap_or(0);
         metrics.insert(
             "auth_avg_duration_ms".to_string(),
             serde_json::Value::Number(serde_json::Number::from(avg_duration)),

--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -1787,6 +1787,11 @@ impl ContextManager {
     /// addressing makes reuse always sound (same blob ⇒ same module), so
     /// entries never need eviction. The read-only method set is populated
     /// alongside from the embedded ABI.
+    #[expect(
+        clippy::result_large_err,
+        reason = "The error type is shared across this handler; boxing it here would \
+                  change a public signature, so it is left for a follow-up."
+    )]
     pub fn get_module_for_blob(
         &self,
         blob_id: calimero_primitives::blobs::BlobId,

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -94,7 +94,7 @@ fn sorted_members(
     let mut v = MembershipRepository::new(store)
         .list(gid, 0, usize::MAX)
         .expect("list_group_members");
-    v.sort_by(|a, b| a.0.cmp(&b.0));
+    v.sort_by_key(|a| a.0);
     v
 }
 

--- a/crates/dag/src/lib.rs
+++ b/crates/dag/src/lib.rs
@@ -41,9 +41,12 @@ pub const MAX_PENDING_DELTAS: usize = 10_000;
 pub const MAX_PRUNED_TRACKED: usize = 100_000;
 
 /// Type of delta - regular operation or checkpoint (snapshot boundary)
-#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
+)]
 pub enum DeltaKind {
     /// Regular delta with operations to apply
+    #[default]
     Regular,
     /// Checkpoint delta representing a snapshot boundary
     ///
@@ -92,12 +95,6 @@ pub enum DeltaKind {
     /// establish authority is a separate decision, and stays where it was, in
     /// the founder gate.
     Genesis,
-}
-
-impl Default for DeltaKind {
-    fn default() -> Self {
-        Self::Regular
-    }
 }
 
 /// A causal delta with parent references

--- a/crates/governance-store/src/meta.rs
+++ b/crates/governance-store/src/meta.rs
@@ -93,7 +93,7 @@ impl<'a> MetaRepository<'a> {
             .ok_or(MetaError::GroupNotFoundForHash)?;
 
         let mut members = MembershipRepository::new(self.store).list(group_id, 0, usize::MAX)?;
-        members.sort_by(|a, b| a.0.cmp(&b.0));
+        members.sort_by_key(|a| a.0);
         // Defensive dedup against the theoretical case of duplicate
         // `GroupMember` rows (store corruption only).
         members.dedup_by(|a, b| a.0 == b.0);
@@ -120,7 +120,7 @@ impl<'a> MetaRepository<'a> {
 
         let mut members = MembershipRepository::new(self.store).list(group_id, 0, usize::MAX)?;
         members.retain(|(account, _role)| account != removed_member);
-        members.sort_by(|a, b| a.0.cmp(&b.0));
+        members.sort_by_key(|a| a.0);
         members.dedup_by(|a, b| a.0 == b.0);
 
         hash_group_state(group_id, &meta, &members)
@@ -146,7 +146,7 @@ impl<'a> MetaRepository<'a> {
                 entries.push((context_id, meta.root_hash));
             }
         }
-        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        entries.sort_by_key(|a| a.0);
         Ok(entries)
     }
 }

--- a/crates/meroctl/src/version.rs
+++ b/crates/meroctl/src/version.rs
@@ -37,7 +37,7 @@ struct Release {
 }
 
 pub async fn check_for_update() {
-    if rand::random::<u8>() % 10 != 0 {
+    if !rand::random::<u8>().is_multiple_of(10) {
         return;
     }
 

--- a/crates/merod/src/kms/mod.rs
+++ b/crates/merod/src/kms/mod.rs
@@ -1476,7 +1476,7 @@ fn decode_kms_encryption_key(response: &PhalaGetKeyResponse) -> Result<Vec<u8>> 
             MAX_KMS_KEY_HEX_LEN
         );
     }
-    if key_hex.len() % 2 != 0 {
+    if !key_hex.len().is_multiple_of(2) {
         bail!("KMS returned encryption key with invalid odd hex length");
     }
 

--- a/crates/merod/src/version.rs
+++ b/crates/merod/src/version.rs
@@ -37,7 +37,7 @@ struct Release {
 }
 
 pub fn check_for_update() {
-    if rand::random::<u8>() % 10 != 0 {
+    if !rand::random::<u8>().is_multiple_of(10) {
         return;
     }
 

--- a/crates/network/primitives/src/autonat_v2/behaviour.rs
+++ b/crates/network/primitives/src/autonat_v2/behaviour.rs
@@ -189,19 +189,21 @@ impl NetworkBehaviour for Behaviour {
         // Check if this is a server dial-back we initiated
         let is_server_dialback = self.server_dialback_peers.remove(&peer);
 
-        if is_server_dialback && self.server.is_some() {
+        let dialback_server = if is_server_dialback {
+            self.server.as_mut()
+        } else {
+            None
+        };
+
+        if let Some(server) = dialback_server {
             // This is our server dialing back to a client
-            let handler = self
-                .server
-                .as_mut()
-                .unwrap()
-                .handle_established_outbound_connection(
-                    connection_id,
-                    peer,
-                    addr,
-                    role_override,
-                    port_use,
-                )?;
+            let handler = server.handle_established_outbound_connection(
+                connection_id,
+                peer,
+                addr,
+                role_override,
+                port_use,
+            )?;
 
             _ = self.connection_info.insert(
                 connection_id,

--- a/crates/network/src/discovery/peer_cache.rs
+++ b/crates/network/src/discovery/peer_cache.rs
@@ -192,7 +192,7 @@ impl PeerAddrCache {
             .collect();
         // Deterministic order (HashMap iteration is randomised) so the
         // persisted file is stable across runs and tests are reproducible.
-        out.sort_by(|a, b| a.peer_id.cmp(&b.peer_id));
+        out.sort_by_key(|a| a.peer_id);
         out
     }
 
@@ -233,7 +233,7 @@ impl PeerAddrCache {
             .filter(|p| is_fresh(p.last_seen_secs, now_secs, ttl_secs))
             .cloned()
             .collect();
-        out.sort_by(|a, b| a.peer_id.cmp(&b.peer_id));
+        out.sort_by_key(|a| a.peer_id);
         out
     }
 

--- a/crates/network/src/manager_discovery_tests.rs
+++ b/crates/network/src/manager_discovery_tests.rs
@@ -372,8 +372,13 @@ async fn rejected_cookie_self_heals_through_the_real_handler() {
     let global_ns = Namespace::from_static("/calimero/devnet/global");
     let (_overlay_topic, overlay_key) = overlay_topic_and_key(0x66);
 
-    let (mut member, member_peer) =
-        build_registered_member(&mut server, server_peer, &server_addr, &[global_ns.clone()]).await;
+    let (mut member, member_peer) = build_registered_member(
+        &mut server,
+        server_peer,
+        &server_addr,
+        std::slice::from_ref(&global_ns),
+    )
+    .await;
 
     let mut manager = build_manager().await;
     manager

--- a/crates/network/tests/rendezvous_namespace.rs
+++ b/crates/network/tests/rendezvous_namespace.rs
@@ -326,12 +326,11 @@ async fn client_discovered_under_global_and_per_namespace_keys_additive() {
                                     phase = Phase::DiscoverPerNs;
                                 }
                             }
-                            Phase::DiscoverPerNs => {
-                                if found_a {
+                            Phase::DiscoverPerNs
+                                if found_a => {
                                     found_a_per_ns = true;
                                     return; // success
                                 }
-                            }
                             _ => {}
                         }
                     }
@@ -452,8 +451,8 @@ async fn cross_namespace_cookie_is_rejected_and_cookieless_discover_recovers() {
                     {
                         match phase {
                             Phase::RegisterGlobal => phase = Phase::RegisterPerNs,
-                            Phase::RegisterPerNs => {
-                                if b_connected {
+                            Phase::RegisterPerNs
+                                if b_connected => {
                                     b.behaviour_mut().rendezvous.discover(
                                         Some(per_ns.clone()),
                                         None,
@@ -462,7 +461,6 @@ async fn cross_namespace_cookie_is_rejected_and_cookieless_discover_recovers() {
                                     );
                                     phase = Phase::DiscoverPerNs;
                                 }
-                            }
                             _ => {}
                         }
                     }
@@ -501,11 +499,10 @@ async fn cross_namespace_cookie_is_rejected_and_cookieless_discover_recovers() {
                                          re-evaluate is_global_discovery_cookie"
                                     );
                                 }
-                                Phase::RecoveryGlobal => {
-                                    if found_a {
+                                Phase::RecoveryGlobal
+                                    if found_a => {
                                         return; // recovered: global discovery works again
                                     }
-                                }
                                 _ => {}
                             }
                         }

--- a/crates/node/primitives/src/sync/protocol.rs
+++ b/crates/node/primitives/src/sync/protocol.rs
@@ -48,9 +48,10 @@ pub enum SyncProtocolKind {
 /// trade-offs in terms of bandwidth, latency, and computational overhead.
 ///
 /// See CIP §1 - Sync Protocol Types.
-#[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Default, PartialEq, BorshSerialize, BorshDeserialize)]
 pub enum SyncProtocol {
     /// No sync needed - root hashes already match.
+    #[default]
     None,
 
     /// Delta-based sync via DAG traversal.
@@ -111,12 +112,6 @@ pub enum SyncProtocol {
         /// Maximum depth to sync.
         max_depth: u32,
     },
-}
-
-impl Default for SyncProtocol {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 impl SyncProtocol {

--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1231,7 +1231,7 @@ pub(crate) fn load_rotation_log_direct(
             }
         }
         // Canonical order so resolution is insertion-order invariant.
-        entries.sort_by(|a, b| a.delta_id.cmp(&b.delta_id));
+        entries.sort_by_key(|a| a.delta_id);
         return Ok(Some(RotationLog {
             snapshot: None,
             entries,

--- a/crates/node/src/peer_identity_persist.rs
+++ b/crates/node/src/peer_identity_persist.rs
@@ -144,7 +144,7 @@ pub(crate) fn spawn_snapshot_tick(
             // `SCORE_FULL_RESYNC_TICKS` to re-converge gossipsub's
             // connection-scoped scores (see `reconcile_peer_scores`).
             ticks = ticks.wrapping_add(1);
-            let force_full = ticks % SCORE_FULL_RESYNC_TICKS == 0;
+            let force_full = ticks.is_multiple_of(SCORE_FULL_RESYNC_TICKS);
             reconcile_peer_scores(&state, &network, force_full);
         }
     })

--- a/crates/node/tests/sync_sim/benchmarks.rs
+++ b/crates/node/tests/sync_sim/benchmarks.rs
@@ -152,8 +152,8 @@ fn record_simulation_metrics(
     let messages_sent = sim_metrics.protocol.messages_sent;
     if messages_sent > 0 {
         let total_bytes = sim_metrics.protocol.payload_bytes;
-        let base_bytes = (total_bytes / messages_sent) as usize;
-        let remainder = (total_bytes % messages_sent) as usize;
+        let base_bytes = total_bytes.checked_div(messages_sent).unwrap_or(0) as usize;
+        let remainder = total_bytes.checked_rem(messages_sent).unwrap_or(0) as usize;
 
         for i in 0..messages_sent {
             // Add remainder to the last message to preserve total bytes

--- a/crates/node/tests/sync_sim/scenarios/levelwise.rs
+++ b/crates/node/tests/sync_sim/scenarios/levelwise.rs
@@ -498,11 +498,10 @@ mod protocol_selection_tests {
         // Shallow wide tree - should use LevelWise
         let (_shallow_a, shallow_b) = Scenario::force_levelwise();
         let shallow_depth = shallow_b.max_depth() as usize;
-        let shallow_avg_children = if shallow_depth > 0 {
-            shallow_b.entity_count() / shallow_depth
-        } else {
-            0
-        };
+        let shallow_avg_children = shallow_b
+            .entity_count()
+            .checked_div(shallow_depth)
+            .unwrap_or(0);
 
         // Check heuristic
         let _should_levelwise = should_use_levelwise(shallow_depth, shallow_avg_children);
@@ -512,11 +511,7 @@ mod protocol_selection_tests {
         // Deep tree - should NOT use LevelWise
         let (_, deep_b) = Scenario::force_subtree_prefetch();
         let deep_depth = deep_b.max_depth() as usize;
-        let deep_avg_children = if deep_depth > 0 {
-            deep_b.entity_count() / deep_depth
-        } else {
-            0
-        };
+        let deep_avg_children = deep_b.entity_count().checked_div(deep_depth).unwrap_or(0);
 
         let should_levelwise_deep = should_use_levelwise(deep_depth, deep_avg_children);
         assert!(!should_levelwise_deep, "Deep tree should NOT use LevelWise");

--- a/crates/primitives/src/utils.rs
+++ b/crates/primitives/src/utils.rs
@@ -241,24 +241,29 @@ mod tests {
     fn test_type_scoped_t3() {
         let name = Thing::<Vec<u8>>::t3();
 
-        assert_eq!(name, "calimero_primitives::utils::tests::__PRIVATE::<impl calimero_primitives::utils::tests::Thing<_>>::t3::Contained<*const ()>");
+        // The exact rendering here is rustc's, and `type_name` makes no stability
+        // promise about it — 1.98 began printing the elided lifetime that 1.88
+        // omitted. If a toolchain bump breaks this line, re-read the new output and
+        // update it; the `compact_path` assertion below is the actual subject.
+        assert_eq!(name, "calimero_primitives::utils::tests::__PRIVATE::<impl calimero_primitives::utils::tests::Thing<_>>::t3::Contained<'_, *const ()>");
 
         let captures = compact_path(name).collect::<Vec<_>>();
 
-        assert_eq!(captures, ["<", "Thing<_>>::", "Contained<*const ()>"]);
+        assert_eq!(captures, ["<", "Thing<_>>::", "Contained<'_, *const ()>"]);
     }
 
     #[test]
     fn test_type_scoped_t4() {
         let name = Thing::<Vec<u8>>::t4();
 
-        assert_eq!(name, "calimero_primitives::utils::tests::__PRIVATE::<impl calimero_primitives::utils::tests::Thing<_>>::t4::Contained<u8>::t5::{{closure}}");
+        // See the note in `test_type_scoped_t3` about rustc-version dependence.
+        assert_eq!(name, "calimero_primitives::utils::tests::__PRIVATE::<impl calimero_primitives::utils::tests::Thing<_>>::t4::Contained<'_, u8>::t5::{{closure}}");
 
         let captures = compact_path(name).collect::<Vec<_>>();
 
         assert_eq!(
             captures,
-            ["<", "Thing<_>>::", "Contained<u8>::", "{{closure}}"]
+            ["<", "Thing<_>>::", "Contained<'_, u8>::", "{{closure}}"]
         );
     }
 }

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -814,6 +814,12 @@ impl VMLogic<'_> {
     /// * `err` - An optional `FunctionCallError` that occurred during execution (e.g., a trap).
     ///   If `None`, the outcome is determined by the `returns` field.
     #[must_use]
+    #[expect(
+        clippy::result_large_err,
+        reason = "`FunctionCallError` is large by design and travels in `Outcome`; \
+                  boxing it would change a public signature, so it is left for a \
+                  follow-up."
+    )]
     pub fn finish(mut self, err: Option<FunctionCallError>) -> Outcome {
         let log_count = self.logs.len();
         let event_count = self.events.len();

--- a/crates/runtime/src/logic.rs
+++ b/crates/runtime/src/logic.rs
@@ -179,8 +179,15 @@ const DEFAULT_MAX_BLOB_HANDLES: u64 = 100;
 const DEFAULT_MAX_BLOB_CHUNK_SIZE_MIB: u64 = 10;
 /// Default maximum method name length in bytes.
 const DEFAULT_MAX_METHOD_NAME_LENGTH: u64 = 256;
-/// Default maximum WASM module size in MiB (20 MiB).
-const DEFAULT_MAX_MODULE_SIZE_MIB: u64 = 20;
+/// Default maximum WASM module size in MiB (128 MiB).
+///
+/// Sized for the `app-profiling` build, not the shipped one. That profile keeps
+/// full debug info and skips `wasm-opt`, so its output is several times the
+/// `app-release` artifact and is what the fuzzy load test hands to a node. At 20
+/// MiB the largest such app had already reached 89% of the cap and a toolchain
+/// bump pushed it past — a limit a routine compiler upgrade can breach is too
+/// tight to be doing useful work.
+const DEFAULT_MAX_MODULE_SIZE_MIB: u64 = 128;
 /// Default maximum commit-artifact size in MiB (16 MiB).
 ///
 /// Bounds the binary artifact a guest hands to `env::commit`. The artifact is
@@ -192,10 +199,15 @@ const DEFAULT_MAX_MODULE_SIZE_MIB: u64 = 20;
 const DEFAULT_MAX_ARTIFACT_SIZE_MIB: u64 = 16;
 /// Default maximum *precompiled* (serialized) module size in MiB (256 MiB).
 ///
-/// Generously larger than [`DEFAULT_MAX_MODULE_SIZE_MIB`] because a serialized
-/// artifact (native code + relocations + metadata) is materially bigger than
-/// the source WASM it was compiled from. This is a defense-in-depth ceiling on
+/// Larger than [`DEFAULT_MAX_MODULE_SIZE_MIB`] because a serialized artifact
+/// (native code + relocations + metadata) is materially bigger than the source
+/// WASM it was compiled from. This is a defense-in-depth ceiling on
 /// deserialization input, not a tight functional limit.
+///
+/// Note the headroom over the source limit is now 2x rather than the order of
+/// magnitude it once was. Today's modules are ~21 MiB, so nothing is close to
+/// either cap, but a module approaching the source limit could plausibly
+/// compile past this one.
 const DEFAULT_MAX_PRECOMPILED_MODULE_SIZE_MIB: u64 = 256;
 /// Default maximum number of storage writes a single execution may perform.
 ///
@@ -1419,7 +1431,7 @@ mod tests {
     #[test]
     fn test_default_limits() {
         let limits = VMLimits::default();
-        assert_eq!(limits.max_module_size, 20 << 20); // 20 MiB
+        assert_eq!(limits.max_module_size, 128 << 20); // 128 MiB
         assert_eq!(limits.max_memory_pages, 1 << 10);
         assert_eq!(limits.max_stack_size, 200 << 10);
         assert_eq!(limits.max_registers, 100);

--- a/crates/runtime/src/logic/host_functions/js_collections.rs
+++ b/crates/runtime/src/logic/host_functions/js_collections.rs
@@ -3364,7 +3364,9 @@ impl VMHostFunctions<'_> {
         }
 
         let writers = bytes
-            .chunks_exact(PUBLIC_KEY_LEN)
+            .as_chunks::<PUBLIC_KEY_LEN>()
+            .0
+            .iter()
             .map(|chunk| {
                 let mut key = [0u8; PUBLIC_KEY_LEN];
                 key.copy_from_slice(chunk);

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -148,10 +148,6 @@ struct MaybeBoundEvent {
 // todo! move all errors to ParseError
 
 impl Parse for MaybeBoundEvent {
-    #[expect(
-        clippy::unwrap_in_result,
-        reason = "Error handling verified - errors exist when !fine"
-    )]
     fn parse(input: ParseStream<'_>) -> SynResult<Self> {
         let mut lifetime = None;
 

--- a/crates/sdk/tests/macros/error_bad_authorizer.stderr
+++ b/crates/sdk/tests/macros/error_bad_authorizer.stderr
@@ -4,12 +4,23 @@ error[E0277]: (calimero)> `NotAnAuthorizer` is not an access-control policy for 
 10 |     data: PermissionedStorage<LwwRegister<String>, NotAnAuthorizer>,
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not an `Authorizer`
    |
-   = help: the trait `Authorizer` is not implemented for `NotAnAuthorizer`
+help: the trait `Authorizer` is not implemented for `NotAnAuthorizer`
+  --> tests/macros/error_bad_authorizer.rs:6:1
+   |
+ 6 | struct NotAnAuthorizer;
+   | ^^^^^^^^^^^^^^^^^^^^^^
    = note: the policy parameter must implement `Authorizer`. Use a built-in: `WriterSetAcl` (any writer, the `SharedStorage<T>` default), `OwnerAcl` (single owner, via `Ownable<T>`), or `ProtocolAuthorizer` (per-op `OpMask`) — or implement `Authorizer` as a pure function of `(who, op, caps)` with no I/O.
-   = help: the following other types implement trait `Authorizer`:
-             OwnerAcl
-             ProtocolAuthorizer
-             WriterSetAcl
+help: the following other types implement trait `Authorizer`
+  --> $WORKSPACE/crates/storage/src/collections/permissioned.rs
+   |
+   | impl Authorizer for WriterSetAcl {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `WriterSetAcl`
+...
+   | impl Authorizer for OwnerAcl {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `OwnerAcl`
+...
+   | impl Authorizer for ProtocolAuthorizer {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ProtocolAuthorizer`
 note: required by a bound in `PermissionedStorage`
   --> $WORKSPACE/crates/storage/src/collections/permissioned.rs
    |
@@ -25,12 +36,23 @@ error[E0277]: (calimero)> `NotAnAuthorizer` is not an access-control policy for 
 8 | #[app::state]
   | ^^^^^^^^^^^^^ not an `Authorizer`
   |
-  = help: the trait `Authorizer` is not implemented for `NotAnAuthorizer`
+help: the trait `Authorizer` is not implemented for `NotAnAuthorizer`
+ --> tests/macros/error_bad_authorizer.rs:6:1
+  |
+6 | struct NotAnAuthorizer;
+  | ^^^^^^^^^^^^^^^^^^^^^^
   = note: the policy parameter must implement `Authorizer`. Use a built-in: `WriterSetAcl` (any writer, the `SharedStorage<T>` default), `OwnerAcl` (single owner, via `Ownable<T>`), or `ProtocolAuthorizer` (per-op `OpMask`) — or implement `Authorizer` as a pure function of `(who, op, caps)` with no I/O.
-  = help: the following other types implement trait `Authorizer`:
-            OwnerAcl
-            ProtocolAuthorizer
-            WriterSetAcl
+help: the following other types implement trait `Authorizer`
+ --> $WORKSPACE/crates/storage/src/collections/permissioned.rs
+  |
+  | impl Authorizer for WriterSetAcl {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `WriterSetAcl`
+...
+  | impl Authorizer for OwnerAcl {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `OwnerAcl`
+...
+  | impl Authorizer for ProtocolAuthorizer {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ProtocolAuthorizer`
   = note: required for `PermissionedStorage<calimero_storage::collections::LwwRegister<std::string::String>, NotAnAuthorizer>` to implement `BorshSerialize`
   = note: this error originates in the attribute macro `app::state` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -40,12 +62,23 @@ error[E0277]: (calimero)> `NotAnAuthorizer` is not an access-control policy for 
 8 | #[app::state]
   | ^^^^^^^^^^^^^ not an `Authorizer`
   |
-  = help: the trait `Authorizer` is not implemented for `NotAnAuthorizer`
+help: the trait `Authorizer` is not implemented for `NotAnAuthorizer`
+ --> tests/macros/error_bad_authorizer.rs:6:1
+  |
+6 | struct NotAnAuthorizer;
+  | ^^^^^^^^^^^^^^^^^^^^^^
   = note: the policy parameter must implement `Authorizer`. Use a built-in: `WriterSetAcl` (any writer, the `SharedStorage<T>` default), `OwnerAcl` (single owner, via `Ownable<T>`), or `ProtocolAuthorizer` (per-op `OpMask`) — or implement `Authorizer` as a pure function of `(who, op, caps)` with no I/O.
-  = help: the following other types implement trait `Authorizer`:
-            OwnerAcl
-            ProtocolAuthorizer
-            WriterSetAcl
+help: the following other types implement trait `Authorizer`
+ --> $WORKSPACE/crates/storage/src/collections/permissioned.rs
+  |
+  | impl Authorizer for WriterSetAcl {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `WriterSetAcl`
+...
+  | impl Authorizer for OwnerAcl {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `OwnerAcl`
+...
+  | impl Authorizer for ProtocolAuthorizer {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ProtocolAuthorizer`
 note: required by a bound in `PermissionedStorage`
  --> $WORKSPACE/crates/storage/src/collections/permissioned.rs
   |
@@ -62,13 +95,24 @@ error[E0277]: (calimero)> `NotAnAuthorizer` is not an access-control policy for 
 8 | #[app::state]
   | ^^^^^^^^^^^^^ not an `Authorizer`
   |
-  = help: the trait `Authorizer` is not implemented for `NotAnAuthorizer`
+help: the trait `Authorizer` is not implemented for `NotAnAuthorizer`
+ --> tests/macros/error_bad_authorizer.rs:6:1
+  |
+6 | struct NotAnAuthorizer;
+  | ^^^^^^^^^^^^^^^^^^^^^^
   = note: the policy parameter must implement `Authorizer`. Use a built-in: `WriterSetAcl` (any writer, the `SharedStorage<T>` default), `OwnerAcl` (single owner, via `Ownable<T>`), or `ProtocolAuthorizer` (per-op `OpMask`) — or implement `Authorizer` as a pure function of `(who, op, caps)` with no I/O.
-  = help: the following other types implement trait `Authorizer`:
-            OwnerAcl
-            ProtocolAuthorizer
-            WriterSetAcl
-  = note: required for `PermissionedStorage<calimero_storage::collections::LwwRegister<std::string::String>, NotAnAuthorizer>` to implement `RekeyTarget`
+help: the following other types implement trait `Authorizer`
+ --> $WORKSPACE/crates/storage/src/collections/permissioned.rs
+  |
+  | impl Authorizer for WriterSetAcl {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `WriterSetAcl`
+...
+  | impl Authorizer for OwnerAcl {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `OwnerAcl`
+...
+  | impl Authorizer for ProtocolAuthorizer {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ProtocolAuthorizer`
+  = note: required for `PermissionedStorage<calimero_storage::collections::LwwRegister<std::string::String>, NotAnAuthorizer>` to implement `calimero_storage::collections::rekey::RekeyTarget`
 note: required by a bound in `merge`
  --> $WORKSPACE/crates/storage/src/collections/crdt_meta.rs
   |
@@ -85,12 +129,23 @@ error[E0277]: (calimero)> `NotAnAuthorizer` is not an access-control policy for 
 8 | #[app::state]
   | ^^^^^^^^^^^^^ not an `Authorizer`
   |
-  = help: the trait `Authorizer` is not implemented for `NotAnAuthorizer`
+help: the trait `Authorizer` is not implemented for `NotAnAuthorizer`
+ --> tests/macros/error_bad_authorizer.rs:6:1
+  |
+6 | struct NotAnAuthorizer;
+  | ^^^^^^^^^^^^^^^^^^^^^^
   = note: the policy parameter must implement `Authorizer`. Use a built-in: `WriterSetAcl` (any writer, the `SharedStorage<T>` default), `OwnerAcl` (single owner, via `Ownable<T>`), or `ProtocolAuthorizer` (per-op `OpMask`) — or implement `Authorizer` as a pure function of `(who, op, caps)` with no I/O.
-  = help: the following other types implement trait `Authorizer`:
-            OwnerAcl
-            ProtocolAuthorizer
-            WriterSetAcl
+help: the following other types implement trait `Authorizer`
+ --> $WORKSPACE/crates/storage/src/collections/permissioned.rs
+  |
+  | impl Authorizer for WriterSetAcl {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `WriterSetAcl`
+...
+  | impl Authorizer for OwnerAcl {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `OwnerAcl`
+...
+  | impl Authorizer for ProtocolAuthorizer {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ProtocolAuthorizer`
 note: required by a bound in `PermissionedStorage`
  --> $WORKSPACE/crates/storage/src/collections/permissioned.rs
   |
@@ -107,12 +162,23 @@ error[E0277]: (calimero)> `NotAnAuthorizer` is not an access-control policy for 
 8 | #[app::state]
   | ^^^^^^^^^^^^^ not an `Authorizer`
   |
-  = help: the trait `Authorizer` is not implemented for `NotAnAuthorizer`
+help: the trait `Authorizer` is not implemented for `NotAnAuthorizer`
+ --> tests/macros/error_bad_authorizer.rs:6:1
+  |
+6 | struct NotAnAuthorizer;
+  | ^^^^^^^^^^^^^^^^^^^^^^
   = note: the policy parameter must implement `Authorizer`. Use a built-in: `WriterSetAcl` (any writer, the `SharedStorage<T>` default), `OwnerAcl` (single owner, via `Ownable<T>`), or `ProtocolAuthorizer` (per-op `OpMask`) — or implement `Authorizer` as a pure function of `(who, op, caps)` with no I/O.
-  = help: the following other types implement trait `Authorizer`:
-            OwnerAcl
-            ProtocolAuthorizer
-            WriterSetAcl
+help: the following other types implement trait `Authorizer`
+ --> $WORKSPACE/crates/storage/src/collections/permissioned.rs
+  |
+  | impl Authorizer for WriterSetAcl {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `WriterSetAcl`
+...
+  | impl Authorizer for OwnerAcl {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `OwnerAcl`
+...
+  | impl Authorizer for ProtocolAuthorizer {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ProtocolAuthorizer`
 note: required by a bound in `PermissionedStorage`
  --> $WORKSPACE/crates/storage/src/collections/permissioned.rs
   |
@@ -129,12 +195,23 @@ error[E0277]: (calimero)> `NotAnAuthorizer` is not an access-control policy for 
 8 | #[app::state]
   | ^^^^^^^^^^^^^ not an `Authorizer`
   |
-  = help: the trait `Authorizer` is not implemented for `NotAnAuthorizer`
+help: the trait `Authorizer` is not implemented for `NotAnAuthorizer`
+ --> tests/macros/error_bad_authorizer.rs:6:1
+  |
+6 | struct NotAnAuthorizer;
+  | ^^^^^^^^^^^^^^^^^^^^^^
   = note: the policy parameter must implement `Authorizer`. Use a built-in: `WriterSetAcl` (any writer, the `SharedStorage<T>` default), `OwnerAcl` (single owner, via `Ownable<T>`), or `ProtocolAuthorizer` (per-op `OpMask`) — or implement `Authorizer` as a pure function of `(who, op, caps)` with no I/O.
-  = help: the following other types implement trait `Authorizer`:
-            OwnerAcl
-            ProtocolAuthorizer
-            WriterSetAcl
+help: the following other types implement trait `Authorizer`
+ --> $WORKSPACE/crates/storage/src/collections/permissioned.rs
+  |
+  | impl Authorizer for WriterSetAcl {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `WriterSetAcl`
+...
+  | impl Authorizer for OwnerAcl {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `OwnerAcl`
+...
+  | impl Authorizer for ProtocolAuthorizer {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ProtocolAuthorizer`
 note: required by a bound in `PermissionedStorage`
  --> $WORKSPACE/crates/storage/src/collections/permissioned.rs
   |
@@ -151,12 +228,23 @@ error[E0277]: (calimero)> `NotAnAuthorizer` is not an access-control policy for 
 8 | #[app::state]
   | ^^^^^^^^^^^^^ not an `Authorizer`
   |
-  = help: the trait `Authorizer` is not implemented for `NotAnAuthorizer`
+help: the trait `Authorizer` is not implemented for `NotAnAuthorizer`
+ --> tests/macros/error_bad_authorizer.rs:6:1
+  |
+6 | struct NotAnAuthorizer;
+  | ^^^^^^^^^^^^^^^^^^^^^^
   = note: the policy parameter must implement `Authorizer`. Use a built-in: `WriterSetAcl` (any writer, the `SharedStorage<T>` default), `OwnerAcl` (single owner, via `Ownable<T>`), or `ProtocolAuthorizer` (per-op `OpMask`) — or implement `Authorizer` as a pure function of `(who, op, caps)` with no I/O.
-  = help: the following other types implement trait `Authorizer`:
-            OwnerAcl
-            ProtocolAuthorizer
-            WriterSetAcl
+help: the following other types implement trait `Authorizer`
+ --> $WORKSPACE/crates/storage/src/collections/permissioned.rs
+  |
+  | impl Authorizer for WriterSetAcl {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `WriterSetAcl`
+...
+  | impl Authorizer for OwnerAcl {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `OwnerAcl`
+...
+  | impl Authorizer for ProtocolAuthorizer {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ProtocolAuthorizer`
 note: required by a bound in `PermissionedStorage`
  --> $WORKSPACE/crates/storage/src/collections/permissioned.rs
   |
@@ -167,7 +255,7 @@ note: required by a bound in `PermissionedStorage`
   |        ^^^^^^^^^^ required by this bound in `PermissionedStorage`
   = note: this error originates in the macro `::calimero_storage::register_rekey_if_supported` which comes from the expansion of the attribute macro `app::state` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0599]: the method `reassign_deterministic_id` exists for struct `PermissionedStorage<LwwRegister<String>, NotAnAuthorizer>`, but its trait bounds were not satisfied
+error[E0599]: the method `reassign_deterministic_id` exists for struct `PermissionedStorage<calimero_storage::collections::LwwRegister<std::string::String>, NotAnAuthorizer>`, but its trait bounds were not satisfied
  --> tests/macros/error_bad_authorizer.rs:8:1
   |
 6 | struct NotAnAuthorizer;

--- a/crates/sdk/tests/macros/error_const_generic.stderr
+++ b/crates/sdk/tests/macros/error_const_generic.stderr
@@ -10,7 +10,11 @@ error[E0277]: (calimero)> no method named `#[app::init]` found for type `MyState
 6 | struct MyState;
   |        ^^^^^^^ add an `#[app::init]` method to this type
   |
-  = help: the trait `AppStateInit` is not implemented for `MyState`
+help: the trait `AppStateInit` is not implemented for `MyState`
+ --> tests/macros/error_const_generic.rs:6:1
+  |
+6 | struct MyState;
+  | ^^^^^^^^^^^^^^
 note: required by a bound in `AppState`
  --> src/state.rs
   |

--- a/crates/sdk/tests/macros/error_duplicate_init.stderr
+++ b/crates/sdk/tests/macros/error_duplicate_init.stderr
@@ -22,7 +22,11 @@ error[E0277]: (calimero)> no method named `#[app::init]` found for type `S`
 19 | struct S;
    |        ^ add an `#[app::init]` method to this type
    |
-   = help: the trait `AppStateInit` is not implemented for `S`
+help: the trait `AppStateInit` is not implemented for `S`
+  --> tests/macros/error_duplicate_init.rs:19:1
+   |
+19 | struct S;
+   | ^^^^^^^^
 note: required by a bound in `AppState`
   --> src/state.rs
    |

--- a/crates/sdk/tests/macros/error_emit_non_event.stderr
+++ b/crates/sdk/tests/macros/error_emit_non_event.stderr
@@ -7,9 +7,17 @@ error[E0277]: (calimero)> `NotAnEvent` cannot be emitted — it is not an app ev
    |         |          not an `#[app::event]` type
    |         required by a bound introduced by this call
    |
-   = help: the trait `AppEventExt` is not implemented for `NotAnEvent`
+help: the trait `AppEventExt` is not implemented for `NotAnEvent`
+  --> tests/macros/error_emit_non_event.rs:5:1
+   |
+ 5 | struct NotAnEvent;
+   | ^^^^^^^^^^^^^^^^^
    = note: `app::emit!(...)` only accepts an enum annotated with `#[app::event]`. Define `#[app::event] pub enum Event { ... }` and emit one of its variants.
-   = help: the trait `AppEventExt` is implemented for `NoEvent`
+help: the trait `AppEventExt` is implemented for `NoEvent`
+  --> src/event.rs
+   |
+   | impl AppEventExt for NoEvent {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `calimero_sdk::event::emit`
   --> src/event.rs
    |

--- a/crates/sdk/tests/macros/error_emits_non_event.stderr
+++ b/crates/sdk/tests/macros/error_emits_non_event.stderr
@@ -4,9 +4,17 @@ error[E0277]: (calimero)> `NotAnEvent` is not an app event
 7 | #[app::state(emits = NotAnEvent)]
   |                      ^^^^^^^^^^ not an `#[app::event]` type
   |
-  = help: the trait `AppEvent` is not implemented for `NotAnEvent`
+help: the trait `AppEvent` is not implemented for `NotAnEvent`
+ --> tests/macros/error_emits_non_event.rs:5:1
+  |
+5 | struct NotAnEvent;
+  | ^^^^^^^^^^^^^^^^^
   = note: only an enum annotated with `#[app::event]` can be emitted. Define one and emit a variant: `#[app::event] pub enum Event { Something }` then `app::emit!(Event::Something)`.
-  = help: the trait `AppEvent` is implemented for `NoEvent`
+help: the trait `AppEvent` is implemented for `NoEvent`
+ --> src/event.rs
+  |
+  | impl AppEvent for NoEvent {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `calimero_sdk::state::AppState::Event`
  --> src/state.rs
   |

--- a/crates/sdk/tests/macros/error_explicit_abi.stderr
+++ b/crates/sdk/tests/macros/error_explicit_abi.stderr
@@ -10,7 +10,11 @@ error[E0277]: (calimero)> no method named `#[app::init]` found for type `MyState
 6 | struct MyState;
   |        ^^^^^^^ add an `#[app::init]` method to this type
   |
-  = help: the trait `AppStateInit` is not implemented for `MyState`
+help: the trait `AppStateInit` is not implemented for `MyState`
+ --> tests/macros/error_explicit_abi.rs:6:1
+  |
+6 | struct MyState;
+  | ^^^^^^^^^^^^^^
 note: required by a bound in `AppState`
  --> src/state.rs
   |

--- a/crates/sdk/tests/macros/error_impl_trait_arg.stderr
+++ b/crates/sdk/tests/macros/error_impl_trait_arg.stderr
@@ -4,7 +4,11 @@ error[E0277]: (calimero)> no method named `#[app::init]` found for type `MyState
 7 | struct MyState;
   |        ^^^^^^^ add an `#[app::init]` method to this type
   |
-  = help: the trait `AppStateInit` is not implemented for `MyState`
+help: the trait `AppStateInit` is not implemented for `MyState`
+ --> tests/macros/error_impl_trait_arg.rs:7:1
+  |
+7 | struct MyState;
+  | ^^^^^^^^^^^^^^
 note: required by a bound in `AppState`
  --> src/state.rs
   |

--- a/crates/sdk/tests/macros/error_init_not_named.stderr
+++ b/crates/sdk/tests/macros/error_init_not_named.stderr
@@ -10,7 +10,11 @@ error[E0277]: (calimero)> no method named `#[app::init]` found for type `MyState
 6 | struct MyState;
   |        ^^^^^^^ add an `#[app::init]` method to this type
   |
-  = help: the trait `AppStateInit` is not implemented for `MyState`
+help: the trait `AppStateInit` is not implemented for `MyState`
+ --> tests/macros/error_init_not_named.rs:6:1
+  |
+6 | struct MyState;
+  | ^^^^^^^^^^^^^^
 note: required by a bound in `AppState`
  --> src/state.rs
   |

--- a/crates/sdk/tests/macros/error_init_with_self.stderr
+++ b/crates/sdk/tests/macros/error_init_with_self.stderr
@@ -10,7 +10,11 @@ error[E0277]: (calimero)> no method named `#[app::init]` found for type `MyState
 6 | struct MyState;
   |        ^^^^^^^ add an `#[app::init]` method to this type
   |
-  = help: the trait `AppStateInit` is not implemented for `MyState`
+help: the trait `AppStateInit` is not implemented for `MyState`
+ --> tests/macros/error_init_with_self.rs:6:1
+  |
+6 | struct MyState;
+  | ^^^^^^^^^^^^^^
 note: required by a bound in `AppState`
  --> src/state.rs
   |

--- a/crates/sdk/tests/macros/error_init_without_attr.stderr
+++ b/crates/sdk/tests/macros/error_init_without_attr.stderr
@@ -10,7 +10,11 @@ error[E0277]: (calimero)> no method named `#[app::init]` found for type `MyState
 6 | struct MyState;
   |        ^^^^^^^ add an `#[app::init]` method to this type
   |
-  = help: the trait `AppStateInit` is not implemented for `MyState`
+help: the trait `AppStateInit` is not implemented for `MyState`
+ --> tests/macros/error_init_without_attr.rs:6:1
+  |
+6 | struct MyState;
+  | ^^^^^^^^^^^^^^
 note: required by a bound in `AppState`
  --> src/state.rs
   |

--- a/crates/sdk/tests/macros/error_interior_mutability.stderr
+++ b/crates/sdk/tests/macros/error_interior_mutability.stderr
@@ -18,8 +18,13 @@ error[E0277]: the trait bound `BadState: Identity` is not satisfied
   --> tests/macros/error_interior_mutability.rs:17:22
    |
 17 |     pub fn init() -> BadState {
-   |                      ^^^^^^^^ the trait `AppState` is not implemented for `BadState`
+   |                      ^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `AppState` is not implemented for `BadState`
+  --> tests/macros/error_interior_mutability.rs:9:1
+   |
+ 9 | struct BadState {
+   | ^^^^^^^^^^^^^^^
    = note: required for `BadState` to implement `Identity`
 note: required by a bound in `calimero_sdk::state::AppStateInit::Return`
   --> src/state.rs

--- a/crates/sdk/tests/macros/error_non_mergeable_field.stderr
+++ b/crates/sdk/tests/macros/error_non_mergeable_field.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `Plain: AbiType` is not satisfied
   --> tests/macros/error_non_mergeable_field.rs:18:12
    |
 18 |     items: UnorderedMap<String, Plain>,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AbiType` is not implemented for `Plain`
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `AbiType` is not implemented for `Plain`
+  --> tests/macros/error_non_mergeable_field.rs:12:1
+   |
+12 | struct Plain {
+   | ^^^^^^^^^^^^
    = help: the following other types implement trait `AbiType`:
              &T
              &mut T
@@ -25,5 +30,9 @@ error[E0277]: (calimero)> `calimero_storage::collections::UnorderedMap<std::stri
    = help: the trait `Mergeable` is not implemented for `calimero_storage::collections::UnorderedMap<std::string::String, Plain>`
    = note: every `#[app::state]` field and every collection value must be `Mergeable` so replicas converge.
    = note: fixes: wrap a plain value in `LwwRegister<calimero_storage::collections::UnorderedMap<std::string::String, Plain>>` (last-write-wins) or `Counter`; use `UnorderedMap`/`UnorderedSet`/`Vector` for collections; or `#[derive(Mergeable)]` on your own struct (every field must itself be `Mergeable`).
-   = help: the trait `Mergeable` is implemented for `S`
+help: the trait `Mergeable` is implemented for `S`
+  --> tests/macros/error_non_mergeable_field.rs:16:1
+   |
+16 | #[app::state]
+   | ^^^^^^^^^^^^^
    = note: this error originates in the attribute macro `app::state` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/sdk/tests/macros/error_reserved_method_name.stderr
+++ b/crates/sdk/tests/macros/error_reserved_method_name.stderr
@@ -16,7 +16,11 @@ error[E0277]: (calimero)> no method named `#[app::init]` found for type `S`
 6 | struct S;
   |        ^ add an `#[app::init]` method to this type
   |
-  = help: the trait `AppStateInit` is not implemented for `S`
+help: the trait `AppStateInit` is not implemented for `S`
+ --> tests/macros/error_reserved_method_name.rs:6:1
+  |
+6 | struct S;
+  | ^^^^^^^^
 note: required by a bound in `AppState`
  --> src/state.rs
   |

--- a/crates/sdk/tests/macros/error_trait_impl.stderr
+++ b/crates/sdk/tests/macros/error_trait_impl.stderr
@@ -10,7 +10,11 @@ error[E0277]: (calimero)> no method named `#[app::init]` found for type `MyState
 6 | struct MyState;
   |        ^^^^^^^ add an `#[app::init]` method to this type
   |
-  = help: the trait `AppStateInit` is not implemented for `MyState`
+help: the trait `AppStateInit` is not implemented for `MyState`
+ --> tests/macros/error_trait_impl.rs:6:1
+  |
+6 | struct MyState;
+  | ^^^^^^^^^^^^^^
 note: required by a bound in `AppState`
  --> src/state.rs
   |

--- a/crates/sdk/tests/macros/error_value_ref_must_use.stderr
+++ b/crates/sdk/tests/macros/error_value_ref_must_use.stderr
@@ -8,7 +8,7 @@ error: unused `ValueRef` that must be used
 note: the lint level is defined here
   --> tests/macros/error_value_ref_must_use.rs:5:9
    |
-5  | #![deny(unused_must_use)]
+ 5 | #![deny(unused_must_use)]
    |         ^^^^^^^^^^^^^^^
 help: use `let _ = ...` to ignore the resulting value
    |

--- a/crates/sdk/tests/macros/error_view_mutates.stderr
+++ b/crates/sdk/tests/macros/error_view_mutates.stderr
@@ -10,7 +10,11 @@ error[E0277]: (calimero)> no method named `#[app::init]` found for type `S`
 6 | struct S;
   |        ^ add an `#[app::init]` method to this type
   |
-  = help: the trait `AppStateInit` is not implemented for `S`
+help: the trait `AppStateInit` is not implemented for `S`
+ --> tests/macros/error_view_mutates.rs:6:1
+  |
+6 | struct S;
+  | ^^^^^^^^
 note: required by a bound in `AppState`
  --> src/state.rs
   |

--- a/crates/sdk/tests/macros/invalid_args.stderr
+++ b/crates/sdk/tests/macros/invalid_args.stderr
@@ -4,7 +4,11 @@ error[E0277]: (calimero)> no method named `#[app::init]` found for type `MyType`
 4 | struct MyType;
   |        ^^^^^^ add an `#[app::init]` method to this type
   |
-  = help: the trait `AppStateInit` is not implemented for `MyType`
+help: the trait `AppStateInit` is not implemented for `MyType`
+ --> tests/macros/invalid_args.rs:4:1
+  |
+4 | struct MyType;
+  | ^^^^^^^^^^^^^
 note: required by a bound in `AppState`
  --> src/state.rs
   |
@@ -17,4 +21,4 @@ warning: unused variable: `value`
 10 |     pub fn method(&self, value: impl MyTrait) {}
    |                          ^^^^^ help: if this is intentional, prefix it with an underscore: `_value`
    |
-   = note: `#[warn(unused_variables)]` on by default
+   = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default

--- a/crates/sdk/tests/macros/invalid_generics.stderr
+++ b/crates/sdk/tests/macros/invalid_generics.stderr
@@ -70,7 +70,7 @@ warning: unused variable: `tag`
 9 |     fn method0<'k, K, 'v, V>(&self, tag: &'t T, key: &'k K, value: &'v V) {}
   |                                     ^^^ help: if this is intentional, prefix it with an underscore: `_tag`
   |
-  = note: `#[warn(unused_variables)]` on by default
+  = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
 
 warning: unused variable: `key`
  --> tests/macros/invalid_generics.rs:9:49

--- a/crates/sdk/tests/macros/invalid_methods.stderr
+++ b/crates/sdk/tests/macros/invalid_methods.stderr
@@ -16,7 +16,11 @@ error[E0277]: (calimero)> no method named `#[app::init]` found for type `MyType`
 4 | struct MyType;
   |        ^^^^^^ add an `#[app::init]` method to this type
   |
-  = help: the trait `AppStateInit` is not implemented for `MyType`
+help: the trait `AppStateInit` is not implemented for `MyType`
+ --> tests/macros/invalid_methods.rs:4:1
+  |
+4 | struct MyType;
+  | ^^^^^^^^^^^^^
 note: required by a bound in `AppState`
  --> src/state.rs
   |

--- a/crates/sdk/tests/macros/invalid_nested_generics.stderr
+++ b/crates/sdk/tests/macros/invalid_nested_generics.stderr
@@ -10,7 +10,11 @@ error[E0277]: (calimero)> no method named `#[app::init]` found for type `MyState
 6 | struct MyState<T>(T);
   |        ^^^^^^^^^^ add an `#[app::init]` method to this type
   |
-  = help: the trait `AppStateInit` is not implemented for `MyState<T>`
+help: the trait `AppStateInit` is not implemented for `MyState<T>`
+ --> tests/macros/invalid_nested_generics.rs:6:1
+  |
+6 | struct MyState<T>(T);
+  | ^^^^^^^^^^^^^^^^^
 note: required by a bound in `AppState`
  --> src/state.rs
   |

--- a/crates/sdk/tests/macros/invalid_receivers.stderr
+++ b/crates/sdk/tests/macros/invalid_receivers.stderr
@@ -130,7 +130,7 @@ warning: unnecessary parentheses around type
 10 |     pub fn method_02(self: (Self)) {}
    |                            ^    ^
    |
-   = note: `#[warn(unused_parens)]` on by default
+   = note: `#[warn(unused_parens)]` (part of `#[warn(unused)]`) on by default
 help: remove these parentheses
    |
 10 -     pub fn method_02(self: (Self)) {}
@@ -295,7 +295,7 @@ warning: variable does not need to be mutable
    |                      |
    |                      help: remove this `mut`
    |
-   = note: `#[warn(unused_mut)]` on by default
+   = note: `#[warn(unused_mut)]` (part of `#[warn(unused)]`) on by default
 
 warning: variable does not need to be mutable
   --> tests/macros/invalid_receivers.rs:13:22

--- a/crates/server/build.rs
+++ b/crates/server/build.rs
@@ -227,7 +227,8 @@ fn release_download_url(repo: &str, version: &str, asset: &str) -> String {
         .replace("{asset}", asset)
 }
 
-#[expect(single_use_lifetimes, reason = "necessary to return itself when empty")]
+// The distinct `'a: 'b` bound lets the empty case hand `str` straight back as the
+// return value instead of allocating a copy.
 fn replace<'a: 'b, 'b>(str: Cow<'a, str>, replace: impl Fn(&str) -> Option<&str>) -> Cow<'b, str> {
     let mut idx = 0;
     let mut buf = str.as_ref();

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2595,7 +2595,7 @@ impl Validate for IssueOwnershipProofApiRequest {
                 field: "nonce",
                 reason: "nonce must be valid hex".into(),
             });
-        } else if n % 2 != 0 {
+        } else if !n.is_multiple_of(2) {
             // An odd-length hex string can't decode to whole bytes, which is
             // inconsistent with the documented "16..=64 raw bytes" contract.
             errors.push(ValidationError::InvalidFormat {
@@ -2660,7 +2660,7 @@ impl Validate for IssueNamespaceOwnershipProofApiRequest {
                 field: "nonce",
                 reason: "nonce must be valid hex".into(),
             });
-        } else if n % 2 != 0 {
+        } else if !n.is_multiple_of(2) {
             // An odd-length hex string can't decode to whole bytes, which is
             // inconsistent with the documented "16..=64 raw bytes" contract.
             errors.push(ValidationError::InvalidFormat {

--- a/crates/storage/src/child_trie.rs
+++ b/crates/storage/src/child_trie.rs
@@ -167,7 +167,7 @@ impl TrieBucket {
 /// The `i`th nibble of `id`, high nibble first.
 fn nibble(id: Id, i: usize) -> u8 {
     let byte = id.as_bytes()[i / 2];
-    if i % 2 == 0 {
+    if i.is_multiple_of(2) {
         byte >> 4
     } else {
         byte & 0x0f

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -236,6 +236,13 @@ impl<T, S: StorageAdaptor> Data for Collection<T, S> {
 }
 
 /// A collection of entries in a map.
+#[expect(
+    dead_code,
+    reason = "Never constructed: the map reaches its children through `Interface` \
+              directly. Retained as the declaration of a map's child layout and as \
+              the only in-tree user of `#[derive(Collection)]`, which would other- \
+              wise go unexercised by this build."
+)]
 #[derive(Collection, Copy, Clone, Debug, Eq, PartialEq)]
 #[children(Entry<T>)]
 struct Entries<T> {
@@ -803,11 +810,7 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
     /// guard over it. The guard ties the borrow to the returned value, so
     /// callers hold the `RefCell` borrow for exactly as long as they use the
     /// set — no aliasing `&mut` outlives it (F166).
-    #[expect(
-        clippy::unwrap_in_result,
-        clippy::expect_used,
-        reason = "cache is populated immediately above"
-    )]
+    #[expect(clippy::expect_used, reason = "cache is populated immediately above")]
     fn children_cache(&self) -> StoreResult<RefMut<'_, IndexSet<Id>>> {
         let mut cache = self.children_ids.borrow_mut();
 

--- a/crates/storage/src/entities.rs
+++ b/crates/storage/src/entities.rs
@@ -611,9 +611,14 @@ pub const fn storage_type_name(storage_type: &StorageType) -> &'static str {
 
 /// Defines the type of storage and its associated authorization rules.
 /// Enum to define the storage domain and its associated data.
-#[derive(BorshDeserialize, BorshSerialize, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+// `Public` is the default for backward compatibility: entries written before the
+// storage domain was recorded decode as public.
+#[derive(
+    BorshDeserialize, BorshSerialize, Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd,
+)]
 pub enum StorageType {
     /// Public data, accessible to all members of context.
+    #[default]
     Public,
     /// Verifiable, user-signed, synchronized storage.
     User {
@@ -681,13 +686,6 @@ pub enum StorageType {
         /// writer set resolved from `anchor` at the action's causal cut.
         signature_data: Option<SignatureData>,
     },
-}
-
-// Default to `Public` for backward compatibility
-impl Default for StorageType {
-    fn default() -> Self {
-        Self::Public
-    }
 }
 
 /// System metadata (timestamps in u64 nanoseconds).

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -509,7 +509,7 @@ impl<S: StorageAdaptor> Interface<S> {
             .map(|(_delta_id, entry)| entry)
             .collect();
         // Canonical order so resolution is insertion-order invariant.
-        entries.sort_by(|a, b| a.delta_id.cmp(&b.delta_id));
+        entries.sort_by_key(|a| a.delta_id);
         Some(crate::rotation_log::RotationLog {
             snapshot: None,
             entries,

--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -602,11 +602,7 @@ fn merge_rotation_log(existing: &[u8], incoming: &[u8]) -> Result<Vec<u8>, Merge
     // delta; the tiebreak only disambiguates incidental byte differences.)
     let mut by_id: std::collections::BTreeMap<[u8; 32], crate::rotation_log::RotationLogEntry> =
         std::collections::BTreeMap::new();
-    for entry in existing_log
-        .entries
-        .into_iter()
-        .chain(incoming_log.entries.into_iter())
-    {
+    for entry in existing_log.entries.into_iter().chain(incoming_log.entries) {
         match by_id.entry(entry.delta_id) {
             std::collections::btree_map::Entry::Vacant(v) => {
                 let _ = v.insert(entry);

--- a/crates/storage/src/merge/registry.rs
+++ b/crates/storage/src/merge/registry.rs
@@ -323,7 +323,7 @@ pub fn try_merge_registered(
             return MergeRegistryResult::NoFunctionsRegistered;
         }
 
-        for (_type_id, merge_fn) in registry.iter() {
+        for merge_fn in registry.values() {
             if let Ok(merged) = merge_fn(existing, incoming, existing_ts, incoming_ts) {
                 return MergeRegistryResult::Success(merged);
             }

--- a/crates/storage/src/tests/crdt.rs
+++ b/crates/storage/src/tests/crdt.rs
@@ -195,8 +195,8 @@ fn tombstone_allows_newer_update() {
     let retrieved = TestInterface::find_by_id::<Page>(id).unwrap();
     // Note: Depending on implementation, this may or may not resurrect
     // The test documents expected behavior
-    if retrieved.is_some() {
-        assert_eq!(retrieved.unwrap().title, "Resurrected");
+    if let Some(retrieved) = retrieved {
+        assert_eq!(retrieved.title, "Resurrected");
     }
 }
 

--- a/crates/storage/tests/compile_fail/mergeable_without_rekeytarget.stderr
+++ b/crates/storage/tests/compile_fail/mergeable_without_rekeytarget.stderr
@@ -1,18 +1,23 @@
-error[E0277]: the trait bound `BadStruct: RekeyTarget` is not satisfied
+error[E0277]: the trait bound `BadStruct: calimero_storage::collections::rekey::RekeyTarget` is not satisfied
   --> tests/compile_fail/mergeable_without_rekeytarget.rs:19:20
    |
 19 | impl Mergeable for BadStruct {
-   |                    ^^^^^^^^^ the trait `RekeyTarget` is not implemented for `BadStruct`
+   |                    ^^^^^^^^^ unsatisfied trait bound
    |
-   = help: the following other types implement trait `RekeyTarget`:
+help: the trait `calimero_storage::collections::rekey::RekeyTarget` is not implemented for `BadStruct`
+  --> tests/compile_fail/mergeable_without_rekeytarget.rs:12:1
+   |
+12 | struct BadStruct {
+   | ^^^^^^^^^^^^^^^^
+   = help: the following other types implement trait `calimero_storage::collections::rekey::RekeyTarget`:
              AccessControl
              AuthoredMap<K, V, S>
              AuthoredVector<V, S>
              Box<T>
              Counter<ALLOW_DECREMENT, S>
-             EmptyData
              FrozenValue<T>
              Option<T>
+             PermissionedStorage<T, A>
            and $N others
 note: required by a bound in `Mergeable`
   --> src/collections/crdt_meta.rs

--- a/crates/storage/tests/read_cost_profile.rs
+++ b/crates/storage/tests/read_cost_profile.rs
@@ -231,7 +231,7 @@ fn profile_full_materialisation_vs_page() {
     let mut n = 0_usize;
     for &target in &CHECKPOINTS {
         while n < target {
-            v.push(make_msg(n, n % 10 == 0)).expect("push");
+            v.push(make_msg(n, n.is_multiple_of(10))).expect("push");
             n += 1;
         }
         reset();
@@ -280,7 +280,7 @@ fn profile_unread_count_scan() {
     let mut n = 0_usize;
     for &target in &CHECKPOINTS {
         while n < target {
-            v.push(make_msg(n, n % 10 == 0)).expect("push");
+            v.push(make_msg(n, n.is_multiple_of(10))).expect("push");
             n += 1;
         }
         let last_read = 1_700_000_000_000_u64 + (target as u64) - 10;
@@ -340,7 +340,7 @@ fn profile_reactions_for_a_page() {
     for &target in &[250_usize, 500, 1_000, 2_000] {
         while n < target {
             // Every 4th message carries reactions, so a page mixes hits/misses.
-            if n % 4 == 0 {
+            if n.is_multiple_of(4) {
                 let mut inner =
                     UnorderedMap::<String, UnorderedSet<String, Counting>, Counting>::new();
                 for emoji in ["thumbsup", "heart"] {
@@ -404,7 +404,9 @@ fn profile_index_backed_page() {
             let mut key = Vec::with_capacity(16);
             key.extend_from_slice(&(1_700_000_000_000_u64 + n as u64).to_be_bytes());
             key.extend_from_slice(&(n as u64).to_be_bytes());
-            let _ = sm.insert(key, make_msg(n, n % 10 == 0)).expect("insert");
+            let _ = sm
+                .insert(key, make_msg(n, n.is_multiple_of(10)))
+                .expect("insert");
             n += 1;
         }
 

--- a/crates/store/src/key/alias.rs
+++ b/crates/store/src/key/alias.rs
@@ -194,10 +194,6 @@ impl Alias {
         // This is more readable with using consts.
         // Even though the `KIND_SIZE` is equal to 1, inclusive range (`KIND_SIZE..=SCOPE_SIZE`)
         // would be very confusing for comprehension (and would require knowing that KIND_SIZE==1.
-        #[expect(
-            clippy::range_plus_one,
-            reason = "It's more readable with using constants"
-        )]
         scope.copy_from_slice(&bytes[KIND_SIZE..KIND_SIZE + SCOPE_SIZE]);
 
         let scope = <T::Scope as StoreScopeCompat>::Scope::from_scope(scope);

--- a/crates/utils/actix/src/lazy.rs
+++ b/crates/utils/actix/src/lazy.rs
@@ -262,6 +262,11 @@ const _: () = {
     use core::mem::size_of;
 
     trait Trait {
+        #[expect(
+            dead_code,
+            reason = "Never called: the trait exists only so `Item` has a vtable whose \
+                      layout the `size_of` assertions below can compare against."
+        )]
         fn method(&self);
     }
 

--- a/crates/utils/actix/src/macros_tests.rs
+++ b/crates/utils/actix/src/macros_tests.rs
@@ -35,8 +35,15 @@ mod _scoped {
     }
 }
 
+#[expect(
+    dead_code,
+    reason = "Never constructed: these are compile-only fixtures. The tests above feed \
+              them to `actor!` to check the macro expands, which needs the types to \
+              exist but never an instance."
+)]
 struct NoopActor;
 
+#[expect(dead_code, reason = "Never constructed: see `NoopActor` above.")]
 struct OneStreamActor {
     stream: Box<Repeat<usize>>,
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.98.0"
 # ^~~ keep this in sync with Dockerfile
 components = ["cargo", "clippy", "rustfmt"]
 

--- a/tools/merodb/src/migration/filters.rs
+++ b/tools/merodb/src/migration/filters.rs
@@ -271,7 +271,7 @@ impl ResolvedFilters {
 /// Returns an error if the hex string has odd length or contains invalid hex characters.
 fn decode_hex_string(value: &str) -> Result<Vec<u8>> {
     let trimmed = value.trim().trim_start_matches("0x");
-    if trimmed.len() % 2 != 0 {
+    if !trimmed.len().is_multiple_of(2) {
         bail!("hex string has odd length");
     }
     Ok(hex::decode(trimmed)?)


### PR DESCRIPTION
## Why

The toolchain pin sat at **1.88.0** (June 2025) — roughly fourteen months behind stable — and it has started to block work.

Dependabot's weekly cargo group (#3656, 83 packages) now fails *before compiling anything*: cargo refuses to build a package whose `rust-version` exceeds the toolchain, and that group wants up to **1.95** (`wasmer 7.3`), **1.94** (`cranelift-*`, `wasmtime`, `libwild`) and **1.93.1** (`serial_test 4`). The `cargo-deny` step in `ci-checks.yml` was already pinned to a specific version for the same reason.

**This PR bumps no dependency.** It only removes the wall in front of that work. The dependency bumps follow as separate, reviewable PRs.

## The base-image digest

Both Dockerfiles digest-pin their base image, and **the digest selects the image regardless of the tag** — so bumping `RUST_VERSION` alone would have quietly kept building on 1.88. The digest is refreshed to the `1.98.0-slim-bookworm` multi-arch index (`sha256:1469a27c…`), resolved with `docker buildx imagetools inspect`.

## Lint fallout

`cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` and `cargo fmt --check` both pass. 46 sites needed attention:

| Count | Change |
|---|---|
| 12 | manual `%`-based multiple checks → `is_multiple_of` |
| 8 | `sort_by` with a plain `cmp` → `sort_by_key` |
| 6 | check-then-divide → `checked_div` / `checked_rem` |
| 3 | `if` inside a match arm → an arm guard |
| 3 | manual `Default` impls → `#[derive(Default)]` + `#[default]` |
| 2 | `is_some()` + `unwrap()` → `if let Some(..)` |
| 2 | `chunks_exact` with a constant size; needless slice `clone` |

Four lint expectations no longer fire on 1.98 and were dropped. Where the `reason` carried something a reader still needs, it stays as a comment.

### Two judgement calls worth a look

**Five dead items are silenced, not deleted** — each exists to be *compiled*, not run, so deleting them would quietly remove coverage:

- `Entries<T>` (`storage/collections.rs`) is the only in-tree user of `#[derive(Collection)]`
- `Trait::method` (`utils/actix/lazy.rs`) gives `Item` a vtable for the `size_of` layout assertion
- `NoopActor` / `OneStreamActor` / `TestInput` are compile-only fixtures

Whether they should go is a real question, but a separate one from moving the toolchain.

**Two `result_large_err` sites** (`get_module_for_blob`, `Logic::finish`) are silenced with a reason: boxing those errors changes a public signature, which does not belong in this change.

## Encoding safety

`#[default]` is an inert helper for the `Default` derive and variant order is untouched, so the **`DeltaKind` and `SyncProtocol` Borsh encodings are unchanged**. Both are wire types, so this was checked deliberately.

The three match-arm-guard rewrites are behaviour-preserving: hoisting the `if` into a guard means the non-matching case falls through to the adjacent `_ => {}` instead of matching and doing nothing.

## Not verified locally

The test suites, the mock-attestation matrix and the Docker build. Those run here in CI — the Docker build is the only check on the new digest.

## Follow-ups (not in this PR)

- `.github/dependabot.yml` groups cargo as `patterns: ["*"]` with no `update-types` split, which is what turns a routine weekly sweep into an 83-package wall. Splitting it would stop this recurring.
- `proc-macro-error2 v2.0.1` (transitive) contains code a future Rust will reject.
- #3656 should be closed rather than rebased: it is `MERGEABLE/BEHIND`, so a rebase is clean and changes nothing about why it is red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
