### PR TITLE
fix(governance-store): give a sealed root op the ack budget its variant earns

### DIFF
--- a/crates/governance-store/src/governance_broadcast.rs
+++ b/crates/governance-store/src/governance_broadcast.rs
@@ -90,6 +90,12 @@ pub const OP_ACK_HEAVY_TIMEOUT: Duration = Duration::from_secs(10);
 ///     classification (e.g. `KeyDelivery` heavy via the rotation
 ///     envelope) requires accepting a wider tail. Member-change is the
 ///     conservative middle ground.
+///   * `RootSealed { .. }`: the same baseline, for the same reason — the wire
+///     form is an opaque blob. But unlike a group op, the PUBLISHER of a sealed
+///     root op holds the key by definition, so it can classify exactly; see
+///     [`NamespaceGovernance::ack_timeout_for`](crate::namespace::governance::NamespaceGovernance::ack_timeout_for).
+///     This function is the fallback for readers that hold no key, and its
+///     answer for a sealed op is a floor rather than a verdict.
 #[must_use]
 pub fn timeout_for_namespace_op(op: &NamespaceOp) -> Duration {
     match op {

--- a/crates/governance-store/src/namespace/governance.rs
+++ b/crates/governance-store/src/namespace/governance.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use calimero_governance_types::NamespaceId;
 
 use crate::{
@@ -634,6 +636,39 @@ impl<'a> NamespaceGovernance<'a> {
     /// [`SignedNamespaceOp::admitter_endorsement`]. Taken here rather than left
     /// to the caller so the op is endorsed before it is applied and published:
     /// attaching it afterwards would apply an op locally that peers refuse.
+    /// The ack budget `op` deserves, opening a sealed root op to classify it.
+    ///
+    /// [`timeout_for_namespace_op`] sees only the wire form, and there a sealed
+    /// root op is an opaque blob — so every one of them fell to the
+    /// member-change default. `GroupDeleted` and `KeyDelivery` quietly lost the
+    /// heavy budget they were given when they travelled in the clear, and those
+    /// are exactly the two that need it: a cascade delete touches every
+    /// descendant row and an envelope unwrap can be large. At 5s instead of 10s
+    /// the publisher reports `Degraded` for an op that was propagating fine.
+    ///
+    /// Raising the wire-form default to heavy would have fixed those two by
+    /// making every other sealed op wait 10s instead of 2s before reporting a
+    /// failure — a worse trade than the bug, on the common admin path.
+    ///
+    /// So classify exactly, which the publisher alone can do: sealing REQUIRES
+    /// the namespace key, so a node that sealed this op holds the key to read it
+    /// back. When it does not open — a rotation raced the publish, or this is a
+    /// forwarding path that never held the key — the wire-form answer stands,
+    /// which is the behaviour before this existed.
+    pub(crate) fn ack_timeout_for(&self, op: &NamespaceOp) -> Duration {
+        let NamespaceOp::RootSealed { key_id, encrypted } = op else {
+            return timeout_for_namespace_op(op);
+        };
+        match open_sealed_root_op(self.store, self.namespace_id, key_id.as_bytes(), encrypted) {
+            Ok(Some(root)) => timeout_for_namespace_op(&NamespaceOp::Root(root)),
+            // Not an error worth logging at warn: a publisher that cannot open
+            // its own sealed op is a real oddity, but the only consequence here
+            // is the ack budget, and the fallback is the value this code used
+            // before it could do better.
+            Ok(None) | Err(_) => timeout_for_namespace_op(op),
+        }
+    }
+
     pub async fn sign_apply_and_publish_returning_op(
         &self,
         node_client: &calimero_node_primitives::client::NodeClient,
@@ -659,7 +694,7 @@ impl<'a> NamespaceGovernance<'a> {
         // cleartext `GroupOp` label; observing them here too would double-count.
         let observe_mesh = !matches!(op, NamespaceOp::Group { .. });
         let op_kind = op.op_kind_label();
-        let op_timeout = timeout_for_namespace_op(&op);
+        let op_timeout = self.ack_timeout_for(&op);
         refuse_unsealed_sealable_root(&op)?;
         let signed = SignedNamespaceOp::sign(
             signer_sk,
@@ -873,7 +908,7 @@ impl<'a> NamespaceGovernance<'a> {
         let head = self.read_head_record()?;
         let observe_mesh = !matches!(op, NamespaceOp::Group { .. });
         let op_kind = op.op_kind_label();
-        let op_timeout = timeout_for_namespace_op(&op);
+        let op_timeout = self.ack_timeout_for(&op);
         refuse_unsealed_sealable_root(&op)?;
         let signed = SignedNamespaceOp::sign(
             signer_sk,

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -8845,3 +8845,73 @@ fn a_subgroup_member_outside_the_namespace_root_is_still_served_by_the_pull() {
          or sealing KeyDelivery locked this member out of its own subgroup"
     );
 }
+
+/// A sealed `GroupDeleted` keeps the heavy ack budget it had in the clear — and
+/// the wire form alone cannot know that.
+///
+/// `timeout_for_namespace_op` classifies from what is on the wire, and there a
+/// sealed root op is an opaque blob, so every one of them fell to the
+/// member-change default. `GroupDeleted` and `KeyDelivery` are the two that were
+/// deliberately given a longer budget — a cascade delete touches every
+/// descendant row, an envelope unwrap can be large — and sealing them silently
+/// halved it from 10s to 5s. The op still propagates; what breaks is the
+/// publisher's verdict, which reports `Degraded` for a delivery that was fine.
+///
+/// The third assertion is the one that says why this is not fixed by raising the
+/// wire-form default: a cheap op must NOT be promoted. Blanket-heavy would make
+/// every sealed `AdminChanged` wait 10s instead of 2s before reporting a real
+/// failure, which is a worse trade than the bug on the common admin path.
+#[test]
+fn a_sealed_root_op_is_given_the_ack_budget_its_cleartext_variant_earns() {
+    use calimero_context_client::local_governance::RootOp;
+
+    use super::governance::NamespaceGovernance;
+    use crate::governance_broadcast::{
+        timeout_for_namespace_op, OP_ACK_CHEAP_TIMEOUT, OP_ACK_HEAVY_TIMEOUT,
+        OP_ACK_MEMBER_CHANGE_TIMEOUT,
+    };
+
+    let store = test_store();
+    let ns_gid = ContextGroupId::from([0xE4u8; 32]);
+    let gov = NamespaceGovernance::new(&store, ns_gid.to_bytes().into());
+
+    let heavy = seal_for_test(
+        &store,
+        ns_gid,
+        RootOp::GroupDeleted {
+            root_group_id: ContextGroupId::from([0xE5u8; 32]),
+            cascade_group_ids: vec![],
+            cascade_context_ids: vec![],
+        },
+    );
+    assert!(
+        matches!(
+            heavy,
+            calimero_context_client::local_governance::NamespaceOp::RootSealed { .. }
+        ),
+        "precondition: this variant travels sealed, or the test proves nothing"
+    );
+    assert_eq!(
+        timeout_for_namespace_op(&heavy),
+        OP_ACK_MEMBER_CHANGE_TIMEOUT,
+        "the key-less classifier can only offer the floor for an opaque blob"
+    );
+    assert_eq!(
+        gov.ack_timeout_for(&heavy),
+        OP_ACK_HEAVY_TIMEOUT,
+        "the publisher holds the key, so it must give the budget the op earns"
+    );
+
+    let cheap = seal_for_test(
+        &store,
+        ns_gid,
+        RootOp::AdminChanged {
+            new_admin: calimero_account::AccountId::from([0xE6u8; 32]),
+        },
+    );
+    assert_eq!(
+        gov.ack_timeout_for(&cheap),
+        OP_ACK_CHEAP_TIMEOUT,
+        "and a cheap op must not be promoted: the fix is exactness, not a raise"
+    );
+}


### PR DESCRIPTION
# [governance] give a sealed root op the ack budget its cleartext variant earns

## Description

Follow-up to #3850, which named this: "`timeout_for_namespace_op` classifies
every `RootSealed` as member-change, so `GroupDeleted` and `KeyDelivery` lost
their heavy-ack timeout when they were sealed."

`timeout_for_namespace_op` decides an op's ack budget from what is on the wire.
For a sealed root op that is an opaque blob, so **every** one of them falls to
the `_ =>` member-change default. Two variants were deliberately given a longer
budget and quietly lost it when sealing moved them behind the key:

| variant | budget in the clear | budget once sealed | why it was given more |
| --- | --- | --- | --- |
| `GroupDeleted` | 10s | **5s** | a cascade delete touches every descendant subtree row |
| `KeyDelivery` | 10s | **5s** | the receiver may unwrap a large envelope |

The op still propagates — this is the ack *wait*, and the DAG apply is local and
authoritative regardless. What breaks is the publisher's verdict: it stops
waiting at 5s and classifies a delivery that was progressing fine as
`Degraded`, which feeds the readiness FSM.

## Why not just raise the default

The obvious one-liner — give `RootSealed` the heavy budget — trades one bug for
a worse one. The timeout is an upper bound, not a sleep (the collect loop breaks
as soon as `min_acks` arrive), so it only bites when acks *don't* come. Under a
blanket raise, every sealed `AdminChanged` and `PolicyUpdated` would wait **10s
instead of 2s** before surfacing a real failure — a 5x latency regression on the
common admin path, to fix a 2x one on two rarer ops.

So classify exactly. Which the publisher can do, and nobody else: sealing
**requires** the namespace key, so a node that sealed this op holds the key to
read it back. `ack_timeout_for` opens it and classifies the cleartext variant;
if it does not open (a rotation raced the publish, or a forwarding path that
never held the key) the wire-form answer stands, which is exactly the behaviour
before this existed. Cost is one extra decrypt per published sealed root op.

No call sites move: both publish paths already computed the timeout in one
place, and that is the line that changed.

## Proof the fix works

- **Reproduction**: `cargo test -p calimero-governance-store a_sealed_root_op_is_given_the_ack_budget_its_cleartext_variant_earns` (new)
- **Before** (`ack_timeout_for` reduced to the wire-form call, everything else intact):
  ```
  assertion `left == right` failed: the publisher holds the key, so it must give
  the budget the op earns
    left: 5s
   right: 10s
  test result: FAILED. 0 passed; 1 failed
  ```
- **After**: `test result: ok. 661 passed; 0 failed`

The test pins three things, and the third is the argument against the blanket
raise:

1. `timeout_for_namespace_op` on a sealed `GroupDeleted` gives the member-change
   floor — documenting the wire-form limit rather than pretending it away.
2. `ack_timeout_for` on the same op gives heavy.
3. `ack_timeout_for` on a sealed `AdminChanged` gives **cheap** — a cheap op must
   not be promoted, or the fix has become the worse trade.

## Test plan

- `cargo test -p calimero-governance-store -p calimero-context -p calimero-governance-types` — no failures.
- `cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings` — clean.
- `cargo fmt --check` — clean (pre-commit hook).
- The `mock-attestation` clippy + test gate, as `ci-checks.yml` runs it.

## Wire contract (SDK gate)

- [ ] Regenerated wire fixtures — n/a, no DTO changed
- [ ] Updated `crates/server/endpoints.json` — n/a, no routes changed
- [ ] Linked the matching mero-js PR — n/a, no wire or HTTP surface changed

Nothing on the wire changes. This only affects how long the publisher waits for
acks on an op it just sealed.

## Documentation update

`timeout_for_namespace_op`'s doc comment now says what it can and cannot see,
and points at the publisher-side classifier for sealed root ops — so the next
reader does not take its answer for a sealed op as a verdict when it is a floor.
No `docs/` page covers ack budgets.

## Relationship to the other open follow-up

#3854 (`root_op_side_effects`) touches the same file but different functions —
the retry/apply path, not the publish path. They do not conflict and can land in
either order.

The third follow-up #3850 listed — not publishing `NamespaceCreated` at all — is
deliberately **not** in this PR and I would not recommend it. The publish is
already free: a brand-new namespace topic has zero known subscribers, so
`min_acks_after_local_mutation` returns 0 and `publish_and_await_ack_namespace`
returns `Ok` immediately on `NoPeersSubscribedToTopic` via an explicit early
return, before the deadline loop. Removing it would mean a second sign-and-apply
path that has to re-do `feed_local_namespace_op` and the readiness notify by
hand (`apply_signed_op` writes the store, head and op-log but not the in-memory
DAG or the projection) — a new place for a subtle bug in a genesis/authority
path, for no measurable gain. There is also a case where the publish is not
inert: `create_group` takes a caller-supplied `group_id` and checks only *local*
meta for collisions, so a node that wiped state and re-creates the same
namespace id publishes a fresh self-authorizing genesis to peers still
subscribed. That path deserves its own reasoning rather than a cleanup.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3)_