### PR TITLE
chore(release): 0.11.0-rc.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core Calimero infrastructure and tools"
 # Update workspace metadata (see docs/RELEASE.md for versioning and release)
 [workspace.metadata.workspaces]
 # Shared version of all public crates; bump this when cutting a release.
-version = "0.11.0-rc.31"
+version = "0.11.0-rc.32"
 exclude = [
     "./crates/git-hooks",
     "./apps/abi_conformance",


### PR DESCRIPTION
Bumps `[workspace.metadata.workspaces] version` to `0.11.0-rc.32`. One line, same shape as #3792.

## Why now

Cut off #3819, so this release carries **schema version 8** — the admitter endorsement moved onto the `SignedNamespaceOp` envelope.

That timing is the whole point. calimero-network/mero-js#134 writes the v8 envelope, and its `E2E (vs released merod)` job runs against the latest **release**, not master. With rc.31 as the newest release, that job fails on version skew no matter what the SDK does:

```
HTTP 400: signed_op is not a SignedNamespaceOp: Not all bytes read
```

So the sequence this unblocks is:

1. **this PR** → rc.32 exists, carrying v8
2. **mero-js#134** merges green against rc.32
3. **dispatch `sdk-e2e` on core master** — on `push` the paired ref resolves to mero-js *master*, so that dispatch is what confirms both halves agree

Step 3 is what finally clears core master's `SDK E2E (paired)`, red since #3804.

## Note for whoever reviews

This is a breaking wire change for anything that encodes namespace ops: the envelope layout changed for **every** op, so nodes and SDKs need to move together. `SIGNED_NAMESPACE_OP_SCHEMA_VERSION` went 7 → 8 and a node refuses any other value, which makes the skew loud rather than silent — but it does mean a re-bootstrap.
