### PR TITLE
fix(sync): bound the admitter dial phase so unreachable hints cannot spend the join

### DIFF
--- a/crates/node/src/sync/manager/namespace_join.rs
+++ b/crates/node/src/sync/manager/namespace_join.rs
@@ -85,6 +85,69 @@ pub(super) struct ConnectBudget {
     pub(super) discovery_wait: std::time::Duration,
 }
 
+/// Reach the invitation's admitters, best-effort and time-boxed.
+///
+/// This is priming, not a prerequisite: [`open_namespace_join_stream`] has its
+/// own budget and will use whichever connection landed, so nothing here needs
+/// to finish for the join to work.
+///
+/// **Bounded by one timeout rather than by how many addresses the invitation
+/// carries.** A dial resolves only when the connection is established or the
+/// transport gives up, so awaiting them one after another let a handful of
+/// unroutable hints spend the whole join before peer selection was asked once.
+/// That is not an edge case: an address is a snapshot from mint time, and an
+/// admitter behind a NAT — or one whose advertised address is not reachable
+/// from where the joiner happens to sit — produces exactly this shape. Docker
+/// networks, split-horizon DNS and CI runners all do.
+///
+/// Concurrent across machines, sequential within one. Several addresses for a
+/// single peer are alternative routes to the same box, so trying them in order
+/// is the point of the per-machine cap in [`group_admitter_routes`]; two
+/// different machines have no reason to wait for each other.
+pub(super) async fn dial_admitter_machines<F, Fut>(
+    routes_by_machine: Vec<(libp2p::PeerId, Vec<libp2p::Multiaddr>)>,
+    budget: std::time::Duration,
+    dial: F,
+) where
+    F: Fn(libp2p::Multiaddr) -> Fut,
+    Fut: std::future::Future<Output = eyre::Result<()>>,
+{
+    // Returning early rather than arming a timeout over nothing: an invitation
+    // with no addresses is the ordinary case for one minted by a node that had
+    // no confirmed external address, and it should cost nothing.
+    if routes_by_machine.is_empty() {
+        return;
+    }
+
+    let attempts = routes_by_machine.into_iter().map(|(peer, routes)| {
+        let dial = &dial;
+        async move {
+            for addr in routes {
+                match dial(addr.clone()).await {
+                    Ok(()) => {
+                        debug!(%peer, %addr, "dialed an admitter named by the invitation");
+                        return;
+                    }
+                    Err(err) => {
+                        debug!(%peer, %addr, %err, "admitter address did not dial")
+                    }
+                }
+            }
+        }
+    });
+
+    if time::timeout(budget, futures_util::future::join_all(attempts))
+        .await
+        .is_err()
+    {
+        debug!(
+            ?budget,
+            "admitter dial budget elapsed; continuing to peer selection with \
+             whatever connected"
+        );
+    }
+}
+
 /// Group admitter addresses by the machine they reach, capped at `max_peers`.
 ///
 /// Order is preserved, and that is load-bearing rather than incidental: the mint
@@ -328,6 +391,7 @@ pub(super) async fn open_namespace_join_stream(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -359,6 +423,141 @@ mod tests {
     /// exercise the protocol-level-retry rejection path.
     fn no_excluded() -> HashSet<PeerId> {
         HashSet::new()
+    }
+
+    /// A dialable multiaddr distinguishable by its port.
+    fn addr(port: u16) -> libp2p::Multiaddr {
+        format!("/ip4/10.0.0.1/udp/{port}/quic-v1")
+            .parse()
+            .expect("a valid multiaddr")
+    }
+
+    /// The property the whole helper exists for: unreachable hints cost one
+    /// budget, not one budget each.
+    ///
+    /// A dial resolves only when the connection is established or the transport
+    /// gives up, so `pending` here is a faithful stand-in for the
+    /// `HandshakeTimedOut` an unroutable address produces. Eight of them
+    /// awaited in turn is how a best-effort priming step came to spend a whole
+    /// join.
+    #[tokio::test(start_paused = true)]
+    async fn unreachable_admitters_cost_one_budget_not_one_each() {
+        let budget = Duration::from_millis(100);
+        let machines: Vec<_> = (0..8)
+            .map(|i| (PeerId::random(), vec![addr(9_000 + i)]))
+            .collect();
+
+        let started = time::Instant::now();
+        dial_admitter_machines(machines, budget, |_addr| async {
+            std::future::pending::<eyre::Result<()>>().await
+        })
+        .await;
+
+        assert_eq!(
+            started.elapsed(),
+            budget,
+            "eight hanging dials must cost one budget; anything more means they \
+             were awaited in sequence"
+        );
+    }
+
+    /// Concurrency across machines, stated as a count rather than a duration so
+    /// it fails for the right reason.
+    ///
+    /// Each dial takes three quarters of the budget, so awaiting them in turn
+    /// would get through one before the deadline. Every machine being attempted
+    /// is only possible if they ran together.
+    #[tokio::test(start_paused = true)]
+    async fn every_machine_is_attempted_because_they_run_concurrently() {
+        let budget = Duration::from_millis(100);
+        let per_dial = Duration::from_millis(75);
+        let attempted = Arc::new(AtomicUsize::new(0));
+
+        let machines: Vec<_> = (0..8)
+            .map(|i| (PeerId::random(), vec![addr(9_100 + i)]))
+            .collect();
+
+        let counter = Arc::clone(&attempted);
+        dial_admitter_machines(machines, budget, move |_addr| {
+            let counter = Arc::clone(&counter);
+            async move {
+                let _prev = counter.fetch_add(1, Ordering::SeqCst);
+                time::sleep(per_dial).await;
+                Ok(())
+            }
+        })
+        .await;
+
+        assert_eq!(
+            attempted.load(Ordering::SeqCst),
+            8,
+            "every named machine must be attempted within one budget"
+        );
+    }
+
+    /// Within one machine the routes stay sequential, and stop at the first
+    /// that answers.
+    ///
+    /// Alternative routes to one peer are the same box — a direct address, a
+    /// relay circuit, whatever it had before it last moved — so dialing them
+    /// all at once would be several connections to one node, and continuing
+    /// after one succeeded would be pointless work.
+    #[tokio::test(start_paused = true)]
+    async fn routes_to_one_machine_are_tried_in_order_until_one_answers() {
+        let tried = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let machines = vec![(PeerId::random(), vec![addr(1), addr(2), addr(3)])];
+
+        let seen = Arc::clone(&tried);
+        dial_admitter_machines(machines, Duration::from_millis(500), move |addr| {
+            let seen = Arc::clone(&seen);
+            async move {
+                seen.lock()
+                    .expect("the log is not poisoned")
+                    .push(addr.clone());
+                // The second route answers, so the third must never be reached.
+                if addr == self::addr(2) {
+                    Ok(())
+                } else {
+                    Err(eyre::eyre!("unreachable"))
+                }
+            }
+        })
+        .await;
+
+        let tried = tried.lock().expect("the log is not poisoned").clone();
+        assert_eq!(
+            tried,
+            vec![addr(1), addr(2)],
+            "routes must be tried in the order the mint put them in, and stop \
+             once the machine answers"
+        );
+    }
+
+    /// An invitation naming no addresses costs nothing.
+    ///
+    /// This is the ordinary case for one minted by a node with no confirmed
+    /// external address, so it must not arm a timeout over an empty set.
+    #[tokio::test(start_paused = true)]
+    async fn no_hints_is_a_no_op() {
+        let called = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&called);
+
+        let started = time::Instant::now();
+        dial_admitter_machines(Vec::new(), Duration::from_secs(30), move |_addr| {
+            let counter = Arc::clone(&counter);
+            async move {
+                let _prev = counter.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        })
+        .await;
+
+        assert_eq!(
+            started.elapsed(),
+            Duration::ZERO,
+            "an empty set must not wait"
+        );
+        assert_eq!(called.load(Ordering::SeqCst), 0, "nothing to dial");
     }
 
     /// An admitter named by the invitation is tried before a peer that

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -1159,54 +1159,49 @@ impl SyncManager {
     /// authenticates the peer id on connect, and admission is decided by the
     /// signed `admitters` list at apply on every peer. A wrong address costs a
     /// failed dial.
-    async fn dial_admitters(&self, invitation_bytes: &[u8]) {
-        let Ok(invitation) = borsh::from_slice::<
-            calimero_context_config::types::SignedGroupOpenInvitation,
-        >(invitation_bytes) else {
-            return;
-        };
-
-        let by_machine = super::namespace_join::group_admitter_routes(
-            &invitation.admitter_addrs,
-            MAX_ADMITTER_MACHINES_DIALED,
-        );
-
-        for (peer, routes) in by_machine {
-            for addr in routes {
-                match self.network_client.dial(addr.clone()).await {
-                    Ok(()) => {
-                        debug!(%peer, %addr, "dialed an admitter named by the invitation");
-                        break;
-                    }
-                    Err(err) => {
-                        debug!(%peer, %addr, %err, "admitter address did not dial")
-                    }
-                }
-            }
-        }
-    }
-
-    fn admitter_peer_ids(invitation_bytes: &[u8]) -> Vec<PeerId> {
+    /// The admitter machines the invitation points at, capped and parsed once.
+    ///
+    /// One call feeds both consumers — the dial below and the peer preference
+    /// handed to the connect loop — so the set that gets dialed and the set
+    /// that gets tried first are the same by construction. They used to be
+    /// derived separately, and only one of them was capped: the preference list
+    /// could hold an entry per address (up to `MAX_ADMITTER_ADDRS`), each of
+    /// which the connect loop would try ahead of discovery at a full
+    /// stream-open timeout apiece.
+    fn admitter_routes(invitation_bytes: &[u8]) -> Vec<(PeerId, Vec<libp2p::Multiaddr>)> {
         let Ok(invitation) = borsh::from_slice::<
             calimero_context_config::types::SignedGroupOpenInvitation,
         >(invitation_bytes) else {
             return Vec::new();
         };
 
-        let mut out = Vec::new();
-        for addr in &invitation.admitter_addrs {
-            let Ok(parsed) = addr.parse::<libp2p::Multiaddr>() else {
-                continue;
-            };
-            // The peer id is the only part of the address this cares about; the
-            // transport half is the dialer's problem, and it has already run.
-            if let Some(libp2p::multiaddr::Protocol::P2p(peer)) = parsed.iter().last() {
-                if !out.contains(&peer) {
-                    out.push(peer);
-                }
-            }
-        }
-        out
+        super::namespace_join::group_admitter_routes(
+            &invitation.admitter_addrs,
+            MAX_ADMITTER_MACHINES_DIALED,
+        )
+    }
+
+    /// Reach the invitation's admitters before asking discovery about them.
+    ///
+    /// `open_namespace_join_stream` prefers them, but preference only helps
+    /// among peers it can open a stream to, and `subscribed_peers` reports who
+    /// is on the topic mesh — which is exactly what has not converged in the
+    /// case this join path exists for. Dialing first is what turns an address
+    /// the invitation carries into a peer the loop can use.
+    ///
+    /// The bounded-and-concurrent part lives in
+    /// [`namespace_join::dial_admitter_machines`] so its timing can be tested
+    /// against a fake dialer, the same reason the connect loop was extracted.
+    /// Reuses the per-peer stream-open timeout rather than adding a second
+    /// knob: both answer "how long is one unreachable peer worth", and a dial
+    /// that has not completed in that long will not be what unblocks this join.
+    async fn dial_admitters(&self, routes_by_machine: Vec<(PeerId, Vec<libp2p::Multiaddr>)>) {
+        super::namespace_join::dial_admitter_machines(
+            routes_by_machine,
+            self.sync_config.open_stream_timeout,
+            |addr| async move { self.network_client.dial(addr).await },
+        )
+        .await;
     }
 
     /// Initiator side: open a stream to a mesh peer and perform the
@@ -1250,15 +1245,16 @@ impl SyncManager {
         // typical 1–3 mesh peers plus headroom.
         const MAX_PROTOCOL_RETRIES: usize = 5;
 
-        // The peers the invitation named as admitters, if it named any
-        // reachable ones. Derived here rather than passed in because the
-        // invitation is already in `params` — the addresses ride along with it,
-        // outside the inviter's signature.
+        // The admitter machines the invitation named. Derived here rather than
+        // passed in because the invitation is already in `params` — the
+        // addresses ride along with it, outside the inviter's signature.
         //
         // Only an admitter can complete this join, so trying one first is not a
         // preference so much as the difference between a round trip that can
         // succeed and one that can only be refused.
-        let admitter_peers = Self::admitter_peer_ids(&params.invitation_bytes);
+        let admitter_routes = Self::admitter_routes(&params.invitation_bytes);
+        let admitter_peers: Vec<libp2p::PeerId> =
+            admitter_routes.iter().map(|(peer, _)| *peer).collect();
 
         // Reach those admitters before asking discovery about them.
         //
@@ -1273,7 +1269,7 @@ impl SyncManager {
         // stream attempts. Failures are ordinary — an address is a snapshot
         // from mint time — and none of them should fail a join that gossip may
         // still complete.
-        self.dial_admitters(&params.invitation_bytes).await;
+        self.dial_admitters(admitter_routes).await;
 
         for protocol_attempt in 1..=MAX_PROTOCOL_RETRIES {
             let (mut stream, peer) = match super::namespace_join::open_namespace_join_stream(
@@ -2862,5 +2858,84 @@ mod join_target_tests {
         // Pairing a valid invitation with someone else's namespace must not
         // release that namespace's key material.
         assert!(join_target_group(&store, namespace, &invitation_to(&admin_sk, stranger)).is_err());
+    }
+}
+
+#[cfg(test)]
+mod admitter_derivation_tests {
+    //! What the joiner derives from an invitation's addresses, and the cap that
+    //! has to apply to it.
+    //!
+    //! The dialed set and the preferred set come from one call now, which is
+    //! the point: they used to be derived separately and only the dial was
+    //! capped, so the preference list could carry an entry per address — up to
+    //! `MAX_ADMITTER_ADDRS` of them — each one tried ahead of discovery at a
+    //! full stream-open timeout apiece.
+
+    use calimero_context_config::types::{
+        ContextGroupId, GroupInvitationFromAdmin, SignedGroupOpenInvitation, SignerId,
+    };
+
+    use super::{SyncManager, MAX_ADMITTER_MACHINES_DIALED};
+
+    /// An invitation carrying `count` addresses, each naming a different peer.
+    fn invitation_naming_distinct_machines(count: usize) -> Vec<u8> {
+        let addrs = (0..count)
+            .map(|i| {
+                // A distinct, well-formed peer id per address, so these count
+                // as separate machines rather than routes to one.
+                let peer = libp2p::identity::Keypair::generate_ed25519()
+                    .public()
+                    .to_peer_id();
+                format!("/ip4/10.0.0.1/udp/{}/quic-v1/p2p/{peer}", 9000 + i)
+            })
+            .collect();
+
+        borsh::to_vec(&SignedGroupOpenInvitation {
+            inviter_account: None,
+            invitation: GroupInvitationFromAdmin {
+                inviter_identity: SignerId::from([0xA1; 32]),
+                group_id: ContextGroupId::from([0xB2; 32]),
+                expiration_timestamp: 0,
+                invitation_nonce: [0xC3; 32],
+                invited_role: 1,
+                admitters: Vec::new(),
+            },
+            inviter_signature: String::new(),
+            application_id: None,
+            bytecode_id: None,
+            admitter_addrs: addrs,
+        })
+        .expect("borsh the invitation")
+    }
+
+    #[test]
+    fn more_machines_than_the_cap_are_dropped_not_carried() {
+        let over = MAX_ADMITTER_MACHINES_DIALED + 4;
+        let routes = SyncManager::admitter_routes(&invitation_naming_distinct_machines(over));
+
+        assert_eq!(
+            routes.len(),
+            MAX_ADMITTER_MACHINES_DIALED,
+            "an invitation naming {over} machines must be capped at \
+             {MAX_ADMITTER_MACHINES_DIALED}; without the cap every one of them \
+             is tried ahead of discovery at a stream-open timeout each"
+        );
+    }
+
+    #[test]
+    fn fewer_machines_than_the_cap_are_all_kept() {
+        let routes = SyncManager::admitter_routes(&invitation_naming_distinct_machines(3));
+        assert_eq!(routes.len(), 3, "the cap must not drop what fits under it");
+    }
+
+    /// Undecodable bytes are a relayed invitation this node cannot read, not a
+    /// reason to fail the join — the addresses are unsigned hints either way.
+    #[test]
+    fn an_invitation_that_does_not_decode_yields_no_machines() {
+        assert!(
+            SyncManager::admitter_routes(b"not an invitation").is_empty(),
+            "a hint set that cannot be read is empty, not an error"
+        );
     }
 }


### PR DESCRIPTION
Fixes the join-path half of #3801.

## What went wrong

#3798 moved `dial_admitters` off a dead code path onto the live one — which is
what it was for, and also the first time a joiner actually dialled the addresses
an invitation carries. Three things then compounded:

- **`NetworkClient::dial` awaits the connection outcome.** The oneshot it blocks
  on is fired by `ConnectionEstablished` / `OutgoingConnectionError`, so an
  unreachable address costs a full transport timeout — the `HandshakeTimedOut`
  in the issue.
- **Those were awaited serially**, up to `MAX_ADMITTER_MACHINES_DIALED` machines
  with their alternate routes each, all *before* `open_namespace_join_stream`
  started its own budget. A best-effort priming step could spend the whole join.
- **The preferred-peer set was uncapped.** `dial_admitters` capped at 8 machines
  but `admitter_peer_ids` capped at nothing, so up to `MAX_ADMITTER_ADDRS` = 256
  peers could be tried ahead of discovery at a stream-open timeout apiece — 768s
  against a 45s deadline.

Unreachable hints are the ordinary case, not the exception: an address is a
snapshot from mint time, and an admitter behind a NAT — or one whose advertised
address is not reachable from where the joiner sits — produces exactly this
shape. Docker networks, split-horizon DNS and CI runners all do.

## What this changes

**The dial phase is bounded by one timeout instead of by how many addresses the
invitation happens to carry.** It is priming, not a prerequisite: the connect
loop that follows has its own budget and will use whichever connection landed,
so nothing in this phase needs to finish for the join to work. Dials now run
concurrently across machines under a single overall timeout, reusing
`open_stream_timeout` rather than adding a second knob — both answer "how long
is one unreachable peer worth".

Sequential *within* a machine is kept deliberately: several addresses for one
peer are alternative routes to the same box, so trying them in order is the
point of the per-machine cap, and continuing after one answers is pointless.

**The dialled set and the preferred set now come from one call.** `admitter_routes`
parses the invitation once and returns capped machines; the peer list is a map
over it. Neither can be uncapped independently again.

The bounded-and-concurrent part lives in `namespace_join::dial_admitter_machines`
so its *timing* can be tested against a fake dialer — the same reason the connect
loop was extracted there.

## Tests

Four timing tests, under `start_paused = true`:

- `unreachable_admitters_cost_one_budget_not_one_each` — eight hanging dials,
  asserts elapsed == one budget. This is the regression.
- `every_machine_is_attempted_because_they_run_concurrently` — each dial takes
  three quarters of the budget, so sequential execution would get through one;
  asserts all eight were attempted. Stated as a count rather than a duration so
  it fails for the right reason.
- `routes_to_one_machine_are_tried_in_order_until_one_answers` — pins the
  within-machine sequencing and the stop-on-success.
- `no_hints_is_a_no_op` — an invitation with no addresses must not arm a timeout
  over an empty set.

Plus three for the cap, driving `admitter_routes` directly.

I checked these discriminate rather than assuming it: reinstating the serial
shape makes `unreachable_admitters_cost_one_budget_not_one_each` **hang
indefinitely** rather than merely fail, which is the failure mode the issue
describes.

## What this does not fix

Two things from #3801 are deliberately out of scope here:

1. **`kad.add_address` runs before the dial** (`handlers/commands/dial.rs`), so
   unroutable addresses enter the routing table under the admitter's PeerId.
   Since `admitter_addrs` sits *outside* the inviter's signature, anyone relaying
   an invitation can write `(peer_id, addr)` pairs into a joiner's routing table.
   That wants moving to the `ConnectionEstablished` path, but it touches every
   dial in the node, so it belongs in its own PR.
2. **Whether the public addresses in the issue came from the invitation at all.**
   One detail argues they did not: `/ip4/95.61.134.160/udp/2428/quic-v1` uses the
   `shared_cluster` fixture's default port range, not the failing workflow's
   `base_port: 9000`, which looks more like a stale peer-cache entry. The
   `admitter address did not dial` debug line settles it either way. This PR makes
   the join robust to unreachable hints regardless of where they came from; it may
   not be the whole root cause.
