### PR TITLE
fix(governance-store,node): bind a pulled group key to the id a signed op names

### DIFF
--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -341,6 +341,12 @@ impl<'a> NamespaceGovernance<'a> {
                             group_id.to_bytes(),
                             envelope,
                             op.signer,
+                            // `None`: a `KeyDelivery` carries no `key_id` to
+                            // check against, and needs none — the op is signed
+                            // and the envelope's sender is pinned to that
+                            // signer, so provenance is already established by
+                            // the DAG rather than by a hash comparison.
+                            None,
                         ) {
                             Ok(retry_divergence) => {
                                 if retry_divergence.is_some() {
@@ -1316,6 +1322,7 @@ impl<'a> NamespaceGovernance<'a> {
         group_id: [u8; 32],
         envelope_bytes: &[u8],
         responder_identity: PublicKey,
+        expected_key_id: Option<[u8; 32]>,
     ) -> EyreResult<Option<super::super::DivergenceReport>> {
         let envelope: KeyEnvelope = match borsh::from_slice(envelope_bytes) {
             Ok(env) => env,
@@ -1324,7 +1331,12 @@ impl<'a> NamespaceGovernance<'a> {
                 return Ok(None);
             }
         };
-        self.apply_received_group_key_envelope(group_id, &envelope, responder_identity)
+        self.apply_received_group_key_envelope(
+            group_id,
+            &envelope,
+            responder_identity,
+            expected_key_id,
+        )
     }
 
     /// Like [`apply_received_group_key`](Self::apply_received_group_key) but
@@ -1336,6 +1348,7 @@ impl<'a> NamespaceGovernance<'a> {
         group_id: [u8; 32],
         envelope: &KeyEnvelope,
         responder_identity: PublicKey,
+        expected_key_id: Option<[u8; 32]>,
     ) -> EyreResult<Option<super::super::DivergenceReport>> {
         let ns_id = ContextGroupId::from(self.namespace_id.to_bytes());
         let gid = ContextGroupId::from(group_id);
@@ -1427,6 +1440,35 @@ impl<'a> NamespaceGovernance<'a> {
                 return Ok(None);
             }
         };
+
+        // Bind the key to what a signed op said it would be.
+        //
+        // The gate above authenticates WHO wrapped this envelope, not WHAT is
+        // inside it: any key-holding member of the group can mint a valid wrap
+        // around a key of its own choosing. That is enough to matter, because a
+        // node that stores a chosen key seals its own subsequent writes under it
+        // — readable by whoever chose it — and cannot decode the group's real
+        // ops. `key_id` is `SHA256(group_key)`, so when the caller knows which
+        // id it is waiting for (a governance op referenced it, and that op is
+        // signed) the hash decides, and the responder stops being trusted for
+        // content at all.
+        //
+        // Rejection is `Ok(None)`, the same benign shape as an envelope
+        // addressed elsewhere: the joiner moves on to the next peer rather than
+        // failing the round, so one dishonest member cannot deny the key.
+        if let Some(expected) = expected_key_id {
+            let served = GroupKeyring::key_id_for(&group_key);
+            if served != expected {
+                tracing::warn!(
+                    group_id = %hex::encode(group_id),
+                    responder = %responder_identity,
+                    expected_key_id = %hex::encode(expected),
+                    served_key_id = %hex::encode(served),
+                    "rejecting received group key: it is not the key the awaiting op names"
+                );
+                return Ok(None);
+            }
+        }
 
         let key_id = GroupKeyring::new(self.store, gid)
             .store_key(&group_key)
@@ -2318,11 +2360,13 @@ pub fn apply_received_group_key(
     group_id: [u8; 32],
     envelope_bytes: &[u8],
     responder_identity: PublicKey,
+    expected_key_id: Option<[u8; 32]>,
 ) -> EyreResult<Option<super::super::DivergenceReport>> {
     NamespaceGovernance::new(store, namespace_id).apply_received_group_key(
         group_id,
         envelope_bytes,
         responder_identity,
+        expected_key_id,
     )
 }
 /// Prepare a root op for publishing, resolving this namespace's key here.

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -6088,7 +6088,7 @@ fn a_responder_serving_a_key_other_than_the_awaited_one_is_refused() {
     use crate::group_keys::GroupKeyring;
     use crate::{build_group_key_delivery, namespace_groups_awaiting_key};
     use calimero_context_client::local_governance::{GroupOp, NamespaceOp, SignedNamespaceOp};
-    use calimero_store::rand::UnwrapErr;
+    use rand::rand_core::UnwrapErr;
     use rand::rngs::SysRng;
 
     let mut rng = UnwrapErr(SysRng);
@@ -6105,10 +6105,9 @@ fn a_responder_serving_a_key_other_than_the_awaited_one_is_refused() {
     let joiner_sk_bytes: [u8; 32] = rand::RngExt::random(&mut rng);
     let joiner_sk = PrivateKey::from(joiner_sk_bytes);
     let joiner_pk = joiner_sk.public_key();
-    let joiner_account = crate::test_fixtures::account_for(&joiner_pk);
 
     let joiner_store = test_store();
-    let (joiner_credential, joiner_device) =
+    let (joiner_account, joiner_device, joiner_credential) =
         crate::test_fixtures::enrol_local_device(&joiner_store, &ns_gid, &joiner_pk);
 
     let responder_sk_bytes: [u8; 32] = rand::RngExt::random(&mut rng);

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -5843,6 +5843,7 @@ fn apply_received_group_key_stores_key_for_recipient() {
         group_id,
         &envelope_bytes,
         sender_sk.public_key(),
+        None,
     )
     .unwrap();
 
@@ -5895,6 +5896,7 @@ fn apply_received_group_key_ignores_envelope_for_other_recipient() {
         group_id,
         &envelope_bytes,
         sender_sk.public_key(),
+        None,
     )
     .unwrap();
     assert!(divergence.is_none());
@@ -6065,6 +6067,184 @@ fn restricted_subgroup_awaits_key_despite_holding_namespace_key() {
     );
 }
 
+/// **The security property.** A member that holds a group key can wrap a key of
+/// its OWN choosing for a joiner, and the authenticated-sender gate does not
+/// stop it: that gate binds WHO wrapped the envelope, not WHAT is inside.
+///
+/// Left unchecked this is not merely a failed join. The joiner stores the
+/// attacker's key as current (a directly-delivered key lands at epoch 0, and a
+/// cold joiner holds nothing to outrank it), then seals its own subsequent
+/// writes under it — readable by whoever chose it — while the group's real ops
+/// stay undecodable.
+///
+/// `key_id` is `SHA256(group_key)`, and a buffered op names the id it is waiting
+/// for, so the joiner can settle this without trusting the responder at all.
+///
+/// Mutation check: drop the `expected_key_id` comparison in
+/// `apply_received_group_key_envelope` and this test fails while the honest
+/// round-trip beside it still passes.
+#[test]
+fn a_responder_serving_a_key_other_than_the_awaited_one_is_refused() {
+    use crate::group_keys::GroupKeyring;
+    use crate::{build_group_key_delivery, namespace_groups_awaiting_key};
+    use calimero_context_client::local_governance::{GroupOp, NamespaceOp, SignedNamespaceOp};
+    use calimero_store::rand::UnwrapErr;
+    use rand::rngs::SysRng;
+
+    let mut rng = UnwrapErr(SysRng);
+    let namespace_id = [0xF4u8; 32];
+    let ns_gid = ContextGroupId::from(namespace_id);
+    let subgroup_id = [0xF5u8; 32];
+    let subgroup_gid = ContextGroupId::from(subgroup_id);
+    // The key the group actually uses, and the one a hostile member substitutes.
+    let real_key = [0x6Cu8; 32];
+    let hostile_key = [0xADu8; 32];
+    let real_key_id = GroupKeyring::key_id_for(&real_key);
+    assert_ne!(real_key_id, GroupKeyring::key_id_for(&hostile_key));
+
+    let joiner_sk_bytes: [u8; 32] = rand::RngExt::random(&mut rng);
+    let joiner_sk = PrivateKey::from(joiner_sk_bytes);
+    let joiner_pk = joiner_sk.public_key();
+    let joiner_account = crate::test_fixtures::account_for(&joiner_pk);
+
+    let joiner_store = test_store();
+    let (joiner_credential, joiner_device) =
+        crate::test_fixtures::enrol_local_device(&joiner_store, &ns_gid, &joiner_pk);
+
+    let responder_sk_bytes: [u8; 32] = rand::RngExt::random(&mut rng);
+    let responder_sk = PrivateKey::from(responder_sk_bytes);
+    let responder_pk = responder_sk.public_key();
+    let responder_account = crate::test_fixtures::account_for(&responder_pk);
+
+    // A member in good standing — this is an insider, not an outsider. It just
+    // keeps a different key in its keyring than the group's real one.
+    let responder_store = test_store();
+    crate::test_fixtures::record_credential(&responder_store, &ns_gid, &joiner_credential);
+    let _ = enrol_member(&responder_store, &ns_gid, &responder_pk);
+    NamespaceRepository::new(&responder_store)
+        .store_identity(&ns_gid, &responder_pk, &responder_sk_bytes)
+        .unwrap();
+    MetaRepository::new(&responder_store)
+        .save(&ns_gid, &sample_meta_with_admin(responder_account))
+        .unwrap();
+    MetaRepository::new(&responder_store)
+        .save(&subgroup_gid, &sample_meta_with_admin(responder_account))
+        .unwrap();
+    NamespaceRepository::new(&responder_store)
+        .nest(&ns_gid, &subgroup_gid)
+        .unwrap();
+    MembershipRepository::new(&responder_store)
+        .add_member(&subgroup_gid, &joiner_account, GroupMemberRole::Member)
+        .unwrap();
+    GroupKeyring::new(&responder_store, subgroup_gid)
+        .store_key(&hostile_key)
+        .unwrap();
+
+    let (envelope_bytes, responder_identity) = build_group_key_delivery(
+        &responder_store,
+        namespace_id.into(),
+        subgroup_id,
+        crate::KeyRequester {
+            identity: joiner_pk,
+            device: Some(joiner_device),
+        },
+        None,
+    )
+    .unwrap();
+    assert!(
+        !envelope_bytes.is_empty(),
+        "precondition: the hostile member produces a well-formed, correctly \
+         addressed envelope — nothing about its shape is wrong"
+    );
+
+    // Cold joiner: no key at all, and a buffered op naming the REAL key's id.
+    NamespaceRepository::new(&joiner_store)
+        .store_identity(&ns_gid, &joiner_pk, &joiner_sk_bytes)
+        .unwrap();
+    let buffered = SignedNamespaceOp::sign(
+        &responder_sk,
+        namespace_id.into(),
+        vec![],
+        1,
+        NamespaceOp::Group {
+            group_id: subgroup_id.into(),
+            key_id: real_key_id.into(),
+            encrypted: GroupKeyring::encrypt_op(&real_key, &GroupOp::Noop).unwrap(),
+            key_rotation: None,
+        },
+    )
+    .unwrap();
+    NamespaceOpLogService::new(&joiner_store, namespace_id.into())
+        .store_signed_operation(&buffered)
+        .unwrap();
+    assert_eq!(
+        namespace_groups_awaiting_key(&joiner_store, namespace_id.into()).unwrap(),
+        vec![subgroup_id],
+        "precondition: the joiner awaits this group's key and holds none"
+    );
+
+    // The refusal. Benign shape on purpose: the joiner tries the next peer
+    // rather than failing the round, so one dishonest member cannot deny it.
+    let divergence = apply_received_group_key(
+        &joiner_store,
+        namespace_id.into(),
+        subgroup_id,
+        &envelope_bytes,
+        responder_identity,
+        Some(real_key_id),
+    )
+    .unwrap();
+    assert!(divergence.is_none());
+    assert!(
+        GroupKeyring::new(&joiner_store, subgroup_gid)
+            .load_current_key()
+            .unwrap()
+            .is_none(),
+        "a key that is not the awaited one must not be stored — storing it would \
+         make it current for a cold joiner and seal that node's own writes under \
+         a key an attacker picked"
+    );
+    assert_eq!(
+        namespace_groups_awaiting_key(&joiner_store, namespace_id.into()).unwrap(),
+        vec![subgroup_id],
+        "and the joiner still awaits the real key, so the next peer is tried"
+    );
+
+    // The control: the SAME call with the real key is accepted. Without this the
+    // test would pass just as happily against a gate that refused everything.
+    GroupKeyring::new(&responder_store, subgroup_gid)
+        .store_key(&real_key)
+        .unwrap();
+    let (honest_bytes, honest_identity) = build_group_key_delivery(
+        &responder_store,
+        namespace_id.into(),
+        subgroup_id,
+        crate::KeyRequester {
+            identity: joiner_pk,
+            device: Some(joiner_device),
+        },
+        None,
+    )
+    .unwrap();
+    apply_received_group_key(
+        &joiner_store,
+        namespace_id.into(),
+        subgroup_id,
+        &honest_bytes,
+        honest_identity,
+        Some(real_key_id),
+    )
+    .unwrap();
+    assert_eq!(
+        GroupKeyring::new(&joiner_store, subgroup_gid)
+            .load_current_key()
+            .unwrap()
+            .map(|(id, _)| id),
+        Some(real_key_id),
+        "the awaited key is accepted, so the check discriminates rather than refusing all"
+    );
+}
+
 #[test]
 fn responder_delivery_round_trips_key_to_joiner_cross_store() {
     // The cross-node exchange minus the libp2p transport: a key-holding
@@ -6184,6 +6364,7 @@ fn responder_delivery_round_trips_key_to_joiner_cross_store() {
         subgroup_id,
         &envelope_bytes,
         responder_identity,
+        None,
     )
     .unwrap();
 
@@ -6322,6 +6503,7 @@ fn responder_delivery_round_trips_key_to_read_only_tee_joiner() {
         subgroup_id,
         &envelope_bytes,
         responder_identity,
+        None,
     )
     .unwrap();
 

--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -1916,7 +1916,44 @@ impl SyncManager {
         }
 
         for (group_id, key_id) in requests {
-            for peer in &candidates {
+            // Anchors first, per group. A group key is the one thing on the
+            // sync paths a peer is trusted for by content rather than by
+            // signature: an op is verified before it mutates anything, but an
+            // unwrapped key is just bytes. Where `key_id` is known the hash
+            // check below settles it and the ordering is only efficiency;
+            // where it is `None` — a group we are a keyless member of, with no
+            // op naming a key yet, which is the cold-start case — preference
+            // for an Admin or `ReadOnlyTee` anchor is the only thing standing
+            // between a cold node and a key chosen by any member who answers.
+            //
+            // A preference, not a requirement: plain members are still tried
+            // after the anchors. Making it a requirement would trade a
+            // confidentiality risk for a liveness one — no anchor online, no
+            // key, no join — and that is a call for the operator, not this
+            // loop. Anchors are resolved per group because `trusted_anchors`
+            // is per group; the candidate pool is the namespace mesh.
+            let mut ordered = candidates.clone();
+            let anchors = {
+                let store = self.context_client.datastore_handle().into_inner();
+                crate::sync::anchor_device_keys(
+                    &store,
+                    &calimero_context_config::types::ContextGroupId::from(group_id),
+                )
+            };
+            let anchor_count = crate::sync::peers::partition_peers_anchor_first(
+                &mut ordered,
+                &*self.state_access,
+                &anchors,
+            );
+            debug!(
+                group_id = %hex::encode(group_id),
+                anchor_peer_count = anchor_count,
+                candidate_count = ordered.len(),
+                verifiable = key_id.is_some(),
+                "group-key recovery: preferring anchor peers"
+            );
+
+            for peer in &ordered {
                 let Some((envelope_bytes, responder_identity)) = self
                     .request_group_key_from_peer(*peer, namespace_id, group_id, requester, key_id)
                     .await
@@ -1934,6 +1971,11 @@ impl SyncManager {
                     group_id,
                     &envelope_bytes,
                     responder_identity,
+                    // What we asked this peer for. `Some` whenever a governance
+                    // op is awaiting a specific key, which is what makes the
+                    // responder untrusted for content rather than merely
+                    // less-preferred.
+                    key_id,
                 );
                 drop(store);
                 match outcome {


### PR DESCRIPTION
# [core] a served group key is now checked against a signed op, not trusted

First of three on group-key/root-op hardening. This one is self-contained and has
**no wire change**; the two that follow it seal ops and need coordinated upgrades.

## Description

The p2p key-recovery path authenticated **who** wrapped an envelope, never **what**
was inside it.

`GroupKeyring::unwrap_any(…, Some(&responder_identity), …)` pins the envelope's
`sender` to the peer that served it, so only a key-holding member of the group can
mint a valid wrap. That is a real gate — this is an insider, and an attributable
one — but it says nothing about the key itself. A member may wrap a key of its own
choosing, and the joiner stored whatever unwrapped.

For a **cold joiner** that key becomes current. A directly-delivered key lands at
epoch 0 via `store_key`, and `key_rank` is `(epoch, insertion_seq, key_id)`, so a
node holding nothing has nothing to outrank it. The node then seals its own
subsequent writes under a key an insider picked — readable by them, undecodable by
the group — while the group's real ops stay dark. A group still on an epoch-0 key
is exposed the same way, decided by local arrival order.

Two existing mitigations bound the blast radius and are worth stating so the
severity isn't overread: the sender gate above (insider only, and named in the
envelope), and a cross-namespace pin that stops a served key being stored under
another namespace's group id.

### The fix: the id was already in the request

`key_id` is `SHA256(group_key)`, and the pull already carried the id it wanted:

```rust
let mut requests: Vec<([u8; 32], Option<[u8; 32]>)> =
    awaiting.into_iter().map(|(g, k)| (g, Some(k))).collect();
for g in member_keyless { requests.push((g, None)); }
```

`Some(key_id)` whenever a governance op is awaiting a specific key — and that op is
signed, so the id has provenance. It just never reached the apply, whose signature
took no key id at all.

* `apply_received_group_key[_envelope]` now take `expected_key_id: Option<[u8; 32]>`
  and refuse a key whose hash does not match. Refusal is `Ok(None)` — the same
  benign shape as an envelope addressed elsewhere — so the joiner moves to the next
  peer rather than failing the round. One dishonest member cannot deny the key.
* The sync pull passes the id it asked for.
* The DAG `KeyDelivery` apply passes `None` **deliberately**: that op carries no
  `key_id` and needs none, since it is signed and the envelope's sender is pinned to
  that signer. Provenance there comes from the DAG, not from a hash.

### Anchor-first, per group

Key-fetch candidates are now ordered anchor-first, reusing the existing
`partition_peers_anchor_first` and `anchor_device_keys`. Group-scoped, because
`trusted_anchors` is per group while the candidate pool is the namespace mesh.

Where `key_id` is known the hash decides and this is only efficiency. Where it is
`None` — a keyless member of a group no op names a key for yet, i.e. **cold start**
— an Admin or `ReadOnlyTee` anchor is the only thing between the node and a key
chosen by whichever member answers first. The two halves of this PR therefore cover
disjoint cases; neither subsumes the other.

**It is a preference, not a requirement.** Plain members are still tried after the
anchors, because requiring an anchor trades a confidentiality risk for a liveness
one — no anchor online, no key, no join. That is an operator's call, not this
loop's, and the reasoning is recorded at the call site. Flipping it to a hard
requirement is a one-line change if that is the policy wanted.

## Test plan

`cargo test -p calimero-governance-store` — **653 passed, 0 failed**.
`cargo test -p calimero-node --lib` — **584 passed, 0 failed**.
`cargo clippy -p calimero-governance-store -p calimero-node --all-targets -- -D warnings`
— exit 0 (one pre-existing `proc-macro-error2` future-incompat note on a dependency).
`cargo fmt --check` clean.

New test: `a_responder_serving_a_key_other_than_the_awaited_one_is_refused`. The
responder is an **insider** — a member in good standing, correctly enrolled, whose
envelope is well-formed and correctly addressed — that simply keeps a different key
in its keyring. The joiner is cold, with a buffered op naming the real key's id.

## Proof the fix works

**Reproduction** — disable the comparison:

```rust
if false && served != expected {
```

**Before:**

```
test namespace::tests::a_responder_serving_a_key_other_than_the_awaited_one_is_refused ... FAILED
test namespace::tests::responder_delivery_round_trips_key_to_joiner_cross_store ... ok
```

**After** — with the comparison restored: `653 passed; 0 failed`.

The honest round-trip beside it passes **either way**, which is the point: the new
test discriminates on the fix rather than on a gate that refuses everything. The
same control is built into the new test itself — after asserting the hostile key is
refused, it delivers the *real* key through the identical call and asserts it is
accepted and becomes current.

Also asserted at the refusal: the keyring stays empty, and the group is still listed
as awaiting its key, so the next peer really is tried.

## Wire contract (SDK gate)

- [x] Regenerated wire fixtures — n/a, no DTO changed
- [x] Updated `crates/server/endpoints.json` — n/a, no routes changed
- [x] Linked the matching mero-js PR — n/a, no HTTP surface touched

`apply_received_group_key` is a Rust-internal signature; nothing crosses the wire.

## Documentation update

No user-facing behaviour changes, so nothing in `docs/` describes this today. If the
anchor preference becomes a requirement, that belongs in the sync docs and I would
add it with that change rather than pre-empting it here.

## Follow-ups in this stack

* **Seal `RootOp::KeyDelivery`.** Its premise — that a joiner acquires keys p2p from
  an anchor — depends on the preference above becoming a requirement. Sealing while
  the p2p path is only probabilistically anchored would remove the authenticated DAG
  fallback without closing the hole, so that decision comes first.
* **Seal `MemberJoined`, `MemberJoinedAt` and root `MemberJoinedViaTeeAttestation`.**
  All three are published by a key-holder today — an admitter (`AdmitterEndorsement`
  is mandatory) or a verifying member — so `root_op_is_sealable`'s "publisher does
  not hold the key yet" no longer describes them. Blocked on a separate question:
  whether a subgroup member that is not a namespace member is a reachable state,
  since such a member already cannot decrypt the five sealed root ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3)_