### PR TITLE
ci(sdk-e2e): baseline the intent-relay GET route

### DIFF
--- a/crates/server/coverage-baseline.json
+++ b/crates/server/coverage-baseline.json
@@ -1,6 +1,7 @@
 [
   "GET /admin-api/account/applications",
   "GET /admin-api/account/devices",
+  "GET /admin-api/contexts/{context_id}/intents",
   "GET /admin-api/groups/{group_id}/member-devices",
   "GET /admin-api/groups/{group_id}/members/{account}/metadata",
   "GET /admin-api/identity",


### PR DESCRIPTION
## Summary

- #3828 added `GET /admin-api/contexts/{context_id}/intents` to `crates/server/endpoints.json` without an SDK e2e hit or a baseline entry, so the endpoint coverage ratchet in sdk-e2e has failed on every master run since that merge, and on every PR that merges master.
- This baselines the route beside its already-baselined POST sibling. It comes off the baseline once mero-js exercises it, which mero-js #135 looks set to do.

## Test plan

- [x] `scripts/check-endpoint-coverage.sh` against a covered list that never hits the route: exit 1 naming `GET /admin-api/contexts/{context_id}/intents` on the old baseline, `OK: 79/97 manifest endpoints exercised; 18 baselined` on this one.
- [ ] sdk-e2e green on this PR.
