### PR TITLE
fix(governance)!: carry the admitter endorsement on the envelope

### DIFF
--- a/.github/workflows/sdk-e2e.yml
+++ b/.github/workflows/sdk-e2e.yml
@@ -17,11 +17,26 @@ concurrency:
 
 on:
   pull_request:
+    # `push` below has no filter, so anything missing here does not skip the
+    # job — it defers it until after merge, when master goes red instead of a
+    # PR. That is how #3804 landed a breaking op layout: it changed
+    # `crates/governance-types`, which was not listed, so this job never ran on
+    # the PR and mero-js's borsh encoder was 96 bytes short on master.
+    #
+    # The rule for this list: any crate whose types the SDK re-encodes or whose
+    # HTTP surface it calls. The SDK hand-encodes namespace ops in borsh, so
+    # the governance crates that define those ops belong here as much as the
+    # server that serves them.
     paths:
       - "crates/server/**"
       - "crates/auth/**"
       - "crates/primitives/**"
       - "crates/merod/**"
+      - "crates/governance-types/**"
+      - "crates/governance-store/**"
+      - "crates/context/**"
+      - "crates/context/config/**"
+      - "crates/node/**"
       - ".github/workflows/sdk-e2e.yml"
       - "scripts/resolve-paired-ref.sh"
   push:

--- a/crates/context/src/handlers/apply_signed_namespace_op.rs
+++ b/crates/context/src/handlers/apply_signed_namespace_op.rs
@@ -812,6 +812,7 @@ mod tests {
                 },
             },
             signature: [0u8; 64],
+            admitter_endorsement: None,
         }
     }
 
@@ -891,6 +892,7 @@ mod tests {
                 policy_bytes: Vec::new(),
             }),
             signature: [0u8; 64],
+            admitter_endorsement: None,
         }
     }
 

--- a/crates/context/src/handlers/join_group.rs
+++ b/crates/context/src/handlers/join_group.rs
@@ -519,8 +519,10 @@ impl Handler<JoinGroupRequest> for ContextManager {
                     signed_invitation: invitation,
                     joined_at: now_secs,
                     account: join_account,
-                    admitter_endorsement,
                 });
+                // Handed in rather than embedded: the endorsement rides the
+                // envelope, outside this node's signature, so it is attached
+                // after signing and before the local apply.
                 match calimero_governance_store::sign_apply_and_publish_namespace_op_returning_op(
                     &datastore,
                     &node_client,
@@ -528,6 +530,7 @@ impl Handler<JoinGroupRequest> for ContextManager {
                     namespace_id.into(),
                     &sk,
                     member_joined_op,
+                    Some(admitter_endorsement),
                 )
                 .await
                 {

--- a/crates/context/src/scope_projection.rs
+++ b/crates/context/src/scope_projection.rs
@@ -2522,6 +2522,7 @@ mod tests {
             nonce: 0,
             op: NamespaceOp::Root(op),
             signature: [0u8; 64],
+            admitter_endorsement: None,
         }
     }
 
@@ -2784,6 +2785,7 @@ mod tests {
                 },
             }),
             signature: [0u8; 64],
+            admitter_endorsement: None,
         };
         let delivery_op = op_from_namespace_op(&key_delivery, None, [0xA1; 32], hlc(1), &[]);
         assert_eq!(
@@ -3498,6 +3500,7 @@ mod tests {
                 },
             },
             signature: [0u8; 64],
+            admitter_endorsement: None,
         }
     }
 
@@ -3522,6 +3525,7 @@ mod tests {
                 key_rotation: None,
             },
             signature: [0u8; 64],
+            admitter_endorsement: None,
         }
     }
 }

--- a/crates/context/tests/local_group_governance_convergence.rs
+++ b/crates/context/tests/local_group_governance_convergence.rs
@@ -370,7 +370,7 @@ fn two_nodes_converge_on_namespace_member_joined() {
         &signed_invitation,
     );
 
-    let ns_op = SignedNamespaceOp::sign(
+    let mut ns_op = SignedNamespaceOp::sign(
         &joiner_sk,
         ns_id.into(),
         vec![],
@@ -380,10 +380,10 @@ fn two_nodes_converge_on_namespace_member_joined() {
             signed_invitation,
             joined_at: 1,
             account: calimero_context::test_support::credential(&joiner_pk),
-            admitter_endorsement,
         }),
     )
     .expect("sign MemberJoinedAt");
+    ns_op.admitter_endorsement = Some(admitter_endorsement);
 
     calimero_governance_store::apply_signed_namespace_op(&store_a, &ns_op).unwrap();
     calimero_governance_store::apply_signed_namespace_op(&store_b, &ns_op).unwrap();
@@ -449,7 +449,7 @@ fn member_joined_at_rejects_expired_invitation() {
         &signed_invitation,
     );
 
-    let ns_op = SignedNamespaceOp::sign(
+    let mut ns_op = SignedNamespaceOp::sign(
         &joiner_sk,
         ns_id.into(),
         vec![],
@@ -459,10 +459,10 @@ fn member_joined_at_rejects_expired_invitation() {
             signed_invitation,
             joined_at: 2_000_000,
             account: calimero_context::test_support::credential(&joiner_pk),
-            admitter_endorsement,
         }),
     )
     .expect("sign MemberJoinedAt");
+    ns_op.admitter_endorsement = Some(admitter_endorsement);
 
     let err = calimero_governance_store::apply_signed_namespace_op(&store, &ns_op)
         .expect_err("expired MemberJoinedAt must be rejected on apply");
@@ -612,7 +612,7 @@ fn member_joined_at_accepts_in_window_invitation() {
         &signed_invitation,
     );
 
-    let ns_op = SignedNamespaceOp::sign(
+    let mut ns_op = SignedNamespaceOp::sign(
         &joiner_sk,
         ns_id.into(),
         vec![],
@@ -622,10 +622,10 @@ fn member_joined_at_accepts_in_window_invitation() {
             signed_invitation,
             joined_at: 1_000_000,
             account: calimero_context::test_support::credential(&joiner_pk),
-            admitter_endorsement,
         }),
     )
     .expect("sign MemberJoinedAt");
+    ns_op.admitter_endorsement = Some(admitter_endorsement);
 
     calimero_governance_store::apply_signed_namespace_op(&store_a, &ns_op).unwrap();
     calimero_governance_store::apply_signed_namespace_op(&store_b, &ns_op).unwrap();
@@ -689,7 +689,7 @@ fn member_joined_at_backdated_joined_at_bypasses_apply_gate_documented_residual(
         &signed_invitation,
     );
 
-    let ns_op = SignedNamespaceOp::sign(
+    let mut ns_op = SignedNamespaceOp::sign(
         &joiner_sk,
         ns_id.into(),
         vec![],
@@ -699,10 +699,10 @@ fn member_joined_at_backdated_joined_at_bypasses_apply_gate_documented_residual(
             signed_invitation,
             joined_at: 0,
             account: calimero_context::test_support::credential(&joiner_pk),
-            admitter_endorsement,
         }),
     )
     .expect("sign MemberJoinedAt");
+    ns_op.admitter_endorsement = Some(admitter_endorsement);
 
     calimero_governance_store::apply_signed_namespace_op(&store, &ns_op).unwrap();
     assert!(
@@ -765,7 +765,7 @@ fn member_joined_at_in_window_converges_when_expiration_already_past_wallclock()
         &signed_invitation,
     );
 
-    let ns_op = SignedNamespaceOp::sign(
+    let mut ns_op = SignedNamespaceOp::sign(
         &joiner_sk,
         ns_id.into(),
         vec![],
@@ -775,10 +775,10 @@ fn member_joined_at_in_window_converges_when_expiration_already_past_wallclock()
             signed_invitation,
             joined_at: 999_999,
             account: calimero_context::test_support::credential(&joiner_pk),
-            admitter_endorsement,
         }),
     )
     .expect("sign MemberJoinedAt");
+    ns_op.admitter_endorsement = Some(admitter_endorsement);
 
     calimero_governance_store::apply_signed_namespace_op(&store_a, &ns_op).unwrap();
     calimero_governance_store::apply_signed_namespace_op(&store_b, &ns_op).unwrap();
@@ -835,7 +835,7 @@ fn member_joined_at_ignores_zero_expiration() {
         &signed_invitation,
     );
 
-    let ns_op = SignedNamespaceOp::sign(
+    let mut ns_op = SignedNamespaceOp::sign(
         &joiner_sk,
         ns_id.into(),
         vec![],
@@ -845,10 +845,10 @@ fn member_joined_at_ignores_zero_expiration() {
             signed_invitation,
             joined_at: u64::MAX,
             account: calimero_context::test_support::credential(&joiner_pk),
-            admitter_endorsement,
         }),
     )
     .expect("sign MemberJoinedAt");
+    ns_op.admitter_endorsement = Some(admitter_endorsement);
 
     calimero_governance_store::apply_signed_namespace_op(&store, &ns_op).unwrap();
     assert!(MembershipRepository::new(&store)
@@ -949,7 +949,7 @@ fn recursive_invite_joins_all_descendant_groups() {
             &calimero_context::test_support::account_for(&joiner_pk),
             signed_inv,
         );
-        let ns_op = SignedNamespaceOp::sign(
+        let mut ns_op = SignedNamespaceOp::sign(
             &joiner_sk,
             ns_id.to_bytes().into(),
             vec![],
@@ -959,10 +959,10 @@ fn recursive_invite_joins_all_descendant_groups() {
                 signed_invitation: signed_inv.clone(),
                 joined_at: 1,
                 account: calimero_context::test_support::credential(&joiner_pk),
-                admitter_endorsement,
             }),
         )
         .expect("sign MemberJoinedAt");
+        ns_op.admitter_endorsement = Some(admitter_endorsement);
 
         calimero_governance_store::apply_signed_namespace_op(&store, &ns_op).unwrap();
     }
@@ -2308,7 +2308,7 @@ fn reapplying_namespace_op_keeps_dag_head_set_clean_and_position_embeddable() {
         &signed_invitation,
     );
 
-    let ns_op = SignedNamespaceOp::sign(
+    let mut ns_op = SignedNamespaceOp::sign(
         &joiner_sk,
         ns_id.into(),
         vec![],
@@ -2318,10 +2318,10 @@ fn reapplying_namespace_op_keeps_dag_head_set_clean_and_position_embeddable() {
             signed_invitation,
             joined_at: 1,
             account: calimero_context::test_support::credential(&joiner_pk),
-            admitter_endorsement,
         }),
     )
     .expect("sign MemberJoinedAt");
+    ns_op.admitter_endorsement = Some(admitter_endorsement);
     let op_hash = ns_op.content_hash().expect("content_hash");
 
     // The bug is in one store's head-set bookkeeping, so a single store that
@@ -2446,10 +2446,14 @@ fn apply_join_endorsed(
             signed_invitation: f.signed_invitation.clone(),
             joined_at: 1,
             account: calimero_context::test_support::credential(&f.joiner_sk.public_key()),
-            admitter_endorsement: endorsement,
         }),
     )
     .expect("sign MemberJoinedAt");
+
+    // On the envelope, so the harness can vary the endorsement independently
+    // of the op — which is the whole point of these tests.
+    let mut ns_op = ns_op;
+    ns_op.admitter_endorsement = Some(endorsement);
 
     calimero_governance_store::apply_signed_namespace_op(&f.store, &ns_op)
         .map(|_| ())

--- a/crates/context/tests/op_store_reconstruction.rs
+++ b/crates/context/tests/op_store_reconstruction.rs
@@ -115,6 +115,7 @@ fn op_store_reconstruction_recovers_late_decrypted_membership_after_key_delivery
             key_rotation: None,
         },
         signature: [0u8; 64],
+        admitter_endorsement: None,
     };
     let delta_id = signed.content_hash().unwrap();
 
@@ -206,6 +207,7 @@ fn completeness_gate_flags_governance_ops_missing_from_the_op_store() {
                 key_rotation: None,
             },
             signature: [0u8; 64],
+            admitter_endorsement: None,
         };
         op_from_namespace_op(&signed, None, [id; 32], hlc(u64::from(id)), &[])
     };
@@ -278,6 +280,7 @@ fn locally_authored_op_lands_in_the_op_store_atomically() {
             key_rotation: None,
         },
         signature: [0u8; 64],
+        admitter_endorsement: None,
     };
     let delta_id = signed.content_hash().unwrap();
     NamespaceOpLogService::new(&store, ns_bytes.into())
@@ -370,6 +373,7 @@ fn a_legacy_noop_row_for_an_unreadable_op_is_re_derived_as_a_hole() {
             key_rotation: None,
         },
         signature: [0u8; 64],
+        admitter_endorsement: None,
     };
     let delta_id = signed.content_hash().unwrap();
 

--- a/crates/context/tests/per_device_authorization.rs
+++ b/crates/context/tests/per_device_authorization.rs
@@ -99,6 +99,7 @@ fn namespace_with_member(member: PublicKey) -> (Store, ScopeProjections, Context
             key_rotation: None,
         },
         signature: [0u8; 64],
+        admitter_endorsement: None,
     };
     let delta_id = signed.content_hash().unwrap();
 
@@ -296,6 +297,7 @@ fn a_cut_containing_a_device_link_still_resolves_an_ordinary_member() {
             key_rotation: None,
         },
         signature: [0u8; 64],
+        admitter_endorsement: None,
     };
     let link_cut = signed.content_hash().unwrap();
     proj.ingest_op(&op_from_namespace_op(
@@ -389,6 +391,7 @@ fn a_member_who_enrols_a_device_is_still_a_member_at_later_cuts() {
             key_rotation: None,
         },
         signature: [0u8; 64],
+        admitter_endorsement: None,
     };
     let link_cut = signed.content_hash().unwrap();
     proj.ingest_op(&op_from_namespace_op(
@@ -516,19 +519,23 @@ fn a_joiners_writer_account_matches_what_its_peers_resolve() {
                 signed_invitation: invitation,
                 joined_at: 1,
                 account: credential,
-                admitter_endorsement: Box::new(
-                    calimero_governance_types::AdmitterEndorsement::sign(
-                        &admin_sk,
-                        &ns_bytes,
-                        &joining_member,
-                        &[0x21; 32],
-                    )
-                    .expect("the admin endorses the join"),
-                ),
             },
         ),
     )
     .expect("joiner signs its join");
+    // On the envelope, after signing: the endorsement is outside the joiner's
+    // signature, which is what lets an admitter attach one to an op it did not
+    // author.
+    let mut join = join;
+    join.admitter_endorsement = Some(Box::new(
+        calimero_governance_types::AdmitterEndorsement::sign(
+            &admin_sk,
+            &ns_bytes,
+            &joining_member,
+            &[0x21; 32],
+        )
+        .expect("the admin endorses the join"),
+    ));
     gov.apply_signed_op(&join).expect("the join applies");
 
     // Plane one: what the joiner itself writes as.

--- a/crates/context/tests/projection_membership_equivalence.rs
+++ b/crates/context/tests/projection_membership_equivalence.rs
@@ -155,6 +155,7 @@ fn fold_subgroup_structure(
             restricted: true,
         }),
         signature: [0u8; 64],
+        admitter_endorsement: None,
     };
     proj.ingest_op(&op_from_namespace_op(
         &created,
@@ -199,6 +200,7 @@ fn ns_group_envelope(
             key_rotation: None,
         },
         signature: [0u8; 64],
+        admitter_endorsement: None,
     }
 }
 
@@ -254,7 +256,7 @@ fn projection_matches_live_across_inherited_join_and_root_removal() {
     );
 
     // (1) joiner joins the namespace root via invitation — a DIRECT membership.
-    let join_ns = SignedNamespaceOp::sign(
+    let mut join_ns = SignedNamespaceOp::sign(
         &joiner_sk,
         ns.to_bytes().into(),
         vec![],
@@ -270,15 +272,15 @@ fn projection_matches_live_across_inherited_join_and_root_removal() {
             ),
             joined_at: 1,
             account: test_join_account_for(&joiner),
-            admitter_endorsement: endorse(
-                &admin_sk,
-                &ns.to_bytes(),
-                &calimero_context::test_support::account_for(&joiner),
-                &[0x42; 32],
-            ),
         }),
     )
     .expect("sign join_ns");
+    join_ns.admitter_endorsement = Some(endorse(
+        &admin_sk,
+        &ns.to_bytes(),
+        &calimero_context::test_support::account_for(&joiner),
+        &[0x42; 32],
+    ));
     calimero_governance_store::apply_signed_namespace_op(&store, &join_ns).unwrap();
     let id1 = [0xA1; 32];
     proj.ingest_op(&op_from_namespace_op(&join_ns, None, id1, hlc(1), &[s2]));
@@ -434,7 +436,7 @@ fn projection_matches_live_across_leave_and_rejoin_inheritance() {
     );
 
     // join ns (nonce 1) + inherit subgroup (nonce 2).
-    let join_ns = SignedNamespaceOp::sign(
+    let mut join_ns = SignedNamespaceOp::sign(
         &joiner_sk,
         ns.to_bytes().into(),
         vec![],
@@ -450,15 +452,15 @@ fn projection_matches_live_across_leave_and_rejoin_inheritance() {
             ),
             joined_at: 1,
             account: test_join_account_for(&joiner),
-            admitter_endorsement: endorse(
-                &admin_sk,
-                &ns.to_bytes(),
-                &calimero_context::test_support::account_for(&joiner),
-                &[0x42; 32],
-            ),
         }),
     )
     .unwrap();
+    join_ns.admitter_endorsement = Some(endorse(
+        &admin_sk,
+        &ns.to_bytes(),
+        &calimero_context::test_support::account_for(&joiner),
+        &[0x42; 32],
+    ));
     calimero_governance_store::apply_signed_namespace_op(&store, &join_ns).unwrap();
     proj.ingest_op(&op_from_namespace_op(
         &join_ns,
@@ -530,7 +532,7 @@ fn projection_matches_live_across_leave_and_rejoin_inheritance() {
     // invitation is spent for the identity that used it, so presenting the same
     // one again after exiting cannot readmit them. Coming back means being
     // re-invited.
-    let rejoin_ns = SignedNamespaceOp::sign(
+    let mut rejoin_ns = SignedNamespaceOp::sign(
         &joiner_sk,
         ns.to_bytes().into(),
         vec![],
@@ -546,15 +548,15 @@ fn projection_matches_live_across_leave_and_rejoin_inheritance() {
             ),
             joined_at: 1,
             account: test_join_account_for(&joiner),
-            admitter_endorsement: endorse(
-                &admin_sk,
-                &ns.to_bytes(),
-                &calimero_context::test_support::account_for(&joiner),
-                &[0x43; 32],
-            ),
         }),
     )
     .unwrap();
+    rejoin_ns.admitter_endorsement = Some(endorse(
+        &admin_sk,
+        &ns.to_bytes(),
+        &calimero_context::test_support::account_for(&joiner),
+        &[0x43; 32],
+    ));
     calimero_governance_store::apply_signed_namespace_op(&store, &rejoin_ns).unwrap();
     proj.ingest_op(&op_from_namespace_op(
         &rejoin_ns,
@@ -633,7 +635,7 @@ fn projection_defers_when_cut_ancestry_incomplete() {
 
     // LIVE applies the full chain — root join + inherited subgroup join — so the
     // live resolver authoritatively sees the joiner as an inherited member.
-    let join_ns = SignedNamespaceOp::sign(
+    let mut join_ns = SignedNamespaceOp::sign(
         &joiner_sk,
         ns.to_bytes().into(),
         vec![],
@@ -649,15 +651,15 @@ fn projection_defers_when_cut_ancestry_incomplete() {
             ),
             joined_at: 1,
             account: test_join_account_for(&joiner),
-            admitter_endorsement: endorse(
-                &admin_sk,
-                &ns.to_bytes(),
-                &calimero_context::test_support::account_for(&joiner),
-                &[0x42; 32],
-            ),
         }),
     )
     .unwrap();
+    join_ns.admitter_endorsement = Some(endorse(
+        &admin_sk,
+        &ns.to_bytes(),
+        &calimero_context::test_support::account_for(&joiner),
+        &[0x42; 32],
+    ));
     calimero_governance_store::apply_signed_namespace_op(&store, &join_ns).unwrap();
     let join_sub = SignedNamespaceOp::sign(
         &joiner_sk,
@@ -765,7 +767,7 @@ fn refreshing_the_missing_ancestor_unblocks_the_authoritative_grant() {
 
     // Both join ops are durably applied to the op-store — the state a node holds
     // after the backfill pull delivered them.
-    let join_ns = SignedNamespaceOp::sign(
+    let mut join_ns = SignedNamespaceOp::sign(
         &joiner_sk,
         ns.to_bytes().into(),
         vec![],
@@ -781,15 +783,15 @@ fn refreshing_the_missing_ancestor_unblocks_the_authoritative_grant() {
             ),
             joined_at: 1,
             account: test_join_account_for(&joiner),
-            admitter_endorsement: endorse(
-                &admin_sk,
-                &ns.to_bytes(),
-                &calimero_context::test_support::account_for(&joiner),
-                &[0x42; 32],
-            ),
         }),
     )
     .unwrap();
+    join_ns.admitter_endorsement = Some(endorse(
+        &admin_sk,
+        &ns.to_bytes(),
+        &calimero_context::test_support::account_for(&joiner),
+        &[0x42; 32],
+    ));
     calimero_governance_store::apply_signed_namespace_op(&store, &join_ns).unwrap();
     let join_sub = SignedNamespaceOp::sign(
         &joiner_sk,
@@ -957,7 +959,7 @@ fn a_folded_join_device_does_not_hide_an_inherited_admin() {
     // has no folded presence in the subgroup, so reaching it can only be the
     // inheritance walk. Folding an open-join into the subgroup instead would
     // hand the admin a direct presence there and prove something easier.
-    let admin_join_root = SignedNamespaceOp::sign(
+    let mut admin_join_root = SignedNamespaceOp::sign(
         &admin_sk,
         ns.to_bytes().into(),
         vec![],
@@ -973,10 +975,15 @@ fn a_folded_join_device_does_not_hide_an_inherited_admin() {
             ),
             joined_at: 1,
             account: admin_credential,
-            admitter_endorsement: endorse(&admin_sk, &ns.to_bytes(), &admin_account, &[0x77; 32]),
         }),
     )
     .expect("sign admin root-join");
+    admin_join_root.admitter_endorsement = Some(endorse(
+        &admin_sk,
+        &ns.to_bytes(),
+        &admin_account,
+        &[0x77; 32],
+    ));
     let id0 = [0xB7; 32];
     proj.ingest_op(&op_from_namespace_op(
         &admin_join_root,
@@ -1006,7 +1013,7 @@ fn a_folded_join_device_does_not_hide_an_inherited_admin() {
     );
 
     // The joiner joins the namespace carrying a credential that really folds.
-    let join_ns = SignedNamespaceOp::sign(
+    let mut join_ns = SignedNamespaceOp::sign(
         &joiner_sk,
         ns.to_bytes().into(),
         vec![],
@@ -1022,15 +1029,15 @@ fn a_folded_join_device_does_not_hide_an_inherited_admin() {
             ),
             joined_at: 1,
             account: real_join_account_for(&joiner, [0x3E; 32]),
-            admitter_endorsement: endorse(
-                &admin_sk,
-                &ns.to_bytes(),
-                &calimero_context::test_support::account_for(&joiner),
-                &[0x42; 32],
-            ),
         }),
     )
     .expect("sign join_ns");
+    join_ns.admitter_endorsement = Some(endorse(
+        &admin_sk,
+        &ns.to_bytes(),
+        &calimero_context::test_support::account_for(&joiner),
+        &[0x42; 32],
+    ));
     let id1 = [0xB1; 32];
     proj.ingest_op(&op_from_namespace_op(&join_ns, None, id1, hlc(1), &[id0]));
 
@@ -1677,7 +1684,7 @@ fn the_grant_path_defers_when_an_ancestor_is_unreadable() {
     );
 
     // The joiner is a member at this cut, by an op the projection HAS folded.
-    let join_ns = SignedNamespaceOp::sign(
+    let mut join_ns = SignedNamespaceOp::sign(
         &joiner_sk,
         ns.to_bytes().into(),
         vec![],
@@ -1693,15 +1700,15 @@ fn the_grant_path_defers_when_an_ancestor_is_unreadable() {
             ),
             joined_at: 1,
             account: test_join_account_for(&joiner),
-            admitter_endorsement: endorse(
-                &admin_sk,
-                &ns.to_bytes(),
-                &calimero_context::test_support::account_for(&joiner),
-                &[0x42; 32],
-            ),
         }),
     )
     .expect("sign join");
+    join_ns.admitter_endorsement = Some(endorse(
+        &admin_sk,
+        &ns.to_bytes(),
+        &calimero_context::test_support::account_for(&joiner),
+        &[0x42; 32],
+    ));
     calimero_governance_store::apply_signed_namespace_op(&store, &join_ns).unwrap();
     let joined = [0xD1; 32];
     proj.ingest_op(&op_from_namespace_op(&join_ns, None, joined, hlc(1), &[s2]));

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -620,12 +620,19 @@ impl<'a> NamespaceGovernance<'a> {
     /// so a caller that needs to rebroadcast it later (e.g. after a publish
     /// that reached no peer) can do so without re-signing - re-signing would
     /// mint a second op at the next nonce.
+    /// `endorsement` is an admitter's consent, for the join ops that need one
+    /// and `None` for everything else. Attached after signing, because it is
+    /// deliberately outside the signature — see
+    /// [`SignedNamespaceOp::admitter_endorsement`]. Taken here rather than left
+    /// to the caller so the op is endorsed before it is applied and published:
+    /// attaching it afterwards would apply an op locally that peers refuse.
     pub async fn sign_apply_and_publish_returning_op(
         &self,
         node_client: &calimero_node_primitives::client::NodeClient,
         ack_router: &AckRouter,
         signer_sk: &PrivateKey,
         op: NamespaceOp,
+        endorsement: Option<Box<calimero_governance_types::AdmitterEndorsement>>,
     ) -> EyreResult<(DeliveryReport, SignedNamespaceOp)> {
         let topic = ns_topic(self.namespace_id);
 
@@ -658,6 +665,9 @@ impl<'a> NamespaceGovernance<'a> {
         // `op_hash` on the synthesized best-effort report (below)
         // consistent with the success path, so log correlation works
         // regardless of whether the publish confirmed.
+        let mut signed = signed;
+        signed.admitter_endorsement = endorsement;
+
         let op_hash = hash_scoped_namespace(topic.as_str().as_bytes(), &signed)
             .map_err(|e| eyre::eyre!("hash_scoped_namespace: {e}"))?;
 
@@ -751,7 +761,7 @@ impl<'a> NamespaceGovernance<'a> {
         op: NamespaceOp,
     ) -> EyreResult<DeliveryReport> {
         let (report, _signed) = self
-            .sign_apply_and_publish_returning_op(node_client, ack_router, signer_sk, op)
+            .sign_apply_and_publish_returning_op(node_client, ack_router, signer_sk, op, None)
             .await?;
         Ok(report)
     }
@@ -2475,9 +2485,10 @@ pub async fn sign_apply_and_publish_namespace_op_returning_op(
     namespace_id: NamespaceId,
     signer_sk: &PrivateKey,
     op: NamespaceOp,
+    endorsement: Option<Box<calimero_governance_types::AdmitterEndorsement>>,
 ) -> EyreResult<(DeliveryReport, SignedNamespaceOp)> {
     NamespaceGovernance::new(store, namespace_id)
-        .sign_apply_and_publish_returning_op(node_client, ack_router, signer_sk, op)
+        .sign_apply_and_publish_returning_op(node_client, ack_router, signer_sk, op, endorsement)
         .await
 }
 

--- a/crates/governance-store/src/namespace/membership.rs
+++ b/crates/governance-store/src/namespace/membership.rs
@@ -218,6 +218,59 @@ impl<'a> NamespaceMembershipService<'a> {
 
     /// Whether this node may admit a claim of `invitation`.
     ///
+    /// Endorse `member`'s join under `signed_invitation`, if this node may.
+    ///
+    /// `Ok(None)` means this node is not an account the invitation named, which
+    /// is an ordinary answer rather than a fault: a member that is not an
+    /// admitter can still serve the key and the governance history, it just
+    /// cannot authorise a membership. The caller reports that as "not endorsed"
+    /// and the joiner goes looking for a node that can.
+    ///
+    /// Shared by the two ways a join gets endorsed — the sync responder
+    /// answering a peer, and the admin endpoint answering a keyholder that has
+    /// no node of its own — because the alternative is two copies of the same
+    /// signing rule drifting apart. The payload is the one the apply gate
+    /// re-derives, so what this node asserts and what every peer verifies are
+    /// the same bytes.
+    ///
+    /// # Errors
+    ///
+    /// When the store cannot be read. A missing identity or binding is
+    /// `Ok(None)`, not an error: it means this node has nothing to endorse
+    /// with.
+    pub fn endorse_join(
+        store: &Store,
+        namespace: &ContextGroupId,
+        member: &AccountId,
+        signed_invitation: &SignedGroupOpenInvitation,
+    ) -> EyreResult<Option<calimero_governance_types::AdmitterEndorsement>> {
+        // This node's own namespace identity — the key it signs governance
+        // with, and the one whose account the invitation's list is checked
+        // against.
+        let Some((signer, secret)) =
+            crate::NamespaceRepository::new(store).resolve_identity(namespace)?
+        else {
+            return Ok(None);
+        };
+
+        let Some(account) = crate::member_account_in_namespace(store, namespace, &signer)? else {
+            return Ok(None);
+        };
+
+        if !signed_invitation.invitation.admitters.contains(&account) {
+            return Ok(None);
+        }
+
+        let endorsement = calimero_governance_types::AdmitterEndorsement::sign(
+            &calimero_primitives::identity::PrivateKey::from(secret),
+            &namespace.to_bytes(),
+            member,
+            &signed_invitation.invitation.invitation_nonce,
+        )?;
+
+        Ok(Some(endorsement))
+    }
+
     /// The list names who may, and everyone else must refuse — including a node
     /// that would otherwise have validated the invitation perfectly well.
     ///
@@ -337,16 +390,16 @@ impl<'a> NamespaceMembershipService<'a> {
         signed_invitation: &SignedGroupOpenInvitation,
         endorsement: Option<&calimero_governance_types::AdmitterEndorsement>,
     ) -> EyreResult<()> {
-        // `MemberJoined` — the pre-`joined_at` variant — has nowhere to carry
-        // consent. Refused rather than waved through: a variant that cannot be
-        // endorsed cannot authorise a membership once `admitters` means
-        // anything, and accepting it would leave the whole gate bypassable by
-        // choosing the older op.
+        // No endorsement, no membership. `admitters` names who may complete a
+        // join, and the joiner signs its own — so without an admitter's
+        // signature the list restricts nothing: a holder of a valid invitation
+        // could publish and every peer would fold it.
+        //
+        // The endorsement rides the envelope rather than the op body, so this
+        // applies uniformly to both join variants; neither can dodge the gate
+        // by being the older shape.
         let Some(endorsement) = endorsement else {
-            bail!(
-                "join op carries no admitter endorsement; the legacy MemberJoined variant \
-                 cannot express one and is no longer sufficient to admit a member"
-            );
+            bail!("join op carries no admitter endorsement, so nobody entitled to admit this member has agreed to it");
         };
         let inv = &signed_invitation.invitation;
 

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -231,11 +231,16 @@ async fn sign_apply_and_publish_returns_the_signed_op() {
         signed_invitation,
         joined_at: 0,
         account: crate::test_fixtures::real_join_account(&sk.public_key()),
-        admitter_endorsement,
     });
 
     let (report, signed) = NamespaceGovernance::new(&store, ns_id)
-        .sign_apply_and_publish_returning_op(&node_client, &ack_router, &sk, op)
+        .sign_apply_and_publish_returning_op(
+            &node_client,
+            &ack_router,
+            &sk,
+            op,
+            Some(admitter_endorsement),
+        )
         .await
         .expect("publish");
 
@@ -272,11 +277,16 @@ async fn a_published_op_is_fed_to_the_local_apply_path() {
         signed_invitation,
         joined_at: 0,
         account: crate::test_fixtures::real_join_account(&sk.public_key()),
-        admitter_endorsement,
     });
 
     let (_report, signed) = NamespaceGovernance::new(&store, ns_id)
-        .sign_apply_and_publish_returning_op(&node_client, &ack_router, &sk, op)
+        .sign_apply_and_publish_returning_op(
+            &node_client,
+            &ack_router,
+            &sk,
+            op,
+            Some(admitter_endorsement),
+        )
         .await
         .expect("publish");
     let published = signed.content_hash().expect("content hash");

--- a/crates/governance-store/src/ops/namespace.rs
+++ b/crates/governance-store/src/ops/namespace.rs
@@ -102,17 +102,30 @@ pub(crate) fn dispatch_root_op(
             role,
             account,
         ),
+        // Both join arms read the endorsement off the ENVELOPE, not the op
+        // body. It is not covered by the joiner's signature, which is what
+        // lets an admitter attach consent to an op it did not author — see
+        // `SignedNamespaceOp::admitter_endorsement`. Neither arm gets to
+        // decide whether one is required; that is the gate's call, and it
+        // requires one from both.
         RootOp::MemberJoined {
             member,
             signed_invitation,
             account,
-        } => member_joined::apply(ctx, op, member, signed_invitation, None, account, None),
+        } => member_joined::apply(
+            ctx,
+            op,
+            member,
+            signed_invitation,
+            None,
+            account,
+            op.admitter_endorsement.as_deref(),
+        ),
         RootOp::MemberJoinedAt {
             member,
             signed_invitation,
             joined_at,
             account,
-            admitter_endorsement,
         } => member_joined::apply(
             ctx,
             op,
@@ -120,7 +133,7 @@ pub(crate) fn dispatch_root_op(
             signed_invitation,
             Some(*joined_at),
             account,
-            Some(&**admitter_endorsement),
+            op.admitter_endorsement.as_deref(),
         ),
         RootOp::MemberJoinedOpen {
             member,

--- a/crates/governance-store/src/tests.rs
+++ b/crates/governance-store/src/tests.rs
@@ -4158,18 +4158,22 @@ fn member_joined_clears_deny_list_for_rejoiner() {
             signed_invitation,
             joined_at: 1,
             account: crate::test_fixtures::real_join_account(&member_sk.public_key()),
-            admitter_endorsement: Box::new(
-                calimero_governance_types::AdmitterEndorsement::sign(
-                    &admin_sk,
-                    &ns_id,
-                    &member,
-                    &[0x42; 32],
-                )
-                .expect("the admin endorses the rejoin"),
-            ),
         }),
     )
     .unwrap();
+    // On the envelope, after signing: the endorsement is outside the joiner's
+    // signature, which is what lets an admitter attach one to an op it did not
+    // author.
+    let mut signed = signed;
+    signed.admitter_endorsement = Some(Box::new(
+        calimero_governance_types::AdmitterEndorsement::sign(
+            &admin_sk,
+            &ns_id,
+            &member,
+            &[0x42; 32],
+        )
+        .expect("the admin endorses the rejoin"),
+    ));
     apply_signed_namespace_op(&store, &signed).unwrap();
 
     // The join materialized the joiner's direct membership row...
@@ -5484,10 +5488,12 @@ fn apply_member_joined(
             signed_invitation,
             joined_at: 1,
             account: crate::test_fixtures::real_join_account(&member_sk.public_key()),
-            admitter_endorsement,
         }),
     )
     .unwrap();
+    // On the envelope, after signing — see above.
+    let mut signed = signed;
+    signed.admitter_endorsement = Some(admitter_endorsement);
     apply_signed_namespace_op(store, &signed).map(|_result| ())
 }
 

--- a/crates/governance-types/src/lib.rs
+++ b/crates/governance-types/src/lib.rs
@@ -906,26 +906,6 @@ pub enum RootOp {
         /// Required and boxed; see [`JoinAccountCredential`] for why this rides
         /// the join op and why it is not optional.
         account: Box<JoinAccountCredential>,
-        /// An admitter's consent to this join.
-        ///
-        /// Required, not optional, and that is the whole point. `admitters`
-        /// names who may complete a membership, and the joiner signs its own
-        /// join — so without evidence in the op that an admitter agreed, the
-        /// list restricts nothing: a holder of a valid invitation could publish
-        /// and every peer would fold it. An `Option` here would leave exactly
-        /// that hole open under a different name.
-        ///
-        /// Verified by every peer at apply against
-        /// [`admitter_endorsement_payload`], with the signer resolved to an
-        /// account and checked against the invitation's *signed* `admitters`.
-        /// The check reads only the op, so every replica reaches the same
-        /// verdict — a gate that consulted local state instead would make
-        /// membership depend on who was asking.
-        ///
-        /// Boxed for the same reason the credential beside it is: this variant
-        /// is much the largest, and `NamespaceOp` is moved around by value on
-        /// every apply and sync path, so the whole enum would pay for it.
-        admitter_endorsement: Box<AdmitterEndorsement>,
     },
     /// **Namespace genesis (#2474).** The first op in every namespace DAG:
     /// authoritatively records the namespace's founding administrator/owner.
@@ -1309,6 +1289,30 @@ pub struct SignedNamespaceOp {
     pub nonce: u64,
     pub op: NamespaceOp,
     pub signature: [u8; 64],
+    /// An admitter's consent to the membership this op records, when it records
+    /// one. `None` on every op that admits nobody.
+    ///
+    /// **On the envelope, deliberately outside `signature` and outside the op
+    /// id.** It is self-authenticating — a signature over
+    /// [`admitter_endorsement_payload`], naming the namespace, the joiner and
+    /// the invitation — so the joiner signing it too adds nothing, while NOT
+    /// signing it buys the thing that matters: whoever relays a join can attach
+    /// consent without invalidating the joiner's signature or changing the op's
+    /// identity. That is what lets a keyholder be admitted at all. It has no
+    /// node, so it signs its own join, hands it to an admitter, and the
+    /// admitter attaches its consent as it relays.
+    ///
+    /// [`to_signable`](SignedNamespaceOp::to_signable) does not copy it, and
+    /// that is load-bearing rather than incidental: `content_hash` is taken
+    /// over the signable form, so two nodes holding the same op with and
+    /// without an endorsement still agree on its id. Copying it there would
+    /// turn attaching consent into a fork.
+    ///
+    /// Unsigned costs nothing an attacker can use. Stripping it makes the apply
+    /// refuse the join — fail closed. Substituting a different endorsement that
+    /// verifies is a no-op, because any such endorsement is over the same
+    /// namespace, joiner and invitation as the one removed.
+    pub admitter_endorsement: Option<Box<AdmitterEndorsement>>,
 }
 
 /// Wire/schema version for [`SignedNamespaceOp`].
@@ -1340,7 +1344,13 @@ pub struct SignedNamespaceOp {
 /// a credential so the founder is bound at genesis — it is the one member no
 /// join op ever admits. Both change the layout of signed structures, so every op
 /// id changes: another re-bootstrap.
-pub const SIGNED_NAMESPACE_OP_SCHEMA_VERSION: u8 = 7;
+/// v8: the admitter endorsement moved off `RootOp::MemberJoinedAt` and onto the
+/// envelope as `SignedNamespaceOp::admitter_endorsement`. The op body loses a
+/// field, so every join op's layout and id changes — another re-bootstrap. The
+/// move is what makes a keyholder join possible: the endorsement is no longer
+/// covered by the joiner's signature, so an admitter can attach its consent to
+/// an op it did not author and cannot alter.
+pub const SIGNED_NAMESPACE_OP_SCHEMA_VERSION: u8 = 8;
 
 /// Domain separation prefix for Ed25519 signatures over namespace ops.
 /// Domain separator for an admitter's endorsement of a join.
@@ -1476,6 +1486,13 @@ impl SignedNamespaceOp {
             nonce: signable.nonce,
             op: signable.op,
             signature: sig.to_bytes(),
+            // Unendorsed. Signing and endorsing are separate acts by separate
+            // parties — the joiner proves it owns the account, an admitter agrees
+            // to admit it — so whoever holds the admitter's key attaches that
+            // afterwards. Nothing here is invalidated by doing so: both the
+            // signature and the op id are taken over the signable form, which does
+            // not carry this field.
+            admitter_endorsement: None,
         })
     }
 

--- a/crates/governance-types/src/tests.rs
+++ b/crates/governance-types/src/tests.rs
@@ -795,11 +795,7 @@ const GOLDEN_ROOT_OP_MEMBER_JOINED_AT: &[u8] = &[
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 253, 23, 36, 56, 90, 160, 199, 91, 100, 251, 120, 205, 96, 47, 161, 217, 145, 253, 235, 247,
-    107, 19, 197, 142, 215, 2, 234, 200, 53, 233, 246, 24, 34, 248, 147, 216, 134, 95, 199, 255,
-    139, 123, 113, 113, 41, 102, 216, 17, 205, 215, 186, 145, 232, 68, 250, 143, 63, 92, 68, 158,
-    220, 239, 127, 72, 115, 104, 53, 223, 2, 229, 188, 6, 206, 115, 142, 11, 180, 61, 164, 199, 54,
-    124, 48, 244, 58, 167, 129, 99, 247, 92, 198, 122, 168, 119, 65, 12,
+    0,
 ];
 
 /// NamespaceOp::Root(RootOp::NamespaceCreated) — RootOp ordinal 9
@@ -1620,6 +1616,7 @@ fn pre_flag_day_namespace_op_version_is_rejected() {
             policy_bytes: vec![],
         }),
         signature: [0u8; 64],
+        admitter_endorsement: None,
     };
     assert!(
         matches!(
@@ -1794,6 +1791,69 @@ mod governance_op_storage_roundtrip {
     }
 
     #[test]
+    fn an_endorsed_envelope_roundtrips_and_keeps_the_op_it_was() {
+        // The property the endorsement design rests on: `content_hash` is taken
+        // over the SIGNABLE form, which does not carry the endorsement, so an
+        // admitter can attach consent to an op it did not author and every
+        // replica still agrees which op it is — and the joiner's signature
+        // still verifies over what the joiner actually signed.
+        //
+        // If the field ever reaches `to_signable`, attaching consent becomes a
+        // fork: the relaying node's copy and the author's copy would have
+        // different ids for the same op. That failure would surface far from
+        // here, as peers disagreeing about history.
+        let unendorsed = signed(NamespaceOp::Root(RootOp::MemberJoinedAt {
+            member: calimero_account::AccountId::from(*PrivateKey::random(&mut OsRng).public_key()),
+            signed_invitation: sample_invitation(),
+            joined_at: 1_800_000_000,
+            account: sample_join_account(),
+        }));
+
+        let id_before = unendorsed.content_hash().expect("hash the unendorsed op");
+        unendorsed
+            .verify_signature()
+            .expect("the author's signature verifies");
+
+        let mut endorsed = unendorsed.clone();
+        endorsed.admitter_endorsement = Some(Box::new(deterministic_endorsement()));
+
+        assert_eq!(
+            endorsed.content_hash().expect("hash the endorsed op"),
+            id_before,
+            "attaching an endorsement must not change the op's id"
+        );
+        assert_eq!(
+            endorsed.signature, unendorsed.signature,
+            "attaching an endorsement must not disturb the author's signature"
+        );
+        endorsed
+            .verify_signature()
+            .expect("the author's signature still verifies once consent is attached");
+
+        // Non-vacuity: the endorsement really is in the encoded envelope. Without
+        // this, the id assertion above would also hold if the field were being
+        // silently dropped, and the test would pass while proving nothing.
+        let bytes_unendorsed = ::borsh::to_vec(&unendorsed).expect("encode unendorsed");
+        let bytes_endorsed = ::borsh::to_vec(&endorsed).expect("encode endorsed");
+        assert_ne!(
+            bytes_unendorsed, bytes_endorsed,
+            "the endorsement must actually be encoded, or the id assertion above \
+             is trivially true"
+        );
+        assert_eq!(
+            bytes_endorsed.len(),
+            // borsh writes `Some` as a 1-byte tag, then the 32-byte signer and
+            // the 64-byte signature.
+            bytes_unendorsed.len() + 96,
+            "an endorsed envelope is exactly the signer and signature longer"
+        );
+
+        // And it survives the store round trip, which is what carries it to
+        // every peer that has to re-check it.
+        assert_roundtrips(&endorsed);
+    }
+
+    #[test]
     fn member_joined_at_roundtrips_through_stored_signed_entry() {
         // The invitation join carries a nested `SignedGroupOpenInvitation`, the
         // largest and most field-rich op payload — the one most exposed to a
@@ -1803,7 +1863,6 @@ mod governance_op_storage_roundtrip {
             signed_invitation: sample_invitation(),
             joined_at: 1_800_000_000,
             account: sample_join_account(),
-            admitter_endorsement: Box::new(deterministic_endorsement()),
         })));
     }
 
@@ -1854,7 +1913,6 @@ mod governance_op_storage_roundtrip {
                 signed_invitation: sample_invitation(),
                 joined_at: 42,
                 account: sample_join_account(),
-                admitter_endorsement: Box::new(deterministic_endorsement()),
             },
         ];
         for root in ops {
@@ -1923,9 +1981,9 @@ mod governance_op_storage_roundtrip {
                 signed_invitation: invitation,
                 joined_at: 1_900_000_000,
                 account,
-                admitter_endorsement: Box::new(deterministic_endorsement()),
             }),
             signature: [0u8; 64],
+            admitter_endorsement: None,
         }
     }
 
@@ -1986,6 +2044,7 @@ mod governance_op_storage_roundtrip {
                 new_admin: calimero_account::AccountId::from([1u8; 32]),
             }),
             signature: [0u8; 64],
+            admitter_endorsement: None,
         };
         assert!(
             op.validate().is_err(),
@@ -2303,7 +2362,6 @@ fn emit_golden_root_op_vectors() {
                 signed_invitation: minimal_invitation.clone(),
                 joined_at: 0,
                 account: deterministic_credential(),
-                admitter_endorsement: Box::new(deterministic_endorsement()),
             }),
         ),
     ] {

--- a/crates/node/src/membership_republish_e2e.rs
+++ b/crates/node/src/membership_republish_e2e.rs
@@ -70,7 +70,7 @@ fn queued_join_op(
     joiner_sk: &PrivateKey,
     invitation: SignedGroupOpenInvitation,
 ) -> SignedNamespaceOp {
-    SignedNamespaceOp::sign(
+    let op = SignedNamespaceOp::sign(
         joiner_sk,
         NS.into(),
         Vec::new(),
@@ -82,20 +82,24 @@ fn queued_join_op(
             signed_invitation: invitation,
             joined_at: 0,
             account: test_join_account(),
-            // A joiner only ever queues an endorsed join — without one it fails
-            // rather than republishing, so the republish fixture carries one.
-            admitter_endorsement: Box::new(
-                calimero_governance_types::AdmitterEndorsement::sign(
-                    &calimero_primitives::identity::PrivateKey::from([5u8; 32]),
-                    &[7u8; 32],
-                    &test_join_account().statement.account,
-                    &[0u8; 32],
-                )
-                .expect("sign endorsement"),
-            ),
         }),
     )
-    .expect("sign join op")
+    .expect("sign join op");
+
+    // A joiner only ever queues an endorsed join — without one it fails rather
+    // than republishing, so the republish fixture carries one. On the envelope,
+    // after signing: the endorsement is outside the joiner's signature.
+    let mut op = op;
+    op.admitter_endorsement = Some(Box::new(
+        calimero_governance_types::AdmitterEndorsement::sign(
+            &calimero_primitives::identity::PrivateKey::from([5u8; 32]),
+            &[7u8; 32],
+            &test_join_account().statement.account,
+            &[0u8; 32],
+        )
+        .expect("sign endorsement"),
+    ));
+    op
 }
 
 /// The single gossipsub payload this node put on the wire, decoded through the

--- a/crates/node/src/readiness/tests.rs
+++ b/crates/node/src/readiness/tests.rs
@@ -674,19 +674,20 @@ fn test_signed_op() -> SignedNamespaceOp {
             signed_invitation: test_invitation(),
             joined_at: 0,
             account: test_join_account(),
-            // A shape test, so this only has to be well formed — the apply is
-            // what checks an endorsement actually names an admitter.
-            admitter_endorsement: Box::new(
-                calimero_governance_types::AdmitterEndorsement::sign(
-                    &calimero_primitives::identity::PrivateKey::from([5u8; 32]),
-                    &[7u8; 32],
-                    &test_join_account().statement.account,
-                    &[0u8; 32],
-                )
-                .expect("sign endorsement"),
-            ),
         }),
         signature: [9u8; 64],
+        // A shape test, so this only has to be well formed — the apply is what
+        // checks an endorsement actually names an admitter. On the envelope now,
+        // which is where it travels.
+        admitter_endorsement: Some(Box::new(
+            calimero_governance_types::AdmitterEndorsement::sign(
+                &calimero_primitives::identity::PrivateKey::from([5u8; 32]),
+                &[7u8; 32],
+                &test_join_account().statement.account,
+                &[0u8; 32],
+            )
+            .expect("sign endorsement"),
+        )),
     }
 }
 

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -820,45 +820,15 @@ impl SyncManager {
         //
         // Signed over the payload the apply gate checks, so what this node
         // asserts and what every other node verifies are the same bytes.
-        let admitter_endorsement_bytes = {
-            // This node's own namespace identity — the key it signs governance
-            // with, and the one whose account the invitation's list is checked
-            // against.
-            let own = calimero_governance_store::NamespaceRepository::new(&store)
-                .resolve_identity(&namespace)
-                .ok()
-                .flatten();
-
-            let self_account = own.as_ref().and_then(|(pk, _)| {
-                calimero_governance_store::member_account_in_namespace(&store, &namespace, pk)
-                    .ok()
-                    .flatten()
-            });
-
-            match self_account {
-                Some(account) if invitation.invitation.admitters.contains(&account) => {
-                    let payload = calimero_governance_types::admitter_endorsement_payload(
-                        &namespace_id,
-                        &joiner_account,
-                        &invitation.invitation.invitation_nonce,
-                    );
-                    // `own` is Some whenever `self_account` resolved from it.
-                    let (signer, secret) = own.expect("identity resolved for the account above");
-                    match calimero_primitives::identity::PrivateKey::from(secret).sign(&payload) {
-                        Ok(signature) => {
-                            let endorsement = calimero_governance_types::AdmitterEndorsement {
-                                signer,
-                                signature: signature.to_bytes(),
-                            };
-                            borsh::to_vec(&endorsement).ok()
-                        }
-                        Err(err) => {
-                            warn!(%err, "namespace join: could not sign the admitter endorsement");
-                            None
-                        }
-                    }
-                }
-                _ => {
+        let admitter_endorsement_bytes =
+            match calimero_governance_store::NamespaceMembershipService::endorse_join(
+                &store,
+                &namespace,
+                &joiner_account,
+                &invitation,
+            ) {
+                Ok(Some(endorsement)) => borsh::to_vec(&endorsement).ok(),
+                Ok(None) => {
                     debug!(
                         namespace_id = %hex::encode(namespace_id),
                         "namespace join: this node is not an admitter for the invitation, \
@@ -866,8 +836,11 @@ impl SyncManager {
                     );
                     None
                 }
-            }
-        };
+                Err(err) => {
+                    warn!(%err, "namespace join: could not sign the admitter endorsement");
+                    None
+                }
+            };
 
         debug!(
             namespace_id = %hex::encode(namespace_id),

--- a/crates/op-adapter/src/tests/root.rs
+++ b/crates/op-adapter/src/tests/root.rs
@@ -13,17 +13,6 @@ use calimero_primitives::identity::PublicKey;
 use crate::payload_from_root_op;
 use crate::tests::support::{real_join_account_for, test_join_account_for};
 
-/// A well-formed endorsement, signed so no test hand-rolls signature bytes.
-fn endorsement_for(seed: [u8; 32]) -> calimero_governance_types::AdmitterEndorsement {
-    calimero_governance_types::AdmitterEndorsement::sign(
-        &calimero_primitives::identity::PrivateKey::from(seed),
-        &[0x91; 32],
-        &AccountId::from([0x63; 32]),
-        &[0x33; 32],
-    )
-    .expect("sign endorsement")
-}
-
 /// An admin-signed invitation for `group`, granting Admin (`invited_role: 0`).
 fn invitation_for(group: [u8; 32]) -> SignedGroupOpenInvitation {
     SignedGroupOpenInvitation {
@@ -145,11 +134,6 @@ fn root_op_encoder_mapping() {
             signed_invitation,
             joined_at: 42,
             account: invited_at.clone(),
-            // The projection maps membership, and an endorsement authorises a
-            // join rather than describing one — so this is deliberately just a
-            // well-formed value. Nothing here verifies it; the apply does, and
-            // that is where the fixtures have to be genuine.
-            admitter_endorsement: Box::new(endorsement_for([0x71; 32])),
         }),
         Some(OpPayload::MemberJoinedWithDevice {
             group: ContextGroupId::from(gid),

--- a/crates/server/src/admin/handlers/namespaces/admit_join.rs
+++ b/crates/server/src/admin/handlers/namespaces/admit_join.rs
@@ -68,7 +68,7 @@ pub async fn handler(
     // topic — anything handed to it, signed by anyone, published under its own
     // connection. Decoding costs one borsh parse and bounds what this endpoint
     // can be used for.
-    let op: SignedNamespaceOp = match borsh::from_slice(&signed_op_bytes) {
+    let mut op: SignedNamespaceOp = match borsh::from_slice(&signed_op_bytes) {
         Ok(op) => op,
         Err(e) => {
             return ApiError {
@@ -171,6 +171,55 @@ pub async fn handler(
         .into_response();
     }
 
+    // This node's consent, attached to the op it is about to carry.
+    //
+    // The joiner could not have supplied this: it has no node, and an
+    // endorsement can only be signed by an account the invitation named. So the
+    // admitter adds its own as it relays — which is possible precisely because
+    // the endorsement rides the envelope and is outside the joiner's signature.
+    // Attaching it changes neither that signature nor the op's id.
+    //
+    // Overwritten rather than preserved if the caller sent one. Whatever a
+    // keyholder put there, this node is the one vouching for the op it
+    // publishes under its own connection, and `require_may_admit` above has
+    // already established it may. A caller-supplied endorsement would have to
+    // be re-verified to be worth keeping, and there is nothing to gain by
+    // keeping it: any endorsement that verifies is over the same namespace,
+    // joiner and invitation as the one written here.
+    let member = match joining_member(&op.op) {
+        Some(member) => *member,
+        // `carries_a_join` already established the variant.
+        None => {
+            return ApiError {
+                status_code: StatusCode::BAD_REQUEST,
+                message: "signed_op is not a join; an admitter carries joins only".to_owned(),
+            }
+            .into_response();
+        }
+    };
+
+    match calimero_governance_store::NamespaceMembershipService::endorse_join(
+        &state.store,
+        &namespace_id,
+        &member,
+        &req.invitation,
+    ) {
+        Ok(Some(endorsement)) => op.admitter_endorsement = Some(Box::new(endorsement)),
+        // `require_may_admit` passed, so the invitation names an account —
+        // reaching here means this node cannot resolve its own identity to
+        // that account, i.e. it is named but holds nothing to sign with.
+        Ok(None) => {
+            return ApiError {
+                status_code: StatusCode::CONFLICT,
+                message: "this node is named as an admitter but holds no namespace identity \
+                          bound to that account, so it cannot endorse this join"
+                    .to_owned(),
+            }
+            .into_response();
+        }
+        Err(err) => return parse_api_error(err).into_response(),
+    }
+
     // Applied here before it is published anywhere.
     //
     // Publishing alone leaves this node with the stalest possible view of the
@@ -238,6 +287,16 @@ pub async fn handler(
 ///
 /// `MemberJoinedOpen` is deliberately absent: it carries no invitation, so there
 /// is nothing naming this node as entitled to carry it.
+/// The account a join op admits, for either join variant.
+const fn joining_member(op: &NamespaceOp) -> Option<&calimero_account::AccountId> {
+    match op {
+        NamespaceOp::Root(
+            RootOp::MemberJoined { member, .. } | RootOp::MemberJoinedAt { member, .. },
+        ) => Some(member),
+        _ => None,
+    }
+}
+
 const fn carries_a_join(op: &NamespaceOp) -> bool {
     matches!(
         op,

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -360,6 +360,7 @@ pub(crate) fn setup(
         .route(
             "/namespaces/{namespace_id}/admit",
             post(namespaces::admit_join::handler),
+
         )
         .route(
             "/namespaces/{namespace_id}/leave",


### PR DESCRIPTION
sdk-ref: fix/keyholder-endorsement-endpoint

**Unbreaks master.** `SDK E2E (paired)` has been red since #3804 landed:

```
HTTP 400: signed_op is not a SignedNamespaceOp: Unexpected length of input
  POST /admin-api/namespaces/<ns>/admit
```

## What broke

#3804 added a required `admitter_endorsement` **inside** `RootOp::MemberJoinedAt`. `mero-js` hand-encodes that op's borsh layout, so its encoding went 96 bytes short and every keyholder join was refused.

I claimed in #3804 that no SDK encodes this op. That was wrong — I grepped only `mero-js/src` on a stale local checkout, while the test file says plainly *"the test that makes the borsh encoding in `signMemberJoinOp` honest."*

## Inside the signature was the wrong place

Not just for the SDK — the keyholder flow cannot work that way at all:

- A keyholder has no node, so it **signs its own join**. It therefore needs the endorsement *before* signing.
- An endorsement can only be signed by an account the invitation named. A keyholder is not one. It cannot have one.
- `/admit` cannot supply it either: the first thing that endpoint does is verify the joiner's signature, so attaching anything that signature covers invalidates what it just checked.

So the endorsement moves onto **`SignedNamespaceOp`**, outside `signature` and outside the op id. `/admit` now attaches its own as it relays — which it is entitled to do, because it has already proved it is a named admitter.

*(An earlier revision of this PR added a `POST /namespaces/:id/endorse` endpoint so a keyholder could fetch one first. That worked, but it bought a round trip and permanent API surface to work around a field being in the wrong place. Dropped.)*

## Why unsigned is safe

The endorsement is self-authenticating: a signature over the namespace, the joiner and the invitation. So the joiner signing it adds nothing, and:

- **Stripping it** makes the apply refuse the join — fail closed.
- **Substituting** another endorsement that verifies is a no-op, because any such endorsement is over the same namespace, joiner and invitation as the one removed.

## The property this rests on

`to_signable` does not copy the field, and `content_hash` is taken over the signable form — so attaching consent leaves the op's **id** alone. If the field ever reached the signable form, relaying a join would **fork history**: the relay's copy and the author's copy would be different ops, surfacing far away as peers disagreeing about history.

`an_endorsed_envelope_roundtrips_and_keeps_the_op_it_was` pins the id and the signature across attachment, and — so the check is not vacuous — that the encoded envelope really does grow by the 96 bytes of signer and signature. Without that second assertion it would also pass if the field were being silently dropped.

## Retires a special case

#3804 refused `MemberJoined` because it "could not express consent". On the envelope it can, so both join arms now read the same field and neither dodges the gate by being the older shape. That variant stays unusable regardless: the pre-existing `joined_at is absent` gate refuses it for any expiring invitation, and core clamps every invitation to a maximum validity.

## Schema version 7 → 8

The op body reverts to **byte-identical to before #3804** — the regenerated golden confirms it at 399 bytes, its original size. The envelope layout changes for every op, hence the bump and a re-bootstrap.

## The CI gap that let this through

`sdk-e2e.yml` filters `pull_request` by path — `crates/server`, `crates/auth`, `crates/primitives`, `crates/merod` — and #3804 touched none of them. But `push: master` has **no** filter. So a missing path does not *skip* that job, it **defers** it until after merge, when master goes red instead of a PR.

Widened to the governance, context and node crates, with the rule recorded in the workflow: any crate whose types the SDK re-encodes, or whose HTTP surface it calls.

## Paired

calimero-network/mero-js#134, same branch name. Because the op body is unchanged, that side is now **two edits in one file** — bump the schema version, and append the borsh `None` tag for the endorsement slot. No client method, no new types, no test changes.

## Merge order

1. **this PR** — additive on the SDK's side of the contract
2. **mero-js#134**
3. **dispatch `sdk-e2e` on master** to confirm — on `push` the paired ref resolves to mero-js *master*, so master only clears once both have landed
