### PR TITLE
feat(sync): a join stream prefers the admitters the invitation named

### DIFF
--- a/crates/node/src/sync/manager/namespace_join.rs
+++ b/crates/node/src/sync/manager/namespace_join.rs
@@ -67,15 +67,37 @@ const MAX_PEERS_PER_ROUND: usize = 4;
 /// `discovery_wait` elapses / the retry budget exhausts. The `peer_id`
 /// lets the caller record a rejection and pass the peer back via
 /// `excluded_peers` on the next call.
+/// How long the connect loop may spend, and how hard it may try.
+///
+/// Grouped because they are one decision, and because four bare `Duration` and
+/// `u32` arguments in a row are transposable at the call site in a way the
+/// compiler cannot catch — swapping the per-peer timeout with the retry delay
+/// type-checks perfectly and changes the behaviour.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ConnectBudget {
+    /// Per-peer stream-open timeout.
+    pub(super) open_timeout: std::time::Duration,
+    /// Rounds to spend once candidates exist and keep failing.
+    pub(super) mesh_retries: u32,
+    /// Pause between rounds, and the poll cadence while waiting for discovery.
+    pub(super) mesh_retry_delay: std::time::Duration,
+    /// Overall deadline for the whole connect loop.
+    pub(super) discovery_wait: std::time::Duration,
+}
+
 pub(super) async fn open_namespace_join_stream(
     sync_network: &dyn SyncNetwork,
     namespace_id: [u8; 32],
-    open_timeout: std::time::Duration,
-    mesh_retries: u32,
-    mesh_retry_delay: std::time::Duration,
-    discovery_wait: std::time::Duration,
+    budget: ConnectBudget,
     excluded_peers: &HashSet<PeerId>,
+    preferred_peers: &[PeerId],
 ) -> eyre::Result<(Stream, PeerId)> {
+    let ConnectBudget {
+        open_timeout,
+        mesh_retries,
+        mesh_retry_delay,
+        discovery_wait,
+    } = budget;
     // Degenerate budgets are a misconfiguration, not a runtime condition:
     // a zero `discovery_wait` makes the first deadline check fire
     // immediately, and a zero `mesh_retries` makes `failed_attempts >=
@@ -118,8 +140,34 @@ pub(super) async fn open_namespace_join_stream(
         }
 
         let discovered = sync_network.subscribed_peers(topic.clone()).await;
-        let discovered_any = !discovered.is_empty();
-        let mut peers = discovered;
+
+        // Peers the invitation named as admitters come first, and are tried
+        // even when discovery has surfaced nobody.
+        //
+        // Both halves matter. Ordering, because only an admitter can complete
+        // this join — a shuffled subscriber that is not one costs a round trip
+        // to be told no. And presence-regardless-of-discovery, because
+        // `subscribed_peers` answers "who is on the topic mesh", which is
+        // exactly what has not converged yet in the case this join path exists
+        // for. The joiner dialed these addresses moments ago, so the transport
+        // may well be up while the mesh is not.
+        let mut peers: Vec<PeerId> = preferred_peers
+            .iter()
+            .copied()
+            .filter(|p| !excluded_peers.contains(p))
+            .collect();
+        // Preferred peers are candidates in their own right, so a round that
+        // has them is not a cold start even with an empty subscriber set —
+        // otherwise the loop would sleep out the discovery budget while
+        // holding an address it could have tried.
+        let discovered_any = !discovered.is_empty() || !peers.is_empty();
+        let preferred_count = peers.len();
+        let already: HashSet<PeerId> = peers.iter().copied().collect();
+        peers.extend(
+            discovered
+                .into_iter()
+                .filter(|p| !already.contains(p) && !excluded_peers.contains(p)),
+        );
         // Filter excluded peers before shuffling so an excluded peer
         // doesn't get picked first and then `continue`'d — that would
         // burn a slot in the shuffle order. Filtering up-front also
@@ -171,7 +219,12 @@ pub(super) async fn open_namespace_join_stream(
         // shuffling so one round can't burn the whole budget on a large
         // all-hanging mesh; the shuffle keeps successive rounds sampling
         // different peers.
-        peers.shuffle(&mut rand::thread_rng());
+        // Shuffle within each band rather than across them: the preferred
+        // prefix keeps its priority while successive rounds still sample
+        // different peers inside it, which is what the shuffle was for.
+        let (preferred, rest) = peers.split_at_mut(preferred_count);
+        preferred.shuffle(&mut rand::thread_rng());
+        rest.shuffle(&mut rand::thread_rng());
         peers.truncate(MAX_PEERS_PER_ROUND);
 
         for peer in &peers {
@@ -248,18 +301,17 @@ mod tests {
     /// the loop iterates the full retry budget when peers all fail,
     /// so individual values stay small.
     ///
-    /// `discovery_wait` is sized well above `mesh_retries` worth of
+    /// `budget.discovery_wait` is sized well above `mesh_retries` worth of
     /// failed rounds so the peer-present tests bind on the retry count
     /// (their historical behaviour); the cold-start tests bind on this
     /// budget instead.
-    fn defaults() -> (Duration, u32, Duration, Duration) {
-        // open_timeout, mesh_retries, mesh_retry_delay, discovery_wait
-        (
-            Duration::from_millis(100),
-            3,
-            Duration::from_millis(50),
-            Duration::from_millis(1_350),
-        )
+    fn defaults() -> ConnectBudget {
+        ConnectBudget {
+            open_timeout: Duration::from_millis(100),
+            mesh_retries: 3,
+            mesh_retry_delay: Duration::from_millis(50),
+            discovery_wait: Duration::from_millis(1_350),
+        }
     }
 
     /// Default-empty exclusion set for tests that don't need to
@@ -268,9 +320,86 @@ mod tests {
         HashSet::new()
     }
 
+    /// An admitter named by the invitation is tried before a peer that
+    /// merely happens to be subscribed.
+    ///
+    /// Only an admitter can complete the join, so picking a subscriber first
+    /// costs a round trip whose only possible outcome is a refusal.
+    #[tokio::test(start_paused = true)]
+    async fn a_named_admitter_is_tried_before_a_mere_subscriber() {
+        let mock = MockSyncNetwork::default();
+        let subscriber = PeerId::random();
+        let admitter = PeerId::random();
+        mock.push_subscribed_peers(vec![subscriber]);
+        let budget = defaults();
+        // Exactly one success: whoever is tried first takes it.
+        mock.push_open_stream_ok();
+
+        let (_stream, peer) =
+            open_namespace_join_stream(&mock, NAMESPACE_ID, budget, &no_excluded(), &[admitter])
+                .await
+                .expect("a reachable admitter opens");
+
+        assert_eq!(
+            peer, admitter,
+            "the invitation's admitter must be tried before an unrelated subscriber"
+        );
+    }
+
+    /// A named admitter is tried even when discovery has surfaced nobody.
+    ///
+    /// This is the case the whole path exists for: `subscribed_peers` answers
+    /// "who is on the topic mesh", and the mesh is exactly what has not
+    /// converged yet. The joiner dialed this address moments earlier, so the
+    /// transport can be up while the mesh is empty — waiting out the discovery
+    /// budget would be waiting for something it does not need.
+    #[tokio::test(start_paused = true)]
+    async fn a_named_admitter_is_tried_with_no_discovered_peers() {
+        let mock = MockSyncNetwork::default();
+        let admitter = PeerId::random();
+        // Discovery surfaces nothing at all.
+        mock.push_subscribed_peers(vec![]);
+        let budget = defaults();
+        mock.push_open_stream_ok();
+
+        let (_stream, peer) =
+            open_namespace_join_stream(&mock, NAMESPACE_ID, budget, &no_excluded(), &[admitter])
+                .await
+                .expect("an admitter is reachable even with an empty subscriber set");
+
+        assert_eq!(peer, admitter);
+    }
+
+    /// An excluded admitter is not retried just for being named.
+    ///
+    /// `excluded_peers` carries the peers that already refused this join;
+    /// preferring the invitation's list must not resurrect one of them.
+    #[tokio::test(start_paused = true)]
+    async fn a_named_admitter_that_already_refused_is_not_retried() {
+        let mock = MockSyncNetwork::default();
+        let admitter = PeerId::random();
+        let subscriber = PeerId::random();
+        mock.push_subscribed_peers(vec![subscriber]);
+        let budget = defaults();
+        mock.push_open_stream_ok();
+
+        let mut excluded = HashSet::new();
+        let _ = excluded.insert(admitter);
+
+        let (_stream, peer) =
+            open_namespace_join_stream(&mock, NAMESPACE_ID, budget, &excluded, &[admitter])
+                .await
+                .expect("falls through to the subscriber");
+
+        assert_eq!(
+            peer, subscriber,
+            "an admitter that already refused must stay excluded"
+        );
+    }
+
     /// All peers in every round return Err → function returns Err
     /// with the deadline+elapsed signature. We seed exactly the
-    /// expected error count (retries × peers = 6) and assert
+    /// expected error count (budget.mesh_retries × peers = 6) and assert
     /// `assert_all_consumed` so an early-exit regression — which
     /// would leave unconsumed entries — fails this test loudly.
     #[tokio::test(start_paused = true)]
@@ -280,24 +409,16 @@ mod tests {
         let p2 = PeerId::random();
         // Sticky-last on mesh_peers means every round sees this pair.
         mock.push_subscribed_peers(vec![p1, p2]);
-        let (open_timeout, retries, retry_delay, discovery_wait) = defaults();
+        let budget = defaults();
         // Each round tries every peer (3 × 2 = 6 attempts) and the
         // retry budget exhausts before any extra inner-loop attempt.
-        let expected_open_calls = (retries as usize) * 2;
+        let expected_open_calls = (budget.mesh_retries as usize) * 2;
         for i in 0..expected_open_calls {
             mock.push_open_stream_err(format!("err-{i}"));
         }
 
-        let result = open_namespace_join_stream(
-            &mock,
-            NAMESPACE_ID,
-            open_timeout,
-            retries,
-            retry_delay,
-            discovery_wait,
-            &no_excluded(),
-        )
-        .await;
+        let result =
+            open_namespace_join_stream(&mock, NAMESPACE_ID, budget, &no_excluded(), &[]).await;
 
         let err = result.unwrap_err().to_string();
         assert!(
@@ -316,7 +437,7 @@ mod tests {
         mock.assert_all_consumed();
     }
 
-    /// Peer hangs past `open_timeout` → `tokio::time::timeout` fires
+    /// Peer hangs past `budget.open_timeout` → `tokio::time::timeout` fires
     /// and the loop continues with the next peer. With all peers
     /// hanging, eventually the deadline is hit and Err is returned.
     /// Under `start_paused` the test completes in virtual-time
@@ -325,43 +446,36 @@ mod tests {
     async fn hanging_peers_are_interrupted_by_per_peer_timeout() {
         let mock = MockSyncNetwork::default();
         mock.push_subscribed_peers(vec![PeerId::random(), PeerId::random()]);
-        // Every peer hangs far longer than open_timeout; tokio's
+        // Every peer hangs far longer than budget.open_timeout; tokio's
         // timeout should fire each time and we move on.
         for i in 0..20 {
             mock.push_open_stream_hang(Duration::from_secs(10), format!("hang-{i}"));
         }
 
-        let (open_timeout, retries, retry_delay, discovery_wait) = defaults();
+        let budget = defaults();
         let start = time::Instant::now();
-        let result = open_namespace_join_stream(
-            &mock,
-            NAMESPACE_ID,
-            open_timeout,
-            retries,
-            retry_delay,
-            discovery_wait,
-            &no_excluded(),
-        )
-        .await;
+        let result =
+            open_namespace_join_stream(&mock, NAMESPACE_ID, budget, &no_excluded(), &[]).await;
         let elapsed = start.elapsed();
 
         assert!(result.is_err(), "expected Err from hanging peers, got Ok");
         // Peers are present every round, so the loop binds on the
-        // retry budget: `retries` rounds, each spending one
-        // `open_timeout` per hanging peer plus an inter-round sleep.
+        // retry budget: `budget.mesh_retries` rounds, each spending one
+        // `budget.open_timeout` per hanging peer plus an inter-round sleep.
         // Bound generously by the whole discovery budget plus one
-        // extra open_timeout slot (the per-peer check may bail an
+        // extra budget.open_timeout slot (the per-peer check may bail an
         // in-flight attempt up to one timeout late).
-        let upper_bound = discovery_wait.saturating_add(open_timeout);
+        let upper_bound = budget.discovery_wait.saturating_add(budget.open_timeout);
         assert!(
             elapsed <= upper_bound,
-            "loop took {elapsed:?}, expected ≤ {upper_bound:?} (discovery_wait {discovery_wait:?} \
-             + one open_timeout slot)"
+            "loop took {elapsed:?}, expected ≤ {upper_bound:?} (discovery_wait {:?} \
+             + one open_timeout slot)",
+            budget.discovery_wait
         );
     }
 
     /// Empty mesh in every round → no peers ever tried → Err once the
-    /// `discovery_wait` budget elapses (cold-start polling path).
+    /// `budget.discovery_wait` budget elapses (cold-start polling path).
     #[tokio::test(start_paused = true)]
     async fn empty_mesh_every_round_returns_err() {
         let mock = MockSyncNetwork::default();
@@ -369,17 +483,9 @@ mod tests {
         // (the "never seeded" path; production-legitimate when the
         // mesh hasn't formed yet).
 
-        let (open_timeout, retries, retry_delay, discovery_wait) = defaults();
-        let result = open_namespace_join_stream(
-            &mock,
-            NAMESPACE_ID,
-            open_timeout,
-            retries,
-            retry_delay,
-            discovery_wait,
-            &no_excluded(),
-        )
-        .await;
+        let budget = defaults();
+        let result =
+            open_namespace_join_stream(&mock, NAMESPACE_ID, budget, &no_excluded(), &[]).await;
 
         assert!(
             result.is_err(),
@@ -401,43 +507,38 @@ mod tests {
             mock.push_open_stream_hang(Duration::from_secs(60), format!("h-{i}"));
         }
 
-        let open_timeout = Duration::from_millis(200);
-        let mesh_retries: u32 = 10; // high enough not to bind first
-        let mesh_retry_delay = Duration::from_millis(10);
-        // Tight budget so the per-peer check inside the peer loop is
-        // what bounds the run.
-        let discovery_wait = Duration::from_millis(500);
+        // Tight discovery budget so the per-peer check inside the peer loop is
+        // what bounds the run; retries high enough not to bind first.
+        let budget = ConnectBudget {
+            open_timeout: Duration::from_millis(200),
+            mesh_retries: 10,
+            mesh_retry_delay: Duration::from_millis(10),
+            discovery_wait: Duration::from_millis(500),
+        };
 
         let start = time::Instant::now();
-        let result = open_namespace_join_stream(
-            &mock,
-            NAMESPACE_ID,
-            open_timeout,
-            mesh_retries,
-            mesh_retry_delay,
-            discovery_wait,
-            &no_excluded(),
-        )
-        .await;
+        let result =
+            open_namespace_join_stream(&mock, NAMESPACE_ID, budget, &no_excluded(), &[]).await;
         let elapsed = start.elapsed();
 
         assert!(result.is_err());
-        // Bail no later than the budget plus one in-flight open_timeout
+        // Bail no later than the budget plus one in-flight budget.open_timeout
         // slot (the per-peer check may interrupt an attempt up to one
         // timeout late).
-        let upper_bound = discovery_wait.saturating_add(open_timeout);
+        let upper_bound = budget.discovery_wait.saturating_add(budget.open_timeout);
         assert!(
             elapsed <= upper_bound,
-            "loop took {elapsed:?}, expected ≤ {upper_bound:?} (budget {discovery_wait:?} + \
-             one open_timeout slot)"
+            "loop took {elapsed:?}, expected ≤ {upper_bound:?} (discovery_wait {:?} + \
+             one open_timeout slot)",
+            budget.discovery_wait
         );
     }
 
     /// A single round tries at most `MAX_PEERS_PER_ROUND` peers, even on
     /// a larger mesh — so one round can't monopolise the budget. Proven
     /// by timing: with a one-round budget and every peer hanging for
-    /// `open_timeout`, the round costs `MAX_PEERS_PER_ROUND × open_timeout`,
-    /// not `mesh_size × open_timeout`.
+    /// `budget.open_timeout`, the round costs `MAX_PEERS_PER_ROUND × budget.open_timeout`,
+    /// not `mesh_size × budget.open_timeout`.
     #[tokio::test(start_paused = true)]
     async fn round_fan_out_is_capped() {
         let mock = MockSyncNetwork::default();
@@ -449,34 +550,30 @@ mod tests {
             mock.push_open_stream_hang(Duration::from_secs(60), format!("h-{i}"));
         }
 
-        let open_timeout = Duration::from_millis(100);
-        let mesh_retries: u32 = 1; // one round, then give up
-        let mesh_retry_delay = Duration::from_millis(10);
-        // Large enough that the budget never bounds the single round.
-        let discovery_wait = Duration::from_secs(10);
+        // One round then give up, with a discovery budget large enough that it
+        // never bounds that round.
+        let budget = ConnectBudget {
+            open_timeout: Duration::from_millis(100),
+            mesh_retries: 1,
+            mesh_retry_delay: Duration::from_millis(10),
+            discovery_wait: Duration::from_secs(10),
+        };
 
         let start = time::Instant::now();
-        let result = open_namespace_join_stream(
-            &mock,
-            NAMESPACE_ID,
-            open_timeout,
-            mesh_retries,
-            mesh_retry_delay,
-            discovery_wait,
-            &no_excluded(),
-        )
-        .await;
+        let result =
+            open_namespace_join_stream(&mock, NAMESPACE_ID, budget, &no_excluded(), &[]).await;
         let elapsed = start.elapsed();
 
         assert!(result.is_err());
         // Exactly the cap's worth of per-peer timeouts, not the whole
-        // mesh: ≥ cap × open_timeout, and < (cap + 1) × open_timeout.
+        // mesh: ≥ cap × budget.open_timeout, and < (cap + 1) × budget.open_timeout.
         let cap = MAX_PEERS_PER_ROUND as u32;
         assert!(
-            elapsed >= open_timeout.saturating_mul(cap)
-                && elapsed < open_timeout.saturating_mul(cap + 1),
-            "round tried peers for {elapsed:?}, expected ≈ {cap} × {open_timeout:?} \
-             (cap), not the whole {mesh_size}-peer mesh"
+            elapsed >= budget.open_timeout.saturating_mul(cap)
+                && elapsed < budget.open_timeout.saturating_mul(cap + 1),
+            "round tried peers for {elapsed:?}, expected ≈ {cap} × {:?} \
+             (cap), not the whole {mesh_size}-peer mesh",
+            budget.open_timeout
         );
     }
 
@@ -488,17 +585,9 @@ mod tests {
     async fn accepts_arc_dyn_sync_network() {
         let mock: Arc<dyn SyncNetwork> = Arc::new(MockSyncNetwork::default());
 
-        let (open_timeout, retries, retry_delay, discovery_wait) = defaults();
-        let result = open_namespace_join_stream(
-            &*mock,
-            NAMESPACE_ID,
-            open_timeout,
-            retries,
-            retry_delay,
-            discovery_wait,
-            &no_excluded(),
-        )
-        .await;
+        let budget = defaults();
+        let result =
+            open_namespace_join_stream(&*mock, NAMESPACE_ID, budget, &no_excluded(), &[]).await;
         // Empty mesh → Err is expected; we're just checking the
         // type coercion compiles and runs.
         assert!(result.is_err());
@@ -519,7 +608,7 @@ mod tests {
         excluded.insert(p1);
         excluded.insert(p2);
 
-        let (open_timeout, retries, retry_delay, discovery_wait) = defaults();
+        let budget = defaults();
         // Crucially: NO `push_open_stream_*` calls. If the connect
         // loop tries to open_stream against an excluded peer, the
         // mock's "no queued response" Err surfaces — but that would
@@ -527,16 +616,7 @@ mod tests {
         // discovered peer is excluded, which counts as a failed round
         // (not a cold-start wait), so the Err returns after the retry
         // budget without consuming the open_stream queue.
-        let result = open_namespace_join_stream(
-            &mock,
-            NAMESPACE_ID,
-            open_timeout,
-            retries,
-            retry_delay,
-            discovery_wait,
-            &excluded,
-        )
-        .await;
+        let result = open_namespace_join_stream(&mock, NAMESPACE_ID, budget, &excluded, &[]).await;
 
         let err = result.unwrap_err().to_string();
         assert!(
@@ -565,7 +645,7 @@ mod tests {
         let blocked = PeerId::random();
         // `mesh_peers` is sticky-last in the mock (see module doc): a
         // single `push_subscribed_peers` call seeds the same list for every
-        // round. The test budget below (`retries` open_stream Errs)
+        // round. The test budget below (`budget.mesh_retries` open_stream Errs)
         // depends on that — if sticky-last ever changes to return an
         // empty list after the first read, the assertion below would
         // pass vacuously instead of guarding the filter behaviour.
@@ -574,26 +654,17 @@ mod tests {
         excluded.insert(blocked);
 
         // Per-round one peer remains → one open_stream attempt per
-        // round → `retries` attempts total. Seed exactly that many
+        // round → `budget.mesh_retries` attempts total. Seed exactly that many
         // errors and assert_all_consumed below catches both
         // "filter let the blocked peer through" (would consume more
         // than seeded → error on exhaust) and "filter blocked the
         // kept peer too" (would consume fewer → unconsumed Errs).
-        let (open_timeout, retries, retry_delay, discovery_wait) = defaults();
-        for i in 0..(retries as usize) {
+        let budget = defaults();
+        for i in 0..(budget.mesh_retries as usize) {
             mock.push_open_stream_err(format!("kept-err-{i}"));
         }
 
-        let result = open_namespace_join_stream(
-            &mock,
-            NAMESPACE_ID,
-            open_timeout,
-            retries,
-            retry_delay,
-            discovery_wait,
-            &excluded,
-        )
-        .await;
+        let result = open_namespace_join_stream(&mock, NAMESPACE_ID, budget, &excluded, &[]).await;
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("excluded 1"),
@@ -620,17 +691,9 @@ mod tests {
             .push_open_stream_err("peer rejected")
             .push_open_stream_ok();
 
-        let (open_timeout, retries, retry_delay, discovery_wait) = defaults();
-        let result = open_namespace_join_stream(
-            &mock,
-            NAMESPACE_ID,
-            open_timeout,
-            retries,
-            retry_delay,
-            discovery_wait,
-            &no_excluded(),
-        )
-        .await;
+        let budget = defaults();
+        let result =
+            open_namespace_join_stream(&mock, NAMESPACE_ID, budget, &no_excluded(), &[]).await;
 
         assert!(
             result.is_ok(),
@@ -651,7 +714,7 @@ mod tests {
     async fn cold_start_peer_appearing_after_retry_budget_is_found() {
         let mock = MockSyncNetwork::default();
         let peer = PeerId::random();
-        // Empty for `retries` (3) rounds, then the peer shows up
+        // Empty for `budget.mesh_retries` (3) rounds, then the peer shows up
         // (sticky-last keeps returning it thereafter).
         mock.push_subscribed_peers(vec![])
             .push_subscribed_peers(vec![])
@@ -659,21 +722,13 @@ mod tests {
             .push_subscribed_peers(vec![peer]);
         mock.push_open_stream_ok();
 
-        let (open_timeout, retries, retry_delay, discovery_wait) = defaults();
+        let budget = defaults();
         assert_eq!(
-            retries, 3,
-            "test assumes the peer appears after exactly `retries` empty rounds"
+            budget.mesh_retries, 3,
+            "test assumes the peer appears after exactly `budget.mesh_retries` empty rounds"
         );
-        let result = open_namespace_join_stream(
-            &mock,
-            NAMESPACE_ID,
-            open_timeout,
-            retries,
-            retry_delay,
-            discovery_wait,
-            &no_excluded(),
-        )
-        .await;
+        let result =
+            open_namespace_join_stream(&mock, NAMESPACE_ID, budget, &no_excluded(), &[]).await;
 
         assert!(
             result.is_ok(),
@@ -684,7 +739,7 @@ mod tests {
     }
 
     /// The cold-start (nothing-discovered-yet) wait spans the whole
-    /// `discovery_wait` budget, not the much shorter
+    /// `budget.discovery_wait` budget, not the much shorter
     /// `mesh_retries × mesh_retry_delay` floor that bounded the prior
     /// round-counted loop. Empty mesh forever → Err only after ~the
     /// full budget elapses.
@@ -693,33 +748,30 @@ mod tests {
         let mock = MockSyncNetwork::default();
         // Never seeded → `subscribed_peers` always empty (cold start).
 
-        let (open_timeout, retries, retry_delay, discovery_wait) = defaults();
+        let budget = defaults();
         let start = time::Instant::now();
-        let result = open_namespace_join_stream(
-            &mock,
-            NAMESPACE_ID,
-            open_timeout,
-            retries,
-            retry_delay,
-            discovery_wait,
-            &no_excluded(),
-        )
-        .await;
+        let result =
+            open_namespace_join_stream(&mock, NAMESPACE_ID, budget, &no_excluded(), &[]).await;
         let elapsed = start.elapsed();
 
         assert!(result.is_err(), "empty mesh forever should still error");
-        // Must wait well past the old `retries × retry_delay` floor
+        // Must wait well past the old `budget.mesh_retries × budget.mesh_retry_delay` floor
         // (3 × 50ms = 150ms) — that floor giving up early was the bug.
-        let old_round_floor = retry_delay.saturating_mul(retries);
+        let old_round_floor = budget.mesh_retry_delay.saturating_mul(budget.mesh_retries);
         assert!(
             elapsed > old_round_floor,
             "cold-start gave up after {elapsed:?}, at/under the old round floor \
-             {old_round_floor:?} — it should wait the discovery budget {discovery_wait:?}"
+             {old_round_floor:?} — it should wait the discovery budget {:?}",
+            budget.discovery_wait
         );
         // And must not overrun the budget by more than one poll cadence.
         assert!(
-            elapsed <= discovery_wait.saturating_add(retry_delay),
-            "cold-start waited {elapsed:?}, expected ≤ budget {discovery_wait:?} + one poll"
+            elapsed
+                <= budget
+                    .discovery_wait
+                    .saturating_add(budget.mesh_retry_delay),
+            "cold-start waited {elapsed:?}, expected ≤ budget {:?} + one poll",
+            budget.discovery_wait
         );
     }
 
@@ -730,16 +782,17 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn degenerate_budgets_return_err_not_panic() {
         let mock = MockSyncNetwork::default();
-        let (open_timeout, retries, retry_delay, discovery_wait) = defaults();
+        let budget = defaults();
 
         let zero_wait = open_namespace_join_stream(
             &mock,
             NAMESPACE_ID,
-            open_timeout,
-            retries,
-            retry_delay,
-            Duration::ZERO,
+            ConnectBudget {
+                discovery_wait: Duration::ZERO,
+                ..budget
+            },
             &no_excluded(),
+            &[],
         )
         .await;
         let err = zero_wait.unwrap_err().to_string();
@@ -751,11 +804,12 @@ mod tests {
         let zero_retries = open_namespace_join_stream(
             &mock,
             NAMESPACE_ID,
-            open_timeout,
-            0,
-            retry_delay,
-            discovery_wait,
+            ConnectBudget {
+                mesh_retries: 0,
+                ..budget
+            },
             &no_excluded(),
+            &[],
         )
         .await;
         let err = zero_retries.unwrap_err().to_string();

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -1126,6 +1126,38 @@ impl SyncManager {
         Ok(ops)
     }
 
+    /// Peer ids for the admitters an invitation names, read out of its addresses.
+    ///
+    /// The addresses carry `/p2p/<peer-id>` precisely so a joiner that has synced
+    /// nothing can name the peer without resolving an account against governance
+    /// state it does not have. That suffix is what makes them usable here.
+    ///
+    /// Best-effort and possibly empty: the field is unsigned and optional, an
+    /// address may be stale, and a malformed one is skipped rather than failing the
+    /// join. An empty result simply leaves peer selection as it was.
+    fn admitter_peer_ids(invitation_bytes: &[u8]) -> Vec<PeerId> {
+        let Ok(invitation) = borsh::from_slice::<
+            calimero_context_config::types::SignedGroupOpenInvitation,
+        >(invitation_bytes) else {
+            return Vec::new();
+        };
+
+        let mut out = Vec::new();
+        for addr in &invitation.admitter_addrs {
+            let Ok(parsed) = addr.parse::<libp2p::Multiaddr>() else {
+                continue;
+            };
+            // The peer id is the only part of the address this cares about; the
+            // transport half is the dialer's problem, and it has already run.
+            if let Some(libp2p::multiaddr::Protocol::P2p(peer)) = parsed.iter().last() {
+                if !out.contains(&peer) {
+                    out.push(peer);
+                }
+            }
+        }
+        out
+    }
+
     /// Initiator side: open a stream to a mesh peer and perform the
     /// NamespaceJoinRequest / NamespaceJoinResponse exchange.
     pub(super) async fn initiate_namespace_join(
@@ -1167,17 +1199,30 @@ impl SyncManager {
         // typical 1–3 mesh peers plus headroom.
         const MAX_PROTOCOL_RETRIES: usize = 5;
 
+        // The peers the invitation named as admitters, if it named any
+        // reachable ones. Derived here rather than passed in because the
+        // invitation is already in `params` — the addresses ride along with it,
+        // outside the inviter's signature.
+        //
+        // Only an admitter can complete this join, so trying one first is not a
+        // preference so much as the difference between a round trip that can
+        // succeed and one that can only be refused.
+        let admitter_peers = Self::admitter_peer_ids(&params.invitation_bytes);
+
         for protocol_attempt in 1..=MAX_PROTOCOL_RETRIES {
             let (mut stream, peer) = match super::namespace_join::open_namespace_join_stream(
                 &*self.sync_network,
                 params.namespace_id,
-                self.sync_config.open_stream_timeout,
-                crate::sync::config::DEFAULT_MESH_RETRIES_UNINITIALIZED,
-                std::time::Duration::from_millis(
-                    crate::sync::config::DEFAULT_MESH_RETRY_DELAY_MS_UNINITIALIZED,
-                ),
-                self.sync_config.namespace_discovery_wait,
+                super::namespace_join::ConnectBudget {
+                    open_timeout: self.sync_config.open_stream_timeout,
+                    mesh_retries: crate::sync::config::DEFAULT_MESH_RETRIES_UNINITIALIZED,
+                    mesh_retry_delay: std::time::Duration::from_millis(
+                        crate::sync::config::DEFAULT_MESH_RETRY_DELAY_MS_UNINITIALIZED,
+                    ),
+                    discovery_wait: self.sync_config.namespace_discovery_wait,
+                },
                 &rejected_peers,
+                &admitter_peers,
             )
             .await
             {

--- a/scripts/classify-mesh-not-ready.py
+++ b/scripts/classify-mesh-not-ready.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Classify `group-join-mesh-not-ready` joiner logs across master runs.
+
+The scenario partitions node-2 from node-1, has it join while partitioned, then
+heals and waits for governance to converge. Because the partition happens BEFORE
+the join, *every* run degrades — and only about half enter the failure mode at
+all. So the job's own conclusion answers a different question than the one worth
+asking: a green run says nothing about whether a recovery path was needed, and a
+red one does not say which path was missing.
+
+This asks the useful question instead. For each run it records whether the joiner
+degraded, and which of the known recovery paths fired:
+
+  #3462  beacon-driven pull       — a beacon proves a peer is reachable
+  #3466  post-heal re-dial        — never yet observed firing in CI
+  #3508  subscription repair      — stale mesh table, re-announce
+  #3513  namespace-pull fallback  — no subscribers, fall back to a known holder
+
+The point is the per-run breakdown. A degraded run with no path firing is the
+gap; a batch where every degraded run shows a path is evidence the known set is
+complete, which is a different and stronger finding than "it stopped failing".
+
+Usage:
+    scripts/classify-mesh-not-ready.py --runs 12
+    scripts/classify-mesh-not-ready.py --runs 20 --keep /tmp/artifacts
+
+Requires `gh` authenticated against calimero-network/core.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+WORKFLOW = "e2e-rust-apps.yml"
+JOB_ARTIFACT_PREFIX = "logs-group-join-mesh-not-ready"
+
+# Marker -> the change that introduced the path. Matched against the joiner's
+# log as substrings, deliberately: these are tracing messages, and a regex over
+# them would break on the field ordering tracing is free to change.
+RECOVERY_PATHS: dict[str, str] = {
+    "#3462 beacon pull": "stranded member: unverifiable beacon signals a reachable peer",
+    "#3466 post-heal re-dial": "discovery book empty on disconnect; re-dialing from the peer cache",
+    "#3508 subscription repair": "re-announcing to rebuild the mesh",
+    "#3513 namespace-pull fallback": "falling back to a peer",
+}
+
+# A run "degraded" if the joiner lost its peer at all. Without this the counts
+# are meaningless: a run that never degraded needed no recovery, and counting it
+# as "no path fired" would report a gap that is not there.
+DEGRADED_MARKERS = (
+    "No peers",
+    "no mesh peers",
+    "partition",
+    "Connection closed",
+)
+
+CONVERGED_MARKER = "Sync verification failed"
+
+
+def sh(*args: str) -> str:
+    return subprocess.run(args, capture_output=True, text=True, check=False).stdout
+
+
+def recent_runs(limit: int) -> list[dict]:
+    raw = sh(
+        "gh", "run", "list",
+        "--workflow", WORKFLOW,
+        "--branch", "master",
+        "--limit", str(limit),
+        "--json", "databaseId,conclusion,headSha,createdAt",
+    )
+    try:
+        return json.loads(raw or "[]")
+    except json.JSONDecodeError:
+        return []
+
+
+def artifact_for(run_id: int, into: Path) -> Path | None:
+    """Download the joiner-log artifact for one run, or None if absent."""
+    raw = sh("gh", "api", f"repos/calimero-network/core/actions/runs/{run_id}/artifacts",
+             "--jq", ".artifacts[] | select(.name | startswith(\"%s\")) | .id" % JOB_ARTIFACT_PREFIX)
+    ids = [line for line in raw.split() if line.strip()]
+    if not ids:
+        return None
+    dest = into / str(run_id)
+    dest.mkdir(parents=True, exist_ok=True)
+    blob = dest / "logs.zip"
+    with blob.open("wb") as fh:
+        proc = subprocess.run(
+            ["gh", "api", f"repos/calimero-network/core/actions/artifacts/{ids[0]}/zip"],
+            stdout=fh, stderr=subprocess.DEVNULL, check=False,
+        )
+    if proc.returncode != 0 or blob.stat().st_size == 0:
+        return None
+    try:
+        with zipfile.ZipFile(blob) as zf:
+            zf.extractall(dest)
+    except zipfile.BadZipFile:
+        return None
+    return dest
+
+
+def classify(logs: Path) -> dict:
+    text = []
+    for path in logs.rglob("*"):
+        if path.is_file() and path.suffix in {".log", ".txt", ""}:
+            try:
+                text.append(path.read_text(errors="replace"))
+            except OSError:
+                continue
+    blob = "\n".join(text)
+    return {
+        "degraded": any(m in blob for m in DEGRADED_MARKERS),
+        "failed_to_converge": CONVERGED_MARKER in blob,
+        "paths": [name for name, marker in RECOVERY_PATHS.items() if marker in blob],
+        "bytes": len(blob),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--runs", type=int, default=12,
+                    help="how many recent master runs to inspect (the issue asks for >= 10)")
+    ap.add_argument("--keep", type=Path, default=None,
+                    help="keep downloaded artifacts here instead of a temp dir")
+    args = ap.parse_args()
+
+    runs = recent_runs(args.runs)
+    if not runs:
+        print("no runs found — is `gh` authenticated for calimero-network/core?", file=sys.stderr)
+        return 1
+
+    workdir = args.keep or Path(tempfile.mkdtemp(prefix="mesh-not-ready-"))
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    for run in runs:
+        rid = run["databaseId"]
+        logs = artifact_for(rid, workdir)
+        if logs is None:
+            rows.append((rid, run["headSha"][:9], run["conclusion"], None))
+            continue
+        rows.append((rid, run["headSha"][:9], run["conclusion"], classify(logs)))
+
+    print(f"{'run':<12} {'sha':<10} {'job':<10} {'degraded':<9} {'converged':<10} paths")
+    print("-" * 92)
+    degraded = 0
+    unexplained = []
+    for rid, sha, conclusion, c in rows:
+        if c is None:
+            print(f"{rid:<12} {sha:<10} {str(conclusion):<10} {'-':<9} {'-':<10} (no artifact)")
+            continue
+        if c["degraded"]:
+            degraded += 1
+        conv = "no" if c["failed_to_converge"] else "yes"
+        paths = ", ".join(c["paths"]) or "NONE"
+        print(f"{rid:<12} {sha:<10} {str(conclusion):<10} "
+              f"{('yes' if c['degraded'] else 'no'):<9} {conv:<10} {paths}")
+        if c["degraded"] and not c["paths"]:
+            unexplained.append(rid)
+
+    print()
+    print(f"runs inspected: {len(rows)}   degraded: {degraded}")
+    if unexplained:
+        print(f"DEGRADED WITH NO RECOVERY PATH: {unexplained}")
+        print("Each of these is a candidate fourth cause — read its joiner log directly.")
+    else:
+        print("Every degraded run shows at least one recovery path firing.")
+        print("That is the evidence #3524 asks for; note WHICH paths, since #3466")
+        print("has never been observed firing and absence there is its own finding.")
+
+    if args.keep is None:
+        shutil.rmtree(workdir, ignore_errors=True)
+    else:
+        print(f"\nartifacts kept in {workdir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Completes the chain #3770 → #3772 started: #3770 put the admitters' addresses in
the invitation, #3772 dialed them, and this uses them to pick who to actually
talk to.

## The gap

`initiate_namespace_join` opens a direct stream and does a
`NamespaceJoinRequest`/`Response` exchange — the responder validates and returns
the group key plus the context list in one shot. Good path, but it chose its peer
from `subscribed_peers`, shuffled.

That ignores the invitation, which says who may admit and (since #3770) where
they are.

**Only an admitter can complete this join.** `require_may_admit` checks the
signed list, so a shuffled subscriber that is not on it costs a round trip whose
only outcome is a refusal — then the loop records the rejection and tries
somebody else.

**And `subscribed_peers` answers the wrong question.** It reports who is on the
topic mesh, and the mesh not having converged is the situation this whole path
exists for. A joiner that dialed an admitter moments ago has a transport that may
be up while the subscriber set is still empty, and the loop would sleep out the
discovery budget rather than try the address it already has.

## Change

Peer ids are read from `admitter_addrs` — the `/p2p/<peer-id>` suffix is carried
so a joiner with no governance state can name a peer without resolving an
account, which is why the address rides with the invitation in the first place.

Those peers:

- go **first**, ahead of discovered subscribers
- are candidates **even when discovery is empty**
- are shuffled **within their band**, so the preference holds while rounds still vary
- are still subject to `excluded_peers` — a named admitter that already refused
  this join is not retried for being named

Nothing is trusted. The list is unsigned, so a wrong entry costs a failed dial:
libp2p authenticates the peer id on connect, and admission is decided by the
**signed** list at apply, on every peer. A malformed address is skipped, and an
invitation naming nobody reachable leaves selection exactly as before.

## Tests

Three added, alongside the 12 existing (15/15 in the module):

| test | pins |
| --- | --- |
| `a_named_admitter_is_tried_before_a_mere_subscriber` | the ordering |
| `a_named_admitter_is_tried_with_no_discovered_peers` | the empty-mesh case, which is the point |
| `a_named_admitter_that_already_refused_is_not_retried` | exclusion beats preference |

The third guards the obvious way to get this wrong.

## `ConnectBudget`

Adding a parameter tripped clippy's 8-arg limit. Rather than an `allow`, the four
budget parameters are now a struct — they were worth grouping regardless, since
two `Duration`s and a `u32` in a row transpose silently at a call site: swapping
the per-peer timeout with the retry delay type-checks perfectly and changes the
behaviour. The degenerate-budget test reads better for it too
(`ConnectBudget { discovery_wait: Duration::ZERO, ..budget }`).

## Verification

`cargo check --workspace --all-targets` clean; `cargo test -p calimero-node --lib
namespace_join` 15 passed / 0 failed. The full CI gate is running locally as this
opens — I will note the counts on the PR, and CI is the authority regardless.
