### PR TITLE
ci: take the Windows stdout workaround out of the e2e lane

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -223,22 +223,18 @@ jobs:
       # Pinned exactly, like `setup-merobox` does: a floor would let a later
       # release change what this gate means without anyone choosing it.
       #
-      # 0.6.74 is the first release that can drive a node here at all — 0.6.73
-      # brought native Windows process management, and 0.6.74 stopped script
-      # steps from being run with a literal `/bin/sh`, which is a path Windows
-      # does not have.
+      # Each of these releases fixed something that stopped a node running here:
+      # 0.6.73 native Windows process management (teardown called
+      # `signal.SIGKILL`, which does not exist there), 0.6.74 script steps run
+      # with a literal `/bin/sh`, and 0.6.75 a crash printing merobox's own
+      # emoji banner to a cp1252 stdout. The last of those is why this step no
+      # longer sets `PYTHONIOENCODING`.
       - name: Install merobox
-        run: pip install merobox==0.6.74
+        run: pip install merobox==0.6.75
 
       - name: Run auth-seam e2e (merobox, embedded auth)
         shell: bash
         env:
-          # merobox prints emoji, and Python on Windows defaults stdout to
-          # cp1252, which cannot encode them — it dies on its own banner with
-          # `UnicodeEncodeError: '\U0001f680'` before starting a single node.
-          # Belongs in merobox, which should not depend on every caller
-          # remembering; this unblocks the lane until it lands there.
-          PYTHONIOENCODING: utf-8
           # Same values and same reasoning as the Linux job above: the admin
           # root key is minted at `merod init` from these, and the script step
           # inherits them to log in with. CI-only values for an ephemeral


### PR DESCRIPTION
merobox 0.6.75 reconfigures stdio to UTF-8 at its own entry point (calimero-network/merobox#399), so this job no longer needs to set `PYTHONIOENCODING` for it.

## What the workaround was

Mine, added when the Windows e2e lane first ran and merobox died printing its own banner:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f680'
```

Windows defaults stdout to cp1252, which cannot encode the emoji merobox prints — so `console.print("🚀 Executing Workflow: ...")` raised before a single node started. Setting the encoding here got the lane moving, but it left the fix in two places and made every future caller responsible for knowing. It belongs in merobox, and now it is there.

## Why both edits are in one commit

They are not independent:

- dropping the env var while pinned to `0.6.74` puts the crash straight back
- bumping the pin while keeping the env var leaves the duplication this is meant to remove

Neither half is correct on its own.

## On the pin

Exact, not a floor — matching `setup-merobox`, so a later release cannot change what this gate means without someone choosing it. The comment now records what each version fixed, since all three were needed before a node could run here at all:

| | |
| --- | --- |
| 0.6.73 | native Windows process management — teardown called `signal.SIGKILL`, which does not exist there |
| 0.6.74 | script steps run with a literal `/bin/sh`, a path Windows does not have |
| 0.6.75 | the cp1252 banner crash |

Verified `0.6.75` is on PyPI's `/simple/` index before pinning to it. Merging a release PR does not publish it, and an exact pin against an unpublished version fails at `pip install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)