### PR TITLE
fix(sync): dial the invitation's admitters from the path that runs

### DIFF
--- a/crates/node/src/join_namespace.rs
+++ b/crates/node/src/join_namespace.rs
@@ -321,106 +321,6 @@ pub async fn join_namespace(
 /// Document this asymmetry rather than wrap the publish in another
 /// timeout layer (which would race with the publish's own ack-collection
 /// logic).
-/// How many distinct admitter **machines** this node will dial.
-///
-/// Counted in peers rather than addresses, because the several addresses a peer
-/// has are alternative routes to the same node: a direct one and a relay
-/// circuit, plus whatever it had before it last moved. If that node is off, all
-/// of them fail and the joiner has learned one fact — so charging four budget
-/// slots for it would spend the budget inside a single unreachable machine and
-/// never reach the next admitter, which may be up.
-///
-/// Deliberately far below the decode bound. `admitter_addrs` sits outside the
-/// inviter's signature, so anyone relaying an invitation may rewrite it, and
-/// dialing is an action taken on a stranger's say-so. A real invitation names a
-/// handful of admitters; anything past that is not a joiner being helped.
-const MAX_ADMITTER_PEERS_DIALED: usize = 8;
-
-/// Group admitter addresses by the machine they reach, capped at `max_peers`.
-///
-/// Order is preserved, and that is load-bearing rather than incidental: the mint
-/// puts TEE admitters first because they are hosted and stay up, and ordering is
-/// the only way it can say so — the field is bare strings, and a joiner that has
-/// synced nothing cannot tell a TEE account from an admin one.
-///
-/// The cap counts **machines**. Several addresses for one peer are alternative
-/// routes to it — a direct one, a relay circuit, whatever it had before it last
-/// moved — so if that machine is off they all fail and the joiner has learned
-/// one fact. Charging each of them against the budget would spend it inside a
-/// single unreachable node and never reach the next admitter.
-///
-/// An address with no `/p2p/<peer-id>` is dropped: without it the joiner cannot
-/// tell who answers there, which is the one thing the address exists to carry.
-fn group_admitter_routes(
-    addrs: &[String],
-    max_peers: usize,
-) -> Vec<(libp2p::PeerId, Vec<libp2p::Multiaddr>)> {
-    let mut by_peer: Vec<(libp2p::PeerId, Vec<libp2p::Multiaddr>)> = Vec::new();
-    for addr in addrs {
-        let Ok(parsed) = addr.parse::<libp2p::Multiaddr>() else {
-            tracing::debug!(%addr, "skipping unparseable admitter address");
-            continue;
-        };
-        let Some(libp2p::multiaddr::Protocol::P2p(peer)) = parsed.iter().last() else {
-            tracing::debug!(%addr, "skipping admitter address with no peer id");
-            continue;
-        };
-        // Split the lookup from the insert: a machine already in the list keeps
-        // collecting routes even once the cap is reached, while a new one past
-        // the cap contributes nothing.
-        if let Some((_, routes)) = by_peer.iter_mut().find(|(known, _)| *known == peer) {
-            routes.push(parsed);
-        } else if by_peer.len() < max_peers {
-            by_peer.push((peer, vec![parsed]));
-        }
-    }
-    by_peer
-}
-
-/// Dial the addresses an invitation offers, best-effort, before publishing.
-///
-/// Failures are expected and ignored: an address is a snapshot from mint time
-/// and may be stale, the peer may be down, and none of that should fail a join
-/// that gossip may well complete anyway. What this buys is the case gossip
-/// cannot cover — a joiner connected to nobody who may admit.
-///
-/// Nothing here trusts the address. libp2p authenticates the peer id during the
-/// handshake, and admission is decided by the *signed* `admitters` list at
-/// apply, on every peer. A wrong address costs a failed dial.
-async fn dial_admitter_addrs(node_client: &NodeClient, op: &NamespaceOp) {
-    let NamespaceOp::Root(RootOp::MemberJoinedAt {
-        signed_invitation, ..
-    }) = op
-    else {
-        return;
-    };
-
-    let offered = signed_invitation.admitter_addrs.len();
-    let by_peer =
-        group_admitter_routes(&signed_invitation.admitter_addrs, MAX_ADMITTER_PEERS_DIALED);
-    tracing::debug!(
-        offered,
-        machines = by_peer.len(),
-        "grouped admitter addresses by machine"
-    );
-
-    for (peer, routes) in by_peer {
-        for addr in routes {
-            match node_client.network_client().dial(addr.clone()).await {
-                Ok(()) => {
-                    tracing::debug!(%peer, %addr, "dialed an admitter named by the invitation");
-                    // One route to a machine is all that machine needs. The
-                    // rest are alternatives, not additions.
-                    break;
-                }
-                // Stale or unreachable is the ordinary case, not a fault: the
-                // address was recorded when the invitation was minted.
-                Err(err) => tracing::debug!(%peer, %addr, %err, "admitter address did not dial"),
-            }
-        }
-    }
-}
-
 pub async fn await_namespace_ready(
     store: &Store,
     node_client: &NodeClient,
@@ -536,13 +436,6 @@ pub async fn await_namespace_ready(
         joined_at: now_secs,
         account: join_account,
     });
-    // Reach an admitter before publishing. The op goes out on the namespace
-    // topic, so it only lands if somebody who may admit is actually connected —
-    // and a joiner that has synced nothing has no reason to be connected to
-    // anyone in particular. Dialing first is what turns the addresses the
-    // invitation carries into a join that completes.
-    dial_admitter_addrs(node_client, &op).await;
-
     let report = NamespaceGovernance::new(store, namespace_id.into())
         .sign_and_publish_without_apply(node_client, ack_router, &signing_key, op, None)
         .await
@@ -798,72 +691,5 @@ mod retry_backoff_tests {
             Duration::from_secs(2),
             max
         ));
-    }
-}
-
-#[cfg(test)]
-mod admitter_route_tests {
-    use super::group_admitter_routes;
-
-    fn addr(peer: &str, port: u16) -> String {
-        format!("/ip4/10.0.0.1/tcp/{port}/p2p/{peer}")
-    }
-
-    const A: &str = "12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN";
-    const B: &str = "12D3KooWQYhTNQdmr3ArTeUHRYzFg94BKyTkoWBDWez9kSCVe2Xo";
-
-    #[test]
-    fn several_routes_to_one_machine_cost_one_slot() {
-        // Four addresses, one machine. If the machine is off they all fail and
-        // the joiner has learned one thing — so they must not consume four
-        // slots and starve the next admitter.
-        let addrs = vec![addr(A, 1), addr(A, 2), addr(A, 3), addr(A, 4), addr(B, 1)];
-
-        let grouped = group_admitter_routes(&addrs, 2);
-
-        assert_eq!(grouped.len(), 2, "two machines, not five addresses");
-        assert_eq!(
-            grouped[0].1.len(),
-            4,
-            "all four routes to the first are kept"
-        );
-        assert_eq!(grouped[1].1.len(), 1);
-    }
-
-    #[test]
-    fn order_is_preserved_so_the_mints_tee_first_ordering_survives() {
-        // The mint expresses "try the hosted node first" as position, because
-        // the field is bare strings with nothing to mark a TEE node. Reordering
-        // here would silently discard that.
-        let addrs = vec![addr(B, 1), addr(A, 1)];
-
-        let grouped = group_admitter_routes(&addrs, 8);
-
-        assert_eq!(grouped[0].0.to_string(), B, "first offered is tried first");
-        assert_eq!(grouped[1].0.to_string(), A);
-    }
-
-    #[test]
-    fn the_cap_drops_machines_not_routes() {
-        let addrs = vec![addr(A, 1), addr(B, 1), addr(A, 2)];
-
-        let grouped = group_admitter_routes(&addrs, 1);
-
-        assert_eq!(grouped.len(), 1, "only the first machine survives the cap");
-        assert_eq!(
-            grouped[0].1.len(),
-            2,
-            "a machine already in the list keeps collecting its later routes"
-        );
-    }
-
-    #[test]
-    fn an_address_with_no_peer_id_is_dropped() {
-        let addrs = vec!["/ip4/10.0.0.1/tcp/2528".to_owned(), addr(A, 1)];
-
-        let grouped = group_admitter_routes(&addrs, 8);
-
-        assert_eq!(grouped.len(), 1);
-        assert_eq!(grouped[0].0.to_string(), A);
     }
 }

--- a/crates/node/src/sync/manager/namespace_join.rs
+++ b/crates/node/src/sync/manager/namespace_join.rs
@@ -85,6 +85,47 @@ pub(super) struct ConnectBudget {
     pub(super) discovery_wait: std::time::Duration,
 }
 
+/// Group admitter addresses by the machine they reach, capped at `max_peers`.
+///
+/// Order is preserved, and that is load-bearing rather than incidental: the mint
+/// puts TEE admitters first because they are hosted and stay up, and ordering is
+/// the only way it can say so — the field is bare strings, and a joiner that has
+/// synced nothing cannot tell a TEE account from an admin one.
+///
+/// The cap counts **machines**. Several addresses for one peer are alternative
+/// routes to it — a direct one, a relay circuit, whatever it had before it last
+/// moved — so if that machine is off they all fail and the joiner has learned
+/// one fact. Charging each of them against the budget would spend it inside a
+/// single unreachable node and never reach the next admitter.
+///
+/// An address with no `/p2p/<peer-id>` is dropped: without it the joiner cannot
+/// tell who answers there, which is the one thing the address exists to carry.
+pub(super) fn group_admitter_routes(
+    addrs: &[String],
+    max_peers: usize,
+) -> Vec<(libp2p::PeerId, Vec<libp2p::Multiaddr>)> {
+    let mut by_peer: Vec<(libp2p::PeerId, Vec<libp2p::Multiaddr>)> = Vec::new();
+    for addr in addrs {
+        let Ok(parsed) = addr.parse::<libp2p::Multiaddr>() else {
+            tracing::debug!(%addr, "skipping unparseable admitter address");
+            continue;
+        };
+        let Some(libp2p::multiaddr::Protocol::P2p(peer)) = parsed.iter().last() else {
+            tracing::debug!(%addr, "skipping admitter address with no peer id");
+            continue;
+        };
+        // Split the lookup from the insert: a machine already in the list keeps
+        // collecting routes even once the cap is reached, while a new one past
+        // the cap contributes nothing.
+        if let Some((_, routes)) = by_peer.iter_mut().find(|(known, _)| *known == peer) {
+            routes.push(parsed);
+        } else if by_peer.len() < max_peers {
+            by_peer.push((peer, vec![parsed]));
+        }
+    }
+    by_peer
+}
+
 pub(super) async fn open_namespace_join_stream(
     sync_network: &dyn SyncNetwork,
     namespace_id: [u8; 32],
@@ -817,5 +858,72 @@ mod tests {
             err.contains("mesh_retries must be > 0"),
             "zero mesh_retries should Err with a diagnostic, got: {err}"
         );
+    }
+}
+
+#[cfg(test)]
+mod admitter_route_tests {
+    use super::group_admitter_routes;
+
+    fn addr(peer: &str, port: u16) -> String {
+        format!("/ip4/10.0.0.1/tcp/{port}/p2p/{peer}")
+    }
+
+    const A: &str = "12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN";
+    const B: &str = "12D3KooWQYhTNQdmr3ArTeUHRYzFg94BKyTkoWBDWez9kSCVe2Xo";
+
+    #[test]
+    fn several_routes_to_one_machine_cost_one_slot() {
+        // Four addresses, one machine. If the machine is off they all fail and
+        // the joiner has learned one thing — so they must not consume four
+        // slots and starve the next admitter.
+        let addrs = vec![addr(A, 1), addr(A, 2), addr(A, 3), addr(A, 4), addr(B, 1)];
+
+        let grouped = group_admitter_routes(&addrs, 2);
+
+        assert_eq!(grouped.len(), 2, "two machines, not five addresses");
+        assert_eq!(
+            grouped[0].1.len(),
+            4,
+            "all four routes to the first are kept"
+        );
+        assert_eq!(grouped[1].1.len(), 1);
+    }
+
+    #[test]
+    fn order_is_preserved_so_the_mints_tee_first_ordering_survives() {
+        // The mint expresses "try the hosted node first" as position, because
+        // the field is bare strings with nothing to mark a TEE node. Reordering
+        // here would silently discard that.
+        let addrs = vec![addr(B, 1), addr(A, 1)];
+
+        let grouped = group_admitter_routes(&addrs, 8);
+
+        assert_eq!(grouped[0].0.to_string(), B, "first offered is tried first");
+        assert_eq!(grouped[1].0.to_string(), A);
+    }
+
+    #[test]
+    fn the_cap_drops_machines_not_routes() {
+        let addrs = vec![addr(A, 1), addr(B, 1), addr(A, 2)];
+
+        let grouped = group_admitter_routes(&addrs, 1);
+
+        assert_eq!(grouped.len(), 1, "only the first machine survives the cap");
+        assert_eq!(
+            grouped[0].1.len(),
+            2,
+            "a machine already in the list keeps collecting its later routes"
+        );
+    }
+
+    #[test]
+    fn an_address_with_no_peer_id_is_dropped() {
+        let addrs = vec!["/ip4/10.0.0.1/tcp/2528".to_owned(), addr(A, 1)];
+
+        let grouped = group_admitter_routes(&addrs, 8);
+
+        assert_eq!(grouped.len(), 1);
+        assert_eq!(grouped[0].0.to_string(), A);
     }
 }

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -112,6 +112,15 @@ fn join_target_group(
     }
 }
 
+/// How many distinct admitter machines a joiner will dial before opening its
+/// join stream.
+///
+/// Deliberately far below what an invitation may carry. The address list sits
+/// outside the inviter's signature, so anyone relaying an invitation may rewrite
+/// it, and dialing is an action taken on a stranger's say-so. A real invitation
+/// names a handful of admitters.
+const MAX_ADMITTER_MACHINES_DIALED: usize = 8;
+
 impl SyncManager {
     /// Actively request governance catch-up from a specific peer whose
     /// identity we don't yet recognize as a context member.
@@ -1135,6 +1144,48 @@ impl SyncManager {
     /// Best-effort and possibly empty: the field is unsigned and optional, an
     /// address may be stale, and a malformed one is skipped rather than failing the
     /// join. An empty result simply leaves peer selection as it was.
+    /// Dial the machines an invitation names, best-effort.
+    ///
+    /// Budgeted per machine rather than per address: the several addresses a
+    /// peer has are alternative routes to it — a direct one, a relay circuit,
+    /// whatever it had before it last moved — so if that machine is off they all
+    /// fail and this has learned one fact. Charging each against the budget
+    /// would spend it inside a single unreachable node and never reach the next
+    /// admitter, which may be up. Dialing a machine stops at the first route
+    /// that connects; the rest are alternatives, not additions.
+    ///
+    /// Nothing here is trusted. The address list is outside the inviter's
+    /// signature, so anyone relaying an invitation may rewrite it — but libp2p
+    /// authenticates the peer id on connect, and admission is decided by the
+    /// signed `admitters` list at apply on every peer. A wrong address costs a
+    /// failed dial.
+    async fn dial_admitters(&self, invitation_bytes: &[u8]) {
+        let Ok(invitation) = borsh::from_slice::<
+            calimero_context_config::types::SignedGroupOpenInvitation,
+        >(invitation_bytes) else {
+            return;
+        };
+
+        let by_machine = super::namespace_join::group_admitter_routes(
+            &invitation.admitter_addrs,
+            MAX_ADMITTER_MACHINES_DIALED,
+        );
+
+        for (peer, routes) in by_machine {
+            for addr in routes {
+                match self.network_client.dial(addr.clone()).await {
+                    Ok(()) => {
+                        debug!(%peer, %addr, "dialed an admitter named by the invitation");
+                        break;
+                    }
+                    Err(err) => {
+                        debug!(%peer, %addr, %err, "admitter address did not dial")
+                    }
+                }
+            }
+        }
+    }
+
     fn admitter_peer_ids(invitation_bytes: &[u8]) -> Vec<PeerId> {
         let Ok(invitation) = borsh::from_slice::<
             calimero_context_config::types::SignedGroupOpenInvitation,
@@ -1208,6 +1259,21 @@ impl SyncManager {
         // preference so much as the difference between a round trip that can
         // succeed and one that can only be refused.
         let admitter_peers = Self::admitter_peer_ids(&params.invitation_bytes);
+
+        // Reach those admitters before asking discovery about them.
+        //
+        // `open_namespace_join_stream` prefers them, but preference only helps
+        // among peers it can open a stream to, and `subscribed_peers` reports
+        // who is on the topic mesh — which is exactly what has not converged in
+        // the case this join path exists for. Dialing first is what turns an
+        // address the invitation carries into a peer the loop below can use.
+        //
+        // Best-effort and before the retry loop, not inside it: one pass over
+        // the invitation's addresses, then the loop's own budget governs the
+        // stream attempts. Failures are ordinary — an address is a snapshot
+        // from mint time — and none of them should fail a join that gossip may
+        // still complete.
+        self.dial_admitters(&params.invitation_bytes).await;
 
         for protocol_attempt in 1..=MAX_PROTOCOL_RETRIES {
             let (mut stream, peer) = match super::namespace_join::open_namespace_join_stream(


### PR DESCRIPTION
Closes #3793.

## The bug

#3772 added the dial of an invitation's `admitter_addrs`, and #3782 made it
budget per machine. Both landed in `join_namespace.rs::await_namespace_ready` —
which **nothing calls**:

- `await_namespace_ready` ← only `join_and_wait_ready`, which has no callers
- `join_namespace_with_retry` ← no callers
- the admin API's join route calls `join_group` (the context actor)
- `meroctl namespace join` hits that same route over HTTP
- `merod` does not reference the module, and nothing outside core depends on
  `calimero-node`

Both functions are `pub` in a `pub mod`, so dead-code analysis never flagged
them and `-D warnings` passed. Two PRs of dialing logic, with tests, that never
executed.

## What still worked

#3770's populate is on the mint route (live), #3782's TEE-first ordering is on
the mint side (live), and #3781's peer preference is in the direct-join path that
runs. So a joiner *did* prefer a named admitter when opening its stream — but
preference only helps among peers it can open a stream to, and
`subscribed_peers` reports who is on the topic mesh, which is precisely what has
not converged in the case this path exists for.

## The move

`dial_admitters` now runs in `SyncManager::initiate_namespace_join`, before the
join-stream retry loop. That location earns it beyond reachability:

- the admitter peer ids are already derived there for #3781's preference, from
  the same `params.invitation_bytes` — so the dial and the preference now read
  one list at one moment, instead of one on a dead path and one on the live one;
- `SyncManager` holds `network_client` directly (`manager/mod.rs:143`), so `dial`
  is callable. The `SyncNetwork` trait has no `dial`, which is why this cannot go
  through `sync_network`.

`group_admitter_routes` and its four tests move to
`sync/manager/namespace_join.rs`, beside the `open_namespace_join_stream` they
serve — deliberately, since #3795 proposes deleting the dead module and none of
this should go with it.

Net 174 lines out, 174 in.

## A side effect worth naming

This call site is on the live path, unlike the old one. So #3772's follow-up
commit — making `dial` report a closed mailbox rather than panicking — now
matters: a dial racing shutdown fails instead of taking the node down. That
hardening was arguably inert where it was.

It also means the panic attribution in that PR was wrong, which #3793 records: I
claimed the dial caused a `sync-resilience-peer-restart-symmetric` panic, and a
dial that never runs cannot have. Whether that scenario flaked or something else
caused it is still unresolved.

## Verification

| check | result |
| --- | --- |
| `cargo fmt --check` | pass |
| `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` | pass |
| `cargo clippy -p merod -p calimero-node -p calimero-server -p calimero-tee-attestation --all-targets --features mock-attestation -- -D warnings` | pass |
| `cargo check -p calimero-node --all-targets` | pass |
| 4 relocated tests, under their new module path | pass |
| full workspace + mock-attestation suites | **still running locally when this opened** |

The two suites were mid-run at push time — disk pressure on this machine has made
full gates slow today. CI runs them properly; I will note the local counts when
they land, and the change is a relocation plus one new call, all of which the
above covers.

## Coverage

merobox#402 adds the scenario that would have caught this: a delegated
invitation, with an `assert_log_present` on the dial line. A functional-only
assertion would have passed throughout, because gossip reaches the admitter
anyway in a small cluster.
