### PR TITLE
feat(governance): seal a root op under the namespace key (E0)

### DIFF
--- a/crates/context/primitives/src/local_governance/mod.rs
+++ b/crates/context/primitives/src/local_governance/mod.rs
@@ -27,12 +27,13 @@ pub use ack_router::AckRouter;
 #[deprecated(note = "use calimero_governance_types::* directly")]
 pub use calimero_governance_types::{
     hash_scoped_group, hash_scoped_namespace, namespace_op_content_hash, namespace_signable_bytes,
-    op_content_hash, signable_bytes, EncryptedGroupOp, EnvelopeRecipient, GovernanceError, GroupOp,
-    GroupTopicMsg, JoinAccountCredential, KeyEnvelope, KeyRotation, NamespaceOp, NamespaceTopicMsg,
-    OpaqueSkeleton, ReadinessProbe, RootOp, SignableGroupOp, SignableNamespaceOp, SignedAck,
-    SignedGroupOp, SignedMigrationHeartbeat, SignedNamespaceOp, SignedReadinessBeacon,
-    StoredNamespaceEntry, GROUP_GOVERNANCE_SIGN_DOMAIN, NAMESPACE_GOVERNANCE_SIGN_DOMAIN,
-    SIGNED_GROUP_OP_SCHEMA_VERSION, SIGNED_NAMESPACE_OP_SCHEMA_VERSION,
+    op_content_hash, signable_bytes, EncryptedGroupOp, EncryptedRootOp, EnvelopeRecipient,
+    GovernanceError, GroupOp, GroupTopicMsg, JoinAccountCredential, KeyEnvelope, KeyRotation,
+    NamespaceOp, NamespaceTopicMsg, OpaqueSkeleton, ReadinessProbe, RootOp, SignableGroupOp,
+    SignableNamespaceOp, SignedAck, SignedGroupOp, SignedMigrationHeartbeat, SignedNamespaceOp,
+    SignedReadinessBeacon, StoredNamespaceEntry, GROUP_GOVERNANCE_SIGN_DOMAIN,
+    NAMESPACE_GOVERNANCE_SIGN_DOMAIN, SIGNED_GROUP_OP_SCHEMA_VERSION,
+    SIGNED_NAMESPACE_OP_SCHEMA_VERSION,
 };
 
 // `SignableReadinessBeacon` was only exported via `wire::*` in the old

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use calimero_account::{AccountId, DeviceId, KemPublicKey};
 use calimero_context_client::local_governance::{
-    EncryptedGroupOp, EnvelopeRecipient, GroupOp, KeyEnvelope, KeyRotation,
+    EncryptedGroupOp, EncryptedRootOp, EnvelopeRecipient, GroupOp, KeyEnvelope, KeyRotation, RootOp,
 };
 use calimero_context_config::types::ContextGroupId;
 use calimero_crypto::{X25519PublicKey, X25519SecretKey};
@@ -411,6 +411,68 @@ impl<'a> GroupKeyring<'a> {
             }
         }
         Ok(false)
+    }
+
+    /// Seal a [`RootOp`] under the namespace key.
+    ///
+    /// The caller picks the key and is responsible for it being the namespace's,
+    /// not a subgroup's — a root op sealed under a subgroup key would decrypt for
+    /// a strict subset of the members entitled to read it, and would look correct
+    /// at every step until some member could not fold namespace structure.
+    ///
+    /// Only the five admin-published variants are sealable; see
+    /// [`EncryptedRootOp`] for why the joins, `KeyDelivery` and
+    /// `NamespaceCreated` are not. This function does not enforce that: E1 gates
+    /// it at the publisher, where the decision belongs, and sealing a join here
+    /// would fail later at a point far from the cause.
+    ///
+    /// # Errors
+    ///
+    /// When borsh encoding or AEAD sealing fails.
+    pub fn encrypt_root_op(namespace_key: &[u8; 32], op: &RootOp) -> EyreResult<EncryptedRootOp> {
+        use calimero_crypto::SharedKey;
+
+        let plaintext = borsh::to_vec(op).map_err(|e| eyre::eyre!("borsh encode RootOp: {e}"))?;
+        let sk = PrivateKey::from(*namespace_key);
+        let shared_key = SharedKey::from_sk(&sk);
+
+        let (nonce, ciphertext) = shared_key
+            .encrypt(plaintext)
+            .ok_or(KeyringError::EncryptionFailed)?;
+
+        Ok(EncryptedRootOp { nonce, ciphertext })
+    }
+
+    /// Open a [`RootOp`] sealed by [`Self::encrypt_root_op`].
+    ///
+    /// A failure here is not necessarily corruption: the ordinary case is a node
+    /// that does not hold the key yet, which must buffer and retry on key
+    /// delivery rather than treat the op as invalid. Callers that cannot tell
+    /// those apart will drop ops a joiner needs.
+    ///
+    /// # Errors
+    ///
+    /// When AEAD opening fails (wrong key, or a tampered nonce/ciphertext), or
+    /// when the plaintext does not decode as a current-schema `RootOp`.
+    pub fn decrypt_root_op(
+        namespace_key: &[u8; 32],
+        encrypted: &EncryptedRootOp,
+    ) -> EyreResult<RootOp> {
+        use calimero_crypto::SharedKey;
+
+        let sk = PrivateKey::from(*namespace_key);
+        let shared_key = SharedKey::from_sk(&sk);
+        let plaintext = shared_key
+            .decrypt(encrypted.ciphertext.clone(), encrypted.nonce)
+            .ok_or(KeyringError::DecryptionFailed)?;
+        borsh::from_slice(&plaintext).map_err(|e| {
+            tracing::warn!(
+                plaintext_len = plaintext.len(),
+                prefix = ?plaintext.first(),
+                "decrypted root op does not match the current RootOp schema"
+            );
+            eyre::eyre!("borsh decode RootOp: {e}")
+        })
     }
 
     pub fn encrypt_op(group_key: &[u8; 32], op: &GroupOp) -> EyreResult<EncryptedGroupOp> {
@@ -1854,5 +1916,113 @@ mod delete_tests {
             val.insertion_seq, 0,
             "the rewrite must carry the original insertion sequence over"
         );
+    }
+}
+
+#[cfg(test)]
+mod root_op_sealing_tests {
+    use super::*;
+
+    fn sealable_root_ops() -> Vec<(&'static str, RootOp)> {
+        let gid = ContextGroupId::from([7u8; 32]);
+        let account = AccountId::from([9u8; 32]);
+        vec![
+            (
+                "GroupCreated",
+                RootOp::GroupCreated {
+                    group_id: gid,
+                    parent_id: ContextGroupId::from([1u8; 32]),
+                    restricted: true,
+                    admin: account,
+                },
+            ),
+            (
+                "GroupReparented",
+                RootOp::GroupReparented {
+                    child_group_id: gid,
+                    new_parent_id: ContextGroupId::from([2u8; 32]),
+                },
+            ),
+            (
+                "GroupDeleted",
+                RootOp::GroupDeleted {
+                    root_group_id: gid,
+                    cascade_group_ids: vec![ContextGroupId::from([3u8; 32])],
+                    cascade_context_ids: Vec::new(),
+                },
+            ),
+            ("AdminChanged", RootOp::AdminChanged { new_admin: account }),
+            (
+                "PolicyUpdated",
+                RootOp::PolicyUpdated {
+                    policy_bytes: vec![1, 2, 3, 4],
+                },
+            ),
+        ]
+    }
+
+    #[test]
+    fn every_sealable_root_op_survives_a_round_trip() {
+        let key = [5u8; 32];
+        for (name, op) in sealable_root_ops() {
+            let sealed = GroupKeyring::encrypt_root_op(&key, &op).expect(name);
+            let opened = GroupKeyring::decrypt_root_op(&key, &sealed).expect(name);
+            // Compared as borsh: RootOp has no PartialEq, and the bytes are what
+            // the receiver actually folds.
+            assert_eq!(
+                borsh::to_vec(&op).unwrap(),
+                borsh::to_vec(&opened).unwrap(),
+                "{name} did not survive sealing"
+            );
+            // The plaintext must not be recoverable from the ciphertext.
+            assert_ne!(
+                sealed.ciphertext,
+                borsh::to_vec(&op).unwrap(),
+                "{name} was stored in the clear"
+            );
+        }
+    }
+
+    #[test]
+    fn a_root_op_does_not_open_under_the_wrong_key() {
+        let (_, op) = sealable_root_ops().remove(3);
+        let sealed = GroupKeyring::encrypt_root_op(&[5u8; 32], &op).unwrap();
+        assert!(
+            GroupKeyring::decrypt_root_op(&[6u8; 32], &sealed).is_err(),
+            "a non-member's key opened a root op"
+        );
+    }
+
+    #[test]
+    fn a_tampered_root_op_does_not_open() {
+        let (_, op) = sealable_root_ops().remove(4);
+        let key = [5u8; 32];
+
+        let mut flipped_ciphertext = GroupKeyring::encrypt_root_op(&key, &op).unwrap();
+        flipped_ciphertext.ciphertext[0] ^= 0x01;
+        assert!(
+            GroupKeyring::decrypt_root_op(&key, &flipped_ciphertext).is_err(),
+            "a flipped ciphertext bit still opened — the payload is not authenticated"
+        );
+
+        let mut flipped_nonce = GroupKeyring::encrypt_root_op(&key, &op).unwrap();
+        flipped_nonce.nonce[0] ^= 0x01;
+        assert!(
+            GroupKeyring::decrypt_root_op(&key, &flipped_nonce).is_err(),
+            "a flipped nonce bit still opened"
+        );
+    }
+
+    #[test]
+    fn sealing_the_same_op_twice_differs() {
+        // A fresh nonce per sealing. Identical ciphertext for identical input
+        // would let an observer match repeated governance actions without
+        // holding the key.
+        let key = [5u8; 32];
+        let (_, op) = sealable_root_ops().remove(1);
+        let a = GroupKeyring::encrypt_root_op(&key, &op).unwrap();
+        let b = GroupKeyring::encrypt_root_op(&key, &op).unwrap();
+        assert_ne!(a.nonce, b.nonce, "nonce reused across two sealings");
+        assert_ne!(a.ciphertext, b.ciphertext, "ciphertext is deterministic");
     }
 }

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -984,6 +984,32 @@ impl NamespaceOp {
     }
 }
 
+/// An encrypted root operation payload. Only namespace members — who hold the
+/// namespace key — can decrypt the inner [`RootOp`].
+///
+/// Structurally identical to [`EncryptedGroupOp`] and deliberately a separate
+/// type: the two are sealed under different keys (namespace vs group), and one
+/// alias for both would let a mistake at a call site typecheck.
+///
+/// Carries no key id of its own. The enclosing op variant does, exactly as
+/// [`NamespaceOp::Group`] does for a group op, so rotation stays resolvable by
+/// `load_key_by_id` rather than by guessing the current key.
+///
+/// **Not every root op can be sealed.** The four `MemberJoined*` variants are
+/// published by a principal that does not hold the key yet; `KeyDelivery` is how
+/// the key arrives, so sealing it under that key is unsatisfiable; and
+/// `NamespaceCreated` is genesis, before any key exists. What remains —
+/// `GroupCreated`, `GroupReparented`, `GroupDeleted`, `AdminChanged`,
+/// `PolicyUpdated` — is published by an admin who is already a member, so no
+/// non-member has any business reading it.
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+pub struct EncryptedRootOp {
+    /// 12-byte AES-GCM nonce.
+    pub nonce: [u8; 12],
+    /// `AES-256-GCM(borsh(RootOp))` using the namespace key.
+    pub ciphertext: Vec<u8>,
+}
+
 /// An encrypted group operation payload. Only members of the group
 /// (who possess the group key) can decrypt the inner [`GroupOp`].
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]


### PR DESCRIPTION
Step **E0** of #3700. Additive: the primitives for encrypting root ops, with no publisher change and no wire change, so it can land while the rest of that plan is staged.

## Design decisions worth reviewing

**`EncryptedRootOp` is a separate type, not an alias for `EncryptedGroupOp`.** They are structurally identical and sealed under *different keys* — namespace versus group. One type for both would let a mistake at a call site typecheck.

**It carries no key id.** The enclosing op variant does, exactly as `NamespaceOp::Group` does for a group op, so rotation stays resolvable by `load_key_by_id` rather than by guessing which key is current.

**`encrypt_root_op` does not enforce which variants are sealable.** E1 gates that at the publisher, where the decision belongs. Enforcing here would fail much later and far from the cause.

## Only 5 of 11 `RootOp` variants can be sealed

| category | variants | sealable |
|---|---|---|
| joins | `MemberJoined`, `MemberJoinedOpen`, `MemberJoinedAt`, `MemberJoinedViaTeeAttestation` | no — publisher holds no key yet |
| structural / policy | `GroupCreated`, `GroupReparented`, `GroupDeleted`, `AdminChanged`, `PolicyUpdated` | **yes** |
| bootstrap | `KeyDelivery`, `NamespaceCreated` | no |

`KeyDelivery` is *how the key arrives*, so sealing it under that key is unsatisfiable — and it needs no sealing, since its payload is already sealed to the recipient in `KeyEnvelope`. `NamespaceCreated` is genesis, before any key exists.

I originally described this as "the five non-join root ops"; that was wrong, and the correction is on the issue. The end state is not "every op encrypted" but "every op except four joins and two bootstrap ops, each excluded because the key it would need cannot exist yet."

## `decrypt_root_op`'s failure mode is documented deliberately

A failure there ordinarily means *this node does not hold the key yet* — not corruption. A caller that conflates the two will drop ops a joiner needs. That distinction is what E2 has to get right.

## Tests (4, all passing on this base)

- every sealable variant round-trips, and none is stored in the clear
- a wrong key does not open one
- a flipped ciphertext **or nonce** bit does not open one — the payload is authenticated, not merely encrypted
- two sealings of the same op differ; deterministic ciphertext would let an observer without the key match repeated governance actions

Confirmed on this base rather than assumed: the earlier pass was pre-rebase, and `cargo check` (330 crates, clean) is not `cargo test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)