### PR TITLE
feat(invite): default admitters to the group's admins and TEE nodes

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -53,7 +53,7 @@ runs:
         # Adding a field to an admin-api response therefore does not reach a
         # scenario until this pin moves. It is the same chain a `crates/client` fix
         # travels, for the same reason.
-        MEROBOX_VERSION="0.6.69"
+        MEROBOX_VERSION="0.6.70"
         TAG="v${MEROBOX_VERSION}"
 
         case "$(uname -m)" in

--- a/crates/context/src/handlers/create_group_invitation.rs
+++ b/crates/context/src/handlers/create_group_invitation.rs
@@ -43,6 +43,19 @@ impl Handler<CreateGroupInvitationRequest> for ContextManager {
                 "create group invitation",
             )?;
 
+            // An invitation nobody restricted is claimable by broadcast, which
+            // publishes it to every subscriber of the namespace topic. Callers
+            // that say nothing get the group's admins and TEE nodes rather than
+            // that, so the exposed case stops being the one you reach by
+            // omission.
+            let admitters = if admitters.is_empty() {
+                calimero_governance_store::NamespaceMembershipService::default_admitters(
+                    &datastore, &group_id,
+                )?
+            } else {
+                admitters
+            };
+
             let private_key = PrivateKey::from(node_sk);
 
             let mut rng = rand::thread_rng();

--- a/crates/governance-store/src/namespace/membership.rs
+++ b/crates/governance-store/src/namespace/membership.rs
@@ -244,6 +244,53 @@ impl<'a> NamespaceMembershipService<'a> {
         );
     }
 
+    /// Who may admit a claim of an invitation the caller did not restrict
+    /// explicitly: the group's current admins, plus every TEE-admitted account.
+    ///
+    /// The point of a default is that an unrestricted invitation stops being the
+    /// easy path. An empty list means "claimable by broadcast", which publishes
+    /// the invitation to every subscriber of the namespace topic — so leaving it
+    /// empty by omission is the one outcome worth designing away.
+    ///
+    /// This is a snapshot, not a live query: the result is signed into the
+    /// invitation, so an admin removed afterwards can still admit until the
+    /// invitation expires. What makes that acceptable is the expiry ceiling —
+    /// the stale window is bounded by `MAX_INVITATION_VALIDITY_SECS`, not by how
+    /// long the group lives. Resolving admitters live at admit time would close
+    /// that window, but it would also mean the joiner could no longer tell from
+    /// the invitation alone who to approach, which is the property that lets it
+    /// reach a node without having synced anything.
+    ///
+    /// TEE nodes are included whatever their role. They are admitters because of
+    /// what they run, not because of what they may do inside the group.
+    ///
+    /// # Errors
+    ///
+    /// When the membership or TEE records cannot be read. An empty result is
+    /// returned as `Ok`, and the caller decides what to do with it — a group
+    /// with no admin and no TEE node is not this function's problem to diagnose.
+    pub fn default_admitters(
+        store: &Store,
+        group_id: &ContextGroupId,
+    ) -> EyreResult<Vec<AccountId>> {
+        // BTreeSet, not Vec: an account that is both an admin and TEE-admitted
+        // would otherwise be named twice, and the list is signed — a duplicate
+        // is a difference in bytes for no difference in meaning.
+        let mut out = std::collections::BTreeSet::new();
+
+        for (account, role) in MembershipRepository::new(store).list(group_id, 0, usize::MAX)? {
+            if role == GroupMemberRole::Admin {
+                let _ = out.insert(account);
+            }
+        }
+
+        for account in crate::tee::tee_admission_records(store, group_id)?.into_keys() {
+            let _ = out.insert(account);
+        }
+
+        Ok(out.into_iter().collect())
+    }
+
     /// The joiner must prove it owns the account the op admits, and the
     /// invitation must be genuinely the inviter's.
     ///

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -359,6 +359,44 @@ fn rewriting_the_admitters_invalidates_the_invitation() {
 }
 
 #[test]
+fn default_admitters_names_admins_and_skips_everybody_else() {
+    let mut rng = rand::rngs::OsRng;
+    let store = test_store();
+    let gid = test_group_id();
+
+    let admin_sk = PrivateKey::random(&mut rng);
+    let admin_account = enrol_member(&store, &gid, &admin_sk.public_key());
+    let reader_sk = PrivateKey::random(&mut rng);
+    let reader_account = enrol_member(&store, &gid, &reader_sk.public_key());
+
+    let repo = MembershipRepository::new(&store);
+    repo.add_member(&gid, &admin_account, GroupMemberRole::Admin)
+        .unwrap();
+    repo.add_member(&gid, &reader_account, GroupMemberRole::ReadOnly)
+        .unwrap();
+
+    let admitters = NamespaceMembershipService::default_admitters(&store, &gid).unwrap();
+
+    // The admin, and only the admin. A read-only member appearing here would
+    // hand admission authority to everyone in the group, which is the opposite
+    // of restricting it.
+    assert_eq!(admitters, vec![admin_account]);
+    assert!(!admitters.contains(&reader_account));
+}
+
+#[test]
+fn default_admitters_is_empty_for_a_group_with_no_admin() {
+    let store = test_store();
+    let gid = test_group_id();
+
+    // Returned as `Ok(vec![])`, not an error: the caller decides. Minting an
+    // invitation nobody can admit is a different problem from failing to read
+    // the membership rows, and collapsing the two would hide the second.
+    let admitters = NamespaceMembershipService::default_admitters(&store, &gid).unwrap();
+    assert!(admitters.is_empty());
+}
+
+#[test]
 fn validate_open_invitation_rejects_expired() {
     let mut rng = rand::rngs::OsRng;
     let store = test_store();


### PR DESCRIPTION
Stacked on #3703 — **merges into `feat/direct-admission`, not master.** Implements the defaulting decision from calimero-network/core#3700.

An invitation nobody restricted is claimable by broadcast, which staples it to a readiness beacon and publishes it as plain borsh on the namespace topic. Any subscriber can read and redeem it, silently — the consumed-invitation row is account-keyed, so a thief and the intended joiner both succeed. Restricting admission only helps if the unrestricted case stops being what you get by saying nothing.

A caller naming no admitters now gets the group's **current admins + every TEE-admitted account**. TEE nodes are included whatever their role: they are admitters because of what they run, not what they may do in the group.

### The snapshot, and why it's safe

The list is signed into the invitation, so it is a snapshot — an admin removed afterwards can still admit until expiry. That is acceptable *only* because #3703 capped expiry at `MAX_INVITATION_VALIDITY_SECS` (24h): the stale window is bounded by the invitation's life, not the group's.

Resolving live at admit time would close that window, at the cost of the property that makes this usable — a joiner that has synced nothing can read who to approach off the invitation alone.

### Behaviour change, and why it isn't in #3703

This changes every invitation. `beacon_admission_provable` refuses a restricted one, so scenarios that join via the readiness beacon take the admitter path instead. That is the intended end state and it is what makes the broadcast claim path deletable — but it needed to not ride in on a PR that was already green and verified.

**This wants the full scenario matrix before merge**, not just the standard checks.

### Verification

`default_admitters` has two tests: admins are named and a read-only member is not (a reader appearing there would hand admission authority to the whole group), and a group with no admin returns `Ok(vec![])` rather than an error. Both pass. Workspace call sites compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)