### PR TITLE
chore(sync)!: remove the handshake versioning that never ran

### DIFF
--- a/crates/node/primitives/src/sync.rs
+++ b/crates/node/primitives/src/sync.rs
@@ -51,9 +51,7 @@ pub mod wire;
 // =============================================================================
 
 // Handshake types
-pub use handshake::{
-    SyncCapabilities, SyncHandshake, SyncHandshakeResponse, SYNC_PROTOCOL_VERSION,
-};
+pub use handshake::{SyncCapabilities, SyncHandshake, SyncHandshakeResponse};
 
 // Protocol types and selection
 pub use protocol::{

--- a/crates/node/primitives/src/sync/handshake.rs
+++ b/crates/node/primitives/src/sync/handshake.rs
@@ -10,11 +10,6 @@ use super::protocol::{SyncProtocol, SyncProtocolKind};
 // Constants
 // =============================================================================
 
-/// Wire protocol version for sync handshake.
-///
-/// Increment on breaking changes to ensure nodes can detect incompatibility.
-pub const SYNC_PROTOCOL_VERSION: u32 = 1;
-
 // =============================================================================
 // Capabilities
 // =============================================================================
@@ -59,8 +54,6 @@ impl Default for SyncCapabilities {
 /// See CIP §2.1 - Handshake Message.
 #[derive(Clone, Debug, PartialEq, BorshSerialize, BorshDeserialize)]
 pub struct SyncHandshake {
-    /// Protocol version for compatibility checking.
-    pub version: u32,
     /// Current Merkle root hash.
     pub root_hash: [u8; 32],
     /// Number of entities in the tree.
@@ -86,7 +79,6 @@ impl SyncHandshake {
     ) -> Self {
         let has_state = root_hash != [0; 32];
         Self {
-            version: SYNC_PROTOCOL_VERSION,
             root_hash,
             entity_count,
             max_depth,
@@ -94,12 +86,6 @@ impl SyncHandshake {
             has_state,
             supported_protocols: SyncCapabilities::default().supported_protocols,
         }
-    }
-
-    /// Check if the remote handshake has a compatible protocol version.
-    #[must_use]
-    pub fn is_version_compatible(&self, other: &Self) -> bool {
-        self.version == other.version
     }
 
     /// Check if root hashes match (already in sync).
@@ -184,7 +170,6 @@ mod tests {
         let decoded: SyncHandshake = borsh::from_slice(&encoded).expect("deserialize");
 
         assert_eq!(handshake, decoded);
-        assert_eq!(decoded.version, SYNC_PROTOCOL_VERSION);
         assert!(decoded.has_state); // non-zero root_hash
     }
 
@@ -200,19 +185,6 @@ mod tests {
         let decoded: SyncHandshakeResponse = borsh::from_slice(&encoded).expect("deserialize");
 
         assert_eq!(response, decoded);
-    }
-
-    #[test]
-    fn test_sync_handshake_version_compatibility() {
-        let local = SyncHandshake::new([1; 32], 10, 2, vec![]);
-        let compatible = SyncHandshake::new([2; 32], 20, 3, vec![]);
-        let incompatible = SyncHandshake {
-            version: SYNC_PROTOCOL_VERSION + 1,
-            ..SyncHandshake::default()
-        };
-
-        assert!(local.is_version_compatible(&compatible));
-        assert!(!local.is_version_compatible(&incompatible));
     }
 
     #[test]

--- a/crates/node/primitives/src/sync/protocol.rs
+++ b/crates/node/primitives/src/sync/protocol.rs
@@ -194,17 +194,6 @@ pub fn select_protocol(local: &SyncHandshake, remote: &SyncHandshake) -> Protoco
         };
     }
 
-    // Check version compatibility first
-    if !local.is_version_compatible(remote) {
-        // Version mismatch - fall back to HashComparison as safest option
-        return ProtocolSelection {
-            protocol: SyncProtocol::HashComparison {
-                root_hash: remote.root_hash,
-            },
-            reason: "version mismatch, using safe fallback",
-        };
-    }
-
     // Rule 2a: Fresh local node - Snapshot allowed
     // CRITICAL: This is the ONLY case where Snapshot is permitted
     if !local.has_state {
@@ -337,7 +326,6 @@ pub fn select_protocol_with_fallback(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sync::handshake::SYNC_PROTOCOL_VERSION;
 
     #[test]
     fn test_sync_protocol_roundtrip() {
@@ -652,20 +640,6 @@ mod tests {
             SyncProtocol::HashComparison { .. }
         ));
         assert!(selection.reason.contains("default"));
-    }
-
-    #[test]
-    fn test_select_protocol_version_mismatch_uses_safe_fallback() {
-        let local = SyncHandshake::new([1; 32], 100, 5, vec![]);
-        let mut remote = SyncHandshake::new([2; 32], 100, 5, vec![]);
-        remote.version = SYNC_PROTOCOL_VERSION + 1; // Incompatible version
-
-        let selection = select_protocol(&local, &remote);
-        assert!(matches!(
-            selection.protocol,
-            SyncProtocol::HashComparison { .. }
-        ));
-        assert!(selection.reason.contains("version mismatch"));
     }
 
     #[test]

--- a/crates/node/src/sync/protocol_selector.rs
+++ b/crates/node/src/sync/protocol_selector.rs
@@ -1,10 +1,19 @@
 //! Protocol-dispatch for the initiator side of a sync session.
 //!
-//! `SyncManager::handle_dag_sync` calls [`select_protocol`] against
-//! local + remote handshakes to choose a sync protocol, then forwards
-//! the resulting `ProtocolSelection` into this module's
-//! [`ProtocolSelector::execute`], which runs the chosen protocol and
-//! walks the fallback chain when one fails:
+//! `SyncManager::handle_dag_sync` decides a `ProtocolSelection` and forwards it
+//! into this module's [`ProtocolSelector::execute`], which runs the chosen
+//! protocol and walks the fallback chain when one fails:
+//!
+//! The choice is made in `SyncManager::handle_dag_sync`, which does call
+//! `select_protocol` — this module only executes the result.
+//!
+//! `select_protocol` used to begin with a version-compatibility check that
+//! could never fail. `build_remote_handshake` fabricates the peer's handshake
+//! LOCALLY from the only two things that cross the wire (its root hash and dag
+//! heads), so the peer's `version` field was filled from this node's own
+//! `SYNC_PROTOCOL_VERSION`. The comparison was a constant against itself, run
+//! on every sync. The constant is gone; #3810 tracks building the negotiation
+//! CIP §2.3 actually specifies.
 //!
 //! - `None` → no-op, sync converged on root-hash match.
 //! - `Snapshot { .. }` → `fallback_to_snapshot_sync`.
@@ -23,8 +32,6 @@
 //! `request_dag_heads_and_sync`) stay on `SyncManager` and are
 //! exposed through the [`ProtocolDispatch`] trait, mirroring the
 //! per-call-injection pattern used by [`crate::sync::reconciler`].
-//!
-//! [`select_protocol`]: calimero_node_primitives::sync::select_protocol
 
 use async_trait::async_trait;
 use calimero_context_client::client::ContextClient;

--- a/crates/node/tests/sync_compliance/negotiation.rs
+++ b/crates/node/tests/sync_compliance/negotiation.rs
@@ -313,28 +313,15 @@ fn test_cip23_rule7_default_hash_comparison() {
     );
 }
 
-// =============================================================================
-// Version Compatibility Tests
-// =============================================================================
-
-/// CIP-2.3: Version mismatch falls back to HashComparison.
-#[test]
-fn test_cip23_version_mismatch_fallback() {
-    let mut hs_local = SyncHandshake::new([1; 32], 50, 3, vec![]);
-    let mut hs_remote = SyncHandshake::new([2; 32], 50, 3, vec![]);
-
-    // Force version mismatch
-    hs_local.version = 1;
-    hs_remote.version = 999;
-
-    let selection = select_protocol(&hs_local, &hs_remote);
-
-    assert!(
-        matches!(selection.protocol, SyncProtocol::HashComparison { .. }),
-        "Version mismatch should fall back to HashComparison, got {:?}",
-        selection.protocol
-    );
-}
+// Version-compatibility tests lived here. `SYNC_PROTOCOL_VERSION` and
+// `is_version_compatible` are gone. The check DID run — on every sync, from
+// `select_protocol` — but could never fail: `build_remote_handshake` builds the
+// peer's handshake locally from the only fields that cross the wire (root hash
+// and dag heads), so its `version` came from this node's own constant. Both
+// sides of the comparison were the same local value, which is why incrementing
+// the constant its doc told you to increment detected nothing. CIP §2.3 does
+// specify negotiation (#3810), so this section should come back when it is
+// real.
 
 // =============================================================================
 // Edge Cases and Priority Tests

--- a/crates/node/tests/sync_scenarios/snapshot_merge_protection.rs
+++ b/crates/node/tests/sync_scenarios/snapshot_merge_protection.rs
@@ -339,26 +339,6 @@ fn test_single_entity_still_prevents_snapshot() {
     );
 }
 
-/// Version mismatch falls back to HashComparison, not Snapshot.
-#[test]
-fn test_version_mismatch_uses_safe_fallback() {
-    let mut local_hs = SyncHandshake::new([1; 32], 50, 3, vec![]);
-    let mut remote_hs = SyncHandshake::new([2; 32], 50, 3, vec![]);
-
-    // Force version mismatch
-    local_hs.version = 1;
-    remote_hs.version = 2;
-
-    let selection = select_protocol(&local_hs, &remote_hs);
-
-    // Should fall back to HashComparison
-    assert!(
-        matches!(selection.protocol, SyncProtocol::HashComparison { .. }),
-        "Version mismatch should fall back to HashComparison, got {:?}",
-        selection.protocol
-    );
-}
-
 /// Same root hash means no sync needed - nodes already in sync.
 #[test]
 fn test_same_hash_means_no_sync_needed() {


### PR DESCRIPTION
Removes a version check that could never fail, and files #3810 to build the negotiation CIP §2.3 specifies.

## What it claimed

```rust
/// Wire protocol version for sync handshake.
///
/// Increment on breaking changes to ensure nodes can detect incompatibility.
pub const SYNC_PROTOCOL_VERSION: u32 = 1;
```

Incrementing it detected nothing.

## Why

The check **ran** — on every sync, from `select_protocol`, which `SyncManager::handle_dag_sync` calls for real (`manager/mod.rs:1574`). What it compared was the problem:

```rust
// manager/handshake.rs — the PEER's handshake, built locally
pub(super) fn build_remote_handshake(
    peer_root_hash: Hash,
    peer_dag_heads: &[[u8; DIGEST_SIZE]],
) -> SyncHandshake {
    ...
    build_handshake_from_raw(root_hash, entity_count, max_depth, peer_dag_heads.to_vec())
}
```

Only the root hash and dag heads cross the wire. Every other field — `version` included — is filled in from **this node's own constants**. So `is_version_compatible` compared `SYNC_PROTOCOL_VERSION` against itself, on every sync, and could not have failed no matter what the peer was running.

`SyncHandshake` never crosses the wire at all; its only borsh round-trip was its own unit test. That is the root of it — nothing the peer says about itself reaches the comparison. It also means dropping the field is not a format change.

## Why remove rather than leave

A mechanism that looks present is worse than an absent one. **Six breaking wire changes shipped today**, and the next person to ship one would reasonably bump the constant, believe stragglers now fail cleanly, and ship something that silently misreads instead.

One of the six is already that shape: **map entries going value-first (#3796)**. Both layouts are the same length, so a pre-upgrade node reads the value where the key should be and carries on — no discriminant to bump, no error to raise. That is the case a working handshake would catch, and the case the broken one gave false confidence about.

## Tests

Three go with it, each leaving a pointer to #3810:

- `test_sync_handshake_version_compatibility`
- `test_select_protocol_version_mismatch_uses_safe_fallback`
- `test_cip23_version_mismatch_fallback`

They passed for years because each set `remote.version` **by hand** — the one thing production cannot do, since the remote handshake is fabricated locally. A test can be perfectly correct about a code path and still describe a situation that cannot arise.

## Not a feature nobody wanted

CIP §2.3 specifies negotiation; one removed test was literally `test_cip23_version_mismatch_fallback`. So this is a **gap**, and #3810 tracks closing it — including the question the removed code answered badly: a mismatch fell back to HashComparison, which is no more tolerant of a layout change than any other protocol, so refusing with a clear log line is probably more honest.

## Test plan

```
$ cargo check -p calimero-node --all-targets                              # 0
$ cargo test -p calimero-node-primitives --lib
322 passed; 0 failed
$ cargo clippy -p calimero-node-primitives --all-targets -- -D warnings   # 0
$ cargo fmt --check                                                       # clean
```

106 lines removed across 6 files. Refs #3810.

---

**Note on an earlier revision of this description.** It said the check was unreachable — that `select_protocol` is "reached only from its own tests". That was wrong: it is called on every sync. The error came from a `grep … | head -6` that truncated before reaching `manager/mod.rs`. The conclusion survives, and the real reason is sharper: the check was live and vacuous, not dead. Corrected here rather than quietly, because "this code is unreachable" and "this comparison is a constant against itself" would lead a reviewer to check very different things.
