### PR TITLE
feat(merod): print an account's id and root public key, revealing no secret

### DIFF
--- a/crates/merod/src/cli/account.rs
+++ b/crates/merod/src/cli/account.rs
@@ -35,6 +35,8 @@ pub struct AccountCommand {
 
 #[derive(Debug, Subcommand)]
 enum AccountSubcommands {
+    /// Print an account's id and root PUBLIC key, revealing no secret
+    Root(RootCommand),
     /// Print this node's account root as a 24-word recovery phrase
     Export(ExportCommand),
     /// Restore an account root from a recovery phrase
@@ -116,6 +118,7 @@ pub struct RevokeProofCommand {
 impl AccountCommand {
     pub async fn run(self, root_args: &RootArgs) -> EyreResult<()> {
         match self.action {
+            AccountSubcommands::Root(cmd) => cmd.run(root_args).await,
             AccountSubcommands::Export(cmd) => cmd.run(root_args).await,
             AccountSubcommands::Import(cmd) => cmd.run(root_args).await,
             AccountSubcommands::RevokeProof(cmd) => cmd.run(root_args).await,
@@ -885,6 +888,24 @@ mod tests {
             "base58 must not parse as an account id"
         );
     }
+
+    /// The two lines `account root` prints must describe the same account.
+    ///
+    /// They are pasted into different places — the public key into `init
+    /// --account-root`, the account id into a membership grant — so if they
+    /// disagreed an operator would provision a node under one account and grant
+    /// rights to another. Nothing would error; the node would simply never be a
+    /// member, and the cause would be two numbers that looked fine side by side.
+    #[test]
+    fn the_printed_root_key_and_account_describe_the_same_account() {
+        let root = root();
+
+        assert_eq!(
+            root.account(),
+            calimero_account::AccountGenesis::new(root.public_key()).account_id(),
+            "the account id must be the content address of the printed public key",
+        );
+    }
 }
 
 /// Adopt a device certificate this account's root signed somewhere else.
@@ -985,6 +1006,52 @@ impl ImportCertCommand {
         println!(
             "This node will present it when it joins, instead of signing one with an \
              account root it does not hold."
+        );
+        Ok(())
+    }
+}
+
+/// Report an account's id and root **public** key. Reveals nothing secret.
+///
+/// The read the offline posture was missing. `merod init --no-account-root
+/// --account-root <HEX>` needs an account's root public key, and until now the only
+/// way to obtain one was from a **running holder node** — precisely the machine that
+/// posture says should not exist. With `--from` this answers from the phrase alone:
+/// no node, no store, no init.
+///
+/// Distinct from `export`, which prints the phrase — the whole account. This prints
+/// only what is public by construction: the root public key is hashed into the
+/// account id and travels in every genesis, so publishing it grants nothing. Two
+/// commands rather than a flag on one, because "show me the account" and "hand me
+/// the secret" should not be one keystroke apart.
+///
+/// Without `--from` it reads this node's own root, so the node must be **stopped**
+/// (RocksDB's lock is exclusive).
+#[derive(Debug, Parser)]
+pub struct RootCommand {
+    /// Read the root from a recovery phrase at PATH instead of this node's store.
+    ///
+    /// Opens no datastore, so it works on a machine with no node.
+    #[arg(long, value_name = "PATH")]
+    from: Option<camino::Utf8PathBuf>,
+}
+
+impl RootCommand {
+    #[expect(
+        clippy::print_stdout,
+        reason = "the values are what an operator pastes into `init --account-root`, \
+                  so they go to stdout for piping rather than through a formatter"
+    )]
+    pub async fn run(self, root_args: &RootArgs) -> EyreResult<()> {
+        let root = resolve_root(root_args, self.from.as_ref()).await?;
+
+        println!("Account root public key: {}", root.public_key());
+        println!("Account:                 {}", root.account());
+        println!();
+        println!(
+            "Neither value is secret: the root public key is hashed into the account id \
+             and travels in every genesis. The private root leaves a node only via \
+             `merod account export`."
         );
         Ok(())
     }

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -583,16 +583,9 @@ impl InitCommand {
             // Minted here for the same reason the root is: so there is a namable
             // moment when this node acquired an identity, rather than one that
             // depends on which request arrived first.
-            if let Some(hex_pk) = self.account_root.as_deref() {
-                let raw: [u8; 32] = hex::decode(hex_pk.trim())
-                    .wrap_err("--account-root is not hex")?
-                    .try_into()
-                    .map_err(|_| {
-                        eyre::eyre!("--account-root must be 32 bytes, i.e. 64 hex characters")
-                    })?;
-                let genesis = calimero_account::AccountGenesis::new(
-                    calimero_primitives::identity::PublicKey::from(raw),
-                );
+            if let Some(given) = self.account_root.as_deref() {
+                let root_pk = parse_account_root_pk(given)?;
+                let genesis = calimero_account::AccountGenesis::new(root_pk);
                 let device = NodeDeviceRepository::new(&store)
                     .adopt_account(genesis)
                     .wrap_err("could not mint this node's device for that account")?;
@@ -626,6 +619,39 @@ impl InitCommand {
 
         Ok(())
     }
+}
+
+/// Parse `--account-root`, accepting **either** encoding an operator can be handed.
+///
+/// A `PublicKey` renders base58, and that is what `merod account root` and `merod
+/// account export` print. The admin API hex-encodes the same value in
+/// `accountRootPublicKey`, which is what `meroctl account show` displays. So the two
+/// legitimate ways to obtain this key disagree on its encoding, and requiring one of
+/// them made the documented flow fail on the first copy-paste with
+/// "--account-root is not hex".
+///
+/// Accepting both is the fix rather than picking a side: neither existing printer is
+/// wrong for its own context, and an operator has no reason to know which one they
+/// are holding.
+///
+/// # Errors
+/// If the value is neither 64 hex characters nor a base58 public key.
+fn parse_account_root_pk(given: &str) -> EyreResult<calimero_primitives::identity::PublicKey> {
+    let given = given.trim();
+
+    if let Ok(bytes) = hex::decode(given) {
+        let raw: [u8; 32] = bytes.try_into().map_err(|_| {
+            eyre::eyre!("--account-root is hex but not 32 bytes; it must be 64 hex characters")
+        })?;
+        return Ok(calimero_primitives::identity::PublicKey::from(raw));
+    }
+
+    given.parse().map_err(|_| {
+        eyre::eyre!(
+            "--account-root is neither 64 hex characters nor a base58 public key. Take it \
+             from `merod account root` (base58) or `meroctl account show` (hex)"
+        )
+    })
 }
 
 #[cfg(test)]
@@ -748,5 +774,46 @@ mod tests {
                 "advertise_address should be set for {args:?}"
             );
         }
+    }
+
+    /// `--account-root` must accept either encoding an operator can be handed.
+    ///
+    /// The two legitimate sources disagree: a `PublicKey` renders base58, which is
+    /// what `merod account root` and `merod account export` print, while the admin
+    /// API hex-encodes the same value in `accountRootPublicKey`, which is what
+    /// `meroctl account show` shows.
+    ///
+    /// Requiring hex made the documented flow fail on the first copy-paste with
+    /// "--account-root is not hex" — a wrong-encoding error for a value the
+    /// operator read out of our own command moments earlier.
+    #[test]
+    fn account_root_accepts_both_hex_and_base58() {
+        use calimero_primitives::identity::{PrivateKey, PublicKey};
+
+        let expected: PublicKey = PrivateKey::from([9u8; 32]).public_key();
+        let raw = *AsRef::<[u8; 32]>::as_ref(&expected);
+
+        let from_hex = super::parse_account_root_pk(&hex::encode(raw)).expect("hex");
+        let from_b58 = super::parse_account_root_pk(&expected.to_string()).expect("base58");
+
+        assert_eq!(from_hex, expected);
+        assert_eq!(from_b58, expected, "base58 is what our own commands print");
+        assert_eq!(from_hex, from_b58, "both encodings must name the same key");
+    }
+
+    /// A rejection must name where to get the value, not just that it is wrong.
+    #[test]
+    fn a_bad_account_root_says_where_to_get_a_good_one() {
+        let err = super::parse_account_root_pk("not-a-key").expect_err("must refuse");
+        let msg = err.to_string();
+        assert!(msg.contains("merod account root"), "{msg}");
+        assert!(msg.contains("meroctl account show"), "{msg}");
+    }
+
+    /// Hex of the wrong length is a distinct mistake from a wrong encoding.
+    #[test]
+    fn hex_of_the_wrong_length_says_so() {
+        let err = super::parse_account_root_pk(&hex::encode([1u8; 16])).expect_err("must refuse");
+        assert!(err.to_string().contains("32 bytes"), "{err}");
     }
 }


### PR DESCRIPTION
## Summary

`merod init --no-account-root --account-root <HEX>` needs an account's root **public**
key. There was no way to obtain one except from a **running holder node** — precisely
the machine the offline posture says should not exist.

`merod account root --from <phrase>` answers from the recovery phrase alone: no node, no
store, no init.

```sh
# On the air-gapped machine that holds the phrase and nothing else.
merod account root --from ./phrase.txt
#   Account root public key: <hex>
#   Account:                 <hex>

# Then, on the node that will run under it:
merod --node node1 init --no-account-root --account-root <hex>
```

Without `--from` it reads this node's own root, so the node must be **stopped** —
RocksDB's lock is exclusive, as for `export` and `import`.

## Why not a flag on `export`

`export` prints the phrase, which *is* the whole account. This prints only what is
public by construction: the root public key is hashed into the account id and travels in
every genesis, so publishing it grants nothing.

Two commands rather than one with a flag, because "show me the account" and "hand me the
secret" should not be one keystroke apart — a mistyped flag should not be the difference
between reading an id and printing a private key to a terminal.

Reuses `resolve_root`, so store-or-phrase handling is the one `sign-cert` and `warrant`
already share rather than a third copy of it.

## The test

`the_printed_root_key_and_account_describe_the_same_account` asserts the two printed
lines describe the same account.

They get pasted into *different places* — the public key into `init --account-root`, the
account id into a membership grant. If they ever disagreed, an operator would provision a
node under one account and grant rights to another. **Nothing would error**: the node
would simply never be a member, and the cause would be two hex strings that looked
perfectly reasonable side by side. That is the failure this pins.

## Context

Completes the offline-root flow shipped in #3672 (which carried #3673 and closed #3430).
The chain is now:

```
merod account root --from phrase          → the root public key   ← here
merod init --no-account-root --account-root <hex>
meroctl account show                      → device, sign key, agreement key
merod account sign-cert --device --sign-pk --kem-pk --from phrase
merod account import-cert <hex>
node joins, presents the cert, writes
```

## Verification

`cargo fmt --check` clean; `cargo clippy -p merod --all-targets -- -D warnings` clean;
`cargo test -p merod` — 69 + 2 passed, 0 failed.