### PR TITLE
fix(node): require a trusted anchor for a group key that cannot be verified

### DIFF
--- a/crates/node/src/sync/manager/namespace_sync.rs
+++ b/crates/node/src/sync/manager/namespace_sync.rs
@@ -1916,22 +1916,12 @@ impl SyncManager {
         }
 
         for (group_id, key_id) in requests {
-            // Anchors first, per group. A group key is the one thing on the
-            // sync paths a peer is trusted for by content rather than by
-            // signature: an op is verified before it mutates anything, but an
-            // unwrapped key is just bytes. Where `key_id` is known the hash
-            // check below settles it and the ordering is only efficiency;
-            // where it is `None` — a group we are a keyless member of, with no
-            // op naming a key yet, which is the cold-start case — preference
-            // for an Admin or `ReadOnlyTee` anchor is the only thing standing
-            // between a cold node and a key chosen by any member who answers.
-            //
-            // A preference, not a requirement: plain members are still tried
-            // after the anchors. Making it a requirement would trade a
-            // confidentiality risk for a liveness one — no anchor online, no
-            // key, no join — and that is a call for the operator, not this
-            // loop. Anchors are resolved per group because `trusted_anchors`
-            // is per group; the candidate pool is the namespace mesh.
+            // Anchors first, per group — `trusted_anchors` is per group, while
+            // the candidate pool is the namespace mesh. Whether the ordering is
+            // merely a preference or a hard restriction is decided by
+            // `key_servers_allowed`, which documents the reasoning: any
+            // candidate may serve a key the hash can check, and only an anchor
+            // may serve one it cannot.
             let mut ordered = candidates.clone();
             let anchors = {
                 let store = self.context_client.datastore_handle().into_inner();
@@ -1945,12 +1935,43 @@ impl SyncManager {
                 &*self.state_access,
                 &anchors,
             );
+            // How many of those may actually serve this request. Anchor-only
+            // when the key cannot be checked; any candidate when it can.
+            let Some(allowed) = crate::sync::peers::key_servers_allowed(
+                ordered.len(),
+                anchor_count,
+                !anchors.is_empty(),
+                key_id.is_some(),
+            ) else {
+                if anchors.is_empty() {
+                    warn!(
+                        group_id = %hex::encode(group_id),
+                        candidate_count = ordered.len(),
+                        "group-key recovery refused: this key cannot be verified \
+                         against a signed op and no trusted anchor can be \
+                         identified for the group, so there is nobody it is safe \
+                         to accept it from; retrying once governance state names \
+                         an Admin or ReadOnlyTee"
+                    );
+                } else {
+                    warn!(
+                        group_id = %hex::encode(group_id),
+                        candidate_count = ordered.len(),
+                        "group-key recovery refused: this key cannot be verified \
+                         against a signed op and no trusted anchor is reachable; \
+                         retrying rather than accepting an unverifiable key from \
+                         a non-anchor peer"
+                    );
+                }
+                continue;
+            };
+            ordered.truncate(allowed);
             debug!(
                 group_id = %hex::encode(group_id),
                 anchor_peer_count = anchor_count,
-                candidate_count = ordered.len(),
+                allowed_servers = allowed,
                 verifiable = key_id.is_some(),
-                "group-key recovery: preferring anchor peers"
+                "group-key recovery: candidate peers selected"
             );
 
             for peer in &ordered {

--- a/crates/node/src/sync/peers.rs
+++ b/crates/node/src/sync/peers.rs
@@ -262,6 +262,51 @@ pub(crate) async fn discover_mesh_peers_with_namespace_fallback(
 ///
 /// Free function (not a method) so it can be unit-tested against
 /// synthetic inputs without spinning up a sync manager.
+/// How many of an anchor-first-ordered candidate list may serve a group key.
+///
+/// A group key is the one thing on the sync paths a peer is trusted for by
+/// *content* rather than by signature. An op is signature-verified before it
+/// mutates anything, so the worst a bad peer can do there is serve nothing or
+/// something stale. An unwrapped key is just bytes: a node that stores a key an
+/// insider chose seals its own later writes under it, and cannot decode the
+/// group's real ops.
+///
+/// So the answer depends on whether this particular request can be verified:
+///
+/// * **`verifiable`** — a governance op awaits a specific `key_id`, and that op
+///   is signed, so `SHA256(served) == expected` settles it and the responder is
+///   not trusted at all. Every candidate may serve; the anchor ordering ahead of
+///   this is then only about not wasting round-trips. Restricting to anchors
+///   here would buy nothing and cost availability.
+/// * **not verifiable** — a keyless member of a group no op names a key for yet,
+///   which is cold start. There is nothing to compare against, so trust in the
+///   responder is all there is, and **only an anchor may serve**: `None` rather
+///   than fall through to an arbitrary member.
+///
+/// `None` means refuse and retry later, deliberately in preference to accepting
+/// an unverifiable key from a non-anchor. That trades a liveness risk for a
+/// confidentiality one — a namespace whose anchors are all unreachable cannot
+/// complete a cold join — which is the intended policy, not an oversight.
+///
+/// The two `None` cases are distinguished by `anchors_known` so callers can log
+/// them apart: "no anchor is reachable" is the accepted cost, while "no anchor
+/// can even be identified" points at unfolded governance state and is worth
+/// noticing.
+pub(crate) fn key_servers_allowed(
+    total_candidates: usize,
+    anchor_count: usize,
+    anchors_known: bool,
+    verifiable: bool,
+) -> Option<usize> {
+    if verifiable {
+        return (total_candidates > 0).then_some(total_candidates);
+    }
+    if !anchors_known || anchor_count == 0 {
+        return None;
+    }
+    Some(anchor_count)
+}
+
 pub(crate) fn partition_peers_anchor_first(
     peers: &mut [PeerId],
     state_access: &dyn SyncStateAccess,
@@ -649,6 +694,46 @@ mod tests {
                 SyncStateAccessCall::PeerIdentities(plain_peer),
                 SyncStateAccessCall::PeerIdentities(anchor_peer),
             ]
+        );
+    }
+    /// A verifiable request may use any candidate: the hash decides, so the
+    /// responder is not trusted and restricting to anchors would only cost
+    /// availability.
+    #[test]
+    fn a_verifiable_key_request_may_use_any_candidate() {
+        assert_eq!(key_servers_allowed(5, 2, true, true), Some(5));
+        assert_eq!(
+            key_servers_allowed(5, 0, false, true),
+            Some(5),
+            "not even an identifiable anchor is needed when the key can be checked"
+        );
+        assert_eq!(
+            key_servers_allowed(0, 0, true, true),
+            None,
+            "but there still has to be somebody to ask"
+        );
+    }
+
+    /// **The gate.** An unverifiable request — cold start, no op naming a key —
+    /// is restricted to anchors, and refuses rather than falling through.
+    #[test]
+    fn an_unverifiable_key_request_is_restricted_to_anchors() {
+        assert_eq!(
+            key_servers_allowed(5, 2, true, false),
+            Some(2),
+            "only the anchors, which the anchor-first ordering has put in front"
+        );
+        assert_eq!(
+            key_servers_allowed(5, 0, true, false),
+            None,
+            "anchors are known but none is reachable: refuse and retry, never \
+             fall through to an arbitrary member"
+        );
+        assert_eq!(
+            key_servers_allowed(5, 0, false, false),
+            None,
+            "and no identifiable anchor refuses too — the distinction is for the \
+             log line, not for the verdict"
         );
     }
 }


### PR DESCRIPTION
# [core] anchor-only where a served key cannot be checked

Second of three on group-key/root-op hardening, and the completion of #3844.
No wire change.

## Why this is a separate PR

#3844 shipped the half that matters most — a served key is now checked against the
`key_id` a signed op names — but it landed while its anchor ordering was still only
a **preference**, so `key_servers_allowed` is not on master. This is that policy
decision, made deliberately rather than left as the default.

## Description

`apply_received_group_key` now refuses a key whose `SHA256` does not match the id
an awaiting op names, which removes trust in the responder **for requests that
carry an id**. What it cannot help is the other case:

```rust
let mut requests: Vec<([u8; 32], Option<[u8; 32]>)> =
    awaiting.into_iter().map(|(g, k)| (g, Some(k))).collect();
for g in member_keyless { requests.push((g, None)); }
```

`None` — a keyless member of a group no op names a key for yet — is **cold start**.
There is nothing to compare against, so trust in whoever answers is all there is,
and a member serving a key of its own choosing is accepted. A cold node then seals
its own later writes under a key an insider picked and cannot decode the group's
real ops.

So the restriction is applied exactly where verification is impossible:

| Request | Who may serve | Why |
| --- | --- | --- |
| `key_id` = `Some` | any candidate | the hash makes the responder untrusted outright, which is strictly stronger than preferring an anchor. Ordering is then only about not wasting round-trips. |
| `key_id` = `None` | **anchors only**, else refuse | nothing to compare against; an Admin or `ReadOnlyTee` is the only basis for accepting it at all. |

**Conditional rather than blanket, on purpose.** Gating the verifiable case too
would buy nothing — the hash already settles it — and would cost availability. Cold
start was the only place responder trust was load-bearing.

The accepted cost, stated plainly: a namespace whose anchors are all unreachable
cannot complete a cold join. Refusing and retrying is preferred to accepting an
unverifiable key from an arbitrary member.

### Shape

The decision is a pure function, `key_servers_allowed(total, anchor_count,
anchors_known, verifiable) -> Option<usize>`, rather than inline conditions inside
an async network loop — so it is unit-testable and the reasoning has one home.
`None` means refuse; `Some(n)` means "the first `n` of the anchor-first-ordered
list", which is `anchor_count` when gated and everything otherwise.

### Two refusals that look alike and are not

`anchor_device_keys` returns an empty set both when a store read fails and when no
anchor is identifiable yet. Both refuse, but they log differently, because only one
is the intended cost:

* **no anchor reachable** — this policy working as designed.
* **no anchor identifiable** — governance state not folded far enough to name one.
  Worth noticing: `AdminChanged` is itself a sealed root op, so a node's view of who
  is Admin can lag until it is keyed. `NamespaceCreated` (unsealed, names the
  founder) and `MemberJoinedViaTeeAttestation` (unsealed) should keep the initial
  anchor set derivable — that is reasoning from the sealing rules, not something
  this PR tests.

## Test plan

`cargo test -p calimero-node --lib` — **586 passed, 0 failed** (584 before; the two
new ones are the gate).
`cargo clippy -p calimero-node --all-targets -- -D warnings` — exit 0.
`cargo fmt --check` — clean.

All three run against the post-#3844 master, not the branch #3844 merged from, since
the merge changed one of the files this touches.

Two tests, one per side of the condition:

* `a_verifiable_key_request_may_use_any_candidate` — every candidate allowed, even
  with no identifiable anchor; and there must still be somebody to ask.
* `an_unverifiable_key_request_is_restricted_to_anchors` — only the anchors, and
  **`None` rather than a fall-through** both when anchors are known but unreachable
  and when none can be identified.

Unit-level because the decision is now a pure function; the surrounding loop is an
async method with network and store dependencies, and testing the policy through it
would test the mocks more than the rule.

## Wire contract (SDK gate)

- [x] Regenerated wire fixtures — n/a, no DTO changed
- [x] Updated `crates/server/endpoints.json` — n/a, no routes changed
- [x] Linked the matching mero-js PR — n/a, no HTTP surface touched

## Documentation update

This is the first change in the stack with operator-visible behaviour: a cold join
can now fail where it previously succeeded against a non-anchor peer. If you would
rather that be documented before it merges than after, say so and I will add it to
the sync docs in this PR — otherwise it belongs with the sealing change that makes
the p2p path the only route.

## Next in this stack

**Seal `RootOp::KeyDelivery`**, stacked on this branch rather than on master —
deliberately, because the order now matters for correctness and not just tidiness.
Sealing while the p2p path is only probabilistically anchored would ship the one
combination this PR exists to avoid: no authenticated DAG fallback *and* no
guarantee about who served the key.

After that, sealing `MemberJoined`, `MemberJoinedAt` and root
`MemberJoinedViaTeeAttestation` — all three are published by a key-holder today, so
`root_op_is_sealable`'s "publisher does not hold the key yet" no longer describes
them. Still blocked on a separate question: whether a subgroup member that is not a
namespace member ever has to fold one of the five already-sealed root ops, which
would be a pre-existing bug rather than one that change introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3)_