### PR TITLE
chore(release): 0.11.0-rc.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.29"
+version = "0.11.0-rc.30"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Cuts the first release carrying the Windows work that is merged but currently reaching nobody.

## What this ships

- **#3757 — `--exit-on-stdin-close`**, the only graceful stop Windows has. There is no `SIGTERM` there, and `taskkill` without `/F` posts `WM_CLOSE` to windows a console process does not have — so a supervisor's sole option is `/F`, which is `TerminateProcess` and runs no code. Without this, merod is killed mid-write on every quit and never drains or flushes.
- **#3761 — secrets written owner-only on Windows** instead of inheriting the containing directory's ACL: the node home and its whole RocksDB datastore, the node config, meroctl's session credentials, and the signing seed. Verified by an `icacls` assertion running on a real Windows runner.

## Why the bump is the thing that matters

`prepare` sets `binary_release` only when the version has no release yet. `0.11.0-rc.29` is already published, so every master push since those merged has been **building** this work and uploading nothing. Merging did not, on its own, put it anywhere.

This is the same trap rc.29 hit: merging is not publishing.

## Downstream

Unblocks the desktop app's graceful-stop wiring — `calimero-network/tauri-app` can then spawn merod with piped stdin and this flag, replacing a `taskkill` phase that cannot reach a console process. That side will probe `merod run --help` for the flag rather than gate on a version, since `VersionId` lets the desktop run any older merod.

## Side effects

The usual release fan-out: crates.io publish, docker images, a Homebrew formula PR, and fleet-bump PRs across the SDK repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)