### PR TITLE
feat(storage)!: require every Mergeable type to declare how it merges

### DIFF
--- a/crates/sdk/macros/src/mergeable.rs
+++ b/crates/sdk/macros/src/mergeable.rs
@@ -85,6 +85,16 @@ pub fn derive(input: DeriveInput) -> TokenStream {
             }
         }
 
+        // Declares HOW this type merges when stored as a collection value:
+        // structurally. Field-by-field delegation reaches the same answer the
+        // storage layer does on its own, so nothing needs dispatching and no
+        // wasm call is paid. `#[app::mergeable]` is the other answer.
+        impl #impl_generics ::calimero_storage::collections::MergeStrategy
+            for #ident #ty_generics #where_clause
+        {
+            const DISPATCHED: bool = false;
+        }
+
         // Deterministic re-keying for use as a CRDT collection VALUE. When this
         // struct is stored as a map/set/vector value under a deterministic entry
         // id, each field's nested collection ids are re-keyed under a

--- a/crates/sdk/macros/src/mergeable_attr.rs
+++ b/crates/sdk/macros/src/mergeable_attr.rs
@@ -142,6 +142,15 @@ pub fn expand(args: &Args, input: DeriveInput) -> TokenStream {
             }
         }
 
+        // Declares HOW this type merges: dispatched. The entry is stamped with
+        // `TYPE_ID` and the merge point calls the rule above, rather than
+        // resolving the entry last-write-wins.
+        impl #impl_generics ::calimero_storage::collections::MergeStrategy
+            for #ident #ty_generics #where_clause
+        {
+            const DISPATCHED: bool = true;
+        }
+
         // Same re-keying the derive generates. A hand-written `Mergeable` has
         // to supply this by hand today, and forgetting it silently loses the
         // nested collections' concurrent writes — so the attribute emits it

--- a/crates/sdk/macros/src/state.rs
+++ b/crates/sdk/macros/src/state.rs
@@ -682,6 +682,17 @@ fn generate_mergeable_impl(
         // (the forbidden-type lint guarantees each field is Mergeable); recursive
         // per subtree. Invoked only on a remote root-state conflict, never on
         // local ops.
+        // Root state has its own merge path — `merge_root_state`, not the
+        // entry-level dispatch — so it declares `false`. The declaration is
+        // still required: `Mergeable` demands one so the distinction between
+        // "merges structurally" and "merges by an app rule the merge point
+        // calls" is recorded on every type rather than assumed.
+        impl #impl_generics ::calimero_storage::collections::MergeStrategy
+            for #ident #ty_generics #where_clause
+        {
+            const DISPATCHED: bool = false;
+        }
+
         impl #impl_generics ::calimero_storage::collections::Mergeable for #ident #ty_generics #where_clause {
             fn merge(&mut self, other: &Self)
                 -> ::core::result::Result<(), ::calimero_storage::collections::crdt_meta::MergeError>

--- a/crates/sdk/tests/macros.rs
+++ b/crates/sdk/tests/macros.rs
@@ -23,6 +23,10 @@ fn all() {
 
     // Generic tests
     t.compile_fail("tests/macros/invalid_generics.rs");
+
+    // A hand-written `Mergeable` with no declared strategy: the failure mode
+    // this whole gate exists for.
+    t.compile_fail("tests/macros/error_undeclared_merge_strategy.rs");
     t.pass("tests/macros/valid_generics.rs");
 
     // Argument tests

--- a/crates/sdk/tests/macros/error_bad_authorizer.stderr
+++ b/crates/sdk/tests/macros/error_bad_authorizer.stderr
@@ -116,7 +116,7 @@ help: the following other types implement trait `Authorizer`
 note: required by a bound in `merge`
  --> $WORKSPACE/crates/storage/src/collections/crdt_meta.rs
   |
-  | pub trait Mergeable: crate::collections::rekey::RekeyTarget {
+  | pub trait Mergeable: crate::collections::rekey::RekeyTarget + MergeStrategy {
   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Mergeable::merge`
 ...
   |     fn merge(&mut self, other: &Self) -> Result<(), MergeError>;

--- a/crates/sdk/tests/macros/error_undeclared_merge_strategy.rs
+++ b/crates/sdk/tests/macros/error_undeclared_merge_strategy.rs
@@ -1,0 +1,28 @@
+//! A hand-written `Mergeable` must say HOW it merges.
+//!
+//! Before this was required, such an impl compiled and — stored as a collection
+//! value — resolved last-write-wins with `merge` never called. It type-checked,
+//! passed convergence tests, and decided nothing. The reference app shipped in
+//! that state for months.
+//!
+//! `#[app::mergeable]` (dispatched) and `#[derive(Mergeable)]` (structural) are
+//! the two answers; this pins that giving neither is a compile error rather
+//! than a silent default.
+
+use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_storage::collections::crdt_meta::MergeError;
+use calimero_storage::collections::{Counter, Mergeable};
+
+#[derive(Default, BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct Undeclared {
+    hits: Counter,
+}
+
+impl Mergeable for Undeclared {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.hits.merge(&other.hits)
+    }
+}
+
+fn main() {}

--- a/crates/sdk/tests/macros/error_undeclared_merge_strategy.stderr
+++ b/crates/sdk/tests/macros/error_undeclared_merge_strategy.stderr
@@ -1,0 +1,45 @@
+error[E0277]: (calimero)> `Undeclared` implements `Mergeable` but never declared how it merges
+  --> tests/macros/error_undeclared_merge_strategy.rs:22:20
+   |
+22 | impl Mergeable for Undeclared {
+   |                    ^^^^^^^^^^ needs `#[app::mergeable]` or `#[derive(Mergeable)]`
+   |
+help: the trait `MergeStrategy` is not implemented for `Undeclared`
+  --> tests/macros/error_undeclared_merge_strategy.rs:18:1
+   |
+18 | struct Undeclared {
+   | ^^^^^^^^^^^^^^^^^
+   = note: Stored as a COLLECTION VALUE, a type that declares nothing resolves last-write-wins and its `merge` is never called — it compiles and silently decides nothing. Root state has its own merge path and is unaffected, but the declaration is still required so the distinction is recorded rather than assumed.
+   = note: Add `#[app::mergeable]` to have the merge dispatched, or `#[derive(Mergeable)]` if plain field-by-field delegation is what you want (the storage layer reaches that answer anyway, with no wasm call).
+note: required by a bound in `Mergeable`
+  --> $WORKSPACE/crates/storage/src/collections/crdt_meta.rs
+   |
+   | pub trait Mergeable: crate::collections::rekey::RekeyTarget + MergeStrategy {
+   |                                                               ^^^^^^^^^^^^^ required by this bound in `Mergeable`
+
+error[E0277]: the trait bound `Undeclared: calimero_storage::collections::rekey::RekeyTarget` is not satisfied
+  --> tests/macros/error_undeclared_merge_strategy.rs:22:20
+   |
+22 | impl Mergeable for Undeclared {
+   |                    ^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `calimero_storage::collections::rekey::RekeyTarget` is not implemented for `Undeclared`
+  --> tests/macros/error_undeclared_merge_strategy.rs:18:1
+   |
+18 | struct Undeclared {
+   | ^^^^^^^^^^^^^^^^^
+   = help: the following other types implement trait `calimero_storage::collections::rekey::RekeyTarget`:
+             AccessControl
+             Box<T>
+             FrozenValue<T>
+             PermissionedStorage<T, A>
+             WriterSetCell<T, S>
+             calimero_storage::collections::AuthoredMap<K, V, S>
+             calimero_storage::collections::AuthoredVector<V, S>
+             calimero_storage::collections::Counter<ALLOW_DECREMENT, S>
+           and $N others
+note: required by a bound in `Mergeable`
+  --> $WORKSPACE/crates/storage/src/collections/crdt_meta.rs
+   |
+   | pub trait Mergeable: crate::collections::rekey::RekeyTarget + MergeStrategy {
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Mergeable`

--- a/crates/sdk/tests/macros/invalid_nested_generics.stderr
+++ b/crates/sdk/tests/macros/invalid_nested_generics.stderr
@@ -85,7 +85,7 @@ error[E0310]: the parameter type `T` may not live long enough
 note: ...that is required by this bound
  --> $WORKSPACE/crates/storage/src/collections/crdt_meta.rs
   |
-  | pub trait Mergeable: crate::collections::rekey::RekeyTarget {
+  | pub trait Mergeable: crate::collections::rekey::RekeyTarget + MergeStrategy {
   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: this error originates in the attribute macro `app::state` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider adding an explicit lifetime bound
@@ -105,7 +105,7 @@ error[E0310]: the parameter type `T` may not live long enough
 note: ...that is required by this bound
  --> $WORKSPACE/crates/storage/src/collections/crdt_meta.rs
   |
-  | pub trait Mergeable: crate::collections::rekey::RekeyTarget {
+  | pub trait Mergeable: crate::collections::rekey::RekeyTarget + MergeStrategy {
   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: this error originates in the attribute macro `app::state` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider adding an explicit lifetime bound

--- a/crates/storage/src/collections.rs
+++ b/crates/storage/src/collections.rs
@@ -29,7 +29,9 @@ pub use rga::ReplicatedGrowableArray;
 pub mod lww_register;
 pub use lww_register::LwwRegister;
 pub mod crdt_meta;
-pub use crdt_meta::{CrdtMeta, CrdtType, Decomposable, Mergeable, StorageKey, StorageStrategy};
+pub use crdt_meta::{
+    CrdtMeta, CrdtType, Decomposable, MergeStrategy, Mergeable, StorageKey, StorageStrategy,
+};
 // Re-export of the `Mergeable` *derive macro*, whose single canonical
 // implementation lives in `calimero-sdk-macros` (it shares the forbidden-type
 // field lint with `#[app::state]`, which is why it can't live in this crate's

--- a/crates/storage/src/collections/access_control.rs
+++ b/crates/storage/src/collections/access_control.rs
@@ -42,7 +42,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_account::AccountId;
 
-use super::crdt_meta::{CrdtMeta, CrdtType, MergeError, Mergeable, StorageStrategy};
+use super::crdt_meta::{CrdtMeta, CrdtType, MergeError, MergeStrategy, Mergeable, StorageStrategy};
 use super::permissioned::{Authorizer, PermissionedStorage, SharedStorage};
 use super::{LwwRegister, StoreError, UnorderedMap};
 use crate::entities::{ChildInfo, Data, Element, OpMask};
@@ -423,6 +423,13 @@ impl CrdtMeta for AccessControl {
     fn can_contain_crdts() -> bool {
         true
     }
+}
+
+/// Structural: the storage layer merges this by its `crdt_type` variant, so
+/// there is no app rule to dispatch. See [`MergeStrategy`].
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for AccessControl {
+    const DISPATCHED: bool = false;
 }
 
 #[cfg(test)]

--- a/crates/storage/src/collections/authored_map.rs
+++ b/crates/storage/src/collections/authored_map.rs
@@ -23,7 +23,7 @@ use std::collections::BTreeMap;
 use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_account::AccountId;
 
-use super::crdt_meta::{CrdtMeta, CrdtType, Mergeable, StorageStrategy};
+use super::crdt_meta::{CrdtMeta, CrdtType, MergeStrategy, Mergeable, StorageStrategy};
 use super::{compute_id, StoreError, UnorderedMap, ValueRef};
 use crate::entities::{ChildInfo, Data, Element, StorageType};
 use crate::index::Index;
@@ -341,6 +341,18 @@ where
     fn can_contain_crdts() -> bool {
         true
     }
+}
+
+/// Structural: the storage layer merges this by its `crdt_type` variant, so
+/// there is no app rule to dispatch. See [`MergeStrategy`].
+#[diagnostic::do_not_recommend]
+impl<K, V, S> MergeStrategy for AuthoredMap<K, V, S>
+where
+    K: BorshSerialize + BorshDeserialize,
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    const DISPATCHED: bool = false;
 }
 
 #[cfg(test)]

--- a/crates/storage/src/collections/authored_vector.rs
+++ b/crates/storage/src/collections/authored_vector.rs
@@ -22,7 +22,7 @@ use std::collections::BTreeMap;
 use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_account::AccountId;
 
-use super::crdt_meta::{CrdtMeta, CrdtType, Mergeable, StorageStrategy};
+use super::crdt_meta::{CrdtMeta, CrdtType, MergeStrategy, Mergeable, StorageStrategy};
 use super::{StoreError, ValueRef, Vector};
 use crate::address::Id;
 use crate::entities::{ChildInfo, Data, Element, StorageType};
@@ -460,6 +460,17 @@ where
     fn can_contain_crdts() -> bool {
         true
     }
+}
+
+/// Structural: the storage layer merges this by its `crdt_type` variant, so
+/// there is no app rule to dispatch. See [`MergeStrategy`].
+#[diagnostic::do_not_recommend]
+impl<V, S> MergeStrategy for AuthoredVector<V, S>
+where
+    V: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    const DISPATCHED: bool = false;
 }
 
 #[cfg(test)]

--- a/crates/storage/src/collections/crdt_impls.rs
+++ b/crates/storage/src/collections/crdt_impls.rs
@@ -8,8 +8,12 @@
 //! - SortedMap
 //! - UnorderedSet
 //! - Vector
+//!
+//! Every built-in here declares `MergeStrategy` with `DISPATCHED = false`: the
+//! storage layer merges it by matching on its `crdt_type` variant, so none of
+//! them needs an app rule dispatched.
 
-use super::crdt_meta::{CrdtMeta, CrdtType, MergeError, Mergeable, StorageStrategy};
+use super::crdt_meta::{CrdtMeta, CrdtType, MergeError, MergeStrategy, Mergeable, StorageStrategy};
 use super::{
     Counter, LwwRegister, ReplicatedGrowableArray, SortedMap, SortedSet, UnorderedMap,
     UnorderedSet, ValueRef, Vector,
@@ -1175,4 +1179,64 @@ mod mapset_tombstone_merge_tests {
             "merge dropped a genuinely new value"
         );
     }
+}
+
+// ============================================================================
+// MergeStrategy — every built-in converges structurally
+// ============================================================================
+//
+// `DISPATCHED = false` for all of them: the storage layer merges each by
+// matching on its `crdt_type` variant, so there is no app rule to reach. These
+// exist so the bound at the collection-value position can distinguish a type
+// that declared how it merges from one that has a `Mergeable` impl nothing will
+// ever call.
+
+#[diagnostic::do_not_recommend]
+impl<T: Mergeable + Clone> MergeStrategy for Option<T> {
+    const DISPATCHED: bool = false;
+}
+
+#[diagnostic::do_not_recommend]
+impl<T: Mergeable> MergeStrategy for Box<T> {
+    const DISPATCHED: bool = false;
+}
+
+#[diagnostic::do_not_recommend]
+impl<T: Clone + borsh::BorshSerialize + 'static> MergeStrategy for LwwRegister<T> {
+    const DISPATCHED: bool = false;
+}
+
+#[diagnostic::do_not_recommend]
+impl<const ALLOW_DECREMENT: bool, S: StorageAdaptor> MergeStrategy for Counter<ALLOW_DECREMENT, S> {
+    const DISPATCHED: bool = false;
+}
+
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for ReplicatedGrowableArray {
+    const DISPATCHED: bool = false;
+}
+
+#[diagnostic::do_not_recommend]
+impl<K, V, S: StorageAdaptor> MergeStrategy for UnorderedMap<K, V, S> {
+    const DISPATCHED: bool = false;
+}
+
+#[diagnostic::do_not_recommend]
+impl<K, V, S: StorageAdaptor> MergeStrategy for SortedMap<K, V, S> {
+    const DISPATCHED: bool = false;
+}
+
+#[diagnostic::do_not_recommend]
+impl<T, S: StorageAdaptor> MergeStrategy for UnorderedSet<T, S> {
+    const DISPATCHED: bool = false;
+}
+
+#[diagnostic::do_not_recommend]
+impl<T, S: StorageAdaptor> MergeStrategy for SortedSet<T, S> {
+    const DISPATCHED: bool = false;
+}
+
+#[diagnostic::do_not_recommend]
+impl<T, S: StorageAdaptor> MergeStrategy for Vector<T, S> {
+    const DISPATCHED: bool = false;
 }

--- a/crates/storage/src/collections/crdt_meta.rs
+++ b/crates/storage/src/collections/crdt_meta.rs
@@ -67,6 +67,25 @@ pub trait CrdtMeta {
     }
 }
 
+/// # Declaring a strategy is required
+///
+/// A `Mergeable` impl alone does not say whether anything will CALL it. Stored
+/// as a collection value, a type that declares nothing resolves last-write-wins
+/// and its `merge` never runs — it compiles, type-checks, and decides nothing.
+/// That is not hypothetical: this crate's own reference app shipped in exactly
+/// that state, and so did the `Entry`-API insert path inside this crate.
+///
+/// So [`MergeStrategy`] is a supertrait, and only the two macros supply it:
+///
+/// - `#[derive(Mergeable)]` — structural. Field-by-field delegation, which the
+///   storage layer reaches on its own, so nothing is dispatched.
+/// - `#[app::mergeable]` — dispatched. The type gets a `CustomTypeId`, entries
+///   holding it are stamped, and the merge point calls this rule.
+///
+/// Hand-writing `impl Mergeable` without either is a compile error. Root state
+/// is unaffected in behaviour — it has its own merge path — but still declares,
+/// so the distinction is recorded on every type rather than assumed.
+///
 /// Marker trait for types that can be merged (all CRDTs).
 ///
 /// `RekeyTarget` is a **supertrait**: a `Mergeable` type that nests a collection
@@ -83,13 +102,55 @@ pub trait CrdtMeta {
             use `UnorderedMap`/`UnorderedSet`/`Vector` for collections; or `#[derive(Mergeable)]` \
             on your own struct (every field must itself be `Mergeable`)."
 )]
-pub trait Mergeable: crate::collections::rekey::RekeyTarget {
+pub trait Mergeable: crate::collections::rekey::RekeyTarget + MergeStrategy {
     /// Merge with another instance of the same type
     ///
     /// # Errors
     ///
     /// Returns error if merge fails (e.g., incompatible states)
     fn merge(&mut self, other: &Self) -> Result<(), MergeError>;
+}
+
+/// How a type's [`Mergeable::merge`] is reached when it is stored as a
+/// collection VALUE.
+///
+/// `Mergeable` alone does not answer that, and the difference is not cosmetic.
+/// A collection entry is merged by matching on its `crdt_type`; a value type
+/// that declares nothing resolves last-write-wins with its `merge` never
+/// consulted. So a hand-written rule can compile, type-check, pass a
+/// convergence test, and still not be the thing deciding the outcome — which is
+/// exactly what shipped here for months.
+///
+/// Implemented ONLY by the two macros, which is the point: a hand-written
+/// `impl Mergeable` gets neither, and the compiler asks which you meant rather
+/// than letting the question go unasked.
+///
+/// - `#[derive(Mergeable)]` → structural. Field-by-field delegation, the same
+///   answer the storage layer reaches on its own, so nothing is dispatched and
+///   nothing is lost.
+/// - `#[app::mergeable]` → dispatched. The type carries a [`CustomTypeId`], the
+///   entry is stamped with it, and the merge point calls this rule.
+///
+/// A type used ONLY as root state needs neither — the root has its own merge
+/// path — which is why this is required at the collection-value position rather
+/// than as a supertrait of `Mergeable`.
+#[diagnostic::on_unimplemented(
+    message = "(calimero)> `{Self}` implements `Mergeable` but never declared how it merges",
+    label = "needs `#[app::mergeable]` or `#[derive(Mergeable)]`",
+    note = "Stored as a COLLECTION VALUE, a type that declares nothing resolves \
+            last-write-wins and its `merge` is never called — it compiles and silently \
+            decides nothing. Root state has its own merge path and is unaffected, but the \
+            declaration is still required so the distinction is recorded rather than assumed.",
+    note = "Add `#[app::mergeable]` to have the merge dispatched, or `#[derive(Mergeable)]` \
+            if plain field-by-field delegation is what you want (the storage layer reaches \
+            that answer anyway, with no wasm call)."
+)]
+pub trait MergeStrategy {
+    /// Whether the merge point calls this type's own rule.
+    ///
+    /// `false` means the type converges structurally and its `merge` runs only
+    /// on a root-blob conflict.
+    const DISPATCHED: bool;
 }
 
 /// An app-defined type whose [`Mergeable::merge`] is dispatched at merge time.
@@ -335,6 +396,13 @@ macro_rules! is_crdt {
 #[macro_export]
 macro_rules! impl_atomic_lww_leaf {
     ($t:ty, $tie:ident) => {
+        // Structural: this is a leaf that resolves by its own tie-breaker, not
+        // an app rule the merge point dispatches to. Declared here so the macro
+        // satisfies `Mergeable`'s requirement on its users' behalf.
+        impl $crate::collections::MergeStrategy for $t {
+            const DISPATCHED: bool = false;
+        }
+
         impl $crate::collections::Mergeable for $t {
             fn merge(
                 &mut self,

--- a/crates/storage/src/collections/frozen.rs
+++ b/crates/storage/src/collections/frozen.rs
@@ -13,7 +13,7 @@
 //! overwrite), so merge can only ever grow the set of stored hashes; conflict
 //! resolution is therefore degenerate (set-union over hash keys).
 
-use super::crdt_meta::{CrdtMeta, CrdtType, Mergeable, StorageStrategy};
+use super::crdt_meta::{CrdtMeta, CrdtType, MergeStrategy, Mergeable, StorageStrategy};
 use super::{StorageError, StoreError, UnorderedMap};
 use crate::entities::{Data, Element, StorageType};
 use crate::store::{MainStorage, StorageAdaptor};
@@ -227,6 +227,17 @@ where
     fn can_contain_crdts() -> bool {
         true // The inner map can contain CRDTs
     }
+}
+
+/// Structural: the storage layer merges this by its `crdt_type` variant, so
+/// there is no app rule to dispatch. See [`MergeStrategy`].
+#[diagnostic::do_not_recommend]
+impl<T, S> MergeStrategy for FrozenStorage<T, S>
+where
+    T: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    const DISPATCHED: bool = false;
 }
 
 #[cfg(test)]

--- a/crates/storage/src/collections/frozen_value.rs
+++ b/crates/storage/src/collections/frozen_value.rs
@@ -1,6 +1,6 @@
 //! A wrapper type for immutable values stored in FrozenStorage.
 
-use crate::collections::crdt_meta::{MergeError, Mergeable};
+use crate::collections::crdt_meta::{MergeError, MergeStrategy, Mergeable};
 use borsh::io::{Read, Write};
 use borsh::{BorshDeserialize, BorshSerialize};
 use core::ops::Deref;
@@ -64,4 +64,11 @@ impl<T> From<T> for FrozenValue<T> {
     fn from(value: T) -> Self {
         Self(value)
     }
+}
+
+/// Structural: the storage layer merges this by its `crdt_type` variant, so
+/// there is no app rule to dispatch. See [`MergeStrategy`].
+#[diagnostic::do_not_recommend]
+impl<T: 'static> MergeStrategy for FrozenValue<T> {
+    const DISPATCHED: bool = false;
 }

--- a/crates/storage/src/collections/permissioned.rs
+++ b/crates/storage/src/collections/permissioned.rs
@@ -42,7 +42,7 @@ use std::marker::PhantomData;
 use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_account::AccountId;
 
-use super::crdt_meta::{CrdtMeta, CrdtType, MergeError, Mergeable, StorageStrategy};
+use super::crdt_meta::{CrdtMeta, CrdtType, MergeError, MergeStrategy, Mergeable, StorageStrategy};
 use super::shared::WriterSetCell;
 use super::StoreError;
 use crate::entities::{ChildInfo, Data, Element, OpMask, SignatureData};
@@ -500,8 +500,20 @@ where
     }
 }
 
+/// Structural: the storage layer merges this by its `crdt_type` variant, so
+/// there is no app rule to dispatch. See [`MergeStrategy`].
+#[diagnostic::do_not_recommend]
+impl<T, A> MergeStrategy for PermissionedStorage<T, A>
+where
+    T: BorshSerialize + BorshDeserialize + Mergeable + Default,
+    A: Authorizer,
+{
+    const DISPATCHED: bool = false;
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::collections::MergeStrategy;
     use std::collections::BTreeSet;
 
     use borsh::{BorshDeserialize, BorshSerialize};
@@ -529,6 +541,12 @@ mod tests {
                 crate::collections::rekey::field_child_id(parent_id, "0")
             );
         }
+    }
+
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for TestVal {
+        const DISPATCHED: bool = false;
     }
 
     impl Mergeable for TestVal {

--- a/crates/storage/src/collections/shared.rs
+++ b/crates/storage/src/collections/shared.rs
@@ -57,7 +57,7 @@ use std::collections::BTreeSet;
 use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_account::AccountId;
 
-use super::crdt_meta::{CrdtMeta, CrdtType, Mergeable, StorageStrategy};
+use super::crdt_meta::{CrdtMeta, CrdtType, MergeStrategy, Mergeable, StorageStrategy};
 use super::{compute_collection_id, compute_id, Collection, StoreError};
 use crate::address::Id;
 use crate::entities::{ChildInfo, Data, Element, OpMask, SignatureData, StorageType};
@@ -680,8 +680,20 @@ where
     }
 }
 
+/// Structural: the storage layer merges this by its `crdt_type` variant, so
+/// there is no app rule to dispatch. See [`MergeStrategy`].
+#[diagnostic::do_not_recommend]
+impl<T, S> MergeStrategy for WriterSetCell<T, S>
+where
+    T: BorshSerialize + BorshDeserialize + Mergeable,
+    S: StorageAdaptor,
+{
+    const DISPATCHED: bool = false;
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::collections::MergeStrategy;
     use std::collections::BTreeSet;
 
     use borsh::{BorshDeserialize, BorshSerialize};
@@ -709,6 +721,12 @@ mod tests {
                 crate::collections::rekey::field_child_id(parent_id, "0")
             );
         }
+    }
+
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for TestVal {
+        const DISPATCHED: bool = false;
     }
 
     impl Mergeable for TestVal {

--- a/crates/storage/src/collections/user.rs
+++ b/crates/storage/src/collections/user.rs
@@ -8,7 +8,7 @@
 //! other cannot see. Which device performed a given write is still recorded, on
 //! the entry's `signature_data.signer`.
 
-use super::crdt_meta::{CrdtMeta, CrdtType, Mergeable, StorageStrategy};
+use super::crdt_meta::{CrdtMeta, CrdtType, MergeStrategy, Mergeable, StorageStrategy};
 use super::{StoreError, UnorderedMap, ValueRef};
 use crate::entities::{ChildInfo, Data, Element, StorageType};
 use crate::env;
@@ -254,6 +254,17 @@ where
     fn can_contain_crdts() -> bool {
         true // The inner map can contain CRDTs
     }
+}
+
+/// Structural: the storage layer merges this by its `crdt_type` variant, so
+/// there is no app rule to dispatch. See [`MergeStrategy`].
+#[diagnostic::do_not_recommend]
+impl<T, S> MergeStrategy for UserStorage<T, S>
+where
+    T: BorshSerialize + BorshDeserialize,
+    S: StorageAdaptor,
+{
+    const DISPATCHED: bool = false;
 }
 
 #[cfg(test)]

--- a/crates/storage/src/merge.rs
+++ b/crates/storage/src/merge.rs
@@ -709,6 +709,12 @@ mod typed_dispatch_tests {
         }
     }
 
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl crate::collections::MergeStrategy for DispatchTestApp {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for DispatchTestApp {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.counter.merge(&other.counter)

--- a/crates/storage/src/merge/registry.rs
+++ b/crates/storage/src/merge/registry.rs
@@ -338,7 +338,7 @@ mod tests {
     use serial_test::serial;
 
     use super::*;
-    use crate::collections::{Counter, Mergeable};
+    use crate::collections::{Counter, MergeStrategy, Mergeable};
     use crate::env;
 
     #[derive(borsh::BorshSerialize, borsh::BorshDeserialize, Debug)]
@@ -354,6 +354,12 @@ mod tests {
                 crate::collections::rekey::field_child_id(parent_id, "counter")
             );
         }
+    }
+
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for TestState {
+        const DISPATCHED: bool = false;
     }
 
     impl Mergeable for TestState {

--- a/crates/storage/src/tests/common.rs
+++ b/crates/storage/src/tests/common.rs
@@ -7,7 +7,7 @@ use ed25519_dalek::{Signer, SigningKey};
 
 use crate::action::Action;
 use crate::address::Id;
-use crate::collections::crdt_meta::{MergeError, Mergeable};
+use crate::collections::crdt_meta::{MergeError, MergeStrategy, Mergeable};
 use crate::entities::{
     AtomicUnit, ChildInfo, Collection, Data, Element, Metadata, OpMask, SignatureData, StorageType,
 };
@@ -46,6 +46,12 @@ impl crate::collections::rekey::RekeyTarget for EmptyData {
 }
 
 // LWW-based merge for test type (no CRDT fields)
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for EmptyData {
+    const DISPATCHED: bool = false;
+}
+
 impl Mergeable for EmptyData {
     fn merge(&mut self, _other: &Self) -> Result<(), MergeError> {
         // EmptyData has no data fields to merge
@@ -96,6 +102,12 @@ impl crate::collections::rekey::RekeyTarget for Page {
 }
 
 // LWW-based merge for test type (no CRDT fields)
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for Page {
+    const DISPATCHED: bool = false;
+}
+
 impl Mergeable for Page {
     fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
         // For simple test types without CRDT fields, use LWW semantics
@@ -162,6 +174,12 @@ impl crate::collections::rekey::RekeyTarget for Paragraph {
 }
 
 // LWW-based merge for test type (no CRDT fields)
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for Paragraph {
+    const DISPATCHED: bool = false;
+}
+
 impl Mergeable for Paragraph {
     fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
         self.text = other.text.clone();
@@ -248,6 +266,12 @@ impl crate::collections::rekey::RekeyTarget for Person {
 }
 
 // LWW-based merge for test type (no CRDT fields)
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for Person {
+    const DISPATCHED: bool = false;
+}
+
 impl Mergeable for Person {
     fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
         self.name = other.name.clone();

--- a/crates/storage/src/tests/merge_integration.rs
+++ b/crates/storage/src/tests/merge_integration.rs
@@ -6,6 +6,7 @@
 //!
 //! Each test's local `impl Mergeable` carries a sibling `impl RekeyTarget`
 //! (the supertrait): re-key each nested collection field, leaf fields no-op.
+use crate::collections::MergeStrategy;
 
 use crate::collections::{
     Counter, LwwRegister, Mergeable, ReplicatedGrowableArray, Root, UnorderedMap, UnorderedSet,
@@ -21,6 +22,12 @@ use serial_test::serial;
 struct TestApp {
     counter: Counter,
     metadata: UnorderedMap<String, LwwRegister<String>>,
+}
+
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for TestApp {
+    const DISPATCHED: bool = false;
 }
 
 impl Mergeable for TestApp {
@@ -210,6 +217,12 @@ fn test_merge_with_nested_map() {
         documents: UnorderedMap<String, UnorderedMap<String, LwwRegister<String>>>,
     }
 
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for AppWithNestedMap {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for AppWithNestedMap {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.documents.merge(&other.documents)?;
@@ -337,6 +350,12 @@ fn test_root_cold_join_with_registered_merger_accepts_remote_contents() {
     #[derive(BorshSerialize, BorshDeserialize, Debug)]
     struct App {
         kv: UnorderedMap<String, LwwRegister<String>>,
+    }
+
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for App {
+        const DISPATCHED: bool = false;
     }
 
     impl Mergeable for App {
@@ -468,6 +487,12 @@ fn test_root_cold_join_bootstrap_signal_with_registered_merger_uses_merger() {
         kv: UnorderedMap<String, LwwRegister<String>>,
     }
 
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for App {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for App {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.kv.merge(&other.kv)?;
@@ -555,6 +580,12 @@ fn test_root_cold_join_bootstrap_signal_with_merger_preserves_local_fields() {
     #[derive(BorshSerialize, BorshDeserialize, Debug)]
     struct App {
         kv: UnorderedMap<String, LwwRegister<String>>,
+    }
+
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for App {
+        const DISPATCHED: bool = false;
     }
 
     impl Mergeable for App {
@@ -694,6 +725,12 @@ fn test_merge_map_of_counters() {
         scores: UnorderedMap<String, Counter>,
     }
 
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for AppWithCounters {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for AppWithCounters {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.scores.merge(&other.scores)?;
@@ -781,6 +818,12 @@ fn test_merge_map_of_lww_registers() {
         settings: UnorderedMap<String, LwwRegister<String>>,
     }
 
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for AppWithRegisters {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for AppWithRegisters {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.settings.merge(&other.settings)?;
@@ -858,6 +901,12 @@ fn test_merge_vector_of_counters() {
     #[derive(BorshSerialize, BorshDeserialize, Debug)]
     struct AppWithVectorCounters {
         metrics: Vector<Counter>,
+    }
+
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for AppWithVectorCounters {
+        const DISPATCHED: bool = false;
     }
 
     impl Mergeable for AppWithVectorCounters {
@@ -944,6 +993,12 @@ fn test_merge_map_of_sets() {
     #[derive(BorshSerialize, BorshDeserialize, Debug)]
     struct AppWithSetTags {
         user_tags: UnorderedMap<String, UnorderedSet<String>>,
+    }
+
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for AppWithSetTags {
+        const DISPATCHED: bool = false;
     }
 
     impl Mergeable for AppWithSetTags {
@@ -1047,6 +1102,12 @@ fn test_merge_nested_document_with_rga() {
         metadata: UnorderedMap<String, LwwRegister<String>>,
     }
 
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for Document {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for Document {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.content.merge(&other.content)?;
@@ -1076,6 +1137,12 @@ fn test_merge_nested_document_with_rga() {
     #[derive(BorshSerialize, BorshDeserialize, Debug)]
     struct CollabEditor {
         documents: UnorderedMap<String, Document>,
+    }
+
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for CollabEditor {
+        const DISPATCHED: bool = false;
     }
 
     impl Mergeable for CollabEditor {
@@ -1231,6 +1298,12 @@ fn test_merge_determinism_reproduces_e2e_issue() {
         file_owner: LwwRegister<String>,
         handler_counter: Counter, // GCounter
         items: UnorderedMap<String, LwwRegister<String>>,
+    }
+
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for E2eKvStoreSimulation {
+        const DISPATCHED: bool = false;
     }
 
     impl Mergeable for E2eKvStoreSimulation {
@@ -1428,6 +1501,12 @@ fn test_counter_serialization_architecture() {
     #[derive(BorshSerialize, BorshDeserialize)]
     struct HandlerApp {
         handler_counter: Counter, // GCounter using MainStorage
+    }
+
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for HandlerApp {
+        const DISPATCHED: bool = false;
     }
 
     impl Mergeable for HandlerApp {
@@ -2278,6 +2357,12 @@ fn test_nested_counter_in_map_concurrent_increments_converge() {
     struct NestedCounters {
         counters: UnorderedMap<String, Counter>,
     }
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for NestedCounters {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for NestedCounters {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.counters.merge(&other.counters)
@@ -2432,6 +2517,12 @@ fn test_nested_counter_first_touch_concurrent_converges() {
     struct NestedCounters {
         counters: UnorderedMap<String, Counter>,
     }
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for NestedCounters {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for NestedCounters {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.counters.merge(&other.counters)
@@ -2582,6 +2673,12 @@ fn test_nested_counter_first_touch_via_entry_api_converges() {
     struct NestedCounters {
         counters: UnorderedMap<String, Counter>,
     }
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for NestedCounters {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for NestedCounters {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.counters.merge(&other.counters)
@@ -2725,6 +2822,12 @@ fn test_nested_map_first_touch_via_or_default_converges() {
     struct NestedMaps {
         outer: UnorderedMap<String, UnorderedMap<String, Counter>>,
     }
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for NestedMaps {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for NestedMaps {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.outer.merge(&other.outer)
@@ -2873,6 +2976,12 @@ fn test_nested_counter_first_touch_via_or_default_converges() {
     struct NestedCounters {
         counters: UnorderedMap<String, Counter>,
     }
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for NestedCounters {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for NestedCounters {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.counters.merge(&other.counters)
@@ -3013,6 +3122,12 @@ fn test_nested_counter_first_touch_via_extend_converges() {
     struct NestedCounters {
         counters: UnorderedMap<String, Counter>,
     }
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for NestedCounters {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for NestedCounters {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.counters.merge(&other.counters)
@@ -3149,6 +3264,12 @@ fn test_nested_set_first_touch_concurrent_converges() {
     struct Tags {
         tags: UnorderedMap<String, UnorderedSet<String>>,
     }
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for Tags {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for Tags {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.tags.merge(&other.tags)
@@ -3303,6 +3424,12 @@ fn test_nested_pncounter_single_writer_converges() {
     struct PnDoc {
         counters: UnorderedMap<String, Counter<true>>,
     }
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for PnDoc {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for PnDoc {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.counters.merge(&other.counters)
@@ -3434,6 +3561,12 @@ fn test_nested_pncounter_concurrent_writers_converge() {
     struct PnDoc {
         counters: UnorderedMap<String, Counter<true>>,
     }
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for PnDoc {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for PnDoc {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.counters.merge(&other.counters)
@@ -3603,6 +3736,12 @@ fn test_kv_map_bidirectional_distinct_key_inserts_converge() {
     struct KvApp {
         kv: UnorderedMap<String, LwwRegister<String>>,
     }
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for KvApp {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for KvApp {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.kv.merge(&other.kv)
@@ -3741,6 +3880,12 @@ fn test_kv_map_same_key_concurrent_writes_converge() {
     struct KvApp {
         kv: UnorderedMap<String, LwwRegister<String>>,
     }
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for KvApp {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for KvApp {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.kv.merge(&other.kv)

--- a/crates/storage/src/tests/rga.rs
+++ b/crates/storage/src/tests/rga.rs
@@ -1,3 +1,4 @@
+use crate::collections::MergeStrategy;
 use crate::collections::ReplicatedGrowableArray;
 use crate::env;
 
@@ -630,6 +631,12 @@ fn test_rga_delete_after_merge_delta_sync_converges() {
             );
         }
     }
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for RgaDoc {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for RgaDoc {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.content.merge(&other.content)
@@ -806,6 +813,12 @@ fn test_rga_concurrent_appends_then_delete_delta_sync_converges() {
             );
         }
     }
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for RgaDoc {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for RgaDoc {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.content.merge(&other.content)
@@ -1092,6 +1105,12 @@ fn test_rga_insert_after_observing_remote_is_causally_ordered() {
             );
         }
     }
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for RgaDoc {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for RgaDoc {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.content.merge(&other.content)
@@ -1242,6 +1261,12 @@ fn test_rga_real_interleave_merge_converges() {
             );
         }
     }
+    // Structural: a test fixture, merged by the storage layer's own rules.
+    #[diagnostic::do_not_recommend]
+    impl MergeStrategy for RgaDoc {
+        const DISPATCHED: bool = false;
+    }
+
     impl Mergeable for RgaDoc {
         fn merge(&mut self, other: &Self) -> Result<(), crate::collections::crdt_meta::MergeError> {
             self.content.merge(&other.content)

--- a/crates/storage/tests/compile_fail/mergeable_without_rekeytarget.stderr
+++ b/crates/storage/tests/compile_fail/mergeable_without_rekeytarget.stderr
@@ -1,3 +1,22 @@
+error[E0277]: (calimero)> `BadStruct` implements `Mergeable` but never declared how it merges
+  --> tests/compile_fail/mergeable_without_rekeytarget.rs:19:20
+   |
+19 | impl Mergeable for BadStruct {
+   |                    ^^^^^^^^^ needs `#[app::mergeable]` or `#[derive(Mergeable)]`
+   |
+help: the trait `MergeStrategy` is not implemented for `BadStruct`
+  --> tests/compile_fail/mergeable_without_rekeytarget.rs:12:1
+   |
+12 | struct BadStruct {
+   | ^^^^^^^^^^^^^^^^
+   = note: Stored as a COLLECTION VALUE, a type that declares nothing resolves last-write-wins and its `merge` is never called — it compiles and silently decides nothing. Root state has its own merge path and is unaffected, but the declaration is still required so the distinction is recorded rather than assumed.
+   = note: Add `#[app::mergeable]` to have the merge dispatched, or `#[derive(Mergeable)]` if plain field-by-field delegation is what you want (the storage layer reaches that answer anyway, with no wasm call).
+note: required by a bound in `Mergeable`
+  --> src/collections/crdt_meta.rs
+   |
+   | pub trait Mergeable: crate::collections::rekey::RekeyTarget + MergeStrategy {
+   |                                                               ^^^^^^^^^^^^^ required by this bound in `Mergeable`
+
 error[E0277]: the trait bound `BadStruct: calimero_storage::collections::rekey::RekeyTarget` is not satisfied
   --> tests/compile_fail/mergeable_without_rekeytarget.rs:19:20
    |
@@ -22,5 +41,5 @@ help: the trait `calimero_storage::collections::rekey::RekeyTarget` is not imple
 note: required by a bound in `Mergeable`
   --> src/collections/crdt_meta.rs
    |
-   | pub trait Mergeable: crate::collections::rekey::RekeyTarget {
+   | pub trait Mergeable: crate::collections::rekey::RekeyTarget + MergeStrategy {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Mergeable`

--- a/crates/storage/tests/converge.rs
+++ b/crates/storage/tests/converge.rs
@@ -8,7 +8,7 @@
 use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_storage::collections::crdt_meta::MergeError;
-use calimero_storage::collections::{Counter, Mergeable, UnorderedMap};
+use calimero_storage::collections::{Counter, MergeStrategy, Mergeable, UnorderedMap};
 use calimero_storage::testing::converge;
 use serial_test::serial;
 
@@ -18,6 +18,12 @@ use serial_test::serial;
 #[borsh(crate = "calimero_sdk::borsh")]
 struct TeamMetrics {
     teams: UnorderedMap<String, Counter>,
+}
+
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for TeamMetrics {
+    const DISPATCHED: bool = false;
 }
 
 impl Mergeable for TeamMetrics {
@@ -79,6 +85,12 @@ fn team_stats_converge_many_ops_and_replicas() {
 struct Inline {
     a: Counter,
     b: Counter,
+}
+
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for Inline {
+    const DISPATCHED: bool = false;
 }
 
 impl Mergeable for Inline {

--- a/crates/storage/tests/custom_merge_e2e.rs
+++ b/crates/storage/tests/custom_merge_e2e.rs
@@ -24,7 +24,7 @@ use calimero_sdk::app;
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_storage::collections::crdt_meta::MergeError;
 use calimero_storage::collections::rekey::register_rekey_cascade;
-use calimero_storage::collections::{Mergeable, Root, UnorderedMap};
+use calimero_storage::collections::{MergeStrategy, Mergeable, Root, UnorderedMap};
 use calimero_storage::env::{self, RuntimeEnv};
 use calimero_storage::interface::ApplyContext;
 use calimero_storage::store::Key;
@@ -90,6 +90,12 @@ impl calimero_storage::collections::rekey::RekeyTarget for AuctionApp {
     fn register_nested_value_types() {
         register_rekey_cascade::<Auction>();
     }
+}
+
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for AuctionApp {
+    const DISPATCHED: bool = false;
 }
 
 impl Mergeable for AuctionApp {

--- a/crates/storage/tests/map_entry_layout.rs
+++ b/crates/storage/tests/map_entry_layout.rs
@@ -21,7 +21,7 @@ use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_storage::address::Id;
 use calimero_storage::collections::crdt_meta::MergeError;
 use calimero_storage::collections::rekey::field_child_id;
-use calimero_storage::collections::{Mergeable, Root, UnorderedMap};
+use calimero_storage::collections::{MergeStrategy, Mergeable, Root, UnorderedMap};
 use calimero_storage::env::{self, RuntimeEnv};
 use calimero_storage::store::Key;
 use calimero_storage::{register_crdt_merge_for_test, rekey_field_if_supported};
@@ -53,6 +53,12 @@ struct Counted {
     n: u32,
 }
 
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for Counted {
+    const DISPATCHED: bool = false;
+}
+
 impl Mergeable for Counted {
     fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
         self.n = self.n.max(other.n);
@@ -62,6 +68,12 @@ impl Mergeable for Counted {
 
 impl calimero_storage::collections::rekey::RekeyTarget for Counted {
     fn rekey_relative_to(&mut self, _parent_id: Id) {}
+}
+
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for App {
+    const DISPATCHED: bool = false;
 }
 
 impl Mergeable for App {

--- a/crates/storage/tests/merge_registry_concurrent.rs
+++ b/crates/storage/tests/merge_registry_concurrent.rs
@@ -16,6 +16,7 @@
 //! has no cleanup hook here, so adding a second `#[test]` in this file
 //! would leak state into it.
 
+use calimero_storage::collections::MergeStrategy;
 use std::sync::{Arc, Barrier};
 use std::thread;
 
@@ -27,6 +28,12 @@ use calimero_storage::merge::{register_crdt_merge, try_merge_registered, MergeRe
 #[derive(BorshSerialize, BorshDeserialize)]
 struct ConcurrentState {
     values: Vec<u32>,
+}
+
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for ConcurrentState {
+    const DISPATCHED: bool = false;
 }
 
 impl Mergeable for ConcurrentState {

--- a/crates/storage/tests/merge_registry_integration.rs
+++ b/crates/storage/tests/merge_registry_integration.rs
@@ -38,12 +38,19 @@
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use calimero_storage::collections::crdt_meta::MergeError;
+use calimero_storage::collections::MergeStrategy;
 use calimero_storage::collections::Mergeable;
 use calimero_storage::merge::{register_crdt_merge, try_merge_registered, MergeRegistryResult};
 
 #[derive(BorshSerialize, BorshDeserialize)]
 struct IntegrationState {
     values: Vec<u32>,
+}
+
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for IntegrationState {
+    const DISPATCHED: bool = false;
 }
 
 impl Mergeable for IntegrationState {

--- a/crates/storage/tests/multi_device_account.rs
+++ b/crates/storage/tests/multi_device_account.rs
@@ -28,7 +28,7 @@
 
 use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_storage::collections::crdt_meta::MergeError;
-use calimero_storage::collections::{Counter, Mergeable};
+use calimero_storage::collections::{Counter, MergeStrategy, Mergeable};
 use calimero_storage::testing::converge;
 use calimero_storage::{env, rekey_field_if_supported};
 use serial_test::serial;
@@ -39,6 +39,12 @@ const REPLICAS: usize = 4;
 #[borsh(crate = "calimero_sdk::borsh")]
 struct Edits {
     count: Counter,
+}
+
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for Edits {
+    const DISPATCHED: bool = false;
 }
 
 impl Mergeable for Edits {

--- a/crates/storage/tests/rekey_record.rs
+++ b/crates/storage/tests/rekey_record.rs
@@ -21,7 +21,7 @@ use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_storage::address::Id;
 use calimero_storage::collections::crdt_meta::MergeError;
 use calimero_storage::collections::rekey::{field_child_id, RekeyTarget};
-use calimero_storage::collections::{Counter, Mergeable, Root, UnorderedMap};
+use calimero_storage::collections::{Counter, MergeStrategy, Mergeable, Root, UnorderedMap};
 use calimero_storage::env::{self, RuntimeEnv};
 use calimero_storage::interface::ApplyContext;
 use calimero_storage::store::Key;
@@ -36,6 +36,12 @@ use serial_test::serial;
 #[borsh(crate = "calimero_sdk::borsh")]
 struct FixedStats {
     wins: Counter,
+}
+
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for FixedStats {
+    const DISPATCHED: bool = false;
 }
 
 impl Mergeable for FixedStats {
@@ -59,6 +65,12 @@ impl RekeyTarget for FixedStats {
 #[borsh(crate = "calimero_sdk::borsh")]
 struct UnfixedStats {
     wins: Counter,
+}
+
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for UnfixedStats {
+    const DISPATCHED: bool = false;
 }
 
 impl Mergeable for UnfixedStats {
@@ -85,6 +97,10 @@ macro_rules! team_app {
         #[borsh(crate = "calimero_sdk::borsh")]
         struct $app {
             teams: UnorderedMap<String, $val>,
+        }
+        #[diagnostic::do_not_recommend]
+        impl MergeStrategy for $app {
+            const DISPATCHED: bool = false;
         }
         impl Mergeable for $app {
             fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
@@ -292,6 +308,12 @@ struct InnerManual {
     score: Counter,
 }
 
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for InnerManual {
+    const DISPATCHED: bool = false;
+}
+
 impl Mergeable for InnerManual {
     fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
         self.score.merge(&other.score)
@@ -311,6 +333,12 @@ struct OuterManual {
     inner: UnorderedMap<String, InnerManual>,
 }
 
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for OuterManual {
+    const DISPATCHED: bool = false;
+}
+
 impl Mergeable for OuterManual {
     fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
         self.inner.merge(&other.inner)
@@ -328,6 +356,12 @@ impl RekeyTarget for OuterManual {
 #[borsh(crate = "calimero_sdk::borsh")]
 struct DeepAppManual {
     groups: UnorderedMap<String, OuterManual>,
+}
+
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for DeepAppManual {
+    const DISPATCHED: bool = false;
 }
 
 impl Mergeable for DeepAppManual {


### PR DESCRIPTION
Implements **option C** from #3803. A hand-written `impl Mergeable` that never says how it merges is now a compile error rather than a silent last-write-wins.

## The failure this removes

A `Mergeable` impl says a type CAN merge. It never said whether anything would CALL it. Stored as a collection value, a type that declared nothing resolved last-write-wins with its `merge` never running — it compiled, type-checked, passed convergence tests, and decided nothing.

Twice, in this repo, by people working on exactly this:

- `apps/team-metrics-custom`, the reference app, shipped that way for months while its docs promised custom validation and conditionally skipping fields (fixed in #3802).
- The `Entry`-API insert path in this crate stamped nothing, so every app reaching its map through `entry(..).or_default()` — the ergonomic way, and what the docs show — got no dispatch at all (fixed in #3802, found by an e2e).

Both were found by accident, months apart. Neither was a coding mistake anyone could reasonably have caught by reading.

## What changes

```rust
pub trait Mergeable: RekeyTarget + MergeStrategy { ... }
```

`MergeStrategy` is supplied only by the two macros:

| | declares | meaning |
| --- | --- | --- |
| `#[derive(Mergeable)]` | `DISPATCHED = false` | structural — the storage layer reaches the same answer, nothing is dispatched, no wasm call |
| `#[app::mergeable]` | `DISPATCHED = true` | dispatched — the type gets a `CustomTypeId`, entries are stamped, the merge point calls this rule |

```
error[E0277]: (calimero)> `Undeclared` implements `Mergeable` but never declared how it merges
   |
22 | impl Mergeable for Undeclared {
   |                    ^^^^^^^^^^ needs `#[app::mergeable]` or `#[derive(Mergeable)]`
```

Root state is unaffected in behaviour — it has its own merge path — but still declares, so the distinction is recorded on every type rather than assumed.

## Why not a warning

Tried first, and it does not work. The condition is *"implements `Mergeable` but NOT `MergeStrategy`"* — a **negative** bound Rust cannot express.

Three-level autoref specialisation selects the right arm, but cannot carry the diagnostic: `#[deprecated]` is a HIR lint on the path expression, so it fires because the call **appears in the impl body's source**, not because that arm was chosen. Every type warned, including `String`, which is not `Mergeable` at all.

Recording that so nobody re-derives it: **autoref gates which method runs, not which method is mentioned.**

Only a real lint pass reads impl bodies, and dylint wants a second toolchain pin, a workspace-excluded crate, a CI job, and re-fixing as `rustc_hir` shifts — infrastructure this repo has deliberately avoided. A compile error needs none of it. See #3803 for the full comparison.

## Three sites GENERATE Mergeable impls

All three now declare, and the third is why this could have gone badly:

- `impl_atomic_lww_leaf!`
- the `rekey_record` fixture macro
- **`#[app::state]`** — emits a `Mergeable` impl for every app's root type. Missing it would have broken every downstream app on upgrade. I found it because a test fixture failed, not by reasoning.

## Diagnostic quality

`#[diagnostic::do_not_recommend]` on all 68 impls, following the convention already applied to `Mergeable`, so rustc's "the following other types implement" list stays out of the message and the goldens stay drift-proof as new impls land.

One bug of mine worth flagging, since it shows the message was checked rather than assumed: the first label read *"stored as a collection value, but nothing dispatches its merge"* — and then fired on a **root** type, which is not a collection value. Wrong for a whole category. The label now states the requirement; the note explains where it bites.

## Cost, measured

- **~11 built-in types** in the storage lib, each matching its own struct bounds
- **~50 test fixtures**, one line each
- **3 generating macros**
- **Breaking for downstream apps** — the error names both fixes

`examples/battleships` (sibling repo) will stop compiling: it hand-writes an LWW `Board::merge` that duplicates what the storage layer already does, and not quite the same LWW. That is the gate working, and it needs a companion PR.

## Test plan

```
$ cargo test -p calimero-storage --features testing --lib
719 passed; 0 failed

$ cargo test -p calimero-storage --features testing --tests
19 binaries, 19 result lines, 797 passed, 0 failed

$ cargo test -p calimero-node --lib
574 passed; 0 failed; 0 filtered out

$ cargo test -p calimero-sdk --test macros          # trybuild, incl. the new case
$ cargo test -p calimero-sdk-macros                 # 85 passed

$ cargo check -p calimero-storage                                   # 0
$ cargo check -p calimero-storage --all-targets --features testing   # 0
$ cargo check -p calimero-storage --all-targets --all-features       # 0
$ cargo check -p calimero-storage --target wasm32-unknown-unknown    # 0
$ cargo clippy -p calimero-storage --all-targets -- -D warnings                     # 0
$ cargo clippy -p calimero-storage -p calimero-sdk-macros -p calimero-sdk \
    --all-targets --features calimero-storage/testing -- -D warnings               # 0
$ cargo fmt --check                                                  # clean
```

**All 63 app packages** checked for `wasm32-unknown-unknown`: 62 pass. The one failure, `migration-harness-example`, fails identically on master (two `#[app::state]` in one crate, so its generated exports collide) — verified to be `E0428` only, with no `MergeStrategy` involvement. CI does not wasm-build it.

Two new compile-fail cases pin the diagnostic: a fresh one in the SDK suite, and `mergeable_without_rekeytarget` re-blessed since `Mergeable` now has two unsatisfied supertraits rather than one.

Closes #3803.
