### PR TITLE
test(server): cover warrant expiry, the one rule a clock decides

### DIFF
--- a/apps/scaffolding-e2e/workflows/delegated-authorship.yml
+++ b/apps/scaffolding-e2e/workflows/delegated-authorship.yml
@@ -315,7 +315,10 @@ steps:
     nonce: 2
     valid_for: 1
     outputs:
-      warrant: expiring_warrant
+      # `<exported name>: <field on the response>`, which is the opposite of what
+      # it reads like. Getting it backwards fails at capture with the field list in
+      # the message, not at use with an unresolved `{{...}}`.
+      expiring_warrant: warrant
 
   - name: Let it go stale
     type: wait

--- a/apps/scaffolding-e2e/workflows/delegated-authorship.yml
+++ b/apps/scaffolding-e2e/workflows/delegated-authorship.yml
@@ -290,6 +290,51 @@ steps:
   # milliseconds before a pending delta finishes applying. Waiting on the read
   # itself cannot pass early, which matters more here than anywhere: a delegated
   # delta is the one thing a peer might verify, authorize, and then still refuse.
+  # DAR-14: expiry, the one rule in this feature that a clock decides.
+  #
+  # Deliberately isolated. The capability is already granted and this nonce has
+  # never been presented, so neither of the other two refusals can explain a
+  # failure here — `not_after` is the only thing left. Minted at `valid_for: 1`
+  # and then waited out, because the CLI takes a duration rather than an absolute
+  # instant, so there is no way to mint something already stale.
+  #
+  # Worth an e2e at all because expiry is checked in exactly one place
+  # (`perform_intent`, the relay side) and never by a peer at apply: wall-clock at
+  # apply is node-dependent, so a receiver checking it would accept a delta on one
+  # node and refuse it on another, and authorization would stop converging.
+  - name: The author mints a warrant that expires almost immediately
+    type: sign_warrant
+    context_id: '{{context_id}}'
+    executor: '{{relay_account}}'
+    method: set
+    args:
+      key: delegated
+      value: this-one-should-never-land
+    device_secret: '{{author_secret}}'
+    credential: '{{author_credential}}'
+    nonce: 2
+    valid_for: 1
+    outputs:
+      warrant: expiring_warrant
+
+  - name: Let it go stale
+    type: wait
+    seconds: 4
+    message: Waiting out the warrant's 1s validity
+
+  - name: The expired warrant is refused
+    type: perform_intent
+    node: delegated-node-1
+    context_id: '{{context_id}}'
+    method: set
+    args:
+      key: delegated
+      value: this-one-should-never-land
+    warrant: '{{expiring_warrant}}'
+    author_proof: '{{author_credential}}'
+    expected_failure: true
+    expected_error: expired
+
   - name: The delegated write reaches the other node
     type: wait_for_sync
     context_id: '{{context_id}}'

--- a/crates/server/src/admin/handlers/context/perform_intent.rs
+++ b/crates/server/src/admin/handlers/context/perform_intent.rs
@@ -183,31 +183,14 @@ async fn perform(
         )))
     })?;
 
-    if warrant.context != context_id {
-        eyre::bail!(IntentRefusal::NotAuthorized(
-            "this warrant authorises a different context than the one it was presented in"
-                .to_owned()
-        ));
-    }
-
     let args = serde_json::to_vec(&req.args_json)
         .map_err(|err| eyre::eyre!("arguments could not be encoded: {err}"))?;
-    if !warrant.covers_intent(&req.method, &args) {
-        eyre::bail!(IntentRefusal::NotAuthorized(
-            "this warrant does not cover the intent presented with it: it commits to a \
-             different method or arguments"
-                .to_owned()
-        ));
-    }
 
-    // The one clock check in the system. See the module header.
-    let now = now_secs();
-    if warrant.not_after < now {
-        eyre::bail!(IntentRefusal::NotAuthorized(format!(
-            "this warrant expired at {} and it is now {now}; mint a fresh one",
-            warrant.not_after
-        )));
-    }
+    // Everything decidable from the warrant, the intent and a clock. Separated
+    // out because the clock is the whole difficulty: with `now_secs()` called
+    // inline, expiry could not be tested without moving the system clock, so the
+    // one time-dependent rule in the feature was the one rule no test covered.
+    warrant_authorises_intent(&warrant, context_id, &req.method, &args, now_secs())?;
 
     // Refuse rather than publish something peers will drop.
     let executor = warrant.executor;
@@ -278,4 +261,170 @@ async fn perform(
                 .and_then(|bytes| serde_json::from_slice(&bytes).ok()),
         },
     })
+}
+
+/// The checks decidable from the warrant, the intent and a clock — nothing else.
+///
+/// `now` is a parameter rather than read here so expiry is testable. See the
+/// module header for why the clock lives on this side at all: a receiver checking
+/// wall-clock expiry would accept a delta on one node and refuse it on another,
+/// and authorization would stop converging.
+///
+/// # Errors
+/// [`IntentRefusal::NotAuthorized`] if the warrant is for another context, does
+/// not commit to this intent, or has expired.
+fn warrant_authorises_intent(
+    warrant: &calimero_account::Warrant,
+    context_id: ContextId,
+    method: &str,
+    args: &[u8],
+    now: u64,
+) -> eyre::Result<()> {
+    if warrant.context != context_id {
+        eyre::bail!(IntentRefusal::NotAuthorized(
+            "this warrant authorises a different context than the one it was presented in"
+                .to_owned()
+        ));
+    }
+
+    if !warrant.covers_intent(method, args) {
+        eyre::bail!(IntentRefusal::NotAuthorized(
+            "this warrant does not cover the intent presented with it: it commits to a \
+             different method or arguments"
+                .to_owned()
+        ));
+    }
+
+    // The one clock check in the system. `<` not `<=`: a warrant is live through
+    // the whole second it names, so `not_after == now` still authorises.
+    if warrant.not_after < now {
+        eyre::bail!(IntentRefusal::NotAuthorized(format!(
+            "this warrant expired at {} and it is now {now}; mint a fresh one",
+            warrant.not_after
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use calimero_account::Warrant;
+    use calimero_primitives::identity::PrivateKey;
+
+    use super::{warrant_authorises_intent, ContextId, IntentRefusal};
+
+    const METHOD: &str = "set";
+    const ARGS: &[u8] = br#"{"key":"k","value":"v"}"#;
+    const NOW: u64 = 1_700_000_000;
+
+    /// A warrant covering `METHOD`/`ARGS`, expiring at `not_after`.
+    ///
+    /// Built as a literal rather than signed: authenticity is established by
+    /// `delegation.verify()` before this function is ever called, so a signature
+    /// here would test `calimero-account`, not this.
+    fn warrant(context: ContextId, not_after: u64) -> Warrant {
+        Warrant {
+            context,
+            author_account: calimero_account::AccountGenesis::new(
+                PrivateKey::from([7u8; 32]).public_key(),
+            )
+            .account_id(),
+            author_device_key: PrivateKey::from([8u8; 32]).public_key(),
+            executor: calimero_account::AccountGenesis::new(
+                PrivateKey::from([9u8; 32]).public_key(),
+            )
+            .account_id(),
+            intent_hash: Warrant::intent_hash(METHOD, ARGS),
+            nonce: 1,
+            not_after,
+            signature: [0u8; 64],
+        }
+    }
+
+    fn refusal(err: &eyre::Report) -> String {
+        err.downcast_ref::<IntentRefusal>().map_or_else(
+            || format!("not an IntentRefusal: {err}"),
+            ToString::to_string,
+        )
+    }
+
+    #[test]
+    fn a_live_warrant_for_its_own_intent_is_authorised() {
+        let ctx = ContextId::from([1u8; 32]);
+        warrant_authorises_intent(&warrant(ctx, NOW + 60), ctx, METHOD, ARGS, NOW)
+            .expect("a warrant that has not expired must authorise its own intent");
+    }
+
+    #[test]
+    fn an_expired_warrant_is_refused() {
+        let ctx = ContextId::from([1u8; 32]);
+        let err = warrant_authorises_intent(&warrant(ctx, NOW - 1), ctx, METHOD, ARGS, NOW)
+            .expect_err("a warrant whose not_after has passed must be refused");
+        let msg = refusal(&err);
+        assert!(msg.contains("expired"), "{msg}");
+        // The message has to carry both clocks, or an operator cannot tell a
+        // stale warrant from a skewed relay.
+        assert!(msg.contains(&(NOW - 1).to_string()), "{msg}");
+        assert!(msg.contains(&NOW.to_string()), "{msg}");
+    }
+
+    /// The boundary, pinned deliberately: the check is `<`, not `<=`.
+    ///
+    /// A warrant is live through the whole second it names. Flipping this to `<=`
+    /// would expire warrants one second early — a change no other test would
+    /// notice, because every other case is far from the boundary.
+    #[test]
+    fn a_warrant_expiring_exactly_now_still_authorises() {
+        let ctx = ContextId::from([1u8; 32]);
+        warrant_authorises_intent(&warrant(ctx, NOW), ctx, METHOD, ARGS, NOW)
+            .expect("not_after == now is the last live second, not the first dead one");
+    }
+
+    /// Expiry must not mask a wrong-context warrant, or a relay presenting a
+    /// warrant for another context would be told to "mint a fresh one".
+    #[test]
+    fn a_warrant_for_another_context_is_refused_before_the_clock_matters() {
+        let err = warrant_authorises_intent(
+            &warrant(ContextId::from([1u8; 32]), NOW - 1),
+            ContextId::from([2u8; 32]),
+            METHOD,
+            ARGS,
+            NOW,
+        )
+        .expect_err("a warrant for another context must be refused");
+        let msg = refusal(&err);
+        assert!(msg.contains("different context"), "{msg}");
+        assert!(!msg.contains("expired"), "expiry must not shadow it: {msg}");
+    }
+
+    #[test]
+    fn a_warrant_committing_to_other_arguments_is_refused() {
+        let ctx = ContextId::from([1u8; 32]);
+        let err = warrant_authorises_intent(
+            &warrant(ctx, NOW + 60),
+            ctx,
+            METHOD,
+            br#"{"key":"k","value":"SOMETHING ELSE"}"#,
+            NOW,
+        )
+        .expect_err("a warrant is not a blank cheque for whatever the relay ran");
+        assert!(
+            refusal(&err).contains("does not cover"),
+            "{}",
+            refusal(&err)
+        );
+    }
+
+    #[test]
+    fn a_warrant_committing_to_another_method_is_refused() {
+        let ctx = ContextId::from([1u8; 32]);
+        let err = warrant_authorises_intent(&warrant(ctx, NOW + 60), ctx, "delete", ARGS, NOW)
+            .expect_err("the method is part of the commitment");
+        assert!(
+            refusal(&err).contains("does not cover"),
+            "{}",
+            refusal(&err)
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`not_after` is enforced in **exactly one place** — `perform_intent.rs`, the relay
side — and never by a peer at apply. That is the correct design: wall-clock at apply
is node-dependent, so a receiver checking expiry would accept a delta on one node and
refuse it on another, and authorization would stop converging.

But that single enforcement point had **no test**, and structurally could not: the
handler called `now_secs()` inline, so expiry was unreachable without moving the
system clock. The one time-dependent rule in the feature was the one rule nothing
covered.

## What changed

Extracted the checks decidable from the warrant, the intent and a clock into
`warrant_authorises_intent(warrant, context_id, method, args, now)` — `now` as a
parameter is the whole point. Datastore-dependent checks stay in the handler.

## Tests

Six, `perform_intent.rs`'s first:

| Test | Guards |
| --- | --- |
| a live warrant authorises its own intent | the happy path |
| an expired one is refused | message carries **both** clocks — without the second, an operator cannot tell a stale warrant from a skewed relay |
| `not_after == now` still authorises | pins `<` not `<=` |
| a wrong-context warrant is refused *before* the clock matters | asserts the message does **not** say "expired", or a relay with a wrong-context warrant is told to "mint a fresh one" |
| wrong arguments | the commitment covers args |
| wrong method | the commitment covers the method |

**The boundary test is mutation-proven, not asserted.** Flipping `<` to `<=` fails
`a_warrant_expiring_exactly_now_still_authorises` and *only* that test — the other
five stay green, because every other case sits far from the boundary. So it catches a
real regression: expiring warrants one second early, silently.

## E2E

`DAR-14` in `delegated-authorship.yml`. Isolated deliberately: the capability is
already granted and nonce 2 has never been presented, so neither of the other two
refusals can explain a failure — `not_after` is all that is left. Minted at
`valid_for: 1` then waited out, because the CLI takes a duration rather than an
absolute instant, so nothing can be minted already-stale.

`valid_for` is a field of `SignWarrantStepConfig` in merobox **v0.6.66** — the exact
version `.github/actions/setup-merobox` pins — so this needs **no release chain**. I
verified the owning class rather than grepping for the string, since a field on a
neighbouring schema would look identical.

## Verification

- `cargo test -p calimero-server perform_intent` — 6 passed, 0 failed
- `cargo clippy -p calimero-server --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- Scenario YAML parses at 33 steps

**Not verified locally:** `merobox bootstrap validate`. The installed 0.6.62 rejects
the scenario's *pre-existing* steps, and installing 0.6.66 fails here because
`calimero-client-py` cannot build a wheel (pyo3 extension). I checked the v0.6.66
schema from source instead; CI is the first real execution of the scenario.