### PR TITLE
chore(deps): bump syn to 3 and prettyplease to 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,7 +627,7 @@ dependencies = [
  "clang-sys",
  "itertools 0.13.0",
  "log",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "regex",
@@ -647,7 +647,7 @@ dependencies = [
  "clang-sys",
  "itertools 0.13.0",
  "log",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "regex",
@@ -1508,11 +1508,11 @@ dependencies = [
 name = "calimero-sdk-macros"
 version = "0.0.0"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.3.0",
  "proc-macro2",
  "quote",
  "sha2 0.10.9",
- "syn 2.0.117",
+ "syn 3.0.3",
  "thiserror 2.0.20",
 ]
 
@@ -1617,7 +1617,7 @@ name = "calimero-storage-macros"
 version = "0.0.0"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6967,6 +6967,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
+dependencies = [
+ "proc-macro2",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7083,7 +7093,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
+ "prettyplease 0.2.37",
  "prost",
  "prost-types",
  "regex",
@@ -11093,7 +11103,7 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.14.1",
- "prettyplease",
+ "prettyplease 0.2.37",
  "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
@@ -11107,7 +11117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
 dependencies = [
  "anyhow",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,7 +256,7 @@ parking_lot = "0.12.3"
 pastey = "0.2.3" # maintained drop-in for the unmaintained `paste`
 percent-encoding = "2.3"
 png = "0.18"
-prettyplease = "0.2.17"
+prettyplease = "0.3"
 proc-macro2 = "1.0"
 # pinned to the major libp2p-metrics uses; moves when libp2p does
 prometheus-client = "0.23"
@@ -276,7 +276,7 @@ serde_with = "3.9.0"
 sha2 = "0.10.8"
 subtle = "2.6.1"
 strum = "0.28.0"
-syn = { version = "2.0", features = ["full"] }
+syn = { version = "3.0", features = ["full"] }
 tar = "0.4"
 tempfile = "3.10"
 windows-sys = "0.61"

--- a/crates/sdk/macros/src/errors.rs
+++ b/crates/sdk/macros/src/errors.rs
@@ -27,6 +27,7 @@ impl Display for Pretty<'_> {
 
         let parsed = unparse(&File {
             shebang: None,
+            frontmatter: None,
             attrs: vec![],
             items: vec![item],
         });

--- a/crates/sdk/macros/src/logic/arg.rs
+++ b/crates/sdk/macros/src/logic/arg.rs
@@ -1,19 +1,49 @@
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
-use syn::{Error as SynError, FnArg, Ident, Pat, Path, Type};
+use syn::{Error as SynError, FnArg, Ident, Pat, Path, Receiver, ReceiverKind, Type};
 
 use crate::errors::{Errors, ParseError, Pretty};
 use crate::logic::ty::{LogicTy, LogicTyInput};
 use crate::logic::utils::typed_path;
 
-pub enum SelfType<'a> {
-    Owned(&'a Type),
-    Mutable(&'a Type),
-    Immutable(&'a Type),
+/// A method's `self` receiver, carrying the tokens a diagnostic about it should
+/// point at.
+pub enum SelfType {
+    Owned(TokenStream),
+    Mutable(TokenStream),
+    Immutable(TokenStream),
+}
+
+impl SelfType {
+    fn by_ref(mutable: bool, span: TokenStream) -> Self {
+        if mutable {
+            Self::Mutable(span)
+        } else {
+            Self::Immutable(span)
+        }
+    }
+}
+
+/// syn models a shorthand receiver without a type, so span what the author wrote:
+/// the ascribed type of `self: T`, else the receiver itself minus a leading `mut`.
+fn receiver_tokens(receiver: &Receiver) -> TokenStream {
+    let self_token = &receiver.self_token;
+
+    #[expect(
+        clippy::wildcard_enum_match_arm,
+        reason = "`ReceiverKind` is `#[non_exhaustive]`"
+    )]
+    match &receiver.kind {
+        ReceiverKind::Typed(_, ty) => ty.to_token_stream(),
+        ReceiverKind::Reference(ampersand, lifetime, mutability) => {
+            quote! { #ampersand #lifetime #mutability #self_token }
+        }
+        _ => self_token.to_token_stream(),
+    }
 }
 
 pub enum LogicArg<'a> {
-    Receiver(SelfType<'a>),
+    Receiver(SelfType),
     Typed(Box<LogicArgTyped<'a>>),
 }
 
@@ -45,40 +75,51 @@ impl<'a, 'b> TryFrom<LogicArgInput<'a, 'b>> for LogicArg<'a> {
 
         match input.arg {
             FnArg::Receiver(receiver) => {
+                let span = receiver_tokens(receiver);
+
                 'recv: {
-                    let Some(path) = typed_path(&receiver.ty, true) else {
-                        break 'recv;
+                    // `self`, `&self` and `&mut self` name the impl type by
+                    // construction; only `self: T` has to be matched against it.
+                    #[expect(
+                        clippy::wildcard_enum_match_arm,
+                        reason = "`ReceiverKind` is `#[non_exhaustive]`"
+                    )]
+                    let (is_self, reference) = match &receiver.kind {
+                        ReceiverKind::Reference(_, _, mutability) => (
+                            true,
+                            Some(SelfType::by_ref(mutability.is_some(), span.clone())),
+                        ),
+                        ReceiverKind::Typed(_, ty) => {
+                            let Some(path) = typed_path(ty, true) else {
+                                break 'recv;
+                            };
+
+                            let mut reference = None;
+
+                            if let Type::Reference(ref_) = &**ty {
+                                reference =
+                                    Some(SelfType::by_ref(ref_.mutability.is_some(), span.clone()));
+                            }
+
+                            (input.type_ == path || path.is_ident("Self"), reference)
+                        }
+                        _ => (true, None),
                     };
 
-                    let is_self = input.type_ == path || path.is_ident("Self");
-
-                    let mut reference = None;
-
-                    if let Type::Reference(ref_) = &*receiver.ty {
-                        reference = ref_
-                            .mutability
-                            .map_or(Some(SelfType::Immutable(&receiver.ty)), |_| {
-                                Some(SelfType::Mutable(&receiver.ty))
-                            });
-                    } else if is_self {
+                    if reference.is_none() && is_self {
                         // todo! circumvent via `#[app::destroy]`
-                        errors.subsume(SynError::new_spanned(
-                            &receiver.ty,
-                            ParseError::NoSelfOwnership,
-                        ));
+                        errors.subsume(SynError::new_spanned(&span, ParseError::NoSelfOwnership));
                     }
 
                     if is_self {
                         errors.check()?;
 
-                        return Ok(Self::Receiver(
-                            reference.unwrap_or(SelfType::Owned(&receiver.ty)),
-                        ));
+                        return Ok(Self::Receiver(reference.unwrap_or(SelfType::Owned(span))));
                     }
                 }
 
                 Err(errors.finish(SynError::new_spanned(
-                    &receiver.ty,
+                    &span,
                     ParseError::ExpectedSelf(Pretty::Path(input.type_)),
                 )))
             }

--- a/crates/sdk/macros/src/logic/method.rs
+++ b/crates/sdk/macros/src/logic/method.rs
@@ -3,7 +3,7 @@ use quote::{quote, quote_spanned, ToTokens};
 use syn::spanned::Spanned;
 use syn::{
     Error as SynError, GenericArgument, GenericParam, Ident, ImplItemFn, Path, PathArguments,
-    ReturnType, Type, Visibility,
+    ReturnType, Safety, Type, Visibility,
 };
 
 use crate::abi_type::nullable;
@@ -53,7 +53,7 @@ pub struct PublicLogicMethod<'a> {
     self_: Path,
 
     name: &'a Ident,
-    self_type: Option<SelfType<'a>>,
+    self_type: Option<SelfType>,
     args: Vec<LogicArgTyped<'a>>,
     ret: Option<LogicTy>,
 
@@ -206,11 +206,11 @@ impl ToTokens for PublicLogicMethod<'_> {
         let (def, mut call) = match &self.self_type {
             Some(type_) => (
                 {
-                    let (mutability, ty) = match type_ {
-                        SelfType::Mutable(ty) => (Some(quote! {mut}), ty),
-                        SelfType::Owned(ty) | SelfType::Immutable(ty) => (None, ty),
+                    let (mutability, span) = match type_ {
+                        SelfType::Mutable(span) => (Some(quote! {mut}), span),
+                        SelfType::Owned(span) | SelfType::Immutable(span) => (None, span),
                     };
-                    quote_spanned! {ty.span()=>
+                    quote_spanned! {span.span()=>
                         let Some(#mutability app) = ::calimero_storage::collections::Root::<#self_>::fetch()
                         else {
                             ::calimero_sdk::env::panic_str("Failed to find or read app state")
@@ -648,7 +648,7 @@ impl<'a, 'b> TryFrom<LogicMethodImplInput<'a, 'b>> for LogicMethod<'a> {
             errors.subsume(SynError::new_spanned(asyncness, ParseError::NoAsyncSupport));
         }
 
-        if let Some(unsafety) = &input.item.sig.unsafety {
+        if let Safety::Unsafe(unsafety) = &input.item.sig.safety {
             errors.subsume(SynError::new_spanned(unsafety, ParseError::NoUnsafeSupport));
         }
 
@@ -704,15 +704,17 @@ impl<'a, 'b> TryFrom<LogicMethodImplInput<'a, 'b>> for LogicMethod<'a> {
         // A `#[app::view]` method is read-only (the node takes a shared read
         // lock), so a `&mut self` receiver is a contradiction.
         if is_view {
-            if let Some(SelfType::Mutable(ty)) = &self_type {
-                errors.subsume(SynError::new_spanned(ty, ParseError::ViewCannotMutate));
+            if let Some(SelfType::Mutable(span)) = &self_type {
+                errors.subsume(SynError::new_spanned(span, ParseError::ViewCannotMutate));
             }
         }
 
         match (is_init, &self_type) {
             (true, Some(self_type)) => errors.subsume(SynError::new_spanned(
                 match self_type {
-                    SelfType::Owned(ty) | SelfType::Mutable(ty) | SelfType::Immutable(ty) => ty,
+                    SelfType::Owned(span) | SelfType::Mutable(span) | SelfType::Immutable(span) => {
+                        span
+                    }
                 },
                 ParseError::NoSelfReceiverAtInit,
             )),

--- a/crates/storage-macros/Cargo.toml
+++ b/crates/storage-macros/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0"
-syn = { version = "2.0", features = ["full", "extra-traits"] }
+syn = { version = "3.0", features = ["full", "extra-traits"] }


### PR DESCRIPTION
## Summary

Bumps the workspace to `syn` 3 and `prettyplease` 0.3. `crates/storage-macros` pinned `syn` directly rather than through the workspace table, so it is bumped too; `Cargo.lock` was regenerated by cargo (`syn 3.0.3`, `prettyplease 0.3.0`).

Three break classes, all in `calimero-sdk-macros`:

- `syn::File` gained a `frontmatter` field - the struct literal in `errors.rs` now sets `frontmatter: None`.
- `Signature.unsafety: Option<Token![unsafe]>` became `Signature.safety: Safety` - the `#[app::logic]` unsafe-method rejection now matches `Safety::Unsafe(..)` instead of testing an `Option`.
- `Receiver.ty` (a synthesized `Type`) was replaced by `Receiver.kind: ReceiverKind`, which models `self` / `&self` / `self: T` as distinct variants and no longer fabricates a type for the shorthand forms. `logic/arg.rs` now matches on `ReceiverKind` to decide owned-vs-shared-vs-mutable, and `SelfType` carries the tokens a diagnostic should point at instead of a `&Type`. A `receiver_tokens` helper reproduces the span syn 2 gave: the ascribed type for `self: T`, otherwise the receiver minus a leading `mut`.

`calimero-storage-macros` needed no source changes.

The trybuild suites were re-blessed workspace-wide with `TRYBUILD=overwrite ... --features calimero-storage/testing`, and **no `.stderr` file changed** - so every `(calimero)` diagnostic line is byte-identical and no macro diagnostic regressed. Preserving the receiver spans is what kept `invalid_receivers.stderr` stable; widening them to the whole receiver would have moved 19 of its span markers.

## Test plan

```
$ cargo fmt --check
FMT=0

$ cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 33.17s
CLIPPY=0

$ cargo deny check licenses sources
licenses ok, sources ok
DENY=0

$ cargo machete
cargo-machete didn't find any unused dependencies in this directory. Good job!
MACHETE=0

$ TRYBUILD=overwrite cargo test -p calimero-sdk -p calimero-storage \
    --features calimero-storage/testing --test macros --test compile_fail
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 39.03s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 10.38s
EXIT=0

$ git diff --stat -- '*.stderr'
(no output - zero .stderr files changed)

$ cargo test -p calimero-sdk-macros -p calimero-storage-macros
test result: ok. 85 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
EXIT=0

$ cargo test -p calimero-sdk --features calimero-storage/testing
test result: ok. 16 passed; 0 failed
test result: ok. 11 passed; 0 failed
test result: ok. 1 passed; 0 failed
test result: ok. 4 passed; 0 failed
test result: ok. 1 passed; 0 failed
test result: ok. 27 passed; 0 failed; 5 ignored
EXIT=0

$ cargo test -p calimero-storage --features testing   # per target
lib exit=0                        merge_registry_concurrent exit=0
abi_crdt_shapes exit=0            merge_registry_integration exit=0
abi_mergeable_coverage exit=0     multi_device_account exit=0
compile_fail exit=0               read_cost_profile exit=0
converge exit=0                   rekey_record exit=0
crdt_contract exit=0              root_fanout_shape exit=0
derive_mergeable exit=0           sorted_index_convergence exit=0
                                  trie_scaling exit=0
                                  write_cost_profile exit=0
```

`cargo test --workspace` was **split** rather than run in one invocation: the dev host ran out of disk mid-link, so the suite was run as the full test suites of every crate touched (`calimero-sdk-macros`, `calimero-storage-macros`) plus both trybuild hosts (`calimero-sdk`, and `calimero-storage` with `testing`, target by target). The remaining workspace members are covered for compilation by the `--all-targets` clippy pass above, which builds every test target in the workspace. Only the two proc-macro crates changed, so CI's own full `cargo test --workspace` is the remaining check.
