### PR TITLE
fix(governance): find a keyless Restricted subgroup while holding the namespace key

### DIFF
--- a/crates/governance-store/src/namespace/retry.rs
+++ b/crates/governance-store/src/namespace/retry.rs
@@ -115,17 +115,30 @@ impl<'a> NamespaceRetryService<'a> {
             None => return Ok(Vec::new()),
         };
 
-        // The namespace (root) key decrypts the root group AND every `Open`
-        // subgroup, so its presence alone means no group here is keyless.
-        // Resolve it once rather than re-reading the namespace keyring for
-        // every group in the loop.
-        let has_namespace_key = GroupKeyring::new(self.store, ns_typed)
-            .load_current_key()
-            .map_err(|e| eyre::eyre!("load_current_key(namespace): {e}"))?
-            .is_some();
-        if has_namespace_key {
-            return Ok(Vec::new());
-        }
+        // No short-circuit on "this node holds the namespace key".
+        //
+        // There was one, on the reasoning that the root key decrypts the root
+        // group and every `Open` subgroup, so holding it means nothing here is
+        // keyless. That skips the case it is most needed for: a **Restricted**
+        // subgroup is covered by its OWN key, which the namespace key does not
+        // open, so a node with a direct row there is a keyless member of it
+        // while holding the namespace key — and returning empty meant no key
+        // request was ever emitted, leaving the membership undecryptable with
+        // nothing to re-drive it and no error anywhere.
+        //
+        // Two ordinary ways in: a subgroup flips `Open -> Restricted`
+        // (`SubgroupVisibilitySet` distributes no key — it writes the visibility
+        // row and queues an event, nothing more), so a direct member that never
+        // needed the group's own key suddenly does; or a `KeyDelivery` for a
+        // Restricted subgroup is missed while the node is offline, which is
+        // precisely what this pull is the safety net for.
+        //
+        // The per-group loop below already answers correctly for every group,
+        // the root included: it requires a direct row, skips anything not
+        // covered by its own keyring (`key_covering_group`), and then reads
+        // THAT group's keyring. So dropping the early return removes a wrong
+        // answer without changing any right one — it costs one descendant walk
+        // in the case that used to return early.
 
         // Every group in the namespace: the root plus all descendants.
         let mut groups = vec![ns_typed];

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -6173,6 +6173,331 @@ fn groups_member_but_keyless_finds_a_restricted_subgroup_while_holding_the_names
     );
 }
 
+/// A keyed local identity in `namespace_id`, ready for the keyless-scan matrix
+/// below. Returns the namespace gid and the account this node acts as.
+///
+/// The identity record matters as much as the membership row: the scan resolves
+/// this node's signing key to an account per group, and a fixture that wrote
+/// only the row would make every case below return empty one step earlier —
+/// passing the negative tests for the wrong reason.
+fn keyless_scan_fixture(
+    store: &Store,
+    namespace_id: [u8; 32],
+    sk_seed: u8,
+) -> (ContextGroupId, calimero_account::AccountId) {
+    let ns_gid = ContextGroupId::from(namespace_id);
+    let sk_bytes = [sk_seed; 32];
+    let my_id = PrivateKey::from(sk_bytes).public_key();
+    let my_account = enrol_member(store, &ns_gid, &my_id);
+    NamespaceRepository::new(store)
+        .store_identity(&ns_gid, &my_id, &sk_bytes)
+        .unwrap();
+    (ns_gid, my_account)
+}
+
+/// The root case the removed short-circuit used to answer, still answered.
+///
+/// Dropping the `has_namespace_key` early return must not cost the case it got
+/// right: a node with a direct row at the root and no namespace key is a keyless
+/// member of the root and has to be reported. The per-group loop reaches this
+/// because `key_covering_group(root) == root`.
+#[test]
+fn groups_member_but_keyless_still_reports_the_root_without_a_namespace_key() {
+    let store = test_store();
+    let namespace_id = [0x60u8; 32];
+    let (ns_gid, my_account) = keyless_scan_fixture(&store, namespace_id, 0x61);
+
+    // The row has to be written explicitly: `keyless_scan_fixture` enrols the
+    // account BINDING (which is what lets the scan resolve this node's key to an
+    // account) and nothing else. No key anywhere.
+    MembershipRepository::new(&store)
+        .add_member(&ns_gid, &my_account, GroupMemberRole::Member)
+        .unwrap();
+
+    assert_eq!(
+        namespace_groups_member_but_keyless(&store, namespace_id.into()).unwrap(),
+        vec![ns_gid.to_bytes()],
+        "a keyless direct member of the root must still be reported"
+    );
+}
+
+/// The scan is a KEY check, not a membership check.
+///
+/// Once the subgroup's own key is present the group drops out, even though the
+/// membership row and the Restricted visibility are unchanged. Without this, a
+/// scan that reported on membership alone would re-request a key it already
+/// holds on every retry pass.
+#[test]
+fn groups_member_but_keyless_is_silent_once_the_subgroup_key_is_held() {
+    use crate::group_keys::GroupKeyring;
+    use calimero_context_config::VisibilityMode;
+
+    let store = test_store();
+    let namespace_id = [0x62u8; 32];
+    let (ns_gid, my_account) = keyless_scan_fixture(&store, namespace_id, 0x63);
+    let sub = ContextGroupId::from([0x64u8; 32]);
+    nest_for_test(&store, &ns_gid, &sub);
+    CapabilitiesRepository::new(&store)
+        .set_subgroup_visibility(&sub, VisibilityMode::Restricted)
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&sub, &my_account, GroupMemberRole::Member)
+        .unwrap();
+    GroupKeyring::new(&store, ns_gid)
+        .store_key(&[0x65; 32])
+        .unwrap();
+
+    assert_eq!(
+        namespace_groups_member_but_keyless(&store, namespace_id.into()).unwrap(),
+        vec![sub.to_bytes()],
+        "precondition: keyless while the subgroup key is absent"
+    );
+
+    GroupKeyring::new(&store, sub)
+        .store_key(&[0x66; 32])
+        .unwrap();
+    assert!(
+        namespace_groups_member_but_keyless(&store, namespace_id.into())
+            .unwrap()
+            .is_empty(),
+        "the group drops out the moment its own key is held"
+    );
+}
+
+/// No direct row, nothing to pull.
+///
+/// An inherited member has no row (`MemberJoinedOpen` writes none — its path is
+/// computed live from `Open` visibility), and once a subgroup is Restricted
+/// there is no inherited path to it at all. Either way this node is not a member
+/// of it, and requesting its key would be asking for a key it is not entitled
+/// to — the responder's own `is_member` gate would refuse.
+#[test]
+fn groups_member_but_keyless_ignores_a_subgroup_without_a_direct_row() {
+    use crate::group_keys::GroupKeyring;
+    use calimero_context_config::VisibilityMode;
+
+    let store = test_store();
+    let namespace_id = [0x67u8; 32];
+    let (ns_gid, _my_account) = keyless_scan_fixture(&store, namespace_id, 0x68);
+    let sub = ContextGroupId::from([0x69u8; 32]);
+    nest_for_test(&store, &ns_gid, &sub);
+    CapabilitiesRepository::new(&store)
+        .set_subgroup_visibility(&sub, VisibilityMode::Restricted)
+        .unwrap();
+    GroupKeyring::new(&store, ns_gid)
+        .store_key(&[0x6A; 32])
+        .unwrap();
+    // Deliberately no `add_member` for `sub`.
+
+    assert!(
+        namespace_groups_member_but_keyless(&store, namespace_id.into())
+            .unwrap()
+            .is_empty(),
+        "a group this node has no direct row in is not its key to request"
+    );
+}
+
+/// An `Open` subgroup behind a `Restricted` ancestor, with the namespace key
+/// held — the case that most needed the short-circuit gone.
+///
+/// The wall breaks the chain, so `key_covering_group` answers the leaf itself
+/// and the namespace key does not open it. A one-hop visibility check reads this
+/// group as Open and would wrongly conclude the held namespace key covers it.
+#[test]
+fn groups_member_but_keyless_finds_an_open_subgroup_behind_a_restricted_ancestor() {
+    use crate::group_keys::GroupKeyring;
+    use calimero_context_config::VisibilityMode;
+
+    let store = test_store();
+    let namespace_id = [0x6Bu8; 32];
+    let (ns_gid, my_account) = keyless_scan_fixture(&store, namespace_id, 0x6C);
+    let mid = ContextGroupId::from([0x6Du8; 32]);
+    let leaf = ContextGroupId::from([0x6Eu8; 32]);
+    nest_for_test(&store, &ns_gid, &mid);
+    nest_for_test(&store, &mid, &leaf);
+    let caps = CapabilitiesRepository::new(&store);
+    caps.set_subgroup_visibility(&mid, VisibilityMode::Restricted)
+        .unwrap();
+    caps.set_subgroup_visibility(&leaf, VisibilityMode::Open)
+        .unwrap();
+
+    // A direct row in the leaf only, and the namespace key held.
+    MembershipRepository::new(&store)
+        .add_member(&leaf, &my_account, GroupMemberRole::Member)
+        .unwrap();
+    GroupKeyring::new(&store, ns_gid)
+        .store_key(&[0x6F; 32])
+        .unwrap();
+
+    assert_eq!(
+        namespace_groups_member_but_keyless(&store, namespace_id.into()).unwrap(),
+        vec![leaf.to_bytes()],
+        "an Open subgroup behind a Restricted wall is covered by its own key,          which the held namespace key does not open"
+    );
+}
+
+/// The contrast to the case above: a genuine Open chain, namespace key held.
+///
+/// Every hop is Open, so the covering key IS the namespace key and the node
+/// already holds it. Nothing is keyless and nothing is requested — which is what
+/// the removed short-circuit was reaching for, now reached per-group and for the
+/// right reason.
+#[test]
+fn groups_member_but_keyless_skips_a_deep_open_chain_while_holding_the_namespace_key() {
+    use crate::group_keys::GroupKeyring;
+    use calimero_context_config::VisibilityMode;
+
+    let store = test_store();
+    let namespace_id = [0x70u8; 32];
+    let (ns_gid, my_account) = keyless_scan_fixture(&store, namespace_id, 0x77);
+    let mid = ContextGroupId::from([0x78u8; 32]);
+    let leaf = ContextGroupId::from([0x79u8; 32]);
+    nest_for_test(&store, &ns_gid, &mid);
+    nest_for_test(&store, &mid, &leaf);
+    let caps = CapabilitiesRepository::new(&store);
+    caps.set_subgroup_visibility(&mid, VisibilityMode::Open)
+        .unwrap();
+    caps.set_subgroup_visibility(&leaf, VisibilityMode::Open)
+        .unwrap();
+    for gid in [&mid, &leaf] {
+        MembershipRepository::new(&store)
+            .add_member(gid, &my_account, GroupMemberRole::Member)
+            .unwrap();
+    }
+    GroupKeyring::new(&store, ns_gid)
+        .store_key(&[0x7A; 32])
+        .unwrap();
+
+    assert!(
+        namespace_groups_member_but_keyless(&store, namespace_id.into())
+            .unwrap()
+            .is_empty(),
+        "an Open chain is covered by the namespace key this node already holds"
+    );
+}
+
+/// Several keyless Restricted subgroups, reported once each and in a stable
+/// order.
+///
+/// The requester turns this list into one key request per group, so a duplicate
+/// is a duplicate request and an unstable order makes the retry pass
+/// non-deterministic between nodes.
+#[test]
+fn groups_member_but_keyless_reports_every_keyless_restricted_subgroup_once() {
+    use crate::group_keys::GroupKeyring;
+    use calimero_context_config::VisibilityMode;
+
+    let store = test_store();
+    let namespace_id = [0x7Bu8; 32];
+    let (ns_gid, my_account) = keyless_scan_fixture(&store, namespace_id, 0x7C);
+    let a = ContextGroupId::from([0x01u8; 32]);
+    let b = ContextGroupId::from([0x02u8; 32]);
+    let keyed = ContextGroupId::from([0x03u8; 32]);
+    let caps = CapabilitiesRepository::new(&store);
+    for gid in [&a, &b, &keyed] {
+        nest_for_test(&store, &ns_gid, gid);
+        caps.set_subgroup_visibility(gid, VisibilityMode::Restricted)
+            .unwrap();
+        MembershipRepository::new(&store)
+            .add_member(gid, &my_account, GroupMemberRole::Member)
+            .unwrap();
+    }
+    GroupKeyring::new(&store, ns_gid)
+        .store_key(&[0x7D; 32])
+        .unwrap();
+    // One of the three is already keyed, so it must not appear.
+    GroupKeyring::new(&store, keyed)
+        .store_key(&[0x7E; 32])
+        .unwrap();
+
+    assert_eq!(
+        namespace_groups_member_but_keyless(&store, namespace_id.into()).unwrap(),
+        vec![a.to_bytes(), b.to_bytes()],
+        "both keyless Restricted subgroups, ascending by group id, and the keyed          one absent"
+    );
+}
+
+/// The headline scenario: a subgroup flips `Open -> Restricted` and its direct
+/// members become keyless for it.
+///
+/// `SubgroupVisibilitySet`'s handler writes the visibility row and queues an
+/// event and nothing else — it distributes no key. So a direct member holding
+/// only the namespace key, which covered the group while it was Open, now needs
+/// the group's own key and has no way to notice. `set_subgroup_visibility` here
+/// is the same store mutation that handler performs.
+///
+/// Before the fix this asserted empty on both sides of the flip: the scan
+/// short-circuited on the held namespace key and never looked at the group.
+#[test]
+fn groups_member_but_keyless_reports_a_subgroup_after_it_flips_to_restricted() {
+    use crate::group_keys::GroupKeyring;
+    use calimero_context_config::VisibilityMode;
+
+    let store = test_store();
+    let namespace_id = [0x7Fu8; 32];
+    let (ns_gid, my_account) = keyless_scan_fixture(&store, namespace_id, 0x80);
+    let sub = ContextGroupId::from([0x81u8; 32]);
+    nest_for_test(&store, &ns_gid, &sub);
+    let caps = CapabilitiesRepository::new(&store);
+    caps.set_subgroup_visibility(&sub, VisibilityMode::Open)
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&sub, &my_account, GroupMemberRole::Member)
+        .unwrap();
+    GroupKeyring::new(&store, ns_gid)
+        .store_key(&[0x82; 32])
+        .unwrap();
+
+    assert!(
+        namespace_groups_member_but_keyless(&store, namespace_id.into())
+            .unwrap()
+            .is_empty(),
+        "while Open the namespace key covers it and nothing is missing"
+    );
+
+    caps.set_subgroup_visibility(&sub, VisibilityMode::Restricted)
+        .unwrap();
+
+    assert_eq!(
+        namespace_groups_member_but_keyless(&store, namespace_id.into()).unwrap(),
+        vec![sub.to_bytes()],
+        "after the flip the group is covered by its own key, which this member          does not hold and nothing delivered"
+    );
+}
+
+/// No namespace identity, no answer.
+///
+/// The scan resolves the missing key against THIS node's namespace identity, so
+/// a store without one has nothing to be keyless about. Pinned because the early
+/// return it takes is the one remaining early exit in the function, and folding
+/// it into the loop would make every group resolve an account for a key that
+/// does not exist.
+#[test]
+fn groups_member_but_keyless_is_empty_without_a_namespace_identity() {
+    use crate::group_keys::GroupKeyring;
+    use calimero_context_config::VisibilityMode;
+
+    let store = test_store();
+    let namespace_id = [0x83u8; 32];
+    let ns_gid = ContextGroupId::from(namespace_id);
+    let sub = ContextGroupId::from([0x84u8; 32]);
+    nest_for_test(&store, &ns_gid, &sub);
+    CapabilitiesRepository::new(&store)
+        .set_subgroup_visibility(&sub, VisibilityMode::Restricted)
+        .unwrap();
+    GroupKeyring::new(&store, ns_gid)
+        .store_key(&[0x85; 32])
+        .unwrap();
+    // No `store_identity`, so no local identity to be keyless on behalf of.
+
+    assert!(
+        namespace_groups_member_but_keyless(&store, namespace_id.into())
+            .unwrap()
+            .is_empty(),
+        "without a namespace identity there is nothing to recover"
+    );
+}
+
 #[test]
 fn restricted_subgroup_awaits_key_despite_holding_namespace_key() {
     // Regression for the whole group-* e2e suite going red: a joiner gets

--- a/crates/governance-store/src/namespace/tests.rs
+++ b/crates/governance-store/src/namespace/tests.rs
@@ -6089,8 +6089,9 @@ fn groups_member_but_keyless_skips_an_open_chain_subgroup() {
         .set_subgroup_visibility(&restricted_sub, VisibilityMode::Restricted)
         .unwrap();
 
-    // A direct member of both, holding no key anywhere — including no namespace
-    // key, which is the only state in which this scan does any work.
+    // A direct member of both, holding no key anywhere — the namespace key
+    // included, so the Open subgroup has no covering key either and the
+    // contrast below is purely about visibility.
     for gid in [&open_sub, &restricted_sub] {
         MembershipRepository::new(&store)
             .add_member(gid, &my_id_account, GroupMemberRole::Member)
@@ -6102,6 +6103,73 @@ fn groups_member_but_keyless_skips_an_open_chain_subgroup() {
         vec![restricted_sub.to_bytes()],
         "only the Restricted subgroup is recoverable; the Open one is covered by \
          the namespace key and has nothing to pull"
+    );
+}
+
+/// Holding the namespace key does not mean nothing is keyless.
+///
+/// `groups_member_but_keyless` short-circuits to empty as soon as the node holds
+/// the namespace key, on the reasoning that that key "decrypts the root group
+/// AND every `Open` subgroup, so its presence alone means no group here is
+/// keyless". That misses a **Restricted** subgroup the node has a direct row in:
+/// such a group is covered by its OWN key, which the namespace key does not
+/// open, so the node is a keyless member of it and the scan is the safety net
+/// that should say so.
+///
+/// Two ways to reach the state, both ordinary:
+///
+/// * a subgroup flips `Open -> Restricted` (`SubgroupVisibilitySet` distributes
+///   no key — the handler only writes the visibility row and queues an event),
+///   so a direct member that never needed the group's own key now does;
+/// * a `KeyDelivery` for a Restricted subgroup is simply missed — the node was
+///   offline, or the op arrived before its account binding folded — and the
+///   pull is what recovers it.
+///
+/// In both cases the node never emits a key request, so the membership stays
+/// undecryptable with nothing to re-drive it, and no error anywhere.
+#[test]
+fn groups_member_but_keyless_finds_a_restricted_subgroup_while_holding_the_namespace_key() {
+    use crate::group_keys::GroupKeyring;
+    use calimero_context_config::VisibilityMode;
+
+    let store = test_store();
+    let namespace_id = [0x51u8; 32];
+    let ns_gid = ContextGroupId::from(namespace_id);
+
+    let sk_bytes = [0x52u8; 32];
+    let my_id = PrivateKey::from(sk_bytes).public_key();
+    let my_account = enrol_member(&store, &ns_gid, &my_id);
+    NamespaceRepository::new(&store)
+        .store_identity(&ns_gid, &my_id, &sk_bytes)
+        .unwrap();
+
+    let restricted_sub = ContextGroupId::from([0x53u8; 32]);
+    nest_for_test(&store, &ns_gid, &restricted_sub);
+    CapabilitiesRepository::new(&store)
+        .set_subgroup_visibility(&restricted_sub, VisibilityMode::Restricted)
+        .unwrap();
+
+    // The node holds the NAMESPACE key — it is an ordinary namespace member —
+    // and has a direct row in the Restricted subgroup while holding no key for
+    // it. This is the post-flip state, and the missed-delivery state.
+    GroupKeyring::new(&store, ns_gid)
+        .store_key(&[0x54; 32])
+        .unwrap();
+    MembershipRepository::new(&store)
+        .add_member(&restricted_sub, &my_account, GroupMemberRole::Member)
+        .unwrap();
+    assert!(
+        GroupKeyring::new(&store, restricted_sub)
+            .load_current_key()
+            .unwrap()
+            .is_none(),
+        "precondition: no key for the subgroup"
+    );
+
+    assert_eq!(
+        namespace_groups_member_but_keyless(&store, namespace_id.into()).unwrap(),
+        vec![restricted_sub.to_bytes()],
+        "a direct member of a Restricted subgroup is keyless for it even while          holding the namespace key, and must be reported so the pull can recover"
     );
 }
 


### PR DESCRIPTION
# [governance] find a keyless Restricted subgroup while holding the namespace key

## Description

`groups_member_but_keyless` — the scan that drives the direct key-delivery pull — short-circuited to empty as soon as the node held the namespace key:

```rust
// The namespace (root) key decrypts the root group AND every `Open`
// subgroup, so its presence alone means no group here is keyless.
if has_namespace_key { return Ok(Vec::new()); }
```

That premise is false for a **Restricted** subgroup. Such a group is covered by its *own* key (`key_covering_group`), which the namespace key does not open — so a node with a direct membership row there is a keyless member of it while holding the namespace key. The scan reported nothing, no key request was ever emitted, and the membership stayed undecryptable with nothing to re-drive it and **no error anywhere**.

Two ordinary ways to reach that state:

- **A subgroup flips `Open -> Restricted`.** `GroupOp::SubgroupVisibilitySet`'s handler writes the visibility row and queues an `OpEvent` and nothing else (`ops/group/subgroup_visibility_set.rs`) — it distributes no key. A direct member that never needed the group's own key while it was Open suddenly does, and has no way to notice.
- **A `KeyDelivery` for a Restricted subgroup is missed** — the node was offline, or the op landed before its account binding folded. Recovering that is precisely what this pull is the safety net for, and it was switched off for exactly the nodes most likely to need it (ordinary namespace members).

**The fix is a deletion.** The per-group loop underneath was already correct for every group, the root included: it requires a direct row, skips anything not covered by its own keyring via `key_covering_group`, then reads *that group's* keyring. Dropping the early return removes a wrong answer without changing a right one. The cost is one descendant walk in the case that used to return early — this runs on key-arrival and retry passes, not per-delta.

No wire format, DTO, route or on-disk change. No coordinated upgrade: a node running this code asks for a key it is entitled to and was already failing to ask for.

### How it was missed

The sibling test added in #3860 carried the comment *"holding no key anywhere — including no namespace key, **which is the only state in which this scan does any work**"*. The short-circuit was noticed, the fixture was written around it, and it was not questioned. That comment is corrected here.

## Test plan

```bash
cargo fmt --check
cargo clippy --workspace --all-targets --features calimero-storage/testing -- -D warnings
cargo test -p calimero-governance-store   # 679 passed, 0 failed
cargo test -p calimero-node --lib         # 586 passed, 0 failed
cargo test -p calimero-context --lib      # 292 passed, 0 failed
```

Nine cases around `groups_member_but_keyless`, committed as reproduction-then-fix (`c46ca839`) followed by the wider matrix (`b0806c41`).

**Verified by reverse-applying the fix and re-running: 5 fail without it, 6 pass either way.** That split is the point — the five prove the fix does something, the six prove the early return's removal cost nothing.

Catching the bug:

| test | what it pins |
| --- | --- |
| `..._finds_a_restricted_subgroup_while_holding_the_namespace_key` | the core case the short-circuit hid |
| `..._finds_an_open_subgroup_behind_a_restricted_ancestor` | the wall breaks the chain, so the held namespace key does not cover it — a one-hop visibility check reads this group as Open and gets it wrong |
| `..._reports_a_subgroup_after_it_flips_to_restricted` | empty before the flip, reported after — the scenario the fix exists for |
| `..._reports_every_keyless_restricted_subgroup_once` | several reported once each, ascending by group id, with an already-keyed sibling absent |
| `..._is_silent_once_the_subgroup_key_is_held` | the group drops out when its key arrives, pinning this as a key check rather than a membership check |

Regression guards, unaffected by the change:

| test | what it protects |
| --- | --- |
| `..._still_reports_the_root_without_a_namespace_key` | the one case the short-circuit answered correctly |
| `..._skips_a_deep_open_chain_while_holding_the_namespace_key` | a genuine Open chain still skipped, now decided per-group |
| `..._ignores_a_subgroup_without_a_direct_row` | not a member ⇒ not this node's key to request; the responder's `is_member` gate would refuse it anyway |
| `..._is_empty_without_a_namespace_identity` | the function's one remaining early exit |

The shared `keyless_scan_fixture` writes the account binding and the identity record — without which every negative case above would pass one step early, for the wrong reason. It deliberately does **not** write a membership row: `enrol_member` never did, and the root test asserts its own row explicitly rather than inheriting a fixture side effect.

## Proof the fix works

**Reproduction** (`crates/governance-store/src/namespace/tests.rs`, `groups_member_but_keyless_finds_a_restricted_subgroup_while_holding_the_namespace_key`): a node with a namespace identity, the namespace key in its keyring, a direct membership row in a Restricted subgroup, and no key for that subgroup.

**Before:**

```
assertion `left == right` failed: a direct member of a Restricted subgroup is
keyless for it even while holding the namespace key, and must be reported so
the pull can recover
  left: []
 right: [[83, 83, 83, ...]]
```

Nothing reported ⇒ no key request ⇒ permanently undecryptable membership, silently.

**After:** the subgroup is reported and the existing pull recovers the key — the responder resolves `key_covering_group` to the subgroup and serves it, since the requester holds a direct row and passes the `is_member` gate.

The flip case has its own before/after in `..._reports_a_subgroup_after_it_flips_to_restricted`, which asserts empty while the subgroup is Open and the subgroup id after the flip. Before this change it asserted empty on both sides.

## Wire contract (SDK gate)

No HTTP wire DTO or route changed.

- [ ] Regenerated wire fixtures — not applicable, no DTO changed
- [ ] Updated `crates/server/endpoints.json` — not applicable, no routes changed
- [ ] Linked the matching mero-js PR — not applicable, no wire change

## Documentation update

None required. The behaviour now matches what `docs/src/content/docs/protocol/encryption.mdx` already describes under *Which group's key covers a group* — a Restricted subgroup is covered by its own key, and the namespace key does not open it. The code was the thing out of step with the docs, not the reverse.

## Related

- #3860 — added `key_covering_group`, which this fix leans on, and whose sibling test carried the comment that shows the short-circuit was seen and not questioned.
- #3859 — the Open-chain half of the same predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lnezo7uTBiJYPsoYPvRiW3)_