### PR TITLE
feat(governance): re-feed sealed root ops when the key arrives (E2)

### DIFF
--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -3,7 +3,8 @@ use crate::{
 };
 use calimero_account::{AccountId, DeviceId, KemPublicKey};
 use calimero_context_client::local_governance::{
-    EncryptedGroupOp, EncryptedRootOp, EnvelopeRecipient, GroupOp, KeyEnvelope, KeyRotation, RootOp,
+    EncryptedGroupOp, EncryptedRootOp, EnvelopeRecipient, GroupOp, KeyEnvelope, KeyId, KeyRotation,
+    NamespaceOp, RootOp,
 };
 use calimero_context_config::types::ContextGroupId;
 use calimero_crypto::{X25519PublicKey, X25519SecretKey};
@@ -441,6 +442,44 @@ impl<'a> GroupKeyring<'a> {
             .ok_or(KeyringError::EncryptionFailed)?;
 
         Ok(EncryptedRootOp { nonce, ciphertext })
+    }
+
+    /// Prepare a root op for publishing: sealed if policy says so, cleartext if
+    /// not.
+    ///
+    /// Every publisher of a root op goes through here, so the decision about
+    /// which variants are sealed is made once rather than at each of the ten
+    /// sites that construct one. A per-site choice is a per-site opportunity to
+    /// disagree with the receiver, and that disagreement does not present as a
+    /// policy difference — it presents as a decode failure on a valid op.
+    ///
+    /// The seal happens before signing, necessarily: the signature covers the
+    /// `NamespaceOp`, so sealing after signing produces an op whose signature
+    /// verifies against bytes nobody sent.
+    ///
+    /// # Errors
+    ///
+    /// When sealing fails, or when a sealable op is offered with no key. The
+    /// latter is refused rather than silently published in the clear — an admin
+    /// publishing a governance change always holds the namespace key, so a
+    /// missing key is a broken assumption, and answering it by publishing
+    /// cleartext would quietly undo the encryption for that op.
+    pub fn prepare_root_op_for_publish(
+        namespace_key: Option<&[u8; 32]>,
+        key_id: KeyId,
+        op: RootOp,
+    ) -> EyreResult<NamespaceOp> {
+        if !calimero_governance_types::root_op_is_sealable(&op) {
+            return Ok(NamespaceOp::Root(op));
+        }
+        let Some(key) = namespace_key else {
+            eyre::bail!(
+                "refusing to publish a sealable root op in the clear: no namespace key was \
+                 available, which an admin publishing a governance change always holds"
+            );
+        };
+        let encrypted = Self::encrypt_root_op(key, &op)?;
+        Ok(NamespaceOp::RootSealed { key_id, encrypted })
     }
 
     /// Open a [`RootOp`] sealed by [`Self::encrypt_root_op`].

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -1963,6 +1963,92 @@ mod delete_tests {
 mod root_op_sealing_tests {
     use super::*;
 
+    // ---- E1: the publish choke point ----
+
+    #[test]
+    fn a_sealable_op_comes_back_sealed_and_opens_to_the_same_bytes() {
+        let key = [5u8; 32];
+        let key_id = KeyId::from([9u8; 32]);
+        let op = RootOp::AdminChanged {
+            new_admin: AccountId::from([1u8; 32]),
+        };
+        let expected = borsh::to_vec(&op).unwrap();
+
+        let prepared =
+            GroupKeyring::prepare_root_op_for_publish(Some(&key), key_id, op).expect("prepare");
+
+        let NamespaceOp::RootSealed {
+            key_id: got_id,
+            encrypted,
+        } = prepared
+        else {
+            panic!("a sealable op must be sealed");
+        };
+        // The id travels with the ciphertext. Without it a receiver holding two
+        // namespace keys after a rotation has to guess which one to try.
+        assert_eq!(got_id, key_id);
+
+        let opened = GroupKeyring::decrypt_root_op(&key, &encrypted).expect("decrypt");
+        assert_eq!(borsh::to_vec(&opened).unwrap(), expected);
+    }
+
+    #[test]
+    fn a_non_sealable_op_passes_through_in_the_clear() {
+        // `NamespaceCreated` is genesis: there is no key yet, so it must survive
+        // the choke point untouched even when one is offered.
+        let prepared = GroupKeyring::prepare_root_op_for_publish(
+            Some(&[5u8; 32]),
+            KeyId::from([9u8; 32]),
+            RootOp::NamespaceCreated {
+                founder: AccountId::from([2u8; 32]),
+                account: deterministic_join_credential(),
+            },
+        )
+        .expect("prepare");
+
+        assert!(matches!(
+            prepared,
+            NamespaceOp::Root(RootOp::NamespaceCreated { .. })
+        ));
+    }
+
+    #[test]
+    fn a_sealable_op_with_no_key_is_refused_not_published_clear() {
+        // The alternative would be publishing this op in the clear, which is the
+        // one outcome sealing exists to prevent — and it would happen exactly
+        // when the node's own state is already wrong.
+        let err = GroupKeyring::prepare_root_op_for_publish(
+            None,
+            KeyId::from([9u8; 32]),
+            RootOp::PolicyUpdated {
+                policy_bytes: vec![1, 2, 3],
+            },
+        )
+        .expect_err("must refuse");
+        assert!(
+            err.to_string().contains("in the clear"),
+            "the error should say what it is refusing to do: {err}"
+        );
+    }
+
+    fn deterministic_join_credential(
+    ) -> Box<calimero_context_client::local_governance::JoinAccountCredential> {
+        let genesis = calimero_account::AccountGenesis::new(PublicKey::from([0u8; 32]));
+        Box::new(calimero_account::AccountProof {
+            statement: calimero_account::DeviceCert {
+                account: genesis.account_id(),
+                device: calimero_account::DeviceId::from([0u8; 32]),
+                sign_pk: PublicKey::from([0u8; 32]),
+                kem_pk: calimero_account::KemPublicKey::from([0u8; 32]),
+                key_epoch: 0,
+                device_epoch: 0,
+                signature: [0u8; 64],
+            },
+            genesis,
+            chain: vec![],
+        })
+    }
+
     fn sealable_root_ops() -> Vec<(&'static str, RootOp)> {
         let gid = ContextGroupId::from([7u8; 32]);
         let account = AccountId::from([9u8; 32]);

--- a/crates/governance-store/src/group_keys.rs
+++ b/crates/governance-store/src/group_keys.rs
@@ -3,11 +3,12 @@ use crate::{
 };
 use calimero_account::{AccountId, DeviceId, KemPublicKey};
 use calimero_context_client::local_governance::{
-    EncryptedGroupOp, EncryptedRootOp, EnvelopeRecipient, GroupOp, KeyEnvelope, KeyId, KeyRotation,
+    EncryptedGroupOp, EncryptedRootOp, EnvelopeRecipient, GroupOp, KeyEnvelope, KeyRotation,
     NamespaceOp, RootOp,
 };
 use calimero_context_config::types::ContextGroupId;
 use calimero_crypto::{X25519PublicKey, X25519SecretKey};
+use calimero_governance_types::KeyId;
 use calimero_primitives::identity::{PrivateKey, PublicKey};
 use calimero_store::key::{GroupKeyEntry, GroupKeyValue, GROUP_KEY_PREFIX};
 use calimero_store::Store;

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -1405,8 +1405,112 @@ impl<'a> NamespaceGovernance<'a> {
             );
         }
 
+        // Sealed root ops first, then the group's own. A root op can be the thing
+        // that makes a group op applicable — `GroupCreated` is sealed, and a group
+        // op for a group this node has not folded yet has nothing to apply
+        // against — so draining them in the other order would leave the group
+        // ops to a later pass for no reason.
+        if let Err(e) = self.retry_sealed_root_ops() {
+            tracing::warn!(
+                namespace_id = %hex::encode(self.namespace_id.as_bytes()),
+                error = %format!("{e:#}"),
+                "sealed-root retry pass failed; group retry continues"
+            );
+        }
+
         self.retry_encrypted_ops_for_group(group_id)
             .map_err(|e| eyre::eyre!("retry_encrypted_ops_for_group: {e}"))
+    }
+
+    /// Re-feed sealed root ops that arrived before this node held the key.
+    ///
+    /// The group retry cannot do this: its op-log walk selects by group id and
+    /// both it and the loop above it match `NamespaceOp::Group`, so a sealed root
+    /// op was skipped at two layers. Nothing re-fed it, which for a joining node
+    /// means never applying a root op that landed before its key — the namespace
+    /// structure it needs, permanently missing, with no error anywhere.
+    ///
+    /// Ops this node signed are skipped, for the reason the group collector
+    /// documents at length: the replay dedups on the namespace-level nonce, which
+    /// the local authoring path never wrote, so a node's own op is not recognised
+    /// as applied and its mutation re-runs — and re-running a removal out of
+    /// causal order deletes state a causally-later op restored. A node's own
+    /// sealed op was never buffered anyway; it held the key to seal it.
+    ///
+    /// # Errors
+    ///
+    /// When the op log cannot be walked. A single op that fails to open is
+    /// logged and skipped rather than failing the pass: one undecryptable op must
+    /// not stop the others from landing.
+    ///
+    /// Returns no divergence report, unlike the group retry: `apply_root_op`
+    /// yields events rather than a post-apply hash comparison, so there is no
+    /// verdict to pass up and a `None` would only look like one that came back
+    /// clean.
+    fn retry_sealed_root_ops(&self) -> EyreResult<()> {
+        let ns_typed = ContextGroupId::from(self.namespace_id.to_bytes());
+        let own_identity = super::NamespaceRepository::new(self.store)
+            .identity(&ns_typed)
+            .map_err(|e| eyre::eyre!("resolve own namespace identity: {e}"))?
+            .map(|(pk, _sk)| pk);
+
+        let entries = NamespaceOpLogService::new(self.store, self.namespace_id)
+            .collect_sealed_root_ops()
+            .map_err(|e| eyre::eyre!("collect_sealed_root_ops: {e}"))?;
+
+        for entry in entries {
+            if own_identity == Some(entry.signed_op.signer) {
+                continue;
+            }
+            let NamespaceOp::RootSealed {
+                key_id,
+                ref encrypted,
+            } = entry.signed_op.op
+            else {
+                continue;
+            };
+            // Still not held: the key that arrived was for something else. Not an
+            // error, and not a reason to stop — a later delivery may bring it.
+            let Some(key) = GroupKeyring::new(self.store, ns_typed)
+                .load_key_by_id(key_id.as_bytes())
+                .map_err(|e| eyre::eyre!("load namespace key for sealed root op: {e}"))?
+            else {
+                continue;
+            };
+            let root = match GroupKeyring::decrypt_root_op(&key, encrypted) {
+                Ok(root) => root,
+                Err(e) => {
+                    tracing::warn!(
+                        namespace_id = %hex::encode(self.namespace_id.as_bytes()),
+                        error = %format!("{e:#}"),
+                        "skipping a sealed root op that would not open on retry"
+                    );
+                    continue;
+                }
+            };
+            // The same relocated check the receive path runs. Skipping it here
+            // would mean a replayed op is validated less than one applied on
+            // arrival, and the difference would only show as divergence.
+            if let Err(e) = root.validate_after_unsealing() {
+                tracing::warn!(
+                    namespace_id = %hex::encode(self.namespace_id.as_bytes()),
+                    error = %format!("{e:#}"),
+                    "skipping a sealed root op that fails validation after unsealing"
+                );
+                continue;
+            }
+            match self.apply_root_op(&entry.signed_op, &root) {
+                Ok(_events) => record_namespace_retry_event("sealed_root_applied"),
+                Err(e) => {
+                    tracing::warn!(
+                        namespace_id = %hex::encode(self.namespace_id.as_bytes()),
+                        error = %format!("{e:#}"),
+                        "sealed root op failed to apply on retry"
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 
     fn retry_encrypted_ops_for_group(

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -247,8 +247,38 @@ impl<'a> NamespaceGovernance<'a> {
         let mut result = ApplyNamespaceOpResult::default();
         let mut root_events: Vec<crate::op_events::OpEvent> = Vec::new();
 
-        match &op.op {
-            NamespaceOp::Root(root) => {
+        // Open a sealed root op before the match, so the arm below sees a `RootOp`
+        // whether it arrived sealed or in the clear and its body stays one
+        // implementation. Two copies of a 187-line apply would be two places for
+        // the sealed and cleartext paths to drift, and the drift would show as
+        // peers disagreeing about state rather than as anything failing.
+        let opened_root: Option<RootOp> = match &op.op {
+            NamespaceOp::RootSealed { key_id, encrypted } => {
+                let ns_id_typed = ContextGroupId::from(self.namespace_id.to_bytes());
+                match GroupKeyring::new(self.store, ns_id_typed)
+                    .load_key_by_id(key_id.as_bytes())?
+                {
+                    Some(key) => {
+                        let inner = GroupKeyring::decrypt_root_op(&key, encrypted)?;
+                        // The validation the envelope could not do. `NamespaceOp::validate`
+                        // bounds the ciphertext and stops there, so for a sealed op the
+                        // inner op's own checks run here or nowhere — and nowhere is
+                        // silent, because no other stage notices that a check moved.
+                        inner.validate_after_unsealing()?;
+                        Some(inner)
+                    }
+                    // Not held yet. Ordinary for a member that has not received
+                    // the namespace key, so it must not be an error: erroring
+                    // would drop an op the node will be able to apply minutes
+                    // later. Left unapplied for the retry pass to pick up.
+                    None => None,
+                }
+            }
+            _ => None,
+        };
+
+        match (&op.op, opened_root.as_ref()) {
+            (NamespaceOp::Root(root), _) | (NamespaceOp::RootSealed { .. }, Some(root)) => {
                 root_events = self.apply_root_op(op, root)?;
 
                 match root {
@@ -435,12 +465,27 @@ impl<'a> NamespaceGovernance<'a> {
                     _ => {}
                 }
             }
-            NamespaceOp::Group {
-                group_id,
-                key_id,
-                encrypted,
-                key_rotation,
-            } => {
+            // Sealed, and the key is not held. Reported rather than applied or
+            // dropped: the op stays in the log for the retry pass that runs on
+            // key delivery.
+            (NamespaceOp::RootSealed { key_id, .. }, None) => {
+                result.key_unwrap_failures.push(KeyUnwrapFailure {
+                    group_id: self.namespace_id.to_bytes(),
+                    reason: format!(
+                        "no namespace key {} held yet for a sealed root op",
+                        hex::encode(key_id.as_bytes())
+                    ),
+                });
+            }
+            (
+                NamespaceOp::Group {
+                    group_id,
+                    key_id,
+                    encrypted,
+                    key_rotation,
+                },
+                _,
+            ) => {
                 let group_id_typed = *group_id;
 
                 // Issue #2256: an `Open` subgroup is encrypted with the

--- a/crates/governance-store/src/namespace/op_log.rs
+++ b/crates/governance-store/src/namespace/op_log.rs
@@ -185,6 +185,76 @@ impl<'a> NamespaceOpLogService<'a> {
         Ok(())
     }
 
+    /// Every sealed root op in this namespace's log.
+    ///
+    /// A sibling of [`Self::collect_signed_group_ops_for_group`] rather than a
+    /// parameter on it, because the two select on different things: a group op is
+    /// found by its group id, and a sealed root op has no group to be found by —
+    /// it is namespace-scoped, and the whole log is its scope.
+    ///
+    /// Needed because both this scan and the retry above it match
+    /// `NamespaceOp::Group` and skip everything else, so a sealed root op was
+    /// invisible to the retry at two layers. Nothing re-fed it after a key
+    /// arrived, which for a joining node means never applying a root op that
+    /// landed before its key.
+    ///
+    /// # Errors
+    ///
+    /// When the op log cannot be iterated.
+    pub fn collect_sealed_root_ops(&self) -> EyreResult<Vec<StoredSignedGroupOp>> {
+        let mut entries = Vec::new();
+        let handle = self.store.handle();
+        let start =
+            calimero_store::key::NamespaceGovOp::new(self.namespace_id.to_bytes(), [0u8; 32]);
+        let mut iter = handle
+            .iter::<calimero_store::key::NamespaceGovOp>()
+            .map_err(|e| eyre::eyre!("iter::<NamespaceGovOp>: {e}"))?;
+        let first = iter.seek(start).transpose();
+        let mut entries_iter = first.into_iter().chain(iter.keys());
+        loop {
+            let key = match entries_iter.next() {
+                None => break,
+                Some(Ok(k)) => k,
+                Some(Err(_)) => {
+                    record_namespace_decode_invalid("sealed_root_iter_end");
+                    break;
+                }
+            };
+            // Both guards, in this order, as the group walk does. Without the
+            // row check the iterator runs on into the key families that sort
+            // after this one, and they are the same width with the namespace id
+            // in the same place — so the id check alone would accept them.
+            if !key.is_gov_op_row() {
+                break;
+            }
+            if key.namespace_id() != self.namespace_id.to_bytes() {
+                break;
+            }
+            let value: calimero_store::key::NamespaceGovOpValue = match handle.get(&key) {
+                Ok(Some(v)) => v,
+                Ok(None) => continue,
+                Err(e) => {
+                    record_namespace_decode_invalid("sealed_root_value");
+                    tracing::warn!(
+                        namespace_id = %hex::encode(self.namespace_id.as_bytes()),
+                        delta_id = %hex::encode(key.delta_id()),
+                        error = %e,
+                        "skipping undecodable NamespaceGovOpValue during sealed-root walk"
+                    );
+                    continue;
+                }
+            };
+            let Some(signed_op) = decode_signed_namespace_op(&value.skeleton_bytes) else {
+                continue;
+            };
+            let NamespaceOp::RootSealed { key_id, .. } = signed_op.op else {
+                continue;
+            };
+            entries.push(StoredSignedGroupOp { signed_op, key_id });
+        }
+        Ok(entries)
+    }
+
     pub fn collect_signed_group_ops_for_group(
         &self,
         group_id: [u8; 32],

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -1674,6 +1674,21 @@ impl GroupOp {
 }
 
 impl RootOp {
+    /// The op's own validation, for a receiver that has just unsealed it.
+    ///
+    /// `NamespaceOp::validate` runs before apply and, for a sealed op, can only
+    /// bound the ciphertext — the inner op is unreadable at that point. So these
+    /// checks have exactly one place left to run, and a receiver that unseals
+    /// without calling this loses validation for every sealed variant with
+    /// nothing to indicate it: no stage reports that a check moved.
+    ///
+    /// # Errors
+    ///
+    /// Whatever the op's own validation rejects.
+    pub fn validate_after_unsealing(&self) -> Result<(), GovernanceError> {
+        self.validate()
+    }
+
     fn validate(&self) -> Result<(), GovernanceError> {
         match self {
             Self::GroupDeleted {

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -683,6 +683,67 @@ pub enum NamespaceOp {
         /// the removed member cannot read it.
         key_rotation: Option<KeyRotation>,
     },
+    /// A root op sealed under the namespace key.
+    ///
+    /// Appended rather than inserted: borsh numbers variants by position, so
+    /// `Root` and `Group` keep discriminants 0 and 1 and every existing op
+    /// encodes byte-identically. Only a sealed op is new on the wire, and an
+    /// older node fails to decode it rather than misreading it — borsh rejects
+    /// an unknown discriminant outright.
+    ///
+    /// Carries `key_id` for the same reason [`NamespaceOp::Group`] does: after a
+    /// rotation the receiver holds more than one namespace key, and resolving by
+    /// id is the difference between decrypting the op and guessing.
+    ///
+    /// Only the five admin-published variants reach here; see
+    /// [`root_op_is_sealable`].
+    RootSealed {
+        key_id: KeyId,
+        encrypted: EncryptedRootOp,
+    },
+}
+
+/// Whether a [`RootOp`] is published sealed.
+///
+/// Five of the eleven variants are. The four `MemberJoined*` are published by a
+/// principal that does not hold the key yet; `KeyDelivery` is how the key
+/// arrives, so sealing it under that key is unsatisfiable — and it needs no
+/// sealing, since its payload is already sealed to the recipient inside
+/// `KeyEnvelope`; `NamespaceCreated` is genesis, before any key exists.
+///
+/// What remains is published by an admin who already holds the key and read by
+/// members who already hold it, so nothing about it needs to be legible to a
+/// non-member.
+///
+/// This is the single place that decision lives. A publisher that seals by its
+/// own judgement can disagree with the receiver about which ops are sealed, and
+/// that disagreement reads as a decode failure on a valid op rather than as a
+/// policy difference.
+/// Written as an exhaustive match with no wildcard, deliberately. `matches!`
+/// would read the same and behave differently on the next variant added: it
+/// would answer `false`, so a new root op that ought to be sealed would ship in
+/// the clear and nothing would say so. This way it does not compile until
+/// somebody decides.
+#[must_use]
+pub const fn root_op_is_sealable(op: &RootOp) -> bool {
+    match op {
+        // Published by an admin who already holds the namespace key.
+        RootOp::GroupCreated { .. }
+        | RootOp::GroupReparented { .. }
+        | RootOp::GroupDeleted { .. }
+        | RootOp::AdminChanged { .. }
+        | RootOp::PolicyUpdated { .. } => true,
+        // Published by a principal that does not hold the key yet.
+        RootOp::MemberJoined { .. }
+        | RootOp::MemberJoinedAt { .. }
+        | RootOp::MemberJoinedOpen { .. }
+        | RootOp::MemberJoinedViaTeeAttestation { .. } => false,
+        // How the key arrives; sealing it under that key is unsatisfiable, and
+        // its payload is already sealed to the recipient in `KeyEnvelope`.
+        RootOp::KeyDelivery { .. } => false,
+        // Genesis, before any key exists.
+        RootOp::NamespaceCreated { .. } => false,
+    }
 }
 
 /// Cleartext administrative operations that affect the entire namespace.
@@ -966,6 +1027,11 @@ impl NamespaceOp {
     #[must_use]
     pub fn op_kind_label(&self) -> &'static str {
         match self {
+            // Sealed ops collapse to one label: the kind is inside the
+            // ciphertext. Metrics broken down by root-op kind lose that
+            // breakdown for the five sealed variants, which is a real cost of
+            // sealing them and not an oversight here.
+            NamespaceOp::RootSealed { .. } => "root_sealed",
             NamespaceOp::Root(RootOp::GroupCreated { .. }) => "group_created",
             NamespaceOp::Root(RootOp::GroupReparented { .. }) => "group_reparented",
             NamespaceOp::Root(RootOp::GroupDeleted { .. }) => "group_deleted",
@@ -1351,7 +1417,11 @@ impl SignedNamespaceOp {
     pub fn group_id(&self) -> Option<ContextGroupId> {
         match &self.op {
             NamespaceOp::Group { group_id, .. } => Some(*group_id),
-            NamespaceOp::Root(_) => None,
+            // A sealed root op may name a group inside — `GroupCreated` does —
+            // but not readably, and answering from the envelope would mean
+            // answering `None` for an op that has one. Callers that need it must
+            // decrypt first.
+            NamespaceOp::Root(_) | NamespaceOp::RootSealed { .. } => None,
         }
     }
 }
@@ -1508,6 +1578,23 @@ impl KeyRotation {
     }
 }
 
+impl EncryptedRootOp {
+    /// Bound the ciphertext, the only thing checkable without the key.
+    ///
+    /// The inner op's own `validate` cannot run here — it needs the plaintext, so
+    /// for a sealed op it runs after decryption instead of before apply. A
+    /// receiver that decrypts and skips it loses validation entirely for the five
+    /// sealed variants, silently, because nothing else in the pipeline notices
+    /// that a check moved.
+    pub fn validate(&self) -> Result<(), GovernanceError> {
+        check_bound(
+            "encrypted_root_op.ciphertext",
+            self.ciphertext.len(),
+            bounds::MAX_CIPHERTEXT_BYTES,
+        )
+    }
+}
+
 impl EncryptedGroupOp {
     /// Bound the ciphertext of an encrypted group op.
     pub fn validate(&self) -> Result<(), GovernanceError> {
@@ -1620,6 +1707,9 @@ impl NamespaceOp {
     fn validate(&self) -> Result<(), GovernanceError> {
         match self {
             Self::Root(root) => root.validate(),
+            // Only the envelope. The inner op is validated after decryption —
+            // see `EncryptedRootOp::validate`.
+            Self::RootSealed { encrypted, .. } => encrypted.validate(),
             Self::Group {
                 encrypted,
                 key_rotation,

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -1766,3 +1766,117 @@ fn emit_golden_root_op_vectors() {
         println!("{bytes:?}");
     }
 }
+
+// ---------------------------------------------------------------------------
+// E1: sealing root ops
+// ---------------------------------------------------------------------------
+
+/// The claim that makes appending `RootSealed` safe: existing ops encode exactly
+/// as before.
+///
+/// Borsh numbers enum variants by declaration position, so appending is only
+/// safe while nothing is inserted ahead of the existing two. Pinned as bytes
+/// rather than trusted, because the failure is silent in the worst way — every
+/// op id in the namespace changes, and the first symptom is peers disagreeing
+/// about history rather than anything refusing to decode.
+#[test]
+fn appending_root_sealed_left_the_existing_discriminants_alone() {
+    let root = NamespaceOp::Root(RootOp::AdminChanged {
+        new_admin: calimero_account::AccountId::from([3u8; 32]),
+    });
+    let group = NamespaceOp::Group {
+        group_id: ContextGroupId::from([4u8; 32]),
+        key_id: KeyId::from([5u8; 32]),
+        encrypted: EncryptedGroupOp {
+            nonce: [6u8; 12],
+            ciphertext: vec![7, 8, 9],
+        },
+        key_rotation: None,
+    };
+    let sealed = NamespaceOp::RootSealed {
+        key_id: KeyId::from([5u8; 32]),
+        encrypted: EncryptedRootOp {
+            nonce: [6u8; 12],
+            ciphertext: vec![7, 8, 9],
+        },
+    };
+
+    assert_eq!(borsh::to_vec(&root).unwrap()[0], 0, "Root must stay 0");
+    assert_eq!(borsh::to_vec(&group).unwrap()[0], 1, "Group must stay 1");
+    assert_eq!(
+        borsh::to_vec(&sealed).unwrap()[0],
+        2,
+        "RootSealed must be appended, never inserted"
+    );
+}
+
+/// A sealed op and a group op with identical payloads must not encode alike.
+///
+/// They carry the same fields in the same order, so only the discriminant tells
+/// them apart. A receiver that read one as the other would look up the right key
+/// id in the wrong keyring and report a missing key rather than a mismatch.
+#[test]
+fn a_sealed_root_op_is_distinguishable_from_a_group_op() {
+    let key_id = KeyId::from([5u8; 32]);
+    let nonce = [6u8; 12];
+    let ciphertext = vec![7, 8, 9];
+
+    let sealed = borsh::to_vec(&NamespaceOp::RootSealed {
+        key_id,
+        encrypted: EncryptedRootOp {
+            nonce,
+            ciphertext: ciphertext.clone(),
+        },
+    })
+    .unwrap();
+    let group = borsh::to_vec(&NamespaceOp::Group {
+        group_id: ContextGroupId::from([5u8; 32]),
+        key_id,
+        encrypted: EncryptedGroupOp { nonce, ciphertext },
+        key_rotation: None,
+    })
+    .unwrap();
+
+    assert_ne!(sealed, group);
+}
+
+/// Every variant's sealability, asserted against the reasons rather than the
+/// implementation.
+///
+/// `root_op_is_sealable` is an exhaustive match, so a twelfth variant fails to
+/// compile until it is classified. This test states what the classification has
+/// to be for the five that carry no bootstrap constraint, so a future edit that
+/// reclassifies one has to argue with a test rather than only with a reviewer.
+#[test]
+fn only_the_admin_published_variants_are_sealable() {
+    assert!(root_op_is_sealable(&RootOp::AdminChanged {
+        new_admin: calimero_account::AccountId::from([1u8; 32]),
+    }));
+    assert!(root_op_is_sealable(&RootOp::PolicyUpdated {
+        policy_bytes: vec![1, 2, 3],
+    }));
+    assert!(root_op_is_sealable(&RootOp::GroupReparented {
+        child_group_id: ContextGroupId::from([2u8; 32]),
+        new_parent_id: ContextGroupId::from([3u8; 32]),
+    }));
+    assert!(root_op_is_sealable(&RootOp::GroupDeleted {
+        root_group_id: ContextGroupId::from([2u8; 32]),
+        cascade_group_ids: vec![],
+        cascade_context_ids: vec![],
+    }));
+    assert!(root_op_is_sealable(&RootOp::GroupCreated {
+        group_id: ContextGroupId::from([2u8; 32]),
+        parent_id: ContextGroupId::from([3u8; 32]),
+        restricted: true,
+        admin: calimero_account::AccountId::from([4u8; 32]),
+    }));
+
+    // `NamespaceCreated` is genesis: there is no namespace key yet to seal it
+    // under, and this op's own apply is what establishes the founder. Asserted
+    // because it is the variant most likely to look sealable to a future reader
+    // — it is admin-published, like the five, and differs only in when it runs.
+    assert!(!root_op_is_sealable(&RootOp::NamespaceCreated {
+        founder: calimero_account::AccountId::from([5u8; 32]),
+        account: deterministic_credential(),
+    }));
+}


### PR DESCRIPTION
Stacked on #3733 — **base is `feat/encrypt-root-ops-e1b`.** Closes the gap E1b left, and it has to land **before** E1c switches publishers over.

## The gap

The retry pass selects op-log entries by group id and then matches `NamespaceOp::Group`, so a sealed root op was skipped at **both** layers. Nothing re-fed it after a key landed.

For a joining node that means never applying a root op that arrived before its key — the namespace structure it needs, missing permanently, **with no error anywhere to say so.**

This is why the plan's order changed: I originally wrote E1c before E2. With the retry blind to sealed root ops, sealing publishers first would have produced exactly that silent loss.

## What I nearly shipped

My first draft of the collector **omitted `is_gov_op_row()`**. That isn't optional: the key families sorting after this one are the same width with the namespace id in the same place, so the namespace-id check alone accepts them and the walk would try to decode unrelated rows as governance ops. Caught by reading the existing walk rather than writing one by analogy.

## Design notes

**A sibling collector, not a parameter.** A group op is found by its group id; a sealed root op has no group to be found by — it's namespace-scoped, and the whole log is its scope. An `Option<group_id>` would have made one function mean two selections.

**Sealed root ops drain first.** A root op can be what makes a group op applicable (`GroupCreated` is sealed, and a group op for an unfolded group has nothing to apply against), so the other order defers group ops to a later pass for no reason.

**Own-signed ops skipped**, for the reason the group collector documents: the replay dedups on the namespace-level nonce, which the local authoring path never wrote, so a node's own op isn't recognised as applied and its mutation re-runs — and re-running a *removal* out of causal order deletes state a causally-later op restored. A node's own sealed op was never buffered anyway; it held the key to seal it.

**Validation runs here too.** A replayed op validated less than one applied on arrival differs only in ways that surface as divergence. `validate_after_unsealing` is now called from both places that unseal — which is why E1a documented the relocation instead of just performing it.

**No divergence report**, unlike the group retry: `apply_root_op` yields events rather than a post-apply hash comparison, so there's no verdict to pass up — and a `None` would read as one that came back clean rather than one never taken. I initially mirrored the group signature and had to silence an always-`None` variable, which was the tell.

## Coverage — please read

**This step adds no tests.** The suite still passes at 639 because nothing here is exercised by it. Reaching this code needs a sealed op in the op log, no key, then a delivery — and nothing seals yet, so the coverage arrives with E1c's end-to-end test.

That makes E2 the least-verified step in the chain, and it's also the one that re-feeds ops into apply. Worth reviewer attention on the own-signed skip and the drain order specifically, since those are the two places a mistake would corrupt state rather than fail.

`cargo check --all-targets` clean, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)