### PR TITLE
fix(governance): drain sealed root ops on every path a key arrives by

### DIFF
--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -1405,19 +1405,6 @@ impl<'a> NamespaceGovernance<'a> {
             );
         }
 
-        // Sealed root ops first, then the group's own. A root op can be the thing
-        // that makes a group op applicable — `GroupCreated` is sealed, and a group
-        // op for a group this node has not folded yet has nothing to apply
-        // against — so draining them in the other order would leave the group
-        // ops to a later pass for no reason.
-        if let Err(e) = self.retry_sealed_root_ops() {
-            tracing::warn!(
-                namespace_id = %hex::encode(self.namespace_id.as_bytes()),
-                error = %format!("{e:#}"),
-                "sealed-root retry pass failed; group retry continues"
-            );
-        }
-
         self.retry_encrypted_ops_for_group(group_id)
             .map_err(|e| eyre::eyre!("retry_encrypted_ops_for_group: {e}"))
     }
@@ -1517,6 +1504,23 @@ impl<'a> NamespaceGovernance<'a> {
         &self,
         group_id: [u8; 32],
     ) -> EyreResult<Option<super::super::DivergenceReport>> {
+        // Sealed root ops first, and here rather than at a caller. A key reaches a
+        // node two ways — a `KeyDelivery` op, and the pull in `group_key_pull` —
+        // and both come through this function. Draining at one of them left the
+        // other silently unable to fold buffered root ops, which is what the
+        // convergence test caught.
+        //
+        // Root before group, because a root op can be what makes a group op
+        // applicable: `GroupCreated` is sealed, and a group op for a group this
+        // node has not folded has nothing to apply against.
+        if let Err(e) = self.retry_sealed_root_ops() {
+            tracing::warn!(
+                namespace_id = %hex::encode(self.namespace_id.as_bytes()),
+                error = %format!("{e:#}"),
+                "sealed-root retry pass failed; group retry continues"
+            );
+        }
+
         let gid_typed = ContextGroupId::from(group_id);
         let retry_service = NamespaceRetryService::new(self.store, self.namespace_id);
         let retry_candidates = retry_service

--- a/crates/node/src/local_governance_node_e2e.rs
+++ b/crates/node/src/local_governance_node_e2e.rs
@@ -3479,3 +3479,113 @@ async fn self_leave_drives_a_real_key_rotation_on_a_remaining_admin() {
         "the pre-rotation key must be retained so already-written ops stay readable"
     );
 }
+
+/// A sealed root op that arrives before the key still lands once it does.
+///
+/// The property the whole E0–E1c chain rests on, and nothing else asserts it.
+/// Sealing group structure is only safe if a member who receives an op before its
+/// key still converges afterwards; if it did not, a joining node would be missing
+/// namespace structure permanently, with no error anywhere to say so.
+///
+/// Written against the three steps in order: E1b buffers the op rather than
+/// erroring, `apply_signed_op` logs it regardless of whether it applied, and E2's
+/// pass finds it — the group retry could not, because its walk selects by group id
+/// and both it and the loop above matched `NamespaceOp::Group`.
+#[tokio::test]
+#[serial(boot_test_node)]
+async fn a_sealed_group_created_lands_after_the_key_arrives() {
+    use calimero_context_client::local_governance::{NamespaceOp, RootOp, SignedNamespaceOp};
+    use calimero_governance_store::{
+        apply_signed_namespace_op, retry_encrypted_ops_for_group, GroupKeyring,
+        MembershipRepository, MetaRepository, NamespaceRepository,
+    };
+
+    let store = Store::new(Arc::new(InMemoryDB::owned()));
+    let mut rng = OsRng;
+
+    let ns_gid = ContextGroupId::from([0xE7u8; 32]);
+    let namespace_id = ns_gid.to_bytes();
+
+    let owner_sk = PrivateKey::random(&mut rng);
+    let owner_pk = owner_sk.public_key();
+    let member_sk = PrivateKey::random(&mut rng);
+    let member_pk = member_sk.public_key();
+
+    MetaRepository::new(&store)
+        .save(
+            &ns_gid,
+            &sample_meta(calimero_context::test_support::account_for(&owner_pk)),
+        )
+        .expect("save namespace root meta");
+    let owner_account = calimero_context::test_support::enrol(&store, &ns_gid, &owner_pk);
+    MembershipRepository::new(&store)
+        .add_member(&ns_gid, &owner_account, GroupMemberRole::Admin)
+        .expect("add owner as namespace-root admin");
+    // The receiver is a different identity from the signer, so the retry's
+    // own-signed skip does not swallow the op under test.
+    NamespaceRepository::new(&store)
+        .replace_identity(&ns_gid, &member_pk, member_sk.as_bytes())
+        .expect("store receiver namespace identity");
+
+    let namespace_key: [u8; 32] = {
+        use rand::RngCore;
+        let mut k = [0u8; 32];
+        rng.fill_bytes(&mut k);
+        k
+    };
+    let key_id = GroupKeyring::key_id_for(&namespace_key);
+    let sub_gid = ContextGroupId::from(*PrivateKey::random(&mut rng).public_key());
+
+    let inner_op = RootOp::GroupCreated {
+        group_id: sub_gid.to_bytes().into(),
+        parent_id: ns_gid.to_bytes().into(),
+        restricted: true,
+        admin: owner_account,
+    };
+    let encrypted =
+        GroupKeyring::encrypt_root_op(&namespace_key, &inner_op).expect("seal GroupCreated");
+
+    let sealed_op = SignedNamespaceOp::sign(
+        &owner_sk,
+        namespace_id.into(),
+        vec![],
+        1,
+        NamespaceOp::RootSealed {
+            key_id: key_id.into(),
+            encrypted,
+        },
+    )
+    .expect("sign NamespaceOp::RootSealed(GroupCreated)");
+
+    // Applied with no key held. Must not error — a member that has not received
+    // the namespace key yet is an ordinary state, and erroring would drop an op
+    // this node can apply minutes later.
+    apply_signed_namespace_op(&store, &sealed_op)
+        .expect("a sealed op with no key must buffer, not fail");
+
+    assert_eq!(
+        NamespaceRepository::new(&store)
+            .parent(&sub_gid)
+            .expect("read parent before the key"),
+        None,
+        "the subgroup must not exist while the op is unreadable"
+    );
+
+    // The key arrives.
+    let _ = GroupKeyring::new(&store, ns_gid)
+        .store_key(&namespace_key)
+        .expect("store namespace key on receiver");
+
+    retry_encrypted_ops_for_group(&store, namespace_id.into(), ns_gid.to_bytes())
+        .expect("retry after key delivery");
+
+    // The assertion the chain exists for: structure the node could not read is
+    // folded once it can, without the op being resent.
+    assert_eq!(
+        NamespaceRepository::new(&store)
+            .parent(&sub_gid)
+            .expect("read parent after the key"),
+        Some(ns_gid),
+        "the sealed GroupCreated must land once the key is held"
+    );
+}


### PR DESCRIPTION
**Fixes a live defect on master** (from #3734), and adds the test that found it. **Must merge before #3736** — E1c is what makes this bug reachable.

## The bug

#3734 wired the sealed-root drain into the `KeyDelivery` handler rather than into `retry_encrypted_ops_for_group`, which **both** key-arrival paths funnel through:

| how the key arrives | drains sealed root ops |
|---|---|
| `KeyDelivery` op | ✅ |
| pull — `group_key_pull` calls the public entry directly | ❌ |

A node that obtains its key by pull never drains the root ops it buffered. Permanently. No error anywhere.

It's the same shape as the field two of three handlers dropped earlier today: correct at the call site I was looking at, absent from the one I wasn't. Moved to the shared entry so both paths get it by construction.

## The test E2 shipped without

`a_sealed_group_created_lands_after_the_key_arrives` asserts the property the whole sealing chain rests on:

```
seal GroupCreated under a key the receiver lacks
  → apply         → must buffer, not error        (E1b)
  → assert absent → subgroup has no parent
  → key arrives
  → retry         → finds it                      (E2)
  → assert present → parent == namespace root
```

It fails on master before this change and passes after. It needs all the pieces together — the receiver buffering instead of erroring, `apply_signed_op` logging the op even unapplied, and the namespace-scoped collector finding it.

Two details that would otherwise make it pass for the wrong reason:

- **the receiver is a different identity from the signer** — the retry skips own-signed ops, so a single-identity test proves nothing
- **it builds the sealed op directly** rather than through E1c's publisher, so it stands on merged code alone and this PR is independent of #3736

## Corroboration from a real scenario

The same defect appears as `26-owner-driven-authored` failing on #3736:

```
JSON-RPC Error: Uninitialized
Execution failed: app state not available after retries
```

Node 2 joins, never folds the sealed `GroupCreated`, and its **write** fails several steps downstream of the cause — naming nothing about keys, root ops, or retries. That's what this looks like in production, and it's why the unit test matters.

## Merge order

1. **this PR**
2. then #3736 — re-run, and `26-owner-driven-authored` should go green

Same scenario failing before and passing after is stronger evidence than the unit test alone.

## Verification

Test passes on plain master with the fix (`1 passed`). `clippy --all-targets --features mock-attestation -- -D warnings` clean. governance-store suite 639 passed.

Note: the test module is `#[cfg(all(test, feature = "mock-attestation"))]`, so `cargo test -p calimero-node` without that feature collects nothing and exits 0 — worth knowing when re-running locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)