### PR TITLE
chore(release): 0.11.0-rc.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.28"
+version = "0.11.0-rc.29"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Cuts the first release since #3747, and therefore the first to carry Windows binaries:

- `merod_x86_64-pc-windows-msvc.tar.gz`
- `meroctl_x86_64-pc-windows-msvc.tar.gz`

## Why the bump is the thing that matters

`prepare` sets `binary_release` only when the version has no release yet. `0.11.0-rc.28` is already published, so every master push since #3747 merged has been **building** Windows and uploading nothing. Merging #3747 did not, on its own, put a Windows archive anywhere.

Verified on master run [33478638412](https://github.com/calimero-network/core/actions/runs/33478638412) — all four targets build, `Release Binaries` skips.

## Downstream

Unblocks [calimero-network/tauri-app#207](https://github.com/calimero-network/tauri-app/pull/207), which cannot pin a Windows-carrying merod until one exists. rc.28 will not gain the asset retroactively, so the desktop app's pin has to move forward to this release.

Also fixes, for Windows users, the desktop app's in-app merod version switcher: `merod_versions.rs` resolves assets by target triple and asks for `x86_64-pc-windows-msvc`, which no release has ever had.

## Side effects

The usual release fan-out: crates.io publish, docker images, a Homebrew formula PR, and fleet-bump PRs across the SDK repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)