### PR TITLE
chore(build): drop cached-path for a small reqwest + zip helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.4.2",
+ "constant_time_eq",
  "cpufeatures 0.3.0",
 ]
 
@@ -909,16 +909,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
 name = "bzip2-sys"
 version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,29 +916,6 @@ checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
  "pkg-config",
-]
-
-[[package]]
-name = "cached-path"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678838d744fc7640e0967cc09a5cb39f52d5cf4909dd28591de75b33fa3db312"
-dependencies = [
- "flate2",
- "fs2",
- "glob",
- "indicatif",
- "infer",
- "log",
- "rand 0.8.5",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tar",
- "tempfile",
- "thiserror 1.0.69",
- "zip",
 ]
 
 [[package]]
@@ -996,9 +963,13 @@ dependencies = [
 name = "calimero-build-utils"
 version = "0.0.0"
 dependencies = [
+ "eyre",
+ "reqwest 0.12.28",
  "rustc_version",
+ "sha2 0.10.9",
  "tempfile",
  "toml 0.8.23",
+ "zip",
 ]
 
 [[package]]
@@ -1544,9 +1515,9 @@ dependencies = [
  "base64 0.22.1",
  "borsh",
  "bytes",
- "cached-path",
  "calimero-account",
  "calimero-blobstore",
+ "calimero-build-utils",
  "calimero-context",
  "calimero-context-client",
  "calimero-context-config",
@@ -1569,7 +1540,6 @@ dependencies = [
  "multiaddr",
  "prometheus-client",
  "rand 0.8.5",
- "reqwest 0.11.27",
  "reqwest 0.12.28",
  "rust-embed",
  "serde",
@@ -2136,19 +2106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "187437900921c8172f33316ad51a3267df588e99a2aebfa5ca1a2ed44df9e703"
 
 [[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,12 +2143,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -3185,12 +3136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3484,16 +3429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3600,7 +3535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
 ]
 
@@ -4162,20 +4097,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
@@ -4183,10 +4104,10 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.6",
 ]
@@ -4460,19 +4381,6 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
- "web-time",
 ]
 
 [[package]]
@@ -5318,7 +5226,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "ring",
- "rustls 0.23.37",
+ "rustls",
  "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
@@ -5483,8 +5391,8 @@ dependencies = [
  "libp2p-identity",
  "rcgen",
  "ring",
- "rustls 0.23.37",
- "rustls-webpki 0.103.9",
+ "rustls",
+ "rustls-webpki",
  "thiserror 2.0.18",
  "x509-parser",
  "yasna",
@@ -5717,8 +5625,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.22.1",
- "bytes",
- "cached-path",
+ "calimero-build-utils",
  "chrono",
  "clap",
  "config",
@@ -5731,7 +5638,6 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "regex",
- "reqwest 0.11.27",
  "reqwest 0.12.28",
  "ring",
  "rocksdb",
@@ -6427,12 +6333,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "oauth2"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6823,17 +6723,6 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "password-hash"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
@@ -6858,18 +6747,6 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
- "password-hash 0.4.2",
- "sha2 0.10.9",
-]
 
 [[package]]
 name = "pbkdf2"
@@ -7456,7 +7333,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.37",
+ "rustls",
  "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
@@ -7477,7 +7354,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -7749,7 +7626,6 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -7757,21 +7633,17 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
  "system-configuration 0.5.1",
  "tokio",
- "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -7791,7 +7663,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -7801,7 +7673,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7809,7 +7681,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.8",
@@ -7837,7 +7709,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -7845,7 +7717,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -7853,7 +7725,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.8",
@@ -8075,18 +7947,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -8096,7 +7956,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -8111,15 +7971,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -8143,10 +7994,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -8158,16 +8009,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -8652,20 +8493,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87af57419b594aa23fa95f09f0e06d80d84ba01c26148c43844cad6ff4485f0"
 dependencies = [
  "cfg-if",
- "password-hash 0.6.1",
+ "password-hash",
  "pbkdf2 0.13.0",
  "salsa20 0.11.0",
  "sha2 0.11.0",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -9091,7 +8922,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.4",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "scrypt 0.12.0",
  "serde",
  "serde_json",
@@ -9761,21 +9592,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
  "tokio",
 ]
 
@@ -9958,7 +9779,7 @@ dependencies = [
  "olpc-cjson",
  "pem",
  "percent-encoding",
- "rustls 0.23.37",
+ "rustls",
  "serde",
  "serde_json",
  "serde_plain",
@@ -9966,7 +9787,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
- "typed-path",
+ "typed-path 0.9.3",
  "untrusted 0.7.1",
  "url",
  "walkdir",
@@ -10267,6 +10088,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82205ffd44a9697e34fc145491aa47310f9871540bb7909eaa9365e0a9a46607"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10379,7 +10206,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.11",
@@ -10978,12 +10805,6 @@ checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
@@ -11814,22 +11635,16 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.6"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "aes",
- "byteorder",
- "bzip2",
- "constant_time_eq 0.1.5",
  "crc32fast",
- "crossbeam-utils",
  "flate2",
- "hmac 0.12.1",
- "pbkdf2 0.11.0",
- "sha1",
- "time",
- "zstd",
+ "indexmap 2.14.1",
+ "memchr",
+ "typed-path 0.12.3",
+ "zopfli",
 ]
 
 [[package]]
@@ -11845,30 +11660,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+name = "zopfli"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
 dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,6 @@ blake3 = "1.5.0"
 borsh = "1.3.1"
 bs58 = "0.5.0"
 bytes = "1.11.1"
-cached-path = { version = "0.8.1", default-features = false, features = ["rustls-tls"] }
 camino = "1.1.6"
 candid = "0.10.10"
 cargo_metadata = "0.20.0"
@@ -307,6 +306,7 @@ wat = "1.243.0"
 web3 = "0.19.0"
 webbrowser = "1.2.2"
 zeroize = "1.8"
+zip = { version = "8.0", default-features = false, features = ["deflate"] }
 
 pyo3 = "0.20"
 

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -50,11 +50,6 @@ tempfile = "3.8"
 tokio-test = "0.4"
 
 [build-dependencies]
-bytes.workspace = true
-cached-path.workspace = true
+calimero-build-utils = { workspace = true, features = ["fetch"] }
 eyre.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
-# cached-path compat
-reqwest-compat = { version = "0.11", package = "reqwest", default-features = false, features = ["blocking", "rustls-tls"] }
-serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true

--- a/crates/auth/build.rs
+++ b/crates/auth/build.rs
@@ -6,24 +6,22 @@ use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
 
-use cached_path::Cache;
-use cached_path::Options;
+use calimero_build_utils::fetch_and_extract;
 use eyre::bail;
 use eyre::OptionExt;
-use reqwest::blocking::Client as ReqwestClient;
+use reqwest::blocking::Client;
+use reqwest::header::AUTHORIZATION;
 use reqwest::redirect::Policy;
 use reqwest::Url;
-use reqwest_compat::blocking::Client as ReqwestCompatClient;
-use reqwest_compat::header::AUTHORIZATION;
 
 const USER_AGENT: &str = "calimero-auth-build";
-const FRESHNESS_LIFETIME: u64 = 60 * 60 * 24 * 7; // 1 week
+const FRESHNESS_LIFETIME: Duration = Duration::from_secs(60 * 60 * 24 * 7);
 const FETCH_RETRY_ATTEMPTS: u32 = 4;
 const FETCH_RETRY_INITIAL_DELAY_SECS: u64 = 2;
 const CALIMERO_AUTH_FRONTEND_REPO: &str = "calimero-network/auth-frontend";
 /// Pinned, not `"latest"`. Resolving `"latest"` at build time meant two builds of
 /// one core commit could embed different auth-frontend bundles, and the resolution
-/// itself was a live GitHub round-trip on every build — outside the download cache
+/// itself was a live GitHub round-trip on every build - outside the download cache
 /// below, so a warm cache did not spare it. Bumping is a deliberate edit here.
 /// `CALIMERO_AUTH_FRONTEND_VERSION=latest` still opts back in per build.
 const CALIMERO_AUTH_FRONTEND_VERSION: &str = "v1.3.3";
@@ -94,7 +92,7 @@ fn try_main() -> eyre::Result<()> {
     let frontend_dir = if is_local_dir {
         Cow::from(Path::new(&*src))
     } else {
-        let mut builder = ReqwestCompatClient::builder().user_agent(USER_AGENT);
+        let mut builder = Client::builder().user_agent(USER_AGENT);
 
         if let Some(token) = token {
             let headers = [(AUTHORIZATION, format!("Bearer {token}").try_into()?)].into_iter();
@@ -102,22 +100,14 @@ fn try_main() -> eyre::Result<()> {
             builder = builder.default_headers(headers.collect());
         }
 
-        let cache = Cache::builder()
-            .client_builder(builder)
-            .freshness_lifetime(FRESHNESS_LIFETIME)
-            .dir(target_dir()?.join("cache"))
-            .build()?;
-
-        let mut options = Options::default().subdir("auth-frontend").extract();
+        let client = builder.build()?;
 
         let force = option_env!("CALIMERO_AUTH_FRONTEND_FETCH")
             .map_or(false, |c| matches!(c, "1" | "true" | "yes"));
 
-        if force {
-            options = options.force();
-        }
+        let cache_dir = target_dir()?.join("cache").join("auth-frontend");
 
-        let workdir = cached_path_with_retry(&cache, &src, &options)?;
+        let workdir = fetch_with_retry(&client, &src, &cache_dir, force)?;
 
         let repo = fs::read_dir(workdir)?
             .filter_map(Result::ok)
@@ -138,21 +128,23 @@ fn try_main() -> eyre::Result<()> {
 
 /// Fetch the frontend archive, retrying a failure that looks transient.
 ///
-/// Mirrors `cached_path_with_retry` in `crates/server/build.rs`, which exists for
-/// the same reason: `cached_path` retries only 502/503/504 and timeouts, and
-/// classifies a 404 as fatal. That is the wrong call for this URL, because
 /// GitHub's codeload builds tag archives on demand and can answer 404 for a tag
-/// that certainly exists — which is how a release build once failed on a tag that
+/// that certainly exists - which is how a release build once failed on a tag that
 /// resolved by hand minutes later. A genuinely bad tag still fails, just after a
 /// few seconds of patience instead of instantly.
-fn cached_path_with_retry(cache: &Cache, src: &str, options: &Options) -> eyre::Result<PathBuf> {
+fn fetch_with_retry(
+    client: &Client,
+    src: &str,
+    cache_dir: &Path,
+    force: bool,
+) -> eyre::Result<PathBuf> {
     let mut delay_secs = FETCH_RETRY_INITIAL_DELAY_SECS;
 
     for attempt in 1..=FETCH_RETRY_ATTEMPTS {
-        match cache.cached_path_with_options(src, options) {
+        match fetch_and_extract(client, src, cache_dir, FRESHNESS_LIFETIME, force) {
             Ok(path) => return Ok(path),
             Err(err) => {
-                let report = eyre::Report::new(err).wrap_err(format!(
+                let report = err.wrap_err(format!(
                     "failed to fetch the auth-frontend archive from {src} (attempt {attempt}/{FETCH_RETRY_ATTEMPTS})"
                 ));
 
@@ -173,7 +165,7 @@ fn cached_path_with_retry(cache: &Cache, src: &str, options: &Options) -> eyre::
 
 fn resolve_latest_release_tag(repo: &str, token: Option<&str>) -> eyre::Result<Option<String>> {
     let latest_release_url = CALIMERO_AUTH_FRONTEND_LATEST_RELEASE_URL.replace("{repo}", repo);
-    let client = ReqwestClient::builder()
+    let client = Client::builder()
         .user_agent(USER_AGENT)
         .redirect(Policy::limited(5))
         .build()?;

--- a/crates/build-utils/AGENTS.md
+++ b/crates/build-utils/AGENTS.md
@@ -1,12 +1,12 @@
 # calimero-build-utils - Build Script Helpers
 
-Shared helpers for `build.rs` scripts: reads the workspace release version and stamps git/rustc metadata into `cargo:rustc-env` vars.
+Shared helpers for `build.rs` scripts: reads the workspace release version and stamps git/rustc metadata into `cargo:rustc-env` vars, and behind the optional `fetch` feature downloads and extracts zip archives into a build cache.
 
 ## Package Identity
 
 - **Crate**: `calimero-build-utils`
-- **Entry**: `src/lib.rs` (single file, no modules)
-- **Key deps**: `rustc_version` (compiler version string), `toml` (parse workspace `Cargo.toml`); dev-only: `tempfile`
+- **Entry**: `src/lib.rs`, plus `src/fetch.rs` behind the `fetch` feature
+- **Key deps**: `rustc_version` (compiler version string), `toml` (parse workspace `Cargo.toml`); `fetch` only: `eyre`, `reqwest`, `sha2`, `tempfile`, `zip`
 
 ## Commands
 
@@ -14,8 +14,8 @@ Shared helpers for `build.rs` scripts: reads the workspace release version and s
 # Build
 cargo build -p calimero-build-utils
 
-# Test (all)
-cargo test -p calimero-build-utils
+# Test (all, including the fetch helpers)
+cargo test -p calimero-build-utils --features fetch
 
 # Test a single case
 cargo test -p calimero-build-utils git_details_or_unknown_returns_unknown_outside_git_repo -- --nocapture
@@ -31,12 +31,13 @@ cargo test -p calimero-build-utils git_details_or_unknown_returns_unknown_outsid
 | `git_details_or_unknown(pkg_dir)` | fn | Same as above but swallows errors into `GitInfo { describe: "unknown", commit: "unknown" }` and emits `cargo:warning` instead of failing the build |
 | `GitInfo` | struct | `{ describe: String, commit: String }` |
 | `run_command(cmd, args, cwd)` | fn | Thin wrapper over `std::process::Command`; returns stdout as `String`, error includes stderr on non-zero exit |
+| `fetch_and_extract(client, src, cache_dir, freshness, force)` | fn | `fetch` feature. Downloads (or reads, for a local path) a zip and returns the directory it was extracted into; reuses a cached extraction younger than `freshness` unless `force` |
 
 `read_workspace_version_for_dir` and `parse_workspace_metadata_version` are private helpers used only by `read_workspace_version` and the test suite.
 
 ## Mental Model
 
-Callers are `merod` and `meroctl` binaries only (`crates/merod/build.rs`, `crates/meroctl/build.rs`), each calling `calimero_build_utils::set_version_env_vars("MEROD")` / `"MEROCTL"` and `.expect()`-ing the result - a build.rs failing hard here is intentional, not a bug to soften.
+`set_version_env_vars` is called by the `merod` and `meroctl` binaries (`crates/merod/build.rs`, `crates/meroctl/build.rs`) as `calimero_build_utils::set_version_env_vars("MEROD")` / `"MEROCTL"`, `.expect()`-ing the result - a build.rs failing hard here is intentional, not a bug to soften. `fetch_and_extract` is called by `crates/server/build.rs` and `crates/auth/build.rs`, which enable the `fetch` feature to pull the admin dashboard and auth frontend bundles.
 
 `set_version_env_vars` composes the other three: it reads the workspace release version (from the workspace-root `[workspace.metadata.workspaces].version`, not the placeholder `0.0.0` in each crate's own `Cargo.toml`), resolves git info relative to `CARGO_MANIFEST_DIR` (falling back to `"unknown"` rather than failing if the crate is built outside a git checkout, e.g. from a source tarball), and reads the active `rustc` version. It then prints four `cargo:rustc-env=...` lines, which downstream code reads via `env!(...)` at compile time (see `crates/merod/src/version.rs`, `crates/merod/src/cli.rs`, `crates/meroctl/src/version.rs`, `crates/meroctl/src/cli.rs`).
 
@@ -44,7 +45,8 @@ Callers are `merod` and `meroctl` binaries only (`crates/merod/build.rs`, `crate
 
 | Path | What's there |
 | --- | --- |
-| `src/lib.rs` | Everything: all public fns, `GitInfo`, and all tests |
+| `src/lib.rs` | Version/git helpers, `GitInfo`, and their tests |
+| `src/fetch.rs` | `fetch_and_extract` and its cache, behind the `fetch` feature |
 
 ## Gotchas
 

--- a/crates/build-utils/Cargo.toml
+++ b/crates/build-utils/Cargo.toml
@@ -14,6 +14,14 @@ path = "src/lib.rs"
 [dependencies]
 rustc_version.workspace = true
 toml.workspace = true
+eyre = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true, features = ["blocking"] }
+sha2 = { workspace = true, optional = true }
+tempfile = { workspace = true, optional = true }
+zip = { workspace = true, optional = true }
+
+[features]
+fetch = ["dep:eyre", "dep:reqwest", "dep:sha2", "dep:tempfile", "dep:zip"]
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/build-utils/src/fetch.rs
+++ b/crates/build-utils/src/fetch.rs
@@ -1,0 +1,249 @@
+//! Cached download and extraction of zip archives for build scripts.
+
+use std::fmt::Write as _;
+use std::fs;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, UNIX_EPOCH};
+
+use eyre::{bail, Context, Result};
+use reqwest::blocking::Client;
+use sha2::{Digest, Sha256};
+use zip::ZipArchive;
+
+const CACHE_KEY_BYTES: usize = 16; // truncated sha256, wide enough that two sources never collide
+
+/// Fetch a zip archive and return the directory it was extracted into.
+///
+/// `src` is an `http(s)` URL or an absolute path to a local zip. Extractions live
+/// under `cache_dir` keyed by `src`, and are reused while younger than `freshness`.
+pub fn fetch_and_extract(
+    client: &Client,
+    src: &str,
+    cache_dir: &Path,
+    freshness: Duration,
+    force: bool,
+) -> Result<PathBuf> {
+    let dest = cache_dir.join(cache_key(src));
+
+    if !force && is_fresh(&dest, freshness) {
+        return Ok(dest);
+    }
+
+    let archive = read_archive(client, src)?;
+
+    fs::create_dir_all(cache_dir).wrap_err_with(|| {
+        format!(
+            "failed to create the cache directory {}",
+            cache_dir.display()
+        )
+    })?;
+
+    // Extract aside and rename in, so an interrupted build never leaves a
+    // half-written entry that the next one would treat as a cache hit.
+    let staging = tempfile::tempdir_in(cache_dir)?;
+
+    ZipArchive::new(Cursor::new(archive))
+        .and_then(|mut archive| archive.extract(staging.path()))
+        .wrap_err_with(|| format!("failed to extract the archive from {src}"))?;
+
+    let staged = staging.keep();
+
+    let _ignored = fs::remove_dir_all(&dest);
+
+    if fs::rename(&staged, &dest).is_err() {
+        let _ignored = fs::remove_dir_all(&staged);
+
+        // A parallel build may have renamed its own extraction in first.
+        if !dest.is_dir() {
+            bail!(
+                "failed to move the extracted archive into {}",
+                dest.display()
+            );
+        }
+    }
+
+    Ok(dest)
+}
+
+/// Anything that is not an `http(s)` URL is a path to a local archive.
+fn is_remote(src: &str) -> bool {
+    src.starts_with("http://") || src.starts_with("https://")
+}
+
+fn cache_key(src: &str) -> String {
+    let mut hasher = Sha256::new();
+
+    hasher.update(src.as_bytes());
+
+    // A local archive keeps its path across rebuilds, so only mtime tells two
+    // builds of it apart.
+    if let Some(mtime) = local_mtime(src) {
+        hasher.update(mtime.to_le_bytes());
+    }
+
+    let digest = hasher.finalize();
+
+    let mut key = String::with_capacity(CACHE_KEY_BYTES * 2);
+
+    for byte in &digest[..CACHE_KEY_BYTES] {
+        // Writing to a String is infallible.
+        let _ignored = write!(key, "{byte:02x}");
+    }
+
+    key
+}
+
+fn local_mtime(src: &str) -> Option<u64> {
+    if is_remote(src) {
+        return None;
+    }
+
+    let modified = fs::metadata(src).and_then(|meta| meta.modified()).ok()?;
+
+    Some(modified.duration_since(UNIX_EPOCH).ok()?.as_secs())
+}
+
+fn is_fresh(dir: &Path, lifetime: Duration) -> bool {
+    fs::metadata(dir)
+        .and_then(|meta| meta.modified())
+        .ok()
+        .and_then(|modified| modified.elapsed().ok())
+        .is_some_and(|age| age < lifetime)
+}
+
+fn read_archive(client: &Client, src: &str) -> Result<Vec<u8>> {
+    if !is_remote(src) {
+        return fs::read(src).wrap_err_with(|| format!("failed to read the archive at {src}"));
+    }
+
+    let response = client
+        .get(src)
+        .send()
+        .wrap_err_with(|| format!("failed to request {src}"))?
+        .error_for_status()
+        .wrap_err_with(|| format!("failed to download {src}"))?;
+
+    Ok(response
+        .bytes()
+        .wrap_err_with(|| format!("failed to read the response body from {src}"))?
+        .to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use zip::write::{SimpleFileOptions, ZipWriter};
+    use zip::CompressionMethod;
+
+    use super::*;
+
+    const FRESH: Duration = Duration::from_secs(60);
+
+    fn write_archive(path: &Path, contents: &str) {
+        let file = fs::File::create(path).expect("the archive must be creatable");
+        let mut zip = ZipWriter::new(file);
+
+        zip.start_file(
+            "index.html",
+            SimpleFileOptions::default().compression_method(CompressionMethod::Deflated),
+        )
+        .expect("the entry must be writable");
+
+        zip.write_all(contents.as_bytes())
+            .expect("the entry body must be writable");
+
+        zip.finish().expect("the archive must be finalizable");
+    }
+
+    #[test]
+    fn extracts_a_local_archive_and_then_reuses_it() {
+        let tmp = tempfile::tempdir().expect("temp dir must be creatable");
+        let archive = tmp.path().join("webui.zip");
+        let cache = tmp.path().join("cache");
+
+        write_archive(&archive, "first");
+
+        let src = archive.to_str().expect("path should be valid utf-8");
+        let client = Client::new();
+
+        let extracted = fetch_and_extract(&client, src, &cache, FRESH, false)
+            .expect("the archive should extract");
+
+        assert_eq!(
+            fs::read_to_string(extracted.join("index.html")).expect("the entry should exist"),
+            "first"
+        );
+
+        // Survives only if the second call reused the entry instead of re-extracting.
+        let sentinel = extracted.join("sentinel");
+        fs::write(&sentinel, "kept").expect("the sentinel must be writable");
+
+        let reused = fetch_and_extract(&client, src, &cache, FRESH, false)
+            .expect("the cached extraction should be reused");
+
+        assert_eq!(reused, extracted);
+        assert!(sentinel.is_file());
+    }
+
+    #[test]
+    fn a_fresh_entry_is_served_without_reaching_the_network() {
+        let tmp = tempfile::tempdir().expect("temp dir must be creatable");
+        let cache = tmp.path().to_path_buf();
+        let src = "https://unresolvable.invalid/webui.zip";
+
+        let entry = cache.join(cache_key(src));
+        fs::create_dir_all(&entry).expect("the cache entry must be creatable");
+
+        let served = fetch_and_extract(&Client::new(), src, &cache, FRESH, false)
+            .expect("a fresh entry must not be re-downloaded");
+
+        assert_eq!(served, entry);
+    }
+
+    #[test]
+    fn force_re_extracts_over_a_cache_hit() {
+        let tmp = tempfile::tempdir().expect("temp dir must be creatable");
+        let archive = tmp.path().join("webui.zip");
+        let cache = tmp.path().join("cache");
+
+        write_archive(&archive, "first");
+
+        let src = archive.to_str().expect("path should be valid utf-8");
+        let client = Client::new();
+
+        let _extracted = fetch_and_extract(&client, src, &cache, FRESH, false)
+            .expect("the archive should extract");
+
+        write_archive(&archive, "second");
+
+        let forced = fetch_and_extract(&client, src, &cache, FRESH, true)
+            .expect("the archive should re-extract");
+
+        assert_eq!(
+            fs::read_to_string(forced.join("index.html")).expect("the entry should exist"),
+            "second"
+        );
+    }
+
+    #[test]
+    fn distinct_sources_get_distinct_cache_entries() {
+        assert_ne!(
+            cache_key("https://example.invalid/a.zip"),
+            cache_key("https://example.invalid/b.zip")
+        );
+    }
+
+    #[test]
+    fn a_missing_local_archive_reports_the_path() {
+        let tmp = tempfile::tempdir().expect("temp dir must be creatable");
+        let missing = tmp.path().join("absent.zip");
+        let src = missing.to_str().expect("path should be valid utf-8");
+
+        let err = fetch_and_extract(&Client::new(), src, tmp.path(), FRESH, false)
+            .expect_err("a missing archive should fail");
+
+        assert!(err.to_string().contains(src));
+    }
+}

--- a/crates/build-utils/src/lib.rs
+++ b/crates/build-utils/src/lib.rs
@@ -1,7 +1,8 @@
 //! Shared build script utilities for Calimero binaries and crates.
 //!
 //! Provides workspace version reading and git metadata so build scripts stay DRY
-//! and consistent (e.g. correct git_dir resolution for rerun-if-changed).
+//! and consistent (e.g. correct git_dir resolution for rerun-if-changed), plus,
+//! behind the `fetch` feature, cached download and extraction of zip archives.
 
 use std::error::Error;
 use std::path::Path;
@@ -9,6 +10,12 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use toml::Value;
+
+#[cfg(feature = "fetch")]
+mod fetch;
+
+#[cfg(feature = "fetch")]
+pub use fetch::fetch_and_extract;
 
 /// Read `[workspace.metadata.workspaces].version` from the workspace root Cargo.toml.
 /// Used so binaries and crates get the release version instead of the workspace

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -71,10 +71,8 @@ calimero-utils-actix.workspace = true
 
 [build-dependencies]
 bytes.workspace = true
-cached-path.workspace = true
+calimero-build-utils = { workspace = true, features = ["fetch"] }
 eyre.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
-# cached-path compat
-reqwest-compat = { version = "0.11", package = "reqwest", default-features = false, features = ["blocking", "rustls-tls"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/server/build.rs
+++ b/crates/server/build.rs
@@ -1,10 +1,13 @@
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use std::{env, fs};
 
 use bytes::Bytes;
-use cached_path::{Cache, Options};
+use calimero_build_utils::fetch_and_extract;
 use eyre::{bail, Context, OptionExt};
+use reqwest::blocking::Client;
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -21,7 +24,7 @@ struct Release {
 }
 
 const USER_AGENT: &str = "calimero-server-build";
-const FRESHNESS_LIFETIME: u64 = 60 * 60 * 24 * 7; // 1 week
+const FRESHNESS_LIFETIME: Duration = Duration::from_secs(60 * 60 * 24 * 7);
 const CALIMERO_WEBUI_REPO: &str = "calimero-network/admin-dashboard";
 const CALIMERO_WEBUI_VERSION: &str = "latest";
 const CALIMERO_WEBUI_DEFAULT_ASSET: &str = "admin-dashboard-build.zip";
@@ -80,11 +83,9 @@ fn try_main() -> eyre::Result<()> {
                 _ => None,
             });
 
-            let builder = reqwest::blocking::Client::builder()
-                .user_agent(USER_AGENT)
-                .build()?;
+            let client = Client::builder().user_agent(USER_AGENT).build()?;
 
-            let mut req = builder.get(&*release_url);
+            let mut req = client.get(&*release_url);
 
             if let Some(token) = token {
                 req = req.bearer_auth(token);
@@ -125,39 +126,27 @@ fn try_main() -> eyre::Result<()> {
     let webui_dir = if is_local_dir {
         Cow::from(Path::new(&*src))
     } else {
-        let mut builder = reqwest_compat::blocking::Client::builder().user_agent(USER_AGENT);
-
-        let mut headers = reqwest_compat::header::HeaderMap::new();
-        headers.insert(
-            reqwest_compat::header::ACCEPT,
-            reqwest_compat::header::HeaderValue::from_static("application/octet-stream"),
-        );
+        let mut headers = HeaderMap::new();
+        headers.insert(ACCEPT, HeaderValue::from_static("application/octet-stream"));
 
         if let Some(token) = token {
             if src.starts_with("https://api.github.com/") {
                 let token_header = format!("Bearer {token}").try_into()?;
-                headers.insert(reqwest_compat::header::AUTHORIZATION, token_header);
+                headers.insert(AUTHORIZATION, token_header);
             }
         }
 
-        builder = builder.default_headers(headers);
-
-        let cache = Cache::builder()
-            .client_builder(builder)
-            .freshness_lifetime(FRESHNESS_LIFETIME)
-            .dir(target_dir()?.join("cache"))
+        let client = Client::builder()
+            .user_agent(USER_AGENT)
+            .default_headers(headers)
             .build()?;
-
-        let mut options = Options::default().subdir("webui").extract();
 
         let force = option_env!("CALIMERO_WEBUI_FETCH")
             .map_or(false, |c| matches!(c, "1" | "true" | "yes"));
 
-        if force {
-            options = options.force();
-        }
+        let cache_dir = target_dir()?.join("cache").join("webui");
 
-        let workdir = cached_path_with_retry(&cache, &src, &options)?;
+        let workdir = fetch_with_retry(&client, &src, &cache_dir, force)?;
 
         workdir.into()
     };
@@ -171,14 +160,24 @@ fn try_main() -> eyre::Result<()> {
     Ok(())
 }
 
-fn cached_path_with_retry(cache: &Cache, src: &str, options: &Options) -> eyre::Result<PathBuf> {
+/// Fetch the webui archive, retrying a failure that looks transient.
+///
+/// GitHub's codeload builds release archives on demand and can answer 404 for an
+/// asset that certainly exists, so a fresh release is worth a few seconds of
+/// patience. A genuinely missing asset still fails, just not instantly.
+fn fetch_with_retry(
+    client: &Client,
+    src: &str,
+    cache_dir: &Path,
+    force: bool,
+) -> eyre::Result<PathBuf> {
     let mut delay_secs = CALIMERO_WEBUI_FETCH_RETRY_INITIAL_DELAY_SECS;
 
     for attempt in 1..=CALIMERO_WEBUI_FETCH_RETRY_ATTEMPTS {
-        match cache.cached_path_with_options(src, options) {
+        match fetch_and_extract(client, src, cache_dir, FRESHNESS_LIFETIME, force) {
             Ok(path) => return Ok(path),
             Err(err) => {
-                let report = eyre::Report::new(err).wrap_err(format!(
+                let report = err.wrap_err(format!(
                     "failed to fetch CALIMERO_WEBUI_SRC from {src} (attempt {attempt}/{CALIMERO_WEBUI_FETCH_RETRY_ATTEMPTS})"
                 ));
 
@@ -188,7 +187,7 @@ fn cached_path_with_retry(cache: &Cache, src: &str, options: &Options) -> eyre::
 
                 eprintln!("cargo:warning={report:#}");
                 eprintln!("cargo:warning=retrying CALIMERO_WEBUI fetch in {delay_secs}s");
-                std::thread::sleep(std::time::Duration::from_secs(delay_secs));
+                std::thread::sleep(Duration::from_secs(delay_secs));
                 delay_secs = delay_secs.saturating_mul(2);
             }
         }

--- a/deny.toml
+++ b/deny.toml
@@ -19,14 +19,7 @@ ignore = [
     { id = "RUSTSEC-2026-0119", reason = "hickory-proto, via libp2p-dns; pending libp2p upgrade" },
     { id = "RUSTSEC-2026-0097", reason = "rand, transitive; pending upstream upgrade" },
     { id = "RUSTSEC-2023-0071", reason = "rsa Marvin timing attack, transitive; no upstream fix available" },
-    # The shipped path IS fixed: hyper 1.x's h2 is bumped to 0.4.16 in this same
-    # change. What remains is h2 0.3.27 under reqwest 0.11, reached only as a
-    # BUILD dep (cached-path, in calimero-server / mero-auth) and a DEV dep
-    # (jsonschema, in calimero-wasm-abi) - neither is in merod or meroctl. The
-    # 0.3 line is unpatched upstream (the fix landed only in 0.4.16), so this
-    # cannot be lock-bumped; clearing it means moving cached-path 0.8 -> 0.10 and
-    # jsonschema 0.17 -> 0.49, both breaking, tracked separately.
-    { id = "RUSTSEC-2026-0258", reason = "h2 0.3.27 via reqwest 0.11, build+dev only; 0.3 unpatched upstream. Runtime h2 is 0.4.16" },
+    { id = "RUSTSEC-2026-0258", reason = "h2 0.3.27 via reqwest 0.11, dev only; 0.3 unpatched upstream. Runtime h2 is 0.4.16" },
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

`cargo deny check licenses` fails on #3715 because `cached-path` depends on `zip` with default features, and `zip` enables all nine of its codecs by default. That drags in `bzip2`, which at the version #3715 resolves to (`cached-path` 0.8.1 -> 0.10.1) becomes `bzip2 0.6.1 -> libbz2-rs-sys 0.2.5`, licensed `bzip2-1.0.6` and not in `deny.toml`'s allow-list. Cargo features are an additive union, so no manifest of ours can narrow another crate's features. Dropping the dependency is the only fix in our control.

`crates/server/build.rs` and `crates/auth/build.rs` were the only consumers, and both used `cached-path` for exactly one thing: fetch a zip, extract it, cache the result. That is now `calimero_build_utils::fetch_and_extract`, built on `reqwest` plus `zip` with the deflate codec only, behind an optional `fetch` feature so `merod` and `meroctl` do not grow `reqwest` and `zip` in their own build scripts.

This also deletes the `reqwest-compat` shim. It existed only so both build scripts could hand `cached_path::Cache` a reqwest 0.11 client; with `cached-path` gone, both scripts use the workspace's reqwest 0.12 directly.

**This unblocks #3715**: with `cached-path` gone from the repo, that PR can drop both its `cached-path` bump and the `reqwest-compat` removal it was carrying.

Behaviour is preserved: every `CALIMERO_WEBUI_*` and `CALIMERO_AUTH_FRONTEND_*` knob (including the `_FETCH` force flags and `_FETCH_TOKEN`), the one-week freshness lifetime, the per-consumer cache subdirs (`webui` / `auth-frontend`), and both scripts' retry loops, which exist because GitHub's codeload answers 404 for freshly-created tag archives. Two improvements over `cached-path`: extraction goes into a temp dir and is renamed into place, so an interrupted build cannot leave a half-written entry that the next build treats as a cache hit; and a local zip is keyed by path plus mtime, where `cached-path` keyed it by *time elapsed since* mtime and so re-extracted on every build.

Net effect on the lock file: `bzip2`, `cached-path`, `zstd`/`zstd-safe`/`zstd-sys`, `fs2`, `password-hash`/`pbkdf2`, `indicatif`/`console`, and a whole duplicate rustls stack (`rustls`, `rustls-webpki`, `sct`, `tokio-rustls`, `hyper-rustls`, `webpki-roots`, `rustls-pemfile`) all leave; `typed-path`, `zlib-rs` and `zopfli` arrive with `zip` 8.

## Test plan

`cargo deny` was run with the version CI pins (0.19.9). Full-workspace `clippy`/`test` were **not** run locally (they time out on this machine); CI covers them.

**1. `cargo check -p calimero-build-utils` / `--features fetch`**

```
Checking calimero-build-utils v0.0.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.41s

Checking zip v8.6.0
Checking reqwest v0.12.28
Checking calimero-build-utils v0.0.0
Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.42s
```

**2. `cargo check -p calimero-server`** (runs the build script, downloads the dashboard zip)

```
warning: calimero-server@0.0.0: PROBE downloading https://github.com/calimero-network/admin-dashboard/releases/latest/download/admin-dashboard-build.zip
Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 13s
```

**3. `cargo check -p mero-auth`** (same, for the auth frontend)

```
warning: mero-auth@0.0.0: PROBE downloading https://github.com/calimero-network/auth-frontend/archive/refs/tags/v1.3.3.zip
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.18s
```

Extracted trees are correct, and no staging dir is left behind:

```
$ ls target/debug/cache/webui/e430400038b281e1f00564fc6cea7916
404.html  assets  index.html  public

$ ls target/debug/cache/auth-frontend/21dab3c2fc03dfe02d537e4058dfe287/*/build
assets  calimero-icon.svg  favicon.ico  index.html  mockServiceWorker.js
```

**4. Cache proven.** A temporary `PROBE` line (since removed) on both branches of the helper, with the build scripts touched between runs to force a rerun:

```
########## RUN 1 (cold cache) ##########
warning: mero-auth@0.0.0: PROBE downloading https://github.com/calimero-network/auth-frontend/archive/refs/tags/v1.3.3.zip
warning: calimero-server@0.0.0: PROBE downloading https://github.com/calimero-network/admin-dashboard/releases/latest/download/admin-dashboard-build.zip

########## RUN 2 ##########
warning: mero-auth@0.0.0: PROBE cache hit target/debug/cache/auth-frontend/21dab3c2fc03dfe02d537e4058dfe287
warning: calimero-server@0.0.0: PROBE cache hit target/debug/cache/webui/e430400038b281e1f00564fc6cea7916

########## RUN 3 (build scripts forced to rerun) ##########
warning: calimero-server@0.0.0: PROBE cache hit target/debug/cache/webui/e430400038b281e1f00564fc6cea7916
warning: mero-auth@0.0.0: PROBE cache hit target/debug/cache/auth-frontend/21dab3c2fc03dfe02d537e4058dfe287
```

Unit tests in `crates/build-utils/src/fetch.rs` cover the same logic hermetically (cache hit reuses rather than re-extracts; a fresh entry is served without touching the network; `force` re-extracts; a missing local archive names the path):

```
$ cargo test -p calimero-build-utils --features fetch
test fetch::tests::a_fresh_entry_is_served_without_reaching_the_network ... ok
test fetch::tests::extracts_a_local_archive_and_then_reuses_it ... ok
test fetch::tests::force_re_extracts_over_a_cache_hit ... ok
test fetch::tests::a_missing_local_archive_reports_the_path ... ok
test fetch::tests::distinct_sources_get_distinct_cache_entries ... ok
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

**5. Dependency tree**

```
$ cargo tree -i zip
zip v8.6.0
└── calimero-build-utils v0.0.0 (crates/build-utils)
    [build-dependencies]

$ cargo tree -e features -i zip
zip v8.6.0
├── zip feature "_deflate-any"
│   ├── zip feature "deflate-flate2"
│   │   └── zip feature "deflate-flate2-zlib-rs"
│   │       └── zip feature "deflate"

$ cargo tree -i bzip2
error: package ID specification `bzip2` did not match any packages

$ cargo tree -i libbz2-rs-sys
error: package ID specification `libbz2-rs-sys` did not match any packages

$ cargo tree -i cached-path
error: package ID specification `cached-path` did not match any packages
```

**6. `cargo deny` (0.19.9, as CI pins)** - the headline gate

```
$ cargo deny check licenses bans sources
bans ok, licenses ok, sources ok

$ cargo deny check advisories bans licenses sources
advisories ok, bans ok, licenses ok, sources ok
```

**7. `cargo machete` (0.9.2)** - would have caught a leftover `reqwest-compat`

```
cargo-machete didn't find any unused dependencies in this directory. Good job!
```

**8. `cargo fmt --check`** - clean, no output.

**9. `cargo clippy -- -D warnings`**

```
$ cargo clippy -p calimero-build-utils --all-targets --features fetch -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.32s

$ cargo clippy -p calimero-server --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 20.28s

$ cargo clippy -p mero-auth --all-targets -- -D warnings
mero-auth clippy EXIT=0
```

**10. No live references remain**

```
$ grep -rn "cached.path\|cached_path\|reqwest_compat\|reqwest-compat" crates/ tools/ Cargo.toml
crates/node/src/sync/snapshot.rs:1471:/// pending writes gives exactly the sequence the uncached path would, one
```

The single match is incidental prose ("uncached path"), not a reference.
