### PR TITLE
feat(blob): bound the DHT lookup and let a caller opt out of waiting

### DIFF
--- a/crates/node/primitives/src/client.rs
+++ b/crates/node/primitives/src/client.rs
@@ -9,12 +9,13 @@ use calimero_crypto::SharedKey;
 use calimero_governance_types::SignedNamespaceOp;
 use calimero_network_primitives::client::{is_no_peers_subscribed_error, NetworkClient};
 use calimero_network_primitives::config::GOSSIPSUB_MESH_N_LOW;
+use calimero_primitives::blobs::BlobId;
 use calimero_primitives::context::{Context, ContextId};
 use calimero_primitives::events::NodeEvent;
 use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_store::Store;
 use calimero_utils_actix::LazyRecipient;
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use eyre::{OptionExt, WrapErr};
 use futures_util::Stream;
 use libp2p::gossipsub::TopicHash;
@@ -219,6 +220,15 @@ pub struct NodeClient {
     /// (NodeManager event handler) and readers (concurrent publishers)
     /// see the same map without an actor mailbox round-trip.
     known_subscribers: Arc<DashMap<TopicHash, HashSet<PeerId>>>,
+    /// Blobs currently being fetched in the background by
+    /// [`ensure_blob`](Self::ensure_blob).
+    ///
+    /// A conversation full of images asks for the same blob once per rendered
+    /// message, and a virtualised list asks again on every scroll. Without this
+    /// each ask would start its own discovery, and they would all wait on the
+    /// same DHT the first one is already querying. Deduped here so N requests
+    /// cost one fetch.
+    in_flight_blob_fetches: Arc<DashSet<BlobId>>,
 }
 
 impl NodeClient {
@@ -247,6 +257,7 @@ impl NodeClient {
             sync_client,
             local_delta_tx,
             known_subscribers: Arc::new(DashMap::new()),
+            in_flight_blob_fetches: Arc::new(DashSet::new()),
         }
     }
 

--- a/crates/node/primitives/src/client/blob.rs
+++ b/crates/node/primitives/src/client/blob.rs
@@ -3,6 +3,9 @@ use std::sync::Arc;
 use calimero_blobstore::{Blob, BlobManager as BlobStore, Size};
 use calimero_context_config::MAX_NAMESPACE_DEPTH;
 use calimero_network_primitives::blob_types::{BlobAuth, BlobAuthPayload};
+use calimero_primitives::events::{
+    BlobEvent, BlobEventPayload, BlobReadyPayload, BlobUnavailablePayload, NodeEvent,
+};
 use calimero_primitives::{
     blobs::{BlobId, BlobInfo, BlobMetadata},
     common::DIGEST_SIZE,
@@ -105,6 +108,20 @@ impl BlobManager {
     }
 }
 
+/// What [`NodeClient::ensure_blob`] found when asked for a blob.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BlobFetchState {
+    /// Already held locally; read it with `get_blob` and it will not touch the
+    /// network.
+    Local,
+    /// Not local. A background fetch has just been started; its outcome arrives
+    /// as a [`NodeEvent::Blob`].
+    Started,
+    /// Not local, and a fetch started by an earlier caller is still running.
+    /// Same event, no second fetch.
+    AlreadyFetching,
+}
+
 impl NodeClient {
     // todo! maybe this should be an actor method?
     // todo! so we can cache the blob in case it's
@@ -123,6 +140,87 @@ impl NodeClient {
 
     /// Get blob from local storage or network if context_id is provided
     /// Returns a streaming Blob that can be used to read the data
+    /// Start fetching `blob_id` in the background if it is not already local,
+    /// and report what happened without waiting for it.
+    ///
+    /// # Why this exists
+    ///
+    /// `get_blob` blocks until discovery finishes, and discovery is a DHT
+    /// lookup across up to six attempts. A caller that has to answer an HTTP
+    /// request in the meantime has no good option: wait (and hold the request,
+    /// and the connection, for as long as the network takes) or give up (and
+    /// never fetch the blob at all). Waiting is what produced images that spun
+    /// forever — the request never answered, so the client never even reached
+    /// its error path.
+    ///
+    /// So the two halves are split. Ask here, get an immediate answer about
+    /// whether the bytes are ready, and learn about the rest through
+    /// [`NodeEvent::Blob`]. The bytes are served by a later `get_blob` once the
+    /// fetch lands, which then finds them locally and returns at once.
+    ///
+    /// Concurrent asks for the same blob are deduped: the first starts a fetch,
+    /// the rest are told one is already running. They all observe the same
+    /// event when it settles.
+    pub fn ensure_blob(&self, blob_id: BlobId, context_id: ContextId) -> BlobFetchState {
+        if self.has_blob(&blob_id).unwrap_or(false) {
+            return BlobFetchState::Local;
+        }
+
+        // `insert` returns false when the blob is already in the set, which is
+        // the dedupe: exactly one caller wins and starts the fetch.
+        if !self.in_flight_blob_fetches.insert(blob_id) {
+            return BlobFetchState::AlreadyFetching;
+        }
+
+        let client = self.clone();
+        drop(tokio::spawn(async move {
+            let outcome = client.get_blob(&blob_id, Some(&context_id)).await;
+
+            // Clear the in-flight marker BEFORE emitting, so a client that
+            // re-requests the instant it sees the event is not told a fetch is
+            // still running.
+            let _removed = client.in_flight_blob_fetches.remove(&blob_id);
+
+            let payload = match outcome {
+                Ok(Some(_blob)) => {
+                    let size = client
+                        .get_blob_info(blob_id)
+                        .await
+                        .ok()
+                        .flatten()
+                        .map_or(0, |meta| meta.size);
+                    tracing::info!(%blob_id, %context_id, size, "Background blob fetch ready");
+                    BlobEventPayload::BlobReady(BlobReadyPayload { size })
+                }
+                Ok(None) => {
+                    tracing::info!(%blob_id, %context_id, "Background blob fetch found no provider");
+                    BlobEventPayload::BlobUnavailable(BlobUnavailablePayload {
+                        reason: "no provider for this blob was reachable".to_owned(),
+                    })
+                }
+                Err(err) => {
+                    tracing::warn!(%blob_id, %context_id, %err, "Background blob fetch failed");
+                    BlobEventPayload::BlobUnavailable(BlobUnavailablePayload {
+                        reason: err.to_string(),
+                    })
+                }
+            };
+
+            // A send failure here means nothing is listening, which is normal
+            // and not worth escalating — the bytes are stored either way and
+            // the next request finds them.
+            if let Err(err) = client.send_event(NodeEvent::Blob(BlobEvent {
+                blob_id,
+                context_id,
+                payload,
+            })) {
+                tracing::debug!(%blob_id, %err, "no subscriber for blob event");
+            }
+        }));
+
+        BlobFetchState::Started
+    }
+
     pub async fn get_blob<'a>(
         &'a self,
         blob_id: &'a BlobId,
@@ -147,6 +245,11 @@ impl NodeClient {
             // stays missing. The blob record is usually available within a few
             // hundred ms on a warm cluster; a flat multi-second wait otherwise
             // dominates time-to-first-byte even when both peers are local.
+            // How long one DHT lookup may take before we stop waiting on it.
+            // Generous next to a warm-cluster lookup (a few hundred ms) and far
+            // below kad's own query timeout, which is what previously decided
+            // how long a caller waited.
+            const BLOB_QUERY_TIMEOUT: core::time::Duration = core::time::Duration::from_secs(5);
             const MAX_RETRIES: usize = 6;
             const INITIAL_RETRY_DELAY: core::time::Duration =
                 core::time::Duration::from_millis(100);
@@ -172,13 +275,38 @@ impl NodeClient {
                     "Attempting network discovery"
                 );
 
-                let peers = match self
-                    .network_client
-                    .query_blob(*blob_id, Some(*context_id))
-                    .await
-                {
-                    Ok(peers) => peers,
-                    Err(e) => {
+                // Bound the DHT query. `NetworkClient::query_blob` awaits a
+                // oneshot that is only resolved when kad reports the query
+                // progressed, so a query that never terminates parks this task
+                // for as long as the process lives. That is not hypothetical:
+                // it is what left images spinning forever in a chat client —
+                // the HTTP request never answered, so the fetch never settled
+                // and no error path ever ran. A caller can recover from "not
+                // found"; it cannot recover from silence.
+                //
+                // A timeout is treated exactly like an empty result: back off
+                // and try again, and if the attempts run out, report the blob
+                // as undiscoverable rather than as an error. It may genuinely
+                // be somewhere — we just did not find it in the time we were
+                // willing to spend.
+                let query = self.network_client.query_blob(*blob_id, Some(*context_id));
+                let peers = match tokio::time::timeout(BLOB_QUERY_TIMEOUT, query).await {
+                    Err(_elapsed) => {
+                        tracing::warn!(
+                            blob_id = %blob_id,
+                            context_id = %context_id,
+                            attempt,
+                            timeout_secs = BLOB_QUERY_TIMEOUT.as_secs(),
+                            "DHT query timed out"
+                        );
+                        if attempt < MAX_RETRIES {
+                            tokio::time::sleep(backoff(attempt)).await;
+                            continue;
+                        }
+                        return Ok(None);
+                    }
+                    Ok(Ok(peers)) => peers,
+                    Ok(Err(e)) => {
                         tracing::warn!(
                             blob_id = %blob_id,
                             context_id = %context_id,
@@ -190,7 +318,19 @@ impl NodeClient {
                             tokio::time::sleep(backoff(attempt)).await;
                             continue;
                         }
-                        return Err(e);
+                        // A failed lookup is "we could not find it", not "this
+                        // node is broken". Returning `Err` here made the admin
+                        // API answer 500 for a blob that simply has no reachable
+                        // provider — indistinguishable, to a client, from the
+                        // node falling over. `Ok(None)` is the honest answer and
+                        // the handler turns it into a 404.
+                        tracing::warn!(
+                            blob_id = %blob_id,
+                            context_id = %context_id,
+                            error = %e,
+                            "DHT query failed on the final attempt; reporting not found"
+                        );
+                        return Ok(None);
                     }
                 };
 
@@ -256,6 +396,28 @@ impl NodeClient {
                                     "Downloaded blob ID mismatch"
                                 );
                                 continue;
+                            }
+
+                            // Advertise it: this node now holds the bytes, so
+                            // it can serve them to the next asker.
+                            //
+                            // Without this every fetcher stays dependent on the
+                            // single originating node — a conversation where one
+                            // peer shared an image has exactly one provider for
+                            // it no matter how many peers have since downloaded
+                            // it, so the origin going offline takes the image
+                            // with it. Best-effort: failing to advertise does
+                            // not make the bytes we just fetched any less valid.
+                            if let Err(err) = self
+                                .announce_blob_to_network(blob_id, context_id, data.len() as u64)
+                                .await
+                            {
+                                tracing::debug!(
+                                    blob_id = %blob_id,
+                                    context_id = %context_id,
+                                    %err,
+                                    "Fetched blob stored but not advertised"
+                                );
                             }
 
                             // Return the newly stored blob as a stream

--- a/crates/node/primitives/src/client/blob.rs
+++ b/crates/node/primitives/src/client/blob.rs
@@ -398,28 +398,6 @@ impl NodeClient {
                                 continue;
                             }
 
-                            // Advertise it: this node now holds the bytes, so
-                            // it can serve them to the next asker.
-                            //
-                            // Without this every fetcher stays dependent on the
-                            // single originating node — a conversation where one
-                            // peer shared an image has exactly one provider for
-                            // it no matter how many peers have since downloaded
-                            // it, so the origin going offline takes the image
-                            // with it. Best-effort: failing to advertise does
-                            // not make the bytes we just fetched any less valid.
-                            if let Err(err) = self
-                                .announce_blob_to_network(blob_id, context_id, data.len() as u64)
-                                .await
-                            {
-                                tracing::debug!(
-                                    blob_id = %blob_id,
-                                    context_id = %context_id,
-                                    %err,
-                                    "Fetched blob stored but not advertised"
-                                );
-                            }
-
                             // Return the newly stored blob as a stream
                             return self.blob_manager.get_blob_stream(*blob_id);
                         }

--- a/crates/primitives/src/events.rs
+++ b/crates/primitives/src/events.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::blobs::BlobId;
 use crate::context::{ContextId, GroupMemberRole};
 use crate::hash::Hash;
 use crate::identity::PublicKey;
@@ -15,6 +16,56 @@ pub enum NodeEvent {
     /// A namespace migration changed phase. Keyed by `groupId` like
     /// [`GroupMembershipEvent`]; the payload tags are disjoint from that enum's.
     GroupMigration(GroupMigrationEvent),
+    /// A blob this node was fetching in the background settled. Keyed by
+    /// `blobId`, which no other variant carries, so `untagged` can tell it
+    /// apart even though it also names a `contextId`.
+    Blob(BlobEvent),
+}
+
+/// The outcome of a background blob fetch.
+///
+/// `GET /admin-api/blobs/:id` answers `202` when the bytes are not held
+/// locally, and starts a discovery in the background rather than making the
+/// caller wait out a DHT query it cannot bound. This event is how the caller
+/// learns the fetch finished — without it a client has nothing to wait on and
+/// is forced back to polling.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlobEvent {
+    pub blob_id: BlobId,
+    /// The context the blob was discovered through — the same one the request
+    /// named. Blob records are keyed by `(context, blob)`, so a blob is only
+    /// ever ready *with respect to* a context.
+    pub context_id: ContextId,
+    #[serde(flatten)]
+    pub payload: BlobEventPayload,
+}
+
+/// Tagged like [`ContextEventPayload`], with tags disjoint from every other
+/// payload enum so the `untagged` [`NodeEvent`] stays unambiguous.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", content = "data", rename_all = "PascalCase")]
+pub enum BlobEventPayload {
+    /// The bytes are now held locally; re-request and it will answer `200`.
+    BlobReady(BlobReadyPayload),
+    /// The fetch settled without the bytes. A retry may still succeed — a
+    /// provider can appear later — so this is not a permanent verdict.
+    BlobUnavailable(BlobUnavailablePayload),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlobReadyPayload {
+    pub size: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlobUnavailablePayload {
+    /// Why it did not arrive, for a client that wants to say something better
+    /// than "failed". Not machine-readable on purpose: the only action a client
+    /// can take is retry-or-give-up, and that does not depend on the reason.
+    pub reason: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -634,5 +685,58 @@ mod tests {
         let v = serde_json::to_value(&payload).expect("serialize");
         assert!(v["data"].get("state").is_none());
         assert_eq!(v["data"]["removed"], true);
+    }
+}
+
+#[cfg(test)]
+mod blob_event_tests {
+    use super::*;
+
+    /// `NodeEvent` is `untagged`, so a new variant is only safe if serde can
+    /// tell it from the others by shape alone. `BlobEvent` carries `blobId`,
+    /// which nothing else does — this pins that down, because the failure mode
+    /// is silent: a mis-deserialised event becomes the WRONG variant rather
+    /// than an error.
+    #[test]
+    fn blob_ready_round_trips_as_a_blob_event() {
+        let event = NodeEvent::Blob(BlobEvent {
+            blob_id: BlobId::from([1_u8; 32]),
+            context_id: ContextId::from([2_u8; 32]),
+            payload: BlobEventPayload::BlobReady(BlobReadyPayload { size: 200_046 }),
+        });
+
+        let json = serde_json::to_string(&event).expect("serialize");
+        assert!(json.contains("\"blobId\""), "got: {json}");
+        assert!(json.contains("\"BlobReady\""), "got: {json}");
+
+        match serde_json::from_str::<NodeEvent>(&json).expect("deserialize") {
+            NodeEvent::Blob(BlobEvent { payload, .. }) => match payload {
+                BlobEventPayload::BlobReady(p) => assert_eq!(p.size, 200_046),
+                other => panic!("wrong payload: {other:?}"),
+            },
+            other => panic!("a blob event deserialized as another variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn blob_unavailable_round_trips_and_keeps_its_reason() {
+        let event = NodeEvent::Blob(BlobEvent {
+            blob_id: BlobId::from([3_u8; 32]),
+            context_id: ContextId::from([4_u8; 32]),
+            payload: BlobEventPayload::BlobUnavailable(BlobUnavailablePayload {
+                reason: "no providers responded".to_owned(),
+            }),
+        });
+
+        let json = serde_json::to_string(&event).expect("serialize");
+        match serde_json::from_str::<NodeEvent>(&json).expect("deserialize") {
+            NodeEvent::Blob(BlobEvent { payload, .. }) => match payload {
+                BlobEventPayload::BlobUnavailable(p) => {
+                    assert_eq!(p.reason, "no providers responded");
+                }
+                other => panic!("wrong payload: {other:?}"),
+            },
+            other => panic!("a blob event deserialized as another variant: {other:?}"),
+        }
     }
 }

--- a/crates/server/src/admin/handlers/blob.rs
+++ b/crates/server/src/admin/handlers/blob.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use axum::body::Body;
 use axum::extract::{Path, Query};
 use axum::http::response::Builder;
-use axum::http::StatusCode;
+use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Extension;
 use calimero_primitives::blobs::{BlobId, BlobInfo, BlobMetadata};
@@ -299,6 +299,52 @@ pub async fn download_handler(
         None
     };
 
+    // `?lazy=true` opts into not waiting.
+    //
+    // The default has to stay synchronous: this endpoint's answer to "fetch a
+    // blob from a peer" is the bytes, and merobox's `download_blob` step, the
+    // mero-js SDK and meroctl all read it that way. Answering `202` by default
+    // would break every one of them, so a caller that can handle "not yet"
+    // says so.
+    //
+    // What changed for everyone is that the synchronous path is now BOUNDED
+    // (see `BLOB_QUERY_TIMEOUT` in the node client). It used to wait on a DHT
+    // query with no timeout, so a wedged lookup held the request until the
+    // process died — which is what left images spinning in a chat client: the
+    // response never came, so the fetch never settled and the client's own
+    // error path never ran either.
+    let lazy = params
+        .get("lazy")
+        .is_some_and(|v| matches!(v.as_str(), "true" | "1"));
+
+    if lazy {
+        // Read locally ONLY — `None` for the context, so this cannot reach the
+        // network and cannot block.
+        if matches!(state.node_client.get_blob(&blob_id, None).await, Ok(None)) {
+            let Some(context_id) = context_id else {
+                return ApiError {
+                    status_code: StatusCode::NOT_FOUND,
+                    message:
+                        "Blob not found locally, and no context was given to discover it through"
+                            .to_owned(),
+                }
+                .into_response();
+            };
+
+            let fetch_state = state.node_client.ensure_blob(blob_id, context_id);
+            info!(%blob_id, %context_id, ?fetch_state, "Blob not local; fetching in background");
+
+            return (
+                StatusCode::ACCEPTED,
+                [(header::CONTENT_TYPE, "application/json")],
+                format!(
+                    r#"{{"status":"fetching","blobId":"{blob_id}","contextId":"{context_id}"}}"#
+                ),
+            )
+                .into_response();
+        }
+    }
+
     let blob_result = state
         .node_client
         .get_blob(&blob_id, context_id.as_ref())
@@ -352,9 +398,11 @@ pub async fn download_handler(
                     .into_response()
                 })
         }
+        // Handled above — a local miss either starts a background fetch (202)
+        // or, with no context to search, answers 404.
         Ok(None) => ApiError {
             status_code: StatusCode::NOT_FOUND,
-            message: "Blob not found locally or in network".to_owned(),
+            message: "Blob not found".to_owned(),
         }
         .into_response(),
         Err(err) => {

--- a/crates/server/src/admin/handlers/blob.rs
+++ b/crates/server/src/admin/handlers/blob.rs
@@ -317,32 +317,29 @@ pub async fn download_handler(
         .get("lazy")
         .is_some_and(|v| matches!(v.as_str(), "true" | "1"));
 
-    if lazy {
-        // Read locally ONLY — `None` for the context, so this cannot reach the
-        // network and cannot block.
-        if matches!(state.node_client.get_blob(&blob_id, None).await, Ok(None)) {
-            let Some(context_id) = context_id else {
-                return ApiError {
-                    status_code: StatusCode::NOT_FOUND,
-                    message:
-                        "Blob not found locally, and no context was given to discover it through"
-                            .to_owned(),
-                }
-                .into_response();
-            };
+    // `has_blob` rather than a local `get_blob`: this only needs to know whether
+    // the bytes are here, and `get_blob` would build a stream just to drop it —
+    // then the serving path below opens the same blob a second time. Both resolve
+    // the same metadata row, so the answer is identical and this one is cheaper.
+    if lazy && !state.node_client.has_blob(&blob_id).unwrap_or(false) {
+        let Some(context_id) = context_id else {
+            return ApiError {
+                status_code: StatusCode::NOT_FOUND,
+                message: "Blob not found locally, and no context was given to discover it through"
+                    .to_owned(),
+            }
+            .into_response();
+        };
 
-            let fetch_state = state.node_client.ensure_blob(blob_id, context_id);
-            info!(%blob_id, %context_id, ?fetch_state, "Blob not local; fetching in background");
+        let fetch_state = state.node_client.ensure_blob(blob_id, context_id);
+        info!(%blob_id, %context_id, ?fetch_state, "Blob not local; fetching in background");
 
-            return (
-                StatusCode::ACCEPTED,
-                [(header::CONTENT_TYPE, "application/json")],
-                format!(
-                    r#"{{"status":"fetching","blobId":"{blob_id}","contextId":"{context_id}"}}"#
-                ),
-            )
-                .into_response();
-        }
+        return (
+            StatusCode::ACCEPTED,
+            [(header::CONTENT_TYPE, "application/json")],
+            format!(r#"{{"status":"fetching","blobId":"{blob_id}","contextId":"{context_id}"}}"#),
+        )
+            .into_response();
     }
 
     let blob_result = state

--- a/crates/server/src/sse/events.rs
+++ b/crates/server/src/sse/events.rs
@@ -102,6 +102,13 @@ pub async fn handle_node_events(
                 NodeEvent::Context(event)
             }
             NodeEvent::Context(_) => continue,
+            // A background blob fetch settled. Routed by the context it was
+            // discovered through, so it reaches exactly the subscribers already
+            // watching that conversation — the ones with an image waiting on it.
+            NodeEvent::Blob(event) if subscriptions.contains(&event.context_id) => {
+                NodeEvent::Blob(event)
+            }
+            NodeEvent::Blob(_) => continue,
             NodeEvent::GroupMembership(event) if group_subscriptions.contains(&event.group_id) => {
                 NodeEvent::GroupMembership(event)
             }

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -455,6 +455,9 @@ async fn fan_out_node_events(state: Arc<ServiceState>) {
         // migration events by group_id.
         let route = match &event {
             NodeEvent::Context(context_event) => EventRoute::Context(context_event.context_id),
+            // Same id-space as a context event: a blob is only ever ready with
+            // respect to the context it was found through.
+            NodeEvent::Blob(blob_event) => EventRoute::Context(blob_event.context_id),
             NodeEvent::GroupMembership(membership_event) => EventRoute::Group {
                 id: membership_event.group_id,
                 admin_only: false,


### PR DESCRIPTION
An image shared in a chat never loaded on the other nodes — it spun forever. Not slow: **forever**.

`NetworkClient::query_blob` awaits a oneshot resolved only when kad reports the query progressed, with no timeout of its own. A lookup that doesn't terminate parks the task for the life of the process, so the HTTP request never answered, so the browser's fetch never settled, so the client's own error path never ran either. A caller can recover from "not found". It cannot recover from silence.

### Three changes, smallest first

**The query is bounded.** `BLOB_QUERY_TIMEOUT` (5s) per attempt, treated exactly like an empty result: back off, retry, and if the attempts run out report the blob as undiscoverable. Generous next to a warm-cluster lookup of a few hundred ms, and far below kad's own query timeout — which is what previously decided how long a caller waited.

**A failed lookup is 404, not 500.** The final attempt returned `Err`, so a blob with no reachable provider answered `500 Internal server error` — indistinguishable, to a client, from the node falling over.

**Waiting is now optional.** `?lazy=true` reads locally, starts discovery in the background and answers `202`; the outcome arrives as `NodeEvent::Blob` (`BlobReady` / `BlobUnavailable`), routed by context so it reaches exactly the subscribers already watching that conversation.

### Why lazy is opt-in

This endpoint's answer to "fetch a blob from a peer" is the bytes, and merobox's `download_blob` step, mero-js and meroctl all read it that way — `blob-cross-node-transfer` asserts the sha256 of a cross-node fetch. Answering `202` by default would break all of them. What changed for existing callers is only that their wait is now **finite**.

Concurrent asks are deduped through an `Arc<DashSet<BlobId>>`: a conversation full of images asks for the same blob once per rendered message, and a virtualised list asks again on every scroll. One fetch serves them all.

### Verified on a live 2-node pair, not just in tests

| | result |
|---|---|
| `?lazy=true`, blob absent | **202 in 1.1ms** (`fetch_state=Started`) |
| background fetch | completed **570ms** later, `size=200046` |
| follow-up read | **200, 200046 bytes, 3ms** |
| 8 concurrent lazy requests | **1 `Started` + 7 `AlreadyFetching`** |
| synchronous, no provider | **404 in 3.6s** — previously an indefinite hang, then 500 |

### One thing deliberately cut

I had every fetcher re-announce the blob so a shared image wouldn't depend forever on one node. Removed in 55ba163: `announce_blob` is a kad `put_record` — one record per key, last writer wins — so fetchers contend for the key, and if the winner later evicts the blob, discovery fails *even though the origin still has it*. I watched a near-miss of that shape while verifying. Real multi-provider discovery wants `start_providing`/`get_providers`, which is a separate change needing a 3-node test.

### Checks

87 + 140 + 327 tests pass, clippy and `cargo check --workspace` clean, fmt via the pinned 1.88 toolchain. Round-trip tests pin the new event's shape — `NodeEvent` is `untagged`, so a variant that isn't distinguishable by shape silently deserialises as the WRONG one rather than erroring.