### PR TITLE
chore(release): 0.11.0-rc.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.30"
+version = "0.11.0-rc.31"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
## Summary

Cuts `0.11.0-rc.31`. One line: the shared workspace version in `Cargo.toml`.

22 commits since `0.11.0-rc.30`, including two breaking changes:

- **`feat!: registry-only application distribution` (#3652)** - applications are signed `.mpk` bundles fetched from one configured source. `POST /admin-api/install-application` now takes `{ package, version }` and refuses a body carrying `url`. `SIGNED_GROUP_OP_SCHEMA_VERSION` 10 -> 11.
- **`refactor(primitives)!: give CrdtType::Custom a digest instead of a type name` (#3789)**

Also in: hosted-admitter dialling and invitation admitter addresses (#3782, #3781, #3772, #3770), sync request coalescing fix (#3631), a real Windows node in CI (#3771), and dependency bumps.

## Upgrade notes

Schema v11 is compared strictly equal, so a v10 peer rejects every v11 op - upgrade a namespace's peers together. v11 also changes the on-disk layout of the group governance rows, which borsh cannot decode from an older binary, so nodes need a datastore reset as well as a restart. See `docs/protocol/upgrades`.

Downstream clients that mirror the admin API (mero-js, Tauri) need the `install-application` request-shape change before they can talk to a node from this release.

## Test plan

Merging this is what tags the release and builds the binaries, so the gate is master being green at the commit this branches from (`1416cacdc`) plus this PR's own checks.