### PR TITLE
fix(merod): accept hex or base58 for sign-cert's key arguments

### DIFF
--- a/crates/merod/src/cli/account.rs
+++ b/crates/merod/src/cli/account.rs
@@ -716,11 +716,34 @@ async fn resolve_root(
 }
 
 /// Parse a 32-byte hex key, naming the argument it rejected.
+/// Parse a 32-byte key given as **either** hex or base58.
+///
+/// Both, because the two legitimate sources disagree and an operator has no way to
+/// know which they are holding. `GET /admin-api/identity` renders the device's
+/// signing key with `PublicKey`'s own `Display`, which is base58, while
+/// hex-encoding the device id and agreement key beside it. `merod account device`
+/// prints all three as hex. So the same key reaches a caller in two spellings
+/// depending on where they read it, and requiring one made the documented flow
+/// fail on a copy-paste with "--sign-pk is not hex".
+///
+/// This mirrors `--account-root`, which took the same fix for the same reason.
 fn parse_key(raw: &str, arg: &str) -> EyreResult<[u8; 32]> {
-    let bytes = hex::decode(raw.trim()).wrap_err_with(|| format!("--{arg} is not hex"))?;
-    bytes
-        .try_into()
-        .map_err(|_ignored| eyre::eyre!("--{arg} is not 32 bytes (64 hex characters)"))
+    let raw = raw.trim();
+
+    if let Ok(bytes) = hex::decode(raw) {
+        return bytes.try_into().map_err(|_ignored| {
+            eyre::eyre!("--{arg} is hex but not 32 bytes (64 hex characters)")
+        });
+    }
+
+    let key: calimero_primitives::identity::PublicKey = raw.parse().map_err(|_ignored| {
+        eyre::eyre!(
+            "--{arg} is neither 64 hex characters nor a base58 key. Both spellings are \
+             in circulation: `merod account device` prints hex, `meroctl account show` \
+             prints the signing key base58"
+        )
+    })?;
+    Ok(*AsRef::<[u8; 32]>::as_ref(&key))
 }
 
 /// Parse a hex `DeviceId`.
@@ -959,6 +982,45 @@ mod tests {
                 .public_key,
             signing_key,
         );
+    }
+
+    /// `sign-cert`'s key arguments must accept both spellings in circulation.
+    ///
+    /// `GET /admin-api/identity` renders the signing key base58 — `PublicKey`'s own
+    /// Display — while hex-encoding the device id and agreement key beside it.
+    /// `merod account device` prints all three hex. So a caller pasting from the
+    /// API supplies base58 for one argument and hex for the others, which is
+    /// exactly what the offline-root e2e did before this.
+    #[test]
+    fn sign_cert_keys_accept_hex_and_base58() {
+        let key = PrivateKey::from([6u8; 32]).public_key();
+        let raw = *AsRef::<[u8; 32]>::as_ref(&key);
+
+        assert_eq!(
+            super::parse_key(&hex::encode(raw), "sign-pk").expect("hex"),
+            raw
+        );
+        assert_eq!(
+            super::parse_key(&key.to_string(), "sign-pk").expect("base58"),
+            raw,
+            "base58 is what the identity endpoint prints for this key",
+        );
+    }
+
+    /// A rejection must name both spellings and where each comes from.
+    #[test]
+    fn a_bad_key_says_which_spellings_are_accepted() {
+        let err = super::parse_key("not-a-key", "sign-pk").expect_err("must refuse");
+        let msg = err.to_string();
+        assert!(msg.contains("merod account device"), "{msg}");
+        assert!(msg.contains("meroctl account show"), "{msg}");
+    }
+
+    /// Hex of the wrong length is a distinct mistake from a wrong encoding.
+    #[test]
+    fn a_short_hex_key_says_so() {
+        let err = super::parse_key(&hex::encode([1u8; 16]), "kem-pk").expect_err("must refuse");
+        assert!(err.to_string().contains("32 bytes"), "{err}");
     }
 }
 


### PR DESCRIPTION
> Blocks #3676 — the offline-root scenario cannot get past certification without it.

## What broke

The e2e read three values from the node and passed them straight to `sign-cert`, which
refused one of them:

```
--device  1efcbf9a…                                     hex
--sign-pk FRFT47ZeJx7oi68p3xmbFq5eNB1uufGbKtawYMBB5aeJ   base58  ← "--sign-pk is not hex"
--kem-pk  b3e46d81…                                      hex
```

`GET /admin-api/identity` renders the device's signing key with `PublicKey`'s own
`Display`, which is **base58**, while **hex**-encoding the device id and agreement key
beside it. And `merod account device` (#3683) prints all three as hex.

So the same key reaches a caller in two spellings depending on where they read it, and
**two of our own commands disagree**. A caller pasting from the API supplies base58 for
one argument and hex for the other two — which is exactly what the scenario did.

## The fix

`parse_key` accepts either, and names both sources when it refuses:

> *"--sign-pk is neither 64 hex characters nor a base58 key. Both spellings are in
> circulation: `merod account device` prints hex, `meroctl account show` prints the
> signing key base58"*

Neither printer is wrong for its own context, and an operator has no way to know which
they are holding — the same reasoning, and the same fix, that `--account-root` took in
#3675.

## Verified with real binaries

Not only unit tests: certifying with the **base58** form the endpoint actually emits now
produces a credential. A unit test alone would not have caught a wrong `AsRef` here.

Three tests: both spellings parse to the same bytes, a bad value names both sources, and
hex of the wrong length reports length rather than encoding.

## Worth raising separately

This is the **second** time this has been patched at the parser, and the fourth
hex/base58 collision in this work. The cause is upstream: **`GET /admin-api/identity` is
internally inconsistent** — three keys in one response, one base58 and two hex. Permissive
parsers stop the bleeding; a consistent response would stop the cause, but that is a
breaking change to a field consumers already read.

I would rather file that as its own issue than patch a third parser. Flagging it here
rather than silently widening the next one.

## Verification

76 + 2 tests pass; `cargo fmt --check` and `clippy -D warnings` clean.