### PR TITLE
fix(apps): give the badge e2e explicit per-node values

### DIFF
--- a/apps/team-metrics-custom/src/lib.rs
+++ b/apps/team-metrics-custom/src/lib.rs
@@ -152,27 +152,6 @@ impl TeamMetricsApp {
         Ok(stats.badges)
     }
 
-    /// Award the badge that belongs to the CALLING device, derived from its
-    /// device id.
-    ///
-    /// This exists to be testable, and the reason is worth stating. A
-    /// convergence harness applies the same op list to every replica, so an op
-    /// taking an explicit badge number leaves every replica computing the same
-    /// value — no conflict, nothing for a merge to do, and a test that passes
-    /// with the merge rule deleted. A counter avoids that by being per-writer;
-    /// this makes the badge per-writer for the same reason, so identical ops
-    /// still produce divergent blobs that only a union can reconcile.
-    pub fn award_own_badge(&mut self, team_id: String) -> app::Result<u64> {
-        let badge = u64::from(calimero_sdk::env::device_id()[0] % 64);
-        let _ = self.award_badge(team_id, badge)?;
-
-        // Returns the BIT, not the mask. A workflow has to be able to check
-        // that two nodes awarded DIFFERENT badges before it can read anything
-        // into a merged count of one: without that, "the merge never ran" and
-        // "both nodes happened to pick the same bit" look identical.
-        Ok(badge)
-    }
-
     /// How many badges the team holds.
     ///
     /// Exposed so an e2e assertion can be a plain integer comparison: the

--- a/apps/team-metrics-custom/tests/converge.rs
+++ b/apps/team-metrics-custom/tests/converge.rs
@@ -73,7 +73,12 @@ fn team_stats_converge_to_correct_value() {
 //      so the two agree whenever LWW's tiebreak picks the larger side;
 //   2. two `.ops(..)` closures awarding explicit badges — the harness applies
 //      EVERY op to EVERY replica, so both computed the union directly;
-//   3. a per-device badge — defeated by the thread-local above.
+//   3. a per-device badge — defeated by the thread-local above. It briefly
+//      lived in the workflow instead, where it worked but was FLAKY: two device
+//      ids can agree in the byte the badge came from, and CI duly produced
+//      badge 61 on both nodes. The workflow now passes explicit badges, which
+//      it can because every merobox step names the node it runs on — the
+//      same-op-list constraint that motivated deriving one exists only here.
 //
 // Where the proof actually lives:
 //

--- a/apps/team-metrics-custom/workflows/team-metrics-custom.yml
+++ b/apps/team-metrics-custom/workflows/team-metrics-custom.yml
@@ -315,34 +315,32 @@ steps:
   # calimero-storage/tests/custom_merge_e2e.rs proves the mechanism, and the
   # convergence harness cannot do it at all (see tests/converge.rs).
   # ---------------------------------------------------------------------------
-  - name: Node 1 awards its own badge
+  # Explicit badge numbers, one per node. An earlier version derived the badge
+  # from the node's own device id, which is what a CONVERGENCE HARNESS needs —
+  # there every replica runs the same op list, so an op taking an explicit
+  # argument cannot make two replicas diverge. That constraint does not exist
+  # here: every merobox step names the node it runs on, so the two calls are
+  # already different. Deriving it instead bought nothing and made the test
+  # flaky, since two device ids can agree in the byte the badge came from — CI
+  # duly produced badge 61 on both nodes and the run failed on a collision
+  # rather than on anything about merging.
+  - name: Node 1 awards badge 0
     type: call
     node: team-custom-node-1
     context_id: "{{context_id}}"
-    method: award_own_badge
+    method: award_badge
     args:
       team_id: team-alpha
-    outputs:
-      own_badge_node1: result.output
+      badge: 0
 
-  - name: Node 2 awards its own badge concurrently
+  - name: Node 2 awards badge 1 concurrently
     type: call
     node: team-custom-node-2
     context_id: "{{context_id}}"
-    method: award_own_badge
+    method: award_badge
     args:
       team_id: team-alpha
-    outputs:
-      own_badge_node2: result.output
-
-  # Precondition, not decoration. If both nodes picked the same bit, a merged
-  # count of 1 is CORRECT and the assertion below would fail for a reason that
-  # has nothing to do with merging. Checking it here means a failure downstream
-  # can only mean the merge did not happen.
-  - name: Assert the two nodes picked different badges
-    type: assert
-    statements:
-      - "{{own_badge_node1}} != {{own_badge_node2}}"
+      badge: 1
 
   - name: Wait for the badge blobs to merge
     type: wait_for_sync


### PR DESCRIPTION
The badge e2e added in #3802 is flaky. It derived each node's badge from that node's own device id, and two device ids can agree in the byte it read — CI produced badge 61 on **both** nodes, so the run failed on the collision rather than on anything about merging.

## Why it was derived in the first place

To be testable under a convergence harness. `converge_app` applies the same op list to every replica, so an op taking an explicit badge number leaves every replica computing the same value — no conflict, nothing for a merge to do, and a test that passes with the merge rule deleted. Deriving from identity was the way around that.

**That constraint does not exist in merobox.** Every step names the node it runs on, so the two calls are already different. The workflow now passes 0 and 1.

## The precondition did its job on the way out

`Assert the two nodes picked different badges` existed because a derived badge might collide, and its purpose was to stop a collision being mistaken for a merge failure. That is exactly what happened: the run failed on the precondition, not on the badge count, so the diagnosis was one line rather than an investigation into whether host-side dispatch had regressed.

It is removed along with the derivation, since explicit values cannot collide.

## Also

`award_own_badge` is deleted rather than left unused — nothing else called it. The rationale comment in `tests/converge.rs`, which lists the approaches that did **not** work for testing the custom rule, gains this one: it worked in the workflow but was flaky, and why.

## Test plan

```
$ cargo test -p team-metrics-custom --lib          # 3 passed
$ cargo test -p team-metrics-custom --test converge # 2 passed
$ cargo check -p team-metrics-custom --target wasm32-unknown-unknown  # 0
$ cargo fmt --check                                 # clean
```

The workflow itself runs in CI. It was passing on #3802 and #3807 before this collision, so the underlying dispatch is fine — this is the test being unreliable, not the feature.