### PR TITLE
test(merod): run a real node on Windows in CI

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -48,6 +48,48 @@ jobs:
       - name: Test the owner-only file helper
         run: cargo test -p calimero-utils-fs
 
+  # The only place merod is RUN on Windows rather than merely built. Everything
+  # else Windows-related in this repository is a build-time property, and "the
+  # binary links" says nothing about whether RocksDB opens, the server binds, or
+  # the node can be stopped -- the three things that have no unix equivalent to
+  # borrow confidence from.
+  #
+  # Costs one Windows runner (~15 min with a warm cache) per pull request. That
+  # is deliberate: a merod.exe that cannot start is shipped to users by the
+  # release workflow, which only builds it.
+  windows-node-smoke:
+    name: Windows node smoke
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        with:
+          shared-key: windows-node-smoke
+
+      # Same two the release build needs: librocksdb-sys is pulled with
+      # `bindgen-runtime`, and aws-lc-sys assembles its x86_64 primitives with NASM.
+      - name: Point bindgen at the image's LLVM
+        shell: bash
+        run: printf 'LIBCLANG_PATH=%s\n' 'C:\Program Files\LLVM\bin' >> "$GITHUB_ENV"
+
+      - name: Install NASM
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
+
+      # `--include-ignored` because these drive a real node and are ignored by
+      # default. The unix-only watches are `cfg(unix)` and simply do not exist
+      # here; what remains is start, serve, stop.
+      - name: Drive a real node on Windows
+        run: cargo test -p merod --test watchdog_live -- --include-ignored --test-threads 1
+
   rust:
     name: Rust
     runs-on: big-machine

--- a/crates/merod/tests/watchdog_live.rs
+++ b/crates/merod/tests/watchdog_live.rs
@@ -88,6 +88,13 @@ fn wait_until_ready(node: &Node) {
 }
 
 fn init(home: &Path, node: &str) {
+    let _ = init_returning_port(home, node);
+}
+
+/// [`init`], reporting the server port it picked, for a test that wants to talk
+/// to the node rather than only watch it exit.
+fn init_returning_port(home: &Path, node: &str) -> u16 {
+    let server_port = free_port();
     let out = Command::new(env!("CARGO_BIN_EXE_merod"))
         .args([
             "--home".as_ref(),
@@ -101,7 +108,7 @@ fn init(home: &Path, node: &str) {
             // failure in a tight loop that floods the log and starves the node.
             "--no-mdns",
             "--server-port",
-            &free_port().to_string(),
+            &server_port.to_string(),
             "--swarm-port",
             &free_port().to_string(),
         ])
@@ -112,6 +119,7 @@ fn init(home: &Path, node: &str) {
         "init: {}",
         String::from_utf8_lossy(&out.stderr)
     );
+    server_port
 }
 
 /// Runs the node and waits until its store is open, so a test that follows is
@@ -153,6 +161,11 @@ fn wait_for_exit(node: &mut Node, what: &str) -> Duration {
 
 /// `SIGKILL` on the parent runs no code, so the closed pipe is the only thing that
 /// can report it. Closing the write end here is that same event.
+///
+/// Unix-only because the mechanism is: `--exit-on-eof` takes a `RawFd` and merod
+/// refuses the flag outright off unix. `the_node_stops_when_its_stdin_closes`
+/// below is the portable form of the same guarantee.
+#[cfg(unix)]
 #[test]
 #[ignore = "drives a real node; needs an environment with netlink"]
 fn the_node_stops_when_the_pipe_to_its_parent_closes() {
@@ -188,6 +201,78 @@ fn the_node_stops_when_the_pipe_to_its_parent_closes() {
 
     let took = wait_for_exit(&mut node, "the pipe closed");
     println!("node exited {took:?} after its parent's pipe closed");
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+/// The whole point of a Windows lane: a node that starts, serves, and stops.
+///
+/// `/admin-api/health` is unauthenticated and answers "alive" only when
+/// `store.ping()` succeeds, so a 200 here is RocksDB opening and answering a
+/// read on this platform — not merely a process that has not exited yet. That
+/// distinction matters: every Windows check before this one was a build-time
+/// property, and "the binary links" says nothing about whether the datastore
+/// works.
+///
+/// Deliberately portable. It is the only test here that asserts the node does
+/// something rather than that it stops doing it.
+#[test]
+#[ignore = "drives a real node; needs an environment with netlink"]
+fn the_node_serves_health_and_then_stops() {
+    use std::io::{Read as _, Write as _};
+
+    let home = scratch("health");
+    let port = init_returning_port(&home, "n1");
+
+    let log = Node::log_path("health");
+    let sink = std::fs::File::create(&log).expect("log file");
+    let child = Command::new(env!("CARGO_BIN_EXE_merod"))
+        .args([
+            "--home".as_ref(),
+            home.as_os_str(),
+            "--node".as_ref(),
+            "n1".as_ref(),
+        ])
+        .args(["run", "--exit-on-stdin-close"])
+        .env("RUST_LOG", "info")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(sink.try_clone().expect("clone log")))
+        .stderr(Stdio::from(sink))
+        .spawn()
+        .expect("spawn merod run");
+    let mut node = Node { child, log };
+    wait_until_ready(&node);
+
+    // Raw HTTP rather than a client crate: one request, and a test dependency
+    // that only this line would justify is not worth the build time on a
+    // Windows runner.
+    let mut sock = std::net::TcpStream::connect(("127.0.0.1", port)).unwrap_or_else(|e| {
+        panic!("the node logged ready but nothing is listening on {port}: {e}")
+    });
+    sock.set_read_timeout(Some(Duration::from_secs(30)))
+        .expect("read timeout");
+    sock.write_all(
+        b"GET /admin-api/health HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+    )
+    .expect("send the health request");
+
+    let mut response = String::new();
+    let _ = sock.read_to_string(&mut response);
+
+    assert!(
+        response.starts_with("HTTP/1.1 200"),
+        "health did not answer 200 — the datastore ping is what this reports on.\nResponse:\n{response}\nNode log:\n{}",
+        node.tail()
+    );
+    assert!(
+        response.contains("alive"),
+        "health answered 200 without reporting alive: {response}"
+    );
+
+    // And it still stops cleanly afterwards, which on Windows is the only
+    // graceful stop there is.
+    drop(node.child.stdin.take().expect("child stdin"));
+    let took = wait_for_exit(&mut node, "stdin closed");
+    println!("node served health, then exited {took:?} after its stdin closed");
     let _ = std::fs::remove_dir_all(&home);
 }
 
@@ -238,6 +323,11 @@ fn the_node_stops_when_its_stdin_closes() {
 
 /// `rm -rf` removes a name, not a file, so nothing tells the node - it has to
 /// notice that the directory it holds is no longer the one at its path.
+/// Unix-only because `data_dir_replaced` identifies a directory by `(dev, ino)`.
+/// Windows has an analogue in `GetFileInformationByHandle`, but until merod uses
+/// it there is no watch there to test — and asserting this on Windows would fail
+/// for a reason that is a known gap rather than a regression.
+#[cfg(unix)]
 #[test]
 #[ignore = "drives a real node; needs an environment with netlink"]
 fn the_node_stops_when_its_data_directory_is_deleted() {
@@ -252,6 +342,10 @@ fn the_node_stops_when_its_data_directory_is_deleted() {
 }
 
 /// The watch must not stop a node whose directory is merely busy.
+///
+/// Runs everywhere. On Windows there is no data-directory watch to mis-fire, so
+/// this degrades into "a node left alone keeps running" — still worth asserting,
+/// since a node that dies on its own is exactly what a smoke test should catch.
 #[test]
 #[ignore = "drives a real node; needs an environment with netlink"]
 fn the_node_keeps_running_while_its_data_directory_is_intact() {
@@ -271,6 +365,10 @@ fn the_node_keeps_running_while_its_data_directory_is_intact() {
 
 /// The control: if this fails too, the node cannot shut down in this environment
 /// at all, and the two watchdogs above are not what broke.
+///
+/// Unix-only: there is no `SIGTERM` on Windows, which is the whole reason
+/// `--exit-on-stdin-close` exists.
+#[cfg(unix)]
 #[test]
 #[ignore = "drives a real node; needs an environment with netlink"]
 fn the_node_stops_on_sigterm() {


### PR DESCRIPTION
Everything Windows-related in this repository is verified at build time. The release workflow builds `merod.exe` and ships it; **nothing anywhere starts it.** "The binary links" says nothing about whether RocksDB opens, whether the server binds, or whether the node can be stopped — and each of those is precisely where Windows differs, so there is no unix result to borrow confidence from.

## Why not merobox

That was the obvious answer, and it does not work today.

`BinaryManager` tears nodes down with `os.kill(pid, signal.SIGTERM)` then `signal.SIGKILL`. **`signal.SIGKILL` does not exist on Windows** — it is an `AttributeError` there — and `os.kill(pid, 0)`, used for liveness, raises rather than reporting. So the `--no-docker --binary-path` mode cannot manage a node's lifecycle on Windows without work in a third repository.

The Docker path is worse, not better: merod would run in a *Linux container* on a Windows host, which tests Linux. Whatever runs has to be `merod.exe` on the host.

Meanwhile `crates/merod/tests/watchdog_live.rs` already drives a real node, and its harness turned out to be entirely portable — `temp_dir`, `TcpListener`, `CARGO_BIN_EXE_merod`, log tailing. It only needed the unix-only *tests* to say they were unix-only.

Fixing merobox for Windows is still worth doing for full workflow coverage (multi-node, app install, sync) and would be a good follow-up — notably, it could use the `--exit-on-stdin-close` from #3757 as its graceful stop there. This gets the floor in place first.

## What runs on Windows now

| Test | What it proves |
| --- | --- |
| `the_node_serves_health_and_then_stops` *(new)* | RocksDB opens **and answers a read**, the server binds, the node stops |
| `the_node_stops_when_its_stdin_closes` | the only graceful stop Windows has |
| `the_node_keeps_running_while_its_data_directory_is_intact` | a node left alone does not die |

`/admin-api/health` is unauthenticated and reports `alive` **only when `store.ping()` succeeds**, so a 200 is the datastore answering — not a process that merely has not exited yet. That distinction is the whole value of the test.

## Three tests are now `cfg(unix)`

Because their mechanisms are:

- `the_node_stops_on_sigterm` — there is no `SIGTERM` on Windows, which is why `--exit-on-stdin-close` exists.
- `the_node_stops_when_the_pipe_to_its_parent_closes` — `--exit-on-eof` takes a `RawFd`, and merod refuses the flag off unix.
- `the_node_stops_when_its_data_directory_is_deleted` — `data_dir_replaced` identifies a directory by `(dev, ino)`. Windows has an analogue in `GetFileInformationByHandle`, but until merod uses it there is no watch to test, and asserting it would fail for a **known gap rather than a regression**.

They compiled on Windows before this — they would simply have failed at runtime.

## Notes

Raw HTTP over `TcpStream` rather than a client crate: one request does not justify a test dependency's build time on a Windows runner.

Locally all six pass on unix in 25.9s, with the new one reporting:

```
node served health, then exited 105.028708ms after its stdin closed
```

## Cost

One Windows runner per pull request, ~15 min with a warm cache — the Windows merod build in the release workflow takes 11 min, comparable to Linux. Deliberate: a `merod.exe` that cannot start is otherwise shipped by a release workflow that only builds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)