### PR TITLE
fix(auth)!: refuse unknown fields on every request body

### DIFF
--- a/crates/auth/src/api/handlers/auth.rs
+++ b/crates/auth/src/api/handlers/auth.rs
@@ -109,6 +109,7 @@ pub async fn login_handler(state: Extension<Arc<AppState>>) -> impl IntoResponse
 
 /// Base token request with common fields
 #[derive(Debug, Deserialize, Validate)]
+#[serde(deny_unknown_fields)]
 pub struct BaseTokenRequest {
     /// Authentication method
     #[validate(length(min = 1, message = "Authentication method is required"))]
@@ -338,6 +339,7 @@ pub async fn token_handler(
 
 /// Refresh token request
 #[derive(Debug, Deserialize, Validate)]
+#[serde(deny_unknown_fields)]
 pub struct RefreshTokenRequest {
     /// Access token
     #[validate(length(min = 1, message = "Access token is required"))]
@@ -828,6 +830,7 @@ pub async fn callback_handler(
 
 /// Revoke token request
 #[derive(Debug, Deserialize, Validate)]
+#[serde(deny_unknown_fields)]
 pub struct RevokeTokenRequest {
     /// Client ID to revoke
     #[validate(length(min = 1, message = "Client ID cannot be empty"))]
@@ -898,6 +901,7 @@ pub async fn revoke_token_handler(
 /// Mock token request for CI and testing
 #[cfg(debug_assertions)]
 #[derive(Debug, Deserialize, Validate)]
+#[serde(deny_unknown_fields)]
 pub struct MockTokenRequest {
     /// Client name for identification
     #[validate(length(min = 1, message = "Client name is required"))]

--- a/crates/auth/src/api/handlers/client_keys.rs
+++ b/crates/auth/src/api/handlers/client_keys.rs
@@ -16,6 +16,7 @@ use crate::storage::models::{Key, KeyType};
 
 /// Client key generation request
 #[derive(Debug, Deserialize, Validate)]
+#[serde(deny_unknown_fields)]
 pub struct GenerateClientKeyRequest {
     /// Context ID selected by user
     pub context_id: Option<String>,

--- a/crates/auth/src/api/handlers/permissions.rs
+++ b/crates/auth/src/api/handlers/permissions.rs
@@ -16,6 +16,7 @@ use crate::storage::StorageError;
 
 /// Key permissions update request
 #[derive(Debug, Deserialize, Validate)]
+#[serde(deny_unknown_fields)]
 pub struct UpdateKeyPermissionsRequest {
     /// Permissions to add
     pub add: Option<Vec<String>>,

--- a/crates/auth/src/api/handlers/root_keys.rs
+++ b/crates/auth/src/api/handlers/root_keys.rs
@@ -16,6 +16,7 @@ use crate::storage::models::KeyType;
 
 /// Create key request
 #[derive(Debug, Deserialize, Validate)]
+#[serde(deny_unknown_fields)]
 pub struct CreateKeyRequest {
     /// Public key
     #[validate(length(min = 1, message = "Public key is required"))]

--- a/crates/auth/tests/deny_unknown_fields.rs
+++ b/crates/auth/tests/deny_unknown_fields.rs
@@ -1,0 +1,47 @@
+//! Every request body `mero-auth` deserializes is a closed set: a client
+//! sending a field the service no longer knows gets a 400, never a silent
+//! drop. A struct is listed here when it gains `deny_unknown_fields`; a new
+//! request type belongs here too.
+
+use mero_auth::api::handlers::auth::{BaseTokenRequest, RefreshTokenRequest, RevokeTokenRequest};
+use mero_auth::api::handlers::client_keys::GenerateClientKeyRequest;
+use mero_auth::api::handlers::permissions::UpdateKeyPermissionsRequest;
+use mero_auth::api::handlers::root_keys::CreateKeyRequest;
+
+macro_rules! rejects_unknown_fields {
+    ($($ty:ty),* $(,)?) => {
+        $({
+            let err = serde_json::from_str::<$ty>(r#"{"bogus":1}"#)
+                .err()
+                .map(|e| e.to_string())
+                .unwrap_or_default();
+            assert!(
+                err.contains("unknown field `bogus`"),
+                "{} accepts unknown fields: {err:?}",
+                stringify!($ty)
+            );
+        })*
+    };
+}
+
+#[test]
+fn every_request_body_is_a_closed_set() {
+    rejects_unknown_fields!(
+        BaseTokenRequest,
+        RefreshTokenRequest,
+        RevokeTokenRequest,
+        CreateKeyRequest,
+        GenerateClientKeyRequest,
+        UpdateKeyPermissionsRequest,
+    );
+}
+
+// `/auth/mock-token` only exists in debug builds; its request type is
+// compiled out of a release build the same way.
+#[cfg(debug_assertions)]
+#[test]
+fn mock_token_request_is_a_closed_set() {
+    use mero_auth::api::handlers::auth::MockTokenRequest;
+
+    rejects_unknown_fields!(MockTokenRequest);
+}


### PR DESCRIPTION
## Summary

`crates/auth` was left open when #3830 added `deny_unknown_fields` to every admin/JSON-RPC/WS/SSE request body, because its hand-written clients had not been audited. This closes that gap.

Adds `#[serde(deny_unknown_fields)]` to every request body struct `crates/auth` deserializes:

| Route | Struct | Fields |
| --- | --- | --- |
| `POST /auth/token` | `BaseTokenRequest` | `auth_method`, `public_key`, `client_name`, `permissions?`, `timestamp`, `provider_data` |
| `POST /auth/refresh` | `RefreshTokenRequest` | `access_token`, `refresh_token` |
| `POST /auth/mock-token` (debug builds only) | `MockTokenRequest` | `client_name`, `permissions?`, `node_url?`, `access_token_expiry?`, `refresh_token_expiry?` |
| `POST /admin/revoke` | `RevokeTokenRequest` | `client_id` |
| `POST /admin/keys` | `CreateKeyRequest` | `public_key`, `auth_method`, `provider_data`, `target_node_url?` |
| `POST /admin/client-key` | `GenerateClientKeyRequest` | `context_id?`, `context_identity?`, `permissions?`, `target_node_url?`, `ttl_secs?` |
| `PUT /admin/keys/{key_id}/permissions` | `UpdateKeyPermissionsRequest` | `add?`, `remove?` |

Every hand-written client that talks to these routes was audited against the exact keys it sends:

| Client | Route(s) used | Verdict |
| --- | --- | --- |
| merobox `commands/auth.py` (pinned 0.6.75) | `/auth/token`, `/auth/refresh` | sends a subset of declared keys only |
| `scripts/e2e-auth-seam.sh` | `/auth/token`, `/admin/client-key` | sends declared keys only |
| `scripts/get-mock-token.sh` | `/auth/mock-token` | sends a subset of declared keys only |
| `.github/workflows/sdk-e2e.yml` | `/auth/token` | sends declared keys only |
| mero-js `auth-api/auth-client.ts` (typed request interfaces) | all seven routes | sends a subset of declared keys only |
| tauri-app desktop (`token-broker.ts`, `agent-connect.ts`) | `/auth/refresh`, `/admin/client-key` | sends a subset of declared keys only |

No client sends a field outside the struct it targets, so every struct above was safe to close.

## Test plan

- Added `crates/auth/tests/deny_unknown_fields.rs`, mirroring `crates/server/primitives/tests/deny_unknown_fields.rs`: every closed struct probed with `{"bogus":1}` and asserted to be rejected.
- Verified the test actually catches a regression: removed `deny_unknown_fields` from `RefreshTokenRequest`, confirmed the test failed, restored it.
- `cargo fmt --check`
- `cargo clippy -p mero-auth --all-targets -- -D warnings`
- `cargo test -p mero-auth` (179 unit tests + `client_token_contract` + the new `deny_unknown_fields` tests, all passing)
