### PR TITLE
fix(storage): give the converge harness a per-replica SDK identity

### DIFF
--- a/crates/sdk/src/testing.rs
+++ b/crates/sdk/src/testing.rs
@@ -485,6 +485,42 @@ where
     }
 }
 
+/// Runs `f` with the SDK host reporting `device` and `account` as the executing
+/// identity, restoring both on the way out — including on unwind.
+///
+/// The SDK host and `calimero-storage`'s `RuntimeEnv` keep **separate** copies of
+/// "who is executing", and setting one does not set the other. A harness that
+/// sets only the storage half leaves `calimero_sdk::env::device_id()` reading its
+/// process-wide default inside app code, so every simulated replica reports the
+/// same writer and any rule that varies by writer silently degenerates into one
+/// that does not — the failure looks like a rule that does not work rather than a
+/// harness that never varied its input.
+///
+/// [`TestHost::call_as`] does the equivalent internally for its own scope; this is
+/// the same alignment for a harness that drives the storage layer directly.
+pub fn with_identity<R>(device: [u8; 32], account: [u8; 32], f: impl FnOnce() -> R) -> R {
+    /// Restores on scope exit so a panicking body cannot leak one replica's
+    /// identity into the next.
+    struct Restore {
+        device: [u8; 32],
+        account: [u8; 32],
+    }
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            host::set_device_id(self.device);
+            host::set_account_id(self.account);
+        }
+    }
+
+    let _restore = Restore {
+        device: host::device_id(),
+        account: host::account_id(),
+    };
+    host::set_device_id(device);
+    host::set_account_id(account);
+    f()
+}
+
 /// Asserts a migration **converges**: runs `migrate_fn` from an identical,
 /// deterministically-installed `install_v1()` state under two different executor
 /// identities and checks the two migrated **merkle root hashes** are equal.

--- a/crates/storage/src/testing.rs
+++ b/crates/storage/src/testing.rs
@@ -36,6 +36,16 @@
 //! every *other* replica's deltas, also in shuffled order. Convergence =
 //! identical root hash across all replicas, regardless of interleaving.
 //!
+//! "Its own executor id" holds at **both** layers an app can observe: the
+//! storage `RuntimeEnv` and the SDK host are set together for each replica's
+//! scope, so `calimero_sdk::env::device_id()` — what app code actually calls —
+//! varies per replica, and `account_id()` follows
+//! [`one_account`](Converge::one_account). This matters for any rule that
+//! branches on the writer: with only the storage half set, such a rule reads one
+//! device on every replica and quietly degenerates into a rule that does not
+//! branch at all, which reads as a broken rule rather than a harness that never
+//! varied its input.
+//!
 //! # What this actually proves
 //!
 //! It proves your **app state converges end-to-end** — the property whose
@@ -77,6 +87,7 @@ use std::rc::Rc;
 use std::sync::Mutex;
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use calimero_sdk::testing::with_identity;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::SeedableRng;
@@ -367,12 +378,12 @@ where
         // Genesis: install the base state once, then snapshot it byte-for-byte
         // into every replica so all replicas share identical ids + base hash.
         let genesis: Store = new_store();
-        env::with_runtime_env(
-            env_for(&genesis, GENESIS_EXECUTOR, self.account_of(usize::MAX)),
-            || {
+        let genesis_account = self.account_of(usize::MAX);
+        with_identity(GENESIS_EXECUTOR, genesis_account, || {
+            env::with_runtime_env(env_for(&genesis, GENESIS_EXECUTOR, genesis_account), || {
                 Root::new(|| (self.build)()).commit();
-            },
-        );
+            });
+        });
         let base = genesis.borrow().clone();
 
         let stores: Vec<Store> = (0..n)
@@ -397,15 +408,17 @@ where
             ));
 
             let mut replica_deltas = Vec::with_capacity(order.len());
-            env::with_runtime_env(env_for(store, executor_for(r), self.account_of(r)), || {
-                for &op_idx in &order {
-                    let mut app = Root::<T>::fetch().expect("converge: genesis not installed");
-                    (self.ops[op_idx])(&mut app);
-                    app.commit();
-                    if let Some(artifact) = env::take_last_artifact() {
-                        replica_deltas.push(artifact);
+            with_identity(executor_for(r), self.account_of(r), || {
+                env::with_runtime_env(env_for(store, executor_for(r), self.account_of(r)), || {
+                    for &op_idx in &order {
+                        let mut app = Root::<T>::fetch().expect("converge: genesis not installed");
+                        (self.ops[op_idx])(&mut app);
+                        app.commit();
+                        if let Some(artifact) = env::take_last_artifact() {
+                            replica_deltas.push(artifact);
+                        }
                     }
-                }
+                });
             });
             deltas.push(replica_deltas);
         }
@@ -422,7 +435,7 @@ where
                 self.seed ^ 0xDEAD_BEEF ^ (r as u64).wrapping_mul(0x85EB_CA77),
             ));
 
-            let failed =
+            let failed = with_identity(executor_for(r), self.account_of(r), || {
                 env::with_runtime_env(env_for(store, executor_for(r), self.account_of(r)), || {
                     for (s, k) in foreign {
                         Root::<T>::sync(&deltas[s][k], &ApplyContext::empty())
@@ -435,7 +448,8 @@ where
                         .filter(|(_, check)| !check(&app))
                         .map(|(desc, _)| desc.clone())
                         .collect::<Vec<_>>()
-                });
+                })
+            });
             hashes.push(env::root_hash());
             assert!(
                 failed.is_empty(),

--- a/crates/storage/tests/converge_identity.rs
+++ b/crates/storage/tests/converge_identity.rs
@@ -1,0 +1,193 @@
+//! The convergence harness must vary the executing identity at **both** layers.
+//!
+//! `calimero-storage`'s `RuntimeEnv` and the SDK's mock host keep separate copies
+//! of "who is executing", and setting one does not set the other. The harness
+//! used to set only the storage copy, so `calimero_sdk::env::device_id()` — the
+//! function app code actually calls — returned the same process default on every
+//! replica.
+//!
+//! That does not fail loudly. It makes any app rule that varies by writer
+//! degenerate into one that does not, so the rule appears broken while the
+//! harness is what never varied its input. It is why the `#[app::mergeable]`
+//! custom-merge assertion had to be written as a two-node merobox workflow
+//! instead of an in-process test.
+//!
+//! These tests read the identity from inside an op closure — the same vantage an
+//! app method has — rather than inspecting the harness's own plumbing, because
+//! the defect was precisely that the plumbing was right on one side and never
+//! reached the other.
+//!
+//! Run with: `cargo test -p calimero-storage --features testing --test converge_identity`
+
+#![cfg(feature = "testing")]
+#![allow(clippy::unwrap_used)]
+
+use std::collections::BTreeSet;
+use std::sync::Mutex;
+
+use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use calimero_storage::collections::crdt_meta::MergeError;
+use calimero_storage::collections::{Counter, MergeStrategy, Mergeable};
+use calimero_storage::testing::converge;
+use calimero_storage::{env, rekey_field_if_supported};
+
+const REPLICAS: usize = 3;
+
+#[derive(BorshSerialize, BorshDeserialize, Default)]
+#[borsh(crate = "calimero_sdk::borsh")]
+struct Edits {
+    count: Counter,
+}
+
+// Structural: a test fixture, merged by the storage layer's own rules.
+#[diagnostic::do_not_recommend]
+impl MergeStrategy for Edits {
+    const DISPATCHED: bool = false;
+}
+
+impl Mergeable for Edits {
+    fn merge(&mut self, other: &Self) -> Result<(), MergeError> {
+        self.count.merge(&other.count)
+    }
+}
+
+impl calimero_storage::collections::rekey::RekeyTarget for Edits {
+    fn rekey_relative_to(&mut self, parent_id: calimero_storage::address::Id) {
+        use calimero_storage::collections::rekey::field_child_id;
+        rekey_field_if_supported!(&mut self.count, field_child_id(parent_id, "count"));
+    }
+}
+
+/// Identities observed from inside an op, one set per test so the tests do not
+/// share collectors (the harness serializes runs, but not these statics).
+struct Seen {
+    storage_devices: Mutex<BTreeSet<[u8; 32]>>,
+    sdk_devices: Mutex<BTreeSet<[u8; 32]>>,
+    sdk_accounts: Mutex<BTreeSet<[u8; 32]>>,
+}
+
+impl Seen {
+    const fn new() -> Self {
+        Self {
+            storage_devices: Mutex::new(BTreeSet::new()),
+            sdk_devices: Mutex::new(BTreeSet::new()),
+            sdk_accounts: Mutex::new(BTreeSet::new()),
+        }
+    }
+
+    fn record(&self) {
+        let _ = self
+            .storage_devices
+            .lock()
+            .unwrap()
+            .insert(env::device_id());
+        let _ = self
+            .sdk_devices
+            .lock()
+            .unwrap()
+            .insert(calimero_sdk::env::device_id());
+        let _ = self
+            .sdk_accounts
+            .lock()
+            .unwrap()
+            .insert(calimero_sdk::env::account_id());
+    }
+
+    fn counts(&self) -> (usize, usize, usize) {
+        (
+            self.storage_devices.lock().unwrap().len(),
+            self.sdk_devices.lock().unwrap().len(),
+            self.sdk_accounts.lock().unwrap().len(),
+        )
+    }
+}
+
+/// **An app method sees a different device on every replica.**
+///
+/// The SDK half is the assertion that mattered: the storage half already passed
+/// before the fix, which is why the gap survived so long.
+#[test]
+fn both_layers_see_a_distinct_device_per_replica() {
+    static SEEN: Seen = Seen::new();
+
+    converge::<Edits>()
+        .replicas(REPLICAS)
+        .ops(|s: &mut Edits| {
+            SEEN.record();
+            s.count.increment().unwrap();
+        })
+        .assert_all_replicas_equal();
+
+    let (storage, sdk, accounts) = SEEN.counts();
+    assert_eq!(
+        storage, REPLICAS,
+        "storage layer should report one device per replica"
+    );
+    assert_eq!(
+        sdk, REPLICAS,
+        "SDK layer should report one device per replica; \
+         a count of 1 means the harness never left the host default"
+    );
+    assert_eq!(
+        accounts, REPLICAS,
+        "each replica writes as its own account unless `one_account()` is set"
+    );
+}
+
+/// **`one_account()` shares the person, not the device.**
+///
+/// The distinction the harness exists to preserve: N devices of one account must
+/// keep N per-writer slots. Flattening the SDK account onto the device (or vice
+/// versa) would make an account-keyed gate and a device-keyed one behave alike.
+#[test]
+fn one_account_shares_the_account_but_not_the_device() {
+    static SEEN: Seen = Seen::new();
+
+    converge::<Edits>()
+        .replicas(REPLICAS)
+        .one_account()
+        .ops(|s: &mut Edits| {
+            SEEN.record();
+            s.count.increment().unwrap();
+        })
+        .assert_all_replicas_equal();
+
+    let (storage, sdk, accounts) = SEEN.counts();
+    assert_eq!(storage, REPLICAS, "devices stay distinct under one_account");
+    assert_eq!(
+        sdk, REPLICAS,
+        "SDK devices stay distinct under one_account too"
+    );
+    assert_eq!(
+        accounts, 1,
+        "one_account means every replica writes as the same account"
+    );
+}
+
+/// **The harness restores the ambient identity it borrowed.**
+///
+/// A run that left its last replica's device installed would silently key any
+/// later test in the same binary to that replica.
+#[test]
+fn a_run_does_not_leak_its_last_replica_identity() {
+    let before = (
+        calimero_sdk::env::device_id(),
+        calimero_sdk::env::account_id(),
+    );
+
+    converge::<Edits>()
+        .replicas(REPLICAS)
+        .ops(|s: &mut Edits| {
+            s.count.increment().unwrap();
+        })
+        .assert_all_replicas_equal();
+
+    let after = (
+        calimero_sdk::env::device_id(),
+        calimero_sdk::env::account_id(),
+    );
+    assert_eq!(
+        before, after,
+        "the SDK host identity must be restored after a converge run"
+    );
+}


### PR DESCRIPTION
Fixes #3815.

## What was wrong

The convergence harness gave each replica its own device identity at the
**storage** layer and left the **SDK** host at its default. So
`calimero_sdk::env::device_id()` — the function app code actually calls —
returned `DEFAULT_DEVICE_ID` (`[237; 32]`) on every replica.

Nothing failed. An app rule that branches on the writer simply took the same
branch everywhere, so **the rule looked broken while the harness was what never
varied its input.** That is why the `#[app::mergeable]` custom-merge assertion
had to be written as a two-node merobox workflow: three in-process attempts were
vacuous before the cause was understood.

The two layers keep separate copies of "who is executing", and setting one does
not set the other. `TestHost::call_as` already aligns both, with a comment saying
exactly that — `converge` never got the same treatment.

## What changed

- **`calimero_sdk::testing::with_identity(device, account, f)`** — sets the SDK
  host device and account for a scope and restores both on the way out,
  including on unwind, so a panicking op cannot leak one replica's identity into
  the next. `host::set_device_id` is `pub(crate)`, hence the shim.
- **All three harness apply sites wrapped** — genesis, local apply, gossip — so
  the SDK half tracks the storage half already passed to `env_for`.
- Device and account stay distinct, and `one_account()` still means N devices of
  one person. Flattening either onto the other would make an account-keyed gate
  and a device-keyed one behave identically, which is the confusion this harness
  exists to expose.
- Module docs now state the guarantee, since its absence was the trap.

## Proof

`crates/storage/tests/converge_identity.rs` reads both ids from inside an op —
the vantage an app method has — rather than inspecting the harness's own
plumbing, because the defect was that the plumbing was right on one side and
never reached the other.

**Before** (probe on master):

```
DISTINCT storage::env::device_id() = 3
DISTINCT sdk::env::device_id()     = 1  (value: 237)
```

**After:** 3 and 3.

**Reverting only the storage-side wrapping** fails two of the three new tests
with `left: 1, right: 3`. The third (`a_run_does_not_leak_its_last_replica_identity`)
passes either way by design — it guards the RAII restore against a future
regression rather than covering this bug, and calling it a third regression test
would overstate the evidence.

## Verification

| check | result |
| --- | --- |
| `cargo test -p calimero-storage --features testing` | **806 passed, 0 failed** |
| `cargo test -p calimero-sdk` | 0 failed |
| `cargo fmt --check` | clean |
| `cargo clippy --all-targets --features calimero-storage/testing -- -D warnings` | clean, 0 warnings |
| kv-store / nested-crdt-test / sorted-set-store / team-metrics-custom / team-metrics-macro `--test converge` | 9 passed, 0 failed |

Those five app suites are the blast radius that mattered: they drive the harness
with real `#[app::state]` types, so a perturbed identity would surface there
first. `team-metrics-custom` is the app whose per-device rule exposed the gap.

## Not in this PR

#3815's last checkbox — porting the badge assertion down from
`apps/team-metrics-custom/workflows/` into an in-process test — is now unblocked
but is separate work, and worth doing against a landed harness rather than
alongside a change to it. The E2E stays either way; the point is to stop it
being the *only* proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
