### PR TITLE
refactor(storage)!: store map entries value-first so a value is decodable without its key type

### DIFF
--- a/crates/node/src/delta_store.rs
+++ b/crates/node/src/delta_store.rs
@@ -1203,8 +1203,9 @@ pub(crate) fn load_rotation_log_direct(
             >::children_with(map_id, read_row)
             {
                 // P3: each child is an `UnorderedMap` entry, so its stored value
-                // is `borsh(Entry<([u8;32], RotationLogEntry)>)` — decode the
-                // single entry it holds (NOT a bare `RotationLog` blob).
+                // is `borsh(Entry<(RotationLogEntry, [u8;32])>)` — value-first,
+                // like every map entry — so decode the single entry it holds
+                // (NOT a bare `RotationLog` blob).
                 if let Some(bytes) = read_entity_value_direct(
                     context_client,
                     context_id,

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -1925,8 +1925,11 @@ mod tests {
         let value = b"immutable-frozen-payload".to_vec();
         let key_hash: [u8; 32] = Sha256::digest(&value).into();
         let mut blob = Vec::new();
-        blob.extend_from_slice(&key_hash);
+        // Value-first: a map entry stores `(V, K)`, so a frozen entry blob is
+        // `[value][key_hash (32)][element id (32)]`. `verify_frozen_action_upsert`
+        // slices it at those offsets.
         blob.extend_from_slice(&value);
+        blob.extend_from_slice(&key_hash);
         blob.extend_from_slice(frozen_id.as_bytes());
 
         with_runtime_env(runtime_env.clone(), || {
@@ -2033,8 +2036,11 @@ mod tests {
         let value = b"freshly-pushed-frozen".to_vec();
         let key_hash: [u8; 32] = Sha256::digest(&value).into();
         let mut blob = Vec::new();
-        blob.extend_from_slice(&key_hash);
+        // Value-first: a map entry stores `(V, K)`, so a frozen entry blob is
+        // `[value][key_hash (32)][element id (32)]`. `verify_frozen_action_upsert`
+        // slices it at those offsets.
         blob.extend_from_slice(&value);
+        blob.extend_from_slice(&key_hash);
         blob.extend_from_slice(frozen_id.as_bytes());
 
         with_runtime_env(runtime_env.clone(), || {

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -69,5 +69,9 @@ name = "rekey_record"
 required-features = ["testing"]
 
 [[test]]
+name = "map_entry_layout"
+required-features = ["testing"]
+
+[[test]]
 name = "custom_merge_dispatch"
 required-features = ["testing"]

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -265,18 +265,23 @@ struct Entry<T> {
 /// core#2716).
 ///
 /// A rotation-log map child is an ordinary [`UnorderedMap`] entry, so its stored
-/// value is `borsh(Entry<([u8; 32], RotationLogEntry)>)` — NOT a bare
+/// value is `borsh(Entry<(RotationLogEntry, [u8; 32])>)` — NOT a bare
 /// `RotationLog` blob. The node-side direct reader (`delta_store`) reads child
 /// bytes straight from RocksDB outside a storage env, so it cannot go through
 /// the `UnorderedMap` handle; this exposes the exact borsh layout the collection
 /// writes (`item` then the `#[storage]` `Element`, whose only serialized field
 /// is its id). Returns `None` if the bytes are not a valid map entry.
+///
+/// Note the tuple is VALUE-first: a map entry stores `(V, K)` so the value sits
+/// at offset 0 whatever the key type. This is the one reader that spells the
+/// layout out, so it moves in lockstep with
+/// [`UnorderedMap::inner`](unordered_map::UnorderedMap).
 pub fn decode_rotation_log_entry_child(
     bytes: &[u8],
 ) -> Option<crate::rotation_log::RotationLogEntry> {
-    borsh::from_slice::<Entry<([u8; 32], crate::rotation_log::RotationLogEntry)>>(bytes)
+    borsh::from_slice::<Entry<(crate::rotation_log::RotationLogEntry, [u8; 32])>>(bytes)
         .ok()
-        .map(|entry| entry.item.1)
+        .map(|entry| entry.item.0)
 }
 
 #[expect(unused_qualifications, reason = "AtomicUnit macro is unsanitized")]

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -843,8 +843,9 @@ mod tests {
         let wrapper_id = guarded.element().id();
         let map_id = <Map as Data>::id(guarded.get().expect("get"));
         let child = compute_id(map_id, "k".as_bytes());
+        // Value-first: a map entry stores `(V, K)`.
         let entry = <Interface<MainStorage>>::find_by_id::<
-            crate::collections::Entry<(String, LwwRegister<String>)>,
+            crate::collections::Entry<(LwwRegister<String>, String)>,
         >(child)
         .expect("load child")
         .expect("child exists");

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -97,7 +97,9 @@ use std::collections::{BTreeMap, BTreeSet};
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct SortedMap<K, V, S: StorageAdaptor = MainStorage> {
     #[borsh(bound(serialize = "", deserialize = ""))]
-    inner: Collection<(K, V), S>,
+    /// Entries are stored **value first**: `(V, K)`. See
+    /// [`UnorderedMap`](super::UnorderedMap::inner) for why.
+    inner: Collection<(V, K), S>,
 }
 
 /// Convert a `RangeBounds` endpoint into the byte-bound the ordered index
@@ -360,7 +362,7 @@ where
                     .inner
                     .get_mut(id)?
                     .ok_or(StoreError::StorageError(StorageError::NotFound(id)))?;
-                let (_, v) = &mut *entry;
+                let (v, _) = &mut *entry;
                 mem::replace(v, value)
             };
             // The key set didn't change by THIS op, so if the index was already
@@ -383,7 +385,7 @@ where
 
         let _ignored = self
             .inner
-            .insert_with_storage_type(Some(id), (key, value), storage_type)?;
+            .insert_with_storage_type(Some(id), (value, key), storage_type)?;
 
         if let Some(order_key) = order_key {
             // Done after the inner write so the collection's `full_hash` already
@@ -440,7 +442,7 @@ where
     {
         let id = compute_id(self.inner.id(), key.as_ref());
 
-        Ok(self.inner.get(id)?.map(|(_, v)| ValueRef::new(v)))
+        Ok(self.inner.get(id)?.map(|(v, _)| ValueRef::new(v)))
     }
 
     /// Returns a mutable `ValueMut` guard for the value at `key`.
@@ -545,7 +547,7 @@ where
             return Ok(None);
         };
 
-        let removed = entry.remove().map(|(_, v)| v)?;
+        let removed = entry.remove().map(|(v, _)| v)?;
 
         // Keep the ordered index in step with the removal (no-op when the
         // adaptor doesn't back it). `entry.remove()` has already recomputed the
@@ -718,8 +720,9 @@ where
     /// bound.
     fn iter_unordered(&self) -> Result<impl Iterator<Item = (K, V)> + '_, StoreError> {
         let collection_id = self.inner.id();
+        // Inner yields `(V, K)`; the public contract is `(K, V)`.
         Ok(self.inner.entries()?.filter_map(move |result| match result {
-            Ok(entry) => Some(entry),
+            Ok((value, key)) => Some((key, value)),
             Err(error) => {
                 tracing::error!(
                     target: "calimero_storage::iter_drop",
@@ -897,8 +900,9 @@ where
     fn resolve_hits(&self, hits: Vec<(Vec<u8>, Id)>) -> Result<Vec<(K, V)>, StoreError> {
         let mut out = Vec::with_capacity(hits.len());
         for (_order_key, id) in hits {
-            if let Some(kv) = self.inner.get(id)? {
-                out.push(kv);
+            // Stored value-first; the public contract is `(K, V)`.
+            if let Some((value, key)) = self.inner.get(id)? {
+                out.push((key, value));
             }
         }
         Ok(out)
@@ -946,7 +950,7 @@ where
     {
         if self.ensure_index()? {
             return match S::index_last(self.inner.id()) {
-                Some((_order_key, id)) => self.inner.get(id),
+                Some((_order_key, id)) => Ok(self.inner.get(id)?.map(|(v, k)| (k, v))),
                 None => Ok(None),
             };
         }
@@ -1099,7 +1103,7 @@ where
             // two nodes that independently build the same entry never converge.
             super::rekey::rekey_nested_value(&mut v, id);
 
-            (Some(id), (k, v))
+            (Some(id), (v, k))
         });
 
         self.inner.extend(iter);
@@ -1131,7 +1135,7 @@ where
     V: BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    entry_mut: EntryMut<'a, (K, V), S>,
+    entry_mut: EntryMut<'a, (V, K), S>,
 }
 
 impl<K, V, S> Deref for ValueMut<'_, K, V, S>
@@ -1143,7 +1147,7 @@ where
     type Target = V;
 
     fn deref(&self) -> &Self::Target {
-        &self.entry_mut.deref().1
+        &self.entry_mut.deref().0
     }
 }
 
@@ -1154,7 +1158,7 @@ where
     S: StorageAdaptor,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.entry_mut.deref_mut().1
+        &mut self.entry_mut.deref_mut().0
     }
 }
 
@@ -1183,7 +1187,7 @@ where
     V: BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    entry_mut: EntryMut<'a, (K, V), S>,
+    entry_mut: EntryMut<'a, (V, K), S>,
 }
 
 /// A view into a vacant entry in a [`SortedMap`].
@@ -1287,12 +1291,12 @@ where
 {
     /// Gets a reference to the value in the entry.
     pub fn get(&self) -> &V {
-        &self.entry_mut.1
+        &self.entry_mut.0
     }
 
     /// Gets a mutable reference to the value in the entry.
     pub fn get_mut(&mut self) -> &mut V {
-        &mut self.entry_mut.1
+        &mut self.entry_mut.0
     }
 
     /// Replaces the value in the entry and returns the old value.
@@ -1303,7 +1307,7 @@ where
         // Re-key nested collections in the replacement value relative to this
         // entry's (stable, deterministic) id — same reason as `VacantEntry::insert`.
         super::rekey::rekey_nested_value(&mut value, self.entry_mut.id());
-        mem::replace(&mut self.entry_mut.1, value)
+        mem::replace(&mut self.entry_mut.0, value)
     }
 
     /// Removes the entry from the map and returns the removed value.
@@ -1313,7 +1317,7 @@ where
     /// If an error occurs when interacting with the storage system, an error
     /// will be returned.
     pub fn remove(self) -> Result<V, StoreError> {
-        self.entry_mut.remove().map(|(_, v)| v)
+        self.entry_mut.remove().map(|(v, _)| v)
     }
 }
 
@@ -1350,7 +1354,7 @@ where
         // Capture the order key before `self.key` is moved, to warm the index.
         let order_key = S::index_supported().then(|| self.key.as_ref().to_vec());
 
-        drop(self.map.inner.insert(Some(id), (self.key, value))?);
+        drop(self.map.inner.insert(Some(id), (value, self.key))?);
 
         if let Some(order_key) = order_key {
             // Only stamp the validity marker if the index was consistent before

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -48,7 +48,19 @@ use std::collections::BTreeMap;
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct UnorderedMap<K, V, S: StorageAdaptor = MainStorage> {
     #[borsh(bound(serialize = "", deserialize = ""))]
-    inner: Collection<(K, V), S>,
+    /// Entries are stored **value first**: `(V, K)`, not `(K, V)`.
+    ///
+    /// The key is not used to find anything — `get` hashes it into the child id
+    /// (`compute_id`) and never reads the stored copy. It is kept only so
+    /// `entries()` can hand keys back, since a hash cannot be inverted.
+    ///
+    /// Putting it after the value means the value sits at offset 0 of every
+    /// entry, whatever the key type. That is what lets app-defined merge decode
+    /// an entry without knowing `K`: a `String` key is length-prefixed and a
+    /// `[u8; 32]` key is 32 bare bytes, and nothing in the blob says which — so
+    /// with the key in front there is no way to skip it. The public API is
+    /// unchanged and still speaks `(K, V)`.
+    inner: Collection<(V, K), S>,
 }
 
 /// Re-key a nested map (a map stored as another collection's value) relative to
@@ -220,7 +232,7 @@ where
         // (AuthoredMap / guarded Shared writers) survive the re-key; a plain
         // `(K, V)` snapshot would re-insert as `Public` and silently strip
         // ownership.
-        let entries: Vec<((K, V), StorageType)> = self
+        let entries: Vec<((V, K), StorageType)> = self
             .inner
             .entries_with_storage_type()
             .expect("failed to read entries for re-key");
@@ -239,7 +251,7 @@ where
 
         // Re-insert all entries (they will get new IDs based on new parent ID),
         // preserving each entry's original `StorageType`.
-        for ((key, value), storage_type) in entries {
+        for ((value, key), storage_type) in entries {
             self.insert_with_storage_type(key, value, storage_type, None)
                 .expect("failed to re-insert entry during re-key");
         }
@@ -353,7 +365,7 @@ where
         super::rekey::rekey_nested_value(&mut value, id);
 
         if let Some(mut entry) = self.inner.get_mut(id)? {
-            let (_, v) = &mut *entry;
+            let (v, _) = &mut *entry;
 
             return Ok(Some(mem::replace(v, value)));
         }
@@ -362,7 +374,7 @@ where
         // Pass the `StorageType` directly to the `Collection`.
         let _ignored = self
             .inner
-            .insert_with_storage_type(Some(id), (key, value), storage_type)?;
+            .insert_with_storage_type(Some(id), (value, key), storage_type)?;
 
         Ok(None)
     }
@@ -385,8 +397,10 @@ where
         // future races a precise anchor instead of a downstream
         // content mismatch.
         let collection_id = self.inner.id();
+        // The inner collection yields `(V, K)`; the public contract is
+        // `(K, V)`, so flip it back here.
         Ok(self.inner.entries()?.filter_map(move |result| match result {
-            Ok(entry) => Some(entry),
+            Ok((value, key)) => Some((key, value)),
             Err(error) => {
                 tracing::error!(
                     target: "calimero_storage::iter_drop",
@@ -463,7 +477,7 @@ where
     {
         let id = compute_id(self.inner.id(), key.as_ref());
 
-        Ok(self.inner.get(id)?.map(|(_, v)| ValueRef::new(v)))
+        Ok(self.inner.get(id)?.map(|(v, _)| ValueRef::new(v)))
     }
 
     /// Returns a mutable reference to the value corresponding to the key.
@@ -574,7 +588,7 @@ where
             return Ok(None);
         };
 
-        entry.remove().map(|(_, v)| Some(v))
+        entry.remove().map(|(v, _)| Some(v))
     }
 
     /// Clear the map, removing all entries.
@@ -749,7 +763,7 @@ where
             // two nodes that independently build the same entry never converge.
             super::rekey::rekey_nested_value(&mut v, id);
 
-            (Some(id), (k, v))
+            (Some(id), (v, k))
         });
 
         self.inner.extend(iter);
@@ -782,7 +796,7 @@ where
     S: StorageAdaptor,
 {
     /// This holds the mutable entry for the *entire* tuple.
-    entry_mut: EntryMut<'a, (K, V), S>,
+    entry_mut: EntryMut<'a, (V, K), S>,
 }
 
 impl<K, V, S> Deref for ValueMut<'_, K, V, S>
@@ -794,8 +808,8 @@ where
     type Target = V;
 
     fn deref(&self) -> &Self::Target {
-        // self.entry_mut.deref() returns &(K, V), so with .1 it accesses the V
-        &self.entry_mut.deref().1
+        // self.entry_mut.deref() returns &(V, K), so `.0` is the V
+        &self.entry_mut.deref().0
     }
 }
 
@@ -806,8 +820,8 @@ where
     S: StorageAdaptor,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        // self.entry_mut.deref() returns &(K, V), so with .1 it accesses the V
-        &mut self.entry_mut.deref_mut().1
+        // self.entry_mut.deref() returns &(V, K), so `.0` is the V
+        &mut self.entry_mut.deref_mut().0
     }
 }
 
@@ -839,7 +853,7 @@ where
     V: BorshSerialize + BorshDeserialize,
     S: StorageAdaptor,
 {
-    entry_mut: EntryMut<'a, (K, V), S>,
+    entry_mut: EntryMut<'a, (V, K), S>,
 }
 
 /// A view into a vacant entry in an `UnorderedMap`.
@@ -930,7 +944,7 @@ where
 {
     /// Gets a reference to the value in the entry.
     pub fn get(&self) -> &V {
-        &self.entry_mut.1
+        &self.entry_mut.0
     }
 
     /// Gets a mutable reference to the value in the entry.
@@ -938,7 +952,7 @@ where
     /// Changes are written back to storage when the returned `DerefMut`
     /// guard is dropped.
     pub fn get_mut(&mut self) -> &mut V {
-        &mut self.entry_mut.1
+        &mut self.entry_mut.0
     }
 
     /// Replaces the value in the entry and returns the old value.
@@ -952,7 +966,7 @@ where
         // otherwise leave it carrying a random internal id that diverges across
         // nodes.
         super::rekey::rekey_nested_value(&mut value, self.entry_mut.id());
-        mem::replace(&mut self.entry_mut.1, value)
+        mem::replace(&mut self.entry_mut.0, value)
     }
 
     /// Removes the entry from the map and returns the removed value.
@@ -962,7 +976,7 @@ where
     /// If an error occurs when interacting with the storage system, an error
     /// will be returned.
     pub fn remove(self) -> Result<V, StoreError> {
-        self.entry_mut.remove().map(|(_, v)| v)
+        self.entry_mut.remove().map(|(v, _)| v)
     }
 }
 
@@ -994,7 +1008,7 @@ where
         super::rekey::rekey_nested_value(&mut value, id);
 
         // Insert the new (key, value) pair
-        drop(self.map.inner.insert(Some(id), (self.key, value))?);
+        drop(self.map.inner.insert(Some(id), (value, self.key))?);
 
         // Now, get a mutable guard to the new entry.
         // We `expect` here because this is a logic error: we just inserted

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -4295,7 +4295,16 @@ fn verify_frozen_action_upsert(action: &Action, data: &[u8]) -> Result<(), Stora
     }
 
     // Verify the content-addressing via byte-slicing.
-    // The data blob is: [key_hash (32 bytes)] + [value_bytes (N bytes)] + [element_id (32 bytes)]
+    //
+    // A `FrozenStorage<T>` is an `UnorderedMap<Hash, FrozenValue<T>>`, and a map
+    // entry is stored VALUE-FIRST — `(V, K)`, so the value sits at offset 0
+    // whatever the key type. The blob is therefore:
+    //
+    //   [value_bytes (N)] + [key_hash (32)] + [element_id (32)]
+    //
+    // Both trailing fields are fixed 32-byte arrays, which is what makes this
+    // sliceable at all. If the entry layout moves again, this moves with it —
+    // `tests/map_entry_layout.rs` pins the bytes for exactly that reason.
     const KEY_HASH_SIZE: usize = 32;
     const ELEMENT_ID_SIZE: usize = 32;
     const MIN_LEN: usize = KEY_HASH_SIZE + ELEMENT_ID_SIZE;
@@ -4307,10 +4316,8 @@ fn verify_frozen_action_upsert(action: &Action, data: &[u8]) -> Result<(), Stora
     }
 
     // Extract the three components
-    let key_from_entry = &data[..KEY_HASH_SIZE];
-    // We don't need the `Element::Id` from the end, but we know it's there and
-    // we need to remove it from the value_bytes.
-    let value_bytes = &data[KEY_HASH_SIZE..data.len() - ELEMENT_ID_SIZE];
+    let value_bytes = &data[..data.len() - MIN_LEN];
+    let key_from_entry = &data[data.len() - MIN_LEN..data.len() - ELEMENT_ID_SIZE];
 
     // Re-calculate the hash of the `value bytes`
     let calculated_hash: [u8; 32] = Sha256::digest(value_bytes).into();

--- a/crates/storage/src/tests/interface.rs
+++ b/crates/storage/src/tests/interface.rs
@@ -2364,12 +2364,16 @@ mod frozen_storage_verification {
     use crate::env;
 
     /// Helper to create valid frozen data blob.
-    /// Format: [key_hash (32 bytes)] + [value_bytes (N bytes)] + [element_id (32 bytes)]
+    ///
+    /// Format: `[value_bytes (N)] + [key_hash (32)] + [element_id (32)]` — a
+    /// map entry is stored VALUE-FIRST, so this mirrors what `UnorderedMap`
+    /// actually writes. It is hand-built rather than produced by the collection,
+    /// which is why it has to be kept honest by `tests/map_entry_layout.rs`.
     fn create_valid_frozen_blob(value: &[u8], element_id: Id) -> Vec<u8> {
         let key_hash: [u8; 32] = Sha256::digest(value).into();
         let mut blob = Vec::new();
-        blob.extend_from_slice(&key_hash);
         blob.extend_from_slice(value);
+        blob.extend_from_slice(&key_hash);
         blob.extend_from_slice(element_id.as_bytes());
         blob
     }
@@ -2379,8 +2383,8 @@ mod frozen_storage_verification {
         let mut key_hash: [u8; 32] = Sha256::digest(value).into();
         key_hash[0] ^= 0xFF; // Corrupt the hash
         let mut blob = Vec::new();
-        blob.extend_from_slice(&key_hash);
         blob.extend_from_slice(value);
+        blob.extend_from_slice(&key_hash);
         blob.extend_from_slice(element_id.as_bytes());
         blob
     }

--- a/crates/storage/tests/map_entry_layout.rs
+++ b/crates/storage/tests/map_entry_layout.rs
@@ -1,0 +1,129 @@
+//! Recorded bytes for a map entry's stored layout.
+//!
+//! The layout is not private: `decode_rotation_log_entry_child` reads it
+//! positionally straight out of RocksDB, and app-defined merge dispatch needs
+//! the value at a known offset. A silent reordering would break both, so the
+//! exact bytes are pinned here rather than left to whatever the tuple happens
+//! to be.
+//!
+//! Own test binary — `ROOT_ID` is a process-wide `LazyLock` derived from
+//! `context_id()`, so a sibling test that touches a collection outside a
+//! `RuntimeEnv` freezes it at the no-env fallback and genesis here fails.
+
+#![cfg(feature = "testing")]
+#![allow(clippy::unwrap_used)]
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_storage::address::Id;
+use calimero_storage::collections::crdt_meta::MergeError;
+use calimero_storage::collections::rekey::field_child_id;
+use calimero_storage::collections::{Mergeable, Root, UnorderedMap};
+use calimero_storage::env::{self, RuntimeEnv};
+use calimero_storage::store::Key;
+use calimero_storage::{register_crdt_merge_for_test, rekey_field_if_supported};
+use serial_test::serial;
+
+type Store = Rc<RefCell<HashMap<[u8; 32], Vec<u8>>>>;
+
+fn env_for(s: &Store) -> RuntimeEnv {
+    let r = s.clone();
+    let reader = Rc::new(move |k: &Key| r.borrow().get(&k.to_bytes()).cloned());
+    let w = s.clone();
+    let writer =
+        Rc::new(move |k: Key, v: &[u8]| w.borrow_mut().insert(k.to_bytes(), v.to_vec()).is_some());
+    let rm = s.clone();
+    let remover = Rc::new(move |k: &Key| rm.borrow_mut().remove(&k.to_bytes()).is_some());
+    RuntimeEnv::new(reader, writer, remover, [7u8; 32], [1u8; 32], [0xACu8; 32])
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Default)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct App {
+    items: UnorderedMap<String, Counted>,
+}
+
+/// A value whose borsh encoding is short and unmistakable in a hex dump.
+#[derive(BorshSerialize, BorshDeserialize, Default)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct Counted {
+    n: u32,
+}
+
+impl Mergeable for Counted {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.n = self.n.max(other.n);
+        Ok(())
+    }
+}
+
+impl calimero_storage::collections::rekey::RekeyTarget for Counted {
+    fn rekey_relative_to(&mut self, _parent_id: Id) {}
+}
+
+impl Mergeable for App {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.items.merge(&other.items)
+    }
+}
+
+impl calimero_storage::collections::rekey::RekeyTarget for App {
+    fn rekey_relative_to(&mut self, parent_id: Id) {
+        rekey_field_if_supported!(&mut self.items, field_child_id(parent_id, "items"));
+    }
+}
+
+/// One entry, one known key, one known value — then read the raw stored bytes.
+///
+/// `AABBCCDD` little-endian is `0xDDCCBBAA`, chosen so the value is impossible
+/// to confuse with the key's length prefix or with the trailing id.
+#[test]
+#[serial]
+fn a_map_entry_stores_the_value_before_the_key() {
+    env::reset_environment();
+    register_crdt_merge_for_test::<App>();
+
+    let store: Store = Default::default();
+    env::with_runtime_env(env_for(&store), || {
+        Root::new(App::default).commit();
+    });
+
+    let entry_bytes = env::with_runtime_env(env_for(&store), || {
+        let mut app = Root::<App>::fetch().unwrap();
+        app.items
+            .insert("ab".to_owned(), Counted { n: 0xDDCC_BBAA })
+            .unwrap();
+        app.commit();
+
+        // Find the one child whose bytes contain the value marker.
+        let marker = [0xAA, 0xBB, 0xCC, 0xDD];
+        store
+            .borrow()
+            .values()
+            .find(|v| v.windows(4).any(|w| w == marker))
+            .cloned()
+            .expect("the entry must be in the store")
+    });
+
+    // value (4) ++ key len (4) ++ key (2) ++ element id (32) = 42
+    assert_eq!(
+        entry_bytes.len(),
+        42,
+        "unexpected entry size: {entry_bytes:02x?}"
+    );
+
+    assert_eq!(
+        &entry_bytes[..4],
+        &[0xAA, 0xBB, 0xCC, 0xDD],
+        "the VALUE must come first — merge dispatch decodes it at offset 0 \
+         without knowing the key's type. Got: {entry_bytes:02x?}"
+    );
+    assert_eq!(
+        &entry_bytes[4..10],
+        &[2, 0, 0, 0, b'a', b'b'],
+        "the key follows the value, borsh-framed"
+    );
+}

--- a/tools/merodb/src/export.rs
+++ b/tools/merodb/src/export.rs
@@ -4,7 +4,7 @@ use borsh::BorshDeserialize;
 use calimero_storage::collections::CrdtType;
 use calimero_store::types::ContextDagDelta as StoreContextDagDelta;
 use calimero_wasm_abi::schema::{
-    CollectionType, CrdtCollectionType, Field, Manifest, ScalarType, TypeDef, TypeRef,
+    CollectionType, CrdtCollectionType, Field, Manifest, TypeDef, TypeRef,
 };
 use core::ops::Deref;
 use eyre::{Result, WrapErr};
@@ -510,8 +510,8 @@ fn type_ref_label(type_ref: &TypeRef) -> String {
 }
 
 fn decode_map_entry(bytes: &[u8], field: &MapField, manifest: &Manifest) -> Result<Value> {
-    // Entry<T> where T = (K, V) serializes as:
-    // - item: (K, V) - the tuple itself
+    // Entry<T> where T = (V, K) serializes as:
+    // - item: (V, K) - the tuple itself, VALUE FIRST
     // - storage: Element - metadata (ID, timestamps, etc.)
     // So we need to deserialize: (K, V, Element)
 
@@ -525,49 +525,46 @@ fn decode_map_entry(bytes: &[u8], field: &MapField, manifest: &Manifest) -> Resu
         hex::encode(&bytes[..bytes.len().min(128)])
     );
 
-    // Quick format check: For String keys, verify it looks like a Borsh-serialized string
-    // Borsh strings start with u32 length. If the first 4 bytes don't look like a reasonable length,
-    // or if the first 32 bytes look like a raw ID, this is probably not an Entry<(K, V)>.
-    if let TypeRef::Scalar(ScalarType::String) = field.key_type {
-        if bytes.len() < 4 {
-            return Err(eyre::eyre!(
-                "Entry too short to contain a Borsh-serialized string key"
-            ));
-        }
-        let length_bytes = [bytes[0], bytes[1], bytes[2], bytes[3]];
-        let key_length = u32::from_le_bytes(length_bytes) as usize;
-
-        // Sanity check: String length should be reasonable (< 1MB) and the entry should be long enough
-        if key_length > 1_000_000 || bytes.len() < 4 + key_length {
-            eprintln!("[decode_map_entry] First 4 bytes don't look like a valid string length: {} (u32: {})", 
-                hex::encode(length_bytes), key_length);
-            return Err(eyre::eyre!(
-                "Entry doesn't appear to be Entry<(String, V)> format (invalid string length: {})",
-                key_length
-            ));
-        }
-
-        // Additional check: If the first 32 bytes look like a raw ID (all non-zero, no obvious string pattern),
-        // this is probably not an Entry<(K, V)>
-        if bytes.len() >= 32 {
-            let first_32 = &bytes[..32];
-            // Check if it looks like a raw ID (32 bytes, mostly non-zero, not starting with a small u32)
-            if first_32.iter().all(|&b| b != 0)
-                && u32::from_le_bytes([first_32[0], first_32[1], first_32[2], first_32[3]]) > 1000
-            {
-                eprintln!("[decode_map_entry] First 32 bytes look like a raw ID, not a Borsh-serialized string");
-                return Err(eyre::eyre!(
-                    "Entry doesn't appear to be Entry<(String, V)> format (looks like raw ID)"
-                ));
-            }
-        }
-    }
-
+    // No front heuristic here any more. It used to sanity-check that the entry
+    // began with a Borsh-serialized string key — but a map entry is stored
+    // VALUE-FIRST (`Entry<(V, K)>`), so offset 0 is the value and there is
+    // nothing key-shaped to check without decoding that value first. The
+    // deserialization below is the check.
     let mut cursor = Cursor::new(bytes);
 
     // Deserialize the tuple (K, V)
     // For Borsh, a tuple (K, V) serializes as: K (serialized) + V (serialized)
     // For a String key, Borsh serializes as: u32 length + bytes
+    // `Entry<(V, K)>` is laid out as V + K + Element ID (32 bytes) — value
+    // first, which is what lets a reader find the value without knowing the
+    // key's type.
+    eprintln!(
+        "[decode_map_entry] Attempting to deserialize value (type: {:?})",
+        field.value_type
+    );
+    let value_value = match deserializer::deserialize_type_ref_from_cursor(
+        &mut cursor,
+        &field.value_type,
+        manifest,
+    ) {
+        Ok(v) => v,
+        Err(e) => {
+            let shown = bytes.len().min(64);
+            eprintln!(
+                "[decode_map_entry] Value deserialization failed for field {}: {}. First {} bytes: {}",
+                field.name, e, shown, hex::encode(&bytes[..shown])
+            );
+            return Err(eyre::eyre!(
+                "Failed to deserialize value (type: {:?}, total bytes: {}, error: {})",
+                field.value_type,
+                bytes.len(),
+                e
+            ));
+        }
+    };
+    let value_end = usize::try_from(cursor.position()).unwrap_or(bytes.len());
+    let value_raw = bytes[..value_end].to_vec();
+
     eprintln!(
         "[decode_map_entry] Attempting to deserialize key (type: {:?})",
         field.key_type
@@ -576,48 +573,20 @@ fn decode_map_entry(bytes: &[u8], field: &MapField, manifest: &Manifest) -> Resu
         deserializer::deserialize_type_ref_from_cursor(&mut cursor, &field.key_type, manifest)
             .wrap_err_with(|| {
                 format!(
-                    "Failed to deserialize key (type: {:?}, first 32 bytes: {})",
+                    "Failed to deserialize key (type: {:?}, bytes after value: {})",
                     field.key_type,
-                    hex::encode(&bytes[..bytes.len().min(32)])
+                    hex::encode(&bytes[value_end..bytes.len().min(value_end + 32)])
                 )
             })?;
     eprintln!("[decode_map_entry] Successfully deserialized key: {key_value:?}");
     let key_end = usize::try_from(cursor.position()).unwrap_or(bytes.len());
-    let key_raw = bytes[..key_end].to_vec();
-
-    // For Counter values in map entries, the Counter is stored directly (not wrapped in Entry)
-    // The Entry<(K, V)> structure is: K + V + Element ID (32 bytes)
-    // So we deserialize V (Counter) directly, then handle the Element ID separately
-    let value_value = match deserializer::deserialize_type_ref_from_cursor(
-        &mut cursor,
-        &field.value_type,
-        manifest,
-    ) {
-        Ok(v) => v,
-        Err(e) => {
-            // If Counter deserialization fails, log the bytes for debugging
-            let remaining = bytes.len() - key_end;
-            let bytes_to_show = remaining.min(64);
-            eprintln!(
-                "[decode_map_entry] Counter deserialization failed for field {}: {}. First {} bytes of value: {}",
-                field.name, e, bytes_to_show, hex::encode(&bytes[key_end..key_end + bytes_to_show])
-            );
-            return Err(eyre::eyre!(
-                "Failed to deserialize value (type: {:?}, remaining bytes: {}, error: {})",
-                field.value_type,
-                remaining,
-                e
-            ));
-        }
-    };
-    let value_end = usize::try_from(cursor.position()).unwrap_or(bytes.len());
-    let value_raw = bytes[key_end..value_end].to_vec();
+    let key_raw = bytes[value_end..key_end].to_vec();
 
     // Now deserialize Element (which contains id, timestamps, etc.)
     // Element serializes as: (id: Option<Id>, parent_id: Option<Id>, children: Option<Vec<ChildInfo>>, full_hash: [u8; 32], own_hash: [u8; 32], metadata: Metadata, deleted_at: Option<u64>)
     // For simplicity, we'll just try to read the ID (first 32 bytes if Some, or 1 byte if None)
-    let element_id = if value_end + 32 <= bytes.len() {
-        if let Ok(id) = borsh::from_slice::<Id>(&bytes[value_end..value_end + 32]) {
+    let element_id = if key_end + 32 <= bytes.len() {
+        if let Ok(id) = borsh::from_slice::<Id>(&bytes[key_end..key_end + 32]) {
             Some(hex::encode(id.as_bytes()))
         } else {
             None


### PR DESCRIPTION
Prerequisite for #3785's dispatch work, and useful on its own. **No API change** — `entries()`, `range()`, `page()`, `Extend`, `FromIterator` all still speak `(K, V)`. Only the stored tuple flips.

## Why

A map entry is stored as `Entry<(K, V)>`, so on disk it is:

```
02 00 00 00  61 62   aa bb cc dd   <32-byte element id>
└─ key len ┘ └"ab"┘  └─ value ─┘   └──────────────────┘
```

The value's offset depends on the key's type — a `String` key writes a length prefix, a `[u8; 32]` key writes 32 bare bytes, and **nothing in the blob says which**. So anything that wants the value out of an entry must already know `K`.

That is fine today because nothing does. It stops being fine the moment app-defined merge dispatches on an entry (#3785): the merge function is registered per value type and handed the whole blob, with no `K` in scope. Every way around that is worse than fixing the layout — teaching each collection to supply a decoder collides silently when two maps share a value type with different key types, and putting the key type in the dispatch tag makes a type's identity depend on where it is stored.

## What

The key is **not used to find anything**. `get` hashes it into the child id (`compute_id`) and discards the stored copy; the only reason it is stored at all is that `entries()` has to hand keys back and a hash cannot be inverted. Nothing requires it to be first.

```rust
- inner: Collection<(K, V), S>,
+ inner: Collection<(V, K), S>,
```

Now the value sits at offset 0 of every entry, whatever the key type — matching what sets and vectors already do. The key stays inside the hashed payload (`own_hash = Sha256(data)`), so it keeps its Merkle coverage; moving it to metadata would have quietly dropped that, since metadata is Merkle-invisible.

## The readers that spell the layout out

Three, and the third is why this PR has a byte pin.

- `decode_rotation_log_entry_child` — reads `Entry<(..)>` raw from RocksDB outside a storage env, because the node-side reader cannot go through the map handle. Updated, doc updated.
- `collections/shared.rs` test — `find_by_id::<Entry<(String, LwwRegister<String>)>>`. Updated.
- **`verify_frozen_action_upsert`** (`interface.rs`) — slices the blob by byte offset:

  ```rust
  let key_from_entry = &data[..KEY_HASH_SIZE];
  let value_bytes    = &data[KEY_HASH_SIZE..data.len() - ELEMENT_ID_SIZE];
  ```

  `FrozenStorage<T>` is an `UnorderedMap<Hash, FrozenValue<T>>`, so its content-addressing check reads the entry positionally. It does not contain the string `Entry<`, so a type-level grep does not find it. It surfaced as `create_then_apply_converges` failing with two different root hashes — a real convergence break, caught by an existing test rather than by review.

Four hand-built fixtures (`create_valid_frozen_blob` and friends) also encoded the old order and were updated.

## Byte pin

`crates/storage/tests/map_entry_layout.rs` inserts one entry with a deliberately unmistakable value (`0xDDCCBBAA`) and asserts the exact stored bytes. Written **before** the change and watched failing on the old layout:

```
Got: [02, 00, 00, 00, 61, 62, aa, bb, cc, dd, 27, 73, ...]
  left: [2, 0, 0, 0]        ← key length, where the value should be
 right: [170, 187, 204, 221]
```

It is its own test binary because `ROOT_ID` is a process-wide `LazyLock` derived from `context_id()`; a sibling test that touches a collection outside a `RuntimeEnv` freezes it at the no-env fallback `[236; 32]` and genesis here then fails `CannotCreateOrphan`.

## Compatibility

This changes the stored bytes of every existing map entry, so it is a declared lockstep upgrade like #3743 and #3789 — but unlike those, it is real rows on disk rather than an enum tag nothing constructed. Nodes must upgrade together; a mixed cluster will read entries wrong rather than fail loudly, because the two layouts are the same length.

That asymmetry is worth a reviewer's attention: there is no tag to bump here, so nothing makes a stale reader error. If that is not acceptable, the alternative is a format marker in entry metadata, which this PR does not attempt.

## Test plan

```
$ cargo test -p calimero-storage --features testing --lib
test result: ok. 719 passed; 0 failed

$ cargo test -p calimero-storage --features testing --tests
18 binaries, 18 result lines, 793 passed, 0 failed

$ cargo test -p calimero-storage --features testing --test map_entry_layout
test result: ok. 1 passed; 0 failed

$ cargo clippy -p calimero-storage --all-targets --features testing -- -D warnings   # exit 0
$ cargo clippy -p calimero-storage --all-targets -- -D warnings                      # exit 0
$ cargo check -p calimero-storage --target wasm32-unknown-unknown                    # exit 0
$ cargo check -p calimero-storage --all-targets --all-features                       # exit 0
$ cargo fmt --check                                                                  # clean
```

`calimero-node` is **not built locally** — `librocksdb-sys`' C++ build exhausts the disk on this machine. That matters more than usual here: `delta_store.rs` holds the node-side raw rotation-log reader, and a byte-offset reader is exactly the class this PR already missed once. CI is the first thing to compile it.

Refs #3785.
