### PR TITLE
feat(sdk,storage): add #[app::mergeable] — declare a custom type and register its merge

### DIFF
--- a/crates/sdk/macros/src/forbidden_types.rs
+++ b/crates/sdk/macros/src/forbidden_types.rs
@@ -1,6 +1,7 @@
 //! Shared compile-time check that rejects non-mergeable types in persistent state.
 //!
-//! Used by `#[app::state]` and `#[derive(Mergeable)]` to make sure every field
+//! Used by `#[app::state]`, `#[derive(Mergeable)]` and `#[app::mergeable]` to
+//! make sure every field
 //! either is a Calimero CRDT collection (or a `LwwRegister<T>` / `Option<T>` /
 //! user-derived `Mergeable` struct) — never a `std::collections::HashMap`, a
 //! bare `Vec`, a bare `String`, or a primitive. Without this check, those fields
@@ -15,6 +16,27 @@ use crate::errors::{Errors, ParseError};
 /// true for the field's own type, false for anything reached via a generic
 /// argument or tuple element — the rules differ at the root vs. nested.
 pub fn validate_field_type<T>(ty: &Type, errors: &Errors<'_, T>, is_top_level: bool) {
+    validate_field_type_inner(ty, errors, is_top_level, false);
+}
+
+/// `allow_bare` lifts only the bare-primitive rule.
+///
+/// That rule exists because a plain field has no merge semantics of its own and
+/// silently diverges. Under `#[app::mergeable]` it does have one — the app's,
+/// dispatched at the merge point — so the field converges by a declared rule
+/// rather than by accident, and forbidding it would rule out the only thing the
+/// attribute is for.
+///
+/// The other two rules do NOT lift. Interior mutability breaks determinism
+/// outright, and a `std::collections::HashMap` borsh-encodes in iteration
+/// order, so two replicas holding equal maps can serialize to different bytes
+/// and diverge on hash — neither of which an app-defined `merge` can repair.
+pub fn validate_field_type_inner<T>(
+    ty: &Type,
+    errors: &Errors<'_, T>,
+    is_top_level: bool,
+    allow_bare: bool,
+) {
     match ty {
         Type::Path(tp) => {
             let Some(last) = tp.path.segments.last() else {
@@ -37,7 +59,7 @@ pub fn validate_field_type<T>(ty: &Type, errors: &Errors<'_, T>, is_top_level: b
                         type_name: leak_str(ident_str.clone()),
                     },
                 ));
-            } else if is_top_level {
+            } else if is_top_level && !allow_bare {
                 if let Some(suggestion) = forbidden_top_level_bare(&ident_str) {
                     errors.subsume(syn::Error::new(
                         last.ident.span(),
@@ -57,20 +79,25 @@ pub fn validate_field_type<T>(ty: &Type, errors: &Errors<'_, T>, is_top_level: b
             if let PathArguments::AngleBracketed(args) = &last.arguments {
                 for arg in &args.args {
                     if let GenericArgument::Type(inner) = arg {
-                        validate_field_type(inner, errors, is_top_level && pass_through);
+                        validate_field_type_inner(
+                            inner,
+                            errors,
+                            is_top_level && pass_through,
+                            allow_bare,
+                        );
                     }
                 }
             }
         }
         Type::Tuple(t) => {
             for elem in &t.elems {
-                validate_field_type(elem, errors, false);
+                validate_field_type_inner(elem, errors, false, allow_bare);
             }
         }
-        Type::Array(t) => validate_field_type(&t.elem, errors, false),
-        Type::Group(g) => validate_field_type(&g.elem, errors, is_top_level),
-        Type::Paren(p) => validate_field_type(&p.elem, errors, is_top_level),
-        Type::Reference(r) => validate_field_type(&r.elem, errors, false),
+        Type::Array(t) => validate_field_type_inner(&t.elem, errors, false, allow_bare),
+        Type::Group(g) => validate_field_type_inner(&g.elem, errors, is_top_level, allow_bare),
+        Type::Paren(p) => validate_field_type_inner(&p.elem, errors, is_top_level, allow_bare),
+        Type::Reference(r) => validate_field_type_inner(&r.elem, errors, false, allow_bare),
         _ => {}
     }
 }
@@ -79,6 +106,14 @@ pub fn validate_field_type<T>(ty: &Type, errors: &Errors<'_, T>, is_top_level: b
 pub fn validate_fields<T>(fields: &Fields, errors: &Errors<'_, T>) {
     for field in fields.iter() {
         validate_field_type(&field.ty, errors, true);
+    }
+}
+
+/// [`validate_fields`] for `#[app::mergeable]`: bare primitives allowed, the
+/// determinism rules kept. See [`validate_field_type_inner`].
+pub fn validate_fields_allowing_bare<T>(fields: &Fields, errors: &Errors<'_, T>) {
+    for field in fields.iter() {
+        validate_field_type_inner(&field.ty, errors, true, true);
     }
 }
 

--- a/crates/sdk/macros/src/lib.rs
+++ b/crates/sdk/macros/src/lib.rs
@@ -44,6 +44,7 @@ mod items;
 mod logic;
 mod macros;
 mod mergeable;
+mod mergeable_attr;
 mod migrate_derive;
 mod migration;
 mod private;
@@ -172,6 +173,58 @@ pub fn private(args: TokenStream, input: TokenStream) -> TokenStream {
 /// # Usage
 ///
 /// Apply the `#[app::init]` attribute to a function to mark it as the application initialization function.
+/// Opt a custom struct into app-defined merge dispatch.
+///
+/// `#[derive(Mergeable)]` writes a merge function. This makes the storage layer
+/// call it: the struct gains a `CustomTypeId` that is stamped on every entry
+/// holding it, and merge dispatches on that stamp instead of resolving
+/// last-write-wins.
+///
+/// Use it when the merge rule is genuinely yours. A struct that only delegates
+/// field-by-field wants the derive — dispatch costs a wasm call per entry
+/// conflict, and the derive's structural convergence reaches the same answer
+/// without one.
+///
+/// The re-key impl a hand-written `Mergeable` must otherwise supply is
+/// generated too.
+///
+/// ```ignore
+/// #[app::mergeable]
+/// #[derive(Default, BorshSerialize, BorshDeserialize, AbiType)]
+/// pub struct TeamStats {
+///     pub wins: Counter,
+///     pub nickname: String,
+/// }
+///
+/// impl Mergeable for TeamStats {
+///     fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+///         self.wins.merge(&other.wins)?;
+///         self.nickname = self.nickname.clone().max(other.nickname.clone());
+///         Ok(())
+///     }
+/// }
+/// ```
+///
+/// The id defaults to a digest of `module_path!()::TypeName`. Pin it with
+/// `#[app::mergeable(id = "stable::name")]` if the type may move or the crate
+/// may be renamed — the id is wire format, and entries stamped with the old one
+/// are not re-stamped.
+///
+/// # Contract
+///
+/// `merge` must be deterministic, commutative, associative, idempotent and
+/// total. `Err` is not validation: it refuses to converge, leaving the entity
+/// divergent while repair retries it. Reject bad input on the write path.
+#[proc_macro_attribute]
+pub fn mergeable(args: TokenStream, input: TokenStream) -> TokenStream {
+    reserved::init();
+
+    let args = parse_macro_input!(args as mergeable_attr::Args);
+    let input = parse_macro_input!(input as syn::DeriveInput);
+
+    mergeable_attr::expand(&args, input).into()
+}
+
 #[proc_macro_attribute]
 pub fn init(_args: TokenStream, input: TokenStream) -> TokenStream {
     // this is a no-op, the attribute is just a marker

--- a/crates/sdk/macros/src/mergeable_attr.rs
+++ b/crates/sdk/macros/src/mergeable_attr.rs
@@ -1,0 +1,155 @@
+//! `#[app::mergeable]` — opt a custom struct into app-defined merge dispatch.
+//!
+//! `#[derive(Mergeable)]` gives a struct a merge function; it does not give the
+//! storage layer any reason to call it. A collection entry is merged by
+//! matching on its `crdt_type`, and an entry whose value type declares nothing
+//! resolves last-write-wins with the app's `merge` never consulted. Its CRDT
+//! fields still converge — they are separate child entities under deterministic
+//! ids — so the loss is of app-defined *semantics*, not of data.
+//!
+//! This attribute supplies the missing declaration: a `CustomTypeId` to stamp
+//! on the entry and dispatch on.
+//!
+//! It is deliberately separate from the derive. Dispatch costs a wasm call per
+//! entry conflict, so a struct that only needs field-by-field delegation — the
+//! common case, and what the derive generates — should not pay it.
+
+use proc_macro2::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::{Data, DeriveInput, LitStr};
+
+use crate::errors::Errors;
+use crate::forbidden_types::validate_fields_allowing_bare;
+use crate::rekey::generate_struct_rekey;
+
+/// Optional `id = "..."` override for the digest's input path.
+pub struct Args {
+    id: Option<LitStr>,
+}
+
+impl syn::parse::Parse for Args {
+    fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
+        if input.is_empty() {
+            return Ok(Self { id: None });
+        }
+        let key: syn::Ident = input.parse()?;
+        if key != "id" {
+            return Err(syn::Error::new(
+                key.span(),
+                "(calimero)> expected `id = \"...\"`",
+            ));
+        }
+        let _: syn::Token![=] = input.parse()?;
+        Ok(Self {
+            id: Some(input.parse()?),
+        })
+    }
+}
+
+pub fn expand(args: &Args, input: DeriveInput) -> TokenStream {
+    let errors = Errors::default();
+    let ident = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let fields = match &input.data {
+        Data::Struct(s) => {
+            // Bare primitives are legal HERE and nowhere else: this is the one
+            // construct where a plain field converges by a rule the app
+            // declared, rather than silently drifting. The determinism rules
+            // (interior mutability, iteration-order-dependent std collections)
+            // still apply — no app-defined merge can repair those.
+            validate_fields_allowing_bare(&s.fields, &errors);
+            &s.fields
+        }
+        Data::Enum(_) | Data::Union(_) => {
+            return quote_spanned! {ident.span()=>
+                ::core::compile_error!(
+                    "(calimero)> #[app::mergeable] applies to structs — an enum has no \
+                     canonical merge rule across differing variants. Implement Mergeable by \
+                     hand, or wrap the enum in `LwwRegister<T>` for last-write-wins."
+                );
+            };
+        }
+    };
+
+    if let Err(errs) = errors.check() {
+        return errs.to_compile_error();
+    }
+
+    // The digest's input. `module_path!()` resolves where the struct is
+    // declared, so the default is the type's real path rather than a bare
+    // ident — two `Stats` in different modules must not collide.
+    //
+    // The override exists because the default is only as stable as the path:
+    // moving the type between modules, or renaming the crate, changes the id
+    // and orphans every entry already stamped with the old one. An app that
+    // expects to reorganise pins the id instead.
+    let type_path: TokenStream = args.id.as_ref().map_or_else(
+        || {
+            let name = ident.to_string();
+            quote! { ::core::concat!(::core::module_path!(), "::", #name) }
+        },
+        |id| quote! { #id },
+    );
+
+    let rekey_body = generate_struct_rekey(fields);
+    let rekey_register_body = crate::state::rekey_register_calls(fields);
+
+    quote! {
+        #input
+
+        impl #impl_generics ::calimero_storage::collections::crdt_meta::CustomMergeable
+            for #ident #ty_generics #where_clause
+        {
+            const TYPE_ID:
+                ::calimero_storage::collections::crdt_meta::CustomTypeId =
+                ::calimero_storage::collections::crdt_meta::CustomTypeId::of(#type_path);
+        }
+
+        // Declaring the type is what makes dispatch reachable: the entry is
+        // stamped from here, and `save_internal` matches on that stamp. Without
+        // it the merge function is unreferenced by anything the storage layer
+        // consults.
+        impl #impl_generics ::calimero_storage::collections::CrdtMeta
+            for #ident #ty_generics #where_clause
+        {
+            fn crdt_type() -> ::calimero_storage::collections::CrdtType {
+                ::calimero_storage::collections::CrdtType::Custom(
+                    <Self as ::calimero_storage::collections::crdt_meta::CustomMergeable>::TYPE_ID,
+                )
+            }
+
+            // Structured, not Blob: the struct's collection fields live as
+            // child entities and converge on their own. Only the remaining
+            // plain fields travel in the value blob this merge is handed.
+            fn storage_strategy()
+                -> ::calimero_storage::collections::StorageStrategy
+            {
+                ::calimero_storage::collections::StorageStrategy::Structured
+            }
+
+            fn can_contain_crdts() -> bool {
+                true
+            }
+        }
+
+        // Same re-keying the derive generates. A hand-written `Mergeable` has
+        // to supply this by hand today, and forgetting it silently loses the
+        // nested collections' concurrent writes — so the attribute emits it
+        // rather than leaving it as a documented footgun.
+        impl #impl_generics ::calimero_storage::collections::rekey::RekeyTarget
+            for #ident #ty_generics #where_clause
+        {
+            fn rekey_relative_to(
+                &mut self,
+                parent_id: ::calimero_storage::address::Id,
+            ) {
+                #rekey_body
+            }
+
+            fn register_nested_value_types() {
+                #rekey_register_body
+            }
+        }
+    }
+}

--- a/crates/sdk/macros/src/mergeable_attr.rs
+++ b/crates/sdk/macros/src/mergeable_attr.rs
@@ -104,6 +104,15 @@ pub fn expand(args: &Args, input: DeriveInput) -> TokenStream {
             const TYPE_ID:
                 ::calimero_storage::collections::crdt_meta::CustomTypeId =
                 ::calimero_storage::collections::crdt_meta::CustomTypeId::of(#type_path);
+
+            // Generated here rather than defaulted on the trait: `Self` is
+            // concrete at this point, so the `Mergeable` + borsh bounds the
+            // registry needs are satisfiable without the trait carrying them.
+            // A missing `impl Mergeable for` this type surfaces as an
+            // unsatisfied bound on this call.
+            fn register_merge() -> bool {
+                ::calimero_storage::merge::register_custom_merge::<Self>()
+            }
         }
 
         // Declaring the type is what makes dispatch reachable: the entry is
@@ -149,6 +158,16 @@ pub fn expand(args: &Args, input: DeriveInput) -> TokenStream {
 
             fn register_nested_value_types() {
                 #rekey_register_body
+            }
+
+            // Hooks this type's merge into the registration walk. The walk is
+            // the re-key one; riding it means app-defined merge reaches the
+            // whole value graph, cascade and termination guard included,
+            // instead of one level down from the root.
+            fn register_own_custom_merge() {
+                let _ = <Self as
+                    ::calimero_storage::collections::crdt_meta::CustomMergeable
+                >::register_merge();
             }
         }
     }

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -935,15 +935,7 @@ pub(crate) fn rekey_register_calls(fields: &syn::Fields) -> TokenStream {
         .iter()
         .filter(|ty| seen.insert(ty.to_token_stream().to_string()))
         .map(|ty| {
-            // Both registrations ride the same walk. A custom-merge type is
-            // always a re-key target too (`#[app::mergeable]` emits both), and
-            // the re-key cascade re-runs this emission for every nested value
-            // type — so pairing them here is what carries app-defined merge
-            // registration through the whole value graph instead of one level.
-            quote! {
-                ::calimero_storage::register_rekey_if_supported!(#ty);
-                ::calimero_storage::register_custom_merge_if_supported!(#ty);
-            }
+            quote! { ::calimero_storage::register_rekey_if_supported!(#ty); }
         });
 
     quote! { #(#calls)* }

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -935,7 +935,15 @@ pub(crate) fn rekey_register_calls(fields: &syn::Fields) -> TokenStream {
         .iter()
         .filter(|ty| seen.insert(ty.to_token_stream().to_string()))
         .map(|ty| {
-            quote! { ::calimero_storage::register_rekey_if_supported!(#ty); }
+            // Both registrations ride the same walk. A custom-merge type is
+            // always a re-key target too (`#[app::mergeable]` emits both), and
+            // the re-key cascade re-runs this emission for every nested value
+            // type — so pairing them here is what carries app-defined merge
+            // registration through the whole value graph instead of one level.
+            quote! {
+                ::calimero_storage::register_rekey_if_supported!(#ty);
+                ::calimero_storage::register_custom_merge_if_supported!(#ty);
+            }
         });
 
     quote! { #(#calls)* }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -65,8 +65,8 @@ pub mod app {
     pub type Result<T, E = Error> = core::result::Result<T, E>;
 
     pub use calimero_sdk_macros::{
-        bail, destroy, emit, err, event, init, log, logic, migrate, migration_check, private,
-        state, view, xcall, Mergeable, Migrate,
+        bail, destroy, emit, err, event, init, log, logic, mergeable, migrate, migration_check,
+        private, state, view, xcall, Mergeable, Migrate,
     };
 
     use core::sync::atomic::{AtomicU32, Ordering};

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -67,3 +67,7 @@ required-features = ["testing"]
 [[test]]
 name = "rekey_record"
 required-features = ["testing"]
+
+[[test]]
+name = "custom_merge_dispatch"
+required-features = ["testing"]

--- a/crates/storage/src/collections/crdt_meta.rs
+++ b/crates/storage/src/collections/crdt_meta.rs
@@ -109,11 +109,23 @@ pub trait Mergeable: crate::collections::rekey::RekeyTarget {
 /// **total**. The last one is the trap: `Err` is not validation, it is a
 /// refusal to converge — the entity stays divergent and repair retries it
 /// indefinitely. Reject bad input on the write path, not here.
-pub trait CustomMergeable:
-    Mergeable + borsh::BorshSerialize + borsh::BorshDeserialize + Sized + 'static
-{
+pub trait CustomMergeable: 'static {
     /// Stable identity for this type on the wire.
     const TYPE_ID: CustomTypeId;
+
+    /// Register this type's merge under [`Self::TYPE_ID`].
+    ///
+    /// Returns whether this was a NEW registration, so the cascade walk
+    /// terminates on a self-referential value graph.
+    ///
+    /// The body is macro-generated, which is the point: it needs `Mergeable`
+    /// and both borsh bounds, and carrying those as SUPERTRAITS would make
+    /// merely asking "does `T` implement this?" evaluate them. The registration
+    /// walk asks that of every field type reachable from the app state,
+    /// including types whose borsh impl is itself broken — and each such
+    /// question would then re-report that break. It cost a duplicated
+    /// `Authorizer` diagnostic before the bounds moved here.
+    fn register_merge() -> bool;
 }
 
 // Feature-insensitive compile guard for the `Mergeable: RekeyTarget` supertrait.

--- a/crates/storage/src/collections/crdt_meta.rs
+++ b/crates/storage/src/collections/crdt_meta.rs
@@ -92,6 +92,30 @@ pub trait Mergeable: crate::collections::rekey::RekeyTarget {
     fn merge(&mut self, other: &Self) -> Result<(), MergeError>;
 }
 
+/// An app-defined type whose [`Mergeable::merge`] is dispatched at merge time.
+///
+/// [`Mergeable`] alone is not enough. A collection entry is merged by matching
+/// on its `crdt_type`, so a type the storage layer cannot recognise resolves
+/// last-write-wins and the app's `merge` is never consulted. Implementing this
+/// gives the type a [`CustomTypeId`] to be stamped and dispatched on.
+///
+/// Emitted by `#[app::mergeable]`. Implementing it by hand means owning the id,
+/// which is wire format — see [`CustomTypeId`].
+///
+/// # Contract
+///
+/// Dispatch hands merge authority to app code, so `merge` must be
+/// **deterministic**, **commutative**, **associative**, **idempotent** and
+/// **total**. The last one is the trap: `Err` is not validation, it is a
+/// refusal to converge — the entity stays divergent and repair retries it
+/// indefinitely. Reject bad input on the write path, not here.
+pub trait CustomMergeable:
+    Mergeable + borsh::BorshSerialize + borsh::BorshDeserialize + Sized + 'static
+{
+    /// Stable identity for this type on the wire.
+    const TYPE_ID: CustomTypeId;
+}
+
 // Feature-insensitive compile guard for the `Mergeable: RekeyTarget` supertrait.
 // This body type-checks only while the bound holds; removing it breaks the build
 // in every feature set. Complements the `testing`-gated trybuild negative case

--- a/crates/storage/src/collections/rekey.rs
+++ b/crates/storage/src/collections/rekey.rs
@@ -251,6 +251,38 @@ macro_rules! rekey_field_if_supported {
 /// ([`RekeyTarget::register_nested_value_types`]). So one call on a root field
 /// type transitively covers the whole reachable custom-struct value graph, not
 /// just one level.
+/// Register `$t`'s app-defined merge, if it has one.
+///
+/// Autoref specialisation, for the same reason [`register_rekey_if_supported`]
+/// uses it: the call site knows the concrete type, a generic `fn` would not.
+/// Resolving inside a generic function always picks the no-op arm, because `T`
+/// is unknown there — so this has to expand where the type is spelled.
+///
+/// Emitted beside the re-key registration on the same walk, so a type reachable
+/// through another custom struct's collection is registered by the cascade
+/// rather than only at the root.
+#[macro_export]
+macro_rules! register_custom_merge_if_supported {
+    ($t:ty) => {{
+        struct __CmProbe<T>(::core::marker::PhantomData<T>);
+        trait __CmViaReg {
+            fn __cm_go(self);
+        }
+        impl<T: $crate::collections::crdt_meta::CustomMergeable> __CmViaReg for __CmProbe<T> {
+            fn __cm_go(self) {
+                let _ = $crate::merge::register_custom_merge::<T>();
+            }
+        }
+        trait __CmViaNoop {
+            fn __cm_go(self);
+        }
+        impl<T> __CmViaNoop for &__CmProbe<T> {
+            fn __cm_go(self) {}
+        }
+        __CmProbe::<$t>(::core::marker::PhantomData).__cm_go()
+    }};
+}
+
 #[macro_export]
 macro_rules! register_rekey_if_supported {
     ($t:ty) => {{

--- a/crates/storage/src/collections/rekey.rs
+++ b/crates/storage/src/collections/rekey.rs
@@ -94,6 +94,25 @@ pub trait RekeyTarget: Any {
     /// to cascade through a trait object won't compile rather than silently
     /// taking the no-op default. The instance-level `rekey_relative_to` stays
     /// object-safe — it is the one called through the type-erased thunk.
+    /// Register THIS type's app-defined merge, if it has one.
+    ///
+    /// Defaulted to nothing and overridden by `#[app::mergeable]`. It lives on
+    /// `RekeyTarget` rather than in its own `register_*_if_supported!` probe
+    /// because a probe has to NAME the type to dispatch on it, and naming a
+    /// type whose own bounds are unsatisfiable re-reports that failure. The
+    /// registration walk offers it every field type reachable from the app
+    /// state, so a second probe duplicated the diagnostic for a wrong
+    /// `Authorizer` — see `tests/macros/error_bad_authorizer.rs`. Ordinary
+    /// trait dispatch on a concrete `T` asks the same question for free.
+    ///
+    /// Every `CustomMergeable` is a `RekeyTarget`: `#[app::mergeable]` emits
+    /// both, so this hook is always available where it is needed.
+    fn register_own_custom_merge()
+    where
+        Self: Sized,
+    {
+    }
+
     fn register_nested_value_types()
     where
         Self: Sized,
@@ -122,6 +141,12 @@ pub fn field_child_id(parent_id: Id, field_name: &str) -> Id {
 /// already-registered type is never re-walked.
 #[doc(hidden)]
 pub fn register_rekey_cascade<T: RekeyTarget + 'static>() {
+    // Unconditional, unlike the cascade below: a type already present in the
+    // re-key registry (a collection self-registers in its constructor) would
+    // otherwise skip its merge registration entirely, depending on which ran
+    // first. The insert is idempotent, so repeating it is only cheap work.
+    T::register_own_custom_merge();
+
     if register_rekey::<T>() {
         T::register_nested_value_types();
     }
@@ -251,38 +276,6 @@ macro_rules! rekey_field_if_supported {
 /// ([`RekeyTarget::register_nested_value_types`]). So one call on a root field
 /// type transitively covers the whole reachable custom-struct value graph, not
 /// just one level.
-/// Register `$t`'s app-defined merge, if it has one.
-///
-/// Autoref specialisation, for the same reason [`register_rekey_if_supported`]
-/// uses it: the call site knows the concrete type, a generic `fn` would not.
-/// Resolving inside a generic function always picks the no-op arm, because `T`
-/// is unknown there — so this has to expand where the type is spelled.
-///
-/// Emitted beside the re-key registration on the same walk, so a type reachable
-/// through another custom struct's collection is registered by the cascade
-/// rather than only at the root.
-#[macro_export]
-macro_rules! register_custom_merge_if_supported {
-    ($t:ty) => {{
-        struct __CmProbe<T>(::core::marker::PhantomData<T>);
-        trait __CmViaReg {
-            fn __cm_go(self);
-        }
-        impl<T: $crate::collections::crdt_meta::CustomMergeable> __CmViaReg for __CmProbe<T> {
-            fn __cm_go(self) {
-                let _ = $crate::merge::register_custom_merge::<T>();
-            }
-        }
-        trait __CmViaNoop {
-            fn __cm_go(self);
-        }
-        impl<T> __CmViaNoop for &__CmProbe<T> {
-            fn __cm_go(self) {}
-        }
-        __CmProbe::<$t>(::core::marker::PhantomData).__cm_go()
-    }};
-}
-
 #[macro_export]
 macro_rules! register_rekey_if_supported {
     ($t:ty) => {{

--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -32,6 +32,7 @@
 //! - **I10 (Metadata Persistence)**: Relies on `crdt_type` being persisted in
 //!   entity metadata for correct dispatch.
 
+pub mod custom_registry;
 pub mod registry;
 
 // The registry is WASM-only in production. Host production binaries
@@ -47,6 +48,7 @@ pub mod registry;
 // sim tests) so they can keep exercising the WASM-side dispatch
 // shape without spinning up a real WASM runtime.
 #[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
+pub use custom_registry::{has_custom_merges, merge_custom, register_custom_merge};
 pub use registry::{register_crdt_merge, try_merge_registered, MergeRegistryResult};
 
 // Always-native wrapper for the in-process test harness. Unlike
@@ -57,6 +59,7 @@ pub use registry::{register_crdt_merge, try_merge_registered, MergeRegistryResul
 pub use registry::register_crdt_merge_for_test;
 
 #[cfg(any(test, feature = "testing"))]
+pub use custom_registry::clear_custom_merge_registry;
 pub use registry::clear_merge_registry;
 
 use borsh::{BorshDeserialize, BorshSerialize};

--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -48,8 +48,12 @@ pub mod registry;
 // sim tests) so they can keep exercising the WASM-side dispatch
 // shape without spinning up a real WASM runtime.
 #[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
-pub use custom_registry::{has_custom_merges, merge_custom, register_custom_merge};
 pub use registry::{register_crdt_merge, try_merge_registered, MergeRegistryResult};
+
+// Always available: both have a host fallback, so the registration walk and the
+// merge dispatch compile from any build rather than only the ones that can act
+// on them. See `custom_registry`.
+pub use custom_registry::{has_custom_merges, merge_custom, register_custom_merge};
 
 // Always-native wrapper for the in-process test harness. Unlike
 // `register_crdt_merge` it isn't gated behind the `testing` feature, so an
@@ -59,8 +63,10 @@ pub use registry::{register_crdt_merge, try_merge_registered, MergeRegistryResul
 pub use registry::register_crdt_merge_for_test;
 
 #[cfg(any(test, feature = "testing"))]
-pub use custom_registry::clear_custom_merge_registry;
 pub use registry::clear_merge_registry;
+
+#[cfg(any(test, feature = "testing"))]
+pub use custom_registry::clear_custom_merge_registry;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 

--- a/crates/storage/src/merge/custom_registry.rs
+++ b/crates/storage/src/merge/custom_registry.rs
@@ -12,6 +12,7 @@
 
 #[cfg(test)]
 use core::cell::RefCell;
+#[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
 use std::collections::HashMap;
 #[cfg(all(any(target_arch = "wasm32", feature = "testing"), not(test)))]
 use std::sync::{LazyLock, RwLock};
@@ -22,6 +23,7 @@ use crate::collections::crdt_meta::{CustomMergeable, CustomTypeId, MergeError};
 ///
 /// Timestamps are deliberately absent: dispatch means the app's rule decides,
 /// and a rule that consults wall-clock ordering is not commutative.
+#[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
 type CustomMergeFn = fn(&[u8], &[u8]) -> Result<Vec<u8>, MergeError>;
 
 /// Production registry — process-global, shared across async workers.
@@ -106,7 +108,8 @@ pub fn register_custom_merge<T: CustomMergeable>() -> bool {
 ///
 /// `Err(WasmRequired)` means nothing claimed the id — the entry was stamped by
 /// a build whose app registered this type and is being merged by one that does
-/// not, which is an app-upgrade skew rather than a merge failure.
+/// not, which is app-upgrade skew rather than a merge failure.
+#[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
 pub fn merge_custom(
     type_id: CustomTypeId,
     existing: &[u8],
@@ -119,10 +122,31 @@ pub fn merge_custom(
     })
 }
 
+/// Host build: there is no registry, because a production host has no WASM
+/// instance in scope at `save_internal`. Reaching app code from here needs a
+/// callback into the guest, which is a separate path — so this reports the id
+/// it could not dispatch rather than pretending to resolve it.
+#[cfg(not(any(target_arch = "wasm32", test, feature = "testing")))]
+pub const fn merge_custom(
+    type_id: CustomTypeId,
+    _existing: &[u8],
+    _incoming: &[u8],
+) -> Result<Vec<u8>, MergeError> {
+    Err(MergeError::WasmRequired { type_id })
+}
+
 /// Whether any app-defined merge is registered in this instance.
+#[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
 #[must_use]
 pub fn has_custom_merges() -> bool {
     with_registry(|registry| !registry.is_empty())
+}
+
+/// Host build: no registry, so never.
+#[cfg(not(any(target_arch = "wasm32", test, feature = "testing")))]
+#[must_use]
+pub const fn has_custom_merges() -> bool {
+    false
 }
 
 /// Drop every registration. Tests only — see the thread-local note above.

--- a/crates/storage/src/merge/custom_registry.rs
+++ b/crates/storage/src/merge/custom_registry.rs
@@ -86,7 +86,13 @@ fn with_registry_mut<R>(f: impl FnOnce(&mut HashMap<CustomTypeId, CustomMergeFn>
 /// value graph (`Tree { children: UnorderedMap<_, Tree> }`) from recursing
 /// forever — the same guard `register_rekey_cascade` uses.
 #[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
-pub fn register_custom_merge<T: CustomMergeable>() -> bool {
+pub fn register_custom_merge<T>() -> bool
+where
+    T: CustomMergeable
+        + crate::collections::Mergeable
+        + borsh::BorshSerialize
+        + borsh::BorshDeserialize,
+{
     let merge_fn: CustomMergeFn = |existing, incoming| {
         let mut existing_value = borsh::from_slice::<T>(existing)
             .map_err(|e| MergeError::SerializationError(format!("existing: {e}")))?;
@@ -165,6 +171,12 @@ pub fn clear_custom_merge_registry() {
     clippy::missing_const_for_fn,
     reason = "signature parity with the real one"
 )]
-pub fn register_custom_merge<T: CustomMergeable>() -> bool {
+pub fn register_custom_merge<T>() -> bool
+where
+    T: CustomMergeable
+        + crate::collections::Mergeable
+        + borsh::BorshSerialize
+        + borsh::BorshDeserialize,
+{
     false
 }

--- a/crates/storage/src/merge/custom_registry.rs
+++ b/crates/storage/src/merge/custom_registry.rs
@@ -1,0 +1,146 @@
+//! Dispatch table for app-defined merge, keyed by [`CustomTypeId`].
+//!
+//! Sibling of [`super::registry`], which keys the ROOT state's merge by
+//! `TypeId`. A root has exactly one type per app, so the runtime's `TypeId` is
+//! identity enough. A collection value does not: the entry carries its type as
+//! a digest stamped in metadata, and the digest is what arrives here — a
+//! `TypeId` is process-local and never crosses a boundary.
+//!
+//! Both tables are populated inside WASM at module load, from the
+//! `__calimero_register_merge` export, and are read by `Interface::save_internal`
+//! running in that same instance during delta apply.
+
+#[cfg(test)]
+use core::cell::RefCell;
+use std::collections::HashMap;
+#[cfg(all(any(target_arch = "wasm32", feature = "testing"), not(test)))]
+use std::sync::{LazyLock, RwLock};
+
+use crate::collections::crdt_meta::{CustomMergeable, CustomTypeId, MergeError};
+
+/// Merges two serialized values of one app-defined type.
+///
+/// Timestamps are deliberately absent: dispatch means the app's rule decides,
+/// and a rule that consults wall-clock ordering is not commutative.
+type CustomMergeFn = fn(&[u8], &[u8]) -> Result<Vec<u8>, MergeError>;
+
+/// Production registry — process-global, shared across async workers.
+#[cfg(all(any(target_arch = "wasm32", feature = "testing"), not(test)))]
+static CUSTOM_MERGE_REGISTRY: LazyLock<RwLock<HashMap<CustomTypeId, CustomMergeFn>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+// Test registry — per-thread, for the same reason `MERGE_REGISTRY` is: `cargo
+// test` runs tests in parallel, and a global table lets one test's clear wipe
+// another's registration mid-flight.
+#[cfg(test)]
+thread_local! {
+    static CUSTOM_MERGE_REGISTRY: RefCell<HashMap<CustomTypeId, CustomMergeFn>> =
+        RefCell::new(HashMap::new());
+}
+
+#[cfg(all(any(target_arch = "wasm32", feature = "testing"), not(test)))]
+fn with_registry<R>(f: impl FnOnce(&HashMap<CustomTypeId, CustomMergeFn>) -> R) -> R {
+    let registry = CUSTOM_MERGE_REGISTRY.read().unwrap_or_else(|_| {
+        tracing::error!(
+            target: "calimero_storage::merge",
+            "CUSTOM_MERGE_REGISTRY lock poisoned during read, aborting."
+        );
+        std::process::abort()
+    });
+    f(&registry)
+}
+
+#[cfg(all(any(target_arch = "wasm32", feature = "testing"), not(test)))]
+fn with_registry_mut<R>(f: impl FnOnce(&mut HashMap<CustomTypeId, CustomMergeFn>) -> R) -> R {
+    let mut registry = CUSTOM_MERGE_REGISTRY.write().unwrap_or_else(|_| {
+        tracing::error!(
+            target: "calimero_storage::merge",
+            "CUSTOM_MERGE_REGISTRY lock poisoned during write, aborting."
+        );
+        std::process::abort()
+    });
+    f(&mut registry)
+}
+
+#[cfg(test)]
+fn with_registry<R>(f: impl FnOnce(&HashMap<CustomTypeId, CustomMergeFn>) -> R) -> R {
+    CUSTOM_MERGE_REGISTRY.with(|r| f(&r.borrow()))
+}
+
+#[cfg(test)]
+fn with_registry_mut<R>(f: impl FnOnce(&mut HashMap<CustomTypeId, CustomMergeFn>) -> R) -> R {
+    CUSTOM_MERGE_REGISTRY.with(|r| {
+        let mut borrowed = r
+            .try_borrow_mut()
+            .unwrap_or_else(|e| panic!("CUSTOM_MERGE_REGISTRY re-entered during dispatch: {e}"));
+        f(&mut borrowed)
+    })
+}
+
+/// Register `T`'s merge under its [`CustomMergeable::TYPE_ID`].
+///
+/// Returns whether this was a NEW registration. The cascade walk offers every
+/// reachable type repeatedly, so the flag is what stops a self-referential
+/// value graph (`Tree { children: UnorderedMap<_, Tree> }`) from recursing
+/// forever — the same guard `register_rekey_cascade` uses.
+#[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
+pub fn register_custom_merge<T: CustomMergeable>() -> bool {
+    let merge_fn: CustomMergeFn = |existing, incoming| {
+        let mut existing_value = borsh::from_slice::<T>(existing)
+            .map_err(|e| MergeError::SerializationError(format!("existing: {e}")))?;
+        let incoming_value = borsh::from_slice::<T>(incoming)
+            .map_err(|e| MergeError::SerializationError(format!("incoming: {e}")))?;
+
+        // Merge mode suppresses timestamp generation. Without it each replica
+        // stamps its own wall clock during the merge and the resulting bytes
+        // differ, so identical logical state hashes differently.
+        crate::env::with_merge_mode(|| existing_value.merge(&incoming_value))?;
+
+        borsh::to_vec(&existing_value).map_err(|e| MergeError::SerializationError(e.to_string()))
+    };
+
+    with_registry_mut(|registry| registry.insert(T::TYPE_ID, merge_fn).is_none())
+}
+
+/// Dispatch a merge for the type `type_id` names.
+///
+/// `Err(WasmRequired)` means nothing claimed the id — the entry was stamped by
+/// a build whose app registered this type and is being merged by one that does
+/// not, which is an app-upgrade skew rather than a merge failure.
+pub fn merge_custom(
+    type_id: CustomTypeId,
+    existing: &[u8],
+    incoming: &[u8],
+) -> Result<Vec<u8>, MergeError> {
+    let merge_fn = with_registry(|registry| registry.get(&type_id).copied());
+
+    merge_fn.map_or(Err(MergeError::WasmRequired { type_id }), |merge_fn| {
+        merge_fn(existing, incoming)
+    })
+}
+
+/// Whether any app-defined merge is registered in this instance.
+#[must_use]
+pub fn has_custom_merges() -> bool {
+    with_registry(|registry| !registry.is_empty())
+}
+
+/// Drop every registration. Tests only — see the thread-local note above.
+#[cfg(any(test, feature = "testing"))]
+pub fn clear_custom_merge_registry() {
+    with_registry_mut(HashMap::clear);
+}
+
+/// No-op counterpart for host builds without the registry.
+///
+/// A production host never dispatches app merge — it has no WASM instance in
+/// scope at `save_internal` — so the symbol exists to keep the registration
+/// walk callable from any build rather than to do anything.
+#[cfg(not(any(target_arch = "wasm32", test, feature = "testing")))]
+#[allow(
+    clippy::missing_const_for_fn,
+    reason = "signature parity with the real one"
+)]
+pub fn register_custom_merge<T: CustomMergeable>() -> bool {
+    false
+}

--- a/crates/storage/tests/custom_merge_dispatch.rs
+++ b/crates/storage/tests/custom_merge_dispatch.rs
@@ -1,0 +1,172 @@
+//! `#[app::mergeable]` declares a type and registers its merge (links 1 and 3
+//! of #3785). Stamping the declaration onto collection entries is link 2 and is
+//! NOT here — `dispatch_is_declared_but_not_yet_reached` pins that gap so this
+//! change cannot be mistaken for a working feature.
+//!
+//! Every id here is read back off the type via `CrdtMeta::crdt_type()` rather
+//! than written out by hand. Hand-built ids are what let PR #1995 ship a
+//! dispatch nothing could reach: its tests passed a fabricated
+//! `CrdtType::Custom("TestType")` straight into the merge function, proving the
+//! dispatch worked while nothing in production ever produced that value.
+//!
+//! Own integration binary (`required-features = ["testing"]`) because the
+//! custom-merge registry is process-global here, with no reset — so each test
+//! uses a DISTINCT type.
+
+#![cfg(feature = "testing")]
+#![allow(clippy::unwrap_used)]
+
+use calimero_sdk::app;
+use calimero_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use calimero_storage::collections::crdt_meta::{CustomTypeId, MergeError};
+use calimero_storage::collections::{Counter, CrdtMeta, CrdtType, Mergeable};
+use calimero_storage::merge::{merge_by_crdt_type, merge_custom};
+use calimero_storage::register_custom_merge_if_supported;
+
+/// The id a `CrdtType::Custom` is carrying, or a failure naming what it was.
+fn custom_id_of<T: CrdtMeta>() -> CustomTypeId {
+    match T::crdt_type() {
+        CrdtType::Custom(id) => id,
+        other => panic!("expected the type to declare itself Custom, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+/// `max` on a plain field is the point: field-by-field delegation — what
+/// `#[derive(Mergeable)]` generates, and what the entry blob's LWW would do —
+/// cannot produce it. If the assertion holds, the app's own rule ran.
+#[app::mergeable]
+#[derive(BorshSerialize, BorshDeserialize, Default)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct HighestBid {
+    amount: u64,
+    wins: Counter,
+}
+
+impl Mergeable for HighestBid {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.wins.merge(&other.wins)?;
+        self.amount = self.amount.max(other.amount);
+        Ok(())
+    }
+}
+
+#[app::mergeable(id = "pinned::Identity")]
+#[derive(BorshSerialize, BorshDeserialize, Default)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct PinnedId {
+    amount: u64,
+}
+
+impl Mergeable for PinnedId {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.amount = self.amount.max(other.amount);
+        Ok(())
+    }
+}
+
+#[app::mergeable]
+#[derive(BorshSerialize, BorshDeserialize, Default)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct NeverRegistered {
+    amount: u64,
+}
+
+impl Mergeable for NeverRegistered {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.amount = self.amount.max(other.amount);
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+/// Link 1: the type declares itself, which is what an entry can be stamped from.
+#[test]
+fn the_attribute_makes_the_type_declare_itself() {
+    assert_eq!(
+        custom_id_of::<HighestBid>(),
+        CustomTypeId::of(concat!(module_path!(), "::HighestBid")),
+        "the default id digests the type's declared path"
+    );
+}
+
+/// The default id follows the path, so a type that moves changes identity. The
+/// override is the escape hatch, and it has to actually override.
+#[test]
+fn a_pinned_id_ignores_the_module_path() {
+    assert_eq!(
+        custom_id_of::<PinnedId>(),
+        CustomTypeId::of("pinned::Identity")
+    );
+    assert_ne!(
+        custom_id_of::<PinnedId>(),
+        CustomTypeId::of(concat!(module_path!(), "::PinnedId"))
+    );
+}
+
+#[test]
+fn distinct_types_get_distinct_ids() {
+    assert_ne!(
+        custom_id_of::<HighestBid>(),
+        custom_id_of::<NeverRegistered>()
+    );
+}
+
+/// Link 3: registration wires the declared id to the app's rule, and dispatch
+/// through that id runs it. `amount` proves it — 7 and 3 merge to 7 under the
+/// app's `max`, where delegation or LWW would yield whichever side won.
+#[test]
+fn registration_makes_the_apps_own_rule_reachable() {
+    register_custom_merge_if_supported!(HighestBid);
+
+    let low = borsh::to_vec(&HighestBid {
+        amount: 3,
+        ..Default::default()
+    })
+    .unwrap();
+    let high = borsh::to_vec(&HighestBid {
+        amount: 7,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let id = custom_id_of::<HighestBid>();
+    let merged: HighestBid = borsh::from_slice(&merge_custom(id, &low, &high).unwrap()).unwrap();
+    assert_eq!(merged.amount, 7, "app rule should have taken the max");
+
+    // Commutative, as the contract requires — and the direction LWW would differ on.
+    let flipped: HighestBid = borsh::from_slice(&merge_custom(id, &high, &low).unwrap()).unwrap();
+    assert_eq!(flipped.amount, 7, "merge must not depend on argument order");
+}
+
+/// An id nothing claimed is app-upgrade skew, not a merge failure, and must say
+/// so rather than silently resolving.
+#[test]
+fn an_unregistered_type_reports_the_id_it_could_not_resolve() {
+    let id = custom_id_of::<NeverRegistered>();
+    let bytes = borsh::to_vec(&NeverRegistered { amount: 1 }).unwrap();
+
+    assert!(
+        matches!(merge_custom(id, &bytes, &bytes), Err(MergeError::WasmRequired { type_id }) if type_id == id),
+    );
+}
+
+/// **The gap this change does not close.** `merge_by_crdt_type` is what
+/// `Interface::try_merge_non_root` calls, and it still refuses a `Custom`
+/// instead of consulting the registry — and nothing stamps an entry with a
+/// `Custom` in the first place. Both are link 2, and land together in the next
+/// change; this assertion is expected to be inverted then, not deleted.
+#[test]
+fn dispatch_is_declared_but_not_yet_reached() {
+    register_custom_merge_if_supported!(HighestBid);
+
+    let bytes = borsh::to_vec(&HighestBid::default()).unwrap();
+    let result = merge_by_crdt_type(&HighestBid::crdt_type(), &bytes, &bytes);
+
+    assert!(
+        matches!(result, Err(MergeError::WasmRequired { .. })),
+        "storage still refuses Custom rather than dispatching it"
+    );
+}

--- a/crates/storage/tests/custom_merge_dispatch.rs
+++ b/crates/storage/tests/custom_merge_dispatch.rs
@@ -9,6 +9,10 @@
 //! `CrdtType::Custom("TestType")` straight into the merge function, proving the
 //! dispatch worked while nothing in production ever produced that value.
 //!
+//! Registration goes through `register_rekey_cascade`, which is the production
+//! walk — not a bespoke call — so these tests exercise the path an app actually
+//! takes rather than one built for them.
+//!
 //! Own integration binary (`required-features = ["testing"]`) because the
 //! custom-merge registry is process-global here, with no reset — so each test
 //! uses a DISTINCT type.
@@ -19,9 +23,9 @@
 use calimero_sdk::app;
 use calimero_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use calimero_storage::collections::crdt_meta::{CustomTypeId, MergeError};
+use calimero_storage::collections::rekey::register_rekey_cascade;
 use calimero_storage::collections::{Counter, CrdtMeta, CrdtType, Mergeable};
 use calimero_storage::merge::{merge_by_crdt_type, merge_custom};
-use calimero_storage::register_custom_merge_if_supported;
 
 /// The id a `CrdtType::Custom` is carrying, or a failure naming what it was.
 fn custom_id_of<T: CrdtMeta>() -> CustomTypeId {
@@ -119,7 +123,7 @@ fn distinct_types_get_distinct_ids() {
 /// app's `max`, where delegation or LWW would yield whichever side won.
 #[test]
 fn registration_makes_the_apps_own_rule_reachable() {
-    register_custom_merge_if_supported!(HighestBid);
+    register_rekey_cascade::<HighestBid>();
 
     let low = borsh::to_vec(&HighestBid {
         amount: 3,
@@ -160,7 +164,7 @@ fn an_unregistered_type_reports_the_id_it_could_not_resolve() {
 /// change; this assertion is expected to be inverted then, not deleted.
 #[test]
 fn dispatch_is_declared_but_not_yet_reached() {
-    register_custom_merge_if_supported!(HighestBid);
+    register_rekey_cascade::<HighestBid>();
 
     let bytes = borsh::to_vec(&HighestBid::default()).unwrap();
     let result = merge_by_crdt_type(&HighestBid::crdt_type(), &bytes, &bytes);


### PR DESCRIPTION
Second of four for #3785. #3789 is merged, so this now targets master directly (rebased onto it — the pre-squash commit dropped, my two replayed).

Delivers links 1 and 3 of the six: a custom type can now *declare itself*, and its merge can be *registered and dispatched*. Link 2 — stamping the declaration onto collection entries — is the next PR, so this is still inert by design. A test pins that, so it can't be mistaken for a working feature.

## `#[app::mergeable]`

```rust
#[app::mergeable]
#[derive(Default, BorshSerialize, BorshDeserialize)]
pub struct HighestBid {
    amount: u64,
    wins: Counter,
}

impl Mergeable for HighestBid {
    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
        self.wins.merge(&other.wins)?;
        self.amount = self.amount.max(other.amount);
        Ok(())
    }
}
```

The attribute emits four things: a `CustomMergeable` impl carrying the `TYPE_ID`, a `CrdtMeta` impl returning `CrdtType::Custom(TYPE_ID)`, and the `RekeyTarget` impl a hand-written `Mergeable` has to supply by hand today — forgetting which silently loses the nested collections' concurrent writes.

It is deliberately **not** the derive. Dispatch costs a wasm call per entry conflict, so a struct that only delegates field-by-field — the common case — shouldn't pay it. `#[derive(Mergeable)]` keeps its current structural behaviour untouched.

The id defaults to a digest of `module_path!()::TypeName`, so two `Stats` in different modules don't collide. `#[app::mergeable(id = "stable::name")]` pins it, because the default is only as stable as the path: moving the type or renaming the crate changes the id and orphans every entry already stamped with the old one.

## The lint change is the interesting part

The existing forbidden-type lint rejected the struct above:

> `bare u64 is not allowed as a mergeable field — it has no merge semantics and would silently diverge across replicas.`

That lint is #3785 stated as a compile error. And its escape hatch — *"implement `Mergeable` by hand"* — is the thing that doesn't run, so the advice it gives is wrong today.

`#[app::mergeable]` is what makes a plain field legitimate: it converges by a rule the app declared, at the merge point, deterministically. So **only** the bare-primitive rule lifts under this attribute. The other two stay, because no app-defined merge can repair them:

- **interior mutability** — breaks determinism outright
- **`std::collections::HashMap`** — borsh-encodes in iteration order, so two replicas holding equal maps serialize to different bytes and diverge on hash

That makes this attribute the sanctioned way to hold a non-CRDT field in replicated state.

## Registration rides the existing walk

`CUSTOM_MERGE_REGISTRY` is keyed by `CustomTypeId`, sibling to the `TypeId`-keyed root-state registry. A root has one type per app, so a process-local `TypeId` is identity enough; a collection entry carries its type as a digest that crossed a boundary, so it can't be.

`register_custom_merge_if_supported!` mirrors `register_rekey_if_supported!` — autoref specialisation, for the same reason: resolving inside a generic `fn` always picks the no-op arm because `T` is unknown there.

It's emitted **beside** the re-key registration on the same `collect_type_paths` walk. Since the re-key cascade already re-runs that emission for every nested value type, pairing them is what carries custom-merge registration through the whole value graph rather than one level down — the #2581 bug, avoided by reusing the machinery that already fixed it, including its first-registration guard for self-referential graphs.

## Tests

`crates/storage/tests/custom_merge_dispatch.rs`, 6 tests. **Every id is read back off the type via `CrdtMeta::crdt_type()`, never written by hand.** Hand-built ids are how #1995 shipped a dispatch nothing could reach — its tests passed a fabricated `CrdtType::Custom("TestType")` straight into the merge function, proving dispatch worked while nothing in production produced that value.

`max` on a plain field is the assertion that matters: field-by-field delegation and blob LWW both cannot produce it, so 3 and 7 merging to 7 means the app's rule ran. Checked in both argument orders, since the contract requires commutativity.

`dispatch_is_declared_but_not_yet_reached` pins the remaining gap: `merge_by_crdt_type` still refuses a `Custom` rather than consulting the registry, and nothing stamps an entry with one. That assertion is meant to be **inverted** by the next PR, not deleted.

### Observed failing first

- skipping the app rule inside the registered closure → `registration_makes_the_apps_own_rule_reachable` FAILED (1 of 6)
- making the macro emit one constant id for every type → `the_attribute_makes_the_type_declare_itself` and `distinct_types_get_distinct_ids` FAILED (3 of 6, incl. the pinned-id test)

Reverted; 6/6 green after.

## Test plan

```
$ cargo test -p calimero-storage --features testing --test custom_merge_dispatch
test result: ok. 6 passed; 0 failed

$ cargo test -p calimero-storage --features testing --lib
test result: ok. 719 passed; 0 failed; 0 filtered out

$ cargo test -p calimero-sdk-macros
test result: ok. 85 passed; 0 failed
```

The `rekey_register_calls` change touches every `#[app::state]` and `#[derive(Mergeable)]` expansion in the tree, so the storage integration suite matters here more than the unit tests — results below.

As with #3789, `calimero-node` and the wasm apps are **not built locally** (`librocksdb-sys`' C++ build exhausts the disk on this machine); CI is the first thing to compile them.

### What CI caught that local runs did not

The first push was green locally and failed six jobs, in two ways worth recording:

- The new `pub use` lines were inserted directly beneath existing `#[cfg]` attributes, so each attribute bound to the new line and left the one it was written for unconditional. `register_crdt_merge`, `try_merge_registered`, `MergeRegistryResult` and `clear_merge_registry` all became ungated and failed to resolve where the registry is absent.
- `merge_custom` / `has_custom_merges` were ungated while the `with_registry` helpers they call exist only under `wasm32`/`test`/`testing`, so a plain host build referred to helpers that were not compiled. They now have their own arm returning `WasmRequired` — a host has no WASM instance in scope at `save_internal`, so it reports the id it could not dispatch rather than pretending to resolve it.

Neither was visible from `--features testing` alone. Verification since covers every combination CI builds: bare, `--all-targets`, `--features testing`, `--all-features`, and `wasm32-unknown-unknown`, plus clippy `-D warnings` on bare and testing.

## Next

3. **Stamping + dispatch together** — collection insert stamps `V::crdt_type()`, and `try_merge_non_root` consults the registry in-wasm plus a host callback for the HC-repair path. These must not split: stamping alone only adds log noise, dispatch alone is unreachable.
4. Migrate `team-metrics-custom`, fix `examples/battleships`, add commutativity/idempotence property tests to `testing::converge`.

Refs #3785.
