### PR TITLE
chore: cut release 0.11.0-rc.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.25"
+version = "0.11.0-rc.26"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Bumps `[workspace.metadata.workspaces].version` to `0.11.0-rc.26`. Merging this creates the tag and the release.

38 commits since rc.25 (`d6308156a`).

## ⚠️ This release is a flag day for existing node state

`#3633` moved a parent's children out of the index row and into their own `ChildTrie` keyspace. `EntityIndex`'s borsh layout changed as a result, so **an index row written by rc.25 or earlier does not decode under rc.26**:

```rust
// crates/storage/src/index.rs
EntityIndex::try_from_slice(&data).map_err(StorageError::DeserializationError)?
```

The failure is loud and immediate — a `DeserializationError`, not a silent misread. That is deliberate (a prefix decoder used to accept an old row and hand back a hash read out of the `children` field, which is the worst available failure mode), but it means:

**A node carrying pre-rc.26 state must start from a clean store and resync. There is no migration pass in this release.**

Who consumes core releases and should be checked before this goes out:
- **mero-tee** — `merodVersion` in `mero-tee/versions.json` pins the merod baked into the GCP node image.
- **mdma** — `dispatcher/app/startup_script.py` downloads the merod release asset onto each VM at boot.
- **tauri-app** — `merod-config.json` pins the merod bundled into the desktop build; desktop users have local state.

The migration is mostly already written if it turns out some state must survive: `rebuild_child_tries_after_snapshot` pointed at local state rather than freshly-installed state is the pass. It is a few hours on top of code already merged. The judgement in #3633 was that nothing in production runs a child-trie build, so a flag day is cheaper — that judgement is what this release acts on, so it is worth re-confirming rather than inheriting.

## Also breaking in this window

- `04e15f9e1` `refactor(governance-store)!` — splits the account-root mint out of the read; adds `merod init --no-account-root`.
- `da07c0a47` — one name each for `ApplicationId`, `BytecodeId`, `ContentHash`.

## Notable fixes

- **#3633** — a parent's per-child write cost is now bounded. The append wall that made a collection permanently unwritable is gone: measured against the real mero-chat contract, `send_message` gas is flat (16.0M → 18.9M from n=100 to n=60,000, reads pinned at 305) where it previously walled at 394 messages. Reads are now the binding limit, at ~30,000.
- Child order is stored data rather than something recovered from a hash, a clock, or a count — `Vector`/`AuthoredVector` positional reads follow insertion order within a call, which they did not reliably do before.
- `AuthoredVector`'s id-addressed API is scoped to its own entries.
- Snapshot sync rebuilds child-trie links the install did not create.

