### PR TITLE
ci(dependabot): drop the lockstep group comment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,8 +21,6 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     groups:
-      # Families that version in lockstep, matched first so no member is ever bumped alone:
-      # each appears in the others' public API, so a lone bump lands two incompatible types.
       wasmer:
         patterns: ["wasmer", "wasmer-*"]
       libp2p:


### PR DESCRIPTION
## Summary

Removes the two-line comment above the `wasmer`, `libp2p` and `tower` dependabot groups added in #3719. The groups themselves, and their declaration order ahead of the catch-all, are unchanged.

## Test plan

- `.github/dependabot.yml` still parses, and group order is preserved: `[['wasmer', 'libp2p', 'tower', 'cargo'], ['actions'], ['npm'], ['docker']]`
- Comment-only change; no behaviour to test.