### PR TITLE
feat(governance): apply a sealed root op, and validate it after unsealing (E1b)

### DIFF
--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -3,7 +3,8 @@ use crate::{
 };
 use calimero_account::{AccountId, DeviceId, KemPublicKey};
 use calimero_context_client::local_governance::{
-    EncryptedGroupOp, EncryptedRootOp, EnvelopeRecipient, GroupOp, KeyEnvelope, KeyRotation, RootOp,
+    EncryptedGroupOp, EncryptedRootOp, EnvelopeRecipient, GroupOp, KeyEnvelope, KeyId, KeyRotation,
+    NamespaceOp, RootOp,
 };
 use calimero_context_config::types::ContextGroupId;
 use calimero_crypto::{X25519PublicKey, X25519SecretKey};
@@ -441,6 +442,44 @@ impl<'a> GroupKeyring<'a> {
             .ok_or(KeyringError::EncryptionFailed)?;
 
         Ok(EncryptedRootOp { nonce, ciphertext })
+    }
+
+    /// Prepare a root op for publishing: sealed if policy says so, cleartext if
+    /// not.
+    ///
+    /// Every publisher of a root op goes through here, so the decision about
+    /// which variants are sealed is made once rather than at each of the ten
+    /// sites that construct one. A per-site choice is a per-site opportunity to
+    /// disagree with the receiver, and that disagreement does not present as a
+    /// policy difference — it presents as a decode failure on a valid op.
+    ///
+    /// The seal happens before signing, necessarily: the signature covers the
+    /// `NamespaceOp`, so sealing after signing produces an op whose signature
+    /// verifies against bytes nobody sent.
+    ///
+    /// # Errors
+    ///
+    /// When sealing fails, or when a sealable op is offered with no key. The
+    /// latter is refused rather than silently published in the clear — an admin
+    /// publishing a governance change always holds the namespace key, so a
+    /// missing key is a broken assumption, and answering it by publishing
+    /// cleartext would quietly undo the encryption for that op.
+    pub fn prepare_root_op_for_publish(
+        namespace_key: Option<&[u8; 32]>,
+        key_id: KeyId,
+        op: RootOp,
+    ) -> EyreResult<NamespaceOp> {
+        if !calimero_governance_types::root_op_is_sealable(&op) {
+            return Ok(NamespaceOp::Root(op));
+        }
+        let Some(key) = namespace_key else {
+            eyre::bail!(
+                "refusing to publish a sealable root op in the clear: no namespace key was \
+                 available, which an admin publishing a governance change always holds"
+            );
+        };
+        let encrypted = Self::encrypt_root_op(key, &op)?;
+        Ok(NamespaceOp::RootSealed { key_id, encrypted })
     }
 
     /// Open a [`RootOp`] sealed by [`Self::encrypt_root_op`].

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -1963,6 +1963,92 @@ mod delete_tests {
 mod root_op_sealing_tests {
     use super::*;
 
+    // ---- E1: the publish choke point ----
+
+    #[test]
+    fn a_sealable_op_comes_back_sealed_and_opens_to_the_same_bytes() {
+        let key = [5u8; 32];
+        let key_id = KeyId::from([9u8; 32]);
+        let op = RootOp::AdminChanged {
+            new_admin: AccountId::from([1u8; 32]),
+        };
+        let expected = borsh::to_vec(&op).unwrap();
+
+        let prepared =
+            GroupKeyring::prepare_root_op_for_publish(Some(&key), key_id, op).expect("prepare");
+
+        let NamespaceOp::RootSealed {
+            key_id: got_id,
+            encrypted,
+        } = prepared
+        else {
+            panic!("a sealable op must be sealed");
+        };
+        // The id travels with the ciphertext. Without it a receiver holding two
+        // namespace keys after a rotation has to guess which one to try.
+        assert_eq!(got_id, key_id);
+
+        let opened = GroupKeyring::decrypt_root_op(&key, &encrypted).expect("decrypt");
+        assert_eq!(borsh::to_vec(&opened).unwrap(), expected);
+    }
+
+    #[test]
+    fn a_non_sealable_op_passes_through_in_the_clear() {
+        // `NamespaceCreated` is genesis: there is no key yet, so it must survive
+        // the choke point untouched even when one is offered.
+        let prepared = GroupKeyring::prepare_root_op_for_publish(
+            Some(&[5u8; 32]),
+            KeyId::from([9u8; 32]),
+            RootOp::NamespaceCreated {
+                founder: AccountId::from([2u8; 32]),
+                account: deterministic_join_credential(),
+            },
+        )
+        .expect("prepare");
+
+        assert!(matches!(
+            prepared,
+            NamespaceOp::Root(RootOp::NamespaceCreated { .. })
+        ));
+    }
+
+    #[test]
+    fn a_sealable_op_with_no_key_is_refused_not_published_clear() {
+        // The alternative would be publishing this op in the clear, which is the
+        // one outcome sealing exists to prevent — and it would happen exactly
+        // when the node's own state is already wrong.
+        let err = GroupKeyring::prepare_root_op_for_publish(
+            None,
+            KeyId::from([9u8; 32]),
+            RootOp::PolicyUpdated {
+                policy_bytes: vec![1, 2, 3],
+            },
+        )
+        .expect_err("must refuse");
+        assert!(
+            err.to_string().contains("in the clear"),
+            "the error should say what it is refusing to do: {err}"
+        );
+    }
+
+    fn deterministic_join_credential(
+    ) -> Box<calimero_context_client::local_governance::JoinAccountCredential> {
+        let genesis = calimero_account::AccountGenesis::new(PublicKey::from([0u8; 32]));
+        Box::new(calimero_account::AccountProof {
+            statement: calimero_account::DeviceCert {
+                account: genesis.account_id(),
+                device: calimero_account::DeviceId::from([0u8; 32]),
+                sign_pk: PublicKey::from([0u8; 32]),
+                kem_pk: calimero_account::KemPublicKey::from([0u8; 32]),
+                key_epoch: 0,
+                device_epoch: 0,
+                signature: [0u8; 64],
+            },
+            genesis,
+            chain: vec![],
+        })
+    }
+
     fn sealable_root_ops() -> Vec<(&'static str, RootOp)> {
         let gid = ContextGroupId::from([7u8; 32]);
         let account = AccountId::from([9u8; 32]);

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -3,11 +3,12 @@ use crate::{
 };
 use calimero_account::{AccountId, DeviceId, KemPublicKey};
 use calimero_context_client::local_governance::{
-    EncryptedGroupOp, EncryptedRootOp, EnvelopeRecipient, GroupOp, KeyEnvelope, KeyId, KeyRotation,
+    EncryptedGroupOp, EncryptedRootOp, EnvelopeRecipient, GroupOp, KeyEnvelope, KeyRotation,
     NamespaceOp, RootOp,
 };
 use calimero_context_config::types::ContextGroupId;
 use calimero_crypto::{X25519PublicKey, X25519SecretKey};
+use calimero_governance_types::KeyId;
 use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_store::key::{GroupKeyEntry, GroupKeyValue, GROUP_KEY_PREFIX};
 use calimero_store::Store;

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -247,8 +247,38 @@ impl<'a> NamespaceGovernance<'a> {
         let mut result = ApplyNamespaceOpResult::default();
         let mut root_events: Vec<crate::op_events::OpEvent> = Vec::new();
 
-        match &op.op {
-            NamespaceOp::Root(root) => {
+        // Open a sealed root op before the match, so the arm below sees a `RootOp`
+        // whether it arrived sealed or in the clear and its body stays one
+        // implementation. Two copies of a 187-line apply would be two places for
+        // the sealed and cleartext paths to drift, and the drift would show as
+        // peers disagreeing about state rather than as anything failing.
+        let opened_root: Option<RootOp> = match &op.op {
+            NamespaceOp::RootSealed { key_id, encrypted } => {
+                let ns_id_typed = ContextGroupId::from(self.namespace_id.to_bytes());
+                match GroupKeyring::new(self.store, ns_id_typed)
+                    .load_key_by_id(key_id.as_bytes())?
+                {
+                    Some(key) => {
+                        let inner = GroupKeyring::decrypt_root_op(&key, encrypted)?;
+                        // The validation the envelope could not do. `NamespaceOp::validate`
+                        // bounds the ciphertext and stops there, so for a sealed op the
+                        // inner op's own checks run here or nowhere — and nowhere is
+                        // silent, because no other stage notices that a check moved.
+                        inner.validate_after_unsealing()?;
+                        Some(inner)
+                    }
+                    // Not held yet. Ordinary for a member that has not received
+                    // the namespace key, so it must not be an error: erroring
+                    // would drop an op the node will be able to apply minutes
+                    // later. Left unapplied for the retry pass to pick up.
+                    None => None,
+                }
+            }
+            _ => None,
+        };
+
+        match (&op.op, opened_root.as_ref()) {
+            (NamespaceOp::Root(root), _) | (NamespaceOp::RootSealed { .. }, Some(root)) => {
                 root_events = self.apply_root_op(op, root)?;
 
                 match root {
@@ -435,12 +465,27 @@ impl<'a> NamespaceGovernance<'a> {
                     _ => {}
                 }
             }
-            NamespaceOp::Group {
-                group_id,
-                key_id,
-                encrypted,
-                key_rotation,
-            } => {
+            // Sealed, and the key is not held. Reported rather than applied or
+            // dropped: the op stays in the log for the retry pass that runs on
+            // key delivery.
+            (NamespaceOp::RootSealed { key_id, .. }, None) => {
+                result.key_unwrap_failures.push(KeyUnwrapFailure {
+                    group_id: self.namespace_id.to_bytes(),
+                    reason: format!(
+                        "no namespace key {} held yet for a sealed root op",
+                        hex::encode(key_id.as_bytes())
+                    ),
+                });
+            }
+            (
+                NamespaceOp::Group {
+                    group_id,
+                    key_id,
+                    encrypted,
+                    key_rotation,
+                },
+                _,
+            ) => {
                 let group_id_typed = *group_id;
 
                 // Issue #2256: an `Open` subgroup is encrypted with the

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -1674,6 +1674,21 @@ impl GroupOp {
 }
 
 impl RootOp {
+    /// The op's own validation, for a receiver that has just unsealed it.
+    ///
+    /// `NamespaceOp::validate` runs before apply and, for a sealed op, can only
+    /// bound the ciphertext — the inner op is unreadable at that point. So these
+    /// checks have exactly one place left to run, and a receiver that unseals
+    /// without calling this loses validation for every sealed variant with
+    /// nothing to indicate it: no stage reports that a check moved.
+    ///
+    /// # Errors
+    ///
+    /// Whatever the op's own validation rejects.
+    pub fn validate_after_unsealing(&self) -> Result<(), GovernanceError> {
+        self.validate()
+    }
+
     fn validate(&self) -> Result<(), GovernanceError> {
         match self {
             Self::GroupDeleted {

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -683,6 +683,67 @@ pub enum NamespaceOp {
         /// the removed member cannot read it.
         key_rotation: Option<KeyRotation>,
     },
+    /// A root op sealed under the namespace key.
+    ///
+    /// Appended rather than inserted: borsh numbers variants by position, so
+    /// `Root` and `Group` keep discriminants 0 and 1 and every existing op
+    /// encodes byte-identically. Only a sealed op is new on the wire, and an
+    /// older node fails to decode it rather than misreading it — borsh rejects
+    /// an unknown discriminant outright.
+    ///
+    /// Carries `key_id` for the same reason [`NamespaceOp::Group`] does: after a
+    /// rotation the receiver holds more than one namespace key, and resolving by
+    /// id is the difference between decrypting the op and guessing.
+    ///
+    /// Only the five admin-published variants reach here; see
+    /// [`root_op_is_sealable`].
+    RootSealed {
+        key_id: KeyId,
+        encrypted: EncryptedRootOp,
+    },
+}
+
+/// Whether a [`RootOp`] is published sealed.
+///
+/// Five of the eleven variants are. The four `MemberJoined*` are published by a
+/// principal that does not hold the key yet; `KeyDelivery` is how the key
+/// arrives, so sealing it under that key is unsatisfiable — and it needs no
+/// sealing, since its payload is already sealed to the recipient inside
+/// `KeyEnvelope`; `NamespaceCreated` is genesis, before any key exists.
+///
+/// What remains is published by an admin who already holds the key and read by
+/// members who already hold it, so nothing about it needs to be legible to a
+/// non-member.
+///
+/// This is the single place that decision lives. A publisher that seals by its
+/// own judgement can disagree with the receiver about which ops are sealed, and
+/// that disagreement reads as a decode failure on a valid op rather than as a
+/// policy difference.
+/// Written as an exhaustive match with no wildcard, deliberately. `matches!`
+/// would read the same and behave differently on the next variant added: it
+/// would answer `false`, so a new root op that ought to be sealed would ship in
+/// the clear and nothing would say so. This way it does not compile until
+/// somebody decides.
+#[must_use]
+pub const fn root_op_is_sealable(op: &RootOp) -> bool {
+    match op {
+        // Published by an admin who already holds the namespace key.
+        RootOp::GroupCreated { .. }
+        | RootOp::GroupReparented { .. }
+        | RootOp::GroupDeleted { .. }
+        | RootOp::AdminChanged { .. }
+        | RootOp::PolicyUpdated { .. } => true,
+        // Published by a principal that does not hold the key yet.
+        RootOp::MemberJoined { .. }
+        | RootOp::MemberJoinedAt { .. }
+        | RootOp::MemberJoinedOpen { .. }
+        | RootOp::MemberJoinedViaTeeAttestation { .. } => false,
+        // How the key arrives; sealing it under that key is unsatisfiable, and
+        // its payload is already sealed to the recipient in `KeyEnvelope`.
+        RootOp::KeyDelivery { .. } => false,
+        // Genesis, before any key exists.
+        RootOp::NamespaceCreated { .. } => false,
+    }
 }
 
 /// Cleartext administrative operations that affect the entire namespace.
@@ -966,6 +1027,11 @@ impl NamespaceOp {
     #[must_use]
     pub fn op_kind_label(&self) -> &'static str {
         match self {
+            // Sealed ops collapse to one label: the kind is inside the
+            // ciphertext. Metrics broken down by root-op kind lose that
+            // breakdown for the five sealed variants, which is a real cost of
+            // sealing them and not an oversight here.
+            NamespaceOp::RootSealed { .. } => "root_sealed",
             NamespaceOp::Root(RootOp::GroupCreated { .. }) => "group_created",
             NamespaceOp::Root(RootOp::GroupReparented { .. }) => "group_reparented",
             NamespaceOp::Root(RootOp::GroupDeleted { .. }) => "group_deleted",
@@ -1351,7 +1417,11 @@ impl SignedNamespaceOp {
     pub fn group_id(&self) -> Option<ContextGroupId> {
         match &self.op {
             NamespaceOp::Group { group_id, .. } => Some(*group_id),
-            NamespaceOp::Root(_) => None,
+            // A sealed root op may name a group inside — `GroupCreated` does —
+            // but not readably, and answering from the envelope would mean
+            // answering `None` for an op that has one. Callers that need it must
+            // decrypt first.
+            NamespaceOp::Root(_) | NamespaceOp::RootSealed { .. } => None,
         }
     }
 }
@@ -1508,6 +1578,23 @@ impl KeyRotation {
     }
 }
 
+impl EncryptedRootOp {
+    /// Bound the ciphertext, the only thing checkable without the key.
+    ///
+    /// The inner op's own `validate` cannot run here — it needs the plaintext, so
+    /// for a sealed op it runs after decryption instead of before apply. A
+    /// receiver that decrypts and skips it loses validation entirely for the five
+    /// sealed variants, silently, because nothing else in the pipeline notices
+    /// that a check moved.
+    pub fn validate(&self) -> Result<(), GovernanceError> {
+        check_bound(
+            "encrypted_root_op.ciphertext",
+            self.ciphertext.len(),
+            bounds::MAX_CIPHERTEXT_BYTES,
+        )
+    }
+}
+
 impl EncryptedGroupOp {
     /// Bound the ciphertext of an encrypted group op.
     pub fn validate(&self) -> Result<(), GovernanceError> {
@@ -1620,6 +1707,9 @@ impl NamespaceOp {
     fn validate(&self) -> Result<(), GovernanceError> {
         match self {
             Self::Root(root) => root.validate(),
+            // Only the envelope. The inner op is validated after decryption —
+            // see `EncryptedRootOp::validate`.
+            Self::RootSealed { encrypted, .. } => encrypted.validate(),
             Self::Group {
                 encrypted,
                 key_rotation,

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -1766,3 +1766,117 @@ fn emit_golden_root_op_vectors() {
         println!("{bytes:?}");
     }
 }
+
+// ---------------------------------------------------------------------------
+// E1: sealing root ops
+// ---------------------------------------------------------------------------
+
+/// The claim that makes appending `RootSealed` safe: existing ops encode exactly
+/// as before.
+///
+/// Borsh numbers enum variants by declaration position, so appending is only
+/// safe while nothing is inserted ahead of the existing two. Pinned as bytes
+/// rather than trusted, because the failure is silent in the worst way — every
+/// op id in the namespace changes, and the first symptom is peers disagreeing
+/// about history rather than anything refusing to decode.
+#[test]
+fn appending_root_sealed_left_the_existing_discriminants_alone() {
+    let root = NamespaceOp::Root(RootOp::AdminChanged {
+        new_admin: calimero_account::AccountId::from([3u8; 32]),
+    });
+    let group = NamespaceOp::Group {
+        group_id: ContextGroupId::from([4u8; 32]),
+        key_id: KeyId::from([5u8; 32]),
+        encrypted: EncryptedGroupOp {
+            nonce: [6u8; 12],
+            ciphertext: vec![7, 8, 9],
+        },
+        key_rotation: None,
+    };
+    let sealed = NamespaceOp::RootSealed {
+        key_id: KeyId::from([5u8; 32]),
+        encrypted: EncryptedRootOp {
+            nonce: [6u8; 12],
+            ciphertext: vec![7, 8, 9],
+        },
+    };
+
+    assert_eq!(borsh::to_vec(&root).unwrap()[0], 0, "Root must stay 0");
+    assert_eq!(borsh::to_vec(&group).unwrap()[0], 1, "Group must stay 1");
+    assert_eq!(
+        borsh::to_vec(&sealed).unwrap()[0],
+        2,
+        "RootSealed must be appended, never inserted"
+    );
+}
+
+/// A sealed op and a group op with identical payloads must not encode alike.
+///
+/// They carry the same fields in the same order, so only the discriminant tells
+/// them apart. A receiver that read one as the other would look up the right key
+/// id in the wrong keyring and report a missing key rather than a mismatch.
+#[test]
+fn a_sealed_root_op_is_distinguishable_from_a_group_op() {
+    let key_id = KeyId::from([5u8; 32]);
+    let nonce = [6u8; 12];
+    let ciphertext = vec![7, 8, 9];
+
+    let sealed = borsh::to_vec(&NamespaceOp::RootSealed {
+        key_id,
+        encrypted: EncryptedRootOp {
+            nonce,
+            ciphertext: ciphertext.clone(),
+        },
+    })
+    .unwrap();
+    let group = borsh::to_vec(&NamespaceOp::Group {
+        group_id: ContextGroupId::from([5u8; 32]),
+        key_id,
+        encrypted: EncryptedGroupOp { nonce, ciphertext },
+        key_rotation: None,
+    })
+    .unwrap();
+
+    assert_ne!(sealed, group);
+}
+
+/// Every variant's sealability, asserted against the reasons rather than the
+/// implementation.
+///
+/// `root_op_is_sealable` is an exhaustive match, so a twelfth variant fails to
+/// compile until it is classified. This test states what the classification has
+/// to be for the five that carry no bootstrap constraint, so a future edit that
+/// reclassifies one has to argue with a test rather than only with a reviewer.
+#[test]
+fn only_the_admin_published_variants_are_sealable() {
+    assert!(root_op_is_sealable(&RootOp::AdminChanged {
+        new_admin: calimero_account::AccountId::from([1u8; 32]),
+    }));
+    assert!(root_op_is_sealable(&RootOp::PolicyUpdated {
+        policy_bytes: vec![1, 2, 3],
+    }));
+    assert!(root_op_is_sealable(&RootOp::GroupReparented {
+        child_group_id: ContextGroupId::from([2u8; 32]),
+        new_parent_id: ContextGroupId::from([3u8; 32]),
+    }));
+    assert!(root_op_is_sealable(&RootOp::GroupDeleted {
+        root_group_id: ContextGroupId::from([2u8; 32]),
+        cascade_group_ids: vec![],
+        cascade_context_ids: vec![],
+    }));
+    assert!(root_op_is_sealable(&RootOp::GroupCreated {
+        group_id: ContextGroupId::from([2u8; 32]),
+        parent_id: ContextGroupId::from([3u8; 32]),
+        restricted: true,
+        admin: calimero_account::AccountId::from([4u8; 32]),
+    }));
+
+    // `NamespaceCreated` is genesis: there is no namespace key yet to seal it
+    // under, and this op's own apply is what establishes the founder. Asserted
+    // because it is the variant most likely to look sealable to a future reader
+    // — it is admin-published, like the five, and differs only in when it runs.
+    assert!(!root_op_is_sealable(&RootOp::NamespaceCreated {
+        founder: calimero_account::AccountId::from([5u8; 32]),
+        account: deterministic_credential(),
+    }));
+}


### PR DESCRIPTION
Stacked on #3731 — **base is `feat/encrypt-root-ops-e1`, not master.** Step E1b of #3700: the receiver half. Nothing seals yet, so still behaviour-neutral.

## One apply body, two op shapes

```rust
match (&op.op, opened_root.as_ref()) {
    (NamespaceOp::Root(root), _)
    | (NamespaceOp::RootSealed { .. }, Some(root)) => { /* 187 lines, unchanged */ }
```

A sealed op is opened *before* the match, so an or-pattern binds `root` from either shape and the existing body is untouched. A second arm would have meant two copies of a 187-line apply — two places for the sealed and cleartext paths to drift, and that drift shows up as **peers disagreeing about state**, not as anything failing.

## The validation problem was access, not discipline

#3731 documented "a receiver that decrypts and skips validation loses it silently" as a risk to watch. It was worse than that: **`RootOp::validate` was private**, so a receiver *couldn't* have validated an unsealed op even knowing it should.

`NamespaceOp::validate` bounds the ciphertext and stops, because the inner op is unreadable before the key is applied. So for a sealed op these checks run at unsealing or nowhere — and nowhere is silent, since no stage reports that a check moved. Now exposed as `validate_after_unsealing`, with a doc saying why it's the last place they can run.

## A missing key is not an error

It's the ordinary state of a member that hasn't received the namespace key yet. Erroring would drop an op the node can apply minutes later. The op is left unapplied and reported through the existing `key_unwrap_failures` channel.

## This changes the order of what follows

The retry pass matches `NamespaceOp::Group` explicitly (governance.rs:1391, 1540), so a sealed root op falls into that `else` and **nothing re-feeds it after the key lands**.

So **E2 must precede E1c**, which reverses what I originally wrote:

| | |
|---|---|
| ~~E1a → E1b → E1c → E2~~ | as originally scoped |
| **E1a → E1b → E2 → E1c** | correct |

If publishers seal before the retry handles root ops, a joining node **permanently misses every sealed root op that arrived before its key**. Nothing seals yet, so the gap is inert today.

## Tests

Three on the choke point:

- a sealable op comes back `RootSealed`, carrying the `key_id` it was given, and opens to byte-identical bytes (the id matters: after a rotation a receiver holds two keys and would otherwise guess)
- a non-sealable op passes through in the clear **even when a key is offered** — `NamespaceCreated`, the variant most likely to be misclassified later
- a sealable op with no key is refused rather than published unsealed, and the error says so

Full governance-store suite: **639 passed, 0 failed** (636 on this base + 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)