### PR TITLE
test(governance-store): pin what the key pull does for a subgroup-only member

### DIFF
--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -8595,3 +8595,178 @@ fn the_live_path_folds_an_account_device_linked_when_the_key_is_already_held() {
         "with the key held on arrival the link folds and the binding is written"
     );
 }
+
+/// A member added to a subgroup, holding no binding in the owning namespace,
+/// is served nothing by the pull either — so it has no way to get the key at all.
+///
+/// `add_group_members` already knows the push cannot reach this account:
+/// `key_deliveries` scans the namespace's binding column, finds none, and the
+/// handler logs *"no group key was delivered to the added member; it must pull
+/// the key itself"*. This pins what that advice is worth **at the moment it is
+/// logged**: nothing. The pull resolves a requester through the same binding
+/// column (`member_account_in_namespace`), so an account the push could not
+/// address is an account the pull cannot authorise either — both doors are the
+/// same door.
+///
+/// Deliberately NOT claiming this is permanent. Naming an account the namespace
+/// has not converged on is an allowed and documented move (see
+/// `member_account::resolve`'s note on the ambiguity it accepts), and the moment
+/// a binding for this account does land the pull starts working — that is the
+/// sibling test below. What is unproven, and what an issue should settle, is
+/// whether a member added ONLY to a subgroup has any path to acquiring that
+/// binding: the writers are namespace joins and device links, and a member that
+/// never joins the namespace reaches neither on its own.
+///
+/// This is NOT a consequence of sealing `RootOp::KeyDelivery`. The push was
+/// already empty for this account before sealing — there was nothing to seal.
+/// Pinning it here so the boundary is a decision rather than a surprise, and so
+/// the sibling test below cannot be misread as covering it.
+#[test]
+fn an_added_member_with_no_namespace_binding_is_served_nothing_by_the_pull() {
+    let namespace_id = [0xC1u8; 32];
+    let ns_gid = ContextGroupId::from(namespace_id);
+    let subgroup_id = [0xC2u8; 32];
+    let subgroup_gid = ContextGroupId::from(subgroup_id);
+    let group_key = [0x7Au8; 32];
+
+    let admin_sk = PrivateKey::from([0x31u8; 32]);
+    let admin_pk = admin_sk.public_key();
+
+    let store = test_store();
+    let admin_account = enrol_member(&store, &ns_gid, &admin_pk);
+    NamespaceRepository::new(&store)
+        .store_identity(&ns_gid, &admin_pk, admin_sk.as_bytes())
+        .unwrap();
+    MetaRepository::new(&store)
+        .save(&ns_gid, &sample_meta_with_admin(admin_account))
+        .unwrap();
+    MetaRepository::new(&store)
+        .save(&subgroup_gid, &sample_meta_with_admin(admin_account))
+        .unwrap();
+    NamespaceRepository::new(&store)
+        .nest(&ns_gid, &subgroup_gid)
+        .unwrap();
+    GroupKeyring::new(&store, subgroup_gid)
+        .store_key(&group_key)
+        .unwrap();
+
+    // The added member: a real account with a real key, but never enrolled in
+    // this namespace, so no binding row names it. An admin may still add it —
+    // `member_added` gates only on the SIGNER's `require_manage_members` and
+    // never asks whether the added account is known here.
+    let stranger_sk = PrivateKey::from([0x32u8; 32]);
+    let stranger_pk = stranger_sk.public_key();
+    let stranger_account = crate::test_fixtures::account_for(&stranger_pk);
+    MembershipRepository::new(&store)
+        .add_member(&subgroup_gid, &stranger_account, GroupMemberRole::Member)
+        .unwrap();
+
+    assert!(
+        MembershipRepository::new(&store)
+            .is_member(&subgroup_gid, &stranger_account)
+            .unwrap(),
+        "precondition: the add landed, so this is a genuine member of the subgroup"
+    );
+    assert_eq!(
+        crate::member_account_in_namespace(&store, &ns_gid, &stranger_pk).unwrap(),
+        None,
+        "precondition: and it holds no binding in the owning namespace"
+    );
+
+    let (envelope_bytes, _responder) = build_group_key_delivery(
+        &store,
+        namespace_id.into(),
+        subgroup_id,
+        crate::KeyRequester {
+            identity: stranger_pk,
+            device: None,
+        },
+        None,
+    )
+    .unwrap();
+
+    assert!(
+        envelope_bytes.is_empty(),
+        "a member the binding column cannot resolve is served nothing, so at the \
+         point the push gives up the pull is not yet a fallback"
+    );
+}
+
+/// The case sealing DID change: a subgroup member that is not a member of the
+/// owning namespace root, and so cannot open a `KeyDelivery` sealed under the
+/// namespace key. The pull has to carry it, and this is what says it does.
+///
+/// `responder_delivery_round_trips_key_to_read_only_tee_joiner` covers the same
+/// shape for a `ReadOnlyTee`; this is the plain `Member` case, which is the one
+/// an ordinary `add_group_members` to a Restricted subgroup produces. The
+/// difference that matters is not the role — the responder gate is
+/// role-agnostic — but that this member holds a namespace BINDING while holding
+/// no namespace MEMBERSHIP, which is exactly the combination the sealed push
+/// leaves stranded.
+#[test]
+fn a_subgroup_member_outside_the_namespace_root_is_still_served_by_the_pull() {
+    let namespace_id = [0xC3u8; 32];
+    let ns_gid = ContextGroupId::from(namespace_id);
+    let subgroup_id = [0xC4u8; 32];
+    let subgroup_gid = ContextGroupId::from(subgroup_id);
+    let group_key = [0x7Bu8; 32];
+
+    let admin_sk = PrivateKey::from([0x41u8; 32]);
+    let admin_pk = admin_sk.public_key();
+
+    let store = test_store();
+    let admin_account = enrol_member(&store, &ns_gid, &admin_pk);
+    NamespaceRepository::new(&store)
+        .store_identity(&ns_gid, &admin_pk, admin_sk.as_bytes())
+        .unwrap();
+    MetaRepository::new(&store)
+        .save(&ns_gid, &sample_meta_with_admin(admin_account))
+        .unwrap();
+    MetaRepository::new(&store)
+        .save(&subgroup_gid, &sample_meta_with_admin(admin_account))
+        .unwrap();
+    NamespaceRepository::new(&store)
+        .nest(&ns_gid, &subgroup_gid)
+        .unwrap();
+    GroupKeyring::new(&store, subgroup_gid)
+        .store_key(&group_key)
+        .unwrap();
+
+    // Bound in the namespace (so it is resolvable) but a member ONLY of the
+    // subgroup — never added at the root.
+    let member_sk = PrivateKey::from([0x42u8; 32]);
+    let member_pk = member_sk.public_key();
+    let member_store = test_store();
+    let (member_account, member_device, member_credential) =
+        crate::test_fixtures::enrol_local_device(&member_store, &ns_gid, &member_pk);
+    crate::test_fixtures::record_credential(&store, &ns_gid, &member_credential);
+    MembershipRepository::new(&store)
+        .add_member(&subgroup_gid, &member_account, GroupMemberRole::Member)
+        .unwrap();
+
+    assert!(
+        !MembershipRepository::new(&store)
+            .is_member(&ns_gid, &member_account)
+            .unwrap(),
+        "precondition: this member is NOT in the namespace root, so it holds no \
+         namespace key and cannot open a sealed KeyDelivery"
+    );
+
+    let (envelope_bytes, _responder) = build_group_key_delivery(
+        &store,
+        namespace_id.into(),
+        subgroup_id,
+        crate::KeyRequester {
+            identity: member_pk,
+            device: Some(member_device),
+        },
+        None,
+    )
+    .unwrap();
+
+    assert!(
+        !envelope_bytes.is_empty(),
+        "the pull must carry a subgroup member that the sealed push cannot reach, \
+         or sealing KeyDelivery locked this member out of its own subgroup"
+    );
+}


### PR DESCRIPTION
# [core] Does sealing `KeyDelivery` lock a subgroup-only member out?

No. This is the test that says so, plus the one that marks where the ground
actually stops being solid.

## Description

#3847 seals `RootOp::KeyDelivery` under the **namespace** key. `add_group_members`
does that too, and there the target `group_id` may be a **subgroup**:

```rust
seal_root_op_for_publish(
    &datastore,
    ns_id.to_bytes().into(),          // sealed under the NAMESPACE key
    RootOp::KeyDelivery { group_id: group_id.to_bytes().into(), envelope },
)
```

So a member of a subgroup who is **not** a member of the namespace root holds no
namespace key and cannot open its own key delivery. The push stopped reaching it;
only the pull can. Nothing tested that.

That member is reachable, not hypothetical: `ops/group/member_added.rs` gates only
on the **signer's** `require_manage_members` and never asks whether the added
account is a namespace member.

The closest existing scenario is not coverage — `dm-subgroup-privacy` has its
subgroup member (node-3) `join_namespace` first (lines 106-114), so it holds the
namespace key and never needs the fallback.

### The answer: the pull carries it

`build_group_key_delivery` gates on membership of the **requested group**, not of
the namespace:

```rust
let requester_account = member_account_in_namespace(store, &group_gid, &requester.identity)?;
let is_member = match requester_account {
    Some(account) => MembershipRepository::new(store).is_member(&group_gid, &account)?,
    None => false,
};
```

A subgroup-only member passes. **Sealing locked nobody out.**

### Why nothing broke, and why that was luck

`responder_delivery_round_trips_key_to_read_only_tee_joiner` already had this exact
shape — it adds its joiner to the subgroup only, never to the root. But it reads as
a test about the **`ReadOnlyTee` role**, and the responder gate is role-agnostic.
The property holding the seal up is "namespace **binding**, no namespace
**membership**", and it was load-bearing and unnamed. Stated as its own test so the
next person to touch the seal does not have to work out which existing test they
must not break.

### The other side of the boundary, which predates sealing

Pinning that turned up a second case. Being explicit that this is **not** fallout
from #3847: the push was already empty here before sealing, because there was
nothing to seal.

An account with **no binding** in the namespace gets nothing from the push
(`key_deliveries` scans the binding column and finds none — its own test,
`an_account_with_no_device_gets_nothing`, says so) *and* nothing from the pull,
which resolves requesters through that same column. Both doors are the same door.
Meanwhile the handler logs:

> `no group key was delivered to the added member; it must pull the key itself`

At the moment it is logged, that advice is worth nothing.

The test deliberately does **not** claim this is permanent, and its doc says why:
naming an account the namespace has not converged on is an allowed, documented move
(see `member_account`'s note on the ambiguity it accepts), and a binding landing
later makes the pull work — which is the sibling test. What is unproven is whether
a member added **only** to a subgroup has any path to acquiring one: the writers are
namespace joins and device links, and such a member reaches neither on its own.
That wants a decision (refuse the add? make the pull work? fix the message?), not a
guess encoded in a test.

## Test plan

`cargo test -p calimero-governance-store` — **658 passed**, 0 failed (656 before,
plus the two here).

`CALIMERO_WEBUI_SRC=<stub> CALIMERO_AUTH_FRONTEND_SRC=<stub> cargo clippy -p
calimero-governance-store --all-targets --features calimero-storage/testing --
-D warnings` — exit 0.

`cargo fmt --check` — clean.

Both new tests are in-process against a real `Store`, so they need no Docker and
take milliseconds:

| test | asserts |
| --- | --- |
| `a_subgroup_member_outside_the_namespace_root_is_still_served_by_the_pull` | a member with a namespace binding but no namespace membership **is** served the subgroup key |
| `an_added_member_with_no_namespace_binding_is_served_nothing_by_the_pull` | an account with no binding is served nothing, so at the point the push gives up the pull is not yet a fallback |

Each carries an explicit precondition assertion (`is_member(subgroup)` true /
`is_member(namespace)` false / binding present or absent), so a fixture that drifts
fails on the precondition rather than passing vacuously on the real one — the
failure mode that bit me twice in #3847.

## Proof the fix works

Not applicable in the usual sense: this PR fixes no bug and changes no behaviour.
It is test-only, and its point is that the behaviour under test is **already
correct** — the concern that motivated it did not reproduce.

What stands in for before/after is the discrimination check. The first test fails
if `build_group_key_delivery`'s gate is narrowed from group membership to namespace
membership, which is the plausible way someone "tightens" this later and silently
strands every subgroup-only member.

## Wire contract (SDK gate)

- [x] Regenerated wire fixtures — n/a, no DTO changed
- [x] Updated `crates/server/endpoints.json` — n/a, no routes changed
- [x] Linked the matching mero-js PR — n/a, no HTTP surface

## Documentation update

None required for the merged behaviour: the tests document it where it is decided.

One follow-up worth its own issue rather than this PR — the
`no group key was delivered to the added member; it must pull the key itself`
warning in `add_group_members` promises a fallback that is unavailable at the
moment it fires. Fixing the message is a one-liner; deciding whether the situation
should be reachable at all is not, which is why neither is here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3)_