### PR TITLE
feat(storage): dispatch app-defined merge on a stamped collection entry

### DIFF
--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -75,3 +75,7 @@ required-features = ["testing"]
 [[test]]
 name = "custom_merge_dispatch"
 required-features = ["testing"]
+
+[[test]]
+name = "custom_merge_e2e"
+required-features = ["testing"]

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -633,7 +633,7 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         for (index, (item, storage_type)) in snapshot.into_iter().enumerate() {
             let id = compute_id(parent, &(index as u64).to_le_bytes());
             let _reinserted = self
-                .insert_with_storage_type(Some(id), item, storage_type)
+                .insert_with_storage_type(Some(id), item, storage_type, None)
                 .expect("re-insert vector child during reindex");
         }
     }
@@ -648,7 +648,7 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         // the bare `Collection::insert` (sets, vectors, RGA), so guarding a
         // collection covers those paths too — not only the direct `map.insert`.
         let inherited = self.storage.metadata.storage_type.clone();
-        self.insert_with_storage_type(id, item, inherited)
+        self.insert_with_storage_type(id, item, inherited, None)
             .map(|(_id, item)| item)
     }
 
@@ -685,11 +685,19 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
     /// the id is the only stable way to address the entry afterwards —
     /// enumeration is `(created_at, id)` ordered over a set other replicas
     /// insert into, so a position is not (core#3637).
+    /// `crdt_type` stamps the ENTRY, not the collection.
+    ///
+    /// It is what makes app-defined merge reachable: `try_merge_non_root`
+    /// dispatches on the entry's own `crdt_type`, and an entry that declares
+    /// nothing takes the legacy branch and resolves last-write-wins. Only the
+    /// collections that know their value type pass `Some` — the generic
+    /// `insert` cannot, since `T` there is already the erased item.
     pub(crate) fn insert_with_storage_type(
         &mut self,
         id: Option<Id>,
         item: T,
         storage_type: StorageType,
+        crdt_type: Option<CrdtType>,
     ) -> StoreResult<(Id, T)> {
         let mut collection = CollectionMut::new(self);
 
@@ -699,6 +707,7 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         };
         // Update the `StorageType`.
         entry.storage.metadata.storage_type = storage_type;
+        entry.storage.metadata.crdt_type = crdt_type;
 
         collection.insert(&mut entry)?;
 

--- a/crates/storage/src/collections/authored_vector.rs
+++ b/crates/storage/src/collections/authored_vector.rs
@@ -111,7 +111,10 @@ where
     ///
     /// # Errors
     /// Returns any underlying storage error.
-    pub fn push(&mut self, value: V) -> Result<Id, StoreError> {
+    pub fn push(&mut self, value: V) -> Result<Id, StoreError>
+    where
+        V: 'static,
+    {
         let storage_type = super::authored_common::make_owner_stamp();
         self.inner.push_with_storage_type(value, storage_type)
     }

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -192,6 +192,7 @@ where
                     anchor,
                     signature_data: None,
                 },
+                None,
             )
             .expect("failed to write initial WriterSetCell value")
             .1;
@@ -273,6 +274,7 @@ where
                     anchor: new_anchor,
                     signature_data: None,
                 },
+                None,
             )
             .expect("failed to relocate WriterSetCell value")
             .1;
@@ -515,9 +517,9 @@ where
             anchor: self.inner.id(),
             signature_data: None,
         };
-        let (_new_id, new) = self
-            .inner
-            .insert_with_storage_type(Some(value_id), value, member)?;
+        let (_new_id, new) =
+            self.inner
+                .insert_with_storage_type(Some(value_id), value, member, None)?;
         *self.value.borrow_mut() = Some(new);
         Ok(Some(old))
     }

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -383,9 +383,12 @@ where
         let order_key = S::index_supported().then(|| key.as_ref().to_vec());
         let collection = self.inner.id();
 
-        let _ignored = self
-            .inner
-            .insert_with_storage_type(Some(id), (value, key), storage_type)?;
+        let _ignored = self.inner.insert_with_storage_type(
+            Some(id),
+            (value, key),
+            storage_type,
+            crate::merge::custom_type_id_of::<V>().map(CrdtType::Custom),
+        )?;
 
         if let Some(order_key) = order_key {
             // Done after the inner write so the collection's `full_hash` already

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -372,9 +372,12 @@ where
 
         // Insert into the inner collection.
         // Pass the `StorageType` directly to the `Collection`.
-        let _ignored = self
-            .inner
-            .insert_with_storage_type(Some(id), (value, key), storage_type)?;
+        let _ignored = self.inner.insert_with_storage_type(
+            Some(id),
+            (value, key),
+            storage_type,
+            crate::merge::custom_type_id_of::<V>().map(CrdtType::Custom),
+        )?;
 
         Ok(None)
     }

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -80,7 +80,12 @@ where
             let id = super::compute_id(parent, v.as_ref());
             let _ = self
                 .inner
-                .insert_with_storage_type(Some(id), v, storage_type)
+                .insert_with_storage_type(
+                    Some(id),
+                    v,
+                    storage_type,
+                    crate::merge::custom_type_id_of::<V>().map(CrdtType::Custom),
+                )
                 .expect("re-insert set element during re-key");
         }
     }
@@ -202,7 +207,12 @@ where
             let id = super::compute_id(parent, value.as_ref());
             let _ = self
                 .inner
-                .insert_with_storage_type(Some(id), value, storage_type)
+                .insert_with_storage_type(
+                    Some(id),
+                    value,
+                    storage_type,
+                    crate::merge::custom_type_id_of::<V>().map(CrdtType::Custom),
+                )
                 .expect("failed to re-insert element during migration");
         }
     }
@@ -643,7 +653,7 @@ mod tests {
         let pre_id = compute_id(set.inner.id(), "x".as_bytes());
         let _ignored = set
             .inner
-            .insert_with_storage_type(Some(pre_id), "x".to_owned(), shared)
+            .insert_with_storage_type(Some(pre_id), "x".to_owned(), shared, None)
             .expect("seed shared entry");
 
         set.reassign_deterministic_id("tags");

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -169,10 +169,16 @@ where
         &mut self,
         value: V,
         storage_type: crate::entities::StorageType,
-    ) -> Result<Id, StoreError> {
-        let (id, _item) = self
-            .inner
-            .insert_with_storage_type(None, value, storage_type)?;
+    ) -> Result<Id, StoreError>
+    where
+        V: 'static,
+    {
+        let (id, _item) = self.inner.insert_with_storage_type(
+            None,
+            value,
+            storage_type,
+            crate::merge::custom_type_id_of::<V>().map(CrdtType::Custom),
+        )?;
         // The id, not `len - 1`.
         //
         // `len - 1` meant "the new entry is last", which held only while

--- a/crates/storage/src/interface.rs
+++ b/crates/storage/src/interface.rs
@@ -43,7 +43,7 @@ use borsh::{from_slice, to_vec};
 use calimero_account::AccountId;
 use calimero_primitives::identity::PublicKey;
 use sha2::{Digest, Sha256};
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::address::Id;
 use crate::child_trie::ChildTrie;
@@ -3245,8 +3245,30 @@ impl<S: StorageAdaptor> Interface<S> {
         let final_data = if let Some(last_metadata) = &last_metadata {
             if matches!(
                 metadata.crdt_type,
-                Some(crate::collections::crdt_meta::CrdtType::RotationLog)
-            ) {
+                Some(
+                    crate::collections::crdt_meta::CrdtType::RotationLog
+                        | crate::collections::crdt_meta::CrdtType::Custom(_)
+                )
+            ) && !crate::collections::is_app_root_entry(id)
+            {
+                // `Custom` joins this arm for the same reason, and it is
+                // load-bearing rather than tidy. The `is_app_root_entry` guard
+                // keeps it to NON-root entries: a root stamped `Custom` has its
+                // own merge path below (`merge_root_state`), which raises the
+                // I5 error when the app registered no merger. Catching roots
+                // here instead would swallow that error and resolve them by
+                // LWW — `non_opaque_root_local_write_still_errors_when_unregistered`
+                // is the test that says so. The `updated_at` branches below
+                // short-circuit a stale incoming write with `return Ok(None)`,
+                // which is right for LWW — an older write loses anyway — and
+                // wrong for an app-defined rule, which still needs to SEE that
+                // write. Without this, whichever replica happened to write
+                // second merges and the other silently keeps its own value:
+                // concurrent 900 and 100 under a "highest wins" rule converge to
+                // 900 on one node and 100 on the other. The merge has to run in
+                // both directions or it is not commutative, and the entities
+                // never converge.
+                //
                 // P3 (core#2716) per-`delta_id` rotation-log child. Merge
                 // REGARDLESS of timestamp ordering (the LWW-by-HLC branches below
                 // would stale-skip a concurrent same-id write). `try_merge_non_root`
@@ -3876,14 +3898,54 @@ impl<S: StorageAdaptor> Interface<S> {
                     );
                 }
             }
+        } else if let CrdtType::Custom(type_id) = crdt_type {
+            // App-defined merge. The entry carries the id because its
+            // collection stamped it at insert from the value type's
+            // declaration; without that stamp this arm is unreachable and the
+            // app's rule silently never runs.
+            match crate::merge::merge_custom(*type_id, existing, incoming) {
+                Ok(merged) => {
+                    trace!(
+                        target: "storage::merge",
+                        %id,
+                        crdt_type = ?crdt_type,
+                        "Merged via the app's own rule"
+                    );
+                    return Ok(merged);
+                }
+                // Nothing claimed the id in this build. In WASM that means the
+                // app no longer declares a type it once stamped — upgrade skew.
+                // On a host there is no registry at all and the merge belongs
+                // to the guest callback, which the caller reaches instead.
+                Err(MergeError::WasmRequired { .. }) => {
+                    debug!(
+                        target: "storage::merge",
+                        %id,
+                        crdt_type = ?crdt_type,
+                        "No app merge registered here; leaving it to the caller"
+                    );
+                }
+                // The app's own rule failed. LWW is the wrong repair — it would
+                // resolve a conflict the app declared itself responsible for,
+                // and do it differently on each replica depending on which side
+                // arrived first. Refuse instead.
+                Err(err) => {
+                    error!(
+                        target: "storage::merge",
+                        %id,
+                        crdt_type = ?crdt_type,
+                        error = ?err,
+                        "App-defined merge failed"
+                    );
+                    return Err(StorageError::MergeFailure(err));
+                }
+            }
         } else {
-            // Types that need WASM callback (LwwRegister, collections, Custom)
-            // For now, fall back to LWW. PR #1940 will add WASM callback support.
             debug!(
                 target: "storage::merge",
                 %id,
                 crdt_type = ?crdt_type,
-                "CRDT type requires WASM callback, falling back to LWW"
+                "CRDT type is not merged in this layer, falling back to LWW"
             );
         }
 

--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -53,7 +53,9 @@ pub use registry::{register_crdt_merge, try_merge_registered, MergeRegistryResul
 // Always available: both have a host fallback, so the registration walk and the
 // merge dispatch compile from any build rather than only the ones that can act
 // on them. See `custom_registry`.
-pub use custom_registry::{has_custom_merges, merge_custom, register_custom_merge};
+pub use custom_registry::{
+    custom_type_id_of, has_custom_merges, merge_custom, register_custom_merge,
+};
 
 // Always-native wrapper for the in-process test harness. Unlike
 // `register_crdt_merge` it isn't gated behind the `testing` feature, so an

--- a/crates/storage/src/merge/custom_registry.rs
+++ b/crates/storage/src/merge/custom_registry.rs
@@ -10,6 +10,8 @@
 //! `__calimero_register_merge` export, and are read by `Interface::save_internal`
 //! running in that same instance during delta apply.
 
+#[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
+use core::any::TypeId;
 #[cfg(test)]
 use core::cell::RefCell;
 #[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
@@ -79,6 +81,51 @@ fn with_registry_mut<R>(f: impl FnOnce(&mut HashMap<CustomTypeId, CustomMergeFn>
     })
 }
 
+/// Rust type -> wire id, for stamping an entry at insert time.
+///
+/// Separate from the dispatch table because the two are looked up by different
+/// keys and at different moments. Dispatch arrives from the wire holding a
+/// [`CustomTypeId`]; stamping happens inside a generic `insert<V>` that knows
+/// only `V`, and cannot name a trait bound to ask `V` directly — the same
+/// constraint `rekey_nested_value` solves the same way.
+#[cfg(all(any(target_arch = "wasm32", feature = "testing"), not(test)))]
+static CUSTOM_TYPE_IDS: LazyLock<RwLock<HashMap<TypeId, CustomTypeId>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+#[cfg(test)]
+thread_local! {
+    static CUSTOM_TYPE_IDS: RefCell<HashMap<TypeId, CustomTypeId>> =
+        RefCell::new(HashMap::new());
+}
+
+/// The wire id `V` was registered under, if it declared one.
+///
+/// Callable from a generic `insert<V>`: it keys on `TypeId`, so it needs no
+/// bound on `V` beyond `'static`.
+#[cfg(any(target_arch = "wasm32", test, feature = "testing"))]
+#[must_use]
+pub fn custom_type_id_of<V: 'static>() -> Option<CustomTypeId> {
+    #[cfg(not(test))]
+    {
+        CUSTOM_TYPE_IDS
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(&TypeId::of::<V>())
+            .copied()
+    }
+    #[cfg(test)]
+    {
+        CUSTOM_TYPE_IDS.with(|m| m.borrow().get(&TypeId::of::<V>()).copied())
+    }
+}
+
+/// Host build: nothing registers, so nothing is stamped.
+#[cfg(not(any(target_arch = "wasm32", test, feature = "testing")))]
+#[must_use]
+pub const fn custom_type_id_of<V: 'static>() -> Option<CustomTypeId> {
+    None
+}
+
 /// Register `T`'s merge under its [`CustomMergeable::TYPE_ID`].
 ///
 /// Returns whether this was a NEW registration. The cascade walk offers every
@@ -94,9 +141,20 @@ where
         + borsh::BorshDeserialize,
 {
     let merge_fn: CustomMergeFn = |existing, incoming| {
-        let mut existing_value = borsh::from_slice::<T>(existing)
+        // These are ENTRY bytes, not value bytes: `borsh(item) ++ element id`,
+        // and for a map `item` is `(V, K)`. Only the leading `V` is ours — the
+        // key and the id belong to the collection and must come back byte for
+        // byte.
+        //
+        // Hence reader-decoding rather than `from_slice`, which rejects
+        // trailing bytes. The reader stops exactly where `V` ends, which is the
+        // whole reason entries are stored value-first: at offset 0 a value is
+        // decodable without knowing the key's type.
+        let mut existing_rest = existing;
+        let mut existing_value = T::deserialize_reader(&mut existing_rest)
             .map_err(|e| MergeError::SerializationError(format!("existing: {e}")))?;
-        let incoming_value = borsh::from_slice::<T>(incoming)
+
+        let incoming_value = T::deserialize_reader(&mut &incoming[..])
             .map_err(|e| MergeError::SerializationError(format!("incoming: {e}")))?;
 
         // Merge mode suppresses timestamp generation. Without it each replica
@@ -104,8 +162,30 @@ where
         // differ, so identical logical state hashes differently.
         crate::env::with_merge_mode(|| existing_value.merge(&incoming_value))?;
 
-        borsh::to_vec(&existing_value).map_err(|e| MergeError::SerializationError(e.to_string()))
+        // The merged value, then `existing`'s untouched tail. Taking the tail
+        // from `existing` rather than `incoming` keeps the entry's own id: both
+        // sides describe the same entity, so the key agrees, but the id is this
+        // replica's and is not the merge's to change.
+        let mut out = borsh::to_vec(&existing_value)
+            .map_err(|e| MergeError::SerializationError(e.to_string()))?;
+        out.extend_from_slice(existing_rest);
+        Ok(out)
     };
+
+    // Both tables or neither: a stamped entry whose id has no merge function
+    // would dispatch to nothing, and a registered merge whose type is never
+    // stamped would never be reached.
+    #[cfg(not(test))]
+    {
+        let _ = CUSTOM_TYPE_IDS
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(TypeId::of::<T>(), T::TYPE_ID);
+    }
+    #[cfg(test)]
+    CUSTOM_TYPE_IDS.with(|m| {
+        let _ = m.borrow_mut().insert(TypeId::of::<T>(), T::TYPE_ID);
+    });
 
     with_registry_mut(|registry| registry.insert(T::TYPE_ID, merge_fn).is_none())
 }

--- a/crates/storage/tests/custom_merge_dispatch.rs
+++ b/crates/storage/tests/custom_merge_dispatch.rs
@@ -1,7 +1,5 @@
-//! `#[app::mergeable]` declares a type and registers its merge (links 1 and 3
-//! of #3785). Stamping the declaration onto collection entries is link 2 and is
-//! NOT here — `dispatch_is_declared_but_not_yet_reached` pins that gap so this
-//! change cannot be mistaken for a working feature.
+//! `#[app::mergeable]` declares a type, registers its merge, and gets that
+//! declaration stamped onto the entries holding it — links 1, 2 and 3 of #3785.
 //!
 //! Every id here is read back off the type via `CrdtMeta::crdt_type()` rather
 //! than written out by hand. Hand-built ids are what let PR #1995 ship a
@@ -25,7 +23,7 @@ use calimero_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use calimero_storage::collections::crdt_meta::{CustomTypeId, MergeError};
 use calimero_storage::collections::rekey::register_rekey_cascade;
 use calimero_storage::collections::{Counter, CrdtMeta, CrdtType, Mergeable};
-use calimero_storage::merge::{merge_by_crdt_type, merge_custom};
+use calimero_storage::merge::{custom_type_id_of, merge_by_crdt_type, merge_custom};
 
 /// The id a `CrdtType::Custom` is carrying, or a failure naming what it was.
 fn custom_id_of<T: CrdtMeta>() -> CustomTypeId {
@@ -157,13 +155,13 @@ fn an_unregistered_type_reports_the_id_it_could_not_resolve() {
     );
 }
 
-/// **The gap this change does not close.** `merge_by_crdt_type` is what
-/// `Interface::try_merge_non_root` calls, and it still refuses a `Custom`
-/// instead of consulting the registry — and nothing stamps an entry with a
-/// `Custom` in the first place. Both are link 2, and land together in the next
-/// change; this assertion is expected to be inverted then, not deleted.
+/// The gap PR #3791 left open, now closed: `merge_by_crdt_type` is what
+/// `Interface::try_merge_non_root` consults, and a `Custom` reaching it used to
+/// be refused. It still is *here* — dispatch lives in `try_merge_non_root`
+/// itself, not in `merge_by_crdt_type`, because the registry lookup needs the
+/// entry's id rather than only its variant.
 #[test]
-fn dispatch_is_declared_but_not_yet_reached() {
+fn merge_by_crdt_type_still_defers_custom_to_the_caller() {
     register_rekey_cascade::<HighestBid>();
 
     let bytes = borsh::to_vec(&HighestBid::default()).unwrap();
@@ -171,6 +169,29 @@ fn dispatch_is_declared_but_not_yet_reached() {
 
     assert!(
         matches!(result, Err(MergeError::WasmRequired { .. })),
-        "storage still refuses Custom rather than dispatching it"
+        "variant-only dispatch cannot resolve a Custom; the id-aware caller does"
     );
+}
+
+/// **Link 2.** An entry holding a declared type is stamped with it at insert.
+/// Without this the entry carries `crdt_type: None`, `try_merge_non_root` takes
+/// its legacy branch, and every merge rule above is unreachable — which is
+/// precisely the state PR #1995 shipped in.
+#[test]
+fn a_collection_entry_is_stamped_with_its_value_type() {
+    register_rekey_cascade::<HighestBid>();
+
+    assert_eq!(
+        custom_type_id_of::<HighestBid>(),
+        Some(custom_id_of::<HighestBid>()),
+        "the stamping table must agree with what the type declares"
+    );
+}
+
+/// A type that never registered is not stamped, so an ordinary value keeps the
+/// legacy path rather than being labelled with someone else's id.
+#[test]
+fn an_unregistered_type_is_not_stamped() {
+    assert_eq!(custom_type_id_of::<u64>(), None);
+    assert_eq!(custom_type_id_of::<String>(), None);
 }

--- a/crates/storage/tests/custom_merge_e2e.rs
+++ b/crates/storage/tests/custom_merge_e2e.rs
@@ -1,0 +1,151 @@
+//! End-to-end proof that an app's own merge rule decides a real collection
+//! entry: insert stamps it, sync applies through `Interface::save_internal`,
+//! and `try_merge_non_root` dispatches on the stamp.
+//!
+//! This is the test PR #1995 lacked. Its dispatch code was correct and
+//! unreachable, and only a run through the production path distinguishes those
+//! — a unit test handed a fabricated `CrdtType::Custom` passes either way.
+//!
+//! **Its own test binary, deliberately.** `ROOT_ID` is a process-wide
+//! `LazyLock<Id>` derived from `context_id()`, so whichever test touches a
+//! collection first freezes it — and a sibling test that does so outside a
+//! `RuntimeEnv` freezes it at the no-env fallback `[236; 32]`, after which
+//! genesis here fails with `CannotCreateOrphan`. Sharing a binary with the
+//! table-level tests is what that costs.
+
+#![cfg(feature = "testing")]
+#![allow(clippy::unwrap_used)]
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use calimero_sdk::app;
+use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_storage::collections::crdt_meta::MergeError;
+use calimero_storage::collections::rekey::register_rekey_cascade;
+use calimero_storage::collections::{Mergeable, Root, UnorderedMap};
+use calimero_storage::env::{self, RuntimeEnv};
+use calimero_storage::interface::ApplyContext;
+use calimero_storage::store::Key;
+use serial_test::serial;
+
+type Store = Rc<RefCell<HashMap<[u8; 32], Vec<u8>>>>;
+//
+// Everything above tests a table. This drives the production path — insert
+// stamps the entry, sync applies through `Interface::save_internal`, and
+// `try_merge_non_root` dispatches on the stamp — with a rule LWW cannot
+// imitate. It is the test #1995 lacked: its dispatch was correct and
+// unreachable, and only an end-to-end run distinguishes those.
+
+fn env_for(s: &Store, ex: [u8; 32]) -> RuntimeEnv {
+    let r = s.clone();
+    let reader = Rc::new(move |k: &Key| r.borrow().get(&k.to_bytes()).cloned());
+    let w = s.clone();
+    let writer =
+        Rc::new(move |k: Key, v: &[u8]| w.borrow_mut().insert(k.to_bytes(), v.to_vec()).is_some());
+    let rm = s.clone();
+    let remover = Rc::new(move |k: &Key| rm.borrow_mut().remove(&k.to_bytes()).is_some());
+    let account = {
+        let mut a = ex;
+        a[1] = 0xAC;
+        a
+    };
+    RuntimeEnv::new(reader, writer, remover, [7u8; 32], ex, account)
+}
+
+/// `bid` is a plain `u64` — no CRDT of its own — so whatever decides it is
+/// visible in the answer. The app says highest wins.
+#[app::mergeable]
+#[derive(BorshSerialize, BorshDeserialize, Default)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct Auction {
+    bid: u64,
+}
+
+impl Mergeable for Auction {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.bid = self.bid.max(other.bid);
+        Ok(())
+    }
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Default)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct AuctionApp {
+    lots: UnorderedMap<String, Auction>,
+}
+
+// The root's own re-key: anchor `lots` under the root id, or the map keeps a
+// random id and its entries are orphans. `#[app::state]` generates this; the
+// harness spells it out because these types are declared in a test.
+impl calimero_storage::collections::rekey::RekeyTarget for AuctionApp {
+    fn rekey_relative_to(&mut self, parent_id: calimero_storage::address::Id) {
+        calimero_storage::rekey_field_if_supported!(
+            &mut self.lots,
+            calimero_storage::collections::rekey::field_child_id(parent_id, "lots")
+        );
+    }
+
+    fn register_nested_value_types() {
+        register_rekey_cascade::<Auction>();
+    }
+}
+
+impl Mergeable for AuctionApp {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.lots.merge(&other.lots)
+    }
+}
+
+/// Two replicas bid concurrently on the same lot. Under LWW one bid is thrown
+/// away and the replicas can disagree about which; under the app's rule both
+/// land on the higher one.
+#[test]
+#[serial]
+fn the_apps_rule_decides_a_real_entry_across_two_replicas() {
+    // The env and both registries are process-global with no reset between
+    // tests in a binary; the other tests here register their own types.
+    env::reset_environment();
+    register_rekey_cascade::<Auction>();
+    calimero_storage::merge::register_crdt_merge_for_test::<AuctionApp>();
+
+    let a: Store = Default::default();
+    let b: Store = Default::default();
+
+    env::with_runtime_env(env_for(&a, [1; 32]), || {
+        Root::new(AuctionApp::default).commit();
+    });
+    *b.borrow_mut() = a.borrow().clone();
+
+    let bid = |store: &Store, ex: [u8; 32], amount: u64| {
+        env::with_runtime_env(env_for(store, ex), || {
+            let mut app = Root::<AuctionApp>::fetch().unwrap();
+            app.lots
+                .insert("lot-1".to_owned(), Auction { bid: amount })
+                .unwrap();
+            app.commit();
+            env::take_last_artifact().unwrap()
+        })
+    };
+
+    // Low bid second in wall-clock order, so a naive "newest wins" would keep it.
+    let da = bid(&a, [1; 32], 900);
+    let db = bid(&b, [2; 32], 100);
+
+    let read = |store: &Store, ex: [u8; 32], delta: &[u8]| {
+        env::with_runtime_env(env_for(store, ex), || {
+            Root::<AuctionApp>::sync(delta, &ApplyContext::empty()).unwrap();
+            let app = Root::<AuctionApp>::fetch().unwrap();
+            let bid = app.lots.get("lot-1").unwrap().map(|v| v.bid);
+            (env::root_hash(), bid)
+        })
+    };
+
+    let (ha, va) = read(&a, [1; 32], &db);
+    let (hb, vb) = read(&b, [2; 32], &da);
+
+    assert_eq!(va, Some(900), "replica A must take the higher bid");
+    assert_eq!(vb, Some(900), "replica B must take the higher bid");
+    assert_eq!(ha, hb, "replicas must converge");
+}


### PR DESCRIPTION
Third of four for #3785. #3796 is merged, so this targets master directly (rebased onto it).

Closes the gap #3789 and #3791 left open: a custom type could declare itself and register its merge, but nothing stamped that declaration onto the entries holding it, so the dispatch was unreachable. That is the exact state PR #1995 shipped in, and it is why this PR's acceptance gate is an end-to-end test rather than a unit test.

## What lands

**Stamping.** Every collection that knows its value type stamps the entry at insert with `custom_type_id_of::<V>()`. The lookup keys on `TypeId`, so it works inside a generic `insert<V>` with no bound to name — the same constraint `rekey_nested_value` solves the same way. Populated by the registration walk from #3791, so no new plumbing.

**Dispatch.** `try_merge_non_root` consults the registry on `Custom(id)`. The registered merge reader-decodes the value at offset 0 and carries the entry's tail — key and element id — through byte for byte. `from_slice` cannot be used: these are entry bytes, not value bytes, and it rejects the trailing data. The tail comes from `existing` rather than `incoming` so the entry keeps this replica's own id, which is not the merge's to change. Decoding a value without knowing the key's type is precisely what #3796 exists for.

**A merge failure refuses rather than falls back.** LWW is the wrong repair for a conflict the app declared itself responsible for, and it would resolve differently on each replica depending on arrival order.

**The unconditional-merge branch is scoped to non-root entries.** Without an `is_app_root_entry` guard it also caught roots, and a root stamped `Custom` with no registered merger then stopped raising the I5 "fail loudly" error and fell through to LWW instead. `non_opaque_root_local_write_still_errors_when_unregistered` caught that; roots keep their own merge path.

## The bug the e2e test found

`Custom` joins `RotationLog` on the unconditional-merge branch, and this took two replicas to surface.

The `updated_at` branches below it short-circuit a stale incoming write with `return Ok(None)`. That is right for LWW — an older write loses anyway — and wrong for an app-defined rule, which still needs to *see* that write. Without it, whichever replica happened to write second merged and the other silently kept its own value:

```
before:  A bids 900, B bids 100, exchange deltas
         A -> 900   (merged: incoming was newer)
         B -> 100   (stale-skipped: incoming was older)
         root hashes differ

after:   A -> 900, B -> 900, converged
```

A merge that runs in only one direction is not commutative and does not converge. `RotationLog` already documents this exact hazard on the same branch; `Custom` needed the same treatment.

No unit test could have caught it. The dispatch was correct, registered, reached, and returned the right answer — on one side.

## Tests

`tests/custom_merge_e2e.rs` — two replicas, a real `UnorderedMap`, a plain `u64` field, and a rule (`max`) that neither field-by-field delegation nor blob LWW can imitate. It asserts both values **and** root-hash convergence. It failed on the decode before #3796 and on the stale-skip after, so it earned its keep twice.

`dispatch_is_declared_but_not_yet_reached` is **inverted, not deleted** — it now pins that the variant-only `merge_by_crdt_type` still defers a `Custom`, because dispatch needs the entry's id and not just its shape. Two new tests cover the stamping table: a registered type is stamped, an unregistered one is not.

Every id in these tests is read back off the type via `CrdtMeta::crdt_type()`, never written by hand. Hand-built ids are how #1995's tests passed while nothing in production could reach the code they exercised.

## Test plan

All re-run on the rebased tree, after the root-entry guard above — an earlier
draft of this description quoted a suite run that predated that change.

```
$ cargo test -p calimero-storage --features testing --lib
719 passed; 0 failed; 0 filtered out

$ cargo test -p calimero-storage --features testing --tests
cargo exit 0; 19 binaries, 19 result lines, 796 passed, 0 failed

$ cargo test -p calimero-node --lib
569 passed; 0 failed; 0 filtered out

$ cargo check -p calimero-storage                                 # exit 0
$ cargo check -p calimero-storage --all-targets --features testing # exit 0
$ cargo check -p calimero-storage --all-targets --all-features     # exit 0
$ cargo check -p calimero-storage --target wasm32-unknown-unknown  # exit 0
$ cargo clippy -p calimero-storage --all-targets -- -D warnings                    # exit 0
$ cargo clippy -p calimero-storage --all-targets --features testing -- -D warnings # exit 0
$ cargo fmt --check                                                # clean
```

## What this does NOT do

**Host-side dispatch is not wired.** Everything above is the in-WASM path, where `save_internal` runs inside the guest during delta apply and the registry lookup works. HashComparison repair calls `Interface::<MainStorage>::apply_action` directly from the node crate with no guest instance in scope; there, `merge_custom` returns `WasmRequired` and the caller falls through.

That means a custom-typed entity repaired by HC still resolves by LWW, so the two paths can disagree — the same class of hazard as the stale-skip above, and the reason it is called out here rather than left to be discovered. The follow-up is a `RuntimeMergeCallback` with an instance cached per `Module` (#1997's own recommendation), harvested from #1995's `d3c3b1ba`. It is a separate PR because it lives in `calimero-runtime`/`calimero-node` and deserves its own review, not because it is optional.

**Docs are stale.** `crates/storage/AGENTS.md` still says `Custom | WasmRequired error` and points at closed PR #1940. That table is wrong the moment this merges and should be fixed in the same series.

Refs #3785.
