### PR TITLE
chore: stop dependabot grouping cargo majors into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,20 @@
 version: 2
 updates:
   # Rust crates (workspace root).
+  #
+  # Patch and minor land as ONE grouped PR; majors get one PR each.
+  #
+  # Grouping everything, majors included, produced a single unreviewable PR of 83
+  # crates spanning hashing, signing, key derivation, the web stack and the on-disk
+  # format (#3656). It could not be landed or even compiled: cargo refuses a package
+  # whose `rust-version` exceeds the toolchain, so it failed before building, and
+  # behind that sat an axum path-syntax change that compiles clean and then 404s.
+  # A sweep that can only be merged all-or-nothing is one nobody can review, and it
+  # blocks the routine patches riding along with it.
+  #
+  # `update-types` here bounds the GROUP, not what dependabot proposes: a major
+  # falls outside the group and opens on its own, which is the reviewable unit for
+  # a breaking change.
   - package-ecosystem: cargo
     directory: "/"
     schedule:
@@ -9,6 +23,7 @@ updates:
     groups:
       cargo:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # GitHub Actions — also keeps the SHA-pinned `uses:` refs current.
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Why

`.github/dependabot.yml` groups every cargo update — majors included — into one PR:

```yaml
groups:
  cargo:
    patterns: ["*"]
```

That produced **#3656: 83 crates in a single diff** (+2621/−1632) spanning hashing, signing, key derivation, the web stack and the on-disk format. It was neither reviewable nor landable:

- It **failed before compiling anything**. Cargo refuses a package whose `rust-version` exceeds the toolchain, and the group wanted up to 1.95 (`wasmer 7.3`), 1.94 (`cranelift`/`wasmtime`) and 1.93.1 (`serial_test 4`). 14 of 15 real jobs went red in seconds.
- Behind that sat changes that pass CI while breaking behaviour: **`axum 0.7 → 0.8`** changes path-param syntax, so all 66 `:id` routes become literal segments — compiles clean, then 404s. **`serde_json_canonicalizer 0.2 → 0.3`** feeds `bundle/src/signature.rs`, i.e. the exact bytes that get signed.
- **`libp2p-identity 0.2 → 0.3` is incoherent on its own**: `libp2p = "0.56"` pins `libp2p-identity 0.2.13`, so the bump puts two incompatible `PeerId` types in the graph.

The cost isn't only review effort. An all-or-nothing sweep also **strands the routine patches** riding along inside it — none of the 40-odd safe bumps could land while the group was blocked.

## The change

```yaml
groups:
  cargo:
    patterns: ["*"]
    update-types: ["minor", "patch"]
```

`update-types` bounds the **group**, not what dependabot proposes. Patch and minor still arrive as one grouped PR; a major falls outside the group and opens on its own — which is the reviewable unit for a breaking change. `open-pull-requests-limit: 10` still caps how many are in flight at once.

## Scope

The other three ecosystems (`github-actions`, `npm`, `docker`) use the same `patterns: ["*"]` shape. The same one-line split would apply, but there's no evidence yet of the same failure there, and for `docker` (digest pins) and SHA-pinned action refs the grouping is arguably correct. Left alone rather than changed on suspicion — happy to extend if you'd prefer consistency.

## Related

- #3666 (merged) removed the MSRV wall by moving the toolchain to 1.98.0, so the bumps in #3656 are now buildable.
- #3656 itself should be **closed rather than rebased** — it's `MERGEABLE/BEHIND`, so a rebase produces a clean tree that is red for exactly the same reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
