### PR TITLE
feat(client): bind the account device listings and relink

### DIFF
--- a/crates/client/src/client/namespace.rs
+++ b/crates/client/src/client/namespace.rs
@@ -1,10 +1,12 @@
 use calimero_server_primitives::admin::{
-    AccountPairCompleteApiRequest, AccountPairInitApiRequest, CreateGroupInvitationApiRequest,
-    CreateNamespaceApiRequest, CreateNamespaceApiResponse, DeleteNamespaceApiRequest,
-    DeleteNamespaceApiResponse, GetNamespaceApiResponse, JoinGroupApiRequest,
-    JoinNamespaceApiResponse, ListNamespaceGroupsApiResponse, ListNamespacesApiResponse,
-    NamespaceApiResponse, NodeIdentityApiResponse, PairDeviceCompleteApiResponse,
-    PairDeviceInitApiResponse, RevokeDeviceApiRequest, RevokeDeviceApiResponse,
+    AccountApplicationsApiResponse, AccountDevicesApiResponse, AccountPairCompleteApiRequest,
+    AccountPairInitApiRequest, CreateGroupInvitationApiRequest, CreateNamespaceApiRequest,
+    CreateNamespaceApiResponse, DeleteNamespaceApiRequest, DeleteNamespaceApiResponse,
+    GetNamespaceApiResponse, JoinGroupApiRequest, JoinNamespaceApiResponse,
+    ListNamespaceGroupsApiResponse, ListNamespacesApiResponse, NamespaceApiResponse,
+    NodeIdentityApiResponse, PairDeviceCompleteApiResponse, PairDeviceInitApiResponse,
+    RelinkDeviceApiRequest, RelinkDeviceApiResponse, RevokeDeviceApiRequest,
+    RevokeDeviceApiResponse,
 };
 use eyre::Result;
 use serde::Serialize;
@@ -121,6 +123,48 @@ where
         let response = self
             .connection
             .post("admin-api/account/pair-complete", request)
+            .await?;
+        Ok(response)
+    }
+
+    /// Repair or widen the reach of a device this account already certified.
+    ///
+    /// Re-runs pairing's fan-out against the namespaces this node takes part in
+    /// now, which is what closes the drift a namespace gained afterwards leaves
+    /// behind. Naming no application repairs without widening.
+    pub async fn relink_device(
+        &self,
+        device_id: &str,
+        request: RelinkDeviceApiRequest,
+    ) -> Result<RelinkDeviceApiResponse> {
+        let response = self
+            .connection
+            .post(
+                &format!("admin-api/account/devices/{device_id}/relink"),
+                request,
+            )
+            .await?;
+        Ok(response)
+    }
+
+    /// Every device of this account, with the scope and bindings this node can see.
+    ///
+    /// Joined from the node-local certificate cache and the live bindings of every
+    /// namespace this node takes part in, so it reports devices this node never
+    /// certified as well as the ones it did.
+    pub async fn list_account_devices(&self) -> Result<AccountDevicesApiResponse> {
+        let response = self.connection.get("admin-api/account/devices").await?;
+        Ok(response)
+    }
+
+    /// The applications this account speaks in.
+    ///
+    /// The only route by which a device that is a member of nothing can learn
+    /// them: a namespace summary is withheld from non-members.
+    pub async fn list_account_applications(&self) -> Result<AccountApplicationsApiResponse> {
+        let response = self
+            .connection
+            .get("admin-api/account/applications")
             .await?;
         Ok(response)
     }


### PR DESCRIPTION
## Summary

#3657 shipped three routes with no client binding:

- `GET /admin-api/account/devices`
- `GET /admin-api/account/applications`
- `POST /admin-api/account/devices/:device_id/relink`

`calimero-client-py` wraps this crate rather than speaking HTTP itself, and `Client::connection` is private, so those routes are unreachable from Python today. That leaves merobox unable to express the steps and the e2e suite driving all three through `curl` scripts instead of native workflow steps.

Three thin wrappers over the request and response types that already exist in `calimero-server-primitives`, matching the shape `pair_device_init` and `pair_device_complete` established.

No behaviour change: no route, type or existing signature is touched.

## Test plan

- `cargo check -p calimero-client` clean.
- `cargo clippy -p calimero-client --all-targets` clean, no new warnings.
- `cargo fmt --check` clean.

Exercised end to end by the follow-up in `calimero-client-py`, which binds these three for merobox to consume.