### PR TITLE
feat(governance): populate admitter addresses on a minted invitation

### DIFF
--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -514,7 +514,7 @@ async fn create_namespace_invitation() {
         .create_namespace_invitation(
             GID,
             CreateGroupInvitationApiRequest {
-                admitter_hints: Vec::new(),
+                admitter_addrs: Vec::new(),
                 expiration_timestamp: None,
                 recursive: None,
                 admitters: Vec::new(),

--- a/crates/client/src/tests.rs
+++ b/crates/client/src/tests.rs
@@ -514,6 +514,7 @@ async fn create_namespace_invitation() {
         .create_namespace_invitation(
             GID,
             CreateGroupInvitationApiRequest {
+                admitter_hints: Vec::new(),
                 expiration_timestamp: None,
                 recursive: None,
                 admitters: Vec::new(),

--- a/crates/context/config/src/types.rs
+++ b/crates/context/config/src/types.rs
@@ -584,54 +584,6 @@ pub struct SignedOpenInvitation {
 ///
 /// A ceiling rather than a default: a caller asking for longer is clamped, not
 /// obeyed. A default alone protects only the callers who never pass a value,
-/// Where an admitter can be reached, and over which transport.
-///
-/// Two, because a claim arrives by two different routes and they are not
-/// interchangeable. A joining **node** dials libp2p; a **keyholder with no
-/// node** — the case direct admission exists for — has no swarm to dial from and
-/// reaches the admitter over HTTPS. An untyped string could not tell them apart,
-/// and a joiner would have to guess by inspecting the text.
-///
-/// Unsigned, like the rest of the hints: a wrong endpoint costs a failed
-/// connection, because the admitting node still has to appear in the *signed*
-/// `admitters` list for its admission to count. It can misdirect where you
-/// knock, never who may answer.
-///
-/// Best-effort by nature. An address recorded when the invitation was minted may
-/// have moved by the time it is used — which is survivable now that an
-/// invitation lives at most [`MAX_INVITATION_VALIDITY_SECS`], and was not when
-/// they lasted a year.
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum AdmitterEndpoint {
-    /// A libp2p multiaddr including the peer id, e.g.
-    /// `/ip4/10.0.0.1/tcp/2528/p2p/12D3KooW...`. For a joiner that runs a node.
-    ///
-    /// Carries the peer id because a joiner cannot resolve one: the
-    /// identity-to-peer map is in-memory and lost on restart, and a joiner that
-    /// has synced nothing has no entry for anybody.
-    Multiaddr(String),
-    /// An `https://` base URL serving the admin API. For a joiner that holds
-    /// only a key.
-    ///
-    /// The stable option: a hosted or TEE admitter keeps its URL across the
-    /// restarts and re-addressing that invalidate a multiaddr.
-    Url(String),
-}
-
-impl AdmitterEndpoint {
-    /// The account this endpoint claims to reach.
-    ///
-    /// Returns nothing on its own — deliberately. An endpoint is a hint, and the
-    /// authority to admit comes from the *signed* `admitters` list, checked
-    /// against the account the admitter proves it holds. Resolving a hint to an
-    /// account here would invite treating the hint as the answer.
-    #[must_use]
-    pub const fn is_dialable_by_a_node(&self) -> bool {
-        matches!(self, Self::Multiaddr(_))
-    }
-}
-
 /// and those are not the ones that make an invitation dangerous.
 pub const MAX_INVITATION_VALIDITY_SECS: u64 = 24 * 60 * 60;
 
@@ -672,7 +624,7 @@ pub struct GroupInvitationFromAdmin {
     /// Accounts rather than `PeerId`s: an account survives the node re-keying,
     /// and governance names accounts everywhere else. Where to *reach* them is a
     /// separate, unsigned question — see
-    /// [`SignedGroupOpenInvitation::admitter_hints`].
+    /// [`SignedGroupOpenInvitation::admitter_addrs`].
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub admitters: Vec<calimero_account::AccountId>,
 }
@@ -748,21 +700,30 @@ pub struct SignedGroupOpenInvitation {
     /// existed and costs only a slower cold start.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inviter_account: Option<calimero_account::AccountId>,
-    /// Where to reach the accounts in
+    /// libp2p addresses for the accounts in
     /// [`GroupInvitationFromAdmin::admitters`] (unsigned bootstrap field).
     ///
-    /// Outside the signature deliberately, beside the other hints. An account
-    /// is reached through a `PeerId`, and the identity-to-peer map is held in
-    /// memory and lost on restart — so a joiner that has synced nothing has no
-    /// way to resolve one. Shipping the hint is what makes the signed list
-    /// usable at all.
+    /// Each is a full multiaddr including the `/p2p/<peer-id>` suffix, e.g.
+    /// `/ip4/10.0.0.1/tcp/2528/p2p/12D3KooW...`. The peer id travels with the
+    /// address because a joiner cannot derive it: resolving an account to a peer
+    /// needs governance state, which is exactly what a joiner has not synced yet.
     ///
-    /// Unsigned is safe here in a way it would not be for `admitters` itself:
-    /// a wrong hint costs a failed dial, because the admitting node still has
-    /// to be in the signed list for its admission to count. It can misdirect
-    /// where you knock, never who may answer.
+    /// Outside the signature deliberately. An account is reached through a peer,
+    /// so requiring the address to be signed would mean the inviter had to know
+    /// every admitter's current address at mint time and re-mint whenever one
+    /// moved. Carrying it unsigned is what makes the signed list usable at all.
+    ///
+    /// Unsigned is safe here in a way it would not be for `admitters` itself: a
+    /// wrong address costs a failed dial, because libp2p authenticates the peer
+    /// id on connect and the admitting node still has to be in the signed list
+    /// for its admission to count. It can misdirect where you knock, never who
+    /// may answer.
+    ///
+    /// Best-effort and possibly empty. An address recorded at mint may have
+    /// moved by the time it is used — survivable because an invitation lives at
+    /// most [`MAX_INVITATION_VALIDITY_SECS`].
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub admitter_hints: Vec<AdmitterEndpoint>,
+    pub admitter_addrs: Vec<String>,
     /// Application ID for the group (unsigned bootstrap field).
     /// `None` for backwards compatibility with invitations created before
     /// this field was added; joiners fall back to zero when absent.
@@ -911,7 +872,7 @@ mod tests {
             inviter_account: None,
             application_id: Some([0x44; 32]),
             bytecode_id: Some([0x55; 32]),
-            admitter_hints: Vec::new(),
+            admitter_addrs: Vec::new(),
         };
 
         // Round-tripping unchanged JSON is what pins the wire name; swapping in
@@ -946,7 +907,7 @@ mod tests {
             inviter_account: None,
             application_id: Some([0x44; 32]),
             bytecode_id: Some([0x55; 32]),
-            admitter_hints: Vec::new(),
+            admitter_addrs: Vec::new(),
         };
 
         let json = serde_json::to_string(&signed).expect("serialize");
@@ -976,7 +937,7 @@ mod tests {
             inviter_account: None,
             application_id: Some([0x44; 32]),
             bytecode_id: Some([0x66; 32]),
-            admitter_hints: Vec::new(),
+            admitter_addrs: Vec::new(),
         };
 
         let mut value = serde_json::to_value(&signed).expect("serialize");

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -271,10 +271,21 @@ pub struct CreateGroupInvitationRequest {
     pub expiration_timestamp: Option<u64>,
     /// Accounts permitted to admit a claim of this invitation.
     ///
-    /// Empty leaves admission open to broadcast, which publishes the invitation
-    /// to every subscriber of the namespace topic. Signed into the invitation,
-    /// so it cannot be redirected afterwards.
+    /// Empty is filled in at mint from the group's admins and TEE nodes, and
+    /// refused if that yields nobody — an empty list on the wire authorizes any
+    /// node to admit, so it is not a value worth reaching by omission. Signed
+    /// into the invitation, so it cannot be redirected afterwards.
     pub admitters: Vec<calimero_account::AccountId>,
+    /// Where to reach the admitters, for a caller that knows better than this
+    /// node does.
+    ///
+    /// Supplied hints are used as given and are not merged with what the node
+    /// can work out for itself: a caller that names endpoints is usually
+    /// correcting the node's view, not extending it. Empty asks the node to fill
+    /// them in best-effort.
+    ///
+    /// Unsigned, so a wrong value costs a failed connection and nothing more.
+    pub admitter_hints: Vec<calimero_context_config::types::AdmitterEndpoint>,
 }
 
 impl Message for CreateGroupInvitationRequest {

--- a/crates/context/primitives/src/group.rs
+++ b/crates/context/primitives/src/group.rs
@@ -276,16 +276,16 @@ pub struct CreateGroupInvitationRequest {
     /// node to admit, so it is not a value worth reaching by omission. Signed
     /// into the invitation, so it cannot be redirected afterwards.
     pub admitters: Vec<calimero_account::AccountId>,
-    /// Where to reach the admitters, for a caller that knows better than this
-    /// node does.
+    /// libp2p addresses for the admitters, for a caller that knows better than
+    /// this node does.
     ///
-    /// Supplied hints are used as given and are not merged with what the node
-    /// can work out for itself: a caller that names endpoints is usually
+    /// Supplied addresses are used as given and are not merged with what the
+    /// node can work out for itself: a caller that names one is usually
     /// correcting the node's view, not extending it. Empty asks the node to fill
     /// them in best-effort.
     ///
-    /// Unsigned, so a wrong value costs a failed connection and nothing more.
-    pub admitter_hints: Vec<calimero_context_config::types::AdmitterEndpoint>,
+    /// Unsigned, so a wrong value costs a failed dial and nothing more.
+    pub admitter_addrs: Vec<String>,
 }
 
 impl Message for CreateGroupInvitationRequest {

--- a/crates/context/src/group_key_pull.rs
+++ b/crates/context/src/group_key_pull.rs
@@ -115,7 +115,7 @@ mod tests {
             inviter_signature: hex::encode(signature.to_bytes()),
             application_id: None,
             bytecode_id: None,
-            admitter_hints: Vec::new(),
+            admitter_addrs: Vec::new(),
         }
     }
 

--- a/crates/context/src/handlers/create_group_invitation.rs
+++ b/crates/context/src/handlers/create_group_invitation.rs
@@ -1,7 +1,7 @@
 use actix::{ActorResponse, Handler, Message, WrapFuture as _};
 use calimero_context_client::group::{CreateGroupInvitationRequest, CreateGroupInvitationResponse};
 use calimero_context_config::types::{
-    AdmitterEndpoint, GroupInvitationFromAdmin, SignedGroupOpenInvitation, SignerId,
+    GroupInvitationFromAdmin, SignedGroupOpenInvitation, SignerId,
 };
 use calimero_context_config::MemberCapabilities;
 use calimero_governance_store::{MembershipRepository, MetaRepository, MetadataRepository};
@@ -11,20 +11,20 @@ use sha2::{Digest, Sha256};
 
 use crate::ContextManager;
 
-/// Format this node's confirmed external addresses as endpoints a joiner can
+/// Format this node's confirmed external addresses as multiaddrs a joiner can
 /// dial.
 ///
 /// Split from the lookup so the shape is testable without a live swarm: the
 /// peer id is appended because a bare address does not say who answers at it,
 /// and a joiner cannot resolve that for itself — the identity-to-peer map is
 /// exactly what it does not have yet.
-fn dialable_self_endpoints(
+fn dialable_self_addrs(
     local_peer_id: &impl std::fmt::Display,
     external_addrs: &[impl std::fmt::Display],
-) -> Vec<AdmitterEndpoint> {
+) -> Vec<String> {
     external_addrs
         .iter()
-        .map(|addr| AdmitterEndpoint::Multiaddr(format!("{addr}/p2p/{local_peer_id}")))
+        .map(|addr| format!("{addr}/p2p/{local_peer_id}"))
         .collect()
 }
 
@@ -44,14 +44,14 @@ fn dialable_self_endpoints(
 /// Best-effort throughout: the caches expire, so an admitter not seen lately is
 /// simply not hinted. That is a joiner with one fewer address to try, never a
 /// wrong one — the signed `admitters` list still decides who may answer.
-async fn resolve_admitter_endpoints(
+async fn resolve_admitter_addrs(
     node_client: &calimero_node_primitives::client::NodeClient,
     datastore: &calimero_store::Store,
     signed: &SignedGroupOpenInvitation,
     signer_account: calimero_account::AccountId,
-) -> Vec<AdmitterEndpoint> {
+) -> Vec<String> {
     let group_id = signed.invitation.group_id;
-    let mut hints = Vec::new();
+    let mut addrs = Vec::new();
 
     // This node, if it is one of the admitters. `external_addrs` rather than
     // `listen_addrs`: the latter includes `0.0.0.0` and loopback, which are not
@@ -59,7 +59,7 @@ async fn resolve_admitter_endpoints(
     // relay-circuit form a NAT'd node is reachable on.
     if signed.invitation.admitters.contains(&signer_account) {
         let status = node_client.network_status().await;
-        hints.extend(dialable_self_endpoints(
+        addrs.extend(dialable_self_addrs(
             &status.local_peer_id,
             &status.external_addrs,
         ));
@@ -92,21 +92,15 @@ async fn resolve_admitter_endpoints(
                 .peer_addrs_for_identities(group_id, identities)
                 .await
             {
-                hints.push(AdmitterEndpoint::Multiaddr(format!("{addr}/p2p/{peer}")));
+                addrs.push(format!("{addr}/p2p/{peer}"));
             }
         }
     }
 
     let mut seen = std::collections::BTreeSet::new();
-    hints.retain(|hint| {
-        let key = match hint {
-            AdmitterEndpoint::Multiaddr(value) => (0u8, value.clone()),
-            AdmitterEndpoint::Url(value) => (1u8, value.clone()),
-        };
-        seen.insert(key)
-    });
+    addrs.retain(|addr| seen.insert(addr.clone()));
 
-    if hints.is_empty() {
+    if addrs.is_empty() {
         // Said out loud, because the alternative is minting a credential that
         // silently cannot be redeemed: a joiner holding a hintless invitation
         // has to already know where to knock, and for a keyholder with no node
@@ -118,7 +112,7 @@ async fn resolve_admitter_endpoints(
              address, so the joiner needs one out of band"
         );
     }
-    hints
+    addrs
 }
 
 impl Handler<CreateGroupInvitationRequest> for ContextManager {
@@ -130,7 +124,7 @@ impl Handler<CreateGroupInvitationRequest> for ContextManager {
             group_id,
             expiration_timestamp,
             admitters,
-            admitter_hints,
+            admitter_addrs,
         }: CreateGroupInvitationRequest,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
@@ -190,7 +184,7 @@ impl Handler<CreateGroupInvitationRequest> for ContextManager {
                 // The cost is reachability, not authority. A non-admin inviter
                 // mints invitations it cannot admit, so the invitee has to reach
                 // an admin or TEE node rather than whoever handed it the
-                // invitation — which is what `admitter_hints` is for. This node
+                // invitation — which is what `admitter_addrs` is for. This node
                 // can only hint the admitters it can address, and itself is the
                 // one it always can; see the hint pass below for what that
                 // leaves uncovered.
@@ -259,7 +253,7 @@ impl Handler<CreateGroupInvitationRequest> for ContextManager {
                     // applies silently skips the subtree — divergence
                     // between originator and joiner.
                     bytecode_id: Some(meta.bytecode_id),
-                    admitter_hints,
+                    admitter_addrs,
                 },
                 group_name,
                 signer_account,
@@ -283,8 +277,8 @@ impl Handler<CreateGroupInvitationRequest> for ContextManager {
         ActorResponse::r#async(
             async move {
                 let mut signed_invitation = signed_invitation;
-                if signed_invitation.admitter_hints.is_empty() {
-                    signed_invitation.admitter_hints = resolve_admitter_endpoints(
+                if signed_invitation.admitter_addrs.is_empty() {
+                    signed_invitation.admitter_addrs = resolve_admitter_addrs(
                         &node_client,
                         &datastore_for_hints,
                         &signed_invitation,
@@ -304,19 +298,17 @@ impl Handler<CreateGroupInvitationRequest> for ContextManager {
 
 #[cfg(test)]
 mod tests {
-    use super::{dialable_self_endpoints, AdmitterEndpoint};
+    use super::dialable_self_addrs;
 
     #[test]
-    fn an_endpoint_carries_the_peer_id_the_address_alone_does_not() {
+    fn an_address_carries_the_peer_id_it_alone_does_not() {
         // A joiner cannot turn a bare address into "who answers there" — the
         // identity-to-peer map is precisely what it has not synced yet. So the
         // peer id travels in the hint or the hint is unusable.
-        let hints = dialable_self_endpoints(&"12D3KooWTEST", &["/ip4/10.0.0.1/tcp/2528"]);
+        let addrs = dialable_self_addrs(&"12D3KooWTEST", &["/ip4/10.0.0.1/tcp/2528"]);
         assert_eq!(
-            hints,
-            vec![AdmitterEndpoint::Multiaddr(
-                "/ip4/10.0.0.1/tcp/2528/p2p/12D3KooWTEST".to_owned()
-            )]
+            addrs,
+            vec!["/ip4/10.0.0.1/tcp/2528/p2p/12D3KooWTEST".to_owned()]
         );
     }
 
@@ -326,23 +318,21 @@ mod tests {
         // reachable only through its relay reservation, so dropping circuit
         // addresses would leave exactly the nodes that most need a hint
         // advertising nothing.
-        let hints = dialable_self_endpoints(
+        let addrs = dialable_self_addrs(
             &"12D3KooWSELF",
             &["/ip4/1.2.3.4/tcp/4001/p2p/12D3KooWRELAY/p2p-circuit"],
         );
         assert_eq!(
-            hints,
-            vec![AdmitterEndpoint::Multiaddr(
-                "/ip4/1.2.3.4/tcp/4001/p2p/12D3KooWRELAY/p2p-circuit/p2p/12D3KooWSELF".to_owned()
-            )]
+            addrs,
+            vec!["/ip4/1.2.3.4/tcp/4001/p2p/12D3KooWRELAY/p2p-circuit/p2p/12D3KooWSELF".to_owned()]
         );
     }
 
     #[test]
     fn no_external_address_yields_no_hint_rather_than_a_useless_one() {
-        let hints = dialable_self_endpoints(&"12D3KooWSELF", &[] as &[String]);
+        let addrs = dialable_self_addrs(&"12D3KooWSELF", &[] as &[String]);
         assert!(
-            hints.is_empty(),
+            addrs.is_empty(),
             "a node with no confirmed external address has nothing dialable to offer"
         );
     }

--- a/crates/context/src/handlers/create_group_invitation.rs
+++ b/crates/context/src/handlers/create_group_invitation.rs
@@ -1,7 +1,7 @@
-use actix::{ActorResponse, Handler, Message};
+use actix::{ActorResponse, Handler, Message, WrapFuture as _};
 use calimero_context_client::group::{CreateGroupInvitationRequest, CreateGroupInvitationResponse};
 use calimero_context_config::types::{
-    GroupInvitationFromAdmin, SignedGroupOpenInvitation, SignerId,
+    AdmitterEndpoint, GroupInvitationFromAdmin, SignedGroupOpenInvitation, SignerId,
 };
 use calimero_context_config::MemberCapabilities;
 use calimero_governance_store::{MembershipRepository, MetaRepository, MetadataRepository};
@@ -10,6 +10,116 @@ use rand::Rng;
 use sha2::{Digest, Sha256};
 
 use crate::ContextManager;
+
+/// Format this node's confirmed external addresses as endpoints a joiner can
+/// dial.
+///
+/// Split from the lookup so the shape is testable without a live swarm: the
+/// peer id is appended because a bare address does not say who answers at it,
+/// and a joiner cannot resolve that for itself — the identity-to-peer map is
+/// exactly what it does not have yet.
+fn dialable_self_endpoints(
+    local_peer_id: &impl std::fmt::Display,
+    external_addrs: &[impl std::fmt::Display],
+) -> Vec<AdmitterEndpoint> {
+    external_addrs
+        .iter()
+        .map(|addr| AdmitterEndpoint::Multiaddr(format!("{addr}/p2p/{local_peer_id}")))
+        .collect()
+}
+
+/// Where the invitation's admitters can be reached, best-effort.
+///
+/// Two sources, because the two cases fail differently. This node answers for
+/// itself out of the swarm's confirmed external addresses, which are current by
+/// construction. Every other admitter is answered out of the durable caches,
+/// which is the only thing that makes a *delegated* invitation usable at all:
+/// `CAN_INVITE_MEMBERS` lets a member mint invitations it may not admit, so the
+/// admitters are other nodes and the joiner has no way to find them.
+///
+/// Only `Multiaddr` endpoints are produced. A `Url` hint would need a node to
+/// know the base URL its own admin API is served on, and nothing records that —
+/// so a keyholder with no node still supplies its own.
+///
+/// Best-effort throughout: the caches expire, so an admitter not seen lately is
+/// simply not hinted. That is a joiner with one fewer address to try, never a
+/// wrong one — the signed `admitters` list still decides who may answer.
+async fn resolve_admitter_endpoints(
+    node_client: &calimero_node_primitives::client::NodeClient,
+    datastore: &calimero_store::Store,
+    signed: &SignedGroupOpenInvitation,
+    signer_account: calimero_account::AccountId,
+) -> Vec<AdmitterEndpoint> {
+    let group_id = signed.invitation.group_id;
+    let mut hints = Vec::new();
+
+    // This node, if it is one of the admitters. `external_addrs` rather than
+    // `listen_addrs`: the latter includes `0.0.0.0` and loopback, which are not
+    // addresses anybody else can dial, and the former already carries the
+    // relay-circuit form a NAT'd node is reachable on.
+    if signed.invitation.admitters.contains(&signer_account) {
+        let status = node_client.network_status().await;
+        hints.extend(dialable_self_endpoints(
+            &status.local_peer_id,
+            &status.external_addrs,
+        ));
+    }
+
+    // Every other admitter, through the two durable caches. An account is not
+    // an address: it fans out to the signing keys its live devices hold, each
+    // of which may have been seen on some peer, each of which may have a cached
+    // address. Any link missing just means no hint for that admitter.
+    let others: Vec<_> = signed
+        .invitation
+        .admitters
+        .iter()
+        .filter(|account| **account != signer_account)
+        .copied()
+        .collect();
+
+    if !others.is_empty() {
+        let by_account = calimero_governance_store::AccountBindingRepository::new(datastore)
+            .live_devices_by_account(&group_id)
+            .unwrap_or_default();
+        let identities: Vec<_> = others
+            .iter()
+            .filter_map(|account| by_account.get(account))
+            .flat_map(|devices| devices.iter().map(|d| d.sign_pk))
+            .collect();
+
+        if !identities.is_empty() {
+            for (peer, addr) in node_client
+                .peer_addrs_for_identities(group_id, identities)
+                .await
+            {
+                hints.push(AdmitterEndpoint::Multiaddr(format!("{addr}/p2p/{peer}")));
+            }
+        }
+    }
+
+    let mut seen = std::collections::BTreeSet::new();
+    hints.retain(|hint| {
+        let key = match hint {
+            AdmitterEndpoint::Multiaddr(value) => (0u8, value.clone()),
+            AdmitterEndpoint::Url(value) => (1u8, value.clone()),
+        };
+        seen.insert(key)
+    });
+
+    if hints.is_empty() {
+        // Said out loud, because the alternative is minting a credential that
+        // silently cannot be redeemed: a joiner holding a hintless invitation
+        // has to already know where to knock, and for a keyholder with no node
+        // that is the case direct admission exists to remove.
+        tracing::warn!(
+            group_id = ?group_id,
+            admitters = signed.invitation.admitters.len(),
+            "invitation minted with no admitter hints: no admitter has a known \
+             address, so the joiner needs one out of band"
+        );
+    }
+    hints
+}
 
 impl Handler<CreateGroupInvitationRequest> for ContextManager {
     type Result = ActorResponse<Self, <CreateGroupInvitationRequest as Message>::Result>;
@@ -20,6 +130,7 @@ impl Handler<CreateGroupInvitationRequest> for ContextManager {
             group_id,
             expiration_timestamp,
             admitters,
+            admitter_hints,
         }: CreateGroupInvitationRequest,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
@@ -79,8 +190,10 @@ impl Handler<CreateGroupInvitationRequest> for ContextManager {
                 // The cost is reachability, not authority. A non-admin inviter
                 // mints invitations it cannot admit, so the invitee has to reach
                 // an admin or TEE node rather than whoever handed it the
-                // invitation — which is what `admitter_hints` is for, and nothing
-                // populates those yet.
+                // invitation — which is what `admitter_hints` is for. This node
+                // can only hint the admitters it can address, and itself is the
+                // one it always can; see the hint pass below for what that
+                // leaves uncovered.
                 defaulted
             } else {
                 admitters
@@ -146,13 +259,14 @@ impl Handler<CreateGroupInvitationRequest> for ContextManager {
                     // applies silently skips the subtree — divergence
                     // between originator and joiner.
                     bytecode_id: Some(meta.bytecode_id),
-                    admitter_hints: Vec::new(),
+                    admitter_hints,
                 },
                 group_name,
+                signer_account,
             ))
         })();
 
-        let (signed_invitation, group_name) = match result {
+        let (signed_invitation, group_name, signer_account) = match result {
             Ok(v) => v,
             Err(e) => return ActorResponse::reply(Err(e)),
         };
@@ -160,9 +274,76 @@ impl Handler<CreateGroupInvitationRequest> for ContextManager {
         // No commitment publishing needed — the signed invitation is a
         // self-contained bearer credential. The joiner will present it
         // in a RootOp::MemberJoined on the namespace topic.
-        ActorResponse::reply(Ok(CreateGroupInvitationResponse {
-            invitation: signed_invitation,
-            group_name,
-        }))
+        //
+        // Hints are attached AFTER signing, which is what makes this an async
+        // tail rather than a restructure: they sit outside the signature, so
+        // nothing here can change what was signed above.
+        let node_client = self.node_client.clone();
+        let datastore_for_hints = self.datastore.clone();
+        ActorResponse::r#async(
+            async move {
+                let mut signed_invitation = signed_invitation;
+                if signed_invitation.admitter_hints.is_empty() {
+                    signed_invitation.admitter_hints = resolve_admitter_endpoints(
+                        &node_client,
+                        &datastore_for_hints,
+                        &signed_invitation,
+                        signer_account,
+                    )
+                    .await;
+                }
+                Ok(CreateGroupInvitationResponse {
+                    invitation: signed_invitation,
+                    group_name,
+                })
+            }
+            .into_actor(self),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{dialable_self_endpoints, AdmitterEndpoint};
+
+    #[test]
+    fn an_endpoint_carries_the_peer_id_the_address_alone_does_not() {
+        // A joiner cannot turn a bare address into "who answers there" — the
+        // identity-to-peer map is precisely what it has not synced yet. So the
+        // peer id travels in the hint or the hint is unusable.
+        let hints = dialable_self_endpoints(&"12D3KooWTEST", &["/ip4/10.0.0.1/tcp/2528"]);
+        assert_eq!(
+            hints,
+            vec![AdmitterEndpoint::Multiaddr(
+                "/ip4/10.0.0.1/tcp/2528/p2p/12D3KooWTEST".to_owned()
+            )]
+        );
+    }
+
+    #[test]
+    fn a_relay_circuit_address_is_hinted_like_any_other() {
+        // The NAT'd case, and the one worth pinning: a node behind NAT is
+        // reachable only through its relay reservation, so dropping circuit
+        // addresses would leave exactly the nodes that most need a hint
+        // advertising nothing.
+        let hints = dialable_self_endpoints(
+            &"12D3KooWSELF",
+            &["/ip4/1.2.3.4/tcp/4001/p2p/12D3KooWRELAY/p2p-circuit"],
+        );
+        assert_eq!(
+            hints,
+            vec![AdmitterEndpoint::Multiaddr(
+                "/ip4/1.2.3.4/tcp/4001/p2p/12D3KooWRELAY/p2p-circuit/p2p/12D3KooWSELF".to_owned()
+            )]
+        );
+    }
+
+    #[test]
+    fn no_external_address_yields_no_hint_rather_than_a_useless_one() {
+        let hints = dialable_self_endpoints(&"12D3KooWSELF", &[] as &[String]);
+        assert!(
+            hints.is_empty(),
+            "a node with no confirmed external address has nothing dialable to offer"
+        );
     }
 }

--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -812,7 +812,7 @@ mod tests {
             inviter_account: None,
             application_id: Some(APP),
             bytecode_id: Some([0xD5; 32]),
-            admitter_hints: Vec::new(),
+            admitter_addrs: Vec::new(),
         }
     }
 

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -2544,7 +2544,7 @@ mod tests {
                 inviter_signature: "deadbeef".to_string(),
                 application_id: None,
                 bytecode_id: None,
-                admitter_hints: Vec::new(),
+                admitter_addrs: Vec::new(),
             },
             account: test_join_account_for(PublicKey::from([0x55; 32])),
         }
@@ -2625,7 +2625,7 @@ mod tests {
             inviter_signature: "deadbeef".to_string(),
             application_id: None,
             bytecode_id: None,
-            admitter_hints: Vec::new(),
+            admitter_addrs: Vec::new(),
         };
 
         let account = test_join_account_for(member);

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -60,7 +60,7 @@ fn sign_invitation(
         inviter_signature: hex::encode(inv_sig.to_bytes()),
         application_id: None,
         bytecode_id: None,
-        admitter_hints: Vec::new(),
+        admitter_addrs: Vec::new(),
     }
 }
 
@@ -327,7 +327,7 @@ fn two_nodes_converge_on_namespace_member_joined() {
         inviter_signature: hex::encode(inv_sig.to_bytes()),
         application_id: None,
         bytecode_id: None,
-        admitter_hints: Vec::new(),
+        admitter_addrs: Vec::new(),
     };
 
     let ns_op = SignedNamespaceOp::sign(
@@ -2154,7 +2154,7 @@ fn reapplying_namespace_op_keeps_dag_head_set_clean_and_position_embeddable() {
         inviter_signature: hex::encode(inv_sig.to_bytes()),
         application_id: None,
         bytecode_id: None,
-        admitter_hints: Vec::new(),
+        admitter_addrs: Vec::new(),
     };
 
     let ns_op = SignedNamespaceOp::sign(

--- a/crates/context/tests/per_device_authorization.rs
+++ b/crates/context/tests/per_device_authorization.rs
@@ -487,7 +487,7 @@ fn a_joiners_writer_account_matches_what_its_peers_resolve() {
         inviter_signature: hex::encode(inv_sig.to_bytes()),
         application_id: None,
         bytecode_id: None,
-        admitter_hints: Vec::new(),
+        admitter_addrs: Vec::new(),
     };
 
     let gov = NamespaceGovernance::new(&store, ns_bytes.into());

--- a/crates/context/tests/projection_membership_equivalence.rs
+++ b/crates/context/tests/projection_membership_equivalence.rs
@@ -101,7 +101,7 @@ fn sign_invitation(
         inviter_signature: hex::encode(inv_sig.to_bytes()),
         application_id: None,
         bytecode_id: None,
-        admitter_hints: Vec::new(),
+        admitter_addrs: Vec::new(),
     }
 }
 

--- a/crates/governance-store/src/namespace/core.rs
+++ b/crates/governance-store/src/namespace/core.rs
@@ -380,7 +380,7 @@ impl<'a> NamespaceRepository<'a> {
                 inviter_account: Some(inviter_account),
                 application_id,
                 bytecode_id,
-                admitter_hints: Vec::new(),
+                admitter_addrs: Vec::new(),
             };
 
             result.push((gid, signed));

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -178,7 +178,7 @@ fn test_signed_invitation_with_admitters(
         inviter_signature: hex::encode(inv_sig.to_bytes()),
         application_id: None,
         bytecode_id: None,
-        admitter_hints: Vec::new(),
+        admitter_addrs: Vec::new(),
     }
 }
 

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -4129,7 +4129,7 @@ fn member_joined_clears_deny_list_for_rejoiner() {
         inviter_signature: hex::encode(inv_sig.to_bytes()),
         application_id: None,
         bytecode_id: None,
-        admitter_hints: Vec::new(),
+        admitter_addrs: Vec::new(),
     };
 
     let signed = SignedNamespaceOp::sign(
@@ -5408,7 +5408,7 @@ fn signed_invitation_for(
         inviter_signature: hex::encode(inv_sig.to_bytes()),
         application_id: None,
         bytecode_id: None,
-        admitter_hints: Vec::new(),
+        admitter_addrs: Vec::new(),
     }
 }
 

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -557,7 +557,7 @@ const GOLDEN_ROOT_OP_POLICY_UPDATED: &[u8] = &[
 /// Encoding: member (32 bytes) + SignedGroupOpenInvitation — a minimal
 /// GroupInvitationFromAdmin (inviter_identity[0;32] + group_id[0;32] +
 /// expiration_timestamp 0 (u64) + invitation_nonce[0;32] + invited_role 1 (u8)
-/// + admitters len 0 (u32)) + inviter_signature "" + admitter_hints len 0 (u32)
+/// + admitters len 0 (u32)) + inviter_signature "" + admitter_addrs len 0 (u32)
 /// + application_id None + bytecode_id None — then the joiner credential.
 const GOLDEN_ROOT_OP_MEMBER_JOINED: &[u8] = &[
     0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1525,7 +1525,7 @@ mod governance_op_storage_roundtrip {
             inviter_signature: "deadbeef".to_string(),
             application_id: Some([0x44; 32]),
             bytecode_id: Some([0x55; 32]),
-            admitter_hints: Vec::new(),
+            admitter_addrs: Vec::new(),
         }
     }
 
@@ -1737,7 +1737,7 @@ fn emit_golden_root_op_vectors() {
             admitters: Vec::new(),
         },
         inviter_signature: String::new(),
-        admitter_hints: Vec::new(),
+        admitter_addrs: Vec::new(),
         application_id: None,
         bytecode_id: None,
     };

--- a/crates/meroctl/src/cli/namespace/invite.rs
+++ b/crates/meroctl/src/cli/namespace/invite.rs
@@ -1,3 +1,4 @@
+use calimero_context_config::types::AdmitterEndpoint;
 use calimero_server_primitives::admin::CreateGroupInvitationApiRequest;
 use clap::Parser;
 use eyre::Result;
@@ -24,25 +25,58 @@ pub struct InviteCommand {
 
     /// Accounts permitted to admit a claim of this invitation.
     ///
-    /// Without any, the joiner announces itself on the namespace topic and any
-    /// ready peer may admit it — which means the invitation is published to
-    /// every subscriber of that topic. Naming admitters keeps it off the topic:
-    /// the joiner presents it to one of them directly.
+    /// Without any, the node fills the list in from the group's admins and TEE
+    /// nodes. Naming them narrows that set.
     #[clap(
         long = "admitter",
         value_name = "ACCOUNT_HEX",
         help = "Account permitted to admit this invitation (repeatable). \
-                Without it, admission is by broadcast."
+                Without it, the node uses the group's admins and TEE nodes."
     )]
     pub admitters: Vec<String>,
+
+    /// Where a joining NODE can dial an admitter.
+    ///
+    /// Only worth passing when this node cannot work the address out itself —
+    /// it has no entry for that account, or the one it has is stale.
+    #[clap(
+        long = "admitter-multiaddr",
+        value_name = "MULTIADDR",
+        help = "libp2p multiaddr (with peer id) for an admitter, for a joiner \
+                that runs a node (repeatable)."
+    )]
+    pub admitter_multiaddrs: Vec<String>,
+
+    /// Where a joining KEYHOLDER can reach an admitter over HTTPS.
+    ///
+    /// The one that survives restarts, and the one a joiner with no node of its
+    /// own can actually use.
+    #[clap(
+        long = "admitter-url",
+        value_name = "URL",
+        help = "https:// base URL of an admitter's admin API, for a joiner \
+                holding only a key (repeatable)."
+    )]
+    pub admitter_urls: Vec<String>,
 }
 
 impl InviteCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
+        // Passed through as given. The two kinds are not interchangeable — a
+        // keyholder has no swarm to dial a multiaddr from — so they stay
+        // separate flags rather than one the node has to guess the shape of.
+        let admitter_hints: Vec<AdmitterEndpoint> = self
+            .admitter_multiaddrs
+            .into_iter()
+            .map(AdmitterEndpoint::Multiaddr)
+            .chain(self.admitter_urls.into_iter().map(AdmitterEndpoint::Url))
+            .collect();
+
         let request = CreateGroupInvitationApiRequest {
             expiration_timestamp: self.expiration_timestamp,
             recursive: Some(self.recursive),
             admitters: self.admitters,
+            admitter_hints,
         };
 
         let client = environment.client()?;

--- a/crates/meroctl/src/cli/namespace/invite.rs
+++ b/crates/meroctl/src/cli/namespace/invite.rs
@@ -1,4 +1,3 @@
-use calimero_context_config::types::AdmitterEndpoint;
 use calimero_server_primitives::admin::CreateGroupInvitationApiRequest;
 use clap::Parser;
 use eyre::Result;
@@ -35,48 +34,27 @@ pub struct InviteCommand {
     )]
     pub admitters: Vec<String>,
 
-    /// Where a joining NODE can dial an admitter.
+    /// Where a joiner can dial an admitter.
     ///
     /// Only worth passing when this node cannot work the address out itself —
     /// it has no entry for that account, or the one it has is stale.
     #[clap(
-        long = "admitter-multiaddr",
+        long = "admitter-addr",
         value_name = "MULTIADDR",
-        help = "libp2p multiaddr (with peer id) for an admitter, for a joiner \
-                that runs a node (repeatable)."
+        help = "libp2p multiaddr of an admitter, including its /p2p/<peer-id> \
+                suffix (repeatable). Usually unnecessary: the node fills these \
+                in from addresses it already has."
     )]
-    pub admitter_multiaddrs: Vec<String>,
-
-    /// Where a joining KEYHOLDER can reach an admitter over HTTPS.
-    ///
-    /// The one that survives restarts, and the one a joiner with no node of its
-    /// own can actually use.
-    #[clap(
-        long = "admitter-url",
-        value_name = "URL",
-        help = "https:// base URL of an admitter's admin API, for a joiner \
-                holding only a key (repeatable)."
-    )]
-    pub admitter_urls: Vec<String>,
+    pub admitter_addrs: Vec<String>,
 }
 
 impl InviteCommand {
     pub async fn run(self, environment: &mut Environment) -> Result<()> {
-        // Passed through as given. The two kinds are not interchangeable — a
-        // keyholder has no swarm to dial a multiaddr from — so they stay
-        // separate flags rather than one the node has to guess the shape of.
-        let admitter_hints: Vec<AdmitterEndpoint> = self
-            .admitter_multiaddrs
-            .into_iter()
-            .map(AdmitterEndpoint::Multiaddr)
-            .chain(self.admitter_urls.into_iter().map(AdmitterEndpoint::Url))
-            .collect();
-
         let request = CreateGroupInvitationApiRequest {
             expiration_timestamp: self.expiration_timestamp,
             recursive: Some(self.recursive),
             admitters: self.admitters,
-            admitter_hints,
+            admitter_addrs: self.admitter_addrs,
         };
 
         let client = environment.client()?;

--- a/crates/network/primitives/src/client.rs
+++ b/crates/network/primitives/src/client.rs
@@ -34,8 +34,8 @@ pub fn is_no_peers_subscribed_error(err: &eyre::Report) -> bool {
 use crate::blob_types::BlobAuth;
 use crate::messages::{
     AnnounceBlob, Bootstrap, Dial, ListenOn, MeshPeerCount, MeshPeers, MeshStats, NetworkMessage,
-    NetworkStatus, OpenStream, PeerCount, Publish, QueryBlob, RequestBlob, SetPeerScore, Subscribe,
-    SubscribedPeers, Unsubscribe,
+    NetworkStatus, OpenStream, PeerAddrs, PeerCount, Publish, QueryBlob, RequestBlob, SetPeerScore,
+    Subscribe, SubscribedPeers, Unsubscribe,
 };
 use crate::network_status::NetworkStatusSnapshot;
 use crate::stream::Stream;
@@ -154,6 +154,24 @@ impl NetworkClient {
         self.network_manager
             .send(NetworkMessage::OpenStream {
                 request: OpenStream(peer_id),
+                outcome: tx,
+            })
+            .await
+            .expect("Mailbox not to be dropped");
+
+        rx.await.expect("Mailbox not to be dropped")
+    }
+
+    /// Last known dialable addresses for `peer_id`, from the persistent cache.
+    ///
+    /// Empty means "no address to offer", never "no such peer" — a cache entry
+    /// expires, so a peer last seen long ago answers the same as one never seen.
+    pub async fn peer_addrs(&self, peer_id: libp2p::PeerId) -> Vec<libp2p::Multiaddr> {
+        let (tx, rx) = oneshot::channel();
+
+        self.network_manager
+            .send(NetworkMessage::PeerAddrs {
+                request: PeerAddrs(peer_id),
                 outcome: tx,
             })
             .await

--- a/crates/network/primitives/src/messages.rs
+++ b/crates/network/primitives/src/messages.rs
@@ -111,6 +111,11 @@ pub enum NetworkMessage {
         request: OpenStream,
         outcome: oneshot::Sender<<OpenStream as actix::Message>::Result>,
     },
+    /// Last known dialable addresses for a peer, from the persistent cache.
+    PeerAddrs {
+        request: PeerAddrs,
+        outcome: oneshot::Sender<<PeerAddrs as actix::Message>::Result>,
+    },
     /// Get the count of connected peers.
     PeerCount {
         request: PeerCount,
@@ -288,6 +293,23 @@ pub struct OpenStream(pub PeerId);
 
 impl actix::Message for OpenStream {
     type Result = eyre::Result<Stream>;
+}
+
+/// Request the last known dialable addresses for a peer.
+///
+/// Answered from the persistent peer-address cache, not from the live swarm, so
+/// it works for a peer this node is not currently connected to — which is the
+/// whole point: an address is worth handing out precisely when the holder is not
+/// already talking to that peer.
+///
+/// Empty when the cache has nothing fresh. Entries expire, so a peer last seen
+/// beyond the cache TTL answers the same as one never seen; both mean "no
+/// address to offer" rather than "no such peer".
+#[derive(Clone, Copy, Debug)]
+pub struct PeerAddrs(pub libp2p::PeerId);
+
+impl actix::Message for PeerAddrs {
+    type Result = Vec<libp2p::Multiaddr>;
 }
 
 /// Request to get the count of connected peers.

--- a/crates/network/src/handlers/commands.rs
+++ b/crates/network/src/handlers/commands.rs
@@ -13,6 +13,7 @@ mod mesh_peers;
 mod mesh_stats;
 mod network_status;
 mod open_stream;
+mod peer_addrs;
 mod peer_count;
 mod publish;
 mod query_blob;
@@ -49,6 +50,9 @@ impl Handler<NetworkMessage> for NetworkManager {
                 self.forward_handler(ctx, request, outcome);
             }
             NetworkMessage::OpenStream { request, outcome } => {
+                self.forward_handler(ctx, request, outcome);
+            }
+            NetworkMessage::PeerAddrs { request, outcome } => {
                 self.forward_handler(ctx, request, outcome);
             }
             NetworkMessage::PeerCount { request, outcome } => {

--- a/crates/network/src/handlers/commands/peer_addrs.rs
+++ b/crates/network/src/handlers/commands/peer_addrs.rs
@@ -1,0 +1,19 @@
+use actix::{Context, Handler, Message};
+use calimero_network_primitives::messages::PeerAddrs;
+
+use crate::NetworkManager;
+
+impl Handler<PeerAddrs> for NetworkManager {
+    type Result = <PeerAddrs as Message>::Result;
+
+    /// Served from the persistent address cache rather than the live swarm.
+    ///
+    /// A caller asks this to learn where a peer it is NOT connected to can be
+    /// reached, so answering from current connections would answer only the
+    /// cases that did not need asking. The cache keeps relay-circuit addresses
+    /// alongside direct ones, which is what makes a NAT'd peer answerable at
+    /// all.
+    fn handle(&mut self, PeerAddrs(peer_id): PeerAddrs, _ctx: &mut Context<Self>) -> Self::Result {
+        self.peer_cache_addrs_for(&peer_id)
+    }
+}

--- a/crates/node/primitives/src/client.rs
+++ b/crates/node/primitives/src/client.rs
@@ -582,6 +582,46 @@ impl NodeClient {
     /// Snapshot of the local node's libp2p connectivity state — relays,
     /// rendezvous registrations, DCUtR upgrade outcomes, AutoNAT v2
     /// reachability. Backs `GET /admin-api/network/status`.
+    /// Last known dialable addresses for one peer, from the persistent cache.
+    ///
+    /// Thin delegation to the network client, exposed here because the node
+    /// actor resolving identities to addresses holds a `NodeClient`, not a
+    /// `NetworkClient`.
+    pub async fn peer_addrs(&self, peer_id: libp2p::PeerId) -> Vec<libp2p::Multiaddr> {
+        self.network_client.peer_addrs(peer_id).await
+    }
+
+    /// Where the given member identities of `group_id` were last reachable.
+    ///
+    /// Each address is paired with the peer that answers there, because an
+    /// address alone does not say who is at it and the caller — a joiner that
+    /// has synced nothing — is exactly the party that cannot look that up.
+    ///
+    /// Empty is an ordinary answer: both caches behind this expire, so a member
+    /// not seen recently is indistinguishable from one never seen.
+    pub async fn peer_addrs_for_identities(
+        &self,
+        group_id: calimero_context_config::types::ContextGroupId,
+        identities: Vec<calimero_primitives::identity::PublicKey>,
+    ) -> Vec<(libp2p::PeerId, libp2p::Multiaddr)> {
+        let (tx, rx) = oneshot::channel();
+
+        if self
+            .node_manager
+            .send(NodeMessage::PeerAddrsForIdentities {
+                group_id,
+                identities,
+                outcome: tx,
+            })
+            .await
+            .is_err()
+        {
+            return Vec::new();
+        }
+
+        rx.await.unwrap_or_default()
+    }
+
     pub async fn network_status(
         &self,
     ) -> calimero_network_primitives::network_status::NetworkStatusSnapshot {

--- a/crates/node/primitives/src/messages.rs
+++ b/crates/node/primitives/src/messages.rs
@@ -16,6 +16,22 @@ pub enum NodeMessage {
         request: GetBlobBytesRequest,
         outcome: oneshot::Sender<<GetBlobBytesRequest as Message>::Result>,
     },
+    /// Last known dialable addresses for the given member identities of a
+    /// group, each paired with the peer that answers there.
+    ///
+    /// Two caches away from the caller and both are node-local, which is why
+    /// this crosses the actor boundary: identity-to-peer lives on `NodeState`,
+    /// peer-to-address lives in the network manager, and neither is reachable
+    /// from `crates/context`.
+    ///
+    /// Best-effort by construction. Both caches expire entries, so an empty
+    /// answer means "nothing fresh to offer" and never "this identity does not
+    /// exist" — a caller must treat it as a missing hint, not a missing member.
+    PeerAddrsForIdentities {
+        group_id: calimero_context_config::types::ContextGroupId,
+        identities: Vec<calimero_primitives::identity::PublicKey>,
+        outcome: oneshot::Sender<Vec<(libp2p::PeerId, libp2p::Multiaddr)>>,
+    },
     /// Forward a `NamespaceOpApplied` signal from the publisher path
     /// (which lives in `crates/context`, with no direct line into the
     /// node-side `ReadinessManager` actor) to the readiness FSM. The

--- a/crates/node/src/handlers.rs
+++ b/crates/node/src/handlers.rs
@@ -51,6 +51,46 @@ impl Handler<NodeMessage> for NodeManager {
                     namespace_id,
                 ));
             }
+            NodeMessage::PeerAddrsForIdentities {
+                group_id,
+                identities,
+                outcome,
+            } => {
+                // Two hops, and the first one is synchronous off the durable
+                // identity cache: which peers have been seen hosting these
+                // member identities, TTL-filtered so a long-gone peer is not
+                // offered as an address.
+                let wanted: std::collections::BTreeSet<_> = identities.into_iter().collect();
+                let peers: Vec<libp2p::PeerId> = self
+                    .state
+                    .lock_peer_identity_cache()
+                    .members_for_group(
+                        &group_id,
+                        crate::state::now_unix_secs(),
+                        crate::peer_identity_cache::PEER_IDENTITY_TTL_SECS,
+                    )
+                    .into_iter()
+                    .filter(|member| wanted.contains(&member.identity))
+                    .flat_map(|member| member.peers)
+                    .collect();
+
+                // The second hop is a mailbox round-trip per peer, so it is
+                // spawned rather than blocking this actor. A dropped receiver
+                // just means the caller gave up.
+                let node_client = self.clients.node.clone();
+                let _ignored = ctx.spawn(
+                    async move {
+                        let mut out = Vec::new();
+                        for peer in peers {
+                            for addr in node_client.peer_addrs(peer).await {
+                                out.push((peer, addr));
+                            }
+                        }
+                        let _ignored = outcome.send(out);
+                    }
+                    .into_actor(self),
+                );
+            }
             NodeMessage::ForwardNamespaceOpApplied { namespace_id } => {
                 // Forward the publisher-side signal to the readiness FSM.
                 // Mirrors `addr.do_send(NamespaceOpApplied { namespace_id })`

--- a/crates/node/src/membership_republish_e2e.rs
+++ b/crates/node/src/membership_republish_e2e.rs
@@ -61,7 +61,7 @@ fn signed_invitation(
         inviter_signature: hex::encode(signature.to_bytes()),
         application_id: None,
         bytecode_id: None,
-        admitter_hints: Vec::new(),
+        admitter_addrs: Vec::new(),
     }
 }
 

--- a/crates/node/src/readiness/tests.rs
+++ b/crates/node/src/readiness/tests.rs
@@ -650,7 +650,7 @@ fn test_invitation() -> SignedGroupOpenInvitation {
         inviter_signature: String::new(),
         application_id: None,
         bytecode_id: None,
-        admitter_hints: Vec::new(),
+        admitter_addrs: Vec::new(),
     }
 }
 

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -2703,7 +2703,7 @@ mod join_target_tests {
             inviter_signature: hex::encode(signature.to_bytes()),
             application_id: None,
             bytecode_id: None,
-            admitter_hints: Vec::new(),
+            admitter_addrs: Vec::new(),
         }
     }
 

--- a/crates/node/src/test_node_harness.rs
+++ b/crates/node/src/test_node_harness.rs
@@ -103,6 +103,13 @@ impl actix::Handler<calimero_network_primitives::messages::NetworkMessage> for S
             NetworkMessage::MeshStats { outcome, .. } => {
                 let _ = outcome.send(Vec::new());
             }
+            // No swarm here, so no peer has ever been observed at an address.
+            // Empty is the honest answer and the one a caller must already
+            // handle: the real cache expires, so "no address for this peer" is
+            // an ordinary result rather than a harness artefact.
+            NetworkMessage::PeerAddrs { outcome, .. } => {
+                let _ = outcome.send(Vec::new());
+            }
             NetworkMessage::PeerCount { outcome, .. } => {
                 let _ = outcome.send(0);
             }

--- a/crates/op-adapter/src/tests/root.rs
+++ b/crates/op-adapter/src/tests/root.rs
@@ -28,7 +28,7 @@ fn invitation_for(group: [u8; 32]) -> SignedGroupOpenInvitation {
         inviter_signature: "deadbeef".to_string(),
         application_id: None,
         bytecode_id: None,
-        admitter_hints: Vec::new(),
+        admitter_addrs: Vec::new(),
     }
 }
 

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2283,16 +2283,23 @@ pub struct CreateGroupInvitationApiRequest {
     pub recursive: Option<bool>,
     /// Accounts permitted to admit a claim of this invitation, 64 hex each.
     ///
-    /// Empty or absent keeps the existing behaviour: the joiner announces
-    /// itself on the namespace topic and any ready peer may admit it.
-    ///
-    /// Naming admitters means the joiner presents the invitation to one of them
-    /// directly instead. Worth doing because the broadcast path staples the
-    /// whole invitation to a readiness beacon, and those go out on the namespace
-    /// topic as plain borsh to any peer that subscribes — so an invitation that
-    /// travels that way is readable by more than its intended holder.
+    /// Empty or absent is filled in at mint from the group's admins and TEE
+    /// nodes. Naming them explicitly narrows that set; it cannot widen it past
+    /// what the caller is entitled to name, because the list is signed and
+    /// checked against the account an admitter proves it holds.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub admitters: Vec<String>,
+    /// Where to reach those admitters, for a caller that knows better than the
+    /// node does.
+    ///
+    /// `{"multiaddr": "/ip4/.../p2p/12D3Koo..."}` for a joiner that runs a node,
+    /// `{"url": "https://..."}` for one holding only a key. Empty or absent asks
+    /// the node to fill them in from what it knows.
+    ///
+    /// Unsigned: a wrong endpoint misdirects where a joiner knocks, never who
+    /// may answer.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub admitter_hints: Vec<calimero_context_config::types::AdmitterEndpoint>,
 }
 
 impl Validate for CreateGroupInvitationApiRequest {

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -2289,17 +2289,16 @@ pub struct CreateGroupInvitationApiRequest {
     /// checked against the account an admitter proves it holds.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub admitters: Vec<String>,
-    /// Where to reach those admitters, for a caller that knows better than the
-    /// node does.
+    /// libp2p addresses for those admitters, each a full multiaddr including
+    /// the `/p2p/<peer-id>` suffix.
     ///
-    /// `{"multiaddr": "/ip4/.../p2p/12D3Koo..."}` for a joiner that runs a node,
-    /// `{"url": "https://..."}` for one holding only a key. Empty or absent asks
-    /// the node to fill them in from what it knows.
+    /// Empty or absent asks the node to fill them in from addresses it already
+    /// has on file. Supplied values are used as given rather than merged.
     ///
-    /// Unsigned: a wrong endpoint misdirects where a joiner knocks, never who
-    /// may answer.
+    /// Unsigned: a wrong address misdirects where a joiner knocks, never who may
+    /// answer.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub admitter_hints: Vec<calimero_context_config::types::AdmitterEndpoint>,
+    pub admitter_addrs: Vec<String>,
 }
 
 impl Validate for CreateGroupInvitationApiRequest {

--- a/crates/server/src/admin/handlers/groups/create_group_invitation.rs
+++ b/crates/server/src/admin/handlers/groups/create_group_invitation.rs
@@ -54,7 +54,7 @@ pub async fn handler(
             group_id,
             expiration_timestamp: req.expiration_timestamp,
             admitters,
-            admitter_hints: req.admitter_hints,
+            admitter_addrs: req.admitter_addrs,
         })
         .await
         .map_err(parse_api_error);

--- a/crates/server/src/admin/handlers/groups/create_group_invitation.rs
+++ b/crates/server/src/admin/handlers/groups/create_group_invitation.rs
@@ -54,6 +54,7 @@ pub async fn handler(
             group_id,
             expiration_timestamp: req.expiration_timestamp,
             admitters,
+            admitter_hints: req.admitter_hints,
         })
         .await
         .map_err(parse_api_error);

--- a/crates/server/src/admin/handlers/namespaces/admit_join.rs
+++ b/crates/server/src/admin/handlers/namespaces/admit_join.rs
@@ -280,7 +280,7 @@ mod tests {
                 admitters: Vec::new(),
             },
             inviter_signature: String::new(),
-            admitter_hints: Vec::new(),
+            admitter_addrs: Vec::new(),
             application_id: None,
             bytecode_id: None,
         };

--- a/crates/server/src/admin/handlers/namespaces/invite_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/invite_namespace.rs
@@ -152,7 +152,7 @@ pub async fn handler(
             group_id: namespace_id,
             expiration_timestamp: req.expiration_timestamp,
             admitters,
-            admitter_hints: req.admitter_hints,
+            admitter_addrs: req.admitter_addrs,
         })
         .await
         .map_err(parse_api_error);

--- a/crates/server/src/admin/handlers/namespaces/invite_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/invite_namespace.rs
@@ -152,6 +152,7 @@ pub async fn handler(
             group_id: namespace_id,
             expiration_timestamp: req.expiration_timestamp,
             admitters,
+            admitter_hints: req.admitter_hints,
         })
         .await
         .map_err(parse_api_error);

--- a/docs/src/content/docs/operate/admin-api.mdx
+++ b/docs/src/content/docs/operate/admin-api.mdx
@@ -303,13 +303,13 @@ the path parameter — these are reproduced exactly as routed below.
 | POST | `/admin-api/namespaces` | Create a namespace. |
 | GET | `/admin-api/namespaces/:namespace_id` | Get a namespace. |
 | DELETE | `/admin-api/namespaces/:namespace_id` | Delete a namespace. |
-| POST | `/admin-api/namespaces/:namespace_id/invite` | Invite into a namespace. Body may name `admitters` and `admitterHints` — see [below](#invitation-body-admitters-and-hints). |
+| POST | `/admin-api/namespaces/:namespace_id/invite` | Invite into a namespace. Body may name `admitters` and `admitterAddrs` — see [below](#invitation-body-admitters-and-addresses). |
 | POST | `/admin-api/namespaces/:namespace_id/join` | Join a namespace. |
 | POST | `/admin-api/namespaces/:namespace_id/admit` | Publish a join signed by a keyholder that has no node of its own. See [Direct Admission](/protocol/direct-admission/). |
 | POST | `/admin-api/namespaces/:namespace_id/leave` | Leave a namespace. |
 | GET | `/admin-api/namespaces/for-application/:application_id` | List namespaces for an application. |
 
-#### Invitation body: admitters and hints
+#### Invitation body: admitters and addresses
 
 Both `/groups/:group_id/invite` and `/namespaces/:namespace_id/invite` accept the
 same body. Every field is optional.
@@ -319,9 +319,8 @@ same body. Every field is optional.
   "expirationTimestamp": 3600,
   "recursive": false,
   "admitters": ["8f2c…e1", "b04a…77"],
-  "admitterHints": [
-    { "multiaddr": "/ip4/203.0.113.7/tcp/2528/p2p/12D3KooWExample" },
-    { "url": "https://node-1.example.com" }
+  "admitterAddrs": [
+    "/ip4/203.0.113.7/tcp/2528/p2p/12D3KooWExample"
   ]
 }
 ```
@@ -331,26 +330,18 @@ same body. Every field is optional.
 | `expirationTimestamp` | Validity in **seconds**, clamped to 24 hours. Not an absolute time despite the name. |
 | `recursive` | Also mint invitations for the namespace's child groups. |
 | `admitters` | Accounts allowed to admit a claim, 64 hex each. **Signed** into the invitation. Omit and the node fills in the group's admins plus its TEE nodes; it refuses to mint if that set is empty. |
-| `admitterHints` | Where to reach those admitters. **Not signed.** Omit and the node fills in what it knows. |
+| `admitterAddrs` | libp2p multiaddrs for those admitters, each including its `/p2p/<peer-id>` suffix. **Not signed.** Omit and the node fills in what it knows. |
 
-`admitterHints` entries are tagged by transport, and the two are not
-interchangeable:
+The peer id has to be in the address: a joiner cannot resolve an account to a peer
+without governance state, which is precisely what it has not synced yet.
 
-- `{ "multiaddr": "…" }` — for a joiner that runs a node. Must include the
-  `/p2p/<peer-id>` suffix; a joiner cannot resolve one for itself.
-- `{ "url": "…" }` — for a joiner holding only a key, which has no swarm to dial
-  from. **A node never generates these**, so a URL appears only if the caller
-  supplies it.
+Supplied addresses are used **as given** and are not merged with the node's own
+view — a caller naming one is usually correcting that view, not extending it.
 
-Supplied hints are used **as given** and are not merged with the node's own view:
-a caller naming endpoints is usually correcting that view, not extending it.
-
-Because hints are unsigned, a wrong one costs a failed connection and nothing
-more — the signed `admitters` list still decides who may answer. [Direct
-Admission](/protocol/direct-admission/) covers why that makes a multiaddr safe to
-guess and a URL not.
-| GET | `/admin-api/namespaces/:namespace_id/groups` | List groups in a namespace. |
-| POST | `/admin-api/namespaces/:namespace_id/groups` | Create a group inside a namespace. |
+Because they are unsigned, a wrong address costs a failed dial and nothing more:
+libp2p authenticates the peer id on connect, and the signed `admitters` list still
+decides who may answer. [Direct Admission](/protocol/direct-admission/) covers the
+split.
 
 ## Admin API — Blobs
 

--- a/docs/src/content/docs/operate/admin-api.mdx
+++ b/docs/src/content/docs/operate/admin-api.mdx
@@ -303,11 +303,52 @@ the path parameter — these are reproduced exactly as routed below.
 | POST | `/admin-api/namespaces` | Create a namespace. |
 | GET | `/admin-api/namespaces/:namespace_id` | Get a namespace. |
 | DELETE | `/admin-api/namespaces/:namespace_id` | Delete a namespace. |
-| POST | `/admin-api/namespaces/:namespace_id/invite` | Invite into a namespace. |
+| POST | `/admin-api/namespaces/:namespace_id/invite` | Invite into a namespace. Body may name `admitters` and `admitterHints` — see [below](#invitation-body-admitters-and-hints). |
 | POST | `/admin-api/namespaces/:namespace_id/join` | Join a namespace. |
 | POST | `/admin-api/namespaces/:namespace_id/admit` | Publish a join signed by a keyholder that has no node of its own. See [Direct Admission](/protocol/direct-admission/). |
 | POST | `/admin-api/namespaces/:namespace_id/leave` | Leave a namespace. |
 | GET | `/admin-api/namespaces/for-application/:application_id` | List namespaces for an application. |
+
+#### Invitation body: admitters and hints
+
+Both `/groups/:group_id/invite` and `/namespaces/:namespace_id/invite` accept the
+same body. Every field is optional.
+
+```json
+{
+  "expirationTimestamp": 3600,
+  "recursive": false,
+  "admitters": ["8f2c…e1", "b04a…77"],
+  "admitterHints": [
+    { "multiaddr": "/ip4/203.0.113.7/tcp/2528/p2p/12D3KooWExample" },
+    { "url": "https://node-1.example.com" }
+  ]
+}
+```
+
+| field | meaning |
+| --- | --- |
+| `expirationTimestamp` | Validity in **seconds**, clamped to 24 hours. Not an absolute time despite the name. |
+| `recursive` | Also mint invitations for the namespace's child groups. |
+| `admitters` | Accounts allowed to admit a claim, 64 hex each. **Signed** into the invitation. Omit and the node fills in the group's admins plus its TEE nodes; it refuses to mint if that set is empty. |
+| `admitterHints` | Where to reach those admitters. **Not signed.** Omit and the node fills in what it knows. |
+
+`admitterHints` entries are tagged by transport, and the two are not
+interchangeable:
+
+- `{ "multiaddr": "…" }` — for a joiner that runs a node. Must include the
+  `/p2p/<peer-id>` suffix; a joiner cannot resolve one for itself.
+- `{ "url": "…" }` — for a joiner holding only a key, which has no swarm to dial
+  from. **A node never generates these**, so a URL appears only if the caller
+  supplies it.
+
+Supplied hints are used **as given** and are not merged with the node's own view:
+a caller naming endpoints is usually correcting that view, not extending it.
+
+Because hints are unsigned, a wrong one costs a failed connection and nothing
+more — the signed `admitters` list still decides who may answer. [Direct
+Admission](/protocol/direct-admission/) covers why that makes a multiaddr safe to
+guess and a URL not.
 | GET | `/admin-api/namespaces/:namespace_id/groups` | List groups in a namespace. |
 | POST | `/admin-api/namespaces/:namespace_id/groups` | Create a group inside a namespace. |
 

--- a/docs/src/content/docs/operate/meroctl.mdx
+++ b/docs/src/content/docs/operate/meroctl.mdx
@@ -187,7 +187,7 @@ Alias: `ns`. Namespaces are root groups (application instances).
 | `create`                           | Create a new namespace.                           | `--application-id`, `--name`, `--bytecode-id` (alias: `--app-key`) |
 | `get <NAMESPACE_ID>`               | Get details about a namespace.                    | `NAMESPACE_ID`                                                |
 | `delete` (`del`) `<NAMESPACE_ID>`  | Delete a namespace.                               | `NAMESPACE_ID`                                |
-| `invite <NAMESPACE_ID>`            | Create an invitation for a namespace.             | `NAMESPACE_ID`, `--expiration-timestamp`, `--recursive`, `--admitter`, `--admitter-multiaddr`, `--admitter-url` (see [below](#invitation-admitters-and-hints)) |
+| `invite <NAMESPACE_ID>`            | Create an invitation for a namespace.             | `NAMESPACE_ID`, `--expiration-timestamp`, `--recursive`, `--admitter`, `--admitter-addr` (see [below](#invitation-admitters-and-addresses)) |
 | `join <NAMESPACE_ID> <INVITATION>` | Join a namespace using an invitation.             | `NAMESPACE_ID`, invitation JSON                              |
 | `leave <NAMESPACE_ID>`             | Leave a namespace (cascades through descendants). | `NAMESPACE_ID`                                               |
 | `groups <NAMESPACE_ID>`            | List direct groups under a namespace.             | `NAMESPACE_ID`                                               |
@@ -203,48 +203,38 @@ meroctl --node node2 namespace join <namespace_id> '<invitation_json>'
 ---
 
 
-### Invitation admitters and hints
+### Invitation admitters and addresses
 
-`namespace invite` takes three optional flags that decide **who** may admit a
-joiner and **where** the joiner should look for them. All are repeatable.
+`namespace invite` takes two optional flags that decide **who** may admit a joiner
+and **where** the joiner should look for them. Both are repeatable.
 
 | flag | value | what it does |
 | --- | --- | --- |
 | `--admitter` | account, 64 hex | Narrows who may admit this invitation. Omit and the node uses the group's admins plus its TEE nodes. **Signed**, so it cannot be redirected afterwards. |
-| `--admitter-multiaddr` | `/ip4/…/tcp/…/p2p/<peer-id>` | Where a joiner **that runs a node** can dial an admitter. |
-| `--admitter-url` | `https://…` | Where a joiner **holding only a key** can reach an admitter's admin API. |
+| `--admitter-addr` | `/ip4/…/tcp/…/p2p/<peer-id>` | Where a joiner can dial an admitter. **Unsigned**, and must include the `/p2p/` suffix. |
 
-The two hint flags are separate because the endpoints are not interchangeable: a
-keyholder has no swarm to dial a multiaddr from. One flag taking a bare string
-would leave the node guessing which kind it received.
-
-**You usually need none of them.** The node names the admitters itself, and fills
-in multiaddr hints from the addresses it already has on file. Reach for the flags
-when:
+**You usually need neither.** The node names the admitters itself and fills in
+addresses from what it already has on file. Reach for them when:
 
 - `--admitter` — you want a *narrower* set than every admin and TEE node.
-- `--admitter-multiaddr` — the node's address for an admitter is stale or missing
-  (it has not seen that peer within the cache's 24-hour window).
-- `--admitter-url` — you are inviting a keyholder. **The node never generates a URL
-  hint**, so this one is only ever present if you pass it.
+- `--admitter-addr` — the node's address for an admitter is stale or missing (it
+  has not seen that peer within the cache's 24-hour window).
 
 ```bash
 # Ordinary case: let the node decide who admits and where they are.
 meroctl namespace invite $NS
 
-# Invite a keyholder to a hosted deployment.
-meroctl namespace invite $NS --admitter-url https://node-1.example.com
-
 # Narrow admission to one account, and say where it is.
 meroctl namespace invite $NS \
   --admitter 8f2c...e1 \
-  --admitter-multiaddr /ip4/203.0.113.7/tcp/2528/p2p/12D3KooWExample
+  --admitter-addr /ip4/203.0.113.7/tcp/2528/p2p/12D3KooWExample
 ```
 
-Hints are **unsigned**, deliberately. A wrong multiaddr costs a failed dial and
-nothing more, because the signed `--admitter` list still decides who may answer.
-See [Direct Admission](/protocol/direct-admission/) for why a URL is not guessed
-the way a multiaddr is.
+Addresses are **unsigned**, deliberately. A wrong one costs a failed dial and
+nothing more: libp2p authenticates the peer id on connect, and the signed
+`--admitter` list still decides who may answer. See
+[Direct Admission](/protocol/direct-admission/) for why an address travels
+unsigned while the admitter list cannot.
 
 ## blob
 

--- a/docs/src/content/docs/operate/meroctl.mdx
+++ b/docs/src/content/docs/operate/meroctl.mdx
@@ -187,7 +187,7 @@ Alias: `ns`. Namespaces are root groups (application instances).
 | `create`                           | Create a new namespace.                           | `--application-id`, `--name`, `--bytecode-id` (alias: `--app-key`) |
 | `get <NAMESPACE_ID>`               | Get details about a namespace.                    | `NAMESPACE_ID`                                                |
 | `delete` (`del`) `<NAMESPACE_ID>`  | Delete a namespace.                               | `NAMESPACE_ID`                                |
-| `invite <NAMESPACE_ID>`            | Create an invitation for a namespace.             | `NAMESPACE_ID`, `--expiration-timestamp`, `--recursive` |
+| `invite <NAMESPACE_ID>`            | Create an invitation for a namespace.             | `NAMESPACE_ID`, `--expiration-timestamp`, `--recursive`, `--admitter`, `--admitter-multiaddr`, `--admitter-url` (see [below](#invitation-admitters-and-hints)) |
 | `join <NAMESPACE_ID> <INVITATION>` | Join a namespace using an invitation.             | `NAMESPACE_ID`, invitation JSON                              |
 | `leave <NAMESPACE_ID>`             | Leave a namespace (cascades through descendants). | `NAMESPACE_ID`                                               |
 | `groups <NAMESPACE_ID>`            | List direct groups under a namespace.             | `NAMESPACE_ID`                                               |
@@ -201,6 +201,50 @@ meroctl --node node2 namespace join <namespace_id> '<invitation_json>'
 ```
 
 ---
+
+
+### Invitation admitters and hints
+
+`namespace invite` takes three optional flags that decide **who** may admit a
+joiner and **where** the joiner should look for them. All are repeatable.
+
+| flag | value | what it does |
+| --- | --- | --- |
+| `--admitter` | account, 64 hex | Narrows who may admit this invitation. Omit and the node uses the group's admins plus its TEE nodes. **Signed**, so it cannot be redirected afterwards. |
+| `--admitter-multiaddr` | `/ip4/…/tcp/…/p2p/<peer-id>` | Where a joiner **that runs a node** can dial an admitter. |
+| `--admitter-url` | `https://…` | Where a joiner **holding only a key** can reach an admitter's admin API. |
+
+The two hint flags are separate because the endpoints are not interchangeable: a
+keyholder has no swarm to dial a multiaddr from. One flag taking a bare string
+would leave the node guessing which kind it received.
+
+**You usually need none of them.** The node names the admitters itself, and fills
+in multiaddr hints from the addresses it already has on file. Reach for the flags
+when:
+
+- `--admitter` — you want a *narrower* set than every admin and TEE node.
+- `--admitter-multiaddr` — the node's address for an admitter is stale or missing
+  (it has not seen that peer within the cache's 24-hour window).
+- `--admitter-url` — you are inviting a keyholder. **The node never generates a URL
+  hint**, so this one is only ever present if you pass it.
+
+```bash
+# Ordinary case: let the node decide who admits and where they are.
+meroctl namespace invite $NS
+
+# Invite a keyholder to a hosted deployment.
+meroctl namespace invite $NS --admitter-url https://node-1.example.com
+
+# Narrow admission to one account, and say where it is.
+meroctl namespace invite $NS \
+  --admitter 8f2c...e1 \
+  --admitter-multiaddr /ip4/203.0.113.7/tcp/2528/p2p/12D3KooWExample
+```
+
+Hints are **unsigned**, deliberately. A wrong multiaddr costs a failed dial and
+nothing more, because the signed `--admitter` list still decides who may answer.
+See [Direct Admission](/protocol/direct-admission/) for why a URL is not guessed
+the way a multiaddr is.
 
 ## blob
 

--- a/docs/src/content/docs/protocol/direct-admission.mdx
+++ b/docs/src/content/docs/protocol/direct-admission.mdx
@@ -129,8 +129,98 @@ Unsigned on purpose. A hint is only *where* to look; who may admit stays inside 
 signature, so a wrong or stale hint costs a failed connection and nothing more —
 the admitting node still has to be in the signed list for its admission to count.
 
-Nothing populates hints yet, which is tracked separately. Until it does, a joiner
-needs the address out of band.
+### Where hints come from
+
+A caller can supply them, and otherwise the node resolves them:
+
+| case | what you get |
+| --- | --- |
+| caller passes `admitterHints` | used exactly as given, never merged with the node's own view — a caller naming endpoints is usually correcting that view, not extending it |
+| the minting node is itself an admitter | its confirmed external addresses, each with its peer id appended, including the relay-circuit form a NAT'd node is reachable on |
+| any other admitter | its last known address, resolved through the node's durable caches |
+
+That last row is what makes a **delegated** invitation usable. `CAN_INVITE_MEMBERS`
+lets a member mint invitations it may not admit, so the admitters are other nodes
+— and a joiner that has synced nothing cannot look up where those are.
+
+Resolution runs account → signing keys of the account's live devices → peers those
+keys have been seen on → last known addresses of those peers. The first link is
+governance state; the other two are node-local caches that persist across restarts
+and expire after 24 hours, which is also the longest an invitation can live. So a
+hint can never outlive the credential carrying it.
+
+Best-effort at every link. An admitter not seen recently is simply not hinted — one
+fewer address for the joiner to try, never a wrong one, because the signed
+`admitters` list still decides who may answer. A mint that can hint nobody says so
+in the log rather than issuing a credential that quietly cannot be redeemed.
+
+### Why no `{ url }` hint is generated
+
+Only `{ multiaddr }` hints are produced. That is a deliberate stop, not a missing
+feature, and the two kinds are not equally safe to guess.
+
+A multiaddr carries `/p2p/<peer-id>`, which libp2p authenticates during the
+handshake — dial the wrong host and it fails having disclosed nothing. A URL has no
+such property: HTTPS authenticates a domain, not a node. An invitation is a bearer
+credential, so a guessed URL risks presenting a redeemable credential to whatever
+answers there.
+
+A node also cannot derive its own. It terminates no TLS and `AuthMode::Proxy` is
+the default, so the address callers should use is a reverse proxy's — different
+host, different port, `https` where the node speaks plain HTTP. `listen` says where
+the process binds, which under a proxy is not an address to send anyone to.
+
+For the hosted tier this is resolved on the client instead: a keyholder with no node
+writes through delegated execution, which goes via hosted TEE relays, so the client
+falls back to the known relay endpoint when no multiaddr is usable. Note the
+invitation cannot inform that decision — `admitters` are plain accounts with no
+marker saying which are TEE-admitted — so it is an unconditional fallback rather
+than a conditional one.
+
+A third-party TEE deployment would need its endpoint recorded per node, alongside
+the attestation record that already names it. Nothing stores that yet. Until then,
+pass `--admitter-url` if you know it.
+
+## The two joining flows
+
+Which path a joiner takes is decided by one thing: whether it runs a node.
+
+### A joiner that runs a node
+
+1. It receives the invitation out of band (the inviter sends it however it likes).
+2. It signs its own `MemberJoinedAt` op — the invitation authorises the join, but
+   the joiner authors it, so no admitter ever signs on its behalf.
+3. It publishes that op on the namespace topic.
+4. Any node in the signed `admitters` list that sees it applies it. Every peer
+   re-checks `join_op_proves_ownership` at apply, so an admitter relays a join, it
+   never grants one.
+
+`admitter_hints` exists to make step 3 reliable when the joiner is not already
+connected to an admitter. **Today the hints are written into the invitation but
+nothing dials them yet** — a joiner still depends on gossip reaching an admitter.
+Consuming them is a separate change.
+
+### A joiner holding only a key
+
+This is the case direct admission exists for: a keyholder with no node, no swarm,
+and no governance state.
+
+1. It mints its account root and signs its device certificate **offline**.
+2. It signs its own `MemberJoinedAt`, exactly as a node joiner would.
+3. It `POST`s that op to `/admin-api/namespaces/:namespace_id/admit` on a node that
+   is named in `admitters`.
+4. That node verifies the signature, checks it may admit, applies the membership
+   locally, and publishes.
+
+Step 3 needs an address, and a multiaddr is no use here — there is no swarm to dial
+one from. So this path wants a `{ url }` hint, which is the one kind a node never
+generates.
+
+For the hosted tier that is resolved on the client rather than in the invitation:
+a keyholder writes through delegated execution, which runs via hosted TEE relays,
+so the client can ask whether the namespace has a TEE policy and present its claim
+to the known relay endpoint. Asking first matters — it keeps a self-hosted
+namespace's invitation from being handed to a cloud that has no business with it.
 
 ## Invitations expire within a day
 
@@ -148,3 +238,7 @@ op to **somebody else's** node still needs a credential on that node. Everything
 else in the flow works without one — the account, the certificate, and the op are
 all produced offline — but the last hop is not yet answered for a node the
 keyholder has no relationship with.
+
+The same guard covers the TEE-admission-policy lookup a client would use to decide
+where to present a claim, so both are unblocked by one piece of work rather than
+two.

--- a/docs/src/content/docs/protocol/direct-admission.mdx
+++ b/docs/src/content/docs/protocol/direct-admission.mdx
@@ -119,11 +119,13 @@ restricted credential the system can express would be the wrong response.
 
 `admitters` names **accounts**. Connecting needs a peer id, and a joiner that has
 synced nothing has no governance state to resolve one from. So
-`SignedGroupOpenInvitation` also carries `admitter_hints`, **outside** the
-signature:
+`SignedGroupOpenInvitation` also carries `admitter_addrs`, **outside** the
+signature: libp2p multiaddrs, each including its `/p2p/<peer-id>` suffix, e.g.
+`/ip4/203.0.113.7/tcp/2528/p2p/12D3KooW…`.
 
-- `{ multiaddr }` for a joiner that runs a node
-- `{ url }` for one that holds only a key and reaches the admin API over HTTPS
+The peer id has to travel with the address. Resolving an account to a peer needs
+governance state, and a joiner that has synced nothing has none — that
+circularity is why the field exists at all.
 
 Unsigned on purpose. A hint is only *where* to look; who may admit stays inside the
 signature, so a wrong or stale hint costs a failed connection and nothing more —
@@ -135,7 +137,7 @@ A caller can supply them, and otherwise the node resolves them:
 
 | case | what you get |
 | --- | --- |
-| caller passes `admitterHints` | used exactly as given, never merged with the node's own view — a caller naming endpoints is usually correcting that view, not extending it |
+| caller passes `admitterAddrs` | used exactly as given, never merged with the node's own view — a caller naming an address is usually correcting that view, not extending it |
 | the minting node is itself an admitter | its confirmed external addresses, each with its peer id appended, including the relay-circuit form a NAT'd node is reachable on |
 | any other admitter | its last known address, resolved through the node's durable caches |
 
@@ -154,32 +156,29 @@ fewer address for the joiner to try, never a wrong one, because the signed
 `admitters` list still decides who may answer. A mint that can hint nobody says so
 in the log rather than issuing a credential that quietly cannot be redeemed.
 
-### Why no `{ url }` hint is generated
+### Why the field holds addresses and not URLs
 
-Only `{ multiaddr }` hints are produced. That is a deliberate stop, not a missing
-feature, and the two kinds are not equally safe to guess.
+It carries libp2p multiaddrs only, and that is a deliberate narrowing rather than
+a gap.
 
-A multiaddr carries `/p2p/<peer-id>`, which libp2p authenticates during the
-handshake — dial the wrong host and it fails having disclosed nothing. A URL has no
-such property: HTTPS authenticates a domain, not a node. An invitation is a bearer
-credential, so a guessed URL risks presenting a redeemable credential to whatever
-answers there.
+A multiaddr ends in `/p2p/<peer-id>`, which libp2p authenticates during the
+handshake — dial the wrong host and it fails having disclosed nothing. An HTTPS
+URL has no equivalent: it proves a domain, not a node. An invitation is a bearer
+credential, so an address that can be wrong *and* still be talked to is a way to
+hand a redeemable credential to whatever answers.
 
-A node also cannot derive its own. It terminates no TLS and `AuthMode::Proxy` is
-the default, so the address callers should use is a reverse proxy's — different
-host, different port, `https` where the node speaks plain HTTP. `listen` says where
-the process binds, which under a proxy is not an address to send anyone to.
+A node could not derive its own URL anyway. It terminates no TLS and
+`AuthMode::Proxy` is the default, so the address callers should use belongs to a
+reverse proxy — different host, port and scheme from anything `listen` describes.
 
-For the hosted tier this is resolved on the client instead: a keyholder with no node
-writes through delegated execution, which goes via hosted TEE relays, so the client
-falls back to the known relay endpoint when no multiaddr is usable. Note the
-invitation cannot inform that decision — `admitters` are plain accounts with no
-marker saying which are TEE-admitted — so it is an unconditional fallback rather
-than a conditional one.
+For the hosted tier this is answered outside the invitation. A keyholder with no
+node writes through delegated execution, which runs via hosted TEE relays, so the
+client asks whether the namespace has a TEE policy and presents its claim to the
+known relay endpoint. Asking first is what keeps a self-hosted namespace's
+invitation from being handed to a cloud with no business holding it.
 
-A third-party TEE deployment would need its endpoint recorded per node, alongside
-the attestation record that already names it. Nothing stores that yet. Until then,
-pass `--admitter-url` if you know it.
+A third-party TEE deployment would want its endpoint recorded per node, alongside
+the attestation record that already names it. Nothing stores that yet.
 
 ## The two joining flows
 
@@ -195,10 +194,10 @@ Which path a joiner takes is decided by one thing: whether it runs a node.
    re-checks `join_op_proves_ownership` at apply, so an admitter relays a join, it
    never grants one.
 
-`admitter_hints` exists to make step 3 reliable when the joiner is not already
-connected to an admitter. **Today the hints are written into the invitation but
-nothing dials them yet** — a joiner still depends on gossip reaching an admitter.
-Consuming them is a separate change.
+`admitter_addrs` exists to make step 3 reliable when the joiner is not already
+connected to an admitter. **Today the addresses are written into the invitation
+but nothing dials them yet** — a joiner still depends on gossip reaching an
+admitter. Consuming them is a separate change.
 
 ### A joiner holding only a key
 
@@ -212,9 +211,9 @@ and no governance state.
 4. That node verifies the signature, checks it may admit, applies the membership
    locally, and publishes.
 
-Step 3 needs an address, and a multiaddr is no use here — there is no swarm to dial
-one from. So this path wants a `{ url }` hint, which is the one kind a node never
-generates.
+Step 3 needs an address, and `admitter_addrs` is no use here — those are
+multiaddrs, and there is no swarm to dial one from. This path is answered outside
+the invitation, on the client.
 
 For the hosted tier that is resolved on the client rather than in the invitation:
 a keyholder writes through delegated execution, which runs via hosted TEE relays,


### PR DESCRIPTION
Closes #3723.

An invitation names **who** may admit a claim of it, by account, and said nothing
about **where** to find them. `admitter_addrs` exists for exactly that and was
`Vec::new()` at all 22 sites that built an invitation. So a joiner could redeem
one only if it already knew, out of band, how to reach an admitter — and for a
keyholder with no node, the case direct admission exists for, that is the normal
situation rather than an edge case.

## The data was already there

Every link was already on disk and already survived a restart. Nothing had joined
them up:

| link | source | persistence |
| --- | --- | --- |
| account → signing keys | `live_devices_by_account` | RocksDB rows |
| signing key → peer | `PeerIdentityCache` (`calimero-idpeers`) | snapshot every 30s, hydrated at startup, 24h TTL |
| peer → address | `PeerAddrCache` (`calimero-peercch`) | re-persisted on the rendezvous tick, 24h TTL |

The 24h TTL matches `MAX_INVITATION_VALIDITY_SECS`, so a hint cannot outlive the
credential carrying it. Both caches are documented as "routing hint, never
authority", which is exactly the status an unsigned field should have.

## Most of the diff is reach, not logic

Both caches were `pub(crate)`, and the network layer had **no message that
returned peer addresses at all**. So:

- `NetworkMessage::PeerAddrs` over the existing `peer_cache_addrs_for`
- `NodeMessage::PeerAddrsForIdentities` for the identity hop, which lives on `NodeState`
- `NodeClient::peer_addrs`, because the node actor doing the resolving holds a `NodeClient`

The node-side message returns `(PeerId, Multiaddr)` **pairs**, not bare addresses:
an address does not say who answers at it, and the joiner is precisely the party
that cannot look that up. Invitation semantics stay in `crates/context`; the node
layer only deals in identities and addresses.

## Callers can supply hints too

New `admitterAddrs` on both invite routes, and `--admitter-addr` on
`meroctl namespace invite`. Supplied addresses are used **as given** rather than
merged: a caller naming one is usually correcting the node's view, not extending
it.

## Why multiaddrs are generated and URLs never are

A multiaddr carries `/p2p/<peer-id>` and libp2p authenticates it on connect, so a
wrong one fails the handshake having disclosed nothing. A URL has no equivalent —
HTTPS proves a domain, not a node. An invitation is a bearer credential, so a
guessed URL risks presenting a redeemable credential to whatever answers there.

A node also cannot derive its own URL: it terminates no TLS and `AuthMode::Proxy`
is the default, so the address callers should use is a reverse proxy's — different
host, port and scheme from what `listen` describes.

A mint that can hint nobody **warns**, rather than quietly issuing a credential
that cannot be redeemed.

## Scope: this populates, it does not consume

Nothing reads `admitter_addrs` yet. A node joiner still reaches an admitter by
publishing on the namespace topic and relying on gossip. This closes #3723 as
written — the field is populated — but "the invitation contains an address" is not
yet "the joiner uses it". That consumer is a separate, small change now that the
addresses are in the invitation, and it is called out in the docs so the page does
not overstate what works.

## Verification

CI's gate, run verbatim from `ci-checks.yml`:

| command | result |
| --- | --- |
| `cargo fmt --check` | pass |
| `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` | pass |
| `cargo clippy -p merod -p calimero-node -p calimero-server -p calimero-tee-attestation --all-targets --features mock-attestation -- -D warnings` | pass |
| `cargo test -- --nocapture --skip bundle_produces_signed_mpk` | 5262 passed, 0 failed, 0 filtered out |
| `cargo test -p merod -p calimero-node -p calimero-tee-attestation --features mock-attestation -- --nocapture` | 1072 passed, 0 failed, 0 filtered out |

Three new tests cover the endpoint shape, including the relay-circuit case —
dropping circuit addresses would leave exactly the NAT'd nodes that most need a
hint advertising nothing.

Docs updated in three places: `meroctl.mdx` (the flags, and the pre-existing
`--admitter` which was never documented), `admin-api.mdx` (request body and the
tagged endpoint forms), and `direct-admission.mdx` (both joining flows, and what
is not yet wired).


---

## Naming, and the enum that went with it

The field started as `admitter_hints: Vec<AdmitterEndpoint>` and is now
`admitter_addrs: Vec<String>`. "Hints" described how much to trust the field and
never what it held, and it holds exactly one thing: libp2p multiaddrs of peers
that may admit.

The enum's `Url` variant is gone with it. It was write-only — nothing generated
one, nothing read one — and keeping it forced the vague name, because the field
genuinely could have carried two unlike things. Dropping it is what lets the name
be exact, and it simplified the code: dedup is a string compare again rather than
a variant-aware key.

URLs are not coming back here. A node cannot derive its own — it terminates no
TLS and `AuthMode::Proxy` is the default, so the address a caller should use
belongs to a reverse proxy, which `listen` does not describe. The keyholder case
is answered on the client, and a third-party TEE endpoint would belong per-node
beside the attestation record that already names it.

## Cross-repo

Paired with **mero-js#132** (merged). That side is not just a rename: its
`encodeSignedInvitation` borsh-encodes the invitation into the op that gets
signed, and a `Vec<enum>` writes a discriminant ahead of every entry where a
`Vec<String>` does not. Left alone it would have shifted every following byte and
failed as `invalid invitation signature`, an error naming the signature and
pointing nowhere near the encoder. Nothing had tested that function, so two
differential tests now pin the layout — confirmed against an injected regression.

`calimero-client-py` names neither field and picks the type up from its core pin,
so it needs a repin rather than a change. Unlike the `admitters` break that cost
93 scenarios, this field sits **outside** the inviter's signature, so a stale pin
silently drops addresses rather than invalidating an invitation. `merobox`
references nothing here.
