### PR TITLE
docs: direct admission, and three corrections to the endpoint table

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -174,6 +174,7 @@ export default defineConfig({
                 'protocol/identities',
                 'protocol/accounts',
                 'protocol/delegated-authorship',
+                'protocol/direct-admission',
                 'protocol/encryption',
                 'protocol/key-rotation',
                 'protocol/security-model',

--- a/docs/src/content/docs/operate/admin-api.mdx
+++ b/docs/src/content/docs/operate/admin-api.mdx
@@ -305,8 +305,8 @@ the path parameter — these are reproduced exactly as routed below.
 | DELETE | `/admin-api/namespaces/:namespace_id` | Delete a namespace. |
 | POST | `/admin-api/namespaces/:namespace_id/invite` | Invite into a namespace. |
 | POST | `/admin-api/namespaces/:namespace_id/join` | Join a namespace. |
+| POST | `/admin-api/namespaces/:namespace_id/admit` | Publish a join signed by a keyholder that has no node of its own. See [Direct Admission](/protocol/direct-admission/). |
 | POST | `/admin-api/namespaces/:namespace_id/leave` | Leave a namespace. |
-| GET | `/admin-api/namespaces/:namespace_id/identity` | Get the node's identity in a namespace. |
 | GET | `/admin-api/namespaces/for-application/:application_id` | List namespaces for an application. |
 | GET | `/admin-api/namespaces/:namespace_id/groups` | List groups in a namespace. |
 | POST | `/admin-api/namespaces/:namespace_id/groups` | Create a group inside a namespace. |
@@ -334,6 +334,7 @@ the path parameter — these are reproduced exactly as routed below.
 
 | Method | Path | Purpose |
 | --- | --- | --- |
+| GET | `/admin-api/identity` | Get this node's account and device identity. Replaced the per-namespace route: identity is node-level, one root to one account to one device. |
 | POST | `/admin-api/identity/context` | Generate a new context identity (keypair). |
 | POST | `/admin-api/alias/create/context` | Create an alias for a context. |
 | POST | `/admin-api/alias/create/application` | Create an alias for an application. |

--- a/docs/src/content/docs/protocol/direct-admission.mdx
+++ b/docs/src/content/docs/protocol/direct-admission.mdx
@@ -1,0 +1,150 @@
+---
+title: Direct Admission
+description: How an account with no node joins a namespace, and why an invitation names who may admit it.
+sidebar:
+  order: 46
+---
+
+import SeqDiagram from '../../../components/SeqDiagram.astro';
+import { Steps } from '@astrojs/starlight/components';
+
+## Two ways in, for two different callers
+
+A member joins a namespace by getting one op onto the governance DAG:
+`MemberJoinedAt`, carrying the invitation it claims and a credential proving the
+account is its own. Every peer applies that op the same way regardless of how it
+arrived.
+
+What differs is who can *publish* it.
+
+- **`POST /admin-api/namespaces/:id/join`** — the caller **is** the node that
+  becomes the member. It holds a device key, builds the credential from its own
+  store, signs, applies locally, and publishes to the namespace topic. One call,
+  no third party.
+- **`POST /admin-api/namespaces/:id/admit`** — the caller holds **only a key**. It
+  signs the op itself and hands it to a node the inviter named, which publishes on
+  its behalf.
+
+The second exists because a keyholder — a browser tab, a phone, an agent — has an
+account, a [device certificate it signed offline](/protocol/accounts/), and nowhere
+to publish from. `/join` cannot serve it, because `/join` assumes the caller is the
+node that will become the member.
+
+## Why invitations name their admitters
+
+An open invitation used to be claimable by broadcast: the joiner announced itself
+on the namespace topic and any ready peer answered. That published the whole
+invitation, in the clear, to every subscriber of that topic — and because the
+consumed-invitation row is keyed by account, a thief and the intended joiner both
+succeeded, silently.
+
+So `GroupInvitationFromAdmin` carries an `admitters` list, **inside the inviter's
+signature**. Being named is permission to carry a valid claim, and nothing else.
+
+<SeqDiagram
+  id="d-admit"
+  title="A keyholder joins through an admitter"
+  lanes={[
+    { label: 'Keyholder (key only)', color: '#f0883e' },
+    { label: 'Admitter node', color: '#3fb950' },
+    { label: 'Peers', color: '#a371f7' },
+  ]}
+  steps={[
+    { from: 0, to: 0, label: 'sign device cert with the account root, offline', color: '#a5ff11' },
+    { from: 0, to: 0, label: 'sign MemberJoinedAt with the DEVICE key', color: '#a5ff11' },
+    { from: 0, to: 1, label: 'POST admit { invitation, signedOp }' },
+    { from: 1, to: 1, label: 'verify the op signature' },
+    { from: 1, to: 1, label: 'refuse unless named in signed admitters', color: '#ff7b72' },
+    { from: 1, to: 1, label: 'validate invitation: inviter, group, expiry' },
+    { from: 1, to: 1, label: 'apply locally, then publish' },
+    { from: 1, to: 2, label: 'broadcast MemberJoinedAt' },
+    { from: 2, to: 2, label: 'check signer == credential.sign_pk, then fold' },
+  ]}
+/>
+
+<Steps>
+
+1. **The credential is signed offline.** The account root signs a device
+   certificate naming the device's signing and KEM keys. No node participates, and
+   nothing is published.
+
+2. **The op is signed by the device key** the credential names. This is what makes
+   handing it over safe: every peer checks `signer == credential.statement.sign_pk`
+   when applying a join, so an admitter cannot substitute a different account.
+
+3. **The admitter checks what it can, then applies before publishing.** It
+   verifies the op's signature, that it is named in the signed `admitters` list,
+   and that the invitation is genuinely the inviter's and unexpired. It applies to
+   its own state first, so only an op its own state accepted reaches the network
+   under its name.
+
+4. **Peers fold it normally.** The op is an ordinary `MemberJoinedAt`; nothing
+   about the admit path relaxes what applying one requires.
+
+</Steps>
+
+## What an admitter can and cannot do
+
+It can **decline to publish**. That is the whole of its power.
+
+It cannot admit a different account, change the group, or grant a role, because
+all of that sits inside a signature it does not hold. The check that stops
+substitution — `signer == credential.statement.sign_pk` — lives at apply on every
+peer, deliberately rather than at the endpoint, because it has to hold for ops the
+endpoint never sees.
+
+A hostile admitter is therefore a liveness problem, not an authority one, which is
+why an invitation naming several is worth more than one naming a single node.
+
+## Who is an admitter by default
+
+Admins and TEE nodes. A caller that names none gets that set; the inviter is
+**not** added to it.
+
+That is a deliberate separation of duties. `CAN_INVITE_MEMBERS` lets a non-admin
+member create an invitation, but not see it through — admission stays with admins
+and TEE nodes, so a delegated inviter cannot complete a membership alone.
+
+The cost is reachability rather than authority: a non-admin inviter mints
+invitations it cannot itself admit, so the invitee has to reach an admin or TEE
+node rather than whoever handed it the invitation.
+
+An invitation with an **empty** admitter list is the one that means "claimable by
+broadcast", so minting refuses when the default set comes back empty. Every group
+has an admin — the last one cannot be removed or demoted away — so an empty result
+means the node's own state is inconsistent, and answering that by issuing the least
+restricted credential the system can express would be the wrong response.
+
+## Finding an admitter
+
+`admitters` names **accounts**. Connecting needs a peer id, and a joiner that has
+synced nothing has no governance state to resolve one from. So
+`SignedGroupOpenInvitation` also carries `admitter_hints`, **outside** the
+signature:
+
+- `{ multiaddr }` for a joiner that runs a node
+- `{ url }` for one that holds only a key and reaches the admin API over HTTPS
+
+Unsigned on purpose. A hint is only *where* to look; who may admit stays inside the
+signature, so a wrong or stale hint costs a failed connection and nothing more —
+the admitting node still has to be in the signed list for its admission to count.
+
+Nothing populates hints yet, which is tracked separately. Until it does, a joiner
+needs the address out of band.
+
+## Invitations expire within a day
+
+`MAX_INVITATION_VALIDITY_SECS` is 24 hours, clamped where invitations are minted
+rather than at the API edge, so an internal caller cannot ask for longer.
+
+An invitation is a bearer credential: possession is enough. A long-lived one keeps
+a leak redeemable for as long as it lasts, and guarantees any address hint shipped
+with it has gone stale.
+
+## Known gap
+
+`/admit` sits behind the admin API's auth guard, so a keyholder presenting a signed
+op to **somebody else's** node still needs a credential on that node. Everything
+else in the flow works without one — the account, the certificate, and the op are
+all produced offline — but the last hop is not yet answered for a node the
+keyholder has no relationship with.


### PR DESCRIPTION
Nothing in `docs/` explained how an account with no node joins a namespace. The only existing hit for "direct admission" is unrelated prose about Restricted subgroups being a wall.

Independent of #3736 and #3737 — docs only, no code.

## New page: `protocol/direct-admission`

Covers what the code does and, where it matters, why:

- **the two join paths** and which caller each serves — `/join` assumes the caller *is* the node becoming a member, which is exactly what a keyholder isn't
- **what an admitter can and cannot do** — decline to publish, and nothing else. `signer == credential.statement.sign_pk` is checked at apply by every peer rather than at the endpoint, deliberately, because it has to hold for ops the endpoint never sees
- **admins ∪ TEE as the default**, with the inviter excluded so `CAN_INVITE_MEMBERS` grants *creating* an invitation rather than completing a membership — and the reachability cost that follows
- **why an empty admitter list is refused at mint** rather than read as "unrestricted": every group has an admin, so an empty set means the store is inconsistent
- **why hints sit outside the signature** — an account is addressed by peer id, and a joiner that has synced nothing cannot resolve one
- **the 24-hour ceiling** — a bearer credential that lasts a year keeps a leak redeemable for a year
- **the auth gap**, written down rather than omitted: a keyholder presenting a signed op to somebody else's node still needs a credential there, and that's the one part of the flow with no answer yet

Includes a `SeqDiagram` of the keyholder flow, matching the delegated-authorship page's conventions.

## Three endpoint-table fixes, two predating this work

| | |
|---|---|
| **added** | `POST /admin-api/namespaces/:namespace_id/admit` |
| **removed** | `GET /admin-api/namespaces/:namespace_id/identity` — retired when identity became node-level, and absent from `endpoints.json` |
| **added** | `GET /admin-api/identity` — the route that replaced it, live and undocumented |

So the table was simultaneously advertising a dead endpoint and omitting its live replacement.

It drifts because it's hand-maintained and nothing ties it to the route manifest: the manifest gate makes a new endpoint declare itself in `endpoints.json` *and* carry an SDK e2e, and says nothing about docs. Worth considering whether that gate should also check the table.

## Verification

`npm run build` clean — `/protocol/direct-admission/index.html` is in the output, so the page renders and the sidebar entry resolves. Both internal links (`/protocol/accounts/`, `/protocol/encryption/`) point at pages that exist.

`npm install` also stripped 102 lines of `libc: [glibc]` / `[musl]` platform metadata from `package-lock.json` — macOS npm removing Linux entries. I committed that by accident and amended it out; the lockfile is byte-identical to master here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)