### PR TITLE
ci(e2e): skip the fixture registry on dht matrix entries

### DIFF
--- a/.github/workflows/e2e-rust-apps.yml
+++ b/.github/workflows/e2e-rust-apps.yml
@@ -1030,6 +1030,7 @@ jobs:
       # Nodes fetch bundles from here rather than from each other. The URL is
       # discovered on this runner, so it is stamped in rather than prebuilt.
       - name: Serve app bundles from a fixture registry
+        if: matrix.image != 'merod:local-dht'
         run: |
           url=$(./scripts/e2e-fixture-registry.sh)
           ./scripts/set-registry-mode.sh merod:local http "$url"


### PR DESCRIPTION
## Summary

Guard the `Serve app bundles from a fixture registry` step in `e2e-rust-apps.yml` with `if: matrix.image != 'merod:local-dht'`. The dht matrix entries never fetch bundles over http, so starting the fixture registry for them is meaningless; the step now only runs for the matrix entries that actually use it.

## Test plan

- `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/e2e-rust-apps.yml'))"` — parses cleanly.
- `actionlint .github/workflows/e2e-rust-apps.yml` — no new findings (pre-existing runner-label and shellcheck notes are unrelated to this change).