### PR TITLE
feat(node,sdk): dispatch app-defined merge for entries the host defers

### DIFF
--- a/crates/context/primitives/src/client/mod.rs
+++ b/crates/context/primitives/src/client/mod.rs
@@ -1783,6 +1783,102 @@ impl ContextClient {
         }
     }
 
+    /// Invoke the app's merge for one custom-typed collection ENTRY and return
+    /// the merged bytes.
+    ///
+    /// The receive-side counterpart to [`Self::merge_root_state`], for entries
+    /// rather than the root. Sync apply cannot do this itself: it is a
+    /// synchronous call inside the storage env, and reaching the rule means
+    /// reaching into this module. So the apply defers the entry and the sync
+    /// driver calls here once the session is over — nothing is nested, which is
+    /// why no second WASM instance is needed.
+    ///
+    /// Dispatch is by `CustomTypeId`, which the entry itself carries, so one
+    /// export serves every `#[app::mergeable]` type rather than one per type.
+    ///
+    /// Returns `InternalErrorKind::Merge` if the app's rule failed, if this
+    /// build's app no longer registers that id (an upgrade skew), or if the
+    /// module exports nothing — which means the app never used `#[app::state]`.
+    /// The caller leaves the entity for the next sync round rather than
+    /// resolving it by LWW, which is the wrong answer for a conflict the app
+    /// declared itself responsible for.
+    pub async fn merge_custom(
+        &self,
+        context_id: &ContextId,
+        executor: &PublicKey,
+        request: calimero_storage::merge::MergeCustomRequest,
+    ) -> Result<Vec<u8>, ExecuteError> {
+        let payload = borsh::to_vec(&request).map_err(|err| {
+            tracing::error!(
+                %context_id,
+                %err,
+                "merge_custom: failed to serialize MergeCustomRequest"
+            );
+            ExecuteError::InternalError {
+                kind: InternalErrorKind::Merge,
+            }
+        })?;
+
+        let response = self
+            .execute(
+                context_id,
+                executor,
+                "__calimero_merge_custom".to_owned(),
+                payload,
+                None,
+            )
+            .await?;
+
+        let return_bytes = match response.returns {
+            Ok(Some(bytes)) => bytes,
+            Ok(None) => {
+                tracing::error!(
+                    %context_id,
+                    "merge_custom: WASM export returned no bytes"
+                );
+                return Err(ExecuteError::InternalError {
+                    kind: InternalErrorKind::Merge,
+                });
+            }
+            Err(err) => {
+                tracing::error!(
+                    %context_id,
+                    ?err,
+                    "merge_custom: WASM export reported a function-call error"
+                );
+                return Err(ExecuteError::InternalError {
+                    kind: InternalErrorKind::Merge,
+                });
+            }
+        };
+
+        let response: calimero_storage::merge::MergeCustomResponse =
+            borsh::from_slice(&return_bytes).map_err(|err| {
+                tracing::error!(
+                    %context_id,
+                    %err,
+                    "merge_custom: failed to deserialize MergeCustomResponse"
+                );
+                ExecuteError::InternalError {
+                    kind: InternalErrorKind::Merge,
+                }
+            })?;
+
+        match response {
+            calimero_storage::merge::MergeCustomResponse::Ok(bytes) => Ok(bytes),
+            calimero_storage::merge::MergeCustomResponse::Err(msg) => {
+                tracing::error!(
+                    %context_id,
+                    error = %msg,
+                    "merge_custom: WASM Mergeable::merge returned an error"
+                );
+                Err(ExecuteError::InternalError {
+                    kind: InternalErrorKind::Merge,
+                })
+            }
+        }
+    }
+
     /// Sends a request to update the application for a given context.
     /// This is an asynchronous operation handled by the `ContextManager` actor.
     ///

--- a/crates/node/src/sync/hash_comparison_protocol.rs
+++ b/crates/node/src/sync/hash_comparison_protocol.rs
@@ -41,7 +41,7 @@
 use crate::sync::helpers::{
     apply_leaf_with_crdt_merge, apply_leaf_with_crdt_merge_gated, apply_under_context_lock,
     generate_nonce, get_local_root_hash_for_context, handle_entity_push,
-    is_leaf_currently_authorized, LeafOutcome, MAX_ENTITIES_PER_PUSH,
+    is_leaf_currently_authorized, LeafDisposition, LeafOutcome, MAX_ENTITIES_PER_PUSH,
 };
 use async_trait::async_trait;
 use calimero_context_client::client::ContextClient;
@@ -51,7 +51,7 @@ use calimero_node_primitives::sync::{
     TreeLeafData, TreeNode, TreeNodeResponse, MAX_LEAF_VALUE_SIZE, MAX_NODES_PER_RESPONSE,
 };
 use calimero_primitives::context::ContextId;
-use calimero_primitives::crdt::CrdtType;
+use calimero_primitives::crdt::{CrdtType, CustomTypeId};
 use calimero_primitives::hash::Hash;
 use calimero_primitives::identity::PublicKey;
 use calimero_storage::address::Id;
@@ -160,6 +160,15 @@ pub struct HashComparisonStats {
     /// the dispatch uses the actual remote write time instead of a
     /// synthetic value.
     pub deferred_root_merges: Vec<([u8; 32], Vec<u8>, u64)>,
+
+    /// Custom-typed ENTRIES deferred for the same reason, with the id the
+    /// entry declares so the dispatch does not have to re-read it.
+    ///
+    /// Without this the host resolves such an entry by LWW while the in-WASM
+    /// delta path resolves it by the app's rule — the same conflict settling
+    /// two different ways depending on which path delivered it. An app rule is
+    /// only a CRDT if it is the only thing deciding.
+    pub deferred_custom_merges: Vec<([u8; 32], CustomTypeId, Vec<u8>, u64)>,
 }
 
 /// HashComparison sync protocol.
@@ -393,14 +402,28 @@ async fn run_initiator_impl<T: SyncTransport>(
                     // `apply_leaf_with_crdt_merge` which LWW-writes
                     // them directly (no Mergeable to dispatch).
                     let entity_id = calimero_storage::address::Id::new(leaf_data.key);
-                    let is_opaque = leaf_data.metadata.crdt_type.is_opaque_leaf();
-                    if calimero_storage::collections::is_app_root_entry(entity_id) && !is_opaque {
-                        stats.deferred_root_merges.push((
-                            leaf_data.key,
-                            leaf_data.value.clone(),
-                            leaf_data.metadata.hlc_timestamp,
-                        ));
-                        continue;
+                    match crate::sync::helpers::classify_leaf(
+                        entity_id,
+                        &leaf_data.metadata.crdt_type,
+                    ) {
+                        LeafDisposition::DeferRoot => {
+                            stats.deferred_root_merges.push((
+                                leaf_data.key,
+                                leaf_data.value.clone(),
+                                leaf_data.metadata.hlc_timestamp,
+                            ));
+                            continue;
+                        }
+                        LeafDisposition::DeferCustom(type_id) => {
+                            stats.deferred_custom_merges.push((
+                                leaf_data.key,
+                                type_id,
+                                leaf_data.value.clone(),
+                                leaf_data.metadata.hlc_timestamp,
+                            ));
+                            continue;
+                        }
+                        LeafDisposition::Apply => {}
                     }
 
                     // PR-6b Task 6b.7: gate on the loaded reader. The HC repair

--- a/crates/node/src/sync/helpers.rs
+++ b/crates/node/src/sync/helpers.rs
@@ -5,6 +5,7 @@ use calimero_context_client::client::ContextClient;
 use calimero_node_primitives::sync::{EntityDeletion, TreeLeafData};
 use calimero_primitives::application::ApplicationId;
 use calimero_primitives::context::ContextId;
+use calimero_primitives::crdt::{CrdtType, CustomTypeId};
 use calimero_primitives::identity::PublicKey;
 use calimero_storage::address::Id;
 use calimero_storage::entities::{ChildInfo, Metadata, StorageType};
@@ -479,6 +480,47 @@ pub(crate) fn signer_account_for(
     calimero_governance_store::member_account_in_namespace(store, &group_id, &signer)
         .ok()
         .flatten()
+}
+
+/// What a receiver should do with one incoming leaf.
+///
+/// Both DFS walks — HashComparison and level-wise — face the same three-way
+/// choice, and had it inline twice. It lives here so the two cannot drift, and
+/// so the classification is testable without a transport.
+#[derive(Debug, PartialEq, Eq)]
+pub enum LeafDisposition {
+    /// Apply it here and now; the storage layer can merge this itself.
+    Apply,
+    /// An app root: defer for `__calimero_merge_root_state`.
+    DeferRoot,
+    /// A custom-typed entry: defer for `__calimero_merge_custom`, carrying the
+    /// id the entry declares.
+    DeferCustom(CustomTypeId),
+}
+
+/// Decide what to do with `leaf_metadata` for `entity_id`.
+///
+/// Neither deferral is an optimisation. A leaf whose merge rule lives in the
+/// app's module cannot be merged from the DFS at all: the apply is synchronous
+/// and runs inside `with_runtime_env`, so it cannot call into the runtime.
+/// Applying it anyway falls through to last-write-wins, which for a custom type
+/// contradicts the in-WASM delta path and leaves the two replicas settling the
+/// same conflict differently depending on which path delivered it.
+///
+/// An **opaque** root is the exception and applies directly: the synthetic
+/// `Opaque` marker means there is no `Mergeable` to dispatch to, so LWW is the
+/// only rule available and also the right one.
+#[must_use]
+pub fn classify_leaf(entity_id: Id, crdt_type: &CrdtType) -> LeafDisposition {
+    if calimero_storage::collections::is_app_root_entry(entity_id) && !crdt_type.is_opaque_leaf() {
+        return LeafDisposition::DeferRoot;
+    }
+
+    if let CrdtType::Custom(type_id) = crdt_type {
+        return LeafDisposition::DeferCustom(*type_id);
+    }
+
+    LeafDisposition::Apply
 }
 
 pub fn apply_leaf_with_crdt_merge_gated(
@@ -1636,5 +1678,81 @@ mod empty_chain_placement_tests {
             ScopeVerdict::DataDiverged
         );
         assert_eq!(scope_verdict(None, None, E1, E1), ScopeVerdict::Converged);
+    }
+}
+
+#[cfg(test)]
+mod classify_leaf_tests {
+    use calimero_primitives::crdt::{CrdtType, CustomTypeId};
+    use calimero_storage::address::Id;
+
+    use super::{classify_leaf, LeafDisposition};
+
+    /// The reachability check. A stamped entry must be recognised from the
+    /// metadata that actually crosses the wire — the sender carries the
+    /// entity's stored `crdt_type` verbatim, so this is the tag that arrives.
+    /// If this returned `Apply`, the whole dispatch below it would be
+    /// unreachable and the app's rule would silently never run.
+    #[test]
+    fn a_custom_entry_defers_and_carries_its_id() {
+        let id = CustomTypeId::of("team::Stats");
+        assert_eq!(
+            classify_leaf(Id::random(), &CrdtType::Custom(id)),
+            LeafDisposition::DeferCustom(id),
+            "the id must survive classification — the dispatcher has no other \
+             way to know which rule to run"
+        );
+    }
+
+    /// Built-ins merge in the storage layer and must NOT be deferred; deferring
+    /// them would park work the receiver could have finished immediately.
+    #[test]
+    fn builtin_entries_apply_directly() {
+        for crdt_type in [
+            CrdtType::GCounter,
+            CrdtType::PnCounter,
+            CrdtType::UnorderedMap,
+            CrdtType::Vector,
+            CrdtType::lww_register(),
+        ] {
+            assert_eq!(
+                classify_leaf(Id::random(), &crdt_type),
+                LeafDisposition::Apply,
+                "{crdt_type:?} merges in the storage layer"
+            );
+        }
+    }
+
+    /// An app root goes to the root dispatcher, not the custom one, even though
+    /// both defer — they call different exports.
+    #[test]
+    fn an_app_root_defers_as_a_root() {
+        assert_eq!(
+            classify_leaf(Id::root(), &CrdtType::lww_register()),
+            LeafDisposition::DeferRoot
+        );
+    }
+
+    /// The exception that keeps sync working for opaque roots: no `Mergeable`
+    /// exists to dispatch to, so LWW is the only available rule and applying
+    /// directly is correct. Deferring here would send the root to an export
+    /// that cannot resolve it, and the entity would never settle.
+    #[test]
+    fn an_opaque_root_applies_rather_than_deferring() {
+        assert_eq!(
+            classify_leaf(Id::root(), &CrdtType::opaque_leaf()),
+            LeafDisposition::Apply
+        );
+    }
+
+    /// Root wins over custom when a root somehow carries a `Custom` tag: the
+    /// root export dispatches through the app's registered root `Mergeable`,
+    /// which is the rule that owns the whole state.
+    #[test]
+    fn a_root_stamped_custom_still_defers_as_a_root() {
+        assert_eq!(
+            classify_leaf(Id::root(), &CrdtType::Custom(CustomTypeId::of("x"))),
+            LeafDisposition::DeferRoot
+        );
     }
 }

--- a/crates/node/src/sync/level_sync.rs
+++ b/crates/node/src/sync/level_sync.rs
@@ -161,6 +161,16 @@ pub struct LevelWiseStats {
     /// `ContextClient::merge_root_state` after the sync completes.
     /// Each entry is `(entity_id_bytes, incoming_bytes, incoming_hlc_ts)`.
     pub deferred_root_merges: Vec<([u8; 32], Vec<u8>, u64)>,
+
+    /// Custom-typed ENTRIES deferred for WASM dispatch; same rationale as
+    /// `HashComparisonStats::deferred_custom_merges`. Applying one here would
+    /// fall through to LWW and contradict the in-WASM delta path.
+    pub deferred_custom_merges: Vec<(
+        [u8; 32],
+        calimero_primitives::crdt::CustomTypeId,
+        Vec<u8>,
+        u64,
+    )>,
 }
 
 // =============================================================================
@@ -475,14 +485,28 @@ async fn run_initiator_impl<T: SyncTransport>(
                     // `apply_leaf_with_crdt_merge` which LWW-writes
                     // them directly (no Mergeable to dispatch).
                     let entity_id = calimero_storage::address::Id::new(leaf_data.key);
-                    let is_opaque = leaf_data.metadata.crdt_type.is_opaque_leaf();
-                    if calimero_storage::collections::is_app_root_entry(entity_id) && !is_opaque {
-                        stats.deferred_root_merges.push((
-                            leaf_data.key,
-                            leaf_data.value.clone(),
-                            leaf_data.metadata.hlc_timestamp,
-                        ));
-                        continue;
+                    match crate::sync::helpers::classify_leaf(
+                        entity_id,
+                        &leaf_data.metadata.crdt_type,
+                    ) {
+                        crate::sync::helpers::LeafDisposition::DeferRoot => {
+                            stats.deferred_root_merges.push((
+                                leaf_data.key,
+                                leaf_data.value.clone(),
+                                leaf_data.metadata.hlc_timestamp,
+                            ));
+                            continue;
+                        }
+                        crate::sync::helpers::LeafDisposition::DeferCustom(type_id) => {
+                            stats.deferred_custom_merges.push((
+                                leaf_data.key,
+                                type_id,
+                                leaf_data.value.clone(),
+                                leaf_data.metadata.hlc_timestamp,
+                            ));
+                            continue;
+                        }
+                        crate::sync::helpers::LeafDisposition::Apply => {}
                     }
 
                     // PR-6b Task 6b.7: gate on the loaded reader so a

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -291,6 +291,20 @@ impl ProtocolSelector {
                             .await;
                         }
 
+                        // Same pass for custom-typed entries. Both dispatchers
+                        // run here rather than inside the DFS because neither
+                        // can call into WASM from a synchronous apply.
+                        if !stats.deferred_custom_merges.is_empty() {
+                            dispatch_deferred_custom_merges(
+                                &self.context_client,
+                                &store,
+                                context_id,
+                                our_identity,
+                                &stats.deferred_custom_merges,
+                            )
+                            .await;
+                        }
+
                         // P6.S3: the post-sync governance-divergence pull moved to
                         // a single check in the manager (`handle_dag_sync`, after
                         // `execute` returns) so it covers EVERY data backend —
@@ -434,6 +448,20 @@ impl ProtocolSelector {
                             .await;
                         }
 
+                        // Same pass for custom-typed entries. Both dispatchers
+                        // run here rather than inside the DFS because neither
+                        // can call into WASM from a synchronous apply.
+                        if !stats.deferred_custom_merges.is_empty() {
+                            dispatch_deferred_custom_merges(
+                                &self.context_client,
+                                &store,
+                                context_id,
+                                our_identity,
+                                &stats.deferred_custom_merges,
+                            )
+                            .await;
+                        }
+
                         // P6.S3: post-sync governance pull centralised in the
                         // manager (covers all data backends); see the HashComparison
                         // arm above.
@@ -504,6 +532,161 @@ impl ProtocolSelector {
 /// partial progress is preferable to dropping the whole batch on a
 /// single failure. The next sync tick will re-attempt anything that
 /// stays divergent.
+/// Apply the custom-typed ENTRY merges that sync deferred, for the same reason
+/// [`dispatch_deferred_root_merges`] exists: the apply is synchronous and inside
+/// the storage env, so it cannot reach a rule that lives in the app's module.
+///
+/// Doing it here — after the session, with nothing nested — is what makes a
+/// second WASM instance unnecessary. Per entry:
+///
+/// 1. Read the locally-stored entry bytes + metadata.
+/// 2. Send both sides plus the entry's `CustomTypeId` into
+///    `__calimero_merge_custom`, which resolves the id against the registry the
+///    module populated at load.
+/// 3. Write the merged bytes back with `write_pre_merged_root_state`, which
+///    updates storage and the Merkle index without re-running the merge.
+///
+/// An entry with no local bytes is SKIPPED rather than accepted: unlike a root
+/// there is no bootstrap case to serve, and a merge of one side is not a merge.
+/// The plain apply path stores such an entry on its own.
+///
+/// Failures are per-entry and logged. Nothing falls back to LWW — that would
+/// resolve a conflict the app declared itself responsible for, and resolve it
+/// differently depending on arrival order. The entity stays divergent until the
+/// next round, which is recoverable; a silently wrong value is not.
+pub(crate) async fn dispatch_deferred_custom_merges(
+    context_client: &ContextClient,
+    store: &calimero_store::Store,
+    context_id: ContextId,
+    our_identity: PublicKey,
+    deferred: &[(
+        [u8; 32],
+        calimero_primitives::crdt::CustomTypeId,
+        Vec<u8>,
+        u64,
+    )],
+) {
+    use calimero_storage::address::Id;
+    use calimero_storage::entities::Metadata;
+    use calimero_storage::env::with_runtime_env;
+    use calimero_storage::index::Index;
+    use calimero_storage::interface::Interface;
+    use calimero_storage::merge::MergeCustomRequest;
+    use calimero_storage::store::{MainStorage, StorageAdaptor};
+
+    let Ok(account) = calimero_governance_store::account_for_context(store, &context_id) else {
+        tracing::warn!(
+            %context_id,
+            "cannot resolve this node's account for the context; skipping the \
+             deferred custom-merge pass (retried on the next sync tick)"
+        );
+        return;
+    };
+    let runtime_env = calimero_node_primitives::sync::create_runtime_env(
+        store,
+        context_id,
+        our_identity,
+        account,
+    );
+
+    for (key, type_id, incoming, incoming_hlc_ts) in deferred {
+        let entity_id = Id::new(*key);
+
+        let read_result: eyre::Result<(Option<Vec<u8>>, Metadata)> =
+            with_runtime_env(runtime_env.clone(), || {
+                let meta = Index::<MainStorage>::get_index(entity_id)
+                    .map_err(|e| eyre::eyre!("get_index: {e}"))?
+                    .map(|idx| idx.metadata)
+                    .unwrap_or_default();
+                let existing = <MainStorage as StorageAdaptor>::storage_read(
+                    calimero_storage::store::Key::Entry(entity_id),
+                );
+                Ok((existing, meta))
+            });
+
+        let (existing, existing_metadata) = match read_result {
+            Ok(pair) => pair,
+            Err(err) => {
+                tracing::warn!(
+                    %context_id,
+                    entity_id = %hex::encode(key),
+                    %err,
+                    "deferred custom merge: failed to read the stored entry, skipping"
+                );
+                continue;
+            }
+        };
+
+        let Some(existing) = existing else {
+            tracing::debug!(
+                %context_id,
+                entity_id = %hex::encode(key),
+                "deferred custom merge: nothing stored locally, leaving it to the \
+                 plain apply path"
+            );
+            continue;
+        };
+
+        let existing_ts: u64 = *existing_metadata.updated_at;
+
+        let merged = match context_client
+            .merge_custom(
+                &context_id,
+                &our_identity,
+                MergeCustomRequest {
+                    type_id: *type_id,
+                    existing,
+                    incoming: incoming.clone(),
+                },
+            )
+            .await
+        {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                tracing::warn!(
+                    %context_id,
+                    entity_id = %hex::encode(key),
+                    ?err,
+                    "deferred custom merge: WASM dispatch failed, leaving the entity \
+                     divergent for the next round"
+                );
+                continue;
+            }
+        };
+
+        // `updated_at` advances past both inputs so the next LWW comparison
+        // resolves consistently, exactly as the root path does. The entry's
+        // `crdt_type` is preserved: `update_hash_for` only overwrites the stored
+        // tag when handed `Some`, and this path passes `None` for a non-root id
+        // — so the entry stays stamped and keeps dispatching.
+        let mut new_metadata = existing_metadata.clone();
+        new_metadata.updated_at = existing_ts.max(*incoming_hlc_ts).into();
+
+        let write_result = with_runtime_env(runtime_env.clone(), || {
+            Interface::<MainStorage>::write_pre_merged_root_state(entity_id, &merged, new_metadata)
+                .map_err(|e| eyre::eyre!("write_pre_merged_root_state: {e}"))
+        });
+
+        match write_result {
+            Ok(_full_hash) => {
+                tracing::info!(
+                    %context_id,
+                    entity_id = %hex::encode(key),
+                    "deferred custom merge: applied"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    %context_id,
+                    entity_id = %hex::encode(key),
+                    %err,
+                    "deferred custom merge: failed to write merged bytes back"
+                );
+            }
+        }
+    }
+}
+
 pub(crate) async fn dispatch_deferred_root_merges(
     context_client: &ContextClient,
     store: &calimero_store::Store,

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -751,6 +751,68 @@ fn generate_registration_hook(
         //
         // Developer impact: ZERO — the macro hides the export entirely.
         //
+        // ============================================================================
+        // AUTO-GENERATED WASM Export — Host-Initiated Custom-Entry Merge
+        // ============================================================================
+        //
+        // The sibling of `__calimero_merge_root_state`, for a collection ENTRY
+        // holding an app-defined type. The host defers such an entry during
+        // sync apply — it cannot merge it there, because the rule lives in this
+        // module and the apply is a synchronous call inside the storage env —
+        // then dispatches here once the session is over.
+        //
+        // Unlike the root export this body is generic: it names no app type,
+        // because the entry carries its own `CustomTypeId` and the registry
+        // `__calimero_register_merge` populated resolves it. One export serves
+        // every `#[app::mergeable]` type in the app.
+        //
+        #[cfg(target_arch = "wasm32")]
+        #[no_mangle]
+        pub extern "C" fn __calimero_merge_custom() {
+            ::calimero_sdk::env::setup_panic_hook();
+
+            let Some(args) = ::calimero_sdk::env::input() else {
+                ::calimero_sdk::env::panic_str(
+                    "Expected MergeCustomRequest payload for __calimero_merge_custom",
+                )
+            };
+
+            let request: ::calimero_storage::merge::MergeCustomRequest =
+                ::calimero_sdk::borsh::from_slice(&args).unwrap_or_else(|err| {
+                    ::calimero_sdk::env::panic_str(&::std::format!(
+                        "Failed to deserialize MergeCustomRequest: {err}",
+                    ))
+                });
+
+            let response = match ::calimero_storage::merge::merge_custom(
+                request.type_id,
+                &request.existing,
+                &request.incoming,
+            ) {
+                ::core::result::Result::Ok(bytes) => {
+                    ::calimero_storage::merge::MergeCustomResponse::Ok(bytes)
+                }
+                ::core::result::Result::Err(err) => {
+                    ::calimero_storage::merge::MergeCustomResponse::Err(::std::format!("{err:?}"))
+                }
+            };
+
+            let serialized = ::calimero_sdk::borsh::to_vec(&response).unwrap_or_else(|err| {
+                ::calimero_sdk::env::panic_str(&::std::format!(
+                    "Failed to serialize MergeCustomResponse: {err}",
+                ))
+            });
+
+            // Same wire convention as every other generated export: the
+            // `Result` discriminant is the transport's, and the merge's own
+            // success or failure lives inside `MergeCustomResponse`. See the
+            // matching note on `__calimero_merge_root_state` below.
+            ::calimero_sdk::env::value_return(&::core::result::Result::<
+                ::std::vec::Vec<u8>,
+                ::std::vec::Vec<u8>,
+            >::Ok(serialized));
+        }
+
         #[cfg(target_arch = "wasm32")]
         #[no_mangle]
         pub extern "C" fn __calimero_merge_root_state() {

--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -72,7 +72,7 @@ pub use custom_registry::clear_custom_merge_registry;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
-use crate::collections::crdt_meta::{CrdtType, MergeError, Mergeable};
+use crate::collections::crdt_meta::{CrdtType, CustomTypeId, MergeError, Mergeable};
 use crate::collections::{Counter, ReplicatedGrowableArray};
 use crate::store::MainStorage;
 
@@ -103,6 +103,40 @@ pub struct MergeRootStateRequest {
 /// having to panic in WASM.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
 pub enum MergeRootStateResponse {
+    Ok(Vec<u8>),
+    Err(String),
+}
+
+/// Request the host sends into WASM to merge one custom-typed ENTRY.
+///
+/// Sibling of [`MergeRootStateRequest`], and deliberately smaller. A root
+/// merge needs `existing_created_at` for its bootstrap fast-path, where a
+/// freshly-materialised default state must accept `incoming` wholesale. An
+/// entry has no such state: it exists because something wrote it, so there is
+/// nothing to bootstrap and both sides are real history.
+///
+/// Timestamps are absent for a stronger reason — an app-defined rule that
+/// consults them is not commutative, and the whole point of dispatching is
+/// that the app's rule decides. The host advances `updated_at` on the write
+/// back, exactly as the root path does.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
+pub struct MergeCustomRequest {
+    /// Which app-defined type this entry holds, as stamped on the entry.
+    pub type_id: CustomTypeId,
+    /// The receiver's stored entry bytes.
+    pub existing: Vec<u8>,
+    /// The entry bytes that arrived over the wire.
+    pub incoming: Vec<u8>,
+}
+
+/// Response from the WASM-side custom-merge dispatcher.
+///
+/// `Err(message)` covers both a genuine merge failure and an id this build's
+/// app no longer registers — an app-upgrade skew. Either way the host logs it
+/// and leaves the entity for the next sync round rather than resolving it by
+/// LWW, which would be the wrong answer for a conflict the app owns.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
+pub enum MergeCustomResponse {
     Ok(Vec<u8>),
     Err(String),
 }


### PR DESCRIPTION
Fourth of #3785. Closes the gap #3799 left open: host-side HashComparison repair resolved a custom-typed entry by LWW while the in-WASM delta path resolved it by the app's rule — the same conflict settling two different ways depending on which path delivered it.

## Not a second WASM instance

The plan going in was a `RuntimeMergeCallback` with an instance cached per `Module`, harvested from #1995 and recommended by #1997. **That turned out to be solving a problem the codebase had already solved differently.**

Root-state merge faces the identical constraint, and the comment at its defer site names it:

> *"the helper is sync and inside `with_runtime_env`, so it can't call into the runtime to do the merge itself"*

Its answer is not to reach into WASM from the apply at all. It records what it could not merge, finishes the session, and dispatches afterwards through the normal execute path:

```
DFS hits a leaf it can't merge  →  stats.deferred_root_merges.push(..)  →  continue
...session ends...              →  dispatch_deferred_root_merges(..)    →  __calimero_merge_root_state
                                →  write_pre_merged_root_state(..)
```

Nothing is nested, so there is no reentrancy to work around — which is the only reason a second instance was ever needed. #1997 was reasoning about #1995's architecture, where the callback fired *during* the apply. This PR mirrors the deferred pattern instead: no `Mutex<Store>`, no per-`Module` cache, no instance-lifetime question, and ~60 lines borrowed from `d3c3b1ba` rather than its 382.

## What lands

**`classify_leaf`** (`sync/helpers.rs`) — both DFS walks had the root-defer decision inline, and this change would have duplicated a three-way decision twice. It is now one function they share, which removes the drift risk and makes the decision testable without a transport or a WASM module.

**Deferral** — `deferred_custom_merges: Vec<(key, CustomTypeId, incoming, hlc)>` on both `HashComparisonStats` and `LevelWiseStats`, populated where the DFS previously fell through to LWW.

**One guest export** — `__calimero_merge_custom`, emitted by `#[app::state]`. Unlike #1995's `__calimero_merge_{TypeName}` there is exactly one, because the entry carries its own `CustomTypeId` and the registry `__calimero_register_merge` populated resolves it. No name mangling, no per-type export probing.

**`ContextClient::merge_custom`** — the entry-level sibling of `merge_root_state`.

**`dispatch_deferred_custom_merges`** — runs after the session at both call sites (HC and level-wise).

Two deliberate differences from the root dispatcher:

- **An entry with no local bytes is skipped, not accepted.** A root has a bootstrap case — freshly-materialised default state must take `incoming` wholesale. An entry has none: it exists because something wrote it, and a merge of one side is not a merge. The plain apply path stores it.
- **Nothing falls back to LWW on failure.** A failed merge, or an id this build no longer registers, leaves the entity divergent for the next round. That is recoverable; resolving a conflict the app owns by a rule it did not choose is not.

`MergeCustomRequest` carries no timestamps, unlike the root request. An app rule that consults wall-clock ordering is not commutative, and the host advances `updated_at` on write-back anyway.

## Reachability

The link that broke twice in this series is "dispatch exists, nothing feeds it" — #1995 shipped 1400 correct unreachable lines, and #3799's dispatch was unreachable until entries were stamped. So the sender side was checked **before** writing the dispatch, not after (`hash_comparison_protocol.rs:1351`):

```rust
let crdt_type = index.metadata.crdt_type.clone().unwrap_or_else(|| CrdtType::opaque_leaf());
```

The entity's stored stamp is carried verbatim, so a stamped entry arrives tagged and the defer branch sees it.

The write-back preserves that stamp: `update_hash_for` overwrites the stored `crdt_type` only when handed `Some`, and this path passes `None` for a non-root id. Without that, a repaired entry would lose its stamp and stop dispatching on the next conflict.

## Tests

Five on `classify_leaf`, including the two that catch a silent break:

- **a `Custom` entry defers AND carries its id** — if this returned `Apply`, everything below it is unreachable and the app's rule silently never runs.
- **an opaque root applies rather than deferring** — there is no `Mergeable` to dispatch to, so LWW is the only available rule. Deferring would send it to an export that cannot resolve it and the entity would never settle.

Watched failing first: removing the `Custom` arm reds the first; removing the `is_opaque_leaf` guard reds the second. Restored, 5/5.

## What is NOT tested here

**The dispatch round trip.** `__calimero_merge_custom` actually invoking the app's rule needs a real WASM module and two diverging nodes — merobox, not `cargo test`. This PR unit-tests the *decision* and compiles the plumbing; it does not prove the export runs.

That coverage wants `apps/team-metrics-custom` migrated to `#[app::mergeable]` first, which is the next PR. Reviewers should read this as "the deferral is verified, the round trip is not yet" — stated plainly because the alternative reading is exactly the mistake this series has been unwinding.

## Test plan

```
$ cargo test -p calimero-node --lib
574 passed; 0 failed; 0 filtered out          (569 + 5 new)

$ cargo test -p calimero-storage --features testing --lib
719 passed; 0 failed; 0 filtered out

$ cargo clippy -p calimero-node --all-targets -- -D warnings                                   # 0
$ cargo clippy -p calimero-storage -p calimero-sdk-macros -p calimero-context-client \
    --all-targets --features calimero-storage/testing -- -D warnings                           # 0
$ cargo check -p calimero-storage --target wasm32-unknown-unknown                              # 0
$ cargo check -p calimero-storage --all-targets --all-features                                 # 0
$ cargo fmt --check                                                                            # clean
```

Refs #3785.
