### PR TITLE
fix(governance-store): refuse a sealable root op offered to the signer in the clear

### DIFF
--- a/crates/context/src/handlers/execute/mod.rs
+++ b/crates/context/src/handlers/execute/mod.rs
@@ -2101,9 +2101,11 @@ async fn internal_execute(
     let account = principal.account;
     let storage = ContextStorage::from(datastore.clone(), context.id);
     let private_storage = ContextPrivateStorage::from(datastore, context.id);
-    // Still both derived from this node's own identity, so behaviour is
-    // unchanged. This is the single site that has to change for a run to be
-    // attributed to the caller instead — see `principal::Principal`.
+    // Self-authored: both halves are this node's own identity. Delegated: both
+    // come from the warrant, resolved in the match above — which is what keeps a
+    // `User` leaf's owner equal to its delta's author and so survives
+    // `user_leaf_author_is_its_owner` on the receive path. See
+    // `principal::Principal`.
     let (mut outcome, storage, private_storage) = execute(
         guard,
         module,

--- a/crates/context/src/handlers/execute/principal.rs
+++ b/crates/context/src/handlers/execute/principal.rs
@@ -28,14 +28,20 @@
 //! the account was resolved inside the execute handler rather than passed down
 //! from the RPC layer — and it survives unchanged here.
 //!
-//! It also does not yet allow the principal and the signer to differ. Every
-//! construction site still derives both from this node's own identity, so
-//! behaviour is identical. Letting them diverge needs the delta envelope to
-//! carry a warrant, because the sync path already refuses a `User` leaf whose
-//! owner is not its author's account — `user_leaf_author_is_its_owner` in
-//! `calimero-node`. Without that, a change attributed to a member but signed by
-//! a relay would apply on the gossip path and be dropped on hash-comparison,
-//! which is silent divergence rather than a partial feature.
+//! The principal and the signer DO differ, on exactly one path: a delegated
+//! execution reads both halves off the warrant
+//! (`Principal::new(warrant.author_account, warrant.author_device_key)`), while
+//! the envelope is signed by this node's own key. Every other construction site
+//! still derives both from the node's identity.
+//!
+//! That divergence had a precondition, and it is why it waited for delegated
+//! authorship rather than landing on its own: the sync path refuses a `User` leaf
+//! whose owner is not its author's account — `user_leaf_author_is_its_owner` in
+//! `calimero-node`. Both halves coming from the same warrant is what satisfies
+//! it. Take the account from the warrant and the device from the node and the
+//! leaf's owner stops matching its author: the change applies on the gossip path
+//! and is dropped on hash-comparison, which is silent divergence rather than a
+//! partial feature.
 
 use calimero_account::AccountId;
 use calimero_primitives::identity::PublicKey;

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -658,6 +658,7 @@ impl<'a> NamespaceGovernance<'a> {
         let observe_mesh = !matches!(op, NamespaceOp::Group { .. });
         let op_kind = op.op_kind_label();
         let op_timeout = timeout_for_namespace_op(&op);
+        refuse_unsealed_sealable_root(&op)?;
         let signed = SignedNamespaceOp::sign(
             signer_sk,
             self.namespace_id,
@@ -871,6 +872,7 @@ impl<'a> NamespaceGovernance<'a> {
         let observe_mesh = !matches!(op, NamespaceOp::Group { .. });
         let op_kind = op.op_kind_label();
         let op_timeout = timeout_for_namespace_op(&op);
+        refuse_unsealed_sealable_root(&op)?;
         let signed = SignedNamespaceOp::sign(
             signer_sk,
             self.namespace_id,
@@ -2534,6 +2536,38 @@ pub async fn sign_apply_and_publish_namespace_op_returning_op(
     NamespaceGovernance::new(store, namespace_id)
         .sign_apply_and_publish_returning_op(node_client, ack_router, signer_sk, op, endorsement)
         .await
+}
+
+/// Refuse to sign a sealable root op that reached the publisher in the clear.
+///
+/// The publish-side counterpart to the gate in `apply_signed_namespace_op`, which
+/// refuses the same shape on arrival. That gate is what makes sealing a rule
+/// rather than a convention, but it only ever fires on somebody ELSE's node: a
+/// publisher that forgets `seal_root_op_for_publish` signs happily, broadcasts,
+/// and every peer drops the op. The failure is total and it is invisible from the
+/// side that caused it.
+///
+/// #3846 is the worked example. Flipping `KeyDelivery` to sealable without routing
+/// its three publishers through the helper looked like a no-op locally — the
+/// classification changed a match arm, and 653 tests that hand-build the op and
+/// apply it directly did not care. What it actually produced was three publishers
+/// emitting ops no peer would accept. Nothing said so at the point of the mistake.
+///
+/// So this answers the same question the receiver answers, at the moment the
+/// mistake is made, naming the fix. It cannot break a working publisher: an op it
+/// refuses is an op every receiver already refuses.
+pub(super) fn refuse_unsealed_sealable_root(op: &NamespaceOp) -> EyreResult<()> {
+    if let NamespaceOp::Root(root) = op {
+        if calimero_governance_types::root_op_is_sealable(root) {
+            eyre::bail!(
+                "refusing to publish a sealable root op in the clear: this variant is \
+                 published under the namespace key and every peer refuses the cleartext \
+                 form, so signing it here would broadcast an op nothing accepts. Route it \
+                 through `seal_root_op_for_publish`."
+            );
+        }
+    }
+    Ok(())
 }
 
 pub async fn sign_and_publish_namespace_op(

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -380,26 +380,43 @@ async fn a_published_op_is_fed_to_the_local_apply_path() {
 /// second write path goes unfed.
 #[actix::test]
 async fn the_publish_only_path_also_feeds_the_local_apply_path() {
-    use calimero_context_client::local_governance::{NamespaceOp, RootOp};
+    use calimero_context_client::local_governance::RootOp;
     use calimero_node_primitives::messages::NodeMessage;
 
     let (store, node_client, ack_router, ns_id, sk, _tmp, mut node_msgs) =
         namespace_publish_fixture().await;
     // A `KeyDelivery` stands in for any publish-only op: it carries no local
     // mutation, so this path signs and publishes without applying first.
-    let op = NamespaceOp::Root(RootOp::KeyDelivery {
-        group_id: ns_id.to_bytes().into(),
-        envelope: calimero_context_client::local_governance::KeyEnvelope {
-            recipient: calimero_governance_types::EnvelopeRecipient::Member {
-                identity: sk.public_key(),
-                ephemeral_pk: sk.public_key(),
+    //
+    // Sealed, because `KeyDelivery` is sealable and the publisher now refuses
+    // the cleartext form — the same refusal every receiver has always made. The
+    // op is incidental to what this test is about (that the feed fires before
+    // the publish is awaited), but publishing it the way production does is not
+    // incidental: a fixture that publishes what nothing else can is a fixture
+    // that stops predicting anything.
+    let ns_gid = ContextGroupId::from(ns_id.to_bytes());
+    let namespace_key = [0x8Cu8; 32];
+    let _ = GroupKeyring::new(&store, ns_gid)
+        .store_key(&namespace_key)
+        .expect("mint the namespace key, as create_group does");
+    let op = crate::seal_root_op_for_publish(
+        &store,
+        ns_id,
+        RootOp::KeyDelivery {
+            group_id: ns_id.to_bytes().into(),
+            envelope: calimero_context_client::local_governance::KeyEnvelope {
+                recipient: calimero_governance_types::EnvelopeRecipient::Member {
+                    identity: sk.public_key(),
+                    ephemeral_pk: sk.public_key(),
+                },
+                sender: sk.public_key(),
+                nonce: [0u8; 12],
+                ciphertext: Vec::new(),
+                signature: [0u8; 64],
             },
-            sender: sk.public_key(),
-            nonce: [0u8; 12],
-            ciphertext: Vec::new(),
-            signature: [0u8; 64],
         },
-    });
+    )
+    .expect("seal the stand-in op");
 
     // The publish itself gathers no acks against the stub network; irrelevant
     // here — the feed fires before the publish is awaited, which is the point
@@ -8594,4 +8611,76 @@ fn the_live_path_folds_an_account_device_linked_when_the_key_is_already_held() {
         Some(linked_account),
         "with the key held on arrival the link folds and the binding is written"
     );
+}
+
+/// The publish side refuses a sealable root op offered in the clear, the same
+/// shape the receive side refuses on arrival.
+///
+/// Without this the two sides disagree about when the mistake is visible. The
+/// receiver has always refused; the publisher signed and broadcast, so the only
+/// symptom was every peer silently dropping the op — a signal that never reaches
+/// the node that caused it. #3846 shipped exactly that and its local test run was
+/// green.
+///
+/// `KeyDelivery` is the subject because it is the variant that was got wrong.
+#[test]
+fn signing_a_sealable_root_op_in_the_clear_is_refused_at_the_publisher() {
+    let ns_gid = ContextGroupId::from([0xD7u8; 32]);
+    let namespace_id = ns_gid.to_bytes();
+
+    let signer_sk = PrivateKey::from([0x51u8; 32]);
+    let signer_pk = signer_sk.public_key();
+
+    let store = test_store();
+    let signer_account = enrol_member(&store, &ns_gid, &signer_pk);
+    NamespaceRepository::new(&store)
+        .store_identity(&ns_gid, &signer_pk, signer_sk.as_bytes())
+        .unwrap();
+    MetaRepository::new(&store)
+        .save(&ns_gid, &sample_meta_with_admin(signer_account))
+        .unwrap();
+
+    use calimero_context_client::local_governance::RootOp;
+
+    let namespace_key = [0x52u8; 32];
+    let _ = GroupKeyring::new(&store, ns_gid)
+        .store_key(&namespace_key)
+        .unwrap();
+
+    let envelope =
+        GroupKeyring::wrap_for_member(&signer_sk, &signer_pk, &ns_gid.to_bytes(), &namespace_key)
+            .unwrap();
+    let cleartext =
+        calimero_context_client::local_governance::NamespaceOp::Root(RootOp::KeyDelivery {
+            group_id: namespace_id.into(),
+            envelope,
+        });
+
+    let err = super::governance::refuse_unsealed_sealable_root(&cleartext)
+        .expect_err("a cleartext sealable root op must not reach the signer");
+    let err = format!("{err:#}");
+    assert!(
+        err.contains("seal_root_op_for_publish"),
+        "the refusal must name the fix, not just the fault: {err}"
+    );
+
+    // And the sealed form of the very same op passes, so the guard rejects the
+    // MISTAKE rather than the variant.
+    let sealed = crate::seal_root_op_for_publish(
+        &store,
+        namespace_id.into(),
+        RootOp::KeyDelivery {
+            group_id: namespace_id.into(),
+            envelope: GroupKeyring::wrap_for_member(
+                &signer_sk,
+                &signer_pk,
+                &ns_gid.to_bytes(),
+                &namespace_key,
+            )
+            .unwrap(),
+        },
+    )
+    .unwrap();
+    super::governance::refuse_unsealed_sealable_root(&sealed)
+        .expect("the sealed form of the same op must publish");
 }


### PR DESCRIPTION
# [core] Make the sealing mistake fail where it is made

Started as "seal the remaining root ops". It ends as the enforcement instead, and
the reason for that is the substance of this PR.

## Description

### Why none of the remaining five are sealed here

Five root ops are still cleartext. I traced each publisher rather than reason from
the classification comment, because the failure mode is unforgiving: the receive
gate refuses a cleartext sealable root op **unconditionally**, so getting one wrong
is not a degradation — it is a total, wire-breaking outage for that operation.

| op | publisher | holds the namespace key? |
| --- | --- | --- |
| `NamespaceCreated` | genesis | no key exists yet |
| `MemberJoined`, `MemberJoinedAt` | the joining outsider | no |
| `MemberJoinedViaTeeAttestation` | admitter, carrying a **fleet outsider's** credential | `admit_tee_node` documents cleartext as the requirement |
| `MemberJoinedOpen` | an inherited member **requesting** a key | **unproven** |

`admit_tee_node` says it outright:

> A FLEET replica is an outsider joining the namespace, so its device has to be
> bound in the same apply as its membership — and that means peers must be able to
> read the credential, which means cleartext.

And `MemberJoinedOpen` turns out to be a *request for a key*: the joiner publishes
it precisely because no admin sent them a `KeyDelivery`. Sealing a key request
under the key being requested is the bootstrap circularity — in the one case where
the publisher cannot be shown to hold the namespace key at all, since an inherited
member may anchor at an intermediate subgroup rather than the root.

**Six of eleven is where this stops.** #3846 is what an override of a documented
rationale costs when it is reasoned rather than traced.

### What is here instead

`root_op_is_sealable` was enforced on **arrival** and nowhere else. That gate is
what makes sealing a rule rather than a convention — but it only ever fires on
somebody *else's* node. A publisher that forgets `seal_root_op_for_publish` signs
happily, broadcasts, and every peer drops the op. Nothing says so at the point the
mistake is made.

#3846 is the worked example. Flipping `KeyDelivery` to sealable without routing its
three publishers through the helper looked like a no-op locally: the classification
changed a match arm, and 653 tests that hand-build the op and apply it directly did
not care. What it actually produced was three publishers emitting ops no peer would
accept, and it took an E2E run to find out.

`refuse_unsealed_sealable_root` asks the receiver's question at both signing sites
and names the fix in the error. **It cannot break a working publisher**: an op it
refuses is an op every receiver already refuses.

### It caught one immediately, and that case is the point

`the_publish_only_path_also_feeds_the_local_apply_path` published a cleartext
`KeyDelivery` as, in its own words, *"a stand-in for any publish-only op"*. The op
is incidental to what that test checks; publishing it the way production cannot is
not. A fixture that publishes what nothing else can is a fixture that has stopped
predicting anything. Sealed, exactly as the two `mock-attestation` fixtures were in
#3847.

### Two comments that had come to say the opposite of the code

Found while tracing delegated execution for an unrelated question.
`principal.rs` claimed the principal and the signer may not differ and that every
construction site derives both from this node's identity. `execute/mod.rs` repeated
it **directly below** the match that reads both off a delegated warrant.

Both now describe the delegated path, and more usefully *why it was safe to allow*:
taking the account from the warrant and the device from the node would break
`user_leaf_author_is_its_owner` on the receive path — the leaf's owner would stop
matching its delta's author, and the change would apply on gossip and be dropped on
hash-comparison. Silent divergence, not a partial feature.

## Test plan

`cargo test -p calimero-governance-store` — **657 passed**, 0 failed.
`cargo test -p calimero-context` — 292 passed.
`cargo test -p calimero-node --lib` — 586 passed.
`cargo test -p merod -p calimero-node -p calimero-tee-attestation --features
mock-attestation` — **exit 0**, all 16 suites ok.
`cargo clippy -p calimero-governance-store -p calimero-context -p calimero-node
--all-targets --features calimero-storage/testing -- -D warnings` — exit 0.
`cargo fmt --check` — clean.

The `mock-attestation` pass is run deliberately and is not optional here: it is the
gate that went red on #3847 for exactly this class of problem, and this change
touches the publish path it exercises. It is also the gate `CLAUDE.md` documents as
running separately — skipping it is what let #3847 reach CI red.

`signing_a_sealable_root_op_in_the_clear_is_refused_at_the_publisher` pins both
directions: the cleartext form is refused **and the sealed form of the very same
op publishes**, so the guard rejects the mistake rather than the variant.

## Proof the fix works

**Reproduction** — the guard's first run against the existing suite:

```
test namespace::tests::the_publish_only_path_also_feeds_the_local_apply_path ... FAILED
the local-apply feed must fire within the timeout: Elapsed(())
```

A fixture publishing a cleartext `KeyDelivery`, which production has been unable to
do since #3847. Before this PR nothing anywhere reported that.

**After** — the fixture publishes the sealed form, as production does:
`657 passed; 0 failed`.

## Wire contract (SDK gate)

- [x] Regenerated wire fixtures — n/a, no DTO changed
- [x] Updated `crates/server/endpoints.json` — n/a, no routes changed
- [x] Linked the matching mero-js PR — n/a, no HTTP surface. mero-js does not
      publish any sealable root op: it emits only the two join variants, and lists
      the rest solely to check the numbering against core.

## Documentation update

The guard's own doc comment carries the reasoning, including #3846 as the worked
example, so the next person to flip a classification meets the explanation at the
point of the mistake.

The `root_op_is_sealable` docs already state which variants are sealable and why;
this PR does not change that set, so they stay correct.

One follow-up left out on purpose: `AdminChanged` and `PolicyUpdated` are
classified sealable and have **no production publisher anywhere** — the only
constructions outside apply/projection code are in `admit_join.rs`'s test module,
and mero-js is ruled out by its own comment. That wants a `technical_issue` and a
decision, not a deletion: removing them renumbers `RootOp` discriminants 3 and 4
and breaks the wire for core and mero-js to reclaim nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3)_