### PR TITLE
chore(dependabot): group axum with the tower family

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,8 @@ updates:
         patterns: ["wasmer", "wasmer-*"]
       libp2p:
         patterns: ["libp2p", "libp2p-*", "multiaddr", "prometheus-client"]
-      tower:
-        patterns: ["tower", "tower-*"]
+      axum:
+        patterns: ["axum", "axum-*", "tower", "tower-*", "tokio-tungstenite"]
       cargo:
         patterns: ["*"]
         update-types: ["minor", "patch"]


### PR DESCRIPTION
## Summary

Group axum with the tower dependency family. tower-sessions 0.15 requires axum-core 0.5, which is axum 0.8, so tower and axum cannot move separately. Dependabot PR #3722 proves this by landing both axum-core 0.4.5 and 0.5.6 in one lockfile. axum's ws feature also re-exports tungstenite types, so tokio-tungstenite rides along.

## Test plan

Verify YAML parse and cargo groups order:
```
['wasmer', 'libp2p', 'axum', 'cargo']
```