### PR TITLE
fix(merod): provision the node's signing identity at init

### DIFF
--- a/crates/governance-store/src/namespace/core.rs
+++ b/crates/governance-store/src/namespace/core.rs
@@ -644,6 +644,52 @@ impl<'a> NamespaceRepository<'a> {
         self.note_participation(namespace_id)
     }
 
+    /// Mint this node's signing keypair now, if it has none.
+    ///
+    /// Takes no namespace, unlike [`Self::participate_in`], because there is no
+    /// namespace yet — this runs at `merod init`, before the node has joined
+    /// anything. It writes the keypair only, never a participation marker: the
+    /// two are separate questions, and claiming participation in nothing would
+    /// put this node into `participating_namespaces` for a namespace it has never
+    /// seen.
+    ///
+    /// # Why init needs this at all
+    ///
+    /// The keypair was minted lazily, on first join. That is invisible for an
+    /// ordinary node, which signs its own device certificate at that same moment.
+    /// It is fatal for a node whose account root lives elsewhere: the certificate
+    /// has to be signed over this key BEFORE the join, by a root this node does
+    /// not hold — and the key did not exist until the join it was meant to
+    /// enable. Two of the three values `merod account sign-cert` needs existed at
+    /// cold start and the third did not.
+    ///
+    /// Safe for every node, not just that one: [`Self::participate_in`] notes
+    /// participation and then reads the existing keypair, so a key provisioned
+    /// here is *reused* at first join rather than replaced — which
+    /// [`Self::store_identity`] would refuse outright.
+    ///
+    /// # Errors
+    /// Propagates the store read or write failure.
+    pub fn provision_node_identity(&self) -> EyreResult<PublicKey> {
+        if let Some(existing) = self.node_identity()? {
+            return Ok(existing.public_key);
+        }
+
+        let private_key = PrivateKey::random(&mut OsRng);
+        let public_key = private_key.public_key();
+
+        let mut handle = self.store.handle();
+        handle.put(
+            &NodeIdentity::new(),
+            &NodeIdentityValue {
+                public_key: *public_key,
+                private_key: *private_key.as_bytes(),
+            },
+        )?;
+
+        Ok(public_key)
+    }
+
     /// The key this node signs with, regardless of scope.
     ///
     /// [`Self::identity`] gates the same key on participation, because its

--- a/crates/governance-store/src/namespace/core.rs
+++ b/crates/governance-store/src/namespace/core.rs
@@ -783,7 +783,16 @@ impl<'a> NamespaceRepository<'a> {
     }
 
     /// Record that this node takes part in the namespace containing `group_id`,
-    /// and return the one key it signs with — minting it on first use.
+    /// and return the one key it signs with — minting it if absent.
+    ///
+    /// The mint is now a **back-compatibility path**, not the normal one:
+    /// `merod init` calls [`Self::provision_node_identity`], so a node initialised
+    /// by a current binary already holds its key and this only reads it. It still
+    /// mints for a node initialised before that existed, which is why the branch
+    /// stays rather than becoming an error the way the account root's did — a
+    /// lazily minted signing key is harmless (the node self-signs its own device
+    /// certificate at this same moment), whereas a lazily minted *root* would have
+    /// the node speak as an account nobody recognises.
     ///
     /// It was `get_or_create_identity`, which read as "an identity per group".
     /// There is one identity: the create half mints the NODE's keypair, once

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -7576,3 +7576,73 @@ fn resolving_an_identity_does_not_enlist_the_node_but_get_or_create_does() {
         "one node, one signing key — a second call must not mint another"
     );
 }
+
+/// A key provisioned at init must be REUSED at first join, not replaced.
+///
+/// This is the assumption the cold-start fix rests on. `store_identity` refuses to
+/// replace a *different* key — deliberately, because one node signs with one key —
+/// so if `participate_in` minted a fresh keypair instead of finding this one, every
+/// first join on every node would fail outright. That is a much worse bug than the
+/// one being fixed, which is why it gets its own test rather than being assumed.
+#[test]
+fn a_preprovisioned_signing_key_survives_the_first_join() {
+    let store = test_store();
+    let repo = NamespaceRepository::new(&store);
+    let ns = test_group_id();
+
+    let provisioned = repo.provision_node_identity().expect("provision at init");
+
+    let (_, joined_pk, _) = repo
+        .participate_in(&ns)
+        .expect("first join must not refuse");
+
+    assert_eq!(
+        joined_pk, provisioned,
+        "the join must reuse the provisioned key, not mint a second one",
+    );
+    assert_eq!(
+        repo.node_identity()
+            .expect("read")
+            .expect("present")
+            .public_key,
+        provisioned,
+        "and the stored key is still the provisioned one",
+    );
+}
+
+/// Provisioning is idempotent: a second call returns the first key.
+///
+/// `merod init` is re-runnable, and a second keypair would silently change what
+/// every namespace signs with.
+#[test]
+fn provisioning_the_signing_key_twice_keeps_the_first() {
+    let store = test_store();
+    let repo = NamespaceRepository::new(&store);
+
+    let first = repo.provision_node_identity().expect("first");
+    let second = repo.provision_node_identity().expect("second");
+
+    assert_eq!(first, second);
+}
+
+/// Provisioning must NOT claim participation in anything.
+///
+/// The keypair and the participation marker answer different questions, and
+/// `participating_namespaces` is what the node walks to decide where to sync. A
+/// marker written at init would enlist the node in a namespace it has never seen.
+#[test]
+fn provisioning_the_signing_key_joins_nothing() {
+    let store = test_store();
+    let repo = NamespaceRepository::new(&store);
+    let ns = test_group_id();
+
+    let _ = repo.provision_node_identity().expect("provision");
+
+    assert!(
+        !repo.participates_in(&ns).expect("query"),
+        "provisioning a key must not enlist the node anywhere",
+    );
+    // The namespace-gated reader still answers None: "who am I here" is not yet a
+    // question this node can answer, even though it has a key.
+    assert!(repo.identity_record(&ns).expect("read").is_none());
+}

--- a/crates/merod/AGENTS.md
+++ b/crates/merod/AGENTS.md
@@ -61,6 +61,14 @@ anyone's) and cannot be the holder half of a pairing, so `ensure_enrolled` fails
 on it by design. It *can* still name its account, because a certified device row
 answers before the root fallback does.
 
+**The signing key is provisioned at init too.** `merod init` mints the keypair the
+node signs ops with, not just the account root. That used to happen on first
+namespace join, which is invisible for an ordinary node — it self-signs its device
+certificate at that same moment — and fatal for a node whose account root lives
+elsewhere: the certificate must be signed over that key BEFORE the join, and the key
+did not exist until the join it was meant to enable. `participate_in` still mints for
+nodes initialised by older binaries, and reuses the provisioned key otherwise.
+
 ```bash
 # Print the 24-word phrase to stdout.
 merod --node node1 account export

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -565,6 +565,23 @@ impl InitCommand {
         let datastore_path = path.join(&config.datastore.path);
         let store = Store::open::<RocksDB>(&StoreConfig::new(datastore_path.clone()))?;
 
+        // The key this node signs ops with, minted here rather than on first join.
+        //
+        // For an ordinary node this only moves *when*: it self-signs its device
+        // certificate at join time either way. For a node whose account root
+        // lives elsewhere it is the difference between working and not — that
+        // certificate must be signed over this key BEFORE the join, by a root
+        // this node does not hold, and the key did not exist until the join it
+        // was meant to enable.
+        //
+        // `participate_in` notes participation and then reads the existing
+        // keypair, so this is reused at first join rather than replaced —
+        // `store_identity` refuses a replacement outright.
+        let signing_key = calimero_governance_store::NamespaceRepository::new(&store)
+            .provision_node_identity()
+            .wrap_err("could not provision this node's signing identity")?;
+        info!(signing_key = %signing_key, "Provisioned the node's signing identity");
+
         // The one place a root is generated. Nothing mints lazily any more: what
         // needs a root calls `require_account_root`, which errors when there is
         // none. So a node has an account root because it was provisioned here,

--- a/crates/server/src/admin/handlers/identity/get_node_identity.rs
+++ b/crates/server/src/admin/handlers/identity/get_node_identity.rs
@@ -102,8 +102,9 @@ pub async fn handler(Extension(state): Extension<Arc<AdminState>>) -> impl IntoR
             Ok(None) => {
                 return ApiError {
                     status_code: StatusCode::NOT_FOUND,
-                    message: "this node holds an account root but no signing identity yet; \
-                          one is provisioned when it first joins a namespace"
+                    message: "this node holds an account root but no signing identity. \
+                          `merod init` provisions one; a node initialised before that \
+                          did so mints it on its first namespace join"
                         .to_owned(),
                 }
                 .into_response();

--- a/docs/src/content/docs/protocol/identities.mdx
+++ b/docs/src/content/docs/protocol/identities.mdx
@@ -20,7 +20,7 @@ Every node has an Ed25519 keypair used only by the network layer. Its public key
 
 ## Member identity — authoring operations
 
-Authority lives in the **member identity**: a single Ed25519 keypair per node, generated on first use and persisted. It is the `author` on every operation and the key that signs an operation's `id` (see [Operations & the DAG](/protocol/operations/)). Membership, roles, and capabilities (defined in [Governance](/protocol/governance/)) are expressed in terms of the **account** this key writes as, not the key itself.
+Authority lives in the **member identity**: a single Ed25519 keypair per node, provisioned at `merod init` and persisted. (A node initialised before that was the case mints it on its first namespace join instead — the key is the same either way, only the moment differs.) It is the `author` on every operation and the key that signs an operation's `id` (see [Operations & the DAG](/protocol/operations/)). Membership, roles, and capabilities (defined in [Governance](/protocol/governance/)) are expressed in terms of the **account** this key writes as, not the key itself.
 
 One key, not one per namespace. It is recorded as the node's device signing key, and a device is one installation rather than one installation per scope. A key that varied by namespace would also have bought nothing: it is published in every namespace's device binding, so it correlates a node across namespaces exactly as a shared one does.
 


### PR DESCRIPTION
> Unblocks #3676, which is red because it found this.

## What was broken

The cold-start offline-root path shipped in #3672 is incomplete. `adopt_account` mints
the device row — device id and KEM secret — but the **signing key** lives in
`NamespaceRepository` and was minted lazily on first join.

So a node whose account root lives elsewhere held **two of the three values** `merod
account sign-cert` needs, and the third did not exist until the join it was meant to
enable:

1. To join, `join_credential::build` needs a certificate over the device's signing key.
2. The signing key was only created *during* the first join.
3. So at cold start there was nothing to certify — you could not obtain the certificate
   that joining requires.

Pairing works precisely because `pair-init` mints all three key materials up front.
Cold start minted two.

## How it was found

The `offline-account-root` e2e (#3676), on its **first real run**, failing at its first
substantive step with the endpoint stating the problem outright:

> *"this node holds an account root but no signing identity yet; one is provisioned when
> it first joins a namespace"*

No unit test could have caught it: they exercise `adopt_account` and
`join_credential::build` separately, and neither knows the signing identity is written by
a different repository.

## The fix

`NamespaceRepository::provision_node_identity()` — mints the keypair with **no
namespace**, because there is none yet, and writes **only** the keypair, never a
participation marker. The two answer different questions, and `participating_namespaces`
drives what the node syncs; a marker written at init would enlist the node in a namespace
it has never seen.

Called from `merod init` for **every** node, not just the root-free one. Safe (below), and
it matches the rule #3664 set: provisioned deliberately at init, never lazily.

## The test to read first

`a_preprovisioned_signing_key_survives_the_first_join`.

`store_identity` refuses to replace a *different* key — deliberately, because one node
signs with one key. So if `participate_in` minted a fresh keypair instead of finding the
provisioned one, **every first join on every node would fail outright**: a far worse bug
than the one being fixed. It reuses it, and that is now pinned rather than assumed.

Two others cover idempotence (`merod init` is re-runnable) and that provisioning claims
participation in nothing.

## The documentation follow-through

Moving *when* the key is provisioned makes four statements false, so they are corrected
here rather than left to contradict the fix on master:

- **`get_node_identity`'s 404** said *"provisioned when it first joins a namespace"*.
  That message is what diagnosed this bug, so it has to stay accurate.
- **`identities.mdx`** said the member identity is *"generated on first use"*. I judged
  that line accurate earlier in this work and left it — it was, until this PR.
- **`participate_in`'s doc** now marks its mint as the back-compat path it has become,
  and says why the branch stays rather than becoming an error the way the account root's
  did: a lazily minted signing key is harmless, because the node self-signs its device
  certificate at that same moment. A lazily minted *root* would have the node speak as an
  account nobody recognises.
- **`merod/AGENTS.md`** already said "nothing mints a root lazily"; the signing key
  belongs in that paragraph now.

## Verified against a moving master

#3657 (account-level pairing) and #3680 (docs) both landed while this was open. I
re-checked the premise rather than trusting a clean rebase:

- the endpoint still 404s on a missing signing identity
- init still did not provision one
- `provision_node_identity` did not exist on master
- `adopt_account` survived #3657's rewrite

And after rebasing onto #3680 I confirmed the diff is **additive only** — an earlier push
would have silently reverted #3680's docs fixes.

## Verification

627 governance-store tests, 5 suites across governance-store and server, `cargo fmt
--check` and `clippy -D warnings` clean, docs build 81 pages with links OK. Diff is 6
files, +155/−4.