### PR TITLE
fix(network): dial the named peer, and stop seeding kad from unverified hints

### DIFF
--- a/crates/network/src/handlers/commands.rs
+++ b/crates/network/src/handlers/commands.rs
@@ -6,7 +6,7 @@ use crate::NetworkManager;
 
 mod announce_blob;
 mod bootstrap;
-mod dial;
+pub(crate) mod dial;
 mod listen;
 mod mesh_peer_count;
 mod mesh_peers;

--- a/crates/network/src/handlers/commands/dial.rs
+++ b/crates/network/src/handlers/commands/dial.rs
@@ -3,10 +3,68 @@ use std::collections::hash_map::Entry;
 use actix::{Context, Handler, Message, Response};
 use calimero_network_primitives::messages::Dial;
 use eyre::eyre;
+use libp2p::swarm::dial_opts::{DialOpts, PeerCondition};
+use libp2p::swarm::DialError as SwarmDialError;
 use multiaddr::Protocol;
 use tokio::sync::oneshot;
+use tracing::debug;
 
 use crate::NetworkManager;
+
+/// Outcome of starting one dial, so the handler's decision is separable from
+/// the actor plumbing it answers through.
+pub(crate) enum DialStart {
+    /// A dial is in flight; the sender was parked in `pending_dial`.
+    Started,
+    /// Nothing was started and the caller should be answered immediately —
+    /// either because a dial is already in flight, or because a connection to
+    /// this peer already exists.
+    AlreadyUnderway,
+    /// The swarm refused the dial outright.
+    Refused(String),
+}
+
+impl NetworkManager {
+    /// Start a dial to `peer_id` at `peer_addr`, parking `sender` for whichever
+    /// swarm event resolves it.
+    ///
+    /// Split out of the `Dial` handler so the routing-table and
+    /// peer-verification behaviour can be asserted against a real manager —
+    /// `Handler::handle` needs an actix `Context`, which a test cannot
+    /// fabricate.
+    pub(crate) fn start_dial(
+        &mut self,
+        peer_id: libp2p::PeerId,
+        peer_addr: multiaddr::Multiaddr,
+        sender: oneshot::Sender<eyre::Result<()>>,
+    ) -> DialStart {
+        match self.pending_dial.entry(peer_id) {
+            Entry::Occupied(_) => DialStart::AlreadyUnderway,
+            Entry::Vacant(entry) => {
+                let opts = DialOpts::peer_id(peer_id)
+                    .condition(PeerCondition::DisconnectedAndNotDialing)
+                    .addresses(vec![peer_addr])
+                    .build();
+
+                match self.swarm.dial(opts) {
+                    Ok(()) => {
+                        let _ignored = entry.insert(sender);
+                        DialStart::Started
+                    }
+                    Err(SwarmDialError::DialPeerConditionFalse(condition)) => {
+                        debug!(
+                            %peer_id,
+                            ?condition,
+                            "dial skipped: already connected or dialing this peer"
+                        );
+                        DialStart::AlreadyUnderway
+                    }
+                    Err(e) => DialStart::Refused(e.to_string()),
+                }
+            }
+        }
+    }
+}
 
 impl Handler<Dial> for NetworkManager {
     type Result = Response<<Dial as Message>::Result>;
@@ -18,34 +76,16 @@ impl Handler<Dial> for NetworkManager {
 
         let (sender, receiver) = oneshot::channel();
 
-        match self.pending_dial.entry(peer_id) {
-            Entry::Occupied(_) => {
-                // todo! await the existing receiver
-                //
-                // NB: this `Ok(())` means "a dial to this peer is already in
-                // flight", not "the dial succeeded". The in-flight dial owns
-                // the only sender, so we can't subscribe to its result here
-                // without a broadcast/clone; until that's wired up, a caller
-                // hitting this branch gets a spurious success even if the
-                // real dial later fails.
-                return Response::reply(Ok(()));
-            }
-            Entry::Vacant(entry) => {
-                let _ignored = self
-                    .swarm
-                    .behaviour_mut()
-                    .kad
-                    .add_address(&peer_id, peer_addr.clone());
-
-                match self.swarm.dial(peer_addr) {
-                    Ok(()) => {
-                        let _ignored = entry.insert(sender);
-                    }
-                    Err(e) => {
-                        return Response::reply(Err(eyre!(e)));
-                    }
-                }
-            }
+        match self.start_dial(peer_id, peer_addr, sender) {
+            DialStart::Started => {}
+            // NB: this `Ok(())` means "a dial to this peer is already in
+            // flight, or a connection already exists", not "the dial
+            // succeeded". For the in-flight case the running dial owns the
+            // only sender, so we cannot subscribe to its result here without a
+            // broadcast/clone; until that is wired up, a caller hitting this
+            // branch gets a spurious success even if the real dial later fails.
+            DialStart::AlreadyUnderway => return Response::reply(Ok(())),
+            DialStart::Refused(err) => return Response::reply(Err(eyre!(err))),
         }
 
         Response::fut(async move {

--- a/crates/network/src/manager_discovery_tests.rs
+++ b/crates/network/src/manager_discovery_tests.rs
@@ -611,3 +611,87 @@ async fn startup_without_a_store_is_a_no_op() {
 
     assert!(manager.peer_cache_addrs_for(&PeerId::random()).is_empty());
 }
+
+/// Whether kad holds any address for `peer` — the routing table this fix keeps
+/// unverified hints out of.
+fn kad_knows(manager: &mut NetworkManager, peer: PeerId) -> bool {
+    manager
+        .swarm
+        .behaviour_mut()
+        .kad
+        .kbucket(peer)
+        .is_some_and(|bucket| {
+            bucket
+                .iter()
+                .any(|entry| entry.node.key.preimage() == &peer)
+        })
+}
+
+/// A dial offers its address to the dial, and does NOT write it to the routing
+/// table.
+///
+/// This is a security property rather than tidiness. One caller's addresses are
+/// attacker-influenced: the namespace join dials the `admitter_addrs` an
+/// invitation carries, and that field sits OUTSIDE the inviter's signature, so
+/// anyone relaying an invitation can rewrite it. Seeding kad before dialing
+/// turned "an address I could not reach" into "an address my routing table now
+/// offers for that peer" — writable by whoever relayed the invitation.
+///
+/// The address here is unroutable, so the dial cannot succeed and nothing may
+/// be recorded. `identify` adds the address on an established connection, which
+/// is the point at which it has been shown to reach that peer.
+#[tokio::test]
+async fn a_dial_does_not_seed_the_routing_table_with_an_unverified_address() {
+    let mut manager = build_manager().await;
+    let peer = PeerId::random();
+    // TEST-NET-2 (RFC 5737), so nothing can answer even on a networked runner.
+    let addr: Multiaddr = "/ip4/198.51.100.7/udp/4001/quic-v1".parse().unwrap();
+
+    assert!(
+        !kad_knows(&mut manager, peer),
+        "precondition: the table must not already know this random peer"
+    );
+
+    let (tx, _rx) = tokio::sync::oneshot::channel();
+    let _outcome = manager.start_dial(peer, addr, tx);
+
+    assert!(
+        !kad_knows(&mut manager, peer),
+        "the dial's address must not enter the routing table before a \
+         connection proves it reaches that peer"
+    );
+}
+
+/// The dial names the peer it expects, so a `pending_dial` cannot be resolved
+/// by whoever happens to occupy the address.
+///
+/// Asserted through the swarm rather than by inspecting the opts: dialing with
+/// a peer id brings a peer condition with it, and `DisconnectedAndNotDialing`
+/// means a second dial to the same peer is refused while the first is in
+/// flight. That refusal is only observable if the peer id was actually attached.
+#[tokio::test]
+async fn a_dial_names_the_peer_so_a_second_one_is_recognised_as_a_duplicate() {
+    let mut manager = build_manager().await;
+    let peer = PeerId::random();
+    let addr: Multiaddr = "/ip4/198.51.100.8/udp/4001/quic-v1".parse().unwrap();
+
+    let (tx, _rx) = tokio::sync::oneshot::channel();
+    assert!(
+        matches!(
+            manager.start_dial(peer, addr.clone(), tx),
+            crate::handlers::commands::dial::DialStart::Started
+        ),
+        "the first dial to an unknown peer must start"
+    );
+
+    // Same peer, different address: the in-flight dial owns `pending_dial`, so
+    // this is answered without starting a second one.
+    let (tx2, _rx2) = tokio::sync::oneshot::channel();
+    assert!(
+        matches!(
+            manager.start_dial(peer, addr, tx2),
+            crate::handlers::commands::dial::DialStart::AlreadyUnderway
+        ),
+        "a second dial while one is in flight must not start another"
+    );
+}


### PR DESCRIPTION
Closes the address-injection half of #3801.

## The problem

`NetworkClient::dial` seeded the Kademlia routing table *before* dialing:

```rust
kad.add_address(&peer_id, peer_addr.clone());
match self.swarm.dial(peer_addr) { .. }
```

So any address handed to this handler became a routing-table entry for that
peer, whether or not anything was reachable there.

That matters because one caller's addresses are **attacker-influenced**. The
namespace join dials the `admitter_addrs` an invitation carries, and that field
sits *outside* the inviter's signature — deliberately, so a client that
round-trips an invitation through its own typed model cannot invalidate the
signature by dropping an unknown field. Anyone relaying an invitation can
rewrite it. Seeding first turned "a hint I could not reach" into "an address my
routing table now offers for that peer", writable by the relayer. It is bounded
by the invitation's own validation (256 addresses × 512 bytes) but not
authenticated at all.

It also poisoned the table for exactly the peer a join most needs: #3801's node-2
had one `admitter_addrs` entry, a relay circuit through a public relay, which
failed to negotiate — and that unroutable address was recorded against the
admitter's peer id regardless.

Second, smaller problem in the same three lines: the handler **popped** the
`/p2p/<id>` off and dialed a bare address, so libp2p never verified who
answered. `pending_dial` is keyed by the *expected* peer, so a connection from
whoever actually occupies that address could resolve — or strand — a dial
awaiting a different peer.

## What this changes

Dial **with** the peer id, and pass the address as an explicit candidate rather
than seeding the table:

```rust
let opts = DialOpts::peer_id(peer_id)
    .condition(PeerCondition::DisconnectedAndNotDialing)
    .addresses(vec![peer_addr])
    .build();
```

libp2p now verifies the peer answering is the one named, and the routing table
is no longer writable by a caller that merely has an address to try.

**Nothing is lost by waiting.** A dial that succeeds leaves a live connection
the stream layer reuses directly, and `identify` then adds the address on the
established connection — already the case today, with filtering this path never
had (no relayed, no self-observed, only dialable; `swarm/identify.rs`). So kad
still learns addresses, just only ones shown to reach the peer.

Naming a peer brings a **peer condition** with it that a bare-address dial did
not have, so `DialPeerConditionFalse` is mapped to success rather than to an
error: the honest answer to "connect me to this peer" when a connection already
exists is yes. It is answered without parking the sender, because no dial was
started — parking it would leave the caller waiting out its own timeout for a
connection it already had.

## Tests

The decision moved into `NetworkManager::start_dial` so it can be driven against
a real manager — `Handler::handle` needs an actix `Context` a test cannot
fabricate. Two tests, both against `build_manager()` with a real swarm:

- `a_dial_does_not_seed_the_routing_table_with_an_unverified_address` — dials an
  RFC 5737 address that cannot answer, asserts kad holds nothing for the peer.
- `a_dial_names_the_peer_so_a_second_one_is_recognised_as_a_duplicate` — the
  peer id is observably attached, since a duplicate is recognised as such.

I checked the first discriminates rather than assuming it: reinstating the
pre-dial `kad.add_address` makes it fail with exactly its own message.

## Scope

`discovery.rs` also seeds kad before its own re-dials. Left alone deliberately:
those addresses come from the discovery book and the persistent peer cache —
addresses this node learned from established connections — not from an
untrusted hint. Same shape, different provenance.

This does **not** close #3801. The join-path hardening was #3805, and the
evidence in that issue points at the local sibling connection never being made
rather than at either fix; see the analysis there.
