### PR TITLE
chore(release): 0.11.0-rc.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.27"
+version = "0.11.0-rc.28"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Cuts `0.11.0-rc.28`.

Two changes since rc.27 matter to anything that tests against *the latest core release*:

- **#3696** — the example apps move off base58, fixing an intermittent `scaffolding-e2e` blob-id decode failure. It surfaced only when a content hash contained a `0`, since a hex id without one decodes as valid base58 to different bytes.
- **#3697** — `merod account warrant --not-after`, without which a warrant cannot be minted reproducibly.

## Why now rather than at the next routine cut

calimero-network/mero-js's delegated-intent e2e is **silently skipped in its own CI**: `describe.skipIf(!MEROD)`, and `MEROD_BINARY` is set only in core's `sdk-e2e.yml`. So mero-js reports green having run none of it, and nothing structurally prevents that continuing indefinitely.

The fix there is one `env:` line — mero-js's E2E job already downloads merod — but its byte-comparison test invokes `--not-after`, which no released merod carries. This release unblocks it.

Version only: one line in `[workspace.metadata.workspaces]`, which is what the release workflow reads.