### PR TITLE
fix(node): cap the file read in install_application_from_path

### DIFF
--- a/crates/node/primitives/src/client/application/bundle.rs
+++ b/crates/node/primitives/src/client/application/bundle.rs
@@ -24,9 +24,7 @@ use tracing::{debug, warn};
 const MAX_MANIFEST_SCAN_BYTES: u64 = 8 * 1024 * 1024;
 
 /// How far any one archive walk may decompress. Every read walks the whole
-/// archive, so this bounds a bundle's total decompressed size. Also the cap
-/// `install_application_from_path` checks a file's size against before
-/// reading it into memory.
+/// archive, so this bounds a bundle's total decompressed size.
 pub const MAX_ARCHIVE_BYTES: u64 = 512 * 1024 * 1024;
 
 /// Bounds total decompressed bytes. `tar` buffers GNU long-name, long-link and

--- a/crates/node/primitives/src/client/application/bundle.rs
+++ b/crates/node/primitives/src/client/application/bundle.rs
@@ -24,8 +24,10 @@ use tracing::{debug, warn};
 const MAX_MANIFEST_SCAN_BYTES: u64 = 8 * 1024 * 1024;
 
 /// How far any one archive walk may decompress. Every read walks the whole
-/// archive, so this bounds a bundle's total decompressed size.
-const MAX_ARCHIVE_BYTES: u64 = 512 * 1024 * 1024;
+/// archive, so this bounds a bundle's total decompressed size. Also the cap
+/// `install_application_from_path` checks a file's size against before
+/// reading it into memory.
+pub const MAX_ARCHIVE_BYTES: u64 = 512 * 1024 * 1024;
 
 /// Bounds total decompressed bytes. `tar` buffers GNU long-name, long-link and
 /// pax members with an unbounded read inside `entries()`, before any `Entry` is

--- a/crates/node/primitives/src/client/application/install.rs
+++ b/crates/node/primitives/src/client/application/install.rs
@@ -156,6 +156,14 @@ impl NodeClient {
         };
         trace!(path = %path, "application path canonicalized");
 
+        let file_size = tokio::fs::metadata(&path).await?.len();
+        if file_size > bundle::MAX_ARCHIVE_BYTES {
+            bail!(
+                "application file at {path} is {file_size} bytes, exceeding the {} byte bundle cap",
+                bundle::MAX_ARCHIVE_BYTES
+            );
+        }
+
         let bundle_data: Arc<[u8]> = tokio::fs::read(&path).await?.into();
         if !bundle::is_bundle_blob(&bundle_data) {
             bail!("{NOT_A_BUNDLE}: {path}");

--- a/crates/node/primitives/tests/bundle_installation.rs
+++ b/crates/node/primitives/tests/bundle_installation.rs
@@ -5,6 +5,7 @@ use std::fs;
 use calimero_node_primitives::bundle::{
     derive_signer_id_did_key, sign_manifest_json, BundleManifest,
 };
+use calimero_node_primitives::client::application::bundle::MAX_ARCHIVE_BYTES;
 use calimero_node_primitives::client::NodeClient;
 use camino::Utf8PathBuf;
 use ed25519_dalek::SigningKey;
@@ -1887,4 +1888,27 @@ async fn a_raw_wasm_payload_is_refused() {
             "{name} got: {err}"
         );
     }
+}
+
+/// A file over the bundle cap must be refused by its metadata length, before
+/// it is ever read into memory. `set_len` makes a sparse file so the test
+/// does not actually write out the cap's worth of bytes.
+#[tokio::test]
+async fn install_from_path_rejects_a_file_over_the_bundle_cap() {
+    let temp_dir = TempDir::new().unwrap();
+    let (node_client, _data_dir, _blob_dir) = create_test_node_client(None).await;
+
+    let path = temp_dir.path().join("huge.mpk");
+    let file = fs::File::create(&path).unwrap();
+    file.set_len(MAX_ARCHIVE_BYTES + 1).unwrap();
+    let path: Utf8PathBuf = path.try_into().unwrap();
+
+    let err = node_client
+        .install_application_from_path(path)
+        .await
+        .expect_err("a file over the bundle cap must be refused");
+    assert!(
+        err.to_string().contains(&MAX_ARCHIVE_BYTES.to_string()),
+        "error should name the byte cap, got: {err}"
+    );
 }


### PR DESCRIPTION
## Summary

`install_application_from_path` (reachable from the admin `install-dev-application` endpoint) read the entire file at the given path into memory with `tokio::fs::read` before checking whether it was even a bundle. A path to an arbitrarily large file was read in full with no bound.

Checks the file's metadata length against the existing 512 MiB bundle cap (`bundle::MAX_ARCHIVE_BYTES`, already enforced on decompressed archive size) and refuses the install before reading, reusing the constant instead of duplicating the number.

## Test plan

Added `install_from_path_rejects_a_file_over_the_bundle_cap` in `crates/node/primitives/tests/bundle_installation.rs`, using a sparse file (`set_len`) sized one byte over the cap so the test costs no real disk I/O.

- Before the fix: the test failed because the whole file was read and only then rejected for not being a signed bundle (`not a signed application bundle`), not for its size.
- After the fix: the test passes, and the file-size check runs in ~0.01s instead of reading and failing the whole 512 MiB+ file.

Also ran:
- `cargo fmt --check`
- `cargo clippy -p calimero-node-primitives --all-targets --features calimero-storage/testing -- -D warnings`
- `cargo test -p calimero-node-primitives` (all suites green, including the new test)