### PR TITLE
fix(security): write secrets owner-only on Windows too

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -29,6 +29,25 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
+  # The one thing about this repository that cannot be checked on Linux: whether
+  # a secret written on Windows is readable by other local users. `calimero-utils-fs`
+  # has no C dependencies, so this is a small, fast job rather than a second full
+  # Windows build -- and without it the ACL claim is asserted nowhere.
+  windows-secrets:
+    name: Windows secret permissions
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Test the owner-only file helper
+        run: cargo test -p calimero-utils-fs
+
   rust:
     name: Rust
     runs-on: big-machine

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,7 +1708,6 @@ dependencies = [
 name = "calimero-utils-fs"
 version = "0.0.0"
 dependencies = [
- "eyre",
  "tempfile",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,7 @@ dependencies = [
  "calimero-node-primitives",
  "calimero-runtime",
  "calimero-server",
+ "calimero-utils-fs",
  "camino",
  "eyre",
  "libp2p-identity",
@@ -1701,6 +1702,15 @@ dependencies = [
  "pastey",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "calimero-utils-fs"
+version = "0.0.0"
+dependencies = [
+ "eyre",
+ "tempfile",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5618,6 +5628,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.23.1",
  "calimero-bundle",
+ "calimero-utils-fs",
  "clap",
  "ed25519-dalek",
  "eyre",
@@ -5642,6 +5653,7 @@ dependencies = [
  "calimero-crypto",
  "calimero-primitives",
  "calimero-server-primitives",
+ "calimero-utils-fs",
  "camino",
  "clap",
  "color-eyre",
@@ -5689,6 +5701,7 @@ dependencies = [
  "calimero-store-rocksdb",
  "calimero-tee-attestation",
  "calimero-utils-actix",
+ "calimero-utils-fs",
  "camino",
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ members = [
     "./crates/store/impl/rocksdb",
     "./crates/sys",
     "./crates/utils/actix",
+    "./crates/utils/fs",
     "./crates/wasm-abi",
 
     "./apps/scaffolding-e2e",
@@ -278,6 +279,7 @@ strum = "0.28.0"
 syn = { version = "2.0", features = ["full"] }
 tar = "0.4"
 tempfile = "3.10"
+windows-sys = "0.61"
 tdx-quote = "0.0.4"
 tdx_workload_attestation = "0.1.0"
 thiserror = "2.0.20"
@@ -347,6 +349,7 @@ calimero-store-rocksdb = { path = "./crates/store/impl/rocksdb" }
 calimero-sys = { path = "./crates/sys" }
 calimero-tee-attestation = { path = "./crates/tee-attestation" }
 calimero-utils-actix = { path = "./crates/utils/actix" }
+calimero-utils-fs = { path = "./crates/utils/fs" }
 calimero-wasm-abi = { path = "./crates/wasm-abi" }
 mero-abi = { path = "./tools/calimero-abi" }
 mero-auth = { path = "./crates/auth" }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -11,6 +11,7 @@ publish = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+calimero-utils-fs.workspace = true
 bs58.workspace = true
 camino = { workspace = true, features = ["serde1"] }
 eyre.workspace = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -544,14 +544,12 @@ pub async fn write_atomic(path: &Utf8Path, content: String) -> EyreResult<()> {
         let mut tmp = tempfile::NamedTempFile::new_in(dir)
             .wrap_err_with(|| format!("failed to create temp file in {dir:?}"))?;
 
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            // Set explicitly so 0600 holds if tempfile's default ever changes.
-            tmp.as_file()
-                .set_permissions(std::fs::Permissions::from_mode(0o600))
-                .wrap_err("failed to set temp file permissions")?;
-        }
+        // Narrowed before the rename, not after: a rename carries the file's own
+        // permissions with it, so the config is never briefly readable at its
+        // real path. On Windows this replaces an inherited ACL with one naming
+        // only this user, which is the whole difference on that platform.
+        calimero_utils_fs::restrict_existing_to_owner(tmp.path())
+            .wrap_err("failed to restrict temp file permissions")?;
 
         std::io::Write::write_all(&mut tmp, content.as_bytes())
             .wrap_err("failed to write config contents")?;

--- a/crates/meroctl/Cargo.toml
+++ b/crates/meroctl/Cargo.toml
@@ -10,6 +10,8 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+calimero-utils-fs.workspace = true
+tempfile.workspace = true
 borsh.workspace = true
 calimero-account.workspace = true
 calimero-crypto.workspace = true

--- a/crates/meroctl/src/config.rs
+++ b/crates/meroctl/src/config.rs
@@ -61,34 +61,30 @@ impl Config {
         let contents =
             toml::to_string_pretty(self).wrap_err("Failed to serialize config to TOML")?;
 
-        // Write with owner-only permissions (0600) from the start to avoid the
-        // TOCTOU window that exists when writing first and then chmod-ing after.
-        // On non-Unix platforms we fall back to a plain async write.
-        #[cfg(unix)]
-        {
+        // Written to a sibling temp file, narrowed, then renamed into place.
+        //
+        // The previous shape opened the real path with `create(true)`, which
+        // keeps an EXISTING file's permissions — so a config that had somehow
+        // been created world-readable stayed that way however often it was
+        // rewritten, and on Windows every rewrite simply inherited the
+        // directory's ACL. Narrowing the temp file before the rename means the
+        // credentials are never readable at the path anyone would look at.
+        let path2 = path.clone();
+        let bytes = contents.into_bytes();
+        tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             use std::io::Write as _;
-            use std::os::unix::fs::OpenOptionsExt;
-            let path2 = path.clone();
-            let bytes = contents.into_bytes();
-            tokio::task::spawn_blocking(move || {
-                std::fs::OpenOptions::new()
-                    .write(true)
-                    .create(true)
-                    .truncate(true)
-                    .mode(0o600)
-                    .open(&path2)
-                    .and_then(|mut f| f.write_all(&bytes))
-            })
-            .await
-            .wrap_err("thread panicked while writing config file")?
-            .wrap_err_with(|| format!("Failed to write config file: {}", path.display()))?;
-        }
-        #[cfg(not(unix))]
-        {
-            fs::write(&path, contents)
-                .await
-                .wrap_err_with(|| format!("Failed to write config file: {}", path.display()))?;
-        }
+
+            let dir = path2.parent().unwrap_or_else(|| std::path::Path::new("."));
+            let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+            calimero_utils_fs::restrict_existing_to_owner(tmp.path())?;
+            tmp.write_all(&bytes)?;
+            tmp.as_file().sync_all()?;
+            tmp.persist(&path2).map_err(|e| e.error)?;
+            Ok(())
+        })
+        .await
+        .wrap_err("thread panicked while writing config file")?
+        .wrap_err_with(|| format!("Failed to write config file: {}", path.display()))?;
 
         Ok(())
     }

--- a/crates/merod/Cargo.toml
+++ b/crates/merod/Cargo.toml
@@ -36,6 +36,7 @@ url = { workspace = true, features = ["serde"] }
 
 calimero-blobstore.workspace = true
 calimero-config.workspace = true
+calimero-utils-fs.workspace = true
 calimero-crypto.workspace = true
 calimero-context.workspace = true
 calimero-network-primitives.workspace = true

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -35,21 +35,21 @@ use super::auth_mode::AuthModeArg;
 use crate::cli;
 
 /// Restrict a single path to the given owner-only `mode` (`0700` for
-/// directories, `0600` for files). No-op on non-Unix platforms, which lack
-/// POSIX mode bits.
-#[cfg(unix)]
+/// directories, `0600` for files) — and to the equivalent DACL on Windows,
+/// where a file otherwise inherits whatever the containing directory allows.
+///
+/// `mode` is the unix spelling of the intent. Windows has no mode, so the
+/// helper derives the same intent from whether the path is a directory; the
+/// argument is ignored there rather than approximated.
 async fn restrict_to_owner(path: impl AsRef<Path>, mode: u32) -> EyreResult<()> {
-    use std::os::unix::fs::PermissionsExt;
-
-    let path = path.as_ref();
-    fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
-        .await
-        .wrap_err_with(|| format!("failed to restrict permissions on {path:?}"))
-}
-
-#[cfg(not(unix))]
-async fn restrict_to_owner(_path: impl AsRef<Path>, _mode: u32) -> EyreResult<()> {
-    Ok(())
+    let _ = mode;
+    let path = path.as_ref().to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        calimero_utils_fs::restrict_existing_to_owner(&path)
+            .wrap_err_with(|| format!("failed to restrict permissions on {path:?}"))
+    })
+    .await
+    .wrap_err("failed to join the permission-restriction task")?
 }
 
 /// Recursively restrict a directory tree to owner-only access: `0700` for every
@@ -61,7 +61,10 @@ async fn restrict_to_owner(_path: impl AsRef<Path>, _mode: u32) -> EyreResult<()
 /// left untouched (RocksDB creates none here). `pub(crate)` so
 /// `auth set-admin` applies the same pinning to the auth database it may
 /// create.
-#[cfg(unix)]
+///
+/// Runs on every platform. It used to be unix-only, which left the whole
+/// datastore on Windows inheriting the ACL of wherever `--home` pointed — the
+/// one place the raw node data lives.
 pub(crate) async fn restrict_tree_to_owner(root: impl AsRef<Path>) -> EyreResult<()> {
     let mut stack = vec![root.as_ref().to_path_buf()];
 
@@ -85,11 +88,6 @@ pub(crate) async fn restrict_tree_to_owner(root: impl AsRef<Path>) -> EyreResult
     Ok(())
 }
 
-#[cfg(not(unix))]
-pub(crate) async fn restrict_tree_to_owner(_root: impl AsRef<Path>) -> EyreResult<()> {
-    Ok(())
-}
-
 /// Create `path` and any missing parents, with directories created owner-only
 /// (`0700`) on Unix. Using the mode at creation time means the node home is
 /// never momentarily visible to other users with permissive bits — the window a
@@ -105,7 +103,16 @@ async fn create_dir_owner_only(path: impl AsRef<Path>) -> EyreResult<()> {
     builder
         .create(path)
         .await
-        .wrap_err_with(|| format!("failed to create directory {path:?}"))
+        .wrap_err_with(|| format!("failed to create directory {path:?}"))?;
+
+    // Unconditional, not `cfg(windows)`. Windows has no mode to set at creation,
+    // so the directory arrives with the parent's inherited ACL and has to be
+    // narrowed immediately afterwards; on unix the mode above already did it and
+    // this re-applies the same 0700. Writing it without a `cfg` costs one
+    // redundant syscall per directory at init and keeps the call type-checked on
+    // every host, where a `cfg(windows)` body is compiled by nothing a
+    // pull request runs.
+    restrict_to_owner(path, 0o700).await
 }
 
 // Sync configuration - aggressive defaults for fast CRDT convergence

--- a/crates/utils/fs/Cargo.toml
+++ b/crates/utils/fs/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "calimero-utils-fs"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+description.workspace = true
+publish = true
+
+[dependencies]
+eyre.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_System_Memory",
+    "Win32_System_Threading",
+] }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/utils/fs/Cargo.toml
+++ b/crates/utils/fs/Cargo.toml
@@ -8,9 +8,6 @@ license.workspace = true
 description.workspace = true
 publish = true
 
-[dependencies]
-eyre.workspace = true
-
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",

--- a/crates/utils/fs/src/lib.rs
+++ b/crates/utils/fs/src/lib.rs
@@ -1,0 +1,328 @@
+//! Writing a secret to disk so only its owner can read it, on every platform
+//! this node runs on.
+//!
+//! Unix answers this with a mode. Windows has no mode: a new file inherits the
+//! containing directory's ACL, so a key written into a shared, roaming or
+//! loosely-permissioned directory is readable by other local users, and nothing
+//! says so. Every site that writes a secret used to spell the unix half itself
+//! and leave the other platform a silent no-op — three spellings of the same
+//! intent that had already drifted apart. This is the one place that intent
+//! lives.
+
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+/// Create `path` for writing, readable and writable by its owner alone.
+///
+/// Created **exclusively**: an existing file is an error rather than something
+/// to truncate and inherit the permissions of. That is not caution for its own
+/// sake — `OpenOptions::create(true)` leaves an attacker-placed file's ACL in
+/// place, and on unix a `set_permissions` afterwards only narrows the window in
+/// which the secret is world-readable rather than removing it. Exclusive
+/// creation removes it, and refuses to follow a symlink or junction planted at
+/// the path.
+///
+/// # Errors
+///
+/// When the file exists, when creation fails, or — on Windows — when the ACL
+/// cannot be applied. An ACL failure deletes the file before returning: a
+/// secret that exists but is not protected is worse than no secret at all,
+/// because the caller has no reason to look at it again.
+pub fn create_owner_only(path: &Path) -> io::Result<File> {
+    let file = create_exclusive(path)?;
+
+    #[cfg(windows)]
+    if let Err(err) = windows_impl::restrict_to_current_user(path) {
+        drop(file);
+        let _ = std::fs::remove_file(path);
+        return Err(err);
+    }
+
+    Ok(file)
+}
+
+/// [`create_owner_only`], writing `contents` and flushing them to the device.
+///
+/// # Errors
+///
+/// As [`create_owner_only`], plus any write or sync failure.
+pub fn write_owner_only(path: &Path, contents: &[u8]) -> io::Result<()> {
+    use io::Write as _;
+
+    let mut file = create_owner_only(path)?;
+    file.write_all(contents)?;
+    file.sync_all()
+}
+
+/// Restrict a file or directory that already exists to its owner.
+///
+/// For the paths a secret arrives at by another route: a directory tree, or a
+/// datastore whose files were created by a library with its own ideas about
+/// permissions. Prefer [`create_owner_only`] wherever the file is ours to
+/// create — this necessarily leaves a window in which the path was readable.
+///
+/// # Errors
+///
+/// When the permissions or ACL cannot be applied.
+pub fn restrict_existing_to_owner(path: &Path) -> io::Result<()> {
+    // Exactly one of these survives `cfg`, so each is the function's tail
+    // expression rather than an early return.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        // A directory needs the execute bit to be traversable by its owner.
+        let mode = if path.is_dir() { 0o700 } else { 0o600 };
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+    }
+    #[cfg(windows)]
+    {
+        windows_impl::restrict_to_current_user(path)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = path;
+        Ok(())
+    }
+}
+
+fn create_exclusive(path: &Path) -> io::Result<File> {
+    let mut options = std::fs::OpenOptions::new();
+    let _ = options.write(true).create_new(true);
+
+    // Set at creation on unix, so the file is never briefly group- or
+    // world-readable. Windows cannot express this in the open call and is
+    // handled by the caller applying a DACL immediately afterwards.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        let _ = options.mode(0o600);
+    }
+
+    options.open(path)
+}
+
+#[cfg(windows)]
+mod windows_impl {
+    use std::io;
+    use std::os::windows::ffi::OsStrExt as _;
+    use std::path::Path;
+
+    use windows_sys::Win32::Foundation::{CloseHandle, LocalFree, HANDLE};
+    use windows_sys::Win32::Security::Authorization::{
+        SetEntriesInAclW, SetNamedSecurityInfoW, EXPLICIT_ACCESS_W, NO_MULTIPLE_TRUSTEE,
+        SET_ACCESS, SE_FILE_OBJECT, TRUSTEE_IS_SID, TRUSTEE_IS_USER, TRUSTEE_W,
+    };
+    use windows_sys::Win32::Security::{
+        GetTokenInformation, TokenUser, ACL, DACL_SECURITY_INFORMATION, NO_INHERITANCE,
+        PROTECTED_DACL_SECURITY_INFORMATION, SUB_CONTAINERS_AND_OBJECTS_INHERIT, TOKEN_QUERY,
+        TOKEN_USER,
+    };
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    /// `GENERIC_ALL` — the owner keeps full control; nobody else appears in the
+    /// ACL at all.
+    const OWNER_ACCESS: u32 = 0x1000_0000;
+
+    /// Replace `path`'s DACL with one naming only the calling user.
+    ///
+    /// `PROTECTED_DACL_SECURITY_INFORMATION` is the point of the whole exercise:
+    /// without it the parent's inheritable entries are merged back in and the
+    /// file stays as readable as the directory it sits in, which is exactly the
+    /// behaviour being fixed.
+    pub(super) fn restrict_to_current_user(path: &Path) -> io::Result<()> {
+        let sid_buffer = current_user_sid()?;
+        // SAFETY: `sid_buffer` is a TOKEN_USER written by GetTokenInformation,
+        // so its `User.Sid` points inside the same allocation and outlives the
+        // borrow below.
+        let sid = unsafe { (*sid_buffer.as_ptr().cast::<TOKEN_USER>()).User.Sid };
+
+        let mut access = EXPLICIT_ACCESS_W {
+            grfAccessPermissions: OWNER_ACCESS,
+            grfAccessMode: SET_ACCESS,
+            grfInheritance: if path.is_dir() {
+                SUB_CONTAINERS_AND_OBJECTS_INHERIT
+            } else {
+                NO_INHERITANCE
+            },
+            Trustee: TRUSTEE_W {
+                pMultipleTrustee: std::ptr::null_mut(),
+                MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
+                TrusteeForm: TRUSTEE_IS_SID,
+                TrusteeType: TRUSTEE_IS_USER,
+                ptstrName: sid.cast(),
+            },
+        };
+
+        let mut acl: *mut ACL = std::ptr::null_mut();
+        // SAFETY: one EXPLICIT_ACCESS_W entry, no existing ACL to merge into.
+        // On success `acl` is a LocalAlloc'd block we free below.
+        let status =
+            unsafe { SetEntriesInAclW(1, &raw mut access, std::ptr::null_mut(), &raw mut acl) };
+        if status != 0 {
+            return Err(io::Error::from_raw_os_error(status as i32));
+        }
+
+        let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+        wide.push(0);
+
+        // SAFETY: `wide` is NUL-terminated and `acl` is the ACL built above.
+        let status = unsafe {
+            SetNamedSecurityInfoW(
+                wide.as_ptr(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                acl,
+                std::ptr::null_mut(),
+            )
+        };
+        // SAFETY: `acl` came from SetEntriesInAclW, which allocates with LocalAlloc.
+        unsafe { LocalFree(acl.cast()) };
+
+        if status != 0 {
+            return Err(io::Error::from_raw_os_error(status as i32));
+        }
+        Ok(())
+    }
+
+    /// The calling process's user SID, as a `TOKEN_USER` byte buffer.
+    fn current_user_sid() -> io::Result<Vec<u8>> {
+        struct OwnedHandle(HANDLE);
+        impl Drop for OwnedHandle {
+            fn drop(&mut self) {
+                // SAFETY: opened by OpenProcessToken below and closed once.
+                unsafe { CloseHandle(self.0) };
+            }
+        }
+
+        let mut token: HANDLE = std::ptr::null_mut();
+        // SAFETY: pseudo-handle from GetCurrentProcess needs no close; `token`
+        // is written on success and owned below.
+        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &raw mut token) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let token = OwnedHandle(token);
+
+        // Sized by the first call, which is expected to fail for that reason.
+        let mut needed = 0_u32;
+        // SAFETY: a null buffer with length 0 is the documented way to ask for
+        // the required size.
+        let _ = unsafe {
+            GetTokenInformation(token.0, TokenUser, std::ptr::null_mut(), 0, &raw mut needed)
+        };
+        if needed == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let mut buffer = vec![0_u8; needed as usize];
+        // SAFETY: `buffer` is `needed` bytes, the size the call just asked for.
+        if unsafe {
+            GetTokenInformation(
+                token.0,
+                TokenUser,
+                buffer.as_mut_ptr().cast(),
+                needed,
+                &raw mut needed,
+            )
+        } == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(buffer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The property that matters everywhere: a secret is never written over
+    /// something already there, whose permissions we would inherit.
+    #[test]
+    fn an_existing_file_is_refused_rather_than_reused() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("key");
+        std::fs::write(&path, b"planted by someone else").unwrap();
+
+        let err = create_owner_only(&path).expect_err("must refuse an existing path");
+
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            b"planted by someone else",
+            "the refusal must not have truncated it"
+        );
+    }
+
+    #[test]
+    fn contents_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("key");
+
+        write_owner_only(&path, b"secret").unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"secret");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_new_secret_is_0600_from_creation() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("key");
+
+        let file = create_owner_only(&path).unwrap();
+
+        assert_eq!(
+            file.metadata().unwrap().permissions().mode() & 0o777,
+            0o600,
+            "set in the open call, so the file is never briefly world-readable"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restricting_an_existing_directory_uses_0700() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("data");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::set_permissions(&nested, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        restrict_existing_to_owner(&nested).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&nested).unwrap().permissions().mode() & 0o777,
+            0o700,
+            "a directory needs execute to be traversable by its owner"
+        );
+    }
+
+    /// The Windows half of the same guarantee. `icacls` is the supported way to
+    /// read an effective ACL, and the string it prints for an inherited entry
+    /// carries `(I)` — its absence is what says the DACL is protected.
+    #[cfg(windows)]
+    #[test]
+    fn a_new_secret_does_not_inherit_the_directory_acl() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("key");
+
+        drop(create_owner_only(&path).unwrap());
+
+        let out = std::process::Command::new("icacls")
+            .arg(&path)
+            .output()
+            .expect("icacls should be present on every supported Windows");
+        let acl = String::from_utf8_lossy(&out.stdout);
+
+        assert!(
+            !acl.contains("(I)"),
+            "the DACL must be protected, so no entry is inherited from the parent: {acl}"
+        );
+    }
+}

--- a/tools/mero-sign/Cargo.toml
+++ b/tools/mero-sign/Cargo.toml
@@ -14,6 +14,7 @@ name = "mero_sign"
 
 [dependencies]
 calimero-bundle.workspace = true
+calimero-utils-fs.workspace = true
 clap = { workspace = true, features = ["derive"] }
 ed25519-dalek = { workspace = true, features = ["rand_core"] }
 serde_json.workspace = true

--- a/tools/mero-sign/src/lib.rs
+++ b/tools/mero-sign/src/lib.rs
@@ -273,8 +273,6 @@ pub fn generate_key(output_path: &Path, force: bool) -> Result<()> {
 /// only. Other platforms inherit the default ACL, and say so. Without `force`,
 /// `create_new` leaves an existing key untouched and reports `AlreadyExists`.
 fn write_private_key(path: &Path, contents: &str, force: bool) -> std::io::Result<()> {
-    use std::io::Write as _;
-
     if force {
         match fs::remove_file(path) {
             Ok(()) => {}
@@ -283,24 +281,12 @@ fn write_private_key(path: &Path, contents: &str, force: bool) -> std::io::Resul
         }
     }
 
-    let mut options = fs::OpenOptions::new();
-    let _ = options.write(true).create_new(true);
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt as _;
-        let _ = options.mode(0o600);
-    }
-    // std cannot set a Windows ACL, so the file inherits the directory's. Say so
-    // rather than leaving the operator to assume the key is protected.
-    #[cfg(not(unix))]
-    eprintln!(
-        "warning: {} inherits the directory's default permissions on this platform; \
-         keep it out of shared or world-readable locations",
-        path.display()
-    );
-
-    options.open(path)?.write_all(contents.as_bytes())
+    // Exclusive creation, owner-only on every platform. This used to be `0600`
+    // on unix and a printed warning everywhere else, because std cannot set a
+    // Windows ACL — the signing seed is the one key that cannot be regenerated,
+    // and whoever reads it can publish under this publisher's ApplicationId, so
+    // a warning was never the right answer.
+    calimero_utils_fs::write_owner_only(path, contents.as_bytes())
 }
 
 /// Derive the signerId from a key file


### PR DESCRIPTION
Closes #3313.

## The gap

Every place core writes a secret restricts it to the owner on unix and does **nothing at all** elsewhere. On Windows a new file inherits the containing directory's ACL, so on a shared, roaming or loosely-permissioned host the secret is readable by other local users. Four of the five sites said nothing about it.

The two that mattered most were not files but silent no-ops:

```rust
#[cfg(not(unix))]
async fn restrict_to_owner(_path: ..., _mode: u32) -> EyreResult<()> { Ok(()) }

#[cfg(not(unix))]
pub(crate) async fn restrict_tree_to_owner(_root: ...) -> EyreResult<()> { Ok(()) }
```

`restrict_tree_to_owner` is what makes the whole RocksDB datastore owner-only, because RocksDB creates its files with the process umask. On Windows the entire node home simply inherited whatever `--home` pointed at — the one place the raw node data lives.

## One helper, four callers

The issue asks for a shared helper rather than four `cfg` branches, and the drift it warned about had already happened: `meroctl` used `create(true)`, which keeps an **existing** file's permissions, so a config once created world-readable stayed that way however often it was rewritten.

`calimero-utils-fs` now holds the intent once — exclusive owner-only creation, and narrowing a path that already exists.

| Caller | What it protects | Change |
| --- | --- | --- |
| `merod init` | node home, tree, datastore | no longer a no-op off unix |
| `calimero-config` | node identity material | narrowed **before** the rename, so it is never briefly readable at its real path |
| `meroctl` | session credentials | temp-write → narrow → rename, replacing `create(true)` |
| `mero-sign` | the signing seed | was a printed warning |

`mero-sign` is worth calling out: it is the one key that cannot be regenerated, and whoever reads it can publish under this publisher's `ApplicationId`. A warning was never the right answer.

`PROTECTED_DACL_SECURITY_INFORMATION` is the point of the Windows path. Without it the parent's inheritable entries merge straight back in and the file stays exactly as readable as the directory holding it — the behaviour being fixed.

## Verification

The issue deferred this partly for want of *"a Windows CI job to verify"*. #3747 added one, so this adds **`windows-secrets`**: the helper's tests on `windows-latest`, asserting via `icacls` that no entry carries `(I)` — an inherited ACE. `calimero-utils-fs` has no C dependencies, so it is a small, fast job rather than a second full Windows build.

Locally the crate compiles and is clippy-clean for `x86_64-pc-windows-msvc`, which genuinely type-checks the unsafe Win32 code — I confirmed that by planting a deliberate type error inside `mod windows_impl` and watching it fail, rather than trusting a suspiciously fast build.

- host tests: 9 passed
- `cargo fmt --check --all`: clean
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings`: clean, on both host and Windows targets

## One deliberate choice

The call in `create_dir_owner_only` is unconditional rather than `#[cfg(windows)]`. A `cfg(windows)` body is compiled by nothing a pull request runs — the release matrix is Linux-only on PRs — so it would first be type-checked on master. One redundant `set_permissions` per directory at init is a cheap price for keeping it honest everywhere.

## Not covered

Whether RocksDB itself behaves on Windows — file locking on delete, `MAX_PATH` on deep datastore paths — is unaffected by this and still wants a real run on the platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)