### PR TITLE
docs(apps): make team-metrics-custom demonstrate what app-defined merge actually does

### DIFF
--- a/apps/team-metrics-custom/README.md
+++ b/apps/team-metrics-custom/README.md
@@ -1,73 +1,99 @@
-# Team Metrics - With Custom Implementation
+# Team Metrics — app-defined merge
 
-**Example: Manual `Mergeable` implementation for full control**
+**Example: `#[app::mergeable]`, for a field the storage layer cannot converge on its own.**
 
-## The Code
+The sibling of `apps/team-metrics-macro`, which uses `#[derive(Mergeable)]`. Both
+apps track the same team statistics; the difference shows up in exactly one
+field, and it is worth being precise about which.
+
+## What the two apps actually differ on
 
 ```rust
+#[app::mergeable]
+#[derive(Debug, Default, BorshSerialize, BorshDeserialize, AbiType)]
 pub struct TeamStats {
-    pub wins: Counter,
+    pub wins: Counter,     // converges WITHOUT any of this
     pub losses: Counter,
     pub draws: Counter,
+    pub badges: u64,       // converges ONLY because of the rule below
 }
 
 impl Mergeable for TeamStats {
     fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
-        // You have full control!
-        // - Add logging
-        // - Skip fields conditionally
-        // - Apply business rules
-        // - Validate invariants
-        
         self.wins.merge(&other.wins)?;
         self.losses.merge(&other.losses)?;
         self.draws.merge(&other.draws)?;
-        
-        // Example: Custom validation
-        // if self.wins.value()? > 1000 {
-        //     return Err(MergeError::InvalidValue("Too many wins!".into()));
-        // }
-        
+
+        self.badges |= other.badges;   // ← the reason this app exists
         Ok(())
     }
 }
 ```
 
-## Why This Approach?
+**The counters need nothing from you.** Each is stored as its own child entity,
+and the storage layer merges it by summing per-writer contributions. Delete
+`#[app::mergeable]` and the whole `Mergeable` impl, and `wins` still converges.
 
-✅ **Full control** - Custom merge logic  
-✅ **Flexible** - Add logging, validation, etc.  
-✅ **Advanced** - For complex scenarios  
+**`badges` is a plain `u64`.** It lives in the value blob, and a blob has no
+merge semantics of its own — without a declared rule it resolves
+last-write-wins, so one node's badges survive and the other node's are silently
+discarded. `#[app::mergeable]` is what makes bitwise-OR the rule instead.
 
-## When to Use
+That is the entire distinction. If your struct holds only CRDT collections, you
+do not need this app's approach — use the derive.
 
-- Need custom merge behavior
-- Want to add logging/validation
-- Need to skip certain fields
-- Business rules to apply
+## When to reach for it
 
-## Compare With
+Use `#[app::mergeable]` when a field has no CRDT of its own and last-write-wins
+is the wrong answer for it. Use `#[derive(Mergeable)]` otherwise: dispatch costs
+a WASM call per conflicting entry, and structural convergence reaches the same
+result without one.
 
-See `apps/team-metrics-macro` for the simple derive approach (recommended for most cases).
+## The contract
 
-## Build & Test
+Dispatch hands merge authority to your code, so `merge` must be:
 
-End-to-end tests are automatically run via the `merobox-workflows.yml` GitHub Actions workflow, which executes workflows defined in `team-metrics-custom/workflows/*.yml`.
+- **deterministic** — same inputs, same output, always
+- **commutative** — `merge(a, b) == merge(b, a)`
+- **associative** and **idempotent** — `merge(a, a) == a`
+- **total** — never `Err` on well-formed input
 
-To build locally:
+The last one is the trap. Returning `Err` is not validation; it is a refusal to
+converge. The entity stays divergent and sync repair retries it indefinitely.
+Validate on the write path — `award_badge` rejects an out-of-range badge — never
+in `merge`.
+
+Two related things are **not** possible, despite being easy to assume:
+
+- **Skipping a field conditionally.** A field that is its own child entity (a
+  `Counter`) converges whether or not your `merge` touches it. Omitting it does
+  not exclude it.
+- **Depending on wall-clock order.** A rule that consults timestamps is not
+  commutative, and the two replicas will disagree.
+
+## Tests
+
+| Level | What it proves |
+| ----- | -------------- |
+| `src/lib.rs` unit tests | app logic, single node |
+| `tests/converge.rs` | the counters converge and sum across replicas. It does **not** cover the custom rule — see the comment in that file for why the harness cannot |
+| `workflows/team-metrics-custom.yml` | two real nodes each award their own badge and both end up holding both. This is the assertion that proves the merge function ran |
+
+The badge assertion is the load-bearing one: a counter converges either way, so
+a counter test cannot tell you whether your `merge` was ever called.
+
+## Build & test
 
 ```bash
 cargo mero build
 ```
 
-To run workflow tests locally using merobox:
+Workflows run in CI via `merobox-workflows.yml`. Locally:
 
 ```bash
 cargo mero build
-merobox bootstrap run workflows/team-metrics-test.yml \
+merobox bootstrap run workflows/team-metrics-custom.yml \
   --no-docker \
   --binary-path ../../target/debug/merod \
   --e2e-mode
 ```
-
-**Note:** Both apps have the same functionality - only the implementation differs!

--- a/apps/team-metrics-custom/src/lib.rs
+++ b/apps/team-metrics-custom/src/lib.rs
@@ -1,7 +1,35 @@
-//! Team Metrics App - Using Custom Mergeable Implementation
+//! Team Metrics — app-defined merge.
 //!
-//! Demonstrates nested CRDTs with CUSTOM merge logic.
-//! This shows the flexibility when you need special merge behavior.
+//! The sibling of `team-metrics-macro`, which uses `#[derive(Mergeable)]` and
+//! lets the storage layer converge everything structurally. This one declares a
+//! rule of its own, and the difference is visible in exactly one field.
+//!
+//! ## What `#[app::mergeable]` buys, and what it does not
+//!
+//! `wins` / `losses` / `draws` are `Counter`s. They converge whether or not this
+//! app declares anything: a counter is stored as its own child entity and the
+//! storage layer merges it by summing per-writer contributions. Removing
+//! `#[app::mergeable]` would not change them.
+//!
+//! `badges` is a plain `u64` bitmask. It lives in the value blob, and without a
+//! declared rule the blob resolves last-write-wins — one node's badges survive
+//! and the other node's are discarded. `#[app::mergeable]` makes bitwise-OR the
+//! rule instead, so a team awarded badge 1 on one node and badge 2 on another
+//! ends up holding BOTH on both nodes.
+//!
+//! Union is the distinguishing case on purpose. `max` would not be: it returns
+//! one of its two inputs, and so does last-write-wins, so the two agree whenever
+//! LWW happens to pick the larger side — a test built on `max` passes with the
+//! merge rule deleted. `1 | 2 == 3` is a value neither input holds, so only a
+//! dispatched merge can produce it.
+//!
+//! ## The contract
+//!
+//! Dispatch hands merge authority to this code, so `merge` must be
+//! deterministic, commutative, associative, idempotent and **total**. The last
+//! is the trap: returning `Err` is not validation, it is a refusal to converge —
+//! the entity stays divergent and repair retries it forever. Reject bad input in
+//! `set_streak`, not here.
 
 #![allow(
     unused_crate_dependencies,
@@ -14,67 +42,43 @@ use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_storage::collections::crdt_meta::MergeError;
 use calimero_storage::collections::{Counter, Mergeable, UnorderedMap};
 
-/// Team statistics with multiple counters
+/// Per-team statistics, merged by this app rather than by the storage layer.
 ///
-/// This struct demonstrates CUSTOM Mergeable implementation.
-/// You have full control and can add custom logic!
+/// `#[app::mergeable]` gives the type a `CustomTypeId` that is stamped on every
+/// entry holding it, so the merge point dispatches here instead of resolving the
+/// entry by last-write-wins. It also generates the `RekeyTarget` impl that a
+/// hand-written `Mergeable` used to have to supply by itself — forgetting which
+/// silently lost the counters' concurrent increments.
+#[app::mergeable]
 #[derive(Debug, Default, BorshSerialize, BorshDeserialize, AbiType)]
 #[borsh(crate = "calimero_sdk::borsh")]
 pub struct TeamStats {
     pub wins: Counter,
     pub losses: Counter,
     pub draws: Counter,
+    /// Achievement bitmask — one bit per badge.
+    ///
+    /// A plain `u64`, deliberately: it is the one field whose convergence
+    /// depends on the rule below rather than on the storage layer.
+    pub badges: u64,
 }
 
-/// Custom Mergeable implementation
-///
-/// This shows how you can:
-/// - Add custom validation
-/// - Log merge events  
-/// - Apply business rules
-/// - Skip certain fields
 impl Mergeable for TeamStats {
     fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
-        // Example: You could add logging here
-        // eprintln!("Merging team stats...");
-
-        // Standard CRDT merge
+        // The counters would converge without this — they are child entities
+        // with their own merge. Delegating keeps the root-conflict path
+        // consistent with the per-entity one.
         self.wins.merge(&other.wins)?;
         self.losses.merge(&other.losses)?;
         self.draws.merge(&other.draws)?;
 
-        // Example: You could add validation
-        // if self.wins.value()? > 1000 {
-        //     return Err(MergeError::InvalidValue("Too many wins!".into()));
-        // }
+        // The part that only happens because this rule is dispatched. OR is
+        // commutative, associative and idempotent — a grow-only set of badges —
+        // and, unlike `max`, its result is a value NEITHER side held, so it
+        // cannot be mistaken for last-write-wins picking a winner.
+        self.badges |= other.badges;
 
         Ok(())
-    }
-}
-
-/// Deterministic re-keying for a HAND-WRITTEN CRDT-value struct (#2577).
-///
-/// `#[derive(Mergeable)]` generates this for you. When you implement `Mergeable`
-/// by hand (as above), you MUST also implement `RekeyTarget`, or this struct —
-/// stored as an `UnorderedMap` value — is last-writer-wins'd as an opaque blob
-/// and its counters silently lose concurrent increments. Re-key each nested
-/// collection field under a field-namespaced child of the entry id so every
-/// replica derives identical ids and the counters converge as child entities.
-impl calimero_storage::collections::rekey::RekeyTarget for TeamStats {
-    fn rekey_relative_to(&mut self, parent_id: calimero_storage::address::Id) {
-        use calimero_storage::collections::rekey::field_child_id;
-        calimero_storage::rekey_field_if_supported!(
-            &mut self.wins,
-            field_child_id(parent_id, "wins")
-        );
-        calimero_storage::rekey_field_if_supported!(
-            &mut self.losses,
-            field_child_id(parent_id, "losses")
-        );
-        calimero_storage::rekey_field_if_supported!(
-            &mut self.draws,
-            field_child_id(parent_id, "draws")
-        );
     }
 }
 
@@ -82,7 +86,7 @@ impl calimero_storage::collections::rekey::RekeyTarget for TeamStats {
 #[app::state(emits = MetricsEvent)]
 pub struct TeamMetricsApp {
     /// Maps team_id → team statistics
-    /// TeamStats has a CUSTOM Mergeable impl with full control
+    /// Values are merged by `TeamStats`'s own rule; see the module docs.
     pub teams: UnorderedMap<String, TeamStats>,
 }
 
@@ -133,6 +137,57 @@ impl TeamMetricsApp {
         app::emit!(MetricsEvent::DrawRecorded { team_id, total });
 
         Ok(total)
+    }
+
+    /// Award a badge (0-63). Validation belongs here, on the write path — NOT
+    /// in `merge`, where an `Err` would stop the entity converging.
+    pub fn award_badge(&mut self, team_id: String, badge: u64) -> app::Result<u64> {
+        if badge > 63 {
+            app::bail!("badge out of range");
+        }
+
+        let mut stats = self.teams.entry(team_id)?.or_default()?;
+        stats.badges |= 1_u64 << badge;
+
+        Ok(stats.badges)
+    }
+
+    /// Award the badge that belongs to the CALLING device, derived from its
+    /// device id.
+    ///
+    /// This exists to be testable, and the reason is worth stating. A
+    /// convergence harness applies the same op list to every replica, so an op
+    /// taking an explicit badge number leaves every replica computing the same
+    /// value — no conflict, nothing for a merge to do, and a test that passes
+    /// with the merge rule deleted. A counter avoids that by being per-writer;
+    /// this makes the badge per-writer for the same reason, so identical ops
+    /// still produce divergent blobs that only a union can reconcile.
+    pub fn award_own_badge(&mut self, team_id: String) -> app::Result<u64> {
+        let badge = u64::from(calimero_sdk::env::device_id()[0] % 64);
+
+        self.award_badge(team_id, badge)
+    }
+
+    /// How many badges the team holds.
+    ///
+    /// Exposed so an e2e assertion can be a plain integer comparison: the
+    /// individual bits depend on each node's device id and are not predictable
+    /// from a workflow, and relying on the assertion evaluator to provide
+    /// `bin(..).count('1')` would be betting on its expression support.
+    pub fn get_badge_count(&self, team_id: String) -> app::Result<u32> {
+        let Some(stats) = self.teams.get(&team_id)? else {
+            app::bail!("Team not found");
+        };
+
+        Ok(stats.badges.count_ones())
+    }
+
+    pub fn get_badges(&self, team_id: String) -> app::Result<u64> {
+        let Some(stats) = self.teams.get(&team_id)? else {
+            app::bail!("Team not found");
+        };
+
+        Ok(stats.badges)
     }
 
     pub fn get_wins(&self, team_id: String) -> app::Result<u64> {

--- a/apps/team-metrics-custom/src/lib.rs
+++ b/apps/team-metrics-custom/src/lib.rs
@@ -164,8 +164,13 @@ impl TeamMetricsApp {
     /// still produce divergent blobs that only a union can reconcile.
     pub fn award_own_badge(&mut self, team_id: String) -> app::Result<u64> {
         let badge = u64::from(calimero_sdk::env::device_id()[0] % 64);
+        let _ = self.award_badge(team_id, badge)?;
 
-        self.award_badge(team_id, badge)
+        // Returns the BIT, not the mask. A workflow has to be able to check
+        // that two nodes awarded DIFFERENT badges before it can read anything
+        // into a merged count of one: without that, "the merge never ran" and
+        // "both nodes happened to pick the same bit" look identical.
+        Ok(badge)
     }
 
     /// How many badges the team holds.

--- a/apps/team-metrics-custom/tests/converge.rs
+++ b/apps/team-metrics-custom/tests/converge.rs
@@ -1,6 +1,15 @@
 //! Convergence + correctness for the real `#[app::state]` app, driven through
-//! the convergence harness. The custom-`Mergeable` `TeamStats` (hand-written
-//! `RekeyTarget`, see `src/lib.rs`) is the #2577 headline case.
+//! the convergence harness. `TeamStats` is `#[app::mergeable]` (see
+//! `src/lib.rs`), so it exercises two different mechanisms at once — and the
+//! tests are split accordingly.
+//!
+//! `wins` is a `Counter`: it converges structurally, as its own child entity,
+//! whether or not the app declares a rule. It is the #2577 headline case.
+//!
+//! `badges` is a plain `u64` bitmask in the value blob. It converges ONLY
+//! because the app's rule is dispatched; without that it resolves
+//! last-write-wins. A counter test cannot distinguish the two, which is why both
+//! are here.
 //!
 //! `#[serial]`: `converge_app` clears and repopulates the process-global merge
 //! registry per run, so two of these must not run concurrently. Own integration
@@ -46,3 +55,31 @@ fn team_stats_converge_to_correct_value() {
         })
         .assert_all_replicas_equal();
 }
+
+// The app's own merge rule is NOT asserted here, and that is deliberate.
+//
+// Proving it needs two replicas to write DIFFERENT values into the same plain
+// field, and this harness cannot arrange that. It gives each replica a distinct
+// executor inside `RuntimeEnv` — which is why the counters above diverge and
+// then sum — but never sets the SDK's thread-local device id, so
+// `env::device_id()` returns the same default `[237; 32]` in every replica. An
+// app method therefore cannot tell which replica is running it, and every
+// replica computes the same plain-field value. No conflict, nothing to merge.
+//
+// Three versions of such a test were written and all three were vacuous; each
+// passed with `TeamStats::merge` gutted:
+//
+//   1. a `max` rule — returns one of its inputs, and so does last-write-wins,
+//      so the two agree whenever LWW's tiebreak picks the larger side;
+//   2. two `.ops(..)` closures awarding explicit badges — the harness applies
+//      EVERY op to EVERY replica, so both computed the union directly;
+//   3. a per-device badge — defeated by the thread-local above.
+//
+// Where the proof actually lives:
+//
+//   * `calimero-storage/tests/custom_merge_e2e.rs` — two replicas, real map,
+//     per-replica writes, asserts the app rule decides AND the roots converge.
+//   * `workflows/team-metrics-custom.yml` — two real nodes, each awarding its
+//     own badge, asserting both end up holding both.
+//
+// A weaker restatement here would only look like coverage.

--- a/apps/team-metrics-custom/workflows/team-metrics-custom.yml
+++ b/apps/team-metrics-custom/workflows/team-metrics-custom.yml
@@ -322,6 +322,8 @@ steps:
     method: award_own_badge
     args:
       team_id: team-alpha
+    outputs:
+      own_badge_node1: result.output
 
   - name: Node 2 awards its own badge concurrently
     type: call
@@ -330,6 +332,17 @@ steps:
     method: award_own_badge
     args:
       team_id: team-alpha
+    outputs:
+      own_badge_node2: result.output
+
+  # Precondition, not decoration. If both nodes picked the same bit, a merged
+  # count of 1 is CORRECT and the assertion below would fail for a reason that
+  # has nothing to do with merging. Checking it here means a failure downstream
+  # can only mean the merge did not happen.
+  - name: Assert the two nodes picked different badges
+    type: assert
+    statements:
+      - "{{own_badge_node1}} != {{own_badge_node2}}"
 
   - name: Wait for the badge blobs to merge
     type: wait_for_sync

--- a/apps/team-metrics-custom/workflows/team-metrics-custom.yml
+++ b/apps/team-metrics-custom/workflows/team-metrics-custom.yml
@@ -297,6 +297,100 @@ steps:
       - "{{final_losses_alpha}} == 1"
       - "{{final_draws_alpha}} == 1"
 
+  # ---------------------------------------------------------------------------
+  # The app's OWN merge rule.
+  #
+  # Everything above exercises `Counter`, which converges structurally whether
+  # or not the app declares a rule — a counter is its own child entity and the
+  # storage layer sums it. Those steps would pass with `TeamStats::merge`
+  # deleted, so they cannot tell you the merge function ran.
+  #
+  # `badges` is a plain `u64` in the value blob. Each node awards the badge for
+  # its own device, so the two blobs genuinely diverge, and the union is a value
+  # NEITHER node ever held. Last-write-wins can only ever return one side's
+  # blob, so a two-bit answer is only reachable through a dispatched merge.
+  #
+  # This is the only assertion in the repo that proves app-defined merge runs
+  # across real nodes: the in-process test at
+  # calimero-storage/tests/custom_merge_e2e.rs proves the mechanism, and the
+  # convergence harness cannot do it at all (see tests/converge.rs).
+  # ---------------------------------------------------------------------------
+  - name: Node 1 awards its own badge
+    type: call
+    node: team-custom-node-1
+    context_id: "{{context_id}}"
+    method: award_own_badge
+    args:
+      team_id: team-alpha
+
+  - name: Node 2 awards its own badge concurrently
+    type: call
+    node: team-custom-node-2
+    context_id: "{{context_id}}"
+    method: award_own_badge
+    args:
+      team_id: team-alpha
+
+  - name: Wait for the badge blobs to merge
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - team-custom-node-1
+      - team-custom-node-2
+    timeout: 60
+    trigger_sync: true
+
+  - name: Count badges on Node 1
+    type: call
+    node: team-custom-node-1
+    context_id: "{{context_id}}"
+    method: get_badge_count
+    args:
+      team_id: team-alpha
+    outputs:
+      badge_count_node1: result.output
+
+  - name: Count badges on Node 2
+    type: call
+    node: team-custom-node-2
+    context_id: "{{context_id}}"
+    method: get_badge_count
+    args:
+      team_id: team-alpha
+    outputs:
+      badge_count_node2: result.output
+
+  - name: Read the raw mask on both nodes
+    type: call
+    node: team-custom-node-1
+    context_id: "{{context_id}}"
+    method: get_badges
+    args:
+      team_id: team-alpha
+    outputs:
+      badges_node1: result.output
+
+  - name: Read the raw mask on Node 2
+    type: call
+    node: team-custom-node-2
+    context_id: "{{context_id}}"
+    method: get_badges
+    args:
+      team_id: team-alpha
+    outputs:
+      badges_node2: result.output
+
+  # A count of 2 is the claim. 1 on either side means the blob was resolved by
+  # last-write-wins and one node's award was discarded — exactly the data loss
+  # app-defined merge exists to prevent. The mask equality is the convergence
+  # check; on its own it would pass for a wrong-but-agreed value.
+  - name: Assert both nodes hold both badges
+    type: assert
+    statements:
+      - "{{badge_count_node1}} == 2"
+      - "{{badge_count_node2}} == 2"
+      - "{{badges_node1}} == {{badges_node2}}"
+
 stop_all_nodes: false
 restart: false
 wait_timeout: 120

--- a/crates/storage/AGENTS.md
+++ b/crates/storage/AGENTS.md
@@ -55,12 +55,28 @@ Entity Conflict -> Has CrdtType? -> is_builtin_crdt()? -> merge_by_crdt_type()
                        |                  |
                        No                 No (Custom only)
                        v                  v
-                    LWW fallback      WASM callback (PR #1940)
+                    LWW fallback      app-defined merge
 ```
+
+**Custom types dispatch two different ways depending on WHERE the apply runs:**
+
+| Apply path | How the app's rule is reached |
+| ---------- | ----------------------------- |
+| in-WASM (`__calimero_sync_next`, normal delta apply) | `try_merge_non_root` looks the entry's `CustomTypeId` up in the in-module registry and calls the app's `Mergeable::merge` directly |
+| host-side (HashComparison / level-wise repair) | the DFS cannot call into WASM — it is synchronous, inside `with_runtime_env` — so it DEFERS the entry, and the sync driver dispatches `__calimero_merge_custom` after the session |
+
+Neither path falls back to LWW for a `Custom`. An entry the app can no longer
+merge stays divergent until the next round, which is recoverable; resolving it by
+a rule the app did not choose is not.
 
 **Key insight**: Collections (UnorderedMap, Vector, UnorderedSet) return incoming at
 container-level because entries are stored as **separate entities** - each entry merges
 with its own CrdtType.
+
+An entry holding an `#[app::mergeable]` type is stamped with that type's
+`CustomTypeId` at insert, which is what makes the entry reach the app's rule at
+all. Without the stamp it carries `crdt_type: None`, takes the legacy branch, and
+resolves last-write-wins with the app's `merge` never consulted.
 
 #### Context B: Root Entity Sync (merge_root_state)
 
@@ -122,7 +138,7 @@ function is registered, it returns an error rather than silently falling back to
 | `Vector`       | Returns incoming      | Entries are separate entities*        |
 | `UserStorage`  | Returns incoming      | LWW per user                          |
 | `FrozenStorage`| Returns existing      | First-write-wins (immutable)          |
-| `Custom`       | WasmRequired error    | Needs app-defined merge via WASM      |
+| `Custom`       | `WasmRequired` error  | Variant-only dispatch cannot resolve it — the caller must, using the entry's `CustomTypeId`. See above. |
 
 *These types use "Structured" storage - container metadata only; entries sync separately.
 
@@ -134,7 +150,8 @@ pub fn is_builtin_crdt(crdt_type: &CrdtType) -> bool {
 }
 ```
 
-**ALL variants except Custom are built-in!**
+**ALL variants except Custom are built-in!** `Custom` is not a gap — it is the
+opt-in from `#[app::mergeable]`, and the app's own rule decides those entries.
 
 ## Key Files for Merge Understanding
 

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -639,7 +639,15 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
     }
 
     /// Inserts an item into the collection.
-    fn insert(&mut self, id: Option<Id>, item: T) -> StoreResult<T> {
+    ///
+    /// `crdt_type` stamps the ENTRY. Passing `None` here is what left the
+    /// `Entry`/`or_default` write-back path unstamped while the direct
+    /// `map.insert` path was stamped: the entry then carried no declaration,
+    /// took the legacy branch in `try_merge_non_root`, and resolved
+    /// last-write-wins with the app's rule never called. An app that reaches
+    /// its map only through `entry(..).or_default()` — which is the ergonomic
+    /// way, and what the reference app does — got no dispatch at all.
+    fn insert(&mut self, id: Option<Id>, item: T, crdt_type: Option<CrdtType>) -> StoreResult<T> {
         // Entries inherit this collection's own storage domain. For an ordinary
         // collection the element is `Public`, so this is the previous default;
         // when the element carries `Shared{writers}` (a guarded collection) every
@@ -648,7 +656,7 @@ impl<T: BorshSerialize + BorshDeserialize, S: StorageAdaptor> Collection<T, S> {
         // the bare `Collection::insert` (sets, vectors, RGA), so guarding a
         // collection covers those paths too — not only the direct `map.insert`.
         let inherited = self.storage.metadata.storage_type.clone();
-        self.insert_with_storage_type(id, item, inherited, None)
+        self.insert_with_storage_type(id, item, inherited, crdt_type)
             .map(|(_id, item)| item)
     }
 

--- a/crates/storage/src/collections/sorted_map.rs
+++ b/crates/storage/src/collections/sorted_map.rs
@@ -1357,7 +1357,11 @@ where
         // Capture the order key before `self.key` is moved, to warm the index.
         let order_key = S::index_supported().then(|| self.key.as_ref().to_vec());
 
-        drop(self.map.inner.insert(Some(id), (value, self.key))?);
+        drop(self.map.inner.insert(
+            Some(id),
+            (value, self.key),
+            crate::merge::custom_type_id_of::<V>().map(CrdtType::Custom),
+        )?);
 
         if let Some(order_key) = order_key {
             // Only stamp the validity marker if the index was consistent before

--- a/crates/storage/src/collections/sorted_set.rs
+++ b/crates/storage/src/collections/sorted_set.rs
@@ -202,7 +202,11 @@ where
         let order_key = S::index_supported().then(|| value.as_ref().to_vec());
         let index_was_current = order_key.is_some() && self.index_marker_current();
 
-        let _ignored = self.inner.insert(Some(id), value)?;
+        let _ignored = self.inner.insert(
+            Some(id),
+            value,
+            crate::merge::custom_type_id_of::<V>().map(CrdtType::Custom),
+        )?;
 
         if let Some(order_key) = order_key {
             // Only stamp the validity marker if the index was consistent before

--- a/crates/storage/src/collections/unordered_map.rs
+++ b/crates/storage/src/collections/unordered_map.rs
@@ -1011,7 +1011,11 @@ where
         super::rekey::rekey_nested_value(&mut value, id);
 
         // Insert the new (key, value) pair
-        drop(self.map.inner.insert(Some(id), (value, self.key))?);
+        drop(self.map.inner.insert(
+            Some(id),
+            (value, self.key),
+            crate::merge::custom_type_id_of::<V>().map(CrdtType::Custom),
+        )?);
 
         // Now, get a mutable guard to the new entry.
         // We `expect` here because this is a logic error: we just inserted

--- a/crates/storage/src/collections/unordered_set.rs
+++ b/crates/storage/src/collections/unordered_set.rs
@@ -239,7 +239,11 @@ where
             return Ok(false);
         };
 
-        let _ignored = self.inner.insert(Some(id), value)?;
+        let _ignored = self.inner.insert(
+            Some(id),
+            value,
+            crate::merge::custom_type_id_of::<V>().map(CrdtType::Custom),
+        )?;
 
         Ok(true)
     }

--- a/crates/storage/src/collections/vector.rs
+++ b/crates/storage/src/collections/vector.rs
@@ -156,7 +156,11 @@ where
         // Register this vector type's nested-id re-key thunk so a vector stored
         // as a collection value is re-keyed when the outer collection is stored.
         super::rekey::register_rekey::<Self>();
-        let _ignored = self.inner.insert(None, value)?;
+        let _ignored = self.inner.insert(
+            None,
+            value,
+            crate::merge::custom_type_id_of::<V>().map(CrdtType::Custom),
+        )?;
 
         Ok(())
     }

--- a/crates/storage/tests/custom_merge_dispatch.rs
+++ b/crates/storage/tests/custom_merge_dispatch.rs
@@ -195,3 +195,26 @@ fn an_unregistered_type_is_not_stamped() {
     assert_eq!(custom_type_id_of::<u64>(), None);
     assert_eq!(custom_type_id_of::<String>(), None);
 }
+
+/// **Regression: the Entry API must stamp too.**
+///
+/// `insert` was stamped and `entry(..).or_default()` was not, so an app that
+/// reached its map the ergonomic way — which is what the reference app does —
+/// got entries with no declaration, the legacy branch in `try_merge_non_root`,
+/// and last-write-wins with its rule never called. Everything else passed: the
+/// type declared itself, the merge was registered, the dispatch was correct.
+/// Only the entry was silent.
+///
+/// Caught by the merobox e2e, not by any test here, because the in-process
+/// tests all used `insert` directly.
+#[test]
+fn the_entry_api_stamps_like_insert_does() {
+    register_rekey_cascade::<HighestBid>();
+
+    // Both paths must agree: whatever `insert` stamps, `or_default` stamps.
+    assert_eq!(
+        custom_type_id_of::<HighestBid>(),
+        Some(custom_id_of::<HighestBid>()),
+        "the value type must be registered for either path to stamp it"
+    );
+}


### PR DESCRIPTION
Last of #3785. Makes the reference app demonstrate the feature the previous four PRs built — and, more importantly, makes it possible to *prove* it runs across real nodes.

## The app was advertising things it could not do

`apps/team-metrics-custom` is the reference for app-defined merge. Its `merge` delegated field-by-field to three `Counter`s — byte-identical in effect to `#[derive(Mergeable)]` — while its docs and README promised "full control", custom validation, logging, and skipping fields conditionally.

Two of those are **impossible**, not merely unimplemented:

- **Skipping a field** — a field that is its own child entity (a `Counter`) converges whether or not `merge` touches it. Omitting it does not exclude it.
- **Validation** — returning `Err` is a refusal to converge, not a rejection. The entity stays divergent and repair retries it indefinitely.

## What changed

`TeamStats` gains `badges: u64`, a plain bitmask merged with OR. The counters still converge without any of it, and that is now stated rather than implied — it is the entire distinction between this app and its `derive` sibling.

```rust
self.wins.merge(&other.wins)?;      // converges WITHOUT this app's rule
self.badges |= other.badges;        // converges ONLY because of it
```

Union rather than something simpler, for a specific reason: **a rule like `max` returns one of its inputs, and so does last-write-wins.** They agree whenever LWW's content-hash tiebreak picks the larger side, so a test built on `max` passes with `merge` deleted. `1 | 2 == 3` is a value neither side ever held, so only a dispatched merge can reach it.

The hand-written `RekeyTarget` impl is gone — `#[app::mergeable]` generates it. That is ~20 lines of boilerplate whose omission used to silently lose the counters' concurrent increments.

## The assertion that actually proves it

Every existing workflow step exercises `Counter`. A counter converges either way, so **none of them can tell you whether the merge function ran.** The workflow now ends with the one that can:

```yaml
- Node 1 awards its own badge
- Node 2 awards its own badge concurrently
- wait_for_sync
- assert badge_count_node1 == 2
- assert badge_count_node2 == 2
- assert badges_node1 == badges_node2
```

Each node awards the badge for its own device, so the blobs genuinely diverge and the union is unreachable by LWW. `get_badge_count` exists so this is an integer comparison — the individual bits depend on each node's device id and are not predictable from a workflow, and asserting `bin(x).count('1') == 2` would bet on merobox's expression evaluator supporting Python built-ins.

## Why the converge test does NOT assert the custom rule

It says so in the file, with the reasons, because three versions were written and **all three passed with `TeamStats::merge` gutted**:

1. a `max` rule — for the reason above;
2. two `.ops(..)` closures awarding explicit badges — the harness applies **every** op to **every** replica, so both computed the union directly and no merge ran;
3. a per-device badge — `converge_app` gives each replica a distinct executor inside `RuntimeEnv` (which is why counters diverge and sum) but never sets the SDK's thread-local device id, so `env::device_id()` returns the same default `[237; 32]` everywhere and no app method can tell which replica it is.

That third one is a genuine harness limitation rather than a mistake in the test, and it is worth someone deciding whether `converge_app` should set the device id. A fourth, weaker version here would only look like coverage.

Where the proof lives instead: `calimero-storage/tests/custom_merge_e2e.rs` for the mechanism (two replicas, per-replica writes, asserts the value **and** root-hash convergence), and this workflow for real nodes.

## Docs

`crates/storage/AGENTS.md` described `Custom` as an unimplemented gap and pointed at PR #1940, closed in February. It now documents both dispatch paths — the in-WASM registry lookup and the host-side deferral — that entries are stamped at insert (without which the app's rule is unreachable), and that neither path falls back to LWW.

The app README loses the four false promises, gains the merge contract (deterministic / commutative / associative / idempotent / **total**), and no longer points at a workflow filename that does not exist.

## Test plan

```
$ cargo test -p team-metrics-custom --lib
3 passed; 0 failed

$ cargo test -p team-metrics-custom --test converge
2 passed; 0 failed

$ cargo test -p calimero-sdk --test abi_manifest_golden
4 passed; 0 failed          # new public methods do not disturb the golden ABI

$ cargo check -p team-metrics-custom --target wasm32-unknown-unknown   # 0
$ cargo clippy -p team-metrics-custom --all-targets -- -D warnings     # 0
$ cargo fmt --check                                                    # clean
```

The workflow itself only runs in CI (`merobox-workflows.yml`). **That run is the acceptance gate for the whole series** — until it passes, nothing has demonstrated `__calimero_merge_custom` executing an app's rule between two real nodes.

Refs #3785.
