### PR TITLE
test(storage): check the merge contract instead of only documenting it

### DIFF
--- a/apps/team-metrics-custom/tests/converge.rs
+++ b/apps/team-metrics-custom/tests/converge.rs
@@ -83,3 +83,17 @@ fn team_stats_converge_to_correct_value() {
 //     own badge, asserting both end up holding both.
 //
 // A weaker restatement here would only look like coverage.
+
+// `assert_merge_laws` is NOT applied to `TeamStats`, and the reason is a real
+// limit rather than an oversight.
+//
+// The helper compares borsh encodings, and `TeamStats` embeds three `Counter`
+// handles. A handle is storage IDENTITY, not value: constructed outside a
+// storage env each one gets a random id, so `merge(a, b)` and `merge(b, a)`
+// encode differently in the first ~96 bytes while agreeing perfectly on
+// `badges` — the field the rule actually decides. The helper would report a
+// commutativity violation that is an artifact of the handles.
+//
+// That is not a gap in coverage. The counters converge structurally whatever
+// `merge` does, so the only thing worth checking here is `badges`, and the laws
+// belong on a type that is plain data. See `calimero-storage/tests/merge_laws.rs`.

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -73,6 +73,10 @@ name = "map_entry_layout"
 required-features = ["testing"]
 
 [[test]]
+name = "merge_laws"
+required-features = ["testing"]
+
+[[test]]
 name = "custom_merge_dispatch"
 required-features = ["testing"]
 

--- a/crates/storage/src/testing.rs
+++ b/crates/storage/src/testing.rs
@@ -480,6 +480,139 @@ fn check_converged(seed: u64, hashes: &[Option<[u8; 32]>]) -> Result<(), String>
     ))
 }
 
+// ============================================================================
+// Merge-law conformance
+// ============================================================================
+
+/// Assert that `T`'s `Mergeable::merge` obeys the laws it is required to.
+///
+/// [`converge`] answers "do replicas agree?"; this answers "is the rule they
+/// agree by actually a merge?". Those are different questions, and the second
+/// has been documented on [`Mergeable`](crate::collections::Mergeable),
+/// `#[app::mergeable]` and the reference app's README while being checked
+/// nowhere.
+///
+/// The gap is not theoretical. A merge that ran in only one direction shipped
+/// in this crate: an incoming write older than the stored one was
+/// short-circuited before dispatch, so whichever replica wrote second merged
+/// and the other silently kept its own value. Concurrent bids of 900 and 100
+/// under a "highest wins" rule settled on 900 on one node and 100 on the other.
+/// It was found by a two-replica end-to-end test that happened to look, not by
+/// anything asserting commutativity.
+///
+/// Checked over every ordered pair and triple of `samples`, comparing borsh
+/// encodings rather than `PartialEq` — the stored bytes are what the Merkle
+/// hash sees, so two values that compare equal but encode differently are still
+/// a divergence.
+///
+/// # Choosing samples
+///
+/// Include values that DIFFER in the fields the rule reads. Identical samples
+/// satisfy every law trivially and prove nothing — the same way a `Counter`
+/// test cannot tell you whether a custom rule ran.
+///
+/// # Not for types that embed collections
+///
+/// A `Counter`, `UnorderedMap` or any other collection field is a HANDLE:
+/// storage identity, not value. Built outside a storage env each one gets a
+/// random id, so two merges of the same pair encode differently no matter what
+/// the rule does, and this helper would report a commutativity violation that
+/// is entirely an artifact of the handles.
+///
+/// That is not a coverage gap. Collection fields converge structurally — as
+/// their own child entities, under the storage layer's own rules — whatever
+/// `merge` does with them. The part of a custom rule that can actually be wrong
+/// is the part deciding PLAIN data, which is also the only reason to reach for
+/// `#[app::mergeable]` at all. Point this at that part; use
+/// [`converge`] for the whole type.
+///
+/// # Panics
+///
+/// On the first violated law, naming which one and the two encodings.
+///
+/// ```ignore
+/// assert_merge_laws(&[
+///     Stats { badges: 0b001, ..Default::default() },
+///     Stats { badges: 0b010, ..Default::default() },
+///     Stats { badges: 0b100, ..Default::default() },
+/// ]);
+/// ```
+pub fn assert_merge_laws<T>(samples: &[T])
+where
+    T: crate::collections::Mergeable + BorshSerialize + BorshDeserialize,
+{
+    assert!(
+        samples.len() >= 2,
+        "assert_merge_laws needs at least two DIFFERENT samples; one value \
+         satisfies every law trivially and proves nothing"
+    );
+
+    let enc = |v: &T| borsh::to_vec(v).expect("sample must serialize");
+
+    // Copies come from a borsh round-trip rather than `Clone`, and not only to
+    // avoid the bound — an app type holding a `Counter` or a collection cannot
+    // be `Clone`, which would have made this helper unusable on exactly the
+    // types it is for. It is also the more faithful copy: the laws are about
+    // the value as STORED, and stored is what borsh produces.
+    let copy = |v: &T| T::try_from_slice(&enc(v)).expect("sample must round-trip through borsh");
+
+    // Merge mode is what production uses, and it suppresses timestamp
+    // generation. Without it a rule that touches a nested CRDT stamps a fresh
+    // wall clock on each call, so even a correct merge encodes differently
+    // every time and every law below fails for the wrong reason.
+    let merged = |a: &T, b: &T| -> Vec<u8> {
+        let mut out = copy(a);
+        crate::env::with_merge_mode(|| out.merge(b)).expect(
+            "merge must be TOTAL: returning Err refuses to converge, leaving the entity \
+                     divergent while repair retries it forever. Reject bad input on the write \
+                     path instead.",
+        );
+        enc(&out)
+    };
+
+    for (i, a) in samples.iter().enumerate() {
+        // Idempotent: merging a value with itself must not move it.
+        assert_eq!(
+            merged(a, a),
+            enc(a),
+            "merge is not IDEMPOTENT for sample {i}: merge(a, a) != a. Re-delivery of the \
+             same state is normal in sync, so a rule that drifts on it never settles."
+        );
+
+        for (j, b) in samples.iter().enumerate() {
+            // Commutative: the answer cannot depend on which side arrived first.
+            assert_eq!(
+                merged(a, b),
+                merged(b, a),
+                "merge is not COMMUTATIVE for samples {i} and {j}: merge(a, b) != merge(b, a). \
+                 Two replicas seeing the same pair in different orders will settle on different \
+                 values and never converge."
+            );
+
+            for (k, c) in samples.iter().enumerate() {
+                // Associative: grouping cannot matter either, since replicas
+                // batch arrivals differently.
+                let left = {
+                    let mut ab = copy(a);
+                    crate::env::with_merge_mode(|| ab.merge(b)).expect("merge must be total");
+                    merged(&ab, c)
+                };
+                let right = {
+                    let mut bc = copy(b);
+                    crate::env::with_merge_mode(|| bc.merge(c)).expect("merge must be total");
+                    merged(a, &bc)
+                };
+                assert_eq!(
+                    left, right,
+                    "merge is not ASSOCIATIVE for samples {i}, {j}, {k}: \
+                     merge(merge(a, b), c) != merge(a, merge(b, c)). Replicas batch incoming \
+                     state differently, so grouping must not change the result."
+                );
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::check_converged;

--- a/crates/storage/tests/merge_laws.rs
+++ b/crates/storage/tests/merge_laws.rs
@@ -1,0 +1,91 @@
+//! The merge contract, checked rather than documented.
+//!
+//! `Mergeable`'s docs, `#[app::mergeable]`'s docs and the reference app's README
+//! all state that a merge rule must be deterministic, commutative, associative,
+//! idempotent and total. Nothing enforced any of it until this file.
+//!
+//! Own binary because `assert_merge_laws` runs under `with_merge_mode`, which is
+//! process-global state the convergence harness also drives.
+
+#![cfg(feature = "testing")]
+#![allow(clippy::unwrap_used)]
+
+use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_storage::address::Id;
+use calimero_storage::collections::crdt_meta::MergeError;
+use calimero_storage::collections::rekey::RekeyTarget;
+use calimero_storage::collections::{MergeStrategy, Mergeable};
+use calimero_storage::testing::assert_merge_laws;
+
+/// A well-behaved rule: bitwise-OR is a grow-only set.
+#[derive(Clone, Default, BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct Badges {
+    mask: u64,
+}
+
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for Badges {
+    const DISPATCHED: bool = false;
+}
+impl RekeyTarget for Badges {
+    fn rekey_relative_to(&mut self, _parent_id: Id) {}
+}
+impl Mergeable for Badges {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.mask |= other.mask;
+        Ok(())
+    }
+}
+
+/// The rule people actually write when they mean "latest wins", and the one the
+/// laws exist to reject. `battleships` ships this exact shape.
+#[derive(Clone, Default, BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct TakeOther {
+    value: u64,
+}
+
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for TakeOther {
+    const DISPATCHED: bool = false;
+}
+impl RekeyTarget for TakeOther {
+    fn rekey_relative_to(&mut self, _parent_id: Id) {}
+}
+impl Mergeable for TakeOther {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        *self = other.clone();
+        Ok(())
+    }
+}
+
+fn badges(mask: u64) -> Badges {
+    Badges { mask }
+}
+
+#[test]
+fn a_union_rule_satisfies_every_law() {
+    assert_merge_laws(&[badges(0b001), badges(0b010), badges(0b100)]);
+}
+
+/// The whole point. "Just take the other side" is the most natural thing to
+/// write and it is not a merge: `merge(a, b)` and `merge(b, a)` disagree, so two
+/// replicas seeing the same pair in different orders settle on different values
+/// and never converge.
+///
+/// Without this assertion the helper could be vacuous — passing everything —
+/// and nothing would say so.
+#[test]
+#[should_panic(expected = "not COMMUTATIVE")]
+fn take_other_is_rejected_as_non_commutative() {
+    assert_merge_laws(&[TakeOther { value: 1 }, TakeOther { value: 2 }]);
+}
+
+/// A single sample satisfies every law trivially, so the helper refuses rather
+/// than reporting a pass that means nothing.
+#[test]
+#[should_panic(expected = "at least two DIFFERENT samples")]
+fn one_sample_is_refused() {
+    assert_merge_laws(&[badges(0b001)]);
+}


### PR DESCRIPTION
The merge contract is stated on `Mergeable`, on `#[app::mergeable]`, and in the reference app's README. Nothing enforced any of it until now.

## Why it matters

The gap has already cost something. A merge that ran in only one direction shipped in this crate: an incoming write older than the stored one was short-circuited before dispatch, so whichever replica wrote second merged and the other silently kept its own value.

```
A bids 900, B bids 100, deltas exchanged, rule is "highest wins"
  A -> 900   (merged: incoming was newer)
  B -> 100   (stale-skipped: incoming was older)
  root hashes differ
```

Found by a two-replica end-to-end test that happened to look — not by anything asserting commutativity. This is that assertion.

## `assert_merge_laws`

Checks commutativity, associativity, idempotence and totality over every ordered pair and triple of the samples given.

**Compares borsh encodings, not `PartialEq`.** The stored bytes are what the Merkle hash sees, so two values comparing equal while encoding differently are still a divergence.

**Copies come from a borsh round-trip, not `Clone`.** An app type holding a `Counter` or a collection cannot be `Clone`, which would have made the helper unusable on exactly the types it exists for. The round-trip is also the more faithful copy — the laws are about the value *as stored*.

**Runs under `with_merge_mode`**, as production does. Without it a rule touching a nested CRDT stamps a fresh wall clock per call, and every law fails for the wrong reason.

## Two of the three tests are `should_panic`

A conformance helper that accepts everything is worse than none, so the suite proves it rejects:

- **`take_other_is_rejected_as_non_commutative`** — `*self = other.clone()`, the most natural way to write "latest wins", and the exact shape `examples/battleships` ships. Two replicas seeing the same pair in different orders settle on different values.
- **`one_sample_is_refused`** — one value satisfies every law trivially, so the helper refuses rather than reporting a pass that means nothing.

## What it is NOT for, and why that is stated

It is deliberately not applied to `TeamStats`, and the reason is a real limit rather than an oversight.

That type embeds three `Counter` handles. A handle is storage IDENTITY, not value: built outside a storage env each gets a random id, so `merge(a, b)` and `merge(b, a)` encode differently in the first ~96 bytes while agreeing perfectly on `badges` — the field the rule actually decides. Applying it there reported a commutativity violation that was entirely an artifact of the handles.

That is not a coverage gap. Collection fields converge structurally — as their own child entities, under the storage layer's rules — whatever `merge` does with them. The part of a custom rule that can be wrong is the part deciding PLAIN data, which is also the only reason to reach for `#[app::mergeable]`. The helper covers exactly that; `converge` covers the whole type. Documented on the helper and at the call site that declined it.

## Test plan

```
$ cargo test -p calimero-storage --features testing --test merge_laws
3 passed; 0 failed          (1 conformance + 2 should_panic)

$ cargo test -p team-metrics-custom --test converge
2 passed; 0 failed

$ cargo clippy -p calimero-storage --all-targets --features testing -- -D warnings   # 0
$ cargo clippy -p calimero-storage --all-targets -- -D warnings                      # 0
$ cargo fmt --check                                                                  # clean
```

Own test binary: `assert_merge_laws` constructs values outside a storage env, and `ROOT_ID` is a process-wide `LazyLock` derived from `context_id()` — whichever test touches a collection first freezes it, and a sibling doing so outside a `RuntimeEnv` freezes it at the no-env fallback, after which genesis elsewhere in the binary fails `CannotCreateOrphan`. That is not hypothetical; it happened while writing this.

The full storage suites run in CI rather than being quoted here — the change is additive to `testing.rs` plus one new binary, and CI covers it faster than a local sweep.

Follows the #3785 series (#3789, #3791, #3796, #3799, #3800, #3802, #3807).
