### PR TITLE
feat(merod): reset a revoked device identity so the node can re-pair

### DIFF
--- a/apps/scaffolding-e2e/workflows/account-device-revoke-lockout.yml
+++ b/apps/scaffolding-e2e/workflows/account-device-revoke-lockout.yml
@@ -83,6 +83,12 @@ description: >
        line no code path emits in this shape. The refusal is still logged at
        `info` on the responder for the day a scenario can drive it.
 
+    8. The lockout has an exit, and it is an operator command. A revoked id is
+       spent for good, so `merod account device --reset` drops the row offline and
+       the re-pair mints a fresh replica under the same account. The same rule
+       guards it in reverse: the fresh device still serves, so resetting it again
+       is refused rather than stranding the state held under it.
+
   What this does NOT cover (intentionally):
     * Self-service revocation (an account revoking its own lost device without
       an admin). Needs the root-signed revocation proof, which is a wire
@@ -516,12 +522,95 @@ steps:
       value: phone-really-should-not-land
     expected_failure: true
 
+  # ── Phase 8: reset the spent identity and re-pair ─────────────────
+  #
+  # The lockout has an exit. A revoked id is spent for good, so until the device
+  # row is dropped the node keeps presenting it and every certificate minted for
+  # it is refused by every peer. `account device --reset` drops it on demand.
+  #
+  # Offline by construction, which is why it is a `merod` subcommand and not an
+  # admin route: the row lives in the datastore and RocksDB's lock is exclusive.
+
+  - name: Stop the revoked node so its device row can be dropped
+    type: stop_node
+    nodes: account-revoke-node-3
+
+  - name: Reset the revoked device identity
+    type: node_exec
+    node: account-revoke-node-3
+    args: [account, device, --reset]
+    capture:
+      reset_device: '^Reset device ([0-9a-f]{64})$'
+    outputs:
+      reset_device: reset_device
+
+  - name: The reset dropped exactly the device that was revoked
+    type: json_assert
+    statements:
+      - 'json_equal({{reset_device}}, {{paired_device}})'
+
+  # The step that makes the reset load-bearing rather than decorative. A pair-init
+  # re-mints on its own once the tombstone has landed, so the re-pair below would
+  # succeed either way; only a direct observation of the empty slot proves the
+  # command did the dropping. `account device` has nothing left to print.
+  - name: The node now holds no device at all
+    type: node_exec
+    node: account-revoke-node-3
+    args: [account, device]
+    expected_failure: true
+
+  - name: The reset node comes back up
+    type: start_node
+    nodes: account-revoke-node-3
+
+  - name: Log back in to node-3
+    type: login
+    node: account-revoke-node-3
+    username: dev
+    password: dev-password
+
+  - name: Re-pair node-3 onto Alice's account
+    type: account_pair
+    node: account-revoke-node-3
+    holder: account-revoke-node-2
+    root_key: '{{root_key}}'
+    namespaces:
+      - '{{namespace_id}}'
+
+  - name: What node-3 speaks as after the re-pair
+    type: node_identity
+    node: account-revoke-node-3
+    outputs:
+      repaired_account: accountId
+      repaired_device: deviceId
+
+  # A fresh replica under the same account, which is the whole point: the account
+  # survived the revocation, the device id did not.
+  - name: The re-pair minted a fresh device under the same account
+    type: json_assert
+    statements:
+      - 'json_not_equal({{repaired_device}}, {{paired_device}})'
+      - 'json_equal({{repaired_account}}, {{alice_account}})'
+
+  # The guard, at the other end of the same rule. The fresh device is live, and a
+  # device id IS its replica lineage, so dropping this one would strand the CRDT
+  # state held under it with nothing able to author there again.
+  - name: Stop node-3 again to attempt a reset of a live device
+    type: stop_node
+    nodes: account-revoke-node-3
+
+  - name: Resetting a device that still serves is refused
+    type: node_exec
+    node: account-revoke-node-3
+    args: [account, device, --reset]
+    expected_failure: true
+
 # ── Wiring ─────────────────────────────────────────────────────────
 #
 # Wired into `.github/workflows/e2e-rust-apps.yml`.
 #
-# `node_identity`, `account_pair`, `account_revoke` and `account_show` are all
-# native merobox steps. `account_pair` drives the account-level routes as of
+# `node_identity`, `account_pair`, `account_revoke`, `account_show` and
+# `node_exec` are all native merobox steps. `account_pair` drives the account-level routes as of
 # merobox 0.6.71; before that it drove the namespace-scoped ones, which no
 # longer exist - they took one namespace from the path and fanned the link out
 # to every namespace regardless.

--- a/crates/governance-store/src/node_device.rs
+++ b/crates/governance-store/src/node_device.rs
@@ -1124,6 +1124,46 @@ impl<'a> NodeDeviceRepository<'a> {
         Ok(self.revoked_in(held.device())?.is_empty().then_some(held))
     }
 
+    /// Drop this node's device identity so the next enrolment mints a fresh one.
+    ///
+    /// The operator's forcing handle on the revocation lockout: a spent row keeps
+    /// being certified until some enrolment happens to consult the namespace that
+    /// holds the tombstone, and this runs that decision on demand instead.
+    ///
+    /// Gated on [`Self::stored_identity_still_serves`] rather than on a rule of its
+    /// own, across every namespace this node takes part in. A live device's id *is*
+    /// its replica lineage - counter slots and an HLC seed - so dropping a row the
+    /// enrolment path would have kept strands that state with nothing able to
+    /// author under it again.
+    ///
+    /// # Errors
+    /// If no device is stored, if the stored one still serves a namespace this node
+    /// takes part in, or the store read or write fails.
+    pub fn reset_device(&self) -> EyreResult<DeviceId> {
+        let _guard = NODE_DEVICE_MINT_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let Some(existing) = self.get()? else {
+            eyre::bail!("this node holds no device identity, so there is nothing to reset");
+        };
+        let account = existing.account;
+
+        for namespace in NamespaceRepository::new(self.store).participating_namespaces()? {
+            if self.stored_identity_still_serves(&namespace, &existing, account)? {
+                eyre::bail!(
+                    "device {} still serves namespace {namespace:?}: it is neither revoked \
+                     nor unlinked, and dropping it would strand the replica state held under \
+                     it. Revoke the device first, then reset",
+                    hex::encode(existing.device().as_bytes())
+                );
+            }
+        }
+
+        self.delete()?;
+        Ok(existing.device())
+    }
+
     /// Drop this node's device identity. Idempotent.
     ///
     /// Called by the namespace teardown for the same reason the group keyring is
@@ -1306,6 +1346,61 @@ mod tests {
             repo.get().expect("read").is_some(),
             "and the row itself stays, because the KEM secret still opens keys \
              already wrapped for it"
+        );
+    }
+
+    /// The operator's forcing handle: a revoked row is spent, so dropping it is
+    /// what lets the next pairing mint an id peers will admit.
+    #[test]
+    fn resetting_drops_a_revoked_device() {
+        let store = test_store();
+        let ns = test_group_id();
+        let repo = NodeDeviceRepository::new(&store);
+        NamespaceRepository::new(&store)
+            .note_participation(&ns)
+            .expect("take part in the namespace");
+
+        let spent = repo.ensure_enrolled(&ns).expect("enroll");
+        AccountBindingRepository::new(&store)
+            .apply_revocation(&ns, spent.device())
+            .expect("tombstone the device");
+
+        assert_eq!(repo.reset_device().expect("reset"), spent.device());
+        assert!(
+            repo.get().expect("read").is_none(),
+            "the row is gone, which is what releases the slot"
+        );
+        assert_ne!(
+            repo.ensure_enrolled(&ns).expect("re-enroll").device(),
+            spent.device(),
+            "and the next enrolment mints a fresh id rather than the spent one"
+        );
+    }
+
+    /// The guard. A live device's id is its replica lineage, so a reset the
+    /// enrolment rule would not have released has to be refused rather than
+    /// orphan the state held under it.
+    #[test]
+    fn resetting_a_device_that_still_serves_is_refused() {
+        let store = test_store();
+        let ns = test_group_id();
+        let repo = NodeDeviceRepository::new(&store);
+        NamespaceRepository::new(&store)
+            .note_participation(&ns)
+            .expect("take part in the namespace");
+        let held = repo.ensure_enrolled(&ns).expect("enroll");
+
+        let err = repo
+            .reset_device()
+            .expect_err("a device that still serves must be refused");
+        assert!(
+            err.to_string().contains("still serves"),
+            "the refusal must say why: {err}"
+        );
+        assert_eq!(
+            repo.get().expect("read").expect("present").device(),
+            held.device(),
+            "and it must leave the row alone"
         );
     }
 

--- a/crates/merod/src/cli/account.rs
+++ b/crates/merod/src/cli/account.rs
@@ -1262,7 +1262,17 @@ impl RootCommand {
 /// the agreement key is what wrapped scope keys are addressed to. The secrets that
 /// match the latter two are reachable from no command and no route.
 #[derive(Debug, Parser)]
-pub struct DeviceCommand {}
+pub struct DeviceCommand {
+    /// Drop this node's device identity so the next pairing mints a fresh one.
+    ///
+    /// For a device that was revoked while this node was offline: the stored id is
+    /// spent, every certificate minted for it is refused by every peer, and nothing
+    /// re-mints until an enrolment happens to consult the namespace holding the
+    /// tombstone. Refused while the device still serves a namespace this node takes
+    /// part in, because its id is the replica the node's CRDT state is held under.
+    #[arg(long, default_value_t = false)]
+    reset: bool,
+}
 
 impl DeviceCommand {
     #[expect(
@@ -1272,6 +1282,13 @@ impl DeviceCommand {
     )]
     pub async fn run(self, root_args: &RootArgs) -> EyreResult<()> {
         let store = open_store(root_args).await?;
+
+        if self.reset {
+            let dropped = NodeDeviceRepository::new(&store).reset_device()?;
+            println!("Reset device {}", hex::encode(dropped.as_bytes()));
+            println!("The next pairing or namespace join mints a fresh identity.");
+            return Ok(());
+        }
 
         let device = NodeDeviceRepository::new(&store)
             .get()

--- a/docs/src/content/docs/operate/merod.mdx
+++ b/docs/src/content/docs/operate/merod.mdx
@@ -142,11 +142,11 @@ The account-root command family. These are the operations whose whole point is t
 a machine with no node at all.
 
 ```sh
-merod --node node1 account <export|import|sign-cert|revoke-proof|warrant>
+merod --node node1 account <export|import|device|sign-cert|revoke-proof|warrant>
 ```
 
-<Aside type="caution" title="export and import need the node stopped">
-Both open the datastore directly, and RocksDB's lock is exclusive. A KMS-encrypted
+<Aside type="caution" title="export, import and device need the node stopped">
+They open the datastore directly, and RocksDB's lock is exclusive. A KMS-encrypted
 store is refused rather than misread. `sign-cert`, `revoke-proof` and `warrant` avoid
 this entirely when given `--from`, because they open no store.
 </Aside>
@@ -334,6 +334,25 @@ all.
 
 ```sh
 merod account revoke-proof --device <64-hex DeviceId> --from ./phrase.txt
+```
+
+### device
+
+Print this node's device id and public keys, or with `--reset` drop the device row so
+the next pairing or namespace join mints a fresh one.
+Revocation is terminal: once a device is tombstoned its id can never be linked again,
+so a node revoked while it was offline keeps presenting a spent id and every peer
+refuses the certificates minted for it.
+The stored row is normally released automatically once the tombstone arrives, and
+`--reset` is the handle for forcing that decision offline instead of waiting for a sync
+round to reach the namespace holding it.
+It applies the same rule the enrolment path does and refuses while the device still
+serves a namespace this node takes part in, because a live device's id is the replica
+the node's CRDT state is held under.
+Like `export` and `import` it opens the datastore directly, so the node must be stopped.
+
+```sh
+merod --node node1 account device --reset
 ```
 
 ### warrant


### PR DESCRIPTION
Stacked on #3837 (`fix/pair-complete-revoked-device`), which is this PR's base. Rebase onto master once that merges.

## Summary

A revoked device id is spent for good. A node revoked while it was offline keeps presenting the same id, every certificate minted for it is refused by every peer, and nothing re-mints until an enrolment happens to consult the namespace holding the tombstone. There was no way to force that.

`merod --node <name> account device --reset` drops the device row on demand.

**Why merod and not meroctl.** The operation is `NodeDeviceRepository::delete()`, which opens the node's datastore directly, and RocksDB's lock is exclusive while `merod run` is up. That rules out an admin route: there is no running node to serve it. It is the same offline shape as `account export` and `account import`, so it lands as a flag on the existing `merod account device` subcommand rather than as a new command family.

**The rule is reused, not re-derived.** `NodeDeviceRepository::reset_device()` gates on the existing private `stored_identity_still_serves`, evaluated across every namespace this node takes part in. A live device's id *is* its replica lineage (counter slots and an HLC seed), so dropping a row the enrolment path would have kept strands that state with nothing able to author under it again. A device that still serves is refused with a message naming the device, the namespace, and what to do instead.

## Test plan

**Unit** (`crates/governance-store/src/node_device.rs`), both written before the implementation and observed failing:

- `resetting_drops_a_revoked_device` - enrol, tombstone, reset returns the spent id, the row is gone, and the next enrolment mints a different one.
- `resetting_a_device_that_still_serves_is_refused` - enrol, reset is refused, the row is untouched.

Before:

```
error[E0599]: no method named `reset_device` found for struct `NodeDeviceRepository<'a>`
error: could not compile `calimero-governance-store` (lib test) due to 2 previous errors
```

After:

```
test node_device::tests::resetting_a_device_that_still_serves_is_refused ... ok
test node_device::tests::resetting_drops_a_revoked_device ... ok
```

**E2E.** `apps/scaffolding-e2e/workflows/account-device-revoke-lockout.yml` gains a phase 8 on top of the fixture it already builds. `node_exec` runs an offline `merod` subcommand against a stopped node's data directory and is a native merobox step (0.6.75), already used by four scenarios in this repo, so no Rust integration test was needed.

The phase stops node-3, runs `account device --reset`, asserts the id it printed is exactly the device that was revoked, then runs plain `account device` under `expected_failure` to prove the row is actually gone. That step is what makes the reset load-bearing: a `pair-init` re-mints on its own once the tombstone has landed, so the re-pair would succeed either way, and only a direct observation of the empty slot proves the command did the dropping. Node-3 then restarts, re-pairs onto the same account, and the new device id is asserted different from the revoked one under the same account id. Finally the guard is exercised from the other side: the fresh device is live, so a second `--reset` is asserted to be refused.

**Manual smoke.**

```
$ merod --home … --node n1 account device --reset
Error:
   0: this node holds no device identity, so there is nothing to reset
```

**Gates.** `cargo fmt --check`, `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings`, `cargo clippy -p merod --all-targets --features mock-attestation -- -D warnings`, `cargo test -p calimero-governance-store` (646 passed), `cargo test -p merod` - all pass.

**Docs.** `docs/src/content/docs/operate/merod.mdx` gains a `### device` section under the account family and the stopped-node caution now names `device` alongside `export` and `import`.
