### PR TITLE
fix(server)!: refuse unknown fields on every request body

### DIFF
--- a/.github/actions/setup-merobox/action.yml
+++ b/.github/actions/setup-merobox/action.yml
@@ -9,7 +9,7 @@ runs:
       run: |
         set -euo pipefail
 
-        MEROBOX_VERSION="0.6.72"
+        MEROBOX_VERSION="0.6.75"
         TAG="v${MEROBOX_VERSION}"
 
         case "$(uname -m)" in

--- a/crates/server/AGENTS.md
+++ b/crates/server/AGENTS.md
@@ -221,3 +221,4 @@ Authentication handled via middleware in `src/auth.rs`:
 - WebSocket requires context subscription
 - SSE streams are per-context
 - All responses use consistent error format
+- Every request body is `deny_unknown_fields`; add a new request type to the list in `primitives/tests/deny_unknown_fields.rs`

--- a/crates/server/coverage-baseline.json
+++ b/crates/server/coverage-baseline.json
@@ -1,6 +1,7 @@
 [
   "GET /admin-api/account/applications",
   "GET /admin-api/account/devices",
+  "GET /admin-api/contexts/{context_id}/intents",
   "GET /admin-api/groups/{group_id}/member-devices",
   "GET /admin-api/groups/{group_id}/members/{account}/metadata",
   "GET /admin-api/identity",

--- a/crates/server/primitives/src/admin/mod.rs
+++ b/crates/server/primitives/src/admin/mod.rs
@@ -50,7 +50,7 @@ impl InstallApplicationResponse {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct InstallDevApplicationRequest {
     pub path: Utf8PathBuf,
 }
@@ -202,7 +202,7 @@ impl GetApplicationAbiResponse {
 }
 // -------------------------------------------- Context API --------------------------------------------
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CreateContextRequest {
     pub application_id: ApplicationId,
     /// Which service from the application bundle to run. Optional for single-service apps.
@@ -382,7 +382,7 @@ impl GetContextsResponse {
 /// app's embedded ABI and resolved by the node during a group upgrade — the
 /// caller never names a migrate method.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UpdateContextApplicationRequest {
     pub application_id: ApplicationId,
     pub executor_public_key: PublicKey,
@@ -798,7 +798,7 @@ impl TryFrom<tdx_quote::Quote> for Quote {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TeeAttestRequest {
     /// Client-provided nonce for freshness (32 bytes as hex string)
     pub nonce: String,
@@ -817,7 +817,7 @@ impl TeeAttestRequest {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct FleetJoinRequest {
     pub group_id: String,
 }
@@ -1110,7 +1110,7 @@ impl Validate for TeeAttestRequest {
 // -------------------------------------------- Group API --------------------------------------------
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CreateGroupApiRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub group_id: Option<String>,
@@ -1155,7 +1155,7 @@ pub struct CreateGroupApiResponseData {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CreateNamespaceApiRequest {
     pub application_id: ApplicationId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1193,7 +1193,7 @@ pub struct CreateNamespaceApiResponse {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DeleteNamespaceApiRequest {}
 
 impl Validate for DeleteNamespaceApiRequest {
@@ -1215,7 +1215,7 @@ pub struct DeleteNamespaceApiResponse {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DeleteGroupApiRequest {}
 
 impl Validate for DeleteGroupApiRequest {
@@ -1277,7 +1277,7 @@ pub struct GroupInfoApiResponseData {
 /// does not — the warrant commits to `H(method ‖ args)` and the detail is sealed
 /// beside the operations.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PerformIntentApiRequest {
     /// The method to run.
     pub method: String,
@@ -1353,7 +1353,7 @@ pub struct PerformIntentApiResponse {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AddGroupMembersApiRequest {
     pub members: Vec<GroupMemberApiInput>,
 }
@@ -1377,7 +1377,7 @@ impl Validate for AddGroupMembersApiRequest {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct GroupMemberApiInput {
     /// The member's ACCOUNT - what every other verb on this resource names and
     /// what the listing returns.
@@ -1405,7 +1405,7 @@ pub struct GroupMemberApiInput {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RemoveGroupMembersApiRequest {
     /// The members to remove, named by ACCOUNT — the principal the membership
     /// rows are keyed by. `GET .../members` returns these same ids.
@@ -1499,7 +1499,7 @@ pub struct ListGroupContextsQuery {
 /// A group upgrade names only the target application — whether and what to
 /// migrate is resolved by the node from the apps' embedded ABIs.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UpgradeGroupApiRequest {
     pub target_application_id: ApplicationId,
     /// When `true`, emit one atomic `GroupOp::CascadeUpgrade` fanning out to
@@ -1686,7 +1686,7 @@ pub struct AbortMigrationApiResponse {
 /// overwrites local state with a peer's, discarding any local DAG heads, so
 /// `force` must be set when the context still holds them.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ResyncContextApiRequest {
     #[serde(default)]
     pub force: bool,
@@ -1727,7 +1727,7 @@ pub struct GroupUpgradeStatusApiData {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RetryGroupUpgradeApiRequest {}
 
 impl Validate for RetryGroupUpgradeApiRequest {
@@ -1821,7 +1821,7 @@ pub struct PairDeviceCompleteApiResponse {
 /// set of namespaces. One device for the whole set, so the response carries one
 /// id, one key pair and one code however many namespaces it covers.
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AccountPairInitApiRequest {
     /// Hex-encoded epoch-0 root **public** key (32 bytes). Named for the half it
     /// carries: private and public are both 32 hex bytes, and the private root
@@ -1865,7 +1865,7 @@ impl Validate for AccountPairInitApiRequest {
 /// Every field but `applications` is what that node's `pair-init` returned, and
 /// the response is [`PairDeviceCompleteApiResponse`] unchanged.
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AccountPairCompleteApiRequest {
     /// Hex-encoded `DeviceId` the other node minted (32 bytes).
     pub device_id: String,
@@ -1929,7 +1929,7 @@ impl Validate for AccountPairCompleteApiRequest {
 
 /// Withdraw a device from an account, terminally.
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RevokeDeviceApiRequest {
     /// Hex-encoded `DeviceId` to withdraw (32 bytes).
     pub device_id: String,
@@ -2045,7 +2045,7 @@ pub struct RevokeDeviceApiResponse {
 /// re-running pairing's fan-out against the namespaces this node takes part in
 /// now. The device is named in the path and need not be online.
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RelinkDeviceApiRequest {
     /// Applications to add to the stored scope, hex-encoded. Empty repairs
     /// without widening; it is not overloaded to mean "every application" so the
@@ -2164,7 +2164,7 @@ pub struct AccountApplicationsApiResponse {
 /// certificate, and nowhere to publish from. This is how such a joiner gets its
 /// membership op onto the DAG.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AdmitJoinApiRequest {
     /// The invitation being claimed. Must name this node in its `admitters`,
     /// and must otherwise verify — being designated is permission to carry a
@@ -2213,7 +2213,7 @@ pub struct AdmitJoinApiResponse {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CreateGroupInvitationApiRequest {
     /// Duration in seconds for the invitation validity.
     /// Defaults to 1 year when not provided.
@@ -2285,7 +2285,7 @@ pub struct CreateRecursiveInvitationApiResponse {
 /// Atomically move a group to a new parent. Replaces the old
 /// nest/unnest pair — orphan state is no longer reachable.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ReparentGroupApiRequest {
     pub new_parent_id: String,
 }
@@ -2344,7 +2344,7 @@ pub struct ListNamespaceGroupsApiResponse {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct JoinGroupApiRequest {
     pub invitation: SignedGroupOpenInvitation,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2412,7 +2412,7 @@ pub struct AddGroupMembersApiResponse {}
 pub struct RemoveGroupMembersApiResponse {}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UpdateMemberRoleApiRequest {
     pub role: GroupMemberRole,
 }
@@ -2436,7 +2436,7 @@ impl Validate for UpdateMemberRoleApiRequest {
 pub struct DetachContextFromGroupApiResponse {}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DetachContextFromGroupApiRequest {}
 
 impl Validate for DetachContextFromGroupApiRequest {
@@ -2448,7 +2448,7 @@ impl Validate for DetachContextFromGroupApiRequest {
 // ---- Sync Group ----
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SyncGroupApiRequest {}
 
 impl Validate for SyncGroupApiRequest {
@@ -2551,7 +2551,7 @@ pub struct LeaveGroupApiResponseData {
 // `b"calimero.ownership-claim.v1\x00"` (defined in calimero-context).
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct IssueOwnershipProofApiRequest {
     pub audience: String,
     /// Hex-encoded 32-byte context id. Parsed server-side via `parse_context_id`,
@@ -2632,7 +2632,7 @@ impl Validate for IssueOwnershipProofApiRequest {
 /// [`IssueOwnershipProofApiResponse`] verbatim. Purely additive to
 /// `calimero-server-primitives`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct IssueNamespaceOwnershipProofApiRequest {
     pub audience: String,
     pub subject: String,
@@ -2715,7 +2715,7 @@ pub struct GetContextGroupApiResponse {
 // ---- Group Permissions API ----
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SetMemberCapabilitiesApiRequest {
     pub capabilities: u32,
 }
@@ -2730,7 +2730,7 @@ impl Validate for SetMemberCapabilitiesApiRequest {
 pub struct SetMemberCapabilitiesApiResponse {}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SetMemberAutoFollowApiRequest {
     /// When true, the target auto-joins new contexts registered in this group.
     pub auto_follow_contexts: bool,
@@ -2750,7 +2750,7 @@ pub struct SetMemberAutoFollowApiResponse {}
 // ---- Set Metadata (group / member / context) ----
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SetMetadataApiRequest {
     /// New display name. Absent field keeps the current name.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2807,7 +2807,7 @@ pub struct GetMemberCapabilitiesApiData {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SetDefaultCapabilitiesApiRequest {
     pub default_capabilities: u32,
 }
@@ -2822,7 +2822,7 @@ impl Validate for SetDefaultCapabilitiesApiRequest {
 pub struct SetDefaultCapabilitiesApiResponse {}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SetTeeAdmissionPolicyApiRequest {
     #[serde(default)]
     pub allowed_mrtd: Vec<String>,
@@ -2885,7 +2885,7 @@ impl GetTeeAdmissionPolicyApiResponse {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SetSubgroupVisibilityApiRequest {
     pub subgroup_visibility: String,
 }

--- a/crates/server/primitives/src/jsonrpc.rs
+++ b/crates/server/primitives/src/jsonrpc.rs
@@ -69,7 +69,12 @@ impl Request<RequestPayload> {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(tag = "method", content = "params", rename_all = "snake_case")]
+#[serde(
+    tag = "method",
+    content = "params",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
 pub enum RequestPayload {
     Execute(ExecutionRequest),
     SyncStatus(SyncStatusRequest),
@@ -138,7 +143,7 @@ pub enum ServerResponseError {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct ExecutionRequest {
     pub context_id: ContextId,
@@ -188,7 +193,7 @@ pub enum ExecutionError {
 /// hit `Uninitialized` on `execute` tell whether sync is actively running,
 /// waiting for a peer, or wedged — instead of guessing from one opaque error.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct SyncStatusRequest {
     pub context_id: ContextId,
@@ -263,7 +268,7 @@ pub enum SyncStatusError {
 /// `state` is the raw presence bytes (e.g. cursor position, typing indicator).
 /// Rejected by the handler when `state.len() > EPHEMERAL_MAX_BYTES` (16 384).
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct SetEphemeralRequest {
     pub context_id: ContextId,

--- a/crates/server/primitives/src/sse.rs
+++ b/crates/server/primitives/src/sse.rs
@@ -22,14 +22,19 @@ pub struct Request<P> {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(tag = "method", content = "params", rename_all = "snake_case")]
+#[serde(
+    tag = "method",
+    content = "params",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
 pub enum RequestPayload {
     Subscribe(ContextIds),
     Unsubscribe(ContextIds),
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ContextIds {
     /// Default so a group-only subscribe (no `contextIds`) still parses.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/server/primitives/src/ws.rs
+++ b/crates/server/primitives/src/ws.rs
@@ -21,7 +21,12 @@ pub struct Request<P> {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(tag = "method", content = "params", rename_all = "snake_case")]
+#[serde(
+    tag = "method",
+    content = "params",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
 pub enum RequestPayload {
     Subscribe(SubscribeRequest),
     Unsubscribe(UnsubscribeRequest),
@@ -72,7 +77,7 @@ pub enum ServerResponseError {
 
 // **************************** subscribe method *******************************
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SubscribeRequest {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub context_ids: Vec<ContextId>,
@@ -94,7 +99,7 @@ pub struct SubscribeResponse {
 
 // **************************** unsubscribe method *******************************
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct UnsubscribeRequest {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub context_ids: Vec<ContextId>,

--- a/crates/server/primitives/tests/deny_unknown_fields.rs
+++ b/crates/server/primitives/tests/deny_unknown_fields.rs
@@ -1,0 +1,93 @@
+//! Every body the server deserializes is a closed set: a client sending a field
+//! the node no longer knows gets a 400, never a silent drop. A struct is listed
+//! here when it gains `deny_unknown_fields`; a new request type belongs here too.
+
+use calimero_server_primitives::{admin, jsonrpc, sse, ws};
+
+/// serde reports an unknown key before it checks for missing fields, so a lone
+/// unknown key distinguishes a closed type from an open one for every shape.
+/// An adjacently tagged enum phrases the refusal as an invalid tag key.
+macro_rules! rejects_unknown_fields {
+    ($($ty:ty),* $(,)?) => {
+        $({
+            let err = serde_json::from_str::<$ty>(r#"{"bogus":1}"#)
+                .err()
+                .map(|e| e.to_string())
+                .unwrap_or_default();
+            assert!(
+                err.contains("unknown field `bogus`")
+                    || err.contains(r#"string "bogus", expected "method" or "params""#),
+                "{} accepts unknown fields: {err:?}",
+                stringify!($ty)
+            );
+        })*
+    };
+}
+
+#[test]
+fn every_request_body_is_a_closed_set() {
+    rejects_unknown_fields!(
+        admin::InstallApplicationRequest,
+        admin::InstallDevApplicationRequest,
+        admin::CreateContextRequest,
+        admin::UpdateContextApplicationRequest,
+        admin::PerformIntentApiRequest,
+        admin::ResyncContextApiRequest,
+        admin::CreateGroupApiRequest,
+        admin::DeleteGroupApiRequest,
+        admin::ReparentGroupApiRequest,
+        admin::AddGroupMembersApiRequest,
+        admin::GroupMemberApiInput,
+        admin::RemoveGroupMembersApiRequest,
+        admin::UpdateMemberRoleApiRequest,
+        admin::SetMetadataApiRequest,
+        admin::DetachContextFromGroupApiRequest,
+        admin::UpgradeGroupApiRequest,
+        admin::RetryGroupUpgradeApiRequest,
+        admin::IssueOwnershipProofApiRequest,
+        admin::IssueNamespaceOwnershipProofApiRequest,
+        admin::SyncGroupApiRequest,
+        admin::SetMemberCapabilitiesApiRequest,
+        admin::SetMemberAutoFollowApiRequest,
+        admin::SetDefaultCapabilitiesApiRequest,
+        admin::SetTeeAdmissionPolicyApiRequest,
+        admin::SetSubgroupVisibilityApiRequest,
+        admin::CreateGroupInvitationApiRequest,
+        admin::JoinGroupApiRequest,
+        admin::AccountPairInitApiRequest,
+        admin::AccountPairCompleteApiRequest,
+        admin::RelinkDeviceApiRequest,
+        admin::RevokeDeviceApiRequest,
+        admin::CreateNamespaceApiRequest,
+        admin::DeleteNamespaceApiRequest,
+        admin::AdmitJoinApiRequest,
+        admin::TeeAttestRequest,
+        admin::FleetJoinRequest,
+        jsonrpc::RequestPayload,
+        jsonrpc::ExecutionRequest,
+        jsonrpc::SyncStatusRequest,
+        jsonrpc::SetEphemeralRequest,
+        ws::RequestPayload,
+        ws::SubscribeRequest,
+        ws::UnsubscribeRequest,
+        sse::RequestPayload,
+        sse::ContextIds,
+    );
+}
+
+/// The envelope flattens its payload, so a stray sibling of `method`/`params`
+/// lands in the payload and must be refused there.
+#[test]
+fn a_stray_envelope_key_is_refused_by_the_payload() {
+    let err = serde_json::from_str::<jsonrpc::RequestPayload>(
+        r#"{"method":"sync_status",
+            "params":{"contextId":"0000000000000000000000000000000000000000000000000000000000000000"},
+            "bogus":1}"#,
+    )
+    .expect_err("a stray key beside method/params must not deserialize");
+    assert!(
+        err.to_string()
+            .contains(r#"string "bogus", expected "method" or "params""#),
+        "got: {err}"
+    );
+}

--- a/crates/server/src/admin/handlers/applications/install_dev_application.rs
+++ b/crates/server/src/admin/handlers/applications/install_dev_application.rs
@@ -89,3 +89,22 @@ pub async fn handler(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use calimero_server_primitives::admin::InstallDevApplicationRequest;
+
+    /// The pre-bundle body carried `metadata`; ignoring it would let a stale
+    /// client install while silently dropping what it sent.
+    #[test]
+    fn a_legacy_body_with_metadata_is_refused() {
+        let err = serde_json::from_str::<InstallDevApplicationRequest>(
+            r#"{"path":"/tmp/app.mpk","metadata":[]}"#,
+        )
+        .expect_err("a legacy body must not deserialize");
+        assert!(
+            err.to_string().contains("unknown field `metadata`"),
+            "got: {err}"
+        );
+    }
+}

--- a/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
+++ b/crates/server/src/admin/handlers/namespaces/create_group_in_namespace.rs
@@ -14,7 +14,7 @@ use crate::admin::service::{parse_api_error, ApiResponse};
 use crate::AdminState;
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CreateGroupInNamespaceBody {
     pub group_name: Option<String>,
     /// Optional subgroup visibility at birth (#2771): `"open"` or
@@ -215,5 +215,20 @@ pub async fn handler(
             error!(?err, "Failed to create group in namespace");
             parse_api_error(err).into_response()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CreateGroupInNamespaceBody;
+
+    #[test]
+    fn a_body_with_an_unknown_field_is_refused() {
+        let err = serde_json::from_str::<CreateGroupInNamespaceBody>(r#"{"bogus":1}"#)
+            .expect_err("an unknown field must not deserialize");
+        assert!(
+            err.to_string().contains("unknown field `bogus`"),
+            "got: {err}"
+        );
     }
 }

--- a/docs/src/content/docs/operate/admin-api.mdx
+++ b/docs/src/content/docs/operate/admin-api.mdx
@@ -30,6 +30,10 @@ variable. For example `NODE_PATH_PREFIX=/node1` makes the admin API live at
 `/node1/admin-api`. The tables below show the unprefixed paths.
 </Aside>
 
+Every request body on these surfaces is a closed set.
+A body carrying a field the node does not declare is a 400 at deserialization, never a silent drop, so a client built against a different shape fails loudly instead of installing, joining, or upgrading something it did not name.
+Query strings stay lenient.
+
 ## Choosing an API surface
 
 All four surfaces are mounted on a single HTTP server and wrapped by the **same

--- a/docs/src/content/docs/protocol/applications.mdx
+++ b/docs/src/content/docs/protocol/applications.mdx
@@ -95,8 +95,8 @@ There are two ways to install one, and no third:
 
 Neither request names a location on the network.
 The caller says *which* application; the node's own `[registry]` config says *where from*.
-The coordinate request sets `deny_unknown_fields`, so a body carrying a `url` field is a
-400 rather than an install of something the caller did not name.
+Like every admin request body, the coordinate request refuses unknown fields, so a body
+carrying a `url` field is a 400 rather than an install of something the caller did not name.
 
 ## How bytecode reaches a node
 


### PR DESCRIPTION
## Summary

- Every body the server deserializes is now `deny_unknown_fields`: 34 admin request structs, the JSON-RPC, WebSocket and SSE payload enums and their param structs, and the namespace subgroup body. Only `install-application` had it before.
- A client sending a field the node does not declare gets a 400 at deserialization, never a silent drop. This is a wire-compatibility break for any client that relied on extra fields being ignored.
- The three transport envelopes keep `#[serde(flatten)]`, which serde cannot combine with the attribute. The payload enums carry it instead and still refuse a stray sibling of `method`/`params`, because the envelope flattens leftovers into the payload. `CreateAliasRequest<T>` keeps its flatten for the same reason. Query-string structs stay lenient on purpose.
- CI pins merobox v0.6.75. v0.6.72's bundled Python client predates #3652 and still sends `metadata` on install-dev-application, which this branch refuses. v0.6.75 is the first release pinning calimero-client-py 0.7.0, built against core after #3652.
- CI baselines `GET /admin-api/contexts/{context_id}/intents` in the SDK coverage ratchet. #3828 added the route with no SDK hit and no baseline entry, so sdk-e2e has been red on master since that merge. It comes off the baseline once mero-js exercises it.
- Docs: the admin API reference states the contract once, the applications page no longer implies the install route is special, and the server crate's AGENTS.md tells the next author to list a new request type in the test.

**Companion: mero-js.** mero-js master sends `upgradePolicy` on create-namespace and create-group and `requester` on 18 request types, none of which core declares, so it 400s against this branch. The paired fix is calimero-network/mero-js#136.

sdk-ref: fix/deny-unknown-fields-admin-requests

## Test plan

- [x] `crates/server/primitives/tests/deny_unknown_fields.rs` probes all 45 closed types with `{"bogus":1}`. serde reports an unknown key before a missing field, so one probe covers every shape. Observed red with the attribute removed from `SyncGroupApiRequest` (the test named it) and from `jsonrpc::RequestPayload` (both tests failed), green with it restored.
- [x] Handler tests pin the install-dev legacy body (`metadata` refused, observed failing before the attribute) and the subgroup body.
- [x] `cargo fmt --check`, workspace clippy with `-D warnings`, `cargo test` for server-primitives, server, client and meroctl.
- [x] Wire-contract fixtures pass unchanged; none carries a field its struct lacks.
- [x] Clients checked field-for-field: merobox, meroctl, the desktop app and calimero-client-py already send exactly the declared fields. merobox builds its bodies from these very structs through calimero-client-py.
- [x] First CI run went red on stale clients, as designed: 133 merobox scenarios on `unknown field metadata` from the v0.6.72 client, and one paired mero-js test sending `name` where core reads `groupName`. Both fixed by updating the clients, not by reopening the structs.
- [x] Coverage ratchet: `scripts/check-endpoint-coverage.sh` against a run that never hits the intents GET exits 1 naming it on the old baseline, `OK: 79/97` on this one.
- [ ] sdk-e2e green paired with the companion branch; merobox lanes green on v0.6.75.
