### PR TITLE
chore(release): 0.11.0-rc.27, the first release carrying hex ids

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.26"
+version = "0.11.0-rc.27"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Cuts `0.11.0-rc.27`, the first core release that spells ids in hex.

## Why now

rc.26 was cut on 2026-08-27 — the day before #3691 removed base58 from every id.
So master and the newest release now disagree about how an id is written, and
**every consumer that tests against "the latest core release" is red on it**:

- **merobox** — the TEE scenarios build merod from the latest release *tag*
  (`build-merod-mock`), so they run a base58 node against the hex-parsing
  client-py 0.6.36 that merobox floors on in
  calimero-network/merobox#389.
- **mero-js** — its e2e downloads the latest release, and the hex assertions
  landed in calimero-network/mero-js#118.

This is the same mismatch that took core's own e2e red, running the other way.
There, an old client read a new node; here, a new client reads an old node.
Neither consumer tracks master, so a release is the only thing that closes it.

## What is in it

Everything on master since rc.26, of which the load-bearing one is #3691:
`Hash`, `ContextId`, `ApplicationId`, `BlobId` and `PublicKey` now render and
parse as 64 lowercase hex, joining `AccountId` and `DeviceId`, and base58 is
gone rather than accepted alongside.

Consumers pinning rc.27 should expect that break. The notable surfaces are the
gossipsub context topic (a mixed-version network partitions silently, with no
error to observe), the blob upload `?hash=` query parameter, and the
ownership-proof payload that mdma verifies byte-for-byte
(calimero-network/mdma#208).

## Version only

One line — `[workspace.metadata.workspaces] version` — which is what the release
workflow reads. Member crates carry `0.0.0` and are managed by cargo-workspaces.
