### PR TITLE
feat(governance): dial the admitter addresses an invitation carries

### DIFF
--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -1524,6 +1524,23 @@ pub mod bounds {
     /// well over two years to reach it.
     pub const MAX_ROOT_KEY_HANDOFFS: usize = 1_024;
     /// Max entries in a metadata map (`GroupOp::*MetadataSet.data`).
+    /// Admitters named in an invitation, and addresses offered for them.
+    ///
+    /// Both are small by nature — the default set is a group's admins plus its
+    /// TEE nodes — so the cap is about what a *hostile* invitation may claim
+    /// rather than what a real one needs.
+    ///
+    /// `admitter_addrs` matters more than its size suggests. It sits outside the
+    /// inviter's signature, so anyone relaying an invitation may rewrite it, and
+    /// a joiner acts on it by dialing. Unbounded, that turns a relayed invitation
+    /// into a way to point somebody else's node at a list of the sender's
+    /// choosing.
+    pub const MAX_ADMITTERS: usize = 256;
+    /// See [`MAX_ADMITTERS`].
+    pub const MAX_ADMITTER_ADDRS: usize = 256;
+    /// See [`MAX_ADMITTERS`]. Long enough for a relay-circuit multiaddr, which
+    /// names two peers and a transport, with room to spare.
+    pub const MAX_ADMITTER_ADDR_LEN: usize = 512;
     pub const MAX_METADATA_ENTRIES: usize = 1_024;
     /// Max byte length of a metadata name / key / value string.
     pub const MAX_METADATA_STRING_LEN: usize = 8_192;
@@ -1713,9 +1730,46 @@ impl RootOp {
                 bounds::MAX_BLOB_BYTES,
             ),
             Self::KeyDelivery { envelope, .. } => envelope.validate(),
+            // The join variants carry an invitation, and its two admitter lists
+            // are the only attacker-shaped things in one: `admitter_addrs` is
+            // outside the inviter's signature, so a relay may rewrite it, and a
+            // joiner acts on it by dialing.
+            Self::MemberJoined {
+                signed_invitation, ..
+            }
+            | Self::MemberJoinedAt {
+                signed_invitation, ..
+            } => validate_invitation_bounds(signed_invitation),
             _ => Ok(()),
         }
     }
+}
+
+/// Bound the lists an invitation carries.
+///
+/// Split out because two `RootOp` variants embed the same structure, and a bound
+/// applied to one of them is not a bound.
+fn validate_invitation_bounds(
+    signed: &calimero_context_config::types::SignedGroupOpenInvitation,
+) -> Result<(), GovernanceError> {
+    check_bound(
+        "invitation.admitters",
+        signed.invitation.admitters.len(),
+        bounds::MAX_ADMITTERS,
+    )?;
+    check_bound(
+        "invitation.admitter_addrs",
+        signed.admitter_addrs.len(),
+        bounds::MAX_ADMITTER_ADDRS,
+    )?;
+    for addr in &signed.admitter_addrs {
+        check_bound(
+            "invitation.admitter_addrs[]",
+            addr.len(),
+            bounds::MAX_ADMITTER_ADDR_LEN,
+        )?;
+    }
+    Ok(())
 }
 
 impl NamespaceOp {

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -1675,6 +1675,70 @@ mod governance_op_storage_roundtrip {
         assert!(ok.validate().is_ok(), "a normal ciphertext must pass");
     }
 
+    /// Build a `MemberJoinedAt` around `invitation`, the shape a joiner sends.
+    fn join_op_with(invitation: SignedGroupOpenInvitation) -> SignedNamespaceOp {
+        let account = sample_join_account();
+        SignedNamespaceOp {
+            version: SIGNED_NAMESPACE_OP_SCHEMA_VERSION,
+            namespace_id: NamespaceId::from([0u8; 32]),
+            parent_op_hashes: vec![[0u8; 32]],
+            signer: PublicKey::from([0u8; 32]),
+            nonce: 1,
+            op: NamespaceOp::Root(RootOp::MemberJoinedAt {
+                member: account.statement.account,
+                signed_invitation: invitation,
+                joined_at: 1_900_000_000,
+                account,
+            }),
+            signature: [0u8; 64],
+        }
+    }
+
+    #[test]
+    fn validate_bounds_admitter_addrs() {
+        // `admitter_addrs` is outside the inviter's signature, so anyone
+        // relaying an invitation may rewrite it — and a joiner acts on it by
+        // dialing. Unbounded, that is a way to point somebody else's node at a
+        // list of the sender's choosing.
+        let mut invitation = sample_invitation();
+        invitation.admitter_addrs =
+            vec!["/ip4/10.0.0.1/tcp/1".to_owned(); bounds::MAX_ADMITTER_ADDRS + 1];
+        assert!(
+            join_op_with(invitation).validate().is_err(),
+            "an invitation offering more addresses than the bound must be rejected"
+        );
+
+        let mut invitation = sample_invitation();
+        invitation.admitter_addrs = vec!["x".repeat(bounds::MAX_ADMITTER_ADDR_LEN + 1)];
+        assert!(
+            join_op_with(invitation).validate().is_err(),
+            "a single oversized address must be rejected too — a short list of \
+             enormous strings is the same attack"
+        );
+
+        let mut invitation = sample_invitation();
+        invitation.admitter_addrs = vec![
+            "/ip4/203.0.113.7/tcp/2528/p2p/12D3KooWExample".to_owned(),
+            "/ip4/198.51.100.4/tcp/4001/p2p/12D3KooWRelay/p2p-circuit/p2p/12D3KooWTarget"
+                .to_owned(),
+        ];
+        assert!(
+            join_op_with(invitation).validate().is_ok(),
+            "a realistic pair of addresses, including a relay circuit, must pass"
+        );
+    }
+
+    #[test]
+    fn validate_bounds_admitters() {
+        let mut invitation = sample_invitation();
+        invitation.invitation.admitters =
+            vec![calimero_account::AccountId::from([1u8; 32]); bounds::MAX_ADMITTERS + 1];
+        assert!(
+            join_op_with(invitation).validate().is_err(),
+            "an invitation naming more admitters than the bound must be rejected"
+        );
+    }
+
     #[test]
     fn validate_bounds_parent_op_hashes() {
         let mut op = SignedNamespaceOp {

--- a/crates/network/primitives/src/client.rs
+++ b/crates/network/primitives/src/client.rs
@@ -51,6 +51,14 @@ impl NetworkClient {
         Self { network_manager }
     }
 
+    /// Dial a peer.
+    ///
+    /// Unlike its siblings here, this reports a closed mailbox as an error
+    /// rather than panicking on it. Those assume the network actor outlives the
+    /// caller, which holds for anything running while the node is up — but a
+    /// dial can be issued on a path that races shutdown, and a node tearing down
+    /// is not a reason to panic a node. The signature already carries an error;
+    /// this uses it.
     pub async fn dial(&self, peer_addr: Multiaddr) -> eyre::Result<()> {
         let (tx, rx) = oneshot::channel();
 
@@ -60,9 +68,10 @@ impl NetworkClient {
                 outcome: tx,
             })
             .await
-            .expect("Mailbox not to be dropped");
+            .map_err(|e| eyre::eyre!("network mailbox unavailable: {e}"))?;
 
-        rx.await.expect("Mailbox not to be dropped")
+        rx.await
+            .map_err(|e| eyre::eyre!("network dropped the dial response: {e}"))?
     }
 
     pub async fn listen_on(&self, addr: Multiaddr) -> eyre::Result<()> {

--- a/crates/node/src/join_namespace.rs
+++ b/crates/node/src/join_namespace.rs
@@ -316,6 +316,56 @@ pub async fn join_namespace(
 /// Document this asymmetry rather than wrap the publish in another
 /// timeout layer (which would race with the publish's own ack-collection
 /// logic).
+/// How many of an invitation's addresses this node will dial.
+///
+/// Deliberately far below the decode bound. `admitter_addrs` sits outside the
+/// inviter's signature, so anyone relaying an invitation may rewrite it, and
+/// dialing is an action taken on a stranger's say-so. A real invitation names a
+/// handful of admitters; anything past that is not a joiner being helped.
+const MAX_ADMITTER_DIALS: usize = 8;
+
+/// Dial the addresses an invitation offers, best-effort, before publishing.
+///
+/// Failures are expected and ignored: an address is a snapshot from mint time
+/// and may be stale, the peer may be down, and none of that should fail a join
+/// that gossip may well complete anyway. What this buys is the case gossip
+/// cannot cover — a joiner connected to nobody who may admit.
+///
+/// Nothing here trusts the address. libp2p authenticates the peer id during the
+/// handshake, and admission is decided by the *signed* `admitters` list at
+/// apply, on every peer. A wrong address costs a failed dial.
+async fn dial_admitter_addrs(node_client: &NodeClient, op: &NamespaceOp) {
+    let NamespaceOp::Root(RootOp::MemberJoinedAt {
+        signed_invitation, ..
+    }) = op
+    else {
+        return;
+    };
+
+    let mut dialed = 0usize;
+    for addr in &signed_invitation.admitter_addrs {
+        if dialed == MAX_ADMITTER_DIALS {
+            tracing::debug!(
+                offered = signed_invitation.admitter_addrs.len(),
+                dialed,
+                "invitation offers more admitter addresses than this node will dial"
+            );
+            break;
+        }
+        let Ok(parsed) = addr.parse::<libp2p::Multiaddr>() else {
+            tracing::debug!(%addr, "skipping unparseable admitter address");
+            continue;
+        };
+        dialed += 1;
+        match node_client.network_client().dial(parsed).await {
+            Ok(()) => tracing::debug!(%addr, "dialed an admitter named by the invitation"),
+            // Stale or unreachable is the ordinary case, not a fault: the
+            // address was recorded when the invitation was minted.
+            Err(err) => tracing::debug!(%addr, %err, "admitter address did not dial"),
+        }
+    }
+}
+
 pub async fn await_namespace_ready(
     store: &Store,
     node_client: &NodeClient,
@@ -431,6 +481,13 @@ pub async fn await_namespace_ready(
         joined_at: now_secs,
         account: join_account,
     });
+    // Reach an admitter before publishing. The op goes out on the namespace
+    // topic, so it only lands if somebody who may admit is actually connected —
+    // and a joiner that has synced nothing has no reason to be connected to
+    // anyone in particular. Dialing first is what turns the addresses the
+    // invitation carries into a join that completes.
+    dial_admitter_addrs(node_client, &op).await;
+
     let report = NamespaceGovernance::new(store, namespace_id.into())
         .sign_and_publish_without_apply(node_client, ack_router, &signing_key, op, None)
         .await


### PR DESCRIPTION
Follows #3770, which populated the field. This is the reader.

## What changes for a joiner

A joiner publishes `MemberJoinedAt` on the namespace topic and relies on gossip
reaching somebody who may admit. That works when it is already connected to one,
and is precisely the problem when it is not — which is the ordinary state for a
node that has synced nothing.

It now dials the addresses the invitation carries, then publishes as before. No
new protocol: the op still travels the topic, and dialing only makes it likely a
peer who can admit is there to hear it.

Failures are ignored by design. An address is a snapshot from mint time, so stale
or unreachable is the common case, and it should not fail a join that gossip may
complete anyway.

Nothing here trusts the address: libp2p authenticates the peer id during the
handshake, and admission is decided by the **signed** `admitters` list at apply on
every peer. A wrong address costs a failed dial.

## The bounds are the other half, and belong in this PR

`admitter_addrs` sits **outside** the inviter's signature, so anyone relaying an
invitation may rewrite it — and as of this change a joiner *acts* on it by
dialing. Unbounded, that is a way to point somebody else's node at a list of the
sender's choosing; the 64 KiB op cap leaves room for on the order of a thousand
short addresses.

The field was harmless while nothing read it. Adding the reader is what creates
the exposure, so the bound ships in the same change rather than as a follow-up.

| bound | value | why |
| --- | --- | --- |
| `MAX_ADMITTERS` | 256 | The real set is a group's admins plus its TEE nodes |
| `MAX_ADMITTER_ADDRS` | 256 | Same shape |
| `MAX_ADMITTER_ADDR_LEN` | 512 | Fits a relay-circuit multiaddr, which names two peers and a transport |
| `MAX_ADMITTER_DIALS` | **8** | What this node will act on, not what an invitation may claim |

Two things worth calling out:

- The join variants previously fell through `RootOp::validate`'s `_ => Ok(())`,
  so **neither** list was bounded at all. That predates #3770.
- The check is a single helper because `MemberJoined` and `MemberJoinedAt` both
  embed an invitation, and a bound applied to one of them is not a bound.
- The dial cap is deliberately far below the decode bound. One is what a hostile
  invitation may *claim*; the other is what this node will *do*.

## Tests

Three new, all against `SignedNamespaceOp::validate` through a real
`MemberJoinedAt`:

- more addresses than the bound → rejected
- one oversized address → rejected (a short list of enormous strings is the same
  attack, and a count-only bound would miss it)
- a realistic pair including a relay circuit → accepted

## Verification

| command | result |
| --- | --- |
| `cargo fmt --check` | pass |
| `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` | pass |
| `cargo clippy -p merod -p calimero-node -p calimero-server -p calimero-tee-attestation --all-targets --features mock-attestation -- -D warnings` | pass |
| `cargo test -- --nocapture --skip bundle_produces_signed_mpk` | 5264 passed, 0 failed, 0 filtered out |
| `cargo test -p merod -p calimero-node -p calimero-tee-attestation --features mock-attestation -- --nocapture` | 1072 passed, 0 failed, 0 filtered out |

5262 → 5264 is the two new bound tests; both confirmed by name rather than
inferred from the total.

## Scope

The dial happens on the node-joiner path (`await_namespace_ready`). A keyholder
with no node does not dial at all — it has no swarm — and reaches an admitter over
the admin API instead, which is unchanged here.
