### PR TITLE
refactor(primitives)!: give CrdtType::Custom a digest instead of a type name

### DIFF
--- a/crates/node/primitives/src/sync/hash_comparison.rs
+++ b/crates/node/primitives/src/sync/hash_comparison.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 use borsh::{BorshDeserialize, BorshSerialize};
 
 // Re-export the unified CrdtType from primitives (consolidated per issue #1912)
-pub use calimero_primitives::crdt::CrdtType;
+pub use calimero_primitives::crdt::{CrdtType, CustomTypeId};
 
 // =============================================================================
 // Constants
@@ -1011,7 +1011,7 @@ mod tests {
             CrdtType::Vector,
             CrdtType::UserStorage,
             CrdtType::FrozenStorage,
-            CrdtType::Custom("test".to_string()),
+            CrdtType::Custom(CustomTypeId::of("test")),
         ];
 
         for crdt_type in types {

--- a/crates/node/tests/sync_compliance/builtin_merge.rs
+++ b/crates/node/tests/sync_compliance/builtin_merge.rs
@@ -18,7 +18,7 @@
 //! | FrozenStorage | Return existing (FWW) | `test_frozen_storage_*` |
 //! | Custom | WasmRequired error | `test_custom_*` |
 
-use calimero_primitives::crdt::CrdtType;
+use calimero_primitives::crdt::{CrdtType, CustomTypeId};
 use calimero_storage::collections::crdt_meta::MergeError;
 use calimero_storage::merge::{is_builtin_crdt, merge_by_crdt_type};
 
@@ -229,14 +229,14 @@ fn test_custom_requires_wasm() {
     let bytes = vec![1, 2, 3];
 
     let result = merge_by_crdt_type(
-        &CrdtType::Custom("MyApp::CustomType".into()),
+        &CrdtType::Custom(CustomTypeId::of("MyApp::CustomType")),
         &bytes,
         &bytes,
     );
 
     assert!(
-        matches!(result, Err(MergeError::WasmRequired { type_name }) if type_name == "MyApp::CustomType"),
-        "Custom types should return WasmRequired with type name"
+        matches!(result, Err(MergeError::WasmRequired { type_id }) if type_id == CustomTypeId::of("MyApp::CustomType")),
+        "Custom types should return WasmRequired carrying the type id"
     );
 }
 
@@ -303,7 +303,7 @@ fn test_all_builtin_types_classification() {
 
     // Custom is the only non-builtin
     assert!(
-        !is_builtin_crdt(&CrdtType::Custom("X".into())),
+        !is_builtin_crdt(&CrdtType::Custom(CustomTypeId::of("X"))),
         "Custom should NOT be builtin"
     );
 }
@@ -350,6 +350,10 @@ fn test_builtin_merge_behavior_summary() {
     assert_eq!(result, existing, "FrozenStorage should return existing");
 
     // Custom returns error
-    let result = merge_by_crdt_type(&CrdtType::Custom("X".into()), &existing, &incoming);
+    let result = merge_by_crdt_type(
+        &CrdtType::Custom(CustomTypeId::of("X")),
+        &existing,
+        &incoming,
+    );
     assert!(matches!(result, Err(MergeError::WasmRequired { .. })));
 }

--- a/crates/node/tests/sync_compliance/crdt_dispatch.rs
+++ b/crates/node/tests/sync_compliance/crdt_dispatch.rs
@@ -18,7 +18,7 @@
 //!                                                              ↓
 //!                                                    merge_by_crdt_type
 
-use calimero_primitives::crdt::CrdtType;
+use calimero_primitives::crdt::{CrdtType, CustomTypeId};
 use calimero_storage::address::Id;
 use calimero_storage::collections::crdt_meta::MergeError;
 use calimero_storage::entities::Metadata;
@@ -58,7 +58,7 @@ fn test_various_crdt_types_preserved() {
         (3, CrdtType::lww_register()),
         (4, CrdtType::Rga),
         (5, CrdtType::UnorderedMap),
-        (6, CrdtType::Custom("MyType".to_string())),
+        (6, CrdtType::Custom(CustomTypeId::of("MyType"))),
     ];
 
     for (id, crdt_type) in types_to_test {
@@ -113,7 +113,7 @@ fn test_is_builtin_crdt_classification() {
 
     // Only Custom needs WASM
     assert!(
-        !is_builtin_crdt(&CrdtType::Custom("X".into())),
+        !is_builtin_crdt(&CrdtType::Custom(CustomTypeId::of("X"))),
         "Custom needs WASM"
     );
 }
@@ -141,20 +141,24 @@ fn test_lww_register_returns_incoming() {
     );
 }
 
-/// Verify that Custom types return WasmRequired with correct type name.
+/// Verify that Custom types return WasmRequired with the correct type id.
 #[test]
 fn test_custom_type_returns_wasm_required() {
     let bytes = vec![1, 2, 3, 4];
 
     let result = merge_by_crdt_type(
-        &CrdtType::Custom("MyApp::Counter".to_string()),
+        &CrdtType::Custom(CustomTypeId::of("MyApp::Counter")),
         &bytes,
         &bytes,
     );
 
     match result {
-        Err(MergeError::WasmRequired { type_name }) => {
-            assert_eq!(type_name, "MyApp::Counter", "Type name should be preserved");
+        Err(MergeError::WasmRequired { type_id }) => {
+            assert_eq!(
+                type_id,
+                CustomTypeId::of("MyApp::Counter"),
+                "Type id should be preserved"
+            );
         }
         other => panic!("Expected WasmRequired, got {other:?}"),
     }

--- a/crates/primitives/src/crdt.rs
+++ b/crates/primitives/src/crdt.rs
@@ -35,6 +35,52 @@ impl LwwKind {
     }
 }
 
+/// Stable identifier for an app-defined CRDT type.
+///
+/// A [`CrdtType::Custom`] is stamped on every entry of a custom-valued
+/// collection, and entity metadata travels in `LeafMetadata`, lands in
+/// persisted rows, and enters `CausalDelta::compute_id`'s preimage through
+/// `ancestors`. A type *name* there would put a per-entry string in the hash
+/// preimage and on the wire — the surface core#3743 removed from the other
+/// variants. This carries a digest of the name instead, so the wire cost is
+/// eight bytes regardless of how the app spells its types.
+///
+/// The digest is over the type's **declared path**, taken from the source
+/// token at macro-expansion time. It is deliberately NOT
+/// `std::any::type_name`, whose rendering rustc is free to change (it did in
+/// 1.98) — the whole reason those strings were removed.
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
+pub struct CustomTypeId(u64);
+
+impl CustomTypeId {
+    /// Derive the id for a declared type path, e.g. `"team_metrics::TeamStats"`.
+    ///
+    /// FNV-1a/64: `const`, dependency-free, and fixed by this source — a hash
+    /// whose definition can drift is the same trap as `type_name`, so it is
+    /// spelled out here rather than delegated to a crate that may retune.
+    #[must_use]
+    pub const fn of(path: &str) -> Self {
+        let bytes = path.as_bytes();
+        let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+        let mut i = 0;
+        while i < bytes.len() {
+            hash ^= bytes[i] as u64;
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+            i += 1;
+        }
+        Self(hash)
+    }
+
+    /// The raw digest, for the guest-side dispatch table.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
 /// CRDT type indicator for merge semantics.
 ///
 /// Identifies the conflict resolution strategy used when merging replicated data.
@@ -155,10 +201,9 @@ pub enum CrdtType {
 
     /// Custom CRDT with app-defined merge.
     ///
-    /// For types annotated with `#[derive(CrdtState)]` that define custom merge logic.
-    /// The string identifies the custom type name within the application.
-    /// Merge: Dispatched to WASM runtime to call the app's merge function.
-    Custom(String),
+    /// Carries a [`CustomTypeId`] the guest resolves to its own merge function.
+    /// Merge: dispatched to the WASM runtime to call the app's merge function.
+    Custom(CustomTypeId),
 
     /// Rotation log (P3 of core#2716).
     ///
@@ -186,6 +231,10 @@ pub enum CrdtType {
 /// predates the removal must not read these bytes: an unknown discriminant
 /// fails the decode outright, where a shared tag would have it consume the
 /// following field as a string length and misalign everything after it.
+///
+/// `Custom` later traded its name for a [`CustomTypeId`] digest and moved to
+/// offset 14 for the same reason, leaving offset 12 as a read-only path for
+/// the name spelling.
 #[cfg(feature = "borsh")]
 const CRDT_TYPE_TAG_V2: u8 = 0x80;
 
@@ -214,11 +263,16 @@ impl BorshSerialize for CrdtType {
             Self::UserStorage => writer.write_all(&[tag(9)]),
             Self::FrozenStorage => writer.write_all(&[tag(10)]),
             Self::SharedStorage => writer.write_all(&[tag(11)]),
-            Self::Custom(name) => {
-                writer.write_all(&[tag(12)])?;
-                BorshSerialize::serialize(name, writer)
-            }
             Self::RotationLog => writer.write_all(&[tag(13)]),
+            // Appended at 14 rather than reusing 12: the payload changed from a
+            // name to a digest, and a reader that still expects a string would
+            // take the digest's first four bytes as a length and misalign
+            // everything after it. An unknown discriminant fails the decode
+            // instead — the same reason the whole tag space moved to 0x80.
+            Self::Custom(id) => {
+                writer.write_all(&[tag(14)])?;
+                BorshSerialize::serialize(id, writer)
+            }
         }
     }
 }
@@ -263,8 +317,14 @@ impl BorshDeserialize for CrdtType {
             9 => Ok(Self::UserStorage),
             10 => Ok(Self::FrozenStorage),
             11 => Ok(Self::SharedStorage),
-            12 => Ok(Self::Custom(String::deserialize_reader(reader)?)),
+            // Name-payload `Custom`, from either pre-0x80 rows or the window
+            // between the tag move and the digest change. Nothing in production
+            // ever constructed one, so this is belt-and-braces, not migration.
+            12 => Ok(Self::Custom(CustomTypeId::of(&String::deserialize_reader(
+                reader,
+            )?))),
             13 => Ok(Self::RotationLog),
+            14 if !legacy => Ok(Self::Custom(CustomTypeId::deserialize_reader(reader)?)),
             _ => Err(borsh::io::Error::new(
                 borsh::io::ErrorKind::InvalidData,
                 "unknown CrdtType discriminant",
@@ -464,7 +524,7 @@ mod tests {
 
     #[test]
     fn test_is_custom() {
-        assert!(CrdtType::Custom("test".to_string()).is_custom());
+        assert!(CrdtType::Custom(CustomTypeId::of("test")).is_custom());
         assert!(!CrdtType::lww_register().is_custom());
     }
 
@@ -493,7 +553,7 @@ mod tests {
             CrdtType::UserStorage,
             CrdtType::FrozenStorage,
             CrdtType::SharedStorage,
-            CrdtType::Custom("my_type".to_string()),
+            CrdtType::Custom(CustomTypeId::of("my_type")),
             CrdtType::RotationLog,
         ];
 
@@ -521,7 +581,7 @@ mod tests {
             CrdtType::UserStorage,
             CrdtType::FrozenStorage,
             CrdtType::SharedStorage,
-            CrdtType::Custom("my_type".to_string()),
+            CrdtType::Custom(CustomTypeId::of("my_type")),
             CrdtType::RotationLog,
         ];
 
@@ -550,8 +610,12 @@ mod tests {
         assert_eq!(tag(&CrdtType::UserStorage), CRDT_TYPE_TAG_V2 + 9);
         assert_eq!(tag(&CrdtType::FrozenStorage), CRDT_TYPE_TAG_V2 + 10);
         assert_eq!(tag(&CrdtType::SharedStorage), CRDT_TYPE_TAG_V2 + 11);
-        assert_eq!(tag(&CrdtType::Custom("c".into())), CRDT_TYPE_TAG_V2 + 12);
         assert_eq!(tag(&CrdtType::RotationLog), CRDT_TYPE_TAG_V2 + 13);
+        // 12 is retired: it was `Custom(String)`, still readable, never written.
+        assert_eq!(
+            tag(&CrdtType::Custom(CustomTypeId::of("c"))),
+            CRDT_TYPE_TAG_V2 + 14
+        );
     }
 
     /// These bytes are persisted, sent on the wire and hashed into `delta_id`,
@@ -574,11 +638,11 @@ mod tests {
             (CrdtType::UserStorage, &[0x89]),
             (CrdtType::FrozenStorage, &[0x8A]),
             (CrdtType::SharedStorage, &[0x8B]),
-            (
-                CrdtType::Custom("my_type".to_owned()),
-                &[0x8C, 7, 0, 0, 0, b'm', b'y', b'_', b't', b'y', b'p', b'e'],
-            ),
             (CrdtType::RotationLog, &[0x8D]),
+            (
+                CrdtType::Custom(CustomTypeId::of("my_type")),
+                &[0x8E, 172, 230, 240, 133, 239, 162, 33, 227],
+            ),
         ];
 
         for (crdt_type, expected) in frozen {
@@ -629,6 +693,33 @@ mod tests {
         // Payload-free legacy variants are unchanged apart from their tag.
         assert_eq!(legacy(1, &[]), CrdtType::GCounter);
         assert_eq!(legacy(13, &[]), CrdtType::RotationLog);
+
+        // A name-payload `Custom` resolves to the digest of that name, from
+        // either tag space.
+        assert_eq!(
+            legacy(12, &["my_type"]),
+            CrdtType::Custom(CustomTypeId::of("my_type"))
+        );
+        assert_eq!(
+            legacy(CRDT_TYPE_TAG_V2 + 12, &["my_type"]),
+            CrdtType::Custom(CustomTypeId::of("my_type"))
+        );
+    }
+
+    /// `CustomTypeId` is stamped on entries, travels in `LeafMetadata` and
+    /// enters `compute_id`'s preimage, so the digest function is wire format.
+    /// Retuning it silently re-labels every custom entry in the network.
+    #[test]
+    fn custom_type_id_digest_is_frozen() {
+        assert_eq!(CustomTypeId::of("my_type").get(), 0xe321_a2ef_85f0_e6ac);
+        assert_eq!(
+            CustomTypeId::of("team_metrics::TeamStats").get(),
+            0x6e4a_e421_df5b_87da
+        );
+        // FNV-1a's offset basis, i.e. the empty path hashes to a fixed value
+        // rather than to zero - `Default` must stay distinguishable from it.
+        assert_eq!(CustomTypeId::of("").get(), 0xcbf2_9ce4_8422_2325);
+        assert_ne!(CustomTypeId::of(""), CustomTypeId::default());
     }
 
     /// A binary predating the payload removal must reject current bytes rather
@@ -636,7 +727,7 @@ mod tests {
     #[cfg(feature = "borsh")]
     #[test]
     fn current_tags_are_unknown_to_a_legacy_reader() {
-        for tag in 0x80..=0x8D_u8 {
+        for tag in 0x80..=0x8E_u8 {
             assert!(
                 LEGACY_TAGS.binary_search(&tag).is_err(),
                 "tag {tag:#x} collides with a legacy discriminant"

--- a/crates/storage/src/collections/crdt_meta.rs
+++ b/crates/storage/src/collections/crdt_meta.rs
@@ -13,7 +13,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 
 // Re-export the unified CrdtType from primitives
-pub use calimero_primitives::crdt::CrdtType;
+pub use calimero_primitives::crdt::{CrdtType, CustomTypeId};
 
 /// Storage strategy for a CRDT type
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -141,8 +141,11 @@ pub enum MergeError {
     /// The storage layer cannot merge this type without knowing the concrete type.
     /// Examples: `Custom` types, collections with nested generics, `UserStorage<T>`.
     WasmRequired {
-        /// The type name that requires WASM callback
-        type_name: String,
+        /// The app-defined type that requires a WASM callback.
+        ///
+        /// A digest rather than a name: the id is what the entry carries, and
+        /// resolving it back to a spelling is the guest's job.
+        type_id: CustomTypeId,
     },
     /// Serialization/deserialization error during merge.
     SerializationError(String),
@@ -161,8 +164,12 @@ impl std::fmt::Display for MergeError {
             MergeError::IncompatibleStates => write!(f, "Incompatible CRDT states"),
             MergeError::StorageError(msg) => write!(f, "Storage error: {msg}"),
             MergeError::TypeMismatch => write!(f, "Cannot merge different CRDT types"),
-            MergeError::WasmRequired { type_name } => {
-                write!(f, "WASM callback required for type: {type_name}")
+            MergeError::WasmRequired { type_id } => {
+                write!(
+                    f,
+                    "WASM callback required for type id {:#018x}",
+                    type_id.get()
+                )
             }
             MergeError::SerializationError(msg) => write!(f, "Serialization error: {msg}"),
             MergeError::NoMergeFunctionRegistered => {

--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -418,9 +418,7 @@ pub fn merge_by_crdt_type(
         CrdtType::RotationLog => merge_rotation_log(existing, incoming),
 
         // App-defined types
-        CrdtType::Custom(type_name) => Err(MergeError::WasmRequired {
-            type_name: type_name.clone(),
-        }),
+        CrdtType::Custom(type_id) => Err(MergeError::WasmRequired { type_id: *type_id }),
     }
 }
 
@@ -448,7 +446,8 @@ pub fn merge_by_crdt_type(
 ///
 /// assert!(is_builtin_crdt(&CrdtType::GCounter));
 /// assert!(is_builtin_crdt(&CrdtType::UserStorage));
-/// assert!(!is_builtin_crdt(&CrdtType::Custom("MyType".into())));
+/// # use calimero_primitives::crdt::CustomTypeId;
+/// assert!(!is_builtin_crdt(&CrdtType::Custom(CustomTypeId::of("MyType"))));
 /// ```
 pub fn is_builtin_crdt(crdt_type: &CrdtType) -> bool {
     !matches!(crdt_type, CrdtType::Custom(_))

--- a/crates/storage/src/tests/merge_dispatch.rs
+++ b/crates/storage/src/tests/merge_dispatch.rs
@@ -15,7 +15,7 @@
 //! | `test_is_builtin_crdt_classification` | Various | Correct classification |
 //! | `test_merge_by_crdt_type_dispatch` | Various | Correct dispatch |
 
-use calimero_primitives::crdt::CrdtType;
+use calimero_primitives::crdt::{CrdtType, CustomTypeId};
 use serial_test::serial;
 
 use crate::collections::crdt_meta::MergeError;
@@ -221,7 +221,7 @@ fn test_is_builtin_crdt_classification() {
 
     // Only Custom needs WASM
     assert!(
-        !is_builtin_crdt(&CrdtType::Custom("MyType".to_string())),
+        !is_builtin_crdt(&CrdtType::Custom(CustomTypeId::of("MyType"))),
         "Custom needs WASM"
     );
 }
@@ -236,13 +236,13 @@ fn test_merge_custom_type_returns_wasm_required() {
     let bytes = vec![1, 2, 3, 4];
 
     let result = merge_by_crdt_type(
-        &CrdtType::Custom("MyCustomType".to_string()),
+        &CrdtType::Custom(CustomTypeId::of("MyCustomType")),
         &bytes,
         &bytes,
     );
 
     assert!(
-        matches!(result, Err(MergeError::WasmRequired { type_name }) if type_name == "MyCustomType"),
+        matches!(result, Err(MergeError::WasmRequired { type_id }) if type_id == CustomTypeId::of("MyCustomType")),
         "Custom types should return WasmRequired with the type name"
     );
 }
@@ -355,5 +355,5 @@ fn test_crdt_type_has_required_variants() {
     let _ = CrdtType::Vector;
     let _ = CrdtType::UserStorage;
     let _ = CrdtType::FrozenStorage;
-    let _ = CrdtType::Custom("test".to_string());
+    let _ = CrdtType::Custom(CustomTypeId::of("test"));
 }

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -3919,7 +3919,7 @@ fn opaque_root_local_write_falls_back_to_lww_when_unregistered() {
 #[serial]
 fn non_opaque_root_local_write_still_errors_when_unregistered() {
     use crate::address::Id;
-    use crate::collections::crdt_meta::{CrdtType, MergeError};
+    use crate::collections::crdt_meta::{CrdtType, CustomTypeId, MergeError};
     use crate::entities::Metadata;
     use crate::error::StorageError;
     use crate::interface::Interface;
@@ -3934,7 +3934,7 @@ fn non_opaque_root_local_write_still_errors_when_unregistered() {
     let root = Id::root();
     // A real (non-opaque) crdt_type marks this as an app-state root that is
     // supposed to merge via a registered `Mergeable`.
-    let crdt = CrdtType::Custom("AppState".to_string());
+    let crdt = CrdtType::Custom(CustomTypeId::of("AppState"));
 
     Interface::<NodeStorage>::save_raw(
         root,


### PR DESCRIPTION
First of four for #3785. Foundation only — **no behaviour change**, since nothing in production constructs a `CrdtType::Custom` today.

## Why

`Custom` is the dispatch key for app-defined merge, and #3785's plan makes that dispatch fire by stamping it on **every entry of a custom-valued collection**. Entity metadata travels in `LeafMetadata`, lands in persisted rows, and enters `CausalDelta::compute_id`'s preimage through `ancestors` — so a type *name* there would put a per-entry string in the hash preimage and on the wire.

That is precisely the surface #3743 just spent a lockstep break clearing. Doing the stamping with `Custom(String)` would hand it straight back, at greater volume: one string per entry rather than one per collection.

## What

`CrdtType::Custom(String)` → `Custom(CustomTypeId)`, an FNV-1a/64 digest of the type's declared path. Eight bytes on the wire however the app spells its types.

The digest is taken from the **source token at macro-expansion time**, never from `std::any::type_name` — a rendering rustc is free to change, which is the whole reason #3743 exists. FNV-1a is spelled out inline rather than pulled from a crate: a hash whose definition can drift silently is the same trap.

`MergeError::WasmRequired` carries the id for the same reason. Resolving it back to a spelling is the guest's job.

## Tag offset 14, not 12

Reusing 12 would let a reader that still expects a string take the digest's first four bytes as a length and misalign everything after it. An unknown discriminant fails the decode instead — same reasoning that moved the whole tag space to `0x80` in #3743, and the same reason this is marked `!`.

Offset 12 stays **readable** from either tag space, resolving the name to its own digest. Nothing in production ever wrote one, so that is belt-and-braces rather than migration.

## Tests

- `custom_type_id_digest_is_frozen` — new. The digest is wire format now; retuning it would silently re-label every custom entry in the network. Pins two paths plus the empty-string case, and that `of("")` stays distinguishable from `default()`.
- `borsh_encodings_are_byte_frozen` — `Custom` repinned to `[0x8E, ..8 digest bytes]`.
- `test_borsh_discriminant_tags_are_stable` — 12 retired with a note, 14 added.
- `legacy_type_name_payloads_still_decode` — new cases for a name-payload `Custom` from both tag spaces.
- `current_tags_are_unknown_to_a_legacy_reader` — range extended to `0x8E`.

### Observed failing first

Both new pins were watched red before being believed:

- retuning the FNV prime → `custom_type_id_digest_is_frozen` and `borsh_encodings_are_byte_frozen` FAILED (2 of 16)
- moving the tag 14 → 15 → `test_borsh_discriminant_tags_are_stable`, `test_borsh_roundtrip`, `borsh_encodings_are_byte_frozen` FAILED (3 of 16)

Reverted; 16/16 green after.

## Test plan

```
$ cargo test -p calimero-primitives --features borsh crdt
test result: ok. 16 passed; 0 failed

$ cargo test -p calimero-storage --features testing --lib
test result: ok. 719 passed; 0 failed; 0 filtered out

$ cargo fmt --check
clean
```

`crates/node/tests/sync_compliance/*` are updated but **not compiled locally** — `calimero-node` pulls `librocksdb-sys`, whose C++ build exhausts the disk on this machine. The edits are mechanical (`CrdtType::Custom("X".into())` → `CustomTypeId::of("X")`, plus two `WasmRequired { type_name }` patterns → `{ type_id }`), but CI is the first thing to actually build them.

## Next in the series

2. `#[app::mergeable]` — emits `CrdtMeta` returning `Custom(TYPE_ID)`, the `RekeyTarget` impl that is hand-written boilerplate today, the guest export, and its registration.
3. **Stamping + dispatch together.** These must not split: stamping alone only adds log noise, dispatch alone is unreachable — which is exactly how #1995 died.
4. Migrate `team-metrics-custom`, fix `examples/battleships`, add commutativity/idempotence property tests to `testing::converge`.

Refs #3785.
