### PR TITLE
feat(server,meroctl,client): make delegated execution reachable, grantable and discoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@
   everywhere, but no CLI could grant it, so delegated execution could not be
   turned on at all. Note the mask is replaced, not merged.
 
+- **`Client::get_intent_relay`** in `calimero-client`, and `meroctl context
+  intent` now uses it. The command previously took `executor` from
+  `GET admin-api/identity`, which needs a credential on the relay — so on the
+  relay the feature exists for, the credential-free one, it could not read it at
+  all — and which does not report the grant, so it signed and spent `--nonce`
+  before learning the write would be refused. It now reads both from the
+  descriptor and refuses beforehand when the grant is missing, naming the group
+  and the account in the `set-capabilities` command to ask an admin for.
+
 - **`server.admin.public_intents`** (and `merod init --public-intents`): serve
   the two delegated-execution routes above without a node credential. **Off by
   default.** It opens exactly those two and nothing else, because they carry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`GET admin-api/contexts/:context_id/intents`** — the relay descriptor a
+  keyholder needs *before* minting a warrant: `executorAccount` (whom the
+  warrant's `executor` must name), `canAuthorOnBehalf` (whether this node holds
+  the grant on the owning group) and `groupId` (whose admin grants it).
+  Both facts belong to the node, so a client could not compose them, and asking
+  after the fact is too late: minting a warrant spends a nonce from a monotonic
+  per-device sequence, and one naming the wrong executor is unspendable.
+  `canAuthorOnBehalf: false` is an answer rather than an error — it is the
+  default state of every context, since the capability is implied by neither
+  membership nor admin.
+
+- **`--can-author-on-behalf`** on `meroctl group members set-capabilities`, and
+  the same row in `check-access`. The capability existed and was enforced
+  everywhere, but no CLI could grant it, so delegated execution could not be
+  turned on at all. Note the mask is replaced, not merged.
+
+- **`server.admin.public_intents`** (and `merod init --public-intents`): serve
+  the two delegated-execution routes above without a node credential. **Off by
+  default.** It opens exactly those two and nothing else, because they carry
+  their own credential — the warrant commits to this context, method and
+  arguments, is single-use, and is refused before execution unless the node
+  holds `CAN_AUTHOR_ON_BEHALF`. A node token proves none of that, and requiring
+  one makes the feature unreachable for the callers it exists for: a browser
+  tab or an agent holding one signing key and no relationship with the relay.
+  This is the write half of the known gap recorded in
+  [direct admission](docs/src/content/docs/protocol/direct-admission.mdx);
+  `/admit` is still behind the guard.
+
+  **Breaking** for `calimero-server`: `AdminConfig::new` now takes
+  `(enabled, public_intents)`. One constructor rather than a defaulting one,
+  because this flag decides whether a node exposes a write path to callers
+  holding no credential on it, and a convenience default is how a relay ships
+  with the posture nobody intended — in either direction.
+
 ### Removed
 
 - **`upgradePolicy`** from the namespace and group-info responses (`GET

--- a/crates/client/src/client/contexts.rs
+++ b/crates/client/src/client/contexts.rs
@@ -4,7 +4,7 @@ use calimero_primitives::context::ContextId;
 use calimero_server_primitives::admin::{
     CreateContextRequest, CreateContextResponse, DeleteContextApiRequest, DeleteContextResponse,
     GetContextIdentitiesResponse, GetContextResponse, GetContextStorageResponse,
-    GetContextsResponse, PerformIntentApiRequest, PerformIntentApiResponse,
+    GetContextsResponse, IntentRelayApiResponse, PerformIntentApiRequest, PerformIntentApiResponse,
     ResyncContextApiRequest, ResyncContextApiResponse, SyncContextResponse,
     UpdateContextApplicationRequest, UpdateContextApplicationResponse,
 };
@@ -29,6 +29,23 @@ where
                 &format!("admin-api/contexts/{context_id}/application"),
                 request,
             )
+            .await?;
+        Ok(response)
+    }
+
+    /// Ask what this node would need to be named as, and whether it may act, before
+    /// minting a warrant for it.
+    ///
+    /// This is the read half of `perform_intent`, and it is a separate call from
+    /// `get_node_identity` for two reasons. It reports `canAuthorOnBehalf`, which
+    /// no identity read carries — and authorship is the default-off capability, so
+    /// the common answer is "no" and finding that out from a refusal costs the
+    /// author a nonce it cannot reuse. And it is readable without a credential on
+    /// this node, which is the whole point of a relay a keyholder has no account on.
+    pub async fn get_intent_relay(&self, context_id: &str) -> Result<IntentRelayApiResponse> {
+        let response = self
+            .connection
+            .get(&format!("admin-api/contexts/{context_id}/intents"))
             .await?;
         Ok(response)
     }

--- a/crates/governance-store/src/warrant_gate.rs
+++ b/crates/governance-store/src/warrant_gate.rs
@@ -365,6 +365,71 @@ mod tests {
         );
     }
 
+    /// A group's default capabilities reach an attested TEE node on admission,
+    /// so a fleet relay does not need a per-node grant.
+    ///
+    /// This is the ergonomic answer to "every fleet node lands
+    /// authorship-closed": set the mask once on the namespace and every
+    /// non-admin member admitted afterwards inherits it. It is asserted through
+    /// `account_may_author` rather than by reading the capability row, because
+    /// that function is what `POST .../intents` and the relay descriptor both
+    /// call — a row that the gate does not read would prove nothing.
+    ///
+    /// The role matters: `ReadOnlyTee` is read-only for its OWN writes, and the
+    /// read-only gate is only ever applied to a delta's author, never to its
+    /// executor. So a read-only TEE node relaying for someone else is coherent,
+    /// and this pins that it is also reachable.
+    #[test]
+    fn a_groups_default_capabilities_reach_an_admitted_tee_node() {
+        let w = seed(7);
+        let tee = calimero_account::AccountId::from([0x7E; 32]);
+
+        CapabilitiesRepository::new(&w.store)
+            .set_default_capabilities(&w.group, MemberCapabilities::CAN_AUTHOR_ON_BEHALF.bits())
+            .expect("set the group default");
+
+        // Admitted AFTER the default is set, and never granted anything
+        // directly — the whole point is that no per-node op is needed.
+        //
+        // Through `admit_member_if_absent`, which is the call both TEE-attestation
+        // apply handlers make (`ops/namespace/member_joined_via_tee.rs`,
+        // `ops/group/member_joined_via_tee_attestation.rs`), rather than the
+        // `add_member` it currently delegates to. Asserting the entry point means
+        // a refactor that stops routing admission through `add_member` fails here
+        // instead of passing while production regresses.
+        crate::membership::MembershipPolicy::new(&w.store, w.group)
+            .admit_member_if_absent(&tee, &GroupMemberRole::ReadOnlyTee)
+            .expect("admit the TEE node");
+
+        assert!(
+            account_may_author(&w.store, &w.context, tee).expect("read the grant"),
+            "a TEE node admitted under a default mask carrying CAN_AUTHOR_ON_BEHALF \
+             must be able to relay without a per-node grant"
+        );
+    }
+
+    /// The control for the test above: without the default, the same admission
+    /// leaves the node closed.
+    ///
+    /// Without this, that test would pass just as happily if `add_member` were
+    /// granting authorship to every TEE node regardless of the default — which
+    /// is the failure it is meant to rule out, not demonstrate.
+    #[test]
+    fn an_admitted_tee_node_is_closed_when_no_default_is_set() {
+        let w = seed(7);
+        let tee = calimero_account::AccountId::from([0x7E; 32]);
+
+        crate::membership::MembershipPolicy::new(&w.store, w.group)
+            .admit_member_if_absent(&tee, &GroupMemberRole::ReadOnlyTee)
+            .expect("admit the TEE node");
+
+        assert!(
+            !account_may_author(&w.store, &w.context, tee).expect("read the grant"),
+            "admission alone must not confer authorship — it is implied by \
+             neither membership nor the TEE role"
+        );
+    }
+
     /// The author must be a member. This is the check that would silently pass
     /// if it were keyed by device rather than by account — a thin client's
     /// device is in no group's rows.

--- a/crates/meroctl/src/cli/context/intent.rs
+++ b/crates/meroctl/src/cli/context/intent.rs
@@ -117,13 +117,41 @@ impl IntentCommand {
         // Which operator is being authorized is read from the node, not asserted
         // here: the warrant has to name the account that will actually run it,
         // and a client guessing that would mint warrants nothing can spend.
+        //
+        // Read from the relay descriptor rather than from `identity`, because the
+        // descriptor answers the other half too — whether this node may author at
+        // all — and needs no credential on the node to answer either. See below
+        // for why asking first matters.
         let client = environment.client()?;
-        let executor: calimero_account::AccountId = client
-            .get_node_identity()
+        let relay = client
+            .get_intent_relay(&self.context_id)
             .await
-            .wrap_err("could not ask the node which account it acts as")?
+            .wrap_err("could not ask the node whether it can relay intents for this context")?;
+
+        // Refuse here rather than after signing. `CAN_AUTHOR_ON_BEHALF` is implied
+        // by nothing — not membership, not admin, not the subgroup cascade — so
+        // "no" is the default answer and the ordinary one. Minting anyway spends
+        // `--nonce` on a write every peer will reject, and the author cannot reuse
+        // that number: the next attempt has to pick a higher one, and the gap is
+        // permanent.
+        if !relay.data.can_author_on_behalf {
+            eyre::bail!(
+                "this node's account ({}) may not author on behalf of members of this context, \
+                 so the warrant would be refused and --nonce {} spent for nothing. Ask an admin \
+                 of group {} to grant it:\n\n    meroctl group members set-capabilities {} {} \
+                 --can-author-on-behalf\n\nThe mask is replaced, not merged, so re-pass any \
+                 capability that account already holds.",
+                relay.data.executor_account,
+                self.nonce,
+                relay.data.group_id,
+                relay.data.group_id,
+                relay.data.executor_account,
+            );
+        }
+
+        let executor: calimero_account::AccountId = relay
             .data
-            .account_id
+            .executor_account
             .parse()
             .wrap_err("the node reported an account this client cannot parse")?;
 

--- a/crates/meroctl/src/cli/group.rs
+++ b/crates/meroctl/src/cli/group.rs
@@ -42,6 +42,14 @@ pub const EXAMPLES: &str = r"
   # List members of a group
   $ meroctl --node node1 group members list <group_id>
 
+  # Let a relay write on members' behalf (delegated execution). The mask is
+  # REPLACED, not merged — re-pass any flag the member already holds.
+  $ meroctl --node node1 group members set-capabilities <group_id> <relay_account> \
+      --can-author-on-behalf
+
+  # Show an account's role and every capability it holds, decoded
+  $ meroctl --node node1 group members check-access <group_id> <account>
+
   # List contexts in a group
   $ meroctl --node node1 group contexts list <group_id>
 ";

--- a/crates/meroctl/src/cli/group/members.rs
+++ b/crates/meroctl/src/cli/group/members.rs
@@ -271,6 +271,20 @@ pub struct SetCapabilitiesCommand {
         help = "Allow member to set name/data on the group, its members, or its contexts"
     )]
     pub can_manage_metadata: bool,
+
+    /// The grant delegated execution runs on.
+    ///
+    /// Not implied by membership, not implied by admin, and not propagated by
+    /// the subgroup-admit cascade — so every group is authorship-closed until
+    /// this is set, and this command is the only way to open one. A relay
+    /// without it is refused at the API before it executes, and a delta it
+    /// somehow published would be dropped by every peer at the cut.
+    #[clap(
+        long,
+        help = "Allow member to publish writes attributed to ANOTHER member, under a warrant \
+                that member signed (delegated execution; held by relays)"
+    )]
+    pub can_author_on_behalf: bool,
 }
 
 impl SetCapabilitiesCommand {
@@ -383,6 +397,10 @@ impl CheckAccessCommand {
             "CAN_MANAGE_METADATA:     {}",
             caps & MemberCapabilities::CAN_MANAGE_METADATA.bits() != 0
         );
+        println!(
+            "CAN_AUTHOR_ON_BEHALF:    {}",
+            caps & MemberCapabilities::CAN_AUTHOR_ON_BEHALF.bits() != 0
+        );
 
         Ok(())
     }
@@ -420,6 +438,9 @@ fn encode_capabilities(cmd: &SetCapabilitiesCommand) -> u32 {
     if cmd.can_manage_metadata {
         capabilities |= MemberCapabilities::CAN_MANAGE_METADATA.bits();
     }
+    if cmd.can_author_on_behalf {
+        capabilities |= MemberCapabilities::CAN_AUTHOR_ON_BEHALF.bits();
+    }
     capabilities
 }
 
@@ -445,6 +466,7 @@ mod tests {
             can_delete_subgroup: false,
             can_manage_visibility: false,
             can_manage_metadata: false,
+            can_author_on_behalf: false,
         }
     }
 
@@ -505,6 +527,11 @@ mod tests {
                 expected: MemberCapabilities::CAN_MANAGE_METADATA,
                 name: "can_manage_metadata",
             },
+            FlagCase {
+                set: |c| c.can_author_on_behalf = true,
+                expected: MemberCapabilities::CAN_AUTHOR_ON_BEHALF,
+                name: "can_author_on_behalf",
+            },
         ];
 
         for case in cases {
@@ -529,6 +556,7 @@ mod tests {
         c.can_delete_subgroup = true;
         c.can_manage_visibility = true;
         c.can_manage_metadata = true;
+        c.can_author_on_behalf = true;
 
         let all = encode_capabilities(&c);
         let expected = (MemberCapabilities::CAN_CREATE_CONTEXT
@@ -537,10 +565,11 @@ mod tests {
             | MemberCapabilities::CAN_CREATE_SUBGROUP
             | MemberCapabilities::CAN_DELETE_SUBGROUP
             | MemberCapabilities::CAN_MANAGE_VISIBILITY
-            | MemberCapabilities::CAN_MANAGE_METADATA)
+            | MemberCapabilities::CAN_MANAGE_METADATA
+            | MemberCapabilities::CAN_AUTHOR_ON_BEHALF)
             .bits();
         assert_eq!(all, expected);
         // Every set bit is distinct (no two flags collide on a bit).
-        assert_eq!(all.count_ones(), 7);
+        assert_eq!(all.count_ones(), 8);
     }
 }

--- a/crates/merod/src/cli/init.rs
+++ b/crates/merod/src/cli/init.rs
@@ -218,6 +218,20 @@ pub struct InitCommand {
     #[clap(long)]
     pub no_admin: bool,
 
+    /// Run this node as a delegated-execution relay: serve
+    /// `GET`/`POST /admin-api/contexts/:context_id/intents` without a node
+    /// credential.
+    ///
+    /// Off by default. Pass it only for a node whose job is to write on behalf
+    /// of keyholders that have no relationship with it — a hosted TEE relay.
+    /// The two routes are self-authenticating: the warrant is the credential,
+    /// and a request is refused before anything executes unless the warrant is
+    /// this member's, covers this exact intent, has not expired, has an unspent
+    /// nonce, and this node holds `CAN_AUTHOR_ON_BEHALF` on the owning group.
+    /// Nothing else on the admin API is opened.
+    #[clap(long, default_value_t = false)]
+    pub public_intents: bool,
+
     /// Enable mDNS discovery. Off by default: a node that announces itself on
     /// the local network and dials whoever answers is a convenience for two
     /// terminals on one laptop and a tenancy question anywhere else — on a
@@ -534,7 +548,7 @@ impl InitCommand {
                 .into_iter()
                 .map(|host| Multiaddr::from(host).with(Protocol::Tcp(self.server_port)))
                 .collect(),
-            Some(AdminConfig::new(true)),
+            Some(AdminConfig::new(true, self.public_intents)),
             Some(JsonRpcConfig::new(true)),
             Some(WsConfig::new(true)),
             Some(SseConfig::new(true)),

--- a/crates/server/endpoints.json
+++ b/crates/server/endpoints.json
@@ -18,6 +18,7 @@
   "GET /admin-api/contexts/{context_id}/group",
   "GET /admin-api/contexts/{context_id}/identities",
   "GET /admin-api/contexts/{context_id}/identities-owned",
+  "GET /admin-api/contexts/{context_id}/intents",
   "GET /admin-api/contexts/{context_id}/storage",
   "GET /admin-api/contexts/for-application/{application_id}",
   "GET /admin-api/contexts/with-executors/for-application/{application_id}",

--- a/crates/server/primitives/fixtures/wire/contexts/intent_relay.res.json
+++ b/crates/server/primitives/fixtures/wire/contexts/intent_relay.res.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "executorAccount": "4d073803aabbccdd00112233445566778899aabbccddeeff0011223344558899",
+    "canAuthorOnBehalf": true,
+    "groupId": "7c9a0b1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f900112233"
+  }
+}

--- a/crates/server/primitives/fixtures/wire/contexts/intent_relay.res.json
+++ b/crates/server/primitives/fixtures/wire/contexts/intent_relay.res.json
@@ -1,7 +1,7 @@
 {
   "data": {
-    "executorAccount": "4d073803aabbccdd00112233445566778899aabbccddeeff0011223344558899",
     "canAuthorOnBehalf": true,
+    "executorAccount": "4d073803aabbccdd00112233445566778899aabbccddeeff0011223344558899",
     "groupId": "7c9a0b1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f900112233"
   }
 }

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -1352,6 +1352,46 @@ pub struct PerformIntentApiResponse {
     pub data: PerformIntentApiResponseData,
 }
 
+/// What a keyholder needs to know before it mints a warrant for this node.
+///
+/// A warrant binds `executor` to an **account**, and that account is the one
+/// thing a client cannot derive: it is this node's, not the caller's, and it is a
+/// content address rather than a key on any wire the client already reads. Making
+/// the client ask `/admin-api/identity` separately and then guess whether the
+/// grant exists is two round trips to answer one question — "can this relay run
+/// my intent, and whose name do I put in the warrant?"
+///
+/// Answering both together is also what lets a client fail *before* signing.
+/// A warrant naming the wrong executor, or a relay with no grant, is refused at
+/// `POST .../intents` — after the author has spent a nonce from its monotonic
+/// sequence on a warrant no relay will ever accept.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IntentRelayApiResponseData {
+    /// The account a warrant for this node must name as its `executor`, hex.
+    ///
+    /// An account, not this node's signing key: one of the relay's processes
+    /// re-keying must not void warrants already issued to it.
+    pub executor_account: String,
+    /// Whether this node holds `CAN_AUTHOR_ON_BEHALF` on the group owning this
+    /// context.
+    ///
+    /// `false` is not an error and not permanent — it is the state of a context
+    /// no admin has opened to delegated execution yet, which is every context by
+    /// default. A client reads it to tell "ask an admin" from "retry later".
+    pub can_author_on_behalf: bool,
+    /// The group owning this context, hex — the group whose admin must grant the
+    /// capability, so a refusal can name where to go.
+    pub group_id: String,
+}
+
+/// Wrapped in `data` like every neighbouring response.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IntentRelayApiResponse {
+    pub data: IntentRelayApiResponseData,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AddGroupMembersApiRequest {

--- a/crates/server/primitives/tests/wire_fixtures.rs
+++ b/crates/server/primitives/tests/wire_fixtures.rs
@@ -17,9 +17,9 @@ use serde_json::Value;
 
 use calimero_server_primitives::admin::{
     AddGroupMembersApiRequest, CreateContextRequest, CreateContextResponseData,
-    GetGroupUpgradeStatusApiResponse, GetMigrationStatusApiResponse, JoinGroupApiResponse,
-    JoinNamespaceApiResponse, ReparentGroupApiRequest, ReparentGroupApiResponse,
-    UpgradeGroupApiResponse,
+    GetGroupUpgradeStatusApiResponse, GetMigrationStatusApiResponse, IntentRelayApiResponse,
+    JoinGroupApiResponse, JoinNamespaceApiResponse, ReparentGroupApiRequest,
+    ReparentGroupApiResponse, UpgradeGroupApiResponse,
 };
 use calimero_server_primitives::jsonrpc::{ExecutionRequest, ExecutionResponse};
 
@@ -100,6 +100,14 @@ wire_fixtures! {
     upgrade_res: UpgradeGroupApiResponse => "groups/upgrade.res.json",
     upgrade_status_res: GetGroupUpgradeStatusApiResponse => "groups/upgrade_status.res.json",
     migration_status_res: GetMigrationStatusApiResponse => "groups/migration_status.res.json",
+    // The relay descriptor a keyholder reads before minting a warrant. Pinned
+    // because `executorAccount` is the one field whose value a client copies
+    // verbatim into a signed object: rename it and every relay client mints
+    // warrants naming nobody, which surfaces as a 403 nowhere near the cause.
+    // The account and the group are both 64-hex, so they carry deliberately
+    // different values — a field crossed between them shows as a diff rather
+    // than round-tripping cleanly.
+    intent_relay_res: IntentRelayApiResponse => "contexts/intent_relay.res.json",
     execute_req: ExecutionRequest => "jsonrpc/execute.req.json",
     execute_res: ExecutionResponse => "jsonrpc/execute.res.json",
 }

--- a/crates/server/src/admin/handlers/context.rs
+++ b/crates/server/src/admin/handlers/context.rs
@@ -7,6 +7,7 @@ pub mod get_context_ids;
 pub mod get_context_storage;
 pub mod get_contexts_for_application;
 pub mod get_contexts_with_executors_for_application;
+pub mod intent_relay;
 pub mod join_context;
 pub mod leave_context;
 pub mod perform_intent;

--- a/crates/server/src/admin/handlers/context/intent_relay.rs
+++ b/crates/server/src/admin/handlers/context/intent_relay.rs
@@ -1,0 +1,136 @@
+//! `GET /admin-api/contexts/:context_id/intents` — what a keyholder needs to
+//! know before it mints a warrant for this node.
+//!
+//! # Why this is a read on the same path as the write
+//!
+//! Minting a warrant is an offline act, and every input to it is something the
+//! author already holds — except one. `Warrant::executor` names *this node's*
+//! account, which is a content address the client has no way to derive, and
+//! whether the node may act here at all is a row in the owning group's
+//! capabilities that the client cannot read either.
+//!
+//! Both facts belong to the same question — "can this relay run my intent, and
+//! whose name do I put in the warrant?" — so they are one answer, on the path
+//! the intent will be presented to. A client that had to compose them from
+//! `/admin-api/identity` plus a group read would need two calls, a group id it
+//! does not have, and a credential on this node to make the second one.
+//!
+//! # Why it must be readable without the grant already existing
+//!
+//! `canAuthorOnBehalf: false` is the default state of every context: authorship
+//! is deliberately not implied by membership, not implied by admin, and not
+//! propagated by the subgroup cascade. So the common first answer here is "no",
+//! and a client has to be able to *get* that answer in order to say "ask an
+//! admin of this group to grant it" rather than presenting a warrant that will
+//! be refused — after the author has already spent a nonce from its monotonic
+//! sequence on it.
+
+use std::sync::Arc;
+
+use axum::extract::Path;
+use axum::response::IntoResponse;
+use axum::Extension;
+use calimero_primitives::context::ContextId;
+use calimero_server_primitives::admin::{IntentRelayApiResponse, IntentRelayApiResponseData};
+use reqwest::StatusCode;
+use tracing::error;
+
+use crate::admin::handlers::identity::get_node_identity::node_identity;
+use crate::admin::service::{ApiError, ApiResponse};
+use crate::AdminState;
+
+pub async fn handler(
+    Path(context_id_str): Path<String>,
+    Extension(state): Extension<Arc<AdminState>>,
+) -> impl IntoResponse {
+    let context_id: ContextId = match context_id_str.parse() {
+        Ok(id) => id,
+        Err(err) => {
+            return ApiError {
+                status_code: StatusCode::BAD_REQUEST,
+                message: format!("context id '{context_id_str}' is not valid: {err}"),
+            }
+            .into_response()
+        }
+    };
+
+    let store = state.ctx_client.datastore();
+
+    // The group first: a context registered to none has nothing to authorize a
+    // delegated write in, and reporting `canAuthorOnBehalf: false` for it would
+    // send a client to look for an admin of a group that does not exist.
+    let group_id = match calimero_governance_store::get_group_for_context(store, &context_id) {
+        Ok(Some(group_id)) => group_id,
+        Ok(None) => {
+            return ApiError {
+                status_code: StatusCode::NOT_FOUND,
+                message: "this context belongs to no group, so a delegated write has no \
+                          group to be authorized in"
+                    .to_owned(),
+            }
+            .into_response()
+        }
+        Err(err) => {
+            error!(error = ?err, %context_id, "Failed to resolve the group owning this context");
+            return ApiError {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                message: "Failed to resolve the group owning this context".to_owned(),
+            }
+            .into_response();
+        }
+    };
+
+    // A failed read is not a missing row: telling a client "this node has no
+    // account" when the truth is "could not look" sends it to mint a warrant
+    // naming nobody.
+    let executor_account = match node_identity(store) {
+        Ok(Some((account, ..))) => account,
+        Ok(None) => {
+            return ApiError {
+                status_code: StatusCode::NOT_FOUND,
+                message: "this node holds neither a usable device nor an account root yet, \
+                          so it can be named as no warrant's executor"
+                    .to_owned(),
+            }
+            .into_response()
+        }
+        Err(err) => {
+            error!(error = ?err, "Failed to read this node's identity");
+            return ApiError {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                message: "Failed to read this node's identity".to_owned(),
+            }
+            .into_response();
+        }
+    };
+
+    // The same question `POST .../intents` asks before it executes, and the same
+    // one every peer asks at the cut — read here so a client learns the answer
+    // before it signs rather than from a 403 after it has.
+    let can_author_on_behalf = match calimero_governance_store::warrant_gate::account_may_author(
+        store,
+        &context_id,
+        executor_account,
+    ) {
+        Ok(may) => may,
+        Err(err) => {
+            error!(error = ?err, %context_id, "Failed to read this node's authorship grant");
+            return ApiError {
+                status_code: StatusCode::INTERNAL_SERVER_ERROR,
+                message: "Failed to read this node's authorship grant".to_owned(),
+            }
+            .into_response();
+        }
+    };
+
+    ApiResponse {
+        payload: IntentRelayApiResponse {
+            data: IntentRelayApiResponseData {
+                executor_account: hex::encode(executor_account.as_bytes()),
+                can_author_on_behalf,
+                group_id: hex::encode(group_id.to_bytes()),
+            },
+        },
+    }
+    .into_response()
+}

--- a/crates/server/src/admin/service.rs
+++ b/crates/server/src/admin/service.rs
@@ -27,8 +27,8 @@ use crate::admin::handlers::applications::{
 use crate::admin::handlers::context::{
     create_context, delete_context, get_context, get_context_group, get_context_identities,
     get_context_ids, get_context_storage, get_contexts_for_application,
-    get_contexts_with_executors_for_application, join_context, leave_context, perform_intent,
-    resync_context, sync, update_context_application,
+    get_contexts_with_executors_for_application, intent_relay, join_context, leave_context,
+    perform_intent, resync_context, sync, update_context_application,
 };
 use crate::admin::handlers::identity::{generate_context_identity, get_node_identity};
 use crate::admin::handlers::network;
@@ -43,12 +43,74 @@ use crate::AdminState;
 pub struct AdminConfig {
     #[serde(default = "calimero_primitives::common::bool_true")]
     pub enabled: bool,
+
+    /// Serve the delegated-execution routes without a node credential.
+    ///
+    /// # What this opens, and what it does not
+    ///
+    /// It opens exactly two routes — `GET`/`POST
+    /// /admin-api/contexts/:context_id/intents` — and nothing else. Both are
+    /// self-authenticating: the `POST` carries a warrant signed by the author's
+    /// device key that commits to this context, this method and these arguments,
+    /// has not expired, and whose nonce this node has not spent; and it is
+    /// refused unless this node holds `CAN_AUTHOR_ON_BEHALF` on the group owning
+    /// the context. A node token proves none of that and none of that needs a
+    /// node token.
+    ///
+    /// # Why it is off by default and why it exists at all
+    ///
+    /// Off, because a self-hosted node's operator did not ask for an
+    /// unauthenticated surface and the routes are useless to them: a member with
+    /// a node authors its own writes.
+    ///
+    /// On, because the clients delegated authorship exists for — a browser tab,
+    /// a phone, an agent holding one signing key — have no relationship with the
+    /// relay and so cannot hold a credential on it. Requiring one makes the
+    /// feature unreachable for precisely the callers it was built for, which is
+    /// recorded as the known gap in the direct-admission docs. Hosted TEE relays
+    /// set this; nothing else should need to.
+    ///
+    /// The residual exposure is warrant verification on an unauthenticated
+    /// request: signature checks and one store read, refused before anything is
+    /// executed or published. Rate limiting that hop belongs to the deployment's
+    /// reverse proxy, as it does for the other public routes.
+    ///
+    /// # What it does under each auth mode — read this before relying on it
+    ///
+    /// Under [`AuthMode::Embedded`](crate::config::AuthMode::Embedded) this is
+    /// the gate: the guard layer wraps the protected router only, so moving the
+    /// routes across genuinely removes the credential requirement.
+    ///
+    /// Under [`AuthMode::Proxy`](crate::config::AuthMode::Proxy) — the default —
+    /// **core installs no guard at all**, on either router. A reverse proxy
+    /// enforces auth, and it is the only thing that does. So flipping this alone
+    /// changes nothing a caller can observe, and *not* flipping it does not
+    /// close the path: whatever the proxy exempts is open regardless.
+    ///
+    /// That asymmetry is the trap. A proxy deployment must set this **and**
+    /// exempt exactly this path at the ingress, from one source of truth, or the
+    /// two drift — and the drift is silent in the unsafe direction, because the
+    /// ingress exemption is the half that actually opens the door. mero-tee's
+    /// node image drives both from a single Ansible variable for this reason.
+    #[serde(default)]
+    pub public_intents: bool,
 }
 
 impl AdminConfig {
+    /// One constructor taking both flags, rather than a `new(enabled)` plus a
+    /// `with_public_intents`.
+    ///
+    /// `public_intents` decides whether this node exposes a write path to
+    /// callers holding no credential on it, so there should be no way to build
+    /// this type without answering that. A default-false convenience
+    /// constructor is exactly how a relay ships with the posture nobody
+    /// intended — in either direction.
     #[must_use]
-    pub const fn new(enabled: bool) -> Self {
-        Self { enabled }
+    pub const fn new(enabled: bool, public_intents: bool) -> Self {
+        Self {
+            enabled,
+            public_intents,
+        }
     }
 }
 
@@ -65,7 +127,7 @@ pub(crate) fn setup(
     config: &ServerConfig,
     shared_state: Arc<AdminState>,
 ) -> Option<(String, Router, Router)> {
-    let _ = match &config.admin {
+    let admin_config = match &config.admin {
         Some(config) if config.enabled => config,
         _ => {
             info!("Admin api is disabled");
@@ -125,10 +187,6 @@ pub(crate) fn setup(
         .route(
             "/contexts/{context_id}/application",
             post(update_context_application::handler),
-        )
-        .route(
-            "/contexts/{context_id}/intents",
-            post(perform_intent::handler),
         )
         .route(
             "/contexts/{context_id}/resync",
@@ -380,6 +438,15 @@ pub(crate) fn setup(
         .nest("/tee", tee::protected_service())
         // Alias management
         .nest("/alias", alias::service())
+        // Delegated execution, unless this deployment serves it publicly. The
+        // routes are built once and mounted on exactly one of the two routers,
+        // so the two postures cannot both be live and no ordering between the
+        // routers decides which wins.
+        .merge(if admin_config.public_intents {
+            Router::new()
+        } else {
+            delegated_execution_routes()
+        })
         .layer(Extension(Arc::clone(&shared_state)))
         .layer(session_layer.clone());
 
@@ -389,9 +456,37 @@ pub(crate) fn setup(
         .route("/is-authed", get(is_authed_handler))
         .route("/certificate", get(certificate_handler))
         .nest("/tee", tee::service())
+        .merge(if admin_config.public_intents {
+            info!(
+                "Delegated execution is served publicly: a warrant is the credential on \
+                 GET/POST {admin_path}/contexts/:context_id/intents"
+            );
+            delegated_execution_routes()
+        } else {
+            Router::new()
+        })
         .layer(Extension(shared_state));
 
     Some((admin_path, protected_routes, public_routes))
+}
+
+/// The delegated-execution surface: run one intent a member authorized, and read
+/// what a member needs to know before authorizing one.
+///
+/// One function rather than two route lines in each router, because the two
+/// halves have to move together. A client that can `POST` but not `GET` cannot
+/// learn which account to name as the executor, and a client that can `GET` but
+/// not `POST` learns the answer to a question it cannot then act on — either
+/// split is a surface that looks available and is not.
+///
+/// Which router this is merged into is [`AdminConfig::public_intents`]; see there
+/// for why an unauthenticated posture is a coherent choice for these two routes
+/// and only these two.
+fn delegated_execution_routes() -> Router {
+    Router::new().route(
+        "/contexts/{context_id}/intents",
+        post(perform_intent::handler).get(intent_relay::handler),
+    )
 }
 
 /// Creates a router for serving static node-ui files and providing fallback to `index.html` for SPA routing.

--- a/docs/src/content/docs/protocol/delegated-authorship.mdx
+++ b/docs/src/content/docs/protocol/delegated-authorship.mdx
@@ -112,6 +112,8 @@ GET /admin-api/contexts/:context_id/intents
 
 Asking before signing is not politeness. A nonce is spent from a monotonic per-device sequence to mint a warrant, and one naming the wrong executor is unspendable: the number is gone and the write never happened.
 
+`meroctl context intent` makes this read itself, before it signs anything: it takes `executor` from the answer rather than from `/admin-api/identity`, and refuses outright when `canAuthorOnBehalf` is false — naming the group and the account so the message is the grant command to ask an admin for. So the nonce is only ever spent on a warrant the relay can actually run.
+
 ## Reaching a relay you have no account on
 
 `POST .../intents` sits on the admin API, which is guarded. For a member using their *own* node that is the right default and costs nothing. For the case delegated authorship exists for it is fatal: a browser tab or an agent holding one signing key has no relationship with the relay and so no credential on it, which is [recorded as the known gap](/protocol/direct-admission/#known-gap) in direct admission.

--- a/docs/src/content/docs/protocol/delegated-authorship.mdx
+++ b/docs/src/content/docs/protocol/delegated-authorship.mdx
@@ -88,6 +88,54 @@ A self-authored envelope signs under `calimero/delta/2` instead. The two domains
 
 Authoring for others is a capability of its own, `CAN_AUTHOR_ON_BEHALF`, and it is granted like any other — see [capability inheritance](/protocol/capability-inheritance/). It is not implied by membership, and not implied by admin. A relay that has not been granted it gets a clean refusal at the API, before anything is executed or published, which matters: a delta peers would reject is worse than a request that never happened.
 
+An admin grants it with:
+
+```bash
+meroctl --node node1 group members set-capabilities <GROUP_ID> <RELAY_ACCOUNT> \
+  --can-author-on-behalf
+```
+
+The mask is **replaced**, not merged, so re-pass any other flag the member already holds. `meroctl group members check-access <GROUP_ID> <ACCOUNT>` prints the decoded set, `CAN_AUTHOR_ON_BEHALF` included.
+
+Note the subject: an **account**, not a key. That is what lets the relay rotate the key one of its processes signs with without the grant — or any warrant already issued against it — having to be reissued.
+
+## Discovery: what the author has to be told first
+
+Every input to a warrant is something the author already holds, with one exception. `executor` names the *relay's* account, which is a content address the client cannot derive, and whether that relay may act in this context is a row in the owning group's capabilities the client cannot read. So the relay answers both, on the path the intent will be presented to:
+
+```http
+GET /admin-api/contexts/:context_id/intents
+→ { "data": { "executorAccount": "…", "canAuthorOnBehalf": true, "groupId": "…" } }
+```
+
+`canAuthorOnBehalf: false` is not an error and not permanent — it is the state of every context no admin has opened yet, so it has to come back as an *answer*. A client reads it to tell "ask an admin of `groupId`" from "retry later", and reads `executorAccount` to know whom that admin must grant it to.
+
+Asking before signing is not politeness. A nonce is spent from a monotonic per-device sequence to mint a warrant, and one naming the wrong executor is unspendable: the number is gone and the write never happened.
+
+## Reaching a relay you have no account on
+
+`POST .../intents` sits on the admin API, which is guarded. For a member using their *own* node that is the right default and costs nothing. For the case delegated authorship exists for it is fatal: a browser tab or an agent holding one signing key has no relationship with the relay and so no credential on it, which is [recorded as the known gap](/protocol/direct-admission/#known-gap) in direct admission.
+
+So a node may be run as a relay, with `merod init --public-intents` (or `server.admin.public_intents = true` in `config.toml`). It opens exactly the two routes above and nothing else, because they are the two that carry their own credential:
+
+- the warrant is signed by the author's device key and commits to this context, this method and these exact arguments;
+- it is refused unless unexpired, its nonce unspent, and the relay holds `CAN_AUTHOR_ON_BEHALF` — all before anything is executed or published;
+- the delta is attributed to the author, and every peer re-checks both signature layers and re-authorizes at the cut.
+
+A node token proves none of that, and none of that needs one. What is left is signature verification on an unauthenticated request — cheap, and refused before execution; rate-limiting that hop belongs to the deployment's reverse proxy, as it does for the other public routes.
+
+Off by default: a self-hosted node's operator did not ask for an unauthenticated surface, and the routes are useless to them anyway, since a member with a node authors its own writes.
+
+### It is the gate only under embedded auth
+
+Worth being exact about, because the two auth modes differ and the difference is where the mistakes live.
+
+Under `--auth-mode embedded` this setting *is* the gate: the guard wraps the protected router only, so moving the two routes across genuinely removes the credential requirement.
+
+Under `--auth-mode proxy` — the default, and what every hosted node runs — **the node installs no guard on either router**. A reverse proxy enforces auth and is the only thing that does. So setting this alone changes nothing a caller can observe, and leaving it unset does not close the path: whatever the proxy exempts is open regardless.
+
+That asymmetry is the trap. A proxy deployment has to set this **and** exempt exactly this path at its ingress, from one source of truth, or the two drift — and the drift is silent in the unsafe direction, because the ingress exemption is the half that actually opens the door. The [fleet sidecar docs](https://calimero-network.github.io/mero-tee/understand/fleet-sidecar/#delegated-execution-the-node-as-a-relay) describe how the hosted node image drives both from a single variable for exactly this reason.
+
 ## Replay, and why the ledger is a window
 
 A warrant's signature stays valid forever — that is what a signature is. So replay is not forgery, and the envelope check cannot be what stops it: a relay re-presenting the same authorization would produce a second perfectly-verifiable delta. Every node therefore keeps a per-`(context, author device)` ledger and spends the nonce as part of admitting the delta.

--- a/docs/src/content/docs/protocol/direct-admission.mdx
+++ b/docs/src/content/docs/protocol/direct-admission.mdx
@@ -303,6 +303,15 @@ else in the flow works without one — the account, the certificate, and the op 
 all produced offline — but the last hop is not yet answered for a node the
 keyholder has no relationship with.
 
+The same gap on the *write* path is answered:
+[`POST .../intents`](/protocol/delegated-authorship/#reaching-a-relay-you-have-no-account-on)
+can be served without a node credential, because a warrant is one — it commits to a
+single context, method and argument set, is single-use, and is refused before
+execution unless the relay holds `CAN_AUTHOR_ON_BEHALF`. A join op is a comparable
+self-contained credential, so the same treatment should extend to `/admit`;
+that is not done yet, and until it is, joining somebody else's node is the step
+that still needs an out-of-band arrangement while writing through it does not.
+
 The same guard covers the TEE-admission-policy lookup a client would use to decide
 where to present a claim, so both are unblocked by one piece of work rather than
 two.


### PR DESCRIPTION
## Description

Delegated authorship shipped complete on the wire — a warrant, two signature domains, a nonce ledger, a capability enforced at the API and again at the cut. It was unusable for the callers it exists for, and none of the reasons were protocol reasons.

**Nothing could grant the capability.** `CAN_AUTHOR_ON_BEHALF` is implied by neither membership nor admin and is not propagated by the subgroup cascade, so every group is authorship-closed by default. But `meroctl group members set-capabilities` had no flag for it — the feature could be enforced and never enabled. `check-access` also omitted the row, so an operator could not even see it. (The mask is *replaced*, not merged; re-pass any flag the member already holds.)

**The client could not learn what to sign.** Every input to a warrant is something the author already holds except `executor`, which names the *relay's* account — a content address no client can derive — and whether that relay may act in this context, a capability row no client can read. New `GET /admin-api/contexts/:context_id/intents` answers both, on the path the intent will be presented to:

```json
{ "data": { "executorAccount": "…", "canAuthorOnBehalf": true, "groupId": "…" } }
```

`canAuthorOnBehalf: false` comes back as an *answer*, not an error, because it is the default state of every context: a client reads it to say "ask an admin of `groupId`" instead of presenting a warrant that will be refused. Asking before signing is the point — minting a warrant spends a nonce from a monotonic per-device sequence, and one naming the wrong executor is unspendable.

**And the endpoint was closed to exactly the callers it exists for.** `POST .../intents` sits on the guarded admin API. For a member using their own node that is right and free. For a browser tab or an agent holding one signing key it is fatal: they have no relationship with the relay and so no credential on it — the [known gap](docs/src/content/docs/protocol/direct-admission.mdx) the direct-admission docs record. So `server.admin.public_intents` (`merod init --public-intents`) serves those two routes, and nothing else, without a node credential — because they are the two that carry their own:

- the warrant is signed by the author's device key and commits to this context, this method and these exact arguments;
- it is refused unless unexpired, its nonce unspent, and the relay holds `CAN_AUTHOR_ON_BEHALF` — all before anything is executed or published;
- the delta is attributed to the author, and every peer re-checks both signature layers and re-authorizes at the cut.

A node token proves none of that, and none of that needs one.

**Off by default**, and the docs are explicit that it is the gate only under embedded auth: under the default proxy mode the node installs no guard on either router (`with_optional_auth` returns the router unchanged when there is no auth service), so the setting alone neither opens nor closes the path, and a deployment must drive it and its ingress exemption from one source of truth. The drift is silent in the unsafe direction — which is why mero-tee's node image derives both from a single Ansible variable.

### `meroctl context intent` was broken for the same case (`5b208294`)

Found while wiring the fleet relay. The command took the warrant's `executor` from `GET admin-api/identity`, which is wrong twice over:

- **It is guarded**, so it needs a credential on the relay — and on the credential-free relay this feature exists for, the one call the command made to prepare its warrant was the one call it could not make.
- **An identity read does not report the grant.** So the command signed, spent `--nonce`, and learned otherwise from the refusal. Peers refuse a repeat, so the next attempt must pick a higher number and the gap never closes.

Both facts now come from the descriptor via a new `Client::get_intent_relay`, and the command refuses *before* signing when the grant is missing — printing the `set-capabilities` line to hand an admin, with the group and account filled in. `get_node_identity` keeps its other caller (`meroctl account show`).

### Granting at fleet scale (`def24841`)

The per-node grant is the obvious reading of this PR and it does not scale: a namespace admitting TEE nodes continuously would need one admin-signed op per admission. The group's **default-capability mask** already answers that, and two tests in `crates/governance-store/src/warrant_gate.rs` pin it — set the mask once on the namespace and every non-admin member admitted afterwards inherits it, with no per-node op.

Both assert through `account_may_author` (the function `POST .../intents` and the descriptor both call) rather than reading the capability row, since a row the gate does not read would prove nothing. Admission runs through `MembershipPolicy::admit_member_if_absent` — the call both TEE-attestation apply handlers make — rather than the `add_member` it currently delegates to, so a refactor that stops routing admission through `add_member` fails the test instead of passing while production regresses. The second test is the control: without it the first would pass just as happily if admission granted authorship to every TEE node regardless of the default.

This also pins a topology nothing exercised before: a **read-only** TEE node relaying for someone else. That is coherent by design — every `is_read_only_for_context` call site passes a delta's *author*, never its executor — but it was previously true only by code reading.

### Breaking

`AdminConfig::new` now takes `(enabled, public_intents)` — **breaking for `calimero-server`**. One constructor rather than a defaulting one, because this flag decides whether a node exposes a write path to callers holding no credential on it, and a convenience default is how a relay ships with the posture nobody intended, in either direction. One call site in-tree (`merod init`).

## Test plan

```bash
cargo fmt --check
cargo clippy -p calimero-server -p calimero-server-primitives -p meroctl -p merod \
             -p calimero-client -p calimero-governance-store --all-targets -- -D warnings
cargo test -p calimero-server -p calimero-server-primitives -p meroctl \
           -p calimero-client -p calimero-governance-store
```

All green on this branch. Specifically:

- `route_manifest` — passes with the new `GET` row in `endpoints.json`.
- `wire_fixtures` — 13 fixtures including the new `contexts/intent_relay.res.json`, and the regenerate-clean step is a no-op (`94865968` fixed a hand-written fixture whose key order did not match the canonical writer's).
- `meroctl` capability-encoding tests — every flag maps to its own bit (now 8, each distinct), including `--can-author-on-behalf`.
- `calimero-governance-store` — 644 tests, including the two new default-capability tests. Verified by mutation: removing the `set_default_capabilities` call makes the positive one fail.
- `perform_intent`'s unit tests are unchanged and still cover the clock, wrong-context, wrong-args and wrong-method refusals.

**End-to-end coverage** is the paired mero-js PR's `delegated-intent` e2e, which asserts the new descriptor **either side of the grant** — `canAuthorOnBehalf: false` before `setMemberCapabilities`, `true` after — so the field is pinned to the capability rather than to a constant.

### ⚠️ What is NOT covered, stated plainly

**`server.admin.public_intents` has no test.** Grepping the repo for it returns only its implementation and doc comments. The flag whose whole purpose is admitting a caller with no credential is exercised by nothing, and that is a harness gap rather than something closable in this diff:

- the mero-js e2e authenticates in `beforeAll`, so every request carries a session;
- `apps/scaffolding-e2e/workflows/delegated-authorship.yml` opens with `type: login`, reads the relay account via `type: node_identity` (an authenticated admin read), and grants with `capabilities: 512` — a raw integer through the API, never `meroctl`;
- **no scenario anywhere runs `auth_mode: proxy` behind a reverse proxy** — 0 of 137 — which is the default mode, what every hosted node runs, and the only topology where the ingress exemption this flag pairs with exists.

Both suites also relay through the node that is *also* the namespace admin, whereas a fleet node is admitted `ReadOnlyTee` — so the non-admin-relay axis is untested end to end too.

Tracked in #3829 with a reproduction and resolution criteria. The cheapest path there is extending `scripts/e2e-auth-seam.sh`, which already drives raw HTTP and asserts exact status codes from a scenario that deliberately has no `login` step — in both directions, since a test asserting only "the intents routes answer" would pass against a node with no guard at all.

## Proof the blockers were real

- **Before:** `set-capabilities --help` listed seven flags, none setting bit 9 — no CLI invocation could produce a mask containing `CAN_AUTHOR_ON_BEHALF`, and `all_flags_or_together` asserted `count_ones() == 7`. The unit test encoded the gap as correct.
- **After:** `--can-author-on-behalf` is present, `each_flag_maps_to_its_own_bit` covers it, and the same test asserts `count_ones() == 8`.
- **Before:** `GET /admin-api/contexts/<ctx>/intents` → 404. A client had to compose the executor account from `/admin-api/identity` plus a group read it has no group id for and no credential to make.
- **After:** the route returns the descriptor, and the paired SDK e2e shows it flipping with the grant.
- **Before:** `meroctl context intent` read the executor from a guarded route and never checked the grant, so it spent a nonce to discover a refusal.
- **After:** it reads the descriptor and refuses before signing, naming the group and account in the grant command.

## Wire contract (SDK gate)

- [x] Regenerated wire fixtures — added `crates/server/primitives/fixtures/wire/contexts/intent_relay.res.json` plus its row. `IntentRelayApiResponseData` is a new DTO that three SDKs mirror by hand, and `executorAccount` is the one field whose value a client copies verbatim into a *signed* object: rename it and every relay client mints warrants naming nobody, surfacing as a 403 nowhere near the cause rather than as a decode error. The account and the group id are both 64 hex, so the fixture gives them deliberately different values.
- [x] Updated `crates/server/endpoints.json` — one added row, `GET /admin-api/contexts/{context_id}/intents`. Covered by the SDK e2e rather than baselined.
- [x] Linked the matching mero-js PR — below. Purely additive to `calimero-server-primitives` (two new response types); no existing DTO changed.

```
sdk-ref: claude/delegated-execution-rollout-3hlfmf
```

## Documentation update

- `docs/protocol/delegated-authorship.mdx` — how an admin grants the capability, the new discovery read and why it must be answerable *before* the grant exists, how to reach a relay you have no account on (including the embedded-vs-proxy distinction, which is where the mistakes live), and that `meroctl context intent` now makes the read itself.
- `docs/protocol/direct-admission.mdx` — the known gap now records that the *write* half is answered while `/admit` is not, so the remaining work is named rather than implied.
- `CHANGELOG.md` — every addition plus the breaking constructor note.

## Rollout — please read before releasing

This is the core half of a four-repo change. The fleet side is blocked on a release carrying it:

- **mero-tee** pins `merodVersion` and now **fails the image build** when delegated execution is enabled without a merod that has `--public-intents`. It is on `0.11.0-rc.17`, so the relay image cannot be built until a release carries this. That gate is deliberate: without it the image builds, boots, joins namespaces and reports itself to the cloud, then a pre-feature merod ignores the unknown config key and 404s the discovery read — so the cloud advertises a relay that never answers, and it surfaces in someone's browser days later.
- Bumping `merodVersion` also crosses six breaking wire changes between rc.17 and rc.32, one of which (#3796, map entries value-first) does **not** announce itself. So the fleet takes one coordinated jump straight to the release carrying this, rather than paying that flag-day twice.

Paired PRs (branch `claude/delegated-execution-rollout-3hlfmf` in each): **mero-js** calimero-network/mero-js#135 (SDK: cloud client, relay client, `connectCloud`, the e2e above), **mdma** calimero-network/mdma#210 (relay discovery + the machine view), **mero-tee** calimero-network/mero-tee#244 (the fleet node as a relay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3