### PR TITLE
feat(governance): a sealed root-op variant, and one place that decides (E1a)

### DIFF
--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -3,7 +3,8 @@ use crate::{
 };
 use calimero_account::{AccountId, DeviceId, KemPublicKey};
 use calimero_context_client::local_governance::{
-    EncryptedGroupOp, EncryptedRootOp, EnvelopeRecipient, GroupOp, KeyEnvelope, KeyRotation, RootOp,
+    EncryptedGroupOp, EncryptedRootOp, EnvelopeRecipient, GroupOp, KeyEnvelope, KeyId, KeyRotation,
+    NamespaceOp, RootOp,
 };
 use calimero_context_config::types::ContextGroupId;
 use calimero_crypto::{X25519PublicKey, X25519SecretKey};
@@ -441,6 +442,44 @@ impl<'a> GroupKeyring<'a> {
             .ok_or(KeyringError::EncryptionFailed)?;
 
         Ok(EncryptedRootOp { nonce, ciphertext })
+    }
+
+    /// Prepare a root op for publishing: sealed if policy says so, cleartext if
+    /// not.
+    ///
+    /// Every publisher of a root op goes through here, so the decision about
+    /// which variants are sealed is made once rather than at each of the ten
+    /// sites that construct one. A per-site choice is a per-site opportunity to
+    /// disagree with the receiver, and that disagreement does not present as a
+    /// policy difference — it presents as a decode failure on a valid op.
+    ///
+    /// The seal happens before signing, necessarily: the signature covers the
+    /// `NamespaceOp`, so sealing after signing produces an op whose signature
+    /// verifies against bytes nobody sent.
+    ///
+    /// # Errors
+    ///
+    /// When sealing fails, or when a sealable op is offered with no key. The
+    /// latter is refused rather than silently published in the clear — an admin
+    /// publishing a governance change always holds the namespace key, so a
+    /// missing key is a broken assumption, and answering it by publishing
+    /// cleartext would quietly undo the encryption for that op.
+    pub fn prepare_root_op_for_publish(
+        namespace_key: Option<&[u8; 32]>,
+        key_id: KeyId,
+        op: RootOp,
+    ) -> EyreResult<NamespaceOp> {
+        if !calimero_governance_types::root_op_is_sealable(&op) {
+            return Ok(NamespaceOp::Root(op));
+        }
+        let Some(key) = namespace_key else {
+            eyre::bail!(
+                "refusing to publish a sealable root op in the clear: no namespace key was \
+                 available, which an admin publishing a governance change always holds"
+            );
+        };
+        let encrypted = Self::encrypt_root_op(key, &op)?;
+        Ok(NamespaceOp::RootSealed { key_id, encrypted })
     }
 
     /// Open a [`RootOp`] sealed by [`Self::encrypt_root_op`].

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -3,11 +3,12 @@ use crate::{
 };
 use calimero_account::{AccountId, DeviceId, KemPublicKey};
 use calimero_context_client::local_governance::{
-    EncryptedGroupOp, EncryptedRootOp, EnvelopeRecipient, GroupOp, KeyEnvelope, KeyId, KeyRotation,
+    EncryptedGroupOp, EncryptedRootOp, EnvelopeRecipient, GroupOp, KeyEnvelope, KeyRotation,
     NamespaceOp, RootOp,
 };
 use calimero_context_config::types::ContextGroupId;
 use calimero_crypto::{X25519PublicKey, X25519SecretKey};
+use calimero_governance_types::KeyId;
 use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_store::key::{GroupKeyEntry, GroupKeyValue, GROUP_KEY_PREFIX};
 use calimero_store::Store;

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -683,6 +683,67 @@ pub enum NamespaceOp {
         /// the removed member cannot read it.
         key_rotation: Option<KeyRotation>,
     },
+    /// A root op sealed under the namespace key.
+    ///
+    /// Appended rather than inserted: borsh numbers variants by position, so
+    /// `Root` and `Group` keep discriminants 0 and 1 and every existing op
+    /// encodes byte-identically. Only a sealed op is new on the wire, and an
+    /// older node fails to decode it rather than misreading it — borsh rejects
+    /// an unknown discriminant outright.
+    ///
+    /// Carries `key_id` for the same reason [`NamespaceOp::Group`] does: after a
+    /// rotation the receiver holds more than one namespace key, and resolving by
+    /// id is the difference between decrypting the op and guessing.
+    ///
+    /// Only the five admin-published variants reach here; see
+    /// [`root_op_is_sealable`].
+    RootSealed {
+        key_id: KeyId,
+        encrypted: EncryptedRootOp,
+    },
+}
+
+/// Whether a [`RootOp`] is published sealed.
+///
+/// Five of the eleven variants are. The four `MemberJoined*` are published by a
+/// principal that does not hold the key yet; `KeyDelivery` is how the key
+/// arrives, so sealing it under that key is unsatisfiable — and it needs no
+/// sealing, since its payload is already sealed to the recipient inside
+/// `KeyEnvelope`; `NamespaceCreated` is genesis, before any key exists.
+///
+/// What remains is published by an admin who already holds the key and read by
+/// members who already hold it, so nothing about it needs to be legible to a
+/// non-member.
+///
+/// This is the single place that decision lives. A publisher that seals by its
+/// own judgement can disagree with the receiver about which ops are sealed, and
+/// that disagreement reads as a decode failure on a valid op rather than as a
+/// policy difference.
+/// Written as an exhaustive match with no wildcard, deliberately. `matches!`
+/// would read the same and behave differently on the next variant added: it
+/// would answer `false`, so a new root op that ought to be sealed would ship in
+/// the clear and nothing would say so. This way it does not compile until
+/// somebody decides.
+#[must_use]
+pub const fn root_op_is_sealable(op: &RootOp) -> bool {
+    match op {
+        // Published by an admin who already holds the namespace key.
+        RootOp::GroupCreated { .. }
+        | RootOp::GroupReparented { .. }
+        | RootOp::GroupDeleted { .. }
+        | RootOp::AdminChanged { .. }
+        | RootOp::PolicyUpdated { .. } => true,
+        // Published by a principal that does not hold the key yet.
+        RootOp::MemberJoined { .. }
+        | RootOp::MemberJoinedAt { .. }
+        | RootOp::MemberJoinedOpen { .. }
+        | RootOp::MemberJoinedViaTeeAttestation { .. } => false,
+        // How the key arrives; sealing it under that key is unsatisfiable, and
+        // its payload is already sealed to the recipient in `KeyEnvelope`.
+        RootOp::KeyDelivery { .. } => false,
+        // Genesis, before any key exists.
+        RootOp::NamespaceCreated { .. } => false,
+    }
 }
 
 /// Cleartext administrative operations that affect the entire namespace.
@@ -966,6 +1027,11 @@ impl NamespaceOp {
     #[must_use]
     pub fn op_kind_label(&self) -> &'static str {
         match self {
+            // Sealed ops collapse to one label: the kind is inside the
+            // ciphertext. Metrics broken down by root-op kind lose that
+            // breakdown for the five sealed variants, which is a real cost of
+            // sealing them and not an oversight here.
+            NamespaceOp::RootSealed { .. } => "root_sealed",
             NamespaceOp::Root(RootOp::GroupCreated { .. }) => "group_created",
             NamespaceOp::Root(RootOp::GroupReparented { .. }) => "group_reparented",
             NamespaceOp::Root(RootOp::GroupDeleted { .. }) => "group_deleted",
@@ -1351,7 +1417,11 @@ impl SignedNamespaceOp {
     pub fn group_id(&self) -> Option<ContextGroupId> {
         match &self.op {
             NamespaceOp::Group { group_id, .. } => Some(*group_id),
-            NamespaceOp::Root(_) => None,
+            // A sealed root op may name a group inside — `GroupCreated` does —
+            // but not readably, and answering from the envelope would mean
+            // answering `None` for an op that has one. Callers that need it must
+            // decrypt first.
+            NamespaceOp::Root(_) | NamespaceOp::RootSealed { .. } => None,
         }
     }
 }
@@ -1508,6 +1578,23 @@ impl KeyRotation {
     }
 }
 
+impl EncryptedRootOp {
+    /// Bound the ciphertext, the only thing checkable without the key.
+    ///
+    /// The inner op's own `validate` cannot run here — it needs the plaintext, so
+    /// for a sealed op it runs after decryption instead of before apply. A
+    /// receiver that decrypts and skips it loses validation entirely for the five
+    /// sealed variants, silently, because nothing else in the pipeline notices
+    /// that a check moved.
+    pub fn validate(&self) -> Result<(), GovernanceError> {
+        check_bound(
+            "encrypted_root_op.ciphertext",
+            self.ciphertext.len(),
+            bounds::MAX_CIPHERTEXT_BYTES,
+        )
+    }
+}
+
 impl EncryptedGroupOp {
     /// Bound the ciphertext of an encrypted group op.
     pub fn validate(&self) -> Result<(), GovernanceError> {
@@ -1620,6 +1707,9 @@ impl NamespaceOp {
     fn validate(&self) -> Result<(), GovernanceError> {
         match self {
             Self::Root(root) => root.validate(),
+            // Only the envelope. The inner op is validated after decryption —
+            // see `EncryptedRootOp::validate`.
+            Self::RootSealed { encrypted, .. } => encrypted.validate(),
             Self::Group {
                 encrypted,
                 key_rotation,

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -1766,3 +1766,117 @@ fn emit_golden_root_op_vectors() {
         println!("{bytes:?}");
     }
 }
+
+// ---------------------------------------------------------------------------
+// E1: sealing root ops
+// ---------------------------------------------------------------------------
+
+/// The claim that makes appending `RootSealed` safe: existing ops encode exactly
+/// as before.
+///
+/// Borsh numbers enum variants by declaration position, so appending is only
+/// safe while nothing is inserted ahead of the existing two. Pinned as bytes
+/// rather than trusted, because the failure is silent in the worst way — every
+/// op id in the namespace changes, and the first symptom is peers disagreeing
+/// about history rather than anything refusing to decode.
+#[test]
+fn appending_root_sealed_left_the_existing_discriminants_alone() {
+    let root = NamespaceOp::Root(RootOp::AdminChanged {
+        new_admin: calimero_account::AccountId::from([3u8; 32]),
+    });
+    let group = NamespaceOp::Group {
+        group_id: ContextGroupId::from([4u8; 32]),
+        key_id: KeyId::from([5u8; 32]),
+        encrypted: EncryptedGroupOp {
+            nonce: [6u8; 12],
+            ciphertext: vec![7, 8, 9],
+        },
+        key_rotation: None,
+    };
+    let sealed = NamespaceOp::RootSealed {
+        key_id: KeyId::from([5u8; 32]),
+        encrypted: EncryptedRootOp {
+            nonce: [6u8; 12],
+            ciphertext: vec![7, 8, 9],
+        },
+    };
+
+    assert_eq!(borsh::to_vec(&root).unwrap()[0], 0, "Root must stay 0");
+    assert_eq!(borsh::to_vec(&group).unwrap()[0], 1, "Group must stay 1");
+    assert_eq!(
+        borsh::to_vec(&sealed).unwrap()[0],
+        2,
+        "RootSealed must be appended, never inserted"
+    );
+}
+
+/// A sealed op and a group op with identical payloads must not encode alike.
+///
+/// They carry the same fields in the same order, so only the discriminant tells
+/// them apart. A receiver that read one as the other would look up the right key
+/// id in the wrong keyring and report a missing key rather than a mismatch.
+#[test]
+fn a_sealed_root_op_is_distinguishable_from_a_group_op() {
+    let key_id = KeyId::from([5u8; 32]);
+    let nonce = [6u8; 12];
+    let ciphertext = vec![7, 8, 9];
+
+    let sealed = borsh::to_vec(&NamespaceOp::RootSealed {
+        key_id,
+        encrypted: EncryptedRootOp {
+            nonce,
+            ciphertext: ciphertext.clone(),
+        },
+    })
+    .unwrap();
+    let group = borsh::to_vec(&NamespaceOp::Group {
+        group_id: ContextGroupId::from([5u8; 32]),
+        key_id,
+        encrypted: EncryptedGroupOp { nonce, ciphertext },
+        key_rotation: None,
+    })
+    .unwrap();
+
+    assert_ne!(sealed, group);
+}
+
+/// Every variant's sealability, asserted against the reasons rather than the
+/// implementation.
+///
+/// `root_op_is_sealable` is an exhaustive match, so a twelfth variant fails to
+/// compile until it is classified. This test states what the classification has
+/// to be for the five that carry no bootstrap constraint, so a future edit that
+/// reclassifies one has to argue with a test rather than only with a reviewer.
+#[test]
+fn only_the_admin_published_variants_are_sealable() {
+    assert!(root_op_is_sealable(&RootOp::AdminChanged {
+        new_admin: calimero_account::AccountId::from([1u8; 32]),
+    }));
+    assert!(root_op_is_sealable(&RootOp::PolicyUpdated {
+        policy_bytes: vec![1, 2, 3],
+    }));
+    assert!(root_op_is_sealable(&RootOp::GroupReparented {
+        child_group_id: ContextGroupId::from([2u8; 32]),
+        new_parent_id: ContextGroupId::from([3u8; 32]),
+    }));
+    assert!(root_op_is_sealable(&RootOp::GroupDeleted {
+        root_group_id: ContextGroupId::from([2u8; 32]),
+        cascade_group_ids: vec![],
+        cascade_context_ids: vec![],
+    }));
+    assert!(root_op_is_sealable(&RootOp::GroupCreated {
+        group_id: ContextGroupId::from([2u8; 32]),
+        parent_id: ContextGroupId::from([3u8; 32]),
+        restricted: true,
+        admin: calimero_account::AccountId::from([4u8; 32]),
+    }));
+
+    // `NamespaceCreated` is genesis: there is no namespace key yet to seal it
+    // under, and this op's own apply is what establishes the founder. Asserted
+    // because it is the variant most likely to look sealable to a future reader
+    // — it is admin-published, like the five, and differs only in when it runs.
+    assert!(!root_op_is_sealable(&RootOp::NamespaceCreated {
+        founder: calimero_account::AccountId::from([5u8; 32]),
+        account: deterministic_credential(),
+    }));
+}


### PR DESCRIPTION
Step **E1a** of #3700 — the wire and publisher plumbing for sealing root ops. **Nothing seals yet** (no publisher is switched over), so this is behaviour-neutral alone.

## Appended, not inserted

```rust
enum NamespaceOp { Root(RootOp), Group{..}, RootSealed{key_id, encrypted} }
```

Borsh numbers variants by position, so `Root` and `Group` keep 0 and 1 and **every existing op encodes byte-identically**. Only a sealed op is new on the wire, and an older node fails to decode it rather than misreading it.

Pinned as bytes in a test, not trusted: inserting ahead of the existing two would change **every op id in the namespace**, and the first symptom would be peers disagreeing about history rather than anything refusing to decode.

This also makes E1 a smaller change than I originally scoped it as — I'd said "schema version bump + re-bootstrap", and appending may not need the version bump at all. Worth a reviewer's opinion.

## The policy is exhaustive on purpose

I wrote `root_op_is_sealable` with `matches!` first. It reads identically and behaves differently on the next variant added: it answers `false`, so **a new root op that ought to be sealed would ship in the clear and nothing would say so.** It's now an exhaustive match that doesn't compile until someone classifies the new variant.

All eleven carry their reason:

| | |
|---|---|
| `GroupCreated`, `GroupReparented`, `GroupDeleted`, `AdminChanged`, `PolicyUpdated` | sealable — admin-published, key already held |
| the four `MemberJoined*` | publisher holds no key yet |
| `KeyDelivery` | it *is* how the key arrives; payload already sealed via `KeyEnvelope` |
| `NamespaceCreated` | genesis, before any key exists |

## One choke point, not ten call sites

Ten sites construct a root op. `publish_and_await_ack_namespace` takes an *already-signed* op, so sealing can't live there — the signature covers the op.

So `prepare_root_op_for_publish` is the only place that seals. A per-site decision is a per-site chance to disagree with the receiver, and that disagreement presents as **a decode failure on a valid op**, not as a policy difference. (Directly the lesson from #3717's sibling bug, where a field added to a shared request struct was silently dropped by two of three handlers.)

It **refuses** a sealable op offered with no key rather than publishing cleartext — an admin publishing a governance change always holds the namespace key, so a missing key is a broken assumption, and falling back would quietly unseal exactly that op.

## Two costs the variant makes real

Recorded where they land, rather than discovered later:

- **Validation moves.** `validate` can only bound the ciphertext, so the inner op's validation shifts from decode-time to post-decrypt. A receiver that decrypts and skips it **loses validation for all five variants, silently** — nothing else notices a check relocating. This is a constraint on E1b.
- **Metrics lose a breakdown.** `op_kind_label` collapses sealed ops to `"root_sealed"`, so dashboards broken down by root-op kind lose the five. A real trade, not an oversight.

## Ordering correction for the rest of E1

I originally wrote E1 as "publisher seals, receiver accepts both" as one step. Split across PRs that's the wrong order — **the receiver must accept sealed ops before any publisher emits them**:

- **E1a** (this) — types, policy, helper. Safe alone.
- **E1b** — receiver decodes sealed, re-validating post-decrypt.
- **E1c** — publishers route through the helper.

## Verification status — please read

3 tests written (discriminant stability, sealed-vs-group distinguishability, per-variant classification). `governance-types` compiles clean.

**The tests have not run and the workspace check has not completed.** Both are queued on a shared build cache with 5.3Gi disk free; the workspace check has been running 21 minutes. I'm relying on CI rather than reporting a local green I don't have. See #3694 for the disk issue behind this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)