### PR TITLE
feat(merod): a graceful stop that works on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,13 +208,7 @@ jobs:
     strategy:
       matrix:
         # Keep legacy check names for required status checks.
-        #
-        # TEMPORARY (remove before merge): this PR's whole subject is behaviour
-        # under `cfg(not(unix))`, which is never type-checked when building for
-        # a unix host. The pull_request arm is Linux-only for cost, so without
-        # this the Windows arm of the new stop watch would first compile on
-        # master. Remove once this PR is green.
-        include: ${{ fromJSON(github.event_name == 'pull_request' && '[{"name":"ubuntu-24.04-8cpu, x86_64-unknown-linux-gnu","runner":"big-machine","target":"x86_64-unknown-linux-gnu"},{"name":"windows-latest, x86_64-pc-windows-msvc","runner":"windows-latest","target":"x86_64-pc-windows-msvc"}]' || '[{"name":"ubuntu-24.04-8cpu, x86_64-unknown-linux-gnu","runner":"big-machine","target":"x86_64-unknown-linux-gnu"},{"name":"ubuntu-24.04-arm, aarch64-unknown-linux-gnu","runner":"ubuntu-24.04-arm","target":"aarch64-unknown-linux-gnu"},{"name":"macos-latest, aarch64-apple-darwin","runner":"macos-latest","target":"aarch64-apple-darwin"},{"name":"windows-latest, x86_64-pc-windows-msvc","runner":"windows-latest","target":"x86_64-pc-windows-msvc"}]') }}
+        include: ${{ fromJSON(github.event_name == 'pull_request' && '[{"name":"ubuntu-24.04-8cpu, x86_64-unknown-linux-gnu","runner":"big-machine","target":"x86_64-unknown-linux-gnu"}]' || '[{"name":"ubuntu-24.04-8cpu, x86_64-unknown-linux-gnu","runner":"big-machine","target":"x86_64-unknown-linux-gnu"},{"name":"ubuntu-24.04-arm, aarch64-unknown-linux-gnu","runner":"ubuntu-24.04-arm","target":"aarch64-unknown-linux-gnu"},{"name":"macos-latest, aarch64-apple-darwin","runner":"macos-latest","target":"aarch64-apple-darwin"},{"name":"windows-latest, x86_64-pc-windows-msvc","runner":"windows-latest","target":"x86_64-pc-windows-msvc"}]') }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,13 @@ jobs:
     strategy:
       matrix:
         # Keep legacy check names for required status checks.
-        include: ${{ fromJSON(github.event_name == 'pull_request' && '[{"name":"ubuntu-24.04-8cpu, x86_64-unknown-linux-gnu","runner":"big-machine","target":"x86_64-unknown-linux-gnu"}]' || '[{"name":"ubuntu-24.04-8cpu, x86_64-unknown-linux-gnu","runner":"big-machine","target":"x86_64-unknown-linux-gnu"},{"name":"ubuntu-24.04-arm, aarch64-unknown-linux-gnu","runner":"ubuntu-24.04-arm","target":"aarch64-unknown-linux-gnu"},{"name":"macos-latest, aarch64-apple-darwin","runner":"macos-latest","target":"aarch64-apple-darwin"},{"name":"windows-latest, x86_64-pc-windows-msvc","runner":"windows-latest","target":"x86_64-pc-windows-msvc"}]') }}
+        #
+        # TEMPORARY (remove before merge): this PR's whole subject is behaviour
+        # under `cfg(not(unix))`, which is never type-checked when building for
+        # a unix host. The pull_request arm is Linux-only for cost, so without
+        # this the Windows arm of the new stop watch would first compile on
+        # master. Remove once this PR is green.
+        include: ${{ fromJSON(github.event_name == 'pull_request' && '[{"name":"ubuntu-24.04-8cpu, x86_64-unknown-linux-gnu","runner":"big-machine","target":"x86_64-unknown-linux-gnu"},{"name":"windows-latest, x86_64-pc-windows-msvc","runner":"windows-latest","target":"x86_64-pc-windows-msvc"}]' || '[{"name":"ubuntu-24.04-8cpu, x86_64-unknown-linux-gnu","runner":"big-machine","target":"x86_64-unknown-linux-gnu"},{"name":"ubuntu-24.04-arm, aarch64-unknown-linux-gnu","runner":"ubuntu-24.04-arm","target":"aarch64-unknown-linux-gnu"},{"name":"macos-latest, aarch64-apple-darwin","runner":"macos-latest","target":"aarch64-apple-darwin"},{"name":"windows-latest, x86_64-pc-windows-msvc","runner":"windows-latest","target":"x86_64-pc-windows-msvc"}]') }}
       fail-fast: false
     runs-on: ${{ matrix.runner }}
 

--- a/crates/merod/src/cli/run.rs
+++ b/crates/merod/src/cli/run.rs
@@ -29,6 +29,20 @@ pub struct RunCommand {
     #[arg(long, value_name = "FD")]
     pub exit_on_eof: Option<i32>,
 
+    /// Stop when stdin reaches EOF. The portable form of `--exit-on-eof`: a
+    /// supervisor keeps merod's stdin open and closes it to ask for a graceful
+    /// stop, and the OS closes it anyway if the supervisor dies.
+    ///
+    /// This is the only graceful stop Windows has. There is no `SIGTERM` there,
+    /// and `taskkill` without `/F` posts `WM_CLOSE` to windows a console process
+    /// does not have — so a supervisor's only other option is `/F`, which is
+    /// `TerminateProcess` and runs none of the drain and flush below.
+    ///
+    /// Off by default: merod inherits a terminal's stdin when run by hand, and a
+    /// node must not exit because someone piped it from a finished command.
+    #[arg(long, default_value_t = false)]
+    pub exit_on_stdin_close: bool,
+
     /// DEV/TEST ONLY. Produce and accept MOCK TEE attestation quotes (no real TDX).
     /// Insecure — never use in production. Refuses to start alongside a real KMS.
     /// CLI-only flag (no env inheritance); the mock path is compiled in only under
@@ -238,9 +252,14 @@ impl RunCommand {
             let (tx, rx) = tokio::sync::oneshot::channel();
             let data_dir = datastore_config.path.clone().into_std_path_buf();
             let parent_fd = self.exit_on_eof;
+            let stdin_close = self.exit_on_stdin_close;
             drop(tokio::spawn(async move {
                 let cause = tokio::select! {
                     detail = crate::watchdog::parent_closed(parent_fd) => {
+                        warn!("{detail}; shutting down");
+                        StopCause::ParentExited
+                    }
+                    detail = crate::watchdog::stdin_closed(stdin_close) => {
                         warn!("{detail}; shutting down");
                         StopCause::ParentExited
                     }
@@ -256,8 +275,21 @@ impl RunCommand {
             }));
             Some(rx)
         };
+        // Off unix this is the whole watchdog. `parent_closed` needs an inherited
+        // fd and `data_dir_replaced` identifies a directory by `(dev, ino)`, so
+        // both stay unix-only; stdin EOF needs neither.
         #[cfg(not(unix))]
-        let stop_watch = None;
+        let stop_watch = if self.exit_on_stdin_close {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            drop(tokio::spawn(async move {
+                let detail = crate::watchdog::stdin_closed(true).await;
+                warn!("{detail}; shutting down");
+                let _ = tx.send(StopCause::ParentExited);
+            }));
+            Some(rx)
+        } else {
+            None
+        };
 
         start(NodeConfig {
             home: path.clone(),

--- a/crates/merod/src/main.rs
+++ b/crates/merod/src/main.rs
@@ -14,7 +14,6 @@ mod defaults;
 mod kms;
 mod kms_policy;
 mod version;
-#[cfg(unix)]
 mod watchdog;
 
 use cli::RootCommand;

--- a/crates/merod/src/watchdog.rs
+++ b/crates/merod/src/watchdog.rs
@@ -1,15 +1,78 @@
 //! Reasons to stop that no signal announces: the process that spawned this node
 //! going away, or the data directory it opened being replaced underneath it.
 
+#[cfg(unix)]
 use std::os::fd::{FromRawFd, RawFd};
+#[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
+#[cfg(unix)]
 use std::path::PathBuf;
+#[cfg(unix)]
 use std::time::Duration;
+
+/// Resolves when this process's stdin reaches EOF.
+///
+/// The portable half of what `parent_closed` does on unix, and on Windows the
+/// only half there is. A supervisor holds the write end of merod's stdin and
+/// closes it to ask for a graceful stop; the OS closes it too if the supervisor
+/// dies, so one channel covers both without the supervisor having to tell them
+/// apart.
+///
+/// Windows has no `SIGTERM`. The alternative there is
+/// `GenerateConsoleCtrlEvent`, which addresses a *process group sharing the
+/// caller's console* — and a GUI supervisor has no console to share, so it
+/// would have to allocate or attach one purely to deliver the event. A pipe
+/// needs no console, no process group, and no platform code at all.
+///
+/// Read on a plain OS thread rather than a runtime blocking task, deliberately.
+/// A thread parked in `read` cannot be cancelled, and runtime shutdown waits for
+/// its blocking pool — so a node whose supervisor outlives it would hang on the
+/// way out, which is the same trap `parent_closed` documents. A detached thread
+/// does not delay process exit.
+///
+/// Parks forever when not enabled, so a caller can `select!` on it either way.
+pub async fn stdin_closed(enabled: bool) -> String {
+    if !enabled {
+        return std::future::pending().await;
+    }
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    // Not `tokio::task::spawn_blocking`: see the note above about shutdown.
+    drop(std::thread::spawn(move || {
+        use std::io::Read as _;
+
+        let mut scratch = [0_u8; 64];
+        let mut stdin = std::io::stdin();
+        let reason = loop {
+            match stdin.read(&mut scratch) {
+                Ok(0) => break "the process that started this node closed its stdin".to_owned(),
+                // A supervisor that writes down the pipe is not saying anything
+                // yet, so anything it sends is discarded rather than read as a
+                // stop. Mirrors `parent_closed`.
+                Ok(_) => continue,
+                Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(err) => {
+                    break format!("the pipe to the process that started this node failed: {err}")
+                }
+            }
+        };
+        let _ = tx.send(reason);
+    }));
+
+    match rx.await {
+        Ok(reason) => reason,
+        // The reader thread is gone without reporting. Parking is the safe
+        // answer: resolving would stop a node nobody asked to stop.
+        Err(_) => std::future::pending().await,
+    }
+}
 
 /// A stat is microseconds, so this is short enough to bound how long a node whose
 /// directory is gone keeps writing, which is the damage this prevents.
+#[cfg(unix)]
 pub const DATA_DIR_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 
+#[cfg(unix)]
 /// Identifies a directory rather than its name. `rm -rf` removes the name, so the
 /// path can resolve to a different directory while this one is still held open.
 fn identity(meta: &std::fs::Metadata) -> (u64, u64) {
@@ -18,6 +81,7 @@ fn identity(meta: &std::fs::Metadata) -> (u64, u64) {
 
 /// Resolves when the directory this node opened is no longer the one its path
 /// points at - deleted, replaced, or on a volume that went away.
+#[cfg(unix)]
 pub async fn data_dir_replaced(path: PathBuf, interval: Duration) -> String {
     // Held open for as long as the watch runs: that keeps the inode allocated, so a
     // directory created later at this path cannot reuse the number and slip past.
@@ -57,6 +121,7 @@ pub async fn data_dir_replaced(path: PathBuf, interval: Duration) -> String {
 /// Resolves when the write end of `fd` is closed, which the kernel does when the
 /// process holding it exits - including a `SIGKILL`, which runs no code of its own.
 /// Parks when there is no fd, so a caller can watch it either way.
+#[cfg(unix)]
 pub async fn parent_closed(fd: Option<RawFd>) -> String {
     use tokio::io::AsyncReadExt;
 
@@ -92,7 +157,27 @@ pub async fn parent_closed(fd: Option<RawFd>) -> String {
     }
 }
 
+/// Portable half of the watchdog tests. The dangerous failure for a default-off
+/// watch is that it resolves anyway, which stops a node nobody asked to stop.
 #[cfg(test)]
+mod portable_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_disabled_stdin_watch_never_resolves() {
+        let mut watch = tokio::spawn(stdin_closed(false));
+
+        let waited = tokio::time::timeout(std::time::Duration::from_millis(200), &mut watch).await;
+
+        assert!(
+            waited.is_err(),
+            "a node that did not ask to watch stdin must never stop because of it"
+        );
+        watch.abort();
+    }
+}
+
+#[cfg(all(test, unix))]
 mod tests {
     use std::os::fd::IntoRawFd;
 

--- a/crates/merod/tests/watchdog_live.rs
+++ b/crates/merod/tests/watchdog_live.rs
@@ -191,6 +191,51 @@ fn the_node_stops_when_the_pipe_to_its_parent_closes() {
     let _ = std::fs::remove_dir_all(&home);
 }
 
+/// The portable stop, and on Windows the only one: no `SIGTERM`, and `taskkill`
+/// without `/F` cannot reach a console process with no window. A supervisor
+/// closing merod's stdin has to be enough on its own.
+///
+/// Deliberately not `#[cfg(unix)]`, unlike the pipe test above: this is exactly
+/// the path that has no unix machinery behind it, so restricting it to unix
+/// would exercise everything except the case it exists for.
+#[test]
+#[ignore = "drives a real node; needs an environment with netlink"]
+fn the_node_stops_when_its_stdin_closes() {
+    let home = scratch("stdin");
+    init(&home, "n1");
+
+    let log = Node::log_path("stdin");
+    let sink = std::fs::File::create(&log).expect("log file");
+    let child = Command::new(env!("CARGO_BIN_EXE_merod"))
+        .args([
+            "--home".as_ref(),
+            home.as_os_str(),
+            "--node".as_ref(),
+            "n1".as_ref(),
+        ])
+        .args(["run", "--exit-on-stdin-close"])
+        .env("RUST_LOG", "info")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(sink.try_clone().expect("clone log")))
+        .stderr(Stdio::from(sink))
+        .spawn()
+        .expect("spawn merod run");
+    let mut node = Node { child, log };
+
+    wait_until_ready(&node);
+    assert!(
+        node.child.try_wait().expect("try_wait").is_none(),
+        "node stopped before its stdin closed"
+    );
+
+    // The whole event: the supervisor lets go of the write end.
+    drop(node.child.stdin.take().expect("child stdin"));
+
+    let took = wait_for_exit(&mut node, "stdin closed");
+    println!("node exited {took:?} after its stdin closed");
+    let _ = std::fs::remove_dir_all(&home);
+}
+
 /// `rm -rf` removes a name, not a file, so nothing tells the node - it has to
 /// notice that the directory it holds is no longer the one at its path.
 #[test]


### PR DESCRIPTION
## The problem

Windows has no `SIGTERM`, and `taskkill` without `/F` posts `WM_CLOSE` to windows a console process does not have. So a supervisor's only way to stop merod there is `taskkill /F` — `TerminateProcess`, which runs no code.

The consequence is concrete: `StopCause::flushes` never runs, and the desktop app hard-kills a node mid-write on **every quit**. `kill_pids` in tauri-app already notes merod needs ~10s to flush and that hard-killing it was a bug on unix; on Windows it is the only behaviour available today.

`--exit-on-eof` cannot cover this. It takes a `RawFd` and watches it with `tokio::net::unix::pipe`, neither of which exists off unix — `run.rs` already bails with *"--exit-on-eof is only supported on unix"*.

## Why stdin rather than a console control event

`GenerateConsoleCtrlEvent` is the usual answer, and it addresses a process group **sharing the caller's console**. A GUI supervisor has no console, so it would have to allocate or attach one purely to deliver the event — and `CREATE_NEW_PROCESS_GROUP` disables `CTRL_C` for the child, so the payload has to become `CTRL_BREAK` too. That is a lot of platform machinery for one signal, and it fights `CREATE_NO_WINDOW`, which the desktop app needs so merod does not sit behind a black console window.

Closing a pipe needs no console, no process group, and no platform code. It also carries both meanings on one channel:

- the supervisor **closes stdin** to ask for a graceful stop, and
- the OS **closes it anyway** if the supervisor dies

which is the same guarantee `--exit-on-eof` gives on unix, spelled portably.

## Shape

`--exit-on-stdin-close`, off by default — merod inherits a terminal's stdin when run by hand, and a node must not exit because someone piped it from a finished command.

Two details worth keeping:

- **Read on a plain OS thread, not `spawn_blocking`.** A thread parked in `read` cannot be cancelled and runtime shutdown waits for the blocking pool, so a node whose supervisor outlives it would hang on the way out. `parent_closed` documents the same trap. A detached thread does not delay process exit.
- **`parent_closed` and `data_dir_replaced` stay unix-only** — one needs an inherited fd, the other identifies a directory by `(dev, ino)`. Off unix the stdin watch is the whole watchdog, so `mod watchdog` is no longer `cfg(unix)`.

## Verification

`the_node_stops_when_its_stdin_closes` drives a real node and is deliberately **not** `cfg(unix)`: restricting it would exercise everything except the case it exists for.

```
node exited 100.397125ms after its stdin closed
test the_node_stops_when_its_stdin_closes ... ok
```

The unit test covers the dangerous direction for a default-off watch — that it never resolves when disabled, since a watch that fires spontaneously stops a node nobody asked to stop.

`cargo test -p merod --bin merod`: 79 passed. CI's `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings`: clean.

## Before merging

The matrix's `pull_request` arm carries a **`TEMPORARY`-marked** Windows entry. This PR's entire subject is behaviour under `cfg(not(unix))`, which is never type-checked when building for a unix host — without it, the Windows arm of the new stop watch would first compile on master. **Remove that line before merge.**

## Downstream

`calimero-network/tauri-app` then spawns merod with piped stdin and this flag, and closes the pipe to stop it — replacing a `taskkill` graceful phase that cannot do anything to a console process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)