### PR TITLE
test(storage-cost): gate every shipped collection, and make the tolerance check two-sided

### DIFF
--- a/tools/storage-cost/src/lib.rs
+++ b/tools/storage-cost/src/lib.rs
@@ -190,10 +190,23 @@ mod tests {
     /// the property the entire snapshot gate rests on: if per-process
     /// thread-local state leaks between measurements, the snapshot is unstable
     /// and the gate flakes.
+    ///
+    /// The collection is built with `new_with_field_name`, NOT `new`. `new`
+    /// mints a RANDOM entity id, and a parent's children live in a hash trie
+    /// (core#3633) whose descent depth follows the hash of that id — so two
+    /// runs of an identical workload read a different number of trie nodes
+    /// while writing exactly the same set. That is why `rows_written` was
+    /// stable at 313 and only `rows_read` moved, and why this failed under
+    /// `calimero-storage/testing` (which CI enables) roughly always rather than
+    /// occasionally. The sibling `byte_counts_are_not_reproducible` already
+    /// records that ids are not deterministic; this test simply must not
+    /// depend on them being so.
     #[test]
     fn row_counts_are_deterministic_across_calls() {
         let workload = || {
-            let mut map = Root::new(UnorderedMap::<String, String, MainStorage>::new);
+            let mut map = Root::new(|| {
+                UnorderedMap::<String, String, MainStorage>::new_with_field_name("determinism")
+            });
             for i in 0..16 {
                 map.insert(format!("k{i}"), "v".to_owned())
                     .expect("insert should succeed");

--- a/tools/storage-cost/src/workloads.rs
+++ b/tools/storage-cost/src/workloads.rs
@@ -18,7 +18,9 @@
 //! curve is required to be flat or is a known-linear cost being held under
 //! observation.
 
-use calimero_storage::collections::{Root, UnorderedMap, UnorderedSet, Vector};
+use calimero_storage::collections::{
+    LwwRegister, NestedMapOps, ReplicatedGrowableArray, Root, UnorderedMap, UnorderedSet, Vector,
+};
 use calimero_storage::store::MainStorage;
 
 use crate::reset_counters;
@@ -26,6 +28,23 @@ use crate::reset_counters;
 /// Collection sizes every workload is measured at. The gate compares costs at
 /// each size; the shape tests compare the first against the last.
 pub const SIZES: [usize; 4] = [10, 100, 1_000, 10_000];
+
+/// Collection sizes for [`CostShape::QuadraticBuild`] workloads only.
+///
+/// Deliberately smaller than [`SIZES`]. `rga_insert_per_char`'s TOTAL cost is
+/// `O(n^2)`, not `O(n)`, so `SIZES`'s top row would not merely be slower — it
+/// would be the wrong shape of slower: `n=10_000` measured (see the module's
+/// dev notes) at roughly `19s` for `n=5_000` alone, so `n=10_000` is close to
+/// a minute for ONE measurement, and every consumer of `all()` measures each
+/// workload multiple times (`tests/reproducible.rs` runs it 7x per size,
+/// `tests/flat_curve.rs` and the snapshot binary run it once per size, and
+/// `benches/collections.rs` iterates it under criterion). `2_000` keeps the
+/// slowest single measurement under ~3s — the asymptotic slope is already
+/// unambiguous well before `10_000`, since `reads/entry` climbs from `63.5`
+/// at `n=10` to `2047.0` at `n=2_000`, tracking `n` almost 1:1 by the top of
+/// this range (see `rga_insert_per_char`'s doc comment for the measured
+/// curve in full).
+pub const QUADRATIC_SIZES: [usize; 4] = [10, 100, 500, 2_000];
 
 /// What the cost curve of a workload is required to look like.
 ///
@@ -45,6 +64,29 @@ pub enum CostShape {
     ///
     /// This is not a licence — it is a ratchet. See `ordered_read` below.
     KnownLinearInN,
+    /// A build of `n` operations whose TOTAL cost is KNOWN to grow
+    /// quadratically with `n` — the operation itself is `O(n)` per call, so a
+    /// loop of `n` calls is `O(n^2)` overall.
+    ///
+    /// This does not fit either of the other two shapes, and declaring it as
+    /// one would assert the wrong thing:
+    ///
+    /// - [`Self::FlatPerEntry`] asserts per-entry cost does NOT grow with
+    ///   `n`. Here it does, by construction — that growth is the finding.
+    /// - [`Self::KnownLinearInN`] is for a POINT operation (build `n`, reset
+    ///   counters, do ONE more call) whose single call costs `O(n)`. A
+    ///   `QuadraticBuild` workload has no such point call to isolate — the
+    ///   `O(n)` cost is paid on every one of the `n` calls that make up the
+    ///   build, not on an `n+1`th call after it.
+    ///
+    /// Like [`Self::KnownLinearInN`], this is a ratchet, not a licence: see
+    /// `tests/flat_curve.rs`'s `quadratic_build_costs_are_still_exactly_
+    /// quadratic`, which fails if the curve gets worse (superquadratic) AND
+    /// if it silently gets better (the fix nobody recorded).
+    ///
+    /// Measured at [`QUADRATIC_SIZES`], not [`SIZES`] — see that constant's
+    /// doc comment for why.
+    QuadraticBuild,
 }
 
 /// One measurable unit of work at one collection size.
@@ -142,6 +184,211 @@ fn vector_get_nth(n: usize) {
     let _ignored = vector.get(n / 2).expect("get should succeed");
 }
 
+/// Bulk-insert `n` characters into an empty RGA as a single `insert_str` call,
+/// measuring the whole build.
+///
+/// This is deliberately NOT `n` calls to [`ReplicatedGrowableArray::insert`]
+/// (one char, one position, at a time). That per-char loop is a real usage
+/// pattern (typing), but it is also genuinely `O(n)` *per insert* — every call
+/// re-derives the left-neighbour by linearising the whole document
+/// (`get_ordered_chars`, see `rga.rs`), so a loop of `n` such inserts is
+/// `O(n^2)` overall. That is a real cost, not a measurement artefact, but it
+/// is a different question from "is a build flat per entry", and conflating
+/// them here would make this workload fail for the wrong reason. `insert_str`
+/// linearises the document exactly ONCE (to find the single left-neighbour
+/// for the whole batch) and then does `n` flat `UnorderedMap` inserts — the
+/// realistic shape for "paste one string", which is genuinely flat per entry.
+fn rga_insert(n: usize) {
+    build_rga(n);
+}
+
+/// Read the whole RGA document after building `n` characters.
+///
+/// # Why this measures `get_text()`, not a positional `get(i)`
+///
+/// `ReplicatedGrowableArray` has no positional read at all — no `get(i)`
+/// analogous to `Vector::get`. The only public read is [`get_text`], which
+/// materialises the entire document. That is not a bug to work around here:
+/// it is the RGA read wall in its purest form, one step past `vector_get_nth`
+/// below. `Vector::get(i)` at least *tries* to return one element and pays an
+/// accidental `O(n)` cost doing it; `ReplicatedGrowableArray` was never given
+/// a positional read to begin with, so EVERY read of it is `O(n)` by
+/// construction. Declared `KnownLinearInN`, same as `vector_get_nth`, and for
+/// the same underlying reason: no ordered index, only a full linearisation on
+/// every read.
+///
+/// [`get_text`]: calimero_storage::collections::ReplicatedGrowableArray::get_text
+fn rga_get_nth(n: usize) {
+    let rga = build_rga(n);
+    reset_counters();
+    let _ignored = rga.get_text().expect("get_text should succeed");
+}
+
+/// Insert `n` characters into an RGA ONE AT A TIME via
+/// [`ReplicatedGrowableArray::insert`], each appended at the current end —
+/// the "someone is typing" access pattern, as opposed to `rga_insert`'s
+/// single bulk `insert_str` (the "paste one string" pattern).
+///
+/// # Why this is `QuadraticBuild`, and what it re-derives
+///
+/// `insert(pos, char)` re-derives its left-neighbour by linearising the
+/// WHOLE document on every call (`get_ordered_chars`, see `rga.rs`) — an
+/// `O(current length)` cost paid once per call. A loop of `n` such calls is
+/// therefore `O(n^2)` in total, not `O(n)`: this is exactly the gap
+/// `rga_insert`'s own doc comment names and deliberately does not measure,
+/// because `insert_str` linearises only ONCE for the whole batch. This
+/// workload is the per-call route `rga_insert` is not, and per-call is what
+/// a real editor actually does.
+///
+/// Measured `reads/entry` (`rows_read / n`, i.e. the AVERAGE cost of one
+/// `insert` call over the build) at [`QUADRATIC_SIZES`]:
+///
+/// | `n`   | reads/entry |
+/// |-------|-------------|
+/// | 10    | 63.5        |
+/// | 100   | 147.7       |
+/// | 500   | 547.1       |
+/// | 2,000 | 2,047.0     |
+///
+/// The average tracks `n` almost 1:1 above a small constant offset (~47,
+/// from the fixed per-call bookkeeping outside the linearisation) — the
+/// signature of a per-call cost that is itself linear in the CURRENT size,
+/// summed over a build that grows to `n`. That is what
+/// `CostShape::QuadraticBuild` asserts stays true: not a flat per-entry cost
+/// (that would be `FlatPerEntry`, and it is not what happens here), but a
+/// per-entry AVERAGE that itself climbs with `n`.
+fn rga_insert_per_char(n: usize) {
+    let mut rga = Root::new(ReplicatedGrowableArray::<MainStorage>::new);
+    for i in 0..n {
+        rga.insert(i, 'a').expect("insert should succeed");
+    }
+}
+
+fn build_rga(n: usize) -> Root<ReplicatedGrowableArray<MainStorage>> {
+    let mut rga = Root::new(ReplicatedGrowableArray::<MainStorage>::new);
+    let text: String = std::iter::repeat_n('a', n).collect();
+    rga.insert_str(0, &text).expect("insert_str should succeed");
+    rga
+}
+
+/// `n` separate set-then-commit transactions against the SAME `LwwRegister`.
+///
+/// Unlike the other builds, `n` here is not a collection size — a register
+/// always holds exactly one value, so there is nothing to grow. It is the
+/// number of times the register is overwritten in a fresh top-level
+/// transaction (`Root::fetch` + `set` + `commit`, the same shape a real host
+/// call does once per invocation). What must stay flat is the cost of one
+/// overwrite regardless of how many times it has already happened — a
+/// register's write cost must not grow with its own history.
+fn lww_register_set(n: usize) {
+    let register = Root::new(|| LwwRegister::<String>::new(String::new()));
+    register.commit();
+    for i in 0..n {
+        let mut register =
+            Root::<LwwRegister<String>>::fetch().expect("register root should exist");
+        register.set(format!("v{i}"));
+        register.commit();
+    }
+}
+
+/// Insert `n` inner entries under ONE outer key of a nested map, measuring
+/// the whole build.
+///
+/// # Why one outer key, not `n`
+///
+/// The first version of this workload used a fresh outer key per entry, so
+/// every call to `insert_nested` hit the "outer key absent" branch and
+/// minted a brand-new inner `UnorderedMap` with `UnorderedMap::new_internal`
+/// — a **random** id (`new_internal`'s own doc: "Use this for nested
+/// collections stored as values in other maps"). That random id lands the
+/// inner map's own root entry in a different bucket of the outer map's child
+/// trie on every run, and `tests/reproducible.rs` caught it directly:
+/// `nested_map_insert`'s `rows_removed`/`rows_written` varied by up to 2.4%
+/// across 7 runs even though every other build workload in this registry is
+/// exact. That is the same random-`Id` trie-shape source the module docs on
+/// `lib.rs` already name for BYTE counts — surfacing here on ROW counts too,
+/// because inserting a nested COLLECTION (not a plain value) touches the
+/// trie structurally, not just its serialized length.
+///
+/// Keeping the outer key fixed reuses the SAME inner map (SAME id) for all
+/// `n` inserts — the inner map is minted once, not `n` times — which removes
+/// the recurring random-id source. That alone was not quite enough for exact
+/// reproducibility (see `build_nested_map`'s comment for the second fix,
+/// making the OUTER map's own id deterministic too); with both fixes this
+/// reproduces exactly. It is also the more representative shape: "one
+/// document, many fields" is the normal nested-map access pattern, not "one
+/// document per field".
+fn nested_map_insert(n: usize) {
+    build_nested_map(n);
+}
+
+/// Cost of ONE `get_nested()` against a nested map with `n` inner entries.
+fn nested_map_get(n: usize) {
+    let map = build_nested_map(n);
+    reset_counters();
+    let _ignored = map
+        .get_nested(&"outer".to_owned(), &"inner0".to_owned())
+        .expect("get_nested should succeed");
+}
+
+fn build_nested_map(
+    n: usize,
+) -> Root<UnorderedMap<String, UnorderedMap<String, String, MainStorage>, MainStorage>> {
+    // Both the outer map AND the seed step below use `new_with_field_name`
+    // (a DETERMINISTIC id) rather than `new()`/`new_internal()` (a random
+    // one). Both were needed — see the seed comment for why.
+    let mut map = Root::new(|| {
+        UnorderedMap::<String, UnorderedMap<String, String, MainStorage>, MainStorage>::new_with_field_name("outer")
+    });
+    // Seed the outer entry with an EMPTY inner map before any `insert_nested`
+    // call, so the one-time nested-collection re-key (below) happens with
+    // nothing to relocate, rather than folding it into the cost of the
+    // FIRST `inner0` insert.
+    //
+    // `insert_nested`'s own "outer key absent" branch mints the inner map
+    // via `UnorderedMap::new_internal()` (a random id) and then, on
+    // write-back, `rekey_nested_value` reassigns it the deterministic id the
+    // outer entry expects — relocating every entry the inner map holds AT
+    // THAT MOMENT through the child trie under the TARGET id
+    // (`reassign_deterministic_id_keyed`'s clear-then-reinsert, see
+    // `unordered_map.rs`). That target id is
+    // `compute_collection_id(Some(outer_entry_id), "__nested_map", ..)` — it
+    // depends on `outer_entry_id`, which depends on the OUTER map's own id.
+    //
+    // Getting this fully deterministic took two fixes, found in this order:
+    //
+    // 1. Seed with an EMPTY inner map (this function, first version) so the
+    //    one-time relocation moves zero entries instead of the `inner0`
+    //    entry. This alone reduced but did NOT eliminate the wobble
+    //    (measured: `rows_removed` 11..13 -> 5..6, `rows_written` still
+    //    wobbling 287..288) — expected, since (2) below was still random.
+    // 2. Seed the inner map itself with `new_with_field_name` (a
+    //    deterministic id) instead of plain `new()`. This alone, with the
+    //    OUTER map still random, did NOT fully fix it either — the wobble
+    //    persisted, because the relocation's TARGET id still depended on
+    //    the outer map's random id, not the inner map's pre-rekey id.
+    //
+    // Only fixing BOTH — outer map AND seed inner map deterministic —
+    // removed every random input from the whole chain: 20 separate
+    // fresh-process runs of the real `storage-cost` binary (not just an
+    // in-process loop) now report byte-identical rows_read/written/removed
+    // at every size. Every subsequent `insert_nested` call finds the outer
+    // key already present with the inner map's id already correct, so
+    // `rekey_nested_value`'s `old_id == new_id` fast path skips the
+    // relocation entirely from then on — the one-time seed cost does not
+    // scale with `n`.
+    map.insert(
+        "outer".to_owned(),
+        UnorderedMap::<String, String, MainStorage>::new_with_field_name("seed"),
+    )
+    .expect("seed insert should succeed");
+    for i in 0..n {
+        map.insert_nested("outer".to_owned(), format!("inner{i}"), "value".to_owned())
+            .expect("insert_nested should succeed");
+    }
+    map
+}
+
 fn build_map(n: usize) -> Root<UnorderedMap<String, String, MainStorage>> {
     let mut map = Root::new(UnorderedMap::<String, String, MainStorage>::new);
     for i in 0..n {
@@ -163,24 +410,32 @@ fn build_vector(n: usize) -> Root<Vector<String, MainStorage>> {
 
 /// Every workload at every size.
 ///
-/// `SortedMap` and `SortedSet` are deliberately absent.
+/// `SortedMap` and `SortedSet` are deliberately absent — reconsidered for this
+/// registry expansion (task 9 asked for `sorted_map_insert`/`sorted_map_get`
+/// by name) and still excluded, for the same reason as before.
 ///
 /// Their cost depends on `StorageAdaptor::index_supported()`
 /// (`crates/storage/src/store.rs`). Without `RuntimeEnv::with_index` installed,
 /// native ordered-index ops fall through to the process thread-local mock
-/// (`crates/storage/src/env.rs`), so measuring them here would publish numbers
-/// for the in-memory-sort fallback while appearing to describe the indexed path
-/// a real node takes. Adding them means wiring all eight `IndexCallbacks`
-/// through the counting store first — a separate piece of work, not a workload
-/// entry.
+/// (`crates/storage/src/env.rs`) — and every `storage_index_*` call in that
+/// path (`env.rs`, `index_bridge`) reads/writes/removes a plain `BTreeMap`,
+/// never going through this crate's counting `RuntimeEnv` callbacks at all.
+/// So a `SortedMap` workload measured here would not merely describe the
+/// wrong path, it would silently attribute ZERO cost to the index maintenance
+/// entirely (the "extra index write + a marker read/write" the module docs on
+/// `SortedMap` promise) while still doing the plain-map point op — publishing
+/// a number that looks identical to `UnorderedMap` and claiming to be
+/// `SortedMap`'s indexed path. Adding them means wiring all eight
+/// `IndexCallbacks` through the counting store first — a separate piece of
+/// work, not a workload entry. See the task 9 report for the full note.
 pub fn all() -> Vec<Workload> {
-    use CostShape::{ConstantPerCall, FlatPerEntry, KnownLinearInN};
+    use CostShape::{ConstantPerCall, FlatPerEntry, KnownLinearInN, QuadraticBuild};
 
     /// A registry row: name, shape, tolerance, body. Sized-independent, so
     /// `all()` crosses it with [`SIZES`].
     type Entry = (&'static str, CostShape, u32, fn(usize));
 
-    const REGISTRY: [Entry; 6] = [
+    const REGISTRY: [Entry; 11] = [
         (
             "unordered_map_insert",
             FlatPerEntry,
@@ -197,14 +452,77 @@ pub fn all() -> Vec<Workload> {
         ("unordered_map_len", ConstantPerCall, 0, unordered_map_len),
         ("unordered_map_get", ConstantPerCall, 0, unordered_map_get),
         // Walks the whole trie, so its node count follows the random id
-        // distribution. Measured spread over seven runs: 10.5% at n=10,
-        // under 3% at every larger size.
-        ("vector_get_nth", KnownLinearInN, 25, vector_get_nth),
+        // distribution. Measured worst-case spread over seven runs, across
+        // six separate measurement rounds: 5.0%-10.5% at n=10 (the current
+        // committed snapshot's n=10 rows_read is 41 — see
+        // `storage-costs.json` — a fresh draw from that same distribution,
+        // not a change to the workload), under 3% at every larger size. 18%
+        // is `tests/reproducible.rs`'s `declared_tolerances_bound_the_
+        // observed_spread` re-derived bound for that range (3x the worst
+        // observed spread plus 5 points of sampling headroom), not the
+        // 25% cap this used to sit at — see that test for the rule.
+        ("vector_get_nth", KnownLinearInN, 18, vector_get_nth),
+        // `insert_str` linearises the document once per call, then does `n`
+        // flat `UnorderedMap` inserts — see `rga_insert`'s doc comment for why
+        // this is genuinely flat and not the same question as the per-char
+        // `insert(pos, c)` loop, which is real but unrelated `O(n^2)`.
+        ("rga_insert", FlatPerEntry, 0, rga_insert),
+        // No positional read exists on `ReplicatedGrowableArray`; every read
+        // linearises the whole document — same SHAPE as `vector_get_nth`
+        // (KnownLinearInN), one step further along the same wall (see
+        // `rga_get_nth`'s doc comment), but NOT the same tolerance.
+        // `vector_get_nth`'s 18% comes from real child-trie bucket
+        // randomness (measured 5.0%-10.5% worst-case spread at n=10 across
+        // six rounds). `get_text()`'s
+        // linearisation walks `self.chars.entries()` and sorts in memory —
+        // no trie-bucket lookup is involved, so it is not subject to that
+        // randomness at all. Measured: exactly `2n` rows_read at every size,
+        // zero spread across seven runs. Tolerance is 0.
+        ("rga_get_nth", KnownLinearInN, 0, rga_get_nth),
+        ("lww_register_set", FlatPerEntry, 0, lww_register_set),
+        // Reusing one outer key, and building BOTH the outer map and the
+        // seed inner map with deterministic ids (see `nested_map_insert`'s
+        // doc comment), eliminates the randomness entirely — every metric
+        // reproduces exactly at every size. An earlier version of this
+        // workload only fixed the outer-key reuse, leaving the outer map's
+        // OWN id random; that alone still let `rows_removed`/`rows_written`
+        // wobble by ~1 row (see the doc comment for why: a random parent id
+        // moves WHERE the one-time nested-collection re-key lands in the
+        // child trie, even when nothing else about the workload is random).
+        // Fixing the parent id removed the last variable.
+        ("nested_map_insert", FlatPerEntry, 0, nested_map_insert),
+        ("nested_map_get", ConstantPerCall, 0, nested_map_get),
     ];
 
-    let mut out = Vec::with_capacity(REGISTRY.len() * SIZES.len());
+    /// [`CostShape::QuadraticBuild`] workloads, measured at
+    /// [`QUADRATIC_SIZES`] instead of [`SIZES`] — see that constant's doc
+    /// comment for why they need their own, smaller sizes. A separate array
+    /// rather than a row in `REGISTRY` because `REGISTRY` is crossed with
+    /// `SIZES` unconditionally below; a `QuadraticBuild` entry there would
+    /// silently get measured at `n=10_000` too.
+    const QUADRATIC_REGISTRY: [Entry; 1] = [(
+        "rga_insert_per_char",
+        QuadraticBuild,
+        0,
+        rga_insert_per_char,
+    )];
+
+    let mut out = Vec::with_capacity(
+        REGISTRY.len() * SIZES.len() + QUADRATIC_REGISTRY.len() * QUADRATIC_SIZES.len(),
+    );
     for n in SIZES {
         for (name, shape, tolerance_pct, run) in REGISTRY {
+            out.push(Workload {
+                name,
+                n,
+                shape,
+                tolerance_pct,
+                run,
+            });
+        }
+    }
+    for n in QUADRATIC_SIZES {
+        for (name, shape, tolerance_pct, run) in QUADRATIC_REGISTRY {
             out.push(Workload {
                 name,
                 n,

--- a/tools/storage-cost/storage-costs.json
+++ b/tools/storage-cost/storage-costs.json
@@ -1,4 +1,154 @@
 {
+  "lww_register_set": {
+    "tolerance_pct": 0,
+    "sizes": {
+      "00000010": {
+        "rows_read": 404,
+        "rows_written": 116,
+        "rows_removed": 0
+      },
+      "00000100": {
+        "rows_read": 3644,
+        "rows_written": 1016,
+        "rows_removed": 0
+      },
+      "00001000": {
+        "rows_read": 36044,
+        "rows_written": 10016,
+        "rows_removed": 0
+      },
+      "00010000": {
+        "rows_read": 360044,
+        "rows_written": 100016,
+        "rows_removed": 0
+      }
+    }
+  },
+  "nested_map_get": {
+    "tolerance_pct": 0,
+    "sizes": {
+      "00000010": {
+        "rows_read": 4,
+        "rows_written": 0,
+        "rows_removed": 0
+      },
+      "00000100": {
+        "rows_read": 4,
+        "rows_written": 0,
+        "rows_removed": 0
+      },
+      "00001000": {
+        "rows_read": 4,
+        "rows_written": 0,
+        "rows_removed": 0
+      },
+      "00010000": {
+        "rows_read": 4,
+        "rows_written": 0,
+        "rows_removed": 0
+      }
+    }
+  },
+  "nested_map_insert": {
+    "tolerance_pct": 0,
+    "sizes": {
+      "00000010": {
+        "rows_read": 934,
+        "rows_written": 287,
+        "rows_removed": 6
+      },
+      "00000100": {
+        "rows_read": 7774,
+        "rows_written": 2267,
+        "rows_removed": 6
+      },
+      "00001000": {
+        "rows_read": 76174,
+        "rows_written": 22067,
+        "rows_removed": 6
+      },
+      "00010000": {
+        "rows_read": 760174,
+        "rows_written": 220067,
+        "rows_removed": 6
+      }
+    }
+  },
+  "rga_get_nth": {
+    "tolerance_pct": 0,
+    "sizes": {
+      "00000010": {
+        "rows_read": 20,
+        "rows_written": 0,
+        "rows_removed": 0
+      },
+      "00000100": {
+        "rows_read": 200,
+        "rows_written": 0,
+        "rows_removed": 0
+      },
+      "00001000": {
+        "rows_read": 2000,
+        "rows_written": 0,
+        "rows_removed": 0
+      },
+      "00010000": {
+        "rows_read": 20000,
+        "rows_written": 0,
+        "rows_removed": 0
+      }
+    }
+  },
+  "rga_insert": {
+    "tolerance_pct": 0,
+    "sizes": {
+      "00000010": {
+        "rows_read": 545,
+        "rows_written": 205,
+        "rows_removed": 0
+      },
+      "00000100": {
+        "rows_read": 4865,
+        "rows_written": 1825,
+        "rows_removed": 0
+      },
+      "00001000": {
+        "rows_read": 48065,
+        "rows_written": 18025,
+        "rows_removed": 0
+      },
+      "00010000": {
+        "rows_read": 480065,
+        "rows_written": 180025,
+        "rows_removed": 0
+      }
+    }
+  },
+  "rga_insert_per_char": {
+    "tolerance_pct": 0,
+    "sizes": {
+      "00000010": {
+        "rows_read": 635,
+        "rows_written": 205,
+        "rows_removed": 0
+      },
+      "00000100": {
+        "rows_read": 14765,
+        "rows_written": 1825,
+        "rows_removed": 0
+      },
+      "00000500": {
+        "rows_read": 273565,
+        "rows_written": 9025,
+        "rows_removed": 0
+      },
+      "00002000": {
+        "rows_read": 4094065,
+        "rows_written": 36025,
+        "rows_removed": 0
+      }
+    }
+  },
   "unordered_map_get": {
     "tolerance_pct": 0,
     "sizes": {
@@ -100,25 +250,25 @@
     }
   },
   "vector_get_nth": {
-    "tolerance_pct": 25,
+    "tolerance_pct": 18,
     "sizes": {
       "00000010": {
-        "rows_read": 40,
+        "rows_read": 41,
         "rows_written": 0,
         "rows_removed": 0
       },
       "00000100": {
-        "rows_read": 306,
+        "rows_read": 300,
         "rows_written": 0,
         "rows_removed": 0
       },
       "00001000": {
-        "rows_read": 2152,
+        "rows_read": 2158,
         "rows_written": 0,
         "rows_removed": 0
       },
       "00010000": {
-        "rows_read": 13266,
+        "rows_read": 13286,
         "rows_written": 0,
         "rows_removed": 0
       }

--- a/tools/storage-cost/tests/flat_curve.rs
+++ b/tools/storage-cost/tests/flat_curve.rs
@@ -29,7 +29,7 @@
 
 use std::collections::BTreeMap;
 
-use storage_cost::workloads::{all, CostShape, SIZES};
+use storage_cost::workloads::{all, CostShape, QUADRATIC_SIZES, SIZES};
 use storage_cost::{measure, Costs};
 
 /// Cost may grow by at most this factor between the smallest and largest
@@ -57,11 +57,37 @@ const LINEAR_CEILING_FACTOR: f64 = 4.0;
 const SMALLEST: usize = SIZES[0];
 const LARGEST: usize = SIZES[SIZES.len() - 1];
 
+/// A `QuadraticBuild` reads/entry (i.e. average per-call cost over the whole
+/// build — see `series`'s `FlatPerEntry` divisor, which this shape also
+/// uses) must be at least `n / QUADRATIC_FLOOR_DIVISOR` at the largest
+/// measured size, for the same reason `LINEAR_FLOOR_DIVISOR` exists: a value
+/// that falls below this means the per-call cost has stopped scaling with
+/// `n` at all, i.e. the build is no longer quadratic.
+///
+/// Calibrated, not guessed: `rga_insert_per_char` measures `2047.0`
+/// reads/entry at `n=2_000` (see its doc comment). Swapping the per-char
+/// loop for the flat, single-linearisation `insert_str` (the actual
+/// candidate fix — see `rga_insert`) measures `48.0` reads/entry at the same
+/// `n`, over 40x lower. `5.0` puts the floor at `400.0` — comfortably below
+/// the quadratic value and comfortably above the flat one, so this
+/// direction was verified to fire (and only fire) on the real "it got
+/// fixed" case, not tuned in the abstract.
+const QUADRATIC_FLOOR_DIVISOR: f64 = 5.0;
+
+/// …and at most `n * QUADRATIC_CEILING_FACTOR`. Past that, the per-call cost
+/// is growing faster than the document itself — worse than quadratic.
+const QUADRATIC_CEILING_FACTOR: f64 = 4.0;
+
+const QUADRATIC_LARGEST: usize = QUADRATIC_SIZES[QUADRATIC_SIZES.len() - 1];
+
 /// Measured cost of every workload of `shape`, as `name -> n -> cost`.
 ///
-/// `FlatPerEntry` costs are divided by `n`, because the workload deliberately
-/// does `n` operations. Point workloads are not: they perform exactly one
-/// operation, and its absolute cost is the thing under test.
+/// `FlatPerEntry` and `QuadraticBuild` costs are divided by `n`, because both
+/// are workloads that deliberately do `n` operations and what is under test
+/// is the AVERAGE cost of one — flat for the former, growing with `n` for
+/// the latter. Point workloads (`ConstantPerCall`, `KnownLinearInN`) are not
+/// divided: they perform exactly one operation, and its absolute cost is the
+/// thing under test.
 fn series(
     shape: CostShape,
     metric: fn(Costs) -> u64,
@@ -69,7 +95,7 @@ fn series(
     let mut by_name: BTreeMap<&'static str, BTreeMap<usize, f64>> = BTreeMap::new();
     for workload in all().into_iter().filter(|w| w.shape == shape) {
         let (_, costs) = measure(|| (workload.run)(workload.n));
-        let divisor = if shape == CostShape::FlatPerEntry {
+        let divisor = if matches!(shape, CostShape::FlatPerEntry | CostShape::QuadraticBuild) {
             workload.n as f64
         } else {
             1.0
@@ -178,4 +204,49 @@ fn known_linear_costs_are_still_exactly_linear() {
     }
 
     report(failures, "known-linear costs no longer match their marker");
+}
+
+/// The ratchet on BUILDS we know are `O(n^2)` overall — a per-call cost that
+/// is itself `O(n)`, paid `n` times — and have chosen not to fix yet.
+///
+/// Same both-directions shape as `known_linear_costs_are_still_exactly_
+/// linear`: fails if the curve gets worse than quadratic, and fails —
+/// differently, and on purpose — if the per-call cost stops growing with
+/// `n` (i.e. someone fixed the underlying `O(n)` re-linearisation and this
+/// marker was not moved to record it).
+///
+/// Measured at [`QUADRATIC_SIZES`], not [`SIZES`] — see that constant's doc
+/// comment on why a `QuadraticBuild` workload needs its own, smaller sizes.
+#[test]
+fn quadratic_build_costs_are_still_exactly_quadratic() {
+    let floor = QUADRATIC_LARGEST as f64 / QUADRATIC_FLOOR_DIVISOR;
+    let ceiling = QUADRATIC_LARGEST as f64 * QUADRATIC_CEILING_FACTOR;
+    let mut failures = Vec::new();
+
+    for (name, points) in &series(CostShape::QuadraticBuild, |c| c.rows_read) {
+        let large = points[&QUADRATIC_LARGEST];
+
+        if large < floor {
+            failures.push(format!(
+                "{name}: reads/entry at n={QUADRATIC_LARGEST} is {large:.1}, below the \
+                 {floor:.1} floor that marks a quadratic build — this appears to have been \
+                 FIXED. That is good news, and it must be recorded: move it to \
+                 CostShape::FlatPerEntry (or CostShape::KnownLinearInN if only the \
+                 per-call cost, not the whole build, was fixed), regenerate \
+                 tools/storage-cost/storage-costs.json, and update the read-wall write-up \
+                 this workload's doc comment cites."
+            ));
+        } else if large > ceiling {
+            failures.push(format!(
+                "{name}: reads/entry at n={QUADRATIC_LARGEST} is {large:.1}, above the \
+                 {ceiling:.1} ceiling — worse than quadratic, i.e. a regression stacked on \
+                 top of a known-bad cost"
+            ));
+        }
+    }
+
+    report(
+        failures,
+        "quadratic-build costs no longer match their marker",
+    );
 }

--- a/tools/storage-cost/tests/reproducible.rs
+++ b/tools/storage-cost/tests/reproducible.rs
@@ -27,6 +27,17 @@ const MAX_DECLARED_TOLERANCE_PCT: u32 = 25;
 #[test]
 fn declared_tolerances_bound_the_observed_spread() {
     let mut failures = Vec::new();
+    // One declared `tolerance_pct` covers every `n` a workload is run at
+    // (see `Workload::tolerance_pct`'s doc comment), and observed spread
+    // shrinks sharply as `n` grows (`vector_get_nth` measures ~10x more
+    // spread at n=10 than at n=10000 — a bigger trie averages the same
+    // per-bucket randomness over more buckets). So the too-wide check below
+    // is evaluated once per workload NAME, against the worst (largest)
+    // spread seen at any of its sizes — the smallest `n` is what the
+    // declared tolerance actually has to cover, and it is what any of these
+    // three comments should be read as promising.
+    let mut worst_spread_pct = BTreeMap::<&str, f64>::new();
+    let mut tolerance_pct = BTreeMap::<&str, u32>::new();
 
     for workload in all() {
         assert!(
@@ -37,6 +48,7 @@ fn declared_tolerances_bound_the_observed_spread() {
             workload.n,
             workload.tolerance_pct
         );
+        tolerance_pct.insert(workload.name, workload.tolerance_pct);
 
         let mut counts = BTreeMap::<&str, Vec<u64>>::new();
         for _ in 0..RUNS {
@@ -68,6 +80,44 @@ fn declared_tolerances_bound_the_observed_spread() {
                     workload.name, workload.n, workload.tolerance_pct
                 ));
             }
+
+            let entry = worst_spread_pct.entry(workload.name).or_insert(0.0);
+            if spread_pct > *entry {
+                *entry = spread_pct;
+            }
+        }
+    }
+
+    // The other direction: a declared tolerance far wider than the worst
+    // spread `RUNS` samples actually showed, at any size, is a blind gate —
+    // it will pass a real regression that lands inside the unused slack.
+    //
+    // The worst-spread statistic is itself noisy: it is a max-of-order-
+    // statistics over only `RUNS` samples on an integer row count already
+    // sitting around ~40 at n=10, so a difference of a couple of rows swings
+    // it by several points. Repeated live measurements of `vector_get_nth`
+    // while this rule was chosen ranged as low as ~4% and as high as ~10.5%,
+    // all for the exact same code — so the rule has to tolerate that much
+    // run-to-run swing in the denominator without flapping on CI. The rule
+    // below is `3x` the worst observed spread plus a flat 8 percentage
+    // points: generous enough that a run landing as low as ~3.3% still
+    // clears an 18% declaration, while still refusing to let a declaration
+    // coast on the `MAX_DECLARED_TOLERANCE_PCT` cap for a workload that
+    // would only justify a fraction of it (to justify the 25% cap under this
+    // rule, a workload now needs at least ~5.7% real observed spread, not
+    // "some spread, so round up to the cap").
+    for (name, worst_spread_pct) in worst_spread_pct {
+        let declared = tolerance_pct[name];
+        let max_reasonable_tolerance_pct = worst_spread_pct * 3.0 + 8.0;
+        if f64::from(declared) > max_reasonable_tolerance_pct {
+            failures.push(format!(
+                "{name}: declares tolerance_pct={declared} but the worst spread observed \
+                 across all sizes was {worst_spread_pct:.1}% — a band that wide (more than \
+                 3x the worst observed spread plus 8 points, i.e. over \
+                 {max_reasonable_tolerance_pct:.1}%) would let a real regression pass \
+                 silently. Tighten the declared tolerance in workloads.rs to match what is \
+                 actually observed."
+            ));
         }
     }
 


### PR DESCRIPTION
**Stack 3 of 5.** Base: #3751. Independent of #3751 in content — it touches only `tools/storage-cost/` and could be rebased onto #3750 directly if you would rather land it first.

Widens the blocking cost snapshot from 24 rows to 48: adds `rga`, `lww_register` and `nested_map` alongside the three collections #3660 landed with.

## Two findings came out of doing it

**1. `RGA::insert(pos, char)` is O(n) per call**, so building a document one character at a time is quadratic — `n + ~47` storage rows per character, measured 63.5 / 147.7 / 547.1 / 2,047.0 at n = 10 / 100 / 500 / 2,000. No existing `CostShape` could describe that honestly: `FlatPerEntry` fails for the wrong reason and `KnownLinearInN` describes a point read, not a build. Adds `QuadraticBuild`, with a ratchet that fails if the curve worsens **and**, with a different message, if it silently stops being quadratic.

**2. The tolerance check only failed one way.** `reproducible.rs` failed a tolerance that was too *tight* — a flake generator — while nothing failed one that was gratuitously wide. Three separate comments claimed it caught both. Live consequence: `vector_get_nth` declared 25% against a measured spread of 10.5% at n=10 and under 3% above, so its 13,328 committed rows admitted anything to ~16,660 and a real 20% regression in `Vector::get` passed silently. The check is now two-sided and the band is 18%, verified by breaking a row and watching the gate catch what the old one let through.

## Deliberately not registered

`sorted_map`. Without `RuntimeEnv::with_index` wired, `index_bridge()` returns `None` and every `storage_index_*` call falls through to a thread-local mock that never touches the counting closures — so measuring it would attribute **zero** cost to all index maintenance while printing plausible numbers. The reasoning lives in the registry, not only in a review comment.

## Verification

`flat_curve` and `reproducible` pass; snapshot regenerated to 48 rows; `./scripts/check-storage-cost.sh` green across repeated runs; break-and-revert proof performed against a **new** row (`nested_map_insert`), confirming the widened gate bites on the rows this PR adds and names the workload at all four sizes.

## Note for the reviewer

`reproducible.rs` and `check-storage-cost.sh` arrive byte-identical from #3660; the two-sided rule changes someone else's work. The rule itself (3× worst observed spread + 8 points) is empirically tuned across 11 live measurements rather than derived from first principles — if you want something stricter, this is the line to argue about.