### PR TITLE
ci: pin merobox 0.6.68 so the agreement key actually arrives

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -42,7 +42,18 @@ runs:
         # `offline-account-root.yml`, which cannot boot a single node with
         # `--no-account-root` without the first and cannot read the third input
         # `sign-cert` needs without the second (merobox#383).
-        MEROBOX_VERSION="0.6.67"
+        #
+        # 0.6.68 is what makes that second half actually arrive. The export was
+        # dead code at 0.6.67: merobox reaches the node through `calimero-client`
+        # compiled into the `calimero-client-py` wheel it bundles, and that wheel
+        # pinned a core rev predating #3672 — so the field was dropped on
+        # deserialization before any step could capture it. client-py 0.6.35 pins a
+        # rev carrying it, and 0.6.68 was built after that published.
+        #
+        # Adding a field to an admin-api response therefore does not reach a
+        # scenario until this pin moves. It is the same chain a `crates/client` fix
+        # travels, for the same reason.
+        MEROBOX_VERSION="0.6.68"
         TAG="v${MEROBOX_VERSION}"
 
         case "$(uname -m)" in


### PR DESCRIPTION
## Why

0.6.67 exported `deviceAgreementKey` from `node_identity` (merobox#383) and it was **dead
code**.

merobox reaches a node through `calimero-client`, compiled into the
`calimero-client-py` wheel it bundles — and that wheel pinned a core rev **predating
#3672**. So merod sent five fields, the client kept four, and #3676's scenario failed
with:

```
[OUTPUT_CAPTURE_FAILED] output 'kem_pk_2' captures 'deviceAgreementKey', which the
response does not have. Available: accountId, accountRootPublicKey, deviceId, publicKey
```

Exactly the pre-#3672 shape. The node was right, the step was right, and the client in
between silently dropped the field.

client-py **0.6.35** pins a rev carrying both #3672 and #3679, and merobox **0.6.68** was
built an hour after it published — so the bundled client now decodes it.

## The general lesson, now in the file

**Adding a field to an admin-api response does not reach a scenario until this pin
moves.** It is the same chain a `crates/client` change travels, for the same reason: the
e2e's HTTP client is not the one in this tree. That is worth a comment beside the pin,
because the symptom looks like a broken step rather than a stale dependency.

## Separate from #3676, deliberately

This changes the client **every** scenario talks to nodes through, so the full suite runs
against it here. Folding it into #3676 would make a merobox-side regression read as the
new scenario's fault — the same reason #3678 was kept separate, where a clean 147 was the
evidence that 0.6.67 disturbed nothing.

## Verified before pushing

Both URLs the action constructs return **200** — the binary and its `.sha256`.

Worth checking explicitly: 0.6.68 sat as a **draft for nearly two hours** with a failed
release leg (its `darwin-x86-64` binary missing while the checksum uploaded), and a plain
download URL 404s for a draft. Pinning into that window fails every e2e job on a message
that looks nothing like the cause — which is how 46 merobox jobs went red earlier today.