### PR TITLE
ci: pin merobox 0.6.67 for per-node init args

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -36,7 +36,13 @@ runs:
         #
         # Both are the deliberate bump the note above describes, and the PR
         # carrying it runs the full suite against the new version.
-        MEROBOX_VERSION="0.6.66"
+        #
+        # 0.6.67 adds `nodes.init_args` — per-node `merod init` flags — and
+        # exports `deviceAgreementKey` from `node_identity`. Both are needed by
+        # `offline-account-root.yml`, which cannot boot a single node with
+        # `--no-account-root` without the first and cannot read the third input
+        # `sign-cert` needs without the second (merobox#383).
+        MEROBOX_VERSION="0.6.67"
         TAG="v${MEROBOX_VERSION}"
 
         case "$(uname -m)" in


### PR DESCRIPTION
## Why

0.6.67 carries two things nothing before it has ([merobox#383](https://github.com/calimero-network/merobox/pull/383)):

- **`nodes.init_args`** — per-node `merod init` flags. The init command is otherwise
  built literally in both merobox managers, with `--auth-mode` the only flag a workflow
  can influence, so a posture only *one* node should have could not be expressed at all.
- **`deviceAgreementKey` from `node_identity`** — the third input `merod account
  sign-cert` takes, alongside the device id and signing key. Added to the API in #3672;
  that step predated it and exported four fields.

Both are needed by `offline-account-root.yml` (#3676), which is the e2e for the
cold-storage posture #3430 shipped — currently verified by unit tests only.

## Why this is its own PR

The note already in `setup-merobox/action.yml` says it: *"the PR carrying it runs the
full suite against the new version."*

That is the actual value here. Every existing scenario runs against 0.6.67 in this PR,
so if #383 disturbed anything, it shows up **here** — rather than inside a brand-new
scenario, where a merobox regression would read as the scenario being wrong.

## Verified before pushing

The asset the action builds is present and fetchable, not merely tagged:

```
HEAD .../releases/download/v0.6.67/merobox-v0.6.67-linux-x86-64  → http=200
```

Worth checking explicitly: release assets lag their own release, and a bump pushed into
that window fails every job with `no assets match the file pattern` — which is what
reddened 46 merobox jobs earlier today, on a message that looks nothing like the cause.

## Follow-up

#3676 then gets a **live** matrix entry rather than the commented one it carries now.
That was the wrong shape: `scripts/check-scenario-coverage.py` fails a scenario that runs
in no matrix, and it is right to — the project's answer to "a scenario nothing runs" is
not to have one. With this pinned, #3676's own CI can execute the scenario for real
instead of merging it disabled.