### PR TITLE
bench: measure storage, key-value, blobs, crypto, the VM and the DAG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,6 +842,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "bulk-write-bench"
+version = "0.0.0"
+dependencies = [
+ "calimero-sdk",
+ "calimero-storage",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +997,7 @@ dependencies = [
  "calimero-primitives",
  "calimero-store",
  "camino",
+ "criterion",
  "eyre",
  "futures-util",
  "serde",
@@ -1166,6 +1175,7 @@ name = "calimero-crypto"
 version = "0.0.0"
 dependencies = [
  "calimero-primitives",
+ "criterion",
  "curve25519-dalek",
  "ed25519-dalek",
  "eyre",
@@ -1182,6 +1192,7 @@ dependencies = [
  "async-trait",
  "borsh",
  "calimero-storage",
+ "criterion",
  "rand 0.8.5",
  "serde",
  "thiserror 1.0.69",
@@ -1489,6 +1500,7 @@ dependencies = [
  "calimero-primitives",
  "calimero-storage",
  "calimero-sys",
+ "criterion",
  "ed25519-dalek",
  "eyre",
  "fragile",
@@ -1626,6 +1638,7 @@ dependencies = [
  "calimero-storage-macros",
  "calimero-wasm-abi",
  "claims",
+ "criterion",
  "ed25519-dalek",
  "eyre",
  "fixedstr",
@@ -1657,12 +1670,15 @@ dependencies = [
  "calimero-account",
  "calimero-primitives",
  "calimero-storage",
+ "calimero-store-rocksdb",
  "camino",
+ "criterion",
  "eyre",
  "generic-array 1.3.5",
  "serde",
  "serde_json",
  "strum 0.26.3",
+ "tempfile",
  "thiserror 1.0.69",
  "thunderdome",
  "zeroize",

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -19,6 +19,14 @@ zeroize.workspace = true
 
 calimero-primitives = { workspace = true, features = ["rand"] }
 
+[lib]
+bench = false
+
 [dev-dependencies]
+criterion.workspace = true
 eyre.workspace = true
 rand.workspace = true
+
+[[bench]]
+name = "aead"
+harness = false

--- a/crates/crypto/benches/aead.rs
+++ b/crates/crypto/benches/aead.rs
@@ -1,0 +1,66 @@
+//! What does encryption cost at the sizes this system actually moves?
+//!
+//! Every replicated byte goes through AES-256-GCM: sync deltas, gossip
+//! envelopes (capped at 1 MiB by `GOSSIPSUB_MAX_TRANSMIT_SIZE`) and blob chunks
+//! (exactly 1 MiB, `crates/store/blobs/src/lib.rs:31`). The sizes below are
+//! those, not round numbers.
+//!
+//! `derive_shared_key` is measured separately because it is per-peer-pair, not
+//! per-message: if it turned out to cost as much as encrypting a chunk, caching
+//! it would matter. Today it should not.
+//!
+//! Both `encrypt_with_nonce` and `decrypt` take their payload by value and
+//! encrypt/decrypt in place, so the `.clone()` inside each timed closure below
+//! is unavoidable — it hands the API ownership of a fresh buffer every
+//! iteration — and is deliberately part of what is measured, not setup noise.
+//!
+//! What would change a decision: an encrypt throughput materially below the
+//! network's, which would make crypto — not bandwidth — the transfer ceiling.
+
+use std::hint::black_box;
+
+use calimero_crypto::{Nonce, SharedKey};
+use calimero_primitives::identity::PrivateKey;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
+const NONCE: Nonce = [7_u8; 12];
+
+fn aead(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+    let sk = PrivateKey::random(&mut rng);
+    let key = SharedKey::from_sk(&sk);
+
+    let mut group = c.benchmark_group("aead");
+
+    // 256 B: a governance op. 4 KiB: a typical delta. 64 KiB: libp2p's old
+    // gossip ceiling. 1 MiB: a blob chunk and the current gossip ceiling.
+    for bytes in [256_usize, 4_096, 65_536, 1_048_576] {
+        let plaintext = vec![0xAB_u8; bytes];
+        let ciphertext = key
+            .encrypt_with_nonce(plaintext.clone(), NONCE)
+            .expect("sealing a well-formed payload cannot fail");
+
+        group.throughput(Throughput::Bytes(bytes as u64));
+
+        group.bench_with_input(BenchmarkId::new("encrypt", bytes), &plaintext, |b, pt| {
+            b.iter(|| black_box(key.encrypt_with_nonce(pt.clone(), NONCE)));
+        });
+
+        group.bench_with_input(BenchmarkId::new("decrypt", bytes), &ciphertext, |b, ct| {
+            b.iter(|| black_box(key.decrypt(ct.clone(), NONCE)));
+        });
+    }
+
+    // Per-peer-pair, not per-message.
+    let peer = PrivateKey::random(&mut rng);
+    let peer_pk = peer.public_key();
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("derive_shared_key", |b| {
+        b.iter(|| black_box(SharedKey::new(black_box(&sk), black_box(&peer_pk))));
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, aead);
+criterion_main!(benches);

--- a/crates/dag/Cargo.toml
+++ b/crates/dag/Cargo.toml
@@ -16,10 +16,25 @@ thiserror.workspace = true
 calimero-storage.workspace = true
 tracing.workspace = true
 
+[lib]
+bench = false
+
 [dev-dependencies]
 calimero-storage = { workspace = true, features = ["testing"] }
+criterion.workspace = true
 rand.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "time", "sync"] }
 
 [features]
 testing = []
+
+# `pending` deliberately does NOT need `required-features = ["testing"]`.
+# Its fixture builds `CausalDelta` via the ungated `CausalDelta::new`
+# constructor instead of the `testing`-gated `CausalDelta::new_test` — see
+# the bench's module docs for why that's a safe, equivalent substitution.
+# `required-features` would make a bare `cargo bench -p calimero-dag --bench
+# pending` silently *skip* the target instead of building it, which is
+# exactly the rot Task 1's workspace-wide compile gate exists to catch.
+[[bench]]
+name = "pending"
+harness = false

--- a/crates/dag/benches/pending.rs
+++ b/crates/dag/benches/pending.rs
@@ -1,0 +1,137 @@
+//! What do the pending-set walks cost when the pending set is big?
+//!
+//! A node that has been offline, or is behind a peer mid-catch-up, accumulates
+//! deltas whose parents have not arrived. `get_missing_parents` is called to
+//! build the next sync request, `cleanup_stale` on a timer, `pending_stats` for
+//! metrics — all three walk that set. If any of them is superlinear, a node
+//! that falls behind gets slower at catching up precisely as it needs to be
+//! faster.
+//!
+//! The brief this bench was written from named the DAG type `Dag` and the
+//! parking entry point `restore_applied_delta`. Neither survived contact with
+//! the tree: the type is `DagStore<T>`, and `restore_applied_delta` (`:468`)
+//! marks a delta as *applied* — it exists to replay already-applied history
+//! from storage, not to park anything. Feeding it a delta with a missing
+//! parent does not put that delta in the pending set at all, which would have
+//! made every number below a measurement of an empty set. The real door is
+//! `add_delta_with_outcome` (`:538`): given a delta whose parent is not in the
+//! DAG, `can_apply` fails and it lands in `pending` via `insert_pending`.
+//! `add_delta_with_outcome` is `async` (the DAG's only async surface,
+//! `apply_delta` at `:737`), but it is never actually awaited on the pending
+//! path — `can_apply` fails before any `.await` point is reached — so driving
+//! it through a bare current-thread `tokio` runtime in the fixture setup adds
+//! no meaningful executor overhead, and the setup itself is outside every
+//! timed closure below regardless.
+//!
+//! The brief's fixture built each `CausalDelta` with `CausalDelta::new_test`,
+//! which is `#[cfg(any(test, feature = "testing"))]` — unreachable from a
+//! bench binary (no `cfg(test)`) without the crate's own `testing` feature
+//! turned on. Rather than pull that feature in (which would need either
+//! `required-features` on the `[[bench]]`, making a bare `cargo bench -p
+//! calimero-dag --bench pending` silently skip the target instead of
+//! building it, or a self-referential dev-dependency to force it on), the
+//! fixture uses the crate's ungated public constructor,
+//! `CausalDelta::new(id, parents, payload, hlc)` (`:135`), passing
+//! `HybridTimestamp::default()` for the one field `new_test` filled in for
+//! free. That is the only difference between the two constructors — `new_test`
+//! is a convenience wrapper around `new`, not a distinct code path — so this
+//! fixture exercises the exact same `CausalDelta` shape without needing the
+//! feature at all.
+//!
+//! Each sub-benchmark measures a pending set of exactly the size its `n`
+//! claims: `get_missing_parents` and `pending_stats` are read-only and reuse
+//! one fixture across all their iterations, but `cleanup_stale` mutates (it
+//! evicts), so it rebuilds a fresh `n`-sized pending set per sample via
+//! `iter_batched` rather than draining one shared fixture across the batch.
+//!
+//! What would change a decision: a walk that grows faster than the set, which
+//! would make an index over pending parents worth building.
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use calimero_dag::{AddDeltaOutcome, ApplyError, CausalDelta, DagStore};
+use calimero_storage::logical_clock::HybridTimestamp;
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+
+/// Applier that is never actually invoked: every delta built by
+/// [`pending_dag`] names a parent that is not in the DAG, so
+/// `add_delta_with_outcome` always takes the pending path and `apply` is
+/// never called. Exists only to satisfy `DeltaApplier`'s bound.
+struct NeverApplied;
+
+#[async_trait::async_trait]
+impl calimero_dag::DeltaApplier<Vec<u8>> for NeverApplied {
+    async fn apply(&self, _delta: &CausalDelta<Vec<u8>>) -> Result<(), ApplyError> {
+        unreachable!("fixture deltas never satisfy can_apply, so apply() is never reached")
+    }
+}
+
+/// A pending set of `n` deltas, each depending on a parent that never
+/// arrives, so nothing applies and everything stays pending.
+fn pending_dag(n: usize) -> DagStore<Vec<u8>> {
+    let mut dag = DagStore::new([0_u8; 32]);
+    let applier = NeverApplied;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("building a current-thread runtime cannot fail");
+
+    for i in 0..n as u64 {
+        let mut id = [0_u8; 32];
+        id[..8].copy_from_slice(&i.to_le_bytes());
+        let mut parent = [0xFF_u8; 32];
+        parent[..8].copy_from_slice(&i.to_le_bytes());
+        let delta = CausalDelta::new(id, vec![parent], vec![0_u8; 64], HybridTimestamp::default());
+        let outcome = rt.block_on(dag.add_delta_with_outcome(delta, &applier));
+        assert!(
+            matches!(outcome, Ok(AddDeltaOutcome::Pending)),
+            "fixture delta did not land in the pending set"
+        );
+    }
+    dag
+}
+
+fn pending(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dag");
+
+    for n in [10_usize, 100, 1_000, 10_000] {
+        let dag = pending_dag(n);
+
+        // Proof the fixture is real: pending_stats must report exactly n
+        // pending deltas, not zero. See module docs above.
+        assert_eq!(dag.pending_stats().count, n, "fixture pending count != n");
+
+        group.throughput(Throughput::Elements(n as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("get_missing_parents", n),
+            &dag,
+            |b, dag| {
+                b.iter(|| black_box(dag.get_missing_parents(black_box(128)).len()));
+            },
+        );
+
+        group.bench_with_input(BenchmarkId::new("pending_stats", n), &dag, |b, dag| {
+            b.iter(|| black_box(dag.pending_stats()));
+        });
+
+        // cleanup_stale mutates (it evicts), so unlike the two read-only
+        // benches above it cannot reuse one shared fixture across samples --
+        // that would shrink the pending set on every iteration, so only the
+        // first sample would actually measure n. Rebuild a fresh n-sized
+        // pending set per batch instead, so every measured call sees exactly
+        // n pending deltas.
+        group.bench_with_input(BenchmarkId::new("cleanup_stale", n), &n, |b, &n| {
+            b.iter_batched(
+                || pending_dag(n),
+                |mut dag| black_box(dag.cleanup_stale(Duration::from_secs(0))),
+                BatchSize::LargeInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, pending);
+criterion_main!(benches);

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -48,6 +48,7 @@ name = "demo"
 [dev-dependencies]
 assert-json-diff.workspace = true
 tracing-subscriber.workspace = true
+criterion.workspace = true
 eyre.workspace = true
 owo-colors.workspace = true
 rand.workspace = true
@@ -58,3 +59,29 @@ wat.workspace = true
 
 [features]
 profiling = ["wasmer-compiler-cranelift"]
+
+# A crate that gains a [[bench]] needs `bench = false` on its [lib], [[bin]]
+# and [[test]] targets, or `cargo bench -p calimero-runtime` (no --bench
+# filter) hands those to libtest, which rejects criterion's own CLI flags.
+[lib]
+bench = false
+
+[[test]]
+name = "chat_wall"
+bench = false
+
+[[test]]
+name = "cost_is_flat"
+bench = false
+
+[[test]]
+name = "crdt_conformance"
+bench = false
+
+[[test]]
+name = "tracing_logs"
+bench = false
+
+[[bench]]
+name = "engine"
+harness = false

--- a/crates/runtime/benches/engine.rs
+++ b/crates/runtime/benches/engine.rs
@@ -1,0 +1,103 @@
+//! What does the VM cost, separated into compile and call?
+//!
+//! `Engine::compile` runs wasmer's full pipeline including gas metering
+//! instrumentation, and is paid on every cold path. `Module::run` is the
+//! per-call cost. Splitting them answers the only question that changes a
+//! decision here: whether caching compiled modules is worth building.
+//!
+//! The guest is the fixed-work WAT fixture from
+//! `crates/runtime/tests/cost_is_flat.rs` — deliberately not a real contract,
+//! so a change in the number means a change in the VM rather than in whatever
+//! app happened to be compiled that week.
+//!
+//! Companion, not substitute: `cost_is_flat.rs` asserts that gas and read
+//! counts do not grow with store size. That is the gate. This is the clock.
+
+use std::hint::black_box;
+
+use calimero_account::AccountId;
+use calimero_runtime::logic::VMLimits;
+use calimero_runtime::store::{InMemoryStorage, Storage};
+use calimero_runtime::Engine;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+/// Reads one key `n` times per call; `n` is fixed in the module, so the only
+/// variable across the sweep is how many host calls one execution makes.
+fn guest_wat(reads: u32) -> String {
+    format!(
+        r#"
+(module
+  (import "env" "storage_read" (func $storage_read (param i64 i64) (result i32)))
+  (import "env" "read_register" (func $read_register (param i64 i64) (result i32)))
+  (memory (export "memory") 2)
+  (data (i32.const 0)  "\40\00\00\00\00\00\00\00\01\00\00\00\00\00\00\00")
+  (data (i32.const 64) "k")
+  (func (export "fixed_reads")
+    (local $i i32)
+    (local.set $i (i32.const 0))
+    (block $done
+      (loop $again
+        (br_if $done (i32.ge_u (local.get $i) (i32.const {reads})))
+        (drop (call $storage_read (i64.const 0) (i64.const 0)))
+        (drop (call $read_register (i64.const 0) (i64.const 1024)))
+        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+        (br $again))))
+)
+"#
+    )
+}
+
+fn engine(c: &mut Criterion) {
+    let mut group = c.benchmark_group("engine");
+
+    let wasm = wat::parse_str(guest_wat(64)).expect("the fixture WAT must parse");
+
+    group.bench_function("compile", |b| {
+        b.iter(|| {
+            black_box(
+                Engine::with_limits(VMLimits::default())
+                    .compile(black_box(&wasm))
+                    .expect("the fixture must compile"),
+            )
+        });
+    });
+
+    for reads in [1_u32, 64, 1_024] {
+        let wasm = wat::parse_str(guest_wat(reads)).expect("the fixture WAT must parse");
+        let module = Engine::with_limits(VMLimits::default())
+            .compile(&wasm)
+            .expect("the fixture must compile");
+
+        group.bench_with_input(BenchmarkId::new("run", reads), &module, |b, module| {
+            b.iter_batched(
+                || {
+                    let mut storage = InMemoryStorage::default();
+                    storage.set(b"k".to_vec(), vec![7_u8; 64]);
+                    storage
+                },
+                |mut storage| {
+                    black_box(
+                        module
+                            .run(
+                                [0_u8; 32].into(),
+                                AccountId::from([0_u8; 32]),
+                                [0_u8; 32].into(),
+                                "fixed_reads",
+                                &[],
+                                &mut storage,
+                                None,
+                                None,
+                            )
+                            .expect("the fixture must run"),
+                    )
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, engine);
+criterion_main!(benches);

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -33,12 +33,67 @@ rand.workspace = true
 
 [dev-dependencies]
 claims.workspace = true
+criterion.workspace = true
 hex.workspace = true
 serial_test.workspace = true
 trybuild.workspace = true
 velcro.workspace = true
 
 calimero-sdk.workspace = true
+
+# A crate that gains a [[bench]] needs `bench = false` on its [lib], [[bin]]
+# and [[test]] targets, or `cargo bench -p calimero-storage` (no --bench
+# filter) hands those to libtest, which rejects criterion's own CLI flags.
+[lib]
+bench = false
+
+[[test]]
+name = "abi_crdt_shapes"
+bench = false
+
+[[test]]
+name = "abi_mergeable_coverage"
+bench = false
+
+[[test]]
+name = "compile_fail"
+bench = false
+
+[[test]]
+name = "converge"
+bench = false
+
+[[test]]
+name = "crdt_contract"
+bench = false
+
+[[test]]
+name = "derive_mergeable"
+bench = false
+
+[[test]]
+name = "multi_device_account"
+bench = false
+
+[[test]]
+name = "read_cost_profile"
+bench = false
+
+[[test]]
+name = "root_fanout_shape"
+bench = false
+
+[[test]]
+name = "sorted_index_convergence"
+bench = false
+
+[[test]]
+name = "trie_scaling"
+bench = false
+
+[[test]]
+name = "write_cost_profile"
+bench = false
 
 [features]
 default = []
@@ -59,11 +114,22 @@ testing = []
 [[test]]
 name = "merge_registry_concurrent"
 required-features = ["testing"]
+bench = false
 
 [[test]]
 name = "merge_registry_integration"
 required-features = ["testing"]
+bench = false
 
 [[test]]
 name = "rekey_record"
 required-features = ["testing"]
+bench = false
+
+[[bench]]
+name = "child_trie"
+harness = false
+
+[[bench]]
+name = "merge_root_state"
+harness = false

--- a/crates/storage/benches/child_trie.rs
+++ b/crates/storage/benches/child_trie.rs
@@ -1,0 +1,136 @@
+//! How does a child-trie operation scale with the number of children?
+//!
+//! Every collection write walks this structure (`crates/storage/src/child_trie.rs`),
+//! so a per-operation cost that grows with `n` here is a cost that grows for
+//! every write in the system — the shape of core#3602.
+//!
+//! What would change a decision: `insert` or `get` whose per-call time tracks
+//! `n` rather than `log n`. `children()` IS expected to be linear (it
+//! materialises every child); it is measured so a caller that starts using it
+//! on a hot path shows up as a step change downstream.
+//!
+//! The gate for the same question in operation counts — which is what actually
+//! decides gas — is `tools/storage-cost`. This bench is the wall-clock
+//! companion and never gates.
+//!
+//! `ChildTrie` is generic over its `StorageAdaptor` and defaults to
+//! `MainStorage`. On a native (non-wasm32) build — which is what a bench
+//! compiles as — `MainStorage` itself routes to an in-process thread-local
+//! mock (`calimero_storage::env`'s native `imp` module), so no explicit
+//! adaptor wiring is needed here: the default type parameter already gives
+//! this bench an in-memory backend.
+//!
+//! # What `{n}` means for each id — read this before reading the numbers
+//!
+//! `get/{n}`, `root/{n}` and `children/{n}` each build **one fresh trie of
+//! exactly `n` children** and only then start the timed loop, so every read
+//! in that group is against a trie whose population is exactly `n` — none of
+//! them mutate the trie they read.
+//!
+//! `insert/{n}` is inherently mutating, so it cannot share that trie: instead
+//! it uses `iter_batched` with `BatchSize::PerIteration`, which builds a
+//! freshly made `n`-child trie AND the `ChildInfo` to be inserted
+//! (`Id::random()` + `Metadata::new()`) in the (unmeasured) setup closure
+//! before every single timed call, and the timed closure does nothing but
+//! the `insert` itself. So `insert/{n}` measures "the cost of the `n+1`th
+//! insert into a trie that already holds `n` children" — not the cost of
+//! minting the child to insert, and not contaminated by any other insert in
+//! the same run.
+//!
+//! An earlier version of this bench built one trie per `n` and reused it,
+//! unguarded, across `insert`/`get`/`root`/`children`. Because `insert`'s own
+//! timed closure runs thousands of times during criterion's
+//! calibration+sampling, that shared trie kept growing *during* the `insert`
+//! sub-benchmark — so by the time `get`/`root`/`children` ran against it,
+//! their actual population was `n` plus however many extra inserts criterion
+//! happened to perform, not `n`. That produced a `children/{n}` curve with no
+//! relationship to `n` (`children/10` and `children/1000` came out the same
+//! order of magnitude). See `task-2-3-report.md`'s fix section for the
+//! contaminated numbers next to the corrected ones — the difference is itself
+//! evidence for how much a shared, mutated fixture can lie.
+
+use std::hint::black_box;
+
+use calimero_storage::address::Id;
+use calimero_storage::child_trie::ChildTrie;
+use calimero_storage::entities::{ChildInfo, Metadata};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+
+/// Distinct children with fixed metadata; only the id and hash vary, which is
+/// all the trie keys on.
+fn child(i: u64) -> ChildInfo {
+    let mut merkle_hash = [0_u8; 32];
+    merkle_hash[..8].copy_from_slice(&i.to_le_bytes());
+    merkle_hash[8..16].copy_from_slice(&i.wrapping_mul(2_654_435_761).to_le_bytes());
+    ChildInfo::new(
+        Id::random(),
+        merkle_hash,
+        Metadata::new(1_700_000_000, 1_700_000_000),
+    )
+}
+
+/// A trie with exactly `n` children, and the ids of every one of them.
+fn populated(n: usize) -> (ChildTrie, Vec<Id>) {
+    let trie = ChildTrie::new(Id::random());
+    let mut ids = Vec::with_capacity(n);
+    for i in 0..n as u64 {
+        let c = child(i);
+        ids.push(c.id());
+        let _hash = trie.insert(c);
+    }
+    (trie, ids)
+}
+
+fn child_trie(c: &mut Criterion) {
+    let mut group = c.benchmark_group("child_trie");
+
+    for n in [10_usize, 100, 1_000, 10_000] {
+        group.throughput(Throughput::Elements(1));
+
+        // `insert/{n}`: cost of one insert into a trie that already holds
+        // exactly `n` children. `PerIteration` puts a fresh `n`-child build
+        // AND the `ChildInfo` to be inserted in the unmeasured setup closure
+        // before every single timed call, so neither the trie build nor
+        // `child()`'s `Id::random()` + `Metadata::new()` land in the timed
+        // path — only the `insert` call itself does — and the measured
+        // trie's population never drifts above `n` the way a shared, reused
+        // trie would.
+        group.bench_with_input(BenchmarkId::new("insert", n), &n, |b, &n| {
+            b.iter_batched(
+                || (populated(n).0, child(n as u64 + 1)),
+                |(trie, c)| black_box(trie.insert(c)),
+                BatchSize::PerIteration,
+            );
+        });
+
+        // `get/{n}`, `root/{n}`, `children/{n}`: all read-only, so one fresh
+        // `n`-child trie built once (outside the timed loop) can be shared
+        // safely across all three — none of them mutates it, so its
+        // population stays exactly `n` for the whole group.
+        let (trie, ids) = populated(n);
+
+        group.bench_with_input(BenchmarkId::new("get", n), &ids, |b, ids| {
+            let mut cursor = 0_usize;
+            b.iter(|| {
+                cursor = cursor.wrapping_add(1);
+                black_box(trie.get(ids[cursor % ids.len()]))
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("root", n), &trie, |b, trie| {
+            b.iter(|| black_box(trie.root()));
+        });
+
+        // Linear by construction — measured so a caller that puts it on a hot
+        // path is visible, not because it is expected to be flat.
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::new("children", n), &trie, |b, trie| {
+            b.iter(|| black_box(trie.children().len()));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, child_trie);
+criterion_main!(benches);

--- a/crates/storage/benches/merge_root_state.rs
+++ b/crates/storage/benches/merge_root_state.rs
@@ -1,0 +1,145 @@
+//! What does the merge framework cost per applied delta, independent of what
+//! the app's own merge does?
+//!
+//! `merge::merge_root_state` (`crates/storage/src/merge.rs:200`) is on the
+//! path of every delta a node applies, but its own dispatch step
+//! (`try_merge_registered`, and the `register_crdt_merge` needed to seed it)
+//! is compiled in only under `#[cfg(any(target_arch = "wasm32", test, feature
+//! = "testing"))]` — a plain `cargo bench` (no `--features testing`) builds
+//! neither, so calling `merge_root_state` itself here would just measure the
+//! `NoFunctionsRegistered` bootstrap/error shortcut, not a merge.
+//!
+//! This benches `merge_root_state_typed` (`crates/storage/src/merge.rs:125`)
+//! instead. It is NOT a function `merge_root_state` calls: when the registry
+//! dispatch path IS compiled in, `merge_root_state` -> `try_merge_registered`
+//! -> the `merge_fn` closure built by `register_crdt_merge`
+//! (`crates/storage/src/merge/registry.rs:224-249`), which is an
+//! independent, hand-duplicated decode -> `with_merge_mode(merge)` -> encode
+//! implementation — it never calls `merge_root_state_typed`
+//! (`grep -rn merge_root_state_typed crates/storage/src/` turns up only test
+//! call sites and a doc comment about the WASM-side macro export).
+//! `merge_root_state_typed` is instead the shape the WASM-side
+//! `#[app::state]`-generated `__calimero_merge_root_state` export calls, and
+//! is *functionally equivalent* to what the registry closure duplicates —
+//! same decode -> `Mergeable::merge` -> encode steps, same
+//! `existing_created_at == existing_ts` bootstrap shortcut — without needing
+//! the registry, `TypeId`, or any feature flag to reach it. So what is
+//! measured here is the framework's encode/decode overhead around one
+//! `Mergeable::merge` call: there is no `TypeId` lookup or trial-deserialize
+//! in the timed path, so registry-lookup cost is NOT included, and an
+//! optimization scoped from this number should not assume it is.
+//!
+//! `merge_root_state_typed`'s real signature (read from the source before
+//! writing this bench — it differs from an earlier draft that assumed
+//! `Option<&[u8]>` existing state and a two-argument call):
+//!
+//! ```ignore
+//! pub fn merge_root_state_typed<T>(
+//!     existing: &[u8],
+//!     incoming: &[u8],
+//!     existing_created_at: u64,
+//!     existing_ts: u64,
+//!     _incoming_ts: u64,
+//! ) -> Result<Vec<u8>, MergeError>
+//! where
+//!     T: BorshSerialize + BorshDeserialize + Mergeable;
+//! ```
+//!
+//! `existing_created_at` is set different from `existing_ts` below, so every
+//! call takes the real typed-merge branch, not the `existing_created_at ==
+//! existing_ts` bootstrap fast path that just clones `incoming` verbatim.
+//!
+//! `T` needs a `Mergeable` impl to call `merge` on (there is no
+//! registry involved here — `merge_root_state_typed` is generic and calls
+//! `T::merge` directly), so this bench defines a minimal local `BenchState`
+//! with an O(n) `merge`: a linear zip of `existing`/`incoming`'s identically
+//! ordered, identically sized key sets, standing in for a real CRDT's own
+//! O(n) merge (e.g. `Counter::merge`, `Set::merge`). What is being measured
+//! is the framework's overhead around that call, never a real app's merge
+//! logic.
+//!
+//! What would change a decision: framework cost that is a material fraction
+//! of a real apply (say >1ms at 1k items) would make the encode/decode round
+//! trip worth attacking. #2203 measured ~18us at n=1000 on the pre-trie tree
+//! — this bench re-establishes that number on the current one.
+
+use std::hint::black_box;
+
+use borsh::{to_vec, BorshDeserialize, BorshSerialize};
+use calimero_storage::address::Id;
+use calimero_storage::collections::crdt_meta::{MergeError, Mergeable};
+use calimero_storage::collections::rekey::RekeyTarget;
+use calimero_storage::merge::merge_root_state_typed;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
+/// A borsh payload of `items` string-keyed entries — stands in for a root
+/// state of that size without depending on any particular collection's
+/// encoding.
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug)]
+struct BenchState(Vec<(String, Vec<u8>)>);
+
+impl BenchState {
+    fn new(items: usize, salt: u8) -> Self {
+        Self(
+            (0..items)
+                .map(|i| (format!("key{i:08}"), vec![salt; 32]))
+                .collect(),
+        )
+    }
+}
+
+impl RekeyTarget for BenchState {
+    // No nested collection ids to re-key — every field is a plain byte blob.
+    fn rekey_relative_to(&mut self, _parent_id: Id) {}
+}
+
+impl Mergeable for BenchState {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        // `existing`/`incoming` in this bench always carry the same,
+        // identically ordered key set (see `BenchState::new`), so a single
+        // linear zip is a faithful O(n) stand-in for a real CRDT merge (e.g.
+        // `Counter::merge` summing, `Set::merge` unioning) — not a claim
+        // about this being anyone's actual merge semantics.
+        for (mine, theirs) in self.0.iter_mut().zip(other.0.iter()) {
+            mine.1.clone_from(&theirs.1);
+        }
+        Ok(())
+    }
+}
+
+fn payload(items: usize, salt: u8) -> Vec<u8> {
+    to_vec(&BenchState::new(items, salt)).expect("borsh encode of BenchState cannot fail")
+}
+
+fn merge(c: &mut Criterion) {
+    let mut group = c.benchmark_group("merge_root_state");
+
+    for items in [10_usize, 100, 1_000, 10_000] {
+        let existing = payload(items, 1);
+        let incoming = payload(items, 2);
+
+        group.throughput(Throughput::Elements(items as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(items),
+            &(existing, incoming),
+            |b, (existing, incoming)| {
+                b.iter(|| {
+                    black_box(merge_root_state_typed::<BenchState>(
+                        black_box(existing),
+                        black_box(incoming),
+                        // created_at != existing_ts: take the real typed-merge
+                        // branch, not the bootstrap fast path.
+                        1,
+                        2,
+                        3,
+                    ))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, merge);
+criterion_main!(benches);

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -24,6 +24,26 @@ calimero-account.workspace = true
 calimero-primitives.workspace = true
 calimero-storage.workspace = true
 
+[dev-dependencies]
+criterion.workspace = true
+tempfile.workspace = true
+camino.workspace = true
+calimero-store-rocksdb.workspace = true
+
+# A crate that gains a [[bench]] needs `bench = false` on its [lib], [[bin]]
+# and [[test]] targets, or `cargo bench -p calimero-store` (no --bench
+# filter) hands those to libtest, which rejects criterion's own CLI flags.
+[lib]
+bench = false
+
+[[test]]
+name = "rocksdb"
+bench = false
+
+[[bench]]
+name = "db_ops"
+harness = false
+
 [features]
 borsh = ["borsh/derive"]
 serde = ["dep:serde", "dep:serde_json"]

--- a/crates/store/benches/db_ops.rs
+++ b/crates/store/benches/db_ops.rs
@@ -1,0 +1,172 @@
+//! What does one key-value operation cost, and does it get worse as the
+//! database grows?
+//!
+//! Two backends, deliberately: the in-memory DB is the abstraction floor (no
+//! I/O, so what remains is codec and dispatch), and RocksDB on a tmpdir is the
+//! dispatch-plus-warm-cache cost a node pays on top of that floor. It is NOT a
+//! cold-disk-seek number: the default block cache is 128 MiB
+//! (`DEFAULT_BLOCK_CACHE_SIZE`, `crates/store/impl/rocksdb/src/lib.rs:76`),
+//! and the largest working set benchmarked here (`n = 10_000`, ~176 bytes/row
+//! including key+value+RocksDB's own per-entry overhead) is on the order of
+//! 2 MB — three orders of magnitude under the cache, so every `get_hit` after
+//! the first touch is a cache hit. The measured gap (RocksDB ~3.4x the
+//! in-memory floor at `n = 10_000`) is consistent with FFI call and
+//! column-family dispatch overhead on a warm cache; it says nothing about
+//! disk I/O. To actually measure disk-backed reads, either grow `n` well past
+//! the point where the working set exceeds 128 MiB, shrink the bench's own
+//! `set_block_cache` so eviction happens at these sizes, or read RocksDB's
+//! `rocksdb.block.cache.hit` / `rocksdb.block.cache.miss` statistics
+//! directly — none of which this bench does today.
+//!
+//! `read_then_put` is the merge-path pattern — read the existing value, write
+//! a new one under the same key — which is what a delta apply does per entity.
+//!
+//! Population accounting: each group is populated with exactly `n` distinct
+//! keys before any measurement starts, and the database never grows past `n`
+//! for the rest of the group. `get_hit` and `get_miss` never mutate the
+//! database. `read_then_put` reads and rewrites `hit_keys` — the same 32 keys
+//! `get_hit` reads — in place, one key per iteration. `put` cycles through a
+//! fixed 128-element `put_keys` vector, overwriting the same 128 keys on
+//! every iteration once the cursor wraps. So both mutators hold the database
+//! at exactly `n` rows for the whole group; none of the four benchmarked ops
+//! ever grows it.
+//!
+//! What would change a decision: at these sizes the whole column family fits
+//! in the block cache, so a `get_hit` that climbs with `n` cannot be
+//! compaction/SST-growth pressure (that needs the cache exceeded first, which
+//! none of the benchmarked `n` do) — it would instead point at per-entry
+//! dispatch cost scaling with database size, worth chasing in
+//! `crates/store`'s own code before looking a layer down.
+
+use std::hint::black_box;
+
+use calimero_store::config::StoreConfig;
+use calimero_store::db::{Column, Database, InMemoryDB};
+use calimero_store::slice::Slice;
+use calimero_store_rocksdb::RocksDB;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use tempfile::TempDir;
+
+const KEY_LEN: usize = 48;
+const VALUE_LEN: usize = 128;
+const COLUMN: Column = Column::Generic;
+
+/// Distinct keys spread across the keyspace, so RocksDB's seeks are not all
+/// answered from one hot SST block.
+fn key_bytes(i: u64) -> [u8; KEY_LEN] {
+    let mut k = [0_u8; KEY_LEN];
+    k[..8].copy_from_slice(&i.to_le_bytes());
+    k[8..16].copy_from_slice(&i.wrapping_mul(2_654_435_761).to_le_bytes());
+    k[16..24].copy_from_slice(&i.wrapping_mul(6_364_136_223_846_793_005).to_le_bytes());
+    k
+}
+
+/// 128 bytes — a small delta record after borsh encoding, not a multi-KB root
+/// state.
+fn value_bytes(i: u64) -> [u8; VALUE_LEN] {
+    let mut v = [0_u8; VALUE_LEN];
+    v[..8].copy_from_slice(&i.to_le_bytes());
+    v[VALUE_LEN - 8..].copy_from_slice(&i.wrapping_mul(6_364_136_223_846_793_005).to_le_bytes());
+    v
+}
+
+fn populate<D: for<'a> Database<'a>>(db: &D, n: usize) {
+    for i in 0..n as u64 {
+        let k = key_bytes(i);
+        let v = value_bytes(i);
+        db.put(COLUMN, Slice::from(&k[..]), Slice::from(&v[..]))
+            .expect("populating put must succeed");
+    }
+}
+
+fn run_group<D: for<'a> Database<'a>>(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    db: &D,
+    n: usize,
+) {
+    let hit_keys: Vec<[u8; KEY_LEN]> = (0..32_u64)
+        .map(|i| i * (n as u64 / 32).max(1))
+        .map(key_bytes)
+        .collect();
+    let miss_keys: Vec<[u8; KEY_LEN]> = (0..32_u64).map(|i| key_bytes(n as u64 + 1 + i)).collect();
+    let put_keys: Vec<[u8; KEY_LEN]> = (0..128_u64)
+        .map(|i| key_bytes(n as u64 + 10_000 + i))
+        .collect();
+    let payload = value_bytes(42);
+
+    group.bench_function(BenchmarkId::new("get_hit", n), |b| {
+        let mut cursor = 0_usize;
+        b.iter(|| {
+            cursor = cursor.wrapping_add(1);
+            let k = &hit_keys[cursor % hit_keys.len()];
+            black_box(
+                db.get(COLUMN, Slice::from(&k[..]))
+                    .expect("get must succeed"),
+            )
+        });
+    });
+
+    group.bench_function(BenchmarkId::new("get_miss", n), |b| {
+        let mut cursor = 0_usize;
+        b.iter(|| {
+            cursor = cursor.wrapping_add(1);
+            let k = &miss_keys[cursor % miss_keys.len()];
+            black_box(
+                db.get(COLUMN, Slice::from(&k[..]))
+                    .expect("get must succeed"),
+            )
+        });
+    });
+
+    group.bench_function(BenchmarkId::new("put", n), |b| {
+        let mut cursor = 0_usize;
+        b.iter(|| {
+            cursor = cursor.wrapping_add(1);
+            let k = &put_keys[cursor % put_keys.len()];
+            db.put(COLUMN, Slice::from(&k[..]), Slice::from(&payload[..]))
+                .expect("put must succeed");
+        });
+    });
+
+    group.bench_function(BenchmarkId::new("read_then_put", n), |b| {
+        let mut cursor = 0_usize;
+        b.iter(|| {
+            cursor = cursor.wrapping_add(1);
+            let k = &hit_keys[cursor % hit_keys.len()];
+            let prev = db
+                .get(COLUMN, Slice::from(&k[..]))
+                .expect("get must succeed");
+            black_box(&prev);
+            let v = value_bytes(cursor as u64);
+            db.put(COLUMN, Slice::from(&k[..]), Slice::from(&v[..]))
+                .expect("put must succeed");
+        });
+    });
+}
+
+fn inmem(c: &mut Criterion) {
+    let mut group = c.benchmark_group("inmem");
+    for n in [100_usize, 1_000, 10_000] {
+        let db = InMemoryDB::owned();
+        populate(&db, n);
+        run_group(&mut group, &db, n);
+    }
+    group.finish();
+}
+
+fn rocks(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rocks");
+    for n in [100_usize, 1_000, 10_000] {
+        let dir = TempDir::new().expect("tempdir must create");
+        let path = camino::Utf8PathBuf::from_path_buf(dir.path().to_path_buf())
+            .expect("tempdir path must be utf-8");
+        let db = RocksDB::open(&StoreConfig::new(path)).expect("rocksdb must open");
+        populate(&db, n);
+        run_group(&mut group, &db, n);
+        // `dir` drops here, taking the database with it.
+    }
+    group.finish();
+}
+
+criterion_group!(benches, inmem, rocks);
+criterion_main!(benches);

--- a/crates/store/blobs/Cargo.toml
+++ b/crates/store/blobs/Cargo.toml
@@ -23,8 +23,19 @@ calimero-primitives.workspace = true
 calimero-store = { workspace = true, features = ["datatypes"] }
 
 [dev-dependencies]
+criterion.workspace = true
 tempfile.workspace = true
 # `rt-multi-thread`: the concurrent-put regression test needs a reader and a
 # writer genuinely running at once, not cooperatively interleaved.
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 tokio-util.workspace = true
+
+# A crate that gains a [[bench]] needs `bench = false` on its [lib], [[bin]]
+# and [[test]] targets, or `cargo bench -p calimero-blobstore` (no --bench
+# filter) hands those to libtest, which rejects criterion's own CLI flags.
+[lib]
+bench = false
+
+[[bench]]
+name = "chunking"
+harness = false

--- a/crates/store/blobs/benches/chunking.rs
+++ b/crates/store/blobs/benches/chunking.rs
@@ -1,0 +1,96 @@
+//! What does storing a blob cost per byte?
+//!
+//! `BlobManager::put` splits the stream into 1 MiB chunks (`CHUNK_SIZE`,
+//! `src/lib.rs:31`), SHA-256s each chunk to get its id, writes it, and then
+//! hashes the chunk ids together to get the root id. Every image, avatar and
+//! application bundle pays this on the way in, and the receiving node pays it
+//! again on the way out.
+//!
+//! Sizes bracket the chunk boundary on purpose: just under one chunk
+//! (1,000,000 bytes), exactly one full chunk (1,048,576 bytes — `CHUNK_SIZE`
+//! is `1 << 20` exactly, `src/lib.rs:31`), and several (4,194,304 bytes, four
+//! chunks). A per-byte cost that jumps between the first two sizes means the
+//! chunking path, not the hashing, dominates; the observed measurement is
+//! flat across that boundary (see the benchmark report).
+//!
+//! Measured throughput lands around ~120-126 MiB/s, well short of the naive
+//! "hundreds of MB/s" a single SHA-256 pass would suggest, because
+//! `put_sized` hashes every chunk **twice** into two independent `Sha256`
+//! instances over the same bytes: `blob.digest.update(chunk)` accumulates the
+//! root id and `file.digest.update(chunk)` accumulates that chunk's own id
+//! (`src/lib.rs:132-135` for the `State` struct holding both digests,
+//! `:411-412` for the two updates). Two software SHA-256 passes at roughly
+//! 3-4 ns/byte each account for most of the ~7.9 ns/byte this bench measures;
+//! the filesystem write is the smaller remainder, not the dominant cost.
+//!
+//! Context for the numbers: a receiver abandons a transfer after 60s
+//! (`crates/network/.../request_blob.rs:18`), so the p2p ceiling of 500 MiB
+//! implies a sustained 8.5 MB/s. If local chunking alone cannot beat that, the
+//! transfer limit is unreachable for reasons that have nothing to do with the
+//! network.
+
+use std::hint::black_box;
+use std::path::Path;
+use std::sync::Arc;
+
+use calimero_blobstore::config::BlobStoreConfig;
+use calimero_blobstore::{BlobManager, FileSystem};
+use calimero_store::db::InMemoryDB;
+use calimero_store::Store as DataStore;
+use camino::Utf8PathBuf;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use tempfile::TempDir;
+
+/// Mirrors the crate's own test setup (`src/lib.rs:890-900`): an in-memory
+/// data store for metadata plus a real `FileSystem` blob store rooted in a
+/// fresh temp directory. `FileSystem::new` is async, so this is called from
+/// setup on a throwaway runtime, never from inside a timed closure. The
+/// `TempDir` is returned alongside the manager so it outlives the
+/// measurement — dropping it would delete the store out from under `put`.
+async fn new_manager_async(root: &Path) -> BlobManager {
+    let data_store = DataStore::new(Arc::new(InMemoryDB::owned()));
+    let config = BlobStoreConfig::new(Utf8PathBuf::from_path_buf(root.to_path_buf()).unwrap());
+    let blob_store = FileSystem::new(&config).await.unwrap();
+    BlobManager::new(data_store, blob_store)
+}
+
+fn new_manager(runtime: &tokio::runtime::Runtime) -> (BlobManager, TempDir) {
+    let dir = tempfile::tempdir().expect("a temp dir must be creatable");
+    let manager = runtime.block_on(new_manager_async(dir.path()));
+    (manager, dir)
+}
+
+fn chunking(c: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("a current-thread runtime must build");
+
+    let mut group = c.benchmark_group("blob");
+
+    // Just under one chunk, exactly one, and four.
+    for bytes in [1_000_000_usize, 1_048_576, 4_194_304] {
+        let payload = vec![0xCD_u8; bytes];
+
+        group.throughput(Throughput::Bytes(bytes as u64));
+        group.bench_with_input(BenchmarkId::new("put", bytes), &payload, |b, payload| {
+            b.iter_batched(
+                // A fresh store per iteration: content-addressing means the
+                // second put of identical bytes is a no-op, which would
+                // measure deduplication rather than chunking.
+                || new_manager(&runtime),
+                |(manager, _tempdir)| {
+                    runtime.block_on(async {
+                        black_box(manager.put(&payload[..]).await.expect("put must succeed"))
+                    })
+                },
+                criterion::BatchSize::PerIteration,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, chunking);
+criterion_main!(benches);


### PR DESCRIPTION
**Stack 2 of 5.** Base: #3750.

Eight criterion targets across seven crates. All reporting-only — none can fail a merge. An O(n) read pattern against an in-memory store is nearly free in wall-clock while real gas explodes, so a timing gate would miss exactly the class of regression this suite exists to catch.

## Results, and what each answers

| Bench | Question | Answer |
|---|---|---|
| `storage/child_trie` | Does a trie op scale with child count? | Point ops flat (`get` 905 ns → 1.04 µs from n=10 to 10k); enumeration linear (`children()` ~93 ms at 10k) |
| `storage/merge_root_state` | Is merge framework overhead a material share of an apply? | **No** — 2.41 µs / 22.3 µs / 222 µs / 2.27 ms at 10 / 100 / 1k / 10k. Cleanly linear |
| `store/db_ops` | What does one key-value op cost per backend? | RocksDB `get_hit` 541 ns vs in-memory 159 ns at 10k keys |
| `store/blobs/chunking` | Cost per byte, and is there a chunk-boundary cliff? | ~120 MiB/s, flat across the boundary. Hashing-bound, not disk-bound |
| `crypto/aead` | Could crypto be the transfer ceiling? | **No** — 4.61 GiB/s sealing 1 MiB, 6.62 GiB/s opening |
| `runtime/engine` | Is caching compiled modules worth building? | **Yes** — compile 555.8 µs is 6.76× a 64-host-call run at 82.3 µs |
| `dag/pending` | Do catch-up walks go superlinear? | **No**, all linear. The pending-parent index is not justified |

## Conventions

Fixtures are built in `iter_batched` setup closures, never inside the timed body. No bench carries `required-features` — that makes a plain `cargo bench` skip the target silently and defeats #3750's compile gate. Every module doc states the question and what answer would change a decision.

## Caveats stated in the code

- The RocksDB numbers are warm-cache: ~2 MB working set inside a 128 MiB block cache at every measured size, so they show dispatch cost, not disk I/O. The doc says so.
- Blob throughput is dominated by `put_sized` hashing every chunk **twice** (`crates/store/blobs/src/lib.rs:132-135, :411-412`).
- `dag/get_missing_parents` flattens past n=1,000 because `query_limit` truncates at 128 — capped, not fast.

## Verification

`cargo bench -p <crate> --bench <name> -- --quick` runs for all eight; `cargo bench --workspace --benches --no-run` exit 0; clippy under `-D warnings` clean; fmt clean.