### PR TITLE
ci: pin merobox 0.6.69, the release that parses hex ids

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -53,7 +53,7 @@ runs:
         # Adding a field to an admin-api response therefore does not reach a
         # scenario until this pin moves. It is the same chain a `crates/client` fix
         # travels, for the same reason.
-        MEROBOX_VERSION="0.6.68"
+        MEROBOX_VERSION="0.6.69"
         TAG="v${MEROBOX_VERSION}"
 
         case "$(uname -m)" in


### PR DESCRIPTION
Last hop of the chain behind #3691 (hex ids everywhere). **This is the PR whose
e2e suite going green closes it out.**

## The chain, for the record

| | |
|---|---|
| #3691 | core stops spelling ids in base58 |
| calimero-client-py#101 | repin + `0.6.36` — the client that parses hex |
| #3692 | `0.11.0-rc.27` — first release carrying hex |
| calimero-network/merobox#389 | `0.6.69`, flooring on client-py 0.6.36 |
| **this** | pin merobox `0.6.69` |

Between #3691 merging and this landing, core's e2e suite has been red on:

```
Client error: buffer provided to decode base58 encoded string into
```

The node was never wrong — it installed the application and reported a hex id.
merobox reaches it through the `calimero-client` compiled into the client-py
wheel it bundles, and until 0.6.69 that wheel base58-decoded the response. The
pin is what moves core onto the release that does not.

## Why it is a deliberate edit

`setup-merobox` pins exactly rather than floating, because a merobox release used
to reach every core CI run within minutes of being cut: when 0.6.59 made unknown
scenario-YAML keys fatal, every open PR went red at once and none had touched a
scenario. So bumping is a hand edit, and the PR making it runs the full suite
against the new version first — which is what this one does.

## Verified before pushing

- `merobox-v0.6.69-linux-x86-64` exists on the release, with its `.sha256`; the
  action downloads that asset by name and checksum-verifies it.
- Rebased onto `8ccfd8479`. The branch was cut before #3691 and #3692 landed, so
  before rebasing its diff against master was the whole hex change **in reverse**
  — it would have reverted both.
