### PR TITLE
docs: correct the two-node setup, and say what a certificate does not confer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,14 +311,24 @@ Grounded in the [Concepts & Scopes](docs/src/content/docs/protocol/concepts.mdx)
 ## Running Local Nodes
 
 ```bash
-# Initialize and run first node
-merod --node node1 init --server-port 2428 --swarm-port 2528
+# Initialize and run first node. `--mdns` only matters once a second node has to
+# find it — see below — but it is set here so the pair works as written.
+merod --node node1 init --server-port 2428 --swarm-port 2528 --mdns
 merod --node node1 run
 
-# Second node connecting to first
-merod --node node2 init --server-port 2429 --swarm-port 2529
-merod --node node2 config --swarm-addrs /ip4/127.0.0.1/tcp/2528
+# Second node connecting to first. BOTH need `--mdns`: it is off by default since
+# #3620, and two nodes with no bootstrap peer and no rendezvous have NO other way
+# to find each other. The failure is indirect — the join reports a key-delivery
+# timeout, not "no peer" — so it reads as a broken join rather than as discovery.
+merod --node node2 init --server-port 2429 --swarm-port 2529 --mdns
 merod --node node2 run
+
+# Or an explicit bootstrap, which needs node1's PEER ID — a bare
+# /ip4/../tcp/.. is rejected at startup ("Failed to parse peer id from addr").
+# Read it from a running node1:
+#   curl -s localhost:2428/admin-api/network/status | jq -r .localPeerId
+merod --node node2 init --server-port 2429 --swarm-port 2529 \
+  --boot-nodes /ip4/127.0.0.1/tcp/2528/p2p/<node1-peer-id>
 
 # Debug logging
 RUST_LOG=debug merod --node node1 run

--- a/docs/src/content/docs/contribute/development.mdx
+++ b/docs/src/content/docs/contribute/development.mdx
@@ -61,15 +61,33 @@ two nodes that talk to each other:
 1. Initialize and run the first node:
 
    ```sh
-   merod --node node1 init --server-port 2428 --swarm-port 2528
+   merod --node node1 init --server-port 2428 --swarm-port 2528 --mdns
    merod --node node1 run
    ```
 
-2. Initialize the second node and point it at the first's swarm address:
+2. Initialize the second node so it can find the first:
 
    ```sh
-   merod --node node2 init --server-port 2429 --swarm-port 2529
-   merod --node node2 config --swarm-addrs /ip4/127.0.0.1/tcp/2528
+   merod --node node2 init --server-port 2429 --swarm-port 2529 --mdns
+   merod --node node2 run
+   ```
+
+   `--mdns` is on both, and it is load-bearing rather than tidy-up. mDNS is off by
+   default, and two nodes with no bootstrap peer and no rendezvous have no other
+   way to find each other. Leaving it off does not fail cleanly: the nodes start,
+   the join is accepted locally, and it then times out waiting for a group key —
+   so it reads as a broken join rather than as two nodes that never met.
+
+   To point the second node at the first explicitly instead, you need node1's
+   **peer id** — a bare `/ip4/…/tcp/…` is rejected at startup with "Failed to
+   parse peer id from addr":
+
+   ```sh
+   # with node1 running
+   curl -s localhost:2428/admin-api/network/status | jq -r .localPeerId
+
+   merod --node node2 init --server-port 2429 --swarm-port 2529 \
+     --boot-nodes /ip4/127.0.0.1/tcp/2528/p2p/<node1-peer-id>
    merod --node node2 run
    ```
 

--- a/docs/src/content/docs/operate/merod.mdx
+++ b/docs/src/content/docs/operate/merod.mdx
@@ -176,6 +176,25 @@ mints certificates but needs a running node holding the root, so a thin client �
 phone, a script, anything that runs no application and joins no group — had no way to
 obtain the credential it needs to present itself.
 
+<Aside type="caution" title="A certificate establishes identity, and only identity">
+It proves this device speaks for that account. It does **not** make the device able
+to use anything, and two things still have to come from a peer:
+
+- **Which namespaces and apps to join.** A device is a member of nothing, so it
+  cannot read the account's namespace set off any DAG — there is no replicated
+  account-to-namespaces directory, by design. Today that list is supplied
+  explicitly, at `pair-init` or out of band.
+- **The scope key for each namespace.** The certificate confers *authority*, not
+  *readability*. Without key delivery the link lands and the device still cannot
+  decrypt anything.
+
+So an offline-certified device can prove it belongs to the account and still be
+unable to open a single app until a peer tells it what to join and hands over the
+keys. If you are restoring from a recovery phrase alone, the phrase proves who you
+are and nothing tells you what you are a member of — that has to come from a node
+you run, or from a service that keeps the list for you.
+</Aside>
+
 There are **two independent choices**, which is why the flag list looks larger than the
 number of real modes.
 


### PR DESCRIPTION
Two shipped-documentation defects. Both cost real time this week.

## 1. The two-node instructions do not work

`AGENTS.md` (via the `CLAUDE.md` symlink) and `contribute/development.mdx` both say:

```sh
merod --node node2 config --swarm-addrs /ip4/127.0.0.1/tcp/2528
```

That fails **twice over**:

- `config` no longer takes `--swarm-addrs` — it takes generic `key=value` TOML pairs.
- Even the address form would be rejected. `network/src/behaviour.rs:144` requires a
  `/p2p/<peer_id>` component and bails with *"Failed to parse peer id from addr"*
  without one.

And since #3620 turned mDNS off by default, there was **no working documented way to
link two local nodes at all**.

Both now use `--mdns` on both nodes, with the explicit-bootstrap alternative and where
to get the peer id (`GET /admin-api/network/status` → `localPeerId`).

The comment explains why it is load-bearing rather than tidy-up: **leaving mDNS off does
not fail cleanly.** The nodes start, the join is accepted locally, and it then times out
waiting for a group key — so it presents as a broken join rather than as two nodes that
never met. That precise confusion broke mero-js CI on **every** PR for a day
(calimero-network/mero-js#117), and the 500 it produced pointed nowhere near discovery.

## 2. `sign-cert` reads as more complete than it is

The `merod account` reference presents offline certification as a working posture. It
isn't one on its own. **A certificate establishes identity and only identity.** Two
things still have to come from a peer:

- **Which namespaces and apps to join.** A device is a member of nothing, so it cannot
  read the account's namespace set off any DAG. There is no replicated
  account-to-namespaces directory, and that is deliberate.
- **The scope key for each namespace.** The certificate confers *authority*, not
  *readability*. Without key delivery the link lands and the device still cannot decrypt
  anything.

Someone following the current docs would reasonably expect a certified device to work,
and it will not. The new caution says so, including the case the docs actively invited:
restoring from a recovery phrase alone proves who you are and tells you nothing about
what you are a member of — that comes from a node you run, or a service that keeps the
list for you.

## Verification

`npm run check` — 81 pages built, internal links OK. Both additions confirmed present in
the rendered HTML rather than only in source, since MDX components can silently produce
nothing.